### PR TITLE
fix(nx): remove console.log from update tasks in migrations

### DIFF
--- a/packages/workspace/src/utils/update-task.ts
+++ b/packages/workspace/src/utils/update-task.ts
@@ -39,8 +39,6 @@ export function addUpdateTask(
       }
     });
 
-    console.log(dependencies);
-
     context.addTask(new RunUpdateTask(pkg, to), dependencies);
   };
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

update task dependencies get logged out when running migrations

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

update task dependencies do not get logged out when running migrations

## Issue
