### PR TITLE
fix(schematics): ensure path to file before writing

### DIFF
--- a/packages/schematics/src/utils/fileutils.ts
+++ b/packages/schematics/src/utils/fileutils.ts
@@ -1,9 +1,11 @@
 import { statSync } from 'fs';
 import * as fs from 'fs';
 import * as path from 'path';
+import { ensureDirSync } from 'fs-extra';
 
-export function writeToFile(path: string, str: string) {
-  fs.writeFileSync(path, str);
+export function writeToFile(filePath: string, str: string) {
+  ensureDirSync(path.dirname(filePath));
+  fs.writeFileSync(filePath, str);
 }
 
 /**


### PR DESCRIPTION
Ensure the entire path exists within `writeToFile` before calling `fs.writeFileSync`. This avoids errors thrown in cases where directories leading to a file may not exist.

Closes #726 