### PR TITLE
fix(schematics) use property name in ngrx reducer spec

### DIFF
--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.reducer.spec.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.reducer.spec.ts__tmpl__
@@ -4,7 +4,7 @@ import { <%= propertyName %>Reducer, initialState } from './<%= fileName %>.redu
 describe('<%= propertyName %>Reducer', () => {
   it('should work', () => {
     const action: <%= className %>Loaded = new <%= className %>Loaded({});
-    const actual = <%= fileName %>Reducer(initialState, action);
+    const actual = <%= propertyName %>Reducer(initialState, action);
     expect(actual).toEqual({});
   });
 });

--- a/packages/schematics/src/collection/ngrx/ngrx.spec.ts
+++ b/packages/schematics/src/collection/ngrx/ngrx.spec.ts
@@ -269,6 +269,47 @@ describe('ngrx', () => {
     });
   });
 
+  it('should produce proper specs for the ngrx reducer', () => {
+    const appConfig = getAppConfig();
+    const tree = buildNgrxTree(appConfig);
+
+    const statePath = `${findModuleParent(appConfig.appModule)}/+state`;
+    const contents = tree.readContent(`${statePath}/user.reducer.spec.ts`);
+
+    expect(contents).toContain(`describe('userReducer', () => {`);
+    expect(contents).toContain(
+      `const action: UserLoaded = new UserLoaded({});`
+    );
+    expect(contents).toContain(
+      `const actual = userReducer(initialState, action);`
+    );
+  });
+
+  it('should produce proper specs for the ngrx reducer for a name with a dash', () => {
+    const appConfig = getAppConfig();
+    const tree = schematicRunner.runSchematic(
+      'ngrx',
+      {
+        name: 'super-user',
+        module: appConfig.appModule
+      },
+      appTree
+    );
+
+    const statePath = `${findModuleParent(appConfig.appModule)}/+state`;
+    const contents = tree.readContent(
+      `${statePath}/super-user.reducer.spec.ts`
+    );
+
+    expect(contents).toContain(`describe('superUserReducer', () => {`);
+    expect(contents).toContain(
+      `const action: SuperUserLoaded = new SuperUserLoaded({});`
+    );
+    expect(contents).toContain(
+      `const actual = superUserReducer(initialState, action);`
+    );
+  });
+
   it('should enhance the ngrx effects', () => {
     const appConfig = getAppConfig();
     const tree = buildNgrxTree(appConfig);


### PR DESCRIPTION
The file name was used for the reducer spec actual variable.

This was fine for state names that don't have a dash. But it would not be valid for names with a dash. Using the propertyName fixes this.