### PR TITLE
update(schematics): ngrx facade needs correct store type

### DIFF
--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.facade.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.facade.ts__tmpl__
@@ -13,7 +13,7 @@ export class <%= className %>Facade {
   all<%= className %>$ = this.store.select(<%= propertyName %>Query.getAll<%= className %>);
   selected<%= className %>$ = this.store.select(<%= propertyName %>Query.getSelected<%= className %>);
   
-  constructor( private store: Store<<%= className %>State> ) { }
+  constructor( private store: Store<{<%= propertyName %>: <%= className %>State}> ) { }
  
   loadAll() {
     this.store.dispatch(new Load<%= className %>());


### PR DESCRIPTION
When injecting a store reference, the store state should be an inline type
based on the feature key that was registered with `StoreModule.forFeature(...)`.

Consider the facade generated for feature 'cars':

```ts
StoreModule.forFeature('cars', carsReducer, { initialState: carsInitialState })
```

```ts
@Injectable()
export class CarsFacade {
  constructor( private store: Store<{cars: CarsState}> ) { }
}
```
