### PR TITLE
fix(builders): using fork and getSystemPath

### DIFF
--- a/packages/builders/src/cypress/cypress.builder.spec.ts
+++ b/packages/builders/src/cypress/cypress.builder.spec.ts
@@ -4,6 +4,7 @@ import { normalize } from '@angular-devkit/core';
 import { EventEmitter } from 'events';
 import * as child_process from 'child_process';
 import * as path from 'path';
+import * as fsUtility from '@angular-devkit/schematics/tools/file-system-utility';
 const Cypress = require('cypress');
 
 describe('Cypress builder', () => {
@@ -29,9 +30,14 @@ describe('Cypress builder', () => {
   });
 
   describe('run', () => {
-    it('should call `spawn.child_process` with the tsc command', () => {
+    it('should call `fork.child_process` with the tsc command', () => {
+      spyOn(fsUtility, 'readFile').and.returnValue(
+        JSON.stringify({
+          compilerOptions: { outDir: '../../dist/out-tsc/apps/my-app-e2e/src' }
+        })
+      );
       const fakeEventEmitter = new EventEmitter();
-      const spawn = spyOn(child_process, 'spawn').and.returnValue(
+      const fork = spyOn(child_process, 'fork').and.returnValue(
         fakeEventEmitter
       );
 
@@ -43,7 +49,7 @@ describe('Cypress builder', () => {
           options: cypressBuilderOptions
         })
         .subscribe(() => {
-          expect(spawn).toHaveBeenCalledWith(
+          expect(fork).toHaveBeenCalledWith(
             '/root/node_modules/.bin/tsc',
             cypressBuilderOptions.tsConfig,
             { stdio: [0, 1, 2] }
@@ -54,8 +60,13 @@ describe('Cypress builder', () => {
     });
 
     it('should call `Cypress.run` if headless mode is `true`', () => {
+      spyOn(fsUtility, 'readFile').and.returnValue(
+        JSON.stringify({
+          compilerOptions: { outDir: '../../dist/out-tsc/apps/my-app-e2e/src' }
+        })
+      );
       const fakeEventEmitter = new EventEmitter();
-      spyOn(child_process, 'spawn').and.returnValue(fakeEventEmitter);
+      spyOn(child_process, 'fork').and.returnValue(fakeEventEmitter);
       const cypressRun = spyOn(Cypress, 'run');
       const cypressOpen = spyOn(Cypress, 'open');
 
@@ -78,8 +89,13 @@ describe('Cypress builder', () => {
     });
 
     it('should call `Cypress.open` if headless mode is `false`', () => {
+      spyOn(fsUtility, 'readFile').and.returnValue(
+        JSON.stringify({
+          compilerOptions: { outDir: '../../dist/out-tsc/apps/my-app-e2e/src' }
+        })
+      );
       const fakeEventEmitter = new EventEmitter();
-      spyOn(child_process, 'spawn').and.returnValue(fakeEventEmitter);
+      spyOn(child_process, 'fork').and.returnValue(fakeEventEmitter);
       const cypressRun = spyOn(Cypress, 'run');
       const cypressOpen = spyOn(Cypress, 'open');
 
@@ -102,8 +118,13 @@ describe('Cypress builder', () => {
     });
 
     it('should call `Cypress.run` with provided baseUrl', () => {
+      spyOn(fsUtility, 'readFile').and.returnValue(
+        JSON.stringify({
+          compilerOptions: { outDir: '../../dist/out-tsc/apps/my-app-e2e/src' }
+        })
+      );
       const fakeEventEmitter = new EventEmitter();
-      spyOn(child_process, 'spawn').and.returnValue(fakeEventEmitter);
+      spyOn(child_process, 'fork').and.returnValue(fakeEventEmitter);
       const cypressRun = spyOn(Cypress, 'run');
 
       builder
@@ -126,8 +147,13 @@ describe('Cypress builder', () => {
     });
 
     it('should call `Cypress.run` without baseUrl nor dev server target value', () => {
+      spyOn(fsUtility, 'readFile').and.returnValue(
+        JSON.stringify({
+          compilerOptions: { outDir: '../../dist/out-tsc/apps/my-app-e2e/src' }
+        })
+      );
       const fakeEventEmitter = new EventEmitter();
-      spyOn(child_process, 'spawn').and.returnValue(fakeEventEmitter);
+      spyOn(child_process, 'fork').and.returnValue(fakeEventEmitter);
       const cypressRun = spyOn(Cypress, 'run');
 
       builder

--- a/packages/schematics/src/collection/cypress-project/cypress-project.spec.ts
+++ b/packages/schematics/src/collection/cypress-project/cypress-project.spec.ts
@@ -100,7 +100,7 @@ describe('schematic:cypres-project', () => {
         fixturesFolder: '../../dist/out-tsc/apps/my-app-e2e/src/fixtures',
         integrationFolder: '../../dist/out-tsc/apps/my-app-e2e/src/integration',
         pluginsFile: '../../dist/out-tsc/apps/my-app-e2e/src/plugins/index.js',
-        supportFile: '../../dist/out-tsc/apps/my-app-e2e/src/support/index.js',
+        supportFile: false,
         video: true,
         videosFolder: '../../dist/out-tsc/apps/my-app-e2e/videos',
         screenshotsFolder: '../../dist/out-tsc/apps/my-app-e2e/screenshots',
@@ -145,8 +145,7 @@ describe('schematic:cypres-project', () => {
           '../../../dist/out-tsc/apps/my-dir/my-app-e2e/src/integration',
         pluginsFile:
           '../../../dist/out-tsc/apps/my-dir/my-app-e2e/src/plugins/index.js',
-        supportFile:
-          '../../../dist/out-tsc/apps/my-dir/my-app-e2e/src/support/index.js',
+        supportFile: false,
         video: true,
         videosFolder: '../../../dist/out-tsc/apps/my-dir/my-app-e2e/videos',
         screenshotsFolder:

--- a/packages/schematics/src/collection/cypress-project/files/cypress.json
+++ b/packages/schematics/src/collection/cypress-project/files/cypress.json
@@ -3,7 +3,7 @@
   "fixturesFolder": "<%= offsetFromRoot %>dist/out-tsc/<%= projectRoot %>/src/fixtures",
   "integrationFolder": "<%= offsetFromRoot %>dist/out-tsc/<%= projectRoot %>/src/integration",
   "pluginsFile": "<%= offsetFromRoot %>dist/out-tsc/<%= projectRoot %>/src/plugins/index.js",
-  "supportFile":  "<%= offsetFromRoot %>dist/out-tsc/<%= projectRoot %>/src/support/index.js",
+  "supportFile":  false,
   "video": true,
   "videosFolder": "<%= offsetFromRoot %>dist/out-tsc/<%= projectRoot %>/videos",
   "screenshotsFolder": "<%= offsetFromRoot %>dist/out-tsc/<%= projectRoot %>/screenshots",

--- a/packages/schematics/src/collection/cypress-project/index.ts
+++ b/packages/schematics/src/collection/cypress-project/index.ts
@@ -73,6 +73,8 @@ function checkDependenciesInstalled(): Rule {
     const dependencyList: { name: string; version: string }[] = [];
     if (!packageJson.devDependencies.cypress) {
       dependencyList.push({ name: 'cypress', version: cypressVersion });
+      // NOTE: Need to be removed on the next Cypress release (=>3.1.1)
+      dependencyList.push({ name: '@types/jquery', version: '3.3.6' });
     }
     if (!packageJson.devDependencies['@nrwl/builders']) {
       dependencyList.push({ name: '@nrwl/builders', version: nxVersion });


### PR DESCRIPTION
## Description
The use of `spawn` and `path.resolve` are not consistent between Windows and MacOS. Instead, we use `fork` and `getSystemPath` from the AngularCLI package.
Cypress has now `false` to not error on Windows because of intern bugs.
Same for the `jQuery` dependency, we are waiting for the next Cypress release.