### PR TITLE
fix(scripts): checkcommit allows release commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,17 @@
     "commit": "git-cz",
     "checkcommit": "./scripts/commit-lint.js",
     "e2e": "./scripts/e2e.sh",
-    "format": "prettier \"./**/*.{ts,js,json,css,md}\" \"!./**/{__name__,__directory__}/**\" --write",
+    "format":
+      "prettier \"./**/*.{ts,js,json,css,md}\" \"!./**/{__name__,__directory__}/**\" --write",
     "linknpm": "./scripts/link.sh",
     "nx-release": "./scripts/nx-release.js",
     "copy": "./scripts/copy.sh",
     "test:schematics": "yarn linknpm fast && ./scripts/test_schematics.sh",
     "test:nx": "yarn linknpm fast && ./scripts/test_nx.sh",
-    "test": "yarn linknpm fast && ./scripts/test_nx.sh && ./scripts/test_schematics.sh",
-    "checkformat": "prettier \"./**/*.{ts,js,json,css,md}\" \"!./**/{__name__,__directory__}/**\" --list-different"
+    "test":
+      "yarn linknpm fast && ./scripts/test_nx.sh && ./scripts/test_schematics.sh",
+    "checkformat":
+      "prettier \"./**/*.{ts,js,json,css,md}\" \"!./**/{__name__,__directory__}/**\" --list-different"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.7.2",
@@ -81,10 +84,7 @@
   "author": "Victor Savkin",
   "license": "MIT",
   "jest": {
-    "modulePathIgnorePatterns": [
-      "tmp",
-      "collection/.*/files"
-    ]
+    "modulePathIgnorePatterns": ["tmp", "collection/.*/files"]
   },
   "husky": {
     "hooks": {
@@ -92,10 +92,7 @@
     }
   },
   "lint-staged": {
-    "./**/*.{ts,js,json,css,md}": [
-      "prettier --write",
-      "git add"
-    ]
+    "./**/*.{ts,js,json,css,md}": ["prettier --write", "git add"]
   },
   "config": {
     "commitizen": {

--- a/scripts/commit-lint.js
+++ b/scripts/commit-lint.js
@@ -5,22 +5,25 @@ const gitMessage = require('child_process')
   .execSync('git log -1 --no-merges')
   .toString()
   .trim();
-const matchTest = /([a-z]){0,8}\([a-z.0-9\-]+\):\s(([a-z0-9:\-\s])+)/g.test(
+const matchCommit = /([a-z]){0,8}\([a-z.0-9\-]+\):\s(([a-z0-9:\-\s])+)/g.test(
   gitMessage
 );
-const exitCode = +!matchTest;
+const matchRelease = /release/gi.test(gitMessage);
+const exitCode = +!(matchRelease || matchCommit);
 
 if (exitCode === 0) {
   console.log('Commit ACCEPTED 👌');
 } else {
   console.log(
     '[Error]: Ho no! 😦 Your commit message: \n' +
+      '-------------------------------------------------------------------\n' +
       gitMessage +
-      '\ndoes not follow the commit message convention specified in the CONTRIBUTING.MD file.'
+      '\n-------------------------------------------------------------------' +
+      '\n\n 👉️ Does not follow the commit message convention specified in the CONTRIBUTING.MD file.'
   );
   console.log('\ntype(scope): subject \n BLANK LINE \n body');
   console.log(
-    '\nExample: \n ' +
+    '\nEXAMPLE: \n ' +
       'feat(schematics): add an option to generate lazy-loadable modules\n' +
       '\n`ng generate lib mylib --lazy` provisions the mylib project in tslint.json'
   );


### PR DESCRIPTION
## Description
The `checkcommit` command fails went the release is done.
This allows the release commits, while improving the readability of the message.