### PR TITLE
fix(testing): check if baseUrl flag is set for e2e tests

### DIFF
--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -57,7 +57,7 @@ function run(
   }
 
   return (!legacy
-    ? options.devServerTarget
+    ? options.devServerTarget && !options.baseUrl
       ? startDevServer(options.devServerTarget, options.watch, context)
       : of(options.baseUrl)
     : legacyCompile(options, context)


### PR DESCRIPTION
Do not start the dev server, if the base-url flag has been passed. Instead execute e2e tests against
the baseUrl target

#1614


## Current Behavior (This is the behavior we have today, before the PR is merged)
Base Url flag is not passed to cypress
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Base Url is passed to cypress
## Issue
Closes #1614 