### PR TITLE
refactor(schematics): add method for updating and reading json

### DIFF
--- a/e2e/schematics/command-line.test.ts
+++ b/e2e/schematics/command-line.test.ts
@@ -5,7 +5,8 @@ import {
   readFile,
   runCLI,
   runCommand,
-  updateFile
+  updateFile,
+  readJson
 } from '../utils';
 
 describe('Command line', () => {
@@ -20,7 +21,7 @@ describe('Command line', () => {
       newLib('invalidtaglib --tags=invalidtag');
       newLib('validtaglib --tags=validtag');
 
-      const tslint = JSON.parse(readFile('tslint.json'));
+      const tslint = readJson('tslint.json');
       tslint.rules['nx-enforce-module-boundaries'][1].depConstraints = [
         { sourceTag: 'validtag', onlyDependOnLibsWithTags: ['validtag'] },
         ...tslint.rules['nx-enforce-module-boundaries'][1].depConstraints

--- a/e2e/schematics/create-nx-workspace.test.ts
+++ b/e2e/schematics/create-nx-workspace.test.ts
@@ -1,4 +1,9 @@
-import { checkFilesExist, createNxWorkspace, readFile } from '../utils';
+import {
+  checkFilesExist,
+  createNxWorkspace,
+  readFile,
+  readJson
+} from '../utils';
 
 /**
  * Too slow to run on CI :(
@@ -10,7 +15,7 @@ xdescribe('CreateNxWorkspace', () => {
       const res = createNxWorkspace('proj --npmScope=myscope');
       expect(res).toContain("Project 'proj' successfully created.");
 
-      const config = JSON.parse(readFile('.angular-cli.json'));
+      const config = readJson('.angular-cli.json');
       expect(config.project.name).toEqual('proj');
       expect(config.project.npmScope).toEqual('myscope');
 
@@ -25,7 +30,7 @@ xdescribe('CreateNxWorkspace', () => {
       const res = createNxWorkspace('proj --npmScope=myscope --yarn');
       expect(res).toContain("Project 'proj' successfully created.");
 
-      const config = JSON.parse(readFile('.angular-cli.json'));
+      const config = readJson('.angular-cli.json');
       expect(config.project.name).toEqual('proj');
       expect(config.project.npmScope).toEqual('myscope');
 

--- a/e2e/schematics/workspace.test.ts
+++ b/e2e/schematics/workspace.test.ts
@@ -5,7 +5,8 @@ import {
   readFile,
   runCLI,
   runNgNew,
-  updateFile
+  updateFile,
+  readJson
 } from '../utils';
 import { angularCliSchema } from '../../packages/schematics/src/lib-versions';
 
@@ -17,7 +18,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
     copyMissingPackages();
 
     // update package.json
-    const packageJson = JSON.parse(readFile('package.json'));
+    const packageJson = readJson('package.json');
     packageJson.description = 'some description';
     updateFile('package.json', JSON.stringify(packageJson, null, 2));
     // confirm that @nrwl and @ngrx dependencies do not exist yet
@@ -29,12 +30,12 @@ describe('Nrwl Convert to Nx Workspace', () => {
     expect(packageJson.dependencies['@ngrx/store-devtools']).not.toBeDefined();
 
     // update tsconfig.json
-    const tsconfigJson = JSON.parse(readFile('tsconfig.json'));
+    const tsconfigJson = readJson('tsconfig.json');
     tsconfigJson.compilerOptions.paths = { a: ['b'] };
     updateFile('tsconfig.json', JSON.stringify(tsconfigJson, null, 2));
 
     // update angular-cli.json
-    const angularCLIJson = JSON.parse(readFile('.angular-cli.json'));
+    const angularCLIJson = readJson('.angular-cli.json');
     angularCLIJson.apps[0].scripts = ['../node_modules/x.js'];
     updateFile('.angular-cli.json', JSON.stringify(angularCLIJson, null, 2));
 
@@ -51,7 +52,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
     );
 
     // check that package.json got merged
-    const updatedPackageJson = JSON.parse(readFile('package.json'));
+    const updatedPackageJson = readJson('package.json');
     expect(updatedPackageJson.description).toEqual('some description');
     expect(
       updatedPackageJson.devDependencies['@nrwl/schematics']
@@ -65,7 +66,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
     ).toBeDefined();
 
     // check if angular-cli.json get merged
-    const updatedAngularCLIJson = JSON.parse(readFile('.angular-cli.json'));
+    const updatedAngularCLIJson = readJson('.angular-cli.json');
     expect(updatedAngularCLIJson.$schema).toEqual(angularCliSchema);
     expect(updatedAngularCLIJson.apps[0].name).toEqual('proj');
     expect(updatedAngularCLIJson.apps[0].root).toEqual('apps/proj/src');
@@ -93,7 +94,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
     );
 
     // check if tsconfig.json get merged
-    const updatedTsConfig = JSON.parse(readFile('tsconfig.json'));
+    const updatedTsConfig = readJson('tsconfig.json');
     expect(updatedTsConfig.compilerOptions.paths).toEqual({
       a: ['b'],
       '@proj/*': ['libs/*']
@@ -107,7 +108,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
     const schematicsVersion = '0.0.0';
     const ngrxVersion = '0.0.0';
     // update package.json
-    const existingPackageJson = JSON.parse(readFile('package.json'));
+    const existingPackageJson = readJson('package.json');
     existingPackageJson.devDependencies['@nrwl/schematics'] = schematicsVersion;
     existingPackageJson.dependencies['@nrwl/nx'] = nxVersion;
     existingPackageJson.dependencies['@ngrx/store'] = ngrxVersion;
@@ -118,7 +119,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
     // run the command
     runCLI('generate workspace proj --collection=@nrwl/schematics');
     // check that dependencies and devDependencies remained the same
-    const packageJson = JSON.parse(readFile('package.json'));
+    const packageJson = readJson('package.json');
     expect(packageJson.devDependencies['@nrwl/schematics']).toEqual(
       schematicsVersion
     );

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -125,6 +125,10 @@ export function checkFilesExist(...expectedFiles: string[]) {
   });
 }
 
+export function readJson(f: string): any {
+  return JSON.parse(readFile(f));
+}
+
 export function readFile(f: string) {
   const ff = f.startsWith('/') ? f : path.join(getCwd(), 'tmp', projectName, f);
   return readFileSync(ff).toString();

--- a/packages/bazel/src/collection/application/application.spec.ts
+++ b/packages/bazel/src/collection/application/application.spec.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { getFileContent } from '@schematics/angular/utility/test';
 
+import { readJson } from '../../utils/ast-utils';
+
 describe('application', () => {
   const schematicRunner = new SchematicTestRunner(
     '@nrwl/bazel',
@@ -48,9 +50,7 @@ describe('application', () => {
       { name: 'myApp', directory: 'my-app' },
       appTree
     );
-    const packageJson = JSON.parse(
-      getFileContent(tree, '/my-app/package.json')
-    );
+    const packageJson = readJson(tree, '/my-app/package.json');
 
     expect(packageJson.devDependencies['@nrwl/schematics']).toBeDefined();
     expect(packageJson.dependencies['@nrwl/nx']).toBeDefined();

--- a/packages/bazel/src/collection/lib/index.ts
+++ b/packages/bazel/src/collection/lib/index.ts
@@ -19,10 +19,12 @@ import {
   addIncludeToTsConfig,
   addReexport,
   addRoute,
+  getAngularCliConfig,
+  updateJson,
   insert
 } from '../../utils/ast-utils';
 import { offsetFromRoot } from '../../utils/common';
-import { addApp, cliConfig, serializeJson } from '../../utils/fileutils';
+import { addApp, serializeJson } from '../../utils/fileutils';
 import {
   names,
   toClassName,
@@ -49,10 +51,9 @@ function normalizeOptions(options: Schema): NormalizedSchema {
 }
 
 function addLibToAngularCliJson(options: NormalizedSchema): Rule {
-  return (host: Tree) => {
+  return updateJson('.angular-cli.json', angularCliJson => {
     const tags = options.tags ? options.tags.split(',').map(s => s.trim()) : [];
-    const json = cliConfig(host);
-    json.apps = addApp(json.apps, {
+    angularCliJson.apps = addApp(angularCliJson.apps, {
       name: options.fullName,
       root: options.fullPath,
       test: `${offsetFromRoot(options.fullPath)}test.js`,
@@ -60,9 +61,8 @@ function addLibToAngularCliJson(options: NormalizedSchema): Rule {
       tags
     });
 
-    host.overwrite('.angular-cli.json', serializeJson(json));
-    return host;
-  };
+    return angularCliJson;
+  });
 }
 
 function addLazyLoadedRouterConfiguration(modulePath: string): Rule {
@@ -135,7 +135,7 @@ function addRouterConfiguration(
 
 function addLoadChildren(schema: NormalizedSchema): Rule {
   return (host: Tree) => {
-    const json = cliConfig(host);
+    const json = getAngularCliConfig(host);
 
     const moduleSource = host.read(schema.parentModule)!.toString('utf-8');
     const sourceFile = ts.createSourceFile(
@@ -217,7 +217,7 @@ function findClosestTsConfigApp(
 
 function addChildren(schema: NormalizedSchema): Rule {
   return (host: Tree) => {
-    const json = cliConfig(host);
+    const json = getAngularCliConfig(host);
 
     const moduleSource = host.read(schema.parentModule)!.toString('utf-8');
     const sourceFile = ts.createSourceFile(

--- a/packages/bazel/src/utils/ast-utils.ts
+++ b/packages/bazel/src/utils/ast-utils.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { Tree } from '@angular-devkit/schematics';
+import { Tree, Rule } from '@angular-devkit/schematics';
 import {
   findNodes,
   getDecoratorMetadata,
@@ -21,6 +21,7 @@ import {
 import * as ts from 'typescript';
 import { toFileName } from './name-utils';
 import * as path from 'path';
+import { serializeJson } from '../utils/fileutils';
 
 // This should be moved to @schematics/angular once it allows to pass custom expressions as providers
 function _addSymbolToNgModuleMetadata(
@@ -539,13 +540,34 @@ export function insert(host: Tree, modulePath: string, changes: Change[]) {
   host.commitUpdate(recorder);
 }
 
-export function getAppConfig(host: Tree, name: string): any {
-  if (!host.exists('.angular-cli.json')) {
-    throw new Error('Missing .angular-cli.json');
+export function readJson<T = any>(host: Tree, path: string): T {
+  if (!host.exists(path)) {
+    throw new Error(`Cannot find ${path}`);
   }
-  const angularCliJson = JSON.parse(
-    host.read('.angular-cli.json')!.toString('utf-8')
-  );
+  return JSON.parse(host.read(path)!.toString('utf-8'));
+}
+
+/**
+ * @param path path of JSON file
+ * @param callback Manipulation of the JSON data
+ * @returns A rule which updates a JSON file
+ */
+export function updateJson<T = any, O = T>(
+  path: string,
+  callback: (json: T) => O
+): Rule {
+  return (host: Tree): Tree => {
+    host.overwrite(path, serializeJson(callback(readJson(host, path))));
+    return host;
+  };
+}
+
+export function getAngularCliConfig(host: Tree) {
+  return readJson(host, '.angular-cli.json');
+}
+
+export function getAppConfig(host: Tree, name: string): any {
+  const angularCliJson = getAngularCliConfig(host);
   const apps = angularCliJson.apps;
   if (!apps || apps.length === 0) {
     throw new Error(`Cannot find app '${name}'`);

--- a/packages/bazel/src/utils/cli-config-utils.ts
+++ b/packages/bazel/src/utils/cli-config-utils.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs';
 import * as yargsParser from 'yargs-parser';
 
+import { readJsonFile } from './fileutils';
+
 export function getAppDirectoryUsingCliConfig() {
-  const cli = JSON.parse(
-    fs.readFileSync(process.cwd() + '/.angular-cli.json', 'UTF-8')
-  );
+  const cli = readJsonFile(process.cwd() + '/.angular-cli.json');
 
   const appName = getAppName();
 

--- a/packages/bazel/src/utils/common.ts
+++ b/packages/bazel/src/utils/common.ts
@@ -4,31 +4,7 @@ import { Options } from 'prettier';
 import * as cosmiconfig from 'cosmiconfig';
 
 import { angularJsVersion } from '../lib-versions';
-import { serializeJson } from './fileutils';
 import { Schema } from '../collection/app/schema';
-
-export function addUpgradeToPackageJson(): Rule {
-  return (host: Tree) => {
-    if (!host.exists('package.json')) return host;
-
-    const sourceText = host.read('package.json')!.toString('utf-8');
-    const json = JSON.parse(sourceText);
-    if (!json['dependencies']) {
-      json['dependencies'] = {};
-    }
-
-    if (!json['dependencies']['@angular/upgrade']) {
-      json['dependencies']['@angular/upgrade'] =
-        json['dependencies']['@angular/core'];
-    }
-    if (!json['dependencies']['angular']) {
-      json['dependencies']['angular'] = angularJsVersion;
-    }
-
-    host.overwrite('package.json', serializeJson(json));
-    return host;
-  };
-}
 
 export function offsetFromRoot(fullPathToSourceDir: string): string {
   const parts = fullPathToSourceDir.split('/');

--- a/packages/bazel/src/utils/fileutils.ts
+++ b/packages/bazel/src/utils/fileutils.ts
@@ -3,7 +3,7 @@ import { Tree } from '@angular-devkit/schematics';
 import * as path from 'path';
 
 export function updateJsonFile(path: string, callback: (a: any) => any) {
-  const json = JSON.parse(fs.readFileSync(path, 'utf-8'));
+  const json = readJsonFile(path);
   callback(json);
   fs.writeFileSync(path, JSON.stringify(json, null, 2));
 }
@@ -30,17 +30,12 @@ export function serializeJson(json: any): string {
   return `${JSON.stringify(json, null, 2)}\n`;
 }
 
-export function cliConfig(host: Tree): any {
-  if (!host.exists('.angular-cli.json')) {
-    throw new Error('Missing .angular-cli.json');
-  }
-
-  const sourceText = host.read('.angular-cli.json')!.toString('utf-8');
-  return JSON.parse(sourceText);
+export function readJsonFile(path: string): any {
+  return JSON.parse(fs.readFileSync(path, 'utf-8'));
 }
 
 export function readCliConfigFile(): any {
-  return JSON.parse(fs.readFileSync('.angular-cli.json', 'utf-8'));
+  return readJsonFile('.angular-cli.json');
 }
 
 export function copyFile(file: string, target: string) {

--- a/packages/schematics/bin/create-nx-workspace.ts
+++ b/packages/schematics/bin/create-nx-workspace.ts
@@ -12,6 +12,8 @@ import {
 import * as path from 'path';
 import * as yargsParser from 'yargs-parser';
 
+import { readJsonFile } from '../src/utils/fileutils';
+
 interface CommandOptions {
   directory?: string;
   yarn: boolean;
@@ -72,8 +74,8 @@ if (!projectName) {
 // creating the sandbox
 console.log('Creating a sandbox with the CLI and Nx Schematics...');
 const tmpDir = dirSync().name;
-const nxVersion = JSON.parse(
-  readFileSync(path.join(path.dirname(__dirname), 'package.json'), 'UTF-8')
+const nxVersion = readJsonFile(
+  path.join(path.dirname(__dirname), 'package.json')
 ).version;
 writeFileSync(
   path.join(tmpDir, 'package.json'),

--- a/packages/schematics/migrations/20171211-create-tsconfigapp-per-app.ts
+++ b/packages/schematics/migrations/20171211-create-tsconfigapp-per-app.ts
@@ -1,8 +1,4 @@
-import {
-  cliConfig,
-  readCliConfigFile,
-  updateJsonFile
-} from '../src/utils/fileutils';
+import { readCliConfigFile, updateJsonFile } from '../src/utils/fileutils';
 import { writeFileSync, unlinkSync } from 'fs';
 import { offsetFromRoot } from '../src/utils/common';
 import * as path from 'path';

--- a/packages/schematics/src/collection/app/app.spec.ts
+++ b/packages/schematics/src/collection/app/app.spec.ts
@@ -4,6 +4,7 @@ import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { createEmptyWorkspace } from '../../utils/testing-utils';
 import { getFileContent } from '@schematics/angular/utility/test';
 import * as stripJsonComments from 'strip-json-comments';
+import { getAngularCliConfig } from '../../utils/ast-utils';
 
 describe('app', () => {
   const schematicRunner = new SchematicTestRunner(
@@ -25,9 +26,7 @@ describe('app', () => {
         { name: 'myApp', npmScope: 'nrwl' },
         appTree
       );
-      const updatedAngularCLIJson = JSON.parse(
-        getFileContent(tree, '/.angular-cli.json')
-      );
+      const updatedAngularCLIJson = getAngularCliConfig(tree);
       expect(updatedAngularCLIJson.apps).toEqual([
         {
           assets: ['assets', 'favicon.ico'],
@@ -104,9 +103,7 @@ describe('app', () => {
         { name: 'myApp', npmScope: 'nrwl', directory: 'myDir' },
         appTree
       );
-      const updatedAngularCLIJson = JSON.parse(
-        getFileContent(tree, '/.angular-cli.json')
-      );
+      const updatedAngularCLIJson = getAngularCliConfig(tree);
       expect(updatedAngularCLIJson.apps).toEqual([
         {
           assets: ['assets', 'favicon.ico'],
@@ -243,9 +240,7 @@ describe('app', () => {
         { name: 'myApp', npmScope: 'nrwl', tags: 'one,two' },
         appTree
       );
-      const updatedAngularCLIJson = JSON.parse(
-        getFileContent(tree, '/.angular-cli.json')
-      );
+      const updatedAngularCLIJson = getAngularCliConfig(tree);
       expect(updatedAngularCLIJson.apps[0].tags).toEqual(['one', 'two']);
     });
   });

--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { createEmptyWorkspace } from '../../utils/testing-utils';
 import { getFileContent } from '@schematics/angular/utility/test';
+import { readJson } from '../../utils/ast-utils';
 
 describe('application', () => {
   const schematicRunner = new SchematicTestRunner(
@@ -46,9 +47,7 @@ describe('application', () => {
       { name: 'myApp', directory: 'my-app' },
       appTree
     );
-    const packageJson = JSON.parse(
-      getFileContent(tree, '/my-app/package.json')
-    );
+    const packageJson = readJson(tree, '/my-app/package.json');
 
     expect(packageJson.devDependencies['@nrwl/schematics']).toBeDefined();
     expect(packageJson.dependencies['@nrwl/nx']).toBeDefined();
@@ -65,14 +64,10 @@ describe('application', () => {
       appTree
     );
 
-    const angularCliJson = JSON.parse(
-      getFileContent(tree, '/my-app/.angular-cli.json')
-    );
+    const angularCliJson = readJson(tree, '/my-app/.angular-cli.json');
     expect(angularCliJson.project.npmScope).toEqual('myApp');
 
-    const tsconfigJson = JSON.parse(
-      getFileContent(tree, '/my-app/tsconfig.json')
-    );
+    const tsconfigJson = readJson(tree, '/my-app/tsconfig.json');
     expect(tsconfigJson.compilerOptions.paths).toEqual({
       '@myApp/*': ['libs/*']
     });

--- a/packages/schematics/src/collection/downgrade-module/downgrade-module.spec.ts
+++ b/packages/schematics/src/collection/downgrade-module/downgrade-module.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { createApp, createEmptyWorkspace } from '../../utils/testing-utils';
 import { getFileContent } from '@schematics/angular/utility/test';
+import { readJson } from '../../utils/ast-utils';
 
 describe('downgrade-module', () => {
   const schematicRunner = new SchematicTestRunner(
@@ -68,7 +69,7 @@ describe('downgrade-module', () => {
       appTree
     );
 
-    const packageJson = JSON.parse(getFileContent(tree, '/package.json'));
+    const packageJson = readJson(tree, '/package.json');
     expect(packageJson.dependencies['@angular/upgrade']).toEqual('4.4.4');
     expect(packageJson.dependencies['angular']).toBeDefined();
   });
@@ -92,7 +93,7 @@ describe('downgrade-module', () => {
       appTree
     );
 
-    const packageJson = JSON.parse(getFileContent(tree, '/package.json'));
+    const packageJson = readJson(tree, 'package.json');
     expect(packageJson.dependencies['@angular/upgrade']).not.toBeDefined();
   });
 

--- a/packages/schematics/src/collection/lib/lib.spec.ts
+++ b/packages/schematics/src/collection/lib/lib.spec.ts
@@ -4,6 +4,7 @@ import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { createApp, createEmptyWorkspace } from '../../utils/testing-utils';
 import { getFileContent } from '@schematics/angular/utility/test';
 import * as stripJsonComments from 'strip-json-comments';
+import { readJson } from '../../utils/ast-utils';
 
 describe('lib', () => {
   const schematicRunner = new SchematicTestRunner(
@@ -27,9 +28,7 @@ describe('lib', () => {
         { name: 'myLib' },
         appTree
       );
-      const updatedAngularCLIJson = JSON.parse(
-        getFileContent(tree, '/.angular-cli.json')
-      );
+      const updatedAngularCLIJson = readJson(tree, '/.angular-cli.json');
       expect(updatedAngularCLIJson.apps).toEqual([
         {
           appRoot: '',
@@ -91,9 +90,7 @@ describe('lib', () => {
         { name: 'myLib', directory: 'myDir' },
         appTree
       );
-      const updatedAngularCLIJson = JSON.parse(
-        getFileContent(tree, '/.angular-cli.json')
-      );
+      const updatedAngularCLIJson = readJson(tree, '/.angular-cli.json');
       expect(updatedAngularCLIJson.apps).toEqual([
         {
           appRoot: '',
@@ -290,9 +287,7 @@ describe('lib', () => {
           { name: 'myLib', tags: 'one,two' },
           appTree
         );
-        const updatedAngularCLIJson = JSON.parse(
-          getFileContent(tree, '/.angular-cli.json')
-        );
+        const updatedAngularCLIJson = readJson(tree, '/.angular-cli.json');
         expect(updatedAngularCLIJson.apps[0].tags).toEqual(['one', 'two']);
       });
     });

--- a/packages/schematics/src/collection/ngrx/index.ts
+++ b/packages/schematics/src/collection/ngrx/index.ts
@@ -22,7 +22,8 @@ import * as ts from 'typescript';
 import {
   addImportToModule,
   addProviderToModule,
-  insert
+  insert,
+  updateJson
 } from '../../utils/ast-utils';
 import { insertImport } from '@schematics/angular/utility/route-utils';
 import { Schema } from './schema';
@@ -184,34 +185,29 @@ function addImportsToModule(name: string, options: Schema): Rule {
   };
 }
 
-function addNgRxToPackageJson() {
-  return (host: Tree) => {
-    if (!host.exists('package.json')) return host;
-
-    const sourceText = host.read('package.json')!.toString('utf-8');
-    const json = JSON.parse(sourceText);
-    if (!json['dependencies']) {
-      json['dependencies'] = {};
+function addNgRxToPackageJson(): Rule {
+  return updateJson('package.json', packageJson => {
+    if (!packageJson['dependencies']) {
+      packageJson['dependencies'] = {};
     }
 
-    if (!json['dependencies']['@ngrx/store']) {
-      json['dependencies']['@ngrx/store'] = ngrxVersion;
+    if (!packageJson['dependencies']['@ngrx/store']) {
+      packageJson['dependencies']['@ngrx/store'] = ngrxVersion;
     }
-    if (!json['dependencies']['@ngrx/router-store']) {
-      json['dependencies']['@ngrx/router-store'] = routerStoreVersion;
+    if (!packageJson['dependencies']['@ngrx/router-store']) {
+      packageJson['dependencies']['@ngrx/router-store'] = routerStoreVersion;
     }
-    if (!json['dependencies']['@ngrx/effects']) {
-      json['dependencies']['@ngrx/effects'] = ngrxVersion;
+    if (!packageJson['dependencies']['@ngrx/effects']) {
+      packageJson['dependencies']['@ngrx/effects'] = ngrxVersion;
     }
-    if (!json['dependencies']['@ngrx/store-devtools']) {
-      json['dependencies']['@ngrx/store-devtools'] = ngrxVersion;
+    if (!packageJson['dependencies']['@ngrx/store-devtools']) {
+      packageJson['dependencies']['@ngrx/store-devtools'] = ngrxVersion;
     }
-    if (!json['dependencies']['ngrx-store-freeze']) {
-      json['dependencies']['ngrx-store-freeze'] = ngrxStoreFreezeVersion;
+    if (!packageJson['dependencies']['ngrx-store-freeze']) {
+      packageJson['dependencies']['ngrx-store-freeze'] = ngrxStoreFreezeVersion;
     }
-    host.overwrite('package.json', serializeJson(json));
-    return host;
-  };
+    return packageJson;
+  });
 }
 
 export default function(schema: Schema): Rule {

--- a/packages/schematics/src/collection/ngrx/ngrx.spec.ts
+++ b/packages/schematics/src/collection/ngrx/ngrx.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { createApp, createEmptyWorkspace } from '../../utils/testing-utils';
 import { getFileContent } from '@schematics/angular/utility/test';
+import { readJson } from '../../utils/ast-utils';
 
 describe('ngrx', () => {
   const schematicRunner = new SchematicTestRunner(
@@ -153,7 +154,7 @@ describe('ngrx', () => {
       },
       appTree
     );
-    const packageJson = JSON.parse(getFileContent(tree, '/package.json'));
+    const packageJson = readJson(tree, 'package.json');
 
     expect(packageJson.dependencies['@ngrx/store']).toBeDefined();
     expect(packageJson.dependencies['@ngrx/router-store']).toBeDefined();

--- a/packages/schematics/src/collection/upgrade-module/upgrade-module.spec.ts
+++ b/packages/schematics/src/collection/upgrade-module/upgrade-module.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { createApp, createEmptyWorkspace } from '../../utils/testing-utils';
 import { getFileContent } from '@schematics/angular/utility/test';
+import { readJson } from '../../utils/ast-utils';
 
 describe('upgrade-module', () => {
   const schematicRunner = new SchematicTestRunner(
@@ -57,7 +58,7 @@ describe('upgrade-module', () => {
       appTree
     );
 
-    const packageJson = JSON.parse(getFileContent(tree, '/package.json'));
+    const packageJson = readJson(tree, '/package.json');
     expect(packageJson.dependencies['@angular/upgrade']).toEqual('4.4.4');
     expect(packageJson.dependencies['angular']).toBeDefined();
   });
@@ -81,7 +82,7 @@ describe('upgrade-module', () => {
       appTree
     );
 
-    const packageJson = JSON.parse(getFileContent(tree, '/package.json'));
+    const packageJson = readJson(tree, '/package.json');
     expect(packageJson.dependencies['@angular/upgrade']).not.toBeDefined();
   });
 

--- a/packages/schematics/src/command-line/nx-migrate.ts
+++ b/packages/schematics/src/command-line/nx-migrate.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { readCliConfigFile, updateJsonFile } from '../utils/fileutils';
+
 type Migration = { description: string; run(): void };
 type MigrationName = { name: string; migration: Migration };
 
@@ -30,9 +32,7 @@ updateLatestMigration();
 console.log('All migrations run successfully');
 
 function readLatestMigration(): string {
-  const angularCli = JSON.parse(
-    fs.readFileSync('.angular-cli.json').toString()
-  );
+  const angularCli = readCliConfigFile();
   return angularCli.project.latestMigration;
 }
 
@@ -77,13 +77,8 @@ function runMigrations(migrations: MigrationName[]): void {
 
 function updateLatestMigration(): void {
   // we must reread .angular-cli.json because some of the migrations could have modified it
-  const angularCliJson = JSON.parse(
-    fs.readFileSync('.angular-cli.json').toString()
-  );
-  angularCliJson.project.latestMigration =
-    migrationsToRun[migrationsToRun.length - 1].name;
-  fs.writeFileSync(
-    '.angular-cli.json',
-    JSON.stringify(angularCliJson, null, 2)
-  );
+  updateJsonFile('.angular-cli.json', angularCliJson => {
+    angularCliJson.project.latestMigration =
+      migrationsToRun[migrationsToRun.length - 1].name;
+  });
 }

--- a/packages/schematics/src/command-line/shared.ts
+++ b/packages/schematics/src/command-line/shared.ts
@@ -13,6 +13,7 @@ import {
 } from '@nrwl/schematics/src/command-line/affected-apps';
 import { readFileSync, statSync } from 'fs';
 import * as appRoot from 'app-root-path';
+import { readJsonFile } from '../utils/fileutils';
 
 export function parseFiles(
   args: string[]
@@ -75,9 +76,7 @@ export function getProjectNodes(config) {
 }
 
 export function readCliConfig(): any {
-  const config = JSON.parse(
-    fs.readFileSync(`${appRoot.path}/.angular-cli.json`, 'utf-8')
-  );
+  const config = readJsonFile(`${appRoot.path}/.angular-cli.json`);
 
   if (!config.project.npmScope) {
     throw new Error(`.angular-cli.json must define the npmScope property.`);
@@ -149,9 +148,7 @@ export function readDependencies(
     );
     return deps;
   } else {
-    return JSON.parse(
-      fs.readFileSync(`${appRoot.path}/dist/nxdeps.json`, 'UTF-8')
-    );
+    return readJsonFile(`${appRoot.path}/dist/nxdeps.json`);
   }
 }
 

--- a/packages/schematics/src/command-line/update.ts
+++ b/packages/schematics/src/command-line/update.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { updateJsonFile, readCliConfigFile } from '../utils/fileutils';
+
 type Migration = { description: string; run(): void };
 type MigrationName = { name: string; migration: Migration };
 
@@ -39,9 +41,7 @@ function readAllMigrations() {
 }
 
 function readLatestMigration(): string {
-  const angularCli = JSON.parse(
-    fs.readFileSync('.angular-cli.json').toString()
-  );
+  const angularCli = readCliConfigFile();
   return angularCli.project.latestMigration;
 }
 
@@ -140,13 +140,8 @@ function run(latestMigration: string, migrations: MigrationName[]): void {
 
 function updateLatestMigration(migrations: MigrationName[]): void {
   // we must reread .angular-cli.json because some of the migrations could have modified it
-  const angularCliJson = JSON.parse(
-    fs.readFileSync('.angular-cli.json').toString()
-  );
-  angularCliJson.project.latestMigration =
-    migrations[migrations.length - 1].name;
-  fs.writeFileSync(
-    '.angular-cli.json',
-    JSON.stringify(angularCliJson, null, 2)
-  );
+  updateJsonFile('.angular-cli.json', angularCliJson => {
+    angularCliJson.project.latestMigration =
+      migrations[migrations.length - 1].name;
+  });
 }

--- a/packages/schematics/src/migrator/migrator.ts
+++ b/packages/schematics/src/migrator/migrator.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { updateJsonFile, readCliConfigFile } from '../utils/fileutils';
+
 type Migration = { description: string; run(): void };
 type MigrationName = { name: string; migration: Migration };
 
@@ -30,9 +32,7 @@ updateLatestMigration();
 console.log('All migrations run successfully');
 
 function readLatestMigration(): string {
-  const angularCli = JSON.parse(
-    fs.readFileSync('.angular-cli.json').toString()
-  );
+  const angularCli = readCliConfigFile();
   return angularCli.project.latestMigration;
 }
 
@@ -77,13 +77,8 @@ function runMigrations(migrations: MigrationName[]): void {
 
 function updateLatestMigration(): void {
   // we must reread .angular-cli.json because some of the migrations could have modified it
-  const angularCliJson = JSON.parse(
-    fs.readFileSync('.angular-cli.json').toString()
-  );
-  angularCliJson.project.latestMigration =
-    migrationsToRun[migrationsToRun.length - 1].name;
-  fs.writeFileSync(
-    '.angular-cli.json',
-    JSON.stringify(angularCliJson, null, 2)
-  );
+  updateJsonFile('.angular-cli.json', angularCliJson => {
+    angularCliJson.project.latestMigration =
+      migrationsToRun[migrationsToRun.length - 1].name;
+  });
 }

--- a/packages/schematics/src/utils/cli-config-utils.ts
+++ b/packages/schematics/src/utils/cli-config-utils.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs';
 import * as yargsParser from 'yargs-parser';
 
+import { readJsonFile } from './fileutils';
+
 export function getAppDirectoryUsingCliConfig() {
-  const cli = JSON.parse(
-    fs.readFileSync(process.cwd() + '/.angular-cli.json', 'UTF-8')
-  );
+  const cli = readJsonFile(process.cwd() + '/.angular-cli.json');
 
   const appName = getAppName();
 

--- a/packages/schematics/src/utils/common.ts
+++ b/packages/schematics/src/utils/common.ts
@@ -6,28 +6,24 @@ import * as cosmiconfig from 'cosmiconfig';
 import { angularJsVersion } from '../lib-versions';
 import { serializeJson } from './fileutils';
 import { Schema } from '../collection/app/schema';
+import { updateJson } from './ast-utils';
 
 export function addUpgradeToPackageJson(): Rule {
-  return (host: Tree) => {
-    if (!host.exists('package.json')) return host;
-
-    const sourceText = host.read('package.json')!.toString('utf-8');
-    const json = JSON.parse(sourceText);
-    if (!json['dependencies']) {
-      json['dependencies'] = {};
+  return updateJson('package.json', packageJson => {
+    if (!packageJson['dependencies']) {
+      packageJson['dependencies'] = {};
     }
 
-    if (!json['dependencies']['@angular/upgrade']) {
-      json['dependencies']['@angular/upgrade'] =
-        json['dependencies']['@angular/core'];
+    if (!packageJson['dependencies']['@angular/upgrade']) {
+      packageJson['dependencies']['@angular/upgrade'] =
+        packageJson['dependencies']['@angular/core'];
     }
-    if (!json['dependencies']['angular']) {
-      json['dependencies']['angular'] = angularJsVersion;
+    if (!packageJson['dependencies']['angular']) {
+      packageJson['dependencies']['angular'] = angularJsVersion;
     }
 
-    host.overwrite('package.json', serializeJson(json));
-    return host;
-  };
+    return packageJson;
+  });
 }
 
 export function offsetFromRoot(fullPathToSourceDir: string): string {

--- a/packages/schematics/src/utils/fileutils.ts
+++ b/packages/schematics/src/utils/fileutils.ts
@@ -2,10 +2,14 @@ import * as fs from 'fs';
 import { Tree } from '@angular-devkit/schematics';
 import * as path from 'path';
 
+export function readJsonFile(path: string) {
+  return JSON.parse(fs.readFileSync(path, 'utf-8'));
+}
+
 export function updateJsonFile(path: string, callback: (a: any) => any) {
-  const json = JSON.parse(fs.readFileSync(path, 'utf-8'));
+  const json = readJsonFile(path);
   callback(json);
-  fs.writeFileSync(path, JSON.stringify(json, null, 2));
+  fs.writeFileSync(path, serializeJson(json));
 }
 
 export function addApp(apps: any[] | undefined, newApp: any): any[] {
@@ -30,17 +34,8 @@ export function serializeJson(json: any): string {
   return `${JSON.stringify(json, null, 2)}\n`;
 }
 
-export function cliConfig(host: Tree): any {
-  if (!host.exists('.angular-cli.json')) {
-    throw new Error('Missing .angular-cli.json');
-  }
-
-  const sourceText = host.read('.angular-cli.json')!.toString('utf-8');
-  return JSON.parse(sourceText);
-}
-
 export function readCliConfigFile(): any {
-  return JSON.parse(fs.readFileSync('.angular-cli.json', 'utf-8'));
+  return readJsonFile('.angular-cli.json');
 }
 
 export function copyFile(file: string, target: string) {


### PR DESCRIPTION
I refactored a ton of code regarding reading and updating JSON.

I added `readJsonFile(path: string): any` which parses JSON from a path in the filesystem to `fileutils` which should be used to read JSON data from the file system.

I also added `readJson(host: Tree, path: string): any` which parses JSON data from a path in a tree to `ast-utils` which should be used to read JSON data from a tree.

I also created a `updateJson(path: string, callback(json: any): any)` in `ast-utils` which returns a Rule which updates a JSON file similar to updateJsonFile in `fileutils` which can be used to update JSON files in a tree.