### PR TITLE
feat(nx): add in spec option for Cypress Builder

### DIFF
--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -29,6 +29,7 @@ export interface CypressBuilderOptions extends JsonObject {
   watch: boolean;
   browser?: string;
   env?: Record<string, string>;
+  spec?: string;
 }
 
 try {
@@ -80,7 +81,8 @@ function run(
         options.watch,
         baseUrl,
         options.browser,
-        options.env
+        options.env,
+        options.spec
       )
     ),
     options.watch ? tap(noop) : take(1),
@@ -187,7 +189,8 @@ function initCypress(
   isWatching: boolean,
   baseUrl: string,
   browser?: string,
-  env?: Record<string, string>
+  env?: Record<string, string>,
+  spec?: string
 ): Observable<BuilderOutput> {
   // Cypress expects the folder where a `cypress.json` is present
   const projectFolderPath = path.dirname(cypressConfig);
@@ -206,6 +209,9 @@ function initCypress(
 
   if (env) {
     options.env = env;
+  }
+  if (spec) {
+    options.spec = spec;
   }
 
   options.exit = exit;

--- a/packages/cypress/src/builders/cypress/schema.json
+++ b/packages/cypress/src/builders/cypress/schema.json
@@ -56,6 +56,10 @@
     "env": {
       "type": "object",
       "description": "A key-value Pair of environment variables to pass to Cypress runner"
+    },
+    "spec": {
+      "type": "string",
+      "description": "A comma delimited glob string that is provided to the Cypress runner to specify which spec files to run. i.e. '**examples/**,**actions.spec**"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Add in spec option to angular.json so it can be passed to they cypress builder

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)
Today if a spec string is provided in the angular.json you will get an invalid schema

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
The spec property will be supported in the angular.json and passed to the Cypress API to use
## Issue
