### PR TITLE
feat(nx): exclude files from outside the project root when linting

### DIFF
--- a/packages/angular/src/schematics/application/application.spec.ts
+++ b/packages/angular/src/schematics/application/application.spec.ts
@@ -21,6 +21,13 @@ describe('app', () => {
       expect(angularJson.projects['my-app-e2e'].root).toEqual(
         'apps/my-app-e2e'
       );
+
+      expect(
+        angularJson.projects['my-app'].architect.lint.options.exclude
+      ).toEqual(['**/node_modules/**', '!apps/my-app/**']);
+      expect(
+        angularJson.projects['my-app-e2e'].architect.lint.options.exclude
+      ).toEqual(['**/node_modules/**', '!apps/my-app-e2e/**']);
     });
 
     it('should remove the e2e target on the application', async () => {
@@ -148,6 +155,13 @@ describe('app', () => {
       expect(angularJson.projects['my-dir-my-app-e2e'].root).toEqual(
         'apps/my-dir/my-app-e2e'
       );
+
+      expect(
+        angularJson.projects['my-dir-my-app'].architect.lint.options.exclude
+      ).toEqual(['**/node_modules/**', '!apps/my-dir/my-app/**']);
+      expect(
+        angularJson.projects['my-dir-my-app-e2e'].architect.lint.options.exclude
+      ).toEqual(['**/node_modules/**', '!apps/my-dir/my-app-e2e/**']);
     });
 
     it('should update nx.json', async () => {
@@ -392,7 +406,7 @@ describe('app', () => {
               builder: '@angular-devkit/build-angular:tslint',
               options: {
                 tsConfig: 'apps/my-app-e2e/tsconfig.e2e.json',
-                exclude: ['**/node_modules/**']
+                exclude: ['**/node_modules/**', '!apps/my-app-e2e/**']
               }
             }
           }

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -222,6 +222,10 @@ function updateProject(options: NormalizedSchema): Rule {
             path !==
               join(normalize(options.appProjectRoot), 'e2e/tsconfig.json')
         );
+        fixedProject.architect.lint.options.exclude.push(
+          '!' + join(normalize(options.appProjectRoot), '**')
+        );
+
         if (options.e2eTestRunner === 'none') {
           delete json.projects[options.e2eProjectName];
         }
@@ -304,7 +308,10 @@ function updateE2eProject(options: NormalizedSchema): Rule {
               builder: '@angular-devkit/build-angular:tslint',
               options: {
                 tsConfig: `${options.e2eProjectRoot}/tsconfig.e2e.json`,
-                exclude: ['**/node_modules/**']
+                exclude: [
+                  '**/node_modules/**',
+                  '!' + join(normalize(options.e2eProjectRoot), '**')
+                ]
               }
             }
           }

--- a/packages/angular/src/schematics/library/library.spec.ts
+++ b/packages/angular/src/schematics/library/library.spec.ts
@@ -74,6 +74,15 @@ describe('lib', () => {
 
       expect(angularJson.projects['my-lib'].root).toEqual('libs/my-lib');
       expect(angularJson.projects['my-lib'].architect.build).toBeDefined();
+      expect(
+        angularJson.projects['my-lib'].architect.lint.options.tsConfig
+      ).toEqual([
+        'libs/my-lib/tsconfig.lib.json',
+        'libs/my-lib/tsconfig.spec.json'
+      ]);
+      expect(
+        angularJson.projects['my-lib'].architect.lint.options.exclude
+      ).toEqual(['**/node_modules/**', '!libs/my-lib/**']);
     });
 
     it('should remove "build" target from angular.json when a library is not publishable', async () => {
@@ -368,6 +377,16 @@ describe('lib', () => {
       expect(angularJson.projects['my-dir-my-lib'].root).toEqual(
         'libs/my-dir/my-lib'
       );
+
+      expect(
+        angularJson.projects['my-dir-my-lib'].architect.lint.options.tsConfig
+      ).toEqual([
+        'libs/my-dir/my-lib/tsconfig.lib.json',
+        'libs/my-dir/my-lib/tsconfig.spec.json'
+      ]);
+      expect(
+        angularJson.projects['my-dir-my-lib'].architect.lint.options.exclude
+      ).toEqual(['**/node_modules/**', '!libs/my-dir/my-lib/**']);
     });
 
     it('should update tsconfig.json', async () => {
@@ -761,6 +780,9 @@ describe('lib', () => {
         'libs/my-lib/tsconfig.lib.json',
         'libs/my-lib/tsconfig.spec.json'
       ]);
+      expect(
+        angularJson.projects['my-lib'].architect.lint.options.exclude
+      ).toEqual(['**/node_modules/**', '!libs/my-lib/**']);
     });
   });
 

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -334,6 +334,9 @@ function updateProject(options: NormalizedSchema): Rule {
           path =>
             path !== join(normalize(options.projectRoot), 'tsconfig.spec.json')
         );
+        fixedProject.architect.lint.options.exclude.push(
+          '!' + join(normalize(options.projectRoot), '**')
+        );
 
         json.projects[options.name] = fixedProject;
         return json;

--- a/packages/cypress/src/schematics/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/schematics/cypress-project/cypress-project.spec.ts
@@ -2,6 +2,7 @@ import { Tree } from '@angular-devkit/schematics';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
 import { runSchematic } from '../../utils/testing';
 import { readJsonInTree } from '@nrwl/workspace';
+import { join, normalize } from '@angular-devkit/core';
 
 describe('schematic:cypress-project', () => {
   let appTree: Tree;
@@ -50,7 +51,8 @@ describe('schematic:cypress-project', () => {
       expect(project.architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          tsConfig: 'apps/my-app-e2e/tsconfig.e2e.json'
+          tsConfig: 'apps/my-app-e2e/tsconfig.e2e.json',
+          exclude: ['**/node_modules/**', '!apps/my-app-e2e/**']
         }
       });
       expect(project.architect.e2e).toEqual({
@@ -119,7 +121,8 @@ describe('schematic:cypress-project', () => {
         expect(projectConfig.architect.lint).toEqual({
           builder: '@angular-devkit/build-angular:tslint',
           options: {
-            tsConfig: 'apps/my-dir/my-app-e2e/tsconfig.e2e.json'
+            tsConfig: 'apps/my-dir/my-app-e2e/tsconfig.e2e.json',
+            exclude: ['**/node_modules/**', '!apps/my-dir/my-app-e2e/**']
           }
         });
 

--- a/packages/cypress/src/schematics/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/schematics/cypress-project/cypress-project.ts
@@ -64,7 +64,11 @@ function updateAngularJson(options: CypressProjectSchema): Rule {
     architect.lint = {
       builder: '@angular-devkit/build-angular:tslint',
       options: {
-        tsConfig: join(normalize(options.projectRoot), 'tsconfig.e2e.json')
+        tsConfig: join(normalize(options.projectRoot), 'tsconfig.e2e.json'),
+        exclude: [
+          '**/node_modules/**',
+          '!' + join(normalize(options.projectRoot), '**')
+        ]
       }
     };
     json.projects[options.projectName] = {

--- a/packages/node/src/schematics/application/application.spec.ts
+++ b/packages/node/src/schematics/application/application.spec.ts
@@ -52,6 +52,16 @@ describe('app', () => {
           }
         })
       );
+      expect(angularJson.projects['my-node-app'].architect.lint).toEqual({
+        builder: '@angular-devkit/build-angular:tslint',
+        options: {
+          tsConfig: [
+            'apps/my-node-app/tsconfig.app.json',
+            'apps/my-node-app/tsconfig.spec.json'
+          ],
+          exclude: ['**/node_modules/**', '!apps/my-node-app/**']
+        }
+      });
       expect(angularJson.projects['my-node-app-e2e']).toBeUndefined();
       expect(angularJson.defaultProject).toEqual('my-node-app');
     });
@@ -110,6 +120,20 @@ describe('app', () => {
       expect(angularJson.projects['my-dir-my-node-app'].root).toEqual(
         'apps/my-dir/my-node-app'
       );
+
+      expect(angularJson.projects['my-dir-my-node-app'].architect.lint).toEqual(
+        {
+          builder: '@angular-devkit/build-angular:tslint',
+          options: {
+            tsConfig: [
+              'apps/my-dir/my-node-app/tsconfig.app.json',
+              'apps/my-dir/my-node-app/tsconfig.spec.json'
+            ],
+            exclude: ['**/node_modules/**', '!apps/my-dir/my-node-app/**']
+          }
+        }
+      );
+
       expect(angularJson.projects['my-dir-my-node-app-e2e']).toBeUndefined();
       expect(angularJson.defaultProject).toEqual('my-dir-my-node-app');
     });

--- a/packages/node/src/schematics/application/application.ts
+++ b/packages/node/src/schematics/application/application.ts
@@ -66,7 +66,7 @@ function getLintConfig(project: any) {
     builder: '@angular-devkit/build-angular:tslint',
     options: {
       tsConfig: [join(project.root, 'tsconfig.app.json')],
-      exclude: ['**/node_modules/**']
+      exclude: ['**/node_modules/**', '!' + join(project.root, '**')]
     }
   };
 }

--- a/packages/react/src/schematics/application/application.spec.ts
+++ b/packages/react/src/schematics/application/application.spec.ts
@@ -293,7 +293,7 @@ describe('app', () => {
     expect(angularJson.projects['my-app'].architect.lint).toEqual({
       builder: '@angular-devkit/build-angular:tslint',
       options: {
-        exclude: ['**/node_modules/**'],
+        exclude: ['**/node_modules/**', '!apps/my-app/**'],
         tsConfig: [
           'apps/my-app/tsconfig.app.json',
           'apps/my-app/tsconfig.spec.json'

--- a/packages/react/src/schematics/application/application.ts
+++ b/packages/react/src/schematics/application/application.ts
@@ -170,7 +170,10 @@ function addProject(options: NormalizedSchema): Rule {
       builder: '@angular-devkit/build-angular:tslint',
       options: {
         tsConfig: [join(options.appProjectRoot, 'tsconfig.app.json')],
-        exclude: ['**/node_modules/**']
+        exclude: [
+          '**/node_modules/**',
+          '!' + join(options.appProjectRoot, '**')
+        ]
       }
     };
 

--- a/packages/react/src/schematics/library/library.spec.ts
+++ b/packages/react/src/schematics/library/library.spec.ts
@@ -22,7 +22,7 @@ describe('lib', () => {
       expect(angularJson.projects['my-lib'].architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          exclude: ['**/node_modules/**'],
+          exclude: ['**/node_modules/**', '!libs/my-lib/**'],
           tsConfig: [
             'libs/my-lib/tsconfig.lib.json',
             'libs/my-lib/tsconfig.spec.json'
@@ -186,7 +186,7 @@ describe('lib', () => {
       expect(angularJson.projects['my-dir-my-lib'].architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          exclude: ['**/node_modules/**'],
+          exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**'],
           tsConfig: [
             'libs/my-dir/my-lib/tsconfig.lib.json',
             'libs/my-dir/my-lib/tsconfig.spec.json'

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -78,7 +78,10 @@ function addProject(options: NormalizedSchema): Rule {
       builder: '@angular-devkit/build-angular:tslint',
       options: {
         tsConfig: [join(normalize(options.projectRoot), 'tsconfig.lib.json')],
-        exclude: ['**/node_modules/**']
+        exclude: [
+          '**/node_modules/**',
+          '!' + join(normalize(options.projectRoot), '**')
+        ]
       }
     };
 

--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -1,3 +1,9 @@
 {
-  "schematics": {}
+  "schematics": {
+    "update-8.2.0": {
+      "version": "8.2.0-beta.1",
+      "description": "Add exclusions to lint config",
+      "factory": "./src/migrations/update-8-2-0/update-8-2-0"
+    }
+  }
 }

--- a/packages/workspace/src/migrations/update-8-2-0/update-8-2-0.spec.ts
+++ b/packages/workspace/src/migrations/update-8-2-0/update-8-2-0.spec.ts
@@ -1,0 +1,47 @@
+import { Tree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { callRule, runMigration } from '../../utils/testing';
+import {
+  readJsonInTree,
+  updateJsonInTree
+} from '@nrwl/workspace/src/utils/ast-utils';
+
+describe('Update 8.2.0', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createEmptyWorkspace(Tree.empty());
+    tree = await callRule(
+      updateJsonInTree('angular.json', json => {
+        json.projects['my-app'] = {
+          root: 'my-app',
+          architect: {
+            lint: {
+              builder: '@angular-devkit/build-angular:tslint',
+              options: {
+                tsConfig: ['my-app/tsconfig.json'],
+                exclude: ['**/node_modules/**']
+              }
+            }
+          }
+        };
+
+        return json;
+      }),
+      tree
+    );
+  });
+
+  it('should add exclusions for files other than the project root', async () => {
+    const result = await runMigration('update-8.2.0', {}, tree);
+    const angularJson = readJsonInTree(tree, 'angular.json');
+    const project = angularJson.projects['my-app'];
+    expect(project.architect.lint).toEqual({
+      builder: '@angular-devkit/build-angular:tslint',
+      options: {
+        tsConfig: ['my-app/tsconfig.json'],
+        exclude: ['**/node_modules/**', '!my-app/**']
+      }
+    });
+  });
+});

--- a/packages/workspace/src/migrations/update-8-2-0/update-8-2-0.ts
+++ b/packages/workspace/src/migrations/update-8-2-0/update-8-2-0.ts
@@ -1,0 +1,25 @@
+import { updateWorkspace } from '../../utils/workspace';
+import { join, JsonArray, normalize } from '@angular-devkit/core';
+
+const addExcludes = updateWorkspace(workspace => {
+  workspace.projects.forEach(project => {
+    project.targets.forEach(target => {
+      if (target.builder !== '@angular-devkit/build-angular:tslint') {
+        return;
+      }
+      const exceptRootGlob = '!' + join(normalize(project.root), '**');
+
+      if (!target.options.exclude) {
+        target.options.exclude = [];
+      }
+
+      if (!(target.options.exclude as JsonArray).includes(exceptRootGlob)) {
+        (target.options.exclude as JsonArray).push(exceptRootGlob);
+      }
+    });
+  });
+});
+
+export default function() {
+  return addExcludes;
+}

--- a/packages/workspace/src/schematics/library/library.spec.ts
+++ b/packages/workspace/src/schematics/library/library.spec.ts
@@ -22,7 +22,7 @@ describe('lib', () => {
       expect(angularJson.projects['my-lib'].architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          exclude: ['**/node_modules/**'],
+          exclude: ['**/node_modules/**', '!libs/my-lib/**'],
           tsConfig: [
             'libs/my-lib/tsconfig.lib.json',
             'libs/my-lib/tsconfig.spec.json'
@@ -168,7 +168,7 @@ describe('lib', () => {
       expect(angularJson.projects['my-dir-my-lib'].architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          exclude: ['**/node_modules/**'],
+          exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**'],
           tsConfig: [
             'libs/my-dir/my-lib/tsconfig.lib.json',
             'libs/my-dir/my-lib/tsconfig.spec.json'

--- a/packages/workspace/src/schematics/library/library.ts
+++ b/packages/workspace/src/schematics/library/library.ts
@@ -36,7 +36,10 @@ function addProject(options: NormalizedSchema): Rule {
       builder: '@angular-devkit/build-angular:tslint',
       options: {
         tsConfig: [join(normalize(options.projectRoot), 'tsconfig.lib.json')],
-        exclude: ['**/node_modules/**']
+        exclude: [
+          '**/node_modules/**',
+          '!' + join(normalize(options.projectRoot), '**')
+        ]
       }
     };
 

--- a/packages/workspace/src/utils/testing.ts
+++ b/packages/workspace/src/utils/testing.ts
@@ -1,12 +1,27 @@
 import { join } from 'path';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { Tree } from '@angular-devkit/schematics';
+import { Rule, Tree } from '@angular-devkit/schematics';
 
 const testRunner = new SchematicTestRunner(
   '@nrwl/workspace',
   join(__dirname, '../../collection.json')
 );
 
+const migrationTestRunner = new SchematicTestRunner(
+  '@nrwl/workspace/migrations',
+  join(__dirname, '../../migrations.json')
+);
+
 export function runSchematic(schematicName: string, options: any, tree: Tree) {
   return testRunner.runSchematicAsync(schematicName, options, tree).toPromise();
+}
+
+export function callRule(rule: Rule, tree: Tree) {
+  return testRunner.callRule(rule, tree).toPromise();
+}
+
+export function runMigration(migrationName: string, options: any, tree: Tree) {
+  return migrationTestRunner
+    .runSchematicAsync(migrationName, options, tree)
+    .toPromise();
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Linting lints the project's files and any files that are referenced by those files including files from other projects.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Linting lints only the project's files making linting significantly faster.

## Issue
