### PR TITLE
fix(schematics): add fs-extra to dependencies of npm package

### DIFF
--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -33,6 +33,7 @@
     "@schematics/angular": "0.4.6",
     "@types/yargs": "^11.0.0",
     "app-root-path": "^2.0.1",
+    "fs-extra": "5.0.0",
     "graphviz": "0.0.8",
     "npm-run-all": "4.1.2",
     "opn": "^5.3.0",


### PR DESCRIPTION
Used by [workspace-schematic.ts](https://github.com/nrwl/nx/blob/master/packages/schematics/src/command-line/workspace-schematic.ts#L5)