### PR TITLE
feat(schematics-cli): add multiple selection support for prompts

### DIFF
--- a/packages/schematics/src/command-line/workspace-schematic.ts
+++ b/packages/schematics/src/command-line/workspace-schematic.ts
@@ -155,7 +155,7 @@ function createPromptProvider(): schema.PromptProvider {
         case 'list':
           return {
             ...question,
-            type: 'list',
+            type: !!definition.multiselect ? 'checkbox' : 'list',
             choices:
               definition.items &&
               definition.items.map(item => {


### PR DESCRIPTION
Adds check for `multiselect` in prompt definition
(per [PromptDefinition](https://github.com/angular/angular-cli/blob/3ac1cc30a7937784cda54f7762c5831fef6a9a59/packages/angular_devkit/core/src/json/schema/interface.ts#L109) interface from `@angular-devkit`)

## Current Behavior (This is the behavior we have today, before the PR is merged)

Adding `"multiselect": true` to `x-prompt` does nothing

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Adding `"multiselect": true` to `x-prompt` will allow developers to collect an array of values from a workspace prompt


## Issue
closes https://github.com/nrwl/nx/issues/1162
