### PR TITLE
fix(react): update extensions for Prettier to include tsx and jsx files

### DIFF
--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -14,6 +14,8 @@ export interface YargsFormatOptions extends YargsAffectedOptions {
 const PRETTIER_EXTENSIONS = [
   'ts',
   'js',
+  'tsx',
+  'jsx',
   'scss',
   'less',
   'css',


### PR DESCRIPTION

## Current Behavior (This is the behavior we have today, before the PR is merged)

tsx and jsx files are not formatted.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

tsx and jsx files are formatted.