### PR TITLE
feat(react): add redux schematic

### DIFF
--- a/docs/angular/api-react/schematics/redux.md
+++ b/docs/angular/api-react/schematics/redux.md
@@ -1,0 +1,59 @@
+# redux
+
+Create a redux slice for a project
+
+## Usage
+
+```bash
+ng generate redux ...
+```
+
+```bash
+ng g slice ... # same
+```
+
+By default, Nx will search for `redux` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+ng g @nrwl/react:redux ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+ng g redux ... --dry-run
+```
+
+## Options
+
+### appProject
+
+Alias(es): a
+
+Type: `string`
+
+The application project to add the slice to.
+
+### directory
+
+Alias(es): d
+
+Type: `string`
+
+The name of the folder used to contain/group the generated Redux files.
+
+### name
+
+Type: `string`
+
+Redux slice name
+
+### project
+
+Alias(es): p
+
+Type: `string`
+
+The name of the project to add the slice to. If it is an application, then the store configuration will be updated too.

--- a/docs/angular/api-workspace/npmscripts/affected-apps.md
+++ b/docs/angular/api-workspace/npmscripts/affected-apps.md
@@ -8,8 +8,10 @@ Print applications affected by changes
 nx affected:apps
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Print the names of all the apps affected by changing the index.ts file:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected-build.md
+++ b/docs/angular/api-workspace/npmscripts/affected-build.md
@@ -8,8 +8,10 @@ Build applications and publishable libraries affected by changes
 nx affected:build
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run build in parallel:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/angular/api-workspace/npmscripts/affected-dep-graph.md
@@ -8,8 +8,10 @@ Graph dependencies affected by changes
 nx affected:dep-graph
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Open the dep graph of the workspace in the browser, and highlight the projects affected by changing the index.ts file:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected-e2e.md
+++ b/docs/angular/api-workspace/npmscripts/affected-e2e.md
@@ -8,8 +8,10 @@ Run e2e tests for the applications affected by changes
 nx affected:e2e
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run tests in parallel:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected-libs.md
+++ b/docs/angular/api-workspace/npmscripts/affected-libs.md
@@ -8,8 +8,10 @@ Print libraries affected by changes
 nx affected:libs
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Print the names of all the libs affected by changing the index.ts file:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected-lint.md
+++ b/docs/angular/api-workspace/npmscripts/affected-lint.md
@@ -8,8 +8,10 @@ Lint projects affected by changes
 nx affected:lint
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run lint in parallel:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected-test.md
+++ b/docs/angular/api-workspace/npmscripts/affected-test.md
@@ -8,8 +8,10 @@ Test projects affected by changes
 nx affected:test
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run tests in parallel:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/affected.md
+++ b/docs/angular/api-workspace/npmscripts/affected.md
@@ -8,8 +8,10 @@ Run task for affected projects
 nx affected
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run custom target for all affected projects:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/dep-graph.md
+++ b/docs/angular/api-workspace/npmscripts/dep-graph.md
@@ -8,8 +8,10 @@ Graph dependencies within workspace
 nx dep-graph
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Open the dep graph of the workspace in the browser:
 
 ```bash

--- a/docs/angular/api-workspace/npmscripts/format-check.md
+++ b/docs/angular/api-workspace/npmscripts/format-check.md
@@ -8,8 +8,7 @@ Check for un-formatted files
 nx format:check
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
 
 ## Options
 

--- a/docs/angular/api-workspace/npmscripts/format-write.md
+++ b/docs/angular/api-workspace/npmscripts/format-write.md
@@ -8,8 +8,7 @@ Overwrite un-formatted files
 nx format:write
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
 
 ## Options
 

--- a/docs/angular/api-workspace/npmscripts/workspace-lint-files.md
+++ b/docs/angular/api-workspace/npmscripts/workspace-lint-files.md
@@ -8,8 +8,7 @@ Lint workspace or list of files
 nx workspace-lint [files..]
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
 
 ## Options
 

--- a/docs/angular/api-workspace/npmscripts/workspace-schematic-name.md
+++ b/docs/angular/api-workspace/npmscripts/workspace-schematic-name.md
@@ -8,8 +8,7 @@ Runs a workspace schematic from the tools/schematics directory
 nx workspace-schematic [name]
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
 
 ## Options
 

--- a/docs/react/api-react/schematics/redux.md
+++ b/docs/react/api-react/schematics/redux.md
@@ -1,0 +1,59 @@
+# redux
+
+Create a redux slice for a project
+
+## Usage
+
+```bash
+nx generate redux ...
+```
+
+```bash
+nx g slice ... # same
+```
+
+By default, Nx will search for `redux` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/react:redux ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g redux ... --dry-run
+```
+
+## Options
+
+### appProject
+
+Alias(es): a
+
+Type: `string`
+
+The application project to add the slice to.
+
+### directory
+
+Alias(es): d
+
+Type: `string`
+
+The name of the folder used to contain/group the generated Redux files.
+
+### name
+
+Type: `string`
+
+Redux slice name
+
+### project
+
+Alias(es): p
+
+Type: `string`
+
+The name of the project to add the slice to. If it is an application, then the store configuration will be updated too.

--- a/docs/react/api-workspace/npmscripts/affected-apps.md
+++ b/docs/react/api-workspace/npmscripts/affected-apps.md
@@ -8,8 +8,10 @@ Print applications affected by changes
 nx affected:apps
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Print the names of all the apps affected by changing the index.ts file:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected-build.md
+++ b/docs/react/api-workspace/npmscripts/affected-build.md
@@ -8,8 +8,10 @@ Build applications and publishable libraries affected by changes
 nx affected:build
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run build in parallel:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/react/api-workspace/npmscripts/affected-dep-graph.md
@@ -8,8 +8,10 @@ Graph dependencies affected by changes
 nx affected:dep-graph
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Open the dep graph of the workspace in the browser, and highlight the projects affected by changing the index.ts file:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected-e2e.md
+++ b/docs/react/api-workspace/npmscripts/affected-e2e.md
@@ -8,8 +8,10 @@ Run e2e tests for the applications affected by changes
 nx affected:e2e
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run tests in parallel:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected-libs.md
+++ b/docs/react/api-workspace/npmscripts/affected-libs.md
@@ -8,8 +8,10 @@ Print libraries affected by changes
 nx affected:libs
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Print the names of all the libs affected by changing the index.ts file:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected-lint.md
+++ b/docs/react/api-workspace/npmscripts/affected-lint.md
@@ -8,8 +8,10 @@ Lint projects affected by changes
 nx affected:lint
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run lint in parallel:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected-test.md
+++ b/docs/react/api-workspace/npmscripts/affected-test.md
@@ -8,8 +8,10 @@ Test projects affected by changes
 nx affected:test
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run tests in parallel:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/affected.md
+++ b/docs/react/api-workspace/npmscripts/affected.md
@@ -8,8 +8,10 @@ Run task for affected projects
 nx affected
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run custom target for all affected projects:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/dep-graph.md
+++ b/docs/react/api-workspace/npmscripts/dep-graph.md
@@ -8,8 +8,10 @@ Graph dependencies within workspace
 nx dep-graph
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Open the dep graph of the workspace in the browser:
 
 ```bash

