### PR TITLE
fix(schematics): fix e2e lint config in angular cli json

### DIFF
--- a/e2e/schematics/workspace.test.ts
+++ b/e2e/schematics/workspace.test.ts
@@ -82,6 +82,10 @@ describe('Nrwl Convert to Nx Workspace', () => {
       '@nrwl/schematics'
     );
 
+    expect(updatedAngularCLIJson.lint[0].project).toEqual('apps/proj/src/tsconfig.app.json');
+    expect(updatedAngularCLIJson.lint[1].project).toEqual('./tsconfig.spec.json');
+    expect(updatedAngularCLIJson.lint[2].project).toEqual('apps/proj/e2e/tsconfig.e2e.json');
+
     // check if tsconfig.json get merged
     const updatedTsConfig = JSON.parse(readFile('tsconfig.json'));
     expect(updatedTsConfig.compilerOptions.paths).toEqual({

--- a/packages/schematics/src/collection/workspace/index.ts
+++ b/packages/schematics/src/collection/workspace/index.ts
@@ -144,7 +144,7 @@ function updateAngularCLIJson(options: Schema) {
         exclude: '**/node_modules/**'
       },
       {
-        project: `${options.name}/tsconfig.e2e.json`,
+        project: join('apps', options.name, 'e2e', 'tsconfig.e2e.json'),
         exclude: '**/node_modules/**'
       }
     ];


### PR DESCRIPTION
Resolves https://github.com/nrwl/nx/issues/314

This transforms `angular.cli.json` correctly

```diff
    {
-     "project": "e2e/tsconfig.e2e.json",
+     "project": "apps/appname/e2e/tsconfig.e2e.json",
      "exclude": "**/node_modules/**"
    }
```