### PR TITLE
fix(testing): pass setupFilesAfterEnv to jest.runCLI rather than deprecated option

### DIFF
--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -234,7 +234,7 @@ describe('Jest Builder', () => {
     const run = await architect.scheduleBuilder('@nrwl/jest:jest', {
       jestConfig: './jest.config.js',
       tsConfig: './tsconfig.test.json',
-      setupFile: './test.ts',
+      setupFile: './test-setup.ts',
       watch: false
     });
     expect(await run.result).toEqual(
@@ -257,7 +257,7 @@ describe('Jest Builder', () => {
             ]
           }
         }),
-        setupTestFrameworkScriptFile: '/root/test.ts',
+        setupFilesAfterEnv: ['/root/test-setup.ts'],
         watch: false
       },
       ['/root/jest.config.js']

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -14,7 +14,7 @@ try {
   require('dotenv').config();
 } catch (e) {}
 
-const { runCLI } = require('jest');
+import { runCLI } from 'jest';
 
 export interface JestBuilderOptions extends JsonObject {
   codeCoverage?: boolean;
@@ -106,10 +106,9 @@ function run(
   };
 
   if (options.setupFile) {
-    config.setupTestFrameworkScriptFile = path.resolve(
-      context.workspaceRoot,
-      options.setupFile
-    );
+    config.setupFilesAfterEnv = [
+      path.resolve(context.workspaceRoot, options.setupFile)
+    ];
   }
 
   if (options.testFile) {
@@ -131,7 +130,7 @@ function run(
   }
 
   return from(runCLI(config, [options.jestConfig])).pipe(
-    map((results: any) => {
+    map(results => {
       return {
         success: results.results.success
       };


### PR DESCRIPTION
resolves #1343

NB - this will not allow you to specify a different setup file in `jest.config.js` if `setupFile` is defined in your workspace, it will just stop showing the error about `setupFilesAfterEnv` and `setupTestFrameworkScriptFile` being set at the same time.