--- a/docs/react/api-workspace/npmscripts/format-check.md
+++ b/docs/react/api-workspace/npmscripts/format-check.md
@@ -8,8 +8,7 @@ Check for un-formatted files
 nx format:check
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
 
 ## Options
 

--- a/docs/react/api-workspace/npmscripts/format-write.md
+++ b/docs/react/api-workspace/npmscripts/format-write.md
@@ -8,8 +8,7 @@ Overwrite un-formatted files
 nx format:write
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
 
 ## Options
 

--- a/docs/react/api-workspace/npmscripts/workspace-lint-files.md
+++ b/docs/react/api-workspace/npmscripts/workspace-lint-files.md
@@ -8,8 +8,7 @@ Lint workspace or list of files
 nx workspace-lint [files..]
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
 
 ## Options
 

--- a/docs/react/api-workspace/npmscripts/workspace-schematic-name.md
+++ b/docs/react/api-workspace/npmscripts/workspace-schematic-name.md
@@ -8,8 +8,7 @@ Runs a workspace schematic from the tools/schematics directory
 nx workspace-schematic [name]
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
 
 ## Options
 

--- a/docs/web/api-react/schematics/redux.md
+++ b/docs/web/api-react/schematics/redux.md
@@ -1,0 +1,59 @@
+# redux
+
+Create a redux slice for a project
+
+## Usage
+
+```bash
+nx generate redux ...
+```
+
+```bash
+nx g slice ... # same
+```
+
+By default, Nx will search for `redux` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/react:redux ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g redux ... --dry-run
+```
+
+## Options
+
+### appProject
+
+Alias(es): a
+
+Type: `string`
+
+The application project to add the slice to.
+
+### directory
+
+Alias(es): d
+
+Type: `string`
+
+The name of the folder used to contain/group the generated Redux files.
+
+### name
+
+Type: `string`
+
+Redux slice name
+
+### project
+
+Alias(es): p
+
+Type: `string`
+
+The name of the project to add the slice to. If it is an application, then the store configuration will be updated too.

--- a/docs/web/api-workspace/npmscripts/affected-apps.md
+++ b/docs/web/api-workspace/npmscripts/affected-apps.md
@@ -8,8 +8,10 @@ Print applications affected by changes
 nx affected:apps
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Print the names of all the apps affected by changing the index.ts file:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected-build.md
+++ b/docs/web/api-workspace/npmscripts/affected-build.md
@@ -8,8 +8,10 @@ Build applications and publishable libraries affected by changes
 nx affected:build
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run build in parallel:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/web/api-workspace/npmscripts/affected-dep-graph.md
@@ -8,8 +8,10 @@ Graph dependencies affected by changes
 nx affected:dep-graph
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Open the dep graph of the workspace in the browser, and highlight the projects affected by changing the index.ts file:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected-e2e.md
+++ b/docs/web/api-workspace/npmscripts/affected-e2e.md
@@ -8,8 +8,10 @@ Run e2e tests for the applications affected by changes
 nx affected:e2e
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run tests in parallel:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected-libs.md
+++ b/docs/web/api-workspace/npmscripts/affected-libs.md
@@ -8,8 +8,10 @@ Print libraries affected by changes
 nx affected:libs
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Print the names of all the libs affected by changing the index.ts file:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected-lint.md
+++ b/docs/web/api-workspace/npmscripts/affected-lint.md
@@ -8,8 +8,10 @@ Lint projects affected by changes
 nx affected:lint
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run lint in parallel:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected-test.md
+++ b/docs/web/api-workspace/npmscripts/affected-test.md
@@ -8,8 +8,10 @@ Test projects affected by changes
 nx affected:test
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run tests in parallel:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/affected.md
+++ b/docs/web/api-workspace/npmscripts/affected.md
@@ -8,8 +8,10 @@ Run task for affected projects
 nx affected
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Run custom target for all affected projects:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/dep-graph.md
+++ b/docs/web/api-workspace/npmscripts/dep-graph.md
@@ -8,8 +8,10 @@ Graph dependencies within workspace
 nx dep-graph
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
- ### Examples
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
 Open the dep graph of the workspace in the browser:
 
 ```bash

--- a/docs/web/api-workspace/npmscripts/format-check.md
+++ b/docs/web/api-workspace/npmscripts/format-check.md
@@ -8,8 +8,7 @@ Check for un-formatted files
 nx format:check
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
 
 ## Options
 

--- a/docs/web/api-workspace/npmscripts/format-write.md
+++ b/docs/web/api-workspace/npmscripts/format-write.md
@@ -8,8 +8,7 @@ Overwrite un-formatted files
 nx format:write
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
 
 ## Options
 

--- a/docs/web/api-workspace/npmscripts/workspace-lint-files.md
+++ b/docs/web/api-workspace/npmscripts/workspace-lint-files.md
@@ -8,8 +8,7 @@ Lint workspace or list of files
 nx workspace-lint [files..]
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
 
 ## Options
 

