### PR TITLE
tests(e2e): fix failing e2e tests due to incorrect flags

### DIFF
--- a/e2e/schematics/command-line.test.ts
+++ b/e2e/schematics/command-line.test.ts
@@ -142,7 +142,7 @@ describe('Command line', () => {
 
   it('should support workspace-specific schematics', () => {
     newProject();
-    runCLI('g workspace-schematic custom -- --no-interactive');
+    runCLI('g workspace-schematic custom --no-interactive');
     checkFilesExist(
       'tools/schematics/custom/index.ts',
       'tools/schematics/custom/schema.json'
@@ -184,7 +184,7 @@ describe('Command line', () => {
     expect(output).toContain('update angular.json');
     expect(output).toContain('update nx.json');
 
-    runCLI('g workspace-schematic another -- --no-interactive');
+    runCLI('g workspace-schematic another --no-interactive');
 
     const listSchematicsOutput = runCommand(
       'npm run workspace-schematic -- --list-schematics'

--- a/e2e/schematics/ngrx.test.ts
+++ b/e2e/schematics/ngrx.test.ts
@@ -7,14 +7,14 @@ describe('ngrx', () => {
 
     // Generate root ngrx state management
     runCLI(
-      'generate ngrx users --module=apps/myapp/src/app/app.module.ts --root --collection=@nrwl/schematics'
+      'generate ngrx users --module=apps/myapp/src/app/app.module.ts --root'
     );
     copyMissingPackages();
 
     // Generate feature library and ngrx state within that library
     runCLI('g @nrwl/schematics:lib feature-flights --prefix=fl');
     runCLI(
-      'generate ngrx flights --module=libs/feature-flights/src/lib/feature-flights.module.ts --facade --collection=@nrwl/schematics'
+      'generate ngrx flights --module=libs/feature-flights/src/lib/feature-flights.module.ts --facade'
     );
 
     expect(runCLI('lint', { silenceError: true })).not.toContain('ERROR');


### PR DESCRIPTION
## Current Behavior

Some incorrect flags are passed in e2e tests

## Expected Behavior

Fix the incorrect flags

## Notes
> Because this started happening mysteriously

`@angular/cli` updated to be stricter and our e2e tests aren't exactly hermetic so they were picked up.