### PR TITLE
fix(nx): format ng-new projects

### DIFF
--- a/packages/schematics/src/collection/ng-new/index.ts
+++ b/packages/schematics/src/collection/ng-new/index.ts
@@ -20,6 +20,7 @@ import {
   RepositoryInitializerTask
 } from '@angular-devkit/schematics/tasks';
 import { Framework } from '../../utils/frameworks';
+import { formatFiles } from '../../utils/rules/format-files';
 
 export default function(options: Schema): Rule {
   if (!options.directory) {
@@ -32,7 +33,8 @@ export default function(options: Schema): Rule {
       schematic('workspace', workspaceOpts),
       createPreset(options),
       move('/', options.directory),
-      addTasks(options)
+      addTasks(options),
+      formatFiles()
     ])(Tree.empty(), context);
   };
 }


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Projects created with `create-nx-workspace`/`ng new` are not formatted

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Projects created with `create-nx-workspace`/`ng new` are formatted

## Issue