--- a/docs/web/api-workspace/npmscripts/workspace-schematic-name.md
+++ b/docs/web/api-workspace/npmscripts/workspace-schematic-name.md
@@ -8,8 +8,7 @@ Runs a workspace schematic from the tools/schematics directory
 nx workspace-schematic [name]
 ```
 
-Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.  
-
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
 
 ## Options
 

--- a/packages/react/ast-utils.ts
+++ b/packages/react/ast-utils.ts
@@ -1,0 +1,9 @@
+// Exported schematics development outside of Nx. e.g. workspace schematics
+export {
+  findMainRenderStatement,
+  findComponentImportPath,
+  findElements,
+  findDefaultExport,
+  findClosestOpening,
+  isTag
+} from './src/utils/ast-utils';

--- a/packages/react/collection.json
+++ b/packages/react/collection.json
@@ -29,6 +29,13 @@
       "schema": "./src/schematics/component/schema.json",
       "description": "Create a component",
       "aliases": "c"
+    },
+
+    "redux": {
+      "factory": "./src/schematics/redux/redux",
+      "schema": "./src/schematics/redux/schema.json",
+      "description": "Create a redux slice for a project",
+      "aliases": ["slice"]
     }
   }
 }

--- a/packages/react/src/schematics/redux/files/__directory__/__fileName__.slice.spec.ts__tmpl__
+++ b/packages/react/src/schematics/redux/files/__directory__/__fileName__.slice.spec.ts__tmpl__
@@ -1,0 +1,40 @@
+import {
+  <%= propertyName %>Reducer,
+  get<%= className %>Start,
+  get<%= className %>Failure,
+  get<%= className %>Success
+} from './<%= fileName %>.slice';
+
+describe('<%= propertyName %> reducer', () => {
+  it('should handle initial state', () => {
+    expect(<%= propertyName %>Reducer(undefined, { type: '' })).toMatchObject({
+      entities: []
+    });
+  });
+
+  it('should handle get <%= propertyName %> actions', () => {
+    let state = <%= propertyName %>Reducer(undefined, get<%= className %>Start());
+
+    expect(state).toEqual({
+      loaded: false,
+      error: null,
+      entities: []
+    });
+
+    state = <%= propertyName %>Reducer(state, get<%= className %>Success([{ id: 1 }]));
+
+    expect(state).toEqual({
+      loaded: true,
+      error: null,
+      entities: [{ id: 1 }]
+    });
+
+    state = <%= propertyName %>Reducer(state, get<%= className %>Failure('Uh oh'));
+
+    expect(state).toEqual({
+      loaded: true,
+      error: 'Uh oh',
+      entities: [{ id: 1 }]
+    });
+  });
+});

--- a/packages/react/src/schematics/redux/files/__directory__/__fileName__.slice.ts__tmpl__
+++ b/packages/react/src/schematics/redux/files/__directory__/__fileName__.slice.ts__tmpl__
@@ -1,0 +1,118 @@
+import { createSlice, Action, PayloadAction } from 'redux-starter-kit';
+import { ThunkAction } from 'redux-thunk';
+import { createSelector } from 'reselect';
+
+export const <%= constantName %>_FEATURE_KEY = '<%= propertyName %>';
+
+/*
+ * Change this from `any` if there is a more specific error type.
+ */
+export type <%= className %>Error = any;
+
+/*
+ * Update these interfaces according to your requirements.
+ */
+export interface <%= className %>Entity {
+  id: number;
+}
+
+export interface <%= className %>State {
+  entities: <%= className %>Entity[];
+  loaded: boolean;
+  error: <%= className %>Error;
+}
+
+export const initial<%= className %>State: <%= className %>State = {
+  entities: [],
+  loaded: false,
+  error: null
+};
+
+export const <%= propertyName %>Slice = createSlice({
+  slice: <%= constantName %>_FEATURE_KEY,
+  initialState: initial<%= className %>State as <%= className %>State,
+  reducers: {
+    get<%= className %>Start: (state, action: PayloadAction<undefined>) => {
+      state.loaded = false;
+    },
+    get<%= className %>Success: (state, action: PayloadAction<<%= className %>Entity[]>) => {
+      state.loaded = true;
+      state.entities = action.payload;
+    },
+    get<%= className %>Failure: (state, action: PayloadAction<<%= className %>Error>) => {
+      state.error = action.payload;
+    }
+  }
+});
+
+/*
+ * Export reducer for store configuration.
+ */
+export const <%= propertyName %>Reducer = <%= propertyName %>Slice.reducer;
+
+/*
+ * Export action creators to be dispatched. For use with the `useDispatch` hook.
+ *
+ * e.g.
+ * ```
+ * const dispatch = useDispatch();
+ * dispatch(get<%= className %>Success([{ id: 1 }]));
+ * ```
+ *
+ * See: https://react-redux.js.org/next/api/hooks#usedispatch
+ */
+export const {
+  get<%= className %>Start,
+  get<%= className %>Success,
+  get<%= className %>Failure
+} = <%= propertyName %>Slice.actions;
+
+/*
+ * Export selectors to query state. For use with the `useSelector` hook.
+ *
+ * e.g.
+ * ```
+ * const entities = useSelector(select<%= className %>Entities);
+ * ```
+ *
+ * See: https://react-redux.js.org/next/api/hooks#useselector
+ */
+export const get<%= className %>State = (rootState: any): <%= className %>State =>
+  rootState[<%= constantName %>_FEATURE_KEY];
+
+export const select<%= className %>Entities = createSelector(
+  get<%= className %>State,
+  s => s.entities
+);
+
+export const select<%= className %>Loaded = createSelector(
+  get<%= className %>State,
+  s => s.loaded
+);
+
+export const select<%= className %>Error = createSelector(
+  get<%= className %>State,
+  s => s.error
+);
+
+/*
+ * Export default effect, handled by redux-thunk.
+ * You can replace this with your own effects solution.
+ */
+export const fetch<%= className %> = (): ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+> => async dispatch => {
+  try {
+    dispatch(get<%= className %>Start());
+    // Replace this with your custom fetch call.
+    // For example, `const data = await myApi.get<%= className %>`;
+    // Right now we just load an empty array.
+    const data = [];
+    dispatch(get<%= className %>Success(data));
+  } catch (err) {
+    dispatch(get<%= className %>Failure(err));
+  }
+};

--- a/packages/react/src/schematics/redux/redux.spec.ts
+++ b/packages/react/src/schematics/redux/redux.spec.ts
@@ -1,0 +1,65 @@
+import { Tree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { readJsonInTree } from '@nrwl/workspace';
+import { runSchematic } from '../../utils/testing';
+
+describe('lib', () => {
+  let appTree: Tree;
+
+  beforeEach(async () => {
+    appTree = Tree.empty();
+    appTree = createEmptyWorkspace(appTree);
+    appTree = await runSchematic('lib', { name: 'my-lib' }, appTree);
+  });
+
+  it('should add dependencies', async () => {
+    const tree = await runSchematic(
+      'redux',
+      { name: 'my-slice', project: 'my-lib' },
+      appTree
+    );
+    const packageJson = readJsonInTree(tree, '/package.json');
+    expect(packageJson.dependencies['redux-starter-kit']).toBeDefined();
+    expect(packageJson.dependencies['react-redux']).toBeDefined();
+  });
+
+  it('should add slice and spec files', async () => {
+    const tree = await runSchematic(
+      'redux',
+      { name: 'my-slice', project: 'my-lib' },
+      appTree
+    );
+
+    expect(tree.exists('/libs/my-lib/src/lib/my-slice.slice.ts')).toBeTruthy();
+    expect(
+      tree.exists('/libs/my-lib/src/lib/my-slice.slice.spec.ts')
+    ).toBeTruthy();
+  });
+
+  describe('--appProject', () => {
+    it('should configure app main', async () => {
+      appTree = await runSchematic('app', { name: 'my-app' }, appTree);
+      const tree = await runSchematic(
+        'redux',
+        { name: 'my-slice', project: 'my-lib', appProject: 'my-app' },
+        appTree
+      );
+
+      const main = tree.read('/apps/my-app/src/main.tsx').toString();
+      expect(main).toContain('redux-starter-kit');
+      expect(main).toContain('configureStore');
+      expect(main).toContain('[MY_SLICE_FEATURE_KEY]: mySliceReducer');
+      expect(main).toMatch(/<Provider store={store}>/);
+    });
+
+    it('should throw error for lib project', async () => {
+      await expect(
+        runSchematic(
+          'redux',
+          { name: 'my-slice', project: 'my-lib', appProject: 'my-lib' },
+          appTree
+        )
+      ).rejects.toThrow(/Expected m/);
+    });
+  });
+});

--- a/packages/react/src/schematics/redux/redux.ts
+++ b/packages/react/src/schematics/redux/redux.ts
@@ -1,0 +1,213 @@
+import * as ts from 'typescript';
+import { join, Path, strings } from '@angular-devkit/core';
+import '@nrwl/tao/src/compat/angular-cli-compat';
+import {
+  addDepsToPackageJson,
+  addGlobal,
+  getProjectConfig,
+  insert,
+  readJsonInTree
+} from '@nrwl/workspace/src/utils/ast-utils';
+import {
+  apply,
+  chain,
+  mergeWith,
+  move,
+  noop,
+  Rule,
+  SchematicContext,
+  template,
+  Tree,
+  url
+} from '@angular-devkit/schematics';
+
+import { NormalizedSchema, Schema } from './schema';
+import { formatFiles, getWorkspace, names, toFileName } from '@nrwl/workspace';
+import * as path from 'path';
+import { addReduxStoreToMain, updateReduxStore } from '../../utils/ast-utils';
+import {
+  reactReduxTypesVersion,
+  reactReduxVersion,
+  reduxStarterKitversion,
+  reselectVersion
+} from '../../utils/versions';
+
+export default function(schema: any): Rule {
+  return async (host: Tree, context: SchematicContext) => {
+    const options = await normalizeOptions(host, schema);
+
+    return chain([
+      generateReduxFiles(options),
+      addExportsToBarrel(options),
+      addReduxPackageDependencies,
+      addStoreConfiguration(options, context),
+      updateReducerConfiguration(options, context),
+      formatFiles()
+    ]);
+  };
+}
+
+function generateReduxFiles(options: NormalizedSchema) {
+  const templateSource = apply(url('./files'), [
+    template({ ...options, tmpl: '' }),
+    move(options.filesPath)
+  ]);
+
+  return mergeWith(templateSource);
+}
+
+function addReduxPackageDependencies(): Rule {
+  return addDepsToPackageJson(
+    {
+      'redux-starter-kit': reduxStarterKitversion,
+      'react-redux': reactReduxVersion,
+      '@types/react-redux': reactReduxTypesVersion,
+      reselect: reselectVersion
+    },
+    {}
+  );
+}
+
+function addExportsToBarrel(options: NormalizedSchema): Rule {
+  return (host: Tree) => {
+    const indexFilePath = path.join(options.projectSourcePath, 'index.ts');
+
+    const buffer = host.read(indexFilePath);
+    if (!!buffer) {
+      const indexSource = buffer.toString('utf-8');
+      const indexSourceFile = ts.createSourceFile(
+        indexFilePath,
+        indexSource,
+        ts.ScriptTarget.Latest,
+        true
+      );
+
+      const statePath = options.directory
+        ? `./lib/${options.directory}/${options.fileName}`
+        : `./lib/${options.fileName}`;
+
+      insert(host, indexFilePath, [
+        ...addGlobal(
+          indexSourceFile,
+          indexFilePath,
+          `export * from '${statePath}.slice';`
+        )
+      ]);
+    }
+
+    return host;
+  };
+}
+
+function addStoreConfiguration(
+  options: NormalizedSchema,
+  context: SchematicContext
+) {
+  return options.appProjectSourcePath
+    ? (host: Tree) => {
+        const mainSource = host.read(options.appMainFilePath).toString();
+        if (!mainSource.includes('redux')) {
+          const mainSourceFile = ts.createSourceFile(
+            options.appMainFilePath,
+            mainSource,
+            ts.ScriptTarget.Latest,
+            true
+          );
+          insert(
+            host,
+            options.appMainFilePath,
+            addReduxStoreToMain(
+              options.appMainFilePath,
+              mainSourceFile,
+              context
+            )
+          );
+        }
+        return host;
+      }
+    : noop();
+}
+
+function updateReducerConfiguration(
+  options: NormalizedSchema,
+  context: SchematicContext
+) {
+  return options.appProjectSourcePath
+    ? (host: Tree) => {
+        const mainSource = host.read(options.appMainFilePath).toString();
+        const mainSourceFile = ts.createSourceFile(
+          options.appMainFilePath,
+          mainSource,
+          ts.ScriptTarget.Latest,
+          true
+        );
+        insert(
+          host,
+          options.appMainFilePath,
+          updateReduxStore(options.appMainFilePath, mainSourceFile, context, {
+            keyName: `${options.constantName}_FEATURE_KEY`,
+            reducerName: `${options.propertyName}Reducer`,
+            modulePath: `${options.projectModulePath}`
+          })
+        );
+        return host;
+      }
+    : noop();
+}
+
+async function normalizeOptions(
+  host: Tree,
+  options: Schema
+): Promise<NormalizedSchema> {
+  let appProjectSourcePath: Path;
+  let appMainFilePath: string;
+  const extraNames = names(options.name);
+  const { sourceRoot } = getProjectConfig(host, options.project);
+  const workspace = await getWorkspace(host);
+  const projectType = workspace.projects.get(options.project).extensions
+    .projectType as string;
+  const tsConfigJson = readJsonInTree(host, 'tsconfig.json');
+  const tsPaths: { [module: string]: string[] } = tsConfigJson.compilerOptions
+    ? tsConfigJson.compilerOptions.paths || {}
+    : {};
+  const modulePath =
+    projectType === 'application'
+      ? `./app/${extraNames.fileName}.slice`
+      : Object.keys(tsPaths).find(k =>
+          tsPaths[k].some(s => s.includes(sourceRoot))
+        );
+  // If --project is set to an app, automatically configure store
+  // for it without needing to specify --appProject.
+  options.appProject =
+    options.appProject ||
+    (projectType === 'application' ? options.project : undefined);
+  if (options.appProject) {
+    const appConfig = getProjectConfig(host, options.appProject);
+    if (appConfig.projectType !== 'application') {
+      throw new Error(
+        `Expected ${options.appProject} to be an application but got ${
+          appConfig.projectType
+        }`
+      );
+    }
+    appProjectSourcePath = appConfig.sourceRoot;
+    appMainFilePath = path.join(appProjectSourcePath, 'main.tsx');
+    if (!host.exists(appMainFilePath)) {
+      throw new Error(
+        `Could not find ${appMainFilePath} during store configuration`
+      );
+    }
+  }
+  return {
+    ...options,
+    ...extraNames,
+    constantName: strings.underscore(options.name).toUpperCase(),
+    directory: toFileName(options.directory),
+    projectType,
+    projectSourcePath: sourceRoot,
+    projectModulePath: modulePath,
+    appProjectSourcePath,
+    appMainFilePath,
+    filesPath: join(sourceRoot, projectType === 'application' ? 'app' : 'lib')
+  };
+}

--- a/packages/react/src/schematics/redux/schema.d.ts
+++ b/packages/react/src/schematics/redux/schema.d.ts
@@ -1,0 +1,21 @@
+import { Path } from '@angular-devkit/core';
+
+export interface Schema {
+  name: string;
+  project: string;
+  directory: string;
+  appProject: string;
+}
+
+interface NormalizedSchema extends Schema {
+  projectType: string;
+  projectSourcePath: Path;
+  projectModulePath: string;
+  appProjectSourcePath: Path;
+  appMainFilePath: string;
+  filesPath: Path;
+  className: string;
+  constantName: string;
+  propertyName: string;
+  fileName: string;
+}

--- a/packages/react/src/schematics/redux/schema.json
+++ b/packages/react/src/schematics/redux/schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "redux",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Redux slice name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
+    "project": {
+      "type": "string",
+      "description": "The name of the project to add the slice to. If it is an application, then the store configuration will be updated too.",
+      "alias": "p",
+      "$default": {
+        "$source": "projectName"
+      },
+      "x-prompt": "What is the name of the project for this slice?"
+    },
+    "directory": {
+      "type": "string",
+      "alias": "d",
+      "default": "",
+      "description": "The name of the folder used to contain/group the generated Redux files."
+    },
+    "appProject": {
+      "type": "string",
+      "description": "The application project to add the slice to.",
+      "alias": "a"
+    }
+  },
+  "required": ["name"]
+}

--- a/packages/react/src/utils/ast-utils.spec.ts
+++ b/packages/react/src/utils/ast-utils.spec.ts
@@ -3,75 +3,74 @@ import * as ts from 'typescript';
 import { Tree } from '@angular-devkit/schematics';
 import { insert } from '@nrwl/workspace/src/utils/ast-utils';
 
-describe('react ast-utils', () => {
-  describe('findDefaultExport', () => {
-    it('should find exported variable', () => {
-      const sourceCode = `
+describe('findDefaultExport', () => {
+  it('should find exported variable', () => {
+    const sourceCode = `
         const main = () => {}; 
         export default main;
       `;
-      const source = ts.createSourceFile(
-        'test.ts',
-        sourceCode,
-        ts.ScriptTarget.Latest,
-        true
-      );
+    const source = ts.createSourceFile(
+      'test.ts',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
 
-      const result = utils.findDefaultExport(source) as any;
+    const result = utils.findDefaultExport(source) as any;
 
-      expect(result).toBeDefined();
-      expect(result.name.text).toEqual('main');
-    });
+    expect(result).toBeDefined();
+    expect(result.name.text).toEqual('main');
+  });
 
-    it('should find exported function', () => {
-      const sourceCode = `
+  it('should find exported function', () => {
+    const sourceCode = `
         function main() {} 
         export default main;
       `;
-      const source = ts.createSourceFile(
-        'test.ts',
-        sourceCode,
-        ts.ScriptTarget.Latest,
-        true
-      );
+    const source = ts.createSourceFile(
+      'test.ts',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
 
-      const result = utils.findDefaultExport(source) as any;
+    const result = utils.findDefaultExport(source) as any;
 
-      expect(result).toBeDefined();
-      expect(result.name.text).toEqual('main');
-    });
-
-    it('should find default export function', () => {
-      const sourceCode = `
-        export default function main() {};
-      `;
-      const source = ts.createSourceFile(
-        'test.ts',
-        sourceCode,
-        ts.ScriptTarget.Latest,
-        true
-      );
-
-      const result = utils.findDefaultExport(source) as any;
-
-      expect(result).toBeDefined();
-      expect(result.name.text).toEqual('main');
-    });
+    expect(result).toBeDefined();
+    expect(result.name.text).toEqual('main');
   });
 
-  describe('addRoute', () => {
-    let tree: Tree;
-    let context: any;
+  it('should find default export function', () => {
+    const sourceCode = `
+        export default function main() {};
+      `;
+    const source = ts.createSourceFile(
+      'test.ts',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
 
-    beforeEach(() => {
-      context = {
-        warn: jest.fn()
-      };
-      tree = Tree.empty();
-    });
+    const result = utils.findDefaultExport(source) as any;
 
-    it('should add links and routes if they are not present', async () => {
-      const sourceCode = `
+    expect(result).toBeDefined();
+    expect(result.name.text).toEqual('main');
+  });
+});
+
+describe('addRoute', () => {
+  let tree: Tree;
+  let context: any;
+
+  beforeEach(() => {
+    context = {
+      warn: jest.fn()
+    };
+    tree = Tree.empty();
+  });
+
+  it('should add links and routes if they are not present', async () => {
+    const sourceCode = `
 import React from 'react';
 const App = () => (
   <>
@@ -80,29 +79,29 @@ const App = () => (
 );
 export default App; 
       `;
-      tree.create('app.tsx', sourceCode);
-      const source = ts.createSourceFile(
-        'app.tsx',
-        sourceCode,
-        ts.ScriptTarget.Latest,
-        true
-      );
+    tree.create('/app.tsx', sourceCode);
+    const source = ts.createSourceFile(
+      '/app.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
 
-      insert(
-        tree,
-        'app.tsx',
-        utils.addInitialRoutes('app.tsx', source, context)
-      );
+    insert(
+      tree,
+      '/app.tsx',
+      utils.addInitialRoutes('/app.tsx', source, context)
+    );
 
-      const result = tree.read('app.tsx').toString();
+    const result = tree.read('/app.tsx').toString();
 
-      expect(result).toMatch(/role="navigation"/);
-      expect(result).toMatch(/<Link\s+to="\/page-2"/);
-      expect(result).toMatch(/<Route\s+path="\/page-2"/);
-    });
+    expect(result).toMatch(/role="navigation"/);
+    expect(result).toMatch(/<Link\s+to="\/page-2"/);
+    expect(result).toMatch(/<Route\s+path="\/page-2"/);
+  });
 
-    it('should update existing routes', async () => {
-      const sourceCode = `
+  it('should update existing routes', async () => {
+    const sourceCode = `
 import React from 'react';
 import { Home } from '@example/home';
 const App = () => (
@@ -121,70 +120,244 @@ const App = () => (
 );
 export default App; 
       `;
-      tree.create('app.tsx', sourceCode);
-      const source = ts.createSourceFile(
-        'app.tsx',
-        sourceCode,
-        ts.ScriptTarget.Latest,
-        true
-      );
+    tree.create('/app.tsx', sourceCode);
+    const source = ts.createSourceFile(
+      '/app.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
 
-      insert(
-        tree,
-        'app.tsx',
-        utils.addRoute(
-          'app.tsx',
-          source,
-          {
-            routePath: '/about',
-            componentName: 'About',
-            moduleName: '@example/about'
-          },
-          context
-        )
-      );
+    insert(
+      tree,
+      '/app.tsx',
+      utils.addRoute(
+        '/app.tsx',
+        source,
+        {
+          routePath: '/about',
+          componentName: 'About',
+          moduleName: '@example/about'
+        },
+        context
+      )
+    );
 
-      const result = tree.read('app.tsx').toString();
+    const result = tree.read('/app.tsx').toString();
 
-      expect(result).toMatch(/<li><Link\s+to="\/about"/);
-      expect(result).toMatch(/<Route\s+path="\/about"\s+component={About}/);
-    });
+    expect(result).toMatch(/<li><Link\s+to="\/about"/);
+    expect(result).toMatch(/<Route\s+path="\/about"\s+component={About}/);
+  });
+});
+
+describe('addBrowserRouter', () => {
+  let tree: Tree;
+  let context: any;
+
+  beforeEach(() => {
+    context = {
+      warn: jest.fn()
+    };
+    tree = Tree.empty();
   });
 
-  describe('addBrowserRouter', () => {
-    let tree: Tree;
-    let context: any;
-
-    beforeEach(() => {
-      context = {
-        warn: jest.fn()
-      };
-      tree = Tree.empty();
-    });
-
-    it('should wrap around App component', () => {
-      const sourceCode = `
+  it('should wrap around App component', () => {
+    const sourceCode = `
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { App } from '@example/my-app';
 ReactDOM.render(<App/>, document.getElementById('root'));
       `;
-      tree.create('app.tsx', sourceCode);
-      const source = ts.createSourceFile(
-        'app.tsx',
-        sourceCode,
-        ts.ScriptTarget.Latest,
-        true
-      );
+    tree.create('/main.tsx', sourceCode);
+    const source = ts.createSourceFile(
+      '/main.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
 
-      insert(
-        tree,
-        'app.tsx',
-        utils.addBrowserRouter('app.tsx', source, context)
-      );
+    insert(
+      tree,
+      '/main.tsx',
+      utils.addBrowserRouter('/main.tsx', source, context)
+    );
 
-      const result = tree.read('app.tsx').toString();
-      expect(result).toContain('<BrowserRouter><App/></BrowserRouter>');
-    });
+    const result = tree.read('/main.tsx').toString();
+    expect(result).toContain('<BrowserRouter><App/></BrowserRouter>');
+  });
+});
+
+describe('findMainRenderStatement', () => {
+  let tree: Tree;
+  let context: any;
+
+  beforeEach(() => {
+    context = {
+      warn: jest.fn()
+    };
+    tree = Tree.empty();
+  });
+
+  it('should return render(...)', () => {
+    const sourceCode = `
+import React from 'react';
+import ReactDOM from 'react-dom';
+ReactDOM.render(<div/>, document.getElementById('root'));
+      `;
+    tree.create('/main.tsx', sourceCode);
+    const source = ts.createSourceFile(
+      '/main.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const node = utils.findMainRenderStatement(source);
+    expect(node).toBeTruthy();
+  });
+
+  it('should return render(...)', () => {
+    const sourceCode = `
+import React from 'react';
+import { render } from 'react-dom';
+render(<div/>, document.getElementById('root'));
+      `;
+    tree.create('/main.tsx', sourceCode);
+    const source = ts.createSourceFile(
+      '/main.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const node = utils.findMainRenderStatement(source);
+    expect(node).toBeTruthy();
+  });
+
+  it('should return null when not found', () => {
+    const sourceCode = ``;
+    tree.create('/main.tsx', sourceCode);
+    const source = ts.createSourceFile(
+      '/main.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const node = utils.findMainRenderStatement(source);
+    expect(node).toBe(null);
+  });
+});
+
+describe('addReduxStoreToMain', () => {
+  let tree: Tree;
+  let context: any;
+
+  beforeEach(() => {
+    context = {
+      warn: jest.fn()
+    };
+    tree = Tree.empty();
+  });
+
+  it('should wrap around App component', () => {
+    const sourceCode = `
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { App } from '@example/my-app';
+ReactDOM.render(<App/>, document.getElementById('root'));
+      `;
+    tree.create('/main.tsx', sourceCode);
+    const source = ts.createSourceFile(
+      '/main.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    insert(
+      tree,
+      '/main.tsx',
+      utils.addReduxStoreToMain('/main.tsx', source, context)
+    );
+
+    const result = tree.read('/main.tsx').toString();
+    expect(result).toContain('redux-starter-kit');
+    expect(result).toContain('const store = configureStore');
+    expect(result).toContain('<Provider store={store}>');
+  });
+});
+
+describe('updateReduxStore', () => {
+  let tree: Tree;
+  let context: any;
+
+  beforeEach(() => {
+    context = {
+      warn: jest.fn()
+    };
+    tree = Tree.empty();
+  });
+
+  it('should update configureStore call', () => {
+    const sourceCode = `
+import { configureStore } from 'redux-starter-kit';
+const store = configureStore({
+  reducer: {}
+});
+      `;
+    tree.create('/main.tsx', sourceCode);
+    const source = ts.createSourceFile(
+      '/main.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    insert(
+      tree,
+      '/main.tsx',
+      utils.updateReduxStore('/main.tsx', source, context, {
+        keyName: 'SLICE_KEY',
+        reducerName: 'sliceReducer',
+        modulePath: '@test/slice'
+      })
+    );
+
+    const result = tree.read('/main.tsx').toString();
+    expect(result).toContain(
+      "import { SLICE_KEY, sliceReducer } from '@test/slice'"
+    );
+    expect(result).toContain('[SLICE_KEY]: sliceReducer');
+  });
+
+  it('should update combineReducer call', () => {
+    const sourceCode = `
+import { createStore, combineReducer } from 'redux';
+const store = createStore(combineReducer({}));
+      `;
+    tree.create('/main.tsx', sourceCode);
+    const source = ts.createSourceFile(
+      '/main.tsx',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    insert(
+      tree,
+      '/main.tsx',
+      utils.updateReduxStore('/main.tsx', source, context, {
+        keyName: 'SLICE_KEY',
+        reducerName: 'sliceReducer',
+        modulePath: '@test/slice'
+      })
+    );
+
+    const result = tree.read('/main.tsx').toString();
+    expect(result).toContain(
+      "import { SLICE_KEY, sliceReducer } from '@test/slice'"
+    );
+    expect(result).toContain('[SLICE_KEY]: sliceReducer');
   });
 });

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -2,11 +2,189 @@ import {
   addGlobal,
   Change,
   findNodes,
-  InsertChange
+  InsertChange,
+  ReplaceChange
 } from '@nrwl/workspace/src/utils/ast-utils';
 import * as ts from 'typescript';
-import { noop, SchematicContext } from '@angular-devkit/schematics';
-import { join } from '@angular-devkit/core';
+import { SchematicContext } from '@angular-devkit/schematics';
+
+export function findMainRenderStatement(
+  source: ts.SourceFile
+): ts.CallExpression | null {
+  // 1. Try to find ReactDOM.render.
+  const calls = findNodes(
+    source,
+    ts.SyntaxKind.CallExpression
+  ) as ts.CallExpression[];
+
+  for (const expr of calls) {
+    const inner = expr.expression;
+    if (
+      ts.isPropertyAccessExpression(inner) &&
+      /ReactDOM/i.test(inner.expression.getText()) &&
+      inner.name.getText() === 'render'
+    ) {
+      return expr;
+    }
+  }
+
+  // 2. Try to find render from 'react-dom'.
+  const imports = findNodes(
+    source,
+    ts.SyntaxKind.ImportDeclaration
+  ) as ts.ImportDeclaration[];
+  const hasRenderImport = imports.some(
+    i =>
+      i.moduleSpecifier.getText().includes('react-dom') &&
+      /\brender\b/.test(i.importClause.namedBindings.getText())
+  );
+  if (hasRenderImport) {
+    const calls = findNodes(
+      source,
+      ts.SyntaxKind.CallExpression
+    ) as ts.CallExpression[];
+    for (const expr of calls) {
+      if (expr.expression.getText() === 'render') {
+        return expr;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function findDefaultExport(source: ts.SourceFile): ts.Node | null {
+  return (
+    findDefaultExportDeclaration(source) || findDefaultClassOrFunction(source)
+  );
+}
+
+export function findDefaultExportDeclaration(
+  source: ts.SourceFile
+): ts.Node | null {
+  const identifier = findDefaultExportIdentifier(source);
+
+  if (identifier) {
+    const variables = findNodes(source, ts.SyntaxKind.VariableDeclaration);
+    const fns = findNodes(source, ts.SyntaxKind.FunctionDeclaration);
+    const all = variables.concat(fns) as Array<
+      ts.VariableDeclaration | ts.FunctionDeclaration
+    >;
+
+    const exported = all
+      .filter(x => x.name.kind === ts.SyntaxKind.Identifier)
+      .find(x => (x.name as ts.Identifier).text === identifier.text);
+
+    return exported || null;
+  } else {
+    return null;
+  }
+}
+
+export function findDefaultExportIdentifier(
+  source: ts.SourceFile
+): ts.Identifier | null {
+  const exports = findNodes(
+    source,
+    ts.SyntaxKind.ExportAssignment
+  ) as ts.ExportAssignment[];
+
+  const identifier = exports
+    .map(x => x.expression)
+    .find(x => x.kind === ts.SyntaxKind.Identifier) as ts.Identifier;
+
+  return identifier || null;
+}
+
+export function findDefaultClassOrFunction(
+  source: ts.SourceFile
+): ts.FunctionDeclaration | ts.ClassDeclaration | null {
+  const fns = findNodes(
+    source,
+    ts.SyntaxKind.FunctionDeclaration
+  ) as ts.FunctionDeclaration[];
+  const cls = findNodes(
+    source,
+    ts.SyntaxKind.ClassDeclaration
+  ) as ts.ClassDeclaration[];
+
+  return (
+    fns.find(hasDefaultExportModifier) ||
+    cls.find(hasDefaultExportModifier) ||
+    null
+  );
+}
+
+function hasDefaultExportModifier(
+  x: ts.ClassDeclaration | ts.FunctionDeclaration
+) {
+  return (
+    x.modifiers.some(m => m.kind === ts.SyntaxKind.ExportKeyword) &&
+    x.modifiers.some(m => m.kind === ts.SyntaxKind.DefaultKeyword)
+  );
+}
+
+export function findComponentImportPath(
+  componentName: string,
+  source: ts.SourceFile
+) {
+  const allImports = findNodes(
+    source,
+    ts.SyntaxKind.ImportDeclaration
+  ) as ts.ImportDeclaration[];
+  const matching = allImports.filter((i: ts.ImportDeclaration) => {
+    return (
+      i.importClause &&
+      i.importClause.name &&
+      i.importClause.name.getText() === componentName
+    );
+  });
+
+  if (matching.length === 0) {
+    return null;
+  }
+
+  const appImport = matching[0];
+  return appImport.moduleSpecifier.getText().replace(/['"]/g, '');
+}
+
+export function findElements(source: ts.SourceFile, tagName: string) {
+  const nodes = findNodes(source, [
+    ts.SyntaxKind.JsxSelfClosingElement,
+    ts.SyntaxKind.JsxOpeningElement
+  ]);
+  return nodes.filter(node => isTag(tagName, node));
+}
+
+export function findClosestOpening(tagName: string, node: ts.Node) {
+  if (!node) {
+    return null;
+  }
+
+  if (isTag(tagName, node)) {
+    return node;
+  } else {
+    return findClosestOpening(tagName, node.parent);
+  }
+}
+
+export function isTag(tagName: string, node: ts.Node) {
+  if (ts.isJsxOpeningLikeElement(node)) {
+    return (
+      node.tagName.kind === ts.SyntaxKind.Identifier &&
+      node.tagName.text === tagName
+    );
+  }
+
+  if (ts.isJsxElement(node) && node.openingElement) {
+    return (
+      node.openingElement.tagName.kind === ts.SyntaxKind.Identifier &&
+      node.openingElement.tagName.getText() === tagName
+    );
+  }
+
+  return false;
+}
 
 export function addInitialRoutes(
   sourcePath: string,
@@ -162,134 +340,114 @@ export function addBrowserRouter(
   }
 }
 
-export function findDefaultExport(source: ts.SourceFile): ts.Node | null {
-  return (
-    findDefaultExportDeclaration(source) || findDefaultClassOrFunction(source)
-  );
-}
-
-export function findDefaultExportDeclaration(
-  source: ts.SourceFile
-): ts.Node | null {
-  const identifier = findDefaultExportIdentifier(source);
-
-  if (identifier) {
-    const variables = findNodes(source, ts.SyntaxKind.VariableDeclaration);
-    const fns = findNodes(source, ts.SyntaxKind.FunctionDeclaration);
-    const all = variables.concat(fns) as Array<
-      ts.VariableDeclaration | ts.FunctionDeclaration
-    >;
-
-    const exported = all
-      .filter(x => x.name.kind === ts.SyntaxKind.Identifier)
-      .find(x => (x.name as ts.Identifier).text === identifier.text);
-
-    return exported || null;
-  } else {
-    return null;
+export function addReduxStoreToMain(
+  sourcePath: string,
+  source: ts.SourceFile,
+  context: SchematicContext
+): Change[] {
+  const renderStmt = findMainRenderStatement(source);
+  if (!renderStmt) {
+    context.logger.warn(`Could not find ReactDOM.render in ${sourcePath}`);
+    return [];
   }
+  const jsx = renderStmt.arguments[0];
+  return [
+    ...addGlobal(
+      source,
+      sourcePath,
+      `import { configureStore } from 'redux-starter-kit';
+import { Provider } from 'react-redux';`
+    ),
+    new InsertChange(
+      sourcePath,
+      renderStmt.getStart(),
+      `
+const store = configureStore({
+  reducer: {}
+});
+
+`
+    ),
+    new InsertChange(sourcePath, jsx.getStart(), `<Provider store={store}>`),
+    new InsertChange(sourcePath, jsx.getEnd(), `</Provider>`)
+  ];
 }
 
-export function findDefaultExportIdentifier(
-  source: ts.SourceFile
-): ts.Identifier | null {
-  const exports = findNodes(
+export function updateReduxStore(
+  sourcePath: string,
+  source: ts.SourceFile,
+  context: SchematicContext,
+  feature: {
+    keyName: string;
+    reducerName: string;
+    modulePath: string;
+  }
+): Change[] {
+  const calls = findNodes(
     source,
-    ts.SyntaxKind.ExportAssignment
-  ) as ts.ExportAssignment[];
+    ts.SyntaxKind.CallExpression
+  ) as ts.CallExpression[];
 
-  const identifier = exports
-    .map(x => x.expression)
-    .find(x => x.kind === ts.SyntaxKind.Identifier) as ts.Identifier;
+  let reducerDescriptor: ts.ObjectLiteralExpression;
+  // Look for configureStore call
+  for (const expr of calls) {
+    if (!expr.expression.getText().includes('configureStore')) {
+      continue;
+    }
+    const arg = expr.arguments[0];
+    if (ts.isObjectLiteralExpression(arg)) {
+      let found: ts.ObjectLiteralExpression;
+      for (const prop of arg.properties) {
+        if (
+          ts.isPropertyAssignment(prop) &&
+          prop.name.getText() === 'reducer' &&
+          ts.isObjectLiteralExpression(prop.initializer)
+        ) {
+          found = prop.initializer;
+          break;
+        }
+      }
+      if (found) {
+        reducerDescriptor = found;
+        break;
+      }
+    }
+  }
+  // Look for combineReducer call
+  if (!reducerDescriptor) {
+    for (const expr of calls) {
+      if (!expr.expression.getText().includes('combineReducer')) {
+        continue;
+      }
+      const arg = expr.arguments[0];
+      if (ts.isObjectLiteralExpression(arg)) {
+        reducerDescriptor = arg;
+        break;
+      }
+    }
+  }
 
-  return identifier || null;
-}
-
-export function findDefaultClassOrFunction(
-  source: ts.SourceFile
-): ts.FunctionDeclaration | ts.ClassDeclaration | null {
-  const fns = findNodes(
-    source,
-    ts.SyntaxKind.FunctionDeclaration
-  ) as ts.FunctionDeclaration[];
-  const cls = findNodes(
-    source,
-    ts.SyntaxKind.ClassDeclaration
-  ) as ts.ClassDeclaration[];
-
-  return (
-    fns.find(hasDefaultExportModifier) ||
-    cls.find(hasDefaultExportModifier) ||
-    null
-  );
-}
-
-export function findComponentImportPath(name: string, source: ts.SourceFile) {
-  const allImports = findNodes(
-    source,
-    ts.SyntaxKind.ImportDeclaration
-  ) as ts.ImportDeclaration[];
-  const matching = allImports.filter((i: ts.ImportDeclaration) => {
-    return (
-      i.importClause &&
-      i.importClause.name &&
-      i.importClause.name.getText() === name
+  if (!reducerDescriptor) {
+    context.logger.warn(
+      `Could not find configureStore/combineReducer call in ${sourcePath}`
     );
-  });
-
-  if (matching.length === 0) {
-    return null;
+    return [];
   }
 
-  const appImport = matching[0];
-  return appImport.moduleSpecifier.getText().replace(/['"]/g, '');
-}
-
-// -----------------------------------------------------------------------------
-
-function hasDefaultExportModifier(
-  x: ts.ClassDeclaration | ts.FunctionDeclaration
-) {
-  return (
-    x.modifiers.some(m => m.kind === ts.SyntaxKind.ExportKeyword) &&
-    x.modifiers.some(m => m.kind === ts.SyntaxKind.DefaultKeyword)
-  );
-}
-
-function findElements(source: ts.SourceFile, tagName: string) {
-  const nodes = findNodes(source, [
-    ts.SyntaxKind.JsxSelfClosingElement,
-    ts.SyntaxKind.JsxOpeningElement
-  ]);
-  return nodes.filter(node => isTag(tagName, node));
-}
-
-function findClosestOpening(tagName: string, node: ts.Node) {
-  if (!node) {
-    return null;
-  }
-
-  if (isTag(tagName, node)) {
-    return node;
-  } else {
-    return findClosestOpening(tagName, node.parent);
-  }
-}
-
-function isTag(tagName: string, node: ts.Node) {
-  if (ts.isJsxOpeningLikeElement(node)) {
-    return (
-      node.tagName.kind === ts.SyntaxKind.Identifier &&
-      node.tagName.text === tagName
-    );
-  }
-
-  if (ts.isJsxElement(node) && node.openingElement) {
-    return (
-      node.openingElement.tagName.kind === ts.SyntaxKind.Identifier &&
-      node.openingElement.tagName.text === tagName
-    );
-  }
-
-  return false;
+  return [
+    ...addGlobal(
+      source,
+      sourcePath,
+      `import { ${feature.keyName}, ${feature.reducerName} } from '${
+        feature.modulePath
+      }';`
+    ),
+    new InsertChange(
+      sourcePath,
+      reducerDescriptor.getStart() + 1,
+      `[${feature.keyName}]: ${feature.reducerName}${
+        reducerDescriptor.properties.length === 1 ? ',' : ''
+      }`
+    )
+  ];
 }

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -16,7 +16,10 @@ export const babelLoaderVersion = '8.0.6';
 export const babelPluginMacrosVersion = '2.6.1';
 export const coreJsVersion = '3.1.4';
 export const regeneratorVersion = '0.13.3';
-export const eslintConfigReactAppVersion = '5.0.1';
+export const reduxStarterKitversion = '0.6.3';
+export const reactReduxVersion = '7.1.1';
+export const reactReduxTypesVersion = '7.1.2';
+export const reselectVersion = '4.0.0';
 
 export const EsLintPlugins = {
   importVersion: '2.18.2',


### PR DESCRIPTION
This PR adds schematic to generate redux slices.

* Uses `redux-starter-kit` to reduce boilerplate.
* Generates slice and spec files for `--project`.
* Installs all deps.
* `--appProject` automatically configures store for app (handles `configureStore` and `combineReducers` variants).
* Does **not** handle store configuration outside of `main.tsx`. Could be a separate option later on, but likely not needed.
