### PR TITLE
fix(frontend): remove dependency on @angular/compiler-cli

### DIFF
--- a/packages/web/src/utils/web.config.ts
+++ b/packages/web/src/utils/web.config.ts
@@ -1,10 +1,8 @@
 import * as mergeWebpack from 'webpack-merge';
 
-import {
-  getBrowserConfig,
-  getStylesConfig,
-  getCommonConfig
-} from '@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs';
+import { getBrowserConfig } from '@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/browser';
+import { getCommonConfig } from '@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/common';
+import { getStylesConfig } from '@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/styles';
 import { Configuration } from 'webpack';
 import { Logger } from '@angular-devkit/core/src/logger';
 import { resolve } from 'path';

--- a/packages/workspace/src/schematics/workspace/files/package.json__tmpl__
+++ b/packages/workspace/src/schematics/workspace/files/package.json__tmpl__
@@ -35,11 +35,8 @@
     "ts-node": "~7.0.0",
     "tslint": "~5.11.0",
     "typescript": "<%= typescriptVersion %>",
-    "prettier": "<%= prettierVersion %>" <% if(!nxCli) { %>
-    , "@angular/cli": "<%= angularCliVersion %>",
-     "@angular/core": "<%= angularVersion %>",
-    "@angular/compiler": "<%= angularVersion %>",
-    "@angular/compiler-cli": "<%= angularVersion %>"
-    <% } %>
+    "prettier": "<%= prettierVersion %>"<% if(!nxCli) { %>,
+    "@angular/cli": "<%= angularCliVersion %>",
+    "@angular/core": "<%= angularVersion %>"<% } %>
   }
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`@angular/compiler-cli` and `@angular/compiler` are added to `package.json` in a new workspace.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The only `@angular` import is `@angular/cli`

## Issue
