### PR TITLE
fix(schematics): correct node-app framework prompt text

### DIFF
--- a/packages/schematics/src/collection/node-application/schema.json
+++ b/packages/schematics/src/collection/node-application/schema.json
@@ -23,7 +23,7 @@
       "enum": ["express", "nestjs", "none"],
       "description": "Node Framework to use for application.",
       "x-prompt": {
-        "message": "In which directory should the node application be generated?",
+        "message": "Which framework would you like to use for the node application?",
         "type": "list",
         "items": [
           { "value": "nestjs", "label": "NestJS [ https://nestjs.com/ ]" },


### PR DESCRIPTION
## Description

Fixes a simple copy-paste error with the node-app schematic framework prompt to correctly prompt the user to select a framework instead of choosing a directory.