### PR TITLE
fix(react): extend configureStore correctly when adding additional slices

### DIFF
--- a/packages/react/src/schematics/redux/redux.spec.ts
+++ b/packages/react/src/schematics/redux/redux.spec.ts
@@ -39,15 +39,29 @@ describe('lib', () => {
   describe('--appProject', () => {
     it('should configure app main', async () => {
       appTree = await runSchematic('app', { name: 'my-app' }, appTree);
-      const tree = await runSchematic(
+      let tree = await runSchematic(
         'redux',
         { name: 'my-slice', project: 'my-lib', appProject: 'my-app' },
         appTree
+      );
+      tree = await runSchematic(
+        'redux',
+        { name: 'another-slice', project: 'my-lib', appProject: 'my-app' },
+        tree
+      );
+      tree = await runSchematic(
+        'redux',
+        { name: 'third-slice', project: 'my-lib', appProject: 'my-app' },
+        tree
       );
 
       const main = tree.read('/apps/my-app/src/main.tsx').toString();
       expect(main).toContain('redux-starter-kit');
       expect(main).toContain('configureStore');
+      expect(main).toContain('[THIRD_SLICE_FEATURE_KEY]: thirdSliceReducer,');
+      expect(main).toContain(
+        '[ANOTHER_SLICE_FEATURE_KEY]: anotherSliceReducer,'
+      );
       expect(main).toContain('[MY_SLICE_FEATURE_KEY]: mySliceReducer');
       expect(main).toMatch(/<Provider store={store}>/);
     });

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -446,7 +446,7 @@ export function updateReduxStore(
       sourcePath,
       reducerDescriptor.getStart() + 1,
       `[${feature.keyName}]: ${feature.reducerName}${
-        reducerDescriptor.properties.length === 1 ? ',' : ''
+        reducerDescriptor.properties.length > 0 ? ',' : ''
       }`
     )
   ];


### PR DESCRIPTION
havior (This is the behavior we have today, before the PR is merged)

Slices have erroneous commas added.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Slices are added correctly.
