### PR TITLE
fix(testing): do not generate serializers for non-angular apps

### DIFF
--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -416,6 +416,21 @@ describe('app', () => {
         );
       });
 
+      it('should setup jest without serializers', async () => {
+        const tree = await runSchematic(
+          'app',
+          {
+            name: 'my-App',
+            framework: Framework.React
+          },
+          appTree
+        );
+
+        expect(tree.readContent('apps/my-app/jest.config.js')).not.toContain(
+          `'jest-preset-angular/AngularSnapshotSerializer.js',`
+        );
+      });
+
       it('should remove the extract-i18n target', async () => {
         const tree = await runSchematic(
           'app',

--- a/packages/schematics/src/collection/application/index.ts
+++ b/packages/schematics/src/collection/application/index.ts
@@ -539,6 +539,7 @@ export default function(schema: Schema): Rule {
         ? schematic('jest-project', {
             project: options.name,
             supportTsx: options.framework === Framework.React,
+            skipSerializers: options.framework !== Framework.Angular,
             setupFile:
               options.framework === Framework.Angular
                 ? 'angular'


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Angular Serializers are added for non-Angular Apps

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Angular Serializers are not added for non-Angular Apps

## Issue
