### PR TITLE
fix(schematics): fix devkit version for ng-new

### DIFF
--- a/packages/schematics/src/collection/ng-new/files/__directory__/package.json
+++ b/packages/schematics/src/collection/ng-new/files/__directory__/package.json
@@ -47,7 +47,7 @@
     "@angular/cli": "<%= angularCliVersion %>",
     "@angular/compiler-cli": "<%= angularVersion %>",
     "@angular/language-service": "<%= angularVersion %>",
-    "@angular-devkit/build-angular": "~0.6.1",
+    "@angular-devkit/build-angular": "<%= angularDevkitVersion %>",
     "@ngrx/store-devtools": "<%= ngrxVersion %>",
     "ngrx-store-freeze": "<%= ngrxStoreFreezeVersion %>",
     "@nrwl/schematics": "<%= schematicsVersion %>",

--- a/packages/schematics/src/lib-versions.ts
+++ b/packages/schematics/src/lib-versions.ts
@@ -1,5 +1,6 @@
 export const angularCliVersion = '~6.1.2';
 export const angularVersion = '^6.1.0';
+export const angularDevkitVersion = '~0.7.0';
 export const angularJsVersion = '1.6.6';
 export const ngrxVersion = '6.0.1';
 export const ngrxStoreFreezeVersion = '0.2.4';
@@ -15,6 +16,7 @@ export const jasmineMarblesVersion = '0.3.1';
 
 export const libVersions = {
   angularVersion,
+  angularDevkitVersion,
   angularCliVersion,
   angularJsVersion,
   ngrxVersion,


### PR DESCRIPTION
## Current Behavior

The ng-new schematics were not updated with the latest version of `@angular-devkit/schematics`

## Expected Behavior

The version is updated and is set to `~0.7.0`, just like the CLI