### PR TITLE
fix(testing): fix cypress on windows

### DIFF
--- a/packages/cypress/src/builders/cypress/cypress.impl.spec.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.spec.ts
@@ -77,7 +77,7 @@ describe('Cypress builder', () => {
     await run.result;
     await run.stop();
     expect(fork).toHaveBeenCalledWith(
-      '/root/node_modules/.bin/tsc',
+      '/root/node_modules/typescript/bin/tsc',
       ['-p', '/root/apps/my-app-e2e/tsconfig.json'],
       { stdio: [0, 1, 2, 'ipc'] }
     );

--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -115,7 +115,7 @@ function compileTypescriptFiles(
       let args = ['-p', path.join(context.workspaceRoot, tsConfigPath)];
       const tscPath = path.join(
         context.workspaceRoot,
-        '/node_modules/.bin/tsc'
+        '/node_modules/typescript/bin/tsc'
       );
       if (isWatching) {
         args.push('--watch');


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Typescript compilation within the Cypress builder was not working on Windows.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Cypress works on windows

## Issue
