### PR TITLE
fix(schematics): generate defaults for scss

### DIFF
--- a/e2e/schematics/ng-new.test.ts
+++ b/e2e/schematics/ng-new.test.ts
@@ -5,7 +5,11 @@ import {
   readJson,
   runCLI,
   updateFile,
-  fileExists
+  fileExists,
+  exists,
+  runNgNew,
+  cleanup,
+  copyMissingPackages
 } from '../utils';
 
 describe('Nrwl Workspace', () => {
@@ -85,6 +89,25 @@ describe('Nrwl Workspace', () => {
     },
     1000000
   );
+
+  it('should support scss for styles', () => {
+    cleanup();
+    runNgNew('--collection=@nrwl/schematics --npmScope=proj --style scss');
+    copyMissingPackages();
+    newApp('myApp --directory=myDir');
+    newLib(
+      'myLib --directory=myDir --routing --parentModule=apps/my-dir/my-app/src/app/app.module.ts'
+    );
+    runCLI('generate component comp --project my-dir-my-app');
+    runCLI('generate component comp --project my-dir-my-lib');
+
+    expect(
+      exists('./tmp/proj/apps/my-dir/my-app/src/app/comp/comp.component.scss')
+    ).toEqual(true);
+    expect(
+      exists('./tmp/proj/libs/my-dir/my-lib/src/lib/comp/comp.component.scss')
+    ).toEqual(true);
+  });
 
   it(
     'should not generate e2e configuration',

--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -300,6 +300,35 @@ describe('app', () => {
     });
   });
 
+  describe('--style scss', () => {
+    it('should generate scss styles', () => {
+      const result = schematicRunner.runSchematic(
+        'app',
+        { name: 'myApp', style: 'scss' },
+        appTree
+      );
+      expect(result.exists('apps/my-app/src/app/app.component.scss')).toEqual(
+        true
+      );
+    });
+
+    it('should set it as default', () => {
+      const result = schematicRunner.runSchematic(
+        'app',
+        { name: 'myApp', style: 'scss' },
+        appTree
+      );
+
+      const angularJson = readJsonInTree(result, 'angular.json');
+
+      expect(angularJson.projects['my-app'].schematics).toEqual({
+        '@nrwl/schematics:component': {
+          styleext: 'scss'
+        }
+      });
+    });
+  });
+
   describe('--unit-test-runner jest', () => {
     it('should generate a jest config', () => {
       const tree = schematicRunner.runSchematic(

--- a/packages/schematics/src/collection/application/index.ts
+++ b/packages/schematics/src/collection/application/index.ts
@@ -20,12 +20,13 @@ import {
   readJsonInTree
 } from '../../utils/ast-utils';
 import { toFileName } from '../../utils/name-utils';
-import { offsetFromRoot } from '@nrwl/schematics/src/utils/common';
+import { offsetFromRoot } from '../../utils/common';
 import {
   getNpmScope,
   getWorkspacePath,
-  replaceAppNameWithPath
-} from '@nrwl/schematics/src/utils/cli-config-utils';
+  replaceAppNameWithPath,
+  angularSchematicNames
+} from '../../utils/cli-config-utils';
 import { formatFiles } from '../../utils/rules/format-files';
 import { move } from '../../utils/rules/move';
 import { updateKarmaConf } from '../../utils/rules/update-karma-conf';
@@ -162,6 +163,18 @@ function updateProject(options: NormalizedSchema): Rule {
           options.name,
           options.appProjectRoot
         );
+
+        if (fixedProject.schematics) {
+          angularSchematicNames.forEach(type => {
+            const schematic = `@schematics/angular:${type}`;
+            if (schematic in fixedProject.schematics) {
+              fixedProject.schematics[`@nrwl/schematics:${type}`] =
+                fixedProject.schematics[schematic];
+              delete fixedProject.schematics[schematic];
+            }
+          });
+        }
+
         if (options.unitTestRunner !== 'karma') {
           delete fixedProject.architect.test;
 

--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -303,6 +303,16 @@ function updateProject(options: NormalizedSchema): Rule {
           options.projectRoot
         );
 
+        fixedProject.schematics = fixedProject.schematics || {};
+        if (options.style !== 'css') {
+          fixedProject.schematics = {
+            ...fixedProject.schematics,
+            '@nrwl/schematics:component': {
+              styleext: options.style
+            }
+          };
+        }
+
         if (!options.publishable) {
           delete fixedProject.architect.build;
         }
@@ -435,6 +445,7 @@ export default function(schema: Schema): Rule {
       externalSchematic('@schematics/angular', 'library', {
         name: options.name,
         prefix: options.prefix,
+        style: options.style,
         entryFile: 'index',
         skipPackageJson: !options.publishable,
         skipTsConfig: true

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -587,6 +587,24 @@ describe('lib', () => {
     });
   });
 
+  describe('--style scss', () => {
+    it('should set it as default', () => {
+      const result = schematicRunner.runSchematic(
+        'lib',
+        { name: 'myLib', style: 'scss' },
+        appTree
+      );
+
+      const angularJson = readJsonInTree(result, 'angular.json');
+
+      expect(angularJson.projects['my-lib'].schematics).toEqual({
+        '@nrwl/schematics:component': {
+          styleext: 'scss'
+        }
+      });
+    });
+  });
+
   describe('--unit-test-runner jest', () => {
     it('should generate jest configuration', () => {
       const resultTree = schematicRunner.runSchematic(

--- a/packages/schematics/src/collection/library/schema.d.ts
+++ b/packages/schematics/src/collection/library/schema.d.ts
@@ -13,6 +13,7 @@ export interface Schema {
   flat?: boolean;
   commonModule?: boolean;
 
+  style?: string;
   prefix?: string;
   routing?: boolean;
   lazy?: boolean;

--- a/packages/schematics/src/collection/library/schema.json
+++ b/packages/schematics/src/collection/library/schema.json
@@ -55,6 +55,22 @@
         "Update the router configuration of the parent module using loadChildren or children, depending on what `lazy` is set to.",
       "x-prompt": "Which module should import the library?"
     },
+    "style": {
+      "description": "The file extension to be used for style files.",
+      "type": "string",
+      "default": "css",
+      "x-prompt": {
+        "message": "Which stylesheet format would you like to use?",
+        "type": "list",
+        "items": [
+          { "value": "css", "label": "CSS" },
+          { "value": "scss", "label": "SCSS   [ http://sass-lang.com   ]" },
+          { "value": "sass", "label": "SASS   [ http://sass-lang.com   ]" },
+          { "value": "less", "label": "LESS   [ http://lesscss.org     ]" },
+          { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
+        ]
+      }
+    },
     "routing": {
       "type": "boolean",
       "default": false,

--- a/packages/schematics/src/collection/ng-new/files/__directory__/angular.json
+++ b/packages/schematics/src/collection/ng-new/files/__directory__/angular.json
@@ -10,5 +10,13 @@
     },
     "defaultCollection": "@nrwl/schematics"<% if(packageManager) { %>,<% } %>
     <% if(packageManager) { %>"packageManager": "<%= packageManager %>"<% } %>
-  }
+  },
+  "schematics": {<% if (style !== 'css') { %>
+    "@nrwl/schematics:application": {
+      "style": "<%= style %>"
+    },
+    "@nrwl/schematics:library": {
+      "style": "<%= style %>"
+    }
+  <% } %>}
 }

--- a/packages/schematics/src/collection/ng-new/ng-new.spec.ts
+++ b/packages/schematics/src/collection/ng-new/ng-new.spec.ts
@@ -102,4 +102,22 @@ module.exports = () => {
       JSON.parse(tree.readContent('/proj/angular.json')).cli.packageManager
     ).toEqual('yarn');
   });
+
+  it('should configure the project to use style argument', () => {
+    const tree = schematicRunner.runSchematic(
+      'ng-new',
+      { name: 'proj', packageManager: 'yarn', style: 'scss' },
+      projectTree
+    );
+    expect(
+      JSON.parse(tree.readContent('/proj/angular.json')).schematics
+    ).toEqual({
+      '@nrwl/schematics:application': {
+        style: 'scss'
+      },
+      '@nrwl/schematics:library': {
+        style: 'scss'
+      }
+    });
+  });
 });

--- a/packages/schematics/src/collection/ng-new/schema.d.ts
+++ b/packages/schematics/src/collection/ng-new/schema.d.ts
@@ -7,5 +7,6 @@ export interface Schema {
   skipInstall?: boolean;
   skipGit?: boolean;
   packageManager?: string;
+  style?: string;
   commit?: { name: string; email: string; message?: string };
 }

--- a/packages/schematics/src/collection/ng-new/schema.json
+++ b/packages/schematics/src/collection/ng-new/schema.json
@@ -14,6 +14,22 @@
       },
       "x-prompt": "What name would you like to use for the workspace?"
     },
+    "style": {
+      "description": "The file extension to be used for style files.",
+      "type": "string",
+      "default": "css",
+      "x-prompt": {
+        "message": "Which stylesheet format would you like to use?",
+        "type": "list",
+        "items": [
+          { "value": "css", "label": "CSS" },
+          { "value": "scss", "label": "SCSS   [ http://sass-lang.com   ]" },
+          { "value": "sass", "label": "SASS   [ http://sass-lang.com   ]" },
+          { "value": "less", "label": "LESS   [ http://lesscss.org     ]" },
+          { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
+        ]
+      }
+    },
     "directory": {
       "type": "string",
       "format": "path",

--- a/packages/schematics/src/utils/cli-config-utils.ts
+++ b/packages/schematics/src/utils/cli-config-utils.ts
@@ -1,5 +1,15 @@
 import { Tree } from '@angular-devkit/schematics';
 
+export const angularSchematicNames = [
+  'class',
+  'component',
+  'directive',
+  'guard',
+  'module',
+  'pipe',
+  'service'
+];
+
 export function getWorkspacePath(host: Tree) {
   const possibleFiles = ['/angular.json', '/.angular.json'];
   return possibleFiles.filter(path => host.exists(path))[0];


### PR DESCRIPTION
## Current Behavior

Scss needs to be declared every time.

## Expected Behavior

Creating a workspace with `--style scss` or an app/lib with `--style scss` should set defaults so that components generated uses `scss`

## Issue

Fixes https://github.com/nrwl/nx/issues/916