### PR TITLE
fix(schematics): base projectPath on the full path instead of the current working directory of the process

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "tslint": "5.7.0",
     "typescript": "2.5.3",
     "strip-json-comments": "2.0.1",
+    "app-root-path": "^2.0.1",
     "tmp": "0.0.33",
     "semver": "5.4.1"
   },

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -8,12 +8,13 @@
   },
   "main": "index.js",
   "types": "index.d.js",
-  "peerDependencies" :{},
+  "peerDependencies": {},
   "author": "Victor Savkin",
   "license": "MIT",
   "schematics": "./src/collection.json",
   "dependencies": {
-    "tmp": "0.0.33",
-    "semver": "5.4.1"
+    "app-root-path": "^2.0.1",
+    "semver": "5.4.1",
+    "tmp": "0.0.33"
   }
 }

--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -3,6 +3,7 @@ import * as Lint from 'tslint';
 import { IOptions } from 'tslint';
 import * as ts from 'typescript';
 import { readFileSync } from 'fs';
+import * as appRoot from 'app-root-path';
 
 export class Rule extends Lint.Rules.AbstractRule {
   constructor(
@@ -14,8 +15,8 @@ export class Rule extends Lint.Rules.AbstractRule {
   ) {
     super(options);
     if (!path) {
-      const cliConfig = this.readCliConfig();
-      this.path = process.cwd();
+      this.path = appRoot.path;
+      const cliConfig = this.readCliConfig(this.path);
       this.npmScope = cliConfig.project.npmScope;
       this.libNames = cliConfig.apps.filter(p => p.root.startsWith('libs/')).map(a => a.name);
       this.appNames = cliConfig.apps.filter(p => p.root.startsWith('apps/')).map(a => a.name);
@@ -35,8 +36,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     );
   }
 
-  private readCliConfig(): any {
-    return JSON.parse(readFileSync(`.angular-cli.json`, 'UTF-8'));
+  private readCliConfig(projectPath: string): any {
+    return JSON.parse(readFileSync(`${projectPath}/.angular-cli.json`, 'UTF-8'));
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,6 +311,10 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
+app-root-path@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
+
 append-transform@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"


### PR DESCRIPTION
The `nxEnforceModuleBoundariesRule` based the projectPath on `process.cwd()` which won't work in case the linter is run from any other directory.
This change uses the `app-root-path` library for determining the project root folder, independent of the cwd.

I encountered this problem when opening an nx workspace in Atom. I had the `linter-tslint` package enabled, which invokes tslint and reports back the results. In this case `tslint` is not run from the root of the workspace, causing the constructor of the `nxEnforceModuleBoundariesRule` to throw an Error. This occurs even if semantic rules are disabled, as the rule is still initialized even though it will not be applied.

The usage of `app-root-path` was based on the codelyzer project as it also uses this library to check for a `.codelyzer` file at the project root.