### PR TITLE
docs(nx): add tutorial note on restarting TS server when editing with VS…

### DIFF
--- a/docs/angular/tutorial/07-share-code.md
+++ b/docs/angular/tutorial/07-share-code.md
@@ -43,6 +43,10 @@ export interface Todo {
 }
 ```
 
+### A note about VS Code :
+
+If you're using [VS Code](https://code.visualstudio.com/) it may be necessary at this point to restart the TS server so that the new `@myorg/data` package is recognised. This may need to be done **every time a new workspace library is added**.
+
 ## Refactor the API
 
 **Now update `apps/api/src/app/app.service.ts` to import the interface:**

--- a/docs/react/tutorial/07-share-code.md
+++ b/docs/react/tutorial/07-share-code.md
@@ -40,6 +40,10 @@ export interface Todo {
 }
 ```
 
+### A note about VS Code :
+
+If you're using [VS Code](https://code.visualstudio.com/) it may be necessary at this point to restart the TS server so that the new `@myorg/data` package is recognised. This may need to be done **every time a new workspace library is added**.
+
 ## Refactor the API
 
 **Now update `apps/api/src/app/todos.ts` to import the interface:**

--- a/docs/web/tutorial/07-share-code.md
+++ b/docs/web/tutorial/07-share-code.md
@@ -40,6 +40,10 @@ export interface Todo {
 }
 ```
 
+### A note about VS Code :
+
+If you're using [VS Code](https://code.visualstudio.com/) it may be necessary at this point to restart the TS server so that the new `@myorg/data` package is recognised. This may need to be done **every time a new workspace library is added**.
+
 ## Refactor the API
 
 **Now update `apps/api/src/app/todos.ts` to import the interface:**


### PR DESCRIPTION
VS Code doesn't pick up changes to the tsconfig file automatically, so I added a note to each of the tutorials to prompt folks to restart the TS server after adding the lib :

![image](https://user-images.githubusercontent.com/439121/64169744-5d4ef900-ce46-11e9-9fca-59ab1b0539f8.png)
