### PR TITLE
fix(testing): jest should depend directly on devkit packages

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -30,7 +30,9 @@
     "migrations": "./migrations.json"
   },
   "peerDependencies": {
-    "@nrwl/workspace": "*",
+    "@nrwl/workspace": "*"
+  },
+  "dependencies": {
     "@angular-devkit/architect": "0.800.0-rc.4",
     "@angular-devkit/core": "8.0.0-rc.4",
     "@angular-devkit/schematics": "8.0.0-rc.4"


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Installing `@nrwl/jest` warns that peer dependencies on `@angular-devkit` projects cannot be met.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Installing `@nrwl/jest` does produce warnings.

## Issue
