### PR TITLE
fix(schematics): topologically sort projects for `affected:build --all` in v7

### DIFF
--- a/packages/schematics/src/command-line/affected.ts
+++ b/packages/schematics/src/command-line/affected.ts
@@ -13,7 +13,7 @@ import {
   getAllLibNames,
   getProjectNames,
   parseFiles,
-  getAllProjectNamesWithTarget,
+  getAllProjectsWithTarget,
   getAffectedProjectsWithTarget,
   readAngularJson
 } from './shared';
@@ -122,7 +122,7 @@ function getProjects(
   all: boolean
 ) {
   const projects = all
-    ? getAllProjectNamesWithTarget(target)
+    ? getAllProjectsWithTarget(target)
     : getAffectedProjectsWithTarget(target)(parseFiles(parsedArgs).files);
 
   return projects

--- a/packages/schematics/src/command-line/shared.ts
+++ b/packages/schematics/src/command-line/shared.ts
@@ -349,6 +349,16 @@ export function getAllProjectNamesWithTarget(target: string) {
   return getProjectNames(p => p.architect[target]);
 }
 
+export function getAllProjectsWithTarget(target: string) {
+  const angularJson = readAngularJson();
+  const nxJson = readNxJson();
+  const projects = getProjectNodes(angularJson, nxJson);
+  const dependencies = readDependencies(nxJson.npmScope, projects);
+  const sortedProjects = topologicallySortProjects(projects, dependencies);
+
+  return sortedProjects.filter(p => p.architect[target]).map(p => p.name);
+}
+
 export function getProjectNames(
   predicate?: (projectNode: ProjectNode) => boolean
 ): string[] {


### PR DESCRIPTION
## Current Behavior


`affected --build --head` topologically sorts projects while `affected --all` does not.

Notice the dependency from foobar on shared in the following example:

```
$ ./node_modules/.bin/nx affected:build --base=$(git rev-parse HEAD~1) --head=$(git rev-parse HEAD)
Running build for projects:
  shared,
  foobar
Running build for shared
Running build for foobar

$ ./node_modules/.bin/nx affected:build --all
Running build for projects:
  shared,
  foobar
Running build for foobar
Running build for shared
```

## Expected Behavior


```
$ ./node_modules/.bin/nx affected:build --base=$(git rev-parse HEAD~1) --head=$(git rev-parse HEAD)
Running build for projects:
  shared,
  foobar
Running build for shared
Running build for foobar

$ ./node_modules/.bin/nx affected:build --all
Running build for projects:
  shared,
  foobar
Running build for shared
Running build for foobar
```


## Issue

Closes #1302

Aligns behaviour of `affected --base=[SHA] --head=[SHA]` and `affected --all`
