### PR TITLE
feat(testing): Support default Webstorm test runner

### DIFF
--- a/docs/angular/api-jest/builders/jest.md
+++ b/docs/angular/api-jest/builders/jest.md
@@ -44,7 +44,7 @@ Forces test results output color highlighting (even if stdout is not a TTY). Set
 
 Type: `boolean`
 
-Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)
+Alias for `--color`.
 
 ### config
 
@@ -120,7 +120,7 @@ Will not fail if no tests are found (for example while using `--testPathPattern`
 
 Type: `array`
 
-Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/en/cli#reporters)
+Use this configuration option to add custom reporters to Jest. A custom reporter is a class that implements onRunStart, onTestStart, onTestResult, onRunComplete methods that will be called when any of those events occurs
 
 ### runInBand
 
@@ -184,9 +184,9 @@ Divert all output to stderr.
 
 ### verbose
 
-Type: `string`
+Type: `boolean`
 
-Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)
+Indicates whether each individual test should be reported during the run. All errors will also still be shown on the bottom after execution.
 
 ### watch
 

--- a/docs/web/api-jest/builders/jest.md
+++ b/docs/web/api-jest/builders/jest.md
@@ -45,7 +45,7 @@ Forces test results output color highlighting (even if stdout is not a TTY). Set
 
 Type: `boolean`
 
-Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)
+Alias for `--color`.
 
 ### config
 
@@ -121,7 +121,7 @@ Will not fail if no tests are found (for example while using `--testPathPattern`
 
 Type: `array`
 
-Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/en/cli#reporters)
+Use this configuration option to add custom reporters to Jest. A custom reporter is a class that implements onRunStart, onTestStart, onTestResult, onRunComplete methods that will be called when any of those events occurs
 
 ### runInBand
 
@@ -185,9 +185,9 @@ Divert all output to stderr.
 
 ### verbose
 
-Type: `string`
+Type: `boolean`
 
-Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)
+Indicates whether each individual test should be reported during the run. All errors will also still be shown on the bottom after execution.
 
 ### watch
 

--- a/packages/jest/src/builders/jest/schema.json
+++ b/packages/jest/src/builders/jest/schema.json
@@ -90,18 +90,19 @@
       "type": "string"
     },
     "colors": {
-      "description": "Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)",
+      "description": "Alias for `--color`.",
       "type": "boolean"
     },
     "reporters": {
-      "description": "Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters=\"default\" --reporters=\"jest-junit\" (https://jestjs.io/docs/en/cli#reporters)",
+      "description": "Use this configuration option to add custom reporters to Jest. A custom reporter is a class that implements onRunStart, onTestStart, onTestResult, onRunComplete methods that will be called when any of those events occurs",
       "type": "array",
       "items": {
         "type": "string"
       }
     },
     "verbose": {
-      "description": "Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)"
+      "description": "Indicates whether each individual test should be reported during the run. All errors will also still be shown on the bottom after execution.",
+      "type": "boolean"
     },
     "coverage": {
       "description": "Indicates that test coverage information should be collected and reported in the output. This option is also aliased by --collectCoverage. (https://jestjs.io/docs/en/cli#coverage)",


### PR DESCRIPTION
# feat(testing): Support default Webstorm test runner

This change adds additional jest options to builder's `schema.json` and maps them in `jest.impl.ts`.

## Expected Behavior

Webstorm is able to run jest tests without updating the configuration.
Webstorm should be able to open a spec file, click the play icon for the relevant test, and the test should run without an error.

## Current Behavior

Webstorm attempts to run the tests with options supported by jest but the builder.
The unknown options cause the IDE test runner to error with out running the tests.
The specific options are config, colors, reporters, verbose, and testPathPattern.


### Steps to Reproduce

Please provide detailed steps for reproducing the issue.

1. yarn create nx-workspace my-workspace
2. webstorm my-workspace
3. open app.component.spec.ts
4. click play icon
