### PR TITLE
docs(github): update contributing & add templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,52 @@
+_[Please make sure you have read the submission guidelines before posting an issue](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-issue)_
+
+# Prerequisites
+
+Please answer the following questions for yourself before submitting an issue.
+**YOU MAY DELETE THE PREREQUISITES SECTION.**
+
+* [ ] I am running the latest version
+* [ ] I checked the documentation and found no answer
+* [ ] I checked to make sure that this issue has not already been filed
+* [ ] I'm reporting the issue to the correct repository (not related to Angular, AngularCLI or any dependency)
+
+## Expected Behavior
+
+Please describe the behavior you are expecting
+
+## Current Behavior
+
+What is the current behavior?
+
+## Failure Information (for bugs)
+
+Please help provide information about the failure if this is a bug. If it is not a bug, please remove the rest of this template.
+
+### Steps to Reproduce
+
+Please provide detailed steps for reproducing the issue.
+
+1. step 1
+2. step 2
+3. ...
+
+### Context
+
+Please provide any relevant information about your setup:
+
+* version of Nx used
+* version of Angular CLI used
+* `angular.json` configuration
+* version of Angular DevKit used
+* 3rd-party libraries and their versions
+* and most importantly - a use-case that fails
+
+**A minimal reproduce scenario using allows us to quickly confirm a bug (or point out coding problem) as well as confirm that we are fixing the right problem.**
+
+### Failure Logs
+
+Please include any relevant log snippets or files here.
+
+## Other
+
+Any other relevant information that will help us help you.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,12 @@
+## Description
+
+Description the change you would like to have.
+
+## Suggested implementation
+
+How do you think it can be done?
+
+## Describe alternatives
+
+Do you have considered any alternative?
+Teachability, Documentation, Adoption, Migration Strategy...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_
+
+## Description
+
+## Issue

