### PR TITLE
feat(schematics): allow generation of app with jest unit testing

### DIFF
--- a/e2e/schematics/jest.test.ts
+++ b/e2e/schematics/jest.test.ts
@@ -2,25 +2,15 @@ import {
   newProject,
   runCLI,
   newLib,
-  copyMissingPackages,
-  updateFile,
-  readJson,
-  runCommand,
-  runCLIAsync
+  runCLIAsync,
+  newApp,
+  copyMissingPackages
 } from '../utils';
 
 describe('Jest', () => {
   beforeAll(() => {
     newProject();
-    runCLI('generate jest', {
-      silenceError: true
-    });
-    // TODO: remove this hack after there's a version of @nrwl/builders published
-    const packageJson = readJson('package.json');
-    packageJson.devDependencies['@nrwl/builders'] =
-      '../../build/packages/builders';
-    updateFile('package.json', JSON.stringify(packageJson));
-    runCommand('npm install');
+    runCLI('generate jest');
     copyMissingPackages();
   });
 
@@ -35,6 +25,20 @@ describe('Jest', () => {
       const jestResult = await runCLIAsync('test jestlib');
       expect(jestResult.stderr).toContain('Test Suites: 3 passed, 3 total');
       done();
+    },
+    10000
+  );
+
+  it(
+    'should be able to generate a testable application using jest',
+    async () => {
+      newApp('jestapp --unit-test-runner jest');
+      await Promise.all([
+        runCLIAsync('generate service test --project jestapp'),
+        runCLIAsync('generate component test --project jestapp')
+      ]);
+      const jestResult = await runCLIAsync('test jestapp');
+      expect(jestResult.stderr).toContain('Test Suites: 3 passed, 3 total');
     },
     10000
   );

--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -267,4 +267,42 @@ describe('app', () => {
       ).toContain('This is an Angular CLI app built with Nrwl Nx!');
     });
   });
+
+  describe('--unit-test-runner jest', () => {
+    beforeEach(() => {
+      appTree = schematicRunner.runSchematic('jest', {}, appTree);
+    });
+    it('should generate a jest config', () => {
+      const tree = schematicRunner.runSchematic(
+        'app',
+        { name: 'myApp', unitTestRunner: 'jest' },
+        appTree
+      );
+      expect(tree.exists('apps/my-app/src/test.ts')).toBeFalsy();
+      expect(tree.exists('apps/my-app/src/test-setup.ts')).toBeTruthy();
+      expect(tree.exists('apps/my-app/tsconfig.spec.json')).toBeTruthy();
+      expect(tree.exists('apps/my-app/jest.config.js')).toBeTruthy();
+      const angularJson = readJsonInTree(tree, 'angular.json');
+      expect(angularJson.projects['my-app'].architect.test.builder).toEqual(
+        '@nrwl/builders:jest'
+      );
+    });
+  });
+
+  describe('--unit-test-runner none', () => {
+    it('should not generate test configuration', () => {
+      const tree = schematicRunner.runSchematic(
+        'app',
+        { name: 'myApp', unitTestRunner: 'none' },
+        appTree
+      );
+      expect(tree.exists('apps/my-app/src/test-setup.ts')).toBeFalsy();
+      expect(tree.exists('apps/my-app/src/test.ts')).toBeFalsy();
+      expect(tree.exists('apps/my-app/tsconfig.spec.json')).toBeFalsy();
+      expect(tree.exists('apps/my-app/jest.config.js')).toBeFalsy();
+      expect(tree.exists('apps/my-app/karma.config.js')).toBeFalsy();
+      const angularJson = readJsonInTree(tree, 'angular.json');
+      expect(angularJson.projects['my-app'].architect.test).toBeUndefined();
+    });
+  });
 });

--- a/packages/schematics/src/collection/application/schema.d.ts
+++ b/packages/schematics/src/collection/application/schema.d.ts
@@ -1,3 +1,5 @@
+import { UnitTestRunner } from '../../utils/test-runners';
+
 export interface Schema {
   name: string;
   skipFormat: boolean;
@@ -10,4 +12,5 @@ export interface Schema {
   skipTests?: boolean;
   directory?: string;
   tags?: string;
+  unitTestRunner: UnitTestRunner;
 }

--- a/packages/schematics/src/collection/application/schema.json
+++ b/packages/schematics/src/collection/application/schema.json
@@ -68,6 +68,12 @@
     "tags": {
       "type": "string",
       "description": "Add tags to the application (used for linting)"
+    },
+    "unitTestRunner": {
+      "type": "string",
+      "enum": ["karma", "jest", "none"],
+      "description": "Test runner to use for unit tests",
+      "default": "karma"
     }
   },
   "required": []

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -404,7 +404,9 @@ describe('lib', () => {
         { name: 'myLib', unitTestRunner: 'jest' },
         appTree
       );
+      expect(resultTree.exists('libs/my-lib/src/test.ts')).toBeFalsy();
       expect(resultTree.exists('libs/my-lib/src/test-setup.ts')).toBeTruthy();
+      expect(resultTree.exists('libs/my-lib/tsconfig.spec.json')).toBeTruthy();
       expect(resultTree.exists('libs/my-lib/jest.config.js')).toBeTruthy();
       const angularJson = readJsonInTree(resultTree, 'angular.json');
       expect(angularJson.projects['my-lib'].architect.test.builder).toEqual(
@@ -423,6 +425,8 @@ describe('lib', () => {
       expect(
         resultTree.exists('libs/my-lib/src/lib/my-lib.module.spec.ts')
       ).toBeFalsy();
+      expect(resultTree.exists('libs/my-lib/src/test.ts')).toBeFalsy();
+      expect(resultTree.exists('libs/my-lib/src/test.ts')).toBeFalsy();
       expect(resultTree.exists('libs/my-lib/tsconfig.spec.json')).toBeFalsy();
       expect(resultTree.exists('libs/my-lib/jest.config.js')).toBeFalsy();
       expect(resultTree.exists('libs/my-lib/karma.config.js')).toBeFalsy();


### PR DESCRIPTION
This PR requires https://github.com/nrwl/nx/pull/758

## Current Behavior

The option to generate an application with a unit-test-runner of jest is not available

## Expected Behavior

User is able to generate an application which uses jest to run unit tests via:
```sh
ng g jest
ng g app jest-app --unit-test-runner jest
ng test jest-app
```