### PR TITLE
fix(affected): Fix unsafe assertion that project nodes are defined

### DIFF
--- a/packages/schematics/src/command-line/affected.ts
+++ b/packages/schematics/src/command-line/affected.ts
@@ -276,7 +276,8 @@ function topologicallySortProjects(deps: DepGraph): string[] {
     visit(deps.projects.find(p => !marked[p.name]));
   }
 
-  function visit(n: ProjectNode) {
+  function visit(n: ProjectNode|undefined) {
+    if (!n) return;
     if (marked[n.name]) return;
     if (temporary[n.name]) return;
     temporary[n.name] = true;


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Description
This call was unsafe

      visit(deps.projects.find(pp => pp.name === e.projectName));

## Issue
