### PR TITLE
feat(builders): add support for inspect-brk and port

### DIFF
--- a/packages/builders/src/node/execute/node-execute.builder.ts
+++ b/packages/builders/src/node/execute/node-execute.builder.ts
@@ -16,10 +16,16 @@ import {
 } from '../build/node-build.builder';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 
+export const enum InspectType {
+  Inspect = 'inspect',
+  InspectBrk = 'inspect-brk'
+}
+
 export interface NodeExecuteBuilderOptions {
-  inspect: boolean;
+  inspect: boolean | InspectType;
   args: string[];
   buildTarget: string;
+  port: number;
 }
 
 export class NodeExecuteBuilder implements Builder<NodeExecuteBuilderOptions> {
@@ -52,8 +58,20 @@ export class NodeExecuteBuilder implements Builder<NodeExecuteBuilderOptions> {
       throw new Error('Already running');
     }
     this.subProcess = fork(file, options.args, {
-      execArgv: options.inspect ? ['--inspect'] : []
+      execArgv: this.getExecArgv(options)
     });
+  }
+
+  private getExecArgv(options: NodeExecuteBuilderOptions) {
+    if (!options.inspect) {
+      return [];
+    }
+
+    if (options.inspect === true) {
+      options.inspect = InspectType.Inspect;
+    }
+
+    return [`--${options.inspect}=localhost:${options.port}`];
   }
 
   private restartProcess(file: string, options: NodeExecuteBuilderOptions) {

--- a/packages/builders/src/node/execute/schema.json
+++ b/packages/builders/src/node/execute/schema.json
@@ -7,10 +7,23 @@
       "type": "string",
       "description": "The target to run to build you the app"
     },
+    "port": {
+      "type": "number",
+      "default": 7777,
+      "description": "The port to inspect the process on"
+    },
     "inspect": {
-      "type": "boolean",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["inspect", "inspect-brk"]
+        },
+        {
+          "type": "boolean"
+        }
+      ],
       "description": "Ensures the app is starting with debugging",
-      "default": true
+      "default": "inspect"
     },
     "args": {
       "type": "array",

--- a/packages/schematics/src/collection/node-application/index.ts
+++ b/packages/schematics/src/collection/node-application/index.ts
@@ -128,6 +128,7 @@ function getBuildConfig(project: any, options: NormalizedSchema) {
       production: {
         optimization: true,
         extractLicenses: true,
+        inspect: false,
         fileReplacements: [
           {
             replace: join(project.sourceRoot, 'environments/environment.ts'),

--- a/packages/schematics/src/collection/node-application/node-application.spec.ts
+++ b/packages/schematics/src/collection/node-application/node-application.spec.ts
@@ -42,6 +42,7 @@ describe('node-app', () => {
               production: {
                 optimization: true,
                 extractLicenses: true,
+                inspect: false,
                 fileReplacements: [
                   {
                     replace: 'apps/my-node-app/src/environments/environment.ts',


### PR DESCRIPTION
## Current Behavior

There is no way to change the port which the node application is debugged on thus they all try to use `9229`

There is no way to break at the beginning of inspecting a node application

## Expected Behavior

There should be an option for `--port 1234` which will debug the node application on the given port

`--inspect` option should be able to take strings `inspect` and `inspect-brk`

## Issues

Fixes #980 