### PR TITLE
fix(nx): wrap files inputted to prettier in quotes

### DIFF
--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -59,7 +59,9 @@ function getPatterns(args: YargsAffectedOptions) {
       );
 
     const libsAndApp = args.libsAndApps;
-    return libsAndApp ? getPatternsFromApps(patterns) : patterns;
+    return libsAndApp
+      ? getPatternsFromApps(patterns)
+      : patterns.map(f => `"${f}"`);
   } catch (e) {
     return getPatternsWithPathPrefix(['{apps,libs,tools}']);
   }


### PR DESCRIPTION
Files that contained parentheses caused 'yarn format' to fail unless the files passed to the
prettier cli are wrapped in quotes

fix #1473