### PR TITLE
fix(nx): fix lint exclusion for workspace libs

### DIFF
--- a/packages/workspace/src/schematics/library/library.ts
+++ b/packages/workspace/src/schematics/library/library.ts
@@ -11,13 +11,13 @@ import {
   move,
   noop
 } from '@angular-devkit/schematics';
+import { join, normalize } from '@angular-devkit/core';
 import { Schema } from './schema';
 
 import { NxJson } from '@nrwl/workspace';
 import { updateJsonInTree, readJsonInTree } from '@nrwl/workspace';
 import { toFileName, names } from '@nrwl/workspace';
 import { formatFiles } from '@nrwl/workspace';
-import { join, normalize } from 'path';
 import { offsetFromRoot } from '@nrwl/workspace';
 
 export interface NormalizedSchema extends Schema {


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`@nrwl/workspace:lib` uses the `path` module's `join`, and `normalize`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`@nrwl/workspace:lib` uses the `@angular-devkit/core` module's `join`, and `normalize`.

## Issue
Fixes #1578 