### PR TITLE
fix(react): set configPath for @babel/preset-env to match project context

### DIFF
--- a/docs/angular/api-workspace/npmscripts/affected-apps.md
+++ b/docs/angular/api-workspace/npmscripts/affected-apps.md
@@ -8,10 +8,8 @@ Print applications affected by changes
 nx affected:apps
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Print the names of all the apps affected by changing the index.ts file:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected-build.md
+++ b/docs/angular/api-workspace/npmscripts/affected-build.md
@@ -8,10 +8,8 @@ Build applications and publishable libraries affected by changes
 nx affected:build
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run build in parallel:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/angular/api-workspace/npmscripts/affected-dep-graph.md
@@ -8,10 +8,8 @@ Graph dependencies affected by changes
 nx affected:dep-graph
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Open the dep graph of the workspace in the browser, and highlight the projects affected by changing the index.ts file:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected-e2e.md
+++ b/docs/angular/api-workspace/npmscripts/affected-e2e.md
@@ -8,10 +8,8 @@ Run e2e tests for the applications affected by changes
 nx affected:e2e
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run tests in parallel:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected-libs.md
+++ b/docs/angular/api-workspace/npmscripts/affected-libs.md
@@ -8,10 +8,8 @@ Print libraries affected by changes
 nx affected:libs
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Print the names of all the libs affected by changing the index.ts file:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected-lint.md
+++ b/docs/angular/api-workspace/npmscripts/affected-lint.md
@@ -8,10 +8,8 @@ Lint projects affected by changes
 nx affected:lint
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run lint in parallel:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected-test.md
+++ b/docs/angular/api-workspace/npmscripts/affected-test.md
@@ -8,10 +8,8 @@ Test projects affected by changes
 nx affected:test
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run tests in parallel:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected.md
+++ b/docs/angular/api-workspace/npmscripts/affected.md
@@ -8,10 +8,8 @@ Run task for affected projects
 nx affected
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run custom target for all affected projects:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/dep-graph.md
+++ b/docs/angular/api-workspace/npmscripts/dep-graph.md
@@ -8,10 +8,8 @@ Graph dependencies within workspace
 nx dep-graph
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Open the dep graph of the workspace in the browser:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/format-check.md
+++ b/docs/angular/api-workspace/npmscripts/format-check.md
@@ -8,7 +8,8 @@ Check for un-formatted files
 nx format:check
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+
 
 ## Options
 

--- a/docs/angular/api-workspace/npmscripts/format-write.md
+++ b/docs/angular/api-workspace/npmscripts/format-write.md
@@ -8,7 +8,8 @@ Overwrite un-formatted files
 nx format:write
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+
 
 ## Options
 

--- a/docs/angular/api-workspace/npmscripts/workspace-lint-files.md
+++ b/docs/angular/api-workspace/npmscripts/workspace-lint-files.md
@@ -8,7 +8,8 @@ Lint workspace or list of files
 nx workspace-lint [files..]
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+
 
 ## Options
 

--- a/docs/angular/api-workspace/npmscripts/workspace-schematic-name.md
+++ b/docs/angular/api-workspace/npmscripts/workspace-schematic-name.md
@@ -8,7 +8,8 @@ Runs a workspace schematic from the tools/schematics directory
 nx workspace-schematic [name]
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+
 
 ## Options
 

--- a/docs/react/api-workspace/npmscripts/affected-apps.md
+++ b/docs/react/api-workspace/npmscripts/affected-apps.md
@@ -8,10 +8,8 @@ Print applications affected by changes
 nx affected:apps
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Print the names of all the apps affected by changing the index.ts file:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected-build.md
+++ b/docs/react/api-workspace/npmscripts/affected-build.md
@@ -8,10 +8,8 @@ Build applications and publishable libraries affected by changes
 nx affected:build
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run build in parallel:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/react/api-workspace/npmscripts/affected-dep-graph.md
@@ -8,10 +8,8 @@ Graph dependencies affected by changes
 nx affected:dep-graph
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Open the dep graph of the workspace in the browser, and highlight the projects affected by changing the index.ts file:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected-e2e.md
+++ b/docs/react/api-workspace/npmscripts/affected-e2e.md
@@ -8,10 +8,8 @@ Run e2e tests for the applications affected by changes
 nx affected:e2e
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run tests in parallel:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected-libs.md
+++ b/docs/react/api-workspace/npmscripts/affected-libs.md
@@ -8,10 +8,8 @@ Print libraries affected by changes
 nx affected:libs
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Print the names of all the libs affected by changing the index.ts file:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected-lint.md
+++ b/docs/react/api-workspace/npmscripts/affected-lint.md
@@ -8,10 +8,8 @@ Lint projects affected by changes
 nx affected:lint
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run lint in parallel:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected-test.md
+++ b/docs/react/api-workspace/npmscripts/affected-test.md
@@ -8,10 +8,8 @@ Test projects affected by changes
 nx affected:test
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run tests in parallel:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected.md
+++ b/docs/react/api-workspace/npmscripts/affected.md
@@ -8,10 +8,8 @@ Run task for affected projects
 nx affected
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run custom target for all affected projects:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/dep-graph.md
+++ b/docs/react/api-workspace/npmscripts/dep-graph.md
@@ -8,10 +8,8 @@ Graph dependencies within workspace
 nx dep-graph
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Open the dep graph of the workspace in the browser:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/format-check.md
+++ b/docs/react/api-workspace/npmscripts/format-check.md
@@ -8,7 +8,8 @@ Check for un-formatted files
 nx format:check
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+
 
 ## Options
 

