### PR TITLE
feat(frontend): change lazy routes to use dynamic imports

### DIFF
--- a/packages/angular/src/schematics/library/library.spec.ts
+++ b/packages/angular/src/schematics/library/library.spec.ts
@@ -483,7 +483,8 @@ describe('lib', () => {
         expect(moduleContents).toContain(`
       {
         path: 'my-dir-my-lib',
-        loadChildren: '@proj/my-dir/my-lib#MyDirMyLibModule'
+        loadChildren: () =>
+          import('@proj/my-dir/my-lib').then(module => module.MyDirMyLibModule)
       }`);
 
         const tsConfigAppJson = JSON.parse(
@@ -516,12 +517,16 @@ describe('lib', () => {
         expect(moduleContents2).toContain(`
       {
         path: 'my-dir-my-lib',
-        loadChildren: '@proj/my-dir/my-lib#MyDirMyLibModule'
+        loadChildren: () =>
+          import('@proj/my-dir/my-lib').then(module => module.MyDirMyLibModule)
       }`);
         expect(moduleContents2).toContain(`
       {
         path: 'my-dir-my-lib2',
-        loadChildren: '@proj/my-dir/my-lib2#MyDirMyLib2Module'
+        loadChildren: () =>
+          import('@proj/my-dir/my-lib2').then(
+            module => module.MyDirMyLib2Module
+          )
       }`);
 
         const tsConfigAppJson2 = JSON.parse(
@@ -556,16 +561,23 @@ describe('lib', () => {
         expect(moduleContents3).toContain(`
       {
         path: 'my-dir-my-lib',
-        loadChildren: '@proj/my-dir/my-lib#MyDirMyLibModule'
+        loadChildren: () =>
+          import('@proj/my-dir/my-lib').then(module => module.MyDirMyLibModule)
       }`);
         expect(moduleContents3).toContain(`
       {
         path: 'my-dir-my-lib2',
-        loadChildren: '@proj/my-dir/my-lib2#MyDirMyLib2Module'
+        loadChildren: () =>
+          import('@proj/my-dir/my-lib2').then(
+            module => module.MyDirMyLib2Module
+          )
       }`);
-        expect(moduleContents3).toContain(
-          `{ path: 'my-lib3', loadChildren: '@proj/my-dir/my-lib3#MyLib3Module' }`
-        );
+        expect(moduleContents3).toContain(`
+      {
+        path: 'my-lib3',
+        loadChildren: () =>
+          import('@proj/my-dir/my-lib3').then(module => module.MyLib3Module)
+      }`);
 
         const tsConfigAppJson3 = JSON.parse(
           stripJsonComments(

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -125,17 +125,15 @@ function addLoadChildren(options: NormalizedSchema): Rule {
       true
     );
 
-    const loadChildren = `@${npmScope}/${options.projectDirectory}#${
-      options.moduleName
-    }`;
-
     insert(host, options.parentModule, [
       ...addRoute(
         options.parentModule,
         sourceFile,
         `{path: '${toFileName(
           options.fileName
-        )}', loadChildren: '${loadChildren}'}`
+        )}', loadChildren: () => import('@${npmScope}/${
+          options.projectDirectory
+        }').then(module => module.${options.moduleName})}`
       )
     ]);
 

--- a/packages/workspace/src/command-line/deps-calculator.ts
+++ b/packages/workspace/src/command-line/deps-calculator.ts
@@ -275,6 +275,17 @@ export class DepsCalculator {
       return; // stop traversing downwards
     }
 
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      const imp = this.getStringLiteralValue(node.arguments[0]);
+      this.addDepIfNeeded(imp, filePath, DependencyType.loadChildren);
+      return;
+    }
+
     if (node.kind === ts.SyntaxKind.PropertyAssignment) {
       const name = this.getPropertyAssignmentName(
         (node as ts.PropertyAssignment).name

--- a/packages/workspace/src/utils/strip-source-code.spec.ts
+++ b/packages/workspace/src/utils/strip-source-code.spec.ts
@@ -34,7 +34,8 @@ import {
 import {
         Component
       } from "react"
-import "./app.scss"`;
+import "./app.scss"
+import('./module.ts')`;
 
     expect(stripSourceCode(scanner, input)).toEqual(expected);
   });

--- a/packages/workspace/src/utils/strip-source-code.ts
+++ b/packages/workspace/src/utils/strip-source-code.ts
@@ -20,9 +20,7 @@ export function stripSourceCode(scanner: Scanner, contents: string): string {
         ) {
           token = scanner.scan();
         }
-        if (token !== SyntaxKind.OpenParenToken) {
-          start = potentialStart;
-        }
+        start = potentialStart;
         break;
       }
 
@@ -46,6 +44,9 @@ export function stripSourceCode(scanner: Scanner, contents: string): string {
       case SyntaxKind.StringLiteral: {
         if (start !== null) {
           token = scanner.scan();
+          if (token === SyntaxKind.CloseParenToken) {
+            token = scanner.scan();
+          }
           const end = scanner.getStartPos();
           statements.push(contents.substring(start, end));
           start = null;


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Lazy routes use LoadChildren strings which is deprecated.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Lazy routes use LoadChildrenCallbacks via Dynamic Imports. Also, `affected` supports Dynamic Imports.

## Issue
