### PR TITLE
test(nx): reenable documentation check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
   - yarn e2e
   - yarn checkcommit
   - yarn checkimports
+  - yarn documentation
 
 notifications:
   email: false


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Documentation check was removed.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Documentation check is added back

## Issue
