### PR TITLE
feat(builders): add --only-changed and --pass-with-no-tests to jest

### DIFF
--- a/packages/builders/src/jest/jest.builder.spec.ts
+++ b/packages/builders/src/jest/jest.builder.spec.ts
@@ -65,7 +65,9 @@ describe('Jest Builder', () => {
           watch: false,
           codeCoverage: true,
           ci: true,
-          updateSnapshot: true
+          updateSnapshot: true,
+          onlyChanged: true,
+          passWithNoTests: true
         }
       })
       .toPromise();
@@ -80,7 +82,9 @@ describe('Jest Builder', () => {
         watch: false,
         coverage: true,
         ci: true,
-        updateSnapshot: true
+        updateSnapshot: true,
+        onlyChanged: true,
+        passWithNoTests: true
       },
       ['./jest.config.js']
     );

--- a/packages/builders/src/jest/jest.builder.ts
+++ b/packages/builders/src/jest/jest.builder.ts
@@ -17,6 +17,8 @@ export interface JestBuilderOptions {
   watch: boolean;
   ci?: boolean;
   codeCoverage?: boolean;
+  onlyChanged?: boolean;
+  passWithNoTests?: boolean;
   setupFile?: string;
   updateSnapshot?: boolean;
 }
@@ -31,6 +33,8 @@ export default class JestBuilder implements Builder<JestBuilderOptions> {
       coverage: options.codeCoverage,
       ci: options.ci,
       updateSnapshot: options.updateSnapshot,
+      onlyChanged: options.onlyChanged,
+      passWithNoTests: options.passWithNoTests,
       globals: JSON.stringify({
         'ts-jest': {
           tsConfigFile: path.relative(builderConfig.root, options.tsConfig)

--- a/packages/builders/src/jest/schema.json
+++ b/packages/builders/src/jest/schema.json
@@ -23,6 +23,17 @@
         "Run tests when files change. (https://jestjs.io/docs/en/cli#watch)",
       "default": false
     },
+    "onlyChanged": {
+      "type": "boolean",
+      "alias": "o",
+      "description":
+        "Isolate tests affected by uncommitted changes. (https://jestjs.io/docs/en/cli#onlychanged)"
+    },
+    "passWithNoTests": {
+      "type": "boolean",
+      "description":
+        "Allow test suite to pass when no test files are found. (https://jestjs.io/docs/en/cli#passwithnotests)"
+    },
     "codeCoverage": {
       "type": "boolean",
       "description":


### PR DESCRIPTION
## Current Behavior

These jest features are not accessible via the builder.

## Expected Behavior
These jest features are accessible via the builder.

```sh
  --only-changed (-o)
    Isolate tests affected by uncommitted changes. (https://jestjs.io/docs/en/cli#onlychanged)
  --pass-with-no-tests
    Allow test suite to pass when no test files are found. (https://jestjs.io/docs/en/cli#passwithnotests)
```