### PR TITLE
fix(schematics): continue traversing within irrelevant PropertyAssignment nodes

### DIFF
--- a/packages/schematics/src/command-line/affected-apps.ts
+++ b/packages/schematics/src/command-line/affected-apps.ts
@@ -104,18 +104,24 @@ class Deps {
     if (node.kind === ts.SyntaxKind.ImportDeclaration) {
       const imp = this.getStringLiteralValue((node as ts.ImportDeclaration).moduleSpecifier);
       this.addDepIfNeeded(imp, projectName);
-    } else if (node.kind === ts.SyntaxKind.PropertyAssignment) {
+      return; // stop traversing downwards
+    }
+
+    if (node.kind === ts.SyntaxKind.PropertyAssignment) {
       const name = this.getPropertyAssignmentName((node as ts.PropertyAssignment).name);
       if (name === 'loadChildren') {
         const init = (node as ts.PropertyAssignment).initializer;
         if (init.kind === ts.SyntaxKind.StringLiteral) {
           const childrenExpr = this.getStringLiteralValue(init);
           this.addDepIfNeeded(childrenExpr, projectName);
+          return; // stop traversing downwards
         }
       }
-    } else {
-      ts.forEachChild(node, child => this.processNode(projectName, child));
     }
+    /**
+     * Continue traversing down the AST from the current node
+     */
+    ts.forEachChild(node, child => this.processNode(projectName, child));
   }
 
   private getPropertyAssignmentName(nameNode: ts.PropertyName) {


### PR DESCRIPTION
Currently recursive traversal of the TS AST generated for each file within an app is being prematurely stopped for `PropertyAssignment` nodes which are not relevant to dependency resolution.

Taking an example of a lib called `safe`, which has a module called `HistorySearchModule`.

Before this PR, Nx would successful pick up on the `safe` lib as a dependency of the app if the code was written like this:
```ts
// imports etc..

const routes = [
  {
    path: '',
    loadChildren: '@libs/safe/history-search#HistorySearchModule'
  }
]

@NgModule({
  imports: [
 //...
    RouterModule.forRoot(
      routes,
      { useHash: true }
    ),
  ],
 //...
})
export class AppModule {}
```

But not if it was written like this:
```ts
// imports etc..

@NgModule({
  imports: [
 //...
    RouterModule.forRoot(
      [
          {
              path: '',
              loadChildren: '@libs/safe/history-search#HistorySearchModule'
          }
      ],
      { useHash: true }
    ),
  ],
 //...
})
export class AppModule {}
```

I refactored the code slightly and added some comments to try and make the behaviour a little clearer.