### PR TITLE
fix(schematics): set lib npmScope when publishable

### DIFF
--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -369,6 +369,14 @@ function updateTsConfig(options: NormalizedSchema): Rule {
   ]);
 }
 
+function updateLibPackageNpmScope(options: NormalizedSchema): Rule {
+  return updateJsonInTree(`${options.projectRoot}/package.json`, json => {
+    console.log(json);
+    json.name = `@${options.prefix}/${options.name}`;
+    return json;
+  });
+}
+
 export default function(schema: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const options = normalizeOptions(host, schema);
@@ -391,6 +399,7 @@ export default function(schema: Schema): Rule {
       }),
       updateTsConfig(options),
 
+      options.publishable ? updateLibPackageNpmScope(options) : noop(),
       options.routing && options.lazy
         ? addLazyLoadedRouterConfiguration(options)
         : noop(),

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -60,6 +60,16 @@ describe('lib', () => {
       expect(packageJson.devDependencies['ng-packagr']).toBeDefined();
     });
 
+    it("should update npmScope of lib's package.json when publishable", () => {
+      const tree = schematicRunner.runSchematic(
+        'lib',
+        { name: 'myLib', publishable: true },
+        appTree
+      );
+      const packageJson = readJsonInTree(tree, '/libs/my-lib/package.json');
+      expect(packageJson.name).toEqual('@proj/my-lib');
+    });
+
     it('should update angular.json', () => {
       const tree = schematicRunner.runSchematic(
         'lib',


### PR DESCRIPTION
## Description
Update the lib's `package.json` name with the right prefix, when generating a lib with the `publishable` option set to `true`.

### Before
Running `ng g lib test --publishable` inside an "_example_" project:
```javascript
// libs/test/package.json
{
  "name": "test",
  // ...
}
```

### After
Running `ng g lib test --publishable` inside an "_example_" project:
```javascript
// libs/test/package.json
{
  "name": "@example/test",
  // ...
}
```

## Issue
close #677