### PR TITLE
fix(schematics): convert fileReplacements paths for all configurations

### DIFF
--- a/packages/schematics/src/collection/ng-add/index.ts
+++ b/packages/schematics/src/collection/ng-add/index.ts
@@ -165,14 +165,23 @@ function updateAngularCLIJson(options: Schema): Rule {
       )
     };
 
-    buildConfig.configurations.production.fileReplacements = buildConfig.configurations.production.fileReplacements.map(
-      replacement => {
-        return {
-          replace: convertPath(options.name, replacement.replace),
-          with: convertPath(options.name, replacement.with)
-        };
-      }
-    );
+    Object.keys(buildConfig.configurations)
+      .filter(
+        configurationName =>
+          buildConfig.configurations[configurationName].fileReplacements
+      )
+      .forEach(configurationName => {
+        buildConfig.configurations[
+          configurationName
+        ].fileReplacements = buildConfig.configurations[
+          configurationName
+        ].fileReplacements.map(replacement => {
+          return {
+            replace: convertPath(options.name, replacement.replace),
+            with: convertPath(options.name, replacement.with)
+          };
+        });
+      });
 
     const serveConfig = app.architect.serve;
 


### PR DESCRIPTION
## Current Behavior

Converting existing Angular CLI project fails when environments have custom names, only a **production** configuration will be considered.

## Expected Behavior

All configurations are migrated.

see #765