### PR TITLE
docs(nx): fix typo on tutorial

### DIFF
--- a/docs/tutorial/07-share-code.md
+++ b/docs/tutorial/07-share-code.md
@@ -36,7 +36,7 @@ myorg/
 **Copy the interface into the library's index file.**
 
 ```typescript
-interface Todo {
+export interface Todo {
   title: string;
 }
 ```


### PR DESCRIPTION
Tutorial is abort because there is no export in Todo interface, fix it

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

## Issue

error because there was no export interface in Tutorial Chapter 7.
added export.

https://nx.dev/tutorial/07-share-code