### PR TITLE
feat(schematics) include npmScope in ng-package.prod.json

### DIFF
--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -304,6 +304,10 @@ describe('${options.moduleName}', () => {
           }
         };
       }),
+      updateJsonInTree(`${options.projectRoot}/ng-package.prod.json`, json => {
+        json['dest'] = `${offsetFromRoot(options.projectRoot)}dist/@${options.prefix}/${options.name}`;
+        return json;
+      }),
       host => {
         const karma = host
           .read(`${options.projectRoot}/karma.conf.js`)

--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -205,7 +205,7 @@ function updateNgPackage(options: NormalizedSchema): Rule {
   if (!options.publishable) {
     return noop();
   }
-  const dest = `${offsetFromRoot(options.projectRoot)}dist/@${options.prefix}/${
+  const dest = `${offsetFromRoot(options.projectRoot)}dist/libs/@${options.prefix}/${
     options.projectDirectory
   }`;
   return chain([

--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -123,7 +123,7 @@ function addLoadChildren(options: NormalizedSchema): Rule {
 
     const loadChildren = `@${npmScope}/${options.projectDirectory}#${
       options.moduleName
-    }`;
+      }`;
 
     insert(host, options.parentModule, [
       ...addRoute(
@@ -273,7 +273,7 @@ describe('${options.moduleName}', () => {
             ...json.compilerOptions,
             outDir: `${offsetFromRoot(options.projectRoot)}dist/out-tsc/${
               options.projectRoot
-            }`
+              }`
           }
         };
       }),
@@ -285,7 +285,7 @@ describe('${options.moduleName}', () => {
             ...json.compilerOptions,
             outDir: `${offsetFromRoot(options.projectRoot)}dist/out-tsc/${
               options.projectRoot
-            }`
+              }`
           }
         };
       }),
@@ -304,10 +304,14 @@ describe('${options.moduleName}', () => {
           }
         };
       }),
-      updateJsonInTree(`${options.projectRoot}/ng-package.prod.json`, json => {
-        json['dest'] = `${offsetFromRoot(options.projectRoot)}dist/@${options.prefix}/${options.name}`;
-        return json;
-      }),
+      options.publishable
+        ? updateJsonInTree(`${options.projectRoot}/ng-package.prod.json`, json => {
+          return {
+            ...json,
+            dest: `${offsetFromRoot(options.projectRoot)}dist/@${options.prefix}/${options.projectDirectory}`
+          }
+        })
+        : noop(),
       host => {
         const karma = host
           .read(`${options.projectRoot}/karma.conf.js`)
@@ -340,7 +344,7 @@ function updateTsConfig(options: NormalizedSchema): Rule {
   ]);
 }
 
