### PR TITLE
feat(nx): add ability to use interpolated arguments in affected (port)

### DIFF
--- a/e2e/schematics/affected.test.ts
+++ b/e2e/schematics/affected.test.ts
@@ -198,5 +198,10 @@ describe('Affected', () => {
       `npm run affected -- --target extract-i18n --files="libs/${mylib}/src/index.ts"`
     );
     expect(i18n).toContain(`Running extract-i18n for ${myapp}`);
+
+    const interpolatedTests = runCommand(
+      `npm run affected -- --target test --files="libs/${mylib}/src/index.ts" -- --jest-config {project.root}jest.config.js`
+    );
+    expect(interpolatedTests).toContain(`Running test for ${mylib}`);
   }, 1000000);
 });


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

You cannot pass things suchas config paths into affected because all the tasks will get the same value.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

You can interpolate project properties into arguments to tasks.

## Issue
