### PR TITLE
build(scripts): add log about moving libraries

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,3 +36,6 @@ cp LICENSE build/packages/bazel
 cp LICENSE build/packages/builders
 cp LICENSE build/packages/schematics
 cp LICENSE build/packages/nx
+
+echo "Nx libraries available at build/packages:"
+ls build/packages


### PR DESCRIPTION
## Description
This adds a log in the terminal while performing the build, to update the user on the last destination of the Nx libraries. Contrary to the last log from `ng-packagr` saying the build is in `/dist`, it is moved right after in the `/build` folder.

_To avoid the confusion, this log say the right information._