### PR TITLE
fix(schematics): create unique ids for schematic configs

### DIFF
--- a/packages/schematics/src/collection/downgrade-module/schema.json
+++ b/packages/schematics/src/collection/downgrade-module/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "downgrade-module",
+  "id": "SchematicsNxDowngradeModule",
   "title": "Generates downgradeModule setup",
   "type": "object",
   "properties": {

--- a/packages/schematics/src/collection/jest-project/schema.json
+++ b/packages/schematics/src/collection/jest-project/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "Nx Jest Project Schematics Schema",
+  "id": "SchematicsNxJestProject",
   "title": "Create Jest Configuration for the workspace",
   "type": "object",
   "properties": {

--- a/packages/schematics/src/collection/jest/schema.json
+++ b/packages/schematics/src/collection/jest/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "Nx Jest Schematics Schema",
+  "id": "SchematicsNxJest",
   "title": "Create Jest Configuration for the workspace",
   "type": "object",
   "properties": {},

--- a/packages/schematics/src/collection/library/schema.json
+++ b/packages/schematics/src/collection/library/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "Nx Application Options Schema",
+  "id": "SchematicsNxLibrary",
   "title": "Create a library",
   "type": "object",
   "properties": {

--- a/packages/schematics/src/collection/ng-add/schema.json
+++ b/packages/schematics/src/collection/ng-add/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "ng-add",
+  "id": "SchematicsNxNgAdd",
   "title": "Add Nx Schematics to Project and Convert Workspace",
   "description": "NOTE: Does not work in the --dry-run mode",
   "type": "object",

--- a/packages/schematics/src/collection/ng-new/schema.json
+++ b/packages/schematics/src/collection/ng-new/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "workspace",
+  "id": "SchematicsNxNgNew",
   "title": "Create an empty workspace",
   "type": "object",
   "properties": {

--- a/packages/schematics/src/collection/ngrx/schema.json
+++ b/packages/schematics/src/collection/ngrx/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "ngrx",
+  "id": "SchematicsNxNgrx",
   "title": "Add NgRx support to a module",
   "type": "object",
   "properties": {

--- a/packages/schematics/src/collection/node-application/schema.json
+++ b/packages/schematics/src/collection/node-application/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsNxApp",
+  "id": "SchematicsNxNodeApp",
   "title": "Nx Application Options Schema",
   "type": "object",
   "properties": {

--- a/packages/schematics/src/collection/upgrade-module/schema.json
+++ b/packages/schematics/src/collection/upgrade-module/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "upgrade-module",
+  "id": "SchematicsNxUpgradeModule",
   "title": "Generates UpgradeModule setup",
   "type": "object",
   "properties": {

--- a/packages/schematics/src/collection/workspace-schematic/schema.json
+++ b/packages/schematics/src/collection/workspace-schematic/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "schematics",
+  "id": "SchematicsNxWorkspaceSchematic",
   "title": "Create a custom schematic",
   "type": "object",
   "properties": {


### PR DESCRIPTION
## Current Behavior

When writing a Custom Schematic which uses `@nrwl/schematics:application` and `@nrwl/schematics:node-application`, an error is thrown:
```Error: schema with key or id "SchematicsNxApp" already exists```

## Expected Behavior

All schematics should have unique IDs so that this does not happened. I went through all of them and ensured they had a unique ID. 