### PR TITLE
feat(schematics): add support for tagged libs

### DIFF
--- a/packages/schematics/migrations/20180313-add-tags.ts
+++ b/packages/schematics/migrations/20180313-add-tags.ts
@@ -1,0 +1,19 @@
+import {updateJsonFile} from '../../shared/fileutils';
+
+export default {
+  description: 'Add tags to all app and libs',
+  run: async () => {
+    updateJsonFile('.angular-cli.json', json => {
+      json.apps = json.apps.map(app => ({...app, tags: []}));
+    });
+
+    updateJsonFile('tslint.json', json => {
+      if (json.rules["nx-enforce-module-boundaries"]) {
+        json.rules["nx-enforce-module-boundaries"][1].depConstraints = [
+          { "sourceTag": "*", "onlyDependOnLibsWithTags": ["*"] }
+        ];
+        json.rules["nx-enforce-module-boundaries"][1].lazyLoad = undefined;
+      }
+    });
+  }
+};

--- a/packages/schematics/src/collection/app/app.spec.ts
+++ b/packages/schematics/src/collection/app/app.spec.ts
@@ -33,6 +33,7 @@ describe('app', () => {
           root: 'apps/my-app/src',
           scripts: [],
           styles: ['styles.css'],
+          tags: [],
           test: '../../../test.js',
           testTsconfig: '../../../tsconfig.spec.json',
           tsconfig: 'tsconfig.app.json'
@@ -88,6 +89,7 @@ describe('app', () => {
           root: 'apps/my-dir/my-app/src',
           scripts: [],
           styles: ['styles.css'],
+          tags: [],
           test: '../../../../test.js',
           testTsconfig: '../../../../tsconfig.spec.json',
           tsconfig: 'tsconfig.app.json'
@@ -167,6 +169,14 @@ describe('app', () => {
       expect(getFileContent(tree, 'apps/my-dir/my-app/src/app/app.component.ts')).toContain(
         'encapsulation: ViewEncapsulation.Native'
       );
+    });
+  });
+
+  describe('tags', () => {
+    it('should split tags by a comma', () => {
+      const tree = schematicRunner.runSchematic('app', { name: 'myApp', npmScope: 'nrwl', tags: 'one,two' }, appTree);
+      const updatedAngularCLIJson = JSON.parse(getFileContent(tree, '/.angular-cli.json'));
+      expect(updatedAngularCLIJson.apps[0].tags).toEqual(['one', 'two']);
     });
   });
 });

--- a/packages/schematics/src/collection/app/index.ts
+++ b/packages/schematics/src/collection/app/index.ts
@@ -62,6 +62,7 @@ function addAppToAngularCliJson(options: NormalizedSchema): Rule {
       throw new Error('Missing .angular-cli.json');
     }
 
+    const tags = options.tags ? options.tags.split(',').map(s => s.trim()) : [];
     const sourceText = host.read('.angular-cli.json')!.toString('utf-8');
     const json = JSON.parse(sourceText);
     json.apps = addApp(json.apps, {
@@ -82,7 +83,8 @@ function addAppToAngularCliJson(options: NormalizedSchema): Rule {
       environments: {
         dev: 'environments/environment.ts',
         prod: 'environments/environment.prod.ts'
-      }
+      },
+      tags
     });
 
     json.lint = [

--- a/packages/schematics/src/collection/app/schema.d.ts
+++ b/packages/schematics/src/collection/app/schema.d.ts
@@ -11,4 +11,5 @@ export interface Schema {
   skipTests?: boolean;
   prefix?: string;
   style?: string;
+  tags?: string;
 }

--- a/packages/schematics/src/collection/app/schema.json
+++ b/packages/schematics/src/collection/app/schema.json
@@ -59,6 +59,10 @@
       "description": "The file extension to be used for style files.",
       "type": "string",
       "default": "css"
+    },
+    "tags": {
+      "type": "string",
+      "description": "Add tags to the application (used for linting)"
     }
   },
   "required": [

--- a/packages/schematics/src/collection/application/files/__directory__/tslint.json
+++ b/packages/schematics/src/collection/application/files/__directory__/tslint.json
@@ -94,7 +94,10 @@
     "nx-enforce-module-boundaries": [
       true,
       {
-        "allow": []
+        "allow": [],
+        "depConstraints": [
+          { "sourceTag": "*", "onlyDependOnLibsWithTags": ["*"] }
+        ]
       }
     ]
   }

--- a/packages/schematics/src/collection/lib/lib.spec.ts
+++ b/packages/schematics/src/collection/lib/lib.spec.ts
@@ -26,6 +26,7 @@ describe('lib', () => {
           appRoot: '',
           name: 'my-lib',
           root: 'libs/my-lib/src',
+          tags: [],
           test: '../../../test.js'
         }
       ]);
