### PR TITLE
Revert "feat(node): set externalDependencies to none for production b…

### DIFF
--- a/packages/schematics/src/collection/node-application/index.ts
+++ b/packages/schematics/src/collection/node-application/index.ts
@@ -126,8 +126,7 @@ function getBuildConfig(project: any, options: NormalizedSchema) {
             replace: join(project.sourceRoot, 'environments/environment.ts'),
             with: join(project.sourceRoot, 'environments/environment.prod.ts')
           }
-        ],
-        externalDependencies: 'none'
+        ]
       }
     }
   };

--- a/packages/schematics/src/collection/node-application/node-application.spec.ts
+++ b/packages/schematics/src/collection/node-application/node-application.spec.ts
@@ -48,8 +48,7 @@ describe('node-app', () => {
                     with:
                       'apps/my-node-app/src/environments/environment.prod.ts'
                   }
-                ],
-                externalDependencies: 'none'
+                ]
               }
             }
           },


### PR DESCRIPTION
…uilds"

This reverts commit c2fc63d9c8103a1600b0867c05cf2335ca0934ac.

## Current Behavior (This is the behavior we have today, before the PR is merged)

NestJS Production builds have an issue resolving some lazy requires if using `ValidationPipe` or `CacheModule`. Or if NestJS 6 is used.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

NestJS Production builds should work. If you would like to bundle dependencies in your prod build, you can still do so with the `externalDependencies` option.

## Issue
Fixes #1174 
Fixes https://github.com/nestjs/nest/issues/1706