### PR TITLE
fix(nx): npm scripts documentation generation

### DIFF
--- a/docs/api-workspace/npmscripts/affected-apps.md
+++ b/docs/api-workspace/npmscripts/affected-apps.md
@@ -36,25 +36,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/affected-build.md
+++ b/docs/api-workspace/npmscripts/affected-build.md
@@ -54,8 +54,6 @@ Default: `false`
 
 Parallelize the command
 
-### quiet
-
 ### uncommitted
 
 Uncommitted changes

--- a/docs/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/api-workspace/npmscripts/affected-dep-graph.md
@@ -40,25 +40,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/affected-e2e.md
+++ b/docs/api-workspace/npmscripts/affected-e2e.md
@@ -54,8 +54,6 @@ Default: `false`
 
 Parallelize the command
 
-### quiet
-
 ### uncommitted
 
 Uncommitted changes

--- a/docs/api-workspace/npmscripts/affected-libs.md
+++ b/docs/api-workspace/npmscripts/affected-libs.md
@@ -36,25 +36,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/affected-lint.md
+++ b/docs/api-workspace/npmscripts/affected-lint.md
@@ -24,10 +24,6 @@ Default: ``
 
 Exclude certain projects from being processed
 
-### file
-
-output file (e.g. --file=.vis/output.json)
-
 ### files
 
 A list of files delimited by commas
@@ -57,8 +53,6 @@ Isolate projects which previously failed
 Default: `false`
 
 Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/affected-test.md
+++ b/docs/api-workspace/npmscripts/affected-test.md
@@ -54,8 +54,6 @@ Default: `false`
 
 Parallelize the command
 
-### quiet
-
 ### uncommitted
 
 Uncommitted changes

--- a/docs/api-workspace/npmscripts/affected.md
+++ b/docs/api-workspace/npmscripts/affected.md
@@ -54,8 +54,6 @@ Default: `false`
 
 Parallelize the command
 
-### quiet
-
 ### target
 
 Task to run for affected projects

--- a/docs/api-workspace/npmscripts/dep-graph.md
+++ b/docs/api-workspace/npmscripts/dep-graph.md
@@ -40,25 +40,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/format-check.md
+++ b/docs/api-workspace/npmscripts/format-check.md
@@ -26,10 +26,6 @@ Default: ``
 
 Exclude certain projects from being processed
 
-### file
-
-output file (e.g. --file=.vis/output.json)
-
 ### files
 
 A list of files delimited by commas
@@ -42,25 +38,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/format-write.md
+++ b/docs/api-workspace/npmscripts/format-write.md
@@ -26,10 +26,6 @@ Default: ``
 
 Exclude certain projects from being processed
 
-### file
-
-output file (e.g. --file=.vis/output.json)
-
 ### files
 
 A list of files delimited by commas
@@ -42,25 +38,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
 
 ### uncommitted
 

--- a/docs/api-workspace/npmscripts/workspace-lint-files.md
+++ b/docs/api-workspace/npmscripts/workspace-lint-files.md
@@ -10,69 +10,9 @@ workspace-lint [files..]
 
 ## Options
 
-### all
-
-All projects
-
-### apps-and-libs
-
-### base
-
-Base of the current branch (usually master)
-
-### exclude
-
-Default: ``
-
-Exclude certain projects from being processed
-
-### file
-
-output file (e.g. --file=.vis/output.json)
-
-### files
-
-A list of files delimited by commas
-
-### head
-
-Latest commit of the current branch (usually HEAD)
-
 ### help
 
 Show help
-
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
-### only-failed
-
-Default: `false`
-
-Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
-
-### uncommitted
-
-Uncommitted changes
-
-### untracked
-
-Untracked changes
-
-### verbose
-
-Print additional error stack trace on failure
 
 ### version
 

--- a/docs/api-workspace/npmscripts/workspace-schematic-name.md
+++ b/docs/api-workspace/npmscripts/workspace-schematic-name.md
@@ -10,34 +10,6 @@ workspace-schematic [name]
 
 ## Options
 
-### all
-
-All projects
-
-### apps-and-libs
-
-### base
-
-Base of the current branch (usually master)
-
-### exclude
-
-Default: ``
-
-Exclude certain projects from being processed
-
-### file
-
-output file (e.g. --file=.vis/output.json)
-
-### files
-
-A list of files delimited by commas
-
-### head
-
-Latest commit of the current branch (usually HEAD)
-
 ### help
 
 Show help
@@ -46,41 +18,9 @@ Show help
 
 List the available workspace-schematics
 
-### maxParallel
-
-Default: `3`
-
-Max number of parallel processes
-
 ### name
 
 The name of your schematic`
-
-### only-failed
-
-Default: `false`
-
-Isolate projects which previously failed
-
-### parallel
-
-Default: `false`
-
-Parallelize the command
-
-### quiet
-
-### uncommitted
-
-Uncommitted changes
-
-### untracked
-
-Untracked changes
-
-### verbose
-
-Print additional error stack trace on failure
 
 ### version
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "husky": "^3.0.0",
     "identity-obj-proxy": "3.0.0",
     "ignore": "^5.0.4",
+    "import-fresh": "^3.1.0",
     "jasmine-core": "~2.99.1",
     "jasmine-marbles": "~0.6.0",
     "jasmine-spec-reporter": "~4.2.1",

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -104,7 +104,7 @@ export const commandsObject = yargs
   .command(
     'affected:e2e',
     'Run e2e tests for the applications affected by changes',
-    withAffectedOptions,
+    yargs => withAffectedOptions(withParallel(yargs)),
     args =>
       affected({
         ...args,

--- a/scripts/documentation/generate-npmscripts-data.ts
+++ b/scripts/documentation/generate-npmscripts-data.ts
@@ -1,10 +1,11 @@
 import * as fs from 'fs-extra';
-import * as yargs from 'yargs';
 import * as path from 'path';
 import { dedent } from 'tslint/lib/utils';
 
 import { generateFile, sortAlphabeticallyFunction } from './utils';
 import { commandsObject } from '../../packages/workspace';
+
+const importFresh = require('import-fresh');
 
 const commandsOutputDirectory = path.join(
   __dirname,
@@ -15,7 +16,7 @@ function getCommands(command) {
   return command.getCommandInstance().getCommandHandlers();
 }
 function parseCommandInstance(name, command) {
-  const builder = command.builder((<any>yargs).resetOptions());
+  const builder = command.builder(importFresh('yargs')().resetOptions());
   const builderDescriptions = builder.getUsageInstance().getDescriptions();
   const builderDefaultOptions = builder.getOptions().default;
   return {


### PR DESCRIPTION
Before, a single instance of yargs was accumulating options, so commands parsed later would have options from prior commands. That's because all yargs options are global by default. Now, a new instance of yargs is required before each command is parsed, so global options aren't accumulated.

fixes #1567

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

## Issue
