### PR TITLE
feat(builders): expose clearCache to Jest builder

### DIFF
--- a/docs/api-builders/jest.md
+++ b/docs/api-builders/jest.md
@@ -18,6 +18,12 @@ Type: `boolean`
 
 Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/en/cli#ci)
 
+### clearCache
+
+Type: `boolean`
+
+Deletes the Jest cache directory and then exits without running tests. Will delete Jest's default cache directory. _Note: clearing the cache will reduce performance_.
+
 ### codeCoverage
 
 Type: `boolean`

--- a/packages/builders/src/jest/jest.builder.ts
+++ b/packages/builders/src/jest/jest.builder.ts
@@ -25,6 +25,7 @@ export interface JestBuilderOptions {
   bail?: number | boolean;
   ci?: boolean;
   color?: boolean;
+  clearCache?: boolean;
   json?: boolean;
   maxWorkers?: number;
   onlyChanged?: boolean;
@@ -103,6 +104,10 @@ export default class JestBuilder implements Builder<JestBuilderOptions> {
 
     if (options.testFile) {
       config._ = [options.testFile];
+    }
+
+    if (options.clearCache) {
+      config.clearCache = true;
     }
 
     return from(runCLI(config, [options.jestConfig])).pipe(

--- a/packages/builders/src/jest/schema.json
+++ b/packages/builders/src/jest/schema.json
@@ -7,6 +7,10 @@
       "description": "Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)",
       "type": "boolean"
     },
+    "clearCache": {
+      "description": "Deletes the Jest cache directory and then exits without running tests. Will delete Jest's default cache directory. _Note: clearing the cache will reduce performance_.",
+      "type": "boolean"
+    },
     "jestConfig": {
       "description": "The path of the Jest configuration. (https://jestjs.io/docs/en/configuration)",
       "type": "string"


### PR DESCRIPTION
This exposes the `clearCache` option from Jest to Nx. You can now easily clear Jest's default cache directory without running your tests.
