### PR TITLE
Fix: Unable to run tests under Windows with paths that contain spaces

### DIFF
--- a/packages/schematics/src/command-line/affected.ts
+++ b/packages/schematics/src/command-line/affected.ts
@@ -443,7 +443,7 @@ function ngPath() {
       path.dirname(resolve.sync('@angular/cli', { basedir: __dirname }))
     )
   );
-  return path.join(basePath, 'bin', 'ng');
+  return `"${path.join(basePath, 'bin', 'ng')}"`;
 }
 
 /**


### PR DESCRIPTION
This PR fixes paths with spaces under windows.

**Reproduce error:**

Path: `C:\Users\My Name\git\myangularproject`

Command: `./node_modules/.bin/nx affected:test`

```
Error: Cannot find module 'C:\Users\My'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:594:15)
    at Function.Module._load (internal/modules/cjs/loader.js:520:25)
    at Function.Module.runMain (internal/modules/cjs/loader.js:744:10)
    at startup (internal/bootstrap/node.js:238:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:572:3)
```