### PR TITLE
feat(schematics): add option to whitelist deep imports on specific libraries

### DIFF
--- a/packages/schematics/migrations/20171202-change-schema.ts
+++ b/packages/schematics/migrations/20171202-change-schema.ts
@@ -1,0 +1,17 @@
+import { updateJsonFile } from '../src/collection/utility/fileutils';
+
+export default {
+  description: 'Update the schema file to reflect the `allow` option for `nx-enforce-module-boundaries`.',
+  run: () => {
+    updateJsonFile('tslint.json', json => {
+      const ruleName = 'nx-enforce-module-boundaries';
+      const ruleOptionName = 'allow';
+      const rule = ruleName in json.rules ? json.rules[ruleName] : null;
+
+      // Only modify when the rule is configured with optional arguments
+      if (Array.isArray(rule) && typeof rule[2] === 'object' && rule[2] !== null) {
+        rule[2][ruleOptionName] = [];
+      }
+    });
+  }
+};

--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -56,6 +56,9 @@ describe('application', () => {
     expect(tsconfigJson.compilerOptions.paths).toEqual({ '@myApp/*': ['libs/*'] });
 
     const tslintJson = JSON.parse(getFileContent(tree, '/my-app/tslint.json'));
-    expect(tslintJson.rules['nx-enforce-module-boundaries']).toEqual([true, { lazyLoad: [], npmScope: 'myApp' }]);
+    expect(tslintJson.rules['nx-enforce-module-boundaries']).toEqual([
+      true,
+      { allow: [], lazyLoad: [], npmScope: 'myApp' }
+    ]);
   });
 });

--- a/packages/schematics/src/collection/application/files/__directory__/tslint.json
+++ b/packages/schematics/src/collection/application/files/__directory__/tslint.json
@@ -114,7 +114,8 @@
       true,
       {
         "npmScope": "<%= npmScope %>",
-        "lazyLoad": []
+        "lazyLoad": [],
+        "allow": []
       }
     ]
   }

--- a/packages/schematics/src/collection/testing-utils.ts
+++ b/packages/schematics/src/collection/testing-utils.ts
@@ -11,7 +11,8 @@ export function createEmptyWorkspace(tree: Tree): Tree {
           true,
           {
             npmScope: '<%= npmScope %>',
-            lazyLoad: []
+            lazyLoad: [],
+            allow: []
           }
         ]
       }
@@ -41,14 +42,14 @@ export function createApp(tree: Tree, appName: string): Tree {
     `
     import { enableProdMode } from '@angular/core';
     import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-    
+
     import { AppModule } from './app/app.module';
     import { environment } from './environments/environment';
-    
+
     if (environment.production) {
       enableProdMode();
     }
-    
+
     platformBrowserDynamic()
       .bootstrapModule(AppModule)
       .catch(err => console.log(err));

--- a/packages/schematics/src/collection/workspace/index.ts
+++ b/packages/schematics/src/collection/workspace/index.ts
@@ -141,7 +141,7 @@ function updateTsLintJson(options: Schema) {
       ['no-trailing-whitespace', 'one-line', 'quotemark', 'typedef-whitespace', 'whitespace'].forEach(key => {
         json[key] = undefined;
       });
-      json['nx-enforce-module-boundaries'] = [true, { npmScope: npmScope(options), lazyLoad: [] }];
+      json['nx-enforce-module-boundaries'] = [true, { npmScope: npmScope(options), lazyLoad: [], allow: [] }];
     });
     return host;
   };

--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -6,9 +6,10 @@ import { Rule } from './nxEnforceModuleBoundariesRule';
 describe('Enforce Module Boundaries', () => {
   it('should not error when everything is in order', () => {
     const failures = runRule(
-      { npmScope: 'mycompany' },
+      { npmScope: 'mycompany', allow: ['@mycompany/mylib/deep'] },
       `
       import '@mycompany/mylib';
+      import '@mycompany/mylib/deep';
       import '../blah';
     `
     );

--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -24,10 +24,13 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
   public visitImportDeclaration(node: ts.ImportDeclaration) {
     const npmScope = `@${this.getOptions()[0].npmScope}`;
     const lazyLoad = this.getOptions()[0].lazyLoad;
+    const allow: string[] = Array.isArray(this.getOptions()[0].allow)
+      ? this.getOptions()[0].allow.map(a => `${a}`)
+      : [];
     const imp = node.moduleSpecifier.getText().substring(1, node.moduleSpecifier.getText().length - 1);
     const impParts = imp.split(path.sep);
 
-    if (impParts[0] === npmScope && impParts.length > 2) {
+    if (impParts[0] === npmScope && allow.indexOf(imp) === -1 && impParts.length > 2) {
       this.addFailureAt(node.getStart(), node.getWidth(), 'deep imports into libraries are forbidden');
     } else if (impParts[0] === npmScope && impParts.length === 2 && lazyLoad && lazyLoad.indexOf(impParts[1]) > -1) {
       this.addFailureAt(node.getStart(), node.getWidth(), 'import of lazy-loaded libraries are forbidden');


### PR DESCRIPTION
Adds an `allowDeep` option to the `nx-enforce-module-boundaries` rule. This might be helpful in scenarios where a library is meant to be consumed in larger parts under one namespace, e.g., “common”.

Example:
```
@npmScope/common/modules
@npmScope/common/utilities
@npmScope/common/tslint
```

This would not apply to relative imports of a library since the pattern should probably follow using the full library namespace.