### PR TITLE
fix(nx): remove unused double dashes to avoid yarn's warning

### DIFF
--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -216,15 +216,20 @@ async function runCommand(
   }
 
   try {
+    const isYarn = path
+      .basename(process.env.npm_execpath || 'npm')
+      .startsWith('yarn');
     await runAll(
       projects.map(proj => {
         return commonCommands.includes(targetName)
-          ? `${cli} -- ${targetName} ${proj} ${transformArgs(
+          ? `${cli} ${isYarn ? '' : '--'} ${targetName} ${proj} ${transformArgs(
               args,
               proj,
               projectMetadata.get(proj)
             ).join(' ')} `
-          : `${cli} -- run ${proj}:${targetName} ${transformArgs(
+          : `${cli} ${
+              isYarn ? '' : '--'
+            } run ${proj}:${targetName} ${transformArgs(
               args,
               proj,
               projectMetadata.get(proj)


### PR DESCRIPTION
For a scenario:
1. In package.json
```
"affected:lint": "nx affected:lint",
```
2. Then run the script with yarn - `yarn affected:lint --all --parallel`

## Current Behavior (This is the behavior we have today, before the PR is merged)
Got warning: `warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.`
![image](https://user-images.githubusercontent.com/8519685/64504929-8f5bd180-d304-11e9-8189-330cb1eea176.png)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
No warning when using `yarn`, but with `npm`, the command `npm run affected:lint --all --parallel` still works.


