### PR TITLE
fix(nx): fix error message when using angular with nx cli

### DIFF
--- a/packages/angular/scripts/nx-cli-warning.js
+++ b/packages/angular/scripts/nx-cli-warning.js
@@ -8,12 +8,13 @@ try {
     if (Object.keys(workspaceJson.projects).length === 0) {
       const output = require('@nrwl/workspace/src/command-line/output').output;
       output.warn({
-        title: '@nrwl/angular is added an Nx workspace powered by the Nx CLI.',
+        title: '@nrwl/angular added to a Nx workspace powered by the Nx CLI.',
         bodyLines: [
           "You won't be able to use 'ng' to generate artifacts and run tasks.",
           "If you want to use 'ng', you need to create a new workspace powered by the Angular CLI.",
           'You can do it by selecting Angular CLI when creating a new workspace.',
-          "Or by providing --cli as follows: 'create-nx-workspace --cli=angular'."
+          "Or by providing --cli as follows: 'create-nx-workspace --cli=angular'.",
+          "You can invoke the Angular schematics with 'nx generate @nrwl/angular' to generate artifacts."
         ]
       });
     }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
Adding @nrwl/angular to an empty workspace outputs a warning with an unclear error message

```bash
>  NX   WARNING  @nrwl/angular is added an Nx workspace powered by the Nx CLI.
```
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
```bash
@nrwl/angular added to a Nx workspace powered by the Nx CLI.
```
I added a new line at the end, explaining how to invoke the Angular schematics with nx
```
You can invoke the Angular schematics with 'nx generate @nrwl/angular' to generate artifacts.
```
