### PR TITLE
refactor(nx): Modifies log for NestJS apps to reflect global prefix

### DIFF
--- a/packages/schematics/src/collection/node-application/files/nestjs/main.ts__tmpl__
+++ b/packages/schematics/src/collection/node-application/files/nestjs/main.ts__tmpl__
@@ -9,10 +9,11 @@ import { AppModule } from './app/app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.setGlobalPrefix(`api`);
+  const globalPrefix = 'api';
+  app.setGlobalPrefix(globalPrefix);
   const port = process.env.port || 3333;
   await app.listen(port, () => {
-    console.log(`Listening at http://localhost:${port}`);
+    console.log(`Listening at http://localhost:${port}/${globalPrefix}`);
   });
 }
 


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Console.log when bootstrapping a NestJS app states

`Listening at http://localhost:${port}/`

which will throw the following error when hit:

`{"statusCode":404,"error":"Not Found","message":"Cannot GET /"}`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Console.log when bootstrapping a NestJS app will state 

`Listening at http://localhost:${port}/api`

to eliminate confusion.

## Issue

#1132 