### PR TITLE
feat(nx): add js and jsx support to builders and affected

### DIFF
--- a/e2e/schematics/web.test.ts
+++ b/e2e/schematics/web.test.ts
@@ -7,8 +7,11 @@ import {
   updateFile,
   readFile,
   runCLIAsync,
-  checkFilesExist
+  checkFilesExist,
+  renameFile,
+  readJson
 } from '../utils';
+import { serializeJson } from '@nrwl/schematics/src/utils/fileutils';
 
 describe('Web Applications', () => {
   it('should be able to generate a react application', async () => {
@@ -20,6 +23,67 @@ describe('Web Applications', () => {
     newLib(`${libName} --framework none`);
 
     const mainPath = `apps/${appName}/src/main.tsx`;
+    updateFile(mainPath, `import '@proj/${libName}';\n` + readFile(mainPath));
+
+    const lintResults = runCLI(`lint ${appName}`);
+    expect(lintResults).toContain('All files pass linting.');
+    runCLI(`build ${appName}`);
+    checkFilesExist(
+      `dist/apps/${appName}/index.html`,
+      `dist/apps/${appName}/polyfills.js`,
+      `dist/apps/${appName}/runtime.js`,
+      `dist/apps/${appName}/vendor.js`,
+      `dist/apps/${appName}/main.js`,
+      `dist/apps/${appName}/styles.js`
+    );
+    runCLI(`build ${appName} --prod --output-hashing none`);
+    checkFilesExist(
+      `dist/apps/${appName}/index.html`,
+      `dist/apps/${appName}/polyfills.js`,
+      `dist/apps/${appName}/runtime.js`,
+      `dist/apps/${appName}/main.js`,
+      `dist/apps/${appName}/styles.css`
+    );
+    const testResults = await runCLIAsync(`test ${appName}`);
+    expect(testResults.stderr).toContain('Test Suites: 1 passed, 1 total');
+    const lintE2eResults = runCLI(`lint ${appName}-e2e`);
+    expect(lintE2eResults).toContain('All files pass linting.');
+    const e2eResults = runCLI(`e2e ${appName}-e2e`);
+    expect(e2eResults).toContain('All specs passed!');
+  }, 30000);
+
+  it('should be able to generate a jsx react application', async () => {
+    ensureProject();
+    const appName = uniq('app');
+    const libName = uniq('lib');
+
+    newApp(`${appName} --framework react`);
+    newLib(`${libName} --framework none`);
+
+    renameFile(`apps/${appName}/src/main.tsx`, `apps/${appName}/src/main.jsx`);
+    renameFile(
+      `apps/${appName}/src/app/app.tsx`,
+      `apps/${appName}/src/app/app.jsx`
+    );
+    renameFile(
+      `apps/${appName}/src/app/app.spec.tsx`,
+      `apps/${appName}/src/app/app.spec.jsx`
+    );
+    renameFile(
+      `apps/${appName}/src/polyfills.ts`,
+      `apps/${appName}/src/polyfills.js`
+    );
+    const angularJson = readJson('angular.json');
+
+    angularJson.projects[
+      appName
+    ].architect.build.options.main = `apps/${appName}/src/main.jsx`;
+    angularJson.projects[
+      appName
+    ].architect.build.options.polyfills = `apps/${appName}/src/polyfills.js`;
+    updateFile('angular.json', serializeJson(angularJson));
+
+    const mainPath = `apps/${appName}/src/main.jsx`;
     updateFile(mainPath, `import '@proj/${libName}';\n` + readFile(mainPath));
 
     const lintResults = runCLI(`lint ${appName}`);

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,5 +1,5 @@
 import { exec, execSync } from 'child_process';
-import { readFileSync, statSync, writeFileSync } from 'fs';
+import { readFileSync, statSync, writeFileSync, renameSync } from 'fs';
 import { ensureDirSync } from 'fs-extra';
 import * as path from 'path';
 
@@ -215,6 +215,14 @@ export function runCommand(command: string): string {
 export function updateFile(f: string, content: string): void {
   ensureDirSync(path.dirname(path.join(getCwd(), 'tmp', 'proj', f)));
   writeFileSync(path.join(getCwd(), 'tmp', 'proj', f), content);
+}
+
+export function renameFile(f: string, newPath: string): void {
+  ensureDirSync(path.dirname(path.join(getCwd(), 'tmp', 'proj', newPath)));
+  renameSync(
+    path.join(getCwd(), 'tmp', 'proj', f),
+    path.join(getCwd(), 'tmp', 'proj', newPath)
+  );
 }
 
 export function checkFilesExist(...expectedFiles: string[]) {

--- a/packages/builders/src/utils/webpack/config.ts
+++ b/packages/builders/src/utils/webpack/config.ts
@@ -35,7 +35,7 @@ export function getBaseWebpackPartial(
     module: {
       rules: [
         {
-          test: /\.tsx?$/,
+          test: /\.(j|t)sx?$/,
           loader: `ts-loader`,
           options: {
             configFile: options.tsConfig,

--- a/packages/schematics/src/collection/application/files/app/tsconfig.json
+++ b/packages/schematics/src/collection/application/files/app/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "<%= offsetFromRoot %>tsconfig.json",
   "compilerOptions": {<% if (framework === 'react') { %>
-    "jsx": "react",<% } %><% if (framework === 'web-components') { %>
+    "jsx": "react",
+    "allowJs": true,<% } %><% if (framework === 'web-components') { %>
     "target": "es2015",<% } %>
     "types": []
   },

--- a/packages/schematics/src/collection/jest-project/files/tsconfig.spec.json
+++ b/packages/schematics/src/collection/jest-project/files/tsconfig.spec.json
@@ -6,5 +6,11 @@
     "types": ["jest", "node"]
   },<% if(setupFile !== 'none') { %>
   "files": ["src/test-setup.ts"],<% } %>
-  "include": ["**/*.spec.ts", "**/*.d.ts"<% if (supportTsx) { %>, "**/*.spec.tsx", "**/*.d.tsx"<% } %>]
+  "include": [
+    "**/*.spec.ts",<% if (supportTsx) { %>
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",<% } %>
+    "**/*.d.ts"
+  ]
 }

--- a/packages/schematics/src/command-line/deps-calculator.spec.ts
+++ b/packages/schematics/src/command-line/deps-calculator.spec.ts
@@ -647,6 +647,207 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
       });
     });
 
+    it('should calculate dependencies in .tsx files', () => {
+      const deps = dependencies(
+        'nrwl',
+        [
+          {
+            name: 'app1Name',
+            root: 'apps/app1',
+            files: ['app1.tsx'],
+            fileMTimes: {
+              'app1.tsx': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'lib1Name',
+            root: 'libs/lib1',
+            files: ['lib1.tsx'],
+            fileMTimes: {
+              'lib1.tsx': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.lib
+          },
+          {
+            name: 'lib2Name',
+            root: 'libs/lib2',
+            files: ['lib2.tsx'],
+            fileMTimes: {
+              'lib2.tsx': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.lib
+          }
+        ],
+        null,
+        file => {
+          switch (file) {
+            case 'app1.tsx':
+              return `
+            import '@nrwl/lib1';
+            import '@nrwl/lib2/deep';
+          `;
+            case 'lib1.tsx':
+              return `import '@nrwl/lib2'`;
+            case 'lib2.tsx':
+              return '';
+          }
+        }
+      );
+
+      expect(deps).toEqual({
+        app1Name: [
+          { projectName: 'lib1Name', type: DependencyType.es6Import },
+          { projectName: 'lib2Name', type: DependencyType.es6Import }
+        ],
+        lib1Name: [{ projectName: 'lib2Name', type: DependencyType.es6Import }],
+        lib2Name: []
+      });
+    });
+
+    it('should calculate dependencies in .js files', () => {
+      const deps = dependencies(
+        'nrwl',
+        [
+          {
+            name: 'app1Name',
+            root: 'apps/app1',
+            files: ['app1.js'],
+            fileMTimes: {
+              'app1.js': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'lib1Name',
+            root: 'libs/lib1',
+            files: ['lib1.js'],
+            fileMTimes: {
+              'lib1.js': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.lib
+          },
+          {
+            name: 'lib2Name',
+            root: 'libs/lib2',
+            files: ['lib2.js'],
+            fileMTimes: {
+              'lib2.js': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.lib
+          }
+        ],
+        null,
+        file => {
+          switch (file) {
+            case 'app1.js':
+              return `
+            import '@nrwl/lib1';
+            import '@nrwl/lib2/deep';
+          `;
+            case 'lib1.js':
+              return `import '@nrwl/lib2'`;
+            case 'lib2.js':
+              return '';
+          }
+        }
+      );
+
+      expect(deps).toEqual({
+        app1Name: [
+          { projectName: 'lib1Name', type: DependencyType.es6Import },
+          { projectName: 'lib2Name', type: DependencyType.es6Import }
+        ],
+        lib1Name: [{ projectName: 'lib2Name', type: DependencyType.es6Import }],
+        lib2Name: []
+      });
+    });
+
+    it('should calculate dependencies in .jsx files', () => {
+      const deps = dependencies(
+        'nrwl',
+        [
+          {
+            name: 'app1Name',
+            root: 'apps/app1',
+            files: ['app1.jsx'],
+            fileMTimes: {
+              'app1.jsx': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'lib1Name',
+            root: 'libs/lib1',
+            files: ['lib1.jsx'],
+            fileMTimes: {
+              'lib1.jsx': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.lib
+          },
+          {
+            name: 'lib2Name',
+            root: 'libs/lib2',
+            files: ['lib2.jsx'],
+            fileMTimes: {
+              'lib2.jsx': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.lib
+          }
+        ],
+        null,
+        file => {
+          switch (file) {
+            case 'app1.jsx':
+              return `
+            import '@nrwl/lib1';
+            import '@nrwl/lib2/deep';
+          `;
+            case 'lib1.jsx':
+              return `import '@nrwl/lib2'`;
+            case 'lib2.jsx':
+              return '';
+          }
+        }
+      );
+
+      expect(deps).toEqual({
+        app1Name: [
+          { projectName: 'lib1Name', type: DependencyType.es6Import },
+          { projectName: 'lib2Name', type: DependencyType.es6Import }
+        ],
+        lib1Name: [{ projectName: 'lib2Name', type: DependencyType.es6Import }],
+        lib2Name: []
+      });
+    });
+
     it('should infer dependencies expressed via loadChildren', () => {
       const deps = dependencies(
         'nrwl',

--- a/packages/schematics/src/command-line/deps-calculator.ts
+++ b/packages/schematics/src/command-line/deps-calculator.ts
@@ -179,7 +179,12 @@ export class DepsCalculator {
    */
   processFile(filePath: string): void {
     const extension = path.extname(filePath);
-    if (extension !== '.ts' && extension !== '.tsx') {
+    if (
+      extension !== '.ts' &&
+      extension !== '.tsx' &&
+      extension !== '.js' &&
+      extension !== '.jsx'
+    ) {
       return;
     }
     const tsFile = ts.createSourceFile(


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

JS and JSX files are not supported with the web builder + affected

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

JS and JSX files are not supported with the web builder + affected

## Motivation

This will be important for react users who are in mid migration to Typescript and make it easy to drop apps with JS straight into Nx

## Issue
