### PR TITLE
feat(schematics): allow nx projects to specify implicitDependencies

### DIFF
--- a/packages/schematics/src/command-line/affected-apps.spec.ts
+++ b/packages/schematics/src/command-line/affected-apps.spec.ts
@@ -13,6 +13,7 @@ const projects: ProjectNode[] = [
     root: 'apps/app1',
     files: ['apps/app1/app1.ts'],
     tags: [],
+    implicitDependencies: [],
     architect: {},
     type: ProjectType.app
   },
@@ -21,6 +22,7 @@ const projects: ProjectNode[] = [
     root: 'apps/app2',
     files: ['apps/app2/app2.ts'],
     tags: [],
+    implicitDependencies: [],
     architect: {},
     type: ProjectType.app
   },
@@ -29,6 +31,7 @@ const projects: ProjectNode[] = [
     root: 'libs/lib1',
     files: ['libs/lib1/lib1.ts'],
     tags: [],
+    implicitDependencies: [],
     architect: {},
     type: ProjectType.lib
   },
@@ -37,6 +40,7 @@ const projects: ProjectNode[] = [
     root: 'libs/lib2',
     files: ['libs/lib2/lib2.ts'],
     tags: [],
+    implicitDependencies: [],
     architect: {},
     type: ProjectType.lib
   }
@@ -53,6 +57,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app1',
             files: [],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -61,6 +66,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app2',
             files: [],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           }
@@ -71,7 +77,8 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
       expect(deps).toEqual({ app1Name: [], app2Name: [] });
     });
 
