### PR TITLE
fix(schematics): missing CSS import in web component app

### DIFF
--- a/packages/schematics/src/collection/application/application.spec.ts
+++ b/packages/schematics/src/collection/application/application.spec.ts
@@ -1,5 +1,3 @@
-import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import * as path from 'path';
 import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import {
   createEmptyWorkspace,
@@ -370,6 +368,14 @@ describe('app', () => {
         expect(
           tree.exists('apps/my-app/src/app/app.component.spec.ts')
         ).toBeFalsy();
+        expect(tree.exists('apps/my-app/src/app/app.element.ts')).toBeTruthy();
+        expect(
+          getFileContent(tree, 'apps/my-app/src/app/app.element.ts')
+        ).toContain("import './app.element.css';");
+        expect(
+          tree.exists('apps/my-app/src/app/app.element.spec.ts')
+        ).toBeTruthy();
+        expect(tree.exists('apps/my-app/src/app/app.element.css')).toBeTruthy();
       });
     });
 

--- a/packages/schematics/src/collection/application/files/web-components/src/app/app.element.ts__tmpl__
+++ b/packages/schematics/src/collection/application/files/web-components/src/app/app.element.ts__tmpl__
@@ -1,3 +1,5 @@
+import './app.element.<%= style %>';
+
 export class AppElement extends HTMLElement {
   public static observedAttributes = [
 


### PR DESCRIPTION
fix #1249

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)
CSS import is missing from generated web component

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
web component has import on CSS file

## Issue
#1249