### PR TITLE
feat(nx): add ability to ignore files from affected commands

### DIFF
--- a/docs/angular/fundamentals/monorepos-automation.md
+++ b/docs/angular/fundamentals/monorepos-automation.md
@@ -341,6 +341,8 @@ The `tags` array is used to impose constraints on the dependency graph. Read mor
 
 Nx uses its advanced code analysis to construct a dependency graph of all applications and libraries. Some dependencies, however, cannot be determined statically. You can use the `implicitDependencies` array to list the dependencies that cannot be determined statically.
 
+> Note: Glob patterns in the `.gitignore` and `.nxignore` files are ignored during affected commands by default.
+
 ## Summary
 
 With Nx, you can use effective development practices pioneered at Google:

--- a/docs/shared/monorepo-affected.md
+++ b/docs/shared/monorepo-affected.md
@@ -189,3 +189,10 @@ You can also specify dependencies between projects. For instance, if `admin-e2e`
   }
 }
 ```
+
+### Ignoring Additional Files from Affected Commands
+
+Nx provides two methods to exclude additional glob patterns (files and folders) from `affected:*` commands.
+
+- Glob patterns defined in your `.gitignore` file are ignored.
+- Glob patterns defined in an optional `.nxignore` file are ignored.

--- a/docs/web/fundamentals/monorepos-automation.md
+++ b/docs/web/fundamentals/monorepos-automation.md
@@ -342,6 +342,8 @@ The `tags` array is used to impose constraints on the dependency graph. Read mor
 
 Nx uses its advanced code analysis to construct a dependency graph of all applications and libraries. Some dependencies, however, cannot be determined statically. You can use the `implicitDependencies` array to list the dependencies that cannot be determined statically.
 
+> Note: Glob patterns in the `.gitignore` and `.nxignore` files are ignored during affected commands by default.
+
 ## Summary
 
 With Nx, you can use effective development practices pioneered at Google:


### PR DESCRIPTION
Check .nxignore for globs to add to ignored files in affected commands

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

Affected commands ignore files/folders in .gitignore

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Affected commands ignore files/folders in .gitignore and .nxignore

## Issue

Implement #895