-export default function(schema: Schema): Rule {
+export default function (schema: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const options = normalizeOptions(host, schema);
     if (!options.routing && options.lazy) {

--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -205,9 +205,9 @@ function updateNgPackage(options: NormalizedSchema): Rule {
   if (!options.publishable) {
     return noop();
   }
-  const dest = `${offsetFromRoot(options.projectRoot)}dist/libs/@${
-    options.prefix
-  }/${options.projectDirectory}`;
+  const dest = `${offsetFromRoot(options.projectRoot)}dist/libs/${
+    options.projectDirectory
+  }`;
   return chain([
     updateJsonInTree(`${options.projectRoot}/ng-package.prod.json`, json => {
       return {

--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -201,6 +201,29 @@ function addChildren(options: NormalizedSchema): Rule {
   };
 }
 
+function updateNgPackage(options: NormalizedSchema): Rule {
+  if (!options.publishable) {
+    return noop();
+  }
+  const dest = `${offsetFromRoot(options.projectRoot)}dist/@${options.prefix}/${
+    options.projectDirectory
+  }`;
+  return chain([
+    updateJsonInTree(`${options.projectRoot}/ng-package.prod.json`, json => {
+      return {
+        ...json,
+        dest
+      };
+    }),
+    updateJsonInTree(`${options.projectRoot}/ng-package.json`, json => {
+      return {
+        ...json,
+        dest
+      };
+    })
+  ]);
+}
+
 function updateProject(options: NormalizedSchema): Rule {
   return (host: Tree) => {
     // Bug in @angular-devkit/core. Cannot delete these files here.
@@ -304,19 +327,7 @@ describe('${options.moduleName}', () => {
           }
         };
       }),
-      options.publishable
-        ? updateJsonInTree(
-            `${options.projectRoot}/ng-package.prod.json`,
-            json => {
-              return {
-                ...json,
-                dest: `${offsetFromRoot(options.projectRoot)}dist/@${
-                  options.prefix
-                }/${options.projectDirectory}`
-              };
-            }
-          )
-        : noop(),
+      updateNgPackage(options),
       host => {
         const karma = host
           .read(`${options.projectRoot}/karma.conf.js`)

--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -205,9 +205,9 @@ function updateNgPackage(options: NormalizedSchema): Rule {
   if (!options.publishable) {
     return noop();
   }
-  const dest = `${offsetFromRoot(options.projectRoot)}dist/libs/@${options.prefix}/${
-    options.projectDirectory
-  }`;
+  const dest = `${offsetFromRoot(options.projectRoot)}dist/libs/@${
+    options.prefix
+  }/${options.projectDirectory}`;
   return chain([
     updateJsonInTree(`${options.projectRoot}/ng-package.prod.json`, json => {
       return {

--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -123,7 +123,7 @@ function addLoadChildren(options: NormalizedSchema): Rule {
 
     const loadChildren = `@${npmScope}/${options.projectDirectory}#${
       options.moduleName
-      }`;
+    }`;
 
     insert(host, options.parentModule, [
       ...addRoute(
@@ -273,7 +273,7 @@ describe('${options.moduleName}', () => {
             ...json.compilerOptions,
             outDir: `${offsetFromRoot(options.projectRoot)}dist/out-tsc/${
               options.projectRoot
-              }`
+            }`
           }
         };
       }),
@@ -285,7 +285,7 @@ describe('${options.moduleName}', () => {
             ...json.compilerOptions,
             outDir: `${offsetFromRoot(options.projectRoot)}dist/out-tsc/${
               options.projectRoot
-              }`
+            }`
           }
         };
       }),
@@ -305,12 +305,17 @@ describe('${options.moduleName}', () => {
         };
       }),
       options.publishable
-        ? updateJsonInTree(`${options.projectRoot}/ng-package.prod.json`, json => {
-          return {
-            ...json,
-            dest: `${offsetFromRoot(options.projectRoot)}dist/@${options.prefix}/${options.projectDirectory}`
-          }
-        })
+        ? updateJsonInTree(
+            `${options.projectRoot}/ng-package.prod.json`,
+            json => {
+              return {
+                ...json,
+                dest: `${offsetFromRoot(options.projectRoot)}dist/@${
+                  options.prefix
+                }/${options.projectDirectory}`
+              };
+            }
+          )
         : noop(),
       host => {
         const karma = host
@@ -344,7 +349,7 @@ function updateTsConfig(options: NormalizedSchema): Rule {
   ]);
 }
 
-export default function (schema: Schema): Rule {
+export default function(schema: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const options = normalizeOptions(host, schema);
     if (!options.routing && options.lazy) {

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -20,14 +20,16 @@ describe('lib', () => {
   });
 
   describe('not nested', () => {
-
     it('should update ng-package.prod.json', () => {
       const publishableTree = schematicRunner.runSchematic(
         'lib',
         { name: 'myLib', publishable: true },
         appTree
       );
-      let ngPackage = readJsonInTree(publishableTree, 'libs/my-lib/ng-package.prod.json');
+      let ngPackage = readJsonInTree(
+        publishableTree,
+        'libs/my-lib/ng-package.prod.json'
+      );
       expect(ngPackage.dest).toEqual('../../dist/@proj/my-lib');
     });
 
@@ -125,7 +127,10 @@ describe('lib', () => {
         { name: 'myLib', directory: 'myDir', publishable: true },
         appTree
       );
-      let ngPackage = readJsonInTree(publishableTree, 'libs/my-dir/my-lib/ng-package.prod.json');
+      let ngPackage = readJsonInTree(
+        publishableTree,
+        'libs/my-dir/my-lib/ng-package.prod.json'
+      );
       expect(ngPackage.dest).toEqual('../../../dist/@proj/my-dir/my-lib');
     });
 

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -20,6 +20,17 @@ describe('lib', () => {
   });
 
   describe('not nested', () => {
+
+    it('should update ng-package.prod.json', () => {
+      const publishableTree = schematicRunner.runSchematic(
+        'lib',
+        { name: 'myLib', publishable: true },
+        appTree
+      );
+      let ngPackage = readJsonInTree(publishableTree, 'libs/my-lib/ng-package.prod.json');
+      expect(ngPackage.dest).toEqual('../../dist/@proj/my-lib');
+    });
+
     it('should update angular.json', () => {
       const tree = schematicRunner.runSchematic(
         'lib',
@@ -108,6 +119,16 @@ describe('lib', () => {
   });
 
   describe('nested', () => {
+    it('should update ng-package.prod.json', () => {
+      const publishableTree = schematicRunner.runSchematic(
+        'lib',
+        { name: 'myLib', directory: 'myDir', publishable: true },
+        appTree
+      );
+      let ngPackage = readJsonInTree(publishableTree, 'libs/my-dir/my-lib/ng-package.prod.json');
+      expect(ngPackage.dest).toEqual('../../../dist/@proj/my-dir/my-lib');
+    });
+
     it('should update angular.json', () => {
       const tree = schematicRunner.runSchematic(
         'lib',

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -36,8 +36,8 @@ describe('lib', () => {
         'libs/my-lib/ng-package.json'
       );
 
-      expect(ngPackageProd.dest).toEqual('../../dist/@proj/my-lib');
-      expect(ngPackage.dest).toEqual('../../dist/@proj/my-lib');
+      expect(ngPackageProd.dest).toEqual('../../dist/libs/@proj/my-lib');
+      expect(ngPackage.dest).toEqual('../../dist/libs/@proj/my-lib');
     });
 
     it('should update angular.json', () => {
@@ -142,8 +142,10 @@ describe('lib', () => {
         publishableTree,
         'libs/my-dir/my-lib/ng-package.json'
       );
-      expect(ngPackageProd.dest).toEqual('../../../dist/@proj/my-dir/my-lib');
-      expect(ngPackage.dest).toEqual('../../../dist/@proj/my-dir/my-lib');
+      expect(ngPackageProd.dest).toEqual(
+        '../../../dist/libs/@proj/my-dir/my-lib'
+      );
+      expect(ngPackage.dest).toEqual('../../../dist/libs/@proj/my-dir/my-lib');
     });
 
     it('should update angular.json', () => {

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -20,16 +20,23 @@ describe('lib', () => {
   });
 
   describe('not nested', () => {
-    it('should update ng-package.prod.json', () => {
+    it('should update ng-package.json', () => {
       const publishableTree = schematicRunner.runSchematic(
         'lib',
         { name: 'myLib', publishable: true },
         appTree
       );
-      let ngPackage = readJsonInTree(
+
+      let ngPackageProd = readJsonInTree(
         publishableTree,
         'libs/my-lib/ng-package.prod.json'
       );
+      let ngPackage = readJsonInTree(
+        publishableTree,
+        'libs/my-lib/ng-package.json'
+      );
+
+      expect(ngPackageProd.dest).toEqual('../../dist/@proj/my-lib');
       expect(ngPackage.dest).toEqual('../../dist/@proj/my-lib');
     });
 
@@ -121,16 +128,21 @@ describe('lib', () => {
   });
 
   describe('nested', () => {
-    it('should update ng-package.prod.json', () => {
+    it('should update ng-package.json', () => {
       const publishableTree = schematicRunner.runSchematic(
         'lib',
         { name: 'myLib', directory: 'myDir', publishable: true },
         appTree
       );
-      let ngPackage = readJsonInTree(
+      let ngPackageProd = readJsonInTree(
         publishableTree,
         'libs/my-dir/my-lib/ng-package.prod.json'
       );
+      let ngPackage = readJsonInTree(
+        publishableTree,
+        'libs/my-dir/my-lib/ng-package.json'
+      );
+      expect(ngPackageProd.dest).toEqual('../../../dist/@proj/my-dir/my-lib');
       expect(ngPackage.dest).toEqual('../../../dist/@proj/my-dir/my-lib');
     });
 

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -36,8 +36,8 @@ describe('lib', () => {
         'libs/my-lib/ng-package.json'
       );
 
-      expect(ngPackageProd.dest).toEqual('../../dist/libs/@proj/my-lib');
-      expect(ngPackage.dest).toEqual('../../dist/libs/@proj/my-lib');
+      expect(ngPackageProd.dest).toEqual('../../dist/libs/my-lib');
+      expect(ngPackage.dest).toEqual('../../dist/libs/my-lib');
     });
 
     it('should update angular.json', () => {
@@ -142,10 +142,8 @@ describe('lib', () => {
         publishableTree,
         'libs/my-dir/my-lib/ng-package.json'
       );
-      expect(ngPackageProd.dest).toEqual(
-        '../../../dist/libs/@proj/my-dir/my-lib'
-      );
-      expect(ngPackage.dest).toEqual('../../../dist/libs/@proj/my-dir/my-lib');
+      expect(ngPackageProd.dest).toEqual('../../../dist/libs/my-dir/my-lib');
+      expect(ngPackage.dest).toEqual('../../../dist/libs/my-dir/my-lib');
     });
 
     it('should update angular.json', () => {


### PR DESCRIPTION
The ng-package.prod.js dest property now includes the `@npmScope`. This allows prod builds of libraries to be under the same directory

closes #599