### PR TITLE
fix(schematics): check type of tsConfig lint entry (ng-add)

### DIFF
--- a/e2e/schematics/ng-add.test.ts
+++ b/e2e/schematics/ng-add.test.ts
@@ -327,6 +327,31 @@ describe('Nrwl Convert to Nx Workspace', () => {
     );
   });
 
+  it('should handle type array at tslint builder options.tsConfig (e2e project)', () => {
+    // create a new AngularCLI app
+    runNgNew();
+
+    // set array at tslint builder options.tsConfig
+    const existingAngularJson = readJson('angular.json');
+    existingAngularJson.projects['proj-e2e'].architect.lint.options.tsConfig = [
+      'e2e/tsconfig.e2e.json'
+    ];
+    updateFile('angular.json', JSON.stringify(existingAngularJson, null, 2));
+
+    // Add @nrwl/schematics
+    runCLI('add @nrwl/schematics --npmScope projscope --skip-install');
+
+    const updatedAngularCLIJson = readJson('angular.json');
+
+    expect(updatedAngularCLIJson.projects['proj-e2e'].architect.lint).toEqual({
+      builder: '@angular-devkit/build-angular:tslint',
+      options: {
+        tsConfig: ['apps/proj-e2e/tsconfig.e2e.json'],
+        exclude: ['**/node_modules/**']
+      }
+    });
+  });
+
   it('should handle different types of errors', () => {
     // create a new AngularCLI app
     runNgNew();

--- a/packages/schematics/src/collection/ng-add/index.ts
+++ b/packages/schematics/src/collection/ng-add/index.ts
@@ -292,10 +292,16 @@ function updateAngularCLIJson(options: Schema): Rule {
       );
 
       const e2eLintConfig = e2eProject.architect.lint;
-      e2eLintConfig.options.tsConfig = path.join(
-        e2eProject.root,
-        getFilename(e2eLintConfig.options.tsConfig)
-      );
+      e2eLintConfig.options.tsConfig = Array.isArray(
+        e2eLintConfig.options.tsConfig
+      )
+        ? e2eLintConfig.options.tsConfig.map(tsConfigPath =>
+            path.join(e2eProject.root, getFilename(tsConfigPath))
+          )
+        : path.join(
+            e2eProject.root,
+            getFilename(e2eLintConfig.options.tsConfig)
+          );
 
       angularJson.projects[getE2eKey(angularJson)] = e2eProject;
     }


### PR DESCRIPTION
## Current Behavior

The [schema](https://github.com/angular/angular-cli/blob/v6.0.0-rc.8/packages/%40angular/cli/lib/config/schema.json#L1519-L1594) of`angular.json` allows the `tsConfig` entry of `tslint` to be `string` or `array of string`. If you define an array at the e2e project the `ng-add` schematic fails.

## Expected Behavior

The `ng-add` schematic should convert the `tsConfig` path entries for the types `array of string` and `string`.

see #624 and #768 