### PR TITLE
fix(nx): fix affected params interpolation

### DIFF
--- a/e2e/schematics/affected.test.ts
+++ b/e2e/schematics/affected.test.ts
@@ -200,8 +200,10 @@ describe('Affected', () => {
     expect(i18n).toContain(`Running extract-i18n for ${myapp}`);
 
     const interpolatedTests = runCommand(
-      `npm run affected -- --target test --files="libs/${mylib}/src/index.ts" -- --jest-config {project.root}jest.config.js`
+      `npm run affected -- --target test --files="libs/${mylib}/src/index.ts" -- --jest-config {project.root}/jest.config.js`
     );
-    expect(interpolatedTests).toContain(`Running test for ${mylib}`);
+    expect(interpolatedTests).toContain(
+      `Running test for affected projects succeeded.`
+    );
   }, 1000000);
 });

--- a/packages/schematics/src/command-line/affected.ts
+++ b/packages/schematics/src/command-line/affected.ts
@@ -264,7 +264,7 @@ function transformArgs(
 ) {
   return args.map(arg => {
     const regex = /{project\.([^}]+)}/g;
-    arg.replace(regex, (_, group: string) => {
+    return arg.replace(regex, (_, group: string) => {
       if (group.includes('.')) {
         throw new Error('Only top-level properties can be interpolated');
       }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Arguments are stripped from affected.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Arguments are properly interpolated

## Issue
