### PR TITLE
fix(build): add ts version replacement for non-darwin os

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -29,8 +29,10 @@ else
     sed -i "s|\*|$NX_VERSION|g" {schematics,react,web,jest,node,express,nest,cypress,angular,workspace}/package.json
     sed -i "s|NX_VERSION|$NX_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
     sed -i "s|ANGULAR_CLI_VERSION|$ANGULAR_CLI_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
+    sed -i "s|TYPESCRIPT_VERSION|$TYPESCRIPT_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
     sed -i "s|NX_VERSION|$NX_VERSION|g" workspace/bin/create-nx-workspace.js
     sed -i "s|ANGULAR_CLI_VERSION|$ANGULAR_CLI_VERSION|g" workspace/bin/create-nx-workspace.js
+    sed -i "s|TYPESCRIPT_VERSION|$TYPESCRIPT_VERSION|g" workspace/bin/create-nx-workspace.js
 fi
 
 if [[ $NX_VERSION == "*" ]]; then


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Typescript version does not get replaced when building on a non-darwin OS (non-macOS)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Typescript version gets replaced when building on all environments

## Issue
