### PR TITLE
fix(schematics): exclude jest setup file in tsconfig.app.json

### DIFF
--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -303,6 +303,17 @@ describe('app', () => {
         'apps/my-app/tsconfig.app.json',
         'apps/my-app/tsconfig.spec.json'
       ]);
+      const tsconfigAppJson = readJsonInTree(
+        tree,
+        'apps/my-app/tsconfig.app.json'
+      );
+      expect(tsconfigAppJson.exclude).toEqual([
+        'src/test-setup.ts',
+        '**/*.spec.ts'
+      ]);
+      expect(tsconfigAppJson.compilerOptions.outDir).toEqual(
+        '../../dist/out-tsc/apps/my-app'
+      );
     });
   });
 

--- a/packages/schematics/src/collection/application/index.ts
+++ b/packages/schematics/src/collection/application/index.ts
@@ -175,7 +175,6 @@ function updateProject(options: NormalizedSchema): Rule {
         return json;
       }),
       updateJsonInTree(`${options.appProjectRoot}/tsconfig.app.json`, json => {
-        json.exclude = json.exclude || [];
         return {
           ...json,
           extends: `${offsetFromRoot(options.appProjectRoot)}tsconfig.json`,
@@ -185,6 +184,10 @@ function updateProject(options: NormalizedSchema): Rule {
               options.appProjectRoot
             }`
           },
+          exclude:
+            options.unitTestRunner === 'jest'
+              ? ['src/test-setup.ts', '**/*.spec.ts']
+              : json.exclude || [],
           include: ['**/*.ts']
         };
       }),


### PR DESCRIPTION
## Current Behavior

see #781. Setting `--unit-test-runner=jest` is exluding the default karma `src/test.ts` file.

## Expected Behavior

Setting `--unit-test-runner=jest` should exclude `src/test-setup.ts` that will be created for jest.

### Others

I can extend the pr and consider the `skipSetupFile` parameter for the `ng g app` run, that is available at the `jest-project` schematic. I will just pass it through to the `jest-project` call and skip the exclusion of `test-setup.ts` here, if the parameter is set. Or maybe extend/rename the paramter (or add a new one) to be able to point to a file within the workspace? This would allow a global `test-setup.ts` file like discussed at #747 *Workspace configured for Jest conflicts with IDE settings*