### PR TITLE
fix(nx): pass --fix flag to selected linter

### DIFF
--- a/docs/api-linter/builders/lint.md
+++ b/docs/api-linter/builders/lint.md
@@ -22,6 +22,14 @@ Type: `array`
 
 Files to include in linting.
 
+### fix
+
+Default: `false`
+
+Type: `boolean`
+
+Fixes linting errors (may overwrite linted files).
+
 ### format
 
 Default: `prose`

--- a/packages/linter/src/builders/lint/schema.json
+++ b/packages/linter/src/builders/lint/schema.json
@@ -65,6 +65,11 @@
       "items": {
         "type": "string"
       }
+    },
+    "fix": {
+      "type": "boolean",
+      "description": "Fixes linting errors (may overwrite linted files).",
+      "default": false
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
The --fix flag was not passed as an option to the appropriate linter
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
The --fix flag is passed as an option to the appropriate linter
## Issue
#1703 