### PR TITLE
fix(nx): make target a required option when running affected npm script

### DIFF
--- a/docs/api-workspace/npmscripts/affected.md
+++ b/docs/api-workspace/npmscripts/affected.md
@@ -56,6 +56,10 @@ Parallelize the command
 
 ### quiet
 
+### target
+
+Task to run for affected projects
+
 ### uncommitted
 
 Uncommitted changes

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -22,7 +22,7 @@ export const commandsObject = yargs
   .command(
     'affected',
     'Run task for affected projects',
-    yargs => withAffectedOptions(withParallel(yargs)),
+    yargs => withAffectedOptions(withParallel(withTarget(yargs))),
     args => affected(args)
   )
   .command(
@@ -246,4 +246,14 @@ function withParallel(yargs: yargs.Argv): yargs.Argv {
       type: 'number',
       default: 3
     });
+}
+
+function withTarget(yargs: yargs.Argv): yargs.Argv {
+  return yargs.option('target', {
+    describe: 'Task to run for affected projects',
+    type: 'string',
+    requiresArg: true,
+    demandOption: true,
+    global: false
+  });
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`npm run affected` can be ran without a specified target.

![Screen Shot 2019-07-05 at 11 19 21 PM](https://user-images.githubusercontent.com/14145352/60751517-0202a680-9f7c-11e9-9c17-d51871fd73db.png)

### Steps to Reproduce

1. `npm init nx-workspace myworkspace`
2. `npm run affected`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`target` is now listed as an option when running `npm run affected -- --help` and it's required when running `npm run affected`.