### PR TITLE
feat(react): add routing support to react app, lib, and component schematics

### DIFF
--- a/docs/api-angular/schematics/application.md
+++ b/docs/api-angular/schematics/application.md
@@ -25,6 +25,14 @@ Type: `string`
 
 Test runner to use for end to end (e2e) tests
 
+### enableIvy
+
+Default: `false`
+
+Type: `boolean`
+
+**EXPERIMENTAL** True to create a new app that uses the Ivy rendering engine.
+
 ### inlineStyle
 
 Alias(es): s

--- a/docs/api-cypress/builders/cypress.md
+++ b/docs/api-cypress/builders/cypress.md
@@ -66,6 +66,12 @@ Type: `boolean`
 
 Whether or not Cypress should record the results of the tests
 
+### spec
+
+Type: `string`
+
+A comma delimited glob string that is provided to the Cypress runner to specify which spec files to run. i.e. '**examples/**,**actions.spec**
+
 ### tsConfig
 
 Type: `string`

--- a/docs/api-react/schematics/application.md
+++ b/docs/api-react/schematics/application.md
@@ -47,6 +47,12 @@ Type: `boolean`
 
 Use pascal case component file name (e.g. App.tsx)®
 
+### routing
+
+Type: `boolean`
+
+Generate application with routes
+
 ### skipFormat
 
 Default: `false`

--- a/docs/api-react/schematics/component.md
+++ b/docs/api-react/schematics/component.md
@@ -47,6 +47,12 @@ Type: `string`
 
 The name of the project (as specified in angular.json).
 
+### routing
+
+Type: `boolean`
+
+Generate library with routes
+
 ### skipTests
 
 Default: `false`

--- a/docs/api-react/schematics/library.md
+++ b/docs/api-react/schematics/library.md
@@ -23,6 +23,12 @@ Type: `string`
 
 Library name
 
+### parentRoute
+
+Type: `string`
+
+Add new route to the parent component as specified by this path
+
 ### pascalCaseFiles
 
 Default: `false`
@@ -30,6 +36,12 @@ Default: `false`
 Type: `boolean`
 
 Use pascal case component file name (e.g. App.tsx)®
+
+### routing
+
+Type: `boolean`
+
+Generate library with routes
 
 ### skipFormat
 

--- a/docs/api-web/builders/build.md
+++ b/docs/api-web/builders/build.md
@@ -38,6 +38,14 @@ Type: `string`
 
 URL where the application will be deployed.
 
+### differentialLoading
+
+Default: `true`
+
+Type: `boolean`
+
+Enable differential loading for es5 browsers
+
 ### es2015Polyfills
 
 Type: `string`

--- a/packages/react/src/schematics/application/application.spec.ts
+++ b/packages/react/src/schematics/application/application.spec.ts
@@ -442,4 +442,24 @@ describe('app', () => {
       expect(packageJSON.dependencies['@emotion/styled']).toBeDefined();
     });
   });
+
+  describe('--routing', () => {
+    it('should add routes to the App component', async () => {
+      const tree = await runSchematic(
+        'app',
+        { name: 'myApp', routing: true },
+        appTree
+      );
+
+      const componentSource = tree
+        .read('apps/my-app/src/app/app.tsx')
+        .toString();
+
+      expect(componentSource).toContain('react-router-dom');
+      expect(componentSource).toContain('<Router>');
+      expect(componentSource).toContain('</Router>');
+      expect(componentSource).toMatch(/<Route\s*path="\/"/);
+      expect(componentSource).toMatch(/<Link\s*to="\/"/);
+    });
+  });
 });

