### PR TITLE
fix(devkit): update devkit/core version to fix create-nx-workspace issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@angular/cli": "file:./packages/schematics/src/collection/application/files/__directory__/.angular_cli165.tgz",
-    "@angular-devkit/core": "0.0.28",
+    "@angular-devkit/core": "0.0.29",
     "@angular/common": "5.2.1",
     "@angular/compiler": "5.2.1",
     "@angular/compiler-cli": "5.2.1",


### PR DESCRIPTION
Fixes creating new Nx workspace issues

```ts
npm i -g @nrwl/schematics && npm i -g @angular/cli && create-nx-workspace broken-before-this
```

Fix looks to be bumping this to **0.29**
https://github.com/angular/angular-cli/issues/9374#issuecomment-360407400

closes #244 

cc/ @vsavkin 