### PR TITLE
fix(frontend): add style tag to head in html output

### DIFF
--- a/e2e/react.test.ts
+++ b/e2e/react.test.ts
@@ -136,6 +136,12 @@ forEachCli(() => {
         filesToCheck.push(`dist/apps/${appName}/styles.css`);
       }
       checkFilesExist(...filesToCheck);
+      if (styles) {
+        expect(readFile(`dist/apps/${appName}/index.html`)).toContain(
+          `<link rel="stylesheet" href="styles.css">`
+        );
+      }
+
       const testResults = await runCLIAsync(`test ${appName}`);
       expect(testResults.stderr).toContain('Test Suites: 1 passed, 1 total');
       const lintE2eResults = runCLI(`lint ${appName}-e2e`);

--- a/e2e/web.test.ts
+++ b/e2e/web.test.ts
@@ -49,6 +49,9 @@ forEachCli(() => {
         `dist/apps/${appName}/main-es5.js`,
         `dist/apps/${appName}/styles.css`
       );
+      expect(readFile(`dist/apps/${appName}/index.html`)).toContain(
+        `<link rel="stylesheet" href="styles.css">`
+      );
       const testResults = await runCLIAsync(`test ${appName}`);
       expect(testResults.stderr).toContain('Test Suites: 1 passed, 1 total');
       const lintE2eResults = runCLI(`lint ${appName}-e2e`);

--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -105,6 +105,9 @@ export function run(
                     normalize(context.workspaceRoot),
                     options.index
                   ),
+                  files: result2.emittedFiles.filter(
+                    x => x.extension === '.css'
+                  ),
                   noModuleFiles: result2.emittedFiles,
                   moduleFiles: result1.emittedFiles,
                   baseHref: options.baseHref,


### PR DESCRIPTION


## Current Behavior (This is the behavior we have today, before the PR is merged)

Going through these steps:

1. `npx --ignore-existing create-nx-workspace web-diff-loading` with `empty` preset
2. `ng add @nrwl/web`
3. Generate application via `@nrwl/web` schematics
4. `ng build --prod`

The `index.html`output is:

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8" />
    <title>MyApp</title>
    <base href="/">
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <link rel="icon" type="image/x-icon" href="favicon.ico" />
  </head>
  <body>
    <web-diff-loading-root></web-diff-loading-root>
  <script src="runtime-es2015.js" type="module"></script><script src="polyfills-es2015.js" type="module"></script><script src="runtime-es5.js" nomodule></script><script src="polyfills-es5.js" nomodule></script><script src="main-es2015.js" type="module"></script><script src="main-es5.js" nomodule></script></body>
</html>
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

A `<link rel="stylesheet" href="styles.css">` tag should be added to the head when a css output is available.

For this fix, I aimed to stay as close to what the Angular CLI does upon calling `writeIndexHtml`. See https://github.com/angular/angular-cli/blob/8e97df38889b201aebf361ce7e8e07673411cb31/packages/angular_devkit/build_angular/src/browser/index.ts#L245.

## Issue

fix #1623