### PR TITLE
fix(frontend): fix ngrx migration requiring angular cli 8.1

### DIFF
--- a/packages/angular/src/migrations/update-8-3-0/upgrade-ngrx-8-0.ts
+++ b/packages/angular/src/migrations/update-8-3-0/upgrade-ngrx-8-0.ts
@@ -1,18 +1,67 @@
-import { chain, Tree, noop } from '@angular-devkit/schematics';
-import { addUpdateTask, readJsonInTree, formatFiles } from '@nrwl/workspace';
+import { chain, Tree, noop, TaskId } from '@angular-devkit/schematics';
+import {
+  addUpdateTask,
+  readJsonInTree,
+  formatFiles,
+  updateJsonInTree
+} from '@nrwl/workspace';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 
-const runNgrxUpdate = addUpdateTask('@ngrx/store', '8.1.0');
+function updateCLI() {
+  const tasks: TaskId[] = [];
+  const rule = chain([
+    updateJsonInTree('package.json', json => {
+      json.devDependencies = json.devDependencies || {};
+      const cliVersion = json.devDependencies['@angular/cli'];
 
-const updateNgrx = (host: Tree) => {
-  const { dependencies } = readJsonInTree(host, 'package.json');
+      if (
+        cliVersion &&
+        (cliVersion.startsWith('8.1') ||
+          cliVersion.startsWith('~8.1') ||
+          cliVersion.startsWith('^8.1'))
+      ) {
+        return json;
+      }
 
-  if (dependencies && dependencies['@ngrx/store']) {
-    return chain([runNgrxUpdate, formatFiles()]);
-  }
+      if (json['devDependencies']['@angular/cli']) {
+        json['devDependencies']['@angular/cli'] = '8.1.1';
+      }
 
-  return noop();
-};
+      if (json['devDependencies']['@angular-devkit/build-angular']) {
+        json['devDependencies']['@angular-devkit/build-angular'] = '^0.801.1';
+      }
+
+      if (json['devDependencies']['@angular-devkit/build-ng-packagr']) {
+        json['devDependencies']['@angular-devkit/build-ng-packagr'] =
+          '~0.801.1';
+      }
+
+      return json;
+    }),
+    (host, context) => {
+      tasks.push(context.addTask(new NodePackageInstallTask()));
+    }
+  ]);
+
+  return { rule, tasks };
+}
+
+function updateNgrx(updateDeps: TaskId[]) {
+  return (host: Tree) => {
+    const { dependencies } = readJsonInTree(host, 'package.json');
+
+    if (dependencies && dependencies['@ngrx/store']) {
+      return chain([
+        addUpdateTask('@ngrx/store', '8.1.0', updateDeps),
+        formatFiles()
+      ]);
+    }
+
+    return noop();
+  };
+}
 
 export default function() {
-  return chain([updateNgrx]);
+  const { rule: updateCLIRule, tasks } = updateCLI();
+  return chain([updateCLIRule, updateNgrx(tasks)]);
 }

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -31,6 +31,7 @@
     "requirements": {},
     "migrations": "./migrations.json",
     "packageGroup": [
+      "@nrwl/workspace",
       "@nrwl/angular",
       "@nrwl/cypress",
       "@nrwl/express",

--- a/packages/workspace/src/utils/update-task.ts
+++ b/packages/workspace/src/utils/update-task.ts
@@ -4,6 +4,7 @@ import {
   TaskConfiguration,
   TaskConfigurationGenerator,
   TaskExecutorFactory,
+  TaskId,
   Tree
 } from '@angular-devkit/schematics';
 import { Observable } from 'rxjs';
@@ -12,7 +13,11 @@ import { join } from 'path';
 
 let taskRegistered = false;
 
-export function addUpdateTask(pkg: string, to: string): Rule {
+export function addUpdateTask(
+  pkg: string,
+  to: string,
+  dependencies: TaskId[] = []
+): Rule {
   return (host: Tree, context: SchematicContext) => {
     // Workflow should always be there during ng update but not during tests.
     if (!context.engine.workflow) {
@@ -34,7 +39,9 @@ export function addUpdateTask(pkg: string, to: string): Rule {
       }
     });
 
-    context.addTask(new RunUpdateTask(pkg, to));
+    console.log(dependencies);
+
+    context.addTask(new RunUpdateTask(pkg, to), dependencies);
   };
 }
 


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

For whatever reason, the `@nrwl/angular` migrations run before `@nrwl/workspace` migrations... so the `@angular/cli` update doesn't happen in time.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

I moved the `@angular/cli` update to `@nrwl/angular` so it happens before updating `@ngrx`. We could not find a way to make `@nrwl/workspace` migrations happen first.... 

## Issue
