### PR TITLE
fix(schematics): provide <router-outlet> in app.component.html

### DIFF
--- a/e2e/schematics/application.test.ts
+++ b/e2e/schematics/application.test.ts
@@ -58,6 +58,15 @@ describe('Nrwl Workspace', () => {
       },
       100000
     );
+
+    it('should have router-outlet in app.component.ts with routing flag', () => {
+      ngNew('--collection=@nrwl/schematics --skip-install');
+      newApp('myapp --routing');
+
+      const contents = readFile('apps/myapp/src/app/app.component.html');
+
+      expect(contents).toContain('<router-outlet></router-outlet>');
+    });
   });
 
   describe('lib', () => {

--- a/packages/schematics/src/app/component-files/app.component.html__tmpl__
+++ b/packages/schematics/src/app/component-files/app.component.html__tmpl__
@@ -13,4 +13,6 @@ Nx is designed to help you create and build enterprise grade Angular application
 
 <h2>Quick Start & Documentation</h2>
 
-<a href="https://nrwl.io/nx">Watch a 5-minute video on how to get started with Nx.</a>
+<a href="https://nrwl.io/nx">Watch a 5-minute video on how to get started with Nx.</a><% if (routing) { %>
+
+<router-outlet></router-outlet><% } %>


### PR DESCRIPTION
In the AngularCLI schematics, the equivalent to `ng g app` (`ng new`) provides a basic router outlet in the AppComponent's template when given the `--routing` flag. This provides parity to that feature.