### PR TITLE
fix(schematics): use ngrx pipe select operator on Facades

### DIFF
--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.facade.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.facade.ts__tmpl__
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { Store } from '@ngrx/store';
+import { select, Store } from '@ngrx/store';
 
 import { <%= className %>State } from './<%= fileName %>.reducer';
 import { <%= propertyName %>Query } from './<%= fileName %>.selectors';
@@ -9,9 +9,9 @@ import { Load<%= className %> } from './<%= fileName %>.actions';
 @Injectable()
 export class <%= className %>Facade {
 
-  loaded$ = this.store.select(<%= propertyName %>Query.getLoaded);
-  all<%= className %>$ = this.store.select(<%= propertyName %>Query.getAll<%= className %>);
-  selected<%= className %>$ = this.store.select(<%= propertyName %>Query.getSelected<%= className %>);
+  loaded$ = this.store.pipe(select(<%= propertyName %>Query.getLoaded));
+  all<%= className %>$ = this.store.pipe(select(<%= propertyName %>Query.getAll<%= className %>));
+  selected<%= className %>$ = this.store.pipe(select(<%= propertyName %>Query.getSelected<%= className %>));
   
   constructor( private store: Store<{<%= propertyName %>: <%= className %>State}> ) { }
  


### PR DESCRIPTION
## Description
This update the way the Facade select a slice of the Store using the `select` operator through the `pipe`, contrary to the `store.select()` which is now deprecated by the NgRx team.

Information on the [NgRx documentation here](https://github.com/ngrx/platform/blob/master/docs/store/README.md).