### PR TITLE
fix(schematics): fix breaking cli by installing globally via yarn

### DIFF
--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -35,8 +35,6 @@
   },
   "dependencies": {
     "@ngrx/schematics": "5.2.0",
-    "@schematics/angular": "0.6.1",
-    "@angular-devkit/schematics": "0.6.1",
     "@types/yargs": "^11.0.0",
     "app-root-path": "^2.0.1",
     "cosmiconfig": "4.0.0",
@@ -50,5 +48,9 @@
     "viz.js": "^1.8.1",
     "yargs-parser": "10.0.0",
     "yargs": "^11.0.0"
+  },
+  "peerDependencies": {
+    "@schematics/angular": "^0.6.0",
+    "@angular-devkit/schematics": "^0.6.0"
   }
 }


### PR DESCRIPTION
## Current Behavior

Angular related dependencies are direct dependencies of `@nrwl/schematics` and `@angular/cli`

When globally installing via yarn, the flat module structure causes the `@nrwl/schematics` dependencies to overwrite the `@angular/cli` dependencies.

## Expected Behavior

`@nrwl/schematics` has angular related dependencies as peer dependencies. This way, `@nrwl/schematics` uses whatever versions the `@angular/cli` installs.

## Testing

```sh
yarn global add @angular/cli
yarn global add /Users/jason/projects/nx/build/packages/schematics
ng new blah
```

## Caveats

I did not test with every combination of `@angular/cli` but I hope most of the ones after `6.0.0` work...