### PR TITLE
fix(builders): copy fixture folder

### DIFF
--- a/e2e/schematics/cypress.test.ts
+++ b/e2e/schematics/cypress.test.ts
@@ -46,7 +46,7 @@ describe('Cypress E2E Test runner', () => {
       const originalContents = JSON.parse(
         readFile('apps/my-app-e2e/cypress.json')
       );
-      delete originalContents.fixtures;
+      delete originalContents.fixturesFolder;
       updateFile(
         'apps/my-app-e2e/cypress.json',
         JSON.stringify(originalContents)

--- a/packages/builders/src/cypress/cypress.builder.spec.ts
+++ b/packages/builders/src/cypress/cypress.builder.spec.ts
@@ -211,7 +211,7 @@ describe('Cypress builder', () => {
       fakeEventEmitter.emit('exit'); // Passing tsc command
     });
 
-    it('should copy fixtures files to out-dir', () => {
+    it('should copy fixtures folder to out-dir', () => {
       spyOn(fsUtility, 'readFile').and.callFake((path: string) => {
         return path.endsWith('tsconfig.e2e.json')
           ? JSON.stringify({
@@ -220,7 +220,7 @@ describe('Cypress builder', () => {
               }
             })
           : JSON.stringify({
-              fixtures: '../../dist/out-tsc/apps/my-app-e2e/src/fixtures'
+              fixturesFolder: '../../dist/out-tsc/apps/my-app-e2e/src/fixtures'
             });
       });
       const fakeEventEmitter = new EventEmitter();
@@ -253,7 +253,7 @@ describe('Cypress builder', () => {
       fakeEventEmitter.emit('exit'); // Passing tsc command
     });
 
-    it('should copy not fixtures files if they are not defined in the cypress config', () => {
+    it('should not copy fixtures folder if they are not defined in the cypress config', () => {
       spyOn(fsUtility, 'readFile').and.callFake((path: string) => {
         return path.endsWith('tsconfig.e2e.json')
           ? JSON.stringify({

--- a/packages/builders/src/cypress/cypress.builder.ts
+++ b/packages/builders/src/cypress/cypress.builder.ts
@@ -155,13 +155,13 @@ export default class CypressBuilder implements Builder<CypressBuilderOptions> {
   private copyCypressFixtures(tsConfigPath: string, cypressConfigPath: string) {
     const cypressConfig = JSON.parse(readFile(cypressConfigPath));
     // DOn't copy fixtures if cypress config does not have it set
-    if (!cypressConfig.fixtures) {
+    if (!cypressConfig.fixturesFolder) {
       return;
     }
 
     copySync(
       `${path.dirname(tsConfigPath)}/src/fixtures`,
-      path.join(path.dirname(cypressConfigPath), cypressConfig.fixtures),
+      path.join(path.dirname(cypressConfigPath), cypressConfig.fixturesFolder),
       { overwrite: true }
     );
   }


### PR DESCRIPTION
## Current Behavior
When running e2e tests with Cypress, fixtures are not being copied into the dist folder

## Expected Behavior
Fixtures are being copied to the dist folder

## Issue
Fixes [#996](https://github.com/nrwl/nx/issues/996)