### PR TITLE
fix(nx): fix npm lint command

### DIFF
--- a/packages/workspace/src/schematics/workspace/files/package.json__tmpl__
+++ b/packages/workspace/src/schematics/workspace/files/package.json__tmpl__
@@ -10,7 +10,7 @@
     "start": "<%= cliCommand %> serve",
     "build": "<%= cliCommand %> build",
     "test": "<%= cliCommand %> test",
-    "lint": "nx lint && <%= cliCommand %> lint",
+    "lint": "nx workspace-lint && <%= cliCommand %> lint",
     "e2e": "<%= cliCommand %> e2e",
     "affected:apps": "nx affected:apps",
     "affected:libs": "nx affected:libs",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`yarn lint` calls `nx lint && ng lint` for a newly created workspace

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`yarn lint` calls `nx workspace-lint && ng lint` for a newly created workspace

## Issue
