### PR TITLE
fix(frontend): remove e2e target from original angular generated app

### DIFF
--- a/packages/angular/src/schematics/application/application.spec.ts
+++ b/packages/angular/src/schematics/application/application.spec.ts
@@ -23,6 +23,12 @@ describe('app', () => {
       );
     });
 
+    it('should remove the e2e target on the application', async () => {
+      const tree = await runSchematic('app', { name: 'myApp' }, appTree);
+      const angularJson = readJsonInTree(tree, '/angular.json');
+      expect(angularJson.projects['my-app'].architect.e2e).not.toBeDefined();
+    });
+
     it('should update nx.json', async () => {
       const tree = await runSchematic(
         'app',


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

E2E target appears in generated Angular App (the source app)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

E2E target should not be defined in generated Angular App (the source app), only the E2E app.

## Issue
