### PR TITLE
fix(schematics) fix update metadata in package.json and fix migration

### DIFF
--- a/packages/schematics/migrations/legacy-migrations/20180515-switch-to-nx6.ts
+++ b/packages/schematics/migrations/legacy-migrations/20180515-switch-to-nx6.ts
@@ -34,8 +34,13 @@ export default {
         execSync('npm install', { stdio: [0, 1, 2] });
       }
 
-      execSync('ng update @angular/cli@6.0.1', { stdio: [0, 1, 2] });
-      execSync('ng update @nrwl/schematics@6.0.0', { stdio: [0, 1, 2] });
+      execSync('ng update @angular/cli --from 1.7.4 --to 6.0.1', {
+        stdio: [0, 1, 2]
+      });
+      // TODO: remove --next before releasing 6.0.0 final
+      execSync('ng update @nrwl/schematics --from 1.0.3 --to 6.0.0 --next', {
+        stdio: [0, 1, 2]
+      });
     } catch (e) {
       console.warn(stripIndents`
         The automatic upgrade to Nx 6 has failed with the following error: ${e}.

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/nrwl/nx#readme",
   "schematics": "./src/collection.json",
-  "ng-upgrade": {
+  "ng-update": {
     "requirements": {},
     "packageGroup": ["@nrwl/nx", "@nrwl/schematics"],
     "migrations": "./migrations/migrations.json"
@@ -45,6 +45,7 @@
     "npm-run-all": "4.1.2",
     "opn": "^5.3.0",
     "semver": "5.4.1",
+    "strip-json-comments": "2.0.1",
     "tmp": "0.0.33",
     "viz.js": "^1.8.1",
     "yargs-parser": "10.0.0",


### PR DESCRIPTION
Fix the commands the migration uses.

Changed it to
```sh
ng update @angular/cli --from 1.7.1 --to 6.0.1
ng update @nrwl/schematics --from 1.0.3 --to 6.0.0 --next
```
Also add missing dependency for `strip-json-comments` which
Fixes #492 

Also fix the package.json metadata for ng-**update**