### PR TITLE
fix(schematics): make deep import check work for libs with same prefix

### DIFF
--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -63,8 +63,8 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
       return;
     }
 
-    const app = this.appNames.filter(a => imp.startsWith(`@${this.npmScope}/${a}`))[0];
-    if (app && imp !== `@${this.npmScope}/${app}`) {
+    const deepImport = this.appNames.filter(a => imp.startsWith(`@${this.npmScope}/${a}/`))[0];
+    if (deepImport) {
       this.addFailureAt(node.getStart(), node.getWidth(), 'deep imports into libraries are forbidden');
       return;
     }


### PR DESCRIPTION
Adds logic to make check of startsWith work when more than one lib has the same
starting string. Also adds spec to confirm the case.