### PR TITLE
fix(frontend): fix react testing library migration

### DIFF
--- a/packages/react/src/migrations/update-8-3-0/update-8-3-0.ts
+++ b/packages/react/src/migrations/update-8-3-0/update-8-3-0.ts
@@ -96,14 +96,14 @@ function updateDependencies(tree: Tree) {
 }
 
 function updateImports(host: Tree) {
-  let ig = ignore().add(['*', '!*.ts', '!*.tsx']); // include only .tsx? files
+  let ig = ignore();
 
   if (host.exists('.gitignore')) {
     ig = ig.add(host.read('.gitignore').toString());
   }
 
   host.visit(path => {
-    if (ig.ignores(relative('/', path))) {
+    if (ig.ignores(relative('/', path)) || !/\.tsx?$/.test(path)) {
       return;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,7 +472,7 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.2.0"
 
-"@babel/helpers@^7.4.4":
+"@babel/helpers@^7.4.4", "@babel/helpers@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.5.5.tgz#63908d2a73942229d1e6685bc2a0e730dde3b75e"
   integrity sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`.js`, `.jsx`, `.ts`, `.tsx` are all being skipped for this migration.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`.js`, `.jsx`, `.ts`, `.tsx` are not being skipped for this migration.

## Issue
