### PR TITLE
fix(schematics): dont let bad .nx-results file prevent test run

### DIFF
--- a/packages/schematics/src/command-line/workspace-results.spec.ts
+++ b/packages/schematics/src/command-line/workspace-results.spec.ts
@@ -127,6 +127,17 @@ describe('WorkspacesResults', () => {
       expect(results.getResult('proj')).toBe(false);
     });
 
+    it('should handle a corrupted results file', () => {
+      spyOn(fs, 'readFileSync').and.returnValue('invalid json');
+
+      const runTests = () => {
+        results = new WorkspaceResults('test');
+      };
+
+      expect(runTests).not.toThrow();
+      expect((<any>results).startedWithFailedProjects).toBeFalsy();
+    });
+
     it('should not read the existing results when the previous command was different', () => {
       spyOn(fs, 'readFileSync').and.returnValue(
         serializeJson({

--- a/packages/schematics/src/command-line/workspace-results.ts
+++ b/packages/schematics/src/command-line/workspace-results.ts
@@ -29,14 +29,18 @@ export class WorkspaceResults {
 
   constructor(private command: string) {
     const resultsExists = fs.existsSync(RESULTS_FILE);
-    if (!resultsExists) {
-      this.startedWithFailedProjects = false;
-    } else {
-      const commandResults = readJsonFile(RESULTS_FILE);
-      this.startedWithFailedProjects = commandResults.command === command;
-
-      if (this.startedWithFailedProjects) {
-        this.commandResults = commandResults;
+    this.startedWithFailedProjects = false;
+    if (resultsExists) {
+      try {
+        const commandResults = readJsonFile(RESULTS_FILE);
+        this.startedWithFailedProjects = commandResults.command === command;
+        if (this.startedWithFailedProjects) {
+          this.commandResults = commandResults;
+        }
+      } catch (e) {
+        // RESULTS_FILE is likely not valid JSON
+        console.error('Error: .nx-results file is corrupted.');
+        console.error(e);
       }
     }
   }


### PR DESCRIPTION
If the `.nx-results` file got into a bad state, then it caused CLI commands to fail in a cryptic way due to yargs failing JSON parsing. This included having an empty `.nx-results file`. Now we treat this case as if there was no results file in the first place.

I maintained the current code structure, but it might make more sense to add the try/catch and `existsSync` check into the `readJsonFile` utility.