### PR TITLE
feat(builders): add runInBand and maxWorkers options to jest

### DIFF
--- a/packages/builders/src/jest/jest.builder.spec.ts
+++ b/packages/builders/src/jest/jest.builder.spec.ts
@@ -69,7 +69,9 @@ describe('Jest Builder', () => {
           onlyChanged: true,
           passWithNoTests: true,
           bail: true,
-          silent: true
+          silent: true,
+          runInBand: true,
+          maxWorkers: 2
         }
       })
       .toPromise();
@@ -88,7 +90,9 @@ describe('Jest Builder', () => {
         onlyChanged: true,
         passWithNoTests: true,
         bail: true,
-        silent: true
+        silent: true,
+        runInBand: true,
+        maxWorkers: 2
       },
       ['./jest.config.js']
     );

--- a/packages/builders/src/jest/jest.builder.ts
+++ b/packages/builders/src/jest/jest.builder.ts
@@ -19,7 +19,9 @@ export interface JestBuilderOptions {
   ci?: boolean;
   codeCoverage?: boolean;
   onlyChanged?: boolean;
+  maxWorkers?: number;
   passWithNoTests?: boolean;
+  runInBand?: boolean;
   setupFile?: string;
   silent?: boolean;
   updateSnapshot?: boolean;
@@ -39,6 +41,7 @@ export default class JestBuilder implements Builder<JestBuilderOptions> {
       onlyChanged: options.onlyChanged,
       passWithNoTests: options.passWithNoTests,
       silent: options.silent,
+      runInBand: options.runInBand,
       globals: JSON.stringify({
         'ts-jest': {
           tsConfigFile: path.relative(builderConfig.root, options.tsConfig)
@@ -46,6 +49,10 @@ export default class JestBuilder implements Builder<JestBuilderOptions> {
         __TRANSFORM_HTML__: true
       })
     };
+
+    if (options.maxWorkers) {
+      config.maxWorkers = options.maxWorkers;
+    }
 
     if (options.setupFile) {
       config.setupTestFrameworkScriptFile = path.join(

--- a/packages/builders/src/jest/schema.json
+++ b/packages/builders/src/jest/schema.json
@@ -59,6 +59,16 @@
       "type": "boolean",
       "description":
         "Prevent tests from printing messages through the console. (https://jestjs.io/docs/en/cli#silent)"
+    },
+    "runInBand": {
+      "type": "boolean",
+      "description":
+        "Run tests in a single process as opposed to multiple workers. Useful for CI. (https://jestjs.io/docs/en/cli.html#runinband)"
+    },
+    "maxWorkers": {
+      "type": "number",
+      "description":
+        "Max number of workers to run tests across. Useful for CI. (https://jestjs.io/docs/en/cli.html#maxworkers-num)"
     }
   },
   "required": ["jestConfig", "tsConfig"]


### PR DESCRIPTION
Fixes https://github.com/nrwl/nx/issues/754

## Current Behavior

`runInBand` and `maxWorkers` are useful for CI environments but are not available through the builder.

## Expected Behavior

Both `runInBand` and `maxWorkers` have been added and can be used as per [Jest Troubleshooting](https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server).

```sh
  --max-workers
    Max number of workers to run tests across. Useful for CI. (https://jestjs.io/docs/en/cli.html#maxworkers-num)
  --run-in-band
    Run tests in a single process as opposed to multiple workers. Useful for CI. (https://jestjs.io/docs/en/cli.html#runinband)
```