### PR TITLE
fix(nx): extend @nrwl/workspace collection and cleanup inconsistencies

### DIFF
--- a/packages/angular/collection.json
+++ b/packages/angular/collection.json
@@ -1,7 +1,7 @@
 {
   "name": "nx/angular",
   "version": "0.1",
-  "extends": ["@schematics/angular"],
+  "extends": ["@schematics/angular", "@nrwl/workspace"],
   "schematics": {
     "ng-add": {
       "factory": "./src/schematics/ng-add/ng-add",

--- a/packages/angular/src/schematics/application/schema.json
+++ b/packages/angular/src/schematics/application/schema.json
@@ -55,10 +55,18 @@
         "type": "list",
         "items": [
           { "value": "css", "label": "CSS" },
-          { "value": "scss", "label": "SCSS   [ http://sass-lang.com   ]" },
-          { "value": "sass", "label": "SASS   [ http://sass-lang.com   ]" },
-          { "value": "less", "label": "LESS   [ http://lesscss.org     ]" },
-          { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
+          {
+            "value": "scss",
+            "label": "SASS(.scss)  [ http://sass-lang.com   ]"
+          },
+          {
+            "value": "styl",
+            "label": "Stylus(.styl)[ http://stylus-lang.com ]"
+          },
+          {
+            "value": "less",
+            "label": "LESS         [ http://lesscss.org     ]"
+          }
         ]
       }
     },

--- a/packages/express/collection.json
+++ b/packages/express/collection.json
@@ -1,6 +1,7 @@
 {
   "name": "nx/express",
   "version": "0.1",
+  "extends": ["@nrwl/workspace"],
   "schematics": {
     "ng-add": {
       "factory": "./src/schematics/ng-add/ng-add",

--- a/packages/nest/collection.json
+++ b/packages/nest/collection.json
@@ -1,6 +1,7 @@
 {
   "name": "nx/nest",
   "version": "0.1",
+  "extends": ["@nrwl/workspace"],
   "schematics": {
     "ng-add": {
       "factory": "./src/schematics/ng-add/ng-add",

--- a/packages/node/collection.json
+++ b/packages/node/collection.json
@@ -1,6 +1,7 @@
 {
   "name": "nx/node",
   "version": "0.1",
+  "extends": ["@nrwl/workspace"],
   "schematics": {
     "ng-add": {
       "factory": "./src/schematics/ng-add/ng-add",

--- a/packages/react/collection.json
+++ b/packages/react/collection.json
@@ -1,6 +1,7 @@
 {
   "name": "nx/react",
   "version": "0.1",
+  "extends": ["@nrwl/workspace"],
   "schematics": {
     "ng-add": {
       "factory": "./src/schematics/ng-add/ng-add",

--- a/packages/react/src/schematics/library/schema.json
+++ b/packages/react/src/schematics/library/schema.json
@@ -27,10 +27,18 @@
         "type": "list",
         "items": [
           { "value": "css", "label": "CSS" },
-          { "value": "scss", "label": "SCSS   [ http://sass-lang.com   ]" },
-          { "value": "sass", "label": "SASS   [ http://sass-lang.com   ]" },
-          { "value": "less", "label": "LESS   [ http://lesscss.org     ]" },
-          { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
+          {
+            "value": "scss",
+            "label": "SASS(.scss)  [ http://sass-lang.com   ]"
+          },
+          {
+            "value": "styl",
+            "label": "Stylus(.styl)[ http://stylus-lang.com ]"
+          },
+          {
+            "value": "less",
+            "label": "LESS         [ http://lesscss.org     ]"
+          }
         ]
       }
     },

--- a/packages/web/collection.json
+++ b/packages/web/collection.json
@@ -1,6 +1,7 @@
 {
   "name": "nx/web",
   "version": "0.1",
+  "extends": ["@nrwl/workspace"],
   "schematics": {
     "ng-add": {
       "factory": "./src/schematics/ng-add/ng-add",

--- a/packages/workspace/collection.json
+++ b/packages/workspace/collection.json
@@ -26,7 +26,8 @@
     "ng-new": {
       "factory": "./src/schematics/ng-new/ng-new",
       "schema": "./src/schematics/ng-new/schema.json",
-      "description": "Create a workspace"
+      "description": "Create a workspace",
+      "hidden": true
     },
 
     "library": {

--- a/packages/workspace/src/schematics/library/library.spec.ts
+++ b/packages/workspace/src/schematics/library/library.spec.ts
@@ -211,18 +211,6 @@ describe('lib', () => {
     });
   });
 
-  describe('--style scss', () => {
-    it('should use scss for styles', async () => {
-      const result = await runSchematic(
-        'lib',
-        { name: 'myLib', style: 'scss' },
-        appTree
-      );
-
-      expect(result.exists('libs/my-lib/src/lib/my-lib.scss'));
-    });
-  });
-
   describe('--unit-test-runner none', () => {
     it('should not generate test configuration', async () => {
       const resultTree = await runSchematic(

--- a/packages/workspace/src/schematics/library/schema.d.ts
+++ b/packages/workspace/src/schematics/library/schema.d.ts
@@ -4,7 +4,6 @@ import { Framework } from '../../utils/framework';
 export interface Schema {
   name: string;
   directory?: string;
-  style?: string;
   skipTsConfig: boolean;
   skipFormat: boolean;
   tags?: string;

--- a/packages/workspace/src/schematics/library/schema.json
+++ b/packages/workspace/src/schematics/library/schema.json
@@ -18,22 +18,6 @@
       "description": "A directory where the app is placed",
       "x-prompt": "In which directory should the library be generated?"
     },
-    "style": {
-      "description": "The file extension to be used for style files.",
-      "type": "string",
-      "default": "css",
-      "x-prompt": {
-        "message": "Which stylesheet format would you like to use?",
-        "type": "list",
-        "items": [
-          { "value": "css", "label": "CSS" },
-          { "value": "scss", "label": "SCSS   [ http://sass-lang.com   ]" },
-          { "value": "sass", "label": "SASS   [ http://sass-lang.com   ]" },
-          { "value": "less", "label": "LESS   [ http://lesscss.org     ]" },
-          { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
-        ]
-      }
-    },
     "unitTestRunner": {
       "type": "string",
       "enum": ["jest", "none"],

--- a/packages/workspace/src/schematics/ng-add/schema.json
+++ b/packages/workspace/src/schematics/ng-add/schema.json
@@ -7,8 +7,7 @@
   "properties": {
     "npmScope": {
       "type": "string",
-      "description": "Npm scope for importing libs.",
-      "x-prompt": "What is the npm scope you would like to use for your Nx Workspace?"
+      "description": "Npm scope for importing libs."
     },
     "skipInstall": {
       "type": "boolean",

--- a/packages/workspace/src/schematics/ng-new/schema.json
+++ b/packages/workspace/src/schematics/ng-new/schema.json
@@ -23,10 +23,18 @@
         "type": "list",
         "items": [
           { "value": "css", "label": "CSS" },
-          { "value": "scss", "label": "SCSS   [ http://sass-lang.com   ]" },
-          { "value": "sass", "label": "SASS   [ http://sass-lang.com   ]" },
-          { "value": "less", "label": "LESS   [ http://lesscss.org     ]" },
-          { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
+          {
+            "value": "scss",
+            "label": "SASS(.scss)  [ http://sass-lang.com   ]"
+          },
+          {
+            "value": "styl",
+            "label": "Stylus(.styl)[ http://stylus-lang.com ]"
+          },
+          {
+            "value": "less",
+            "label": "LESS         [ http://lesscss.org     ]"
+          }
         ]
       }
     },

--- a/packages/workspace/src/schematics/preset/schema.json
+++ b/packages/workspace/src/schematics/preset/schema.json
@@ -25,10 +25,18 @@
         "type": "list",
         "items": [
           { "value": "css", "label": "CSS" },
-          { "value": "scss", "label": "SCSS   [ http://sass-lang.com   ]" },
-          { "value": "sass", "label": "SASS   [ http://sass-lang.com   ]" },
-          { "value": "less", "label": "LESS   [ http://lesscss.org     ]" },
-          { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
+          {
+            "value": "scss",
+            "label": "SASS(.scss)  [ http://sass-lang.com   ]"
+          },
+          {
+            "value": "styl",
+            "label": "Stylus(.styl)[ http://stylus-lang.com ]"
+          },
+          {
+            "value": "less",
+            "label": "LESS         [ http://lesscss.org     ]"
+          }
         ]
       }
     }

--- a/packages/workspace/src/schematics/workspace/schema.json
+++ b/packages/workspace/src/schematics/workspace/schema.json
@@ -23,10 +23,18 @@
         "type": "list",
         "items": [
           { "value": "css", "label": "CSS" },
-          { "value": "scss", "label": "SCSS   [ http://sass-lang.com   ]" },
-          { "value": "sass", "label": "SASS   [ http://sass-lang.com   ]" },
-          { "value": "less", "label": "LESS   [ http://lesscss.org     ]" },
-          { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
+          {
+            "value": "scss",
+            "label": "SASS(.scss)  [ http://sass-lang.com   ]"
+          },
+          {
+            "value": "styl",
+            "label": "Stylus(.styl)[ http://stylus-lang.com ]"
+          },
+          {
+            "value": "less",
+            "label": "LESS         [ http://lesscss.org     ]"
+          }
         ]
       }
     },


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

None of the collections extend the `@nrwl/workspace` collection.

Thus, you cannot create a basic `library` with most collections.

The styles options are inconsistent, there are two versions.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The collections extend the `@nrwl/workspace` collection. (other than `jest` and `cypress`.

Thus, you can create a basic `library` with all collections but it is overwritten with a more complex `library` schematic if one is available.

The styles options are inconsistent, there is one version which does not allow `.sass` as that is not recommended.

## Issue
