### PR TITLE
fix(nx): install ts-jest for non-angular apps

### DIFF
--- a/packages/schematics/src/collection/jest/index.ts
+++ b/packages/schematics/src/collection/jest/index.ts
@@ -1,16 +1,6 @@
-import {
-  mergeWith,
-  SchematicContext,
-  chain,
-  url
-} from '@angular-devkit/schematics';
-import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
-import { addDepsToPackageJson, updateJsonInTree } from '../../utils/ast-utils';
-import {
-  jestVersion,
-  nxVersion,
-  jestPresetAngularVersion
-} from '../../lib-versions';
+import { mergeWith, chain, url } from '@angular-devkit/schematics';
+import { addDepsToPackageJson } from '../../utils/ast-utils';
+import { jestVersion, nxVersion } from '../../lib-versions';
 import { Rule } from '@angular-devkit/schematics';
 
 const updatePackageJson = addDepsToPackageJson(
@@ -18,8 +8,7 @@ const updatePackageJson = addDepsToPackageJson(
   {
     '@nrwl/builders': nxVersion,
     jest: jestVersion,
-    '@types/jest': jestVersion,
-    'jest-preset-angular': jestPresetAngularVersion
+    '@types/jest': jestVersion
   }
 );
 

--- a/packages/schematics/src/lib-versions.ts
+++ b/packages/schematics/src/lib-versions.ts
@@ -11,6 +11,7 @@ export const prettierVersion = '1.15.2';
 export const typescriptVersion = '3.2.2';
 export const rxjsVersion = '6.3.3';
 export const jestVersion = '23.0.0';
+export const tsJestversion = '23.10.5';
 export const jestPresetAngularVersion = '6.0.1';
 export const jasmineMarblesVersion = '0.4.0';
 export const cypressVersion = '3.1.0';


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Setting up Jest installs `jest-preset-angular` which is not needed for non Angular apps

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Setting up Jest installs `ts-jest` if a non-angular app is setup and `jest-preset-angular` if Angular apps are setup.

## Issue
