### PR TITLE
feat(schematics): make jest flow simpler

### DIFF
--- a/e2e/schematics/jest.test.ts
+++ b/e2e/schematics/jest.test.ts
@@ -10,14 +10,13 @@ import {
 describe('Jest', () => {
   beforeAll(() => {
     newProject();
-    runCLI('generate jest');
-    copyMissingPackages();
   });
 
   it(
     'should be able to generate a testable library using jest',
     async done => {
       newLib('jestlib --unit-test-runner jest');
+      copyMissingPackages();
       await Promise.all([
         runCLIAsync('generate service test --project jestlib'),
         runCLIAsync('generate component test --project jestlib')
@@ -33,6 +32,7 @@ describe('Jest', () => {
     'should be able to generate a testable application using jest',
     async () => {
       newApp('jestapp --unit-test-runner jest');
+      copyMissingPackages();
       await Promise.all([
         runCLIAsync('generate service test --project jestapp'),
         runCLIAsync('generate component test --project jestapp')

--- a/packages/schematics/src/collection.json
+++ b/packages/schematics/src/collection.json
@@ -46,7 +46,8 @@
     "jest": {
       "factory": "./collection/jest",
       "schema": "./collection/jest/schema.json",
-      "description": "Add Jest configuration to the workspace"
+      "description": "Add Jest configuration to the workspace",
+      "hidden": true
     },
 
     "jest-project": {

--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -280,9 +280,6 @@ describe('app', () => {
   });
 
   describe('--unit-test-runner jest', () => {
-    beforeEach(() => {
-      appTree = schematicRunner.runSchematic('jest', {}, appTree);
-    });
     it('should generate a jest config', () => {
       const tree = schematicRunner.runSchematic(
         'app',

--- a/packages/schematics/src/collection/jest-project/index.ts
+++ b/packages/schematics/src/collection/jest-project/index.ts
@@ -9,7 +9,8 @@ import {
   move,
   template,
   noop,
-  filter
+  filter,
+  schematic
 } from '@angular-devkit/schematics';
 import {
   getProjectConfig,
@@ -70,7 +71,7 @@ function updateAngularJson(options: JestProjectSchema): Rule {
   });
 }
 
-function check(options: JestProjectSchema) {
+function check(options: JestProjectSchema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const projectConfig = getProjectConfig(host, options.project);
     if (projectConfig.architect.test) {
@@ -80,9 +81,7 @@ function check(options: JestProjectSchema) {
     }
     const packageJson = readJsonInTree(host, 'package.json');
     if (!packageJson.devDependencies.jest) {
-      throw new Error(
-        `Your workspace does not have jest installed. Please run "ng generate jest" to setup your workspace to run tests with jest.`
-      );
+      return schematic('jest', {});
     }
   };
 }

--- a/packages/schematics/src/collection/jest-project/jest-project.spec.ts
+++ b/packages/schematics/src/collection/jest-project/jest-project.spec.ts
@@ -15,7 +15,6 @@ describe('lib', () => {
   beforeEach(() => {
     appTree = new VirtualTree();
     appTree = createEmptyWorkspace(appTree);
-    appTree = schematicRunner.runSchematic('jest', {}, appTree);
     appTree = schematicRunner.runSchematic(
       'lib',
       {

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -414,10 +414,6 @@ describe('lib', () => {
   });
 
   describe('--unit-test-runner jest', () => {
-    beforeEach(() => {
-      appTree = schematicRunner.runSchematic('jest', {}, appTree);
-    });
-
     it('should generate jest configuration', () => {
       const resultTree = schematicRunner.runSchematic(
         'lib',

--- a/packages/schematics/src/collection/node-application/node-application.spec.ts
+++ b/packages/schematics/src/collection/node-application/node-application.spec.ts
@@ -17,7 +17,6 @@ describe('node-app', () => {
   beforeEach(() => {
     appTree = new VirtualTree();
     appTree = createEmptyWorkspace(appTree);
-    appTree = schematicRunner.runSchematic('jest', {}, appTree);
   });
 
   describe('not nested', () => {


### PR DESCRIPTION
## Current Behavior

User has to do `ng g jest` before generating apps and libs with `jest`.

## Expected Behavior

If they would like to use jest for a project they a generating, they already declared they wanted `jest`. Rather than throwing an error to tell them to go and generate `jest`, it would be simpler and easier to do it for them.