@@ -57,6 +58,7 @@ describe('lib', () => {
           appRoot: '',
           name: 'my-dir/my-lib',
           root: 'libs/my-dir/my-lib/src',
+          tags: [],
           test: '../../../../test.js'
         }
       ]);
@@ -148,16 +150,6 @@ describe('lib', () => {
           '../../../libs/my-dir/my-lib2/index.ts'
         ]);
       });
-
-      it('should register the module as lazy loaded in tslint.json', () => {
-        const tree = schematicRunner.runSchematic(
-          'lib',
-          { name: 'myLib', directory: 'myDir', routing: true, lazy: true },
-          appTree
-        );
-        const tslint = JSON.parse(getFileContent(tree, 'tslint.json'));
-        expect(tslint['rules']['nx-enforce-module-boundaries'][1]['lazyLoad']).toEqual(['my-dir/my-lib']);
-      });
     });
 
     describe('eager', () => {
@@ -190,6 +182,14 @@ describe('lib', () => {
         expect(getFileContent(tree2, 'apps/myapp/src/app/app.module.ts')).toContain(
           `RouterModule.forRoot([{path: 'my-lib', children: myLibRoutes}, {path: 'my-lib2', children: myLib2Routes}])`
         );
+      });
+    });
+
+    describe('tags', () => {
+      it('should split tags by a comma', () => {
+        const tree = schematicRunner.runSchematic('lib', { name: 'myLib', tags: 'one,two' }, appTree);
+        const updatedAngularCLIJson = JSON.parse(getFileContent(tree, '/.angular-cli.json'));
+        expect(updatedAngularCLIJson.apps[0].tags).toEqual(['one', 'two']);
       });
     });
   });

--- a/packages/schematics/src/collection/lib/schema.d.ts
+++ b/packages/schematics/src/collection/lib/schema.d.ts
@@ -11,4 +11,5 @@ export interface Schema {
   routing?: boolean;
   lazy?: boolean;
   parentModule?: string;
+  tags?: string;
 }

--- a/packages/schematics/src/collection/lib/schema.json
+++ b/packages/schematics/src/collection/lib/schema.json
@@ -30,6 +30,10 @@
     "parentModule": {
       "type": "string",
       "description": "Update the router configuration of the parent module using loadChildren or children, depending on what `lazy` is set to."
+    },
+    "tags": {
+      "type": "string",
+      "description": "Add tags to the library (used for linting)"
     }
   },
   "required": [

--- a/packages/schematics/src/collection/workspace/index.ts
+++ b/packages/schematics/src/collection/workspace/index.ts
@@ -106,6 +106,7 @@ function updateAngularCLIJson(options: Schema) {
     app.test = '../../../test.js';
     app.testTsconfig = '../../../tsconfig.spec.json';
     app.scripts = app.scripts.map(p => path.join('../../', p));
+    app.tags = [];
     if (!angularCliJson.defaults) {
       angularCliJson.defaults = {};
     }
@@ -187,7 +188,15 @@ function updateTsLintJson(options: Schema) {
         json[key] = undefined;
       });
       json.rulesDirectory.push('node_modules/@nrwl/schematics/src/tslint');
-      json['nx-enforce-module-boundaries'] = [true, { allow: [] }];
+      json['nx-enforce-module-boundaries'] = [
+        true,
+        {
+          "allow": [],
+          "depConstraints": [
+            { "sourceTag": "*", "onlyDependOnLibsWithTags": ["*"] }
+          ]
+        }
+      ];
     });
     return host;
   };

--- a/packages/schematics/src/command-line/affected-apps.spec.ts
+++ b/packages/schematics/src/command-line/affected-apps.spec.ts
@@ -10,12 +10,14 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             name: 'app1',
             root: '',
             files: [],
+            tags: [],
             type: ProjectType.app
           },
           {
             name: 'app2',
             root: '',
             files: [],
+            tags: [],
             type: ProjectType.app
           }
         ],
@@ -33,18 +35,21 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             name: 'app1',
             root: '',
             files: ['app1.ts'],
+            tags: [],
             type: ProjectType.app
           },
           {
             name: 'lib1',
             root: '',
             files: ['lib1.ts'],
+            tags: [],
             type: ProjectType.lib
           },
           {
             name: 'lib2',
             root: '',
             files: ['lib2.ts'],
+            tags: [],
             type: ProjectType.lib
           }
         ],
@@ -80,18 +85,21 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             name: 'app1',
             root: '',
             files: ['app1.ts'],
