### PR TITLE
fix(bazel): Extend ngrx and angular schematics

### DIFF
--- a/packages/bazel/src/collection.json
+++ b/packages/bazel/src/collection.json
@@ -1,6 +1,7 @@
 {
   "name": "nx-bazel",
   "version": "0.1",
+  "extends": "@ngrx/schematics",
   "schematics": {
     "application": {
       "factory": "./collection/application",
@@ -18,9 +19,7 @@
       "description": "Create a library"
     },
     "module": {
-      "aliases": [
-        "m"
-      ],
+      "aliases": ["m"],
       "factory": "./collection/module",
       "schema": "./collection/module/schema.json",
       "description": "Create a Module"

--- a/packages/bazel/src/collection/app/files/apps/__fullName__/__sourceDir__/BUILD.bazel
+++ b/packages/bazel/src/collection/app/files/apps/__fullName__/__sourceDir__/BUILD.bazel
@@ -31,7 +31,7 @@ STATIC_FILES = [
 ts_devserver(
     name = "devserver",
     data = ["//apps/<%= fullName %>/src/assets"],
-    entry_module = "proj/apps/<%= fullName %>/src/main",
+    entry_module = "<%= workspaceName %>/apps/<%= fullName %>/src/main",
     scripts = ["//:angular_bundles"],
     serving_path = "/bundle.min.js",
     static_files = STATIC_FILES,
@@ -42,7 +42,7 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle", "nodejs_binary")
 
 rollup_bundle(
     name = "bundle",
-    entry_point = "proj/apps/<%= fullName %>/src/main",
+    entry_point = "<%= workspaceName %>/apps/<%= fullName %>/src/main",
     deps = [":<%= sourceDir %>"],
 )
 

--- a/packages/bazel/src/collection/app/index.ts
+++ b/packages/bazel/src/collection/app/index.ts
@@ -29,6 +29,7 @@ import { wrapIntoFormat } from '../../utils/tasks';
 interface NormalizedSchema extends Schema {
   fullName: string;
   fullPath: string;
+  workspaceName: string;
 }
 
 function addBootstrap(path: string): Rule {
@@ -294,5 +295,13 @@ function normalizeOptions(options: Schema): NormalizedSchema {
     ? `${toFileName(options.directory)}/${name}`
     : name;
   const fullPath = `apps/${fullName}/src`;
-  return { ...options, sourceDir: 'src', name, fullName, fullPath };
+  const workspaceName = readCliConfigFile().project.name;
+  return {
+    ...options,
+    sourceDir: 'src',
+    name,
+    fullName,
+    fullPath,
+    workspaceName
+  };
 }

--- a/packages/bazel/src/schema.json
+++ b/packages/bazel/src/schema.json
@@ -1,0 +1,707 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "https://github.com/nrwl/nx/blob/master/packages/bazel/src/schema.json",
+  "title": "Nrwl Nx Config Schema",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "project": {
+      "description": "The global configuration of the project.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the project.",
+          "type": "string"
+        },
+        "latestMigration": {
+          "description": "Npm scope for importing libs.",
+          "type": "string"
+        },
+        "ejected": {
+          "description": "Whether or not this project was ejected.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "apps": {
+      "description":
+        "Properties of the different applications in this project.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "tags": {
+            "type": "array",
+            "description": "Project tags",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the app."
+          },
+          "appRoot": {
+            "type": "string",
+            "description": "Directory where app files are placed.",
+            "default": "app"
+          },
+          "appShell": {
+            "type": "object",
+            "description": "AppShell configuration.",
+            "properties": {
+              "app": {
+                "type": "string",
+                "description": "Index or name of the related AppShell app."
+              },
+              "route": {
+                "type": "string",
+                "description": "Default AppShell route to render."
+              }
+            }
+          },
+          "root": {
+            "type": "string",
+            "description": "The root directory of the app."
+          },
+          "outDir": {
+            "type": "string",
+            "default": "dist/",
+            "description": "The output directory for build results."
+          },
+          "assets": {
+            "type": "array",
+            "description": "List of application assets.",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "glob": {
+                      "type": "string",
+                      "default": "",
+                      "description": "The pattern to match."
+                    },
+                    "input": {
+                      "type": "string",
+                      "default": "",
+                      "description": "The dir to search within."
+                    },
+                    "output": {
+                      "type": "string",
+                      "default": "",
+                      "description": "The output path (relative to the outDir)."
+                    },
+                    "allowOutsideOutDir": {
+                      "type": "boolean",
+                      "description":
+                        "Allow assets to be copied outside the outDir.",
+                      "default": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "default": []
+          },
+          "budgets": {
+            "type": "array",
+            "description": "Threshold definitions for bundle sizes.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "bundle",
+                    "initial",
+                    "allScript",
+                    "all",
+                    "anyScript",
+                    "any"
+                  ],
+                  "description": "The type of budget"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The name of the bundle"
+                },
+                "baseline": {
+                  "type": "string",
+                  "description": "The baseline size for comparison."
+                },
+                "maximumWarning": {
+                  "type": "string",
+                  "description":
+                    "The maximum threshold for warning relative to the baseline."
+                },
+                "maximumError": {
+                  "type": "string",
+                  "description":
+                    "The maximum threshold for error relative to the baseline."
+                },
+                "minimumWarning": {
+                  "type": "string",
+                  "description":
+                    "The minimum threshold for warning relative to the baseline."
+                },
+                "minimumError": {
+                  "type": "string",
+                  "description":
+                    "The minimum threshold for error relative to the baseline."
+                },
+                "warning": {
+                  "type": "string",
+                  "description":
+                    "The threshold for warning relative to the baseline (min & max)."
+                },
+                "error": {
+                  "type": "string",
+                  "description":
+                    "The threshold for error relative to the baseline (min & max)."
+                }
+              }
+            },
+            "default": []
+          },
+          "deployUrl": {
+            "type": "string",
+            "description": "URL where files will be deployed."
+          },
+          "baseHref": {
+            "type": "string",
+            "description": "Base url for the application being built."
+          },
+          "platform": {
+            "type": "string",
+            "enum": ["browser", "server"],
+            "default": "browser",
+            "description": "The runtime platform of the app."
+          },
+          "index": {
+            "type": "string",
+            "default": "index.html",
+            "description": "The name of the start HTML file."
+          },
+          "main": {
+            "type": "string",
+            "description": "The name of the main entry-point file."
+          },
+          "polyfills": {
+            "type": "string",
+            "description": "The name of the polyfills file."
+          },
+          "test": {
+            "type": "string",
+            "description": "The name of the test entry-point file."
+          },
+          "tsconfig": {
+            "type": "string",
+            "default": "tsconfig.app.json",
+            "description": "The name of the TypeScript configuration file."
+          },
+          "testTsconfig": {
+            "type": "string",
+            "description":
+              "The name of the TypeScript configuration file for unit tests."
+          },
+          "prefix": {
+            "type": "string",
+            "description": "The prefix to apply to generated selectors."
+          },
+          "serviceWorker": {
+            "description":
+              "Experimental support for a service worker from @angular/service-worker.",
+            "type": "boolean",
+            "default": false
+          },
+          "styles": {
+            "description": "Global styles to be included in the build.",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "input": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "additionalProperties": false
+          },
+          "stylePreprocessorOptions": {
+            "description": "Options to pass to style preprocessors",
+            "type": "object",
+            "properties": {
+              "includePaths": {
+                "description":
+                  "Paths to include. Paths will be resolved to project root.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": []
+              }
+            },
+            "additionalProperties": false
+          },
+          "scripts": {
+            "description": "Global scripts to be included in the build.",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "input": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": ["input"]
+                }
+              ]
+            },
+            "additionalProperties": false
+          },
+          "environmentSource": {
+            "description": "Source file for environment config.",
+            "type": "string"
+          },
+          "environments": {
+            "description":
+              "Name and corresponding file for environment config.",
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "additionalProperties": false
+    },
+    "e2e": {
+      "type": "object",
+      "description": "Configuration for end-to-end tests.",
+      "properties": {
+        "protractor": {
+          "type": "object",
+          "properties": {
+            "config": {
+              "description": "Path to the config file.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "lint": {
+      "description": "Properties to be passed to TSLint.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "files": {
+            "description": "File glob(s) to lint.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ],
+            "default": []
+          },
+          "project": {
+            "description":
+              "Location of the tsconfig.json project file. Will also use as files to lint if 'files' property not present.",
+            "type": "string"
+          },
+          "tslintConfig": {
+            "description": "Location of the tslint.json configuration.",
+            "type": "string"
+          },
+          "exclude": {
+            "description": "File glob(s) to ignore.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ],
+            "default": []
+          }
+        },
+        "required": ["project"],
+        "additionalProperties": false
+      }
+    },
+    "test": {
+      "description": "Configuration for unit tests.",
+      "type": "object",
+      "properties": {
+        "karma": {
+          "type": "object",
+          "properties": {
+            "config": {
+              "description": "Path to the karma config file.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "codeCoverage": {
+          "type": "object",
+          "properties": {
+            "exclude": {
+              "description": "Globs to exclude from code coverage.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "defaults": {
+      "description": "Specify the default values for generating.",
+      "type": "object",
+      "properties": {
+        "styleExt": {
+          "description": "The file extension to be used for style files.",
+          "type": "string"
+        },
+        "poll": {
+          "description": "How often to check for file updates.",
+          "type": "number"
+        },
+        "lintFix": {
+          "description": "Use lint to fix files after generation",
+          "type": "boolean",
+          "default": false
+        },
+        "class": {
+          "description": "Options for generating a class.",
+          "type": "object",
+          "properties": {
+            "spec": {
+              "description": "Specifies if a spec file is generated.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "component": {
+          "description": "Options for generating a component.",
+          "type": "object",
+          "properties": {
+            "flat": {
+              "description": "Flag to indicate if a dir is created.",
+              "type": "boolean",
+              "default": true
+            },
+            "spec": {
+              "description": "Specifies if a spec file is generated.",
+              "type": "boolean",
+              "default": true
+            },
+            "inlineStyle": {
+              "description": "Specifies if the style will be in the ts file.",
+              "type": "boolean",
+              "default": false
+            },
+            "inlineTemplate": {
+              "description":
+                "Specifies if the template will be in the ts file.",
+              "type": "boolean",
+              "default": false
+            },
+            "viewEncapsulation": {
+              "description": "Specifies the view encapsulation strategy.",
+              "enum": ["Emulated", "Native", "None"],
+              "type": "string"
+            },
+            "changeDetection": {
+              "description": "Specifies the change detection strategy.",
+              "enum": ["Default", "OnPush"],
+              "type": "string"
+            }
+          }
+        },
+        "directive": {
+          "description": "Options for generating a directive.",
+          "type": "object",
+          "properties": {
+            "flat": {
+              "description": "Flag to indicate if a dir is created.",
+              "type": "boolean",
+              "default": true
+            },
+            "spec": {
+              "description": "Specifies if a spec file is generated.",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "guard": {
+          "description": "Options for generating a guard.",
+          "type": "object",
+          "properties": {
+            "flat": {
+              "description": "Flag to indicate if a dir is created.",
+              "type": "boolean",
+              "default": true
+            },
+            "spec": {
+              "description": "Specifies if a spec file is generated.",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "interface": {
+          "description": "Options for generating an interface.",
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "description": "Prefix to apply to interface names. (i.e. I)",
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "module": {
+          "description": "Options for generating a module.",
+          "type": "object",
+          "properties": {
+            "flat": {
+              "description": "Flag to indicate if a dir is created.",
+              "type": "boolean",
+              "default": false
+            },
+            "spec": {
+              "description": "Specifies if a spec file is generated.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "pipe": {
+          "description": "Options for generating a pipe.",
+          "type": "object",
+          "properties": {
+            "flat": {
+              "description": "Flag to indicate if a dir is created.",
+              "type": "boolean",
+              "default": true
+            },
+            "spec": {
+              "description": "Specifies if a spec file is generated.",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "service": {
+          "description": "Options for generating a service.",
+          "type": "object",
+          "properties": {
+            "flat": {
+              "description": "Flag to indicate if a dir is created.",
+              "type": "boolean",
+              "default": true
+            },
+            "spec": {
+              "description": "Specifies if a spec file is generated.",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "build": {
+          "description": "Properties to be passed to the build command.",
+          "type": "object",
+          "properties": {
+            "sourcemaps": {
+              "description": "Output sourcemaps.",
+              "type": "boolean"
+            },
+            "baseHref": {
+              "description": "Base url for the application being built.",
+              "type": "string"
+            },
+            "progress": {
+              "description": "The ssl key used by the server.",
+              "type": "boolean"
+            },
+            "poll": {
+              "description":
+                "Enable and define the file watching poll time period (milliseconds).",
+              "type": "number"
+            },
+            "deleteOutputPath": {
+              "description": "Delete output path before build.",
+              "type": "boolean",
+              "default": true
+            },
+            "preserveSymlinks": {
+              "description": "Do not use the real path when resolving modules.",
+              "type": "boolean",
+              "default": false
+            },
+            "showCircularDependencies": {
+              "description": "Show circular dependency warnings on builds.",
+              "type": "boolean",
+              "default": true
+            },
+            "commonChunk": {
+              "description":
+                "Use a separate bundle containing code used across multiple bundles.",
+              "type": "boolean",
+              "default": true
+            },
+            "namedChunks": {
+              "description": "Use file name for lazy loaded chunks.",
+              "type": "boolean"
+            }
+          }
+        },
+        "serve": {
+          "description": "Properties to be passed to the serve command.",
+          "type": "object",
+          "properties": {
+            "port": {
+              "description": "The port the application will be served on.",
+              "type": "number",
+              "default": 4200
+            },
+            "host": {
+              "description": "The host the application will be served on.",
+              "type": "string",
+              "default": "localhost"
+            },
+            "ssl": {
+              "description": "Enables ssl for the application.",
+              "type": "boolean",
+              "default": false
+            },
+            "sslKey": {
+              "description": "The ssl key used by the server.",
+              "type": "string",
+              "default": "ssl/server.key"
+            },
+            "sslCert": {
+              "description": "The ssl certificate used by the server.",
+              "type": "string",
+              "default": "ssl/server.crt"
+            },
+            "proxyConfig": {
+              "description": "Proxy configuration file.",
+              "type": "string"
+            }
+          }
+        },
+        "schematics": {
+          "description": "Properties about schematics.",
+          "type": "object",
+          "properties": {
+            "collection": {
+              "description": "The schematics collection to use.",
+              "type": "string",
+              "default": "@schematics/angular"
+            },
+            "newApp": {
+              "description": "The new app schematic.",
+              "type": "string",
+              "default": "application"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "packageManager": {
+      "description": "Specify which package manager tool to use.",
+      "enum": ["npm", "cnpm", "yarn", "default"],
+      "default": "default",
+      "type": "string"
+    },
+    "warnings": {
+      "description": "Allow people to disable console warnings.",
+      "type": "object",
+      "properties": {
+        "hmrWarning": {
+          "description":
+            "Show a warning when the user enabled the --hmr option.",
+          "type": "boolean",
+          "default": true
+        },
+        "nodeDeprecation": {
+          "description":
+            "Show a warning when the node version is incompatible.",
+          "type": "boolean",
+          "default": true
+        },
+        "packageDeprecation": {
+          "description": "Show a warning when the user installed angular-cli.",
+          "type": "boolean",
+          "default": true
+        },
+        "versionMismatch": {
+          "description":
+            "Show a warning when the global version is newer than the local one.",
+          "type": "boolean",
+          "default": true
+        },
+        "typescriptMismatch": {
+          "description":
+            "Show a warning when the TypeScript version is incompatible",
+          "type": "boolean",
+          "default": true
+        },
+        "servePathDefault": {
+          "description":
+            "Show a warning when deploy-url/base-href use unsupported serve path values.",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Additionally I fixed the bug where we only supported a workspace name of proj