### PR TITLE
fix(builders): fix node builders on windows

### DIFF
--- a/packages/builders/src/node/build/node-build.builder.ts
+++ b/packages/builders/src/node/build/node-build.builder.ts
@@ -4,11 +4,11 @@ import {
   BuilderConfiguration,
   BuilderContext
 } from '@angular-devkit/architect';
-import { virtualFs, Path } from '@angular-devkit/core';
+import { getSystemPath } from '@angular-devkit/core';
 import { WebpackBuilder } from '@angular-devkit/build-webpack';
 
 import { Observable } from 'rxjs';
-import { Stats, writeFileSync } from 'fs';
+import { writeFileSync } from 'fs';
 import { getWebpackConfig, OUT_FILENAME } from './webpack/config';
 import { resolve } from 'path';
 import { map } from 'rxjs/operators';
@@ -29,7 +29,7 @@ export interface BuildNodeBuilderOptions {
   statsJson?: boolean;
   extractLicenses?: boolean;
 
-  root?: Path;
+  root?: string;
 }
 
 export interface FileReplacement {
@@ -45,12 +45,11 @@ export default class BuildNodeBuilder
   implements Builder<BuildNodeBuilderOptions> {
   webpackBuilder: WebpackBuilder;
 
-  private get root() {
-    return this.context.workspace.root;
-  }
+  root: string;
 
   constructor(private context: BuilderContext) {
     this.webpackBuilder = new WebpackBuilder(this.context);
+    this.root = getSystemPath(this.context.workspace.root);
   }
 
   run(

--- a/packages/builders/src/node/build/webpack/config.spec.ts
+++ b/packages/builders/src/node/build/webpack/config.spec.ts
@@ -1,6 +1,6 @@
 import { getWebpackConfig } from './config';
 import { BuildNodeBuilderOptions } from '../node-build.builder';
-import { normalize } from '@angular-devkit/core';
+import { normalize, getSystemPath } from '@angular-devkit/core';
 
 import * as ts from 'typescript';
 import { LicenseWebpackPlugin } from 'license-webpack-plugin';
@@ -17,7 +17,7 @@ describe('getWebpackConfig', () => {
       tsConfig: 'tsconfig.json',
       externalDependencies: 'all',
       fileReplacements: [],
-      root: normalize('/root')
+      root: getSystemPath(normalize('/root'))
     };
   });
 

--- a/packages/builders/src/node/execute/node-execute.builder.ts
+++ b/packages/builders/src/node/execute/node-execute.builder.ts
@@ -72,10 +72,14 @@ export class NodeExecuteBuilder implements Builder<NodeExecuteBuilderOptions> {
     const observableTreeKill = bindCallback(treeKill);
     return observableTreeKill(this.subProcess.pid, 'SIGTERM').pipe(
       tap(err => {
+        this.subProcess = null;
         if (err) {
-          throw err;
-        } else {
-          this.subProcess = null;
+          if (Array.isArray(err) && err[0] && err[2]) {
+            const errorMessage = err[2];
+            this.context.logger.error(errorMessage);
+          } else if (err.message) {
+            this.context.logger.error(err.message);
+          }
         }
       })
     );


### PR DESCRIPTION
## Part 1 - Paths incorrect for windows

### Current Behavior

Paths are normalized but not converted to System paths causing compilation to fail.

### Expected Behavior

Paths are system paths for windows and other systems.

## Part 2 - Process Termination throws Error on windows

### Current Behavior

`treeKill` calls the callback with a truthy error (an Array) on windows.

### Expected Behavior

Error is logged but flow is not broken. Both windows and normal errors should be handled.