--- a/packages/react/src/schematics/application/application.ts
+++ b/packages/react/src/schematics/application/application.ts
@@ -1,4 +1,4 @@
-import { join, normalize } from '@angular-devkit/core';
+import { join, normalize, Path } from '@angular-devkit/core';
 import {
   apply,
   chain,
@@ -12,24 +12,29 @@ import {
   Tree,
   url
 } from '@angular-devkit/schematics';
-import { Schema } from './schema';
 import {
   formatFiles,
+  insert,
   names,
   NxJson,
   offsetFromRoot,
   toFileName,
   updateJsonInTree
 } from '@nrwl/workspace';
-import ngAdd from '../ng-add/ng-add';
-import { CSS_IN_JS_DEPENDENCIES } from '../../utils/styled';
 import { addDepsToPackageJson } from '@nrwl/workspace/src/utils/ast-utils';
+import ngAdd from '../ng-add/ng-add';
+import * as ts from 'typescript';
+
+import { Schema } from './schema';
+import { CSS_IN_JS_DEPENDENCIES } from '../../utils/styled';
+import { addRouter } from '../../utils/ast-utils';
+import { reactRouterVersion } from '../../utils/versions';
 
 interface NormalizedSchema extends Schema {
   projectName: string;
-  appProjectRoot: string;
+  appProjectRoot: Path;
   e2eProjectName: string;
-  e2eProjectRoot: string;
+  e2eProjectRoot: Path;
   parsedTags: string[];
   fileName: string;
   styledModule: null | string;
@@ -63,6 +68,7 @@ export default function(schema: Schema): Rule {
           })
         : noop(),
       addStyledModuleDependencies(options),
+      addRouting(options),
       formatFiles(options)
     ]);
   };
@@ -103,22 +109,17 @@ function addProject(options: NormalizedSchema): Rule {
       builder: '@nrwl/web:build',
       options: {
         outputPath: join(normalize('dist'), options.appProjectRoot),
-        index: join(normalize(options.appProjectRoot), 'src/index.html'),
-        main: join(normalize(options.appProjectRoot), `src/main.tsx`),
-        polyfills: join(normalize(options.appProjectRoot), 'src/polyfills.ts'),
-        tsConfig: join(normalize(options.appProjectRoot), 'tsconfig.app.json'),
+        index: join(options.appProjectRoot, 'src/index.html'),
+        main: join(options.appProjectRoot, `src/main.tsx`),
+        polyfills: join(options.appProjectRoot, 'src/polyfills.ts'),
+        tsConfig: join(options.appProjectRoot, 'tsconfig.app.json'),
         assets: [
-          join(normalize(options.appProjectRoot), 'src/favicon.ico'),
-          join(normalize(options.appProjectRoot), 'src/assets')
+          join(options.appProjectRoot, 'src/favicon.ico'),
+          join(options.appProjectRoot, 'src/assets')
         ],
         styles: options.styledModule
           ? []
-          : [
-              join(
-                normalize(options.appProjectRoot),
-                `src/styles.${options.style}`
-              )
-            ],
+          : [join(options.appProjectRoot, `src/styles.${options.style}`)],
         scripts: []
       },
       configurations: {
@@ -126,11 +127,11 @@ function addProject(options: NormalizedSchema): Rule {
           fileReplacements: [
             {
               replace: join(
-                normalize(options.appProjectRoot),
+                options.appProjectRoot,
                 `src/environments/environment.ts`
               ),
               with: join(
-                normalize(options.appProjectRoot),
+                options.appProjectRoot,
                 `src/environments/environment.prod.ts`
               )
             }
@@ -168,16 +169,14 @@ function addProject(options: NormalizedSchema): Rule {
     architect.lint = {
       builder: '@angular-devkit/build-angular:tslint',
       options: {
-        tsConfig: [
-          join(normalize(options.appProjectRoot), 'tsconfig.app.json')
-        ],
+        tsConfig: [join(options.appProjectRoot, 'tsconfig.app.json')],
         exclude: ['**/node_modules/**']
       }
     };
 
     json.projects[options.projectName] = {
       root: options.appProjectRoot,
-      sourceRoot: join(normalize(options.appProjectRoot), 'src'),
+      sourceRoot: join(options.appProjectRoot, 'src'),
       projectType: 'application',
       schematics: {},
       architect
@@ -197,6 +196,29 @@ function addStyledModuleDependencies(options: NormalizedSchema): Rule {
     : noop();
 }
 
+function addRouting(options: NormalizedSchema): Rule {
+  return options.routing
+    ? chain([
+        function addRouterToComponent(host: Tree) {
+          const appPath = join(
+            options.appProjectRoot,
+            `src/app/${options.fileName}.tsx`
+          );
+          const appFileContent = host.read(appPath).toString('utf-8');
+          const appSource = ts.createSourceFile(
+            appPath,
+            appFileContent,
+            ts.ScriptTarget.Latest,
+            true
+          );
+
+          insert(host, appPath, addRouter(appPath, appSource));
+        },
+        addDepsToPackageJson({ 'react-router-dom': reactRouterVersion }, {})
+      ])
+    : noop();
+}
+
 function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   const appDirectory = options.directory
     ? `${toFileName(options.directory)}/${toFileName(options.name)}`
@@ -205,8 +227,8 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   const appProjectName = appDirectory.replace(new RegExp('/', 'g'), '-');
   const e2eProjectName = `${appProjectName}-e2e`;
 
-  const appProjectRoot = `apps/${appDirectory}`;
-  const e2eProjectRoot = `apps/${appDirectory}-e2e`;
+  const appProjectRoot = normalize(`apps/${appDirectory}`);
+  const e2eProjectRoot = normalize(`apps/${appDirectory}-e2e`);
 
   const parsedTags = options.tags
     ? options.tags.split(',').map(s => s.trim())

--- a/packages/react/src/schematics/application/schema.d.ts
+++ b/packages/react/src/schematics/application/schema.d.ts
@@ -10,4 +10,5 @@ export interface Schema {
   e2eTestRunner: E2eTestRunner;
   pascalCaseFiles?: boolean;
   classComponent?: boolean;
+  routing?: boolean;
 }

--- a/packages/react/src/schematics/application/schema.json
+++ b/packages/react/src/schematics/application/schema.json
@@ -81,6 +81,10 @@
       "type": "boolean",
       "description": "Use class components instead of functional component",
       "default": false
+    },
+    "routing": {
+      "type": "boolean",
+      "description": "Generate application with routes"
     }
   },
   "required": []

--- a/packages/react/src/schematics/component/component.spec.ts
+++ b/packages/react/src/schematics/component/component.spec.ts
@@ -148,4 +148,24 @@ describe('component', () => {
       expect(packageJSON.dependencies['@emotion/core']).toBeDefined();
     });
   });
+
+  describe('--routing', () => {
+    it('should add routes to the component', async () => {
+      const tree = await runSchematic(
+        'component',
+        { name: 'hello', project: projectName, routing: true },
+        appTree
+      );
+
+      const content = tree
+        .read('libs/my-lib/src/lib/hello/hello.tsx')
+        .toString();
+      expect(content).toContain('react-router-dom');
+      expect(content).toMatch(/<Route\s*path="\/"/);
+      expect(content).toMatch(/<Link\s*to="\/"/);
+
+      const packageJSON = readJsonInTree(tree, 'package.json');
+      expect(packageJSON.dependencies['react-router-dom']).toBeDefined();
+    });
+  });
 });

