### PR TITLE
docs(nx): update description of Nx in schematics and frontend links

### DIFF
--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -103,14 +103,14 @@ function updateComponentTemplate(options: NormalizedSchema): Rule {
   <img width="450" src="https://raw.githubusercontent.com/nrwl/nx/master/nx-logo.png">
 </div>
 
-<p>This is an Angular app built with <a href="https://nx.dev">Nx</a>.</p>
-<p>🔎 **Nx is a set of Angular CLI power-ups for modern development.**</p>
+<p>This is an Angular app built with <a href="https://nx.dev/angular">Nx</a>.</p>
+<p>🔎 **Nx is a set of Extensible Dev Tools for Monorepos.**</p>
 
 <h2>Quick Start & Documentation</h2>
 
 <ul>
-<li><a href="https://nx.dev/getting-started/what-is-nx">30-minute video showing all Nx features</a></li>
-<li><a href="https://nx.dev/tutorial/01-create-application">Interactive tutorial</a></li>
+<li><a href="https://nx.dev/angular/getting-started/what-is-nx">10-minute video showing all Nx features</a></li>
+<li><a href="https://nx.dev/angular/tutorial/01-create-application">Interactive tutorial</a></li>
 </ul>
 `;
     const content = options.routing

--- a/packages/create-nx-workspace/package.json
+++ b/packages/create-nx-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-nx-workspace",
   "version": "0.0.2",
-  "description": "Angular CLI power-ups for modern Web development",
+  "description": "Extensible Dev Tools for Monorepos",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nrwl/nx.git"

--- a/packages/react/src/schematics/application/files/app/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/schematics/application/files/app/src/app/__fileName__.tsx__tmpl__
@@ -34,15 +34,15 @@ export class App extends Component {
             src="https://raw.githubusercontent.com/nrwl/nx/master/nx-logo.png"
           />
         </<%= header %>>
-        <p>This is a React app built with <a href="https://nx.dev">Nx</a>.</p>
-        <p>🔎 **Nx is a set of Angular CLI power-ups for modern development.**</p>
+        <p>This is a React app built with <a href="https://nx.dev/react">Nx</a>.</p>
+        <p>🔎 **Nx is a set of Extensible Dev Tools for Monorepos.**</p>
         <h2>Quick Start & Documentation</h2>
         <ul>
           <li>
-            <a href="https://nx.dev/getting-started/what-is-nx">30-minute video showing all Nx features</a>
+            <a href="https://nx.dev/react/getting-started/what-is-nx">10-minute video showing all Nx features</a>
           </li>
           <li>
-            <a href="https://nx.dev/tutorial/01-create-application">Interactive tutorial</a>
+            <a href="https://nx.dev/react/tutorial/01-create-application">Interactive tutorial</a>
           </li>
         </ul>
       </<%= wrapper %>>
@@ -60,15 +60,15 @@ export const App = () => {
           src="https://raw.githubusercontent.com/nrwl/nx/master/nx-logo.png"
         />
       </<%= header %>>
-      <p>This is a React app built with <a href="https://nx.dev">Nx</a>.</p>
-      <p>🔎 **Nx is a set of Angular CLI power-ups for modern development.**</p>
+      <p>This is a React app built with <a href="https://nx.dev/react">Nx</a>.</p>
+      <p>🔎 **Nx is a set of Extensible Dev Tools for Monorepos.**</p>
       <h2>Quick Start & Documentation</h2>
       <ul>
         <li>
-          <a href="https://nx.dev/getting-started/what-is-nx">30-minute video showing all Nx features</a>
+          <a href="https://nx.dev/react/getting-started/what-is-nx">10-minute video showing all Nx features</a>
         </li>
         <li>
-          <a href="https://nx.dev/tutorial/01-create-application">Interactive tutorial</a>
+          <a href="https://nx.dev/react/tutorial/01-create-application">Interactive tutorial</a>
         </li>
       </ul>
     </<%= wrapper %>>

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nrwl/schematics",
   "version": "0.0.2",
-  "description": "Angular CLI power-ups for modern Web development: Schematics",
+  "description": "Extensible Dev Tools for Monorepos: Schematics",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nrwl/nx.git"

--- a/packages/web/src/schematics/application/files/app/src/app/app.element.ts__tmpl__
+++ b/packages/web/src/schematics/application/files/app/src/app/app.element.ts__tmpl__
@@ -15,15 +15,15 @@ export class AppElement extends HTMLElement {
           src="https://raw.githubusercontent.com/nrwl/nx/master/nx-logo.png"
         />
       </div>
-      <p>This is a Web Components app built with <a href="https://nx.dev">Nx</a>.</p>
-      <p>🔎 **Nx is a set of Angular CLI power-ups for modern development.**</p>
+      <p>This is a Web Components app built with <a href="https://nx.dev/web">Nx</a>.</p>
+      <p>🔎 **Nx is a set of Extensible Dev Tools for Monorepos.**</p>
       <h2>Quick Start & Documentation</h2>
       <ul>
         <li>
-          <a href="https://nx.dev/getting-started/what-is-nx">30-minute video showing all Nx features</a>
+          <a href="https://nx.dev/web/getting-started/what-is-nx">10-minute video showing all Nx features</a>
         </li>
         <li>
-          <a href="https://nx.dev/tutorial/01-create-application">Interactive tutorial</a>
+          <a href="https://nx.dev/web/tutorial/01-create-application">Interactive tutorial</a>
         </li>
       </ul>
     `;

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nrwl/workspace",
   "version": "0.0.1",
-  "description": "Power-ups for Angular CLI",
+  "description": "Extensible Dev Tools for Monorepos",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nrwl/nx.git"

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -36,7 +36,7 @@ export const supportedNxCommands = [
  * be executed correctly.
  */
 export const commandsObject = yargs
-  .usage('Angular CLI power-ups for modern Web development')
+  .usage('Extensible Dev Tools for Monorepos')
   .command(
     'affected',
     'Run task for affected projects',

--- a/packages/workspace/src/schematics/workspace/files/README.md
+++ b/packages/workspace/src/schematics/workspace/files/README.md
@@ -4,13 +4,13 @@ This project was generated using [Nx](https://nx.dev).
 
 <p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/nx-logo.png" width="450"></p>
 
-🔎 **Nx is a set of Angular CLI power-ups for modern development.**
+🔎 **Nx is a set of Extensible Dev Tools for Monorepos.**
 
 ## Quick Start & Documentation
 
 [Nx Documentation](https://nx.dev)
 
-[30-minute video showing all Nx features](https://nx.dev/getting-started/what-is-nx)
+[10-minute video showing all Nx features](https://nx.dev/getting-started/what-is-nx)
 
 [Interactive Tutorial](https://nx.dev/tutorial/01-create-application)
 


### PR DESCRIPTION
The schematics for React and Angular still refer to Angular CLI power-ups.
This also links the generated schematic for an Angular or React application
to their framework-specific pages.