### PR TITLE
fix(angular): skip package.json changes if --skipPackageJson is provided

### DIFF
--- a/packages/angular/src/schematics/application/application.spec.ts
+++ b/packages/angular/src/schematics/application/application.spec.ts
@@ -493,4 +493,17 @@ describe('app', () => {
       });
     });
   });
+
+  describe('--skipPackageJson', () => {
+    it('should not make changes to package.json', async () => {
+      const packageJsonBefore = appTree.read('package.json').toString();
+      const tree = await runSchematic(
+        'app',
+        { name: 'my-app', skipPackageJson: true, skipFormat: true },
+        appTree
+      );
+      const packageJsonAfter = tree.readContent('package.json');
+      expect(packageJsonBefore).toBe(packageJsonAfter);
+    });
+  });
 });

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -638,10 +638,12 @@ export default function(schema: Schema): Rule {
       : `${options.name}/e2e`;
 
     return chain([
-      ngAdd({
-        ...options,
-        skipFormat: true
-      }),
+      options.skipPackageJson
+        ? noop()
+        : ngAdd({
+            ...options,
+            skipFormat: true
+          }),
       addLintFiles(options.appProjectRoot, options.linter, {
         onlyGlobal: true
       }),
@@ -656,7 +658,7 @@ export default function(schema: Schema): Rule {
         enableIvy: options.enableIvy,
         routing: false,
         skipInstall: true,
-        skipPackageJson: false
+        skipPackageJson: options.skipPackageJson
       }),
       addSchematicFiles(appProjectRoot, options),
       options.e2eTestRunner === 'protractor'

--- a/packages/angular/src/schematics/application/schema.d.ts
+++ b/packages/angular/src/schematics/application/schema.d.ts
@@ -19,4 +19,5 @@ export interface Schema {
   unitTestRunner: UnitTestRunner;
   e2eTestRunner: E2eTestRunner;
   backendProject?: string;
+  skipPackageJson: boolean;
 }


### PR DESCRIPTION

## Current Behavior (This is the behavior we have today, before the PR is merged)

There are `package.json` changes even if `--skipPackageJson` is true when running the Angular application schematic.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

There are no changes to `package.json` when running the application schematic if `--skipPackageJson` is true