### PR TITLE
fix(schematics): update jest-preset-angular to 6.0.1

### DIFF
--- a/packages/schematics/migrations/migrations.json
+++ b/packages/schematics/migrations/migrations.json
@@ -19,6 +19,11 @@
       "version": "6.2.0",
       "description": "Add Global Karma Conf",
       "factory": "./update-6-2-0/update-6-2-0"
+    },
+    "update-6.3.2": {
+      "version": "6.3.2",
+      "description": "Update jest-preset-angular",
+      "factory": "./update-6-3-2/update-6-3-2"
     }
   }
 }

--- a/packages/schematics/migrations/update-6-3-2/update-6-3-2.spec.ts
+++ b/packages/schematics/migrations/update-6-3-2/update-6-3-2.spec.ts
@@ -1,0 +1,56 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { serializeJson } from '../../src/utils/fileutils';
+
+import * as path from 'path';
+
+describe('Update 6.2.0', () => {
+  let initialTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(() => {
+    initialTree = Tree.empty();
+    initialTree.create(
+      'package.json',
+      serializeJson({
+        devDependencies: {
+          'jest-preset-angular': '6.0.0'
+        }
+      })
+    );
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/schematics',
+      path.join(__dirname, '../migrations.json')
+    );
+  });
+
+  it('should update jest-preset-angular', () => {
+    const result = schematicRunner.runSchematic(
+      'update-6.3.2',
+      {},
+      initialTree
+    );
+    expect(JSON.parse(result.readContent('package.json'))).toEqual({
+      devDependencies: {
+        'jest-preset-angular': '6.0.1'
+      }
+    });
+  });
+
+  it('should not update jest-preset-angular if it does not exist', () => {
+    initialTree.overwrite(
+      'package.json',
+      serializeJson({
+        devDependencies: {}
+      })
+    );
+    const result = schematicRunner.runSchematic(
+      'update-6.3.2',
+      {},
+      initialTree
+    );
+    expect(JSON.parse(result.readContent('package.json'))).toEqual({
+      devDependencies: {}
+    });
+  });
+});

--- a/packages/schematics/migrations/update-6-3-2/update-6-3-2.ts
+++ b/packages/schematics/migrations/update-6-3-2/update-6-3-2.ts
@@ -1,0 +1,22 @@
+import { Rule, Tree, SchematicContext } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import { updateJsonInTree } from '../../src/utils/ast-utils';
+
+export default function(): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    return updateJsonInTree('package.json', json => {
+      const devDependencies = json.devDependencies;
+
+      if (!devDependencies) {
+        return json;
+      }
+
+      if (devDependencies['jest-preset-angular']) {
+        devDependencies['jest-preset-angular'] = '6.0.1';
+        context.addTask(new NodePackageInstallTask());
+      }
+
+      return json;
+    })(host, context);
+  };
+}

--- a/packages/schematics/src/collection/jest/index.ts
+++ b/packages/schematics/src/collection/jest/index.ts
@@ -6,7 +6,11 @@ import {
 } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { updateJsonInTree } from '../../utils/ast-utils';
-import { jestVersion, nxVersion } from '../../lib-versions';
+import {
+  jestVersion,
+  nxVersion,
+  jestPresetAngularVersion
+} from '../../lib-versions';
 import { Rule } from '@angular-devkit/schematics';
 
 const updatePackageJson = updateJsonInTree('package.json', json => {
@@ -15,7 +19,7 @@ const updatePackageJson = updateJsonInTree('package.json', json => {
     '@nrwl/builders': nxVersion,
     jest: jestVersion,
     '@types/jest': jestVersion,
-    'jest-preset-angular': '6.0.0'
+    'jest-preset-angular': jestPresetAngularVersion
   };
   return json;
 });

--- a/packages/schematics/src/lib-versions.ts
+++ b/packages/schematics/src/lib-versions.ts
@@ -13,6 +13,7 @@ export const prettierVersion = '1.13.7';
 export const typescriptVersion = '~2.7.2';
 export const rxjsVersion = '^6.0.0';
 export const jestVersion = '^23.0.0';
+export const jestPresetAngularVersion = '6.0.1';
 export const jasmineMarblesVersion = '0.3.1';
 
 export const libVersions = {


### PR DESCRIPTION
## Current Behavior

For new workspaces, `jest-preset-angular@6.0.0` brings in `ts-jest@23.10.0` which has a lot of breaking changes.

## Expected Behavior

Workspaces should bring in `jest-preset-angular@6.0.1` which has a fix to lock `ts-jest` to `~23.1.3` without breaking changes.

Workspaces should be migrated to `jest-preset-angular@6.0.1` as well

Fixes https://github.com/nrwl/nx/issues/776

### Notes:

This is causing PRs to fail right now since our e2e tests make a new project