### PR TITLE
fix(testing): merge builder globals with jest.config.js globals 

### DIFF
--- a/e2e/jest.test.ts
+++ b/e2e/jest.test.ts
@@ -1,4 +1,12 @@
-import { runCLIAsync, ensureProject, uniq, runCLI, forEachCli } from './utils';
+import {
+  runCLIAsync,
+  ensureProject,
+  uniq,
+  runCLI,
+  forEachCli,
+  updateFile
+} from './utils';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 
 forEachCli(() => {
   describe('Jest', () => {
@@ -19,6 +27,44 @@ forEachCli(() => {
       expect(appResult.stderr).toContain('Test Suites: 3 passed, 3 total');
       const libResult = await runCLIAsync(`test ${mylib}`);
       expect(libResult.stderr).toContain('Test Suites: 3 passed, 3 total');
+      done();
+    }, 45000);
+
+    it('should merge with jest config globals', async done => {
+      ensureProject();
+      const testGlobal = `'My Test Global'`;
+      const mylib = uniq('mylib');
+      runCLI(`generate @nrwl/workspace:lib ${mylib} --unit-test-runner jest`);
+
+      updateFile(`libs/${mylib}/src/lib/${mylib}.ts`, `export class Test { }`);
+
+      updateFile(
+        `libs/${mylib}/src/lib/${mylib}.spec.ts`,
+        `
+          test('can access jest global', () => {
+            expect((global as any).testGlobal).toBe(${testGlobal});
+          });
+        `
+      );
+
+      updateFile(
+        `libs/${mylib}/jest.config.js`,
+        stripIndents`
+          module.exports = {
+            testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
+            transform: {
+              '^.+\\.(ts|js|html)$': 'ts-jest'
+            },
+            resolver: '@nrwl/jest/plugins/resolver',
+            moduleFileExtensions: ['ts', 'js', 'html'],
+            coverageReporters: ['html'],
+            passWithNoTests: true,
+            globals: { testGlobal: ${testGlobal} }
+          };`
+      );
+
+      const appResult = await runCLIAsync(`test ${mylib} --no-watch`);
+      expect(appResult.stderr).toContain('Test Suites: 1 passed, 1 total');
       done();
     }, 45000);
   });

--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -1,11 +1,11 @@
-// import JestBuilder from './jest.impl';
-import { normalize, schema } from '@angular-devkit/core';
-import {
-  TestLogger,
-  TestingArchitectHost
-} from '@angular-devkit/architect/testing';
+import { schema } from '@angular-devkit/core';
+import { TestingArchitectHost } from '@angular-devkit/architect/testing';
+
 jest.mock('jest');
 const { runCLI } = require('jest');
+const mockJestConfig: any = {};
+jest.mock('/root/jest.config.js', () => mockJestConfig, { virtual: true });
+
 import * as path from 'path';
 import { Architect } from '@angular-devkit/architect';
 
@@ -16,6 +16,8 @@ describe('Jest Builder', () => {
     const registry = new schema.CoreSchemaRegistry();
     registry.addPostTransform(schema.transforms.addUndefinedDefaults);
     const testArchitectHost = new TestingArchitectHost('/root', '/root');
+
+    mockJestConfig.globals = {};
 
     architect = new Architect(testArchitectHost, registry);
     await testArchitectHost.addBuilderFromPackage(
@@ -48,9 +50,6 @@ describe('Jest Builder', () => {
         globals: JSON.stringify({
           'ts-jest': {
             tsConfig: '/root/tsconfig.test.json',
-            diagnostics: {
-              warnOnly: true
-            },
             stringifyContentPathRegex: '\\.(html|svg)$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
@@ -92,9 +91,6 @@ describe('Jest Builder', () => {
         globals: JSON.stringify({
           'ts-jest': {
             tsConfig: '/root/tsconfig.test.json',
-            diagnostics: {
-              warnOnly: true
-            },
             stringifyContentPathRegex: '\\.(html|svg)$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
@@ -138,9 +134,6 @@ describe('Jest Builder', () => {
         globals: JSON.stringify({
           'ts-jest': {
             tsConfig: '/root/tsconfig.test.json',
-            diagnostics: {
-              warnOnly: true
-            },
             stringifyContentPathRegex: '\\.(html|svg)$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
@@ -195,9 +188,6 @@ describe('Jest Builder', () => {
         globals: JSON.stringify({
           'ts-jest': {
             tsConfig: '/root/tsconfig.test.json',
-            diagnostics: {
-              warnOnly: true
-            },
             stringifyContentPathRegex: '\\.(html|svg)$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
@@ -248,9 +238,36 @@ describe('Jest Builder', () => {
         globals: JSON.stringify({
           'ts-jest': {
             tsConfig: '/root/tsconfig.test.json',
-            diagnostics: {
-              warnOnly: true
-            },
+            stringifyContentPathRegex: '\\.(html|svg)$',
+            astTransformers: [
+              'jest-preset-angular/InlineHtmlStripStylesTransformer'
+            ]
+          }
+        }),
+        setupTestFrameworkScriptFile: '/root/test.ts',
+        watch: false
+      },
+      ['/root/jest.config.js']
+    );
+  });
+
+  it('should merge the globals property from jest config', async () => {
+    mockJestConfig.globals = { hereToStay: true };
+
+    await architect.scheduleBuilder('@nrwl/jest:jest', {
+      jestConfig: './jest.config.js',
+      tsConfig: './tsconfig.test.json',
+      setupFile: './test.ts',
+      watch: false
+    });
+
+    expect(runCLI).toHaveBeenCalledWith(
+      {
+        _: [],
+        globals: JSON.stringify({
+          hereToStay: true,
+          'ts-jest': {
+            tsConfig: '/root/tsconfig.test.json',
             stringifyContentPathRegex: '\\.(html|svg)$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -58,12 +58,7 @@ function run(
   options.jestConfig = path.resolve(context.workspaceRoot, options.jestConfig);
 
   const tsJestConfig = {
-    tsConfig: path.resolve(context.workspaceRoot, options.tsConfig),
-    // Typechecking wasn't done in Jest 23 but is done in 24. This makes errors a warning to amend the breaking change for now
-    // Remove for v8 to fail on type checking failure
-    diagnostics: {
-      warnOnly: true
-    }
+    tsConfig: path.resolve(context.workspaceRoot, options.tsConfig)
   };
 
   // TODO: This is hacky, We should probably just configure it in the user's workspace
@@ -75,6 +70,13 @@ function run(
       astTransformers: ['jest-preset-angular/InlineHtmlStripStylesTransformer']
     });
   } catch (e) {}
+
+  // merge the jestConfig globals with our 'ts-jest' override
+  const jestConfig: { globals: any } = require(options.jestConfig);
+  const globals = jestConfig.globals || {};
+  Object.assign(globals, {
+    'ts-jest': tsJestConfig
+  });
 
   const config: any = {
     _: [],
@@ -100,9 +102,7 @@ function run(
     useStderr: options.useStderr,
     watch: options.watch,
     watchAll: options.watchAll,
-    globals: JSON.stringify({
-      'ts-jest': tsJestConfig
-    })
+    globals: JSON.stringify(globals)
   };
 
   if (options.setupFile) {


### PR DESCRIPTION
...rather than override them completely.

Resolves #1059 

This also removes the `diagnostics.warnOnly` flag from the builder globals, allowing the user to set it themselves. This _may_ cause previously passing tests to fail, but only because they have errors.