### PR TITLE
 feat(nx): add migrations for v8

### DIFF
--- a/packages/schematics/migrations/migrations.json
+++ b/packages/schematics/migrations/migrations.json
@@ -69,6 +69,11 @@
       "version": "7.8.1",
       "description": "Update prettier",
       "factory": "./update-7-8-1/update-7-8-1"
+    },
+    "update-8.0.0": {
+      "version": "8.0.0",
+      "description": "V8 migrations",
+      "factory": "./update-8-0-0/update-8-0-0"
     }
   }
 }

--- a/packages/schematics/migrations/update-8-0-0/update-8-0-0.spec.ts
+++ b/packages/schematics/migrations/update-8-0-0/update-8-0-0.spec.ts
@@ -1,0 +1,353 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { updateJsonInTree, readJsonInTree } from '@nrwl/workspace';
+
+import * as path from 'path';
+
+describe('Update 8-0-0', () => {
+  let initialTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(async () => {
+    initialTree = Tree.empty();
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/schematics',
+      path.join(__dirname, '../migrations.json')
+    );
+    initialTree = await schematicRunner
+      .callRule(
+        updateJsonInTree('package.json', json => ({
+          scripts: {
+            update: 'ng update @nrwl/schematics'
+          },
+          dependencies: {
+            '@nrwl/nx': '7.8.1',
+            '@nestjs/core': '5.6.0',
+            express: '4.16.3',
+            react: '16.8.3',
+            '@angular/core': '^7.0.0'
+          },
+          devDependencies: {
+            '@nrwl/schematics': '7.8.1',
+            cypress: '3.1.0',
+            jest: '24.1.0'
+          }
+        })),
+        initialTree
+      )
+      .toPromise();
+    initialTree = await schematicRunner
+      .callRule(
+        updateJsonInTree('angular.json', json => ({
+          projects: {
+            'my-app': {
+              architect: {
+                cypress: {
+                  builder: '@nrwl/builders:cypress',
+                  options: {}
+                },
+                jest: {
+                  builder: '@nrwl/builders:jest',
+                  options: {}
+                },
+                nodeBuild: {
+                  builder: '@nrwl/builders:node-build',
+                  options: {}
+                },
+                nodeServe: {
+                  builder: '@nrwl/builders:node-execute',
+                  options: {}
+                },
+                webBuild: {
+                  builder: '@nrwl/builders:web-build',
+                  options: {}
+                },
+                webServe: {
+                  builder: '@nrwl/builders:web-dev-server',
+                  options: {}
+                },
+                runCommands: {
+                  builder: '@nrwl/builders:run-commands',
+                  options: {}
+                }
+              }
+            }
+          },
+          cli: {
+            defaultCollection: '@nrwl/schematics'
+          }
+        })),
+        initialTree
+      )
+      .toPromise();
+    initialTree = await schematicRunner
+      .callRule(
+        updateJsonInTree('tslint.json', json => ({
+          rulesDirectory: ['node_modules/@nrwl/schematics/src/tslint'],
+          rules: {}
+        })),
+        initialTree
+      )
+      .toPromise();
+  });
+
+  describe('imports', () => {
+    it(`should be migrated from '@nrwl/nx' to '@nrwl/angular'`, async () => {
+      initialTree.create(
+        'file.ts',
+        `
+        import * from '@nrwl/nx';
+        import * from '@nrwl/nx/testing';
+        import { NxModule } from '@nrwl/nx';
+        import { hot } from '@nrwl/nx/testing';
+      `
+      );
+
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+      expect(tree.readContent('file.ts')).toEqual(`
+        import * from '@nrwl/angular';
+        import * from '@nrwl/angular/testing';
+        import { NxModule } from '@nrwl/angular';
+        import { hot } from '@nrwl/angular/testing';
+      `);
+    });
+
+    it(`should be migrated from '@nrwl/schematics' to '@nrwl/workspace'`, async () => {
+      initialTree.create(
+        'file.ts',
+        `
+        import * from '@nrwl/schematics/src/utils/fileutils';
+        import { fileExists } from '@nrwl/schematics/src/utils/fileutils';
+      `
+      );
+
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+      expect(tree.readContent('file.ts')).toEqual(
+        `
+        import * from '@nrwl/workspace/src/utils/fileutils';
+        import { fileExists } from '@nrwl/workspace/src/utils/fileutils';
+      `
+      );
+    });
+  });
+
+  describe('builders', () => {
+    it('should be migrated', async () => {
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+      const { projects } = readJsonInTree(tree, 'angular.json');
+      const { architect } = projects['my-app'];
+      expect(architect.cypress.builder).toEqual('@nrwl/cypress:cypress');
+      expect(architect.jest.builder).toEqual('@nrwl/jest:jest');
+      expect(architect.nodeBuild.builder).toEqual('@nrwl/node:build');
+      expect(architect.nodeServe.builder).toEqual('@nrwl/node:execute');
+      expect(architect.webBuild.builder).toEqual('@nrwl/web:build');
+      expect(architect.webServe.builder).toEqual('@nrwl/web:dev-server');
+      expect(architect.runCommands.builder).toEqual(
+        '@nrwl/workspace:run-commands'
+      );
+    });
+  });
+
+  describe('update npm script', () => {
+    it('should do ng update @nrwl/workspace', async () => {
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+      const packageJson = readJsonInTree(tree, 'package.json');
+      expect(packageJson.scripts.update).toEqual('ng update @nrwl/workspace');
+    });
+  });
+
+  describe('jest config', () => {
+    it('should have the plugin path migrated', async () => {
+      initialTree.create(
+        'jest.config.js',
+        `
+        module.exports = {
+          resolver: '@nrwl/builders/plugins/jest/resolver',
+        };
+      `
+      );
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+      expect(tree.readContent('jest.config.js')).toContain(
+        '@nrwl/jest/plugins/resolver'
+      );
+    });
+  });
+
+  describe('dependencies', () => {
+    it('should change to the new dependencies', async () => {
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+
+      const { dependencies, devDependencies } = readJsonInTree(
+        tree,
+        'package.json'
+      );
+      expect(dependencies['@nrwl/nx']).not.toBeDefined();
+      expect(devDependencies['@nrwl/schematics']).not.toBeDefined();
+      expect(devDependencies['@nrwl/builders']).not.toBeDefined();
+      expect(dependencies['@nrwl/angular']).toBeDefined();
+      expect(devDependencies['@nrwl/express']).toBeDefined();
+      expect(devDependencies['@nrwl/cypress']).toBeDefined();
+      expect(devDependencies['@nrwl/jest']).toBeDefined();
+      expect(devDependencies['@nrwl/nest']).toBeDefined();
+      expect(devDependencies['@nrwl/node']).toBeDefined();
+      expect(devDependencies['@nrwl/react']).toBeDefined();
+      expect(devDependencies['@nrwl/web']).toBeDefined();
+      expect(devDependencies['@nrwl/workspace']).toBeDefined();
+    });
+  });
+
+  describe('lint rules', () => {
+    it('should be migrated to `@nrwl/workspace`', async () => {
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+
+      const { rulesDirectory } = readJsonInTree(tree, 'tslint.json');
+      expect(rulesDirectory).not.toContain(
+        'node_modules/@nrwl/schematics/src/tslint'
+      );
+      expect(rulesDirectory).toContain(
+        'node_modules/@nrwl/workspace/src/tslint'
+      );
+    });
+  });
+
+  describe('defaultCollection', () => {
+    it('should be set to @nrwl/angular if @angular/core is present', async () => {
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+
+      const defaultCollection = readJsonInTree(tree, 'angular.json').cli
+        .defaultCollection;
+      expect(defaultCollection).toEqual('@nrwl/angular');
+    });
+
+    it('should be set to @nrwl/react if react is present', async () => {
+      initialTree = await schematicRunner
+        .callRule(
+          updateJsonInTree('package.json', json => ({
+            ...json,
+            dependencies: {
+              '@nestjs/core': '5.6.0',
+              express: '4.16.3',
+              react: '16.8.3'
+            }
+          })),
+          initialTree
+        )
+        .toPromise();
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+
+      const defaultCollection = readJsonInTree(tree, 'angular.json').cli
+        .defaultCollection;
+      expect(defaultCollection).toEqual('@nrwl/react');
+    });
+
+    it('should be set to @nrwl/nest if @nestjs/core is present', async () => {
+      initialTree = await schematicRunner
+        .callRule(
+          updateJsonInTree('package.json', json => ({
+            ...json,
+            dependencies: {
+              '@nestjs/core': '5.6.0',
+              express: '4.16.3'
+            }
+          })),
+          initialTree
+        )
+        .toPromise();
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+
+      const defaultCollection = readJsonInTree(tree, 'angular.json').cli
+        .defaultCollection;
+      expect(defaultCollection).toEqual('@nrwl/nest');
+    });
+
+    it('should be set to @nrwl/express if express is present', async () => {
+      initialTree = await schematicRunner
+        .callRule(
+          updateJsonInTree('package.json', json => ({
+            ...json,
+            dependencies: {
+              express: '4.16.3'
+            }
+          })),
+          initialTree
+        )
+        .toPromise();
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+
+      const defaultCollection = readJsonInTree(tree, 'angular.json').cli
+        .defaultCollection;
+      expect(defaultCollection).toEqual('@nrwl/express');
+    });
+
+    it('should be set to @nrwl/express if express is present', async () => {
+      initialTree = await schematicRunner
+        .callRule(
+          updateJsonInTree('package.json', json => ({
+            ...json,
+            dependencies: {
+              express: '4.16.3'
+            }
+          })),
+          initialTree
+        )
+        .toPromise();
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+
+      const defaultCollection = readJsonInTree(tree, 'angular.json').cli
+        .defaultCollection;
+      expect(defaultCollection).toEqual('@nrwl/express');
+    });
+
+    it('should fallback to @nrwl/workspace', async () => {
+      initialTree = await schematicRunner
+        .callRule(
+          updateJsonInTree('package.json', json => ({
+            ...json,
+            dependencies: {}
+          })),
+          initialTree
+        )
+        .toPromise();
+      initialTree = await schematicRunner
+        .callRule(
+          updateJsonInTree('angular.json', json => ({
+            ...json,
+            projects: {}
+          })),
+          initialTree
+        )
+        .toPromise();
+      const tree = await schematicRunner
+        .runSchematicAsync('update-8.0.0', {}, initialTree)
+        .toPromise();
+
+      const defaultCollection = readJsonInTree(tree, 'angular.json').cli
+        .defaultCollection;
+      expect(defaultCollection).toEqual('@nrwl/workspace');
+    });
+  });
+});

