### PR TITLE
fix(schematics): clean outDir to avoid blueprint leaks

### DIFF
--- a/packages/schematics/src/command-line/workspace-schematic.ts
+++ b/packages/schematics/src/command-line/workspace-schematic.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import { readFileSync, statSync, writeFileSync } from 'fs';
 import * as path from 'path';
-import { copySync } from 'fs-extra';
+import { copySync, removeSync } from 'fs-extra';
 import {
   FileSystemEngineHost,
   NodeModulesEngineHost,
@@ -48,6 +48,7 @@ export function workspaceSchematic(args: string[]) {
 // compile tools
 function compileTools() {
   const toolsOutDir = getToolsOutDir();
+  removeSync(toolsOutDir);
   compileToolsDir(toolsOutDir);
 
   const schematicsOutDir = path.join(toolsOutDir, 'schematics');


### PR DESCRIPTION
This should close #785 I opened, but I clean the whole tools `outDir` prior a new `tsc` run instead of the blueprints only (hard to identify, delete all seems fast enough):

## Current Behavior

If you delete a file within your custom workspace schematic that is used as a blueprint file, it is still available at the next execution of the workspace schematic and will be created - even though you have deleted it in the source.

## Expected Behavior

Deleted files should be removed from the `outDir`.