### PR TITLE
feat(builders): support es2015 compilation

### DIFF
--- a/packages/builders/src/node/build/webpack/config.spec.ts
+++ b/packages/builders/src/node/build/webpack/config.spec.ts
@@ -69,6 +69,18 @@ describe('getWebpackConfig', () => {
       expect(result.resolve.extensions).toEqual(['.ts', '.js']);
     });
 
+    it('should include module and main in mainFields', () => {
+      spyOn(ts, 'parseJsonConfigFileContent').and.returnValue({
+        options: {
+          target: 'es5'
+        }
+      });
+
+      const result = getWebpackConfig(input);
+      expect(result.resolve.mainFields).toContain('module');
+      expect(result.resolve.mainFields).toContain('main');
+    });
+
     it('should not polyfill node apis', () => {
       const result = getWebpackConfig(input);
 
@@ -127,6 +139,17 @@ describe('getWebpackConfig', () => {
       expect(result.resolve.alias).toEqual({
         '@npmScope/libraryName': '/root/libs/libraryName/src/index.ts'
       });
+    });
+
+    it('should include es2015 in mainFields if typescript is set es2015', () => {
+      spyOn(ts, 'parseJsonConfigFileContent').and.returnValue({
+        options: {
+          target: 'es2015'
+        }
+      });
+
+      const result = getWebpackConfig(input);
+      expect(result.resolve.mainFields).toContain('es2015');
     });
   });
 


### PR DESCRIPTION
## Current Behavior

Compilations with Typescript targetting `es2015` do not use the `es2015` field of `package.json`.

This causes issues with `@angular/elements`

## Expected Behavior

Compilations with Typescript targetting `es2015` should use the `es2015` field as well as normal node `mainFields` (https://webpack.js.org/configuration/resolve/)

This is pretty much the same as https://github.com/angular/angular-cli/pull/7610/files#diff-9eb0a75e499bdadd44d6dc62218812b8. (We do not include `browser` because we are on `node`.