### PR TITLE
fix(schematics): add rxjs-compat during ng-add

### DIFF
--- a/e2e/schematics/ng-add.test.ts
+++ b/e2e/schematics/ng-add.test.ts
@@ -14,7 +14,6 @@ describe('Nrwl Convert to Nx Workspace', () => {
 
   it('should generate a workspace', () => {
     runNgNew();
-    copyMissingPackages();
 
     // update package.json
     const packageJson = readJson('package.json');
@@ -33,10 +32,12 @@ describe('Nrwl Convert to Nx Workspace', () => {
     tsconfigJson.compilerOptions.paths = { a: ['b'] };
     updateFile('tsconfig.json', JSON.stringify(tsconfigJson, null, 2));
 
+    updateFile('src/scripts.ts', '');
+
     // update angular-cli.json
     const angularCLIJson = readJson('angular.json');
-    angularCLIJson.projects.proj.architect.build.options.scripts = [
-      'node_modules/x.js'
+    angularCLIJson.projects.proj.architect.build.options.scripts = angularCLIJson.projects.proj.architect.test.options.scripts = [
+      'src/scripts.ts'
     ];
     angularCLIJson.projects.proj.architect.test.options.styles = [
       'src/styles.css'
@@ -44,7 +45,8 @@ describe('Nrwl Convert to Nx Workspace', () => {
     updateFile('angular.json', JSON.stringify(angularCLIJson, null, 2));
 
     // run the command
-    runCLI('add @nrwl/schematics --npmScope projscope --skip-install');
+    runCLI('add @nrwl/schematics --npmScope projscope');
+    copyMissingPackages();
 
     // check that prettier config exits and that files have been moved!
     checkFilesExist(
@@ -93,6 +95,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
     expect(
       updatedPackageJson.dependencies['@ngrx/store-devtools']
     ).toBeDefined();
+    expect(updatedPackageJson.dependencies['rxjs-compat']).toBeDefined();
 
     expect(
       updatedPackageJson.devDependencies['@ngrx/schematics']
@@ -129,7 +132,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
         tsConfig: 'apps/proj/tsconfig.app.json',
         assets: ['apps/proj/src/favicon.ico', 'apps/proj/src/assets'],
         styles: ['apps/proj/src/styles.css'],
-        scripts: ['node_modules/x.js']
+        scripts: ['apps/proj/src/scripts.ts']
       },
       configurations: {
         production: {
@@ -171,7 +174,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
         tsConfig: 'apps/proj/tsconfig.spec.json',
         karmaConfig: 'apps/proj/karma.conf.js',
         styles: ['apps/proj/src/styles.css'],
-        scripts: [],
+        scripts: ['apps/proj/src/scripts.ts'],
         assets: ['apps/proj/src/favicon.ico', 'apps/proj/src/assets']
       }
     });
@@ -211,6 +214,9 @@ describe('Nrwl Convert to Nx Workspace', () => {
       a: ['b'],
       '@projscope/*': ['libs/*']
     });
+
+    runCLI('build --prod --outputHashing none');
+    checkFilesExist('dist/apps/proj/main.js');
   });
 
   it('should generate a workspace and not change dependencies or devDependencies if they already exist', () => {
@@ -244,7 +250,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
     );
   });
 
-  xit('should generate a workspace from a universal cli project', () => {
+  it('should generate a workspace from a universal cli project', () => {
     // create a new AngularCLI app
     runNgNew();
 
@@ -252,7 +258,8 @@ describe('Nrwl Convert to Nx Workspace', () => {
     runCLI('generate universal --client-project proj');
 
     // Add @nrwl/schematics
-    runCLI('add @nrwl/schematics --npmScope projscope --skip-install');
+    runCLI('add @nrwl/schematics --npmScope projscope');
+    copyMissingPackages();
 
     checkFilesExist('apps/proj/tsconfig.server.json');
 

--- a/packages/schematics/src/collection/ng-add/index.ts
+++ b/packages/schematics/src/collection/ng-add/index.ts
@@ -18,7 +18,8 @@ import {
   routerStoreVersion,
   schematicsVersion,
   jasmineMarblesVersion,
-  ngrxSchematicsVersion
+  ngrxSchematicsVersion,
+  rxjsVersion
 } from '../../lib-versions';
 import * as fs from 'fs';
 import * as ts from 'typescript';
@@ -92,6 +93,9 @@ function updatePackageJson() {
     }
     if (!packageJson.dependencies['ngrx-store-freeze']) {
       packageJson.dependencies['ngrx-store-freeze'] = ngrxStoreFreezeVersion;
+    }
+    if (!packageJson.dependencies['rxjs-compat']) {
+      packageJson.dependencies['rxjs-compat'] = rxjsVersion;
     }
     if (!packageJson.devDependencies['@ngrx/schematics']) {
       packageJson.devDependencies['@ngrx/schematics'] = ngrxSchematicsVersion;


### PR DESCRIPTION
@ngrx 5.x still needs `rxjs-compat` so this needs to be added when we add `@nrwl/schematics` to a project.

This should work
```sh
ng new newproj
cd newproj
ng add @nrwl/schematics
ng build --prod
```

Fixes #567