### PR TITLE
feat(frontend): add differential loading for web apps

### DIFF
--- a/e2e/schematics/react.test.ts
+++ b/e2e/schematics/react.test.ts
@@ -34,18 +34,26 @@ describe('React Applications', () => {
     runCLI(`build ${appName}`);
     checkFilesExist(
       `dist/apps/${appName}/index.html`,
-      `dist/apps/${appName}/polyfills.js`,
-      `dist/apps/${appName}/runtime.js`,
-      `dist/apps/${appName}/vendor.js`,
-      `dist/apps/${appName}/main.js`,
-      `dist/apps/${appName}/styles.js`
+      `dist/apps/${appName}/polyfills-es2015.js`,
+      `dist/apps/${appName}/runtime-es2015.js`,
+      `dist/apps/${appName}/vendor-es2015.js`,
+      `dist/apps/${appName}/main-es2015.js`,
+      `dist/apps/${appName}/styles-es2015.js`,
+      `dist/apps/${appName}/polyfills-es5.js`,
+      `dist/apps/${appName}/runtime-es5.js`,
+      `dist/apps/${appName}/vendor-es5.js`,
+      `dist/apps/${appName}/main-es5.js`,
+      `dist/apps/${appName}/styles-es5.js`
     );
     runCLI(`build ${appName} --prod --output-hashing none`);
     checkFilesExist(
       `dist/apps/${appName}/index.html`,
-      `dist/apps/${appName}/polyfills.js`,
-      `dist/apps/${appName}/runtime.js`,
-      `dist/apps/${appName}/main.js`,
+      `dist/apps/${appName}/polyfills-es2015.js`,
+      `dist/apps/${appName}/runtime-es2015.js`,
+      `dist/apps/${appName}/main-es2015.js`,
+      `dist/apps/${appName}/polyfills-es5.js`,
+      `dist/apps/${appName}/runtime-es5.js`,
+      `dist/apps/${appName}/main-es5.js`,
       `dist/apps/${appName}/styles.css`
     );
     const testResults = await runCLIAsync(`test ${appName}`);
@@ -98,18 +106,26 @@ describe('React Applications', () => {
     runCLI(`build ${appName}`);
     checkFilesExist(
       `dist/apps/${appName}/index.html`,
-      `dist/apps/${appName}/polyfills.js`,
-      `dist/apps/${appName}/runtime.js`,
-      `dist/apps/${appName}/vendor.js`,
-      `dist/apps/${appName}/main.js`,
-      `dist/apps/${appName}/styles.js`
+      `dist/apps/${appName}/polyfills-es2015.js`,
+      `dist/apps/${appName}/runtime-es2015.js`,
+      `dist/apps/${appName}/vendor-es2015.js`,
+      `dist/apps/${appName}/main-es2015.js`,
+      `dist/apps/${appName}/styles-es2015.js`,
+      `dist/apps/${appName}/polyfills-es5.js`,
+      `dist/apps/${appName}/runtime-es5.js`,
+      `dist/apps/${appName}/vendor-es5.js`,
+      `dist/apps/${appName}/main-es5.js`,
+      `dist/apps/${appName}/styles-es5.js`
     );
     runCLI(`build ${appName} --prod --output-hashing none`);
     checkFilesExist(
       `dist/apps/${appName}/index.html`,
-      `dist/apps/${appName}/polyfills.js`,
-      `dist/apps/${appName}/runtime.js`,
-      `dist/apps/${appName}/main.js`,
+      `dist/apps/${appName}/polyfills-es2015.js`,
+      `dist/apps/${appName}/runtime-es2015.js`,
+      `dist/apps/${appName}/main-es2015.js`,
+      `dist/apps/${appName}/polyfills-es5.js`,
+      `dist/apps/${appName}/runtime-es5.js`,
+      `dist/apps/${appName}/main-es5.js`,
       `dist/apps/${appName}/styles.css`
     );
     const testResults = await runCLIAsync(`test ${appName}`);

--- a/e2e/schematics/web.test.ts
+++ b/e2e/schematics/web.test.ts
@@ -19,17 +19,24 @@ describe('Web Components Applications', () => {
     runCLI(`build ${appName}`);
     checkFilesExist(
       `dist/apps/${appName}/index.html`,
-      `dist/apps/${appName}/polyfills.js`,
-      `dist/apps/${appName}/runtime.js`,
-      `dist/apps/${appName}/main.js`,
-      `dist/apps/${appName}/styles.js`
+      `dist/apps/${appName}/polyfills-es2015.js`,
+      `dist/apps/${appName}/runtime-es2015.js`,
+      `dist/apps/${appName}/main-es2015.js`,
+      `dist/apps/${appName}/styles-es2015.js`,
+      `dist/apps/${appName}/polyfills-es5.js`,
+      `dist/apps/${appName}/runtime-es5.js`,
+      `dist/apps/${appName}/main-es5.js`,
+      `dist/apps/${appName}/styles-es5.js`
     );
     runCLI(`build ${appName} --prod --output-hashing none`);
     checkFilesExist(
       `dist/apps/${appName}/index.html`,
-      `dist/apps/${appName}/polyfills.js`,
-      `dist/apps/${appName}/runtime.js`,
-      `dist/apps/${appName}/main.js`,
+      `dist/apps/${appName}/polyfills-es2015.js`,
+      `dist/apps/${appName}/runtime-es2015.js`,
+      `dist/apps/${appName}/main-es2015.js`,
+      `dist/apps/${appName}/polyfills-es5.js`,
+      `dist/apps/${appName}/runtime-es5.js`,
+      `dist/apps/${appName}/main-es5.js`,
       `dist/apps/${appName}/styles.css`
     );
     const testResults = await runCLIAsync(`test ${appName}`);

--- a/package.json
+++ b/package.json
@@ -135,9 +135,7 @@
     ],
     "testPathIgnorePatterns": [
       "node_modules",
-      "<rootDir>/build/packages/angular/spec",
-      "web.*normalize\\.spec\\.js",
-      "web.*config\\.spec\\.js"
+      "<rootDir>/build/packages/angular/spec"
     ],
     "collectCoverage": true,
     "coverageReporters": [

--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -2,7 +2,6 @@ import * as webpack from 'webpack';
 import { Configuration, ProgressPlugin } from 'webpack';
 
 import * as ts from 'typescript';
-import { resolve } from 'path';
 
 import { LicenseWebpackPlugin } from 'license-webpack-plugin';
 import CircularDependencyPlugin = require('circular-dependency-plugin');

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,6 +45,7 @@
     "license-webpack-plugin": "^1.4.0",
     "source-map-support": "0.5.11",
     "ts-loader": "5.3.1",
+    "tsconfig-paths-webpack-plugin": "3.2.0",
     "webpack": "4.29.0",
     "webpack-dev-server": "3.1.14",
     "webpack-node-externals": "1.7.2"

--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -1,17 +1,29 @@
 import { BuilderContext, createBuilder } from '@angular-devkit/architect';
-import { JsonObject } from '@angular-devkit/core';
+import {
+  JsonObject,
+  normalize,
+  join as devkitJoin
+} from '@angular-devkit/core';
 import { runWebpack, BuildResult } from '@angular-devkit/build-webpack';
 
-import { Observable, from } from 'rxjs';
-import { writeFileSync } from 'fs';
-import { resolve } from 'path';
+import { Observable, from, of, forkJoin } from 'rxjs';
 import { normalizeWebBuildOptions } from '../../utils/normalize';
 import { getWebConfig } from '../../utils/web.config';
 import { BuildBuilderOptions } from '../../utils/types';
-import { concatMap, map } from 'rxjs/operators';
+import {
+  bufferCount,
+  concatMap,
+  map,
+  mergeScan,
+  switchMap
+} from 'rxjs/operators';
 import { getSourceRoot } from '../../utils/source-root';
+import { ScriptTarget } from 'typescript';
+import { writeIndexHtml } from '@angular-devkit/build-angular/src/angular-cli-files/utilities/index-file/write-index-html';
+import { NodeJsSyncHost } from '@angular-devkit/core/node';
 
 export interface WebBuildBuilderOptions extends BuildBuilderOptions {
+  differentialLoading: boolean;
   index: string;
   budgets: any[];
   baseHref: string;
@@ -36,40 +48,88 @@ export function run(
   options: WebBuildBuilderOptions,
   context: BuilderContext
 ): Observable<BuildResult> {
-  return from(getSourceRoot(context)).pipe(
+  const host = new NodeJsSyncHost();
+  return from(getSourceRoot(context, host)).pipe(
     map(sourceRoot => {
       options = normalizeWebBuildOptions(
         options,
         context.workspaceRoot,
         sourceRoot
       );
-      let config = getWebConfig(
-        context.workspaceRoot,
-        sourceRoot,
-        options,
-        context.logger
-      );
-      if (options.webpackConfig) {
-        config = require(options.webpackConfig)(config, {
+      let configs = [
+        getWebConfig(
+          context.workspaceRoot,
+          sourceRoot,
           options,
-          configuration: context.target.configuration
-        });
+          context.logger,
+          options.differentialLoading ? ScriptTarget.ES2015 : null
+        )
+      ];
+      if (options.differentialLoading) {
+        configs.push(
+          getWebConfig(
+            context.workspaceRoot,
+            sourceRoot,
+            options,
+            context.logger,
+            ScriptTarget.ES5
+          )
+        );
       }
-      return config;
+      if (options.webpackConfig) {
+        configs = configs.map(config =>
+          require(options.webpackConfig)(config, {
+            options,
+            configuration: context.target.configuration
+          })
+        );
+      }
+      return configs;
     }),
-    concatMap(config =>
-      runWebpack(config, context, {
+    concatMap(configs => {
+      const runWebpackOptions = {
         logging: stats => {
-          if (options.statsJson) {
-            writeFileSync(
-              resolve(context.workspaceRoot, options.outputPath, 'stats.json'),
-              JSON.stringify(stats.toJson(), null, 2)
-            );
-          }
-
           context.logger.info(stats.toString());
         }
-      })
-    )
+      };
+      return forkJoin(
+        configs.map(config => runWebpack(config, context, runWebpackOptions))
+      ).pipe(
+        switchMap(
+          ([result1, result2 = { success: true, emittedFiles: [] }]) => {
+            const success = [result1, result2].every(result => result.success);
+
+            return (options.differentialLoading
+              ? writeIndexHtml({
+                  host,
+                  outputPath: normalize(options.outputPath),
+                  indexPath: devkitJoin(
+                    normalize(context.workspaceRoot),
+                    options.index
+                  ),
+                  ES5BuildFiles: result2.emittedFiles,
+                  ES2015BuildFiles: result1.emittedFiles,
+                  baseHref: options.baseHref,
+                  deployUrl: options.deployUrl,
+                  scripts: options.scripts,
+                  styles: options.styles
+                })
+              : of(null)
+            ).pipe(
+              map(
+                () =>
+                  ({
+                    success,
+                    emittedFiles: [
+                      ...result1.emittedFiles,
+                      ...result2.emittedFiles
+                    ]
+                  } as BuildResult)
+              )
+            );
+          }
+        )
+      );
+    })
   );
 }

--- a/packages/web/src/builders/build/schema.json
+++ b/packages/web/src/builders/build/schema.json
@@ -159,6 +159,11 @@
         }
       ]
     },
+    "differentialLoading": {
+      "type": "boolean",
+      "description": "Enable differential loading for es5 browsers",
+      "default": true
+    },
     "extractCss": {
       "type": "boolean",
       "description": "Extract css into a .css file",

--- a/packages/web/src/utils/config.spec.ts
+++ b/packages/web/src/utils/config.spec.ts
@@ -1,10 +1,11 @@
 import { getBaseWebpackPartial } from './config';
-import { normalize, getSystemPath } from '@angular-devkit/core';
 
 import * as ts from 'typescript';
 import { LicenseWebpackPlugin } from 'license-webpack-plugin';
 import CircularDependencyPlugin = require('circular-dependency-plugin');
 import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+jest.mock('tsconfig-paths-webpack-plugin');
+import TsConfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
 import { ProgressPlugin } from 'webpack';
 import { BuildBuilderOptions } from './types';
 
@@ -19,6 +20,7 @@ describe('getBaseWebpackPartial', () => {
       root: '/root',
       statsJson: false
     };
+    (<any>TsConfigPathsPlugin).mockImplementation(class MockPathsPlugin {});
   });
 
   describe('unconditional options', () => {
@@ -127,7 +129,7 @@ describe('getBaseWebpackPartial', () => {
       expect(typeCheckerPlugin.options.tsconfig).toBe('tsconfig.json');
     });
 
-    it('should set aliases for compilerOptionPaths', () => {
+    it('should add the TsConfigPathsPlugin for resolving', () => {
       spyOn(ts, 'parseJsonConfigFileContent').and.returnValue({
         options: {
           paths: {
@@ -135,11 +137,12 @@ describe('getBaseWebpackPartial', () => {
           }
         }
       });
-
       const result = getBaseWebpackPartial(input);
-      expect(result.resolve.alias).toEqual({
-        '@npmScope/libraryName': '/root/libs/libraryName/src/index.ts'
-      });
+      expect(
+        result.resolve.plugins.some(
+          plugin => plugin instanceof TsConfigPathsPlugin
+        )
+      ).toEqual(true);
     });
 
     it('should include es2015 in mainFields if typescript is set es2015', () => {

--- a/packages/web/src/utils/devserver.config.spec.ts
+++ b/packages/web/src/utils/devserver.config.spec.ts
@@ -1,4 +1,4 @@
-import { getSystemPath, normalize, join } from '@angular-devkit/core';
+import { normalize } from '@angular-devkit/core';
 import { getDevServerConfig } from './devserver.config';
 import { Logger } from '@angular-devkit/core/src/logger';
 jest.mock('tsconfig-paths-webpack-plugin');
@@ -7,6 +7,7 @@ import * as ts from 'typescript';
 import * as fs from 'fs';
 import { WebBuildBuilderOptions } from '../builders/build/build.impl';
 import { WebDevServerOptions } from '../builders/dev-server/dev-server.impl';
+import { join } from 'path';
 
 describe('getDevServerConfig', () => {
   let buildInput: WebBuildBuilderOptions;
@@ -19,6 +20,7 @@ describe('getDevServerConfig', () => {
   beforeEach(() => {
     buildInput = {
       main: 'main.ts',
+      differentialLoading: true,
       index: 'index.html',
       budgets: [],
       baseHref: '/',
@@ -39,8 +41,8 @@ describe('getDevServerConfig', () => {
       tsConfig: 'tsconfig.json',
       fileReplacements: []
     };
-    root = '/root';
-    sourceRoot = '/root/apps/app';
+    root = join(__dirname, '../../../..');
+    sourceRoot = join(root, 'apps/app');
 
     serveInput = {
       host: 'localhost',
@@ -370,7 +372,7 @@ describe('getDevServerConfig', () => {
     describe('proxyConfig option', () => {
       it('should setProxyConfig', () => {
         jest.mock(
-          join(normalize(__dirname), 'proxy.conf'),
+          join(root, 'proxy.conf'),
           () => ({
             proxyConfig: 'proxyConfig'
           }),

--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -27,6 +27,7 @@ export function getDevServerConfig(
     logger
   );
   (webpackConfig as any).devServer = getDevServerPartial(
+    root,
     serveOptions,
     buildOptions
   );
@@ -57,6 +58,7 @@ function getLiveReloadEntry(serveOptions: WebDevServerOptions) {
 }
 
 function getDevServerPartial(
+  root: string,
   options: WebDevServerOptions,
   buildOptions: WebBuildBuilderOptions
 ): WebpackDevServerConfiguration {
@@ -92,11 +94,11 @@ function getDevServerPartial(
   };
 
   if (options.ssl && options.sslKey && options.sslCert) {
-    config.https = getSslConfig(buildOptions.root, options);
+    config.https = getSslConfig(root, options);
   }
 
   if (options.proxyConfig) {
-    config.proxy = getProxyConfig(buildOptions.root, options);
+    config.proxy = getProxyConfig(root, options);
   }
 
   return config;

--- a/packages/web/src/utils/normalize.spec.ts
+++ b/packages/web/src/utils/normalize.spec.ts
@@ -30,10 +30,6 @@ describe('normalizeBuildOptions', () => {
     root = '/root';
     sourceRoot = normalize('apps/nodeapp/src');
   });
-  it('should add the root', () => {
-    const result = normalizeBuildOptions(testOptions, root, sourceRoot);
-    expect(result.root).toEqual('/root');
-  });
 
   it('should resolve main from root', () => {
     const result = normalizeBuildOptions(testOptions, root, sourceRoot);

--- a/packages/web/src/utils/normalize.ts
+++ b/packages/web/src/utils/normalize.ts
@@ -3,6 +3,7 @@ import { normalize } from '@angular-devkit/core';
 import { resolve, dirname, relative, basename } from 'path';
 import { BuildBuilderOptions } from './types';
 import { statSync } from 'fs';
+import { ScriptTarget } from 'typescript';
 
 export interface FileReplacement {
   replace: string;
@@ -16,8 +17,6 @@ export function normalizeBuildOptions<T extends BuildBuilderOptions>(
 ): T {
   return {
     ...options,
-    root: root,
-    sourceRoot: sourceRoot,
     main: resolve(root, options.main),
     outputPath: resolve(root, options.outputPath),
     tsConfig: resolve(root, options.tsConfig),
@@ -112,12 +111,17 @@ export function normalizeWebBuildOptions(
   };
 }
 
-export function convertBuildOptions(buildOptions: WebBuildBuilderOptions): any {
+export function convertBuildOptions(
+  buildOptions: WebBuildBuilderOptions,
+  scriptTargetOverride: ScriptTarget
+): any {
   const options = buildOptions as any;
   return <any>{
     ...options,
     buildOptimizer: options.optimization,
     aot: false,
+    scriptTargetOverride: scriptTargetOverride,
+    esVersionInFileName: !!scriptTargetOverride,
     forkTypeChecker: false,
     lazyModules: [] as string[],
     assets: [] as string[]

--- a/packages/web/src/utils/source-root.ts
+++ b/packages/web/src/utils/source-root.ts
@@ -1,9 +1,9 @@
 import { BuilderContext } from '@angular-devkit/architect';
-import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import { workspaces } from '@angular-devkit/core';
+import { Host } from '@angular-devkit/core/src/virtual-fs/host';
 
-export async function getSourceRoot(context: BuilderContext) {
-  const workspaceHost = workspaces.createWorkspaceHost(new NodeJsSyncHost());
+export async function getSourceRoot(context: BuilderContext, host: Host<{}>) {
+  const workspaceHost = workspaces.createWorkspaceHost(host);
   const { workspace } = await workspaces.readWorkspace(
     context.workspaceRoot,
     workspaceHost

--- a/scripts/check-imports.js
+++ b/scripts/check-imports.js
@@ -28,7 +28,10 @@ function check() {
   const exceptions = [
     'packages/create-nx-workspace/bin/create-nx-workspace.ts',
     'packages/workspace/bin/create-nx-workspace.ts',
+    'packages/web/src/builders/build/build.impl.ts',
+    'packages/web/src/builders/build/build.impl.spec.ts',
     'packages/web/src/utils/web.config.ts',
+    'packages/web/src/utils/web.config.spec.ts',
     'packages/workspace/src/command-line/affected.ts',
     'packages/workspace/src/schematics/preset/preset.ts',
     'packages/workspace/src/schematics/ng-add/ng-add.ts'


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

The web builder does not utilize differential loading:

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The web builder utilizes differential loading.

It is enabled by default.

2 sets of bundles are produced: 1 for evergreen browsers (ones that support es2015) and 1 for older browsers.

## Issue
