### PR TITLE
fix(nx): remove extract-i18n target from non-angular apps

### DIFF
--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -416,6 +416,20 @@ describe('app', () => {
         );
       });
 
+      it('should remove the extract-i18n target', async () => {
+        const tree = await runSchematic(
+          'app',
+          {
+            name: 'my-App',
+            framework: Framework.React
+          },
+          appTree
+        );
+        const angularJson = readJsonInTree(tree, 'angular.json');
+        const architectConfig = angularJson.projects['my-app'].architect;
+        expect(architectConfig['extract-i18n']).not.toBeDefined();
+      });
+
       it('should setup the nrwl web build builder', async () => {
         const tree = await runSchematic(
           'app',

--- a/packages/schematics/src/collection/application/index.ts
+++ b/packages/schematics/src/collection/application/index.ts
@@ -153,6 +153,9 @@ function updateBuilders(options: NormalizedSchema): Rule {
   return (host: Tree) => {
     return updateJsonInTree(getWorkspacePath(host), json => {
       const project = json.projects[options.name];
+
+      delete project.architect['extract-i18n'];
+
       const buildOptions = project.architect.build;
       const serveOptions = project.architect.serve;
 


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`extract-i18n` target is generated for non-angular apps but does not work

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`extract-i18n` target is not generated for non-angular apps

## Issue
