### PR TITLE
fix(nx): correct path of TSLint config. Fixes #1435

### DIFF
--- a/packages/workspace/src/schematics/library/files/lib/tslint.json
+++ b/packages/workspace/src/schematics/library/files/lib/tslint.json
@@ -1,4 +1,4 @@
 {
-  "extends": "<%= offsetFromRoot %>/tslint.json",
+  "extends": "<%= offsetFromRoot %>tslint.json",
   "rules": []
 }

--- a/packages/workspace/src/schematics/library/library.spec.ts
+++ b/packages/workspace/src/schematics/library/library.spec.ts
@@ -150,6 +150,8 @@ describe('lib', () => {
       expect(
         tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.ts')
       ).toBeTruthy();
+      expect(tree.exists('libs/my-dir/my-lib/src/index.ts')).toBeTruthy();
+      expect(tree.exists(`libs/my-dir/my-lib/tslint.json`)).toBeTruthy();
     });
 
     it('should update angular.json', async () => {
@@ -207,6 +209,20 @@ describe('lib', () => {
           types: ['node', 'jest']
         },
         include: ['**/*.ts']
+      });
+    });
+
+    it('should create a local tslint.json', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', directory: 'myDir' },
+        appTree
+      );
+
+      const tslintJson = readJsonInTree(tree, 'libs/my-dir/my-lib/tslint.json');
+      expect(tslintJson).toEqual({
+        extends: '../../../tslint.json',
+        rules: []
       });
     });
   });


### PR DESCRIPTION
Port of #1436 

This change:
- fixes path in TSLint config template
- add tests coverage for creation and content of the library
`tslint.json` configuration file

Thanks!

Fixes #1435 