### PR TITLE
feat(nx): use dynamic imports for lazy-loading

### DIFF
--- a/packages/angular/src/schematics/library/library.spec.ts
+++ b/packages/angular/src/schematics/library/library.spec.ts
@@ -483,7 +483,8 @@ describe('lib', () => {
         expect(moduleContents).toContain(`
       {
         path: 'my-dir-my-lib',
-        loadChildren: '@proj/my-dir/my-lib#MyDirMyLibModule'
+        loadChildren: () =>
+          import('@proj/my-dir/my-lib').then(module => module.MyDirMyLibModule)
       }`);
 
         const tsConfigAppJson = JSON.parse(
@@ -516,12 +517,16 @@ describe('lib', () => {
         expect(moduleContents2).toContain(`
       {
         path: 'my-dir-my-lib',
-        loadChildren: '@proj/my-dir/my-lib#MyDirMyLibModule'
+        loadChildren: () =>
+          import('@proj/my-dir/my-lib').then(module => module.MyDirMyLibModule)
       }`);
         expect(moduleContents2).toContain(`
       {
         path: 'my-dir-my-lib2',
-        loadChildren: '@proj/my-dir/my-lib2#MyDirMyLib2Module'
+        loadChildren: () =>
+          import('@proj/my-dir/my-lib2').then(
+            module => module.MyDirMyLib2Module
+          )
       }`);
 
         const tsConfigAppJson2 = JSON.parse(
@@ -556,15 +561,23 @@ describe('lib', () => {
         expect(moduleContents3).toContain(`
       {
         path: 'my-dir-my-lib',
-        loadChildren: '@proj/my-dir/my-lib#MyDirMyLibModule'
+        loadChildren: () =>
+          import('@proj/my-dir/my-lib').then(module => module.MyDirMyLibModule)
       }`);
         expect(moduleContents3).toContain(`
       {
         path: 'my-dir-my-lib2',
-        loadChildren: '@proj/my-dir/my-lib2#MyDirMyLib2Module'
+        loadChildren: () =>
+          import('@proj/my-dir/my-lib2').then(
+            module => module.MyDirMyLib2Module
+          )
       }`);
         expect(moduleContents3).toContain(`
-      { path: 'my-lib3', loadChildren: '@proj/my-dir/my-lib3#MyLib3Module' }`);
+      {
+        path: 'my-lib3',
+        loadChildren: () =>
+          import('@proj/my-dir/my-lib3').then(module => module.MyLib3Module)
+      }`);
 
         const tsConfigAppJson3 = JSON.parse(
           stripJsonComments(

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -131,9 +131,9 @@ function addLoadChildren(options: NormalizedSchema): Rule {
         sourceFile,
         `{path: '${toFileName(
           options.fileName
-        )}', loadChildren: '@${npmScope}/${options.projectDirectory}#${
-          options.moduleName
-        }'}`
+        )}', loadChildren: () => import('@${npmScope}/${
+          options.projectDirectory
+        }').then(module => module.${options.moduleName})}`
       )
     ]);
 


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Lazy Loading is done via `loadChildren` strings

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Lazy Loading is done via `loadChildren` callbacks via Dynamic Imports

## Issue
