### PR TITLE
feat(nx): set default collection on ngadd

### DIFF
--- a/docs/api-angular/schematics/ng-add.md
+++ b/docs/api-angular/schematics/ng-add.md
@@ -19,6 +19,14 @@ Type: `string`
 
 Test runner to use for end to end (e2e) tests
 
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files
+
 ### skipInstall
 
 Default: `false`

--- a/docs/api-cypress/schematics/cypress-project.md
+++ b/docs/api-cypress/schematics/cypress-project.md
@@ -1,4 +1,4 @@
-# cypress-project
+# cypress-project [hidden]
 
 Add a Cypress E2E Project
 

--- a/docs/api-express/schematics/ng-add.md
+++ b/docs/api-express/schematics/ng-add.md
@@ -8,3 +8,13 @@ Add @nrwl/express to a project
 ng generate ng-add ...
 
 ```
+
+## Options
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files

--- a/docs/api-jest/schematics/jest-project.md
+++ b/docs/api-jest/schematics/jest-project.md
@@ -1,4 +1,4 @@
-# jest-project
+# jest-project [hidden]
 
 Add Jest configuration to a project
 

--- a/docs/api-nest/schematics/ng-add.md
+++ b/docs/api-nest/schematics/ng-add.md
@@ -8,3 +8,13 @@ Add @nrwl/nest to a project
 ng generate ng-add ...
 
 ```
+
+## Options
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files

--- a/docs/api-node/schematics/ng-add.md
+++ b/docs/api-node/schematics/ng-add.md
@@ -8,3 +8,13 @@ Add @nrwl/node to a project
 ng generate ng-add ...
 
 ```
+
+## Options
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files

--- a/docs/api-react/schematics/ng-add.md
+++ b/docs/api-react/schematics/ng-add.md
@@ -8,3 +8,13 @@ Add @nrwl/react to a project
 ng generate ng-add ...
 
 ```
+
+## Options
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files

