### PR TITLE
feat(nx): target es2015 by default for all applications

### DIFF
--- a/e2e/schematics/ng-new.test.ts
+++ b/e2e/schematics/ng-new.test.ts
@@ -45,15 +45,28 @@ describe('Nrwl Workspace', () => {
       `
     );
     runCLI(`build --prod --project=my-dir-${myapp} --output-hashing none`);
-    expect(exists(`./tmp/proj/dist/apps/my-dir/${myapp}/main.js`)).toEqual(
+    expect(
+      exists(`./tmp/proj/dist/apps/my-dir/${myapp}/main-es2015.js`)
+    ).toEqual(true);
+    expect(exists(`./tmp/proj/dist/apps/my-dir/${myapp}/main-es5.js`)).toEqual(
       true
     );
 
     // This is a loose requirement because there are a lot of
     // influences external from this project that affect this.
-    const bundleSize = getSize(`./tmp/proj/dist/apps/my-dir/${myapp}/main.js`);
-    console.log(`The current bundle size is ${bundleSize} KB`);
-    expect(bundleSize).toBeLessThanOrEqual(200000);
+    const es2015BundleSize = getSize(
+      `./tmp/proj/dist/apps/my-dir/${myapp}/main-es2015.js`
+    );
+    console.log(
+      `The current es2015 bundle size is ${es2015BundleSize / 1000} KB`
+    );
+    expect(es2015BundleSize).toBeLessThanOrEqual(150000);
+
+    const es5BundleSize = getSize(
+      `./tmp/proj/dist/apps/my-dir/${myapp}/main-es5.js`
+    );
+    console.log(`The current es5 bundle size is ${es5BundleSize / 1000} KB`);
+    expect(es5BundleSize).toBeLessThanOrEqual(175000);
 
     // running tests for the app
     expectTestsPass(

--- a/e2e/schematics/ngrx.test.ts
+++ b/e2e/schematics/ngrx.test.ts
@@ -31,7 +31,8 @@ describe('ngrx', () => {
       `generate @nrwl/angular:ngrx flights --module=libs/${mylib}/src/lib/${mylib}.module.ts --facade`
     );
 
-    expect(runCLI(`build ${myapp}`)).toContain('chunk {main} main.js,');
+    expect(runCLI(`build ${myapp}`)).toContain('chunk {main} main-es2015.js,');
+    expect(runCLI(`build ${myapp}`)).toContain('chunk {main} main-es5.js,');
     expectTestsPass(await runCLIAsync(`test ${myapp} --no-watch`));
     expectTestsPass(await runCLIAsync(`test ${mylib} --no-watch`));
   }, 1000000);

--- a/e2e/schematics/node.test.ts
+++ b/e2e/schematics/node.test.ts
@@ -30,7 +30,7 @@ function getData(): Promise<any> {
 }
 
 describe('Node Applications', () => {
-  xit('should be able to generate an express application', async done => {
+  it('should be able to generate an express application', async done => {
     ensureProject();
     const nodeapp = uniq('nodeapp');
     runCLI(`generate @nrwl/express:app ${nodeapp}`);

--- a/packages/react/src/schematics/application/files/app/tsconfig.json
+++ b/packages/react/src/schematics/application/files/app/tsconfig.json
@@ -5,7 +5,6 @@
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "target": "es2015",
     "types": []
   },
   "include": ["**/*.ts", "**/*.tsx"]

--- a/packages/web/src/schematics/application/files/app/tsconfig.json
+++ b/packages/web/src/schematics/application/files/app/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "<%= offsetFromRoot %>tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
     "types": []
   },
   "include": ["**/*.ts"]

--- a/packages/workspace/src/schematics/workspace/files/tsconfig.json
+++ b/packages/workspace/src/schematics/workspace/files/tsconfig.json
@@ -8,7 +8,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "esnext",
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2017", "dom"],


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

`es5` is targetted by default for most applications.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

With Differential Loading (#1344) it is now safe to target `es2015`. Legacy browsers which do not support `es2015` will get an `es5` bundle created with differential loading.

## Issue
