### PR TITLE
fix(schematics): pass parsedArgs straight to generateDepGraph

### DIFF
--- a/packages/schematics/src/command-line/affected.ts
+++ b/packages/schematics/src/command-line/affected.ts
@@ -14,7 +14,6 @@ import {
 import * as path from 'path';
 import * as resolve from 'resolve';
 import * as runAll from 'npm-run-all';
-import * as yargsParser from 'yargs-parser';
 import { generateGraph } from './dep-graph';
 import { DepGraph, ProjectNode } from './affected-apps';
 import { GlobalNxArgs } from './nx';
@@ -111,7 +110,7 @@ export function affected(parsedArgs: YargsAffectedOptions): void {
       console.log(libs.join(' '));
       break;
     case 'dep-graph':
-      generateGraph(yargsParser(rest), projects);
+      generateGraph(parsedArgs, projects);
       break;
     default:
       const targetProjects = getProjects(

--- a/packages/schematics/src/command-line/dep-graph.ts
+++ b/packages/schematics/src/command-line/dep-graph.ts
@@ -67,7 +67,6 @@ export enum OutputType {
 export interface UserOptions extends yargs.Arguments {
   file?: string;
   output?: string;
-  files?: string;
 }
 
 type ParsedUserOptions = {


### PR DESCRIPTION
## Current Behavior

`affected:dep-graph` commands are not working

## Expected Behavior

`affected:dep-graph` commands work again.

`parsedArgs` already has all the options `generateDepGraph` is looking for and can be passed straight through to `generateDepGraph`

## Issue

Fixes https://github.com/nrwl/nx/issues/920