### PR TITLE
fix(schematics): use correct action type for LoadError

### DIFF
--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.actions.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.actions.ts__tmpl__
@@ -12,7 +12,7 @@ export class Load<%= className %> implements Action {
 }
 
 export class <%= className %>LoadError implements Action {
- readonly type = <%= className %>ActionTypes.Load<%= className %>;
+ readonly type = <%= className %>ActionTypes.<%= className %>LoadError;
  constructor(public payload: any) { }
 }
 


### PR DESCRIPTION
The `LoadError` action was mapped to the `Load<%= className %>` action type rather than `<%= className %>LoadError`.