### PR TITLE
fix(schematics) change readme instructions to use --project

### DIFF
--- a/packages/schematics/src/collection/ng-new/files/__directory__/README.md
+++ b/packages/schematics/src/collection/ng-new/files/__directory__/README.md
@@ -20,15 +20,15 @@ Run `ng generate app myapp` to generate an application. When using Nx, you can c
 
 ## Development server
 
-Run `ng serve --app=myapp` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+Run `ng serve --project=myapp` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
 ## Code scaffolding
 
-Run `ng generate component component-name --app=myapp` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+Run `ng generate component component-name --project=myapp` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
 
 ## Build
 
-Run `ng build --app=myapp` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `-prod` flag for a production build.
+Run `ng build --project=myapp` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
 
 ## Running unit tests
 


### PR DESCRIPTION
README.md in generated projects should have the correct information in them.

```diff
+ Run `ng build --project=myapp` to build the project.
- Run `ng buid --app=myapp` to build the project.

+ Use the `--prod`
- Use the `-prod`

+ Run `ng generate component component-name --project=myapp`
- Run `ng generate component component-name --app=myapp`
