### PR TITLE
feat(schematics): add support for workspace-specific schematics

### DIFF
--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -101,12 +101,6 @@ export function newModule(name: string): string {
   return runCLI(`generate module ${name}`);
 }
 
-export function runSchematic(command: string): string {
-  return execSync(`./node_modules/.bin/schematics ${command}`, {
-    cwd: `./tmp/${projectName}`
-  }).toString();
-}
-
 export function runCommand(command: string): string {
   return execSync(command, {
     cwd: `./tmp/${projectName}`,

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "tslint": "5.9.1",
     "typescript": "2.6.2",
     "yargs-parser": "9.0.2",
-    "zone.js": "^0.8.19"
+    "zone.js": "^0.8.19",
+    "fs-extra": "5.0.0"
   },
   "author": "Victor Savkin",
   "license": "MIT",

--- a/packages/schematics/migrations/20180405-add-workspace-schematic-command.ts
+++ b/packages/schematics/migrations/20180405-add-workspace-schematic-command.ts
@@ -1,0 +1,13 @@
+import { updateJsonFile } from '@nrwl/schematics/src/utils/fileutils';
+
+export default {
+  description: 'Add a command to generate workspace-specific schematics',
+  run: () => {
+    updateJsonFile('package.json', json => {
+      json.scripts = {
+        ...json.scripts,
+        'workspace-schematic': './node_modules/.bin/nx workspace-schematic'
+      };
+    });
+  }
+};

--- a/packages/schematics/src/collection.json
+++ b/packages/schematics/src/collection.json
@@ -43,6 +43,12 @@
       "factory": "./collection/downgrade-module",
       "schema": "./collection/downgrade-module/schema.json",
       "description": "Generates downgradeModule setup"
+    },
+
+    "workspace-schematic": {
+      "factory": "./collection/workspace-schematic",
+      "schema": "./collection/workspace-schematic/schema.json",
+      "description": "Generates a custom schematic"
     }
   }
 }

--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -33,6 +33,8 @@ describe('application', () => {
       '/my-app/package.json',
       '/my-app/protractor.conf.js',
       '/my-app/test.js',
+      '/my-app/tools/schematics/.gitkeep',
+      '/my-app/tools/tsconfig.tools.json',
       '/my-app/tsconfig.json',
       '/my-app/tsconfig.spec.json',
       '/my-app/tslint.json'

--- a/packages/schematics/src/collection/application/files/__directory__/package.json
+++ b/packages/schematics/src/collection/application/files/__directory__/package.json
@@ -22,6 +22,7 @@
     "update:check": "./node_modules/.bin/nx update check",
     "update:skip": "./node_modules/.bin/nx update skip",
 
+    "workspace-schematic": "./node_modules/.bin/nx workspace-schematic",
     "postinstall": "./node_modules/.bin/nx postinstall"
   },
   "private": true,

--- a/packages/schematics/src/collection/application/files/__directory__/tools/tsconfig.tools.json
+++ b/packages/schematics/src/collection/application/files/__directory__/tools/tsconfig.tools.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc/tools",
+    "rootDir": ".",
+    "module": "commonjs",
+    "target": "es5",
+    "types": [
+      "jasmine",
+      "node"
+    ]
+  },
+  "include": [
+    "**/*.ts"
+  ]
+}

