### PR TITLE
fix(schematics): filter nx specific flags from being passed to ng cli

### DIFF
--- a/e2e/schematics/command-line.test.ts
+++ b/e2e/schematics/command-line.test.ts
@@ -151,11 +151,13 @@ describe('Command line', () => {
         'npm run affected:build -- --files="libs/mylib/index.ts"'
       );
       expect(build).toContain('Building myapp');
+      expect(build).not.toContain('is not registered with the build command');
 
       const e2e = runCommand(
         'npm run affected:e2e -- --files="libs/mylib/index.ts"'
       );
       expect(e2e).toContain('should display welcome message');
+      expect(e2e).not.toContain('is not registered with the build command');
     },
     1000000
   );

--- a/e2e/schematics/command-line.test.ts
+++ b/e2e/schematics/command-line.test.ts
@@ -152,6 +152,31 @@ describe('Command line', () => {
       );
       expect(build).toContain('Building myapp');
       expect(build).not.toContain('is not registered with the build command');
+      expect(build).not.toContain('with flags:');
+
+      // Should work in parallel
+      const buildParallel = runCommand(
+        'npm run affected:build -- --files="libs/mylib/index.ts" --parallel'
+      );
+      expect(buildParallel).toContain('Building myapp');
+
+      const buildExcluded = runCommand(
+        'npm run affected:build -- --files="libs/mylib/index.ts" --exclude myapp'
+      );
+      expect(buildExcluded).toContain('No apps to build');
+
+      const buildExcludedCsv = runCommand(
+        'npm run affected:build -- --files="package.json" --exclude myapp,myapp2'
+      );
+      expect(buildExcludedCsv).toContain('No apps to build');
+
+      // affected:build should pass non-nx flags to the CLI
+      const buildWithFlags = runCommand(
+        'npm run affected:build -- --files="libs/mylib/index.ts" --stats-json'
+      );
+      expect(buildWithFlags).toContain(
+        'Building myapp with flags: --stats-json=true'
+      );
 
       const e2e = runCommand(
         'npm run affected:e2e -- --files="libs/mylib/index.ts"'

--- a/packages/schematics/src/command-line/nx.ts
+++ b/packages/schematics/src/command-line/nx.ts
@@ -17,25 +17,25 @@ yargs
     'affected:apps',
     'Print applications affected by changes',
     withAffectedOptions,
-    () => affected(['apps', ...process.argv.slice(3)])
+    args => affected('apps', args, process.argv.slice(3))
   )
   .command(
     'affected:build',
     'Build applications affected by changes',
     withAffectedOptions,
-    () => affected(['build', ...process.argv.slice(3)])
+    args => affected('build', args, process.argv.slice(3))
   )
   .command(
     'affected:e2e',
     'Test  applications affected by changes',
     withAffectedOptions,
-    () => affected(['e2e', ...process.argv.slice(3)])
+    args => affected('e2e', args, process.argv.slice(3))
   )
   .command(
     'affected:dep-graph',
     'Graph dependencies affected by changes',
     yargs => withAffectedOptions(withDepGraphOptions(yargs)),
-    () => affected(['dep-graph', ...process.argv.slice(3)])
+    args => affected('dep-graph', args, process.argv.slice(3))
   )
   .command(
     'dep-graph',
@@ -110,6 +110,11 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
     .implies('base', 'head')
     .nargs('uncommitted', 0)
     .nargs('untracked', 0)
+    .option('parallel', {
+      describe: 'Build the affected apps in parallel',
+      type: 'boolean',
+      default: false
+    })
     .conflicts({
       SHA1: ['files', 'untracked', 'uncommitted', 'base', 'head'],
       files: ['uncommitted', 'untracked', 'base', 'head'],


### PR DESCRIPTION
Currently if you run `yarn affected:build --head=HEAD --base=master`, we will pass --head and --base to `ng build`, which will show a warning. We need to filter out our parameters before invoking `ng build` or `ng e2e`. This is super annoying 😞 This fixes that

I also added the `exclude` option for affected while I was here which excludes apps from `affected:apps` `affected:build` and `affected:e2e`. Fixes #234 