### PR TITLE
fix(schematics): snapshot not being generated when ran against fixture

### DIFF
--- a/packages/schematics/src/collection/jest-project/files/jest.config.js
+++ b/packages/schematics/src/collection/jest-project/files/jest.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  name: '<%= project %>',
-  preset: '<%= offsetFromRoot %>jest.config.js',
-  coverageDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>'
-};

--- a/packages/schematics/src/collection/jest-project/files/jest.config.js__tmpl__
+++ b/packages/schematics/src/collection/jest-project/files/jest.config.js__tmpl__
@@ -1,0 +1,9 @@
+module.exports = {
+  name: '<%= project %>',
+  preset: '<%= offsetFromRoot %>jest.config.js',
+  coverageDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>'<% if(!skipSerializers) { %>,
+  snapshotSerializers: [
+    'jest-preset-angular/AngularSnapshotSerializer.js',
+    'jest-preset-angular/HTMLCommentSerializer.js'
+  ]<% } %>
+};

--- a/packages/schematics/src/collection/jest-project/index.ts
+++ b/packages/schematics/src/collection/jest-project/index.ts
@@ -23,6 +23,7 @@ import { join, normalize } from '@angular-devkit/core';
 export interface JestProjectSchema {
   project: string;
   skipSetupFile: boolean;
+  skipSerializers: boolean;
 }
 
 function generateFiles(options: JestProjectSchema): Rule {

--- a/packages/schematics/src/collection/jest-project/jest-project.spec.ts
+++ b/packages/schematics/src/collection/jest-project/jest-project.spec.ts
@@ -67,7 +67,11 @@ describe('lib', () => {
       .toBe(`module.exports = {
   name: 'lib1',
   preset: '../../jest.config.js',
-  coverageDirectory: '../../coverage/libs/lib1'
+  coverageDirectory: '../../coverage/libs/lib1',
+  snapshotSerializers: [
+    'jest-preset-angular/AngularSnapshotSerializer.js',
+    'jest-preset-angular/HTMLCommentSerializer.js'
+  ]
 };
 `);
   });
@@ -148,6 +152,26 @@ describe('lib', () => {
         'libs/lib1/tsconfig.spec.json'
       );
       expect(tsConfig.files).toBeUndefined();
+    });
+  });
+
+  describe('--skip-serializers', () => {
+    it('should not list the serializers in jest.config.js', async () => {
+      const resultTree = await runSchematic(
+        'jest-project',
+        {
+          project: 'lib1',
+          skipSerializers: true
+        },
+        appTree
+      );
+      const jestConfig = resultTree.readContent('libs/lib1/jest.config.js');
+      expect(jestConfig).not.toContain(`
+  snapshotSerializers: [
+    'jest-preset-angular/AngularSnapshotSerializer.js',
+    'jest-preset-angular/HTMLCommentSerializer.js'
+  ]
+`);
     });
   });
 });

--- a/packages/schematics/src/collection/jest-project/schema.json
+++ b/packages/schematics/src/collection/jest-project/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "description": "Skips the setup file required for angular",
       "default": false
+    },
+    "skipSerializers": {
+      "type": "boolean",
+      "description": "Skips the serializers required to snapshot angular templates",
+      "default": false
     }
   },
   "required": []

--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -493,7 +493,8 @@ export default function(schema: Schema): Rule {
       options.unitTestRunner === 'jest'
         ? schematic('jest-project', {
             project: options.name,
-            skipSetupFile: !options.module
+            skipSetupFile: !options.module,
+            skipSerializers: !options.module
           })
         : noop(),
 

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -713,13 +713,20 @@ describe('lib', () => {
       ]);
     });
 
-    it('should skip the setup file if no module is generated', async () => {
+    it('should skip the setup file and serializers if no module is generated', async () => {
       const resultTree = await runSchematic(
         'lib',
         { name: 'myLib', unitTestRunner: 'jest', module: false },
         appTree
       );
       expect(resultTree.exists('libs/my-lib/src/test-setup.ts')).toBeFalsy();
+      expect(resultTree.readContent('libs/my-lib/jest.config.js')).not
+        .toContain(`
+  snapshotSerializers: [
+    'jest-preset-angular/AngularSnapshotSerializer.js',
+    'jest-preset-angular/HTMLCommentSerializer.js'
+  ]
+`);
     });
   });
 

--- a/packages/schematics/src/collection/node-application/index.ts
+++ b/packages/schematics/src/collection/node-application/index.ts
@@ -204,7 +204,8 @@ export default function(schema: Schema): Rule {
       options.unitTestRunner === 'jest'
         ? schematic('jest-project', {
             project: options.name,
-            skipSetupFile: true
+            skipSetupFile: true,
+            skipSerializers: true
           })
         : noop(),
       addTypes(options)


### PR DESCRIPTION
fix #958

## Description

I tested this change in an [example app](https://github.com/BuckyMaler/nx-jest-example). You'll find the relevant changes in `jest.config.js` and `apps/example-app/src/app/app.component.spec.ts`. The motivation is to be able to generate a snapshot against an Angular fixture. This makes it easier to generate a snapshot of an entire template, which I think is common. Also, [documentation](https://github.com/thymikee/jest-preset-angular#snapshot-testing) is written such that this should be possible. More granular snapshots are still possible using `querySelector`. The `snapshotSerializers` added are those used by [jest-preset-angular](https://github.com/thymikee/jest-preset-angular#exposed-configuration).

## Issue

#958