### PR TITLE
fix(schematics): remove duplicate schematics dep after ng-add

### DIFF
--- a/packages/schematics/src/collection/ng-add/index.ts
+++ b/packages/schematics/src/collection/ng-add/index.ts
@@ -72,9 +72,6 @@ function updatePackageJson() {
     if (!packageJson.dependencies) {
       packageJson.dependencies = {};
     }
-    if (!packageJson.scripts) {
-      packageJson.scripts = {};
-    }
     if (!packageJson.dependencies['@nrwl/nx']) {
       packageJson.dependencies['@nrwl/nx'] = nxVersion;
     }
@@ -92,6 +89,9 @@ function updatePackageJson() {
     }
     if (!packageJson.devDependencies['ngrx-store-freeze']) {
       packageJson.devDependencies['ngrx-store-freeze'] = ngrxStoreFreezeVersion;
+    }
+    if (packageJson.dependencies['@nrwl/schematics']) {
+      delete packageJson.dependencies['@nrwl/schematics'];
     }
     if (!packageJson.devDependencies['@nrwl/schematics']) {
       packageJson.devDependencies['@nrwl/schematics'] = schematicsVersion;


### PR DESCRIPTION
## Current Behavior

When doing `ng add @nrwl/schematics`, the CLI installs `@nrwl/schematics` as a `dependency`. We then install it as a `devDependency` causing a duplicate dependency.

## Expected Behavior

During `ng-add`, if `@nrwl/schematics` is a `dependency`, remove it so the `devDependency` is the only copy.

Fixes https://github.com/nrwl/nx/issues/699