### PR TITLE
feat(schematics) add migration for implicitDependencies

### DIFF
--- a/e2e/schematics/command-line.test.ts
+++ b/e2e/schematics/command-line.test.ts
@@ -156,6 +156,18 @@ describe('Command line', () => {
       expect(affectedApps).not.toContain('myapp2');
       expect(affectedApps).not.toContain('myapp-e2e');
 
+      const implicitlyAffectedApps = runCommand(
+        'npm run affected:apps -- --files="package.json"'
+      );
+      expect(implicitlyAffectedApps).toContain('myapp');
+      expect(implicitlyAffectedApps).toContain('myapp2');
+
+      const noAffectedApps = runCommand(
+        'npm run affected:apps -- --files="README.md"'
+      );
+      expect(noAffectedApps).not.toContain('myapp');
+      expect(noAffectedApps).not.toContain('myapp2');
+
       const build = runCommand(
         'npm run affected:build -- --files="libs/mylib/src/index.ts"'
       );

--- a/e2e/schematics/ng-add.test.ts
+++ b/e2e/schematics/ng-add.test.ts
@@ -106,6 +106,12 @@ describe('Nrwl Convert to Nx Workspace', () => {
     const nxJson = readJson('nx.json');
     expect(nxJson).toEqual({
       npmScope: 'projscope',
+      implicitDependencies: {
+        'angular.json': '*',
+        'package.json': '*',
+        'tslint.json': '*',
+        'tsconfig.json': '*'
+      },
       projects: {
         proj: {
           tags: []

--- a/packages/schematics/migrations/migrations.json
+++ b/packages/schematics/migrations/migrations.json
@@ -9,6 +9,11 @@
       "version": "6.0.5",
       "description": "Add affected:lint npm script",
       "factory": "./update-6-0-5/update-6-0-5"
+    },
+    "update-to-6.1.0": {
+      "version": "6.1.0",
+      "description": "Add implicitDependencies to nx.json",
+      "factory": "./update-6-1-0/update-6-1-0"
     }
   }
 }

--- a/packages/schematics/migrations/update-6-1-0/update-6-1-0.ts
+++ b/packages/schematics/migrations/update-6-1-0/update-6-1-0.ts
@@ -1,0 +1,38 @@
+import {
+  Rule,
+  Tree,
+  SchematicContext,
+  chain
+} from '@angular-devkit/schematics';
+import { updateJsonInTree } from '../../src/utils/ast-utils';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+
+function displayInformation(host: Tree, context: SchematicContext) {
+  context.logger.info(stripIndents`
+    "implicitDependencies" have been added to your nx.json.
+  `);
+  context.logger.warn(stripIndents`
+    Files not defined in implicitDependencies will NOT affect your projects.
+
+    .ie yarn affected:apps --files=README.md will return no apps since it is not defined.
+
+    You should add additional files which you expect to affect your projects into this configuration.
+  `);
+}
+
+export default function(): Rule {
+  return chain([
+    displayInformation,
+    updateJsonInTree('nx.json', nxJson => {
+      return {
+        ...nxJson,
+        implicitDependencies: {
+          'angular.json': '*',
+          'package.json': '*',
+          'tsconfig.json': '*',
+          'tslint.json': '*'
+        }
+      };
+    })
+  ]);
+}

--- a/packages/schematics/src/collection/ng-add/index.ts
+++ b/packages/schematics/src/collection/ng-add/index.ts
@@ -557,6 +557,12 @@ function createAdditionalFiles(options: Schema): Rule {
       'nx.json',
       serializeJson({
         npmScope: options.npmScope,
+        implicitDependencies: {
+          'angular.json': '*',
+          'package.json': '*',
+          'tsconfig.json': '*',
+          'tslint.json': '*'
+        },
         projects: {
           [options.name]: {
             tags: []

--- a/packages/schematics/src/collection/ng-new/files/__directory__/nx.json
+++ b/packages/schematics/src/collection/ng-new/files/__directory__/nx.json
@@ -1,5 +1,10 @@
 {
   "npmScope": "<%= npmScope %>",
-  "projects": {
-  }
+  "implicitDependencies": {
+    "angular.json": "*",
+    "package.json": "*",
+    "tsconfig.json": "*",
+    "tslint.json": "*"
+  },
+  "projects": {}
 }


### PR DESCRIPTION
Add implicitDependencies for ng-new and ng-add

Produced `implicitDependencies`
```json
  "implicitDependencies": {
    "angular.json": "*",
    "package.json": "*",
    "tsconfig.json": "*",
    "tslint.json": "*"
  }
```

Also add migration for implicitDependencies:

```sh
jason@Jason-PC-U:~/projects/work/temp/newws$ ng g @schematics/update:migrate --from 6.0.0 --to 6.1.0 --package @nrwl/schematics --collection @nrwl/schematics/migrations/migrations.json
            "implicitDependencies" have been added to your nx.json.
            Files not defined in implicitDependencies will NOT affect your projects.

            .ie yarn affected:apps --files=README.md will return no apps since it is not defined.

            You should add additional files which you expect to affect your projects into this configuration.
UPDATE package.json (2514 bytes)
UPDATE nx.json (338 bytes)
```