### PR TITLE
feat(react): update workspace defaults based on app schematic option

### DIFF
--- a/docs/api-cypress/schematics/cypress-project.md
+++ b/docs/api-cypress/schematics/cypress-project.md
@@ -15,7 +15,7 @@ ng generate cypress-project ...
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the project is placed
 
 ### linter
 

--- a/docs/api-react/schematics/application.md
+++ b/docs/api-react/schematics/application.md
@@ -77,6 +77,14 @@ Type: `boolean`
 
 Skip formatting files
 
+### skipWorkspaceJson
+
+Default: `false`
+
+Type: `boolean`
+
+Skip updating workspace.json with default schematic options based on values provided to this app (e.g. babel, style)
+
 ### style
 
 Default: `css`

--- a/packages/react/src/schematics/application/application.spec.ts
+++ b/packages/react/src/schematics/application/application.spec.ts
@@ -499,4 +499,33 @@ describe('app', () => {
       expect(polyfillsSource).toContain('core-js');
     });
   });
+
+  describe('--skipWorkspaceJson', () => {
+    it('should update workspace with defaults when --skipWorkspaceJson=false', async () => {
+      const tree = await runSchematic(
+        'app',
+        {
+          name: 'myApp',
+          babel: true,
+          style: 'styled-components',
+          skipWorkspaceJson: false
+        },
+        appTree
+      );
+
+      const workspaceJson = readJsonInTree(tree, '/workspace.json');
+      expect(workspaceJson.schematics['@nrwl/react']).toMatchObject({
+        application: {
+          babel: true,
+          style: 'styled-components'
+        },
+        component: {
+          style: 'styled-components'
+        },
+        library: {
+          style: 'styled-components'
+        }
+      });
+    });
+  });
 });

--- a/packages/react/src/schematics/application/schema.d.ts
+++ b/packages/react/src/schematics/application/schema.d.ts
@@ -13,4 +13,5 @@ export interface Schema {
   classComponent?: boolean;
   routing?: boolean;
   babel?: boolean;
+  skipWorkspaceJson?: boolean;
 }

--- a/packages/react/src/schematics/application/schema.json
+++ b/packages/react/src/schematics/application/schema.json
@@ -65,6 +65,11 @@
       "type": "boolean",
       "default": false
     },
+    "skipWorkspaceJson": {
+      "description": "Skip updating workspace.json with default schematic options based on values provided to this app (e.g. babel, style)",
+      "type": "boolean",
+      "default": false
+    },
     "unitTestRunner": {
       "type": "string",
       "enum": ["jest", "none"],

--- a/packages/react/src/schematics/library/library.spec.ts
+++ b/packages/react/src/schematics/library/library.spec.ts
@@ -127,8 +127,7 @@ describe('lib', () => {
         {
           name: 'myLib2',
           directory: 'myDir',
-          tags: 'one,two',
-          simpleModuleName: true
+          tags: 'one,two'
         },
         tree
       );

--- a/packages/react/src/schematics/ng-add/ng-add.spec.ts
+++ b/packages/react/src/schematics/ng-add/ng-add.spec.ts
@@ -29,7 +29,7 @@ describe('ng-add', () => {
       const result = await runSchematic('ng-add', {}, tree);
       const workspaceJson = readJsonInTree(result, 'workspace.json');
       expect(workspaceJson.cli.defaultCollection).toEqual('@nrwl/react');
-      expect(workspaceJson.schematics['@nrwl/react:application'].babel).toBe(
+      expect(workspaceJson.schematics['@nrwl/react'].application.babel).toBe(
         true
       );
     });
@@ -48,7 +48,7 @@ describe('ng-add', () => {
       const result = await runSchematic('ng-add', {}, tree);
       const workspaceJson = readJsonInTree(result, 'workspace.json');
       expect(workspaceJson.cli.defaultCollection).toEqual('@nrwl/react');
-      expect(workspaceJson.schematics['@nrwl/react:application'].babel).toBe(
+      expect(workspaceJson.schematics['@nrwl/react'].application.babel).toBe(
         true
       );
     });
@@ -69,9 +69,6 @@ describe('ng-add', () => {
       const result = await runSchematic('ng-add', {}, tree);
       const workspaceJson = readJsonInTree(result, 'workspace.json');
       expect(workspaceJson.cli.defaultCollection).toEqual('@nrwl/angular');
-      expect(
-        workspaceJson.schematics['@nrwl/react:application']
-      ).not.toBeDefined();
     });
   });
 });

--- a/packages/react/src/schematics/ng-add/ng-add.ts
+++ b/packages/react/src/schematics/ng-add/ng-add.ts
@@ -41,8 +41,8 @@ function moveDependency(): Rule {
 
 function setDefault(): Rule {
   return updateWorkspace(workspace => {
+    // Set workspace default collection to 'react' if not already set.
     workspace.extensions.cli = workspace.extensions.cli || {};
-
     const defaultCollection: string =
       workspace.extensions.cli &&
       ((workspace.extensions.cli as JsonObject).defaultCollection as string);
@@ -50,18 +50,27 @@ function setDefault(): Rule {
     if (!defaultCollection || defaultCollection === '@nrwl/workspace') {
       (workspace.extensions.cli as JsonObject).defaultCollection =
         '@nrwl/react';
+    }
 
-      // Also generate apps with babel option by default.
-      workspace.extensions.schematics = {
-        ...(workspace.extensions.schematics
-          ? (workspace.extensions.schematics as JsonObject)
-          : {}),
-        '@nrwl/react:application': {
+    // Also generate all new react apps with babel.
+    workspace.extensions.schematics =
+      jsonIdentity(workspace.extensions.schematics) || {};
+    const reactSchematics =
+      jsonIdentity(workspace.extensions.schematics['@nrwl/react']) || {};
+    workspace.extensions.schematics = {
+      ...workspace.extensions.schematics,
+      '@nrwl/react': {
+        application: {
+          ...jsonIdentity(reactSchematics.application),
           babel: true
         }
-      };
-    }
+      }
+    };
   });
+}
+
+function jsonIdentity(x: any): JsonObject {
+  return x as JsonObject;
 }
 
 export default function(schema: Schema) {


### PR DESCRIPTION
- The defaults make it easier to generate other apps/libs/components later.
- An option `skipWorkspaceJson` can be used to skip updates entirely.
