### PR TITLE
feat(schematics): Added affected:projects script

### DIFF
--- a/e2e/schematics/affected.test.ts
+++ b/e2e/schematics/affected.test.ts
@@ -82,6 +82,32 @@ describe('Affected', () => {
     expect(noAffectedLibs).not.toContain('mylib');
     expect(noAffectedLibs).not.toContain('mylib2');
 
+    const affectedProjects = runCommand(
+      'npm run affected:projects -- --files="libs/mylib/src/index.ts"'
+    );
+    expect(affectedProjects).toContain('myapp');
+    expect(affectedProjects).toContain('mylib');
+    expect(affectedApps).not.toContain('myapp2');
+    expect(affectedApps).not.toContain('myapp-e2e');
+
+    const implicitlyAffectedProjects = runCommand(
+      'npm run affected:projects -- --files="package.json"'
+    );
+    expect(implicitlyAffectedProjects).toContain('myapp');
+    expect(implicitlyAffectedProjects).toContain('myapp2');
+    expect(implicitlyAffectedProjects).toContain('mylib');
+    expect(implicitlyAffectedProjects).toContain('mylib2');
+    expect(implicitlyAffectedProjects).toContain('mypublishablelib');
+
+    const noAffectedProjects = runCommand(
+      'npm run affected:projects -- --files="README.md"'
+    );
+    expect(noAffectedProjects).not.toContain('myapp');
+    expect(noAffectedProjects).not.toContain('myapp2');
+    expect(noAffectedProjects).not.toContain('mylib');
+    expect(noAffectedProjects).not.toContain('mylib2');
+    expect(noAffectedProjects).not.toContain('mypublishablelib');
+
     const build = runCommand(
       'npm run affected:build -- --files="libs/mylib/src/index.ts"'
     );

--- a/e2e/schematics/ng-add.test.ts
+++ b/e2e/schematics/ng-add.test.ts
@@ -75,6 +75,7 @@ describe('Nrwl Convert to Nx Workspace', () => {
       e2e: 'ng e2e',
       'affected:apps': './node_modules/.bin/nx affected:apps',
       'affected:libs': './node_modules/.bin/nx affected:libs',
+      'affected:projects': './node_modules/.bin/nx affected:projects',
       'affected:build': './node_modules/.bin/nx affected:build',
       'affected:e2e': './node_modules/.bin/nx affected:e2e',
       'affected:test': './node_modules/.bin/nx affected:test',

--- a/packages/schematics/migrations/legacy-migrations/20190124-add-affected-projects.ts
+++ b/packages/schematics/migrations/legacy-migrations/20190124-add-affected-projects.ts
@@ -1,0 +1,13 @@
+import { updateJsonFile } from '../../src/utils/fileutils';
+
+export default {
+  description: 'Added affected:projects npm script',
+  run: () => {
+    updateJsonFile('package.json', json => {
+      json.scripts = {
+        ...json.scripts,
+        'affected:projects': './node_modules/.bin/nx affected:projects'
+      };
+    });
+  }
+};

--- a/packages/schematics/src/collection/ng-add/index.ts
+++ b/packages/schematics/src/collection/ng-add/index.ts
@@ -53,6 +53,7 @@ function updatePackageJson() {
       ...packageJson.scripts,
       'affected:apps': './node_modules/.bin/nx affected:apps',
       'affected:libs': './node_modules/.bin/nx affected:libs',
+      'affected:projects': './node_modules/.bin/nx affected:projects',
       'affected:build': './node_modules/.bin/nx affected:build',
       'affected:e2e': './node_modules/.bin/nx affected:e2e',
       'affected:test': './node_modules/.bin/nx affected:test',

--- a/packages/schematics/src/collection/ng-new/files/__directory__/package.json
+++ b/packages/schematics/src/collection/ng-new/files/__directory__/package.json
@@ -11,6 +11,7 @@
     "e2e": "ng e2e",
     "affected:apps": "./node_modules/.bin/nx affected:apps",
     "affected:libs": "./node_modules/.bin/nx affected:libs",
+    "affected:projects": "./node_modules/.bin/nx affected:projects",
     "affected:build": "./node_modules/.bin/nx affected:build",
     "affected:e2e": "./node_modules/.bin/nx affected:e2e",
     "affected:test": "./node_modules/.bin/nx affected:test",

--- a/packages/schematics/src/command-line/affected.ts
+++ b/packages/schematics/src/command-line/affected.ts
@@ -14,7 +14,8 @@ import {
   getProjectNames,
   parseFiles,
   getAllProjectNamesWithTarget,
-  getAffectedProjectsWithTarget
+  getAffectedProjectsWithTarget,
+  getAllProjectNames
 } from './shared';
 import { generateGraph } from './dep-graph';
 import { GlobalNxArgs } from './nx';
@@ -78,8 +79,20 @@ export function affected(parsedArgs: YargsAffectedOptions): void {
           );
         console.log(libs.join(' '));
         break;
+      case 'projects':
+        const projects = (parsedArgs.all
+          ? getAllProjectNames()
+          : getAffectedProjects(parseFiles(parsedArgs).files)
+        )
+          .filter(_project => !parsedArgs.exclude.includes(_project))
+          .filter(
+            _project =>
+              !parsedArgs.onlyFailed || !workspaceResults.getResult(_project)
+          );
+        console.log(projects.join(' '));
+        break;
       case 'dep-graph':
-        const projects = parsedArgs.all
+        const depProjects = parsedArgs.all
           ? getProjectNames()
           : getAffectedProjects(parseFiles(parsedArgs).files)
               .filter(app => !parsedArgs.exclude.includes(app))
@@ -87,7 +100,7 @@ export function affected(parsedArgs: YargsAffectedOptions): void {
                 project =>
                   !parsedArgs.onlyFailed || !workspaceResults.getResult(project)
               );
-        generateGraph(parsedArgs, projects);
+        generateGraph(parsedArgs, depProjects);
         break;
       default:
         const targetProjects = getProjects(

--- a/packages/schematics/src/command-line/nx.ts
+++ b/packages/schematics/src/command-line/nx.ts
@@ -45,6 +45,16 @@ yargs
       })
   )
   .command(
+    'affected:projects',
+    'Print applications and libraries affected by changes',
+    withAffectedOptions,
+    args =>
+      affected({
+        ...args,
+        target: 'projects'
+      })
+  )
+  .command(
     'affected:build',
     'Build applications and publishable libraries affected by changes',
     yargs => withAffectedOptions(withParallel(yargs)),

--- a/packages/schematics/src/command-line/shared.ts
+++ b/packages/schematics/src/command-line/shared.ts
@@ -345,6 +345,12 @@ export function getAllLibNames() {
   return getProjectNames(p => p.type === ProjectType.lib);
 }
 
+export function getAllProjectNames() {
+  return getProjectNames(
+    p => p.type === ProjectType.app || p.type === ProjectType.lib
+  );
+}
+
 export function getAllProjectNamesWithTarget(target: string) {
   return getProjectNames(p => p.architect[target]);
 }


### PR DESCRIPTION
Instead of running affected:apps and affected:libs, affected:projects can be run to output all projects affected. Fixes #967.

Lemme know if I missed updating something. All the unit and e2e tests pass so I assume all is good.