### PR TITLE
fix(nx): npm scripts documentation generation

### DIFF
--- a/docs/api-workspace/npmscripts/affected-apps.md
+++ b/docs/api-workspace/npmscripts/affected-apps.md
@@ -36,25 +36,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/affected-build.md
+++ b/docs/api-workspace/npmscripts/affected-build.md
@@ -54,8 +54,6 @@ Default: `false`
 
 Parallelize the command
 
-### quiet
-
 ### uncommitted
 
 Uncommitted changes

--- a/docs/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/api-workspace/npmscripts/affected-dep-graph.md
@@ -40,25 +40,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/affected-e2e.md
+++ b/docs/api-workspace/npmscripts/affected-e2e.md
@@ -54,8 +54,6 @@ Default: `false`
 
 Parallelize the command
 
-### quiet
-
 ### uncommitted
 
 Uncommitted changes

--- a/docs/api-workspace/npmscripts/affected-libs.md
+++ b/docs/api-workspace/npmscripts/affected-libs.md
@@ -36,25 +36,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/affected-lint.md
+++ b/docs/api-workspace/npmscripts/affected-lint.md
@@ -24,10 +24,6 @@ Default: ``
 
 Exclude certain projects from being processed
 
-### file
-
-output file (e.g. --file=.vis/output.json)
-
 ### files
 
 A list of files delimited by commas
@@ -57,8 +53,6 @@ Isolate projects which previously failed
 Default: `false`
 
 Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/affected-test.md
+++ b/docs/api-workspace/npmscripts/affected-test.md
@@ -54,8 +54,6 @@ Default: `false`
 
 Parallelize the command
 
-### quiet
-
 ### uncommitted
 
 Uncommitted changes

--- a/docs/api-workspace/npmscripts/affected.md
+++ b/docs/api-workspace/npmscripts/affected.md
@@ -54,8 +54,6 @@ Default: `false`
 
 Parallelize the command
 
-### quiet
-
 ### target
 
 Task to run for affected projects

--- a/docs/api-workspace/npmscripts/dep-graph.md
+++ b/docs/api-workspace/npmscripts/dep-graph.md
@@ -40,25 +40,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/format-check.md
+++ b/docs/api-workspace/npmscripts/format-check.md
@@ -26,10 +26,6 @@ Default: ``
 
 Exclude certain projects from being processed
 
-### file
-
-output file (e.g. --file=.vis/output.json)
-
 ### files
 
 A list of files delimited by commas
@@ -42,25 +38,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/format-write.md
+++ b/docs/api-workspace/npmscripts/format-write.md
@@ -26,10 +26,6 @@ Default: ``
 
 Exclude certain projects from being processed
 
-### file
-
-output file (e.g. --file=.vis/output.json)
-
 ### files
 
 A list of files delimited by commas
@@ -42,25 +38,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/workspace-lint-files.md
+++ b/docs/api-workspace/npmscripts/workspace-lint-files.md
@@ -10,69 +10,9 @@ workspace-lint [files..]
 
 ## Options
 
-### all
-
-All projects
-
-### apps-and-libs
-
-### base
-
-Base of the current branch (usually master)
-
-### exclude
-
-Default: ``
-
-Exclude certain projects from being processed
-
-### file
-
-output file (e.g. --file=.vis/output.json)
-
-### files
-
-A list of files delimited by commas
-
-### head
-
-Latest commit of the current branch (usually HEAD)
-
 ### help
 
 Show help
-
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
-### only-failed
-
-Default: `false`
-
-Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
-
-### uncommitted
-
-Uncommitted changes
-
-### untracked
-
-Untracked changes
-
-### verbose
-
-Print additional error stack trace on failure
 
 ### version
 

--- a/docs/api-workspace/npmscripts/workspace-schematic-name.md
+++ b/docs/api-workspace/npmscripts/workspace-schematic-name.md
@@ -10,34 +10,6 @@ workspace-schematic [name]
 
 ## Options
 
