### PR TITLE
fix(schematics): app generator tsconfig types iterable error

### DIFF
--- a/packages/schematics/src/collection/application/index.ts
+++ b/packages/schematics/src/collection/application/index.ts
@@ -241,7 +241,7 @@ function updateProject(options: NormalizedSchema): Rule {
                   ...json,
                   compilerOptions: {
                     ...json.compilerOptions,
-                    types: [...json.compilerOptions.types, 'jasmine']
+                    types: [...(json.compilerOptions.types || []), 'jasmine']
                   }
                 };
               }
@@ -344,7 +344,11 @@ function updateE2eProject(options: NormalizedSchema): Rule {
           ...json,
           compilerOptions: {
             ...json.compilerOptions,
-            types: [...json.compilerOptions.types, 'jasmine', 'jasminewd2']
+            types: [
+              ...(json.compilerOptions.types || []),
+              'jasmine',
+              'jasminewd2'
+            ]
           }
         };
       }),

--- a/packages/schematics/src/collection/cypress-project/index.ts
+++ b/packages/schematics/src/collection/cypress-project/index.ts
@@ -114,7 +114,7 @@ function updateTsConfig(options: CypressProjectSchema): Rule {
         ...json,
         compilerOptions: {
           ...json.compilerOptions,
-          types: [...json.compilerOptions.types, 'cypress']
+          types: [...(json.compilerOptions.types || []), 'cypress']
         }
       };
     }

--- a/packages/schematics/src/collection/jest-project/index.ts
+++ b/packages/schematics/src/collection/jest-project/index.ts
@@ -55,7 +55,7 @@ function updateTsConfig(options: JestProjectSchema): Rule {
         compilerOptions: {
           ...json.compilerOptions,
           types: Array.from(
-            new Set([...json.compilerOptions.types, 'node', 'jest'])
+            new Set([...(json.compilerOptions.types || []), 'node', 'jest'])
           )
         }
       };

--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -408,7 +408,7 @@ function updateKarmaConfig(options: NormalizedSchema) {
         ...json,
         compilerOptions: {
           ...json.compilerOptions,
-          types: [...json.compilerOptions.types, 'jasmine']
+          types: [...(json.compilerOptions.types || []), 'jasmine']
         }
       };
     }),


### PR DESCRIPTION
## Description

App generator will fail under some circumstances due to tsconfig setup.

## Issue

Generating an `app` would error with the following when the tsconfig did not contain any `compilerOptions.types` property:
```
compilerOptions.types is not iterable
```

I went ahead and updated the other locations that could fall victim as well.

/cc @FrozenPandaz 
