### PR TITLE
fix(testing): allow support of svg templates

### DIFF
--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -51,7 +51,7 @@ describe('Jest Builder', () => {
             diagnostics: {
               warnOnly: true
             },
-            stringifyContentPathRegex: '\\.html$',
+            stringifyContentPathRegex: '\\.(html|svg)$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
             ]
@@ -95,7 +95,7 @@ describe('Jest Builder', () => {
             diagnostics: {
               warnOnly: true
             },
-            stringifyContentPathRegex: '\\.html$',
+            stringifyContentPathRegex: '\\.(html|svg)$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
             ]
@@ -141,7 +141,7 @@ describe('Jest Builder', () => {
             diagnostics: {
               warnOnly: true
             },
-            stringifyContentPathRegex: '\\.html$',
+            stringifyContentPathRegex: '\\.(html|svg)$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
             ]
@@ -198,7 +198,7 @@ describe('Jest Builder', () => {
             diagnostics: {
               warnOnly: true
             },
-            stringifyContentPathRegex: '\\.html$',
+            stringifyContentPathRegex: '\\.(html|svg)$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
             ]
@@ -251,7 +251,7 @@ describe('Jest Builder', () => {
             diagnostics: {
               warnOnly: true
             },
-            stringifyContentPathRegex: '\\.html$',
+            stringifyContentPathRegex: '\\.(html|svg)$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
             ]

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -71,7 +71,7 @@ function run(
   try {
     require.resolve('jest-preset-angular');
     Object.assign(tsJestConfig, {
-      stringifyContentPathRegex: '\\.html$',
+      stringifyContentPathRegex: '\\.(html|svg)$',
       astTransformers: ['jest-preset-angular/InlineHtmlStripStylesTransformer']
     });
   } catch (e) {}


### PR DESCRIPTION
Angular 8 supports SVG files in addition of HTML for component templates but they were not correctly parsed by Jest.

## Current Behavior (This is the behavior we have today, before the PR is merged)
Any test including an SVG template fail with the error:
```sh
    SyntaxError: /path/to/file.svg: Unexpected token (1:0)

    > 1 | <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 37.62 37.12">
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Tests pass successfully.

