### PR TITLE
feat(nx): support other package managers (including pnpm)

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -31,12 +31,23 @@ const nxTool = {
   name: 'Schematics',
   packageName: '@nrwl/workspace'
 };
-let useYarn = true;
 
+let packageManager: string;
 try {
-  execSync('yarn --version', { stdio: ['ignore', 'ignore', 'ignore'] });
+  packageManager = execSync('ng config -g cli.packageManager', {
+    stdio: ['ignore', 'pipe', 'ignore']
+  })
+    .toString()
+    .trim();
 } catch (e) {
-  useYarn = false;
+  packageManager = 'yarn';
+}
+try {
+  execSync(`${packageManager} --version`, {
+    stdio: ['ignore', 'ignore', 'ignore']
+  });
+} catch (e) {
+  packageManager = 'npm';
 }
 
 const projectName = parsedArgs._[2];
@@ -69,11 +80,10 @@ writeFileSync(
   })
 );
 
-if (useYarn) {
-  execSync('yarn install --silent', { cwd: tmpDir, stdio: [0, 1, 2] });
-} else {
-  execSync('npm install --silent', { cwd: tmpDir, stdio: [0, 1, 2] });
-}
+execSync(`${packageManager} install --silent`, {
+  cwd: tmpDir,
+  stdio: [0, 1, 2]
+});
 
 // creating the app itself
 const args = process.argv

--- a/packages/workspace/bin/create-nx-workspace.ts
+++ b/packages/workspace/bin/create-nx-workspace.ts
@@ -31,12 +31,23 @@ const nxTool = {
   name: 'Nx Workspace',
   packageName: '@nrwl/workspace'
 };
-let useYarn = true;
 
+let packageManager: string;
 try {
-  execSync('yarn --version', { stdio: ['ignore', 'ignore', 'ignore'] });
+  packageManager = execSync('ng config -g cli.packageManager', {
+    stdio: ['ignore', 'pipe', 'ignore']
+  })
+    .toString()
+    .trim();
 } catch (e) {
-  useYarn = false;
+  packageManager = 'yarn';
+}
+try {
+  execSync(`${packageManager} --version`, {
+    stdio: ['ignore', 'ignore', 'ignore']
+  });
+} catch (e) {
+  packageManager = 'npm';
 }
 
 const projectName = parsedArgs._[2];
@@ -69,11 +80,10 @@ writeFileSync(
   })
 );
 
-if (useYarn) {
-  execSync('yarn install --silent', { cwd: tmpDir, stdio: [0, 1, 2] });
-} else {
-  execSync('npm install --silent', { cwd: tmpDir, stdio: [0, 1, 2] });
-}
+execSync(`${packageManager} install --silent`, {
+  cwd: tmpDir,
+  stdio: [0, 1, 2]
+});
 
 // creating the app itself
 const args = process.argv


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

1. create-nx-workspace tries to use yarn and then falls back to npm.
2. workspace-schematic looks for yarn.lock and then falls back to npm.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

1. create-nx-workspace lets the user specify the package manager to use, ~~with a --packageManager option, like Angular CLI does.~~ by configuring it with `ng config -g cli.packageManager xxx` (in the global angular.json, located in the user directory). _Previously, Angular CLI supported a --packageManager flag, but that seems to have been removed._
2. workspace-schematic supports pnpm - looks for pnpm-lock.yaml and uses pnpm, _edit:_ if a package manager is not defined in the project's angular.json (`ng config cli.packageManager`).

## Issue

This should, at least partially, resolve #1191.

As a side note, running `pnpm install` and then `pnpm run build` in the workspace will fail both with and without the fix. But that's a problem with either the generated workspace's dependencies or those of a dependency, and can currently be worked around by running `pnpm install --save-dev  node-sass tslib`. I'll try to find out in which exact dependency the problem is and fix it there.

#### Use case

In a heavily locked down corporate environment (think antivirus + executable blocker + smartscreen + corp proxy...), where npm installs fail or even yarn installs last 30+ min due to AV and other security tool interference, and node_module deletes last forever, every speed boost helps. PNPM sym-links dependencies, skipping creation of thousands of files, making the install and linking processes much more pleasant, as well as deleting node_modules.