### PR TITLE
refactor(schematics): strongly type cypress pluginsFile params

### DIFF
--- a/packages/schematics/src/collection/cypress-project/files/src/plugins/index.ts__tmpl__
+++ b/packages/schematics/src/collection/cypress-project/files/src/plugins/index.ts__tmpl__
@@ -11,7 +11,7 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-module.exports = (on: any, config: any) => {
+module.exports = (on: Cypress.Actions, config: Cypress.ConfigOptions) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
 };


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior
Cypress plugins file params are typed as any, i.e., untyped for all intents and purposes.

## Expected Behavior
Cypress plugins file will have strongly typed params when the file is generated for new apps.

## Issue
A simple change: the Cypress plugins file would benefit from starting out with typed params, leveraging the fact that the Cypress exports type definitions in their package. The types in this PR are reflective of the behavior as detailed in the [Cypress Plugins Guide](https://docs.cypress.io/guides/tooling/plugins-guide.html#Using-a-plugin) and the [Cypress Plugins API docs](https://docs.cypress.io/api/plugins/writing-a-plugin.html#Plugins-API).
