### PR TITLE
fix(angular): remove tsconfig.lib.json excludes when --unit-test-runner is none

### DIFF
--- a/packages/angular/src/schematics/library/library.spec.ts
+++ b/packages/angular/src/schematics/library/library.spec.ts
@@ -186,7 +186,7 @@ describe('lib', () => {
         ]);
       });
 
-      it('should leave the excludes alone when unitTestRunner is not jest', async () => {
+      it('should leave the excludes alone when unitTestRunner is karma', async () => {
         const tree = await runSchematic(
           'lib',
           { name: 'myLib', unitTestRunner: 'karma' },
@@ -197,6 +197,19 @@ describe('lib', () => {
           'libs/my-lib/tsconfig.lib.json'
         );
         expect(tsconfigJson.exclude).toEqual(['src/test.ts', '**/*.spec.ts']);
+      });
+
+      it('should remove the excludes when unitTestRunner is none', async () => {
+        const tree = await runSchematic(
+          'lib',
+          { name: 'myLib', unitTestRunner: 'none' },
+          appTree
+        );
+        const tsconfigJson = readJsonInTree(
+          tree,
+          'libs/my-lib/tsconfig.lib.json'
+        );
+        expect(tsconfigJson.exclude).toEqual([]);
       });
     });
 

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -356,18 +356,21 @@ function updateProject(options: NormalizedSchema): Rule {
         return json;
       }),
       updateJsonInTree(`${options.projectRoot}/tsconfig.lib.json`, json => {
-        json.exclude = json.exclude || [];
+        if (options.unitTestRunner === 'jest') {
+          json.exclude = ['src/test-setup.ts', '**/*.spec.ts'];
+        } else if (options.unitTestRunner === 'none') {
+          json.exclude = [];
+        } else {
+          json.exclude = json.exclude || [];
+        }
+
         return {
           ...json,
           extends: `./tsconfig.json`,
           compilerOptions: {
             ...json.compilerOptions,
             outDir: `${offsetFromRoot(options.projectRoot)}dist/out-tsc`
-          },
-          exclude:
-            options.unitTestRunner === 'jest'
-              ? ['src/test-setup.ts', '**/*.spec.ts']
-              : json.exclude || []
+          }
         };
       }),
       updateJsonInTree(`${options.projectRoot}/tslint.json`, json => {


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Running `ng g lib my-lib --unit-test-runner none` keeps the `tsconfig.lib.json` excludes generated by Angular CLI.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Running `ng g lib my-lib --unit-test-runner none` removes the `tsconfig.lib.json` excludes generated by Angular CLI because `src/test.ts` and `**/*.spec.ts` don't apply to a library with no unit test runner.