### PR TITLE
fix(schematics): add forbidden properties when renaming

### DIFF
--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -407,5 +407,16 @@ describe('app', () => {
         angularJson.projects['ui']['architect']['build']['builder']
       ).toEqual('@angular-devkit/build-angular:browser');
     });
+
+    it('should protect `angular.json` sensible properties value to be renamed', () => {
+      const tree = schematicRunner.runSchematic(
+        'app',
+        { name: 'ui', prefix: 'ui' },
+        appTree
+      );
+
+      const angularJson = readJsonInTree(tree, 'angular.json');
+      expect(angularJson.projects['ui'].prefix).toEqual('ui');
+    });
   });
 });

--- a/packages/schematics/src/utils/cli-config-utils.ts
+++ b/packages/schematics/src/utils/cli-config-utils.ts
@@ -58,8 +58,14 @@ export function replaceAppNameWithPath(
   } else if (Array.isArray(node)) {
     return node.map(j => replaceAppNameWithPath(j, appName, root));
   } else if (typeof node === 'object' && node) {
+    const forbiddenPropertyList: string[] = ['prefix']; // Some of the properties should not be renamed
     return Object.keys(node).reduce(
-      (m, c) => ((m[c] = replaceAppNameWithPath(node[c], appName, root)), m),
+      (m, c) => (
+        (m[c] = !forbiddenPropertyList.includes(c)
+          ? replaceAppNameWithPath(node[c], appName, root)
+          : node[c]),
+        m
+      ),
       {} as any
     );
   } else {


### PR DESCRIPTION
## Description
Add a `forbiddenPropertyList` into the `replaceAppNameWithPath` function to not override some property's value that should stay pristine.

## Issue
closes #900