### PR TITLE
test(nx): reenable dep-graph tests

### DIFF
--- a/e2e/schematics/command-line.test.ts
+++ b/e2e/schematics/command-line.test.ts
@@ -209,138 +209,138 @@ describe('Command line', () => {
     );
   }, 1000000);
 
-  // describe('dep-graph', () => {
-  //   beforeAll(() => {
-  //     newProject();
-  //     runCLI('generate @nrwl/angular:app myapp');
-  //     runCLI('generate @nrwl/angular:app myapp2');
-  //     runCLI('generate @nrwl/angular:app myapp3');
-  //     runCLI('generate @nrwl/angular:lib mylib');
-  //     runCLI('generate @nrwl/angular:lib mylib2');
-  //
-  //     updateFile(
-  //       'apps/myapp/src/main.ts',
-  //       `
-  //     import '@proj/mylib';
-  //
-  //     const s = {loadChildren: '@proj/mylib2'};
-  //   `
-  //     );
-  //
-  //     updateFile(
-  //       'apps/myapp2/src/app/app.component.spec.ts',
-  //       `import '@proj/mylib';`
-  //     );
-  //
-  //     updateFile(
-  //       'libs/mylib/src/mylib.module.spec.ts',
-  //       `import '@proj/mylib2';`
-  //     );
-  //   });
-  //
-  //   it('dep-graph should output json (without critical path) to file', () => {
-  //     const file = 'dep-graph.json';
-  //
-  //     runCommand(`npm run dep-graph -- --file="${file}"`);
-  //
-  //     expect(() => checkFilesExist(file)).not.toThrow();
-  //
-  //     const jsonFileContents = readJson(file);
-  //
-  //     expect(jsonFileContents).toEqual({
-  //       deps: {
-  //         mylib2: [],
-  //         myapp3: [],
-  //         'myapp3-e2e': [
-  //           {
-  //             projectName: 'myapp3',
-  //             type: 'implicit'
-  //           }
-  //         ],
-  //         myapp2: [
-  //           {
-  //             projectName: 'mylib',
-  //             type: 'es6Import'
-  //           }
-  //         ],
-  //         'myapp2-e2e': [
-  //           {
-  //             projectName: 'myapp2',
-  //             type: 'implicit'
-  //           }
-  //         ],
-  //         mylib: [
-  //           {
-  //             projectName: 'mylib2',
-  //             type: 'es6Import'
-  //           }
-  //         ],
-  //         myapp: [
-  //           {
-  //             projectName: 'mylib',
-  //             type: 'es6Import'
-  //           },
-  //           {
-  //             projectName: 'mylib2',
-  //             type: 'loadChildren'
-  //           }
-  //         ],
-  //         'myapp-e2e': [
-  //           {
-  //             projectName: 'myapp',
-  //             type: 'implicit'
-  //           }
-  //         ]
-  //       },
-  //       criticalPath: []
-  //     });
-  //   }, 1000000);
-  //
-  //   it('dep-graph should output json with critical path to file', () => {
-  //     const file = 'dep-graph.json';
-  //
-  //     runCommand(
-  //       `npm run affected:dep-graph -- --files="libs/mylib/src/index.ts" --file="${file}"`
-  //     );
-  //
-  //     expect(() => checkFilesExist(file)).not.toThrow();
-  //
-  //     const jsonFileContents = readJson(file);
-  //
-  //     expect(jsonFileContents.criticalPath).toContain('myapp');
-  //     expect(jsonFileContents.criticalPath).toContain('myapp2');
-  //     expect(jsonFileContents.criticalPath).toContain('mylib');
-  //     expect(jsonFileContents.criticalPath).not.toContain('mylib2');
-  //   }, 1000000);
-  //
-  //   it('dep-graph should output dot to file', () => {
-  //     const file = 'dep-graph.dot';
-  //
-  //     runCommand(
-  //       `npm run dep-graph -- --files="libs/mylib/index.ts" --file="${file}"`
-  //     );
-  //
-  //     expect(() => checkFilesExist(file)).not.toThrow();
-  //
-  //     const fileContents = readFile(file);
-  //     expect(fileContents).toContain('"myapp" -> "mylib"');
-  //     expect(fileContents).toContain('"myapp2" -> "mylib"');
-  //     expect(fileContents).toContain('"mylib" -> "mylib2"');
-  //   }, 1000000);
-  //
-  //   it('dep-graph should output html to file', () => {
-  //     const file = 'dep-graph.html';
-  //     runCommand(
-  //       `npm run dep-graph -- --files="libs/mylib/index.ts" --file="${file}"`
-  //     );
-  //
-  //     expect(() => checkFilesExist(file)).not.toThrow();
-  //
-  //     const fileContents = readFile(file);
-  //     expect(fileContents).toContain('<html>');
-  //     expect(fileContents).toContain('<title>myapp&#45;&gt;mylib</title>');
-  //     expect(fileContents).toContain('<title>myapp&#45;&gt;mylib2</title>');
-  //     expect(fileContents).toContain('<title>mylib&#45;&gt;mylib2</title>');
-  //   }, 1000000);
-  // });
+  describe('dep-graph', () => {
+    beforeAll(() => {
+      newProject();
+      runCLI('generate @nrwl/angular:app myapp');
+      runCLI('generate @nrwl/angular:app myapp2');
+      runCLI('generate @nrwl/angular:app myapp3');
+      runCLI('generate @nrwl/angular:lib mylib');
+      runCLI('generate @nrwl/angular:lib mylib2');
+
+      updateFile(
+        'apps/myapp/src/main.ts',
+        `
+      import '@proj/mylib';
+
+      const s = {loadChildren: '@proj/mylib2'};
+    `
+      );
+
+      updateFile(
+        'apps/myapp2/src/app/app.component.spec.ts',
+        `import '@proj/mylib';`
+      );
+
+      updateFile(
+        'libs/mylib/src/mylib.module.spec.ts',
+        `import '@proj/mylib2';`
+      );
+    });
+
+    it('dep-graph should output json (without critical path) to file', () => {
+      const file = 'dep-graph.json';
+
+      runCommand(`npm run dep-graph -- --file="${file}"`);
+
+      expect(() => checkFilesExist(file)).not.toThrow();
+
+      const jsonFileContents = readJson(file);
+
+      expect(jsonFileContents).toEqual({
+        deps: {
+          mylib2: [],
+          myapp3: [],
+          'myapp3-e2e': [
+            {
+              projectName: 'myapp3',
+              type: 'implicit'
+            }
+          ],
+          myapp2: [
+            {
+              projectName: 'mylib',
+              type: 'es6Import'
+            }
+          ],
+          'myapp2-e2e': [
+            {
+              projectName: 'myapp2',
+              type: 'implicit'
+            }
+          ],
+          mylib: [
+            {
+              projectName: 'mylib2',
+              type: 'es6Import'
+            }
+          ],
+          myapp: [
+            {
+              projectName: 'mylib',
+              type: 'es6Import'
+            },
+            {
+              projectName: 'mylib2',
+              type: 'loadChildren'
+            }
+          ],
+          'myapp-e2e': [
+            {
+              projectName: 'myapp',
+              type: 'implicit'
+            }
+          ]
+        },
+        criticalPath: []
+      });
+    }, 1000000);
+
+    it('dep-graph should output json with critical path to file', () => {
+      const file = 'dep-graph.json';
+
+      runCommand(
+        `npm run affected:dep-graph -- --files="libs/mylib/src/index.ts" --file="${file}"`
+      );
+
+      expect(() => checkFilesExist(file)).not.toThrow();
+
+      const jsonFileContents = readJson(file);
+
+      expect(jsonFileContents.criticalPath).toContain('myapp');
+      expect(jsonFileContents.criticalPath).toContain('myapp2');
+      expect(jsonFileContents.criticalPath).toContain('mylib');
+      expect(jsonFileContents.criticalPath).not.toContain('mylib2');
+    }, 1000000);
+
+    it('dep-graph should output dot to file', () => {
+      const file = 'dep-graph.dot';
+
+      runCommand(
+        `npm run dep-graph -- --files="libs/mylib/index.ts" --file="${file}"`
+      );
+
+      expect(() => checkFilesExist(file)).not.toThrow();
+
+      const fileContents = readFile(file);
+      expect(fileContents).toContain('"myapp" -> "mylib"');
+      expect(fileContents).toContain('"myapp2" -> "mylib"');
+      expect(fileContents).toContain('"mylib" -> "mylib2"');
+    }, 1000000);
+
+    it('dep-graph should output html to file', () => {
+      const file = 'dep-graph.html';
+      runCommand(
+        `npm run dep-graph -- --files="libs/mylib/index.ts" --file="${file}"`
+      );
+
+      expect(() => checkFilesExist(file)).not.toThrow();
+
+      const fileContents = readFile(file);
+      expect(fileContents).toContain('<html>');
+      expect(fileContents).toContain('<title>myapp&#45;&gt;mylib</title>');
+      expect(fileContents).toContain('<title>myapp&#45;&gt;mylib2</title>');
+      expect(fileContents).toContain('<title>mylib&#45;&gt;mylib2</title>');
+    }, 1000000);
+  });
 });


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Dep graph e2e tests are disabled.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Dep graph e2e tests are enabled.

## Issue
