### PR TITLE
fix(schematics): update other @angular framework packages when updating

### DIFF
--- a/packages/schematics/migrations/update-6-0-0/update-6-0-0.ts
+++ b/packages/schematics/migrations/update-6-0-0/update-6-0-0.ts
@@ -416,6 +416,30 @@ const updatePackageJson = updateJsonInTree('package.json', json => {
     prettier: '1.10.2'
   };
 
+  if (json.dependencies['@angular/http']) {
+    json.dependencies['@angular/http'] = '6.0.1';
+  }
+
+  if (json.dependencies['@angular/platform-server']) {
+    json.dependencies['@angular/platform-server'] = '6.0.1';
+  }
+
+  if (json.dependencies['@angular/service-worker']) {
+    json.dependencies['@angular/service-worker'] = '6.0.1';
+  }
+
+  if (json.dependencies['@angular/platform-webworker']) {
+    json.dependencies['@angular/platform-webworker'] = '6.0.1';
+  }
+
+  if (json.dependencies['@angular/platform-webworker-dynamic']) {
+    json.dependencies['@angular/platform-webworker-dynamic'] = '6.0.1';
+  }
+
+  if (json.dependencies['@angular/upgrade']) {
+    json.dependencies['@angular/upgrade'] = '6.0.1';
+  }
+
   return json;
 });
 

--- a/packages/schematics/migrations/update-6-2-0/update-6-2-0.ts
+++ b/packages/schematics/migrations/update-6-2-0/update-6-2-0.ts
@@ -67,10 +67,15 @@ function updateDependencies() {
         '@angular/compiler',
         '@angular/core',
         '@angular/forms',
+        '@angular/http',
         '@angular/platform-browser',
         '@angular/platform-browser-dynamic',
         '@angular/platform-server',
-        '@angular/router'
+        '@angular/platform-webworker',
+        '@angular/platform-webworker-dynamic',
+        '@angular/router',
+        '@angular/service-worker',
+        '@angular/upgrade'
       ],
       '^6.1.0',
       false


### PR DESCRIPTION
## Current Behavior
Following `@angular` packages are not updated during `nx6+` migrations:
* `@angular/http`
* `@angular/platform-webworker`
* `@angular/platform-webworker-dynamic`
* `@angular/service-worker`
* `@angular/upgrade`

## Expected Behavior
Above packages are updated during migrations

Fixes https://github.com/nrwl/nx/issues/507