### PR TITLE
fix(react): validate style value before proceeding with app/lib/component generate

### DIFF
--- a/packages/react/src/schematics/application/application.ts
+++ b/packages/react/src/schematics/application/application.ts
@@ -50,6 +50,7 @@ import {
   regeneratorVersion
 } from '../../utils/versions';
 import { addImportToModule } from '../../../../angular/src/utils/ast-utils';
+import { assertValidStyle } from '../../utils/assertion';
 
 interface NormalizedSchema extends Schema {
   projectName: string;
@@ -320,6 +321,8 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   const styledModule = /^(css|scss|less|styl)$/.test(options.style)
     ? null
     : options.style;
+
+  assertValidStyle(options.style);
 
   return {
     ...options,

--- a/packages/react/src/schematics/component/component.ts
+++ b/packages/react/src/schematics/component/component.ts
@@ -23,6 +23,7 @@ import {
 } from '@nrwl/workspace/src/utils/ast-utils';
 import { CSS_IN_JS_DEPENDENCIES } from '../../utils/styled';
 import { reactRouterVersion } from '../../utils/versions';
+import { assertValidStyle } from '../../utils/assertion';
 
 interface NormalizedSchema extends Schema {
   projectSourceRoot: Path;
@@ -124,23 +125,23 @@ function normalizeOptions(
   context: SchematicContext
 ): NormalizedSchema {
   const { className, fileName } = names(options.name);
-
   const componentFileName = options.pascalCaseFiles ? className : fileName;
-
   const { sourceRoot: projectSourceRoot, projectType } = getProjectConfig(
     host,
     options.project
   );
+
+  const styledModule = /^(css|scss|less|styl)$/.test(options.style)
+    ? null
+    : options.style;
+
+  assertValidStyle(options.style);
 
   if (options.export && projectType === 'application') {
     context.logger.warn(
       `The "--export" option should not be used with applications and will do nothing.`
     );
   }
-
-  const styledModule = /^(css|scss|less|styl)$/.test(options.style)
-    ? null
-    : options.style;
 
   return {
     ...options,

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -39,6 +39,7 @@ import {
   findComponentImportPath
 } from '../../utils/ast-utils';
 import { reactRouterVersion } from '../../utils/versions';
+import { assertValidStyle } from '../../utils/assertion';
 
 export interface NormalizedSchema extends Schema {
   name: string;
@@ -282,6 +283,8 @@ function normalizeOptions(
       );
     }
   }
+
+  assertValidStyle(normalized.style);
 
   return normalized;
 }

--- a/packages/react/src/utils/assertion.spec.ts
+++ b/packages/react/src/utils/assertion.spec.ts
@@ -1,0 +1,22 @@
+import { assertValidStyle } from './assertion';
+
+describe('assertValidStyle', () => {
+  it('should accept style option values from app, lib, component schematics', () => {
+    const schemas = [
+      require('../schematics/application/schema.json'),
+      require('../schematics/component/schema.json'),
+      require('../schematics/library/schema.json')
+    ];
+
+    schemas.forEach(schema => {
+      const values = schema.properties.style['x-prompt'].items;
+      expect(() =>
+        values.forEach(value => assertValidStyle(value)).not.toThrow()
+      );
+    });
+  });
+
+  it('should throw for invalid values', () => {
+    expect(() => assertValidStyle('bad')).toThrow(/Unsupported/);
+  });
+});

--- a/packages/react/src/utils/assertion.ts
+++ b/packages/react/src/utils/assertion.ts
@@ -1,0 +1,17 @@
+const VALID_STYLES = [
+  'css',
+  'scss',
+  'less',
+  'styl',
+  'styled-components',
+  '@emotion/styled'
+];
+export function assertValidStyle(style: string): void {
+  if (VALID_STYLES.indexOf(style) === -1) {
+    throw new Error(
+      `Unsupported style option found: ${style}. Valid values are: "${VALID_STYLES.join(
+        '", "'
+      )}"`
+    );
+  }
+}


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Bad value mean invalid files are generated (e.g. `src/app/app.not-supported`).

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Error is caught before files are generated.