### PR TITLE
feat(testing): add reporters cli param support for jest

### DIFF
--- a/packages/builders/src/jest/jest.builder.spec.ts
+++ b/packages/builders/src/jest/jest.builder.spec.ts
@@ -72,7 +72,8 @@ describe('Jest Builder', () => {
           silent: true,
           runInBand: true,
           maxWorkers: 2,
-          testNamePattern: 'test'
+          testNamePattern: 'test',
+          reporters: 'reporter'
         }
       })
       .toPromise();
@@ -100,7 +101,8 @@ describe('Jest Builder', () => {
         silent: true,
         runInBand: true,
         maxWorkers: 2,
-        testNamePattern: 'test'
+        testNamePattern: 'test',
+        reporters: ['reporter']
       },
       ['./jest.config.js']
     );

--- a/packages/builders/src/jest/jest.builder.ts
+++ b/packages/builders/src/jest/jest.builder.ts
@@ -31,6 +31,7 @@ export interface JestBuilderOptions {
   silent?: boolean;
   updateSnapshot?: boolean;
   testNamePattern?: string;
+  reporters?: string;
 }
 
 export default class JestBuilder implements Builder<JestBuilderOptions> {
@@ -84,6 +85,15 @@ export default class JestBuilder implements Builder<JestBuilderOptions> {
         '<rootDir>',
         path.relative(builderConfig.root, options.setupFile)
       );
+    }
+
+    if (options.reporters) {
+      try {
+        const reporters = JSON.parse(options.reporters);
+        config.reporters = reporters;
+      } catch (e) {
+        config.reporters = [options.reporters];
+      }
     }
 
     return from(runCLI(config, [options.jestConfig])).pipe(

--- a/packages/builders/src/jest/schema.json
+++ b/packages/builders/src/jest/schema.json
@@ -62,6 +62,10 @@
       "type": "string",
       "alias": "t",
       "description": "Run only tests with a name that matches the regex. (https://jestjs.io/docs/en/cli.html#testnamepattern-regex)"
+    },
+    "reporters": {
+      "type": "string|json",
+      "description": "Run tests with specified reporters. (https://jestjs.io/docs/en/cli#reporters)"
     }
   },
   "required": ["jestConfig", "tsConfig"]


### PR DESCRIPTION
Add the reporters cli option to the jest config. Support for either string or json.

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)
No support for jest `--reporters` cli option

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Added support for jest `--reporters` cli option, supporting both string and json

## Issue
