### PR TITLE
fix(schematics): remove tsconfig.spec.json linting for non-karma apps

### DIFF
--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -297,6 +297,12 @@ describe('app', () => {
       expect(angularJson.projects['my-app'].architect.test.builder).toEqual(
         '@nrwl/builders:jest'
       );
+      expect(
+        angularJson.projects['my-app'].architect.lint.options.tsConfig
+      ).toEqual([
+        'apps/my-app/tsconfig.app.json',
+        'apps/my-app/tsconfig.spec.json'
+      ]);
     });
   });
 
@@ -314,6 +320,9 @@ describe('app', () => {
       expect(tree.exists('apps/my-app/karma.config.js')).toBeFalsy();
       const angularJson = readJsonInTree(tree, 'angular.json');
       expect(angularJson.projects['my-app'].architect.test).toBeUndefined();
+      expect(
+        angularJson.projects['my-app'].architect.lint.options.tsConfig
+      ).toEqual(['apps/my-app/tsconfig.app.json']);
     });
   });
 });

--- a/packages/schematics/src/collection/application/index.ts
+++ b/packages/schematics/src/collection/application/index.ts
@@ -29,6 +29,7 @@ import {
 import { formatFiles } from '../../utils/rules/format-files';
 import { updateKarmaConf } from '../../utils/rules/update-karma-conf';
 import { excludeUnnecessaryFiles } from '@nrwl/schematics/src/utils/rules/filter-tree';
+import { join, normalize } from '@angular-devkit/core';
 
 interface NormalizedSchema extends Schema {
   appProjectRoot: string;
@@ -163,6 +164,12 @@ function updateProject(options: NormalizedSchema): Rule {
         );
         if (options.unitTestRunner !== 'karma') {
           delete fixedProject.architect.test;
+
+          fixedProject.architect.lint.options.tsConfig = fixedProject.architect.lint.options.tsConfig.filter(
+            path =>
+              path !==
+              join(normalize(options.appProjectRoot), 'tsconfig.spec.json')
+          );
         }
         json.projects[options.name] = fixedProject;
         return json;

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -412,6 +412,12 @@ describe('lib', () => {
       expect(angularJson.projects['my-lib'].architect.test.builder).toEqual(
         '@nrwl/builders:jest'
       );
+      expect(
+        angularJson.projects['my-lib'].architect.lint.options.tsConfig
+      ).toEqual([
+        'libs/my-lib/tsconfig.lib.json',
+        'libs/my-lib/tsconfig.spec.json'
+      ]);
     });
   });
 
@@ -432,6 +438,9 @@ describe('lib', () => {
       expect(resultTree.exists('libs/my-lib/karma.config.js')).toBeFalsy();
       const angularJson = readJsonInTree(resultTree, 'angular.json');
       expect(angularJson.projects['my-lib'].architect.test).toBeUndefined();
+      expect(
+        angularJson.projects['my-lib'].architect.lint.options.tsConfig
+      ).toEqual(['libs/my-lib/tsconfig.lib.json']);
     });
   });
 });


### PR DESCRIPTION
## Current Behavior

`tsconfig.spec.json` is duplicated when adding a jest app

## Expected Behavior

`tsconfig.spec.json` is not duplciated when adding a jest app