### PR TITLE
fix(nx): fix app generation for names which match builder properties

### DIFF
--- a/packages/schematics/src/utils/cli-config-utils.ts
+++ b/packages/schematics/src/utils/cli-config-utils.ts
@@ -60,7 +60,7 @@ export function replaceAppNameWithPath(
   } else if (Array.isArray(node)) {
     return node.map(j => replaceAppNameWithPath(j, appName, root));
   } else if (typeof node === 'object' && node) {
-    const forbiddenPropertyList: string[] = ['prefix']; // Some of the properties should not be renamed
+    const forbiddenPropertyList: string[] = ['prefix', 'builder']; // Some of the properties should not be renamed
     return Object.keys(node).reduce(
       (m, c) => (
         (m[c] = !forbiddenPropertyList.includes(c)


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Names like `de` or `devkit` mess up app generation :'(

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Names like `de` or `devkit` are fine because the `builder` property is ignored.

## Issue
Fixes #1165 