### PR TITLE
fix(nx): exclude appropriate test setup file in tsconfig.lib.json

### DIFF
--- a/packages/angular/src/schematics/library/library.spec.ts
+++ b/packages/angular/src/schematics/library/library.spec.ts
@@ -160,13 +160,44 @@ describe('lib', () => {
       expect(tsconfigJson.extends).toEqual('./tsconfig.json');
     });
 
-    it('should extend the local tsconfig.json with tsconfig.lib.json', async () => {
-      const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
-      const tsconfigJson = readJsonInTree(
-        tree,
-        'libs/my-lib/tsconfig.lib.json'
-      );
-      expect(tsconfigJson.extends).toEqual('./tsconfig.json');
+    describe('when creating the tsconfig.lib.json', () => {
+      it('should extend the local tsconfig.json', async () => {
+        const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+        const tsconfigJson = readJsonInTree(
+          tree,
+          'libs/my-lib/tsconfig.lib.json'
+        );
+        expect(tsconfigJson.extends).toEqual('./tsconfig.json');
+      });
+
+      it('should exclude the test setup file when unitTestRunner is jest', async () => {
+        const tree = await runSchematic(
+          'lib',
+          { name: 'myLib', unitTestRunner: 'jest' },
+          appTree
+        );
+        const tsconfigJson = readJsonInTree(
+          tree,
+          'libs/my-lib/tsconfig.lib.json'
+        );
+        expect(tsconfigJson.exclude).toEqual([
+          'src/test-setup.ts',
+          '**/*.spec.ts'
+        ]);
+      });
+
+      it('should leave the excludes alone when unitTestRunner is not jest', async () => {
+        const tree = await runSchematic(
+          'lib',
+          { name: 'myLib', unitTestRunner: 'karma' },
+          appTree
+        );
+        const tsconfigJson = readJsonInTree(
+          tree,
+          'libs/my-lib/tsconfig.lib.json'
+        );
+        expect(tsconfigJson.exclude).toEqual(['src/test.ts', '**/*.spec.ts']);
+      });
     });
 
     it('should generate files', async () => {

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -363,7 +363,11 @@ function updateProject(options: NormalizedSchema): Rule {
           compilerOptions: {
             ...json.compilerOptions,
             outDir: `${offsetFromRoot(options.projectRoot)}dist/out-tsc`
-          }
+          },
+          exclude:
+            options.unitTestRunner === 'jest'
+              ? ['src/test-setup.ts', '**/*.spec.ts']
+              : json.exclude || []
         };
       }),
       updateJsonInTree(`${options.projectRoot}/tslint.json`, json => {

--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -24,6 +24,11 @@
       "version": "8.4.0-beta.1",
       "description": "Add 'nx' script to package.json",
       "factory": "./src/migrations/update-8-4-0/add-nx-script"
+    },
+    "fix-tsconfig-lib-json": {
+      "version": "8.5.0-beta.1",
+      "description": "Fix the exclude paths in tsconfig.lib.json files for Jest projects",
+      "factory": "./src/migrations/update-8-5-0/fix-tsconfig-lib-json"
     }
   }
 }

--- a/packages/workspace/src/migrations/update-8-5-0/fix-tsconfig-lib-json.ts
+++ b/packages/workspace/src/migrations/update-8-5-0/fix-tsconfig-lib-json.ts
@@ -1,0 +1,32 @@
+import { Tree, SchematicContext } from '@angular-devkit/schematics';
+import { readWorkspace, readJsonInTree } from '../../utils/ast-utils';
+
+export default function() {
+  return (host: Tree) => {
+    const config = readWorkspace(host);
+
+    const configsToUpdate = [];
+    Object.keys(config.projects).forEach(name => {
+      const project = config.projects[name];
+      if (
+        project.projectType === 'library' &&
+        project.architect &&
+        project.architect.test &&
+        project.architect.test.builder === '@nrwl/jest:test' &&
+        project.architect.test.options &&
+        project.architect.test.options.setupFile ===
+          project.sourceRoot + '/test-setup.ts'
+      ) {
+        configsToUpdate.push(project.root + '/tsconfig.lib.json');
+      }
+    });
+
+    configsToUpdate.forEach(config => {
+      const tsconfig = readJsonInTree(host, config);
+      if (tsconfig.exclude && tsconfig.exclude[0] === 'src/test.ts') {
+        tsconfig.exclude[0] = 'src/test-setup.ts';
+        host.overwrite(config, JSON.stringify(tsconfig));
+      }
+    });
+  };
+}

