### PR TITLE
chore(commands): workspace integrity check angular.json

### DIFF
--- a/packages/schematics/src/command-line/workspace-integrity-checks.ts
+++ b/packages/schematics/src/command-line/workspace-integrity-checks.ts
@@ -44,7 +44,7 @@ export class WorkspaceIntegrityChecks {
 
     return errors.length === 0
       ? []
-      : [{ header: 'The .angular-cli.json file is out of sync', errors }];
+      : [{ header: 'The angular.json file is out of sync', errors }];
   }
 
   private filesWithoutProjects(): ErrorGroup[] {


### PR DESCRIPTION
## Description
This updates the `.angular-cli.json` to `angular.json` which is now the convention from Angular CLI.