### PR TITLE
fix(builders): do not copy fixtures if not defined by cypress.json

### DIFF
--- a/e2e/schematics/cypress.test.ts
+++ b/e2e/schematics/cypress.test.ts
@@ -4,7 +4,9 @@ import {
   newApp,
   newProject,
   readJson,
-  runCLI
+  runCLI,
+  updateFile,
+  readFile
 } from '../utils';
 
 describe('Cypress E2E Test runner', () => {
@@ -42,6 +44,19 @@ describe('Cypress E2E Test runner', () => {
         newProject();
         newApp('myApp --e2eTestRunner=cypress');
         copyMissingPackages();
+
+        expect(
+          runCLI('e2e --project=my-app-e2e --headless --watch=false')
+        ).toContain('All specs passed!');
+
+        const originalContents = JSON.parse(
+          readFile('apps/my-app-e2e/cypress.json')
+        );
+        delete originalContents.fixtures;
+        updateFile(
+          'apps/my-app-e2e/cypress.json',
+          JSON.stringify(originalContents)
+        );
 
         expect(
           runCLI('e2e --project=my-app-e2e --headless --watch=false')

--- a/packages/builders/src/cypress/cypress.builder.ts
+++ b/packages/builders/src/cypress/cypress.builder.ts
@@ -79,7 +79,9 @@ export default class CypressBuilder implements Builder<CypressBuilderOptions> {
     );
 
     return this.compileTypescriptFiles(options.tsConfig, options.watch).pipe(
-      tap(() => this.copyCypressFixtures(options.tsConfig)),
+      tap(() =>
+        this.copyCypressFixtures(options.tsConfig, options.cypressConfig)
+      ),
       concatMap(
         () =>
           !options.baseUrl && options.devServerTarget
@@ -147,14 +149,16 @@ export default class CypressBuilder implements Builder<CypressBuilderOptions> {
    * This is done because `tsc` doesn't handle `json` files.
    * @param tsConfigPath
    */
-  private copyCypressFixtures(tsConfigPath: string) {
-    const tsconfigJson = JSON.parse(readFile(tsConfigPath));
+  private copyCypressFixtures(tsConfigPath: string, cypressConfigPath: string) {
+    const cypressConfig = JSON.parse(readFile(cypressConfigPath));
+    // DOn't copy fixtures if cypress config does not have it set
+    if (!cypressConfig.fixtures) {
+      return;
+    }
+
     copySync(
       `${path.dirname(tsConfigPath)}/src/fixtures`,
-      `${path.resolve(
-        path.dirname(tsConfigPath),
-        tsconfigJson.compilerOptions.outDir
-      )}/fixtures`,
+      path.join(path.dirname(cypressConfigPath), cypressConfig.fixtures),
       { overwrite: true }
     );
   }


### PR DESCRIPTION
## Current Behavior

Having no fixtures definition in `cypress.json` still tries to copy the fixtures anyways.

## Expected Behavior

If you remove `fixtures` from `cypress.json` it should not try to copy fixtures.