### PR TITLE
fix(nx): set jasmine-marbles peer dependency to 0.4.0

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -7,7 +7,7 @@
   "module": "esm5/nrwl-nx.js",
   "es2015": "esm2015/nrwl-nx.js",
   "peerDependencies": {
-    "jasmine-marbles": "0.3.1"
+    "jasmine-marbles": "0.4.0"
   },
   "author": "Victor Savkin",
   "license": "MIT"


### PR DESCRIPTION
Sets jasmine-marbles peer dependency version in nx package to match rest of project as set in f73c1b5.