### PR TITLE
feat(schematics): add browser option to cypress builder

### DIFF
--- a/packages/builders/src/cypress/cypress.builder.spec.ts
+++ b/packages/builders/src/cypress/cypress.builder.spec.ts
@@ -146,6 +146,35 @@ describe('Cypress builder', () => {
       fakeEventEmitter.emit('exit'); // Passing tsc command
     });
 
+    it('should call `Cypress.run` with provided browser', () => {
+      spyOn(fsUtility, 'readFile').and.returnValue(
+        JSON.stringify({
+          compilerOptions: { outDir: '../../dist/out-tsc/apps/my-app-e2e/src' }
+        })
+      );
+      const fakeEventEmitter = new EventEmitter();
+      spyOn(child_process, 'fork').and.returnValue(fakeEventEmitter);
+      const cypressRun = spyOn(Cypress, 'run');
+
+      builder
+        .run({
+          root: normalize('/root'),
+          projectType: 'application',
+          builder: '@nrwl/builders:cypress',
+          options: Object.assign(cypressBuilderOptions, {
+            browser: 'chrome'
+          })
+        })
+        .subscribe(() => {
+          expect(cypressRun).toHaveBeenCalledWith({
+            config: { browser: 'chrome' },
+            project: path.dirname(cypressBuilderOptions.cypressConfig)
+          });
+        });
+
+      fakeEventEmitter.emit('exit'); // Passing tsc command
+    });
+
     it('should call `Cypress.run` without baseUrl nor dev server target value', () => {
       spyOn(fsUtility, 'readFile').and.returnValue(
         JSON.stringify({

--- a/packages/builders/src/cypress/cypress.builder.ts
+++ b/packages/builders/src/cypress/cypress.builder.ts
@@ -24,6 +24,7 @@ export interface CypressBuilderOptions {
   headless: boolean;
   tsConfig: string;
   watch: boolean;
+  browser?: string;
 }
 
 /**
@@ -91,7 +92,8 @@ export default class CypressBuilder implements Builder<CypressBuilderOptions> {
           options.cypressConfig,
           options.headless,
           options.watch,
-          options.baseUrl
+          options.baseUrl,
+          options.browser
         )
       ),
       options.watch ? tap(noop) : take(1),
@@ -174,7 +176,8 @@ export default class CypressBuilder implements Builder<CypressBuilderOptions> {
     cypressConfig: string,
     headless: boolean,
     isWatching: boolean,
-    baseUrl: string
+    baseUrl: string,
+    browser?: string
   ): Observable<BuildEvent> {
     // Cypress expects the folder where a `cypress.json` is present
     const projectFolderPath = path.dirname(cypressConfig);
@@ -185,6 +188,10 @@ export default class CypressBuilder implements Builder<CypressBuilderOptions> {
     // If not, will use the `baseUrl` normally from `cypress.json`
     if (baseUrl || this.computedCypressBaseUrl) {
       options.config = { baseUrl: baseUrl || this.computedCypressBaseUrl };
+    }
+
+    if (browser) {
+      options.browser = browser;
     }
 
     options.headed = !headless;

--- a/packages/builders/src/cypress/schema.json
+++ b/packages/builders/src/cypress/schema.json
@@ -30,6 +30,11 @@
       "type": "string",
       "description":
         "Use this to pass directly the address of your distant server address with the port running your application"
+    },
+    "browser": {
+      "type": "string",
+      "description":
+        "Use this to specify the browser to run tests in. The browser needs to be installed on your system."
     }
   },
   "additionalProperties": false,

--- a/packages/builders/src/cypress/schema.json
+++ b/packages/builders/src/cypress/schema.json
@@ -33,8 +33,8 @@
     },
     "browser": {
       "type": "string",
-      "description":
-        "Use this to specify the browser to run tests in. The browser needs to be installed on your system."
+      "description": "The browser to run tests in.",
+      "enum": ["electron", "chrome", "chromium", "canary"]
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Cypress supports running the tests in a user-specified browser. This option was not exposed through
the Cypress builder before. This change will add this option in.

Fixes #906