-    it('should create implicit dependencies between e2e an apps', () => {
+    // NOTE: previously we did create an implicit dependency here, but that is now handled in `getProjectNodes`
+    it('should not create implicit dependencies between e2e and apps', () => {
       const deps = dependencies(
         'nrwl',
         [
@@ -80,6 +87,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app1',
             files: [],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -88,6 +96,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app1Name-e2e',
             files: [],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.e2e
           }
@@ -97,8 +106,84 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
 
       expect(deps).toEqual({
         app1Name: [],
-        'app1Name-e2e': [
+        'app1Name-e2e': []
+      });
+    });
+
+    it('should support providing implicit deps for e2e project with custom name', () => {
+      const deps = dependencies(
+        'nrwl',
+        [
+          {
+            name: 'app1Name',
+            root: 'apps/app1',
+            files: [],
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'customName-e2e',
+            root: 'apps/customName-e2e',
+            files: [],
+            tags: [],
+            implicitDependencies: ['app1Name'],
+            architect: {},
+            type: ProjectType.e2e
+          }
+        ],
+        () => null
+      );
+
+      expect(deps).toEqual({
+        app1Name: [],
+        'customName-e2e': [
           { projectName: 'app1Name', type: DependencyType.implicit }
+        ]
+      });
+    });
+
+    it('should support providing implicit deps for e2e project with standard name', () => {
+      const deps = dependencies(
+        'nrwl',
+        [
+          {
+            name: 'app1Name',
+            root: 'apps/app1',
+            files: [],
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'app2Name',
+            root: 'apps/app2',
+            files: [],
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'app1Name-e2e',
+            root: 'apps/app1Name-e2e',
+            files: [],
+            tags: [],
+            implicitDependencies: ['app2Name'],
+            architect: {},
+            type: ProjectType.e2e
+          }
+        ],
+        () => null
+      );
+
+      expect(deps).toEqual({
+        app1Name: [],
+        app2Name: [],
+        'app1Name-e2e': [
+          { projectName: 'app2Name', type: DependencyType.implicit }
         ]
       });
     });
@@ -112,6 +197,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app1',
             files: ['app1.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -120,6 +206,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/lib1',
             files: ['lib1.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.lib
           },
@@ -128,6 +215,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/lib2',
             files: ['lib2.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.lib
           }
@@ -166,6 +254,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app1',
             files: ['app1.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -174,6 +263,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/lib1',
             files: ['lib1.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.lib
           },
@@ -182,6 +272,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/lib2',
             files: ['lib2.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.lib
           }
@@ -222,6 +313,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app1',
             files: ['index.html'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           }
@@ -241,6 +333,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/aa',
             files: ['aa.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -249,6 +342,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/aa/bb',
             files: ['bb.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           }
@@ -278,6 +372,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/aa',
             files: ['aa.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -286,6 +381,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/bb',
             files: ['bb.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           }
@@ -318,6 +414,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/aa',
             files: ['aa.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           }
@@ -342,7 +439,10 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
         'nrwl',
         projects,
         {
-          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          files: {
+            'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          },
+          projects: {}
         },
         file => {
           switch (file) {
@@ -369,7 +469,10 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
         'nrwl',
         projects,
         {
-          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          files: {
+            'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          },
+          projects: {}
         },
         file => {
           switch (file) {
@@ -391,6 +494,76 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
       expect(affected).toEqual(['app2Name', 'app1Name']);
     });
 
+    it('should return list of affected apps if a touched file is part of a project-level implicit dependency', () => {
+      const projects = [
+        {
+          name: 'app1Name',
+          root: 'apps/app1',
+          files: ['apps/app1/app1.ts'],
+          tags: [],
+          implicitDependencies: [],
+          architect: {},
+          type: ProjectType.app
+        },
+        {
+          name: 'app2Name',
+          root: 'apps/app2',
+          files: ['apps/app2/app2.ts'],
+          tags: [],
+          implicitDependencies: [],
+          architect: {},
+          type: ProjectType.app
+        },
+        {
+          name: 'lib1Name',
+          root: 'libs/lib1',
+          files: ['libs/lib1/lib1.ts'],
+          tags: [],
+          implicitDependencies: ['lib2Name'],
+          architect: {},
+          type: ProjectType.lib
+        },
+        {
+          name: 'lib2Name',
+          root: 'libs/lib2',
+          files: ['libs/lib2/lib2.ts'],
+          tags: [],
+          implicitDependencies: [],
+          architect: {},
+          type: ProjectType.lib
+        }
+      ];
+      const affected = affectedAppNames(
+        'nrwl',
+        projects,
+        {
+          files: {
+            'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          },
+          projects: {
+            lib2Name: ['lib1Name']
+          }
+        },
+        file => {
+          switch (file) {
+            case 'apps/app1/app1.ts':
+              return `
+            import '@nrwl/lib1';
+          `;
+            case 'apps/app2/app2.ts':
+              return ``;
+            case 'libs/lib1/lib1.ts':
+              return ``;
+            case 'libs/lib2/lib2.ts':
+              return ``;
+          }
+        },
+        ['libs/lib2/lib2.ts']
+      );
+
+      expect(affected).toEqual(['app1Name']);
+    });
+
     it('should handle slashes', () => {
       const affected = affectedAppNames(
         'nrwl',
@@ -400,12 +573,16 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app1',
             files: ['apps\\app1\\one\\app1.ts', 'apps\\app1\\two\\app1.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           }
         ],
         {
-          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          files: {
+            'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          },
+          projects: {}
         },
         file => {
           switch (file) {
@@ -430,6 +607,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app1',
             files: ['apps/app1/app1.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -438,12 +616,16 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app2',
             files: ['apps/app2/app2.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           }
         ],
         {
-          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          files: {
+            'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          },
+          projects: {}
         },
         file => {
           switch (file) {
@@ -458,13 +640,62 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
 
       expect(affected).toEqual(['app2Name', 'app1Name']);
     });
+
+    it('should handle circular dependencies for project-level implicit dependencies', () => {
+      const affected = affectedAppNames(
+        'nrwl',
+        [
+          {
+            name: 'app1Name',
+            root: 'apps/app1',
+            files: ['apps/app1/app1.ts'],
+            tags: [],
+            implicitDependencies: ['app2Name'],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'app2Name',
+            root: 'apps/app2',
+            files: ['apps/app2/app2.ts'],
+            tags: [],
+            implicitDependencies: ['app1Name'],
+            architect: {},
+            type: ProjectType.app
+          }
+        ],
+        {
+          files: {
+            'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          },
+          projects: {
+            app1Name: ['app2Name'],
+            app2Name: ['app1Name']
+          }
+        },
+        file => {
+          switch (file) {
+            case 'apps/app1/app1.ts':
+              return ``;
+            case 'apps/app2/app2.ts':
+              return ``;
+          }
+        },
+        ['apps/app1/app1.ts']
+      );
+
+      expect(affected).toEqual(['app2Name', 'app1Name']);
+    });
   });
 
   describe('touchedProjects', () => {
     it('should return the list of touchedProjects', () => {
       const tp = touchedProjects(
         {
-          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          files: {
+            'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          },
+          projects: {}
         },
         [
           {
@@ -472,6 +703,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app1',
             files: ['app1.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -480,6 +712,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app2',
             files: ['app2.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -488,6 +721,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/lib1',
             files: ['lib1.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.lib
           },
@@ -496,6 +730,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/lib2',
             files: ['lib2.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.lib
           }
@@ -509,7 +744,10 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
     it('should return the list of touchedProjects independent from the git structure', () => {
       const tp = touchedProjects(
         {
-          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          files: {
+            'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name']
+          },
+          projects: {}
         },
         [
           {
@@ -517,6 +755,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app1',
             files: ['app1.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -525,6 +764,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app2',
             files: ['app2.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -533,6 +773,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/lib1',
             files: ['lib1.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.lib
           },
@@ -541,6 +782,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/lib2',
             files: ['lib2.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.lib
           }
@@ -554,8 +796,11 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
     it('should return the list of implicitly touched projects', () => {
       const tp = touchedProjects(
         {
-          'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name'],
-          Jenkinsfile: ['app1Name', 'app2Name']
+          files: {
+            'package.json': ['app1Name', 'app2Name', 'lib1Name', 'lib2Name'],
+            Jenkinsfile: ['app1Name', 'app2Name']
+          },
+          projects: {}
         },
         [
           {
@@ -563,6 +808,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app1',
             files: ['app1.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -571,6 +817,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'apps/app2',
             files: ['app2.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.app
           },
@@ -579,6 +826,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/lib1',
             files: ['lib1.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.lib
           },
@@ -587,6 +835,7 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
             root: 'libs/lib2',
             files: ['lib2.ts'],
             tags: [],
+            implicitDependencies: [],
             architect: {},
             type: ProjectType.lib
           }

--- a/packages/schematics/src/command-line/dep-graph.spec.ts
+++ b/packages/schematics/src/command-line/dep-graph.spec.ts
@@ -27,6 +27,7 @@ describe('dep-graph', () => {
         root: 'apps/app1',
         type: ProjectType.app,
         tags: [],
+        implicitDependencies: [],
         architect: {},
         files: []
       },
@@ -35,6 +36,7 @@ describe('dep-graph', () => {
         root: 'apps/app2',
         type: ProjectType.app,
         tags: [],
+        implicitDependencies: [],
         architect: {},
         files: []
       },
@@ -43,6 +45,7 @@ describe('dep-graph', () => {
         root: 'libs/lib1',
         type: ProjectType.lib,
         tags: [],
+        implicitDependencies: [],
         architect: {},
         files: []
       },
@@ -51,6 +54,7 @@ describe('dep-graph', () => {
         root: 'libs/lib2',
         type: ProjectType.lib,
         tags: [],
+        implicitDependencies: [],
         architect: {},
         files: []
       },
@@ -59,6 +63,7 @@ describe('dep-graph', () => {
         root: 'libs/lib3',
         type: ProjectType.lib,
         tags: [],
+        implicitDependencies: [],
         architect: {},
         files: []
       }

--- a/packages/schematics/src/command-line/shared.spec.ts
+++ b/packages/schematics/src/command-line/shared.spec.ts
@@ -1,4 +1,12 @@
-import { getImplicitDependencies, assertWorkspaceValidity } from './shared';
+import {
+  getImplicitDependencies,
+  assertWorkspaceValidity,
+  getProjectNodes
+} from './shared';
+import {
+  ProjectType,
+  ProjectNode
+} from '@nrwl/schematics/src/command-line/affected-apps';
 
 describe('assertWorkspaceValidity', () => {
   let mockNxJson;
@@ -63,7 +71,7 @@ describe('assertWorkspaceValidity', () => {
     }
   });
 
-  it('should throw for an invalid implicit dependency', () => {
+  it('should throw for an invalid top-level implicit dependency', () => {
     mockNxJson.implicitDependencies = {
       'README.md': ['invalidproj']
     };
@@ -75,6 +83,21 @@ describe('assertWorkspaceValidity', () => {
         'implicitDependencies specified in nx.json are invalid'
       );
       expect(e.message).toContain('  README.md');
+      expect(e.message).toContain('    invalidproj');
+    }
+  });
+
+  it('should throw for an invalid project-level implicit dependency', () => {
+    mockNxJson.projects.app2.implicitDependencies = ['invalidproj'];
+
+    try {
+      assertWorkspaceValidity(mockAngularJson, mockNxJson);
+      fail('Did not throw');
+    } catch (e) {
+      expect(e.message).toContain(
+        'implicitDependencies specified in nx.json are invalid'
+      );
+      expect(e.message).toContain('  app2');
       expect(e.message).toContain('    invalidproj');
     }
   });
@@ -109,45 +132,235 @@ describe('getImplicitDependencies', () => {
     };
     mockAngularJson = {
       projects: {
-        app1: {},
-        'app1-e2e': {},
-        app2: {},
-        'app2-e2e': {},
-        lib1: {},
-        lib2: {}
+        app1: {
+          projectType: 'application'
+        },
+        'app1-e2e': {
+          projectType: 'application'
+        },
+        app2: {
+          projectType: 'application'
+        },
+        'app2-e2e': {
+          projectType: 'application'
+        },
+        lib1: {
+          projectType: 'library'
+        },
+        lib2: {
+          projectType: 'library'
+        }
       }
     };
   });
 
-  it('should return implicit dependencies', () => {
-    mockNxJson.implicitDependencies = {
-      Jenkinsfile: ['app1', 'app2']
-    };
+  describe('top-level implicit dependencies', () => {
+    it('should return implicit dependencies', () => {
+      mockNxJson.implicitDependencies = {
+        Jenkinsfile: ['app1', 'app2']
+      };
 
-    const result = getImplicitDependencies(mockAngularJson, mockNxJson);
+      const result = getImplicitDependencies(mockAngularJson, mockNxJson);
 
-    expect(result).toEqual({
-      Jenkinsfile: ['app1', 'app2']
+      expect(result).toEqual({
+        files: {
+          Jenkinsfile: ['app1', 'app2']
+        },
+        projects: {
+          app1: ['app1-e2e'],
+          app2: ['app2-e2e']
+        }
+      });
+    });
+
+    it('should normalize wildcards into all projects', () => {
+      mockNxJson.implicitDependencies = {
+        'package.json': '*'
+      };
+
+      const result = getImplicitDependencies(mockAngularJson, mockNxJson);
+
+      expect(result).toEqual({
+        files: {
+          'package.json': [
+            'app1',
+            'app1-e2e',
+            'app2',
+            'app2-e2e',
+            'lib1',
+            'lib2'
+          ]
+        },
+        projects: {
+          app1: ['app1-e2e'],
+          app2: ['app2-e2e']
+        }
+      });
+    });
+
+    it('should call throw for an invalid workspace', () => {
+      delete mockNxJson.projects.app1;
+      try {
+        getImplicitDependencies(mockAngularJson, mockNxJson);
+        fail('did not throw');
+      } catch (e) {}
     });
   });
 
-  it('should normalize wildcards into all projects', () => {
-    mockNxJson.implicitDependencies = {
-      'package.json': '*'
-    };
+  describe('project-based implicit dependencies', () => {
+    it('should default appropriately', () => {
+      const result = getImplicitDependencies(mockAngularJson, mockNxJson);
 
-    const result = getImplicitDependencies(mockAngularJson, mockNxJson);
+      expect(result).toEqual({
+        files: {},
+        projects: {
+          app1: ['app1-e2e'],
+          app2: ['app2-e2e']
+        }
+      });
+    });
 
-    expect(result).toEqual({
-      'package.json': ['app1', 'app1-e2e', 'app2', 'app2-e2e', 'lib1', 'lib2']
+    it('should allow setting on libs and apps', () => {
+      mockNxJson.projects.app2.implicitDependencies = ['app1'];
+      mockNxJson.projects.lib2.implicitDependencies = ['lib1'];
+
+      const result = getImplicitDependencies(mockAngularJson, mockNxJson);
+
+      expect(result).toEqual({
+        files: {},
+        projects: {
+          app1: ['app1-e2e', 'app2'],
+          app2: ['app2-e2e'],
+          lib1: ['lib2']
+        }
+      });
+    });
+
+    // NOTE: originally e2e apps had a magic dependency on their target app by naming convention.
+    // So, 'appName-e2e' depended on 'appName'.
+    it('should override magic e2e dependencies if specified', () => {
+      mockNxJson.projects['app1-e2e'].implicitDependencies = ['app2'];
+
+      const result = getImplicitDependencies(mockAngularJson, mockNxJson);
+
+      expect(result).toEqual({
+        files: {},
+        projects: {
+          app2: ['app1-e2e', 'app2-e2e']
+        }
+      });
+    });
+
+    it('should fallback to magic e2e dependencies if empty array specified', () => {
+      mockNxJson.projects['app1-e2e'].implicitDependencies = [];
+
+      const result = getImplicitDependencies(mockAngularJson, mockNxJson);
+
+      expect(result).toEqual({
+        files: {},
+        projects: {
+          app1: ['app1-e2e'],
+          app2: ['app2-e2e']
+        }
+      });
     });
   });
 
-  it('should call throw for an invalid workspace', () => {
-    delete mockNxJson.projects.app1;
-    try {
-      getImplicitDependencies(mockAngularJson, mockNxJson);
-      fail('did not throw');
-    } catch (e) {}
+  describe('project-based and top-level implicit dependencies', () => {
+    it('allows setting both', () => {
+      mockNxJson.implicitDependencies = {
+        Jenkinsfile: ['app1', 'app2']
+      };
+      mockNxJson.projects.app2.implicitDependencies = ['app1'];
+
+      const result = getImplicitDependencies(mockAngularJson, mockNxJson);
+
+      expect(result).toEqual({
+        files: {
+          Jenkinsfile: ['app1', 'app2']
+        },
+        projects: {
+          app1: ['app1-e2e', 'app2'],
+          app2: ['app2-e2e']
+        }
+      });
+    });
+  });
+});
+
+describe('getProjectNodes', () => {
+  let mockNxJson;
+  let mockAngularJson;
+
+  beforeEach(() => {
+    mockNxJson = {
+      projects: {
+        app1: {
+          tags: []
+        },
+        'app1-e2e': {
+          tags: []
+        },
+        'customName-e2e': {
+          tags: []
+        },
+        lib1: {
+          tags: []
+        },
+        lib2: {
+          tags: []
+        }
+      }
+    };
+    mockAngularJson = {
+      projects: {
+        app1: {
+          projectType: 'application'
+        },
+        'app1-e2e': {
+          projectType: 'application'
+        },
+        'customName-e2e': {
+          projectType: 'application'
+        },
+        lib1: {
+          projectType: 'library'
+        },
+        lib2: {
+          projectType: 'library'
+        }
+      }
+    };
+  });
+
+  it('should parse nodes as correct type', () => {
+    const result: Pick<ProjectNode, 'name' | 'type'>[] = getProjectNodes(
+      mockAngularJson,
+      mockNxJson
+    ).map(node => {
+      return { name: node.name, type: node.type };
+    });
+    expect(result).toEqual([
+      {
+        name: 'app1',
+        type: ProjectType.app
+      },
+      {
+        name: 'app1-e2e',
+        type: ProjectType.e2e
+      },
+      {
+        name: 'customName-e2e',
+        type: ProjectType.e2e
+      },
+      {
+        name: 'lib1',
+        type: ProjectType.lib
+      },
+      {
+        name: 'lib2',
+        type: ProjectType.lib
+      }
+    ]);
   });
 });

--- a/packages/schematics/src/command-line/workspace-integrity-checks.spec.ts
+++ b/packages/schematics/src/command-line/workspace-integrity-checks.spec.ts
@@ -20,6 +20,7 @@ describe('WorkspaceIntegrityChecks', () => {
             type: ProjectType.lib,
             root: 'libs/project1',
             tags: [],
+            implicitDependencies: [],
             architect: {},
             files: ['libs/project1/src/index.ts']
           }
@@ -38,6 +39,7 @@ describe('WorkspaceIntegrityChecks', () => {
             type: ProjectType.lib,
             root: 'libs/project1',
             tags: [],
+            implicitDependencies: [],
             architect: {},
             files: []
           },
@@ -46,6 +48,7 @@ describe('WorkspaceIntegrityChecks', () => {
             type: ProjectType.lib,
             root: 'libs/project2',
             tags: [],
+            implicitDependencies: [],
             architect: {},
             files: ['libs/project2/src/index.ts']
           }
@@ -69,6 +72,7 @@ describe('WorkspaceIntegrityChecks', () => {
             type: ProjectType.lib,
             root: 'libs/project1',
             tags: [],
+            implicitDependencies: [],
             architect: {},
             files: ['libs/project1/src/index.ts']
           }

--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -25,6 +25,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/myapp',
           type: ProjectType.app,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`apps/myapp/src/main.ts`, `apps/myapp/blah.ts`]
         },
@@ -33,6 +34,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/mylib',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/mylib/src/index.ts`, `libs/mylib/src/deep.ts`]
         }
@@ -55,6 +57,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/myapp',
           type: ProjectType.app,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`apps/myapp/src/main.ts`, `apps/myapp/src/blah.ts`]
         },
@@ -63,6 +66,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/myapp2',
           type: ProjectType.app,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: []
         },
@@ -71,6 +75,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/myapp2/mylib',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: ['libs/myapp2/mylib/src/index.ts']
         }
@@ -81,12 +86,13 @@ describe('Enforce Module Boundaries', () => {
   });
 
   describe('depConstraints', () => {
-    const projectNodes = [
+    const projectNodes: ProjectNode[] = [
       {
         name: 'apiName',
         root: 'libs/api',
         type: ProjectType.lib,
         tags: ['api', 'domain1'],
+        implicitDependencies: [],
         architect: {},
         files: [`libs/api/src/index.ts`]
       },
@@ -95,6 +101,7 @@ describe('Enforce Module Boundaries', () => {
         root: 'libs/impl',
         type: ProjectType.lib,
         tags: ['impl', 'domain1'],
+        implicitDependencies: [],
         architect: {},
         files: [`libs/impl/src/index.ts`]
       },
@@ -103,6 +110,7 @@ describe('Enforce Module Boundaries', () => {
         root: 'libs/impl2',
         type: ProjectType.lib,
         tags: ['impl', 'domain1'],
+        implicitDependencies: [],
         architect: {},
         files: [`libs/impl2/src/index.ts`]
       },
@@ -111,6 +119,7 @@ describe('Enforce Module Boundaries', () => {
         root: 'libs/impl-domain2',
         type: ProjectType.lib,
         tags: ['impl', 'domain2'],
+        implicitDependencies: [],
         architect: {},
         files: [`libs/impl-domain2/src/index.ts`]
       },
@@ -119,6 +128,7 @@ describe('Enforce Module Boundaries', () => {
         root: 'libs/impl-both-domains',
         type: ProjectType.lib,
         tags: ['impl', 'domain1', 'domain2'],
+        implicitDependencies: [],
         architect: {},
         files: [`libs/impl-both-domains/src/index.ts`]
       },
@@ -127,6 +137,7 @@ describe('Enforce Module Boundaries', () => {
         root: 'libs/untagged',
         type: ProjectType.lib,
         tags: [],
+        implicitDependencies: [],
         architect: {},
         files: [`libs/untagged/src/index.ts`]
       }
@@ -268,6 +279,7 @@ describe('Enforce Module Boundaries', () => {
             root: 'libs/mylib',
             type: ProjectType.lib,
             tags: [],
+            implicitDependencies: [],
             architect: {},
             files: [`libs/mylib/src/main.ts`, `libs/mylib/other.ts`]
           }
@@ -287,6 +299,7 @@ describe('Enforce Module Boundaries', () => {
             root: 'libs/mylib',
             type: ProjectType.lib,
             tags: [],
+            implicitDependencies: [],
             architect: {},
             files: [`libs/mylib/src/main.ts`, `libs/mylib/other/index.ts`]
           }
@@ -306,6 +319,7 @@ describe('Enforce Module Boundaries', () => {
             root: 'libs/mylib',
             type: ProjectType.lib,
             tags: [],
+            implicitDependencies: [],
             architect: {},
             files: [`libs/mylib/src/main.ts`]
           },
@@ -314,6 +328,7 @@ describe('Enforce Module Boundaries', () => {
             root: 'libs/other',
             type: ProjectType.lib,
             tags: [],
+            implicitDependencies: [],
             architect: {},
             files: ['libs/other/src/index.ts']
           }
@@ -336,6 +351,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/mylib',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/mylib/src/main.ts`, `libs/mylib/src/other.ts`]
         }
@@ -362,6 +378,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/mylib',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/mylib/src/main.ts`, `libs/mylib/src/another-file.ts`]
         },
@@ -370,6 +387,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/other',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/other/src/blah.ts`]
         },
@@ -378,6 +396,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/other/sublib',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/other/sublib/src/blah.ts`]
         }
@@ -402,6 +421,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/mylib',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/mylib/src/main.ts`]
         },
@@ -410,6 +430,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/other',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/other/index.ts`]
         }
@@ -436,6 +457,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/mylib',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/mylib/src/main.ts`]
         },
@@ -444,6 +466,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'apps/myapp',
           type: ProjectType.app,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`apps/myapp/src/index.ts`]
         }
@@ -463,6 +486,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/mylib',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/mylib/src/main.ts`]
         },
@@ -471,6 +495,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/anotherlib',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/anotherlib/src/main.ts`]
         },
@@ -479,6 +504,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'apps/myapp',
           type: ProjectType.app,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`apps/myapp/src/index.ts`]
         }
@@ -505,6 +531,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/mylib',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/mylib/src/main.ts`]
         },
@@ -513,6 +540,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/anotherlib',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/anotherlib/src/main.ts`]
         },
@@ -521,6 +549,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'libs/badcirclelib',
           type: ProjectType.lib,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`libs/badcirclelib/src/main.ts`]
         },
@@ -529,6 +558,7 @@ describe('Enforce Module Boundaries', () => {
           root: 'apps/myapp',
           type: ProjectType.app,
           tags: [],
+          implicitDependencies: [],
           architect: {},
           files: [`apps/myapp/index.ts`]
         }


### PR DESCRIPTION
(@vsavkin - from your suggestion in #644)

`implicitDependencies` between files and projects are already able to be specified in `nx.json`, so this adds the ability to specify `implicitDependencies` between one project and (multiple) others.

By extension, this also enables a more flexible e2e suite naming convention than was previously supported.

Closes #665