### PR TITLE
fix(nx): run nx command in generated workspace

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -64,7 +64,7 @@ determineWorkspaceName(parsedArgs).then(name => {
         return determineCli(preset, parsedArgs).then(cli => {
           const tmpDir = createSandbox(packageManager, cli);
           createApp(tmpDir, cli, parsedArgs, name, preset, appName, style);
-          showNxWarning();
+          showNxWarning(name);
           showCliWarning(preset, parsedArgs);
         });
       });
@@ -368,9 +368,13 @@ function createApp(
   );
 }
 
-function showNxWarning() {
+function showNxWarning(workspaceName: string) {
   try {
-    execSync('nx --version', { stdio: ['ignore', 'ignore', 'ignore'] });
+    const pathToRunNxCommand = path.resolve(process.cwd(), workspaceName);
+    execSync('nx --version', {
+      cwd: pathToRunNxCommand,
+      stdio: ['ignore', 'ignore', 'ignore']
+    });
   } catch (e) {
     // no nx found
     output.addVerticalSeparator();


### PR DESCRIPTION
Fixes #1647

## Current Behavior (This is the behavior we have today, before the PR is merged)
Having @nrwl/cli installed globally, still produces the cli warning
<img width="900" alt="image" src="https://user-images.githubusercontent.com/4339673/62089935-3a3f9100-b26b-11e9-92d0-8693ee1eb7ab.png">

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
This PR fixes the directory where the nx command is executed, using the `cwd` Option of `execSync`
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/4339673/62089987-72df6a80-b26b-11e9-87bd-966118094f1b.png">

## Issue
#1647 