--- a/packages/react/src/schematics/component/component.ts
+++ b/packages/react/src/schematics/component/component.ts
@@ -22,6 +22,7 @@ import {
   insert
 } from '@nrwl/workspace/src/utils/ast-utils';
 import { CSS_IN_JS_DEPENDENCIES } from '../../utils/styled';
+import { reactRouterVersion } from '../../utils/versions';
 
 interface NormalizedSchema extends Schema {
   projectSourceRoot: Path;
@@ -37,6 +38,9 @@ export default function(schema: Schema): Rule {
       createComponentFiles(options),
       addStyledModuleDependencies(options),
       addExportsToBarrel(options),
+      options.routing
+        ? addDepsToPackageJson({ 'react-router-dom': reactRouterVersion }, {})
+        : noop(),
       formatFiles({ skipFormat: false })
     ]);
   };
@@ -103,9 +107,7 @@ function addExportsToBarrel(options: NormalizedSchema): Rule {
               addGlobal(
                 indexSourceFile,
                 indexFilePath,
-                `export { default as ${options.className}, ${
-                  options.className
-                }Props } from './lib/${options.name}/${options.fileName}';`
+                `export * from './lib/${options.name}/${options.fileName}';`
               )
             );
           }

--- a/packages/react/src/schematics/component/files/__name__/__fileName__.tsx__tmpl__
+++ b/packages/react/src/schematics/component/files/__name__/__fileName__.tsx__tmpl__
@@ -3,6 +3,10 @@ import React, { Component } from 'react';
 <% } else { %>
 import React from 'react';
 <% } %>
