### PR TITLE
feat(schematics): add migration for karma app check

### DIFF
--- a/packages/schematics/migrations/20180321-add-karma-app-check.ts
+++ b/packages/schematics/migrations/20180321-add-karma-app-check.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs';
+import * as ts from 'typescript';
+import { getSourceNodes } from '@schematics/angular/utility/ast-utils';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+
+export default {
+  description: 'Add makeSureNoAppIsSelected(); to karma conf',
+  run: async () => {
+    const contents = fs.readFileSync('karma.conf.js').toString();
+    const sourceFile = ts.createSourceFile('karma.conf.js', contents, ts.ScriptTarget.Latest);
+    const nodes = getSourceNodes(sourceFile);
+    const isPresent = nodes
+      .filter(ts.isCallExpression)
+      .filter((callExpr: ts.CallExpression) => ts.isIdentifier(callExpr.expression))
+      .some((callExpr: ts.CallExpression) => {
+        const identifier = callExpr.expression as ts.Identifier;
+        return identifier.escapedText === 'makeSureNoAppIsSelected';
+      });
+    
+    if (isPresent) {
+      return;
+    }
+
+    const snippet = stripIndents`
+      const { makeSureNoAppIsSelected } = require('@nrwl/schematics/src/utils/cli-config-utils');
+      // Nx only supports running unit tests for all apps and libs.
+      makeSureNoAppIsSelected();
+    `;
+
+    const karmaComment = stripIndents`
+      // Karma configuration file, see link for more information
+      // https://karma-runner.github.io/1.0/config/configuration-file.html
+    `;
+
+    let res: string;
+    if (contents.includes(karmaComment)) {
+      res = contents.replace(karmaComment, karmaComment + '\n\n' + snippet);
+    } else {
+      res = snippet + '\n\n' + contents;
+    }
+
+    fs.writeFileSync('karma.conf.js', res);
+  }
+};


### PR DESCRIPTION
Resolves https://github.com/nrwl/nx/issues/324

Add a schematic to add a call to
```ts
      const { makeSureNoAppIsSelected } = require('@nrwl/schematics/src/utils/cli-config-utils');
      // Nx only supports running unit tests for all apps and libs.
      makeSureNoAppIsSelected();
```
to `karma.conf.js`

Checks if one is already present.

if none is present, then It adds it.

either after the karma comment if it can be found, or it prepends it to the file.