### PR TITLE
fix(nx): add rootDir field when using ng add @nrwl/workspace

### DIFF
--- a/packages/workspace/src/schematics/ng-add/ng-add.ts
+++ b/packages/workspace/src/schematics/ng-add/ng-add.ts
@@ -322,6 +322,7 @@ function setUpCompilerOptions(
     tsconfig.compilerOptions.paths = {};
   }
   tsconfig.compilerOptions.baseUrl = '.';
+  tsconfig.compilerOptions.rootDir = '.';
 
   return tsconfig;
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`rootDir` is not set when using `ng add @nrwl/workspace`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`rootDir` is set when using `ng add @nrwl/workspace`

## Issue
Fixes #1479