### PR TITLE
feat(builders): support Cypress exit option

### DIFF
--- a/docs/api-builders/cypress.md
+++ b/docs/api-builders/cypress.md
@@ -36,7 +36,15 @@ Default: `false`
 
 Type: `boolean`
 
-Whether or not the open the Cypress application to run the tests. If set to 'true', will run in headless mode
+Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode
+
+### exit
+
+Default: `true`
+
+Type: `boolean`
+
+Whether or not the Cypress Test Runner will stay open after running tests in a spec file
 
 ### record
 

--- a/packages/builders/src/cypress/cypress.builder.spec.ts
+++ b/packages/builders/src/cypress/cypress.builder.spec.ts
@@ -15,6 +15,7 @@ describe('Cypress builder', () => {
     tsConfig: 'apps/my-app-e2e/tsconfig.json',
     devServerTarget: 'my-app:serve',
     headless: true,
+    exit: true,
     record: false,
     baseUrl: undefined,
     watch: false
@@ -197,6 +198,7 @@ describe('Cypress builder', () => {
             tsConfig: 'apps/my-app-e2e/tsconfig.json',
             devServerTarget: undefined,
             headless: true,
+            exit: true,
             record: false,
             baseUrl: undefined,
             watch: false
@@ -238,6 +240,7 @@ describe('Cypress builder', () => {
             tsConfig: 'apps/my-app-e2e/tsconfig.e2e.json',
             devServerTarget: undefined,
             headless: true,
+            exit: true,
             record: false,
             baseUrl: undefined,
             watch: false
@@ -278,6 +281,7 @@ describe('Cypress builder', () => {
             tsConfig: 'apps/my-app-e2e/tsconfig.e2e.json',
             devServerTarget: undefined,
             headless: true,
+            exit: true,
             record: false,
             baseUrl: undefined,
             watch: false

--- a/packages/builders/src/cypress/cypress.builder.ts
+++ b/packages/builders/src/cypress/cypress.builder.ts
@@ -22,6 +22,7 @@ export interface CypressBuilderOptions {
   cypressConfig: string;
   devServerTarget: string;
   headless: boolean;
+  exit: boolean;
   record: boolean;
   tsConfig: string;
   watch: boolean;
@@ -97,6 +98,7 @@ export default class CypressBuilder implements Builder<CypressBuilderOptions> {
         this.initCypress(
           options.cypressConfig,
           options.headless,
+          options.exit,
           options.record,
           options.watch,
           options.baseUrl,
@@ -184,6 +186,7 @@ export default class CypressBuilder implements Builder<CypressBuilderOptions> {
   private initCypress(
     cypressConfig: string,
     headless: boolean,
+    exit: boolean,
     record: boolean,
     isWatching: boolean,
     baseUrl: string,
@@ -204,6 +207,7 @@ export default class CypressBuilder implements Builder<CypressBuilderOptions> {
       options.browser = browser;
     }
 
+    options.exit = exit;
     options.headed = !headless;
     options.record = record;
 

--- a/packages/builders/src/cypress/schema.json
+++ b/packages/builders/src/cypress/schema.json
@@ -22,8 +22,13 @@
     },
     "headless": {
       "type": "boolean",
-      "description": "Whether or not the open the Cypress application to run the tests. If set to 'true', will run in headless mode",
+      "description": "Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode",
       "default": false
+    },
+    "exit": {
+      "type": "boolean",
+      "description": "Whether or not the Cypress Test Runner will stay open after running tests in a spec file",
+      "default": true
     },
     "record": {
       "type": "boolean",


### PR DESCRIPTION
Support the `exit` option to keep (or not), Cypress open after all tests run.

resolve #1119

