### PR TITLE
fix(testing): warn on type checking errors

### DIFF
--- a/packages/builders/src/jest/jest.builder.spec.ts
+++ b/packages/builders/src/jest/jest.builder.spec.ts
@@ -45,6 +45,9 @@ describe('Jest Builder', () => {
         globals: JSON.stringify({
           'ts-jest': {
             tsConfig: '/root/tsconfig.test.json',
+            diagnostics: {
+              warnOnly: true
+            },
             stringifyContentPathRegex: '\\.html$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
@@ -82,6 +85,9 @@ describe('Jest Builder', () => {
         globals: JSON.stringify({
           'ts-jest': {
             tsConfig: '/root/tsconfig.test.json',
+            diagnostics: {
+              warnOnly: true
+            },
             stringifyContentPathRegex: '\\.html$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
@@ -130,6 +136,9 @@ describe('Jest Builder', () => {
         globals: JSON.stringify({
           'ts-jest': {
             tsConfig: '/root/tsconfig.test.json',
+            diagnostics: {
+              warnOnly: true
+            },
             stringifyContentPathRegex: '\\.html$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
@@ -176,6 +185,9 @@ describe('Jest Builder', () => {
         globals: JSON.stringify({
           'ts-jest': {
             tsConfig: '/root/tsconfig.test.json',
+            diagnostics: {
+              warnOnly: true
+            },
             stringifyContentPathRegex: '\\.html$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'

--- a/packages/builders/src/jest/jest.builder.ts
+++ b/packages/builders/src/jest/jest.builder.ts
@@ -52,7 +52,12 @@ export default class JestBuilder implements Builder<JestBuilderOptions> {
     );
 
     const tsJestConfig = {
-      tsConfig: path.resolve(this.context.workspace.root, options.tsConfig)
+      tsConfig: path.resolve(this.context.workspace.root, options.tsConfig),
+      // Typechecking wasn't done in Jest 23 but is done in 24. This makes errors a warning to amend the breaking change for now
+      // Remove for v8 to fail on type checking failure
+      diagnostics: {
+        warnOnly: true
+      }
     };
 
     // TODO: This is hacky, We should probably just configure it in the user's workspace


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Tests fail when type checking fails.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

In Jest 23, typechecking was not enabled which means tests which used to pass in Jest 23 failed with Jest 24. Now, instead of failing, warnings will be printed instead so there is no breaking change.

In the future, we should fail on typechecking errors.

## Issue
Fixes https://github.com/nrwl/nx/issues/1183