### PR TITLE
fix(schematics): ignore node_modules during affected

### DIFF
--- a/packages/schematics/src/command-line/shared.ts
+++ b/packages/schematics/src/command-line/shared.ts
@@ -388,6 +388,11 @@ export function getProjectRoots(projectNames: string[]): string[] {
 }
 
 export function allFilesInDir(dirName: string): string[] {
+  // Ignore files in nested node_modules directories
+  if (dirName.endsWith('node_modules')) {
+    return [];
+  }
+
   let res = [];
   try {
     fs.readdirSync(dirName).forEach(c => {


### PR DESCRIPTION
## Current Behavior

`affected` commands can hang if there are tons of `node_modules` within a project because they were installed via **Lerna**

## Expected Behavior

`node_modules` are ignored during `affected`