### PR TITLE
fix(schematics): library schematic properly removes extra files

### DIFF
--- a/e2e/schematics/command-line.test.ts
+++ b/e2e/schematics/command-line.test.ts
@@ -175,7 +175,7 @@ describe('Command line', () => {
       );
 
       const output = runCommand(
-        'npm run workspace-schematic -- custom mylib --directory=dir'
+        'npm run workspace-schematic custom mylib -- --directory=dir'
       );
       checkFilesExist('libs/dir/mylib/src/index.ts');
       expect(output).toContain(

--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -227,14 +227,21 @@ function updateNgPackage(options: NormalizedSchema): Rule {
 
 function updateProject(options: NormalizedSchema): Rule {
   return (host: Tree) => {
-    // Bug in @angular-devkit/core. Cannot delete these files here.
-    // host.delete(`${options.projectRoot}/src/lib/${options.name}.service.ts`);
-    // host.delete(`${options.projectRoot}/src/lib/${options.name}.service.spec.ts`);
-    // host.delete(`${options.projectRoot}/src/lib/${options.name}.component.ts`);
-    // host.delete(`${options.projectRoot}/src/lib/${options.name}.component.spec.ts`);
+    const libRoot = `${options.projectRoot}/src/lib/`;
+
+    host.delete(path.join(libRoot, `${options.name}.service.ts`));
+    host.delete(path.join(libRoot, `${options.name}.service.spec.ts`));
+    host.delete(path.join(libRoot, `${options.name}.component.ts`));
+    host.delete(path.join(libRoot, `${options.name}.component.spec.ts`));
+
+    if (!options.publishable) {
+      host.delete(path.join(options.projectRoot, 'ng-package.json'));
+      host.delete(path.join(options.projectRoot, 'ng-package.prod.json'));
+      host.delete(path.join(options.projectRoot, 'package.json'));
+    }
 
     host.overwrite(
-      `${options.projectRoot}/src/lib/${options.name}.module.ts`,
+      path.join(libRoot, `${options.name}.module.ts`),
       `
       import { NgModule } from '@angular/core';
       import { CommonModule } from '@angular/common';
@@ -247,7 +254,7 @@ function updateProject(options: NormalizedSchema): Rule {
       `
     );
     host.create(
-      `${options.projectRoot}/src/lib/${options.name}.module.spec.ts`,
+      path.join(libRoot, `${options.name}.module.spec.ts`),
       `
 import { async, TestBed } from '@angular/core/testing';
 import { ${options.moduleName} } from './${options.name}.module';
@@ -369,48 +376,6 @@ export default function(schema: Schema): Rule {
     if (!options.routing && options.lazy) {
       throw new Error(`routing must be set`);
     }
-
-    // @angular-devkit/core doesn't allow us to delete files
-    setTimeout(() => {
-      fs.unlinkSync(
-        path.join(
-          options.projectRoot,
-          'src',
-          'lib',
-          `${options.name}.service.ts`
-        )
-      );
-      fs.unlinkSync(
-        path.join(
-          options.projectRoot,
-          'src',
-          'lib',
-          `${options.name}.service.spec.ts`
-        )
-      );
-      fs.unlinkSync(
-        path.join(
-          options.projectRoot,
-          'src',
-          'lib',
-          `${options.name}.component.ts`
-        )
-      );
-      fs.unlinkSync(
-        path.join(
-          options.projectRoot,
-          'src',
-          'lib',
-          `${options.name}.component.spec.ts`
-        )
-      );
-
-      if (!schema.publishable) {
-        fs.unlinkSync(path.join(options.projectRoot, 'ng-package.json'));
-        fs.unlinkSync(path.join(options.projectRoot, 'ng-package.prod.json'));
-        fs.unlinkSync(path.join(options.projectRoot, 'package.json'));
-      }
-    }, 0);
 
     return chain([
       externalSchematic('@schematics/angular', 'library', {


### PR DESCRIPTION
Angular CLI now supports `host.delete()`. `updateProject()` now properly removes
the library generated service and component files.

>  Earlier workarounds using `unlink()` were not working.

Refs #650.