### PR TITLE
fix(nx): remove extension from export in lib index for react libs

### DIFF
--- a/packages/schematics/src/collection/library/index.ts
+++ b/packages/schematics/src/collection/library/index.ts
@@ -423,7 +423,7 @@ function createAdditionalFiles(options: NormalizedSchema): Rule {
         (host: Tree) => {
           host.overwrite(
             `${options.projectRoot}/src/index.ts`,
-            ` export * from './lib/${options.fileName}.tsx';\n`
+            ` export * from './lib/${options.fileName}';\n`
           );
         }
       ]);


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

The index of a React lib exports `./lib/libName.tsx`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The index of a React lib exports `./lib/libName`

## Issue
