### PR TITLE
fix(schematics) add NxModule during ng add

### DIFF
--- a/e2e/schematics/ng-add.test.ts
+++ b/e2e/schematics/ng-add.test.ts
@@ -5,7 +5,8 @@ import {
   runCLI,
   runNgNew,
   updateFile,
-  readJson
+  readJson,
+  readFile
 } from '../utils';
 
 describe('Nrwl Convert to Nx Workspace', () => {
@@ -51,6 +52,10 @@ describe('Nrwl Convert to Nx Workspace', () => {
       'apps/proj/src/main.ts',
       'apps/proj/src/app/app.module.ts'
     );
+
+    const appModuleContents = readFile('apps/proj/src/app/app.module.ts');
+    expect(appModuleContents).toContain(`import { NxModule } from '@nrwl/nx';`);
+    expect(appModuleContents).toContain(`NxModule.forRoot()`);
 
     // check that package.json got merged
     const updatedPackageJson = readJson('package.json');


### PR DESCRIPTION
This adds NxModule.forRoot() as an import in the main app module.

The resulting file looks something like this:

```ts
import { BrowserModule } from '@angular/platform-browser';
import { NgModule } from '@angular/core';

import { AppComponent } from './app.component';
import { NxModule } from '@nrwl/nx';

@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    BrowserModule,
    NxModule.forRoot()
  ],
  providers: [],
  bootstrap: [AppComponent]
})
export class AppModule { }
```