### PR TITLE
refactor(utils):remove projectName from the arguments

### DIFF
--- a/e2e/bazel/app.test.ts
+++ b/e2e/bazel/app.test.ts
@@ -5,27 +5,27 @@ describe('application', () => {
 
   it('creates a new application in a workspace', () => {
     runSchematic('@nrwl/bazel:application --name=proj');
-    runSchematic('@nrwl/bazel:app --name=myApp', {projectName: 'proj'});
+    runSchematic('@nrwl/bazel:app --name=myApp');
 
     checkFilesExists(
-        `proj/tsconfig.json`, `proj/WORKSPACE`, `proj/BUILD.bazel`, `proj/apps/my-app/BUILD.bazel`,
-        `proj/apps/my-app/src/index.html`, `proj/apps/my-app/src/app/app.module.ts`,
-        `proj/apps/my-app/src/app/app.component.ts`);
+        `tsconfig.json`, `WORKSPACE`, `BUILD.bazel`, `apps/my-app/BUILD.bazel`,
+        `apps/my-app/src/index.html`, `apps/my-app/src/app/app.module.ts`,
+        `apps/my-app/src/app/app.component.ts`);
 
-    expect(readFile('proj/apps/my-app/src/app/app.module.ts')).toContain('bootstrap: [AppComponent]');
+    expect(readFile('apps/my-app/src/app/app.module.ts')).toContain('bootstrap: [AppComponent]');
 
-    const cliConfig = JSON.parse(readFile('proj/.angular-cli.json'));
+    const cliConfig = JSON.parse(readFile('.angular-cli.json'));
     expect(cliConfig.apps.length).toEqual(1);
     expect(cliConfig.apps[0].name).toEqual('myApp');
     expect(cliConfig.apps[0].root).toEqual('apps/my-app/src');
   });
 
   it('creates multiple applications in a workspace', () => {
-    runSchematic('@nrwl/bazel:application --name=proj2');
-    runSchematic('@nrwl/bazel:app --name=first', {projectName: 'proj2'});
-    runSchematic('@nrwl/bazel:app --name=second', {projectName: 'proj2'});
+    runSchematic('@nrwl/bazel:application --name=proj');
+    runSchematic('@nrwl/bazel:app --name=first');
+    runSchematic('@nrwl/bazel:app --name=second');
 
-    const cliConfig = JSON.parse(readFile('proj2/.angular-cli.json'));
+    const cliConfig = JSON.parse(readFile('.angular-cli.json'));
     expect(cliConfig.apps[0].name).toEqual('first');
     expect(cliConfig.apps[0].root).toEqual('apps/first/src');
     expect(cliConfig.apps[1].name).toEqual('second');

--- a/e2e/bazel/lib.test.ts
+++ b/e2e/bazel/lib.test.ts
@@ -5,13 +5,13 @@ describe('library', () => {
 
   it('creates a new library in a workspace', () => {
     runSchematic('@nrwl/bazel:application --name=proj');
-    runSchematic('@nrwl/bazel:lib --name=myLib', {projectName: 'proj'});
+    runSchematic('@nrwl/bazel:lib --name=myLib');
 
     checkFilesExists(
-        `proj/tsconfig.json`, `proj/WORKSPACE`, `proj/BUILD.bazel`, `proj/libs/my-lib/BUILD.bazel`,
-        `proj/libs/my-lib/index.ts`, `proj/libs/my-lib/src/my-lib.ts`);
+        'tsconfig.json', 'WORKSPACE', 'BUILD.bazel', 'libs/my-lib/BUILD.bazel',
+        'libs/my-lib/index.ts', 'libs/my-lib/src/my-lib.ts');
 
-    const cliConfig = JSON.parse(readFile('proj/.angular-cli.json'));
+    const cliConfig = JSON.parse(readFile('.angular-cli.json'));
     expect(cliConfig.apps[0].name).toEqual('myLib');
     expect(cliConfig.apps[0].root).toEqual('libs/my-lib/src');
   });

--- a/e2e/bazel/nglib.test.ts
+++ b/e2e/bazel/nglib.test.ts
@@ -5,13 +5,13 @@ describe('angular library', () => {
 
   it('creates a new  angularlibrary in a workspace', () => {
     runSchematic('@nrwl/bazel:application --name=proj');
-    runSchematic('@nrwl/bazel:nglib --name=myLib', {projectName: 'proj'});
+    runSchematic('@nrwl/bazel:nglib --name=myLib');
 
     checkFilesExists(
-        `proj/tsconfig.json`, `proj/WORKSPACE`, `proj/BUILD.bazel`, `proj/libs/my-lib/BUILD.bazel`,
-        `proj/libs/my-lib/index.ts`, `proj/libs/my-lib/src/my-lib.module.ts`);
+        'tsconfig.json', 'WORKSPACE', 'BUILD.bazel', 'libs/my-lib/BUILD.bazel',
+        'libs/my-lib/index.ts', 'libs/my-lib/src/my-lib.module.ts');
 
-    const cliConfig = JSON.parse(readFile('proj/.angular-cli.json'));
+    const cliConfig = JSON.parse(readFile('.angular-cli.json'));
     expect(cliConfig.apps[0].name).toEqual('myLib');
     expect(cliConfig.apps[0].root).toEqual('libs/my-lib/src');
   });

--- a/e2e/bazel/workspace.test.ts
+++ b/e2e/bazel/workspace.test.ts
@@ -6,6 +6,6 @@ describe('workspace', () => {
   it('creates a new workspace for developing angular applications', () => {
     runSchematic('@nrwl/bazel:application --name=proj --version=0.1');
 
-    checkFilesExists(`proj/tsconfig.json`, `proj/WORKSPACE`, `proj/BUILD.bazel`);
+    checkFilesExists(`tsconfig.json`, `WORKSPACE`, `BUILD.bazel`);
   });
 });

--- a/e2e/schematics/convert-to-workspace.test.ts
+++ b/e2e/schematics/convert-to-workspace.test.ts
@@ -4,29 +4,28 @@ describe('Nrwl Convert to Nx Workspace', () => {
   beforeEach(cleanup);
 
   it('should generate a workspace', () => {
-    newApp('new proj --skip-install --npmScope=nrwl');
+    newApp('--skip-install --npmScope=nrwl');
 
     // update package.json
-    const packageJson = JSON.parse(readFile('proj/package.json'));
+    const packageJson = JSON.parse(readFile('package.json'));
     packageJson.description = 'some description';
     packageJson.dependencies['@ngrx/store'] = '4.0.3';
     packageJson.devDependencies['@ngrx/router-store'] = '4.0.3';
-    updateFile('proj/package.json', JSON.stringify(packageJson, null, 2));
+    updateFile('package.json', JSON.stringify(packageJson, null, 2));
 
     // update tsconfig.json
-    const tsconfigJson = JSON.parse(readFile('proj/tsconfig.json'));
+    const tsconfigJson = JSON.parse(readFile('tsconfig.json'));
     tsconfigJson.compilerOptions.paths = {'a': ['b']};
-    updateFile('proj/tsconfig.json', JSON.stringify(tsconfigJson, null, 2));
-
+    updateFile('tsconfig.json', JSON.stringify(tsconfigJson, null, 2));
 
     // run the command
-    runSchematic('@nrwl/schematics:convert-to-workspace', {projectName: 'proj'});
+    runSchematic('@nrwl/schematics:convert-to-workspace');
 
     // check that files have been moved!
-    checkFilesExists('proj/apps/proj/src/main.ts', 'proj/apps/proj/src/app/app.module.ts');
+    checkFilesExists('apps/proj/src/main.ts', 'apps/proj/src/app/app.module.ts');
 
     // check that package.json got merged
-    const updatedPackageJson = JSON.parse(readFile('proj/package.json'));
+    const updatedPackageJson = JSON.parse(readFile('package.json'));
     expect(updatedPackageJson.description).toEqual('some description');
     expect(updatedPackageJson.dependencies['@ngrx/store']).toEqual('4.0.3');
     expect(updatedPackageJson.devDependencies['@ngrx/router-store']).toEqual('4.0.3');
@@ -34,7 +33,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
     expect(updatedPackageJson.dependencies['@nrwl/nx']).toBeDefined();
 
     // check if angular-cli.json get merged
-    const updatedAngularCLIJson = JSON.parse(readFile('proj/.angular-cli.json'));
+    const updatedAngularCLIJson = JSON.parse(readFile('.angular-cli.json'));
     expect(updatedAngularCLIJson.apps[0].root).toEqual('apps/proj/src');
     expect(updatedAngularCLIJson.apps[0].outDir).toEqual('dist/apps/proj');
     expect(updatedAngularCLIJson.apps[0].test).toEqual('../../../test.js');
@@ -42,16 +41,16 @@ describe('Nrwl Convert to Nx Workspace', () => {
     expect(updatedAngularCLIJson.apps[0].testTsconfig).toEqual('../../../tsconfig.spec.json');
 
     // check if tsconfig.json get merged
-    const updatedTsConfig = JSON.parse(readFile('proj/tsconfig.json'));
-    expect(updatedTsConfig.compilerOptions.paths).toEqual({'a': ['b'], '@nrwl/*': ['libs/*']});
+    const updatedTsConfig = JSON.parse(readFile('tsconfig.json'));
+    expect(updatedTsConfig.compilerOptions.paths).toEqual({'a': ['b'], '@proj/*': ['libs/*']});
   });
 
   it('should build and test', () => {
-    newApp('new proj');
-    runSchematic('@nrwl/schematics:convert-to-workspace --npmScope=nrwl', {projectName: 'proj'});
-    runSchematic('@nrwl/schematics:lib --name=mylib --ngmodule', {projectName: 'proj'});
+    newApp();
+    runSchematic('@nrwl/schematics:convert-to-workspace --npmScope=nrwl');
+    runSchematic('@nrwl/schematics:lib --name=mylib --ngmodule');
 
-    updateFile('proj/apps/proj/src/app/app.module.ts', `
+    updateFile('apps/proj/src/app/app.module.ts', `
         import { NgModule } from '@angular/core';
         import { BrowserModule } from '@angular/platform-browser';
         import { MylibModule } from '@nrwl/mylib';
@@ -65,7 +64,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
         export class AppModule {}
       `);
 
-    expect(runCLI('build --aot', {projectName: 'proj'})).toContain('{main} main.bundle.js');
-    expect(runCLI('test --single-run', {projectName: 'proj'})).toContain('Executed 4 of 4 SUCCESS');
+    expect(runCLI('build --aot')).toContain('{main} main.bundle.js');
+    expect(runCLI('test --single-run')).toContain('Executed 4 of 4 SUCCESS');
   });
 });

--- a/e2e/schematics/ngrx.test.ts
+++ b/e2e/schematics/ngrx.test.ts
@@ -5,82 +5,82 @@ describe('ngrx', () => {
 
   describe('root', () => {
     it('should generate', () => {
-      newApp('new proj --skip-import');
+      newApp('--skip-import');
 
-      runSchematic('@nrwl/schematics:ngrx --module=src/app/app.module.ts --root', {projectName: 'proj'});
+      runSchematic('@nrwl/schematics:ngrx --module=src/app/app.module.ts --root');
 
       checkFilesExists(
-          `proj/src/app/+state/app.actions.ts`, `proj/src/app/+state/app.effects.ts`,
-          `proj/src/app/+state/app.effects.spec.ts`, `proj/src/app/+state/app.init.ts`,
-          `proj/src/app/+state/app.interfaces.ts`, `proj/src/app/+state/app.reducer.ts`,
-          `proj/src/app/+state/app.reducer.spec.ts`);
+          `src/app/+state/app.actions.ts`, `src/app/+state/app.effects.ts`,
+          `src/app/+state/app.effects.spec.ts`, `src/app/+state/app.init.ts`,
+          `src/app/+state/app.interfaces.ts`, `src/app/+state/app.reducer.ts`,
+          `src/app/+state/app.reducer.spec.ts`);
 
-      const contents = readFile('proj/src/app/app.module.ts');
+      const contents = readFile('src/app/app.module.ts');
       expect(contents).toContain('StoreModule.forRoot');
       expect(contents).toContain('EffectsModule.forRoot');
     });
-
+    //
     it('should build', () => {
-      newApp('new proj');
-      copyMissingPackages('proj');
+      newApp();
+      copyMissingPackages();
 
-      runSchematic('@nrwl/schematics:ngrx --module=src/app/app.module.ts --root', {projectName: 'proj'});
+      runSchematic('@nrwl/schematics:ngrx --module=src/app/app.module.ts --root');
 
-      runCLI('build', {projectName: 'proj'});
-      runCLI('test --single-run', {projectName: 'proj'});
+      runCLI('build');
+      runCLI('test --single-run');
     }, 50000);
 
     it('should add empty root configuration', () => {
-      newApp('new proj2');
-      copyMissingPackages('proj2');
+      newApp();
+      copyMissingPackages();
 
-      runSchematic('@nrwl/schematics:ngrx --module=src/app/app.module.ts --onlyEmptyRoot', {projectName: 'proj2'});
+      runSchematic('@nrwl/schematics:ngrx --module=src/app/app.module.ts --onlyEmptyRoot');
 
-      const contents = readFile('proj2/src/app/app.module.ts');
+      const contents = readFile('src/app/app.module.ts');
       expect(contents).toContain('StoreModule.forRoot');
       expect(contents).toContain('EffectsModule.forRoot');
 
-      runCLI('build', {projectName: 'proj2'});
+      runCLI('build');
     }, 50000);
   });
 
   describe('feature', () => {
     it('should generate', () => {
-      newApp('new proj3 --skipInstall');
-      runSchematic('@nrwl/schematics:ngrx --module=src/app/app.module.ts', {projectName: 'proj3'});
+      newApp('--skipInstall');
+      runSchematic('@nrwl/schematics:ngrx --module=src/app/app.module.ts');
 
       checkFilesExists(
-          `proj3/src/app/+state/app.actions.ts`, `proj3/src/app/+state/app.effects.ts`,
-          `proj3/src/app/+state/app.effects.spec.ts`, `proj3/src/app/+state/app.init.ts`,
-          `proj3/src/app/+state/app.interfaces.ts`, `proj3/src/app/+state/app.reducer.ts`,
-          `proj3/src/app/+state/app.reducer.spec.ts`);
+          `src/app/+state/app.actions.ts`, `src/app/+state/app.effects.ts`,
+          `src/app/+state/app.effects.spec.ts`, `src/app/+state/app.init.ts`,
+          `src/app/+state/app.interfaces.ts`, `src/app/+state/app.reducer.ts`,
+          `src/app/+state/app.reducer.spec.ts`);
 
-      const contents = readFile('proj3/src/app/app.module.ts');
+      const contents = readFile('src/app/app.module.ts');
       expect(contents).toContain('StoreModule.forFeature');
       expect(contents).toContain('EffectsModule.forFeature');
     });
   });
 
   it('should generate files without importing them', () => {
-    newApp('new proj4 --skipInstall');
-    runSchematic('@nrwl/schematics:ngrx --module=src/app/app.module.ts --onlyAddFiles', {projectName: 'proj4'});
+    newApp('--skipInstall');
+    runSchematic('@nrwl/schematics:ngrx --module=src/app/app.module.ts --onlyAddFiles');
 
     checkFilesExists(
-        `proj4/src/app/+state/app.actions.ts`, `proj4/src/app/+state/app.effects.ts`,
-        `proj4/src/app/+state/app.effects.spec.ts`, `proj4/src/app/+state/app.init.ts`,
-        `proj4/src/app/+state/app.interfaces.ts`, `proj4/src/app/+state/app.reducer.ts`,
-        `proj4/src/app/+state/app.reducer.spec.ts`);
+        `src/app/+state/app.actions.ts`, `src/app/+state/app.effects.ts`,
+        `src/app/+state/app.effects.spec.ts`, `src/app/+state/app.init.ts`,
+        `src/app/+state/app.interfaces.ts`, `src/app/+state/app.reducer.ts`,
+        `src/app/+state/app.reducer.spec.ts`);
 
-    const contents = readFile('proj4/src/app/app.module.ts');
+    const contents = readFile('src/app/app.module.ts');
     expect(contents).not.toContain('StoreModule');
     expect(contents).not.toContain('EffectsModule');
   });
 
   it('should update package.json', () => {
-    newApp('new proj5 --skipInstall');
-    runSchematic('@nrwl/schematics:ngrx --module=src/app/app.module.ts', {projectName: 'proj5'});
+    newApp('--skipInstall');
+    runSchematic('@nrwl/schematics:ngrx --module=src/app/app.module.ts');
 
-    const contents = JSON.parse(readFile('proj5/package.json'));
+    const contents = JSON.parse(readFile('package.json'));
 
     expect(contents.dependencies['@ngrx/store']).toBeDefined();
     expect(contents.dependencies['@ngrx/router-store']).toBeDefined();

--- a/e2e/schematics/upgrade-shell.test.ts
+++ b/e2e/schematics/upgrade-shell.test.ts
@@ -4,60 +4,60 @@ describe('Upgrade', () => {
   beforeEach(cleanup);
 
   it('should generate an upgrade shell', () => {
-    newApp('new proj');
+    newApp();
 
-    copyMissingPackages('proj');
-    updateFile('proj/src/legacy.js', `
+    copyMissingPackages();
+    updateFile('src/legacy.js', `
       const angular = window.angular.module('legacy', []);
       angular.component('rootLegacyCmp', {
         template: 'Expected Value'
       });
     `);
 
-    updateFile('proj/src/app/app.component.html', `
+    updateFile('src/app/app.component.html', `
       EXPECTED [<rootLegacyCmp></rootLegacyCmp>]
     `);
 
-    updateFile('proj/src/app/app.component.spec.ts', ``);
+    updateFile('src/app/app.component.spec.ts', ``);
 
     runSchematic(
         '@nrwl/schematics:upgrade-shell ' +
             '--module=src/app/app.module.ts ' +
             '--angularJsImport=../legacy ' +
-            '--angularJsCmpSelector=rootLegacyCmp',
-        {projectName: 'proj'});
+            '--angularJsCmpSelector=rootLegacyCmp'
+        );
 
-    runCLI('build', {projectName: 'proj'});
-    runCLI('test --single-run', {projectName: 'proj'});
+    runCLI('build');
+    runCLI('test --single-run');
   }, 50000);
 
   it('should update package.json', () => {
-    newApp('new proj2 --skipInstall');
+    newApp('--skipInstall');
 
     runSchematic(
         '@nrwl/schematics:upgrade-shell ' +
             '--module=src/app/app.module.ts ' +
             '--angularJsImport=../legacy ' +
-            '--angularJsCmpSelector=rootLegacyCmp',
-        {projectName: 'proj2'});
+            '--angularJsCmpSelector=rootLegacyCmp'
+        );
 
-    const contents = JSON.parse(readFile('proj2/package.json'));
+    const contents = JSON.parse(readFile('package.json'));
     expect(contents.dependencies['@angular/upgrade']).toBeDefined();
     expect(contents.dependencies['angular']).toBeDefined();
   });
 
   it('should not update package.json when --skipPackageJson', () => {
-    newApp('new proj3 --skipInstall');
+    newApp('--skipInstall');
 
     runSchematic(
         '@nrwl/schematics:upgrade-shell ' +
             '--module=src/app/app.module.ts ' +
             '--angularJsImport=../legacy ' +
             '--angularJsCmpSelector=rootLegacyCmp ' +
-            '--skipPackageJson',
-        {projectName: 'proj3'});
+            '--skipPackageJson'
+        );
 
-    const contents = JSON.parse(readFile('proj3/package.json'));
+    const contents = JSON.parse(readFile('package.json'));
     expect(contents.dependencies['@angular/upgrade']).not.toBeDefined();
   });
 });

--- a/e2e/schematics/workspace.test.ts
+++ b/e2e/schematics/workspace.test.ts
@@ -4,84 +4,84 @@ describe('Nrwl Workspace', () => {
   beforeEach(cleanup);
 
   it('should generate an empty workspace', () => {
-    newApp('new proj --collection=@nrwl/schematics --skip-install');
+    newApp('--collection=@nrwl/schematics --skip-install');
 
-    const angularCliJson = JSON.parse(readFile('proj/.angular-cli.json'));
+    const angularCliJson = JSON.parse(readFile('.angular-cli.json'));
     expect(angularCliJson.apps).toEqual([]);
 
-    const packageJson = JSON.parse(readFile('proj/package.json'));
+    const packageJson = JSON.parse(readFile('package.json'));
     expect(packageJson.devDependencies['@nrwl/schematics']).toBeDefined();
     expect(packageJson.dependencies['@nrwl/nx']).toBeDefined();
     checkFilesExists(
-        'proj/test.js', 'proj/tsconfig.app.json', 'proj/tsconfig.spec.json', 'proj/tsconfig.e2e.json', 'proj/apps',
-        'proj/libs');
+        'test.js', 'tsconfig.app.json', 'tsconfig.spec.json', 'tsconfig.e2e.json', 'apps',
+        'libs');
   });
 
   describe('app', () => {
     it('should generate an app', () => {
-      newApp('new proj2 --collection=@nrwl/schematics');
-      copyMissingPackages('proj2');
-      runSchematic('@nrwl/schematics:app --name=myapp', {projectName: 'proj2'});
+      newApp('--collection=@nrwl/schematics');
+      copyMissingPackages();
+      runSchematic('@nrwl/schematics:app --name=myapp');
 
-      const angularCliJson = JSON.parse(readFile('proj2/.angular-cli.json'));
+      const angularCliJson = JSON.parse(readFile('.angular-cli.json'));
       expect(angularCliJson.apps[0].name).toEqual('myapp');
 
       checkFilesExists(
-          'proj2/apps/myapp/src/main.ts', 'proj2/apps/myapp/src/app/app.module.ts',
-          'proj2/apps/myapp/src/app/app.component.ts', 'proj2/apps/myapp/e2e/app.po.ts');
+          'proj/apps/myapp/src/main.ts', 'proj2/apps/myapp/src/app/app.module.ts',
+          'proj/apps/myapp/src/app/app.component.ts', 'proj2/apps/myapp/e2e/app.po.ts');
 
-      runCLI('build --aot', {projectName: 'proj2'});
-      checkFilesExists('proj2/dist/apps/myapp/main.bundle.js');
+      runCLI('build --aot');
+      checkFilesExists('proj/dist/apps/myapp/main.bundle.js');
 
-      expect(runCLI('test --single-run', {projectName: 'proj2'})).toContain('Executed 1 of 1 SUCCESS');
+      expect(runCLI('test --single-run')).toContain('Executed 1 of 1 SUCCESS');
     });
   });
 
   describe('lib', () => {
     it('should generate a lib', () => {
-      newApp('new proj3 --collection=@nrwl/schematics --skip-install');
-      runSchematic('@nrwl/schematics:lib --name=mylib', {projectName: 'proj3'});
+      newApp('--collection=@nrwl/schematics --skip-install');
+      runSchematic('@nrwl/schematics:lib --name=mylib');
 
       checkFilesExists(
-          'proj3/libs/mylib/src/mylib.ts', 'proj3/libs/mylib/src/mylib.spec.ts', 'proj3/libs/mylib/index.ts');
+          'libs/mylib/src/mylib.ts', 'libs/mylib/src/mylib.spec.ts', 'libs/mylib/index.ts');
     });
 
     it('should test a lib', () => {
-      newApp('new proj3 --collection=@nrwl/schematics');
-      copyMissingPackages('proj3');
-      runSchematic('@nrwl/schematics:app --name=myapp', {projectName: 'proj3'});
-      runSchematic('@nrwl/schematics:lib --name=mylib', {projectName: 'proj3'});
+      newApp('--collection=@nrwl/schematics');
+      copyMissingPackages();
+      runSchematic('@nrwl/schematics:app --name=myapp');
+      runSchematic('@nrwl/schematics:lib --name=mylib');
 
-      expect(runCLI('test --single-run', {projectName: 'proj3'})).toContain('Executed 2 of 2 SUCCESS');
+      expect(runCLI('test --single-run')).toContain('Executed 2 of 2 SUCCESS');
     });
   });
 
   describe('nglib', () => {
     it('should generate an ng lib', () => {
-      newApp('new proj3 --collection=@nrwl/schematics --skip-install');
-      runSchematic('@nrwl/schematics:lib --name=mylib --ngmodule', {projectName: 'proj3'});
+      newApp('--collection=@nrwl/schematics --skip-install');
+      runSchematic('@nrwl/schematics:lib --name=mylib --ngmodule');
 
       checkFilesExists(
-          'proj3/libs/mylib/src/mylib.module.ts', 'proj3/libs/mylib/src/mylib.module.spec.ts',
-          'proj3/libs/mylib/index.ts');
+          'libs/mylib/src/mylib.module.ts', 'libs/mylib/src/mylib.module.spec.ts',
+          'libs/mylib/index.ts');
     });
 
     it('should test an ng lib', () => {
-      newApp('new proj3 --collection=@nrwl/schematics');
-      copyMissingPackages('proj3');
-      runSchematic('@nrwl/schematics:app --name=myapp', {projectName: 'proj3'});
-      runSchematic('@nrwl/schematics:lib --name=mylib --ngmodule', {projectName: 'proj3'});
+      newApp('--collection=@nrwl/schematics');
+      copyMissingPackages();
+      runSchematic('@nrwl/schematics:app --name=myapp');
+      runSchematic('@nrwl/schematics:lib --name=mylib --ngmodule');
 
-      expect(runCLI('test --single-run', {projectName: 'proj3'})).toContain('Executed 2 of 2 SUCCESS');
+      expect(runCLI('test --single-run')).toContain('Executed 2 of 2 SUCCESS');
     });
 
     it('should resolve dependencies on the lib', () => {
-      newApp('new proj3 --collection=@nrwl/schematics --npmScope=nrwl');
-      copyMissingPackages('proj3');
-      runSchematic('@nrwl/schematics:app --name=myapp', {projectName: 'proj3'});
-      runSchematic('@nrwl/schematics:lib --name=mylib --ngmodule', {projectName: 'proj3'});
+      newApp('--collection=@nrwl/schematics --npmScope=nrwl');
+      copyMissingPackages();
+      runSchematic('@nrwl/schematics:app --name=myapp');
+      runSchematic('@nrwl/schematics:lib --name=mylib --ngmodule');
 
-      updateFile('proj3/apps/myapp/src/app/app.module.ts', `
+      updateFile('apps/myapp/src/app/app.module.ts', `
         import { NgModule } from '@angular/core';
         import { BrowserModule } from '@angular/platform-browser';
         import { MylibModule } from '@nrwl/mylib';
@@ -95,7 +95,7 @@ describe('Nrwl Workspace', () => {
         export class AppModule {}
       `);
 
-      runCLI('build --aot', {projectName: 'proj3'});
+      runCLI('build --aot');
     });
   });
 });

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -2,30 +2,31 @@ import {execSync} from 'child_process';
 import {readFileSync, statSync, writeFileSync} from 'fs';
 import * as path from 'path';
 
-export function newApp(command: string): string {
-  return execSync(`../node_modules/.bin/ng ${command}`, {cwd: `./tmp`}).toString();
+const projectName:string = 'proj';
+
+export function newApp(command?: string): string {
+  return execSync(`../node_modules/.bin/ng new proj ${command}`, {cwd: `./tmp`}).toString();
 }
-export function runCLI(command: string, {projectName: projectName}: {projectName: string}): string {
-  projectName = projectName === undefined ? '' : projectName;
+
+export function runCLI(command?: string): string {
   return execSync(`../../node_modules/.bin/ng ${command}`, {cwd: `./tmp/${projectName}`}).toString();
 }
-export function runSchematic(command: string, {projectName}: {projectName?: string} = {}): string {
-  const up = projectName ? '../' : '';
-  projectName = projectName === undefined ? '' : projectName;
-  return execSync(`../${up}node_modules/.bin/schematics ${command}`, {cwd: `./tmp/${projectName}`}).toString();
+
+export function runSchematic(command: string): string {
+  return execSync(`../../node_modules/.bin/schematics ${command}`, {cwd: `./tmp/${projectName}`}).toString();
 }
-export function runCommand(command: string, {projectName}: {projectName: string}): string {
-  projectName = projectName === undefined ? '' : projectName;
+
+export function runCommand(command: string): string {
   return execSync(command, {cwd: `./tmp/${projectName}`}).toString();
 }
 
 export function updateFile(f: string, content: string): void {
-  writeFileSync(path.join(getCwd(), 'tmp', f), content);
+  writeFileSync(path.join(getCwd(), 'tmp', 'proj', f), content);
 }
 
 export function checkFilesExists(...expectedFiles: string[]) {
   expectedFiles.forEach(f => {
-    const ff = f.startsWith('/') ? f : path.join(getCwd(), 'tmp', f);
+    const ff = f.startsWith('/') ? f : path.join(getCwd(), 'tmp', projectName, f);
     if (!exists(ff)) {
       throw new Error(`File '${ff}' does not exist`);
     }
@@ -33,7 +34,7 @@ export function checkFilesExists(...expectedFiles: string[]) {
 }
 
 export function readFile(f: string) {
-  const ff = f.startsWith('/') ? f : path.join(getCwd(), 'tmp', f);
+  const ff = f.startsWith('/') ? f : path.join(getCwd(), 'tmp', projectName, f);
   return readFileSync(ff).toString();
 }
 
@@ -65,7 +66,7 @@ export function exists(filePath: string): boolean {
   return directoryExists(filePath) || fileExists(filePath);
 }
 
-export function copyMissingPackages(path: string): void {
+export function copyMissingPackages(): void {
   const modulesToCopy = [
     '@ngrx',
     'jasmine-marbles',
@@ -73,7 +74,7 @@ export function copyMissingPackages(path: string): void {
     'angular',
     '@angular/upgrade',
   ];
-  modulesToCopy.forEach(m => copyNodeModule(path, m));
+  modulesToCopy.forEach(m => copyNodeModule(projectName, m));
 }
 
 function copyNodeModule(path: string, name: string) {


### PR DESCRIPTION
Nx: E2E tests utils should not require proj name. #11