### PR TITLE
fix(nx): update workspace to use prettier v1.18.2

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -58,7 +58,7 @@
     "viz.js": "^1.8.1",
     "yargs-parser": "10.0.0",
     "yargs": "^11.0.0",
-    "prettier": "1.16.4",
+    "prettier": "1.18.2",
     "chalk": "2.4.2",
     "@nrwl/cli": "*"
   }

--- a/packages/workspace/src/utils/versions.ts
+++ b/packages/workspace/src/utils/versions.ts
@@ -2,7 +2,7 @@ export const nxVersion = '*';
 
 export const angularCliVersion = '8.3.3';
 export const typescriptVersion = '~3.4.5';
-export const prettierVersion = '1.16.4';
+export const prettierVersion = '1.18.2';
 export const typescriptESLintVersion = '2.0.0-alpha.4';
 export const eslintVersion = '6.1.0';
 export const eslintConfigPrettierVersion = '6.0.0';


### PR DESCRIPTION
## Current Behavior 

`format:check` with `nx@latest` fails when there is a pair of **()** around async pipes in HTML
Current Behavior
Currently latest nx workspace defaults to prettier version *1.16.2*, whereas latest version of prettier-vscode uses *1.18.x*.
In prettier *1.16.x* prettier adds **()** around async pipes in HTML. i.e.
`<div *ngIf="(isRendered | async)"></div>`
In prettier *1.17* this behaviour was updated to not to have **()** around pipes. i.e.
`<div *ngIf="isRendered | async"></div>`
Current prettier-vscode uses *1.18* so it removes **()** around pipes, but when running `format:check`, nx expects **()** around pipes because of it using prettier *1.16*.

[Reference to prettier issue](https://prettier.io/blog/2019/04/12/1.17.0.html#angular-don-t-add-unnecessary-parentheses-to-pipes-5929-by-voithos) 

## Expected Behavior 

This change updates prettier version to *1.18* same as prettier-vscode to resolve this conflicting behaviour.

