### PR TITLE
feat(schematics): add implicit dependencies

### DIFF
--- a/packages/schematics/src/command-line/affected-apps.spec.ts
+++ b/packages/schematics/src/command-line/affected-apps.spec.ts
@@ -338,6 +338,9 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             type: ProjectType.lib
           }
         ],
+        {
+          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+        },
         file => {
           switch (file) {
             case 'app1.ts':
@@ -387,6 +390,9 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             type: ProjectType.lib
           }
         ],
+        {
+          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+        },
         file => {
           switch (file) {
             case 'app1.ts':
@@ -418,6 +424,9 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             type: ProjectType.app
           }
         ],
+        {
+          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+        },
         file => {
           switch (file) {
             case 'one/app1.ts':
@@ -453,6 +462,9 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             type: ProjectType.app
           }
         ],
+        {
+          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+        },
         file => {
           switch (file) {
             case 'app1.ts':
@@ -471,6 +483,9 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
   describe('touchedProjects', () => {
     it('should return the list of touchedProjects', () => {
       const tp = touchedProjects(
+        {
+          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+        },
         [
           {
             name: 'app1Name',
@@ -508,7 +523,53 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
         ['lib2.ts', 'app2.ts', 'package.json']
       );
 
-      expect(tp).toEqual(['lib2Name', 'app2Name', null]);
+      expect(tp).toEqual(['lib2Name', 'app2Name', 'app1Name', 'lib1Name']);
+    });
+
+    it('should return the list of implicitly touched projects', () => {
+      const tp = touchedProjects(
+        {
+          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name'],
+          Jenkinsfile: ['app1Name', 'app2Name']
+        },
+        [
+          {
+            name: 'app1Name',
+            root: 'apps/app1',
+            files: ['app1.ts'],
+            tags: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'app2Name',
+            root: 'apps/app2',
+            files: ['app2.ts'],
+            tags: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'lib1Name',
+            root: 'libs/lib1',
+            files: ['lib1.ts'],
+            tags: [],
+            architect: {},
+            type: ProjectType.lib
+          },
+          {
+            name: 'lib2Name',
+            root: 'libs/lib2',
+            files: ['lib2.ts'],
+            tags: [],
+            architect: {},
+            type: ProjectType.lib
+          }
+        ],
+        ['Jenkinsfile']
+      );
+
+      expect(tp).toEqual(['app1Name', 'app2Name']);
     });
   });
 });

--- a/packages/schematics/src/command-line/shared.spec.ts
+++ b/packages/schematics/src/command-line/shared.spec.ts
@@ -1,0 +1,153 @@
+import { getImplicitDependencies, assertWorkspaceValidity } from './shared';
+
+describe('assertWorkspaceValidity', () => {
+  let mockNxJson;
+  let mockAngularJson;
+
+  beforeEach(() => {
+    mockNxJson = {
+      projects: {
+        app1: {
+          tags: []
+        },
+        'app1-e2e': {
+          tags: []
+        },
+        app2: {
+          tags: []
+        },
+        'app2-e2e': {
+          tags: []
+        },
+        lib1: {
+          tags: []
+        },
+        lib2: {
+          tags: []
+        }
+      }
+    };
+    mockAngularJson = {
+      projects: {
+        app1: {},
+        'app1-e2e': {},
+        app2: {},
+        'app2-e2e': {},
+        lib1: {},
+        lib2: {}
+      }
+    };
+  });
+
+  it('should not throw for a valid workspace', () => {
+    assertWorkspaceValidity(mockAngularJson, mockNxJson);
+  });
+
+  it('should throw for a missing project in angular.json', () => {
+    delete mockAngularJson.projects.app1;
+    try {
+      assertWorkspaceValidity(mockAngularJson, mockNxJson);
+      fail('Did not throw');
+    } catch (e) {
+      expect(e.message).toContain('projects are missing in angular.json');
+    }
+  });
+
+  it('should throw for a missing project in nx.json', () => {
+    delete mockNxJson.projects.app1;
+    try {
+      assertWorkspaceValidity(mockAngularJson, mockNxJson);
+      fail('Did not throw');
+    } catch (e) {
+      expect(e.message).toContain('projects are missing in nx.json');
+    }
+  });
+
+  it('should throw for an invalid implicit dependency', () => {
+    mockNxJson.implicitDependencies = {
+      'README.md': ['invalidproj']
+    };
+    try {
+      assertWorkspaceValidity(mockAngularJson, mockNxJson);
+      fail('Did not throw');
+    } catch (e) {
+      expect(e.message).toContain(
+        'implicitDependencies specified in nx.json are invalid'
+      );
+      expect(e.message).toContain('  README.md');
+      expect(e.message).toContain('    invalidproj');
+    }
+  });
+});
+
+describe('getImplicitDependencies', () => {
+  let mockNxJson;
+  let mockAngularJson;
+
+  beforeEach(() => {
+    mockNxJson = {
+      projects: {
+        app1: {
+          tags: []
+        },
+        'app1-e2e': {
+          tags: []
+        },
+        app2: {
+          tags: []
+        },
+        'app2-e2e': {
+          tags: []
+        },
+        lib1: {
+          tags: []
+        },
+        lib2: {
+          tags: []
+        }
+      }
+    };
+    mockAngularJson = {
+      projects: {
+        app1: {},
+        'app1-e2e': {},
+        app2: {},
+        'app2-e2e': {},
+        lib1: {},
+        lib2: {}
+      }
+    };
+  });
+
+  it('should return implicit dependencies', () => {
+    mockNxJson.implicitDependencies = {
+      Jenkinsfile: ['app1', 'app2']
+    };
+
+    const result = getImplicitDependencies(mockAngularJson, mockNxJson);
+
+    expect(result).toEqual({
+      Jenkinsfile: ['app1', 'app2']
+    });
+  });
+
+  it('should normalize wildcards into all projects', () => {
+    mockNxJson.implicitDependencies = {
+      'package.json': '*'
+    };
+
+    const result = getImplicitDependencies(mockAngularJson, mockNxJson);
+
+    expect(result).toEqual({
+      'package.json': ['app1', 'app1-e2e', 'app2', 'app2-e2e', 'lib1', 'lib2']
+    });
+  });
+
+  it('should call throw for an invalid workspace', () => {
+    delete mockNxJson.projects.app1;
+    try {
+      getImplicitDependencies(mockAngularJson, mockNxJson);
+      fail('did not throw');
+    } catch (e) {}
+  });
+});


### PR DESCRIPTION
### Current Behavior

Edits to files outside of projects current "affect" all projects as they are assumed to be implicitly depended upon by all projects.

### Expected Behavior
![image](https://user-images.githubusercontent.com/8104246/40855278-30ab83e0-65a2-11e8-88b8-816041db3548.png)

Building _all_ projects takes a looooong time so there should be a way to avoid this if appropriate.

This can be done by specifying **implicitDependencies** in `nx.json`. :tada: 
* Files like `package.json`, probably really do affect every project and can be noted with `'*'`
* Files like `Jenkinsfile`, probably only affect apps and can be noted with `['app1', 'app2']`.
* Files like `README.md`, probably does not affect any project at all and can be left out of the config