### PR TITLE
chore(tools): add jest types so more jest features can be used

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "emitDecoratorMetadata": true,
     "skipLibCheck": true,
     "lib": ["es2017"],
+    "types": ["node", "jest"],
     "declaration": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
Support more matchers (e.g. `expect(...).resolves.toContain(...)`,
`expect(a).toEqual(expect.objectContaining(...))`)

## Current Behavior (This is the behavior we have today, before the PR is merged)

Cannot use non-jasmine features, such as  matchers like `await expect(Promise.reject('Oops')).rejects.toThrow(/Oops/))`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Can use all jest features.
