### PR TITLE
fix(schematics): allow projects without e2e configurations and report…

### DIFF
--- a/packages/schematics/src/utils/fileutils.spec.ts
+++ b/packages/schematics/src/utils/fileutils.spec.ts
@@ -1,4 +1,6 @@
-import { addApp } from './fileutils';
+import { addApp, createDirectory } from './fileutils';
+
+import * as fs from 'fs';
 
 describe('fileutils', () => {
   describe('sortApps', () => {
@@ -36,6 +38,29 @@ describe('fileutils', () => {
         { name: 'a' },
         { name: 'c' }
       ]);
+    });
+  });
+
+  describe('createDirectory', () => {
+    let fakeExistingDirectories: Set<string>;
+
+    beforeEach(() => {
+      fakeExistingDirectories = new Set<string>();
+      fakeExistingDirectories.add('/a');
+      spyOn(fs, 'mkdirSync').and.callFake(path => {
+        fakeExistingDirectories.add(path);
+      });
+      spyOn(fs, 'statSync').and.callFake(path => {
+        return {
+          isDirectory: () => fakeExistingDirectories.has(path)
+        };
+      });
+    });
+
+    it('should recursively create the directory', () => {
+      createDirectory('/a/b/c');
+      const expectedSet = new Set<string>(['/a', '/a/b', '/a/b/c']);
+      expect(fakeExistingDirectories).toEqual(expectedSet);
     });
   });
 });

--- a/packages/schematics/src/utils/fileutils.ts
+++ b/packages/schematics/src/utils/fileutils.ts
@@ -71,8 +71,35 @@ function directoryExists(name) {
   }
 }
 
-export function createDirectory(name: string) {
-  if (!directoryExists(name)) {
-    fs.mkdirSync(name);
+export function createDirectory(directoryPath: string) {
+  const parentPath = path.resolve(directoryPath, '..');
+  if (!directoryExists(parentPath)) {
+    createDirectory(parentPath);
+  }
+  if (!directoryExists(directoryPath)) {
+    fs.mkdirSync(directoryPath);
+  }
+}
+
+export function renameSync(
+  from: string,
+  to: string,
+  cb: (err: Error | null) => void
+) {
+  try {
+    if (!fs.existsSync(from)) {
+      throw new Error(`Path: ${from} does not exist`);
+    } else if (fs.existsSync(to)) {
+      throw new Error(`Path: ${to} already exists`);
+    }
+
+    // Make sure parent path exists
+    const parentPath = path.resolve(to, '..');
+    createDirectory(parentPath);
+
+    fs.renameSync(from, to);
+    cb(null);
+  } catch (e) {
+    cb(e);
   }
 }


### PR DESCRIPTION
… more useful errors during add and update

* Workspaces which did not specify e2e projects properly were failing the update. This change allows projects which legitimately do not have e2e tests to succeed the update.
* There's a new recursive `createDirectory` function.
* There is also a new `renameSync` method in `fileutils` which has more enforceable error handling. The error callback is a required parameter. As such, a lot more error handling is happening now :+1: .
  * Thank you @mrmeku for proposing this.

* Also discovered `context.logger` :sunglasses: 

Fixes yarn update for projects with no e2e tests

Fixes #570

Example warning:
![image](https://user-images.githubusercontent.com/8104246/40855478-b3a830b8-65a2-11e8-86a5-dff0193cb523.png)
