### PR TITLE
fix(nx): use correct schematic for angular components

### DIFF
--- a/packages/angular/src/schematics/application/application.spec.ts
+++ b/packages/angular/src/schematics/application/application.spec.ts
@@ -320,7 +320,7 @@ describe('app', () => {
       const workspaceJson = readJsonInTree(result, 'workspace.json');
 
       expect(workspaceJson.projects['my-app'].schematics).toEqual({
-        '@nrwl/workspace:component': {
+        '@nrwl/angular:component': {
           style: 'scss'
         }
       });

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -216,7 +216,7 @@ function updateProject(options: NormalizedSchema): Rule {
           angularSchematicNames.forEach(type => {
             const schematic = `@schematics/angular:${type}`;
             if (schematic in fixedProject.schematics) {
-              fixedProject.schematics[`@nrwl/workspace:${type}`] =
+              fixedProject.schematics[`@nrwl/angular:${type}`] =
                 fixedProject.schematics[schematic];
               delete fixedProject.schematics[schematic];
             }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
Creating a new nx repo with `npx create-nx-workspace demo` and selecting SASS for styling the  schematic `@nrwl/workspace` has been set in the `schematics` object of `angular.json`
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
The correct schematic should be set to `@nrwl/angular`
## Issue
This fixes #1617 