### PR TITLE
fix(nx): run migrations for beta versions

### DIFF
--- a/packages/schematics/migrations/migrations.json
+++ b/packages/schematics/migrations/migrations.json
@@ -71,7 +71,7 @@
       "factory": "./update-7-8-1/update-7-8-1"
     },
     "update-8.0.0": {
-      "version": "8.0.0",
+      "version": "8.0.0-beta.3",
       "description": "V8 migrations",
       "factory": "./update-8-0-0/update-8-0-0"
     }


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

The migration is targeting `8.0.0` so it does not run for updates during the beta version.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The migration is targeting `8.0.0-beta.3` so it will run for updates during the beta version.

## Issue
