### PR TITLE
fix(nx): fixed path to $schema in ng-package.json

### DIFF
--- a/packages/angular/src/schematics/library/library.spec.ts
+++ b/packages/angular/src/schematics/library/library.spec.ts
@@ -27,6 +27,21 @@ describe('lib', () => {
 
       expect(ngPackage.dest).toEqual('../../dist/libs/my-lib');
     });
+    it('should update ng-package.json $schema to the correct folder', async () => {
+      const publishableTree = await runSchematic(
+        'lib',
+        { name: 'myLib', framework: 'angular', publishable: true },
+        appTree
+      );
+      let ngPackage = readJsonInTree(
+        publishableTree,
+        'libs/my-lib/ng-package.json'
+      );
+
+      expect(ngPackage.$schema).toEqual(
+        '../../node_modules/ng-packagr/ng-package.schema.json'
+      );
+    });
 
     it('should not update package.json by default', async () => {
       const tree = await runSchematic('lib', { name: 'myLib' }, appTree);

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -224,9 +224,19 @@ function updateNgPackage(options: NormalizedSchema): Rule {
   }`;
   return chain([
     updateJsonInTree(`${options.projectRoot}/ng-package.json`, json => {
+      let $schema = json.$schema;
+      if (json.$schema && json.$schema.indexOf('node_modules') >= 0) {
+        $schema = `${offsetFromRoot(
+          options.projectRoot
+        )}${json.$schema.substring(
+          json.$schema.indexOf('node_modules'),
+          json.$schema.length
+        )}`;
+      }
       return {
         ...json,
-        dest
+        dest,
+        $schema
       };
     })
   ]);


### PR DESCRIPTION
The ng-package.json in a library had the $schema generate by the angular cli. This pointed to the ../node_modules by default, instead of  an offset to the project root. This is fixed in this commit.

## Current Behavior (This is the behavior we have today, before the PR is merged)
When generating an angular library, $schema field in the ng-package.json is pointed to the path generated by the cli and doesn't take the offset to the root project in mind.

ng-package.json
```
{
  "$schema": "../node_modules/ng-packagr/ng-package.schema.json",
  "dest": "../../../dist/libs/myapp/feature",
  "lib": {
    "entryFile": "src/index.ts"
  }
}
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
The $schema field should have a correct reference to the ng-package.scheme.json file.

ng-package.json
```
{
  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
  "dest": "../../../dist/libs/myapp/feature",
  "lib": {
    "entryFile": "src/index.ts"
  }
}
```

## Issue
No issue created for it (yet)