### PR TITLE
fix(schematics): add lib module to the parent module

### DIFF
--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -202,7 +202,17 @@ function addChildren(options: NormalizedSchema): Rule {
     const importPath = `@${npmScope}/${options.projectDirectory}`;
 
     insert(host, options.parentModule, [
-      insertImport(sourceFile, options.parentModule, constName, importPath),
+      insertImport(
+        sourceFile,
+        options.parentModule,
+        `${options.moduleName}, ${constName}`,
+        importPath
+      ),
+      ...addImportToModule(
+        sourceFile,
+        options.parentModule,
+        options.moduleName
+      ),
       ...addRoute(
         options.parentModule,
         sourceFile,

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -661,6 +661,7 @@ describe('lib', () => {
           tree,
           'apps/myapp/src/app/app.module.ts'
         );
+        expect(moduleContents).toContain('MyDirMyLibModule');
         expect(moduleContents).toContain('RouterModule.forRoot([');
         expect(moduleContents).toContain(
           "{ path: 'my-dir-my-lib', children: myDirMyLibRoutes }"
@@ -682,6 +683,7 @@ describe('lib', () => {
           tree2,
           'apps/myapp/src/app/app.module.ts'
         );
+        expect(moduleContents2).toContain('MyDirMyLib2Module');
         expect(moduleContents2).toContain('RouterModule.forRoot([');
         expect(moduleContents2).toContain(
           "{ path: 'my-dir-my-lib', children: myDirMyLibRoutes }"
@@ -707,6 +709,7 @@ describe('lib', () => {
           tree3,
           'apps/myapp/src/app/app.module.ts'
         );
+        expect(moduleContents3).toContain('MyLib3Module');
         expect(moduleContents3).toContain('RouterModule.forRoot([');
         expect(moduleContents3).toContain(
           "{ path: 'my-dir-my-lib', children: myDirMyLibRoutes }"


### PR DESCRIPTION
fix #216

## Current Behavior
`ng g lib home     --routing --parent-module=apps/myapp/src/app/app.module.ts`
This command added homeRoutes to app.module.ts but not the HomeModule itself.

## Expected Behavior
Both homeRoutes and HomeMudule should be added to the parent module.
