### PR TITLE
feat(schematics): add generic affected

### DIFF
--- a/e2e/schematics/ng-add.test.ts
+++ b/e2e/schematics/ng-add.test.ts
@@ -80,6 +80,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
       'affected:test': './node_modules/.bin/nx affected:test',
       'affected:lint': './node_modules/.bin/nx affected:lint',
       'affected:dep-graph': './node_modules/.bin/nx affected:dep-graph',
+      affected: './node_modules/.bin/nx affected',
       format: './node_modules/.bin/nx format:write',
       'format:write': './node_modules/.bin/nx format:write',
       'format:check': './node_modules/.bin/nx format:check',

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -63,14 +63,6 @@ export function copyMissingPackages(): void {
   execSync(
     `cp -a node_modules/.bin/webpack tmp/proj/node_modules/.bin/webpack`
   );
-
-  const libIndex = `./tmp/${projectName}/node_modules/@schematics/angular/library/index.js`;
-  const content = readFileSync(libIndex).toString();
-  const updatedContent = content.replace(
-    'context.addTask(new tasks_1.NodePackageInstallTask());',
-    ''
-  );
-  writeFileSync(libIndex, updatedContent);
 }
 
 function copyNodeModule(path: string, name: string) {

--- a/packages/schematics/migrations/migrations.json
+++ b/packages/schematics/migrations/migrations.json
@@ -39,6 +39,11 @@
       "version": "7.0.2",
       "description": "Fix karma conf",
       "factory": "./update-7-0-2/update-7-0-2"
+    },
+    "update-7.1.0": {
+      "version": "7.1.0",
+      "description": "Add generic affected command",
+      "factory": "./update-7-1-0/update-7-1-0"
     }
   }
 }

--- a/packages/schematics/migrations/update-7-1-0/update-7-1-0.spec.ts
+++ b/packages/schematics/migrations/update-7-1-0/update-7-1-0.spec.ts
@@ -1,0 +1,34 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { serializeJson } from '../../src/utils/fileutils';
+
+import * as path from 'path';
+
+describe('Update 7.1.0', () => {
+  let initialTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(() => {
+    initialTree = Tree.empty();
+    initialTree.create(
+      'package.json',
+      serializeJson({
+        scripts: {}
+      })
+    );
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/schematics',
+      path.join(__dirname, '../migrations.json')
+    );
+  });
+
+  it('should add generic affected script', async () => {
+    const result = await schematicRunner
+      .runSchematicAsync('update-7.1.0', {}, initialTree)
+      .toPromise();
+
+    const { scripts } = JSON.parse(result.readContent('package.json'));
+
+    expect(scripts.affected).toEqual('./node_modules/.bin/nx affected');
+  });
+});

--- a/packages/schematics/migrations/update-7-1-0/update-7-1-0.ts
+++ b/packages/schematics/migrations/update-7-1-0/update-7-1-0.ts
@@ -1,0 +1,16 @@
+import { Rule, externalSchematic, chain } from '@angular-devkit/schematics';
+import { updateJsonInTree } from '@nrwl/schematics/src/utils/ast-utils';
+
+export default function(): Rule {
+  return chain([
+    updateJsonInTree('package.json', json => {
+      json.scripts = json.scripts || {};
+      json.scripts = {
+        ...json.scripts,
+        affected: './node_modules/.bin/nx affected'
+      };
+
+      return json;
+    })
+  ]);
+}

