### PR TITLE
fix(nx): handle windows drive letters in nx-enforce-module-boundaries

### DIFF
--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -29,8 +29,14 @@ function removeExt(file: string): string {
   return file.replace(/\.[^/.]+$/, '');
 }
 
+function removeWindowsDriveLetter(osSpecificPath: string): string {
+  return osSpecificPath.replace(/^[A-Z]:/, '');
+}
+
 function normalizePath(osSpecificPath: string): string {
-  return osSpecificPath.split(path.sep).join('/');
+  return removeWindowsDriveLetter(osSpecificPath)
+    .split(path.sep)
+    .join('/');
 }
 
 export function matchImportWithWildcard(


### PR DESCRIPTION
Remove drive letter during path normalization to ensure consistent path structure between project nodes and target files

## Current Behavior (This is the behavior we have today, before the PR is merged)

A deep library import is currently not detected on windows systems.

### Sample
```ts
import { MyService } from '../../../data-access/src/lib/services';
...
```

During Linting the `projectPath`  looks like this ([Code](https://github.com/nrwl/nx/blob/13e7b69c5a/packages/workspace/src/utils/runtime-lint-utils.ts#L51))
```
C/Users/my-user/git/my-project
```
The `projectNodes` looks like this ([Code](https://github.com/nrwl/nx/blob/13e7b69c5a1e2eedad7ae358ce5f9034026feee5/packages/workspace/src/utils/runtime-lint-utils.ts#L52))
```
libs/shared/data-access/src/lib/services/index.ts
```
And the `imp` looks like this ([Code](https://github.com/nrwl/nx/blob/13e7b69c5a1e2eedad7ae358ce5f9034026feee5/packages/workspace/src/utils/runtime-lint-utils.ts#L50))
```
../../../data-access/src/lib/services
C:\C\Users\my-user\git\my-project\libs\shared\data-access\src\lib\services
```

Then this path is been resolved ([Code](https://github.com/nrwl/nx/blob/13e7b69c5a/packages/workspace/src/utils/runtime-lint-utils.ts#L57-L59))
```ts
  const targetFile = normalizePath(
    path.resolve(path.join(projectPath, path.dirname(sourceFilePath)), imp)
  ).substring(projectPath.length + 1);
// resolved:
// => C:\C\Users\my-user\git\my-project\libs\shared\data-access\src\lib\services
// normalized:
// => C:/C/Users/my-user/git/my-project/libs/shared/data-access/src/lib/services
// cutted:
// => t/libs/shared/data-access/src/lib/services
```

The critical part is the inconsistency of the base path of project path (without `C:`) and the file (with `C:`). So the substring doesn't cut enough letters.
While comparing file paths to find the according project ([Code](https://github.com/nrwl/nx/blob/13e7b69c5a1e2eedad7ae358ce5f9034026feee5/packages/workspace/src/utils/runtime-lint-utils.ts#L70)) it doesn't match:
`libs/shared/data-access/src/lib/services/index.ts` projectNodes[n].files[n]
`t/libs/shared/data-access/src/lib/services/index.ts` file

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The normalizePath function will remove the windows drive letter if existing.
[before](https://github.com/nrwl/nx/blob/13e7b69c5a1e2eedad7ae358ce5f9034026feee5/packages/workspace/src/utils/runtime-lint-utils.ts#L32)
```ts
function normalizePath(osSpecificPath: string): string {
  return osSpecificPath.split(path.sep).join('/');
}
```

[after](https://github.com/twittwer/nx/blob/09bfac52a6d8a68b75eb06641d258ef6cda03011/packages/workspace/src/utils/runtime-lint-utils.ts#L36)
```ts
function removeWindowsDriveLetter(osSpecificPath: string): string {
  return osSpecificPath.replace(/^[A-Z]:/, '');
}
function normalizePath(osSpecificPath: string): string {
  return removeWindowsDriveLetter(osSpecificPath)
    .split(path.sep)
    .join('/');
}
```