### PR TITLE
feat(schematics): create global karma conf

### DIFF
--- a/packages/schematics/migrations/migrations.json
+++ b/packages/schematics/migrations/migrations.json
@@ -14,6 +14,11 @@
       "version": "6.1.0",
       "description": "Add implicitDependencies to nx.json",
       "factory": "./update-6-1-0/update-6-1-0"
+    },
+    "update-to-6.2.0": {
+      "version": "6.2.0",
+      "description": "Add Global Karma Conf",
+      "factory": "./update-6-2-0/update-6-2-0"
     }
   }
 }

--- a/packages/schematics/migrations/update-6-0-0/update-6-0-0.ts
+++ b/packages/schematics/migrations/update-6-0-0/update-6-0-0.ts
@@ -7,10 +7,13 @@ import {
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 
-import { readJsonInTree, updateJsonInTree } from '../../src/utils/ast-utils';
+import {
+  createOrUpdate,
+  readJsonInTree,
+  updateJsonInTree
+} from '../../src/utils/ast-utils';
 import { serializeJson, renameSync } from '../../src/utils/fileutils';
 import { parseTarget, serializeTarget } from '../../src/utils/cli-config-utils';
-import * as fs from 'fs';
 import { offsetFromRoot } from '../../src/utils/common';
 import { formatFiles } from '../../src/utils/rules/format-files';
 
@@ -667,14 +670,6 @@ function parseAndNormalizeTarget(s: string) {
 
 function pathToName(s: string) {
   return s.replace(new RegExp('/', 'g'), '-');
-}
-
-function createOrUpdate(host: Tree, path: string, content: string) {
-  if (host.exists(path)) {
-    host.overwrite(path, content);
-  } else {
-    host.create(path, content);
-  }
 }
 
 export default function(): Rule {

--- a/packages/schematics/migrations/update-6-2-0/files/karma.conf.js
+++ b/packages/schematics/migrations/update-6-2-0/files/karma.conf.js
@@ -1,0 +1,34 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+const { join } = require('path');
+const { constants } = require('karma');
+
+module.exports = () => {
+  return {
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage-istanbul-reporter'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageIstanbulReporter: {
+      dir: join(__dirname, '../../coverage'),
+      reports: ['html', 'lcovonly'],
+      fixWebpackSourcePaths: true
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: constants.LOG_INFO,
+    autoWatch: false,
+    browsers: ['Chrome'],
+    singleRun: true
+  };
+};

--- a/packages/schematics/migrations/update-6-2-0/update-6-2-0.ts
+++ b/packages/schematics/migrations/update-6-2-0/update-6-2-0.ts
@@ -1,0 +1,35 @@
+import {
+  Rule,
+  SchematicContext,
+  chain,
+  template,
+  apply,
+  mergeWith,
+  url
+} from '@angular-devkit/schematics';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+
+function displayInformation(_, context: SchematicContext) {
+  context.logger.info(stripIndents`
+    A global base karma config has been added at karma.conf.ts
+    
+    This file exports a karma config to be extended in each project
+
+    This new file is not being used yet!
+
+    Generate a new project to see an example of how it might be used.
+  `);
+}
+
+function addGlobalKarmaConf() {
+  const templateSource = apply(url('./files'), [
+    template({
+      tmpl: ''
+    })
+  ]);
+  return mergeWith(templateSource);
+}
+
+export default function(): Rule {
+  return chain([displayInformation, addGlobalKarmaConf()]);
+}

--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -60,6 +60,7 @@ describe('app', () => {
         { name: 'myApp' },
         appTree
       );
+      expect(tree.exists(`apps/my-app/karma.conf.js`)).toBeTruthy();
       expect(tree.exists('apps/my-app/src/main.ts')).toBeTruthy();
       expect(tree.exists('apps/my-app/src/app/app.module.ts')).toBeTruthy();
       expect(tree.exists('apps/my-app/src/app/app.component.ts')).toBeTruthy();
@@ -165,6 +166,7 @@ describe('app', () => {
         { name: 'myApp', directory: 'myDir' },
         appTree
       );
+      expect(tree.exists(`apps/my-dir/my-app/karma.conf.js`)).toBeTruthy();
       expect(tree.exists('apps/my-dir/my-app/src/main.ts')).toBeTruthy();
       expect(
         tree.exists('apps/my-dir/my-app/src/app/app.module.ts')

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -99,6 +99,7 @@ describe('lib', () => {
         { name: 'myLib' },
         appTree
       );
+      expect(tree.exists(`libs/my-lib/karma.conf.js`)).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/index.ts')).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/lib/my-lib.module.ts')).toBeTruthy();
     });
@@ -128,6 +129,19 @@ describe('lib', () => {
   });
 
   describe('nested', () => {
+    it('should generate files', () => {
+      const tree = schematicRunner.runSchematic(
+        'lib',
+        { name: 'myLib', directory: 'myDir' },
+        appTree
+      );
+      expect(tree.exists(`libs/my-dir/my-lib/karma.conf.js`)).toBeTruthy();
+      expect(tree.exists('libs/my-dir/my-lib/src/index.ts')).toBeTruthy();
+      expect(
+        tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.module.ts')
+      ).toBeTruthy();
+    });
+
     it('should update ng-package.json', () => {
       const publishableTree = schematicRunner.runSchematic(
         'lib',

--- a/packages/schematics/src/collection/ng-add/files/karma.conf.js
+++ b/packages/schematics/src/collection/ng-add/files/karma.conf.js
@@ -1,0 +1,34 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+const { join } = require('path');
+const { constants } = require('karma');
+
+module.exports = () => {
+  return {
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage-istanbul-reporter'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageIstanbulReporter: {
+      dir: join(__dirname, '../../coverage'),
+      reports: ['html', 'lcovonly'],
+      fixWebpackSourcePaths: true
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: constants.LOG_INFO,
+    autoWatch: false,
+    browsers: ['Chrome'],
+    singleRun: true
+  };
+};

--- a/packages/schematics/src/collection/ng-add/index.ts
+++ b/packages/schematics/src/collection/ng-add/index.ts
@@ -4,7 +4,9 @@ import {
   SchematicContext,
   Tree,
   url,
-  mergeWith
+  mergeWith,
+  apply,
+  template
 } from '@angular-devkit/schematics';
 import { Schema } from './schema';
 import * as path from 'path';
@@ -39,11 +41,7 @@ import {
   readJsonInTree,
   addImportToModule
 } from '../../utils/ast-utils';
-import {
-  parseTarget,
-  serializeTarget,
-  editTarget
-} from '../../utils/cli-config-utils';
+import { editTarget } from '../../utils/cli-config-utils';
 import { from } from 'rxjs';
 import { tap, mapTo } from 'rxjs/operators';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
@@ -713,9 +711,14 @@ export default function(schema: Schema): Rule {
     name: toFileName(schema.name),
     npmScope: toFileName(schema.npmScope || schema.name)
   };
+  const templateSource = apply(url('./files'), [
+    template({
+      tmpl: ''
+    })
+  ]);
   return chain([
     checkCanConvertToWorkspace(options),
-    mergeWith(url('./files')),
+    mergeWith(templateSource),
     moveExistingFiles(options),
     createAdditionalFiles(options),
     updatePackageJson(),

--- a/packages/schematics/src/collection/ng-new/files/__directory__/karma.conf.js
+++ b/packages/schematics/src/collection/ng-new/files/__directory__/karma.conf.js
@@ -1,0 +1,34 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+const { join } = require('path');
+const { constants } = require('karma');
+
+module.exports = () => {
+  return {
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage-istanbul-reporter'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageIstanbulReporter: {
+      dir: join(__dirname, '../../coverage'),
+      reports: ['html', 'lcovonly'],
+      fixWebpackSourcePaths: true
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: constants.LOG_INFO,
+    autoWatch: false,
+    browsers: ['Chrome'],
+    singleRun: true
+  };
+};

--- a/packages/schematics/src/collection/ng-new/ng-new.spec.ts
+++ b/packages/schematics/src/collection/ng-new/ng-new.spec.ts
@@ -1,0 +1,66 @@
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { Tree, VirtualTree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '../../utils/testing-utils';
+import { getFileContent } from '@schematics/angular/utility/test';
+import * as stripJsonComments from 'strip-json-comments';
+import { readJsonInTree } from '../../utils/ast-utils';
+
+describe('app', () => {
+  const schematicRunner = new SchematicTestRunner(
+    '@nrwl/schematics',
+    path.join(__dirname, '../../collection.json')
+  );
+
+  let projectTree: Tree;
+
+  beforeEach(() => {
+    projectTree = Tree.empty();
+  });
+
+  it('should update angular.json', () => {
+    const tree = schematicRunner.runSchematic(
+      'ng-new',
+      { name: 'proj' },
+      projectTree
+    );
+    expect(tree.exists('/proj/karma.conf.js')).toBe(true);
+    expect(tree.readContent('/proj/karma.conf.js')).toBe(
+      `// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+const { join } = require('path');
+const { constants } = require('karma');
+
+module.exports = () => {
+  return {
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage-istanbul-reporter'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageIstanbulReporter: {
+      dir: join(__dirname, '../../coverage'),
+      reports: ['html', 'lcovonly'],
+      fixWebpackSourcePaths: true
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: constants.LOG_INFO,
+    autoWatch: false,
+    browsers: ['Chrome'],
+    singleRun: true
+  };
+};
+`
+    );
+  });
+});

--- a/packages/schematics/src/utils/ast-utils.ts
+++ b/packages/schematics/src/utils/ast-utils.ts
@@ -587,6 +587,13 @@ export function getProjectConfig(host: Tree, name: string): any {
   }
 }
 
+export function updateProjectConfig(name: string, projectConfig: any): Rule {
+  return updateJsonInTree('/angular.json', angularJson => {
+    angularJson.projects[name] = projectConfig;
+    return angularJson;
+  });
+}
+
 export function readBootstrapInfo(
   host: Tree,
   app: string
@@ -776,6 +783,14 @@ export function findNodesOfType(
 export interface NameValue {
   name: string;
   value?: string;
+}
+
+export function createOrUpdate(host: Tree, path: string, content: string) {
+  if (host.exists(path)) {
+    host.overwrite(path, content);
+  } else {
+    host.create(path, content);
+  }
 }
 
 export function insertImport(

--- a/packages/schematics/src/utils/rules/update-karma-conf.spec.ts
+++ b/packages/schematics/src/utils/rules/update-karma-conf.spec.ts
@@ -1,0 +1,70 @@
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { Tree } from '@angular-devkit/schematics';
+
+import * as path from 'path';
+
+import { updateKarmaConf } from './update-karma-conf';
+import { createEmptyWorkspace } from '../testing-utils';
+import { updateJsonInTree } from '../ast-utils';
+
+describe('updateKarmaConf', () => {
+  let tree: Tree;
+  let schematicRunner: SchematicTestRunner;
+  beforeEach(done => {
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/schematics',
+      path.join(__dirname, '../../collection.json')
+    );
+    tree = createEmptyWorkspace(Tree.empty());
+    tree.create('apps/projectName/karma.conf.js', '');
+    schematicRunner
+      .callRule(
+        updateJsonInTree('/angular.json', angularJson => {
+          angularJson.projects.projectName = {
+            root: 'apps/projectName',
+            architect: {
+              test: {
+                options: {
+                  karmaConfig: 'apps/projectName/karma.conf.js'
+                }
+              }
+            }
+          };
+          return angularJson;
+        }),
+        tree
+      )
+      .subscribe(done);
+  });
+
+  it('should overwrite the karma.conf.js', done => {
+    schematicRunner
+      .callRule(updateKarmaConf({ projectName: 'projectName' }), tree)
+      .subscribe(result => {
+        const contents = result
+          .read('apps/projectName/karma.conf.js')
+          .toString();
+
+        expect(contents).toEqual(
+          `// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+const { join } = require('path');
+const getBaseKarmaConfig = require('../../karma.conf');
+
+module.exports = function(config) {
+  const baseConfig = getBaseKarmaConfig();
+  config.set({
+    ...baseConfig,
+    coverageIstanbulReporter: {
+      ...baseConfig.coverageIstanbulReporter,
+      dir: join(__dirname, '../../coverage/apps/projectName')
+    }
+  });
+};
+`
+        );
+        done();
+      });
+  });
+});

--- a/packages/schematics/src/utils/rules/update-karma-conf.ts
+++ b/packages/schematics/src/utils/rules/update-karma-conf.ts
@@ -1,0 +1,46 @@
+import { join } from 'path';
+
+import { Rule, Tree, SchematicContext } from '@angular-devkit/schematics';
+import { offsetFromRoot } from '../common';
+import {
+  createOrUpdate,
+  getProjectConfig,
+  updateJsonInTree
+} from '../ast-utils';
+
+/**
+ * This returns a Rule which changes the default Angular CLI Generated karma.conf.js
+ * @param options Object containing projectROot
+ */
+export function updateKarmaConf(options: { projectName: string }): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    const project = getProjectConfig(host, options.projectName);
+    const projectRoot = project.root.replace(/\/$/, '');
+    const karmaPath = project.architect.test.options.karmaConfig;
+
+    createOrUpdate(
+      host,
+      karmaPath,
+      `// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+const { join } = require('path');
+const getBaseKarmaConfig = require('${offsetFromRoot(projectRoot)}karma.conf');
+
+module.exports = function(config) {
+  const baseConfig = getBaseKarmaConfig();
+  config.set({
+    ...baseConfig,
+    coverageIstanbulReporter: {
+      ...baseConfig.coverageIstanbulReporter,
+      dir: join(__dirname, '${offsetFromRoot(
+        projectRoot
+      )}coverage/${projectRoot}')
+    }
+  });
+};
+`
+    );
+    return host;
+  };
+}


### PR DESCRIPTION
## Current Behavior

Karma Confs are duplicated for each and every project

## Expected Behavior

A Global Karma Conf is created which can be extended by each project.

New projects should have the global karma config for both `ng new` and `ng add`.

Projects which update should have a global config generated but not currently be used.

`yarn affected:test --all` should still work

## Fixes
Fixes https://github.com/nrwl/nx/issues/590
Fixes https://github.com/nrwl/nx/issues/582