### PR TITLE
fix windows cypress migration

### DIFF
--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -207,7 +207,7 @@ function isLegacy(
     tsconfigJson.compilerOptions.outDir
   );
 
-  return !relative(tsOutDirPath, integrationFolder).startsWith('../');
+  return !relative(tsOutDirPath, integrationFolder).startsWith('..');
 }
 
 function showLegacyWarning(context: BuilderContext) {

--- a/packages/cypress/src/migrations/update-8-2-0/update-8-2-0.ts
+++ b/packages/cypress/src/migrations/update-8-2-0/update-8-2-0.ts
@@ -28,6 +28,7 @@ import {
   ScriptTarget
 } from 'typescript';
 import { dirname, join, relative } from 'path';
+import { normalize } from '@angular-devkit/core';
 
 async function updateCypressJson(host: Tree, context: SchematicContext) {
   const rules: Rule[] = [];
@@ -57,11 +58,13 @@ async function updateCypressJson(host: Tree, context: SchematicContext) {
             }
             return (
               './' +
-              relative(
-                dirname(target.options.cypressConfig as string),
+              normalize(
                 relative(
-                  './' + tsConfig.options.outDir,
-                  join(dirname(target.options.cypressConfig as string), path)
+                  dirname(target.options.cypressConfig as string),
+                  relative(
+                    './' + tsConfig.options.outDir,
+                    join(dirname(target.options.cypressConfig as string), path)
+                  )
                 )
               )
             );


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

The `@nrwl/cypress` 8.2.0 migration does not normalize the path for `cypress.json` hence producing a broken project 😢 

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The `@nrwl/cypress` 8.2.0 migration normalizes the path for `cypress.json`.

## Issue
