### PR TITLE
Fix some issues with ng add @nrwl/schematics

### DIFF
--- a/e2e/schematics/ng-add.test.ts
+++ b/e2e/schematics/ng-add.test.ts
@@ -55,6 +55,28 @@ describe('Nrwl Convert to Nx Workspace', () => {
     // check that package.json got merged
     const updatedPackageJson = readJson('package.json');
     expect(updatedPackageJson.description).toEqual('some description');
+    expect(updatedPackageJson.scripts).toEqual({
+      ng: 'ng',
+      start: 'ng serve',
+      build: 'ng build',
+      test: 'ng test',
+      lint: './node_modules/.bin/nx lint && ng lint',
+      e2e: 'ng e2e',
+      'affected:apps': './node_modules/.bin/nx affected:apps',
+      'affected:build': './node_modules/.bin/nx affected:build',
+      'affected:e2e': './node_modules/.bin/nx affected:e2e',
+      'affected:test': './node_modules/.bin/nx affected:test',
+      'affected:dep-graph': './node_modules/.bin/nx affected:dep-graph',
+      format: './node_modules/.bin/nx format:write',
+      'format:write': './node_modules/.bin/nx format:write',
+      'format:check': './node_modules/.bin/nx format:check',
+      update: './node_modules/.bin/nx update',
+      'update:check': './node_modules/.bin/nx update:check',
+      'update:skip': './node_modules/.bin/nx update:skip',
+      'dep-graph': './node_modules/.bin/nx dep-graph',
+      'workspace-schematic': './node_modules/.bin/nx workspace-schematic',
+      help: './node_modules/.bin/nx help'
+    });
     expect(
       updatedPackageJson.devDependencies['@nrwl/schematics']
     ).toBeDefined();
@@ -65,6 +87,11 @@ describe('Nrwl Convert to Nx Workspace', () => {
     expect(
       updatedPackageJson.dependencies['@ngrx/store-devtools']
     ).toBeDefined();
+
+    expect(
+      updatedPackageJson.devDependencies['@ngrx/schematics']
+    ).toBeDefined();
+    expect(updatedPackageJson.devDependencies['@angular/cli']).toBeDefined();
 
     const nxJson = readJson('nx.json');
     expect(nxJson).toEqual({

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -39,7 +39,7 @@
     "@angular-devkit/schematics": "0.6.1",
     "@types/yargs": "^11.0.0",
     "app-root-path": "^2.0.1",
-    "cosmiconfig": "5.0.2",
+    "cosmiconfig": "4.0.0",
     "fs-extra": "6.0.0",
     "graphviz": "0.0.8",
     "npm-run-all": "4.1.2",

--- a/packages/schematics/src/collection/ng-add/index.ts
+++ b/packages/schematics/src/collection/ng-add/index.ts
@@ -17,7 +17,8 @@ import {
   prettierVersion,
   routerStoreVersion,
   schematicsVersion,
-  jasmineMarblesVersion
+  jasmineMarblesVersion,
+  ngrxSchematicsVersion
 } from '../../lib-versions';
 import * as fs from 'fs';
 import {
@@ -45,6 +46,7 @@ function updatePackageJson() {
       'affected:apps': './node_modules/.bin/nx affected:apps',
       'affected:build': './node_modules/.bin/nx affected:build',
       'affected:e2e': './node_modules/.bin/nx affected:e2e',
+      'affected:test': './node_modules/.bin/nx affected:test',
       'affected:dep-graph': './node_modules/.bin/nx affected:dep-graph',
       format: './node_modules/.bin/nx format:write',
       'format:write': './node_modules/.bin/nx format:write',
@@ -55,7 +57,7 @@ function updatePackageJson() {
       lint: './node_modules/.bin/nx lint && ng lint',
       'dep-graph': './node_modules/.bin/nx dep-graph',
       'workspace-schematic': './node_modules/.bin/nx workspace-schematic',
-      postinstall: 'echo 1'
+      help: './node_modules/.bin/nx help'
     };
     packageJson.devDependencies = packageJson.devDependencies || {};
     if (!packageJson.dependencies) {
@@ -82,15 +84,16 @@ function updatePackageJson() {
     if (!packageJson.dependencies['ngrx-store-freeze']) {
       packageJson.dependencies['ngrx-store-freeze'] = ngrxStoreFreezeVersion;
     }
+    if (!packageJson.devDependencies['@ngrx/schematics']) {
+      packageJson.devDependencies['@ngrx/schematics'] = ngrxSchematicsVersion;
+    }
     if (!packageJson.devDependencies['@nrwl/schematics']) {
       packageJson.devDependencies['@nrwl/schematics'] = schematicsVersion;
     }
-    if (!packageJson.dependencies['@angular/cli']) {
-      packageJson.dependencies['@angular/cli'] = angularCliVersion;
+    if (!packageJson.devDependencies['@angular/cli']) {
+      packageJson.devDependencies['@angular/cli'] = angularCliVersion;
     }
-    if (!packageJson.dependencies['karma']) {
-      packageJson.dependencies['karma'] = '~2.0.0';
-    }
+    packageJson.devDependencies['karma'] = '~2.0.0';
     if (!packageJson.devDependencies['jasmine-marbles']) {
       packageJson.devDependencies['jasmine-marbles'] = jasmineMarblesVersion;
     }


### PR DESCRIPTION
Theres 2 commits here that fix some issues with ng add.

Mainly, the first commit
Fixes #513.
* `cosmicconfig` `5.0.0` has a new API and it was unintentionally upgraded
* It has been downgraded to `4.0.0`

The second commit fixes some inconsistencies with the `package.json`.
* `@angular/cli` and `karma` were being added as `dependencies` while they should be `devDependencies`.
* `@ngrx/schematics` was not added to the `package.json`
* `yarn affected:test` and `yarn help` were not added to the package.json