### PR TITLE
feat(node): add `--host` option when inspecting a node process

### DIFF
--- a/docs/api-builders/node-execute.md
+++ b/docs/api-builders/node-execute.md
@@ -16,6 +16,14 @@ Type: `string`
 
 The target to run to build you the app
 
+### host
+
+Default: `localhost`
+
+Type: `string`
+
+The host to inspect the process on
+
 ### inspect
 
 Default: `inspect`

--- a/packages/builders/src/node/execute/node-execute.builder.spec.ts
+++ b/packages/builders/src/node/execute/node-execute.builder.spec.ts
@@ -74,7 +74,8 @@ describe('NodeExecuteBuilder', () => {
       args: [],
       buildTarget: 'nodeapp:build',
       port: 9229,
-      waitUntilTargets: []
+      waitUntilTargets: [],
+      host: 'localhost'
     };
   });
 
@@ -173,6 +174,38 @@ describe('NodeExecuteBuilder', () => {
         );
         expect(fork).toHaveBeenCalledWith('outfile.js', [], {
           execArgv: ['--inspect-brk=localhost:9229']
+        });
+      });
+    });
+  });
+
+  describe('--host', () => {
+    describe('0.0.0.0', () => {
+      it('should inspect the process on host 0.0.0.0', () => {
+        expect(
+          builder.run({
+            root: normalize('/root'),
+            projectType: 'application',
+            builder: '@nrwl/builders:node-execute',
+            options: {
+              ...testOptions,
+              host: '0.0.0.0'
+            }
+          })
+        ).toBeObservable(
+          cold('--a--b--a', {
+            a: {
+              success: true,
+              outfile: 'outfile.js'
+            },
+            b: {
+              success: false,
+              outfile: 'outfile.js'
+            }
+          })
+        );
+        expect(fork).toHaveBeenCalledWith('outfile.js', [], {
+          execArgv: ['--inspect=0.0.0.0:9229']
         });
       });
     });

--- a/packages/builders/src/node/execute/node-execute.builder.ts
+++ b/packages/builders/src/node/execute/node-execute.builder.ts
@@ -30,6 +30,7 @@ export interface NodeExecuteBuilderOptions {
   args: string[];
   waitUntilTargets: string[];
   buildTarget: string;
+  host: string;
   port: number;
 }
 
@@ -87,7 +88,7 @@ export class NodeExecuteBuilder implements Builder<NodeExecuteBuilderOptions> {
       options.inspect = InspectType.Inspect;
     }
 
-    return [`--${options.inspect}=localhost:${options.port}`];
+    return [`--${options.inspect}=${options.host}:${options.port}`];
   }
 
   private restartProcess(file: string, options: NodeExecuteBuilderOptions) {

--- a/packages/builders/src/node/execute/schema.json
+++ b/packages/builders/src/node/execute/schema.json
@@ -15,6 +15,11 @@
         "type": "string"
       }
     },
+    "host": {
+      "type": "string",
+      "default": "localhost",
+      "description": "The host to inspect the process on"
+    },
     "port": {
       "type": "number",
       "default": 7777,


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

It is currently not possible to pass a `host` option to the `@nrwl/builders:node-execute builder`. Instead, the `localhost` host is hardcoded: https://github.com/nrwl/nx/blob/5d990308f1ff9d909819219a5978fca3093073d4/packages/builders/src/node/execute/node-execute.builder.ts#L90

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Much like the `port` option, a `host` option is now available to configure the inspect host for the @nrwl/builders:node-execute builder.

## Issue
closes: https://github.com/nrwl/nx/issues/1141