### PR TITLE
fix(schematics): check existence of tslint.json for app (ng-add)

### DIFF
--- a/packages/schematics/src/collection/ng-add/index.ts
+++ b/packages/schematics/src/collection/ng-add/index.ts
@@ -419,9 +419,11 @@ function updateProjectTsLint(options: Schema) {
     const app = angularJson.projects[options.name];
     const offset = '../../';
 
-    updateJsonFile(`${app.root}/tslint.json`, json => {
-      json.extends = `${offset}tslint.json`;
-    });
+    if (host.exists(`${app.root}/tslint.json`)) {
+      updateJsonFile(`${app.root}/tslint.json`, json => {
+        json.extends = `${offset}tslint.json`;
+      });
+    }
 
     return host;
   };


### PR DESCRIPTION
## Current Behavior

If the lint config at `src\tslint.json` does not exist, the schematic `ng-add` fails.

## Expected Behavior

`ng add @nrwl/schematics` should not fail if there is no `src\tslint.json` file.

see #768 for a `ng add` scenario that fails