### PR TITLE
feat(builders): add mjs to extensions for node-app #944

### DIFF
--- a/packages/builders/src/node/build/webpack/config.spec.ts
+++ b/packages/builders/src/node/build/webpack/config.spec.ts
@@ -67,7 +67,7 @@ describe('getWebpackConfig', () => {
     it('should resolve typescript and javascript', () => {
       const result = getWebpackConfig(input);
 
-      expect(result.resolve.extensions).toEqual(['.ts', '.js']);
+      expect(result.resolve.extensions).toEqual(['.ts', '.mjs', '.js']);
     });
 
     it('should include module and main in mainFields', () => {

--- a/packages/builders/src/node/build/webpack/config.ts
+++ b/packages/builders/src/node/build/webpack/config.ts
@@ -46,7 +46,7 @@ export function getWebpackConfig(
       ]
     },
     resolve: {
-      extensions: ['.ts', '.js'],
+      extensions: ['.ts', '.mjs', '.js'],
       alias: getAliases(options, compilerOptions),
       mainFields: [...(supportsEs2015 ? ['es2015'] : []), 'module', 'main']
     },


### PR DESCRIPTION
## Current Behavior

`.mjs` files are not used

## Expected Behavior

`.mjs` files can be bundled.

## Issues

Fixes #944 