### PR TITLE
fix(format.ts): add filtering of deleted files

### DIFF
--- a/packages/schematics/src/command-line/format.ts
+++ b/packages/schematics/src/command-line/format.ts
@@ -4,6 +4,7 @@ import * as resolve from 'resolve';
 import { getProjectRoots, parseFiles } from './shared';
 import { YargsAffectedOptions } from './affected';
 import { getTouchedProjects } from './touched';
+import { fileExists } from '../utils/fileutils';
 
 export interface YargsFormatOptions extends YargsAffectedOptions {
   libsAndApps?: boolean;
@@ -41,9 +42,11 @@ function getPatterns(args: YargsAffectedOptions) {
     }
 
     const p = parseFiles(args);
-    let patterns = p.files.filter(f =>
-      PRETTIER_EXTENSIONS.map(ext => '.' + ext).includes(path.extname(f))
-    );
+    let patterns = p.files
+      .filter(f => fileExists(f))
+      .filter(f =>
+        PRETTIER_EXTENSIONS.map(ext => '.' + ext).includes(path.extname(f))
+      );
 
     const libsAndApp = args.libsAndApps;
     return libsAndApp ? getPatternsFromApps(patterns) : patterns;


### PR DESCRIPTION
Formatting of uncommitted files errors when the only change is the deletion of files. Checking if
the file exists before writing solves this issue.

Fixes #1036
