### PR TITLE
feat(schematics): permit to force app root path when using the nx CLI

### DIFF
--- a/packages/schematics/src/command-line/dep-graph.ts
+++ b/packages/schematics/src/command-line/dep-graph.ts
@@ -1,6 +1,6 @@
 import { writeToFile } from '../utils/fileutils';
 import * as graphviz from 'graphviz';
-import * as appRoot from 'app-root-path';
+import { getAppRootPath } from '../utils/app-root-path';
 import * as opn from 'opn';
 import { readFileSync } from 'fs';
 import {
@@ -268,7 +268,7 @@ function generateGraphJson(criticalPath?: string[]): JSONOutput {
 
   // fetch all apps and libs
   const deps = dependencies(npmScope, projects, f =>
-    readFileSync(`${appRoot.path}/${f}`, 'utf-8')
+    readFileSync(`${getAppRootPath()}/${f}`, 'utf-8')
   );
 
   return {

--- a/packages/schematics/src/command-line/lint.ts
+++ b/packages/schematics/src/command-line/lint.ts
@@ -1,13 +1,13 @@
 import { getProjectNodes, readCliConfig, allFilesInDir } from './shared';
 import { WorkspaceIntegrityChecks } from './workspace-integrity-checks';
-import * as appRoot from 'app-root-path';
+import { getAppRootPath } from '../utils/app-root-path';
 import * as path from 'path';
 import * as fs from 'fs';
 
 export function lint() {
   const nodes = getProjectNodes(readCliConfig());
   const packageJson = JSON.parse(
-    fs.readFileSync(`${appRoot.path}/package.json`, 'utf-8')
+    fs.readFileSync(`${getAppRootPath()}/package.json`, 'utf-8')
   );
 
   const errorGroups = new WorkspaceIntegrityChecks(
@@ -27,7 +27,7 @@ export function lint() {
 
 function readAllFilesFromAppsAndLibs() {
   return [
-    ...allFilesInDir(`${appRoot.path}/apps`),
-    ...allFilesInDir(`${appRoot.path}/libs`)
+    ...allFilesInDir(`${getAppRootPath()}/apps`),
+    ...allFilesInDir(`${getAppRootPath()}/libs`)
   ].filter(f => !path.basename(f).startsWith('.'));
 }

--- a/packages/schematics/src/command-line/nx.ts
+++ b/packages/schematics/src/command-line/nx.ts
@@ -8,15 +8,15 @@ import { patchNg } from './patch-ng';
 import { lint } from './lint';
 import { workspaceSchematic } from './workspace-schematic';
 import { generateGraph } from './dep-graph';
+import { parseArgs } from '../utils/cli-config-utils';
+import { setAppRootPath } from '../utils/app-root-path';
 
-const processedArgs = yargsParser(process.argv, {
-  alias: {
-    app: ['a']
-  },
-  string: ['app']
-});
-const command = processedArgs._[2];
+const { command, appRoot } = parseArgs();
 const args = process.argv.slice(3);
+
+if (appRoot) {
+  setAppRootPath(appRoot);
+}
 
 switch (command) {
   case 'affected':

--- a/packages/schematics/src/command-line/shared.ts
+++ b/packages/schematics/src/command-line/shared.ts
@@ -12,7 +12,7 @@ import {
 } from './affected-apps';
 import * as fs from 'fs';
 import { statSync } from 'fs';
-import * as appRoot from 'app-root-path';
+import { getAppRootPath } from '../utils/app-root-path';
 import { readJsonFile } from '../utils/fileutils';
 
 export function parseFiles(
@@ -95,13 +95,13 @@ export function getProjectNodes(config) {
         root: p.root,
         type: p.root.startsWith('apps/') ? ProjectType.app : ProjectType.lib,
         tags: p.tags,
-        files: allFilesInDir(`${appRoot.path}/${path.dirname(p.root)}`)
+        files: allFilesInDir(`${getAppRootPath()}/${path.dirname(p.root)}`)
       };
     });
 }
 
 export function readCliConfig(): any {
-  const config = readJsonFile(`${appRoot.path}/.angular-cli.json`);
+  const config = readJsonFile(`${getAppRootPath()}/.angular-cli.json`);
 
   if (!config.project.npmScope) {
     throw new Error(`.angular-cli.json must define the npmScope property.`);
@@ -119,7 +119,7 @@ export const getAffected = (affectedNamesFetcher: AffectedFetcher) => (
   return affectedNamesFetcher(
     config.project.npmScope,
     projects,
-    f => fs.readFileSync(`${appRoot.path}/${f}`, 'utf-8'),
+    f => fs.readFileSync(`${getAppRootPath()}/${f}`, 'utf-8'),
     touchedFiles
   );
 };
@@ -148,7 +148,7 @@ export function allFilesInDir(dirName: string): string[] {
       try {
         if (!fs.statSync(child).isDirectory()) {
           // add starting with "apps/myapp/..." or "libs/mylib/..."
-          res.push(normalizePath(child.substring(appRoot.path.length + 1)));
+          res.push(normalizePath(child.substring(getAppRootPath().length + 1)));
         } else if (fs.statSync(child).isDirectory()) {
           res = [...res, ...allFilesInDir(child)];
         }
@@ -163,34 +163,34 @@ export function readDependencies(
   projectNodes: ProjectNode[]
 ): { [projectName: string]: Dependency[] } {
   const m = lastModifiedAmongProjectFiles();
-  if (!directoryExists(`${appRoot.path}/dist`)) {
-    fs.mkdirSync(`${appRoot.path}/dist`);
+  if (!directoryExists(`${getAppRootPath()}/dist`)) {
+    fs.mkdirSync(`${getAppRootPath()}/dist`);
   }
   if (
-    !fileExists(`${appRoot.path}/dist/nxdeps.json`) ||
-    m > mtime(`${appRoot.path}/dist/nxdeps.json`)
+    !fileExists(`${getAppRootPath()}/dist/nxdeps.json`) ||
+    m > mtime(`${getAppRootPath()}/dist/nxdeps.json`)
   ) {
     const deps = dependencies(npmScope, projectNodes, f =>
-      fs.readFileSync(`${appRoot.path}/${f}`, 'UTF-8')
+      fs.readFileSync(`${getAppRootPath()}/${f}`, 'UTF-8')
     );
     fs.writeFileSync(
-      `${appRoot.path}/dist/nxdeps.json`,
+      `${getAppRootPath()}/dist/nxdeps.json`,
       JSON.stringify(deps, null, 2),
       'UTF-8'
     );
     return deps;
   } else {
-    return readJsonFile(`${appRoot.path}/dist/nxdeps.json`);
+    return readJsonFile(`${getAppRootPath()}/dist/nxdeps.json`);
   }
 }
 
 export function lastModifiedAmongProjectFiles() {
   return [
-    recursiveMtime(`${appRoot.path}/libs`),
-    recursiveMtime(`${appRoot.path}/apps`),
-    mtime(`${appRoot.path}/.angular-cli.json`),
-    mtime(`${appRoot.path}/tslint.json`),
-    mtime(`${appRoot.path}/package.json`)
+    recursiveMtime(`${getAppRootPath()}/libs`),
+    recursiveMtime(`${getAppRootPath()}/apps`),
+    mtime(`${getAppRootPath()}/.angular-cli.json`),
+    mtime(`${getAppRootPath()}/tslint.json`),
+    mtime(`${getAppRootPath()}/package.json`)
   ].reduce((a, b) => (a > b ? a : b), 0);
 }
 

--- a/packages/schematics/src/command-line/workspace-schematic.ts
+++ b/packages/schematics/src/command-line/workspace-schematic.ts
@@ -30,9 +30,9 @@ import { Url } from 'url';
 import * as yargsParser from 'yargs-parser';
 import { CoreSchemaRegistry } from '@angular-devkit/core/src/json/schema';
 import { standardFormats } from '@angular-devkit/schematics/src/formats';
-import * as appRoot from 'app-root-path';
+import { getAppRootPath } from '../utils/app-root-path';
 
-const rootDirectory = appRoot.path;
+const rootDirectory = getAppRootPath();
 
 export function workspaceSchematic(args: string[]) {
   const outDir = compileTools();

--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -3,7 +3,7 @@ import * as Lint from 'tslint';
 import { IOptions } from 'tslint';
 import * as ts from 'typescript';
 import { readFileSync } from 'fs';
-import * as appRoot from 'app-root-path';
+import { getAppRootPath } from '../utils/app-root-path';
 import { getProjectNodes, readDependencies } from '../command-line/shared';
 import {
   Dependency,
@@ -22,7 +22,7 @@ export class Rule extends Lint.Rules.AbstractRule {
   ) {
     super(options);
     if (!projectPath) {
-      this.projectPath = appRoot.path;
+      this.projectPath = getAppRootPath();
       if (!(global as any).projectNodes) {
         const cliConfig = this.readCliConfig(this.projectPath);
         (global as any).npmScope = cliConfig.project.npmScope;

--- a/packages/schematics/src/utils/app-root-path.ts
+++ b/packages/schematics/src/utils/app-root-path.ts
@@ -1,0 +1,9 @@
+let explicitlySetPath: string = '';
+
+export function setAppRootPath(dirname) {
+  explicitlySetPath = dirname;
+}
+
+export const getAppRootPath = () => {
+  return explicitlySetPath || require('app-root-path').path;
+};

--- a/packages/schematics/src/utils/cli-config-utils.ts
+++ b/packages/schematics/src/utils/cli-config-utils.ts
@@ -1,11 +1,30 @@
 import * as yargsParser from 'yargs-parser';
 
 import { readJsonFile } from './fileutils';
+import * as path from 'path';
+
+const globalArgsConfig = {
+  alias: {
+    app: ['a'],
+    appRoot: ['r']
+  },
+  string: ['app'],
+  normalize: ['app-root'],
+  coerce: {
+    appRoot: arg => path.resolve(arg)
+  }
+};
+
+export type GlobalUserOptions = {
+  app?: string;
+  appRoot?: string;
+  command: string;
+};
 
 export function getAppDirectoryUsingCliConfig() {
   const cli = readJsonFile(process.cwd() + '/.angular-cli.json');
 
-  const appName = getAppName();
+  const appName = parseArgs().app;
 
   if (appName) {
     const app = cli.apps.find(a => a.name === appName);
@@ -25,7 +44,7 @@ export function getAppDirectoryUsingCliConfig() {
 }
 
 export function makeSureNoAppIsSelected() {
-  if (getAppName()) {
+  if (parseArgs().app) {
     console.error('Nx only supports running unit tests for all apps and libs.');
     console.error('You cannot use -a or --app.');
     console.error('Use fdescribe or fit to select a subset of tests to run.');
@@ -33,11 +52,10 @@ export function makeSureNoAppIsSelected() {
   }
 }
 
-function getAppName() {
-  return yargsParser(process.argv, {
-    alias: {
-      app: ['a']
-    },
-    string: ['app']
-  }).app;
+export function parseArgs(): GlobalUserOptions {
+  const processedArgs = yargsParser(process.argv, globalArgsConfig);
+  return {
+    ...processedArgs,
+    command: processedArgs._[2]
+  };
 }


### PR DESCRIPTION
Add a new "--app-root" (alias "-r") option permiting to manually set the application root folder path.
This option is global, and can be use with every command.
It will be used by any command which use app-root-path (for now : lint, workspace-schematic and dep-graph).
close #408 

This PR, along with #409, allow to use `yarn link` in order to test the nx cli in an Nx project during development. This allow us test "real life" scenarios without requiring to write unit and e2e tests for every use case (which does not supress the need of more tests on command-line).
