### PR TITLE
fix(node): webpack devtool option

### DIFF
--- a/packages/builders/src/utils/webpack/config.spec.ts
+++ b/packages/builders/src/utils/webpack/config.spec.ts
@@ -208,13 +208,13 @@ describe('getBaseWebpackPartial', () => {
       expect(result.devtool).toEqual('source-map');
     });
 
-    it('should enable source-map devtool', () => {
+    it('should disable source-map devtool', () => {
       const result = getBaseWebpackPartial({
         ...input,
         sourceMap: false
       });
 
-      expect(result.devtool).toEqual('eval');
+      expect(result.devtool).toEqual(false);
     });
   });
 

--- a/packages/builders/src/utils/webpack/config.ts
+++ b/packages/builders/src/utils/webpack/config.ts
@@ -26,7 +26,7 @@ export function getBaseWebpackPartial(
     entry: {
       main: [options.main]
     },
-    devtool: options.sourceMap ? 'source-map' : 'eval',
+    devtool: options.sourceMap ? 'source-map' : false,
     mode: options.optimization ? 'production' : 'development',
     output: {
       path: options.outputPath,


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Source maps are inlined with `--source-map false` for node apps.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Source maps are not inlined or generated at all with `--source-map false` for node apps.

<img width="1275" alt="Screen Shot 2019-04-07 at 2 42 40 PM" src="https://user-images.githubusercontent.com/14145352/55689695-77df7d80-594d-11e9-9934-0ec9b4e60647.png">

## Issue

#1229 