--- a/packages/schematics/src/collection/application/index.ts
+++ b/packages/schematics/src/collection/application/index.ts
@@ -26,6 +26,7 @@ export default function(options: Schema): Rule {
       template({
         utils: strings,
         dot: '.',
+        tmpl: '',
         ...libVersions,
         ...(options as object),
         npmScope,

--- a/packages/schematics/src/collection/workspace-schematic/files/__name__/index.ts__tmpl__
+++ b/packages/schematics/src/collection/workspace-schematic/files/__name__/index.ts__tmpl__
@@ -1,0 +1,13 @@
+import {
+  chain,
+  externalSchematic,
+  Rule
+} from '@angular-devkit/schematics';
+
+export default function(schema: any): Rule {
+  return chain([
+    externalSchematic('@nrwl/schematics', 'lib', {
+      name: schema.name
+    })
+  ]);
+}

--- a/packages/schematics/src/collection/workspace-schematic/files/__name__/schema.json
+++ b/packages/schematics/src/collection/workspace-schematic/files/__name__/schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "<%= name %>",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Library name"
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/packages/schematics/src/collection/workspace-schematic/index.ts
+++ b/packages/schematics/src/collection/workspace-schematic/index.ts
@@ -1,0 +1,33 @@
+import {
+  apply,
+  branchAndMerge,
+  chain,
+  mergeWith,
+  Rule,
+  template,
+  url,
+  move
+} from '@angular-devkit/schematics';
+import { Schema } from './schema';
+import { wrapIntoFormat } from '@nrwl/schematics/src/utils/tasks';
+import { toFileName } from '@nrwl/schematics/src/utils/name-utils';
+
+export default function(schema: Schema): Rule {
+  return wrapIntoFormat(() => {
+    const options = normalizeOptions(schema);
+    const templateSource = apply(url('./files'), [
+      template({
+        dot: '.',
+        tmpl: '',
+        ...(options as any)
+      }),
+      move('tools/schematics')
+    ]);
+    return chain([branchAndMerge(chain([mergeWith(templateSource)]))]);
+  });
+}
+
+function normalizeOptions(options: Schema): Schema {
+  const name = toFileName(options.name);
+  return { ...options, name };
+}

--- a/packages/schematics/src/collection/workspace-schematic/schema.d.ts
+++ b/packages/schematics/src/collection/workspace-schematic/schema.d.ts
@@ -1,0 +1,3 @@
+export interface Schema {
+  name: string;
+}

--- a/packages/schematics/src/collection/workspace-schematic/schema.json
+++ b/packages/schematics/src/collection/workspace-schematic/schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "schematics",
+  "title": "Create a custom schematic",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Schematic name"
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/packages/schematics/src/collection/workspace-schematic/workspace-schematic.spec.ts
+++ b/packages/schematics/src/collection/workspace-schematic/workspace-schematic.spec.ts
@@ -1,0 +1,30 @@
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { Tree, VirtualTree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '../../utils/testing-utils';
+
+describe('workspace-schematic', () => {
+  const schematicRunner = new SchematicTestRunner(
+    '@nrwl/schematics',
+    path.join(__dirname, '../../collection.json')
+  );
+
+  let appTree: Tree;
+
+  beforeEach(() => {
+    appTree = new VirtualTree();
+    appTree = createEmptyWorkspace(appTree);
+
+    schematicRunner.logger.subscribe(s => console.log(s));
+  });
+
+  it('should generate files', () => {
+    const tree = schematicRunner.runSchematic(
+      'workspace-schematic',
+      { name: 'custom' },
+      appTree
+    );
+    expect(tree.exists('tools/schematics/custom/index.ts')).toBeTruthy();
+    expect(tree.exists('tools/schematics/custom/schema.json')).toBeTruthy();
+  });
+});

--- a/packages/schematics/src/collection/workspace/index.ts
+++ b/packages/schematics/src/collection/workspace/index.ts
@@ -95,6 +95,8 @@ function updatePackageJson() {
 
     packageJson.scripts['lint'] = './node_modules/.bin/nx lint && ng lint';
     packageJson.scripts['postinstall'] = './node_modules/.bin/nx postinstall';
+    packageJson.scripts['workspace-schematic'] =
+      './node_modules/.bin/nx workspace-schematic';
 
     return packageJson;
   });

--- a/packages/schematics/src/command-line/format.ts
+++ b/packages/schematics/src/command-line/format.ts
@@ -33,7 +33,7 @@ function getPatterns(args: string[]) {
     const libsAndApp = rest.filter(a => a.startsWith('--libs-and-apps'))[0];
     return libsAndApp ? getPatternsFromApps(patterns) : patterns;
   } catch (e) {
-    return ['"{apps,libs}/**/*.ts"'];
+    return ['"{apps,libs,tools}/**/*.ts"'];
   }
 }
 

--- a/packages/schematics/src/command-line/nx.ts
+++ b/packages/schematics/src/command-line/nx.ts
@@ -6,6 +6,7 @@ import { format } from './format';
 import { update } from './update';
 import { patchNg } from './patch-ng';
 import { lint } from './lint';
+import { workspaceSchematic } from './workspace-schematic';
 
 const processedArgs = yargsParser(process.argv, {
   alias: {
@@ -35,6 +36,9 @@ switch (command) {
   case 'postinstall':
     patchNg();
     update(['check']);
+    break;
+  case 'workspace-schematic':
+    workspaceSchematic(args);
     break;
   default:
     throw new Error(`Unrecognized command '${command}'`);

--- a/packages/schematics/src/command-line/patch-ng.ts
+++ b/packages/schematics/src/command-line/patch-ng.ts
@@ -15,7 +15,14 @@ if (options.cliArgs.indexOf('update') > -1) {
 `;
 
 export function patchNg() {
-  const cli = path.join('node_modules', '@angular', 'cli', 'lib', 'cli', 'index.js');
+  const cli = path.join(
+    'node_modules',
+    '@angular',
+    'cli',
+    'lib',
+    'cli',
+    'index.js'
+  );
   if (fileExists(cli)) {
     const file = readFileSync(cli).toString();
     writeFileSync(cli, addNxCheck(file));

--- a/packages/schematics/src/command-line/workspace-schematic.ts
+++ b/packages/schematics/src/command-line/workspace-schematic.ts
@@ -1,0 +1,302 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import { readFileSync, statSync, writeFileSync } from 'fs';
+import * as path from 'path';
+import { copySync } from 'fs-extra';
+import {
+  FileSystemEngineHost,
+  FileSystemHost,
+  NodeModulesEngineHost,
+  validateOptionsWithSchema
+} from '@angular-devkit/schematics/tools';
+import { BuiltinTaskExecutor } from '@angular-devkit/schematics/tasks/node';
+import {
+  CollectionDescription,
+  EngineHost,
+  FileSystemSink,
+  FileSystemTree,
+  RuleFactory,
+  Schematic,
+  SchematicDescription,
+  SchematicEngine,
+  Tree,
+  DryRunSink
+} from '@angular-devkit/schematics';
+import { of } from 'rxjs/observable/of';
+import { concat, concatMap, ignoreElements, map } from 'rxjs/operators';
+import { Observable } from 'rxjs/Observable';
+import { Url } from 'url';
+
+import * as yargsParser from 'yargs-parser';
+import { CoreSchemaRegistry } from '@angular-devkit/core/src/json/schema';
+import { standardFormats } from '@angular-devkit/schematics/src/formats';
+import * as appRoot from 'app-root-path';
+
+const rootDirectory = appRoot.path;
+
+export function workspaceSchematic(args: string[]) {
+  const outDir = compileTools();
+  const schematicName = args[0];
+  const { schematic, host, engine } = prepareExecutionContext(
+    outDir,
+    schematicName
+  );
+  executeSchematic(schematicName, parseOptions(args), schematic, host, engine);
+}
+
+// compile tools
+function compileTools() {
+  const toolsOutDir = getToolsOutDir();
+  compileToolsDir(toolsOutDir);
+
+  const schematicsOutDir = path.join(toolsOutDir, 'schematics');
+  const collectionData = constructCollection();
+  saveCollection(schematicsOutDir, collectionData);
+  return schematicsOutDir;
+}
+
+function getToolsOutDir() {
+  return path.resolve(
+    rootDirectory,
+    'tools',
+    JSON.parse(
+      readFileSync(
+        path.join(rootDirectory, 'tools', 'tsconfig.tools.json'),
+        'UTF-8'
+      )
+    ).compilerOptions.outDir
+  );
+}
+
+function compileToolsDir(outDir: string) {
+  copySync(path.join(rootDirectory, 'tools'), outDir);
+  try {
+    execSync('tsc -p tools/tsconfig.tools.json', {
+      stdio: 'inherit',
+      cwd: rootDirectory
+    });
+  } catch (e) {
+    process.exit(1);
+  }
+}
+
+function constructCollection() {
+  const schematics = {};
+  fs.readdirSync(schematicsDir()).forEach(c => {
+    const childDir = path.join(schematicsDir(), c);
+    if (exists(path.join(childDir, 'schema.json'))) {
+      schematics[c] = {
+        factory: `./${c}`,
+        schema: `./${path.join(c, 'schema.json')}`,
+        description: `Schematic ${c}`
+      };
+    }
+  });
+  return {
+    name: 'workspace-schematics',
+    version: '1.0',
+    schematics
+  };
+}
+
+function saveCollection(dir: string, collection: any) {
+  writeFileSync(
+    path.join(dir, 'workspace-schematics.json'),
+    JSON.stringify(collection)
+  );
+}
+
+function schematicsDir() {
+  return path.join('tools', 'schematics');
+}
+
+// prepareExecutionContext
+function prepareExecutionContext(outDir: string, schematicName: string) {
+  const engineHost = new EngineHostHandlingWorkspaceSchematics(outDir);
+  const engine = new SchematicEngine(engineHost);
+
+  const schematic = engine
+    .createCollection('workspace-schematics')
+    .createSchematic(schematicName);
+  const host = of(new FileSystemTree(new FileSystemHost(rootDirectory)));
+  return { schematic, host, engine };
+}
+
+// execute schematic
+function executeSchematic(
+  schematicName: string,
+  options: { [p: string]: any },
+  schematic: Schematic<any, any>,
+  host: Observable<FileSystemTree>,
+  engine: SchematicEngine<any, object>
+) {
+  const dryRunSink = new DryRunSink(rootDirectory, true);
+  let error = false;
+  dryRunSink.reporter.subscribe((event: any) => {
+    const eventPath = event.path.startsWith('/')
+      ? event.path.substr(1)
+      : event.path;
+    switch (event.kind) {
+      case 'error':
+        const desc =
+          event.description == 'alreadyExist'
+            ? 'already exists'
+            : 'does not exist.';
+        console.error(`error! ${eventPath} ${desc}.`);
+        error = true;
+        break;
+      case 'update':
+        console.log(`update ${eventPath} (${event.content.length} bytes)`);
+        break;
+      case 'create':
+        console.log(`create ${eventPath} (${event.content.length} bytes)`);
+        break;
+      case 'delete':
+        console.log(`delete ${eventPath}`);
+        break;
+      case 'rename':
+        const eventToPath = event.to.startsWith('/')
+          ? event.to.substr(1)
+          : event.to;
+        console.log(`rename ${eventPath} => ${eventToPath}`);
+        break;
+    }
+  });
+
+  const fsSink = new FileSystemSink(rootDirectory, true);
+
+  schematic
+    .call(options, host)
+    .pipe(
+      map((tree: Tree) => Tree.optimize(tree)),
+      concatMap((tree: Tree) =>
+        dryRunSink.commit(tree).pipe(ignoreElements(), concat(of(tree)))
+      ),
+      concatMap(
+        (tree: Tree) =>
+          error
+            ? of(tree)
+            : fsSink.commit(tree).pipe(ignoreElements(), concat(of(tree)))
+      ),
+      concatMap(() => (error ? [] : engine.executePostTasks()))
+    )
+    .subscribe(
+      () => {},
+      e => {
+        console.error(`Error occurred while executing '${schematicName}':`);
+        console.error(e);
+      },
+      () => {
+        console.log(`'${schematicName}' completed.`);
+      }
+    );
+}
+
+/**
+ * It uses FileSystemEngineHost for collection named "workspace-tools" and NodeModulesEngineHost
+ * for everything else.
+ */
+class EngineHostHandlingWorkspaceSchematics implements EngineHost<any, any> {
+  readonly toolsHost: FileSystemEngineHost;
+  readonly defaultHost: NodeModulesEngineHost;
+
+  constructor(outDir: string) {
+    const transforms = validateOptionsWithSchema(
+      new CoreSchemaRegistry(standardFormats)
+    );
+    this.toolsHost = new FileSystemEngineHost(outDir);
+    this.toolsHost.registerOptionsTransform(transforms);
+
+    this.defaultHost = new NodeModulesEngineHost();
+    this.defaultHost.registerOptionsTransform(transforms);
+    this.defaultHost.registerTaskExecutor(BuiltinTaskExecutor.NodePackage, {
+      rootDirectory,
+      packageManager: fileExists('yarn.lock') ? 'yarn' : 'npm'
+    });
+  }
+
+  createCollectionDescription(name: string): CollectionDescription<any> {
+    return this.hostFor(name).createCollectionDescription(name);
+  }
+
+  createSchematicDescription(
+    name: string,
+    collection: CollectionDescription<any>
+  ): SchematicDescription<any, any> | null {
+    return this.hostFor(collection.name).createSchematicDescription(
+      name,
+      collection
+    );
+  }
+
+  getSchematicRuleFactory<OptionT extends object>(
+    schematic: SchematicDescription<any, any>,
+    collection: CollectionDescription<any>
+  ): RuleFactory<OptionT> {
+    return this.hostFor(collection.name).getSchematicRuleFactory(
+      schematic,
+      collection
+    );
+  }
+
+  createSourceFromUrl(url: Url, context: any): any {
+    return this.hostFor(context.schematic.collection.name).createSourceFromUrl(
+      url
+    );
+  }
+
+  transformOptions<OptionT extends object, ResultT extends object>(
+    schematic: SchematicDescription<any, any>,
+    options: OptionT
+  ): Observable<ResultT> {
+    return this.hostFor(schematic.collection.name).transformOptions(
+      schematic,
+      options
+    );
+  }
+
+  listSchematics(collection: any): string[] {
+    return this.listSchematicNames(collection.description);
+  }
+
+  listSchematicNames(collection: CollectionDescription<any>): string[] {
+    return this.hostFor(collection.name).listSchematicNames(collection);
+  }
+
+  createTaskExecutor(name: string): Observable<any> {
+    return this.defaultHost.createTaskExecutor(name);
+  }
+
+  hasTaskExecutor(name: string): boolean {
+    return this.defaultHost.hasTaskExecutor(name);
+  }
+
+  private hostFor(name: string) {
+    return name === 'workspace-schematics' ? this.toolsHost : this.defaultHost;
+  }
+}
+
+function parseOptions(args: string[]): { [k: string]: any } {
+  const parsed = yargsParser(args);
+  if (parsed._ && parsed._.length > 1) {
+    parsed.name = parsed._[1];
+  }
+  delete parsed._;
+  return parsed;
+}
+
+function exists(file: string): boolean {
+  try {
+    return !!fs.statSync(file);
+  } catch (e) {
+    return false;
+  }
+}
+
+function fileExists(filePath: string): boolean {
+  try {
+    return statSync(filePath).isFile();
+  } catch (err) {
+    return false;
+  }
+}

--- a/packages/schematics/src/lib-versions.ts
+++ b/packages/schematics/src/lib-versions.ts
@@ -8,7 +8,7 @@ export const nxVersion = '*';
 export const schematicsVersion = '*';
 export const angularCliSchema =
   './node_modules/@nrwl/schematics/src/schema.json';
-export const latestMigration = '20180328-add-nx-lint';
+export const latestMigration = '20180405-add-workspace-schematic-command';
 export const prettierVersion = '1.10.2';
 export const typescriptVersion = '2.6.2';
 export const rxjsVersion = '^5.5.6';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2774,17 +2774,17 @@ fs-access@^1.0.0:
   dependencies:
     null-check "^1.0.0"
 
-fs-extra@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+fs-extra@5.0.0, fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+fs-extra@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"


### PR DESCRIPTION
Currently, Nx provides a way to quickly generate a set of predefined libs and artifacts.

The problem is that it is not customizable. We would like to give users the ability to extend these capabilities. That's why we are adding support for workspace-specific schematics.


For instance, say we want to define a specific lib type. This is how it can be implemented:

```
ng g workspace-schematic data-access-lib
```

Open `tools/schematics/data-access-lib`.

We can change schema.json:

```
{
  "$schema": "http://json-schema.org/schema",
  "id": "data-access-lib",
  "type": "object",
  "properties": {
    "name": {
      "type": "string",
      "description": "Library name"
    },
    "directory": {
      "type": "string",
      "description": "Library directory"
    }
  },
  "required": [
    "name",
    "directory"
  ]
}
```

And index.ts:

```
import {
  chain,
  externalSchematic,
  Rule
} from '@angular-devkit/schematics';
import * as path from 'path';

export default function(schema: any): Rule {
  if (!schema.name.startsWith('data-access')) {
    throw new Error('Data access lib must be prefixed with "data-access"');
  }

  const stateName = schema.name === 'data-access' ? schema.directory : schema.name.substring(12);
  return chain([
    externalSchematic('@nrwl/schematics', 'lib', {
      name: schema.name,
      directory: schema.directory,
      tags: 'data-access'
    }),
    externalSchematic('@nrwl/schematics', 'ngrx', {
      name: stateName,
      module: path.join('libs', schema.directory, schema.name, 'src', `${schema.name}.module.ts`)
    })
  ]);
}
```

With this, the developer can run:

```
yarn workspace-schematic data-access-lib accounts --directory=bank
```

And a new library with ngrx set up will be created. This library has all the right tags set up, the names are consistent (we are running validations). It's really easy to use.