### PR TITLE
feat(angular): fail cypress builder early if compilation error

### DIFF
--- a/packages/cypress/src/builders/cypress/cypress.impl.spec.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.spec.ts
@@ -85,7 +85,7 @@ describe('Cypress builder', () => {
       expect(cypressOpen).not.toHaveBeenCalled();
       done();
     });
-    fakeEventEmitter.emit('exit'); // Passing tsc command
+    fakeEventEmitter.emit('exit', 0); // Passing tsc command
   });
 
   it('should call `Cypress.open` if headless mode is `false`', async done => {
@@ -105,7 +105,7 @@ describe('Cypress builder', () => {
       expect(cypressRun).not.toHaveBeenCalled();
       done();
     });
-    fakeEventEmitter.emit('exit'); // Passing tsc command
+    fakeEventEmitter.emit('exit', 0); // Passing tsc command
   });
 
   it('should call `Cypress.run` with provided baseUrl', async done => {
@@ -128,7 +128,7 @@ describe('Cypress builder', () => {
       expect(cypressOpen).not.toHaveBeenCalled();
     });
 
-    fakeEventEmitter.emit('exit'); // Passing tsc command
+    fakeEventEmitter.emit('exit', 0); // Passing tsc command
   });
 
   it('should call `Cypress.run` with provided browser', async done => {
@@ -148,7 +148,7 @@ describe('Cypress builder', () => {
       done();
     });
 
-    fakeEventEmitter.emit('exit'); // Passing tsc command
+    fakeEventEmitter.emit('exit', 0); // Passing tsc command
   });
 
   it('should call `Cypress.run` without baseUrl nor dev server target value', async done => {
@@ -174,7 +174,26 @@ describe('Cypress builder', () => {
       done();
     });
 
-    fakeEventEmitter.emit('exit'); // Passing tsc command
+    fakeEventEmitter.emit('exit', 0); // Passing tsc command
+  });
+
+  it('should fail early if application build fails', async done => {
+    (devkitArchitect as any).scheduleTargetAndForget = jest
+      .fn()
+      .mockReturnValue(
+        of({
+          success: false
+        })
+      );
+    const run = await architect.scheduleBuilder(
+      '@nrwl/cypress:cypress',
+      cypressBuilderOptions
+    );
+    run.result.then(async res => {
+      await run.stop();
+      expect(res.success).toBe(false);
+      done();
+    });
   });
 
   describe('legacy', () => {
@@ -190,7 +209,7 @@ describe('Cypress builder', () => {
         '@nrwl/cypress:cypress',
         cypressBuilderOptions
       );
-      fakeEventEmitter.emit('exit');
+      fakeEventEmitter.emit('exit', 0);
       await run.result;
       await run.stop();
       expect(fork).toHaveBeenCalledWith(
@@ -215,7 +234,7 @@ describe('Cypress builder', () => {
         done();
       });
 
-      fakeEventEmitter.emit('exit'); // Passing tsc command
+      fakeEventEmitter.emit('exit', 0); // Passing tsc command
     });
 
     it('should not copy fixtures folder if they are not defined in the cypress config', async done => {
@@ -230,7 +249,7 @@ describe('Cypress builder', () => {
         done();
       });
 
-      fakeEventEmitter.emit('exit'); // Passing tsc command
+      fakeEventEmitter.emit('exit', 0); // Passing tsc command
     });
 
     it('should copy regex files to out-dir', async done => {
@@ -250,7 +269,7 @@ describe('Cypress builder', () => {
         done();
       });
 
-      fakeEventEmitter.emit('exit'); // Passing tsc command
+      fakeEventEmitter.emit('exit', 0); // Passing tsc command
     });
 
     it('should not copy regex files if the regex is not defined', async done => {
@@ -270,7 +289,7 @@ describe('Cypress builder', () => {
         done();
       });
 
-      fakeEventEmitter.emit('exit'); // Passing tsc command
+      fakeEventEmitter.emit('exit', 0); // Passing tsc command
     });
 
     it('should not copy regex files if the integration files are not defined in the cypress config', async done => {
@@ -292,7 +311,21 @@ describe('Cypress builder', () => {
           done();
         });
 
-      fakeEventEmitter.emit('exit'); // Passing tsc command
+      fakeEventEmitter.emit('exit', 0); // Passing tsc command
+    });
+
+    it('should fail early if integration files fail to compile', async done => {
+      const run = await architect.scheduleBuilder(
+        '@nrwl/cypress:cypress',
+        cypressBuilderOptions
+      );
+      run.result.then(async res => {
+        await run.stop();
+        expect(res.success).toBe(false);
+        done();
+      });
+
+      fakeEventEmitter.emit('exit', 1); // Passing tsc command
     });
   });
 });

--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -58,9 +58,7 @@ function run(
 
   return (!legacy
     ? options.devServerTarget
-      ? startDevServer(options.devServerTarget, options.watch, context).pipe(
-          map(output => output.baseUrl)
-        )
+      ? startDevServer(options.devServerTarget, options.watch, context)
       : of(options.baseUrl)
     : legacyCompile(options, context)
   ).pipe(
@@ -167,7 +165,7 @@ export function startDevServer(
   devServerTarget: string,
   isWatching: boolean,
   context: BuilderContext
-): Observable<BuilderOutput> {
+): Observable<string> {
   // Overrides dev server watch setting.
   const overrides = {
     watch: isWatching
@@ -176,6 +174,13 @@ export function startDevServer(
     context,
     targetFromTargetString(devServerTarget),
     overrides
+  ).pipe(
+    map(output => {
+      if (!output.success && !isWatching) {
+        throw new Error('Could not compile application files');
+      }
+      return output.baseUrl as string;
+    })
   );
 }
 

--- a/packages/cypress/src/builders/cypress/legacy.ts
+++ b/packages/cypress/src/builders/cypress/legacy.ts
@@ -34,9 +34,7 @@ export function legacyCompile(
     }),
     concatMap(() =>
       options.devServerTarget
-        ? startDevServer(options.devServerTarget, options.watch, context).pipe(
-            map(output => output.baseUrl)
-          )
+        ? startDevServer(options.devServerTarget, options.watch, context)
         : of(options.baseUrl)
     )
   );
@@ -70,7 +68,9 @@ function compileTypescriptFiles(
       } else {
         tscProcess = fork(tscPath, args, { stdio: [0, 1, 2, 'ipc'] });
         tscProcess.on('exit', code => {
-          subscriber.next({ success: code === 0 });
+          code === 0
+            ? subscriber.next({ success: true })
+            : subscriber.error('Could not compile Typescript files');
           subscriber.complete();
         });
       }


### PR DESCRIPTION
If watch is not enabled and either the application or integration files (legacy) fail to compile,
the cypress angular builder will fail early.

## Current Behavior (This is the behavior we have today, before the PR is merged)

Cypress will still spin up if application or integration files (legacy compile) fails (no watch).

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Cypress will not spin up if application or integration files (legacy compile) fails (no watch).

## Issue

Closes #1780