### PR TITLE
fix(nx): set generated app to default app if none is set

### DIFF
--- a/packages/node/src/schematics/application/application.spec.ts
+++ b/packages/node/src/schematics/application/application.spec.ts
@@ -53,6 +53,7 @@ describe('app', () => {
         })
       );
       expect(angularJson.projects['my-node-app-e2e']).toBeUndefined();
+      expect(angularJson.defaultProject).toEqual('my-node-app');
     });
 
     it('should update nx.json', async () => {
@@ -110,6 +111,7 @@ describe('app', () => {
         'apps/my-dir/my-node-app'
       );
       expect(angularJson.projects['my-dir-my-node-app-e2e']).toBeUndefined();
+      expect(angularJson.defaultProject).toEqual('my-dir-my-node-app');
     });
 
     it('should update nx.json', async () => {

--- a/packages/node/src/schematics/application/application.ts
+++ b/packages/node/src/schematics/application/application.ts
@@ -96,6 +96,8 @@ function updateAngularJson(options: NormalizedSchema): Rule {
     project.architect.lint = getLintConfig(project);
     angularJson.projects[options.name] = project;
 
+    angularJson.defaultProject = angularJson.defaultProject || options.name;
+
     return angularJson;
   });
 }

--- a/packages/react/src/schematics/application/application.spec.ts
+++ b/packages/react/src/schematics/application/application.spec.ts
@@ -21,6 +21,7 @@ describe('app', () => {
       expect(angularJson.projects['my-app-e2e'].root).toEqual(
         'apps/my-app-e2e'
       );
+      expect(angularJson.defaultProject).toEqual('my-app');
     });
 
     it('should update nx.json', async () => {

--- a/packages/react/src/schematics/application/application.ts
+++ b/packages/react/src/schematics/application/application.ts
@@ -182,6 +182,9 @@ function addProject(options: NormalizedSchema): Rule {
       schematics: {},
       architect
     };
+
+    json.defaultProject = json.defaultProject || options.projectName;
+
     return json;
   });
 }

--- a/packages/web/src/schematics/application/application.spec.ts
+++ b/packages/web/src/schematics/application/application.spec.ts
@@ -21,6 +21,7 @@ describe('app', () => {
       expect(angularJson.projects['my-app-e2e'].root).toEqual(
         'apps/my-app-e2e'
       );
+      expect(angularJson.defaultProject).toEqual('my-app');
     });
 
     it('should update nx.json', async () => {

--- a/packages/web/src/schematics/application/application.ts
+++ b/packages/web/src/schematics/application/application.ts
@@ -139,6 +139,9 @@ function addProject(options: NormalizedSchema): Rule {
       schematics: {},
       architect
     };
+
+    json.defaultProject = json.defaultProject || options.projectName;
+
     return json;
   });
 }


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

No default project is set in the `angular.json`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The first generated app should be set as the default project.

## Issue
