### PR TITLE
fix(schematics): bump rxjs to version ^5.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "karma-jasmine": "~1.1.0",
     "karma-webpack": "2.0.4",
     "prettier": "1.8.2",
-    "rxjs": "5.5.2",
+    "rxjs": "^5.5.2",
     "tslint": "5.7.0",
     "typescript": "2.5.3",
     "strip-json-comments": "2.0.1"

--- a/packages/schematics/src/collection/utility/lib-versions.ts
+++ b/packages/schematics/src/collection/utility/lib-versions.ts
@@ -7,7 +7,7 @@ export const schematicsVersion = '*';
 export const latestMigration = '20171213-update-tsconfig-spec-to-exclude-e2e';
 export const prettierVersion = '1.8.2';
 export const typescriptVersion = '2.5.3';
-export const rxjsVersion = '5.5.2';
+export const rxjsVersion = '^5.5.2';
 
 export const libVersions = {
   angularVersion,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5113,11 +5113,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@5.5.2, rxjs@^5.5.2:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.2.tgz#28d403f0071121967f18ad665563255d54236ac3"
+rxjs@^5.5.2:
+  version "5.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.5.tgz#e164f11d38eaf29f56f08c3447f74ff02dd84e97"
   dependencies:
-    symbol-observable "^1.0.1"
+    symbol-observable "1.0.1"
 
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -5653,9 +5653,9 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
 symbol-tree@^3.2.1:
   version "3.2.2"


### PR DESCRIPTION
Fixes issue with `input.mergeMap` error that shows up when running schematics.

Not sure if we want to bump to 5.5.5 or not, @vsavkin can you confirm if this is what we want to do here?

Closes #154