### PR TITLE
fix(nx): fix formatting for paths with space

### DIFF
--- a/packages/schematics/src/command-line/format.ts
+++ b/packages/schematics/src/command-line/format.ts
@@ -60,7 +60,7 @@ function printError(command: string, e: any) {
 
 function write(patterns: string[]) {
   if (patterns.length > 0) {
-    execSync(`node ${prettierPath()} --write ${patterns.join(' ')}`, {
+    execSync(`node "${prettierPath()}" --write ${patterns.join(' ')}`, {
       stdio: [0, 1, 2]
     });
   }
@@ -70,7 +70,7 @@ function check(patterns: string[]) {
   if (patterns.length > 0) {
     try {
       execSync(
-        `node ${prettierPath()} --list-different ${patterns.join(' ')}`,
+        `node "${prettierPath()}" --list-different ${patterns.join(' ')}`,
         {
           stdio: [0, 1, 2]
         }


### PR DESCRIPTION
This addresses https://github.com/nrwl/nx/issues/321

There was an issue with running the prettier path if it had a space. Wrapping it in spaces should help