### PR TITLE
fix(ngrx): fix lint issues in schematic templates

### DIFF
--- a/e2e/schematics/ngrx.test.ts
+++ b/e2e/schematics/ngrx.test.ts
@@ -18,6 +18,8 @@ describe('ngrx', () => {
         'generate ngrx flights --module=libs/feature-flights/src/lib/feature-flights.module.ts --collection=@nrwl/schematics'
       );
 
+      expect(runCLI('lint', { silenceError: true })).not.toContain('ERROR');
+
       expect(runCLI('build')).toContain('chunk {main} main.js,');
       expect(runCLI('test myapp --no-watch')).toContain(
         'Executed 10 of 10 SUCCESS'

--- a/e2e/schematics/upgrade-module.test.ts
+++ b/e2e/schematics/upgrade-module.test.ts
@@ -11,7 +11,7 @@ describe('Upgrade', () => {
         'apps/myapp/src/legacy.js',
         `
       const angular = window.angular.module('legacy', []);
-      angular.component('rootLegacyCmp', {
+      angular.component('proj-root-legacy', {
         template: 'Expected Value'
       });
     `
@@ -20,7 +20,7 @@ describe('Upgrade', () => {
       updateFile(
         'apps/myapp/src/app/app.component.html',
         `
-      EXPECTED [<rootLegacyCmp></rootLegacyCmp>]
+      EXPECTED [<proj-root-legacy></proj-root-legacy>]
     `
       );
 
@@ -28,8 +28,10 @@ describe('Upgrade', () => {
 
       runCLI(
         'generate upgrade-module legacy --angularJsImport=./legacy ' +
-          '--angularJsCmpSelector=rootLegacyCmp --project=myapp'
+          '--angularJsCmpSelector=proj-root-legacy --project=myapp'
       );
+
+      expect(runCLI('lint', { silenceError: true })).not.toContain('ERROR');
 
       runCLI('build');
       runCLI('test --single-run');

--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.actions.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.actions.ts__tmpl__
@@ -26,4 +26,4 @@ export const from<%= className %>Actions = {
   Load<%= className %>,
   <%= className %>Loaded,
   <%= className %>LoadError
-}
+};

--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.reducer.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.reducer.ts__tmpl__
@@ -7,8 +7,10 @@ import { <%= className %>Action, <%= className %>ActionTypes } from './<%= fileN
  *
  *  Note: remove if already defined in another module
  */
+
+/* tslint:disable:no-empty-interface */
 export interface <%= className %> {
-}
+};
 
 export interface <%= className %>State {
   list        : <%= className %>[];   // analogous to a sql normalized table

--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.selectors.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.selectors.ts__tmpl__
@@ -12,7 +12,7 @@ const getAll<%= className %> = createSelector( get<%= className %>State, getLoad
 });
 const getSelectedId = createSelector( get<%= className %>State, (state:<%= className %>State) => state.selectedId );
 const getSelected<%= className %> = createSelector( getAll<%= className %>, getSelectedId, (<%= propertyName %>, id) => {
-    let result = <%= propertyName %>.find(<%= propertyName %> => <%= propertyName %>['id'] == id);
+    const result = <%= propertyName %>.find(it => it['id'] === id);
     return result ? Object.assign({}, result) : undefined;
 });
 

--- a/packages/schematics/src/collection/upgrade-module/files/__name__-setup.ts__tmpl__
+++ b/packages/schematics/src/collection/upgrade-module/files/__name__-setup.ts__tmpl__
@@ -1,4 +1,4 @@
-import {Directive, ElementRef, Injector} from '@angular/core';
+import {Component, ElementRef, Injector} from '@angular/core';
 import {setAngularJSGlobal, UpgradeComponent, downgradeComponent, UpgradeModule} from '@angular/upgrade/static';
 <% if (router) { %>
 import {Router} from '@angular/router';
@@ -20,7 +20,10 @@ angular.module('downgraded', []).
 
 <% if (angularJsCmpSelector) { %>
 // all components upgraded from AngularJS to Angular go here
-@Directive({selector: '<%= angularJsCmpSelector %>'})
+@Component({
+  selector: '<%= angularJsCmpSelector %>',
+  template: '',
+})
 export class <%= className %>Component extends UpgradeComponent {
   constructor(ref: ElementRef, inj: Injector) {
     super('<%= angularJsCmpSelector %>', ref, inj);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7326,7 +7326,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs-compat@^6.0.0:
+rxjs-compat@^6.1.0:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/rxjs-compat/-/rxjs-compat-6.2.2.tgz#3c0fcdb46130cc70aa55412c2b1147905ab4680a"
 
@@ -9095,6 +9095,6 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
 
-zone.js@^0.8.19:
+zone.js@^0.8.26:
   version "0.8.26"
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.26.tgz#7bdd72f7668c5a7ad6b118148b4ea39c59d08d2d"


### PR DESCRIPTION
The ngrx schematic templates have some minor lint errors that manfiest in new ngrx generated code. 

* Also - in the ngrx e2e tests - add check for tsLint errors in the generated code.