### PR TITLE
Keeping original order of dependencies in package.json when adding new one

### DIFF
--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -402,10 +402,12 @@ export function addDepsToPackageJson(
 ): Rule {
   return updateJsonInTree('package.json', (json, context: SchematicContext) => {
     json.dependencies = {
+      ...(json.dependencies || {}),
       ...deps,
       ...(json.dependencies || {})
     };
     json.devDependencies = {
+      ...(json.devDependencies || {}),
       ...devDeps,
       ...(json.devDependencies || {})
     };


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

After running `@nrwl/angular` -> `library` schematic `jest-preset-angular` is moved to the top of `devDependencies` because of calling `addDepsToPackageJson` from `addUnitTestRunner` function. This cause unexpected changes in `package.json` file.

This PR fixes this issue.