+            tags: [],
             type: ProjectType.app
           },
           {
             name: 'lib1',
             root: '',
             files: ['lib1.ts'],
+            tags: [],
             type: ProjectType.lib
           },
           {
             name: 'lib2',
             root: '',
             files: ['lib2.ts'],
+            tags: [],
             type: ProjectType.lib
           }
         ],
@@ -124,6 +132,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             name: 'app1',
             root: '',
             files: ['index.html'],
+            tags: [],
             type: ProjectType.app
           }
         ],
@@ -141,12 +150,14 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             name: 'aa',
             root: '',
             files: ['aa.ts'],
+            tags: [],
             type: ProjectType.app
           },
           {
             name: 'aa/bb',
             root: '',
             files: ['bb.ts'],
+            tags: [],
             type: ProjectType.app
           }
         ],
@@ -173,24 +184,28 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             name: 'app1',
             root: '',
             files: ['app1.ts'],
+            tags: [],
             type: ProjectType.app
           },
           {
             name: 'app2',
             root: '',
             files: ['app2.ts'],
+            tags: [],
             type: ProjectType.app
           },
           {
             name: 'lib1',
             root: '',
             files: ['lib1.ts'],
+            tags: [],
             type: ProjectType.lib
           },
           {
             name: 'lib2',
             root: '',
             files: ['lib2.ts'],
+            tags: [],
             type: ProjectType.lib
           }
         ],
@@ -222,18 +237,21 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             name: 'app1',
             root: '',
             files: ['app1.ts'],
+            tags: [],
             type: ProjectType.app
           },
           {
             name: 'app2',
             root: '',
             files: ['app2.ts'],
+            tags: [],
             type: ProjectType.app
           },
           {
             name: 'lib1',
             root: '',
             files: ['lib1.ts'],
+            tags: [],
             type: ProjectType.lib
           }
         ],
@@ -263,6 +281,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             name: 'app1',
             root: '',
             files: ['one\\app1.ts', 'two/app1.ts'],
+            tags: [],
             type: ProjectType.app
           }
         ],
@@ -288,12 +307,14 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             name: 'app1',
             root: '',
             files: ['app1.ts'],
+            tags: [],
             type: ProjectType.app
           },
           {
             name: 'app2',
             root: '',
             files: ['app2.ts'],
+            tags: [],
             type: ProjectType.app
           }
         ],
@@ -320,24 +341,28 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             name: 'app1',
             root: '',
             files: ['app1.ts'],
+            tags: [],
             type: ProjectType.app
           },
           {
             name: 'app2',
             root: '',
             files: ['app2.ts'],
+            tags: [],
             type: ProjectType.app
           },
           {
             name: 'lib1',
             root: '',
             files: ['lib1.ts'],
+            tags: [],
             type: ProjectType.lib
           },
           {
             name: 'lib2',
             root: '',
             files: ['lib2.ts'],
+            tags: [],
             type: ProjectType.lib
           }
         ],

--- a/packages/schematics/src/command-line/affected-apps.ts
+++ b/packages/schematics/src/command-line/affected-apps.ts
@@ -11,7 +11,7 @@ export enum DependencyType {
   loadChildren = 'loadChildren'
 }
 
-export type ProjectNode = { name: string; root: string; type: ProjectType; files: string[] };
+export type ProjectNode = { name: string; root: string; type: ProjectType; tags: string[]; files: string[] };
 export type Dependency = { projectName: string; type: DependencyType };
 
 export function touchedProjects(projects: ProjectNode[], touchedFiles: string[]) {

--- a/packages/schematics/src/command-line/shared.ts
+++ b/packages/schematics/src/command-line/shared.ts
@@ -47,6 +47,7 @@ export function getProjectNodes(config) {
       name: p.name,
       root: p.root,
       type: p.root.startsWith('apps/') ? ProjectType.app : ProjectType.lib,
+      tags: p.tags,
       files: allFilesInDir(path.dirname(p.root))
     };
   });

--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -43,7 +43,15 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 }
 
+type DepConstraint = {
+  sourceTag: string;
+  onlyDependOnLibsWithTags: string[];
+};
+
 class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