--- a/packages/schematics/src/collection/ng-add/index.ts
+++ b/packages/schematics/src/collection/ng-add/index.ts
@@ -58,6 +58,7 @@ function updatePackageJson() {
       'affected:test': './node_modules/.bin/nx affected:test',
       'affected:lint': './node_modules/.bin/nx affected:lint',
       'affected:dep-graph': './node_modules/.bin/nx affected:dep-graph',
+      affected: './node_modules/.bin/nx affected',
       format: './node_modules/.bin/nx format:write',
       'format:write': './node_modules/.bin/nx format:write',
       'format:check': './node_modules/.bin/nx format:check',

--- a/packages/schematics/src/collection/ng-new/files/__directory__/package.json
+++ b/packages/schematics/src/collection/ng-new/files/__directory__/package.json
@@ -16,6 +16,7 @@
     "affected:test": "./node_modules/.bin/nx affected:test",
     "affected:lint": "./node_modules/.bin/nx affected:lint",
     "affected:dep-graph": "./node_modules/.bin/nx affected:dep-graph",
+    "affected": "./node_modules/.bin/nx affected",
     "format": "./node_modules/.bin/nx format:write",
     "format:write": "./node_modules/.bin/nx format:write",
     "format:check": "./node_modules/.bin/nx format:check",

--- a/packages/schematics/src/command-line/affected-apps.ts
+++ b/packages/schematics/src/command-line/affected-apps.ts
@@ -124,42 +124,6 @@ export function affectedAppNames(
     .map(p => p.name);
 }
 
-export function affectedE2eNames(
-  npmScope: string,
-  projects: ProjectNode[],
-  implicitDependencies: ImplicitDependencies,
-  fileRead: (s: string) => string,
-  touchedFiles: string[]
-): string[] {
-  return affectedProjects(
-    npmScope,
-    projects,
-    implicitDependencies,
-    fileRead,
-    touchedFiles
-  )
-    .filter(p => p.type === ProjectType.e2e)
-    .map(p => p.name);
-}
-
-export function affectedBuildableNames(
-  npmScope: string,
-  projects: ProjectNode[],
-  implicitDependencies: ImplicitDependencies,
-  fileRead: (s: string) => string,
-  touchedFiles: string[]
-): string[] {
-  return affectedProjects(
-    npmScope,
-    projects,
-    implicitDependencies,
-    fileRead,
-    touchedFiles
-  )
-    .filter(p => p.architect.build)
-    .map(p => p.name);
-}
-
 export function affectedLibNames(
   npmScope: string,
   projects: ProjectNode[],
@@ -192,6 +156,28 @@ export function affectedProjectNames(
     fileRead,
     touchedFiles
   ).map(p => p.name);
+}
+
+export function affectedProjectNamesWithTarget(
+  target: string
+): AffectedFetcher {
+  return (
+    npmScope: string,
+    projects: ProjectNode[],
+    implicitDependencies: ImplicitDependencies,
+    fileRead: (s: string) => string,
+    touchedFiles: string[]
+  ) => {
+    return affectedProjects(
+      npmScope,
+      projects,
+      implicitDependencies,
+      fileRead,
+      touchedFiles
+    )
+      .filter(p => p.architect[target])
+      .map(p => p.name);
+  };
 }
 
 function hasDependencyOnTouchedProjects(

--- a/packages/schematics/src/command-line/format.ts
+++ b/packages/schematics/src/command-line/format.ts
@@ -2,6 +2,11 @@ import { execSync } from 'child_process';
 import * as path from 'path';
 import * as resolve from 'resolve';
 import { getProjectRoots, getTouchedProjects, parseFiles } from './shared';
+import { YargsAffectedOptions } from './affected';
+
+export interface YargsFormatOptions extends YargsAffectedOptions {
+  libsAndApps?: boolean;
+}
 
 /*
 * HTML formatting could be added here once Prettier supports it
@@ -9,8 +14,7 @@ import { getProjectRoots, getTouchedProjects, parseFiles } from './shared';
 */
 const PRETTIER_EXTENSIONS = ['.ts', '.scss', '.css'];
 
-export function format(args: string[]) {
-  const command = args[0];
+export function format(command: 'check' | 'write', args: YargsFormatOptions) {
   let patterns: string[];
 
   try {
@@ -33,15 +37,14 @@ export function format(args: string[]) {
   }
 }
 
-function getPatterns(args: string[]) {
+function getPatterns(args: YargsAffectedOptions) {
   try {
-    const p = parseFiles(args.slice(1));
+    const p = parseFiles(args);
     let patterns = p.files.filter(
       f => PRETTIER_EXTENSIONS.indexOf(path.extname(f)) > -1
     );
-    let rest = p.rest;
 
-    const libsAndApp = rest.filter(a => a.startsWith('--libs-and-apps'))[0];
+    const libsAndApp = args.libsAndApps;
     return libsAndApp ? getPatternsFromApps(patterns) : patterns;
   } catch (e) {
     return getPatternsWithPathPrefix('{apps,libs,tools}');

--- a/packages/schematics/src/command-line/nx.ts
+++ b/packages/schematics/src/command-line/nx.ts
@@ -9,9 +9,9 @@ import { workspaceSchematic } from './workspace-schematic';
 import { generateGraph, OutputType } from './dep-graph';
 
 export interface GlobalNxArgs {
-  help: boolean;
-  version: boolean;
-  quiet: boolean;
+  help?: boolean;
+  version?: boolean;
+  quiet?: boolean;
 }
 
 const noop = (yargs: yargs.Argv): yargs.Argv => yargs;
@@ -19,46 +19,80 @@ const noop = (yargs: yargs.Argv): yargs.Argv => yargs;
 yargs
   .usage('Nrwl Extensions for Angular')
   .command(
+    'affected',
+    'Run task for affected projects',
+    yargs => withAffectedOptions(withParallel(yargs)),
+    args => affected(args)
+  )
+  .command(
     'affected:apps',
     'Print applications affected by changes',
     withAffectedOptions,
-    args => affected('apps', args, process.argv.slice(3))
-  )
-  .command(
-    'affected:build',
-    'Build applications and publishable libraries affected by changes',
-    yargs => withAffectedOptions(withParallel(yargs)),
-    args => affected('build', args, process.argv.slice(3))
-  )
-  .command(
-    'affected:test',
-    'Test projects affected by changes',
-    yargs => withAffectedOptions(withParallel(yargs)),
-    args => affected('test', args, process.argv.slice(3))
+    args =>
+      affected({
+        ...args,
+        target: 'apps'
+      })
   )
   .command(
     'affected:libs',
     'Print libraries affected by changes',
     withAffectedOptions,
-    args => affected('lib', args, process.argv.slice(3))
+    args =>
+      affected({
+        ...args,
+        target: 'libs'
+      })
+  )
+  .command(
+    'affected:build',
+    'Build applications and publishable libraries affected by changes',
+    yargs => withAffectedOptions(withParallel(yargs)),
+    args =>
+      affected({
+        ...args,
+        target: 'build'
+      })
+  )
+  .command(
+    'affected:test',
+    'Test projects affected by changes',
+    yargs => withAffectedOptions(withParallel(yargs)),
+    args =>
+      affected({
+        ...args,
+        target: 'test'
+      })
   )
   .command(
     'affected:e2e',
     'Run e2e tests for the applications affected by changes',
     withAffectedOptions,
-    args => affected('e2e', args, process.argv.slice(3))
+    args =>
+      affected({
+        ...args,
+        target: 'e2e'
+      })
   )
   .command(
     'affected:dep-graph',
     'Graph dependencies affected by changes',
     yargs => withAffectedOptions(withDepGraphOptions(yargs)),
-    args => affected('dep-graph', args, process.argv.slice(3))
+    args =>
+      affected({
+        ...args,
+        target: 'dep-graph'
+      })
   )
   .command(
     'affected:lint',
     'Lint projects affected by changes',
     yargs => withAffectedOptions(withParallel(yargs)),
-    args => affected('lint', args, process.argv.slice(3))
+    args =>
+      affected({
+        ...args,
+        target: 'lint'
+      })
   )
   .command(
     'dep-graph',
@@ -70,13 +104,13 @@ yargs
     'format:check',
     'Check for un-formatted files',
     withAffectedOptions,
-    _ => format(['check', ...process.argv.slice(3)])
+    args => format('check', args)
   )
   .command(
     'format:write',
     'Overwrite un-formatted files',
     withAffectedOptions,
-    _ => format(['write', ...process.argv.slice(3)])
+    args => format('write', args)
   )
   .alias('format:write', 'format')
   .command('lint [files..]', 'Lint workspace or list of files', noop, _ =>
@@ -108,7 +142,8 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
     .option('files', {
       describe: 'A list of files delimited by commas',
       type: 'array',
-      requiresArg: true
+      requiresArg: true,
+      coerce: parseCSV
     })
     .option('uncommitted', { describe: 'Uncommitted changes' })
     .option('untracked', { describe: 'Untracked changes' })

--- a/packages/schematics/src/command-line/shared.spec.ts
+++ b/packages/schematics/src/command-line/shared.spec.ts
@@ -3,10 +3,7 @@ import {
   assertWorkspaceValidity,
   getProjectNodes
 } from './shared';
-import {
-  ProjectType,
-  ProjectNode
-} from '@nrwl/schematics/src/command-line/affected-apps';
+import { ProjectType, ProjectNode } from './affected-apps';
 
 describe('assertWorkspaceValidity', () => {
   let mockNxJson;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2388,6 +2388,11 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+  integrity sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=
+
 cli-spinners@^1.0.1, cli-spinners@^1.1.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
@@ -2497,6 +2502,13 @@ combine-lists@^1.0.0:
   integrity sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=
   dependencies:
     lodash "^4.5.0"
+
+combined-stream@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  integrity sha1-cj599ugBrFYTETp+RFqbactjKBg=
+  dependencies:
+    delayed-stream "~1.0.0"
 
 combined-stream@^1.0.5, combined-stream@^1.0.6, combined-stream@~1.0.5, combined-stream@~1.0.6:
   version "1.0.7"
@@ -8364,6 +8376,16 @@ ora@3.0.0:
     log-symbols "^2.2.0"
     strip-ansi "^4.0.0"
     wcwidth "^1.0.1"
+
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  integrity sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
 
 ora@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
## Current Behavior

`affected` commands are specified for each and every target.

## Expected Behavior

`affected` commands take a `target` option which translates to an AngularCLI Architect target allowing users to run the target of all affected projects which have the target.

Also, I allowed the use of `-- --additionalFlags` to be passed correctly to the `angular cli` command.

`nx affected --target extract-i18n -- --configuration prod` will work.

Fixes https://github.com/nrwl/nx/issues/802
Fixes https://github.com/nrwl/nx/issues/784