### PR TITLE
fix(schematics): match ng lib and update versions

### DIFF
--- a/packages/bazel/src/lib-versions.ts
+++ b/packages/bazel/src/lib-versions.ts
@@ -1,5 +1,5 @@
 export const angularCliVersion = '1.7.1';
-export const angularVersion = '5.2.6';
+export const angularVersion = '5.2.7';
 export const angularJsVersion = '1.6.6';
 export const ngrxVersion = '5.1.0';
 export const ngrxStoreFreezeVersion = '^0.2.1';

--- a/packages/schematics/src/lib-versions.ts
+++ b/packages/schematics/src/lib-versions.ts
@@ -1,5 +1,5 @@
 export const angularCliVersion = '1.7.1';
-export const angularVersion = '5.2.6';
+export const angularVersion = '5.2.7';
 export const angularJsVersion = '1.6.6';
 export const ngrxVersion = '5.1.0';
 export const ngrxStoreFreezeVersion = '^0.2.1';


### PR DESCRIPTION
Update the Angular lib version for new workspaces (5.2.6 > 5.2.7) to match [the version specified](https://github.com/nrwl/nx/blob/ce553b732e8ca004e1ecf53cf54bcadb6ba1f7f3/packages/schematics/migrations/20180225-switch-to-cli17.ts#L22-L29) by migration 20180225-switch-to-cli17 (5.2.7)