### PR TITLE
fix(doc): getting started video sizes

### DIFF
--- a/docs/getting-started/resources.md
+++ b/docs/getting-started/resources.md
@@ -2,7 +2,7 @@
 
 ### Learn Nx in 30 Minutes
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/XZpp52IqD2A" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="380" src="https://www.youtube.com/embed/XZpp52IqD2A" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ### Angular Enterprise Monorepo Pattens Book
 

--- a/docs/getting-started/what-is-nx.md
+++ b/docs/getting-started/what-is-nx.md
@@ -2,7 +2,7 @@
 
 Angular CLI power-ups for modern development.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/XZpp52IqD2A" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="380" src="https://www.youtube.com/embed/XZpp52IqD2A" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 With Nx, you can:
 


### PR DESCRIPTION
Update the height of some video to fit the default ratio of the documentation website.
