### PR TITLE
fix(nx): fix migration of angular.json for with no architect property

### DIFF
--- a/packages/schematics/migrations/update-8-0-0/update-8-0-0.ts
+++ b/packages/schematics/migrations/update-8-0-0/update-8-0-0.ts
@@ -33,7 +33,10 @@ function addDependencies() {
     const builders = new Set<string>();
     const projects = readJsonInTree(host, 'angular.json').projects;
     Object.values<any>(projects)
-      .filter(project => typeof project === 'object')
+      .filter(
+        project =>
+          typeof project === 'object' && project.hasOwnProperty('architect')
+      )
       .forEach(project => {
         Object.values<any>(project.architect).forEach(target => {
           const [builderDependency] = target.builder.split(':');

--- a/packages/schematics/migrations/update-8-0-0/update-8-0-0.ts
+++ b/packages/schematics/migrations/update-8-0-0/update-8-0-0.ts
@@ -32,12 +32,14 @@ function addDependencies() {
     const dependencies = readJsonInTree(host, 'package.json').dependencies;
     const builders = new Set<string>();
     const projects = readJsonInTree(host, 'angular.json').projects;
-    Object.values<any>(projects).forEach(project => {
-      Object.values<any>(project.architect).forEach(target => {
-        const [builderDependency] = target.builder.split(':');
-        builders.add(builderDependency);
+    Object.values<any>(projects)
+      .filter(project => typeof project === 'object')
+      .forEach(project => {
+        Object.values<any>(project.architect).forEach(target => {
+          const [builderDependency] = target.builder.split(':');
+          builders.add(builderDependency);
+        });
       });
-    });
     const newDependencies = {};
     const newDevDependencies = {
       '@nrwl/workspace': '8.0.0'


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

This is related issues to #1455.

If there is a project withn no architect in the project of angular.json, the project can not be found, and it fails with the error "Cannot convert undefined or null to object".

The problem seems to occur because the architect can not be found on this line.
https://github.com/nrwl/nx/blob/master/packages/schematics/migrations/update-8-0-0/update-8-0-0.ts#L36

I prepared the code to reproduce.
https://github.com/MSakamaki/breaking-update-v8

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

confirmed that skipping builders that can not find project can update everything without any problems.

## Issue

#1455