### PR TITLE
fix(schematics): add extends for Angular schematics

### DIFF
--- a/e2e/schematics/workspace.test.ts
+++ b/e2e/schematics/workspace.test.ts
@@ -87,7 +87,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
     expect(packageJson.dependencies['@ngrx/store-devtools']).toEqual(ngrxVersion);
   });
 
-  it('should build and test', () => {
+  it('should build and test and support the existing AngularCLI generators', () => {
     ngNew();
     copyMissingPackages();
 
@@ -111,5 +111,15 @@ describe('Nrwl Convert to Nx Workspace', () => {
     expect(runCLI('build --aot')).toContain('{main} main.bundle.js');
     expect(runCLI('test --single-run')).toContain('Executed 4 of 4 SUCCESS');
     expect(runCLI('e2e')).toContain('Executed 1 of 1 spec SUCCESS');
+    const generatorHelpText = runCLI('g -h');
+    expect(generatorHelpText).toContain('class');
+    expect(generatorHelpText).toContain('component');
+    expect(generatorHelpText).toContain('directive');
+    expect(generatorHelpText).toContain('enum');
+    expect(generatorHelpText).toContain('guard');
+    expect(generatorHelpText).toContain('interface');
+    expect(generatorHelpText).toContain('module');
+    expect(generatorHelpText).toContain('pipe');
+    expect(generatorHelpText).toContain('service');
   });
 });

--- a/packages/schematics/src/collection.json
+++ b/packages/schematics/src/collection.json
@@ -36,6 +36,51 @@
       "factory": "./upgrade-shell",
       "schema": "./upgrade-shell/schema.json",
       "description": "Add an upgrade shell to an application"
+    },
+
+    "class": {
+      "aliases": [ "cl" ],
+      "extends": "@schematics/angular:class"
+    },
+
+    "component": {
+      "aliases": [ "c" ],
+      "extends": "@schematics/angular:component"
+    },
+
+    "directive": {
+      "aliases": [ "d" ],
+      "extends": "@schematics/angular:directive"
+    },
+
+    "enum": {
+      "aliases": [ "e" ],
+      "extends": "@schematics/angular:enum"
+    },
+
+    "guard": {
+      "aliases": [ "g" ],
+      "extends": "@schematics/angular:guard"
+    },
+
+    "interface": {
+      "aliases": [ "i" ],
+      "extends": "@schematics/angular:interface"
+    },
+
+    "module": {
+      "aliases": [ "m" ],
+      "extends": "@schematics/angular:module"
+    },
+
+    "pipe": {
+      "aliases": [ "p" ],
+      "extends": "@schematics/angular:pipe"
+    },
+
+    "service": {
+      "aliases": [ "s" ],
+      "extends": "@schematics/angular:service"
     }
   }
 }


### PR DESCRIPTION
Fixes #29 

@vsavkin

Adds the default Angular schematics to the nrwl schematics with the extends prop to make them available. Sounds like there is a feature request to add a way to extend a collection without having to repeat the schematics in your `collection.json`, but this works with the current release for now.

I want to add some e2e tests for this change...but I wanted to get the code up here so it can be looked at first to see if this is how we want to handle it for now. lmk what you think.