### PR TITLE
feat(testing): add findRelatedTests option to jest builder

### DIFF
--- a/docs/api-jest/builders/jest.md
+++ b/docs/api-jest/builders/jest.md
@@ -62,6 +62,12 @@ Type: `string`
 
 A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter
 
+### findRelatedTests
+
+Type: `string`
+
+Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/en/cli#findrelatedtests-spaceseparatedlistofsourcefiles)
+
 ### jestConfig
 
 Type: `string`

--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -44,6 +44,7 @@ describe('Jest Builder', () => {
     );
     expect(runCLI).toHaveBeenCalledWith(
       {
+        _: [],
         globals: JSON.stringify({
           'ts-jest': {
             tsConfig: '/root/tsconfig.test.json',
@@ -113,6 +114,47 @@ describe('Jest Builder', () => {
     );
   });
 
+  it('should send appropriate options to jestCLI when findRelatedTests is specified', async () => {
+    const run = await architect.scheduleBuilder('@nrwl/jest:jest', {
+      findRelatedTests: 'file1.ts,file2.ts',
+      jestConfig: './jest.config.js',
+      tsConfig: './tsconfig.test.json',
+      codeCoverage: false,
+      runInBand: true,
+      testNamePattern: 'should load',
+      watch: false
+    });
+    expect(await run.result).toEqual(
+      jasmine.objectContaining({
+        success: true
+      })
+    );
+
+    expect(runCLI).toHaveBeenCalledWith(
+      {
+        _: ['file1.ts', 'file2.ts'],
+        globals: JSON.stringify({
+          'ts-jest': {
+            tsConfig: '/root/tsconfig.test.json',
+            diagnostics: {
+              warnOnly: true
+            },
+            stringifyContentPathRegex: '\\.html$',
+            astTransformers: [
+              'jest-preset-angular/InlineHtmlStripStylesTransformer'
+            ]
+          }
+        }),
+        coverage: false,
+        findRelatedTests: true,
+        runInBand: true,
+        testNamePattern: 'should load',
+        watch: false
+      },
+      ['/root/jest.config.js']
+    );
+  });
+
   it('should send other options to jestCLI', async () => {
     const run = await architect.scheduleBuilder('@nrwl/jest:jest', {
       jestConfig: './jest.config.js',
@@ -146,6 +188,7 @@ describe('Jest Builder', () => {
     );
     expect(runCLI).toHaveBeenCalledWith(
       {
+        _: [],
         globals: JSON.stringify({
           'ts-jest': {
             tsConfig: '/root/tsconfig.test.json',
@@ -197,6 +240,7 @@ describe('Jest Builder', () => {
     );
     expect(runCLI).toHaveBeenCalledWith(
       {
+        _: [],
         globals: JSON.stringify({
           'ts-jest': {
             tsConfig: '/root/tsconfig.test.json',

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -26,6 +26,7 @@ export interface JestBuilderOptions extends JsonObject {
   ci?: boolean;
   color?: boolean;
   clearCache?: boolean;
+  findRelatedTests?: string;
   json?: boolean;
   maxWorkers?: number;
   onlyChanged?: boolean;
@@ -74,6 +75,7 @@ function run(
   } catch (e) {}
 
   const config: any = {
+    _: [],
     coverage: options.codeCoverage,
     bail: options.bail,
     ci: options.ci,
@@ -108,7 +110,13 @@ function run(
   }
 
   if (options.testFile) {
-    config._ = [options.testFile];
+    config._.push(options.testFile);
+  }
+
+  if (options.findRelatedTests) {
+    const parsedTests = options.findRelatedTests.split(',').map(s => s.trim());
+    config._.push(...parsedTests);
+    config.findRelatedTests = true;
   }
 
   if (options.clearCache) {

--- a/packages/jest/src/builders/jest/schema.json
+++ b/packages/jest/src/builders/jest/schema.json
@@ -41,6 +41,10 @@
       "description": "Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/en/cli#colors)",
       "type": "boolean"
     },
+    "findRelatedTests": {
+      "description": "Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/en/cli#findrelatedtests-spaceseparatedlistofsourcefiles)",
+      "type": "string"
+    },
     "json": {
       "description": "Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/en/cli#json)",
       "type": "boolean"


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`--find-related-tests` is an unknown option to the jest builder.

![Screen Shot 2019-07-01 at 11 07 18 AM](https://user-images.githubusercontent.com/14145352/60451077-d9cc1e00-9bf0-11e9-8bdc-3f1f0c41fae0.png)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`--find-related-tests` is a known option to the jest builder that finds and runs the test files passed as arguments. I have a minor concern that the [jest docs](https://jestjs.io/docs/en/cli#findrelatedtests-spaceseparatedlistofsourcefiles) specify that a space separated list should be passed in, but because of schema validation a comma separated list in needed. Is there a way to validate a space separated list? Below is how I tested the changes.

![Screen Shot 2019-07-03 at 6 19 42 PM](https://user-images.githubusercontent.com/14145352/60630750-31b97f00-9dc1-11e9-9fc3-e4f08f0ed1d5.png)

## Issue

closes #1527