### PR TITLE
fix(schematics): check touchedFile path against the project files

### DIFF
--- a/packages/schematics/src/command-line/affected-apps.spec.ts
+++ b/packages/schematics/src/command-line/affected-apps.spec.ts
@@ -506,6 +506,51 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
       expect(tp).toEqual(['app1Name', 'app2Name', 'lib1Name', 'lib2Name']);
     });
 
+    it('should return the list of touchedProjects independent from the git structure', () => {
+      const tp = touchedProjects(
+        {
+          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+        },
+        [
+          {
+            name: 'app1Name',
+            root: 'apps/app1',
+            files: ['app1.ts'],
+            tags: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'app2Name',
+            root: 'apps/app2',
+            files: ['app2.ts'],
+            tags: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'lib1Name',
+            root: 'libs/lib1',
+            files: ['lib1.ts'],
+            tags: [],
+            architect: {},
+            type: ProjectType.lib
+          },
+          {
+            name: 'lib2Name',
+            root: 'libs/lib2',
+            files: ['lib2.ts'],
+            tags: [],
+            architect: {},
+            type: ProjectType.lib
+          }
+        ],
+        ['gitrepo/some/path/inside/nx/libs/lib2/lib2.ts', 'apps/app2/app2.ts']
+      );
+
+      expect(tp).toEqual(['app2Name', 'lib2Name']);
+    });
+
     it('should return the list of implicitly touched projects', () => {
       const tp = touchedProjects(
         {

--- a/packages/schematics/src/command-line/affected-apps.spec.ts
+++ b/packages/schematics/src/command-line/affected-apps.spec.ts
@@ -500,10 +500,55 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             type: ProjectType.lib
           }
         ],
-        ['gitrepo/some/path/inside/nx/libs/lib2/lib2.ts', 'app2.ts', 'package.json']
+        ['lib2.ts', 'app2.ts', 'package.json']
       );
 
       expect(tp).toEqual(['app1Name', 'app2Name', 'lib1Name', 'lib2Name']);
+    });
+
+    it('should return the list of touchedProjects independend from the git structure', () => {
+      const tp = touchedProjects(
+        {
+          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+        },
+        [
+          {
+            name: 'app1Name',
+            root: 'apps/app1',
+            files: ['app1.ts'],
+            tags: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'app2Name',
+            root: 'apps/app2',
+            files: ['app2.ts'],
+            tags: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'lib1Name',
+            root: 'libs/lib1',
+            files: ['lib1.ts'],
+            tags: [],
+            architect: {},
+            type: ProjectType.lib
+          },
+          {
+            name: 'lib2Name',
+            root: 'libs/lib2',
+            files: ['lib2.ts'],
+            tags: [],
+            architect: {},
+            type: ProjectType.lib
+          }
+        ],
+        ['gitrepo/some/path/inside/nx/libs/lib2/lib2.ts', 'apps/app2/app2.ts']
+      );
+
+      expect(tp).toEqual(['app2Name', 'lib2Name']);
     });
 
     it('should return the list of implicitly touched projects', () => {

--- a/packages/schematics/src/command-line/affected-apps.spec.ts
+++ b/packages/schematics/src/command-line/affected-apps.spec.ts
@@ -500,7 +500,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             type: ProjectType.lib
           }
         ],
-        ['lib2.ts', 'app2.ts', 'package.json']
+        ['gitrepo/some/path/inside/nx/libs/lib2/lib2.ts', 'app2.ts', 'package.json']
       );
 
       expect(tp).toEqual(['app1Name', 'app2Name', 'lib1Name', 'lib2Name']);

--- a/packages/schematics/src/command-line/affected-apps.spec.ts
+++ b/packages/schematics/src/command-line/affected-apps.spec.ts
@@ -506,7 +506,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
       expect(tp).toEqual(['app1Name', 'app2Name', 'lib1Name', 'lib2Name']);
     });
 
-    it('should return the list of touchedProjects independend from the git structure', () => {
+    it('should return the list of touchedProjects independent from the git structure', () => {
       const tp = touchedProjects(
         {
           'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']

--- a/packages/schematics/src/command-line/affected-apps.ts
+++ b/packages/schematics/src/command-line/affected-apps.ts
@@ -60,7 +60,9 @@ function directlyTouchedProjects(
   return projects
     .filter(project => {
       return touchedFiles.some(file => {
-        return file.startsWith(project.root);
+        return project.files.some(projectFile => {
+          return file.endsWith(projectFile);
+        });
       });
     })
     .map(project => project.name);


### PR DESCRIPTION
Fix for the issue https://github.com/nrwl/nx/issues/613.

Problem was here that the path from the file (git) was checked against the project.root with "startWith" which is not working if you haven't nx in your root directory of your repository