--- a/packages/workspace/src/migrations/update-8-5-0/update-8-5-0.spec.ts
+++ b/packages/workspace/src/migrations/update-8-5-0/update-8-5-0.spec.ts
@@ -1,0 +1,97 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { join } from 'path';
+import { readJsonInTree } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { createLibWithTests } from '../../utils/testing';
+
+describe('Update 8.5.0', () => {
+  let tree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  const jestBuilder = '@nrwl/jest:test';
+  const nonJestBuilder = 'something-else';
+
+  beforeEach(async () => {
+    tree = Tree.empty();
+    tree = createEmptyWorkspace(tree);
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/workspace',
+      join(__dirname, '../../../migrations.json')
+    );
+  });
+
+  describe('When fixing tsconfig.lib.json files', () => {
+    const schematicName = 'fix-tsconfig-lib-json';
+
+    it('should not modify non jest projects', async () => {
+      const lib = 'non-jest-lib';
+      const exclude = [`src/test.ts`, '**/*.spec.ts'];
+
+      tree = await createLibWithTests(tree, lib, nonJestBuilder, 'test.ts');
+      tree.create(
+        `/libs/${lib}/tsconfig.lib.json`,
+        JSON.stringify({ exclude })
+      );
+
+      const result = await schematicRunner
+        .runSchematicAsync(schematicName, {}, tree)
+        .toPromise();
+
+      const tsconfigJson = readJsonInTree(
+        result,
+        `libs/${lib}/tsconfig.lib.json`
+      );
+      expect(tsconfigJson.exclude).toEqual(exclude);
+    });
+
+    it('should modify untouched jest projects', async () => {
+      const lib = 'jest-lib';
+      const exclude = [`src/test.ts`, '**/*.spec.ts'];
+      const expected = ['src/test-setup.ts', '**/*.spec.ts'];
+
+      tree = await createLibWithTests(tree, lib, jestBuilder, 'test-setup.ts');
+      tree.create(
+        `/libs/${lib}/tsconfig.lib.json`,
+        JSON.stringify({ exclude })
+      );
+
+      const result = await schematicRunner
+        .runSchematicAsync(schematicName, {}, tree)
+        .toPromise();
+
+      const tsconfigJson = readJsonInTree(
+        result,
+        `libs/${lib}/tsconfig.lib.json`
+      );
+
+      expect(tsconfigJson.exclude).toEqual(expected);
+    });
+
+    it('should not touch modified jest projects', async () => {
+      const lib = 'modified-jest-lib';
+      const exclude = [`src/test-modified.ts`, '**/*.spec.ts'];
+
+      tree = await createLibWithTests(
+        tree,
+        lib,
+        jestBuilder,
+        'test-modified.ts.ts'
+      );
+      tree.create(
+        `/libs/${lib}/tsconfig.lib.json`,
+        JSON.stringify({ exclude })
+      );
+
+      const result = await schematicRunner
+        .runSchematicAsync(schematicName, {}, tree)
+        .toPromise();
+
+      const tsconfigJson = readJsonInTree(
+        result,
+        `libs/${lib}/tsconfig.lib.json`
+      );
+      expect(tsconfigJson.exclude).toEqual(exclude);
+    });
+  });
+});


### PR DESCRIPTION
Resolves #1139 

## Current Behavior
`tsconfig.lib.json` excludes `src/test.js` regardless of unit test runner. This is a problem when the unit test runner is Jest as the setup file then is `src/test-setup.js`.

## Expected Behavior
`tsconfig.lib.json` excludes either `src/test.js` or `src/test-setup.js` depending on the setting of the unitTestRunner option.
