### PR TITLE
docs(nx): fixed typos

### DIFF
--- a/docs/fundamentals/build-full-stack-applications.md
+++ b/docs/fundamentals/build-full-stack-applications.md
@@ -117,7 +117,7 @@ You can run:
 - `ng build api` to build the application
 - `ng test api` to test the application
 
-By default, Nx will use Nest when generating node applications. Nest ia fantastic framework that shares many of its core concepts with Angular. It uses modules, providers, dependency injection, etc.. As a result, most Angular developers find Nest easy to use.
+By default, Nx will use Nest when generating node applications. Nest is a fantastic framework that shares many of its core concepts with Angular. It uses modules, providers, dependency injection, etc.. As a result, most Angular developers find Nest easy to use.
 
 The generated `apps/api/src/app/app.module.ts` will look like this:
 

--- a/packages/workspace/src/schematics/workspace/files/README.md
+++ b/packages/workspace/src/schematics/workspace/files/README.md
@@ -30,11 +30,11 @@ Run `ng build myapp` to build the project. The build artifacts will be stored in
 
 ## Running unit tests
 
-Run `ng test` to execute the unit tests via [Jest](https://karma-runner.github.io).
+Run `ng test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## Running end-to-end tests
 
-Run `ng e2e` to execute the end-to-end tests via [Cypress](http://www.protractortest.org/).
+Run `ng e2e` to execute the end-to-end tests via [Cypress](https://www.cypress.io).
 
 ## Further help
 


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
Two typos in markdown files, see linked issues.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
No typos at all ;)

## Issue
Should fix #1295 and fix #1296 