### PR TITLE
fix(schematics): set correct tsConfig for lint for cypress project

### DIFF
--- a/packages/schematics/src/collection/cypress-project/cypress-project.spec.ts
+++ b/packages/schematics/src/collection/cypress-project/cypress-project.spec.ts
@@ -81,9 +81,13 @@ describe('schematic:cypres-project', () => {
         appTree
       );
       const angularJson = readJsonInTree(tree, 'angular.json');
+      const project = angularJson.projects['my-app-e2e'];
 
-      expect(angularJson.projects['my-app-e2e'].root).toEqual(
-        'apps/my-app-e2e'
+      expect(project.root).toEqual('apps/my-app-e2e');
+
+      expect(project.architect.e2e.builder).toEqual('@nrwl/builders:cypress');
+      expect(project.architect.lint.options.tsConfig).toEqual(
+        'apps/my-app-e2e/tsconfig.e2e.json'
       );
     });
 

--- a/packages/schematics/src/collection/cypress-project/index.ts
+++ b/packages/schematics/src/collection/cypress-project/index.ts
@@ -125,6 +125,10 @@ function updateAngularJson(options: CypressProjectSchema): Rule {
         }
       }
     };
+    projectConfig.architect.lint.options.tsConfig = join(
+      normalize(options.e2eProjectRoot),
+      'tsconfig.e2e.json'
+    );
     json.projects[options.e2eProjectName] = projectConfig;
     return json;
   });


### PR DESCRIPTION
## Current Behavior

The `lint` configuration is incorrect for projects using cypress

## Expected Behavior

The `lint` configuration points to the correct `tsConfig`

Fixes https://github.com/nrwl/nx/issues/891