### PR TITLE
fix(command-line): add ng command test on affected parallel

### DIFF
--- a/packages/schematics/src/command-line/affected.ts
+++ b/packages/schematics/src/command-line/affected.ts
@@ -26,7 +26,7 @@ import {
 import { GlobalNxArgs } from './nx';
 import * as yargs from 'yargs';
 import { WorkspaceResults } from './workspace-results';
-import { workspace } from '@angular-devkit/core/src/experimental';
+import * as fs from 'fs';
 
 export interface YargsAffectedOptions extends yargs.Arguments {}
 
@@ -277,6 +277,16 @@ async function runCommand(
   errorMessage: string
 ) {
   if (parsedArgs.parallel) {
+    // Make sure the `package.json` has the `ng: "ng"` command needed by `npm-run-all`
+    const packageJson = JSON.parse(
+      fs.readFileSync('./package.json').toString('utf-8')
+    );
+    if (!packageJson.scripts || !packageJson.scripts.ng) {
+      console.error(
+        '\nError: Your `package.json` file should contain the `ng: "ng"` command in the `scripts` section.\n'
+      );
+      return process.exit(1);
+    }
     try {
       await runAll(
         projects.map(

--- a/scripts/commit-lint.js
+++ b/scripts/commit-lint.js
@@ -5,7 +5,7 @@ const gitMessage = require('child_process')
   .execSync('git log -1 --no-merges')
   .toString()
   .trim();
-const matchTest = /([a-z]){0,8}\([a-z.0-9]+\):\s(([a-z0-9:\-\s])+)/g.test(
+const matchTest = /([a-z]){0,8}\([a-z.0-9\-]+\):\s(([a-z0-9:\-\s])+)/g.test(
   gitMessage
 );
 const exitCode = +!matchTest;


### PR DESCRIPTION
## Description
When running the affected command with the `--parallel` option, `npm-run-all` is used to achieve the parallel execution of the desired tasks. Because of the use of `npm-run-all`, the `ng` command should be visible and declared as script command in the `package.json` of your project.

This adds a verification before running the command with the `--parallel` option to make sure the `package.json` has the `ng: "ng"` command in the `scripts` section.
If not, it errors before trying with a specific message.

## Issue
close #700