### PR TITLE
feat(schematics): affected support for uncommitted changes

### DIFF
--- a/packages/schematics/src/command-line/affected.ts
+++ b/packages/schematics/src/command-line/affected.ts
@@ -36,6 +36,9 @@ function printError(command: string, e: any) {
   console.error(
     `Or pass the list of files, as follows: npm run affected:${command} -- --files="libs/mylib/index.ts,libs/mylib2/index.ts".`
   );
+  console.error(
+    `Or to get the list of files from staged or unstaged changes: npm run affected:${command} -- staged | unstaged".`
+  );
   console.error(e.message);
 }
 

--- a/packages/schematics/src/command-line/shared.ts
+++ b/packages/schematics/src/command-line/shared.ts
@@ -33,6 +33,11 @@ export function parseFiles(
       files: parseDashDashFiles(dashDashFiles),
       rest: [...unnamed, ...named]
     };
+  } else if (unnamed.length >= 1 && unnamed[0].includes('staged')) {
+    return {
+      files: getFilesFromLocalChanges(unnamed[0].startsWith('staged')),
+      rest: [...unnamed.slice(1), ...named]
+    };
   } else if (unnamed.length >= 2) {
     return {
       files: getFilesFromShash(unnamed[0], unnamed[1]),
@@ -49,6 +54,22 @@ function parseDashDashFiles(dashDashFiles: string): string[] {
     f = f.substring(1, f.length - 1);
   }
   return f.split(',').map(f => f.trim());
+}
+
+function getFilesFromLocalChanges(staged: boolean): string[] {
+  if (staged) {
+      return execSync(`git diff --name-only --cached`)
+      .toString('utf-8')
+      .split('\n')
+      .map(a => a.trim())
+      .filter(a => a.length > 0);
+  } else {
+      return execSync(`git diff --name-only`)
+      .toString('utf-8')
+      .split('\n')
+      .map(a => a.trim())
+      .filter(a => a.length > 0);
+  }
 }
 
 function getFilesFromShash(sha1: string, sha2: string): string[] {


### PR DESCRIPTION
Extended the syntax for affected so that it can get the
list of files from either locally staged changes or all
modified but unstaged files.  Syntax is:

nx affected apps staged
nx affected apps unstaged

This could enable developer to more easily run a subset
of tests locally before committing.

Related to #201