+
+<% if (routing) { %>
+import { Route, Link } from 'react-router-dom';
+<% } %>
 <% if (styledModule) {
   var wrapper = 'Styled' + className;
 %>
@@ -27,7 +31,13 @@ export class <%= className %> extends Component<<%= className %>Props> {
   render() {
     return (
       <<%= wrapper %>>
-      Welcome to <%= name %> component!
+        <h1>Welcome to <%= name %> component!</h1>
+        <% if (routing) { %>
+          <ul>
+            <li><Link to="/"><%= name %> root</Link></li>
+          </ul>
+          <Route path="/" render={() => <div>This is the <%= name %> root route.</div>} />
+        <% } %>
       </<%= wrapper %>>
     );
   }
@@ -36,7 +46,13 @@ export class <%= className %> extends Component<<%= className %>Props> {
 export const <%= className %> = (props: <%= className %>Props) => {
   return (
     <<%= wrapper %>>
-      Welcome to <%= name %> component!
+      <h1>Welcome to <%= name %> component!</h1>
+      <% if (routing) { %>
+        <ul>
+          <li><Link to="/"><%= name %> root</Link></li>
+        </ul>
+        <Route path="/" render={() => <div>This is the <%= name %> root route.</div>} />
+      <% } %>
     </<%= wrapper %>>
   );
 };

--- a/packages/react/src/schematics/component/schema.d.ts
+++ b/packages/react/src/schematics/component/schema.d.ts
@@ -6,4 +6,5 @@ export interface Schema {
   export?: boolean;
   pascalCaseFiles?: boolean;
   classComponent?: boolean;
+  routing?: boolean;
 }

--- a/packages/react/src/schematics/component/schema.json
+++ b/packages/react/src/schematics/component/schema.json
@@ -73,6 +73,10 @@
       "type": "boolean",
       "description": "Use class components instead of functional component",
       "default": false
+    },
+    "routing": {
+      "type": "boolean",
+      "description": "Generate library with routes"
     }
   },
   "required": ["name", "project"]

--- a/packages/react/src/schematics/library/library.spec.ts
+++ b/packages/react/src/schematics/library/library.spec.ts
@@ -263,4 +263,63 @@ describe('lib', () => {
       ).toEqual(['libs/my-lib/tsconfig.lib.json']);
     });
   });
+
+  describe('--parentRoute', () => {
+    it('should add route to parent component', async () => {
+      appTree = await runSchematic(
+        'app',
+        { name: 'myApp', routing: true },
+        appTree
+      );
+
+      const tree = await runSchematic(
+        'lib',
+        {
+          name: 'myLib',
+          parentRoute: 'apps/my-app/src/app/app.tsx'
+        },
+        appTree
+      );
+
+      const appSource = tree.read('apps/my-app/src/app/app.tsx').toString();
+
+      expect(appSource).toMatch(/<Route\s*path="\/my-lib"/);
+      expect(appSource).toContain('@proj/my-lib');
+    });
+
+    it('throws error when parent component file is missing', async () => {
+      await expect(
+        runSchematic(
+          'lib',
+          {
+            name: 'myLib',
+            parentRoute: 'does/not/exist.tsx'
+          },
+          appTree
+        )
+      ).rejects.toThrow('Cannot find');
+    });
+
+    it('should add routing to app if it does not exist yet', async () => {
+      appTree = await runSchematic(
+        'app',
+        { name: 'myApp', routing: false },
+        appTree
+      );
+
+      const tree = await runSchematic(
+        'lib',
+        {
+          name: 'myLib',
+          parentRoute: 'apps/my-app/src/app/app.tsx'
+        },
+        appTree
+      );
+
+      const appSource = tree.read('apps/my-app/src/app/app.tsx').toString();
+
+      expect(appSource).toContain('react-router-dom');
+      expect(appSource).toMatch(/<Route\s*path="\/my-lib"/);
+    });
+  });
 });

--- a/packages/react/src/schematics/library/schema.d.ts
+++ b/packages/react/src/schematics/library/schema.d.ts
@@ -9,5 +9,7 @@ export interface Schema {
   tags?: string;
   simpleModuleName: boolean;
   pascalCaseFiles?: boolean;
+  routing?: boolean;
+  parentRoute?: string;
   unitTestRunner: UnitTestRunner;
 }

