### PR TITLE
fix(schematics): do total recalculation for legacy existing deps

### DIFF
--- a/packages/schematics/src/command-line/deps-calculator.spec.ts
+++ b/packages/schematics/src/command-line/deps-calculator.spec.ts
@@ -288,6 +288,23 @@ describe('DepsCalculator', () => {
         lib2Name: []
       });
     });
+
+    it('should not be incremental if a legacy existing dependencies exists', () => {
+      delete initialDeps.dependencies;
+      delete initialDeps.files;
+      const result = new DepsCalculator(
+        'nrwl',
+        projects,
+        initialDeps,
+        fileRead
+      );
+      expect(result.incrementalEnabled).toEqual(false);
+      expect(result.getDeps()).toEqual({
+        app1Name: [],
+        lib1Name: [],
+        lib2Name: []
+      });
+    });
   });
 
   describe('incremental', () => {

--- a/packages/schematics/src/command-line/deps-calculator.ts
+++ b/packages/schematics/src/command-line/deps-calculator.ts
@@ -206,8 +206,12 @@ export class DepsCalculator {
     this.processNode(filePath, tsFile);
   }
 
+  private isLegacyFormat(existingDeps: any): boolean {
+    return !existingDeps.dependencies && !existingDeps.files;
+  }
+
   private shouldIncrementallyRecalculate(): boolean {
-    if (!this.existingDeps) {
+    if (!this.existingDeps || this.isLegacyFormat(this.existingDeps)) {
       return false;
     }
     const currentProjects = this.projects.map(p => p.name).sort();


### PR DESCRIPTION
## Current Behavior

Existing deps can be legacy deps. However, this causes the dependency calculation to fail

## Expected Behavior

Total recalculation is done for legacy deps.