### PR TITLE
fix(nx): format all files when --all is passed

### DIFF
--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -59,9 +59,11 @@ export function format(command: 'check' | 'write', args: YargsFormatOptions) {
 }
 
 function getPatterns(args: YargsAffectedOptions) {
+  const allFilesPattern = [`"**/*.{${PRETTIER_EXTENSIONS.join(',')}}"`];
+
   try {
     if (args.all) {
-      return getPatternsWithPathPrefix(['{apps,libs,tools}']);
+      return allFilesPattern;
     }
 
     printArgsWarning(args);
@@ -77,13 +79,13 @@ function getPatterns(args: YargsAffectedOptions) {
       ? getPatternsFromApps(patterns)
       : patterns.map(f => `"${f}"`);
   } catch (e) {
-    return getPatternsWithPathPrefix(['{apps,libs,tools}']);
+    return allFilesPattern;
   }
 }
 
 function getPatternsFromApps(affectedFiles: string[]): string[] {
   const roots = getProjectRoots(getTouchedProjects(affectedFiles));
-  return getPatternsWithPathPrefix(roots);
+  return roots.map(root => `"${root}/**/*.{${PRETTIER_EXTENSIONS.join(',')}}"`);
 }
 
 function chunkify(target: string[], size: number): string[][] {
@@ -92,12 +94,6 @@ function chunkify(target: string[], size: number): string[][] {
     current[current.length - 1].push(value);
     return current;
   }, []);
-}
-
-function getPatternsWithPathPrefix(prefixes: string[]): string[] {
-  return prefixes.map(
-    prefix => `"${prefix}/**/*.{${PRETTIER_EXTENSIONS.join(',')}}"`
-  );
 }
 
 function write(patterns: string[]) {


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Running `npm run format -- --all` formats only files inside of `apps/`, `libs/`, and `tools/`. I would expect it to format "all" files. Running `npm run format -- --base origin/master --head HEAD` will format files both inside and outside of `apps/`, `libs/`, and `tools/`. The same goes for [format-files.ts](https://github.com/nrwl/nx/blob/master/packages/workspace/src/utils/rules/format-files.ts), which is useful for workspace schematics.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Running `npm run format -- --all` formats all files in the workspace.

If you consider this a breaking change, I can update the commit message to reflect that. Maybe a notification in a migration script should be added? These changes may cause a users workspace to fail formatting check.