--- a/.github/SAVED_REPLIES.md
+++ b/.github/SAVED_REPLIES.md
@@ -1,0 +1,67 @@
+# Saved Responses for Nx's Issue Tracker
+
+The following are canned responses that the Nx team should use to close issues on our issue tracker that fall into the listed resolution categories.
+
+Since GitHub currently doesn't allow us to have a repository-wide or organization-wide list of [saved replies](https://help.github.com/articles/working-with-saved-replies/), these replies need to be maintained by individual team members. Since the responses can be modified in the future, all responses are versioned to simplify the process of keeping the responses up to date.
+
+## Nx: Already Fixed
+
+```
+Thanks for reporting this issue. Luckily, it has already been fixed in one of the recent releases. Please update to the most recent version to resolve the problem.
+
+If the problem persists in your application after upgrading, please open a new issue, provide a simple repository reproducing the problem, and describe the difference between the expected and current behavior. You can use `create-nx-workspace my-issue` and then `ng g app my-app` to create a new project where you reproduce the problem.
+```
+
+## Nx: Don't Understand
+
+```
+I'm sorry, but we don't understand the problem you are reporting.
+
+Please provide a simple repository reproducing the problem, and describe the difference between the expected and current behavior. You can use `create-nx-workspace my-issue` to create a new project where you reproduce the problem.
+```
+
+## Nx: Duplicate
+
+```
+Thanks for reporting this issue. However, this issue is a duplicate of #<ISSUE_NUMBER>. Please subscribe to that issue for future updates.
+```
+
+## Nx: Insufficient Information Provided
+
+```
+Thanks for reporting this issue. However, you didn't provide sufficient information for us to understand and reproduce the problem. Please check out [our submission guidelines](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-an-issue) to understand why we can't act on issues that are lacking important information.
+
+Please ensure you provide all of the required information when filling out the issue template.
+```
+
+## Nx: NPM install issue
+
+```
+This seems like a problem with your node/npm and not with Nx.
+
+Please have a look at the [fixing npm permissions page](https://docs.npmjs.com/getting-started/fixing-npm-permissions), [common errors page](https://docs.npmjs.com/troubleshooting/common-errors), [npm issue tracker](https://github.com/npm/npm/issues), or open a new issue if the problem you are experiencing isn't known.
+```
+
+## Nx: Issue Outside of Nx
+
+```
+I'm sorry, but this issue is not caused by Nx. Please contact the author(s) of the <PROJECT NAME> project or file an issue on their issue tracker.
+```
+
+## Nx: Non-reproducible
+
+```
+I'm sorry, but we can't reproduce the problem following the instructions you provided.
+Remember that we have a large number of issues to resolve, and have only a limited amount of time to reproduce your issue.
+Short, explicit instructions make it much more likely we'll be able to reproduce the problem so we can fix it.
+
+A good way to make a minimal repro is to create a new app via `create-nx-workspace my-issue` and then `ng g app my-app` and adding the minimum possible code to show the problem. Then you can push this repository to github and link it here.
+```
+
+## Nx: Obsolete
+
+```
+Thanks for reporting this issue. This issue is now obsolete due to changes in the recent releases. Please update to the most recent Nx version.
+
+If the problem persists after upgrading, please open a new issue, provide a simple repository reproducing the problem, and describe the difference between the expected and current behavior.
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,14 @@
-## Contributing to Nx
+# Contributing to Nx
 
 We would love for you to contribute to Nx! Read this document to see how to do it.
 
 ## Got a Question?
 
 We are trying to keep GitHub issues for bug reports and feature requests. Stack Overflow is a much better place to ask general questions about how to use Nx.
+
+## Found an Issue?
+
+If you find a bug in the source code or a mistake in the documentation, you can help us by [submitting an issue](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-issue) to [our GitHub Repository](https://github.com/nrwl/nx). Even better, you can [submit a Pull Request](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr) with a fix.
 
 ## Building the Project
 
@@ -16,15 +20,56 @@ After that run `yarn linknpm`.
 
 ### Running Unit Tests
 
-To make sure your changes do not break any unit tests, run `yarn test`. You can also run `yarn test:schematics` and `yarn test:nx` to test the schematics and nx packages individually.
+To make sure your changes do not break any unit tests, run the following:
 
-> If you need to test only the **collection/ngrx.spec.ts** test [for example], you can use an optional `$1` argument as follows:<br/><br/> `yarn test:schematics schematics/src/collection/ngrx/ngrx`
+```bash
+yarn test
+```
+
+You can also run `yarn test:schematics` and `yarn test:nx` to test the schematics and nx packages individually.
+
+If you need to test only the **collection/ngrx.spec.ts** test [for example], you can use an optional `$1` argument as follows:
+
+```bash
+yarn test:schematics schematics/src/collection/ngrx/ngrx
+```
 
 ### Running E2E Tests
 
-To make sure you changes do not break any unit tests, run `yarn e2e`. Running e2e tests can take some time, so if it often useful to run a single test. You can do it as follows: `yarn e2e lint`
+To make sure you changes do not break any unit tests, run the following:
 
-## Submitting a PR
+```bash
+yarn e2e
+```
+
+Running e2e tests can take some time, so if it often useful to run a single test. You can do it as follows:
+
+```bash
+yarn e2e affected
+```
+
+## Submission Guidelines
+
+### <a name="submit-issue"></a> Submitting an Issue
+
+Before you submit an issue, please search the issue tracker, maybe an issue for your problem already exists and the discussion might inform you of workarounds readily available.
+
+We want to fix all the issues as soon as possible, but before fixing a bug we need to reproduce and confirm it. Having a reproducible scenario gives us wealth of important information without going back & forth to you with additional questions like:
+
+* version of Nx used
+* version of Angular CLI used
+* `angular.json` configuration
+* version of Angular DevKit used
+* 3rd-party libraries and their versions
+* and most importantly - a use-case that fails
+
+A minimal reproduce scenario using allows us to quickly confirm a bug (or point out coding problem) as well as confirm that we are fixing the right problem.
+
+We will be insisting on a minimal reproduce scenario in order to save maintainers time and ultimately be able to fix more bugs. Interestingly, from our experience users often find coding problems themselves while preparing a minimal repository. We understand that sometimes it might be hard to extract essentials bits of code from a larger code-base but we really need to isolate the problem before we can fix it.
+
+You can file new issues by filling out our [issue form](https://github.com/nrwl/nx/issues/new).
+
+### <a name="submit-pr"></a> Submitting a PR
 
 Please follow the following guidelines:
 
@@ -33,7 +78,7 @@ Please follow the following guidelines:
 * Make sure you run `yarn format`
 * Update your commit message to follow the guidelines below
 
-### Commit Message Guidelines
+#### Commit Message Guidelines
 
 Commit message should follow the following format:
 
@@ -43,7 +88,7 @@ BLANK LINE
 body
 ```
 
-#### Type
+##### Type
 
 The type must be one of the following:
 
@@ -55,7 +100,7 @@ The type must be one of the following:
 * docs
 * test
 
-#### Scope
+##### Scope
 
 The scope must be one of the following:
 
@@ -63,7 +108,7 @@ The scope must be one of the following:
 * nx
 * schematics
 
-#### Subject
+##### Subject
 
 The subject must contain a description of the change.
 


### PR DESCRIPTION
## Description
Add saved replies and update contributing section and format.
Add templates for submitting an issue and a pull request.

#### Saved replies
When commenting on an issue or pull request, you can add a saved reply that you've already set up. The saved reply can be the entire comment or if you want to customize it, you can add or delete content.
![saved replies](https://help.github.com/assets/images/help/writing/saved-replies-add-reply-issue-pr.gif)

#### Pull request template
When you add a pull request template to your repository, project contributors will automatically see the template's contents in the pull request body.
![PR template](https://help.github.com/assets/images/help/pull_requests/pr-template-sample.png)

#### Issue template
When you create issue templates for your repository using the issue template builder, they'll be available for contributors to use when they open new issues in the repository.