### PR TITLE
feat(schematics): introduce framework option for lib schematic

### DIFF
--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -1,5 +1,3 @@
-import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import * as path from 'path';
 import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import {
   createApp,
@@ -10,6 +8,7 @@ import { getFileContent } from '@schematics/angular/utility/test';
 import * as stripJsonComments from 'strip-json-comments';
 import { readJsonInTree } from '../../utils/ast-utils';
 import { NxJson } from '../../command-line/shared';
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
 
 describe('lib', () => {
   let appTree: Tree;
@@ -223,6 +222,33 @@ describe('lib', () => {
           'my-lib'
         ].prefix
       ).toEqual('custom');
+    });
+
+    describe('--framework', () => {
+      describe('none', () => {
+        let tree: UnitTestTree;
+        beforeEach(async () => {
+          tree = await runSchematic(
+            'lib',
+            {
+              name: 'myLib',
+              framework: 'none'
+            },
+            appTree
+          );
+        });
+
+        it('should generate a basic typescript lib', () => {
+          expect(
+            tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.module.ts')
+          ).toEqual(false);
+          expect(
+            tree.exists(
+              'libs/my-dir/my-lib/src/lib/my-dir-my-lib.module.spec.ts'
+            )
+          ).toEqual(false);
+        });
+      });
     });
   });
 

--- a/packages/schematics/src/collection/library/schema.d.ts
+++ b/packages/schematics/src/collection/library/schema.d.ts
@@ -1,4 +1,5 @@
 import { UnitTestRunner } from '../../utils/test-runners';
+import { Framework } from '../../utils/framework';
 
 export interface Schema {
   name: string;
@@ -19,6 +20,8 @@ export interface Schema {
   lazy?: boolean;
   parentModule?: string;
   tags?: string;
+
+  framework: Framework;
 
   unitTestRunner: UnitTestRunner;
 }

--- a/packages/schematics/src/collection/library/schema.json
+++ b/packages/schematics/src/collection/library/schema.json
@@ -18,6 +18,26 @@
       "description": "A directory where the app is placed",
       "x-prompt": "In which directory should the library be generated?"
     },
+    "framework": {
+      "type": "string",
+      "enum": ["angular", "none"],
+      "description": "The framework this library uses",
+      "default": "angular",
+      "x-prompt": {
+        "message": "What framework should this library use?",
+        "type": "list",
+        "items": [
+          {
+            "value": "angular",
+            "label": "Angular    [ https://angular.io/             ]"
+          },
+          {
+            "value": "none",
+            "label": "Typescript [ https://www.typescriptlang.org/ ]"
+          }
+        ]
+      }
+    },
     "publishable": {
       "type": "boolean",
       "default": false,
@@ -85,8 +105,7 @@
     "module": {
       "type": "boolean",
       "default": true,
-      "description": "Include an NgModule in the library.",
-      "x-prompt": "Would you like to generate an NgModule within the library?"
+      "description": "[Deprecated]: Include an NgModule in the library."
     },
     "tags": {
       "type": "string",

--- a/packages/schematics/src/utils/frameworks.ts
+++ b/packages/schematics/src/utils/frameworks.ts
@@ -1,0 +1,4 @@
+export const enum Framework {
+  Angular = 'angular',
+  None = 'none'
+}


### PR DESCRIPTION
## Current Behavior

`lib` schematic accepts `--no-module` which is almost synonymous to "Not Angular"

## Expected Behavior

`lib` schematic accepts a `--framework` option which can currently be `angular` or `none` and can be expanded upon in the future 😉 

* `ng g lib --framework angular` will generate an Angular Library
* `ng g lib --framework none` will generate a simple Typescript Library