### PR TITLE
fix(schematics): speed up the dry-run command

### DIFF
--- a/packages/schematics/src/collection/application/index.ts
+++ b/packages/schematics/src/collection/application/index.ts
@@ -27,6 +27,7 @@ import {
 } from '@nrwl/schematics/src/utils/cli-config-utils';
 import { formatFiles } from '../../utils/rules/format-files';
 import { updateKarmaConf } from '../../utils/rules/update-karma-conf';
+import { excludeUnnecessaryFiles } from '@nrwl/schematics/src/utils/rules/filter-tree';
 
 interface NormalizedSchema extends Schema {
   appProjectRoot: string;
@@ -267,6 +268,8 @@ export default function(schema: Schema): Rule {
         viewEncapsulation: options.viewEncapsulation,
         routing: false
       }),
+
+      excludeUnnecessaryFiles(),
 
       move(options.e2eProjectName, options.e2eProjectRoot),
       updateE2eProject(options),

--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -30,9 +30,9 @@ import {
   getWorkspacePath,
   replaceAppNameWithPath
 } from '@nrwl/schematics/src/utils/cli-config-utils';
-import * as fs from 'fs';
 import { formatFiles } from '../../utils/rules/format-files';
 import { updateKarmaConf } from '../../utils/rules/update-karma-conf';
+import { excludeUnnecessaryFiles } from '@nrwl/schematics/src/utils/rules/filter-tree';
 
 interface NormalizedSchema extends Schema {
   name: string;
@@ -384,6 +384,9 @@ export default function(schema: Schema): Rule {
         skipPackageJson: !options.publishable,
         skipTsConfig: true
       }),
+
+      excludeUnnecessaryFiles(),
+
       move(options.name, options.projectRoot),
       updateProject(options),
       updateKarmaConf({

--- a/packages/schematics/src/collection/ngrx/index.ts
+++ b/packages/schematics/src/collection/ngrx/index.ts
@@ -25,6 +25,7 @@ import {
 } from './rules';
 import { formatFiles } from '../../utils/rules/format-files';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import { excludeUnnecessaryFiles } from '@nrwl/schematics/src/utils/rules/filter-tree';
 
 /**
  * Rule to generate the Nx 'ngrx' Collection
@@ -88,6 +89,7 @@ function generateNgrxFilesFromTemplates(options: Schema) {
 
   const templateSource = apply(url('./files'), [
     !options.facade ? filter(excludeFacade) : noop(),
+    excludeUnnecessaryFiles(),
     template({ ...options, tmpl: '', ...names(name) }),
     move(moduleDir)
   ]);

--- a/packages/schematics/src/collection/workspace-schematic/index.ts
+++ b/packages/schematics/src/collection/workspace-schematic/index.ts
@@ -11,10 +11,12 @@ import {
 import { Schema } from './schema';
 import { toFileName } from '../../utils/name-utils';
 import { formatFiles } from '../../utils/rules/format-files';
+import { excludeUnnecessaryFiles } from '@nrwl/schematics/src/utils/rules/filter-tree';
 
 export default function(schema: Schema): Rule {
   const options = normalizeOptions(schema);
   const templateSource = apply(url('./files'), [
+    excludeUnnecessaryFiles(),
     template({
       dot: '.',
       tmpl: '',

--- a/packages/schematics/src/utils/rules/filter-tree.ts
+++ b/packages/schematics/src/utils/rules/filter-tree.ts
@@ -1,0 +1,15 @@
+import { filter, Rule } from '@angular-devkit/schematics';
+
+/**
+ * Exclude common paths from the working Tree
+ */
+export function excludeUnnecessaryFiles(): Rule {
+  return filter(
+    path =>
+      !path.startsWith('/node_modules') &&
+      !path.startsWith('/dist') &&
+      !path.startsWith('/.git') &&
+      !path.startsWith('/.vscode') &&
+      !path.startsWith('/.idea')
+  );
+}


### PR DESCRIPTION
## Description

Currently the `dry-run` command speed is on an average of:
* `ng g app app_name --dry-run`: 7099.051ms to 7207.579ms;
* `ng g lib lib_name --dry-run`: 4015.622ms to 3881.893ms;

This is due to too many files in the tree. While performing the transformation required by the schematic, the tree includes files in the *node_modules, .git, .idea, .vscode* folders.
These files are not needed and impact the performance of the commandline.

This add a filter function on the tree, before anything is moved. With that filter function
the average speed is:
* `ng g app app_name --dry-run`: 1420.826ms to 1435.487ms;
* `ng g lib lib_name --dry-run`: 1382.279ms to 1413.042ms;

## Issue
close #706