### PR TITLE
feat(builders): add coverage and snapshot options for jest

### DIFF
--- a/packages/builders/src/jest/jest.builder.spec.ts
+++ b/packages/builders/src/jest/jest.builder.spec.ts
@@ -45,7 +45,48 @@ describe('Jest Builder', () => {
     );
   });
 
-  it('should send the setupFile to jestCLI', () => {
+  it('should send other options to jestCLI', () => {
+    const runCLI = spyOn(jestCLI, 'runCLI').and.returnValue(
+      Promise.resolve({
+        results: {
+          success: true
+        }
+      })
+    );
+    const root = normalize('/root');
+    builder
+      .run({
+        root,
+        builder: '',
+        projectType: 'application',
+        options: {
+          jestConfig: './jest.config.js',
+          tsConfig: './tsconfig.test.json',
+          watch: false,
+          codeCoverage: true,
+          ci: true,
+          updateSnapshot: true
+        }
+      })
+      .toPromise();
+    expect(runCLI).toHaveBeenCalledWith(
+      {
+        globals: JSON.stringify({
+          'ts-jest': {
+            tsConfigFile: path.relative(root, './tsconfig.test.json')
+          },
+          __TRANSFORM_HTML__: true
+        }),
+        watch: false,
+        coverage: true,
+        ci: true,
+        updateSnapshot: true
+      },
+      ['./jest.config.js']
+    );
+  });
+
+  it('should send the main to jestCLI', () => {
     const runCLI = spyOn(jestCLI, 'runCLI').and.returnValue(
       Promise.resolve({
         results: {

--- a/packages/builders/src/jest/jest.builder.ts
+++ b/packages/builders/src/jest/jest.builder.ts
@@ -15,7 +15,10 @@ export interface JestBuilderOptions {
   jestConfig: string;
   tsConfig: string;
   watch: boolean;
+  ci?: boolean;
+  codeCoverage?: boolean;
   setupFile?: string;
+  updateSnapshot?: boolean;
 }
 
 export default class JestBuilder implements Builder<JestBuilderOptions> {
@@ -25,6 +28,9 @@ export default class JestBuilder implements Builder<JestBuilderOptions> {
     const options = builderConfig.options;
     const config: any = {
       watch: options.watch,
+      coverage: options.codeCoverage,
+      ci: options.ci,
+      updateSnapshot: options.updateSnapshot,
       globals: JSON.stringify({
         'ts-jest': {
           tsConfigFile: path.relative(builderConfig.root, options.tsConfig)

--- a/packages/builders/src/jest/schema.json
+++ b/packages/builders/src/jest/schema.json
@@ -19,8 +19,25 @@
     },
     "watch": {
       "type": "boolean",
-      "description": "Run tests when files change.",
+      "description":
+        "Run tests when files change. (https://jestjs.io/docs/en/cli#watch)",
       "default": false
+    },
+    "codeCoverage": {
+      "type": "boolean",
+      "description":
+        "Export a code coverage report. (https://jestjs.io/docs/en/cli#coverage)"
+    },
+    "updateSnapshot": {
+      "type": "boolean",
+      "alias": "u",
+      "description":
+        "Re-record all failing snapshots. (https://jestjs.io/docs/en/cli#updatesnapshot)"
+    },
+    "ci": {
+      "type": "boolean",
+      "description":
+        "Fail on missing snapshots. (https://jestjs.io/docs/en/cli#ci)"
     }
   },
   "required": ["jestConfig", "tsConfig"]


### PR DESCRIPTION
## Current Behavior

No options for coverage and snapshot reporting

## Expected Behavior

3 New Options:
```sh
options:
  --ci
    Fail on missing snapshots. (https://jestjs.io/docs/en/cli#ci)
  --code-coverage
    Export a code coverage report. (https://jestjs.io/docs/en/cli#coverage)
  --update-snapshot (-u)
    Re-record all failing snapshots. (https://jestjs.io/docs/en/cli#updatesnapshot)
```