### PR TITLE
docs: link to DataPersistence.fetch

### DIFF
--- a/packages/nx/src/data-persistence.ts
+++ b/packages/nx/src/data-persistence.ts
@@ -32,7 +32,7 @@ export interface OptimisticUpdateOpts<T, A> {
 }
 
 /**
- * See {@link DataPersistence.navigation} for more information.
+ * See {@link DataPersistence.fetch} for more information.
  */
 export interface FetchOpts<T, A> {
   id?(a: A, state?: T): any;


### PR DESCRIPTION
Hi, I think that's a typo and FetchOpts should link to DataPersistence.fetch()