--- a/packages/schematics/migrations/update-8-0-0/update-8-0-0.ts
+++ b/packages/schematics/migrations/update-8-0-0/update-8-0-0.ts
@@ -1,0 +1,274 @@
+import {
+  Rule,
+  chain,
+  SchematicContext,
+  Tree
+} from '@angular-devkit/schematics';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+import {
+  readJsonInTree,
+  addDepsToPackageJson,
+  updateJsonInTree,
+  insert,
+  formatFiles
+} from '@nrwl/workspace';
+import {
+  createSourceFile,
+  ScriptTarget,
+  isImportDeclaration,
+  isStringLiteral
+} from 'typescript';
+import { ReplaceChange } from '@schematics/angular/utility/change';
+import { getSourceNodes } from '@schematics/angular/utility/ast-utils';
+
+function addDependencies() {
+  return (host: Tree) => {
+    const dependencies = readJsonInTree(host, 'package.json').dependencies;
+    const builders = new Set<string>();
+    const projects = readJsonInTree(host, 'angular.json').projects;
+    Object.values<any>(projects).forEach(project => {
+      Object.values<any>(project.architect).forEach(target => {
+        const [builderDependency] = target.builder.split(':');
+        builders.add(builderDependency);
+      });
+    });
+    const newDependencies = {};
+    const newDevDependencies = {
+      '@nrwl/workspace': '8.0.0'
+    };
+    if (dependencies['@angular/core']) {
+      newDependencies['@nrwl/angular'] = '8.0.0';
+    }
+    if (dependencies['react']) {
+      newDevDependencies['@nrwl/react'] = '8.0.0';
+    }
+    if (dependencies['@nestjs/core']) {
+      newDevDependencies['@nrwl/nest'] = '8.0.0';
+    }
+    if (dependencies.express) {
+      newDevDependencies['@nrwl/express'] = '8.0.0';
+      newDevDependencies['@nrwl/node'] = '8.0.0';
+    }
+    if (builders.has('@nrwl/web')) {
+      newDevDependencies['@nrwl/web'] = '8.0.0';
+    }
+    if (builders.has('@nrwl/node')) {
+      newDevDependencies['@nrwl/node'] = '8.0.0';
+    }
+    if (builders.has('@nrwl/jest')) {
+      newDevDependencies['@nrwl/jest'] = '8.0.0';
+    }
+    if (builders.has('@nrwl/cypress')) {
+      newDevDependencies['@nrwl/cypress'] = '8.0.0';
+    }
+    return chain([addDepsToPackageJson(newDependencies, newDevDependencies)]);
+  };
+}
+
+const removeOldDependencies = updateJsonInTree('package.json', json => {
+  json.dependencies = json.dependencies || {};
+  json.devDependencies = json.devDependencies || {};
+  delete json.dependencies['@nrwl/nx'];
+  delete json.devDependencies['@nrwl/nx'];
+  delete json.dependencies['@nrwl/schematics'];
+  delete json.devDependencies['@nrwl/schematics'];
+  delete json.dependencies['@nrwl/builders'];
+  delete json.devDependencies['@nrwl/builders'];
+
+  return json;
+});
+
+const updateUpdateScript = updateJsonInTree('package.json', json => {
+  json.scripts = json.scripts || {};
+  json.scripts.update = 'ng update @nrwl/workspace';
+  return json;
+});
+
+const updateBuilders = updateJsonInTree('angular.json', json => {
+  Object.entries<any>(json.projects).forEach(([projectKey, project]) => {
+    Object.entries<any>(project.architect).forEach(([targetKey, target]) => {
+      if (target.builder === '@nrwl/builders:jest') {
+        json.projects[projectKey].architect[targetKey].builder =
+          '@nrwl/jest:jest';
+      }
+      if (target.builder === '@nrwl/builders:cypress') {
+        json.projects[projectKey].architect[targetKey].builder =
+          '@nrwl/cypress:cypress';
+      }
+      if (target.builder === '@nrwl/builders:web-build') {
+        json.projects[projectKey].architect[targetKey].builder =
+          '@nrwl/web:build';
+      }
+      if (target.builder === '@nrwl/builders:web-dev-server') {
+        json.projects[projectKey].architect[targetKey].builder =
+          '@nrwl/web:dev-server';
+      }
+      if (target.builder === '@nrwl/builders:node-build') {
+        json.projects[projectKey].architect[targetKey].builder =
+          '@nrwl/node:build';
+      }
+      if (target.builder === '@nrwl/builders:node-execute') {
+        json.projects[projectKey].architect[targetKey].builder =
+          '@nrwl/node:execute';
+      }
+      if (target.builder === '@nrwl/builders:run-commands') {
+        json.projects[projectKey].architect[targetKey].builder =
+          '@nrwl/workspace:run-commands';
+      }
+    });
+  });
+  return json;
+});
+
+const displayInformation = (host: Tree, context: SchematicContext) => {
+  context.logger.info(stripIndents`
+    Nx has been repackaged. We are installing and migrating your dependencies to the ones necessary.
+
+    If you have workspace schematics, we tried to migrate your imports from "@nrwl/schematics" to "@nrwl/workspace" but your externalSchematics may be broken.
+  `);
+};
+
+const updateNxModuleImports = (host: Tree) => {
+  host.visit(path => {
+    if (!path.endsWith('.ts')) {
+      return;
+    }
+
+    const sourceFile = createSourceFile(
+      path,
+      host.read(path).toString(),
+      ScriptTarget.Latest,
+      true
+    );
+    const changes = [];
+    sourceFile.statements.forEach(statement => {
+      if (
+        isImportDeclaration(statement) &&
+        isStringLiteral(statement.moduleSpecifier)
+      ) {
+        const nodeText = statement.moduleSpecifier.getText(sourceFile);
+        const modulePath = statement.moduleSpecifier
+          .getText(sourceFile)
+          .substr(1, nodeText.length - 2);
+        if (modulePath === '@nrwl/nx') {
+          changes.push(
+            new ReplaceChange(
+              path,
+              statement.moduleSpecifier.getStart(sourceFile),
+              nodeText,
+              `'@nrwl/angular'`
+            )
+          );
+        }
+
+        if (modulePath === '@nrwl/nx/testing') {
+          changes.push(
+            new ReplaceChange(
+              path,
+              statement.moduleSpecifier.getStart(sourceFile),
+              nodeText,
+              `'@nrwl/angular/testing'`
+            )
+          );
+        }
+
+        if (modulePath.startsWith('@nrwl/schematics')) {
+          changes.push(
+            new ReplaceChange(
+              path,
+              statement.moduleSpecifier.getStart(sourceFile),
+              nodeText,
+              nodeText.replace('@nrwl/schematics', '@nrwl/workspace')
+            )
+          );
+        }
+      }
+    });
+    insert(host, path, changes);
+  });
+};
+
+const updateJestPlugin = (host: Tree) => {
+  if (!host.exists('jest.config.js')) {
+    return host;
+  }
+
+  const sourceFile = createSourceFile(
+    'jest.config.js',
+    host.read('jest.config.js').toString(),
+    ScriptTarget.Latest,
+    true
+  );
+  const changes = [];
+
+  getSourceNodes(sourceFile).forEach(node => {
+    if (isStringLiteral(node)) {
+      const value = node
+        .getText(sourceFile)
+        .substr(1, node.getText(sourceFile).length - 2);
+      if (value === '@nrwl/builders/plugins/jest/resolver') {
+        changes.push(
+          new ReplaceChange(
+            'jest.config.js',
+            node.getStart(sourceFile),
+            node.getText(sourceFile),
+            `'@nrwl/jest/plugins/resolver'`
+          )
+        );
+      }
+    }
+  });
+  insert(host, 'jest.config.js', changes);
+};
+
+const updateTslintRules = updateJsonInTree('tslint.json', json => {
+  const { rulesDirectory } = json;
+  json.rulesDirectory = rulesDirectory.map(directory => {
+    return directory === 'node_modules/@nrwl/schematics/src/tslint'
+      ? 'node_modules/@nrwl/workspace/src/tslint'
+      : directory;
+  });
+  return json;
+});
+
+const updateDefaultCollection = (host: Tree) => {
+  const { dependencies, devDependencies } = readJsonInTree(
+    host,
+    'package.json'
+  );
+
+  return updateJsonInTree('angular.json', json => {
+    json.cli = json.cli || {};
+    if (dependencies['@nrwl/angular']) {
+      json.cli.defaultCollection = '@nrwl/angular';
+    } else if (devDependencies['@nrwl/react']) {
+      json.cli.defaultCollection = '@nrwl/react';
+    } else if (devDependencies['@nrwl/nest']) {
+      json.cli.defaultCollection = '@nrwl/nest';
+    } else if (devDependencies['@nrwl/express']) {
+      json.cli.defaultCollection = '@nrwl/express';
+    } else if (devDependencies['@nrwl/web']) {
+      json.cli.defaultCollection = '@nrwl/web';
+    } else if (devDependencies['@nrwl/node']) {
+      json.cli.defaultCollection = '@nrwl/node';
+    } else {
+      json.cli.defaultCollection = '@nrwl/workspace';
+    }
+    return json;
+  });
+};
+
+export default function(): Rule {
+  return chain([
+    displayInformation,
+    removeOldDependencies,
+    updateUpdateScript,
+    updateBuilders,
+    updateJestPlugin,
+    updateNxModuleImports,
+    updateTslintRules,
+    addDependencies(),
+    updateDefaultCollection,
+    formatFiles()
+  ]);
+}

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -34,6 +34,7 @@
     "migrations": "./migrations/migrations.json"
   },
   "dependencies": {
+    "@nrwl/workspace": "*",
     "app-root-path": "^2.0.1",
     "cosmiconfig": "4.0.0",
     "fs-extra": "6.0.0",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -29,7 +29,17 @@
   "builders": "./builders.json",
   "ng-update": {
     "requirements": {},
-    "migrations": "./migrations.json"
+    "migrations": "./migrations.json",
+    "packageGroup": [
+      "@nrwl/angular",
+      "@nrwl/cypress",
+      "@nrwl/express",
+      "@nrwl/jest",
+      "@nrwl/nest",
+      "@nrwl/node",
+      "@nrwl/react",
+      "@nrwl/web"
+    ]
   },
   "dependencies": {
     "@angular-devkit/core": "~7.3.1",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

No migrations exist for v8

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Migrations for the following exist for v8:
* Migrate builders
* Migrate dependencies
* Migrate `yarn update` script
* Migrate `@nrwl/nx` imports
* Migrate `@nrwl/schematics` imports
* Migrate Jest Resolver
* Migrate Tslint Rules
* Migrate defaultCollection

## Issue
#1256 