### PR TITLE
fix(frontend): fix es5 compilation for differential loading

### DIFF
--- a/e2e/react.test.ts
+++ b/e2e/react.test.ts
@@ -99,6 +99,12 @@ describe('React Applications', () => {
       `dist/apps/${appName}/main-es5.js`,
       `dist/apps/${appName}/styles-es5.js`
     );
+    expect(readFile(`dist/apps/${appName}/main-es5.js`)).toContain(
+      'var App = function () {'
+    );
+    expect(readFile(`dist/apps/${appName}/main-es2015.js`)).toContain(
+      'const App = () => {'
+    );
     runCLI(`build ${appName} --prod --output-hashing none`);
     checkFilesExist(
       `dist/apps/${appName}/index.html`,

--- a/e2e/web.test.ts
+++ b/e2e/web.test.ts
@@ -1,6 +1,7 @@
 import {
   checkFilesExist,
   ensureProject,
+  readFile,
   runCLI,
   runCLIAsync,
   uniq
@@ -27,6 +28,12 @@ describe('Web Components Applications', () => {
       `dist/apps/${appName}/runtime-es5.js`,
       `dist/apps/${appName}/main-es5.js`,
       `dist/apps/${appName}/styles-es5.js`
+    );
+    expect(readFile(`dist/apps/${appName}/main-es5.js`)).toContain(
+      'var AppElement = /** @class */ (function (_super) {'
+    );
+    expect(readFile(`dist/apps/${appName}/main-es2015.js`)).toContain(
+      'class AppElement'
     );
     runCLI(`build ${appName} --prod --output-hashing none`);
     checkFilesExist(

--- a/packages/web/src/utils/config.spec.ts
+++ b/packages/web/src/utils/config.spec.ts
@@ -1,13 +1,15 @@
 import { getBaseWebpackPartial } from './config';
 
 import * as ts from 'typescript';
+import { ScriptTarget } from 'typescript';
 import { LicenseWebpackPlugin } from 'license-webpack-plugin';
-import CircularDependencyPlugin = require('circular-dependency-plugin');
-import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-jest.mock('tsconfig-paths-webpack-plugin');
 import TsConfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
 import { ProgressPlugin } from 'webpack';
 import { BuildBuilderOptions } from './types';
+import CircularDependencyPlugin = require('circular-dependency-plugin');
+import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+jest.mock('tsconfig-paths-webpack-plugin');
 
 describe('getBaseWebpackPartial', () => {
   let input: BuildBuilderOptions;
@@ -116,7 +118,8 @@ describe('getBaseWebpackPartial', () => {
       ).toEqual({
         configFile: 'tsconfig.json',
         transpileOnly: true,
-        experimentalWatchApi: true
+        experimentalWatchApi: true,
+        compilerOptions: null
       });
     });
 
@@ -154,6 +157,30 @@ describe('getBaseWebpackPartial', () => {
 
       const result = getBaseWebpackPartial(input);
       expect(result.resolve.mainFields).toContain('es2015');
+    });
+  });
+
+  describe('script overrides', () => {
+    it('should override the compiler options target for es2015', () => {
+      const result = getBaseWebpackPartial(input, ScriptTarget.ES2015);
+
+      expect(
+        (result.module.rules.find(rule => rule.loader === 'ts-loader')
+          .options as any).compilerOptions
+      ).toEqual({
+        target: 'es2015'
+      });
+    });
+
+    it('should override the compiler options target for es5', () => {
+      const result = getBaseWebpackPartial(input, ScriptTarget.ES5);
+
+      expect(
+        (result.module.rules.find(rule => rule.loader === 'ts-loader')
+          .options as any).compilerOptions
+      ).toEqual({
+        target: 'es5'
+      });
     });
   });
 

--- a/packages/web/src/utils/config.ts
+++ b/packages/web/src/utils/config.ts
@@ -17,7 +17,8 @@ import TsConfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
 export const OUT_FILENAME = 'main.js';
 
 export function getBaseWebpackPartial(
-  options: BuildBuilderOptions
+  options: BuildBuilderOptions,
+  overrideScriptTarget?: ScriptTarget
 ): Configuration {
   const { options: compilerOptions } = readTsConfig(options.tsConfig);
   const supportsEs2015 =
@@ -25,6 +26,11 @@ export function getBaseWebpackPartial(
     compilerOptions.target !== ts.ScriptTarget.ES5;
   const extensions = ['.ts', '.tsx', '.mjs', '.js', '.jsx'];
   const mainFields = [...(supportsEs2015 ? ['es2015'] : []), 'module', 'main'];
+  const compilerOptionOverrides = overrideScriptTarget
+    ? {
+        target: overrideScriptTarget === ScriptTarget.ES5 ? 'es5' : 'es2015'
+      }
+    : null;
   const webpackConfig: Configuration = {
     entry: {
       main: [options.main]
@@ -44,7 +50,8 @@ export function getBaseWebpackPartial(
             configFile: options.tsConfig,
             transpileOnly: true,
             // https://github.com/TypeStrong/ts-loader/pull/685
-            experimentalWatchApi: true
+            experimentalWatchApi: true,
+            compilerOptions: compilerOptionOverrides
           }
         }
       ]

--- a/packages/web/src/utils/web.config.ts
+++ b/packages/web/src/utils/web.config.ts
@@ -49,7 +49,7 @@ export function getWebConfig(
     tsConfigPath: options.tsConfig
   };
   return mergeWebpack([
-    _getBaseWebpackPartial(options),
+    _getBaseWebpackPartial(options, overrideScriptTarget),
     getPolyfillsPartial(options, overrideScriptTarget),
     getStylesPartial(wco),
     getCommonPartial(wco),
@@ -86,8 +86,11 @@ function getBrowserPartial(wco: any, options: WebBuildBuilderOptions) {
   return config;
 }
 
-function _getBaseWebpackPartial(options: WebBuildBuilderOptions) {
-  let partial = getBaseWebpackPartial(options);
+function _getBaseWebpackPartial(
+  options: WebBuildBuilderOptions,
+  overrideScriptTarget: ScriptTarget
+) {
+  let partial = getBaseWebpackPartial(options, overrideScriptTarget);
   delete partial.resolve.mainFields;
   return partial;
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

ES5 bundles for web differential loading has ES2015 code.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

ES5 bundles for web differential loading has ES5 code.

## Issue
