### PR TITLE
fix(schematics) add nx.json to ng-new schematic

### DIFF
--- a/packages/schematics/src/collection/ng-new/files/__directory__/nx.json
+++ b/packages/schematics/src/collection/ng-new/files/__directory__/nx.json
@@ -4,7 +4,8 @@
     "angular.json": "*",
     "package.json": "*",
     "tsconfig.json": "*",
-    "tslint.json": "*"
+    "tslint.json": "*",
+    "nx.json": "*"
   },
   "projects": {}
 }


### PR DESCRIPTION
Adds missing `nx.json` implicitDependency for `ng new`