### PR TITLE
feat(nx): update to cypress 3.3.6

### DIFF
--- a/packages/angular/src/schematics/ng-add/ng-add.spec.ts
+++ b/packages/angular/src/schematics/ng-add/ng-add.spec.ts
@@ -143,7 +143,6 @@ describe('ng-add', () => {
         const { devDependencies } = readJsonInTree(tree, 'package.json');
         expect(devDependencies['@nrwl/cypress']).toBeDefined();
         expect(devDependencies['cypress']).toBeDefined();
-        expect(devDependencies['@types/jquery']).toBeDefined();
       });
 
       it('should set defaults', async () => {

--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -1,3 +1,9 @@
 {
-  "schematics": {}
+  "schematics": {
+    "update-8.1.0": {
+      "version": "8.1.0",
+      "description": "Update cypress",
+      "factory": "./migrations/update-8-1-0/update-8-1-0"
+    }
+  }
 }

--- a/packages/cypress/migrations/update-8-1-0/update-8-1-0.spec.ts
+++ b/packages/cypress/migrations/update-8-1-0/update-8-1-0.spec.ts
@@ -1,0 +1,34 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { serializeJson } from '@nrwl/workspace';
+
+import * as path from 'path';
+
+describe('Update 8.1.0', () => {
+  let initialTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(() => {
+    initialTree = Tree.empty();
+    initialTree.create(
+      'package.json',
+      serializeJson({
+        scripts: {}
+      })
+    );
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/cypress',
+      path.join(__dirname, '../../migrations.json')
+    );
+  });
+
+  it('should update cypress', async () => {
+    const result = await schematicRunner
+      .runSchematicAsync('update-8.1.0', {}, initialTree)
+      .toPromise();
+
+    const { devDependencies } = JSON.parse(result.readContent('package.json'));
+
+    expect(devDependencies.cypress).toEqual('~3.3.6');
+  });
+});

--- a/packages/cypress/migrations/update-8-1-0/update-8-1-0.ts
+++ b/packages/cypress/migrations/update-8-1-0/update-8-1-0.ts
@@ -1,0 +1,33 @@
+import {
+  Rule,
+  chain,
+  SchematicContext,
+  Tree
+} from '@angular-devkit/schematics';
+import { updateJsonInTree } from '@nrwl/workspace';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+
+function displayInformation(host: Tree, context: SchematicContext) {
+  context.logger.info(
+    stripIndents`Cypress has been updated to a version that improves network speed by 300%!
+
+      Additionally, this resolves an issue where '@types/jquery' needed to be temporarily included in your 'package.json'.
+      If you're not using '@types/jquery' in your project otherwise, you may now remove it from your 'devDependencies'.`
+  );
+}
+
+export default function(): Rule {
+  return chain([
+    updateJsonInTree('package.json', json => {
+      json.devDependencies = json.devDependencies || {};
+
+      json.devDependencies = {
+        ...json.devDependencies,
+        cypress: '~3.3.6'
+      };
+
+      return json;
+    }),
+    displayInformation
+  ]);
+}

--- a/packages/cypress/src/schematics/ng-add/ng-add.ts
+++ b/packages/cypress/src/schematics/ng-add/ng-add.ts
@@ -11,8 +11,6 @@ function checkDependenciesInstalled(): Rule {
     const dependencyList: { name: string; version: string }[] = [];
     if (!packageJson.devDependencies.cypress) {
       dependencyList.push({ name: 'cypress', version: cypressVersion });
-      // NOTE: Need to be removed on the next Cypress release (=>3.1.1)
-      dependencyList.push({ name: '@types/jquery', version: '3.3.6' });
     }
     if (!packageJson.devDependencies['@nrwl/cypress']) {
       dependencyList.push({ name: '@nrwl/cypress', version: nxVersion });

--- a/packages/cypress/src/utils/versions.ts
+++ b/packages/cypress/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = '*';
-export const cypressVersion = '3.1.0';
+export const cypressVersion = '~3.3.6';


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

Cypress is pinned at `3.1.0`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Cypress is upgraded to `~3.3.6`. Among other improvements, upgrading beyond `3.3.0` brings:

- [Improved network speed by 300%](https://www.cypress.io/blog/2019/05/22/how-we-improved-network-speed-by-300-in-cypress-3-3-0/)!
- Removes having `@types/jquery` in newly generated project's `devDependencies`. This was due to [an issue](cypress-io/cypress#2363) that has since then been fixed on [cypress@3.1.1](https://docs.cypress.io/guides/references/changelog.html#3-1-1). See also nrwl/nx#853.

Note that the migration script only updates Cypress but doesn't actively remove `@types/jquery`, just in case it's in use elsewhere in the project. Instead, I've added some messaging to make the user aware of the option to remove it themselves.

Last but not least, I'm proposing a slightly looser version number, allowing for big fix releases, but happy to change .

## Issue

N/A