### PR TITLE
fix(schematics): update ng packagr for ng7 migration

### DIFF
--- a/packages/schematics/migrations/update-7-0-0/update-7-0-0.spec.ts
+++ b/packages/schematics/migrations/update-7-0-0/update-7-0-0.spec.ts
@@ -3,6 +3,7 @@ import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import { serializeJson } from '../../src/utils/fileutils';
 
 import * as path from 'path';
+import { updateJsonInTree } from '@nrwl/schematics/src/utils/ast-utils';
 
 describe('Update 7.0.0', () => {
   let initialTree: Tree;
@@ -34,5 +35,29 @@ describe('Update 7.0.0', () => {
 
     expect(devDependencies.codelyzer).toEqual('~4.5.0');
     expect(devDependencies['jasmine-marbles']).toEqual('0.4.0');
+  });
+
+  it('should update ng-packagr dependencies', async () => {
+    initialTree = await schematicRunner
+      .callRule(
+        updateJsonInTree('package.json', json => {
+          json.devDependencies = {
+            ...json.devDependencies,
+            'ng-packagr': '^3.0.0'
+          };
+
+          return json;
+        }),
+        initialTree
+      )
+      .toPromise();
+    const result = await schematicRunner
+      .runSchematicAsync('update-7.0.0', {}, initialTree)
+      .toPromise();
+
+    const devDependencies = JSON.parse(result.readContent('package.json'))
+      .devDependencies;
+
+    expect(devDependencies['ng-packagr']).toEqual('^4.2.0');
   });
 });

--- a/packages/schematics/migrations/update-7-0-0/update-7-0-0.ts
+++ b/packages/schematics/migrations/update-7-0-0/update-7-0-0.ts
@@ -11,17 +11,23 @@ export default function(): Rule {
         'jasmine-marbles': '0.4.0'
       };
 
+      if (json.devDependencies['ng-packagr']) {
+        json.devDependencies['ng-packagr'] = '^4.2.0';
+      }
+
       return json;
     }),
     externalSchematic('@schematics/update', 'update', {
       packages: ['@angular/core'],
       from: '6.1.0',
-      to: '7.0.0'
+      to: '7.0.0',
+      force: true
     }),
     externalSchematic('@schematics/update', 'update', {
       packages: ['@angular/cli'],
       from: '6.2.0',
-      to: '7.0.1'
+      to: '7.0.1',
+      force: true
     })
   ]);
 }


### PR DESCRIPTION
## Current Behavior

Angular CLI does not update `ng-packagr` so it is not done during the ng7 migration.

## Expected Behavior

Nx handles the migration of `ng-packagr` and forces the `update` to ensure that it goes through making sure that the appropriate migration is done during `yarn update`.

`ng-packagr` is updated to `^4.2.0`

Fixes https://github.com/nrwl/nx/issues/866
Fixes https://github.com/nrwl/nx/issues/865