### PR TITLE
feat(builders): allow copying of assets for node apps

### DIFF
--- a/e2e/schematics/node.test.ts
+++ b/e2e/schematics/node.test.ts
@@ -34,6 +34,8 @@ describe('Node Applications', () => {
           })
         `
       );
+
+      updateFile('apps/node-app1/src/assets/file.txt', ``);
       const jestResult = await runCLIAsync('test node-app1');
       expect(jestResult.stderr).toContain('Test Suites: 1 passed, 1 total');
 
@@ -54,6 +56,9 @@ describe('Node Applications', () => {
 
       await runCLIAsync('build node-app1');
       expect(exists('./tmp/proj/dist/apps/node-app1/main.js')).toBeTruthy();
+      expect(
+        exists('./tmp/proj/dist/apps/node-app1/assets/file.txt')
+      ).toBeTruthy();
       const server = fork(
         path.join(
           __dirname,

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@angular-devkit/architect": "~0.10.1",
     "@angular-devkit/build-webpack": "~0.10.1",
+    "copy-webpack-plugin": "4.6.0",
     "fork-ts-checker-webpack-plugin": "0.4.9",
     "license-webpack-plugin": "^1.4.0",
     "rxjs": "6.3.3",

--- a/packages/builders/src/node/build/schema.json
+++ b/packages/builders/src/node/build/schema.json
@@ -21,6 +21,14 @@
       "description": "Log progress to the console while building.",
       "default": false
     },
+    "assets": {
+      "type": "array",
+      "description": "List of static application assets.",
+      "default": [],
+      "items": {
+        "$ref": "#/definitions/assetPattern"
+      }
+    },
     "externalDependencies": {
       "oneOf": [
         {
@@ -84,5 +92,42 @@
       "default": []
     }
   },
-  "required": ["tsConfig", "main"]
+  "required": ["tsConfig", "main"],
+
+  "definitions": {
+    "assetPattern": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "glob": {
+              "type": "string",
+              "description": "The pattern to match."
+            },
+            "input": {
+              "type": "string",
+              "description":
+                "The input directory path in which to apply 'glob'. Defaults to the project root."
+            },
+            "ignore": {
+              "description": "An array of globs to ignore.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "output": {
+              "type": "string",
+              "description": "Absolute path within the output."
+            }
+          },
+          "additionalProperties": false,
+          "required": ["glob", "input", "output"]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  }
 }

--- a/packages/builders/src/node/build/webpack/config.spec.ts
+++ b/packages/builders/src/node/build/webpack/config.spec.ts
@@ -6,6 +6,7 @@ import * as ts from 'typescript';
 import { LicenseWebpackPlugin } from 'license-webpack-plugin';
 import CircularDependencyPlugin = require('circular-dependency-plugin');
 import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+import * as CopyWebpackPlugin from 'copy-webpack-plugin';
 import { ProgressPlugin } from 'webpack';
 
 describe('getWebpackConfig', () => {
@@ -266,6 +267,33 @@ describe('getWebpackConfig', () => {
         plugin => plugin instanceof ForkTsCheckerWebpackPlugin
       ) as ForkTsCheckerWebpackPlugin;
       expect(typeCheckerPlugin.options.workers).toEqual(1);
+    });
+  });
+
+  describe('the assets option', () => {
+    it('should add a copy-webpack-plugin', () => {
+      const result = getWebpackConfig({
+        ...input,
+        assets: [
+          {
+            input: 'assets',
+            glob: '**/*',
+            output: 'assets'
+          },
+          {
+            input: '',
+            glob: 'file.txt',
+            output: ''
+          }
+        ]
+      });
+
+      // This test isn't great because it's hard to find CopyWebpackPlugin
+      expect(
+        result.plugins.some(
+          plugin => !(plugin instanceof ForkTsCheckerWebpackPlugin)
+        )
+      ).toBeTruthy();
     });
   });
 

--- a/packages/builders/src/node/build/webpack/config.ts
+++ b/packages/builders/src/node/build/webpack/config.ts
@@ -7,9 +7,11 @@ import { dirname, resolve } from 'path';
 import { LicenseWebpackPlugin } from 'license-webpack-plugin';
 import CircularDependencyPlugin = require('circular-dependency-plugin');
 import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+import * as CopyWebpackPlugin from 'copy-webpack-plugin';
 
 import { BuildNodeBuilderOptions } from '../node-build.builder';
 import * as nodeExternals from 'webpack-node-externals';
+import { AssetPatternObject } from '@angular-devkit/build-angular';
 
 export const OUT_FILENAME = 'main.js';
 
@@ -98,6 +100,34 @@ export function getWebpackConfig(
         callback();
       }
     ];
+  }
+
+  // process asset entries
+  if (options.assets) {
+    const copyWebpackPluginPatterns = options.assets.map(
+      (asset: AssetPatternObject) => {
+        return {
+          context: asset.input,
+          // Now we remove starting slash to make Webpack place it from the output root.
+          to: asset.output,
+          ignore: asset.ignore,
+          from: {
+            glob: asset.glob,
+            dot: true
+          }
+        };
+      }
+    );
+
+    const copyWebpackPluginOptions = {
+      ignore: ['.gitkeep', '**/.DS_Store', '**/Thumbs.db']
+    };
+
+    const copyWebpackPluginInstance = new CopyWebpackPlugin(
+      copyWebpackPluginPatterns,
+      copyWebpackPluginOptions
+    );
+    extraPlugins.push(copyWebpackPluginInstance);
   }
 
   if (options.showCircularDependencies) {

--- a/packages/schematics/src/collection/node-application/index.ts
+++ b/packages/schematics/src/collection/node-application/index.ts
@@ -89,7 +89,8 @@ function getBuildConfig(project: any, options: NormalizedSchema) {
     options: {
       outputPath: join(normalize('dist'), options.appProjectRoot),
       main: join(project.sourceRoot, 'main.ts'),
-      tsConfig: join(options.appProjectRoot, 'tsconfig.app.json')
+      tsConfig: join(options.appProjectRoot, 'tsconfig.app.json'),
+      assets: [join(project.sourceRoot, 'assets')]
     },
     configurations: {
       production: {

--- a/packages/schematics/src/collection/node-application/node-application.spec.ts
+++ b/packages/schematics/src/collection/node-application/node-application.spec.ts
@@ -36,7 +36,8 @@ describe('node-app', () => {
             options: {
               outputPath: 'dist/apps/my-node-app',
               main: 'apps/my-node-app/src/main.ts',
-              tsConfig: 'apps/my-node-app/tsconfig.app.json'
+              tsConfig: 'apps/my-node-app/tsconfig.app.json',
+              assets: ['apps/my-node-app/src/assets']
             },
             configurations: {
               production: {


### PR DESCRIPTION
## Current Behavior

Assets are generated but not copied for node applications

## Expected Behavior

Node applications are configured to copy assets

Fixes #896