### PR TITLE
fix(schematics): fix affected for projects without architect config

### DIFF
--- a/packages/schematics/src/command-line/shared.spec.ts
+++ b/packages/schematics/src/command-line/shared.spec.ts
@@ -363,4 +363,32 @@ describe('getProjectNodes', () => {
       }
     ]);
   });
+
+  it('should normalize missing architect configurations to an empty object', () => {
+    const result = getProjectNodes(mockAngularJson, mockNxJson).map(node => {
+      return { name: node.name, architect: node.architect };
+    });
+    expect(result).toEqual([
+      {
+        name: 'app1',
+        architect: {}
+      },
+      {
+        name: 'app1-e2e',
+        architect: {}
+      },
+      {
+        name: 'customName-e2e',
+        architect: {}
+      },
+      {
+        name: 'lib1',
+        architect: {}
+      },
+      {
+        name: 'lib2',
+        architect: {}
+      }
+    ]);
+  });
 });

--- a/packages/schematics/src/command-line/shared.ts
+++ b/packages/schematics/src/command-line/shared.ts
@@ -296,7 +296,7 @@ export function getProjectNodes(angularJson, nxJson): ProjectNode[] {
       root: p.root,
       type: projectType,
       tags,
-      architect: p.architect,
+      architect: p.architect || {},
       files: allFilesInDir(`${appRoot.path}/${p.root}`),
       implicitDependencies
     };


### PR DESCRIPTION
## Current Behavior

A project doesn't necessarily need an architect but not having one is not handled by `affected`.

Having a project without an architect configuration will cause `affected` to fail.

## Expected Behavior

Having a project without an architect configuration will not cause `affected` to fail.

Fixes https://github.com/nrwl/nx/issues/773