### PR TITLE
feat(schematics) isolate projects which failed a command to rerun

### DIFF
--- a/e2e/schematics/command-line.test.ts
+++ b/e2e/schematics/command-line.test.ts
@@ -7,7 +7,8 @@ import {
   readJson,
   runCLI,
   runCommand,
-  updateFile
+  updateFile,
+  exists
 } from '../utils';
 
 describe('Command line', () => {
@@ -208,6 +209,47 @@ describe('Command line', () => {
         'npm run affected:test -- --files="libs/mylib/src/index.ts"'
       );
       expect(unitTests).toContain('Testing mylib, myapp');
+
+      // Fail a Unit Test
+      updateFile(
+        'apps/myapp/src/app/app.component.spec.ts',
+        readFile('apps/myapp/src/app/app.component.spec.ts').replace(
+          '.toEqual(1)',
+          '.toEqual(2)'
+        )
+      );
+
+      const failedTests = runCommand(
+        'npm run affected:test -- --files="libs/mylib/src/index.ts"'
+      );
+
+      expect(failedTests).toContain('Testing mylib, myapp');
+      expect(failedTests).toContain('Failed projects: myapp');
+      expect(failedTests).toContain(
+        'You can isolate the above projects by passing --only-failed'
+      );
+      expect(readJson('.nx-results')).toEqual({
+        command: 'test',
+        results: {
+          myapp: false,
+          mylib: true
+        }
+      });
+
+      // Fix failing Unit Test
+      updateFile(
+        'apps/myapp/src/app/app.component.spec.ts',
+        readFile('apps/myapp/src/app/app.component.spec.ts').replace(
+          '.toEqual(2)',
+          '.toEqual(1)'
+        )
+      );
+
+      const isolatedTests = runCommand(
+        'npm run affected:test -- --files="libs/mylib/src/index.ts" --only-failed'
+      );
+      expect(isolatedTests).toContain('Testing myapp');
+      expect(exists('.nx-results')).toBe(false);
 
       const linting = runCommand(
         'npm run affected:lint -- --files="libs/mylib/src/index.ts"'

--- a/packages/schematics/src/command-line/affected.ts
+++ b/packages/schematics/src/command-line/affected.ts
@@ -21,6 +21,7 @@ import {
 } from '@nrwl/schematics/src/command-line/affected-apps';
 import { GlobalNxArgs } from './nx';
 import * as yargs from 'yargs';
+import { WorkspaceResults } from './workspace-results';
 
 export interface YargsAffectedOptions extends yargs.Arguments {}
 
@@ -34,6 +35,9 @@ export interface AffectedOptions extends GlobalNxArgs {
   head: string;
   exclude: string[];
   files: string[];
+  onlyFailed: boolean;
+  'only-failed': boolean;
+  'max-parallel': boolean;
 }
 
 export function affected(
@@ -45,28 +49,42 @@ export function affected(
   let e2eProjects: string[];
   let projects: string[];
   let rest: string[];
+  const workspaceResults = new WorkspaceResults(command);
 
   try {
     if (parsedArgs.all) {
       rest = args;
       apps = getAllAppNames().filter(app => !parsedArgs.exclude.includes(app));
-      e2eProjects = getAllE2ENames();
+      e2eProjects = getAllE2ENames().filter(
+        app => !parsedArgs.exclude.includes(app)
+      );
       projects = getAllProjectNames().filter(
         project => !parsedArgs.exclude.includes(project)
       );
     } else {
       const p = parseFiles(args);
       rest = p.rest;
-      apps = getAffectedApps(p.files).filter(
-        app => !parsedArgs.exclude.includes(app)
-      );
-      e2eProjects = getAffectedE2e(p.files);
-      projects = getAffectedProjects(p.files).filter(
-        project => !parsedArgs.exclude.includes(project)
-      );
+      apps = getAffectedApps(p.files)
+        .filter(project => !parsedArgs.exclude.includes(project))
+        .filter(
+          project =>
+            !parsedArgs.onlyFailed || !workspaceResults.getResult(project)
+        );
+      e2eProjects = getAffectedE2e(p.files)
+        .filter(project => !parsedArgs.exclude.includes(project))
+        .filter(
+          project =>
+            !parsedArgs.onlyFailed || !workspaceResults.getResult(project)
+        );
+      projects = getAffectedProjects(p.files)
+        .filter(project => !parsedArgs.exclude.includes(project))
+        .filter(
+          project =>
+            !parsedArgs.onlyFailed || !workspaceResults.getResult(project)
+        );
     }
   } catch (e) {
-    printError(command, e);
+    printError(e);
     process.exit(1);
   }
 
@@ -75,16 +93,16 @@ export function affected(
       console.log(apps.join(' '));
       break;
     case 'build':
-      build(apps, parsedArgs);
+      build(apps, parsedArgs, workspaceResults);
       break;
     case 'test':
-      test(projects, parsedArgs);
+      test(projects, parsedArgs, workspaceResults);
       break;
     case 'lint':
-      lint(projects, parsedArgs);
+      lint(projects, parsedArgs, workspaceResults);
       break;
     case 'e2e':
-      e2e(e2eProjects, parsedArgs);
+      e2e(e2eProjects, parsedArgs, workspaceResults);
       break;
     case 'dep-graph':
       generateGraph(yargsParser(rest), projects);
@@ -92,11 +110,15 @@ export function affected(
   }
 }
 
-function printError(command: string, e: any) {
+function printError(e: any) {
   console.error(e.message);
 }
 
-function build(apps: string[], parsedArgs: YargsAffectedOptions) {
+function build(
+  apps: string[],
+  parsedArgs: YargsAffectedOptions,
+  workspaceResults: WorkspaceResults
+) {
   if (apps.length > 0) {
     const normalizedArgs = filterNxSpecificArgs(parsedArgs);
     let message = `Building ${apps.join(', ')}`;
@@ -110,6 +132,7 @@ function build(apps: string[], parsedArgs: YargsAffectedOptions) {
       apps,
       parsedArgs,
       normalizedArgs,
+      workspaceResults,
       'Building ',
       'Build succeeded.',
       'Build failed.'
@@ -119,7 +142,11 @@ function build(apps: string[], parsedArgs: YargsAffectedOptions) {
   }
 }
 
-function test(projects: string[], parsedArgs: YargsAffectedOptions) {
+function test(
+  projects: string[],
+  parsedArgs: YargsAffectedOptions,
+  workspaceResults: WorkspaceResults
+) {
   const depGraph = readDepGraph();
   const sortedProjects = topologicallySortProjects(depGraph);
   const sortedAffectedProjects = sortedProjects.filter(
@@ -146,6 +173,7 @@ function test(projects: string[], parsedArgs: YargsAffectedOptions) {
       projectsToTest,
       parsedArgs,
       normalizedArgs,
+      workspaceResults,
       'Testing ',
       'Tests passed.',
       'Tests failed.'
@@ -155,7 +183,11 @@ function test(projects: string[], parsedArgs: YargsAffectedOptions) {
   }
 }
 
-function lint(projects: string[], parsedArgs: YargsAffectedOptions) {
+function lint(
+  projects: string[],
+  parsedArgs: YargsAffectedOptions,
+  workspaceResults: WorkspaceResults
+) {
   const depGraph = readDepGraph();
   const sortedProjects = topologicallySortProjects(depGraph);
   const sortedAffectedProjects = sortedProjects.filter(
@@ -179,6 +211,7 @@ function lint(projects: string[], parsedArgs: YargsAffectedOptions) {
       projectsToLint,
       parsedArgs,
       normalizedArgs,
+      workspaceResults,
       'Linting ',
       'Linting passed.',
       'Linting failed.'
@@ -188,46 +221,81 @@ function lint(projects: string[], parsedArgs: YargsAffectedOptions) {
   }
 }
 
-function runCommand(
+async function runCommand(
   command: string,
   projects: string[],
   parsedArgs: YargsAffectedOptions,
   args: string[],
+  workspaceResults: WorkspaceResults,
   iterationMessage: string,
   successMessage: string,
   errorMessage: string
 ) {
   if (parsedArgs.parallel) {
-    runAll(
-      projects.map(
-        app => `ng ${command} -- ${args.join(' ')} --project=${app}`
-      ),
-      {
-        parallel: parsedArgs.parallel,
-        maxParallel: parsedArgs.maxParallel,
-        stdin: process.stdin,
-        stdout: process.stdout,
-        stderr: process.stderr
-      }
-    )
-      .then(() => {
-        console.log(successMessage);
-        process.exit(0);
-      })
-      .catch(err => {
-        console.error(errorMessage);
-        process.exit(1);
-      });
-  } else {
-    projects.forEach(project => {
-      console.log(iterationMessage + project);
-      execSync(
-        `node ${ngPath()} ${command} ${args.join(' ')} --project=${project}`,
+    try {
+      await runAll(
+        projects.map(
+          app => `ng ${command} -- ${args.join(' ')} --project=${app}`
+        ),
         {
-          stdio: [0, 1, 2]
+          parallel: parsedArgs.parallel,
+          maxParallel: parsedArgs.maxParallel,
+          continueOnError: true,
+          stdin: process.stdin,
+          stdout: process.stdout,
+          stderr: process.stderr
         }
       );
+      projects.forEach(project => {
+        workspaceResults.success(project);
+      });
+    } catch (e) {
+      e.results.forEach((result, i) => {
+        if (result.code === 0) {
+          workspaceResults.success(projects[i]);
+        } else {
+          workspaceResults.fail(projects[i]);
+        }
+      });
+    }
+    workspaceResults.saveResults();
+    workspaceResults.printResults(
+      parsedArgs.onlyFailed,
+      successMessage,
+      errorMessage
+    );
+
+    if (workspaceResults.hasFailure) {
+      process.exit(1);
+    }
+  } else {
+    let failedProjects = [];
+    projects.forEach(project => {
+      console.log(iterationMessage + project);
+      try {
+        execSync(
+          `node ${ngPath()} ${command} ${args.join(' ')} --project=${project}`,
+          {
+            stdio: [0, 1, 2]
+          }
+        );
+        workspaceResults.success(project);
+      } catch (e) {
+        failedProjects.push(project);
+        workspaceResults.fail(project);
+      }
     });
+
+    workspaceResults.saveResults();
+    workspaceResults.printResults(
+      parsedArgs.onlyFailed,
+      successMessage,
+      errorMessage
+    );
+
+    if (workspaceResults.hasFailure) {
+      process.exit(1);
+    }
   }
 }
 
@@ -254,15 +322,35 @@ function topologicallySortProjects(deps: DepGraph): string[] {
   return res;
 }
 
-function e2e(apps: string[], parsedArgs: YargsAffectedOptions) {
+function e2e(
+  apps: string[],
+  parsedArgs: YargsAffectedOptions,
+  workspaceResults: WorkspaceResults
+) {
   if (apps.length > 0) {
     const args = filterNxSpecificArgs(parsedArgs);
     console.log(`Testing ${apps.join(', ')}`);
     apps.forEach(app => {
-      execSync(`node ${ngPath()} e2e ${args.join(' ')} --project=${app}`, {
-        stdio: [0, 1, 2]
-      });
+      try {
+        execSync(`node ${ngPath()} e2e ${args.join(' ')} --project=${app}`, {
+          stdio: [0, 1, 2]
+        });
+        workspaceResults.success(app);
+      } catch (e) {
+        workspaceResults.fail(app);
+      }
     });
+
+    workspaceResults.saveResults();
+    workspaceResults.printResults(
+      parsedArgs.onlyFailed,
+      'E2E Tests passed.',
+      'E2E Tests failed.'
+    );
+
+    if (workspaceResults.hasFailure) {
+      process.exit(1);
+    }
   } else {
     console.log('No apps to test');
   }
@@ -311,6 +399,9 @@ function ngPath() {
 const dummyOptions: AffectedOptions = {
   parallel: false,
   maxParallel: 3,
+  'max-parallel': false,
+  onlyFailed: false,
+  'only-failed': false,
   untracked: false,
   uncommitted: false,
   help: false,

--- a/packages/schematics/src/command-line/nx.ts
+++ b/packages/schematics/src/command-line/nx.ts
@@ -136,6 +136,11 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
       coerce: parseCSV,
       default: []
     })
+    .options('only-failed', {
+      describe: 'Isolate projects which previously failed',
+      type: 'boolean',
+      default: false
+    })
     .conflicts({
       files: ['uncommitted', 'untracked', 'base', 'head', 'all'],
       untracked: ['uncommitted', 'files', 'base', 'head', 'all'],

--- a/packages/schematics/src/command-line/workspace-results.spec.ts
+++ b/packages/schematics/src/command-line/workspace-results.spec.ts
@@ -1,0 +1,145 @@
+import * as fs from 'fs';
+
+import { WorkspaceResults } from './workspace-results';
+import { serializeJson } from '../utils/fileutils';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+
+describe('WorkspacesResults', () => {
+  let results: WorkspaceResults;
+
+  beforeEach(() => {
+    results = new WorkspaceResults('test');
+  });
+
+  it('should be instantiable', () => {
+    expect(results).toBeTruthy();
+  });
+
+  it('should default with no failed projects', () => {
+    expect(results.hasFailure).toBe(false);
+  });
+
+  describe('success', () => {
+    it('should return true when getting results', () => {
+      results.success('proj');
+
+      expect(results.getResult('proj')).toBe(true);
+    });
+
+    it('should remove results from file system', () => {
+      spyOn(fs, 'writeSync');
+      spyOn(fs, 'unlinkSync');
+      spyOn(fs, 'existsSync').and.returnValue(true);
+
+      results.success('proj');
+      results.saveResults();
+
+      expect(fs.writeSync).not.toHaveBeenCalled();
+      expect(fs.unlinkSync).toHaveBeenCalledWith('.nx-results');
+    });
+
+    it('should print results', () => {
+      results.success('proj');
+      spyOn(console, 'log');
+
+      results.printResults(false, 'Success', 'Fail');
+
+      expect(console.log).toHaveBeenCalledWith('Success');
+    });
+
+    it('should tell warn the user that not all tests were run', () => {
+      (<any>results).startedWithFailedProjects = true;
+      results.success('proj');
+      spyOn(console, 'warn');
+
+      results.printResults(true, 'Success', 'Fail');
+
+      expect(console.warn).toHaveBeenCalledWith(stripIndents`
+          Warning: Only failed affected projects were run.
+          You should run above command WITHOUT --only-failed
+        `);
+    });
+  });
+
+  describe('fail', () => {
+    it('should return false when getting results', () => {
+      results.fail('proj');
+
+      expect(results.getResult('proj')).toBe(false);
+    });
+
+    it('should save results to file system', () => {
+      spyOn(fs, 'writeFileSync');
+
+      results.fail('proj');
+      results.saveResults();
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '.nx-results',
+        serializeJson({
+          command: 'test',
+          results: {
+            proj: false
+          }
+        })
+      );
+    });
+
+    it('should print results', () => {
+      results.fail('proj');
+      spyOn(console, 'error');
+
+      results.printResults(true, 'Success', 'Fail');
+
+      expect(console.error).toHaveBeenCalledWith('Fail');
+    });
+
+    it('should tell warn the user that not all tests were run', () => {
+      results.fail('proj');
+      spyOn(console, 'log');
+
+      results.printResults(false, 'Success', 'Fail');
+
+      expect(console.log).toHaveBeenCalledWith(
+        `You can isolate the above projects by passing --only-failed`
+      );
+    });
+  });
+
+  describe('when results already exist', () => {
+    beforeEach(() => {
+      spyOn(fs, 'existsSync').and.returnValue(true);
+    });
+
+    it('should read existing results', () => {
+      spyOn(fs, 'readFileSync').and.returnValue(
+        serializeJson({
+          command: 'test',
+          results: {
+            proj: false
+          }
+        })
+      );
+
+      results = new WorkspaceResults('test');
+
+      expect(fs.readFileSync).toHaveBeenCalledWith('.nx-results', 'utf-8');
+      expect(results.getResult('proj')).toBe(false);
+    });
+
+    it('should not read the existing results when the previous command was different', () => {
+      spyOn(fs, 'readFileSync').and.returnValue(
+        serializeJson({
+          command: 'test',
+          results: {
+            proj: false
+          }
+        })
+      );
+
+      results = new WorkspaceResults('build');
+
+      expect(results.getResult('proj')).toBeUndefined();
+    });
+  });
+});

--- a/packages/schematics/src/command-line/workspace-results.ts
+++ b/packages/schematics/src/command-line/workspace-results.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import { readJsonFile, writeJsonFile } from '../utils/fileutils';
+import { unlinkSync } from 'fs';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+
+const RESULTS_FILE = '.nx-results';
+
+interface NxResults {
+  command: string;
+  results: { [key: string]: boolean };
+}
+
+export class WorkspaceResults {
+  private startedWithFailedProjects: boolean;
+  private commandResults: NxResults = {
+    command: this.command,
+    results: {}
+  };
+
+  private get failedProjects() {
+    return Object.entries(this.commandResults.results)
+      .filter(([_, result]) => !result)
+      .map(([project]) => project);
+  }
+
+  public get hasFailure() {
+    return Object.values(this.commandResults.results).some(result => !result);
+  }
+
+  constructor(private command: string) {
+    const resultsExists = fs.existsSync(RESULTS_FILE);
+    if (!resultsExists) {
+      this.startedWithFailedProjects = false;
+    } else {
+      const commandResults = readJsonFile(RESULTS_FILE);
+      this.startedWithFailedProjects = commandResults.command === command;
+
+      if (this.startedWithFailedProjects) {
+        this.commandResults = commandResults;
+      }
+    }
+  }
+
+  getResult(projectName: string): boolean {
+    return this.commandResults.results[projectName];
+  }
+
+  fail(projectName: string) {
+    this.setResult(projectName, false);
+  }
+
+  success(projectName: string) {
+    this.setResult(projectName, true);
+  }
+
+  saveResults() {
+    if (Object.values<boolean>(this.commandResults.results).includes(false)) {
+      writeJsonFile(RESULTS_FILE, this.commandResults);
+    } else if (fs.existsSync(RESULTS_FILE)) {
+      unlinkSync(RESULTS_FILE);
+    }
+  }
+
+  printResults(
+    onlyFailed: boolean,
+    successMessage: string,
+    failureMessage: string
+  ) {
+    const failedProjects = this.failedProjects;
+    if (this.failedProjects.length === 0) {
+      console.log(successMessage);
+      if (onlyFailed && this.startedWithFailedProjects) {
+        console.warn(stripIndents`
+          Warning: Only failed affected projects were run.
+          You should run above command WITHOUT --only-failed
+        `);
+      }
+    } else {
+      console.error(failureMessage);
+      console.log(`Failed projects: ${failedProjects.join(',')}`);
+      if (!onlyFailed && !this.startedWithFailedProjects) {
+        console.log(
+          `You can isolate the above projects by passing --only-failed`
+        );
+      }
+    }
+  }
+
+  private setResult(projectName: string, result: boolean) {
+    this.commandResults.results[projectName] = result;
+  }
+}

--- a/packages/schematics/src/utils/fileutils.ts
+++ b/packages/schematics/src/utils/fileutils.ts
@@ -16,7 +16,7 @@ export function writeToFile(path: string, str: string) {
 export function updateJsonFile(path: string, callback: (a: any) => any) {
   const json = readJsonFile(path);
   callback(json);
-  writeToFile(path, serializeJson(json));
+  writeJsonFile(path, json);
 }
 
 export function addApp(apps: any[] | undefined, newApp: any): any[] {
@@ -49,6 +49,10 @@ export function serializeJson(json: any): string {
  */
 export function readJsonFile(path: string) {
   return JSON.parse(fs.readFileSync(path, 'utf-8'));
+}
+
+export function writeJsonFile(path: string, json: any) {
+  writeToFile(path, serializeJson(json));
 }
 
 export function readCliConfigFile(): any {


### PR DESCRIPTION
In development, when tests or other commands fail (lint, build, e2e), most of the time, it is desirable to rerun only the ones which failed without running the ones that previously passed. The assumption is that hopefully, the projects which previously passed, will stay passing. However, that assumption should be validated when all the previously failing projects are fixed. Here's how that flow would go.

Dev is testing a workspace
```sh
yarn affected:test --base master --head HEAD #Everything affected is tested
# Lib1, App1 fails
# A file is stored in the workspace
# Developer makes changes
yarn affected:test --base master --head HEAD --only-failed #--only-failed is added to isolate the previously failing ones: Lib1 and App1
# Lib1 is fixed, App1 still fails :(
# Developer makes changes
yarn affected:test --base master --head HEAD --only-failed # Only tests App1
# App1 is fixed :)
# Developer is notified to now rerun all the tests
yarn affected:test --base master --head HEAD # Hurray everything passes
```

* This would work for all commands.
* This would work on CI if different environments for each PR is used.
  * The --only-failed ones run first and if it fails, it would fail faster
  * Then, finally, all the tests are run

Implementation Details/ Questions
* A file is stored
  * When all of the tests pass, this file is deleted 
  * Currently it is not ignored and not checked in
  * Theoretically, if the developer switches branches, they can check in the file to save their progress to come back later
  * When a new command is run (user is testing, then they build), the state is reset.