### PR TITLE
feat(docs): fix typo in run-commands

### DIFF
--- a/docs/api-builders/run-commands.md
+++ b/docs/api-builders/run-commands.md
@@ -16,4 +16,4 @@ Run commands in parallel
 
 Type: `string`
 
-String to appear in stdout or stderr that indicates that the task is done. This option can only be used when parallel is set to true. If not specified, the task is one when all the child processes complete.
+String to appear in stdout or stderr that indicates that the task is done. This option can only be used when parallel is set to true. If not specified, the task is done when all the child processes complete.

--- a/packages/builders/src/run-commands/schema.json
+++ b/packages/builders/src/run-commands/schema.json
@@ -24,7 +24,7 @@
     },
     "readyWhen": {
       "type": "string",
-      "description": "String to appear in stdout or stderr that indicates that the task is done. This option can only be used when parallel is set to true. If not specified, the task is one when all the child processes complete."
+      "description": "String to appear in stdout or stderr that indicates that the task is done. This option can only be used when parallel is set to true. If not specified, the task is done when all the child processes complete."
     }
   },
   "required": ["commands"]


### PR DESCRIPTION
## Issue
Typo in builders API docs for run-commands builder