### PR TITLE
feat(schematics): add ability to create bazel workspace

### DIFF
--- a/e2e/schematics/create-nx-workspace.test.ts
+++ b/e2e/schematics/create-nx-workspace.test.ts
@@ -47,6 +47,15 @@ xdescribe('CreateNxWorkspace', () => {
   );
 
   it(
+    'should create a new workspace with the --bazel option',
+    () => {
+      const res = createNxWorkspace('mybazelproj --bazel');
+      expect(res).toContain("Project 'mybazelproj' successfully created.");
+    },
+    1000000
+  );
+
+  it(
     'should error when no name is given',
     () => {
       expect(() => createNxWorkspace('')).toThrowError(


### PR DESCRIPTION
This is step 1 here. It enables a `--bazel` flag for the current `create-nx-workspace`. It should successfully generate a bazel workspace.