### PR TITLE
fix(react): fix eslint config so it does not override module boundaries from parent.

### DIFF
--- a/packages/react/src/utils/lint.ts
+++ b/packages/react/src/utils/lint.ts
@@ -34,13 +34,6 @@ export const reactEslintJson = {
    * https://github.com/facebook/create-react-app
    */
   rules: {
-    '@nrwl/nx/enforce-module-boundaries': [
-      'error',
-      {
-        allow: [],
-        depConstraints: [{ sourceTag: '*', onlyDependOnLibsWithTags: ['*'] }]
-      }
-    ],
     /**
      * Standard ESLint rule configurations
      * https://eslint.org/docs/rules


### PR DESCRIPTION
That rule was put there by mistake. We should always take the root config.