### PR TITLE
feat(schematics): support dry run for workspace-schematics

### DIFF
--- a/e2e/schematics/command-line.test.ts
+++ b/e2e/schematics/command-line.test.ts
@@ -174,6 +174,16 @@ describe('Command line', () => {
         )
       );
 
+      const dryRunOutput = runCommand(
+        'npm run workspace-schematic custom mylib -- --directory=dir -d'
+      );
+      expect(exists('libs/dir/mylib/src/index.ts')).toEqual(false);
+      expect(dryRunOutput).toContain(
+        'create libs/dir/mylib/src/lib/dir-mylib.module.ts'
+      );
+      expect(dryRunOutput).toContain('update angular.json');
+      expect(dryRunOutput).toContain('update nx.json');
+
       const output = runCommand(
         'npm run workspace-schematic custom mylib -- --directory=dir'
       );


### PR DESCRIPTION
## Current Behavior

`nx workspace-schematics` does not support `--dry-run`/`-d`

## Expected Behavior

`nx workspace-schematics` supports `--dry-run`/`-d`