### PR TITLE
feat(schematics): add option for no module in lib

### DIFF
--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -139,6 +139,21 @@ describe('lib', () => {
       ).toBeFalsy();
     });
 
+    it('should not generate a module for --module false', () => {
+      const tree = schematicRunner.runSchematic(
+        'lib',
+        { name: 'myLib', module: false },
+        appTree
+      );
+      expect(tree.exists('libs/my-lib/src/lib/my-lib.module.ts')).toEqual(
+        false
+      );
+      expect(tree.exists('libs/my-lib/src/lib/my-lib.module.spec.ts')).toEqual(
+        false
+      );
+      expect(tree.exists('libs/my-lib/src/lib/.gitkeep')).toEqual(true);
+    });
+
     it('should default the prefix to npmScope', () => {
       const noPrefix = schematicRunner.runSchematic(
         'lib',
@@ -230,6 +245,21 @@ describe('lib', () => {
       expect(
         tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']
       ).toBeUndefined();
+    });
+
+    it('should not generate a module for --module false', () => {
+      const tree = schematicRunner.runSchematic(
+        'lib',
+        { name: 'myLib', directory: 'myDir', module: false },
+        appTree
+      );
+      expect(
+        tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.module.ts')
+      ).toEqual(false);
+      expect(
+        tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.module.spec.ts')
+      ).toEqual(false);
+      expect(tree.exists('libs/my-dir/my-lib/src/lib/.gitkeep')).toEqual(true);
     });
   });
 

--- a/packages/schematics/src/collection/library/schema.d.ts
+++ b/packages/schematics/src/collection/library/schema.d.ts
@@ -6,6 +6,7 @@ export interface Schema {
   directory?: string;
   sourceDir?: string;
   publishable: boolean;
+  module: boolean;
 
   spec?: boolean;
   flat?: boolean;

--- a/packages/schematics/src/collection/library/schema.json
+++ b/packages/schematics/src/collection/library/schema.json
@@ -53,6 +53,11 @@
       "description":
         "Add RouterModule.forChild when set to true, and a simple array of routes when set to false."
     },
+    "module": {
+      "type": "boolean",
+      "default": true,
+      "description": "Include an NgModule in the library."
+    },
     "parentModule": {
       "type": "string",
       "description":


### PR DESCRIPTION
## Current Behavior

An `NgModule` is produced as part of a lib unconditionally

## Expected Behavior

There is a `module` option which defaults to `true`. Using `ng g lib lib1 --no-module` will not produce an `NgModule` or a spec for it. It will preserve the `lib` directory with a `.gitkeep` though.

## Notes

This is mainly for generating libraries for NodeJS which do not run Angular.

The best way to do this would be to do
```sh
ng g lib node-lib --unit-test-runner jest --no-module
```sh