### PR TITLE
feat(nx): export data persistence operators

### DIFF
--- a/packages/nx/index.ts
+++ b/packages/nx/index.ts
@@ -1,2 +1,8 @@
-export { DataPersistence } from './src/data-persistence';
+export {
+  DataPersistence,
+  fetch,
+  navigation,
+  optimisticUpdate,
+  pessimisticUpdate
+} from './src/data-persistence';
 export { NxModule } from './src/nx.module';


### PR DESCRIPTION
DataPersistence methods have been refactored to use pipeable operators, but these operators weren't
exported so they could not be used outside of the library. Now, users will be able to import the
operators themselves.