### PR TITLE
fix(workspace): print additional error info with `--verbose` flag in affected command

### DIFF
--- a/docs/api-npmscripts/affected.md
+++ b/docs/api-npmscripts/affected.md
@@ -64,6 +64,10 @@ Uncommitted changes
 
 Untracked changes
 
+### verbose
+
+Print additional error stack trace on failure
+
 ### version
 
 Show version number

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -39,6 +39,7 @@ export interface AffectedOptions extends GlobalNxArgs {
   onlyFailed?: boolean;
   'only-failed'?: boolean;
   'max-parallel'?: boolean;
+  verbose?: boolean;
 }
 
 // Commands that can do `ng [command]`
@@ -110,7 +111,7 @@ export function affected(parsedArgs: YargsAffectedOptions): void {
         break;
     }
   } catch (e) {
-    printError(e);
+    printError(e, parsedArgs.verbose);
     process.exit(1);
   }
 }
@@ -132,8 +133,12 @@ function getProjects(
     );
 }
 
-function printError(e: any) {
-  console.error(e.message);
+function printError(e: any, verbose?: boolean) {
+  if (verbose && e.stack) {
+    console.error(e.stack);
+  } else {
+    console.error(e.message);
+  }
 }
 
 async function runCommand(
@@ -333,7 +338,8 @@ const dummyOptions: AffectedOptions = {
   base: 'base',
   head: 'head',
   exclude: ['exclude'],
-  files: ['']
+  files: [''],
+  verbose: false
 };
 
 const nxSpecificFlags = Object.keys(dummyOptions);

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -201,6 +201,9 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
       type: 'boolean',
       default: false
     })
+    .option('verbose', {
+      describe: 'Print additional error stack trace on failure'
+    })
     .conflicts({
       files: ['uncommitted', 'untracked', 'base', 'head', 'all'],
       untracked: ['uncommitted', 'files', 'base', 'head', 'all'],


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

```bash
$ node_modules/.bin/affected:test
Cannot read property 'getText' of undefined
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

```bash
$ node_modules/.bin/affected:test --verbose

TypeError: Cannot read property 'getText' of undefined
    at DepsCalculator.getStringLiteralValue (<workspace>/@nrwl/schematics/src/command-line/deps-calculator.js:253:21)
    at DepsCalculator.processNode (<workspace>/node_modules/@nrwl/schematics/src/command-line/deps-calculator.js:203:28)
    at <workspace>/node_modules/@nrwl/schematics/src/command-line/deps-calculator.js:221:63
    at visitNodes (<workspace>/node_modules/typescript/lib/typescript.js:16144:30)
    at Object.forEachChild (<workspace>/node_modules/typescript/lib/typescript.js:16372:24)
    at DepsCalculator.processNode (<workspace>/node_modules/@nrwl/schematics/src/command-line/deps-calculator.js:221:12)
    at DepsCalculator.processFile (<workspace>/node_modules/@nrwl/schematics/src/command-line/deps-calculator.js:153:18)
    at <workspace>/node_modules/@nrwl/schematics/src/command-line/deps-calculator.js:68:24
    at Array.forEach (<anonymous>)
    at <workspace>/node_modules/@nrwl/schematics/src/command-line/deps-calculator.js:67:14
```


## Issue
