### PR TITLE
fix(schematics): workspace schematics support for 'directory' option

### DIFF
--- a/e2e/schematics/command-line.test.ts
+++ b/e2e/schematics/command-line.test.ts
@@ -364,24 +364,8 @@ describe('Command line', () => {
         'tools/schematics/custom/schema.json'
       );
 
-      const json = readJson('tools/schematics/custom/schema.json');
-      json.properties['directory'] = {
-        type: 'string',
-        description: 'lib directory'
-      };
-      updateFile('tools/schematics/custom/schema.json', JSON.stringify(json));
-
-      const indexFile = readFile('tools/schematics/custom/index.ts');
-      updateFile(
-        'tools/schematics/custom/index.ts',
-        indexFile.replace(
-          'name: schema.name',
-          'name: schema.name, directory: schema.directory'
-        )
-      );
-
       const output = runCommand(
-        'npm run workspace-schematic -- custom mylib --directory=dir'
+        'npm run workspace-schematic custom mylib -- --directory=dir'
       );
       checkFilesExist('libs/dir/mylib/src/index.ts');
       expect(output).toContain(

--- a/packages/schematics/src/collection/ngrx/ngrx.spec.ts
+++ b/packages/schematics/src/collection/ngrx/ngrx.spec.ts
@@ -258,7 +258,7 @@ describe('ngrx', () => {
         },
         appTree
       )
-    ).toThrow('Specified module does not exist');
+    ).toThrow(`Required option 'module' was not specified`);
   });
 
   describe('code generation', () => {

--- a/packages/schematics/src/collection/ngrx/rules/add-exports-barrel.ts
+++ b/packages/schematics/src/collection/ngrx/rules/add-exports-barrel.ts
@@ -11,8 +11,10 @@ import { Schema } from '../schema';
  */
 export function addExportsToBarrel(options: Schema): Rule {
   return (host: Tree) => {
-    if (!host.exists(options.module)) {
-      throw new Error('Specified module does not exist');
+    if (!options.module) {
+      throw new Error(`Required option 'module' was not specified`);
+    } else if (!host.exists(options.module)) {
+      throw new Error(`Specified module '${options.module}' does not exist`);
     }
 
     // Only update the public barrel for feature libraries

--- a/packages/schematics/src/collection/ngrx/rules/add-imports-to-module.ts
+++ b/packages/schematics/src/collection/ngrx/rules/add-imports-to-module.ts
@@ -16,8 +16,12 @@ import { RequestContext } from './request-context';
 
 export function addImportsToModule(context: RequestContext): Rule {
   return (host: Tree) => {
-    if (!host.exists(context.options.module)) {
-      throw new Error('Specified module does not exist');
+    if (!context.options.module) {
+      throw new Error(`Required option 'module' was not specified`);
+    } else if (!host.exists(context.options.module)) {
+      throw new Error(
+        `Specified module '${context.options.module}' does not exist`
+      );
     }
     const modulePath = context.options.module;
     const sourceText = host.read(modulePath)!.toString('utf-8');

--- a/packages/schematics/src/collection/workspace-schematic/files/__name__/index.ts__tmpl__
+++ b/packages/schematics/src/collection/workspace-schematic/files/__name__/index.ts__tmpl__
@@ -7,7 +7,8 @@ import {
 export default function(schema: any): Rule {
   return chain([
     externalSchematic('@nrwl/schematics', 'lib', {
-      name: schema.name
+      name: schema.name,
+      directory : schema.directory
     })
   ]);
 }

--- a/packages/schematics/src/collection/workspace-schematic/files/__name__/schema.json
+++ b/packages/schematics/src/collection/workspace-schematic/files/__name__/schema.json
@@ -6,6 +6,10 @@
     "name": {
       "type": "string",
       "description": "Library name"
+    },
+    "directory": {
+      "type": "string",
+      "description": "The container directory for the '<%= name %>' library that will be created."
     }
   },
   "required": [

--- a/packages/schematics/src/collection/workspace-schematic/schema.json
+++ b/packages/schematics/src/collection/workspace-schematic/schema.json
@@ -16,6 +16,10 @@
       "description": "Skip formatting files",
       "type": "boolean",
       "default": false
+    },
+    "directory": {
+      "type": "string",
+      "description": "A container directory for the library that will be created."
     }
   },
   "required": []

--- a/packages/schematics/src/command-line/workspace-schematic.ts
+++ b/packages/schematics/src/command-line/workspace-schematic.ts
@@ -129,8 +129,10 @@ function executeSchematic(
   host: Observable<FileSystemTree>,
   engine: SchematicEngine<any, object>
 ) {
-  const dryRunSink = new DryRunSink(rootDirectory, true);
   let error = false;
+  const fsSink = new FileSystemSink(rootDirectory, true);
+  const dryRunSink = new DryRunSink(rootDirectory, true);
+
   dryRunSink.reporter.subscribe((event: any) => {
     const eventPath = event.path.startsWith('/')
       ? event.path.substr(1)
@@ -161,8 +163,6 @@ function executeSchematic(
         break;
     }
   });
-
-  const fsSink = new FileSystemSink(rootDirectory, true);
 
   schematic
     .call(options, host as any)


### PR DESCRIPTION
The custom workspace schematic generates a schematic for a custom 'lib':

```ts
import { chain, externalSchematic, Rule } from '@angular-devkit/schematics';

export default function(schema: any): Rule {
  return chain([
    externalSchematic('@nrwl/schematics', 'lib', { name: schema.name  })
  ]);
}
```

> This schematic does not support the `--directory=<parent folder>` option.

Here is what **should be** generated:

```ts
import {
  chain,
  externalSchematic,
  Rule
} from '@angular-devkit/schematics';

export default function(schema: any): Rule {
  return chain([
    externalSchematic('@nrwl/schematics', 'lib', {
      name: schema.name,
      directory : schema.directory
    })
  ]);
}
```

>  Here is an example of building and using a [Custom Nx Workspace Schematic](https://gist.github.com/ThomasBurleson/30e45a6bc61f0d53fe07045d69b548e6)

Fixes #642.