### PR TITLE
feat(nx): add in env option for Cypress Builder

### DIFF
--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -28,6 +28,7 @@ export interface CypressBuilderOptions extends JsonObject {
   tsConfig: string;
   watch: boolean;
   browser?: string;
+  env?: Record<string, string>;
 }
 
 try {
@@ -78,7 +79,8 @@ function run(
         options.parallel,
         options.watch,
         baseUrl,
-        options.browser
+        options.browser,
+        options.env
       )
     ),
     options.watch ? tap(noop) : take(1),
@@ -184,7 +186,8 @@ function initCypress(
   parallel: boolean,
   isWatching: boolean,
   baseUrl: string,
-  browser?: string
+  browser?: string,
+  env?: Record<string, string>
 ): Observable<BuilderOutput> {
   // Cypress expects the folder where a `cypress.json` is present
   const projectFolderPath = path.dirname(cypressConfig);
@@ -199,6 +202,10 @@ function initCypress(
 
   if (browser) {
     options.browser = browser;
+  }
+
+  if (env) {
+    options.env = env;
   }
 
   options.exit = exit;

--- a/packages/cypress/src/builders/cypress/schema.json
+++ b/packages/cypress/src/builders/cypress/schema.json
@@ -52,6 +52,10 @@
       "type": "string",
       "description": "The browser to run tests in.",
       "enum": ["electron", "chrome", "chromium", "canary"]
+    },
+    "env": {
+      "type": "object",
+      "description": "A key-value Pair of environment variables to pass to Cypress runner"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Add in env property to cypress builder that can be set from the angular.json in the options section

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior 
Cypress API accepts an env option but Cypress Builder does not accept a way to pass those values from the angular.json to the Cypress API

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
angular.json cypress builder accepts an env object that gets passed to the Cypress Builder and is then passed to the Cypress API

## Issue
