### PR TITLE
Add support for nest6

### DIFF
--- a/packages/nest/src/schematics/ng-add/ng-add.ts
+++ b/packages/nest/src/schematics/ng-add/ng-add.ts
@@ -1,25 +1,30 @@
-import { Rule, chain } from '@angular-devkit/schematics';
+import { chain, Rule } from '@angular-devkit/schematics';
 import {
-  addPackageWithNgAdd,
   addDepsToPackageJson,
+  addPackageWithNgAdd,
   updateJsonInTree
 } from '@nrwl/workspace';
 import {
+  expressTypingsVersion,
   nestJsSchematicsVersion,
   nestJsVersion,
-  nxVersion
+  nxVersion,
+  reflectMetadataVersion
 } from '../../utils/versions';
 
 export function addDependencies(): Rule {
   return addDepsToPackageJson(
     {
       '@nestjs/common': nestJsVersion,
-      '@nestjs/core': nestJsVersion
+      '@nestjs/core': nestJsVersion,
+      '@nestjs/platform-express': nestJsVersion,
+      'reflect-metadata': reflectMetadataVersion
     },
     {
       '@nestjs/schematics': nestJsSchematicsVersion,
       '@nestjs/testing': nestJsVersion,
-      '@nrwl/nest': nxVersion
+      '@nrwl/nest': nxVersion,
+      '@types/express': expressTypingsVersion
     }
   );
 }

--- a/packages/nest/src/utils/versions.ts
+++ b/packages/nest/src/utils/versions.ts
@@ -1,4 +1,7 @@
 export const nxVersion = '*';
 
-export const nestJsVersion = '5.5.0';
-export const nestJsSchematicsVersion = '5.11.2';
+export const nestJsVersion = '^6.1.0';
+export const nestJsSchematicsVersion = '^6.2.0';
+
+export const expressTypingsVersion = '4.16.0';
+export const reflectMetadataVersion = '^0.1.12';


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Nest applications are using Nest 5.5

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Nest applications should use Nest 6.1

## Issue

#1321 

## Other:

test e2e are still missing for nestjs app