### PR TITLE
fix(schematics): use feature key in selector

### DIFF
--- a/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.selectors.ts__tmpl__
+++ b/packages/schematics/src/collection/ngrx/files/__directory__/__fileName__.selectors.ts__tmpl__
@@ -1,8 +1,8 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { <%= className %>State } from './<%= fileName %>.reducer';
+import { <%= className.toUpperCase() %>_FEATURE_KEY, <%= className %>State } from './<%= fileName %>.reducer';
 
 // Lookup the '<%= className %>' feature state managed by NgRx
-const get<%= className %>State = createFeatureSelector<<%= className %>State>('<%= propertyName %>');
+const get<%= className %>State = createFeatureSelector<<%= className %>State>(<%= propertyName.toUpperCase() %>_FEATURE_KEY);
 
 const getLoaded = createSelector( get<%= className %>State, (state:<%= className %>State) => state.loaded );
 const getError = createSelector( get<%= className %>State, (state:<%= className %>State) => state.error );

--- a/packages/schematics/src/collection/ngrx/ngrx.spec.ts
+++ b/packages/schematics/src/collection/ngrx/ngrx.spec.ts
@@ -341,7 +341,7 @@ describe('ngrx', () => {
       const content = getFileContent(tree, `${statePath}/users.selectors.ts`);
 
       [
-        `import { UsersState } from './users.reducer'`,
+        `import { USERS_FEATURE_KEY, UsersState } from './users.reducer'`,
         `export const usersQuery`
       ].forEach(text => {
         expect(content).toContain(text);


### PR DESCRIPTION
## Description
Use now the feature key constant from the reducer to set `createFeatureSelector` with the right state nomination.

## Issue
fix #818