### PR TITLE
fix(workspace): consider ExportDeclaration w/ moduleSpecifier for dependency calculation

### DIFF
--- a/packages/workspace/src/command-line/deps-calculator.spec.ts
+++ b/packages/workspace/src/command-line/deps-calculator.spec.ts
@@ -1133,5 +1133,78 @@ describe('Calculates Dependencies Between Apps and Libs', () => {
 
       expect(deps).toEqual({ aaName: [] });
     });
+
+    it(`should handle an ExportDeclaration w/ moduleSpecifier and w/o moduleSpecifier`, () => {
+      const deps = dependencies(
+        'nrwl',
+        [
+          {
+            name: 'lib1Name',
+            root: 'libs/lib1',
+            files: ['lib1.ts'],
+            fileMTimes: {
+              'lib1.ts': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.lib
+          },
+          {
+            name: 'lib2Name',
+            root: 'libs/lib2',
+            files: ['lib2.ts'],
+            fileMTimes: {
+              'lib2.ts': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.lib
+          },
+          {
+            name: 'lib3Name',
+            root: 'libs/lib3',
+            files: ['lib3.ts'],
+            fileMTimes: {
+              'lib3.ts': 1
+            },
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            type: ProjectType.lib
+          }
+        ],
+        null,
+        file => {
+          switch (file) {
+            case 'lib1.ts':
+              return `
+            const FOO = 23;
+            export { FOO };
+          `;
+            case 'lib2.ts':
+              return `
+            export const BAR = 24;
+          `;
+            case 'lib3.ts':
+              return `
+              import { FOO } from '@nrwl/lib1';
+              export { FOO };
+              export { BAR } from '@nrwl/lib2';
+            `;
+          }
+        }
+      );
+
+      expect(deps).toEqual({
+        lib1Name: [],
+        lib2Name: [],
+        lib3Name: [
+          { projectName: 'lib1Name', type: DependencyType.es6Import },
+          { projectName: 'lib2Name', type: DependencyType.es6Import }
+        ]
+      });
+    });
   });
 });

--- a/packages/workspace/src/command-line/deps-calculator.ts
+++ b/packages/workspace/src/command-line/deps-calculator.ts
@@ -266,7 +266,10 @@ export class DepsCalculator {
   }
 
   private processNode(filePath: string, node: ts.Node): void {
-    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+    if (
+      ts.isImportDeclaration(node) ||
+      (ts.isExportDeclaration(node) && node.moduleSpecifier)
+    ) {
       const imp = this.getStringLiteralValue(node.moduleSpecifier);
       this.addDepIfNeeded(imp, filePath, DependencyType.es6Import);
       return; // stop traversing downwards


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

```bash
$ node_modules/.bin/nx affected:test <..>
Cannot read property 'getText' of undefined
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Success run for affected command and dependency calculation

## Issue

Closes #1303 in Nx 8

