### PR TITLE
fix(schematics): allow multiple e2e suites targeting same app

### DIFF
--- a/packages/schematics/src/command-line/affected-apps.spec.ts
+++ b/packages/schematics/src/command-line/affected-apps.spec.ts
@@ -88,7 +88,13 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app1Name-e2e',
             files: [],
             tags: [],
-            architect: {},
+            architect: {
+              e2e: {
+                options: {
+                  devServerTarget: 'app1Name:serve'
+                }
+              }
+            },
             type: ProjectType.e2e
           }
         ],

--- a/packages/schematics/src/command-line/affected-apps.ts
+++ b/packages/schematics/src/command-line/affected-apps.ts
@@ -265,7 +265,8 @@ class DepsCalculator {
 
   private createImplicitDepsFromE2eToApps() {
     this.projects.filter(p => p.type === ProjectType.e2e).forEach(e2e => {
-      const appName = e2e.name.substring(0, e2e.name.length - 4);
+      // e.g. 'myApp:serve' => 'myApp'
+      const appName = e2e.architect.e2e.options.devServerTarget.split(':')[0];
       if (
         this.projects.find(
           a => a.name === appName && a.type === ProjectType.app

--- a/packages/schematics/src/command-line/shared.spec.ts
+++ b/packages/schematics/src/command-line/shared.spec.ts
@@ -17,7 +17,10 @@ describe('assertWorkspaceValidity', () => {
           tags: []
         },
         'app2-e2e': {
-          tags: []
+          tags: [],
+          architect: {
+            e2e: {}
+          }
         },
         lib1: {
           tags: []

--- a/packages/schematics/src/command-line/shared.ts
+++ b/packages/schematics/src/command-line/shared.ts
@@ -215,7 +215,7 @@ export function getProjectNodes(angularJson, nxJson) {
       root: p.root,
       type:
         p.projectType === 'application'
-          ? key.endsWith('-e2e') ? ProjectType.e2e : ProjectType.app
+          ? p.architect.e2e ? ProjectType.e2e : ProjectType.app
           : ProjectType.lib,
       tags,
       architect: p.architect,


### PR DESCRIPTION
(nrwl is working with my company, and in response to me working around a limitation in nx @jeffbcross recommended I submit this here)

Our company has two e2e suites that target the same application. The way that the suites run are incompatible with each other due to protractor limitations without writing some custom tooling (one suite uses jasmine spec format, the other uses cucumber/gherkin bdd format). We were hoping to remove that tooling and instead leverage features in ng-cli 6 to be able to manage the suites.

The issue is that nx expects a given app ('appName') to have an e2e suite named exactly 'appName-e2e'. This prevents multiple suites with different concerns targeting the same application, and also prevents any flexibility in the e2e name.
