### PR TITLE
fix(schematics) fix ngrx dependencies migration to 7.2

### DIFF
--- a/packages/schematics/migrations/update-7-2-0/update-7-2-0.spec.ts
+++ b/packages/schematics/migrations/update-7-2-0/update-7-2-0.spec.ts
@@ -468,12 +468,14 @@ describe('Update 7.2.0', () => {
       .runSchematicAsync('update-7.2.0', {}, initialTree)
       .toPromise();
 
-    const { devDependencies } = JSON.parse(result.readContent('package.json'));
+    const { dependencies, devDependencies } = JSON.parse(
+      result.readContent('package.json')
+    );
 
-    expect(devDependencies['@ngrx/effects']).toEqual('6.1.2');
-    expect(devDependencies['@ngrx/router-store']).toEqual('6.1.2');
+    expect(dependencies['@ngrx/effects']).toEqual('6.1.2');
+    expect(dependencies['@ngrx/router-store']).toEqual('6.1.2');
+    expect(dependencies['@ngrx/store']).toEqual('6.1.2');
     expect(devDependencies['@ngrx/schematics']).toEqual('6.1.2');
-    expect(devDependencies['@ngrx/store']).toEqual('6.1.2');
     expect(devDependencies['@ngrx/store-devtools']).toEqual('6.1.2');
   });
 });

--- a/packages/schematics/migrations/update-7-2-0/update-7-2-0.ts
+++ b/packages/schematics/migrations/update-7-2-0/update-7-2-0.ts
@@ -224,13 +224,18 @@ const updateAngularCLI = externalSchematic('@schematics/update', 'update', {
 export default function(): Rule {
   return chain([
     updateJsonInTree('package.json', json => {
+      json.dependencies = json.dependencies || {};
+      json.dependencies = {
+        ...json.dependencies,
+        '@ngrx/effects': '6.1.2',
+        '@ngrx/router-store': '6.1.2',
+        '@ngrx/store': '6.1.2'
+      };
+
       json.devDependencies = json.devDependencies || {};
       json.devDependencies = {
         ...json.devDependencies,
-        '@ngrx/effects': '6.1.2',
-        '@ngrx/router-store': '6.1.2',
         '@ngrx/schematics': '6.1.2',
-        '@ngrx/store': '6.1.2',
         '@ngrx/store-devtools': '6.1.2'
       };
 


### PR DESCRIPTION
## Current Behavior

Migration to 7.2 adds ngrx dependencies to `devDependencies`

## Expected Behavior

Migration to 7.2 adds ngrx dependencies to `dependencies`

## Issues

Fixes https://github.com/nrwl/nx/issues/978