### PR TITLE
feat(schematics): make dep-graph export to svg

### DIFF
--- a/packages/schematics/src/command-line/dep-graph.ts
+++ b/packages/schematics/src/command-line/dep-graph.ts
@@ -60,7 +60,8 @@ export type CriticalPathMap = {
 export enum OutputType {
   'json' = 'json',
   'html' = 'html',
-  'dot' = 'dot'
+  'dot' = 'dot',
+  'svg' = 'svg'
 }
 
 export interface UserOptions extends yargs.Arguments {
@@ -339,6 +340,8 @@ function extractDataFromJson(json, type) {
       return getDot(json);
     case OutputType.html:
       return applyHTMLTemplate(viz(getDot(json)));
+    case OutputType.svg:
+      return viz(getDot(json));
     default:
       throw new Error(
         'Unrecognized file extension. Supported extensions are "json", "html", and "dot"'

--- a/packages/schematics/src/command-line/nx.ts
+++ b/packages/schematics/src/command-line/nx.ts
@@ -158,7 +158,12 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
 function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
   return yargs
     .describe('file', 'output file (e.g. --file=.vis/output.json)')
-    .choices('output', [OutputType.json, OutputType.dot, OutputType.html]);
+    .choices('output', [
+      OutputType.json,
+      OutputType.dot,
+      OutputType.html,
+      OutputType.svg
+    ]);
 }
 
 function parseCSV(args: string[]) {


### PR DESCRIPTION
## Description
This enables to export the dependency graph into a `svg` file. It was shown in the documentation but not quite ready yet.

## Issue
fix #811