### PR TITLE
feat(angular): add backendProject flag to angular app generation schematics

### DIFF
--- a/docs/angular/api-angular/schematics/application.md
+++ b/docs/angular/api-angular/schematics/application.md
@@ -28,6 +28,12 @@ ng g application ... --dry-run
 
 ## Options
 
+### backendProject
+
+Type: `string`
+
+Backend project that provides data to this application. This sets up proxy.config.json.
+
 ### directory
 
 Type: `string`

--- a/docs/react/api-angular/schematics/application.md
+++ b/docs/react/api-angular/schematics/application.md
@@ -28,6 +28,12 @@ nx g application ... --dry-run
 
 ## Options
 
+### backendProject
+
+Type: `string`
+
+Backend project that provides data to this application. This sets up proxy.config.json.
+
 ### directory
 
 Type: `string`

--- a/docs/web/api-angular/schematics/application.md
+++ b/docs/web/api-angular/schematics/application.md
@@ -28,6 +28,12 @@ nx g application ... --dry-run
 
 ## Options
 
+### backendProject
+
+Type: `string`
+
+Backend project that provides data to this application. This sets up proxy.config.json.
+
 ### directory
 
 Type: `string`

--- a/packages/angular/src/schematics/application/application.spec.ts
+++ b/packages/angular/src/schematics/application/application.spec.ts
@@ -453,4 +453,44 @@ describe('app', () => {
       expect(workspaceJson.projects['ui'].prefix).toEqual('ui');
     });
   });
+
+  describe('--backend-project', () => {
+    describe('with a backend project', () => {
+      it('should add a proxy.conf.json to app', async () => {
+        const tree = await runSchematic(
+          'app',
+          { name: 'customer-ui', backendProject: 'customer-api' },
+          appTree
+        );
+
+        const proxyConfContent = JSON.stringify(
+          {
+            '/customer-api': {
+              target: 'http://localhost:3333',
+              secure: false
+            }
+          },
+          null,
+          2
+        );
+
+        expect(tree.exists('apps/customer-ui/proxy.conf.json')).toBeTruthy();
+        expect(tree.readContent('apps/customer-ui/proxy.conf.json')).toContain(
+          proxyConfContent
+        );
+      });
+    });
+
+    describe('with no backend project', () => {
+      it('should not generate a proxy.conf.json', async () => {
+        const tree = await runSchematic(
+          'app',
+          { name: 'customer-ui' },
+          appTree
+        );
+
+        expect(tree.exists('apps/customer-ui/proxy.conf.json')).toBeFalsy();
+      });
+    });
+  });
 });

--- a/packages/angular/src/schematics/application/schema.d.ts
+++ b/packages/angular/src/schematics/application/schema.d.ts
@@ -18,4 +18,5 @@ export interface Schema {
   linter: Linter;
   unitTestRunner: UnitTestRunner;
   e2eTestRunner: E2eTestRunner;
+  backendProject?: string;
 }

--- a/packages/angular/src/schematics/application/schema.json
+++ b/packages/angular/src/schematics/application/schema.json
@@ -115,6 +115,10 @@
       "type": "string",
       "enum": ["tslint"],
       "default": "tslint"
+    },
+    "backendProject": {
+      "type": "string",
+      "description": "Backend project that provides data to this application. This sets up proxy.config.json."
     }
   },
   "required": []


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
There is no --backend-project flag
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
The --backend-project flag generates a proxy.conf.json for a newly created angular app
## Issue
closes #1288