### PR TITLE
fix(schematics): add node types for node apps

### DIFF
--- a/packages/schematics/src/collection/node-application/files/app/tsconfig.app.json
+++ b/packages/schematics/src/collection/node-application/files/app/tsconfig.app.json
@@ -2,7 +2,7 @@
   "extends": "<%= offset %>tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= offset %>dist/out-tsc/<%= root %>",
-    "types": []
+    "types": ["node"]
   },
   "exclude": ["**/*.spec.ts"],
   "include": ["**/*.ts"]

--- a/packages/schematics/src/collection/node-application/node-application.spec.ts
+++ b/packages/schematics/src/collection/node-application/node-application.spec.ts
@@ -186,6 +186,11 @@ describe('node-app', () => {
           expectedValue: '../../../dist/out-tsc/apps/my-dir/my-node-app'
         },
         {
+          path: 'apps/my-dir/my-node-app/tsconfig.app.json',
+          lookupFn: json => json.compilerOptions.types,
+          expectedValue: ['node']
+        },
+        {
           path: 'apps/my-dir/my-node-app/tslint.json',
           lookupFn: json => json.extends,
           expectedValue: '../../../tslint.json'


### PR DESCRIPTION
## Current Behavior

Types for `node` just happen to be available when using `express`. It's better to not rely on `express` being there for `node` typings to exist.

## Expected Behavior

Types for `node` are included