### PR TITLE
enhancement(testing): do not bundle node_modules for cypress files

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -38,6 +38,7 @@
     "@cypress/webpack-preprocessor": "~4.1.0",
     "tree-kill": "1.2.1",
     "ts-loader": "5.3.1",
-    "tsconfig-paths-webpack-plugin": "3.2.0"
+    "tsconfig-paths-webpack-plugin": "3.2.0",
+    "webpack-node-externals": "1.7.2"
   }
 }

--- a/packages/cypress/src/plugins/preprocessor.spec.ts
+++ b/packages/cypress/src/plugins/preprocessor.spec.ts
@@ -15,6 +15,7 @@ describe('getWebpackConfig', () => {
     expect(config.module.rules).toContainEqual({
       test: /\.(j|t)sx?$/,
       loader: 'ts-loader',
+      exclude: [/node_modules/],
       options: {
         configFile: './tsconfig.json',
         // https://github.com/TypeStrong/ts-loader/pull/685
@@ -49,5 +50,16 @@ describe('getWebpackConfig', () => {
       '.js',
       '.jsx'
     ]);
+  });
+
+  it('should keep node_modules external', () => {
+    const config = getWebpackConfig({
+      env: {
+        tsConfig: './tsconfig.json'
+      }
+    });
+    const callback = jest.fn();
+    config.externals[0](null, '@nestjs/core', callback);
+    expect(callback).toHaveBeenCalledWith(null, 'commonjs @nestjs/core');
   });
 });

--- a/packages/cypress/src/plugins/preprocessor.ts
+++ b/packages/cypress/src/plugins/preprocessor.ts
@@ -1,5 +1,6 @@
 import * as wp from '@cypress/webpack-preprocessor';
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
+import * as nodeExternals from 'webpack-node-externals';
 
 export function preprocessTypescript(config: any) {
   if (!config.env.tsConfig) {
@@ -30,6 +31,7 @@ export function getWebpackConfig(config: any) {
         {
           test: /\.(j|t)sx?$/,
           loader: 'ts-loader',
+          exclude: [/node_modules/],
           options: {
             configFile: config.env.tsConfig,
             // https://github.com/TypeStrong/ts-loader/pull/685
@@ -37,6 +39,7 @@ export function getWebpackConfig(config: any) {
           }
         }
       ]
-    }
+    },
+    externals: [nodeExternals()]
   };
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`node_modules` are bundled into cypress test files.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`node_modules` should be resolved via node resolution in cypress test files.