### PR TITLE
feat(builders): introduce builders package and jest builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@schematics/angular": "^0.7.2",
     "@types/jasmine": "~2.8.6",
     "@types/jasminewd2": "~2.0.3",
+    "@types/jest": "^23.3.1",
     "@types/node": "~8.9.4",
     "@types/prettier": "^1.10.0",
     "@types/yargs": "^11.0.0",

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@nrwl/builders",
+  "version": "0.0.1",
+  "description": "Nrwl Extensions for Angular: Builders",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nrwl/nx.git"
+  },
+  "keywords": [
+    "Test",
+    "Jest",
+    "Angular",
+    "Workspace",
+    "Builders",
+    "Angular CLI"
+  ],
+  "main": "index.js",
+  "types": "index.d.js",
+  "author": "Victor Savkin",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/nrwl/nx/issues"
+  },
+  "homepage": "https://github.com/nrwl/nx#readme",
+  "builders": "./src/builders.json",
+  "dependencies": {
+    "@angular-devkit/architect": "~0.7.0",
+    "rxjs": "6.2.2"
+  }
+}

--- a/packages/builders/plugins/jest/resolver.ts
+++ b/packages/builders/plugins/jest/resolver.ts
@@ -1,0 +1,50 @@
+import { dirname } from 'path';
+import * as ts from 'typescript';
+import defaultResolver from 'jest-resolve/build/default_resolver';
+
+interface ResolveOptions {
+  rootDir: string;
+  basedir: string;
+  paths: string[];
+  moduleDirectory: string[];
+  browser: boolean;
+  extensions: string[];
+}
+
+function getCompilerSetup(rootDir: string) {
+  const tsConfigPath =
+    ts.findConfigFile(rootDir, ts.sys.fileExists, 'tsconfig.spec.json') ||
+    ts.findConfigFile(rootDir, ts.sys.fileExists, 'tsconfig.test.json') ||
+    ts.findConfigFile(rootDir, ts.sys.fileExists, 'tsconfig.jest.json');
+
+  if (!tsConfigPath) {
+    console.error(
+      `Cannot locate a tsconfig.spec.json. Please create one at ${rootDir}/tsconfig.spec.json`
+    );
+  }
+
+  const readResult = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
+  const config = ts.parseJsonConfigFileContent(
+    readResult.config,
+    ts.sys,
+    dirname(tsConfigPath)
+  );
+  const compilerOptions = config.options;
+  const host = ts.createCompilerHost(compilerOptions, true);
+  return { compilerOptions, host };
+}
+
+let compilerSetup;
+
+module.exports = function(path: string, options: ResolveOptions) {
+  // Try to use the defaultResolver
+  try {
+    return defaultResolver(path, options);
+  } catch (e) {
+    // Fallback to using typescript
+    compilerSetup = compilerSetup || getCompilerSetup(options.rootDir);
+    const { compilerOptions, host } = compilerSetup;
+    return ts.resolveModuleName(path, options.basedir, compilerOptions, host)
+      .resolvedModule.resolvedFileName;
+  }
+};

--- a/packages/builders/src/builders.json
+++ b/packages/builders/src/builders.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../architect/src/builders-schema.json",
+  "builders": {
+    "jest": {
+      "class": "./jest/jest.builder",
+      "schema": "./jest/schema.json",
+      "description": "Run Jest unit tests"
+    }
+  }
+}

--- a/packages/builders/src/jest/jest.builder.spec.ts
+++ b/packages/builders/src/jest/jest.builder.spec.ts
@@ -1,0 +1,114 @@
+import JestBuilder from './jest.builder';
+import { normalize } from '@angular-devkit/core';
+import * as jestCLI from 'jest-cli';
+import * as path from 'path';
+
+describe('Jest Builder', () => {
+  let builder: JestBuilder;
+
+  beforeEach(() => {
+    builder = new JestBuilder();
+  });
+
+  it('should send appropriate options to jestCLI', () => {
+    const runCLI = spyOn(jestCLI, 'runCLI').and.returnValue(
+      Promise.resolve({
+        results: {
+          success: true
+        }
+      })
+    );
+    const root = normalize('/root');
+    builder
+      .run({
+        root,
+        builder: '',
+        projectType: 'application',
+        options: {
+          jestConfig: './jest.config.js',
+          tsConfig: './tsconfig.test.json',
+          watch: false
+        }
+      })
+      .toPromise();
+    expect(runCLI).toHaveBeenCalledWith(
+      {
+        globals: JSON.stringify({
+          'ts-jest': {
+            tsConfigFile: path.relative(root, './tsconfig.test.json')
+          },
+          __TRANSFORM_HTML__: true
+        }),
+        watch: false
+      },
+      ['./jest.config.js']
+    );
+  });
+
+  it('should send the setupFile to jestCLI', () => {
+    const runCLI = spyOn(jestCLI, 'runCLI').and.returnValue(
+      Promise.resolve({
+        results: {
+          success: true
+        }
+      })
+    );
+    const root = normalize('/root');
+    builder
+      .run({
+        root,
+        builder: '',
+        projectType: 'application',
+        options: {
+          jestConfig: './jest.config.js',
+          tsConfig: './tsconfig.test.json',
+          setupFile: './test.ts',
+          watch: false
+        }
+      })
+      .toPromise();
+    expect(runCLI).toHaveBeenCalledWith(
+      {
+        globals: JSON.stringify({
+          'ts-jest': {
+            tsConfigFile: path.relative(root, './tsconfig.test.json')
+          },
+          __TRANSFORM_HTML__: true
+        }),
+        setupTestFrameworkScriptFile: path.join(
+          '<rootDir>',
+          path.relative(root, './test.ts')
+        ),
+        watch: false
+      },
+      ['./jest.config.js']
+    );
+  });
+
+  it('should return the proper result', async done => {
+    spyOn(jestCLI, 'runCLI').and.returnValue(
+      Promise.resolve({
+        results: {
+          success: true
+        }
+      })
+    );
+    const root = normalize('/root');
+    const result = await builder
+      .run({
+        root,
+        builder: '',
+        projectType: 'application',
+        options: {
+          jestConfig: './jest.config.js',
+          tsConfig: './tsconfig.test.json',
+          watch: false
+        }
+      })
+      .toPromise();
+    expect(result).toEqual({
+      success: true
+    });
+    done();
+  });
+});

