### PR TITLE
fix(schematics): fix tslint rules for ngadd

### DIFF
--- a/e2e/schematics/ng-add.test.ts
+++ b/e2e/schematics/ng-add.test.ts
@@ -225,6 +225,15 @@ describe('Nrwl Convert to Nx Workspace', () => {
       '@projscope/*': ['libs/*']
     });
 
+    const updatedTslint = readJson('tslint.json');
+    expect(updatedTslint.rules['nx-enforce-module-boundaries']).toEqual([
+      true,
+      {
+        allow: [],
+        depConstraints: [{ sourceTag: '*', onlyDependOnLibsWithTags: ['*'] }]
+      }
+    ]);
+
     runCLI('build --prod --outputHashing none');
     checkFilesExist('dist/apps/proj/main.js');
   });

--- a/packages/schematics/src/collection/ng-add/index.ts
+++ b/packages/schematics/src/collection/ng-add/index.ts
@@ -410,7 +410,7 @@ function updateTsLint() {
     });
     tslintJson.rulesDirectory = tslintJson.rulesDirectory || [];
     tslintJson.rulesDirectory.push('node_modules/@nrwl/schematics/src/tslint');
-    tslintJson['nx-enforce-module-boundaries'] = [
+    tslintJson.rules['nx-enforce-module-boundaries'] = [
       true,
       {
         allow: [],


### PR DESCRIPTION
## Current Behavior

Fixes https://github.com/nrwl/nx/issues/844

> When calling `ng add @nrwl/schematics` the `nx-enforce-module-boundaries` rule is added one level too high in the tslint.json:
> 
> ```json
> { "rules": { ... }, "nx-enforce-module-boundaries": { ... }}
> ```

## Expected Behavior
> 
> ```json
> { "rules": { ..., "nx-enforce-module-boundaries": { ... } }}
> ```
