### PR TITLE
build(prettier): ignore package.json from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 tmp
 build
 node_modules
+/package.json
 packages/schematics/src/collection/**/files/*.json


### PR DESCRIPTION
## Current Behavior

`package.json` was reformatted incorrectly after publishing.

## Expected Behavior

`/package.json` is ignored from `prettier`. This makes it so the two formatters do not conflict with one another.

## Notes

This is causing all PRs to fail currently