### PR TITLE
fix(nx): remove tslint no-use-before-declare

### DIFF
--- a/packages/workspace/src/schematics/workspace/files/tslint.json
+++ b/packages/workspace/src/schematics/workspace/files/tslint.json
@@ -40,7 +40,6 @@
     "no-switch-case-fall-through": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "prefer-const": true,


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Tslint config has no-use-before-declare rule

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Tslint recommends against using this rule, especially in environments where you aren't using var 

> Since most modern TypeScript doesn’t use var, this rule is generally discouraged and is kept around for legacy purposes. It is slow to compute, is not enabled in the built-in configuration presets, and should not be used to inform TSLint design decisions.

https://palantir.github.io/tslint/rules/no-use-before-declare/
