### PR TITLE
fix(schematics): always npm scope for generating package.json of lib

### DIFF
--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -403,10 +403,12 @@ function updateTsConfig(options: NormalizedSchema): Rule {
 }
 
 function updateLibPackageNpmScope(options: NormalizedSchema): Rule {
-  return updateJsonInTree(`${options.projectRoot}/package.json`, json => {
-    json.name = `@${options.prefix}/${options.name}`;
-    return json;
-  });
+  return (host: Tree) => {
+    return updateJsonInTree(`${options.projectRoot}/package.json`, json => {
+      json.name = `@${getNpmScope(host)}/${options.name}`;
+      return json;
+    });
+  };
 }
 
 function addModule(options: NormalizedSchema): Rule {

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -64,6 +64,16 @@ describe('lib', () => {
       expect(packageJson.name).toEqual('@proj/my-lib');
     });
 
+    it("should update npmScope of lib's package.json when publishable", () => {
+      const tree = schematicRunner.runSchematic(
+        'lib',
+        { name: 'myLib', publishable: true, prefix: 'lib' },
+        appTree
+      );
+      const packageJson = readJsonInTree(tree, '/libs/my-lib/package.json');
+      expect(packageJson.name).toEqual('@proj/my-lib');
+    });
+
     it('should update angular.json', () => {
       const tree = schematicRunner.runSchematic(
         'lib',


### PR DESCRIPTION
## Current Behavior

The prefix option is being used by the library schematic to generate package json name

## Expected Behavior

The package json name is always generated using the npmScope.

## Issue
Fixes https://github.com/nrwl/nx/issues/898