### PR TITLE
 fix(schematics): support app generation with inline-template

### DIFF
--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -240,4 +240,31 @@ describe('app', () => {
       ).toContain('imports: [RouterTestingModule]');
     });
   });
+
+  describe('template generation mode', () => {
+    it('should create Nx specific `app.component.html` template', () => {
+      const tree = schematicRunner.runSchematic(
+        'app',
+        { name: 'myApp', directory: 'myDir' },
+        appTree
+      );
+      expect(
+        getFileContent(tree, 'apps/my-dir/my-app/src/app/app.component.html')
+      ).toBeTruthy();
+      expect(
+        getFileContent(tree, 'apps/my-dir/my-app/src/app/app.component.html')
+      ).toContain('This is an Angular CLI app built with Nrwl Nx!');
+    });
+
+    it("should update `template`'s property of AppComponent with Nx content", () => {
+      const tree = schematicRunner.runSchematic(
+        'app',
+        { name: 'myApp', directory: 'myDir', inlineTemplate: true },
+        appTree
+      );
+      expect(
+        getFileContent(tree, 'apps/my-dir/my-app/src/app/app.component.ts')
+      ).toContain('This is an Angular CLI app built with Nrwl Nx!');
+    });
+  });
 });

--- a/packages/schematics/src/collection/application/index.ts
+++ b/packages/schematics/src/collection/application/index.ts
@@ -13,7 +13,9 @@ import { insertImport } from '@schematics/angular/utility/ast-utils';
 import {
   addImportToModule,
   addImportToTestBed,
+  getDecoratorPropertyValueNode,
   insert,
+  replaceNodeValue,
   updateJsonInTree
 } from '../../utils/ast-utils';
 import { toFileName } from '../../utils/name-utils';
@@ -117,9 +119,27 @@ Nx is designed to help you create and build enterprise grade Angular application
     const content = options.routing
       ? `${baseContent}\n<router-outlet></router-outlet>`
       : baseContent;
-    host.overwrite(
-      `${options.appProjectRoot}/src/app/app.component.html`,
-      content
+
+    if (!options.inlineTemplate) {
+      return host.overwrite(
+        `${options.appProjectRoot}/src/app/app.component.html`,
+        content
+      );
+    }
+
+    const modulePath = `${options.appProjectRoot}/src/app/app.component.ts`;
+    const templateNodeValue = getDecoratorPropertyValueNode(
+      host,
+      modulePath,
+      'Component',
+      'template',
+      '@angular/core'
+    );
+    replaceNodeValue(
+      host,
+      modulePath,
+      templateNodeValue,
+      `\`\n${baseContent}\n\`,\n`
     );
   };
 }


### PR DESCRIPTION
## Description
The generation of the app result in error when generated with `inline-template` flag to `true`. This PR adds the support to generate an application with the `inline-template` flag activated.
Two new _AST_ utils created: `getDecoratorPropertyValueNode` & `replaceNodeValue`.
More tests have been added.

## Issues
#519 