### PR TITLE
feat(builders): add bail and silent options to jest

### DIFF
--- a/packages/builders/src/jest/jest.builder.spec.ts
+++ b/packages/builders/src/jest/jest.builder.spec.ts
@@ -67,7 +67,9 @@ describe('Jest Builder', () => {
           ci: true,
           updateSnapshot: true,
           onlyChanged: true,
-          passWithNoTests: true
+          passWithNoTests: true,
+          bail: true,
+          silent: true
         }
       })
       .toPromise();
@@ -84,7 +86,9 @@ describe('Jest Builder', () => {
         ci: true,
         updateSnapshot: true,
         onlyChanged: true,
-        passWithNoTests: true
+        passWithNoTests: true,
+        bail: true,
+        silent: true
       },
       ['./jest.config.js']
     );

--- a/packages/builders/src/jest/jest.builder.ts
+++ b/packages/builders/src/jest/jest.builder.ts
@@ -15,11 +15,13 @@ export interface JestBuilderOptions {
   jestConfig: string;
   tsConfig: string;
   watch: boolean;
+  bail?: boolean;
   ci?: boolean;
   codeCoverage?: boolean;
   onlyChanged?: boolean;
   passWithNoTests?: boolean;
   setupFile?: string;
+  silent?: boolean;
   updateSnapshot?: boolean;
 }
 
@@ -31,10 +33,12 @@ export default class JestBuilder implements Builder<JestBuilderOptions> {
     const config: any = {
       watch: options.watch,
       coverage: options.codeCoverage,
+      bail: options.bail,
       ci: options.ci,
       updateSnapshot: options.updateSnapshot,
       onlyChanged: options.onlyChanged,
       passWithNoTests: options.passWithNoTests,
+      silent: options.silent,
       globals: JSON.stringify({
         'ts-jest': {
           tsConfigFile: path.relative(builderConfig.root, options.tsConfig)

--- a/packages/builders/src/jest/schema.json
+++ b/packages/builders/src/jest/schema.json
@@ -49,6 +49,16 @@
       "type": "boolean",
       "description":
         "Fail on missing snapshots. (https://jestjs.io/docs/en/cli#ci)"
+    },
+    "bail": {
+      "type": "boolean",
+      "description":
+        "Exit the test suite immediately upon the first failing test suite. (https://jestjs.io/docs/en/cli#bail)"
+    },
+    "silent": {
+      "type": "boolean",
+      "description":
+        "Prevent tests from printing messages through the console. (https://jestjs.io/docs/en/cli#silent)"
     }
   },
   "required": ["jestConfig", "tsConfig"]


### PR DESCRIPTION
Fixes #591 

I agree with @FrozenPandaz that adding all possible options to `jest` is not that useful as stated [here](https://github.com/nrwl/nx/issues/754#issuecomment-420388470) but it would be great to have `--bail` and `--silent` and this PR is adding these options:

* `--bail`: *Exit the test suite immediately upon the first failing test suite.* This is useful e.g. while fixing tests after some refactoring, like mentioned in #591.

* `--silent`: *Prevent tests from printing messages through the console.* This is useful to keep the output at a minimum, if the console outputs are not relevant.

@FrozenPandaz I am not sure about `ng generate jest-project --help` (you also mentioned at the statement, typo I guess `ng test ...`). Should all options be considered at the schematics too? I can try to add them with a separate PR if you want.