### PR TITLE
enhancement(nx): remove @types/yargs from @nrwl/schematics dependencies

### DIFF
--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -37,7 +37,6 @@
     "migrations": "./migrations/migrations.json"
   },
   "dependencies": {
-    "@types/yargs": "^11.0.0",
     "app-root-path": "^2.0.1",
     "cosmiconfig": "4.0.0",
     "fs-extra": "6.0.0",


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

`@types/yargs` is brought in as a dependency by @nrwl/schematics

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Unused dependencies are not brought in

## Issue