--- a/packages/react/src/schematics/library/schema.json
+++ b/packages/react/src/schematics/library/schema.json
@@ -75,6 +75,14 @@
       "type": "boolean",
       "description": "Use pascal case component file name (e.g. App.tsx)®",
       "default": false
+    },
+    "routing": {
+      "type": "boolean",
+      "description": "Generate library with routes"
+    },
+    "parentRoute": {
+      "type": "string",
+      "description": "Add new route to the parent component as specified by this path"
     }
   },
   "required": ["name"]

--- a/packages/react/src/utils/ast-utils.spec.ts
+++ b/packages/react/src/utils/ast-utils.spec.ts
@@ -1,0 +1,59 @@
+import * as utils from './ast-utils';
+import * as ts from 'typescript';
+
+describe('react ast-utils', () => {
+  describe('findDefaultExport', () => {
+    it('should find exported variable', () => {
+      const text = `
+        const main = () => {}; 
+        export default main;
+      `;
+      const source = ts.createSourceFile(
+        'test.ts',
+        text,
+        ts.ScriptTarget.Latest,
+        true
+      );
+
+      const result = utils.findDefaultExport(source) as any;
+
+      expect(result).toBeDefined();
+      expect(result.name.text).toEqual('main');
+    });
+
+    it('should find exported function', () => {
+      const text = `
+        function main() {} 
+        export default main;
+      `;
+      const source = ts.createSourceFile(
+        'test.ts',
+        text,
+        ts.ScriptTarget.Latest,
+        true
+      );
+
+      const result = utils.findDefaultExport(source) as any;
+
+      expect(result).toBeDefined();
+      expect(result.name.text).toEqual('main');
+    });
+
+    it('should find default export function', () => {
+      const text = `
+        export default function main() {};
+      `;
+      const source = ts.createSourceFile(
+        'test.ts',
+        text,
+        ts.ScriptTarget.Latest,
+        true
+      );
+
+      const result = utils.findDefaultExport(source) as any;
+
+      expect(result).toBeDefined();
+      expect(result.name.text).toEqual('main');
+    });
+  });
+});

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -1,0 +1,178 @@
+import {
+  addGlobal,
+  Change,
+  findNodes,
+  InsertChange
+} from '@nrwl/workspace/src/utils/ast-utils';
+import * as ts from 'typescript';
+
+export function addRouter(sourcePath: string, source: ts.SourceFile): Change[] {
+  const jsxOpening = findNodes(source, ts.SyntaxKind.JsxOpeningElement);
+  const jsxClosing = findNodes(source, ts.SyntaxKind.JsxClosingElement);
+
+  const outerMostJsxOpening = jsxOpening[0];
+  const outerMostJsxClosing = jsxClosing[jsxClosing.length - 1];
+
+  const insertOpening = new InsertChange(
+    sourcePath,
+    outerMostJsxOpening.getStart(),
+    '<Router>'
+  );
+
+  const insertClosing = new InsertChange(
+    sourcePath,
+    outerMostJsxClosing.getEnd(),
+    '</Router>'
+  );
+
+  const insertRoute = new InsertChange(
+    sourcePath,
+    outerMostJsxClosing.getStart(),
+    `<Route
+       path="/"
+       exact
+       render={() => (
+         <div>This is the root route.</div>
+       )}
+     />`
+  );
+
+  const insertLink = new InsertChange(
+    sourcePath,
+    outerMostJsxOpening.getEnd(),
+    '<ul><li><Link to="/">Root</Link></li></ul>'
+  );
+
+  findDefaultExport(source);
+
+  return [
+    ...addGlobal(
+      source,
+      sourcePath,
+      `import { BrowserRouter as Router, Route, Link} from 'react-router-dom';`
+    ),
+    insertOpening,
+    insertClosing,
+    insertRoute,
+    insertLink
+  ];
+}
+
+export function addRoute(
+  sourcePath: string,
+  source: ts.SourceFile,
+  options: {
+    libName: string;
+    componentName: string;
+    moduleName: string;
+  }
+): Change[] {
+  const defaultExport = findDefaultExport(source);
+
+  if (!defaultExport) {
+    throw new Error(`Cannot find default export in ${sourcePath}`);
+  }
+
+  const elements = findNodes(
+    defaultExport,
+    ts.SyntaxKind.JsxSelfClosingElement
+  ) as ts.JsxSelfClosingElement[];
+
+  const routes = elements.filter(
+    x =>
+      x.tagName.kind === ts.SyntaxKind.Identifier && x.tagName.text === 'Route'
+  );
+
+  if (routes.length > 0) {
+    const lastRoute = routes[0];
+
+    const addImport = addGlobal(
+      source,
+      sourcePath,
+      `import { ${options.componentName} } from '${options.moduleName}';`
+    );
+
+    const insertRoute = new InsertChange(
+      sourcePath,
+      lastRoute.getEnd(),
+      `<Route path="/${options.libName}" component={${
+        options.componentName
+      }} />`
+    );
+
+    return [...addImport, insertRoute];
+  } else {
+    throw new Error(`Could not find routes in ${sourcePath}`);
+  }
+}
+
+export function findDefaultExport(source: ts.SourceFile): ts.Node | null {
+  return (
+    findDefaultExportDeclaration(source) || findDefaultClassOrFunction(source)
+  );
+}
+
+export function findDefaultExportDeclaration(
+  source: ts.SourceFile
+): ts.Node | null {
+  const identifier = findDefaultExportIdentifier(source);
+
+  if (identifier) {
+    const variables = findNodes(source, ts.SyntaxKind.VariableDeclaration);
+    const fns = findNodes(source, ts.SyntaxKind.FunctionDeclaration);
+    const all = variables.concat(fns) as Array<
+      ts.VariableDeclaration | ts.FunctionDeclaration
+    >;
+
+    const exported = all
+      .filter(x => x.name.kind === ts.SyntaxKind.Identifier)
+      .find(x => (x.name as ts.Identifier).text === identifier.text);
+
+    return exported || null;
+  } else {
+    return null;
+  }
+}
+
+export function findDefaultExportIdentifier(
+  source: ts.SourceFile
+): ts.Identifier | null {
+  const exports = findNodes(
+    source,
+    ts.SyntaxKind.ExportAssignment
+  ) as ts.ExportAssignment[];
+
+  const identifier = exports
+    .map(x => x.expression)
+    .find(x => x.kind === ts.SyntaxKind.Identifier) as ts.Identifier;
+
+  return identifier || null;
+}
+
+export function findDefaultClassOrFunction(
+  source: ts.SourceFile
+): ts.FunctionDeclaration | ts.ClassDeclaration | null {
+  const fns = findNodes(
+    source,
+    ts.SyntaxKind.FunctionDeclaration
+  ) as ts.FunctionDeclaration[];
+  const cls = findNodes(
+    source,
+    ts.SyntaxKind.ClassDeclaration
+  ) as ts.ClassDeclaration[];
+
+  return (
+    fns.find(hasDefaultExportModifier) ||
+    cls.find(hasDefaultExportModifier) ||
+    null
+  );
+}
+
+function hasDefaultExportModifier(
+  x: ts.ClassDeclaration | ts.FunctionDeclaration
+) {
+  return (
+    x.modifiers.some(m => m.kind === ts.SyntaxKind.ExportKeyword) &&
+    x.modifiers.some(m => m.kind === ts.SyntaxKind.DefaultKeyword)
+  );
+}

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -5,4 +5,5 @@ export const styledComponentVersion = '4.2.0';
 export const styledComponentTypesVersion = '4.1.15';
 export const emotionVersion = '10.0.10';
 export const domTypesVersion = '16.8.2';
+export const reactRouterVersion = '5.0.0';
 export const testingLibraryVersion = '6.0.0';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "skipLibCheck": true,
+    "types": ["node", "jest"],
     "lib": ["es2017"],
     "declaration": true,
     "baseUrl": ".",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Routing is not supported by React schematics.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The `--routing` option will:
* Generate _app_ with top-level `<Router>`, and default `<Link>` and `<Route>` elements.
* Generate _lib_ and _component_ with default `<Link>` and `<Route>` elements.

The `--parentRoute` option will:
* Add the lib component as a route in the specified parent component.
  e.g. `ng g @nrwl/react:library -name feature-a --parentRoute apps/my-app/src/app/App.tsx` adds `<Route path="/feature-a">` and `<Link to="/feature-a>feature-a</Link>` to the App component.
