### PR TITLE
fix(bazel): add exlude

### DIFF
--- a/packages/bazel/src/collection/application/files/__directory__/ngc.tsconfig.json
+++ b/packages/bazel/src/collection/application/files/__directory__/ngc.tsconfig.json
@@ -23,5 +23,6 @@
         "node_modules/@angular/tsc-wrapped/**",
         "node_modules/@nrwl/bazel/**",
         "node_modules/@nrwl/schematics/**",
+        "node_modules/@ngrx/schematics/**",
     ]
 }

--- a/packages/schematics/src/command-line/patch-ng.ts
+++ b/packages/schematics/src/command-line/patch-ng.ts
@@ -15,7 +15,14 @@ if (options.cliArgs.indexOf('update') > -1) {
 `;
 
 export function patchNg() {
-  const cli = path.join('node_modules', '@angular', 'cli', 'lib', 'cli', 'index.js');
+  const cli = path.join(
+    'node_modules',
+    '@angular',
+    'cli',
+    'lib',
+    'cli',
+    'index.js'
+  );
   if (fileExists(cli)) {
     const file = readFileSync(cli).toString();
     writeFileSync(cli, addNxCheck(file));


### PR DESCRIPTION
Adding an exclude of `node_modules/@ngrx/schematics/**`

This fixes the Bazel ngc post install compilation 

`"postinstall": "ngc -p ngc.tsconfig.json"`