### PR TITLE
fix(schematics): add missing import from e2e test

### DIFF
--- a/e2e/schematics/workspace.test.ts
+++ b/e2e/schematics/workspace.test.ts
@@ -5,6 +5,7 @@ import {
   runCLI,
   runNgNew,
   updateFile,
+  readFile,
   readJson
 } from '../utils';
 import { angularCliSchema } from '../../packages/schematics/src/lib-versions';


### PR DESCRIPTION
Tests are failing due to a missing import