### PR TITLE
fix(nx): fix path quotes in create-nx-workspace

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -82,12 +82,12 @@ const args = process.argv
   .join(' ');
 console.log(`ng new ${args} --collection=${nxTool.packageName}`);
 execSync(
-  `${path.join(
-    `"${tmpDir}"`,
+  `"${path.join(
+    tmpDir,
     'node_modules',
     '.bin',
     'ng'
-  )} new ${args} --collection=${nxTool.packageName}`,
+  )}" new ${args} --collection=${nxTool.packageName}`,
   {
     stdio: [0, 1, 2]
   }

--- a/packages/workspace/bin/create-nx-workspace.ts
+++ b/packages/workspace/bin/create-nx-workspace.ts
@@ -82,12 +82,12 @@ const args = process.argv
   .join(' ');
 console.log(`ng new ${args} --collection=${nxTool.packageName}`);
 execSync(
-  `${path.join(
-    `"${tmpDir}"`,
+  `"${path.join(
+    tmpDir,
     'node_modules',
     '.bin',
     'ng'
-  )} new ${args} --collection=${nxTool.packageName}`,
+  )}" new ${args} --collection=${nxTool.packageName}`,
   {
     stdio: [0, 1, 2]
   }


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

The quote are wrapped around the `tempDir` which yields `"/tmp/tmp-14816HdOcEeetImPE"/node_modules/.bin/ng new "hello" --collection=@nrwl/workspace`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The quote are wrapped around the whole path to `ng` which yields `"/tmp/tmp-14816HdOcEeetImPE/node_modules/.bin/ng" new "hello" --collection=@nrwl/workspace`

## Issue
Fixes #1414 