### PR TITLE
docs(readme): update to use correct install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npm install -g @nrwl/schematics
 After installing it you can create a new Nx workspace by running:
 
 ```
-ng new myworkspacename --collection=@nrwl/schematics
+create-nx-workspace myworkspacename
 ```
 
 You can also add Nx capabilities to an existing CLI project by running:


### PR DESCRIPTION
`ng new myworkspacename --collection=@nrwl/schematics` doesn't typically work and throws dependency errors like `Cannot find module '@angular-devkit/schematics'`.

Fix to align with documentation.

👋 
🦄🐋 	