### PR TITLE
fix(nx): handle reading json with comments

### DIFF
--- a/packages/workspace/src/utils/ast-utils.spec.ts
+++ b/packages/workspace/src/utils/ast-utils.spec.ts
@@ -22,6 +22,16 @@ describe('readJsonInTree', () => {
     });
   });
 
+  it('should handle json files with comments', () => {
+    tree.create(
+      'data.json',
+      `{
+      // data: 'data'
+      }`
+    );
+    expect(readJsonInTree(tree, 'data.json')).toEqual({});
+  });
+
   it('should throw an error if the file does not exist', () => {
     expect(() => readJsonInTree(tree, 'data.json')).toThrow(
       'Cannot find data.json'

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -7,6 +7,7 @@
  */
 import { Rule, Tree, SchematicContext } from '@angular-devkit/schematics';
 import * as ts from 'typescript';
+import * as stripJsonComments from 'strip-json-comments';
 import { serializeJson } from './fileutils';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 
@@ -361,7 +362,7 @@ export function readJsonInTree<T = any>(host: Tree, path: string): T {
   if (!host.exists(path)) {
     throw new Error(`Cannot find ${path}`);
   }
-  const contents = host.read(path)!.toString('utf-8');
+  const contents = stripJsonComments(host.read(path)!.toString('utf-8'));
   try {
     return JSON.parse(contents);
   } catch (e) {


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`readJsonInTree` and `updateJsonInTree` fail to parse JSON files with comments.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`readJsonInTree` and `updateJsonInTree` can handle JSON files with comments.

## Issue
Fixes https://github.com/nrwl/nx/issues/1462