### PR TITLE
fix(prettier): update prettier to latest verion (1.18.2)

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -58,7 +58,7 @@
     "viz.js": "^1.8.1",
     "yargs-parser": "10.0.0",
     "yargs": "^11.0.0",
-    "prettier": "1.16.4",
+    "prettier": "1.18.2",
     "chalk": "2.4.2",
     "@nrwl/cli": "*"
   }


### PR DESCRIPTION
`format:check` with nx@latest fails when there is a pair of `()` around async pipes in HTML

## Current Behavior 
Currently latest nx workspace defaults to prettier version 1.16.2, whereas latest version of prettier-vscode uses 1.18.

In prettier 1.16.x prettier adds `()` around async pipes in HTML. i.e.
```HTML
<div *ngIf="(isRendered | async)"></div>
```
In prettier 1.17 this behaviour was updated to not to have `()` around pipes. i.e.
```HTML
<div *ngIf="isRendered | async"></div>
```

Current prettier-vscode uses 1.18 so it removes `()` around pipes, but when running `format:check`, nx expects `()` around pipes because of it using prettier 1.16.

Ref: https://prettier.io/blog/2019/04/12/1.17.0.html#angular-don-t-add-unnecessary-parentheses-to-pipes-5929-by-voithos

---
This change update prettier versionto 1.18 same as prettier-vscode to resolve this conflicting behaviour.   
