### PR TITLE
fix(schematics): set typescript version consistent with angular cli

### DIFF
--- a/packages/schematics/src/lib-versions.ts
+++ b/packages/schematics/src/lib-versions.ts
@@ -9,7 +9,7 @@ export const angularCliSchema =
   './node_modules/@nrwl/schematics/src/schema.json';
 export const latestMigration = '20180507-create-nx-json';
 export const prettierVersion = '1.13.7';
-export const typescriptVersion = '2.7.2';
+export const typescriptVersion = '~2.7.2';
 export const rxjsVersion = '^6.0.0';
 export const jasmineMarblesVersion = '0.3.1';
 


### PR DESCRIPTION
## Current Behavior
New projects are generated with `typescript@2.7.2`

## Expected Behavior
New projects are generated with `typescript@~2.7.2` as well

## Notes
This doesn't really matter right now since they are equivalent but it's what the CLI has.