### PR TITLE
feat(nx): add framework react for libs

### DIFF
--- a/e2e/schematics/web.test.ts
+++ b/e2e/schematics/web.test.ts
@@ -17,7 +17,7 @@ describe('Web Applications', () => {
     const libName = uniq('lib');
 
     newApp(`${appName} --framework react`);
-    newLib(`${libName} --framework none`);
+    newLib(`${libName} --framework react`);
 
     const mainPath = `apps/${appName}/src/main.tsx`;
     updateFile(mainPath, `import '@proj/${libName}';\n` + readFile(mainPath));
@@ -47,7 +47,10 @@ describe('Web Applications', () => {
     expect(lintE2eResults).toContain('All files pass linting.');
     const e2eResults = runCLI(`e2e ${appName}-e2e`);
     expect(e2eResults).toContain('All specs passed!');
-  }, 30000);
+
+    const libTestResults = await runCLIAsync(`test ${libName}`);
+    expect(libTestResults.stderr).toContain('Test Suites: 1 passed, 1 total');
+  }, 120000);
 
   it('should be able to generate a web-components application', async () => {
     ensureProject();
@@ -84,5 +87,5 @@ describe('Web Applications', () => {
     expect(lintE2eResults).toContain('All files pass linting.');
     const e2eResults = runCLI(`e2e ${appName}-e2e`);
     expect(e2eResults).toContain('All specs passed!');
-  }, 30000);
+  }, 120000);
 });

--- a/packages/schematics/src/collection/library/files/lib/tsconfig.json
+++ b/packages/schematics/src/collection/library/files/lib/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "<%= offsetFromRoot %>tsconfig.json",
+  "compilerOptions": {<% if (framework === 'react') { %>
+    "jsx": "react",<% } %>
+    "types": []
+  },
+  "include": ["**/*.ts"<% if (framework === 'react') { %>, "**/*.tsx"<% } %>]
+}

--- a/packages/schematics/src/collection/library/files/react/src/lib/__fileName__.spec.tsx__tmpl__
+++ b/packages/schematics/src/collection/library/files/react/src/lib/__fileName__.spec.tsx__tmpl__
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { render, cleanup } from 'react-testing-library';
+
+import { <%= className %> } from './<%= fileName %>';
+
+describe('<%= className %>', () => {
+  afterEach(cleanup);
+
+  it('should render successfully', () => {
+    const { getByText } = render(<<%= className %> />);
+    expect(getByText('<%= name %> works!')).toBeTruthy();
+  });
+});

--- a/packages/schematics/src/collection/library/files/react/src/lib/__fileName__.tsx__tmpl__
+++ b/packages/schematics/src/collection/library/files/react/src/lib/__fileName__.tsx__tmpl__
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { Component } from 'react';
+
+import './<%= fileName %>.<%= style %>';
+
+export class <%= className %> extends Component {
+  render() {
+    const title = '<%= name %>';
+    return (<div><%= name %> works!</div>
+    );
+  }
+}

--- a/packages/schematics/src/collection/library/files/tsconfig.json
+++ b/packages/schematics/src/collection/library/files/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "extends": "<%= offsetFromRoot %>tsconfig.json",
-  "compilerOptions": {
-    "types": []
-  },
-  "include": ["**/*.ts"]
-}

--- a/packages/schematics/src/collection/library/library.spec.ts
+++ b/packages/schematics/src/collection/library/library.spec.ts
@@ -229,6 +229,48 @@ describe('lib', () => {
     });
 
     describe('--framework', () => {
+      describe('react', () => {
+        let tree: UnitTestTree;
+
+        beforeEach(async () => {
+          tree = await runSchematic(
+            'lib',
+            {
+              name: 'home',
+              framework: 'react'
+            },
+            appTree
+          );
+        });
+
+        it('should generate a basic react lib', () => {
+          expect(tree.exists('libs/home/src/lib/home.module.ts')).toEqual(
+            false
+          );
+          expect(tree.exists('libs/home/src/lib/home.module.spec.ts')).toEqual(
+            false
+          );
+          expect(tree.exists('libs/home/src/lib/home.css')).toEqual(true);
+          expect(tree.exists('libs/home/src/lib/home.tsx')).toEqual(true);
+          expect(tree.exists('libs/home/src/lib/home.spec.tsx')).toEqual(true);
+
+          expect(
+            readJsonInTree(tree, 'libs/home/tsconfig.json').compilerOptions.jsx
+          ).toEqual('react');
+
+          expect(tree.readContent('libs/home/src/lib/home.tsx')).toContain(
+            '<div>home works!</div>'
+          );
+          expect(tree.readContent('libs/home/src/lib/home.tsx')).toContain(
+            'export class Home extends Component {'
+          );
+
+          expect(tree.readContent('libs/home/src/lib/home.spec.tsx')).toContain(
+            `describe('Home', () => {`
+          );
+        });
+      });
+
       describe('none', () => {
         let tree: UnitTestTree;
         beforeEach(async () => {

--- a/packages/schematics/src/collection/library/schema.json
+++ b/packages/schematics/src/collection/library/schema.json
@@ -20,7 +20,7 @@
     },
     "framework": {
       "type": "string",
-      "enum": ["angular", "none"],
+      "enum": ["angular", "react", "none"],
       "description": "The framework this library uses",
       "default": "none",
       "x-prompt": {
@@ -28,12 +28,16 @@
         "type": "list",
         "items": [
           {
-            "value": "none",
-            "label": "Typescript [ https://www.typescriptlang.org/ ]"
-          },
-          {
             "value": "angular",
             "label": "Angular    [ https://angular.io/             ]"
+          },
+          {
+            "value": "react",
+            "label": "React      [ https://reactjs.org/            ]"
+          },
+          {
+            "value": "none",
+            "label": "Typescript [ https://www.typescriptlang.org/ ]"
           }
         ]
       }


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Typescript libs don't support testing JSX

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

There's a `framework=react` option for the `lib` schematic

## Issue
