### PR TITLE
fix(jest): change reporters option to array type

### DIFF
--- a/docs/api-jest/builders/jest.md
+++ b/docs/api-jest/builders/jest.md
@@ -44,6 +44,12 @@ Type: `boolean`
 
 Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)
 
+### config
+
+Type: `string`
+
+The path to a Jest config file specifying how to find and execute tests. If no rootDir is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration
+
 ### coverage
 
 Type: `boolean`
@@ -110,7 +116,7 @@ Will not fail if no tests are found (for example while using `--testPathPattern`
 
 ### reporters
 
-Type: `string`
+Type: `array`
 
 Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/en/cli#reporters)
 

--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -57,7 +57,8 @@ describe('Jest Builder', () => {
             ]
           }
         }),
-        watch: false
+        watch: false,
+        reporters: ['default']
       },
       ['/root/jest.config.js']
     );
@@ -73,7 +74,7 @@ describe('Jest Builder', () => {
       testNamePattern: 'should load',
       testPathPattern: '/test/path',
       colors: false,
-      reporters: '/test/path',
+      reporters: ['/test/path'],
       verbose: false,
       coverage: false,
       coverageReporters: 'test',
@@ -106,7 +107,7 @@ describe('Jest Builder', () => {
         testNamePattern: 'should load',
         testPathPattern: '/test/path',
         colors: false,
-        reporters: '/test/path',
+        reporters: ['/test/path'],
         verbose: false,
         coverageReporters: 'test',
         coverageDirectory: '/test/path',
@@ -149,6 +150,7 @@ describe('Jest Builder', () => {
         }),
         coverage: false,
         findRelatedTests: true,
+        reporters: ['default'],
         runInBand: true,
         testNamePattern: 'should load',
         watch: false
@@ -174,7 +176,7 @@ describe('Jest Builder', () => {
       testNamePattern: 'test',
       testPathPattern: '/test/path',
       colors: false,
-      reporters: '/test/path',
+      reporters: ['/test/path'],
       verbose: false,
       coverage: false,
       coverageReporters: 'test',
@@ -218,7 +220,7 @@ describe('Jest Builder', () => {
         testPathPattern: '/test/path',
         colors: false,
         verbose: false,
-        reporters: '/test/path',
+        reporters: ['/test/path'],
         coverageReporters: 'test',
         coverageDirectory: '/test/path',
         updateSnapshot: true,
@@ -257,6 +259,7 @@ describe('Jest Builder', () => {
             ]
           }
         }),
+        reporters: ['default'],
         setupTestFrameworkScriptFile: '/root/test.ts',
         watch: false
       },

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -18,6 +18,7 @@ const { runCLI } = require('jest');
 
 export interface JestBuilderOptions extends JsonObject {
   codeCoverage?: boolean;
+  config?: string;
   jestConfig: string;
   testFile?: string;
   setupFile?: string;
@@ -37,7 +38,7 @@ export interface JestBuilderOptions extends JsonObject {
   testNamePattern?: string;
   testPathPattern?: string;
   colors?: boolean;
-  reporters?: string;
+  reporters?: string[];
   verbose?: false;
   coverage?: false;
   coverageReporters?: string;
@@ -77,6 +78,7 @@ function run(
 
   const config: any = {
     _: [],
+    config: options.config,
     coverage: options.codeCoverage,
     bail: options.bail,
     ci: options.ci,
@@ -123,6 +125,10 @@ function run(
 
   if (options.clearCache) {
     config.clearCache = true;
+  }
+
+  if (!options.reporters || !options.reporters.length) {
+    config.reporters = ['default'];
   }
 
   return from(runCLI(config, [options.jestConfig])).pipe(

--- a/packages/jest/src/builders/jest/schema.json
+++ b/packages/jest/src/builders/jest/schema.json
@@ -7,6 +7,10 @@
       "description": "Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)",
       "type": "boolean"
     },
+    "config": {
+      "description": "The path to a Jest config file specifying how to find and execute tests. If no rootDir is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration",
+      "type": "string"
+    },
     "clearCache": {
       "description": "Deletes the Jest cache directory and then exits without running tests. Will delete Jest's default cache directory. _Note: clearing the cache will reduce performance_.",
       "type": "boolean"
@@ -91,7 +95,10 @@
     },
     "reporters": {
       "description": "Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters=\"default\" --reporters=\"jest-junit\" (https://jestjs.io/docs/en/cli#reporters)",
-      "type": "string"
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "verbose": {
       "description": "Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)"


### PR DESCRIPTION
Jest expects the reporters option to be an array of strings.

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

## Current Behavior (This is the behavior we have today, before the PR is merged)
reporters option is assumed to be of type string and the config option is missing.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
reporters options should be an array of strings and config option should be supported.

## Issue
#1629
#1467 (this PR is basically the same but without conflicts)