### PR TITLE
fix(frontend): remove unused double dashes to avoid yarn's warning

### DIFF
--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -186,12 +186,12 @@ async function runCommand(
       await runAll(
         projects.map(app => {
           return ngCommands.includes(command)
-            ? `ng -- ${command} --project=${app} ${transformArgs(
+            ? `ng ${command} --project=${app} ${transformArgs(
                 args,
                 app,
                 projectMetadata.get(app)
               ).join(' ')} `
-            : `ng -- run ${app}:${command} ${transformArgs(
+            : `ng run ${app}:${command} ${transformArgs(
                 args,
                 app,
                 projectMetadata.get(app)


### PR DESCRIPTION
For a scenario:
1. In package.json
```
"affected:lint": "nx affected:lint",
```
2. Then run the script with yarn - `yarn affected:lint --all --parallel`
## Current Behavior (This is the behavior we have today, before the PR is merged)
Got warning: `warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.`
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
No warning
## Issue
