### PR TITLE
docs(nx): use --save-dev for npm install scripts instead of --dev

### DIFF
--- a/docs/angular/getting-started/getting-started.md
+++ b/docs/angular/getting-started/getting-started.md
@@ -47,12 +47,12 @@ If you haven't specified any presets, you will get an empty Nx workspace. There 
 **Using `npm`**
 
 ```bash
-npm install --dev @nrwl/angular # Adds Angular capabilities
-npm install --dev @nrwl/web # Adds Web capabilities
-npm install --dev @nrwl/react # Adds React capabilities
-npm install --dev @nrwl/node # Adds Node capabilities
-npm install --dev @nrwl/express # Adds Express capabilities
-npm install --dev @nrwl/nest # Adds Nest capabilities
+npm install --save-dev @nrwl/angular # Adds Angular capabilities
+npm install --save-dev @nrwl/web # Adds Web capabilities
+npm install --save-dev @nrwl/react # Adds React capabilities
+npm install --save-dev @nrwl/node # Adds Node capabilities
+npm install --save-dev @nrwl/express # Adds Express capabilities
+npm install --save-dev @nrwl/nest # Adds Nest capabilities
 ```
 
 **Using `yarn`**


### PR DESCRIPTION
--save-dev is the correct option for npm, not --dev which is yarn specific

Closes #1681
## Current Behavior (This is the behavior we have today, before the PR is merged)
Docs says npm install --dev, which is not valid for npm
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Docs says npm install --save-dev, which is valid for npm
## Issue
#1681 
