### PR TITLE
feat(schematics) add migration to add affected:lint npm script

### DIFF
--- a/packages/schematics/migrations/migrations.json
+++ b/packages/schematics/migrations/migrations.json
@@ -2,8 +2,13 @@
   "schematics": {
     "update-to-6.0.0": {
       "version": "6",
-      "description": " ",
+      "description": "Update to Angular CLI 6 and Nx6",
       "factory": "./update-6-0-0/update-6-0-0"
+    },
+    "update-to-6.0.5": {
+      "version": "6.0.5",
+      "description": "Add affected:lint npm script",
+      "factory": "./update-6-0-5/update-6-0-5"
     }
   }
 }

--- a/packages/schematics/migrations/update-6-0-5/update-6-0-5.ts
+++ b/packages/schematics/migrations/update-6-0-5/update-6-0-5.ts
@@ -1,0 +1,15 @@
+import {
+  Rule,
+  Tree,
+  SchematicContext,
+  chain
+} from '@angular-devkit/schematics';
+import { updateJsonInTree } from '../../src/utils/ast-utils';
+
+export default function(): Rule {
+  return updateJsonInTree('package.json', packageJson => {
+    packageJson.scripts['affected:lint'] =
+      './node_modules/.bin/nx affected:lint';
+    return packageJson;
+  });
+}


### PR DESCRIPTION
### Current Behavior

No migration to add `yarn affected:lint`

### Expected Behavior

1. User has `6.0.n` where `n` is less than `5` installed.
2. `ng update @nrwl/schematics`

User is updated to the latest version of `@nrwl/schematics` and `package.json` should have a `affected:lint` npm script