### PR TITLE
feat(bazel): Add correct dependencies to package.json

### DIFF
--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -9,7 +9,10 @@
   "license": "MIT",
   "schematics": "./src/collection.json",
   "dependencies": {
+    "@ngrx/schematics": "5.2.0",
+    "@schematics/angular": "0.4.6",
     "app-root-path": "^2.0.1",
+    "npm-run-all": "4.1.2",
     "semver": "5.4.1",
     "tmp": "0.0.33",
     "yargs-parser": "9.0.2"

--- a/packages/bazel/src/collection/application/index.ts
+++ b/packages/bazel/src/collection/application/index.ts
@@ -18,6 +18,13 @@ import {
 import { libVersions } from '../../lib-versions';
 
 export default function(options: Schema): Rule {
+  if (!/^\w+$/.test(options.name)) {
+    throw new Error(
+      `${options.name} is invalid for a bazel workspace.\n` +
+        'Your workspace name must contain only alphanumeric characters and underscores.'
+    );
+  }
+
   return (host: Tree, context: SchematicContext) => {
     addTasks(options, context);
     const npmScope = options.npmScope ? options.npmScope : options.name;

--- a/packages/schematics/bin/create-nx-workspace.ts
+++ b/packages/schematics/bin/create-nx-workspace.ts
@@ -64,6 +64,16 @@ if (!useYarn) {
 
 const projectName = parsedArgs._[2];
 
+if (parsedArgs.bazel) {
+  if (!/^\w+$/.test(projectName)) {
+    console.error(
+      `${projectName} is invalid for a bazel workspace.\n` +
+        'Your workspace name must contain only alphanumeric characters and underscores.'
+    );
+    process.exit(1);
+  }
+}
+
 // check that the workspace name is passed in
 if (!projectName) {
   console.error(


### PR DESCRIPTION
Before this fix, running `ng new "bazel-proj" --collection=@nrwl/bazel` would errors out because we lacked an explicit dependency on `@ngrx/schematics`