### PR TITLE
fix(schematics): fix ngrx effect services being provided twice

### DIFF
--- a/packages/nx/spec/data-persistence.spec.ts
+++ b/packages/nx/spec/data-persistence.spec.ts
@@ -109,7 +109,6 @@ describe('DataPersistence', () => {
 
       beforeEach(() => {
         TestBed.configureTestingModule({
-          providers: [TodoEffects],
           imports: [EffectsModule.forRoot([TodoEffects])]
         });
       });
@@ -152,7 +151,6 @@ describe('DataPersistence', () => {
 
       beforeEach(() => {
         TestBed.configureTestingModule({
-          providers: [TodoEffects],
           imports: [EffectsModule.forRoot([TodoEffects])]
         });
       });
@@ -206,7 +204,6 @@ describe('DataPersistence', () => {
 
       beforeEach(() => {
         TestBed.configureTestingModule({
-          providers: [TodoEffects],
           imports: [EffectsModule.forRoot([TodoEffects])]
         });
       });


### PR DESCRIPTION
* Remove `TodoEffects` from `providers` because it is already
  provided when calling `EffectsModule.forRoot([TodoEffects])`