### PR TITLE
fix(schematics): do not add setup file for --no-module libs

### DIFF
--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -444,7 +444,8 @@ export default function(schema: Schema): Rule {
       updateTsConfig(options),
       options.unitTestRunner === 'jest'
         ? schematic('jest-project', {
-            project: options.name
+            project: options.name,
+            skipSetupFile: !options.module
           })
         : noop(),
 

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -435,6 +435,15 @@ describe('lib', () => {
         'libs/my-lib/tsconfig.spec.json'
       ]);
     });
+
+    it('should skip the setup file if no module is generated', () => {
+      const resultTree = schematicRunner.runSchematic(
+        'lib',
+        { name: 'myLib', unitTestRunner: 'jest', module: false },
+        appTree
+      );
+      expect(resultTree.exists('libs/my-lib/src/test-setup.ts')).toBeFalsy();
+    });
   });
 
   describe('--unit-test-runner none', () => {


### PR DESCRIPTION
## Current Behavior

A `test-setup` file is generated when `--no-module` is passed.

## Expected Behavior

No `test-setup` file is generated when `--no-module` is passed since it is not an Angular Library.