### PR TITLE
fix(schematics): add dependency for npm-run-all

### DIFF
--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -14,6 +14,7 @@
   "schematics": "./src/collection.json",
   "dependencies": {
     "app-root-path": "^2.0.1",
+    "npm-run-all": "4.1.2",
     "semver": "5.4.1",
     "tmp": "0.0.33",
     "yargs-parser": "9.0.2"

--- a/packages/schematics/src/collection/application/files/__directory__/package.json
+++ b/packages/schematics/src/collection/application/files/__directory__/package.json
@@ -62,7 +62,6 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~5.1.2",
     "ts-node": "~4.1.0",
-    "npm-run-all": "4.1.2",
     "tslint": "~5.9.1",<% } %>
     "typescript": "<%= typescriptVersion %>",
     "prettier": "<%= prettierVersion %>"


### PR DESCRIPTION
Make sure `npm-run-all` is installed for use as a dependency for `@nrwl/schematics`