### PR TITLE
fix(builders) import directly from jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@schematics/angular": "^0.7.2",
     "@types/jasmine": "~2.8.6",
     "@types/jasminewd2": "~2.0.3",
-    "@types/jest": "^23.3.1",
     "@types/node": "~8.9.4",
     "@types/prettier": "^1.10.0",
     "@types/yargs": "^11.0.0",

--- a/packages/builders/src/jest/jest.builder.spec.ts
+++ b/packages/builders/src/jest/jest.builder.spec.ts
@@ -1,6 +1,6 @@
 import JestBuilder from './jest.builder';
 import { normalize } from '@angular-devkit/core';
-import * as jestCLI from 'jest-cli';
+import * as jestCLI from 'jest';
 import * as path from 'path';
 
 describe('Jest Builder', () => {

--- a/packages/builders/src/jest/jest.builder.ts
+++ b/packages/builders/src/jest/jest.builder.ts
@@ -9,7 +9,7 @@ import { map } from 'rxjs/operators';
 
 import * as path from 'path';
 
-import { runCLI as runJest } from 'jest-cli';
+import { runCLI as runJest } from 'jest';
 
 export interface JestBuilderOptions {
   jestConfig: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -275,10 +275,6 @@
   dependencies:
     "@types/jasmine" "*"
 
-"@types/jest@^23.3.1":
-  version "23.3.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.1.tgz#a4319aedb071d478e6f407d1c4578ec8156829cf"
-
 "@types/node@*":
   version "10.5.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.3.tgz#5bcfaf088ad17894232012877669634c06b20cc5"


### PR DESCRIPTION
## Current Behavior

`jest-cli` cannot be found from installing via `npm`

## Expected Behavior

`runCLI` is imported from `jest`

## Caveat

`@types/jest` is incompatible with the latest typescript and breaks compilation.. so it has been removed..