### PR TITLE
fix(testing): allow cypress migration to run during beta version

### DIFF
--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -1,7 +1,7 @@
 {
   "schematics": {
     "update-8.1.0": {
-      "version": "8.1.0",
+      "version": "8.1.0-beta.1",
       "description": "Update cypress",
       "factory": "./src/migrations/update-8-1-0/update-8-1-0"
     }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Cypress migration doesn't run in beta

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Cypress migration does run in beta

## Issue
