### PR TITLE
fix(schematics): handle undefined rulesDirectory

### DIFF
--- a/packages/schematics/src/collection/workspace/index.ts
+++ b/packages/schematics/src/collection/workspace/index.ts
@@ -220,6 +220,7 @@ function updateTsLintJson(options: Schema) {
       ].forEach(key => {
         json[key] = undefined;
       });
+      json.rulesDirectory = json.rulesDirectory || [];
       json.rulesDirectory.push('node_modules/@nrwl/schematics/src/tslint');
       json['nx-enforce-module-boundaries'] = [
         true,


### PR DESCRIPTION
avoid error `cannot read property 'push' of undefined`

fixes issue #356 