### PR TITLE
fix(nx): include typescript in the create-nx-workspace sandbox

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -55,13 +55,15 @@ const tmpDir = dirSync().name;
 
 const nxVersion = 'NX_VERSION';
 const cliVersion = 'ANGULAR_CLI_VERSION';
+const typescriptVersion = 'TYPESCRIPT_VERSION';
 
 writeFileSync(
   path.join(tmpDir, 'package.json'),
   JSON.stringify({
     dependencies: {
       [nxTool.packageName]: nxVersion,
-      '@angular/cli': cliVersion
+      '@angular/cli': cliVersion,
+      typescript: typescriptVersion
     },
     license: 'MIT'
   })

--- a/packages/workspace/bin/create-nx-workspace.ts
+++ b/packages/workspace/bin/create-nx-workspace.ts
@@ -55,13 +55,15 @@ const tmpDir = dirSync().name;
 
 const nxVersion = 'NX_VERSION';
 const cliVersion = 'ANGULAR_CLI_VERSION';
+const typescriptVersion = 'TYPESCRIPT_VERSION';
 
 writeFileSync(
   path.join(tmpDir, 'package.json'),
   JSON.stringify({
     dependencies: {
       [nxTool.packageName]: nxVersion,
-      '@angular/cli': cliVersion
+      '@angular/cli': cliVersion,
+      typescript: typescriptVersion
     },
     license: 'MIT'
   })

--- a/scripts/nx-release.js
+++ b/scripts/nx-release.js
@@ -90,14 +90,16 @@ if (!parsedVersion.isValid) {
   console.log('parsed version: ', JSON.stringify(parsedVersion));
 }
 
-const cliVersion = JSON.parse(
+const { devDependencies } = JSON.parse(
   fs.readFileSync(path.join(__dirname, '../package.json'))
-).devDependencies['@angular/cli'];
+);
+const cliVersion = devDependencies['@angular/cli'];
+const typescriptVersion = devDependencies['typescript'];
 
 console.log('Executing build script:');
 const buildCommand = `./scripts/package.sh ${
   parsedVersion.version
-} ${cliVersion}`;
+} ${cliVersion} ${typescriptVersion}`;
 console.log(`> ${buildCommand}`);
 childProcess.execSync(buildCommand, {
   stdio: [0, 1, 2]

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -5,6 +5,7 @@
 
 NX_VERSION=$1
 ANGULAR_CLI_VERSION=$2
+TYPESCRIPT_VERSION=$3
 
 if [[ $NX_VERSION == "--local" ]]; then
     NX_VERSION="*"
@@ -19,8 +20,10 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     sed -i "" "s|\*|$NX_VERSION|g" {schematics,react,web,jest,node,express,nest,cypress,angular,workspace}/package.json
     sed -i "" "s|NX_VERSION|$NX_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
     sed -i "" "s|ANGULAR_CLI_VERSION|$ANGULAR_CLI_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
+    sed -i "" "s|TYPESCRIPT_VERSION|$TYPESCRIPT_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
     sed -i "" "s|NX_VERSION|$NX_VERSION|g" workspace/bin/create-nx-workspace.js
     sed -i "" "s|ANGULAR_CLI_VERSION|$ANGULAR_CLI_VERSION|g" workspace/bin/create-nx-workspace.js
+    sed -i "" "s|TYPESCRIPT_VERSION|$TYPESCRIPT_VERSION|g" workspace/bin/create-nx-workspace.js
 else
     sed -i "s|exports.nxVersion = '\*';|exports.nxVersion = '$NX_VERSION';|g" {react,web,jest,node,express,nest,cypress,angular,workspace}/src/utils/versions.js
     sed -i "s|\*|$NX_VERSION|g" {schematics,react,web,jest,node,express,nest,cypress,angular,workspace}/package.json


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

`npx -p create-nx-workspace@next create-nx-workspace my-proj --no-interactive` fails because typescript is no longer a dependency of `@angular/cli`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`create-nx-workspace` brings typescript into the sandbox as well so the workspace is created properly

## Issue
