### PR TITLE
feat(web): use stats options from webpackConfig when logging build output

### DIFF
--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -10,17 +10,12 @@ import { Observable, from, of, forkJoin } from 'rxjs';
 import { normalizeWebBuildOptions } from '../../utils/normalize';
 import { getWebConfig } from '../../utils/web.config';
 import { BuildBuilderOptions } from '../../utils/types';
-import {
-  bufferCount,
-  concatMap,
-  map,
-  mergeScan,
-  switchMap
-} from 'rxjs/operators';
+import { concatMap, map, switchMap } from 'rxjs/operators';
 import { getSourceRoot } from '../../utils/source-root';
 import { ScriptTarget } from 'typescript';
 import { writeIndexHtml } from '@angular-devkit/build-angular/src/angular-cli-files/utilities/index-file/write-index-html';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
+import { Configuration } from 'webpack';
 
 export interface WebBuildBuilderOptions extends BuildBuilderOptions {
   differentialLoading: boolean;
@@ -57,7 +52,7 @@ export function run(
         context.workspaceRoot,
         sourceRoot
       );
-      let configs = [
+      let configs: Configuration[] = [
         getWebConfig(
           context.workspaceRoot,
           sourceRoot,
@@ -88,13 +83,14 @@ export function run(
       return configs;
     }),
     concatMap(configs => {
-      const runWebpackOptions = {
-        logging: stats => {
-          context.logger.info(stats.toString());
-        }
-      };
       return forkJoin(
-        configs.map(config => runWebpack(config, context, runWebpackOptions))
+        configs.map(config =>
+          runWebpack(config, context, {
+            logging: stats => {
+              context.logger.info(stats.toString(config.stats));
+            }
+          })
+        )
       ).pipe(
         switchMap(
           ([result1, result2 = { success: true, emittedFiles: [] }]) => {

--- a/packages/web/src/builders/dev-server/dev-server.impl.ts
+++ b/packages/web/src/builders/dev-server/dev-server.impl.ts
@@ -7,7 +7,7 @@ import { JsonObject } from '@angular-devkit/core';
 
 import { Observable, from, forkJoin } from 'rxjs';
 import { normalizeWebBuildOptions } from '../../utils/normalize';
-import { map, switchMap, tap } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 import { WebBuildBuilderOptions } from '../build/build.impl';
 import { Configuration } from 'webpack';
 import { writeFileSync } from 'fs';
@@ -111,7 +111,7 @@ function run(
             );
           }
 
-          context.logger.info(stats.toString());
+          context.logger.info(stats.toString(config.stats));
         }
       }).pipe(
         map(output => {


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

`@nrwl/web` build and dev server output doesn't follow the webpack config `stats` option. Instead, it simply uses `stats.toString()`, which is always the webpack default.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

This PR passes down the `stats` option from webpack config into `stats.toString(...)`, allowing to control the webpack logging output.

## Issue
