### PR TITLE
docs(schematics-ngrx): add 'creators' to --syntax option

### DIFF
--- a/docs/api-angular/schematics/ngrx.md
+++ b/docs/api-angular/schematics/ngrx.md
@@ -101,4 +101,4 @@ Default: `classes`
 
 Type: `string`
 
-Specifies whether to use class-based or creator functions for actions, reducers, and effects.
+Specifies whether to use class-based or creator functions for actions, reducers, and effects. Use `creators` for creator functions.


### PR DESCRIPTION
In NGRX API DOCS there is new --syntax option (string), but there is not specified value for new 'creator functions'.

But in this example https://nx.dev/angular/guides/misc-ngrx#feature-workflow ... there is used --syntax=creators 