### PR TITLE
test(schematics): revert changes to test of relatively importing the same library

### DIFF
--- a/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/schematics/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -343,7 +343,7 @@ describe('Enforce Module Boundaries', () => {
             files: [`libs/mylib/src/main.ts`, `libs/mylib/other/index.ts`],
             fileMTimes: {
               'libs/mylib/src/main.ts': 1,
-              'libs/mylib/src/other/index.ts': 1
+              'libs/mylib/other/index.ts': 1
             }
           }
         ]


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
see https://github.com/nrwl/nx/pull/1216#discussion_r272287374

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
revert to previous implementation

## Issue
#1216