--- a/packages/builders/src/jest/jest.builder.ts
+++ b/packages/builders/src/jest/jest.builder.ts
@@ -1,0 +1,51 @@
+import {
+  Builder,
+  BuildEvent,
+  BuilderConfiguration
+} from '@angular-devkit/architect';
+
+import { Observable, from } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import * as path from 'path';
+
+import { runCLI as runJest } from 'jest-cli';
+
+export interface JestBuilderOptions {
+  jestConfig: string;
+  tsConfig: string;
+  watch: boolean;
+  setupFile?: string;
+}
+
+export default class JestBuilder implements Builder<JestBuilderOptions> {
+  run(
+    builderConfig: BuilderConfiguration<JestBuilderOptions>
+  ): Observable<BuildEvent> {
+    const options = builderConfig.options;
+    const config: any = {
+      watch: options.watch,
+      globals: JSON.stringify({
+        'ts-jest': {
+          tsConfigFile: path.relative(builderConfig.root, options.tsConfig)
+        },
+        __TRANSFORM_HTML__: true
+      })
+    };
+
+    if (options.setupFile) {
+      config.setupTestFrameworkScriptFile = path.join(
+        '<rootDir>',
+        path.relative(builderConfig.root, options.setupFile)
+      );
+    }
+
+    return from(runJest(config, [options.jestConfig])).pipe(
+      map((results: any) => {
+        return {
+          success: results.results.success
+        };
+      })
+    );
+  }
+}

--- a/packages/builders/src/jest/schema.json
+++ b/packages/builders/src/jest/schema.json
@@ -1,0 +1,25 @@
+{
+  "title": "Jest Target",
+  "description": "Jest target options for Build Facade",
+  "type": "object",
+  "properties": {
+    "jestConfig": {
+      "type": "string",
+      "description": "The path of the Jest configuration. (https://jestjs.io/docs/en/configuration.html)"
+    },
+    "tsConfig": {
+      "type": "string",
+      "description": "The name of the Typescript configuration file."
+    },
+    "setupFile": {
+      "type": "string",
+      "description": "The name of a setup file used by Jest. (https://jestjs.io/docs/en/configuration.html#setuptestframeworkscriptfile-string)"
+    },
+    "watch": {
+      "type": "boolean",
+      "description": "Run tests when files change.",
+      "default": false
+    }
+  },
+  "required": ["jestConfig", "tsConfig"]
+}

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -29,7 +29,7 @@
   "schematics": "./src/collection.json",
   "ng-update": {
     "requirements": {},
-    "packageGroup": ["@nrwl/nx", "@nrwl/schematics"],
+    "packageGroup": ["@nrwl/nx", "@nrwl/schematics", "@nrwl/builders"],
     "migrations": "./migrations/migrations.json"
   },
   "dependencies": {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,8 +29,10 @@ chmod +x build/packages/schematics/src/command-line/nx.js
 rm -rf build/packages/install
 rm -rf build/packages/nx/dist
 rm -rf build/packages/nx/spec
+cp README.md build/packages/builders
 cp README.md build/packages/schematics
 cp README.md build/packages/nx
 cp LICENSE build/packages/bazel
+cp LICENSE build/packages/builders
 cp LICENSE build/packages/schematics
 cp LICENSE build/packages/nx

--- a/scripts/nx-release.js
+++ b/scripts/nx-release.js
@@ -129,6 +129,7 @@ const options = {
   pkgFiles: [
     'package.json',
     'build/npm/bazel/package.json',
+    'build/npm/builders/package.json',
     'build/npm/nx/package.json',
     'build/npm/schematics/package.json'
   ],

--- a/scripts/test_schematics.sh
+++ b/scripts/test_schematics.sh
@@ -3,5 +3,5 @@
 if [ -n "$1" ]; then
   jest --maxWorkers=1 ./build/packages/$1.spec.js
 else
-  jest --maxWorkers=1 ./build/packages/{schematics,bazel}
+  jest --maxWorkers=1 ./build/packages/{schematics,bazel,builders}
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,6 +269,10 @@
   dependencies:
     "@types/jasmine" "*"
 
+"@types/jest@^23.3.1":
+  version "23.3.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.1.tgz#a4319aedb071d478e6f407d1c4578ec8156829cf"
+
 "@types/node@*":
   version "10.5.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.3.tgz#5bcfaf088ad17894232012877669634c06b20cc5"


### PR DESCRIPTION
## Objective

Allow testing with [jest](https://jestjs.io/).

Users can switch to jest by altering their `angular.json` to switch the Architect `test` target to use our new builder to run jest tests and having the correct configuration.

## Current Behavior

### Builders Package
* There is no builders package.

### Testing with Jest
* Currently, testing with Jest does not work well with Nx because of our routes
* There is also no builder for using Jest with the Angular CLI

## Expected Behavior

### Builders Package
* This new builders package will be the home of nrwl builders for Architect

### Testing with Jest
* The under-the-hood pieces for testing with Jest are added
* There is a builder for using Jest with the Angular CLI
* Testing with Jest and Nx should work with routes

Example Usage:
https://github.com/FrozenPandaz/nx-node-poc/blob/jest/angular.json#L149