### PR TITLE
docs(nx): fix typo in bash script for creating lib to share code in 07-share-code.md

### DIFF
--- a/docs/tutorial/07-share-code.md
+++ b/docs/tutorial/07-share-code.md
@@ -5,7 +5,7 @@ Awesome! The application is working end to end! However, there is a problem. Bot
 **Run the following generator to create a library:**
 
 ```bash
-ng g #nrwl/workspace:lib data
+ng g @nrwl/workspace:lib data
 ```
 
 The result should look like this:


### PR DESCRIPTION
The bash script has a typo. Change of '#' to '@'.

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)
Current description in tutorial 07-share-code:
```bash
ng g #nrwl/workspace:lib data
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Expected description in tutorial 07-share-code:
```bash
ng g @nrwl/workspace:lib data
```

## Issue
bash script from tutorial does not work