### PR TITLE
test(lint): absolute project path, add roots dynamically

### DIFF
--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -124,14 +124,15 @@ function runRule(
     ruleSeverity: 'error',
     ruleName: 'enforceModuleBoundaries'
   };
+  const roots = [...appNames.map(a => `apps/${a}`), ...libNames.map(l => `libs/${l}`)];
 
   const sourceFile = ts.createSourceFile(
-    'proj/apps/myapp/src/main.ts',
+    '/proj/apps/myapp/src/main.ts',
     content,
     ts.ScriptTarget.Latest,
     true
   );
-  const rule = new Rule(options, 'proj', 'mycompany', libNames, appNames, []);
+  const rule = new Rule(options, '/proj', 'mycompany', libNames, appNames, roots);
   return rule.apply(sourceFile);
 }
 


### PR DESCRIPTION
even if it is not necessary at the moment, safety for future tests. in addition to #290 