### PR TITLE
feat(builders): create sourcemaps for node apps

### DIFF
--- a/e2e/schematics/node.test.ts
+++ b/e2e/schematics/node.test.ts
@@ -55,10 +55,13 @@ describe('Node Applications', () => {
       }
 
       await runCLIAsync('build node-app1');
+
       expect(exists('./tmp/proj/dist/apps/node-app1/main.js')).toBeTruthy();
       expect(
         exists('./tmp/proj/dist/apps/node-app1/assets/file.txt')
       ).toBeTruthy();
+      expect(exists('./tmp/proj/dist/apps/node-app1/main.js.map')).toBeTruthy();
+
       const server = fork(
         path.join(
           __dirname,

--- a/packages/builders/src/node/build/node-build.builder.ts
+++ b/packages/builders/src/node/build/node-build.builder.ts
@@ -22,6 +22,7 @@ export interface BuildNodeBuilderOptions {
   outputPath: string;
   tsConfig: string;
   watch?: boolean;
+  sourceMap?: boolean;
   optimization?: boolean;
   externalDependencies: 'all' | 'none' | string[];
   showCircularDependencies?: boolean;

--- a/packages/builders/src/node/build/schema.json
+++ b/packages/builders/src/node/build/schema.json
@@ -16,6 +16,11 @@
       "description": "Run build when files change.",
       "default": false
     },
+    "sourceMap": {
+      "type": "boolean",
+      "description": "Produce source maps.",
+      "default": true
+    },
     "progress": {
       "type": "boolean",
       "description": "Log progress to the console while building.",

--- a/packages/builders/src/node/build/webpack/config.spec.ts
+++ b/packages/builders/src/node/build/webpack/config.spec.ts
@@ -217,6 +217,26 @@ describe('getWebpackConfig', () => {
     });
   });
 
+  describe('the source map option', () => {
+    it('should enable source-map devtool', () => {
+      const result = getWebpackConfig({
+        ...input,
+        sourceMap: true
+      });
+
+      expect(result.devtool).toEqual('source-map');
+    });
+
+    it('should enable source-map devtool', () => {
+      const result = getWebpackConfig({
+        ...input,
+        sourceMap: false
+      });
+
+      expect(result.devtool).toEqual('eval');
+    });
+  });
+
   describe('the optimization option', () => {
     describe('by default', () => {
       it('should set the mode to development', () => {

--- a/packages/builders/src/node/build/webpack/config.ts
+++ b/packages/builders/src/node/build/webpack/config.ts
@@ -24,6 +24,7 @@ export function getWebpackConfig(
     compilerOptions.target !== ts.ScriptTarget.ES5;
   const webpackConfig: Configuration = {
     entry: [options.main],
+    devtool: options.sourceMap ? 'source-map' : 'eval',
     mode: options.optimization ? 'production' : 'development',
     output: {
       path: options.outputPath,


### PR DESCRIPTION
## Current Behavior

The eval sourcemaps for node-apps point to a webpack version of the source code, not the filesystem version.

## Expected Behavior
Source map files should be generated by default. There is a `--source-map` option to disable the generation.

Fixes https://github.com/nrwl/nx/issues/901