### PR TITLE
fix(nx): fix builders migration for projects with no architect

### DIFF
--- a/packages/schematics/migrations/update-8-0-0/update-8-0-0.ts
+++ b/packages/schematics/migrations/update-8-0-0/update-8-0-0.ts
@@ -106,7 +106,14 @@ const updateUpdateScript = updateJsonInTree('package.json', json => {
 });
 
 const updateBuilders = updateJsonInTree('angular.json', json => {
+  if (!json.projects) {
+    return json;
+  }
   Object.entries<any>(json.projects).forEach(([projectKey, project]) => {
+    if (!project.architect) {
+      return;
+    }
+
     Object.entries<any>(project.architect).forEach(([targetKey, target]) => {
       if (target.builder === '@nrwl/builders:jest') {
         json.projects[projectKey].architect[targetKey].builder =


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Projects with no architect cause the migration to 8 to fail

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Projects with no architect are skipped during builder migration

## Issue
Fixes #1455 