### PR TITLE
fix(frontend): fix peer dependency warning errors

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,6 +33,8 @@
   "dependencies": {
     "@nrwl/cypress": "*",
     "@nrwl/jest": "*",
+    "@angular/compiler": "8.1.2",
+    "@angular/compiler-cli": "8.1.2",
     "@angular-devkit/architect": "0.801.1",
     "@angular-devkit/build-angular": "0.801.1",
     "@angular-devkit/build-webpack": "0.801.1",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Installing `@nrwl/web` emits `PEER` dependency warnings asking for `@angular/compiler-cli`.

This is fine because it is really not used but there is no better way to disable these warnings.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Installing `@nrwl/web` does not emit `PEER` dependency warnings asking for `@angular/compiler-cli`.

## Issue
