### PR TITLE
fix(command-line): format split in chunks patterns

### DIFF
--- a/packages/schematics/src/command-line/format.ts
+++ b/packages/schematics/src/command-line/format.ts
@@ -14,12 +14,15 @@ export function format(args: string[]) {
     process.exit(1);
   }
 
+  // Chunkify the patterns array to prevent crashing the windows terminal
+  const chunkList: string[][] = chunkify(patterns, 70);
+
   switch (command) {
     case 'write':
-      write(patterns);
+      chunkList.forEach(chunk => write(chunk));
       break;
     case 'check':
-      check(patterns);
+      chunkList.forEach(chunk => check(chunk));
       break;
   }
 }
@@ -46,6 +49,14 @@ function getPatternsFromApps(affectedFiles: string[]): string[] {
   } else {
     return [`\"{${roots.join(',')}}/**/*.ts\"`];
   }
+}
+
+function chunkify(target: string[], size: number): string[][] {
+  return target.reduce((current: string[][], value: string, index: number) => {
+    if (index % size === 0) current.push([]);
+    current[current.length - 1].push(value);
+    return current;
+  }, []);
 }
 
 function printError(command: string, e: any) {


### PR DESCRIPTION
## Description
The current format execute the Prettier command by appending all the urls and patterns in only one execution. This breaks during an upgrade if the project contains a lot of files (specifically on Windows).

## Implementation
The format command now splits all the array containing all the urls and patterns given, in smaller chunks arrays, executing the command on each chunks. This prevent to have too long argument on the command for the terminal, which can lead to error on specific OS. The chaining of command is transparent for the user.

## Issue
close #511