### PR TITLE
fix(schematics): add ngrx dependencies to workspace and convert-to-workspace

### DIFF
--- a/e2e/schematics/convert-to-workspace.test.ts
+++ b/e2e/schematics/convert-to-workspace.test.ts
@@ -9,9 +9,14 @@ describe('Nrwl Convert to Nx Workspace', () => {
     // update package.json
     const packageJson = JSON.parse(readFile('package.json'));
     packageJson.description = 'some description';
-    packageJson.dependencies['@ngrx/store'] = '4.0.3';
-    packageJson.devDependencies['@ngrx/router-store'] = '4.0.3';
     updateFile('package.json', JSON.stringify(packageJson, null, 2));
+    // confirm that @nrwl and @ngrx dependencies do not exist yet
+    expect(packageJson.devDependencies['@nrwl/schematics']).not.toBeDefined();
+    expect(packageJson.dependencies['@nrwl/nx']).not.toBeDefined();
+    expect(packageJson.dependencies['@ngrx/store']).not.toBeDefined();
+    expect(packageJson.dependencies['@ngrx/effects']).not.toBeDefined();
+    expect(packageJson.dependencies['@ngrx/router-store']).not.toBeDefined();
+    expect(packageJson.dependencies['@ngrx/store-devtools']).not.toBeDefined();
 
     // update tsconfig.json
     const tsconfigJson = JSON.parse(readFile('tsconfig.json'));
@@ -32,10 +37,12 @@ describe('Nrwl Convert to Nx Workspace', () => {
     // check that package.json got merged
     const updatedPackageJson = JSON.parse(readFile('package.json'));
     expect(updatedPackageJson.description).toEqual('some description');
-    expect(updatedPackageJson.dependencies['@ngrx/store']).toEqual('4.0.3');
-    expect(updatedPackageJson.devDependencies['@ngrx/router-store']).toEqual('4.0.3');
     expect(updatedPackageJson.devDependencies['@nrwl/schematics']).toBeDefined();
     expect(updatedPackageJson.dependencies['@nrwl/nx']).toBeDefined();
+    expect(updatedPackageJson.dependencies['@ngrx/store']).toBeDefined();
+    expect(updatedPackageJson.dependencies['@ngrx/effects']).toBeDefined();
+    expect(updatedPackageJson.dependencies['@ngrx/router-store']).toBeDefined();
+    expect(updatedPackageJson.dependencies['@ngrx/store-devtools']).toBeDefined();
 
     // check if angular-cli.json get merged
     const updatedAngularCLIJson = JSON.parse(readFile('.angular-cli.json'));
@@ -50,6 +57,33 @@ describe('Nrwl Convert to Nx Workspace', () => {
     const updatedTsConfig = JSON.parse(readFile('tsconfig.json'));
     expect(updatedTsConfig.compilerOptions.paths).toEqual({'a': ['b'], '@proj/*': ['libs/*']});
 
+  });
+
+  it('should generate a workspace and not change dependencies or devDependencies if they already exist', () => {
+    // create a new AngularCLI app
+    ngNew('--skip-install --npmScope=nrwl');
+    const nxVersion = '0.0.0';
+    const schematicsVersion = '0.0.0';
+    const ngrxVersion = '0.0.0';
+    // update package.json
+    const existingPackageJson = JSON.parse(readFile('package.json'));
+    existingPackageJson.devDependencies['@nrwl/schematics'] = schematicsVersion;
+    existingPackageJson.dependencies['@nrwl/nx'] = nxVersion;
+    existingPackageJson.dependencies['@ngrx/store'] = ngrxVersion;
+    existingPackageJson.dependencies['@ngrx/effects'] = ngrxVersion;
+    existingPackageJson.dependencies['@ngrx/router-store'] = ngrxVersion;
+    existingPackageJson.dependencies['@ngrx/store-devtools'] = ngrxVersion;
+    updateFile('package.json', JSON.stringify(existingPackageJson, null, 2));
+    // run the command
+    runSchematic('@nrwl/schematics:convert-to-workspace');
+    // check that dependencies and devDependencies remained the same
+    const packageJson = JSON.parse(readFile('package.json'));
+    expect(packageJson.devDependencies['@nrwl/schematics']).toEqual(schematicsVersion);
+    expect(packageJson.dependencies['@nrwl/nx']).toEqual(nxVersion);
+    expect(packageJson.dependencies['@ngrx/store']).toEqual(ngrxVersion);
+    expect(packageJson.dependencies['@ngrx/effects']).toEqual(ngrxVersion);
+    expect(packageJson.dependencies['@ngrx/router-store']).toEqual(ngrxVersion);
+    expect(packageJson.dependencies['@ngrx/store-devtools']).toEqual(ngrxVersion);
   });
 
   it('should build and test', () => {

--- a/e2e/schematics/workspace.test.ts
+++ b/e2e/schematics/workspace.test.ts
@@ -12,6 +12,10 @@ describe('Nrwl Workspace', () => {
     const packageJson = JSON.parse(readFile('package.json'));
     expect(packageJson.devDependencies['@nrwl/schematics']).toBeDefined();
     expect(packageJson.dependencies['@nrwl/nx']).toBeDefined();
+    expect(packageJson.dependencies['@ngrx/store']).toBeDefined();
+    expect(packageJson.dependencies['@ngrx/effects']).toBeDefined();
+    expect(packageJson.dependencies['@ngrx/router-store']).toBeDefined();
+    expect(packageJson.dependencies['@ngrx/store-devtools']).toBeDefined();
     checkFilesExist('test.js', 'tsconfig.app.json', 'tsconfig.spec.json', 'tsconfig.e2e.json', 'apps', 'libs');
   });
 

--- a/packages/schematics/src/convert-to-workspace/index.ts
+++ b/packages/schematics/src/convert-to-workspace/index.ts
@@ -2,7 +2,7 @@ import {apply, branchAndMerge, chain, externalSchematic, mergeWith, move, Rule, 
 import {Schema} from './schema';
 import {names, toFileName} from '@nrwl/schematics';
 import * as path from 'path';
-import {nxVersion, schematicsVersion} from '../utility/lib-versions';
+import {ngrxVersion, nxVersion, schematicsVersion} from '../utility/lib-versions';
 import * as fs from 'fs';
 import {join} from 'path';
 import {updateJsonFile} from '../utility/fileutils';
@@ -19,8 +19,24 @@ function updatePackageJson() {
     if (!packageJson.dependencies) {
       packageJson.dependencies = {};
     }
-    packageJson.dependencies['@nrwl/nx'] = nxVersion;
-    packageJson.devDependencies['@nrwl/schematics'] = schematicsVersion;
+    if (!packageJson.dependencies['@nrwl/nx']) {
+      packageJson.dependencies['@nrwl/nx'] = nxVersion;
+    }
+    if (!packageJson.dependencies['@ngrx/store']) {
+      packageJson.dependencies['@ngrx/store'] = ngrxVersion;
+    }
+    if (!packageJson.dependencies['@ngrx/router-store']) {
+      packageJson.dependencies['@ngrx/router-store'] = ngrxVersion;
+    }
+    if (!packageJson.dependencies['@ngrx/effects']) {
+      packageJson.dependencies['@ngrx/effects'] = ngrxVersion;
+    }
+    if (!packageJson.dependencies['@ngrx/store-devtools']) {
+      packageJson.dependencies['@ngrx/store-devtools'] = ngrxVersion;
+    }
+    if (!packageJson.devDependencies['@nrwl/schematics']) {
+      packageJson.devDependencies['@nrwl/schematics'] = schematicsVersion;
+    }
     host.overwrite('package.json', JSON.stringify(packageJson, null, 2));
     return host;
   };

--- a/packages/schematics/src/workspace/files/__directory__/package.json
+++ b/packages/schematics/src/workspace/files/__directory__/package.json
@@ -24,7 +24,11 @@
     "core-js": "^2.4.1",
     "rxjs": "^5.4.2",
     "zone.js": "^0.8.14",
-    "@nrwl/nx": "<%= nxVersion %>"
+    "@nrwl/nx": "<%= nxVersion %>",
+    "@ngrx/effects": "<%= ngrxVersion %>",
+    "@ngrx/router-store": "<%= ngrxVersion %>",
+    "@ngrx/store": "<%= ngrxVersion %>",
+    "@ngrx/store-devtools": "<%= ngrxVersion %>"
   },
   "devDependencies": {
     "@angular/cli": "nrwl/fix-cli-build",

--- a/packages/schematics/src/workspace/index.ts
+++ b/packages/schematics/src/workspace/index.ts
@@ -1,13 +1,13 @@
 import {apply, branchAndMerge, chain, mergeWith, move, Rule, template, Tree, url} from '@angular-devkit/schematics';
 import {Schema} from './schema';
 import * as stringUtils from '@schematics/angular/strings';
-import {nxVersion, schematicsVersion} from '../utility/lib-versions';
+import {ngrxVersion, nxVersion, schematicsVersion} from '../utility/lib-versions';
 
 export default function(options: Schema): Rule {
   const npmScope = options.npmScope ? options.npmScope : options.name;
   const templateSource = apply(
       url('./files'),
-      [template({utils: stringUtils, dot: '.', nxVersion, schematicsVersion, ...options as object, npmScope})]);
+      [template({utils: stringUtils, dot: '.', nxVersion, ngrxVersion, schematicsVersion, ...options as object, npmScope})]);
 
   return chain([branchAndMerge(chain([mergeWith(templateSource)]))]);
 }


### PR DESCRIPTION
Closes #28 

- Adds ngrx libraries to `package.json` dependencies for `workspace` and `convert-to-workspace` schematics
- Updates workspace e2e test to confirm it adds ngrx dependencies
- Updates convert to workspace e2e test to confirm it adds ngrx dependencies
- Adds convert to workspace e2e test to confirm that dependencies do not get changed if they already exist