--- a/docs/react/api-workspace/npmscripts/format-write.md
+++ b/docs/react/api-workspace/npmscripts/format-write.md
@@ -8,7 +8,8 @@ Overwrite un-formatted files
 nx format:write
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+
 
 ## Options
 

--- a/docs/react/api-workspace/npmscripts/workspace-lint-files.md
+++ b/docs/react/api-workspace/npmscripts/workspace-lint-files.md
@@ -8,7 +8,8 @@ Lint workspace or list of files
 nx workspace-lint [files..]
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+
 
 ## Options
 

--- a/docs/react/api-workspace/npmscripts/workspace-schematic-name.md
+++ b/docs/react/api-workspace/npmscripts/workspace-schematic-name.md
@@ -8,7 +8,8 @@ Runs a workspace schematic from the tools/schematics directory
 nx workspace-schematic [name]
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+
 
 ## Options
 

--- a/docs/web/api-workspace/npmscripts/affected-apps.md
+++ b/docs/web/api-workspace/npmscripts/affected-apps.md
@@ -8,10 +8,8 @@ Print applications affected by changes
 nx affected:apps
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Print the names of all the apps affected by changing the index.ts file:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected-build.md
+++ b/docs/web/api-workspace/npmscripts/affected-build.md
@@ -8,10 +8,8 @@ Build applications and publishable libraries affected by changes
 nx affected:build
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run build in parallel:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/web/api-workspace/npmscripts/affected-dep-graph.md
@@ -8,10 +8,8 @@ Graph dependencies affected by changes
 nx affected:dep-graph
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Open the dep graph of the workspace in the browser, and highlight the projects affected by changing the index.ts file:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected-e2e.md
+++ b/docs/web/api-workspace/npmscripts/affected-e2e.md
@@ -8,10 +8,8 @@ Run e2e tests for the applications affected by changes
 nx affected:e2e
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run tests in parallel:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected-libs.md
+++ b/docs/web/api-workspace/npmscripts/affected-libs.md
@@ -8,10 +8,8 @@ Print libraries affected by changes
 nx affected:libs
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Print the names of all the libs affected by changing the index.ts file:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected-lint.md
+++ b/docs/web/api-workspace/npmscripts/affected-lint.md
@@ -8,10 +8,8 @@ Lint projects affected by changes
 nx affected:lint
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run lint in parallel:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected-test.md
+++ b/docs/web/api-workspace/npmscripts/affected-test.md
@@ -8,10 +8,8 @@ Test projects affected by changes
 nx affected:test
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run tests in parallel:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected.md
+++ b/docs/web/api-workspace/npmscripts/affected.md
@@ -8,10 +8,8 @@ Run task for affected projects
 nx affected
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Run custom target for all affected projects:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/dep-graph.md
+++ b/docs/web/api-workspace/npmscripts/dep-graph.md
@@ -8,10 +8,8 @@ Graph dependencies within workspace
 nx dep-graph
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
-
-### Examples
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+ ### Examples
 Open the dep graph of the workspace in the browser:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/format-check.md
+++ b/docs/web/api-workspace/npmscripts/format-check.md
@@ -8,7 +8,8 @@ Check for un-formatted files
 nx format:check
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+
 
 ## Options
 

--- a/docs/web/api-workspace/npmscripts/format-write.md
+++ b/docs/web/api-workspace/npmscripts/format-write.md
@@ -8,7 +8,8 @@ Overwrite un-formatted files
 nx format:write
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+
 
 ## Options
 

--- a/docs/web/api-workspace/npmscripts/workspace-lint-files.md
+++ b/docs/web/api-workspace/npmscripts/workspace-lint-files.md
@@ -8,7 +8,8 @@ Lint workspace or list of files
 nx workspace-lint [files..]
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+
 
 ## Options
 

--- a/docs/web/api-workspace/npmscripts/workspace-schematic-name.md
+++ b/docs/web/api-workspace/npmscripts/workspace-schematic-name.md
@@ -8,7 +8,8 @@ Runs a workspace schematic from the tools/schematics directory
 nx workspace-schematic [name]
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
+
 
 ## Options
 

--- a/packages/react/src/plugins/babel.ts
+++ b/packages/react/src/plugins/babel.ts
@@ -11,6 +11,8 @@ export function getBabelWebpackConfig(config: Configuration) {
           [
             require('@babel/preset-env').default,
             {
+              // Include any project files, e.g. browserlist, by setting the context as config path
+              configPath: config.context,
               // Allow importing core-js in entrypoint and use browserlist to select polyfills
               useBuiltIns: 'entry',
               corejs: 3,

--- a/packages/react/src/schematics/application/files/app/.browserslistrc
+++ b/packages/react/src/schematics/application/files/app/.browserslistrc
@@ -1,4 +1,7 @@
-# This file is currently used by autoprefixer to adjust CSS to support the below specified browsers
+# This file is used by:
+# 1. autoprefixer to adjust CSS to support the below specified browsers
+# 2. babel preset-env to adjust included polyfills
+#
 # For additional information regarding the format and rule options, please see:
 # https://github.com/browserslist/browserslist#queries
 #


### PR DESCRIPTION

## Current Behavior (This is the behavior we have today, before the PR is merged)

Project files are not picked up (e.g. browserlist).

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Project files are picked up.
