### PR TITLE
feat(ngrx): add support for NgRx Facade classes

### DIFF
--- a/e2e/schematics/ngrx.test.ts
+++ b/e2e/schematics/ngrx.test.ts
@@ -15,7 +15,7 @@ describe('ngrx', () => {
       // Generate feature library and ngrx state within that library
       runCLI('g @nrwl/schematics:lib feature-flights --prefix=fl');
       runCLI(
-        'generate ngrx flights --module=libs/feature-flights/src/lib/feature-flights.module.ts --collection=@nrwl/schematics'
+        'generate ngrx flights --module=libs/feature-flights/src/lib/feature-flights.module.ts --facade --collection=@nrwl/schematics'
       );
 
       expect(runCLI('lint', { silenceError: true })).not.toContain('ERROR');
@@ -25,7 +25,7 @@ describe('ngrx', () => {
         'Executed 10 of 10 SUCCESS'
       );
       expect(runCLI('test feature-flights --no-watch')).toContain(
-        'Executed 8 of 8 SUCCESS'
+        'Executed 10 of 10 SUCCESS'
       );
     },
     1000000

--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.actions.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.actions.ts__tmpl__
@@ -1,4 +1,5 @@
-import {Action} from "@ngrx/store";
+import {Action} from '@ngrx/store';
+import {Entity} from './<%= fileName %>.reducer';
 
 export enum <%= className %>ActionTypes {
  Load<%= className %> = "[<%= className %>] Load <%= className %>",
@@ -17,7 +18,7 @@ export class <%= className %>LoadError implements Action {
 
 export class <%= className %>Loaded implements Action {
  readonly type = <%= className %>ActionTypes.<%= className %>Loaded;
- constructor(public payload: any[]) { }
+ constructor(public payload: Entity[]) { }
 }
 
 export type <%= className %>Action = Load<%= className %> | <%= className %>Loaded | <%= className %>LoadError;

--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.facade.spec.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.facade.spec.ts__tmpl__
@@ -1,0 +1,119 @@
+import { NgModule } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { readFirst } from '@nrwl/nx/testing';
+
+import { EffectsModule } from '@ngrx/effects';
+import { StoreModule, Store } from '@ngrx/store';
+
+import { NxModule } from '@nrwl/nx';
+
+import { <%= className %>Effects } from './<%= fileName %>.effects';
+import { <%= className %>Facade } from './<%= fileName %>.facade';
+
+import { <%= propertyName %>Query } from './<%= fileName %>.selectors';
+import { Load<%= className %>, <%= className %>Loaded } from './<%= fileName %>.actions';
+import {
+  <%= className %>State,
+  Entity,
+  initialState,
+  <%= propertyName %>Reducer
+} from './<%= fileName %>.reducer';
+
+interface TestSchema {
+  '<%= propertyName %>' : <%= className %>State
+}
+
+describe('<%= className %>Facade', () => {
+  let facade: <%= className %>Facade;
+  let store: Store<TestSchema>;
+  let create<%= className %>;
+
+  beforeEach(() => {
+    create<%= className %> = ( id:string, name = '' ): Entity => ({
+       id,
+       name: name || `name-${id}`
+    });
+  });
+
+  describe('used in NgModule', () => {
+
+    beforeEach(() => {
+      @NgModule({
+        imports: [
+          StoreModule.forFeature('<%= propertyName %>', <%= propertyName %>Reducer, { initialState }),
+          EffectsModule.forFeature([<%= className %>Effects])
+        ],
+        providers: [<%= className %>Facade]
+      })
+      class CustomFeatureModule {}
+
+      @NgModule({
+        imports: [
+          NxModule.forRoot(),
+          StoreModule.forRoot({}),
+          EffectsModule.forRoot([]),
+          CustomFeatureModule,
+        ]
+      })
+      class RootModule {}
+      TestBed.configureTestingModule({ imports: [RootModule] });
+
+      store = TestBed.get(Store);
+      facade = TestBed.get(<%= className %>Facade);
+    });
+
+    /**
+     * The initially generated facade::loadAll() returns empty array
+     */
+    it('loadAll() should return empty list with loaded == true', async (done) => {
+      try {
+        let list = await readFirst(facade.all<%= className %>$);
+        let isLoaded = await readFirst(facade.loaded$);
+
+        expect(list.length).toBe(0);
+        expect(isLoaded).toBe(false);
+
+        facade.loadAll();
+
+        list = await readFirst(facade.all<%= className %>$);
+        isLoaded = await readFirst(facade.loaded$);
+
+        expect(list.length).toBe(0);
+        expect(isLoaded).toBe(true);
+
+        done();
+      } catch (err) {
+        done.fail(err);
+      }
+    });
+
+    /**
+     * Use `<%= className %>Loaded` to manually submit list for state management
+     */
+    it('all<%= className %>$ should return the loaded list; and loaded flag == true', async (done) => {
+      try {
+        let list = await readFirst(facade.all<%= className %>$);
+        let isLoaded = await readFirst(facade.loaded$);
+
+        expect(list.length).toBe(0);
+        expect(isLoaded).toBe(false);
+
+        store.dispatch(new <%= className %>Loaded([
+          create<%= className %>('AAA'),
+          create<%= className %>('BBB')
+        ]));
+
+        list = await readFirst(facade.all<%= className %>$);
+        isLoaded = await readFirst(facade.loaded$);
+
+        expect(list.length).toBe(2);
+        expect(isLoaded).toBe(true);
+
+        done();
+      } catch (err) {
+        done.fail(err);
+      }
+    });
+  });
+
+});

--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.facade.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.facade.ts__tmpl__
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+
+import { Store } from '@ngrx/store';
+
+import { <%= className %>State } from './<%= fileName %>.reducer';
+import { <%= propertyName %>Query } from './<%= fileName %>.selectors';
+import { Load<%= className %> } from './<%= fileName %>.actions';
+
+@Injectable()
+export class <%= className %>Facade {
+
+  loaded$ = this.store.select(<%= propertyName %>Query.getLoaded);
+  all<%= className %>$ = this.store.select(<%= propertyName %>Query.getAll<%= className %>);
+  selected<%= className %>$ = this.store.select(<%= propertyName %>Query.getSelected<%= className %>);
+  
+  constructor( private store: Store<<%= className %>State> ) { }
+ 
+  loadAll() {
+    this.store.dispatch(new Load<%= className %>());
+  }  
+}

--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.reducer.spec.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.reducer.spec.ts__tmpl__
@@ -1,12 +1,12 @@
 import { <%= className %>Loaded } from './<%= fileName %>.actions';
-import { <%= className %>State, <%= className %>, initialState, <%= propertyName %>Reducer } from './<%= fileName %>.reducer';
+import { <%= className %>State, Entity, initialState, <%= propertyName %>Reducer } from './<%= fileName %>.reducer';
 
 describe('<%= className %> Reducer', () => {
   const get<%= className %>Id = (it) => it['id'];
   let create<%= className %>;
 
   beforeEach(() => {
-     create<%= className %> = ( id:string, name = '' ): <%= className %> => ({
+     create<%= className %> = ( id:string, name = '' ): Entity => ({
        id,
        name: name || `name-${id}`
      });

--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.reducer.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.reducer.ts__tmpl__
@@ -5,17 +5,17 @@ import { <%= className %>Action, <%= className %>ActionTypes } from './<%= fileN
  *  - <%= className %>State, and
  *  - <%= propertyName %>Reducer
  *
- *  Note: remove if already defined in another module
+ *  Note: replace if already defined in another module
  */
 
 /* tslint:disable:no-empty-interface */
-export interface <%= className %> {
+export interface Entity {
 };
 
 export interface <%= className %>State {
-  list        : <%= className %>[];   // analogous to a sql normalized table
-  loaded      : boolean;              // has the <%= className %> list been loaded
+  list        : Entity[];             // list of <%= className %>; analogous to a sql normalized table
   selectedId ?: string | number;      // which <%= className %> record has been selected
+  loaded      : boolean;              // has the <%= className %> list been loaded
   error      ?: any;                  // last none error (if any)
 };
 

--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.selectors.spec.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.selectors.spec.ts__tmpl__
@@ -1,4 +1,4 @@
-import { <%= className %>, <%= className %>State  } from './<%= fileName %>.reducer';
+import { Entity, <%= className %>State  } from './<%= fileName %>.reducer';
 import { <%= propertyName %>Query } from './<%= fileName %>.selectors';
 
 describe('<%= className %> Selectors', () => {
@@ -8,7 +8,7 @@ describe('<%= className %> Selectors', () => {
   let storeState;
 
   beforeEach(() => {
-     const create<%= className %> = ( id:string, name = '' ): <%= className %> => ({
+     const create<%= className %> = ( id:string, name = '' ): Entity => ({
        id,
        name: name || `name-${id}`
      });
@@ -36,7 +36,7 @@ describe('<%= className %> Selectors', () => {
       expect(selId).toBe('PRODUCT-BBB');
     });
 
-    it('getSelected<%= className %>() should return the selected <%= className %>', () => {
+    it('getSelected<%= className %>() should return the selected Entity', () => {
       const result = <%= propertyName %>Query.getSelected<%= className %>(storeState);
       const selId = get<%= className %>Id(result);
 

--- a/packages/schematics/src/collection/ngrx/index.ts
+++ b/packages/schematics/src/collection/ngrx/index.ts
@@ -5,6 +5,8 @@ import {
   mergeWith,
   template,
   move,
+  noop,
+  filter,
   Rule,
   Tree,
   SchematicContext
@@ -36,6 +38,7 @@ export default function generateNgrxCollection(_options: Schema): Rule {
       options,
       host
     };
+
     const fileGeneration = !options.onlyEmptyRoot
       ? [generateNgrxFilesFromTemplates(options)]
       : [];
@@ -64,12 +67,15 @@ export default function generateNgrxCollection(_options: Schema): Rule {
 // ********************************************************
 
 /**
- * Generate 'feature' scaffolding: actions, reducer, effects, interfaces, selectors
+ * Generate 'feature' scaffolding: actions, reducer, effects, interfaces, selectors, facade
  */
 function generateNgrxFilesFromTemplates(options: Schema) {
   const name = options.name;
   const moduleDir = path.dirname(options.module);
+  const excludeFacade = path => path.match(/^((?!facade).)*$/);
+
   const templateSource = apply(url('./files'), [
+    !options.facade ? filter(excludeFacade) : noop(),
     template({ ...options, tmpl: '', ...names(name) }),
     move(moduleDir)
   ]);

--- a/packages/schematics/src/collection/ngrx/rules/add-exports-barrel.ts
+++ b/packages/schematics/src/collection/ngrx/rules/add-exports-barrel.ts
@@ -19,6 +19,7 @@ export function addExportsToBarrel(options: Schema): Rule {
     if (options.root != true) {
       const moduleDir = path.dirname(options.module);
       const indexFilePath = path.join(moduleDir, '../index.ts');
+      const hasFacade = options.facade == true;
 
       const buffer = host.read(indexFilePath);
       if (!!buffer) {
@@ -31,11 +32,18 @@ export function addExportsToBarrel(options: Schema): Rule {
           true
         );
 
-        // Public API for the feature interfaces, selectors
+        // Public API for the feature interfaces, selectors, and facade
         const { fileName } = names(options.name);
         const statePath = `./lib/${options.directory}/${fileName}`;
 
         insert(host, indexFilePath, [
+          ...(hasFacade
+            ? addGlobal(
+                indexSourceFile,
+                indexFilePath,
+                `export * from '${statePath}.facade';`
+              )
+            : []),
           ...addGlobal(
             indexSourceFile,
             indexFilePath,

--- a/packages/schematics/src/collection/ngrx/rules/add-imports-to-module.ts
+++ b/packages/schematics/src/collection/ngrx/rules/add-imports-to-module.ts
@@ -35,10 +35,12 @@ export function addImportsToModule(context: RequestContext): Rule {
     const pathPrefix = `${dir}/${toFileName(context.featureName)}`;
     const reducerPath = `${pathPrefix}.reducer`;
     const effectsPath = `${pathPrefix}.effects`;
+    const facadePath = `${pathPrefix}.facade`;
 
     const featureName = `${toPropertyName(context.featureName)}`;
     const reducerName = `${toPropertyName(context.featureName)}Reducer`;
     const effectsName = `${toClassName(context.featureName)}Effects`;
+    const facadeName = `${toClassName(context.featureName)}Facade`;
     const reducerImports = `initialState as ${featureName}InitialState, ${reducerName}`;
 
     const storeReducers = `{ ${featureName}: ${reducerName} }`;
@@ -90,13 +92,19 @@ export function addImportsToModule(context: RequestContext): Rule {
           : [])
       ]);
     } else {
-      const common = [
+      let common = [
         addImport.apply(this, storeModule),
         addImport.apply(this, effectsModule),
         addImport(reducerImports, reducerPath),
-        addImport(effectsName, effectsPath),
-        ...addProviderToModule(source, modulePath, `${effectsName}`)
+        addImport(effectsName, effectsPath)
       ];
+      if (context.options.facade) {
+        common = [
+          ...common,
+          addImport(facadeName, facadePath),
+          ...addProviderToModule(source, modulePath, `${facadeName}`)
+        ];
+      }
 
       if (context.options.root) {
         insert(host, modulePath, [

--- a/packages/schematics/src/collection/ngrx/schema.d.ts
+++ b/packages/schematics/src/collection/ngrx/schema.d.ts
@@ -3,6 +3,7 @@ export interface Schema {
   module: string;
   directory: string;
   root: boolean;
+  facade: boolean;
   onlyEmptyRoot: boolean;
   onlyAddFiles: boolean;
   skipFormat: boolean;

--- a/packages/schematics/src/collection/ngrx/schema.json
+++ b/packages/schematics/src/collection/ngrx/schema.json
@@ -30,6 +30,12 @@
       "description":
         "Add StoreModule.forRoot and EffectsModule.forRoot() instead of forFeature (e.g., --root)."
     },
+    "facade": {
+      "type": "boolean",
+      "default": false,
+      "description":
+        "Create a Facade class for the the Feature (e.g., --facade)."
+    },
     "onlyAddFiles": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
Add support to generate NgRx facade classes when the command `--facade` boolean option
is used.

```console
ng g ngrx <feature> --facade
```

> Note this will not generate facades for existing ngrx features; this option
is currently only available for *new* ngrx scaffolding.

* Add code generators for `<feature>.facade.ts` + `<feature>.facade.spec.ts`

Fixes #629. Fixes #638.

use entity