### PR TITLE
ci(travis): add windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,36 @@
-language: node_js
-dist: trusty
-sudo: required
-node_js:
-  - '8.9.3'
+matrix:
+  include:
+    - os: linux
+      language: node_js
+      node_js: 8.9.3
+      dist: trusty
+      sudo: required
+    - os: windows
+      language: node_js
+      node_js: 8.9.3
+
 before_install:
-  - export DISPLAY=:99.0
+  - if [ "$TRAVIS_OS_NAME" == "linux"  ]; then
+    export DISPLAY=:99.0;
+    sh -e /etc/init.d/xvfb start;
+    fi
+
 install:
-  - sh -e /etc/init.d/xvfb start
-  - yarn install
+  - yarn install --network-timeout 1000000 # Timeout needed for Windows (really slow)
+
 script:
   - yarn test
   - yarn e2e
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then yarn checkformat --head=$TRAVIS_PULL_REQUEST_SHA --base=$(git merge-base HEAD $TRAVIS_BRANCH); fi'
   - yarn checkcommit
+
 addons:
   chrome: stable
+
 cache:
   directories:
     - node_modules
+
 notifications:
   email: false
   webhooks:

--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
   "scripts": {
     "build": "./scripts/build.sh",
     "commit": "git-cz",
-    "checkcommit": "./scripts/commit-lint.js",
+    "checkcommit": "node ./scripts/commit-lint.js",
     "e2e": "./scripts/e2e.sh",
-    "format": "prettier \"**/*.{ts,js,json,css,md}\" \"!**/{__name__,__directory__}/**\" --write",
+    "format": "prettier \"**/*.{ts,js,json,css,scss,md}\" \"!**/{__name__,__directory__}/**\" --write",
     "linknpm": "./scripts/link.sh",
     "nx-release": "./scripts/nx-release.js",
     "copy": "./scripts/copy.sh",
     "test:schematics": "yarn linknpm fast && ./scripts/test_schematics.sh",
     "test:nx": "yarn linknpm fast && ./scripts/test_nx.sh",
     "test": "yarn linknpm fast && ./scripts/test_nx.sh && ./scripts/test_schematics.sh",
-    "checkformat": "prettier \"**/*.{ts,js,json,css,md}\" \"!**/{__name__,__directory__}/**\" --list-different"
+    "checkformat": "prettier \"**/*.{ts,js,json,css,scss}\" \"!**/{__name__,__directory__}/**\" --list-different"
   },
   "devDependencies": {
     "@angular-devkit/architect": "0.10.1",


### PR DESCRIPTION
## Description
The build is now done in parallel using two OS: Linux and Windows.
This will enable to have a status of the build running on windows for each PR.

## Note
Windows builds are in early beta on Travis CI but are good enough to use, they are just slower than Unix ones.