### PR TITLE
fix(nx): remove strict check for "file" option for dep-graph

### DIFF
--- a/packages/schematics/src/command-line/nx.ts
+++ b/packages/schematics/src/command-line/nx.ts
@@ -120,7 +120,6 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
 
 function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
   return yargs
-    .demandOption(['file'])
     .describe('file', 'output file (e.g. --file=.vis/output.json)')
     .choices('output', [OutputType.json, OutputType.dot, OutputType.html]);
 }


### PR DESCRIPTION
Allow defaults to be used when running `npm run dep-graph` (remove `file` from being required)