### PR TITLE
fix(schematics): add rxjs dependency

### DIFF
--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -45,6 +45,7 @@
     "ignore": "5.0.4",
     "npm-run-all": "4.1.5",
     "opn": "^5.3.0",
+    "rxjs": "6.3.3",
     "semver": "5.4.1",
     "strip-json-comments": "2.0.1",
     "tmp": "0.0.33",


### PR DESCRIPTION
## Description
so that schematics will run regardless the version of rxjs used in the monorepo.

## Issue
fixes #1050
