### PR TITLE
fix(schematics): missing end-of-options-marker in affected script errors

### DIFF
--- a/packages/schematics/src/command-line/affected.ts
+++ b/packages/schematics/src/command-line/affected.ts
@@ -31,9 +31,7 @@ export function affected(args: string[]): void {
 
 function printError(command: string, e: any) {
   console.error(`Pass the SHA range, as follows: npm run affected:${command} -- SHA1 SHA2.`);
-  console.error(
-    `Or pass the list of files, as follows: npm run affected:${command} --files="libs/mylib/index.ts,libs/mylib2/index.ts".`
-  );
+  console.error(`Or pass the list of files, as follows: npm run affected:${command} -- --files="libs/mylib/index.ts,libs/mylib2/index.ts".`);
   console.error(e.message);
 }
 

--- a/packages/schematics/src/command-line/format.ts
+++ b/packages/schematics/src/command-line/format.ts
@@ -50,9 +50,7 @@ function getPatternsFromApps(affectedFiles: string[]): string[] {
 
 function printError(command: string, e: any) {
   console.error(`Pass the SHA range, as follows: npm run format:${command} -- SHA1 SHA2.`);
-  console.error(
-    `Or pass the list of files, as follows: npm run format:${command} --files="libs/mylib/index.ts,libs/mylib2/index.ts".`
-  );
+  console.error(`Or pass the list of files, as follows: npm run format:${command} -- --files="libs/mylib/index.ts,libs/mylib2/index.ts".`);
   console.error(e.message);
 }
 


### PR DESCRIPTION
Adds `--` end-of-options-marker in affected files script errors to correctly convey how to pass `--files` to those scripts.