### PR TITLE
feat(nx): update to jasmine-marbles 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "identity-obj-proxy": "3.0.0",
     "ignore": "^5.0.4",
     "jasmine-core": "~2.99.1",
-    "jasmine-marbles": "0.4.0",
+    "jasmine-marbles": "~0.5.0",
     "jasmine-spec-reporter": "~4.2.1",
     "jest": "^24.1.0",
     "jest-jasmine2": "^24.1.0",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -37,6 +37,6 @@
     "@nrwl/jest": "*",
     "@angular-devkit/schematics": "8.0.1",
     "@schematics/angular": "8.0.1",
-    "jasmine-marbles": "~0.4.0"
+    "jasmine-marbles": "~0.5.0"
   }
 }

--- a/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
@@ -143,7 +143,7 @@ describe('Command Runner Builder', () => {
         expect(readFile(f)).toEqual('');
       });
       setTimeout(() => {
-        expect(successEmitted).toEqual(true, 'Success must be emitted');
+        expect(successEmitted).toEqual(true);
         expect(readFile(f)).toEqual('1');
         done();
       }, 150);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3869,7 +3869,7 @@ cyclist@~0.2.2:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
-cypress@3.3.1:
+cypress@~3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.3.1.tgz#8a127b1d9fa74bff21f111705abfef58d595fdef"
   integrity sha512-JIo47ZD9P3jAw7oaK7YKUoODzszJbNw41JmBrlMMiupHOlhmXvZz75htuo7mfRFPC9/1MDQktO4lX/V2+a6lGQ==
@@ -7011,10 +7011,10 @@ jasmine-core@~2.99.1:
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.99.1.tgz#e6400df1e6b56e130b61c4bcd093daa7f6e8ca15"
   integrity sha1-5kAN8ea1bhMLYcS80JPap/boyhU=
 
-jasmine-marbles@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/jasmine-marbles/-/jasmine-marbles-0.4.0.tgz#de72331d189d4968e4b1e78b638e51654040c755"
-  integrity sha512-fV8fXz5K3p6LUYyElkmXDMZmtxe9c1/8nmD5H9r2TDix/sJAhd/PFoPXym1c7gZCXByx7tfoiVVyc2t/AxtS6Q==
+jasmine-marbles@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/jasmine-marbles/-/jasmine-marbles-0.5.0.tgz#5d4c51082fcf619bb8dbc85583cb11718a32b200"
+  integrity sha512-hkSYy7VJpcxaKE48s/CasVpGyheElp5ZegguFi5kpYAaUWsyOko6RnMZS1kv14ThMtlJVNqCW5z16f1q6HqbEg==
   dependencies:
     lodash "^4.5.0"
 


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)

`jasmine-marbles@~0.4.0` is a peer dependency for `@nrwl/angular@8.0.0`. `jasmine-marbles@0.5.0` had a breaking change (see synapse-wireless-labs/jasmine-marbles@d530594); however, it's not a breaking change for Angular projects anymore since they require the same version of rxjs since v8 (see angular/angular@94aeeec).

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Upgrade to `jasmine-marbles@~0.5.0`.

## Issue

N/A