### PR TITLE
fix(schematics): fix affected argument delimiting

### DIFF
--- a/e2e/schematics/affected.test.ts
+++ b/e2e/schematics/affected.test.ts
@@ -184,6 +184,12 @@ describe('Affected', () => {
       expect(linting).toContain('Running lint for myapp-e2e');
       expect(linting).toContain('Running lint for mypublishablelib');
 
+      const lintWithJsonFormating = runCommand(
+        'npm run affected:lint -- --files="libs/mylib/src/index.ts" -- --format json'
+      );
+      expect(lintWithJsonFormating).toContain('With flags: --format json');
+      expect(lintWithJsonFormating).toContain('[]');
+
       const unitTestsExcluded = runCommand(
         'npm run affected:test -- --files="libs/mylib/src/index.ts" --exclude=myapp,mypublishablelib'
       );

--- a/packages/schematics/src/command-line/affected.ts
+++ b/packages/schematics/src/command-line/affected.ts
@@ -51,7 +51,7 @@ export function affected(parsedArgs: YargsAffectedOptions): void {
   let projects: string[];
   const target = parsedArgs.target;
   const rest: string[] = [
-    ...parsedArgs._.slice(1, parsedArgs._.length - 1),
+    ...parsedArgs._.slice(1),
     ...filterNxSpecificArgs(parsedArgs)
   ];
 


### PR DESCRIPTION
## Current Behavior

The last argument gets cut off when delimiting arguments

## Expected Behavior

All arguments are passed off to Angular CLI