### PR TITLE
fix(schematics): normalize path in findTargetProject

### DIFF
--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -340,10 +340,10 @@ describe('Enforce Module Boundaries', () => {
             tags: [],
             implicitDependencies: [],
             architect: {},
-            files: [`libs/mylib/src/main.ts`, `libs/mylib/other/index.ts`],
+            files: [`libs/mylib/src/main.ts`, `libs/mylib/src/other/index.ts`],
             fileMTimes: {
               'libs/mylib/src/main.ts': 1,
-              'libs/mylib/other/index.ts': 1
+              'libs/mylib/src/other/index.ts': 1
             }
           }
         ]

--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -340,7 +340,7 @@ describe('Enforce Module Boundaries', () => {
             tags: [],
             implicitDependencies: [],
             architect: {},
-            files: [`libs/mylib/src/main.ts`, `libs/mylib/src/other/index.ts`],
+            files: [`libs/mylib/src/main.ts`, `libs/mylib/other/index.ts`],
             fileMTimes: {
               'libs/mylib/src/main.ts': 1,
               'libs/mylib/src/other/index.ts': 1
@@ -356,6 +356,43 @@ describe('Enforce Module Boundaries', () => {
         {},
         `${process.cwd()}/proj/libs/mylib/src/main.ts`,
         'import "../../other"',
+        [
+          {
+            name: 'mylibName',
+            root: 'libs/mylib',
+            type: ProjectType.lib,
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            files: [`libs/mylib/src/main.ts`],
+            fileMTimes: {
+              'libs/mylib/src/main.ts': 1
+            }
+          },
+          {
+            name: 'otherName',
+            root: 'libs/other',
+            type: ProjectType.lib,
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            files: ['libs/other/src/index.ts'],
+            fileMTimes: {
+              'libs/other/src/main.ts': 1
+            }
+          }
+        ]
+      );
+      expect(failures[0].getFailure()).toEqual(
+        'library imports must start with @mycompany/'
+      );
+    });
+
+    it('should error when relatively importing the src directory of another library', () => {
+      const failures = runRule(
+        {},
+        `${process.cwd()}/proj/libs/mylib/src/main.ts`,
+        'import "../../other/src"',
         [
           {
             name: 'mylibName',

--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -256,13 +256,11 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
   private isRelativeImportIntoAnotherProject(imp: string): boolean {
     if (!this.isRelative(imp)) return false;
 
-    const targetFile = path
+    const targetFile = normalizePath(path
       .resolve(
         path.join(this.projectPath, path.dirname(this.getSourceFilePath())),
         imp
-      )
-      .split(path.sep)
-      .join('/')
+      ))
       .substring(this.projectPath.length + 1);
 
     const sourceProject = this.findSourceProject();
@@ -283,7 +281,12 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
     let targetProject = this.findProjectUsingFile(targetFile);
     if (!targetProject) {
       targetProject = this.findProjectUsingFile(
-        path.join(targetFile, 'src', 'index')
+        normalizePath(path.join(targetFile, 'index'))
+      );
+    }
+    if (!targetProject) {
+      targetProject = this.findProjectUsingFile(
+        normalizePath(path.join(targetFile, 'src', 'index'))
       );
     }
     return targetProject;
@@ -339,4 +342,10 @@ function containsFile(
 
 function removeExt(file: string): string {
   return file.replace(/\.[^/.]+$/, '');
+}
+
+function normalizePath(osSpecificPath: string): string {
+  return osSpecificPath
+    .split(path.sep)
+    .join('/');
 }

--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -256,12 +256,12 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
   private isRelativeImportIntoAnotherProject(imp: string): boolean {
     if (!this.isRelative(imp)) return false;
 
-    const targetFile = normalizePath(path
-      .resolve(
+    const targetFile = normalizePath(
+      path.resolve(
         path.join(this.projectPath, path.dirname(this.getSourceFilePath())),
         imp
-      ))
-      .substring(this.projectPath.length + 1);
+      )
+    ).substring(this.projectPath.length + 1);
 
     const sourceProject = this.findSourceProject();
     const targetProject = this.findTargetProject(targetFile);
@@ -345,7 +345,5 @@ function removeExt(file: string): string {
 }
 
 function normalizePath(osSpecificPath: string): string {
-  return osSpecificPath
-    .split(path.sep)
-    .join('/');
+  return osSpecificPath.split(path.sep).join('/');
 }


### PR DESCRIPTION
findTargetProject returns OS-specific paths which may not match the paths in projectNode.files. To
fix this, the path needs to be normalized the same way as it is done in
isRelativeImportIntoAnotherProject. Also, per default when an import points to a directory, "index"
should be added as a potential import file candidate.

## Current Behavior (This is the behavior we have today, before the PR is merged)
VS Code sometimes auto-generates import paths like this:

`import { ProductsModule } from '../../../products/src';`

However, `nx-enforce-module-boundaries` does not mark this as an error, even though `products` in this example is another library.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
The linter should throw an error like this:

`library imports must start with @ngxp/ (nx-enforce-module-boundaries)`

## Issue
I found two issues:

1) `findTargetProject` creates a path that is OS-specific. On Windows this means that it contains `\` instead of `/`. That's why `findProjectUsingFile` returns no match, as the file paths in `projectNodes` contain UNIX-style paths.

2) The path generated by VS Code does already contain the `/src` part that was added in `findTargetProject`: `path.join(targetFile, 'src', 'index')`, so the generated path contained `src/src/`. I don't know why this change was made - in an older version of this method, the `src` was missing. I added another case where `index` is added without `src`, however maybe the `src` variant can be removed.