+  private readonly allow: string[];
+  private readonly depConstraints: DepConstraint[];
+
   constructor(
     sourceFile: ts.SourceFile,
     options: IOptions,
@@ -53,60 +61,97 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
     private readonly deps: { [projectName: string]: Dependency[] }
   ) {
     super(sourceFile, options);
+
+    this.allow = Array.isArray(this.getOptions()[0].allow)
+      ? this.getOptions()[0].allow.map(a => `${a}`)
+      : [];
+
+    this.depConstraints = Array.isArray(this.getOptions()[0].depConstraints)
+      ? this.getOptions()[0].depConstraints
+      : [];
   }
 
   public visitImportDeclaration(node: ts.ImportDeclaration) {
     const imp = node.moduleSpecifier.getText().substring(1, node.moduleSpecifier.getText().length - 1);
-    const allow: string[] = Array.isArray(this.getOptions()[0].allow)
-      ? this.getOptions()[0].allow.map(a => `${a}`)
-      : [];
 
-    // whitelisted import => return
-    if (allow.indexOf(imp) > -1) {
+    // whitelisted import
+    if (this.allow.indexOf(imp) > -1) {
       super.visitImportDeclaration(node);
       return;
     }
 
+    // check for relative and absolute imports
     if (this.isRelativeImportIntoAnotherProject(imp) || this.isAbsoluteImportIntoAnotherProject(imp)) {
       this.addFailureAt(node.getStart(), node.getWidth(), `library imports must start with @${this.npmScope}/`);
       return;
     }
 
+    // check constraints between libs and apps
     if (imp.startsWith(`@${this.npmScope}/`)) {
       const name = imp.split('/')[1];
       const sourceProject = this.findSourceProject();
       const targetProject = this.findProjectUsingName(name);
 
-      if (sourceProject === targetProject || !targetProject) {
+      // something went wrong => return.
+      if (!sourceProject || !targetProject) {
         super.visitImportDeclaration(node);
         return;
       }
 
+      // same project => allow
+      if (sourceProject === targetProject) {
+        super.visitImportDeclaration(node);
+        return;
+      }
+
+      // cannot import apps
       if (targetProject.type === ProjectType.app) {
         this.addFailureAt(node.getStart(), node.getWidth(), 'imports of apps are forbidden');
         return;
       }
 
+      // deep imports aren't allowed
       if (imp.split('/').length > 2) {
         this.addFailureAt(node.getStart(), node.getWidth(), 'deep imports into libraries are forbidden');
         return;
       }
 
+      // if we import a library using loadChildre, we should not import it using es6imports
       if (this.onlyLoadChildren(sourceProject.name, targetProject.name, [])) {
         this.addFailureAt(node.getStart(), node.getWidth(), 'imports of lazy-loaded libraries are forbidden');
         return;
+      }
+
+      // check that dependency constraints are satisfied
+      if (this.depConstraints.length > 0) {
+        const constraint = this.findConstraintFor(sourceProject);
+
+        // when no constrains found => error. Force the user to provision them.
+        if (!constraint) {
+          this.addFailureAt(node.getStart(), node.getWidth(), `A project without tags cannot depend on any libraries`);
+          return;
+        }
+
+        if (hasNoneOfTheseTags(targetProject, constraint.onlyDependOnLibsWithTags || [])) {
+          const allowedTags = constraint.onlyDependOnLibsWithTags
+            .map(s => `"${s}"`)
+            .join(', ');
+          const error = `A project tagged with "${constraint.sourceTag}" can only depend on libs tagged with ${allowedTags}`;
+          this.addFailureAt(node.getStart(), node.getWidth(), error);
+          return;
+        }
       }
     }
 
     super.visitImportDeclaration(node);
   }
 
-  private onlyLoadChildren(source: string, target: string, path: string[]) {
-    if (path.indexOf(source) > -1) return false;
-    return (this.deps[source] || []).filter(d => {
+  private onlyLoadChildren(sourceProjectName: string, targetProjectName: string, visited: string[]) {
+    if (visited.indexOf(sourceProjectName) > -1) return false;
+    return (this.deps[sourceProjectName] || []).filter(d => {
       if (d.type !== DependencyType.loadChildren) return false;
-      if (d.projectName === target) return true;
-      return this.onlyLoadChildren(d.projectName, target, [...path, source]);
+      if (d.projectName === targetProjectName) return true;
+      return this.onlyLoadChildren(d.projectName, targetProjectName, [...visited, sourceProjectName]);
     }).length > 0;
   }
 
@@ -118,42 +163,60 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
       .split(path.sep)
       .join('/')
       .substring(this.projectPath.length + 1);
+
     const sourceProject = this.findSourceProject();
-
-    let targetProject = this.findProjectUsingFile(targetFile);
-    if (!targetProject) {
-      targetProject = this.findProjectUsingFile(path.join(targetFile, 'index'));
-    }
-    return sourceProject !== targetProject || targetProject === undefined;
-  }
-
-  private findSourceProject() {
-    return this.projectNodes.filter(n => {
-     return n.files.filter(f => removeExt(f) === removeExt(this.getSourceFilePath()))[0];
-    })[0];
+    const targetProject = this.findTargetProject(targetFile);
+    return sourceProject && targetProject && sourceProject !== targetProject;
   }
 
   private getSourceFilePath() {
     return this.getSourceFile().fileName.substring(this.projectPath.length + 1);
   }
 
+  private findSourceProject() {
+    const targetFile = removeExt(this.getSourceFilePath());
+    return this.findProjectUsingFile(targetFile);
+  }
+
+  private findTargetProject(targetFile: string) {
+    let targetProject = this.findProjectUsingFile(targetFile);
+    if (!targetProject) {
+      targetProject = this.findProjectUsingFile(path.join(targetFile, 'index'));
+    }
+    return targetProject;
+  }
+
   private findProjectUsingFile(file: string) {
-    return this.projectNodes.filter(n => {
-     return n.files.filter(f => removeExt(f) === file)[0];
-    })[0];
+    return this.projectNodes.filter(n => containsFile(n.files, file))[0];
   }
 
   private findProjectUsingName(name: string) {
     return this.projectNodes.filter(n => n.name === name)[0];
   }
 
-  private isAbsoluteImportIntoAnotherProject(imp: string): boolean {
+  private isAbsoluteImportIntoAnotherProject(imp: string) {
     return imp.startsWith('libs/') || (imp.startsWith('/libs/') && imp.startsWith('apps/')) || imp.startsWith('/apps/');
   }
 
-  private isRelative(s: string): boolean {
+  private isRelative(s: string) {
     return s.startsWith('.');
   }
+
+  private findConstraintFor(sourceProject: ProjectNode) {
+    return this.depConstraints.filter(f => hasTag(sourceProject, f.sourceTag))[0];
+  }
+}
+
+function hasNoneOfTheseTags(proj: ProjectNode, tags: string[]) {
+  return tags.filter(allowedTag => hasTag(proj, allowedTag)).length === 0;
+}
+
+function hasTag(proj: ProjectNode, tag: string) {
+  return (proj.tags || []).indexOf(tag) > -1 || tag === '*';
+}
+
+function containsFile(files: string[], targetFileWithoutExtension: string): boolean {
+  return !!files.filter(f => removeExt(f) === targetFileWithoutExtension)[0];
 }
 
 function removeExt(file:string): string {


### PR DESCRIPTION
A large workspace contains a lot of apps and libs. Because it is so easy to share code, create new libs and depend on libs, the dependencies between the apps and libs can quickly get out of hand. 

We need a way to impose constraints on the dependency graph. This PR add this capability.

When creating an app or a lib, you can tag them:

```
ng g lib apilib --tags=api
ng g lib utilslib --tags=utils
ng g lib impllib --tags=impl
ng g lib untagged
```

(you can also pass multiple tags `ng g lib apilib --tags=one,two` or modify .angular-cli.json)

You can then define a constraint in tslint.json, like this:

```
    "nx-enforce-module-boundaries": [
      true,
      {
        "allow": [],
        "depConstraints": [
          { "sourceTag": "utils", "onlyDependOnLibsWithTags": ["utils"] },
          { "sourceTag": "api", "onlyDependOnLibsWithTags": ["api", "utils"] },
          { "sourceTag": "impl", "onlyDependOnLibsWithTags": ["api", "utils", "impl"] },
        ]
      }
    ]
```

With this configuration in place:

* utilslib cannot depend on apilib or impllib
* apilib can depend on utilslib
* implib can depend on both utilslib and apilib
* untagged lib cannot depend on anything

You can also use wildcards, like this:

```
{ "sourceTag": "impl", "onlyDependOnLibsWithTags": ["*"] } // impl can depend on anything
```

```
{ "sourceTag": "*", "onlyDependOnLibsWithTags": ["*"] } // anything can depend on anything
```

The system goes through the constrains until it finds the first one matching the source file it's analyzing. 

If we change the configuration to the following:
```
    "nx-enforce-module-boundaries": [
      true,
      {
        "allow": [],
        "depConstraints": [
          { "sourceTag": "utils", "onlyDependOnLibsWithTags": ["utils"] },
          { "sourceTag": "api", "onlyDependOnLibsWithTags": ["api", "utils"] },
          { "sourceTag": "impl", "onlyDependOnLibsWithTags": ["api", "utils", "impl"] },
          { "sourceTag": "*", "onlyDependOnLibsWithTags": ["*"] },
        ]
      }
    ]
```

the following will be true:
* utilslib cannot depend on apilib or impllib
* apilib can depend on utilslib
* implib can depend on both utilslib and apilib
* untagged lib **can** depend on anything
