### PR TITLE
fix(schematics): replaceAppNameWithPath use pattern matching now

### DIFF
--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -367,4 +367,16 @@ describe('app', () => {
       expect(angularJson.projects['my-app-e2e']).toBeUndefined();
     });
   });
+
+  describe('replaceAppNameWithPath', () => {
+    it('should protect `angular.json` commands and properties', () => {
+      const tree = schematicRunner.runSchematic('app', { name: 'ui' }, appTree);
+
+      const angularJson = readJsonInTree(tree, 'angular.json');
+      expect(angularJson.projects['ui']).toBeDefined();
+      expect(
+        angularJson.projects['ui']['architect']['build']['builder']
+      ).toEqual('@angular-devkit/build-angular:browser');
+    });
+  });
 });

--- a/packages/schematics/src/utils/cli-config-utils.ts
+++ b/packages/schematics/src/utils/cli-config-utils.ts
@@ -33,7 +33,11 @@ export function replaceAppNameWithPath(
   root: string
 ): any {
   if (typeof node === 'string') {
-    if (node.indexOf(appName) > -1 && node.indexOf(`${appName}:`) === -1) {
+    const matchPattern = new RegExp(
+      `([^a-z0-9]+(${appName}))|((${appName})[^a-z0-9:]+)`,
+      'gi'
+    );
+    if (!!node.match(matchPattern)) {
       const r = node.replace(appName, root);
       return r.startsWith('/apps') || r.startsWith('/libs')
         ? r.substring(1)


### PR DESCRIPTION
## Description
Make `replaceAppNameWithPath` uses pattern matching while replacing the appName string, making sure it does not mess with the wrong properties or values in `angular.json`.

Example: `ui` was messing with `build` && `@angular-devkit/build-angular`.

## Issue
fix #856