### PR TITLE
chore(nx): update license year to 2019

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 (The MIT License)
 
-Copyright (c) 2018 Narwhal Technologies Inc.
+Copyright (c) 2019 Narwhal Technologies Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

License Year is 2018

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

License Year is 2019