### PR TITLE
fix(angular): use build-angular for linting

### DIFF
--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -369,7 +369,7 @@ export default function(schema: Schema): Rule {
         ...options,
         skipFormat: true
       }),
-      addLintFiles(options.appProjectRoot, 'tslint', true),
+      addLintFiles(options.appProjectRoot, options.linter, true),
       externalSchematic('@schematics/angular', 'application', {
         name: options.name,
         inlineStyle: options.inlineStyle,
@@ -394,7 +394,8 @@ export default function(schema: Schema): Rule {
         ? externalSchematic('@nrwl/cypress', 'cypress-project', {
             name: options.e2eProjectName,
             directory: options.directory,
-            project: options.name
+            project: options.name,
+            linter: options.linter
           })
         : noop(),
       move(appProjectRoot, options.appProjectRoot),

--- a/packages/angular/src/schematics/application/schema.d.ts
+++ b/packages/angular/src/schematics/application/schema.d.ts
@@ -1,5 +1,6 @@
 import { E2eTestRunner } from '../../utils/test-runners';
 import { UnitTestRunner } from '../../utils/UnitTestRunner';
+import { Linter } from '@nrwl/workspace';
 
 export interface Schema {
   name: string;
@@ -14,7 +15,7 @@ export interface Schema {
   skipTests?: boolean;
   directory?: string;
   tags?: string;
-  linter: string;
+  linter: Linter;
   unitTestRunner: UnitTestRunner;
   e2eTestRunner: E2eTestRunner;
 }

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -1,38 +1,41 @@
 import { join, normalize } from '@angular-devkit/core';
 import {
+  apply,
   chain,
   externalSchematic,
-  noop,
-  Rule,
-  Tree,
-  SchematicContext,
-  schematic,
-  url,
-  apply,
+  MergeStrategy,
   mergeWith,
   move,
+  noop,
+  Rule,
+  schematic,
+  SchematicContext,
   template,
-  MergeStrategy
+  Tree,
+  url
 } from '@angular-devkit/schematics';
 import { Schema } from './schema';
 import * as path from 'path';
 import * as ts from 'typescript';
 
 import {
-  NxJson,
-  updateJsonInTree,
-  readJsonInTree,
-  offsetFromRoot,
-  addLintFiles
-} from '@nrwl/workspace';
-import { addGlobal, addIncludeToTsConfig, insert } from '@nrwl/workspace';
-import { toClassName, toFileName, toPropertyName } from '@nrwl/workspace';
-import {
+  addGlobal,
+  addIncludeToTsConfig,
+  addLintFiles,
+  formatFiles,
   getNpmScope,
   getWorkspacePath,
-  replaceAppNameWithPath
+  insert,
+  Linter,
+  NxJson,
+  offsetFromRoot,
+  readJsonInTree,
+  replaceAppNameWithPath,
+  toClassName,
+  toFileName,
+  toPropertyName,
+  updateJsonInTree
 } from '@nrwl/workspace';
-import { formatFiles } from '@nrwl/workspace';
 import { addUnitTestRunner } from '../ng-add/ng-add';
 import { addImportToModule, addRoute } from '../../utils/ast-utils';
 import { insertImport } from '@nrwl/workspace/src/utils/ast-utils';
@@ -431,7 +434,7 @@ export default function(schema: Schema): Rule {
     }
 
     return chain([
-      addLintFiles(options.projectRoot, 'tslint', true),
+      addLintFiles(options.projectRoot, Linter.TsLint, true),
       addUnitTestRunner(options),
       externalSchematic('@schematics/angular', 'library', {
         name: options.name,

--- a/packages/angular/src/schematics/library/schema.d.ts
+++ b/packages/angular/src/schematics/library/schema.d.ts
@@ -1,5 +1,4 @@
 import { UnitTestRunner } from '../../utils/test-runners';
-import { Framework } from '../../utils/framework';
 
 export interface Schema {
   name: string;

--- a/packages/cypress/src/schematics/cypress-project/schema.d.ts
+++ b/packages/cypress/src/schematics/cypress-project/schema.d.ts
@@ -1,6 +1,8 @@
+import { Linter } from '@nrwl/workspace';
+
 export interface Schema {
   project: string;
   name: string;
   directory: string;
-  linter: 'eslint' | 'tslint';
+  linter: Linter;
 }

--- a/packages/express/src/schematics/application/schema.d.ts
+++ b/packages/express/src/schematics/application/schema.d.ts
@@ -1,4 +1,6 @@
 import { UnitTestRunner } from '../../utils/test-runners';
+import { Linter } from '@nrwl/workspace';
+
 export interface Schema {
   name: string;
   skipFormat: boolean;
@@ -6,6 +8,6 @@ export interface Schema {
   directory?: string;
   unitTestRunner: UnitTestRunner;
   tags?: string;
-  linter: string;
+  linter: Linter;
   frontendProject?: string;
 }

--- a/packages/jest/src/schematics/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/schematics/jest-project/jest-project.spec.ts
@@ -15,9 +15,8 @@ describe('jestProject', () => {
           root: 'libs/lib1',
           architect: {
             lint: {
-              builder: '@nrwl/linter:lint',
+              builder: '@angular-devkit/build-angular:tslint',
               options: {
-                linter: 'tslint',
                 tsConfig: []
               }
             }

--- a/packages/nest/src/schematics/application/schema.d.ts
+++ b/packages/nest/src/schematics/application/schema.d.ts
@@ -1,4 +1,6 @@
 import { UnitTestRunner } from '../../utils/test-runners';
+import { Linter } from 'tslint';
+
 export interface Schema {
   name: string;
   skipFormat: boolean;
@@ -6,6 +8,6 @@ export interface Schema {
   directory?: string;
   unitTestRunner: UnitTestRunner;
   tags?: string;
-  linter: string;
+  linter: Linter;
   frontendProject?: string;
 }

--- a/packages/node/src/schematics/application/application.spec.ts
+++ b/packages/node/src/schematics/application/application.spec.ts
@@ -53,9 +53,8 @@ describe('app', () => {
         })
       );
       expect(workspaceJson.projects['my-node-app'].architect.lint).toEqual({
-        builder: '@nrwl/linter:lint',
+        builder: '@angular-devkit/build-angular:tslint',
         options: {
-          linter: 'tslint',
           tsConfig: [
             'apps/my-node-app/tsconfig.app.json',
             'apps/my-node-app/tsconfig.spec.json'
@@ -125,9 +124,8 @@ describe('app', () => {
       expect(
         workspaceJson.projects['my-dir-my-node-app'].architect.lint
       ).toEqual({
-        builder: '@nrwl/linter:lint',
+        builder: '@angular-devkit/build-angular:tslint',
         options: {
-          linter: 'tslint',
           tsConfig: [
             'apps/my-dir/my-node-app/tsconfig.app.json',
             'apps/my-dir/my-node-app/tsconfig.spec.json'

--- a/packages/node/src/schematics/application/schema.d.ts
+++ b/packages/node/src/schematics/application/schema.d.ts
@@ -1,10 +1,12 @@
+import { Linter } from '@nrwl/workspace';
+
 export interface Schema {
   name: string;
   skipFormat: boolean;
   skipPackageJson: boolean;
   directory?: string;
   unitTestRunner: 'jest' | 'none';
-  linter: 'eslint' | 'tslint';
+  linter: Linter;
   tags?: string;
   frontendProject?: string;
 }

--- a/packages/react/src/schematics/application/application.spec.ts
+++ b/packages/react/src/schematics/application/application.spec.ts
@@ -292,9 +292,8 @@ describe('app', () => {
     );
     const workspaceJson = readJsonInTree(tree, 'workspace.json');
     expect(workspaceJson.projects['my-app'].architect.lint).toEqual({
-      builder: '@nrwl/linter:lint',
+      builder: '@angular-devkit/build-angular:tslint',
       options: {
-        linter: 'tslint',
         exclude: ['**/node_modules/**', '!apps/my-app/**'],
         tsConfig: [
           'apps/my-app/tsconfig.app.json',

--- a/packages/react/src/schematics/application/schema.d.ts
+++ b/packages/react/src/schematics/application/schema.d.ts
@@ -1,3 +1,5 @@
+import { Linter } from '@nrwl/workspace';
+
 export interface Schema {
   name: string;
   style?: string;
@@ -6,7 +8,7 @@ export interface Schema {
   tags?: string;
   unitTestRunner: 'jest' | 'none';
   e2eTestRunner: 'cypress' | 'none';
-  linter: 'eslint' | 'tslint';
+  linter: Linter;
   pascalCaseFiles?: boolean;
   classComponent?: boolean;
   routing?: boolean;

--- a/packages/react/src/schematics/library/library.spec.ts
+++ b/packages/react/src/schematics/library/library.spec.ts
@@ -19,9 +19,8 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-lib'].root).toEqual('libs/my-lib');
       expect(workspaceJson.projects['my-lib'].architect.build).toBeUndefined();
       expect(workspaceJson.projects['my-lib'].architect.lint).toEqual({
-        builder: '@nrwl/linter:lint',
+        builder: '@angular-devkit/build-angular:tslint',
         options: {
-          linter: 'tslint',
           exclude: ['**/node_modules/**', '!libs/my-lib/**'],
           tsConfig: [
             'libs/my-lib/tsconfig.lib.json',
@@ -184,9 +183,8 @@ describe('lib', () => {
         'libs/my-dir/my-lib'
       );
       expect(workspaceJson.projects['my-dir-my-lib'].architect.lint).toEqual({
-        builder: '@nrwl/linter:lint',
+        builder: '@angular-devkit/build-angular:tslint',
         options: {
-          linter: 'tslint',
           exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**'],
           tsConfig: [
             'libs/my-dir/my-lib/tsconfig.lib.json',

--- a/packages/react/src/schematics/library/schema.d.ts
+++ b/packages/react/src/schematics/library/schema.d.ts
@@ -1,3 +1,5 @@
+import { Linter } from '@nrwl/workspace';
+
 export interface Schema {
   name: string;
   directory?: string;
@@ -10,5 +12,5 @@ export interface Schema {
   routing?: boolean;
   parentRoute?: string;
   unitTestRunner: 'jest' | 'none';
-  linter: 'eslint' | 'tslint';
+  linter: Linter;
 }

--- a/packages/web/src/schematics/application/application.spec.ts
+++ b/packages/web/src/schematics/application/application.spec.ts
@@ -284,9 +284,8 @@ describe('app', () => {
     const workspaceJson = readJsonInTree(tree, 'workspace.json');
 
     expect(workspaceJson.projects['my-app'].architect.lint).toEqual({
-      builder: '@nrwl/linter:lint',
+      builder: '@angular-devkit/build-angular:tslint',
       options: {
-        linter: 'tslint',
         exclude: ['**/node_modules/**', '!apps/my-app/**'],
         tsConfig: [
           'apps/my-app/tsconfig.app.json',

--- a/packages/web/src/schematics/application/schema.d.ts
+++ b/packages/web/src/schematics/application/schema.d.ts
@@ -7,5 +7,5 @@ export interface Schema {
   tags?: string;
   unitTestRunner: 'jest' | 'none';
   e2eTestRunner: 'cypress' | 'none';
-  linter: 'eslint' | 'tslint';
+  linter: Linter;
 }

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -58,7 +58,7 @@ export {
 
 export { getWorkspace, updateWorkspace } from './src/utils/workspace';
 export { addUpdateTask } from './src/utils/update-task';
-export { addLintFiles, generateProjectLint } from './src/utils/lint';
+export { addLintFiles, generateProjectLint, Linter } from './src/utils/lint';
 
 export { formatFiles } from './src/utils/rules/format-files';
 export { deleteFile } from './src/utils/rules/deleteFile';

--- a/packages/workspace/src/schematics/library/library.spec.ts
+++ b/packages/workspace/src/schematics/library/library.spec.ts
@@ -20,9 +20,8 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-lib'].root).toEqual('libs/my-lib');
       expect(workspaceJson.projects['my-lib'].architect.build).toBeUndefined();
       expect(workspaceJson.projects['my-lib'].architect.lint).toEqual({
-        builder: '@nrwl/linter:lint',
+        builder: '@angular-devkit/build-angular:tslint',
         options: {
-          linter: 'tslint',
           exclude: ['**/node_modules/**', '!libs/my-lib/**'],
           tsConfig: [
             'libs/my-lib/tsconfig.lib.json',
@@ -167,9 +166,8 @@ describe('lib', () => {
         'libs/my-dir/my-lib'
       );
       expect(workspaceJson.projects['my-dir-my-lib'].architect.lint).toEqual({
-        builder: '@nrwl/linter:lint',
+        builder: '@angular-devkit/build-angular:tslint',
         options: {
-          linter: 'tslint',
           exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**'],
           tsConfig: [
             'libs/my-dir/my-lib/tsconfig.lib.json',

--- a/packages/workspace/src/schematics/library/schema.d.ts
+++ b/packages/workspace/src/schematics/library/schema.d.ts
@@ -1,4 +1,4 @@
-import { UnitTestRunner } from '../../utils/test-runners';
+import { Linter } from '@nrwl/workspace/src/utils/lint';
 
 export interface Schema {
   name: string;
@@ -8,5 +8,5 @@ export interface Schema {
   tags?: string;
   simpleModuleName: boolean;
   unitTestRunner: 'jest' | 'none';
-  linter: 'eslint' | 'tslint';
+  linter: Linter;
 }

--- a/packages/workspace/src/utils/lint.ts
+++ b/packages/workspace/src/utils/lint.ts
@@ -13,21 +13,26 @@ import {
   eslintConfigPrettierVersion
 } from './versions';
 
+export const enum Linter {
+  TsLint = 'tslint',
+  EsLint = 'eslint',
+  None = 'none'
+}
+
 export function generateProjectLint(
   projectRoot: string,
   tsConfigPath: string,
-  linter: 'tslint' | 'eslint' | 'none'
+  linter: Linter
 ) {
-  if (linter === 'tslint') {
+  if (linter === Linter.TsLint) {
     return {
-      builder: '@nrwl/linter:lint',
+      builder: '@angular-devkit/build-angular:tslint',
       options: {
-        linter: 'tslint',
         tsConfig: [tsConfigPath],
         exclude: ['**/node_modules/**', '!' + projectRoot + '/**']
       }
     };
-  } else if (linter === 'eslint') {
+  } else if (linter === Linter.EsLint) {
     return {
       builder: '@nrwl/linter:lint',
       options: {
@@ -44,7 +49,7 @@ export function generateProjectLint(
 
 export function addLintFiles(
   projectRoot: string,
-  linter: 'tslint' | 'eslint' | 'none',
+  linter: Linter,
   onlyGlobal = false
 ): Rule {
   return (host: Tree, context: SchematicContext) => {


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`npm run lint` fails on a newly generated Angular workspace because `@nrwl/lint` is not a dependency yet the `e2e` project tries to use it.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`npm run lint` passes on a newly generated Angular workspace and the `e2e` project uses `@angular-devkit/build-angular:tslint`

## Issue
#1674 