--- a/docs/api-web/schematics/ng-add.md
+++ b/docs/api-web/schematics/ng-add.md
@@ -8,3 +8,13 @@ Add @nrwl/web to a project
 ng generate ng-add ...
 
 ```
+
+## Options
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files

--- a/docs/api-workspace/schematics/library.md
+++ b/docs/api-workspace/schematics/library.md
@@ -39,14 +39,6 @@ Type: `boolean`
 
 Do not update tsconfig.json for development experience.
 
-### style
-
-Default: `css`
-
-Type: `string`
-
-The file extension to be used for style files.
-
 ### tags
 
 Type: `string`

--- a/docs/api-workspace/schematics/ng-new.md
+++ b/docs/api-workspace/schematics/ng-new.md
@@ -1,4 +1,4 @@
-# ng-new
+# ng-new [hidden]
 
 Create a workspace
 

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -26,7 +26,7 @@ import {
 } from '@nrwl/workspace';
 import { formatFiles } from '@nrwl/workspace';
 import { join, normalize } from '@angular-devkit/core';
-import { addE2eTestRunner, addUnitTestRunner } from '../ng-add/ng-add';
+import ngAdd from '../ng-add/ng-add';
 import {
   addImportToModule,
   addImportToTestBed,
@@ -317,10 +317,6 @@ function updateE2eProject(options: NormalizedSchema): Rule {
   };
 }
 
-function setupTestRunners(options: NormalizedSchema): Rule {
-  return chain([addUnitTestRunner(options), addE2eTestRunner(options)]);
-}
-
 export default function(schema: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const options = normalizeOptions(host, schema);
@@ -337,7 +333,10 @@ export default function(schema: Schema): Rule {
       : `${options.name}/e2e`;
 
     return chain([
-      setupTestRunners(options),
+      ngAdd({
+        ...options,
+        skipFormat: true
+      }),
       externalSchematic('@schematics/angular', 'application', {
         name: options.name,
         inlineStyle: options.inlineStyle,

--- a/packages/angular/src/schematics/ng-add/ng-add.spec.ts
+++ b/packages/angular/src/schematics/ng-add/ng-add.spec.ts
@@ -1,7 +1,7 @@
 import { Tree } from '@angular-devkit/schematics';
-import { runSchematic } from '../../utils/testing';
+import { runSchematic, callRule } from '../../utils/testing';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
-import { readJsonInTree } from '@nrwl/workspace';
+import { readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
 
 describe('ng-add', () => {
   let appTree: Tree;
@@ -191,6 +191,46 @@ describe('ng-add', () => {
           'protractor'
         );
       });
+    });
+  });
+
+  describe('defaultCollection', () => {
+    it('should be set if none was set before', async () => {
+      const result = await runSchematic('ng-add', {}, appTree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/react');
+    });
+
+    it('should be set if @nrwl/workspace was set before', async () => {
+      appTree = await callRule(
+        updateJsonInTree('angular.json', json => {
+          json.cli = {
+            defaultCollection: '@nrwl/workspace'
+          };
+
+          return json;
+        }),
+        appTree
+      );
+      const result = await runSchematic('ng-add', {}, appTree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/react');
+    });
+
+    it('should not be set if something else was set before', async () => {
+      appTree = await callRule(
+        updateJsonInTree('angular.json', json => {
+          json.cli = {
+            defaultCollection: '@nrwl/angular'
+          };
+
+          return json;
+        }),
+        appTree
+      );
+      const result = await runSchematic('ng-add', {}, appTree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/angular');
     });
   });
 });

--- a/packages/angular/src/schematics/ng-add/schema.d.ts
+++ b/packages/angular/src/schematics/ng-add/schema.d.ts
@@ -2,5 +2,6 @@ import { UnitTestRunner } from '../../utils/test-runners';
 export interface Schema {
   unitTestRunner: UnitTestRunner;
   e2eTestRunner: E2eTestRunner;
+  skipFormat: boolean;
   skipInstall?: boolean;
 }

--- a/packages/angular/src/schematics/ng-add/schema.json
+++ b/packages/angular/src/schematics/ng-add/schema.json
@@ -49,6 +49,11 @@
       "type": "boolean",
       "description": "Skip installing after adding @nrwl/workspace",
       "default": false
+    },
+    "skipFormat": {
+      "description": "Skip formatting files",
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/packages/express/src/schematics/application/application.ts
+++ b/packages/express/src/schematics/application/application.ts
@@ -56,7 +56,7 @@ export default function(schema: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const options = normalizeOptions(schema);
     return chain([
-      ngAdd(),
+      ngAdd({ skipFormat: true }),
       externalSchematic('@nrwl/node', 'application', schema),
       addMainFile(options),
       addTypes(options)

--- a/packages/express/src/schematics/ng-add/schema.d.ts
+++ b/packages/express/src/schematics/ng-add/schema.d.ts
@@ -1,1 +1,3 @@
-export interface Schema {}
+export interface Schema {
+  skipFormat: boolean;
+}

--- a/packages/express/src/schematics/ng-add/schema.json
+++ b/packages/express/src/schematics/ng-add/schema.json
@@ -3,6 +3,12 @@
   "id": "NxExpressNgAdd",
   "title": "Add Nx Express Schematics",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "skipFormat": {
+      "description": "Skip formatting files",
+      "type": "boolean",
+      "default": false
+    }
+  },
   "required": []
 }

--- a/packages/express/src/utils/testing.ts
+++ b/packages/express/src/utils/testing.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { Tree } from '@angular-devkit/schematics';
+import { Rule, Tree } from '@angular-devkit/schematics';
 
 const testRunner = new SchematicTestRunner(
   '@nrwl/express',
@@ -9,4 +9,8 @@ const testRunner = new SchematicTestRunner(
 
 export function runSchematic(schematicName: string, options: any, tree: Tree) {
   return testRunner.runSchematicAsync(schematicName, options, tree).toPromise();
+}
+
+export function callRule(rule: Rule, tree: Tree) {
+  return testRunner.callRule(rule, tree).toPromise();
 }

--- a/packages/nest/src/schematics/application/application.ts
+++ b/packages/nest/src/schematics/application/application.ts
@@ -65,7 +65,9 @@ export default function(schema: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const options = normalizeOptions(schema);
     return chain([
-      ngAdd(),
+      ngAdd({
+        skipFormat: true
+      }),
       externalSchematic('@nrwl/node', 'application', schema),
       addMainFile(options),
       addAppFiles(options)

--- a/packages/nest/src/schematics/ng-add/ng-add.spec.ts
+++ b/packages/nest/src/schematics/ng-add/ng-add.spec.ts
@@ -1,30 +1,62 @@
 import { Tree } from '@angular-devkit/schematics';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
-import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { join } from 'path';
-import { readJsonInTree } from '@nrwl/workspace';
+import { readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
+import { runSchematic, callRule } from '../../utils/testing';
 
 describe('ng-add', () => {
   let tree: Tree;
-  let testRunner: SchematicTestRunner;
 
   beforeEach(() => {
     tree = Tree.empty();
     tree = createEmptyWorkspace(tree);
-    testRunner = new SchematicTestRunner(
-      '@nrwl/nest',
-      join(__dirname, '../../../collection.json')
-    );
   });
 
   it('should add dependencies', async () => {
-    const result = await testRunner
-      .runSchematicAsync('ng-add', {}, tree)
-      .toPromise();
+    const result = await runSchematic('ng-add', {}, tree);
     const packageJson = readJsonInTree(result, 'package.json');
 
     expect(packageJson.dependencies['@nrwl/nest']).toBeUndefined();
     expect(packageJson.devDependencies['@nrwl/nest']).toBeDefined();
     expect(packageJson.dependencies['@nestjs/core']).toBeDefined();
+  });
+
+  describe('defaultCollection', () => {
+    it('should be set if none was set before', async () => {
+      const result = await runSchematic('ng-add', {}, tree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/nest');
+    });
+
+    it('should be set if @nrwl/workspace was set before', async () => {
+      tree = await callRule(
+        updateJsonInTree('angular.json', json => {
+          json.cli = {
+            defaultCollection: '@nrwl/workspace'
+          };
+
+          return json;
+        }),
+        tree
+      );
+      const result = await runSchematic('ng-add', {}, tree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/nest');
+    });
+
+    it('should not be set if something else was set before', async () => {
+      tree = await callRule(
+        updateJsonInTree('angular.json', json => {
+          json.cli = {
+            defaultCollection: '@nrwl/angular'
+          };
+
+          return json;
+        }),
+        tree
+      );
+      const result = await runSchematic('ng-add', {}, tree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/angular');
+    });
   });
 });

--- a/packages/nest/src/schematics/ng-add/schema.d.ts
+++ b/packages/nest/src/schematics/ng-add/schema.d.ts
@@ -1,1 +1,3 @@
-export interface Schema {}
+export interface Schema {
+  skipFormat: boolean;
+}

--- a/packages/nest/src/schematics/ng-add/schema.json
+++ b/packages/nest/src/schematics/ng-add/schema.json
@@ -3,6 +3,12 @@
   "id": "NxNestNgAdd",
   "title": "Add Nx Nest Schematics",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "skipFormat": {
+      "description": "Skip formatting files",
+      "type": "boolean",
+      "default": false
+    }
+  },
   "required": []
 }

--- a/packages/nest/src/utils/testing.ts
+++ b/packages/nest/src/utils/testing.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { Tree } from '@angular-devkit/schematics';
+import { Rule, Tree } from '@angular-devkit/schematics';
 
 const testRunner = new SchematicTestRunner(
   '@nrwl/nest',
@@ -9,4 +9,8 @@ const testRunner = new SchematicTestRunner(
 
 export function runSchematic(schematicName: string, options: any, tree: Tree) {
   return testRunner.runSchematicAsync(schematicName, options, tree).toPromise();
+}
+
+export function callRule(rule: Rule, tree: Tree) {
+  return testRunner.callRule(rule, tree).toPromise();
 }

--- a/packages/node/src/schematics/application/application.ts
+++ b/packages/node/src/schematics/application/application.ts
@@ -146,7 +146,9 @@ export default function(schema: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const options = normalizeOptions(schema);
     return chain([
-      ngAdd(),
+      ngAdd({
+        skipFormat: true
+      }),
       addAppFiles(options),
       updateAngularJson(options),
       updateNxJson(options),

--- a/packages/node/src/schematics/ng-add/ng-add.spec.ts
+++ b/packages/node/src/schematics/ng-add/ng-add.spec.ts
@@ -1,28 +1,60 @@
 import { Tree } from '@angular-devkit/schematics';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
-import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { join } from 'path';
-import { readJsonInTree } from '@nrwl/workspace';
+import { readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
+import { callRule, runSchematic } from '../../utils/testing';
 
 describe('ng-add', () => {
   let tree: Tree;
-  let testRunner: SchematicTestRunner;
 
   beforeEach(() => {
     tree = Tree.empty();
     tree = createEmptyWorkspace(tree);
-    testRunner = new SchematicTestRunner(
-      '@nrwl/node',
-      join(__dirname, '../../../collection.json')
-    );
   });
 
   it('should add dependencies', async () => {
-    const result = await testRunner
-      .runSchematicAsync('ng-add', {}, tree)
-      .toPromise();
+    const result = await runSchematic('ng-add', {}, tree);
     const packageJson = readJsonInTree(result, 'package.json');
     expect(packageJson.dependencies['@nrwl/node']).toBeUndefined();
     expect(packageJson.devDependencies['@nrwl/node']).toBeDefined();
+  });
+
+  describe('defaultCollection', () => {
+    it('should be set if none was set before', async () => {
+      const result = await runSchematic('ng-add', {}, tree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/node');
+    });
+
+    it('should be set if @nrwl/workspace was set before', async () => {
+      tree = await callRule(
+        updateJsonInTree('angular.json', json => {
+          json.cli = {
+            defaultCollection: '@nrwl/workspace'
+          };
+
+          return json;
+        }),
+        tree
+      );
+      const result = await runSchematic('ng-add', {}, tree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/node');
+    });
+
+    it('should not be set if something else was set before', async () => {
+      tree = await callRule(
+        updateJsonInTree('angular.json', json => {
+          json.cli = {
+            defaultCollection: '@nrwl/angular'
+          };
+
+          return json;
+        }),
+        tree
+      );
+      const result = await runSchematic('ng-add', {}, tree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/angular');
+    });
   });
 });

--- a/packages/node/src/schematics/ng-add/ng-add.ts
+++ b/packages/node/src/schematics/ng-add/ng-add.ts
@@ -2,9 +2,13 @@ import { Rule, chain } from '@angular-devkit/schematics';
 import {
   addDepsToPackageJson,
   updateJsonInTree,
-  addPackageWithNgAdd
+  addPackageWithNgAdd,
+  updateWorkspace,
+  formatFiles
 } from '@nrwl/workspace';
+import { Schema } from './schema';
 import { nxVersion } from '../../utils/versions';
+import { JsonObject } from '@angular-devkit/core';
 
 function addDependencies(): Rule {
   return addDepsToPackageJson(
@@ -24,10 +28,26 @@ function moveDependency(): Rule {
   });
 }
 
-export default function() {
+function setDefault(): Rule {
+  return updateWorkspace(workspace => {
+    workspace.extensions.cli = workspace.extensions.cli || {};
+
+    const defaultCollection: string =
+      workspace.extensions.cli &&
+      ((workspace.extensions.cli as JsonObject).defaultCollection as string);
+
+    if (!defaultCollection || defaultCollection === '@nrwl/workspace') {
+      (workspace.extensions.cli as JsonObject).defaultCollection = '@nrwl/node';
+    }
+  });
+}
+
+export default function(schema: Schema) {
   return chain([
+    setDefault(),
     addPackageWithNgAdd('@nrwl/jest'),
     addDependencies(),
-    moveDependency()
+    moveDependency(),
+    formatFiles(schema)
   ]);
 }

--- a/packages/node/src/schematics/ng-add/schema.d.ts
+++ b/packages/node/src/schematics/ng-add/schema.d.ts
@@ -1,1 +1,3 @@
-export interface Schema {}
+export interface Schema {
+  skipFormat: boolean;
+}

--- a/packages/node/src/schematics/ng-add/schema.json
+++ b/packages/node/src/schematics/ng-add/schema.json
@@ -3,6 +3,12 @@
   "id": "NxNodeNgAdd",
   "title": "Add Nx Node Schematics",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "skipFormat": {
+      "description": "Skip formatting files",
+      "type": "boolean",
+      "default": false
+    }
+  },
   "required": []
 }

--- a/packages/node/src/utils/testing.ts
+++ b/packages/node/src/utils/testing.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { Tree } from '@angular-devkit/schematics';
+import { Rule, Tree } from '@angular-devkit/schematics';
 import {
   TestingArchitectHost,
   TestLogger
@@ -16,6 +16,10 @@ const testRunner = new SchematicTestRunner(
 
 export function runSchematic(schematicName: string, options: any, tree: Tree) {
   return testRunner.runSchematicAsync(schematicName, options, tree).toPromise();
+}
+
+export function callRule(rule: Rule, tree: Tree) {
+  return testRunner.callRule(rule, tree).toPromise();
 }
 
 export async function getTestArchitect() {

--- a/packages/react/src/schematics/application/application.ts
+++ b/packages/react/src/schematics/application/application.ts
@@ -3,7 +3,6 @@ import {
   chain,
   Rule,
   Tree,
-  SchematicContext,
   mergeWith,
   apply,
   template,
@@ -148,7 +147,9 @@ export default function(schema: Schema): Rule {
     const options = normalizeOptions(host, schema);
 
     return chain([
-      ngAdd(),
+      ngAdd({
+        skipFormat: true
+      }),
       createApplicationFiles(options),
       updateNxJson(options),
       addProject(options),

--- a/packages/react/src/schematics/ng-add/ng-add.spec.ts
+++ b/packages/react/src/schematics/ng-add/ng-add.spec.ts
@@ -1,26 +1,19 @@
 import { Tree } from '@angular-devkit/schematics';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
-import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { join } from 'path';
 import { readJsonInTree } from '@nrwl/workspace';
+import { updateJsonInTree } from '@nrwl/workspace';
+import { runSchematic, callRule } from '../../utils/testing';
 
 describe('ng-add', () => {
   let tree: Tree;
-  let testRunner: SchematicTestRunner;
 
   beforeEach(() => {
     tree = Tree.empty();
     tree = createEmptyWorkspace(tree);
-    testRunner = new SchematicTestRunner(
-      '@nrwl/react',
-      join(__dirname, '../../../collection.json')
-    );
   });
 
   it('should add react dependencies', async () => {
-    const result = await testRunner
-      .runSchematicAsync('ng-add', {}, tree)
-      .toPromise();
+    const result = await runSchematic('ng-add', {}, tree);
     const packageJson = readJsonInTree(result, 'package.json');
     expect(packageJson.dependencies['@nrwl/react']).toBeUndefined();
     expect(packageJson.dependencies['react']).toBeDefined();
@@ -29,5 +22,45 @@ describe('ng-add', () => {
     expect(packageJson.devDependencies['@types/react']).toBeDefined();
     expect(packageJson.devDependencies['@types/react-dom']).toBeDefined();
     expect(packageJson.devDependencies['react-testing-library']).toBeDefined();
+  });
+
+  describe('defaultCollection', () => {
+    it('should be set if none was set before', async () => {
+      const result = await runSchematic('ng-add', {}, tree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/react');
+    });
+
+    it('should be set if @nrwl/workspace was set before', async () => {
+      tree = await callRule(
+        updateJsonInTree('angular.json', json => {
+          json.cli = {
+            defaultCollection: '@nrwl/workspace'
+          };
+
+          return json;
+        }),
+        tree
+      );
+      const result = await runSchematic('ng-add', {}, tree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/react');
+    });
+
+    it('should not be set if something else was set before', async () => {
+      tree = await callRule(
+        updateJsonInTree('angular.json', json => {
+          json.cli = {
+            defaultCollection: '@nrwl/angular'
+          };
+
+          return json;
+        }),
+        tree
+      );
+      const result = await runSchematic('ng-add', {}, tree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/angular');
+    });
   });
 });

--- a/packages/react/src/schematics/ng-add/ng-add.ts
+++ b/packages/react/src/schematics/ng-add/ng-add.ts
@@ -1,16 +1,11 @@
-import {
-  Rule,
-  chain,
-  externalSchematic,
-  noop,
-  Tree
-} from '@angular-devkit/schematics';
+import { chain, Rule } from '@angular-devkit/schematics';
 import {
   addDepsToPackageJson,
   updateJsonInTree,
-  readJsonInTree,
-  addPackageWithNgAdd
+  addPackageWithNgAdd,
+  updateWorkspace
 } from '@nrwl/workspace';
+import { Schema } from './schema';
 import {
   frameworkVersion,
   typesVersion,
@@ -18,6 +13,7 @@ import {
   testingLibraryVersion,
   nxVersion
 } from '../../utils/versions';
+import { JsonObject } from '@angular-devkit/core';
 
 export function addDependencies(): Rule {
   return addDepsToPackageJson(
@@ -43,8 +39,24 @@ function moveDependency(): Rule {
   });
 }
 
-export default function() {
+function setDefault(): Rule {
+  return updateWorkspace(workspace => {
+    workspace.extensions.cli = workspace.extensions.cli || {};
+
+    const defaultCollection: string =
+      workspace.extensions.cli &&
+      ((workspace.extensions.cli as JsonObject).defaultCollection as string);
+
+    if (!defaultCollection || defaultCollection === '@nrwl/workspace') {
+      (workspace.extensions.cli as JsonObject).defaultCollection =
+        '@nrwl/react';
+    }
+  });
+}
+
+export default function(schema: Schema) {
   return chain([
+    setDefault(),
     addPackageWithNgAdd('@nrwl/jest'),
     addPackageWithNgAdd('@nrwl/cypress'),
     addPackageWithNgAdd('@nrwl/web'),

--- a/packages/react/src/schematics/ng-add/schema.d.ts
+++ b/packages/react/src/schematics/ng-add/schema.d.ts
@@ -1,1 +1,3 @@
-export interface Schema {}
+export interface Schema {
+  skipFormat: boolean;
+}

--- a/packages/react/src/schematics/ng-add/schema.json
+++ b/packages/react/src/schematics/ng-add/schema.json
@@ -3,6 +3,12 @@
   "id": "NxReactNgAdd",
   "title": "Add Nx React Schematics",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "skipFormat": {
+      "description": "Skip formatting files",
+      "type": "boolean",
+      "default": false
+    }
+  },
   "required": []
 }

--- a/packages/react/src/utils/testing.ts
+++ b/packages/react/src/utils/testing.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { Tree } from '@angular-devkit/schematics';
+import { Rule, Tree } from '@angular-devkit/schematics';
 
 const testRunner = new SchematicTestRunner(
   '@nrwl/react',
@@ -9,4 +9,8 @@ const testRunner = new SchematicTestRunner(
 
 export function runSchematic(schematicName: string, options: any, tree: Tree) {
   return testRunner.runSchematicAsync(schematicName, options, tree).toPromise();
+}
+
+export function callRule(rule: Rule, tree: Tree) {
+  return testRunner.callRule(rule, tree).toPromise();
 }

--- a/packages/web/src/schematics/application/application.ts
+++ b/packages/web/src/schematics/application/application.ts
@@ -148,7 +148,9 @@ export default function(schema: Schema): Rule {
     const options = normalizeOptions(host, schema);
 
     return chain([
-      ngAdd(),
+      ngAdd({
+        skipFormat: true
+      }),
       createApplicationFiles(options),
       updateNxJson(options),
       addProject(options),

--- a/packages/web/src/schematics/ng-add/ng-add.spec.ts
+++ b/packages/web/src/schematics/ng-add/ng-add.spec.ts
@@ -1,29 +1,62 @@
 import { Tree } from '@angular-devkit/schematics';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
-import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { join } from 'path';
 import { readJsonInTree } from '@nrwl/workspace';
+import { callRule, runSchematic } from '../../utils/testing';
+import { updateJsonInTree } from '@nrwl/workspace/src/utils/ast-utils';
 
 describe('ng-add', () => {
   let tree: Tree;
-  let testRunner: SchematicTestRunner;
 
   beforeEach(() => {
     tree = Tree.empty();
     tree = createEmptyWorkspace(tree);
-    testRunner = new SchematicTestRunner(
-      '@nrwl/web',
-      join(__dirname, '../../../collection.json')
-    );
   });
 
   it('should add web dependencies', async () => {
-    const result = await testRunner
-      .runSchematicAsync('ng-add', {}, tree)
-      .toPromise();
+    const result = await runSchematic('ng-add', {}, tree);
     const packageJson = readJsonInTree(result, 'package.json');
     expect(packageJson.dependencies['@nrwl/web']).toBeUndefined();
     expect(packageJson.dependencies['document-register-element']).toBeDefined();
     expect(packageJson.devDependencies['@nrwl/web']).toBeDefined();
+  });
+
+  describe('defaultCollection', () => {
+    it('should be set if none was set before', async () => {
+      const result = await runSchematic('ng-add', {}, tree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/web');
+    });
+
+    it('should be set if @nrwl/workspace was set before', async () => {
+      tree = await callRule(
+        updateJsonInTree('angular.json', json => {
+          json.cli = {
+            defaultCollection: '@nrwl/workspace'
+          };
+
+          return json;
+        }),
+        tree
+      );
+      const result = await runSchematic('ng-add', {}, tree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/web');
+    });
+
+    it('should not be set if something else was set before', async () => {
+      tree = await callRule(
+        updateJsonInTree('angular.json', json => {
+          json.cli = {
+            defaultCollection: '@nrwl/angular'
+          };
+
+          return json;
+        }),
+        tree
+      );
+      const result = await runSchematic('ng-add', {}, tree);
+      const angularJson = readJsonInTree(result, 'angular.json');
+      expect(angularJson.cli.defaultCollection).toEqual('@nrwl/angular');
+    });
   });
 });

--- a/packages/web/src/schematics/ng-add/ng-add.ts
+++ b/packages/web/src/schematics/ng-add/ng-add.ts
@@ -1,10 +1,17 @@
 import { Rule, chain } from '@angular-devkit/schematics';
-import { updateJsonInTree, addPackageWithNgAdd } from '@nrwl/workspace';
+import {
+  updateJsonInTree,
+  addPackageWithNgAdd,
+  formatFiles
+} from '@nrwl/workspace';
 import { addDepsToPackageJson } from '@nrwl/workspace';
+import { Schema } from './schema';
 import {
   nxVersion,
   documentRegisterElementVersion
 } from '../../utils/versions';
+import { updateWorkspace } from '@nrwl/workspace';
+import { JsonObject } from '@angular-devkit/core';
 
 function addDependencies(): Rule {
   return addDepsToPackageJson(
@@ -26,11 +33,27 @@ function moveDependency(): Rule {
   });
 }
 
-export default function() {
+function setDefault(): Rule {
+  return updateWorkspace(workspace => {
+    workspace.extensions.cli = workspace.extensions.cli || {};
+
+    const defaultCollection: string =
+      workspace.extensions.cli &&
+      ((workspace.extensions.cli as JsonObject).defaultCollection as string);
+
+    if (!defaultCollection || defaultCollection === '@nrwl/workspace') {
+      (workspace.extensions.cli as JsonObject).defaultCollection = '@nrwl/web';
+    }
+  });
+}
+
+export default function(schema: Schema) {
   return chain([
+    setDefault(),
     addPackageWithNgAdd('@nrwl/jest'),
     addPackageWithNgAdd('@nrwl/cypress'),
     addDependencies(),
-    moveDependency()
+    moveDependency(),
+    formatFiles(schema)
   ]);
 }

--- a/packages/web/src/schematics/ng-add/schema.d.ts
+++ b/packages/web/src/schematics/ng-add/schema.d.ts
@@ -1,1 +1,3 @@
-export interface Schema {}
+export interface Schema {
+  skipFormat: boolean;
+}

--- a/packages/web/src/schematics/ng-add/schema.json
+++ b/packages/web/src/schematics/ng-add/schema.json
@@ -3,6 +3,12 @@
   "id": "NxWebNgAdd",
   "title": "Add Nx Web Schematics",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "skipFormat": {
+      "description": "Skip formatting files",
+      "type": "boolean",
+      "default": false
+    }
+  },
   "required": []
 }

--- a/packages/web/src/utils/testing.ts
+++ b/packages/web/src/utils/testing.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { Tree } from '@angular-devkit/schematics';
+import { Rule, Tree } from '@angular-devkit/schematics';
 import {
   BuilderContext,
   Architect,
@@ -20,6 +20,10 @@ const testRunner = new SchematicTestRunner(
 
 export function runSchematic(schematicName: string, options: any, tree: Tree) {
   return testRunner.runSchematicAsync(schematicName, options, tree).toPromise();
+}
+
+export function callRule(rule: Rule, tree: Tree) {
+  return testRunner.callRule(rule, tree).toPromise();
 }
 
 export async function getTestArchitect() {

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -46,6 +46,8 @@ export {
   serializeTarget
 } from './src/utils/cli-config-utils';
 
+export { getWorkspace, updateWorkspace } from './src/utils/workspace';
+
 export { formatFiles } from './src/utils/rules/format-files';
 export { deleteFile } from './src/utils/rules/deleteFile';
 export * from './src/utils/rules/ng-add';


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

The `defaultCollection` is not set when adding a package so the user always has to specify the collection they want.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The `defaultCollection` is set to the first package which is added via `ng-add` or the first application which is generated. In other words, `defaultCollection` is set when adding a new package if the `defaultCollection` is `@nrwl/workspace` or not defined. 

## Issue
