### PR TITLE
feat(schematics): add node-app --framework nestjs

### DIFF
--- a/packages/schematics/src/collection/jest-project/index.ts
+++ b/packages/schematics/src/collection/jest-project/index.ts
@@ -53,7 +53,9 @@ function updateTsConfig(options: JestProjectSchema): Rule {
         ...json,
         compilerOptions: {
           ...json.compilerOptions,
-          types: [...json.compilerOptions.types, 'node', 'jest']
+          types: Array.from(
+            new Set([...json.compilerOptions.types, 'node', 'jest'])
+          )
         }
       };
     });

--- a/packages/schematics/src/collection/node-application/files/app/tsconfig.json
+++ b/packages/schematics/src/collection/node-application/files/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "<%= offset %>tsconfig.json",
   "compilerOptions": {
-    "types": ["node", "express"]
+    "types": ["node"]
   },
   "include": ["**/*.ts"]
 }

--- a/packages/schematics/src/collection/node-application/files/nestjs/app/app.controller.spec.ts__tmpl__
+++ b/packages/schematics/src/collection/node-application/files/nestjs/app/app.controller.spec.ts__tmpl__
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+describe('AppController', () => {
+  let app: TestingModule;
+
+  beforeAll(async () => {
+    app = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [AppService],
+    }).compile();
+  });
+
+  describe('getData', () => {
+    it('should return "Welcome to <%= name %>!"', () => {
+      const appController = app.get<AppController>(AppController);
+      expect(appController.getData()).toBe('Welcome to <%= name %>!');
+    });
+  });
+});

--- a/packages/schematics/src/collection/node-application/files/nestjs/app/app.controller.ts__tmpl__
+++ b/packages/schematics/src/collection/node-application/files/nestjs/app/app.controller.ts__tmpl__
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getData(): string {
+    return this.appService.getData();
+  }
+}

--- a/packages/schematics/src/collection/node-application/files/nestjs/app/app.module.ts__tmpl__
+++ b/packages/schematics/src/collection/node-application/files/nestjs/app/app.module.ts__tmpl__
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+@Module({
+  imports: [],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/packages/schematics/src/collection/node-application/files/nestjs/app/app.service.spec.ts__tmpl__
+++ b/packages/schematics/src/collection/node-application/files/nestjs/app/app.service.spec.ts__tmpl__
@@ -1,0 +1,21 @@
+import { Test } from '@nestjs/testing';
+
+import { AppService } from './app.service';
+
+describe('AppService', () => {
+  let service: AppService;
+
+  beforeAll(async () => {
+    const app = await Test.createTestingModule({
+      providers: [AppService],
+    }).compile();
+
+    service = app.get<AppService>(AppService);
+  });
+
+  describe('getData', () => {
+    it('should return "Welcome to <%= name %>!"', () => {
+      expect(service.getData()).toBe('Welcome to <%= name %>!');
+    });
+  });
+});

--- a/packages/schematics/src/collection/node-application/files/nestjs/app/app.service.ts__tmpl__
+++ b/packages/schematics/src/collection/node-application/files/nestjs/app/app.service.ts__tmpl__
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getData(): string {
+    return 'Welcome to <%= name %>!';
+  }
+}

--- a/packages/schematics/src/collection/node-application/files/nestjs/main.ts__tmpl__
+++ b/packages/schematics/src/collection/node-application/files/nestjs/main.ts__tmpl__
@@ -1,0 +1,17 @@
+/**
+ * This is not a production server yet!
+ * This is only a minimal backend to get started.
+ **/
+
+import { NestFactory } from '@nestjs/core';
+
+import { AppModule } from './app/app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3333, () => {
+    console.log('Listening at http://localhost:3333');
+  });
+}
+
+bootstrap();

--- a/packages/schematics/src/collection/node-application/node-application.spec.ts
+++ b/packages/schematics/src/collection/node-application/node-application.spec.ts
@@ -245,6 +245,39 @@ describe('node-app', () => {
     });
   });
 
+  describe('--framework nest', () => {
+    it('should create a main file', () => {
+      const tree = schematicRunner.runSchematic(
+        'node-app',
+        {
+          name: 'myNestApp',
+          framework: 'nestjs'
+        },
+        appTree
+      );
+      expect(tree.exists('apps/my-nest-app/src/main.ts')).toEqual(true);
+    });
+
+    it('should update dependencies', () => {
+      const tree = schematicRunner.runSchematic(
+        'node-app',
+        {
+          name: 'myNestApp',
+          framework: 'nestjs'
+        },
+        appTree
+      );
+      const { dependencies, devDependencies } = readJsonInTree(
+        tree,
+        'package.json'
+      );
+      expect(dependencies['@nestjs/common']).toBeDefined();
+      expect(dependencies['@nestjs/core']).toBeDefined();
+      expect(devDependencies['@nestjs/testing']).toBeDefined();
+      expect(devDependencies['@nestjs/schematics']).toBeDefined();
+    });
+  });
+
   describe('--framework none', () => {
     it('should not generate any files', () => {
       const tree = schematicRunner.runSchematic(

--- a/packages/schematics/src/collection/node-application/schema.d.ts
+++ b/packages/schematics/src/collection/node-application/schema.d.ts
@@ -3,7 +3,7 @@ export interface Schema {
   name: string;
   skipFormat: boolean;
   skipPackageJson: boolean;
-  framework: 'express' | 'none';
+  framework: 'express' | 'none' | 'nestjs';
   directory?: string;
   unitTestRunner: UnitTestRunner;
   tags?: string;

--- a/packages/schematics/src/collection/node-application/schema.json
+++ b/packages/schematics/src/collection/node-application/schema.json
@@ -20,8 +20,20 @@
     },
     "framework": {
       "type": "string",
-      "enum": ["express", "none"],
+      "enum": ["express", "nestjs", "none"],
       "description": "Node Framework to use for application.",
+      "x-prompt": {
+        "message": "In which directory should the node application be generated?",
+        "type": "list",
+        "items": [
+          { "value": "nestjs", "label": "NestJS [ https://nestjs.com/ ]" },
+          {
+            "value": "express",
+            "label": "Express [ https://expressjs.com/   ]"
+          }
+        ]
+      },
+
       "default": "express"
     },
     "skipFormat": {

--- a/packages/schematics/src/lib-versions.ts
+++ b/packages/schematics/src/lib-versions.ts
@@ -18,6 +18,9 @@ export const cypressVersion = '^3.1.0';
 export const expressVersion = '4.16.3';
 export const expressTypingsVersion = '4.16.0';
 
+export const nestJsVersion = '5.5.0';
+export const nestJsSchematicsVersion = '5.11.2';
+
 export const libVersions = {
   angularVersion,
   angularDevkitVersion,


### PR DESCRIPTION
## Current Behavior

NestJS is a great choice for enterprises using Angular who are also looking to build backends.

Creating Nest Applications with the nest schematics [has some friction](https://github.com/nestjs/schematics/issues/105#issuecomment-446655741)

## Expected Behavior

A NestJS Application can be created via

```sh
ng g node-app nest-app --framework nestjs
ng g @nestjs/schematics:controller cats --source-root apps/nest-app/src --path app
```

## Notes

This is based off of the work done by @FallenRiteMonk in https://github.com/nrwl/nx/pull/807

@FallenRiteMonk 
Thank you so much for your work. Sorry it was not accepted as is at the time. 

## Issues

Fixes https://github.com/nestjs/schematics/issues/105