-### all
-
-All projects
-
-### apps-and-libs
-
-### base
-
-Base of the current branch (usually master)
-
-### exclude
-
-Default: ``
-
-Exclude certain projects from being processed
-
-### file
-
-output file (e.g. --file=.vis/output.json)
-
-### files
-
-A list of files delimited by commas
-
-### head
-
-Latest commit of the current branch (usually HEAD)
-
 ### help
 
 Show help
@@ -46,41 +18,9 @@ Show help
 
 List the available workspace-schematics
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### name
 
 The name of your schematic`
-
-### only-failed
-
-Default: `false`
-
-Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
-
-### uncommitted
-
-Uncommitted changes
-
-### untracked
-
-Untracked changes
-
-### verbose
-
-Print additional error stack trace on failure
 
 ### version
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "husky": "^3.0.0",
     "identity-obj-proxy": "3.0.0",
     "ignore": "^5.0.4",
+    "import-fresh": "^3.1.0",
     "jasmine-core": "~2.99.1",
     "jasmine-marbles": "~0.6.0",
     "jasmine-spec-reporter": "~4.2.1",

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -86,7 +86,7 @@ export const commandsObject = yargs
   .command(
     'affected:e2e',
     'Run e2e tests for the applications affected by changes',
-    withAffectedOptions,
+    yargs => withAffectedOptions(withParallel(yargs)),
     args =>
       affected({
         ...args,

--- a/scripts/documentation/generate-npmscripts-data.ts
+++ b/scripts/documentation/generate-npmscripts-data.ts
@@ -1,10 +1,11 @@
 import * as fs from 'fs-extra';
-import * as yargs from 'yargs';
 import * as path from 'path';
 import { dedent } from 'tslint/lib/utils';
 
 import { generateFile, sortAlphabeticallyFunction } from './utils';
 import { commandsObject } from '../../packages/workspace';
+
+const importFresh = require('import-fresh');
 
 const commandsOutputDirectory = path.join(
   __dirname,
@@ -15,7 +16,7 @@ function getCommands(command) {
   return command.getCommandInstance().getCommandHandlers();
 }
 function parseCommandInstance(name, command) {
-  const builder = command.builder((<any>yargs).resetOptions());
+  const builder = command.builder(importFresh('yargs')().resetOptions());
   const builderDescriptions = builder.getUsageInstance().getDescriptions();
   const builderDefaultOptions = builder.getOptions().default;
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7011,6 +7011,14 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
+import-fresh@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.1.0.tgz#6d33fa1dcef6df930fae003446f33415af905118"
+  integrity sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
 import-from@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1"
@@ -10266,6 +10274,13 @@ param-case@2.1.x:
   dependencies:
     no-case "^2.2.0"
 
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
+
 parse-asn1@^5.0.0:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.4.tgz#37f6628f823fbdeb2273b4d540434a22f3ef1fcc"
@@ -11467,6 +11482,11 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
   integrity sha1-six699nWiBvItuZTM17rywoYh0g=
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve-pathname@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Before, a single instance of `yargs` was accumulating options, so commands parsed later would have options from prior commands. That's because all `yargs` options are [global by default](http://yargs.js.org/docs/#api-globalglobals-globaltrue). Now, a new instance of `yargs` is required before each command is parsed, so global options aren't accumulated.

I initially added `global: false` to all options in `nx-commands.ts`, but that didn't work because some `yargs` methods such as [implies](https://github.com/nrwl/nx/blob/master/packages/workspace/src/command-line/nx-commands.ts#L189) set globals. Since options being global doesn't seem to be an issue except with the docs gen, I chose to make the change there.

👉 `lint-files`, `update`, `update:check`, and `update:skip` now only document `help` and `version` because the docs are based on `yargs` options and those commands don't have specific `yargs` options. How would you like to handle these? We can leave them as is, filter them out, or add code to the docs gen to handle them? Removing them makes sense to me since `lint-files` and `update:skip` aren't npm scripts, and `update` and `update:check` are handled by Angular CLI.

fixes #1567 #1535 