### PR TITLE
Fix enforceModuleBoundaries for windows -> new PR 290

### DIFF
--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -126,7 +126,7 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
 
   private libraryRoot(): string {
     const sourceFile = this.getSourceFile().fileName.substring(this.projectPath.length + 1);
-    return this.roots.filter(r => sourceFile.startsWith(r))[0];
+    return this.roots.filter(r => sourceFile.startsWith(`${r}/`))[0];
   }
 
   private isAbsoluteImportIntoAnotherProject(imp: string): boolean {

--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -119,7 +119,7 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
     if (targetFile.startsWith(':')) {
       // windows compatibility
       targetFile = targetFile.substring(2); // remove ":\"
-      targetFile = targetFile.split(path.sep).join('/'); // replace "\"" with "/"
+      targetFile = targetFile.split(path.sep).join('/'); // replace "\" with "/"
     }
     return targetFile;
   }

--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -109,9 +109,19 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
   private isRelativeImportIntoAnotherProject(imp: string): boolean {
     if (!this.isRelative(imp)) return false;
     const sourceFile = this.getSourceFile().fileName.substring(this.projectPath.length);
-    const targetFile = path.resolve(path.dirname(sourceFile), imp).substring(1); // remove leading slash
+    const targetFile = this.getTargetFile(imp, sourceFile);
     if (!this.libraryRoot()) return false;
     return !(targetFile.startsWith(`${this.libraryRoot()}/`) || targetFile === this.libraryRoot());
+  }
+
+  private getTargetFile(imp: string, sourceFile: string): string {
+    let targetFile = path.resolve(path.dirname(sourceFile), imp).substring(1); // remove leading slash
+    if (targetFile.startsWith(':')) {
+      // windows compatibility
+      targetFile = targetFile.substring(2); // remove ":\"
+      targetFile = targetFile.split(path.sep).join('/'); // replace "\"" with "/"
+    }
+    return targetFile;
   }
 
   private libraryRoot(): string {


### PR DESCRIPTION
This PR fixes the TSLint rule `nx-enforce-module-boundaries` that is broken on windows (comparison against windows path).

In addition to that the `libraryRoot` will consider lib names that are part of other lib names (eg. my-shared, my-shared-extended).