### PR TITLE
fix(schematics): support migrating projects with root != name from 1.7

### DIFF
--- a/packages/schematics/migrations/legacy-migrations/20180515-switch-to-nx6.ts
+++ b/packages/schematics/migrations/legacy-migrations/20180515-switch-to-nx6.ts
@@ -20,7 +20,7 @@ export default {
     }
 
     updateJsonFile('package.json', json => {
-      json.devDependencies['@angular/cli'] = '6.0.1';
+      json.devDependencies['@angular/cli'] = '6.1.2';
     });
 
     updateJsonFile('package.json', json => {

--- a/packages/schematics/migrations/update-6-0-0/update-6-0-0.ts
+++ b/packages/schematics/migrations/update-6-0-0/update-6-0-0.ts
@@ -287,6 +287,7 @@ function moveE2eTests(host: Tree, context: SchematicContext) {
     if (p.projectType === 'application' && !p.architect.e2e) {
       renameSync(`${p.root}/e2e`, `${p.root}-e2e/src`, err => {
         if (!err) {
+          context.logger.info(`Moved ${p.root}/e2e to ${p.root}-e2e/src`);
           return;
         }
 
@@ -333,6 +334,10 @@ function patchLibIndexFiles(host: Tree, context: SchematicContext) {
           }
           renameSync(`${p.root}/lib`, `${p.sourceRoot}/lib`, err => {
             // This should never error
+            context.logger.info(`Moved ${p.sourceRoot} to ${p.sourceRoot}/lib`);
+            context.logger.warn(
+              'Deep imports may have been affected. Always try to import from the index of the lib.'
+            );
           });
         });
         const npmScope = readJsonInTree(host, 'nx.json').npmScope;
@@ -558,8 +563,6 @@ const updateAngularJson = updateJsonInTree('angular.json', json => {
 
     switch (type) {
       case 'application':
-        project.root = `apps/${key}`;
-        project.sourceRoot = `apps/${key}/src`;
         project.prefix = prefix;
 
         project.architect.build.options.tsConfig = `${
@@ -598,8 +601,6 @@ const updateAngularJson = updateJsonInTree('angular.json', json => {
         break;
 
       case 'library':
-        project.root = `libs/${key}`;
-        project.sourceRoot = `libs/${key}/src`;
         project.prefix = prefix;
 
         project.projectType = 'library';
@@ -629,8 +630,8 @@ const updateAngularJson = updateJsonInTree('angular.json', json => {
         if (appProject.projectType === 'library') {
           break;
         }
-        project.root = `apps/${key}`;
-        project.sourceRoot = `apps/${key}/src`;
+        project.root = `${appProject.root}-e2e`;
+        project.sourceRoot = `${project.root}/src`;
         project.prefix = prefix;
 
         project.architect.e2e.options.protractorConfig = `${


### PR DESCRIPTION
## Current Behavior

The Migration for 1.7 workspaces which contain projects where the name is different from the root fail

## Expected Behavior

The Migration for 1.7 workspaces which contain projects where the name is different from the root succeed and the root is preserved.

Fixes https://github.com/nrwl/nx/issues/512