### PR TITLE
fix(nx): fix nx8 migration

### DIFF
--- a/packages/schematics/migrations/update-8-0-0/update-8-0-0.ts
+++ b/packages/schematics/migrations/update-8-0-0/update-8-0-0.ts
@@ -4,8 +4,7 @@ import {
   SchematicContext,
   Tree,
   externalSchematic,
-  noop,
-  filter
+  noop
 } from '@angular-devkit/schematics';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import {
@@ -159,6 +158,14 @@ const updateNxModuleImports = (host: Tree) => {
   host.visit(path => {
     if (!path.endsWith('.ts')) {
       return;
+    }
+
+    if (host.exists('.gitignore')) {
+      const ig = ignore();
+      ig.add(host.read('.gitignore').toString());
+      if (ig.ignores(relative('/', path))) {
+        return;
+      }
     }
 
     const sourceFile = createSourceFile(
@@ -384,21 +391,9 @@ const updateNestDependencies = updateJsonInTree('package.json', json => {
   return json;
 });
 
-function filterFiles(host: Tree, context: SchematicContext) {
-  const ig = ignore();
-  if (!host.exists('.gitignore')) {
-    return noop();
-  }
-  ig.add(host.read('.gitignore').toString());
-  return filter(file => {
-    return !ig.ignores(relative('/', file));
-  });
-}
-
 export default function(): Rule {
   return chain([
     displayInformation,
-    filterFiles,
     runAngularMigrations,
     removeOldDependencies,
     updateUpdateScript,


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Filtering out `gitignore`'d files was causing issues.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Noop for `.gitignore`'d files for TS migrations

## Issue
