### PR TITLE
fix(schematics): use right command to get help on ng new

### DIFF
--- a/packages/schematics/bin/create-nx-workspace.ts
+++ b/packages/schematics/bin/create-nx-workspace.ts
@@ -27,7 +27,7 @@ if (parsedArgs.help) {
       --bazel               use bazel instead of webpack (default to false)
 
       [ng new options]      any 'ng new' options
-                            run 'ng help new' for more informations
+                            run 'ng new --help' for more information
   `);
   process.exit(0);
 }


### PR DESCRIPTION
Small patch to display the correct command for getting help on `ng new`. 