### PR TITLE
fix(schematics): normalize paths passed to offsetFromRoot

### DIFF
--- a/packages/schematics/src/collection/jest-project/jest-project.spec.ts
+++ b/packages/schematics/src/collection/jest-project/jest-project.spec.ts
@@ -16,9 +16,6 @@ describe('lib', () => {
     appTree = new VirtualTree();
     appTree = createEmptyWorkspace(appTree);
     appTree = schematicRunner.runSchematic('jest', {}, appTree);
-  });
-
-  it('should generate files', () => {
     appTree = schematicRunner.runSchematic(
       'lib',
       {
@@ -27,6 +24,9 @@ describe('lib', () => {
       },
       appTree
     );
+  });
+
+  it('should generate files', () => {
     const resultTree = schematicRunner.runSchematic(
       'jest-project',
       {
@@ -40,14 +40,6 @@ describe('lib', () => {
   });
 
   it('should alter angular.json', () => {
-    appTree = schematicRunner.runSchematic(
-      'lib',
-      {
-        name: 'lib1',
-        unitTestRunner: 'none'
-      },
-      appTree
-    );
     const resultTree = schematicRunner.runSchematic(
       'jest-project',
       {
@@ -69,15 +61,24 @@ describe('lib', () => {
     );
   });
 
-  it('should create a tsconfig.spec.json', () => {
-    appTree = schematicRunner.runSchematic(
-      'lib',
+  it('should create a jest.config.js', () => {
+    const resultTree = schematicRunner.runSchematic(
+      'jest-project',
       {
-        name: 'lib1',
-        unitTestRunner: 'none'
+        project: 'lib1'
       },
       appTree
     );
+    expect(resultTree.readContent('libs/lib1/jest.config.js'))
+      .toBe(`module.exports = {
+  name: 'lib1',
+  preset: '../../jest.config.js',
+  coverageDirectory: '../../coverage/libs/lib1'
+};
+`);
+  });
+
+  it('should create a tsconfig.spec.json', () => {
     const resultTree = schematicRunner.runSchematic(
       'jest-project',
       {
@@ -100,14 +101,6 @@ describe('lib', () => {
 
   describe('--skip-setup-file', () => {
     it('should generate src/test-setup.ts', () => {
-      appTree = schematicRunner.runSchematic(
-        'lib',
-        {
-          name: 'lib1',
-          unitTestRunner: 'none'
-        },
-        appTree
-      );
       const resultTree = schematicRunner.runSchematic(
         'jest-project',
         {
@@ -120,14 +113,6 @@ describe('lib', () => {
     });
 
     it('should not list the setup file in angular.json', () => {
-      appTree = schematicRunner.runSchematic(
-        'lib',
-        {
-          name: 'lib1',
-          unitTestRunner: 'none'
-        },
-        appTree
-      );
       const resultTree = schematicRunner.runSchematic(
         'jest-project',
         {
@@ -143,14 +128,6 @@ describe('lib', () => {
     });
 
     it('should not list the setup file in tsconfig.spec.json', () => {
-      appTree = schematicRunner.runSchematic(
-        'lib',
-        {
-          name: 'lib1',
-          unitTestRunner: 'none'
-        },
-        appTree
-      );
       const resultTree = schematicRunner.runSchematic(
         'jest-project',
         {

--- a/packages/schematics/src/utils/common.spec.ts
+++ b/packages/schematics/src/utils/common.spec.ts
@@ -1,0 +1,19 @@
+import { offsetFromRoot } from './common';
+describe('offsetFromRoot', () => {
+  it('should work for normal paths', () => {
+    const result = offsetFromRoot('apps/appname');
+    expect(result).toBe('../../');
+  });
+  it('should work for paths with a trailing slash', () => {
+    const result = offsetFromRoot('apps/appname/');
+    expect(result).toBe('../../');
+  });
+  it('should work for deep paths', () => {
+    const result = offsetFromRoot('apps/dirname/appname');
+    expect(result).toBe('../../../');
+  });
+  it('should work for deep paths with a trailing slash', () => {
+    const result = offsetFromRoot('apps/dirname/appname/');
+    expect(result).toBe('../../../');
+  });
+});

--- a/packages/schematics/src/utils/common.ts
+++ b/packages/schematics/src/utils/common.ts
@@ -4,6 +4,7 @@ import * as cosmiconfig from 'cosmiconfig';
 
 import { angularJsVersion } from '../lib-versions';
 import { updateJsonInTree } from './ast-utils';
+import { normalize } from '@angular-devkit/core';
 
 export function addUpgradeToPackageJson(): Rule {
   return updateJsonInTree('package.json', packageJson => {
@@ -24,7 +25,7 @@ export function addUpgradeToPackageJson(): Rule {
 }
 
 export function offsetFromRoot(fullPathToSourceDir: string): string {
-  const parts = fullPathToSourceDir.split('/');
+  const parts = normalize(fullPathToSourceDir).split('/');
   let offset = '';
   for (let i = 0; i < parts.length; ++i) {
     offset += '../';


### PR DESCRIPTION
Fixes https://github.com/nrwl/nx/issues/739

## Current Behavior

When using offsetFromRoot it expects paths to not have trailing slashes

## Expected Behavior

paths are normalized within `offsetFromRoot` to make sure that it works for paths with trailing slashes and not trailing slashes