### PR TITLE
fix(testing): fix jest on windows

### DIFF
--- a/packages/builders/src/jest/jest.builder.ts
+++ b/packages/builders/src/jest/jest.builder.ts
@@ -9,6 +9,7 @@ import { from, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import * as path from 'path';
+import { getSystemPath } from '@angular-devkit/core';
 
 try {
   require('dotenv').config();
@@ -47,12 +48,15 @@ export default class JestBuilder implements Builder<JestBuilderOptions> {
     const options = builderConfig.options;
 
     options.jestConfig = path.resolve(
-      this.context.workspace.root,
+      getSystemPath(this.context.workspace.root),
       options.jestConfig
     );
 
     const tsJestConfig = {
-      tsConfig: path.resolve(this.context.workspace.root, options.tsConfig),
+      tsConfig: path.resolve(
+        getSystemPath(this.context.workspace.root),
+        options.tsConfig
+      ),
       // Typechecking wasn't done in Jest 23 but is done in 24. This makes errors a warning to amend the breaking change for now
       // Remove for v8 to fail on type checking failure
       diagnostics: {


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

path to jestConfig could not be resolved on Windows

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

path to jestConfig can be resolved on Windows

## Issue

#1242 