### PR TITLE
fix(schematics): Fix path resolution for modules that are above project root

### DIFF
--- a/packages/schematics/src/command-line/shared.ts
+++ b/packages/schematics/src/command-line/shared.ts
@@ -358,7 +358,7 @@ export function allFilesInDir(dirName: string): string[] {
       try {
         if (!fs.statSync(child).isDirectory()) {
           // add starting with "apps/myapp/..." or "libs/mylib/..."
-          res.push(normalizePath(child.substring(appRoot.path.length + 1)));
+          res.push(normalizePath(path.relative(appRoot.path, child)));
         } else if (fs.statSync(child).isDirectory()) {
           res = [...res, ...allFilesInDir(child)];
         }


### PR DESCRIPTION
In some projects some common code is placed in shared repo outdise of the workspace
In this cases there is upper dir present in paths (..)
For those cases resolved path is absolute to dir that isn't staring with project root path,
and it results in weirdly truncated path in error messages
like instead of /project/root/../shared/module we get /project/root/d/module
this commit uses node implementation, that works fine for those cases

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Description

## Issue
