### PR TITLE
fix(builders): add servePath to computedCypressBaseUrl

### DIFF
--- a/packages/builders/src/cypress/cypress.builder.ts
+++ b/packages/builders/src/cypress/cypress.builder.ts
@@ -258,7 +258,8 @@ export default class CypressBuilder implements Builder<CypressBuilderOptions> {
           this.computedCypressBaseUrl = url.format({
             protocol: builderConfig.options.ssl ? 'https' : 'http',
             hostname: builderConfig.options.host,
-            port: builderConfig.options.port.toString()
+            port: builderConfig.options.port.toString(),
+            pathname: builderConfig.options.servePath || ''
           });
         }
       }),


### PR DESCRIPTION
## Description

This will add the `servePath` (if set) to the `computedCypressBaseUrl`. This way no *redirect*/*url change*/*wait* is required after a `cy.visit('/')` call to stabilize e2e tests.

## Issue

Fixes #990 