### PR TITLE
feat(testing): add regex based copy files option to cypress builder

### DIFF
--- a/packages/cypress/src/builders/cypress/schema.json
+++ b/packages/cypress/src/builders/cypress/schema.json
@@ -60,6 +60,10 @@
     "spec": {
       "type": "string",
       "description": "A comma delimited glob string that is provided to the Cypress runner to specify which spec files to run. i.e. '**examples/**,**actions.spec**"
+    },
+    "copyFiles": {
+      "type": "string",
+      "description": "A regex string that is used to choose what additional integration files to copy to the dist folder"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
The cypress builder does not work for Cucumber (https://github.com/TheBrainFamily/cypress-cucumber-preprocessor) as there is a requirement to copy '.feature' files to the output directory.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
There is now a new builder option to copy additional files to the output directory based on matching a given regex.

## Issue
#1195 