### PR TITLE
enhancement(nx): optimize affected to strip sourcecode down to import…

### DIFF
--- a/packages/schematics/src/command-line/deps-calculator.spec.ts
+++ b/packages/schematics/src/command-line/deps-calculator.spec.ts
@@ -647,6 +647,73 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
       });
     });
 
+    it('should infer deps between projects based on exports', () => {
+      const deps = dependencies(
+        'nrwl',
+        [
+          {
+            name: 'app1Name',
+            root: 'apps/app1',
+            files: ['app1.ts'],
+            fileMTimes: {
+              'app1.ts': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.app
+          },
+          {
+            name: 'lib1Name',
+            root: 'libs/lib1',
+            files: ['lib1.ts'],
+            fileMTimes: {
+              'lib1.ts': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.lib
+          },
+          {
+            name: 'lib2Name',
+            root: 'libs/lib2',
+            files: ['lib2.ts'],
+            fileMTimes: {
+              'lib2.ts': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.lib
+          }
+        ],
+        null,
+        file => {
+          switch (file) {
+            case 'app1.ts':
+              return `
+            export * from '@nrwl/lib1';
+            export { } from '@nrwl/lib2/deep';
+          `;
+            case 'lib1.ts':
+              return `import '@nrwl/lib2'`;
+            case 'lib2.ts':
+              return '';
+          }
+        }
+      );
+
+      expect(deps).toEqual({
+        app1Name: [
+          { projectName: 'lib1Name', type: DependencyType.es6Import },
+          { projectName: 'lib2Name', type: DependencyType.es6Import }
+        ],
+        lib1Name: [{ projectName: 'lib2Name', type: DependencyType.es6Import }],
+        lib2Name: []
+      });
+    });
+
     it('should calculate dependencies in .tsx files', () => {
       const deps = dependencies(
         'nrwl',

--- a/packages/schematics/src/utils/strip-source-code.spec.ts
+++ b/packages/schematics/src/utils/strip-source-code.spec.ts
@@ -1,0 +1,74 @@
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+import { stripSourceCode } from './strip-source-code';
+import { createScanner, ScriptTarget, Scanner } from 'typescript';
+
+describe('stripSourceCode', () => {
+  let scanner: Scanner;
+  beforeEach(() => {
+    scanner = createScanner(ScriptTarget.Latest, false);
+  });
+
+  it('should work on different types of imports', () => {
+    const input = `
+      import * as React from "react";
+      import { Component } from "react";
+      import {
+        Component
+      } from "react"
+      import {
+        Component
+      } from "react";
+      
+      import "./app.scss";
+
+      import('./module.ts')
+
+      const a = 1;
+      export class App {}
+    `;
+    const expected = `import * as React from "react"
+import { Component } from "react"
+import {
+        Component
+      } from "react"
+import {
+        Component
+      } from "react"
+import "./app.scss"`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should work on different types of exports', () => {
+    const input = `export * from './module';
+      export {
+        A
+      } from './a';
+
+      export { B } from './b';
+
+      export { C as D } from './c';
+
+      const a = 1;
+      export class App {}
+    `;
+    const expected = `export * from './module'
+export {
+        A
+      } from './a'
+export { B } from './b'
+export { C as D } from './c'`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should not strip files containing "loadChildren"', () => {
+    const input = `const routes = [
+      {
+        path: 'lazy',
+        loadChildren: '@nrwl/lazy'
+      }
+    ];`;
+    expect(stripSourceCode(scanner, input)).toEqual(input);
+  });
+});

--- a/packages/schematics/src/utils/strip-source-code.ts
+++ b/packages/schematics/src/utils/strip-source-code.ts
@@ -1,0 +1,65 @@
+import { Scanner, SyntaxKind } from 'typescript';
+
+export function stripSourceCode(scanner: Scanner, contents: string): string {
+  if (contents.indexOf('loadChildren') > -1) {
+    return contents;
+  }
+
+  scanner.setText(contents);
+  let token = scanner.scan();
+  const statements = [];
+  let start = null;
+  while (token !== SyntaxKind.EndOfFileToken) {
+    const potentialStart = scanner.getStartPos();
+    switch (token) {
+      case SyntaxKind.ImportKeyword: {
+        token = scanner.scan();
+        while (
+          token === SyntaxKind.WhitespaceTrivia ||
+          token === SyntaxKind.NewLineTrivia
+        ) {
+          token = scanner.scan();
+        }
+        if (token !== SyntaxKind.OpenParenToken) {
+          start = potentialStart;
+        }
+        break;
+      }
+
+      case SyntaxKind.ExportKeyword: {
+        token = scanner.scan();
+        while (
+          token === SyntaxKind.WhitespaceTrivia ||
+          token === SyntaxKind.NewLineTrivia
+        ) {
+          token = scanner.scan();
+        }
+        if (
+          token === SyntaxKind.OpenBraceToken ||
+          token === SyntaxKind.AsteriskToken
+        ) {
+          start = potentialStart;
+        }
+        break;
+      }
+
+      case SyntaxKind.StringLiteral: {
+        if (start !== null) {
+          token = scanner.scan();
+          const end = scanner.getStartPos();
+          statements.push(contents.substring(start, end));
+          start = null;
+        } else {
+          token = scanner.scan();
+        }
+        break;
+      }
+
+      default: {
+        token = scanner.scan();
+      }
+    }
+  }
+
+  return statements.join('\n');
+}


### PR DESCRIPTION
…s/exports

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Parsing a large file into an AST via Typescript might be relatively slow depending on the size of the file.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Instead of parsing the entire file into an AST, the file can be scanned first to strip it down to only the Import and Export statements which are then parsed into an AST.

## Issue
