### PR TITLE
fix(schematics/convert-to-workspace)

### DIFF
--- a/e2e/schematics/convert-to-workspace.test.ts
+++ b/e2e/schematics/convert-to-workspace.test.ts
@@ -52,6 +52,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
     expect(updatedAngularCLIJson.apps[0].tsconfig).toEqual('../../../tsconfig.app.json');
     expect(updatedAngularCLIJson.apps[0].testTsconfig).toEqual('../../../tsconfig.spec.json');
     expect(updatedAngularCLIJson.apps[0].scripts[0]).toEqual('../../../node_modules/x.js');
+    expect(updatedAngularCLIJson.defaults.schematics.collection).toEqual('@nrwl/schematics');
 
     // check if tsconfig.json get merged
     const updatedTsConfig = JSON.parse(readFile('tsconfig.json'));

--- a/packages/schematics/src/convert-to-workspace/index.ts
+++ b/packages/schematics/src/convert-to-workspace/index.ts
@@ -62,13 +62,14 @@ function updateAngularCLIJson() {
     app.tsconfig = '../../../tsconfig.app.json';
     app.testTsconfig = '../../../tsconfig.spec.json';
     app.scripts = app.scripts.map((p) => path.join('../../', p));
-    if (!app.defaults) {
-      app.defaults = {};
+    if (!angularCliJson.defaults) {
+      angularCliJson.defaults = {};
     }
-    if (!app.defaults.schematics) {
-      app.defaults.schematics = {};
+    if (!angularCliJson.defaults.schematics) {
+      angularCliJson.defaults.schematics = {};
     }
-    app.defaults.schematics['newProject'] = ['app', 'lib'];
+    angularCliJson.defaults.schematics['collection'] = '@nrwl/schematics';
+    angularCliJson.defaults.schematics['newProject'] = ['app', 'lib'];
 
     host.overwrite('.angular-cli.json', JSON.stringify(angularCliJson, null, 2));
 
@@ -79,7 +80,7 @@ function updateAngularCLIJson() {
 function updateTsConfigsJson(options: Schema) {
   return (host: Tree) => {
     const angularCliJson = JSON.parse(host.read('.angular-cli.json')!.toString('utf-8'));
-    const npmScope = options.npmScope ? options.npmScope : angularCliJson.project.name;
+    const npmScope = options && options.npmScope ? options.npmScope : angularCliJson.project.name;
 
     updateJsonFile('tsconfig.json', (json) => setUpCompilerOptions(json, npmScope));
 


### PR DESCRIPTION
- update to set defaults.schematics.collection, add expects test (fixes #35)
- add check for options to fix 'cannot read property npmScope' error (fixes #34)