### PR TITLE
fix(nx): fix assets option object input

### DIFF
--- a/packages/node/src/utils/normalize.spec.ts
+++ b/packages/node/src/utils/normalize.spec.ts
@@ -61,7 +61,7 @@ describe('normalizeBuildOptions', () => {
         assets: [
           'apps/nodeapp/src/assets',
           {
-            input: '/outsideroot',
+            input: 'outsideproj',
             output: 'output',
             glob: '**/*',
             ignore: ['**/*.json']
@@ -78,7 +78,7 @@ describe('normalizeBuildOptions', () => {
         glob: '**/*'
       },
       {
-        input: '/outsideroot',
+        input: '/root/outsideproj',
         output: 'output',
         glob: '**/*',
         ignore: ['**/*.json']

--- a/packages/node/src/utils/normalize.ts
+++ b/packages/node/src/utils/normalize.ts
@@ -62,8 +62,12 @@ function normalizeAssets(
           'An asset cannot be written to a location outside of the output path.'
         );
       }
+
+      const assetPath = normalize(asset.input);
+      const resolvedAssetPath = resolve(root, assetPath);
       return {
         ...asset,
+        input: resolvedAssetPath,
         // Now we remove starting slash to make Webpack place it from the output root.
         output: asset.output.replace(/^\//, '')
       };

--- a/packages/web/src/utils/normalize.spec.ts
+++ b/packages/web/src/utils/normalize.spec.ts
@@ -57,7 +57,7 @@ describe('normalizeBuildOptions', () => {
         assets: [
           'apps/nodeapp/src/assets',
           {
-            input: '/outsideroot',
+            input: 'outsideproj',
             output: 'output',
             glob: '**/*',
             ignore: ['**/*.json']
@@ -74,7 +74,7 @@ describe('normalizeBuildOptions', () => {
         glob: '**/*'
       },
       {
-        input: '/outsideroot',
+        input: '/root/outsideproj',
         output: 'output',
         glob: '**/*',
         ignore: ['**/*.json']

--- a/packages/web/src/utils/normalize.ts
+++ b/packages/web/src/utils/normalize.ts
@@ -62,8 +62,12 @@ function normalizeAssets(
           'An asset cannot be written to a location outside of the output path.'
         );
       }
+
+      const assetPath = normalize(asset.input);
+      const resolvedAssetPath = resolve(root, assetPath);
       return {
         ...asset,
+        input: resolvedAssetPath,
         // Now we remove starting slash to make Webpack place it from the output root.
         output: asset.output.replace(/^\//, '')
       };


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Passing in an object into `assets` for `@nrwl/web:build` and `@nrwl/node:build` does not result in assets being copied.

```

              {
                "input": "libs/shared/assets/src/assets",
                "glob": "**/*",
                "output": "assets"
              },
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Passing in an object into `assets` for `@nrwl/web:build` and `@nrwl/node:build` results in assets being copied.

## Issue
