### PR TITLE
feat(nx): add directory arg to create nx workspace command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ If you are an Angular user, you can also add Nx to your existing Angular CLI pro
 ng add @nrwl/workspace
 ```
 
+### Command Line Arguments
+
+```
+--cli: (npm | yarn)
+--preset: (empty | angular | react | web | full-stack)
+--directory: Custom Directory where nx should create workspace
+```
+
 ## Creating First Application
 
 By default, an Nx workspace starts blank. There are no applications to build, serve, and test. To create one, you need to add capabilities to the workspace.


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
Currently there is no option to allow for a custom directory 
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
This will add the --directory flag, where it is possibile to set a custom location for the nx workspace in case tmpDir is blocked by group policy for example.
## Issue
#1564