### PR TITLE
fix(testing): convert testPathPattern to an array

### DIFF
--- a/docs/angular/api-jest/builders/jest.md
+++ b/docs/angular/api-jest/builders/jest.md
@@ -158,9 +158,9 @@ Run only tests with a name that matches the regex pattern. (https://jestjs.io/do
 
 ### testPathPattern
 
-Type: `string`
+Type: `array`
 
-A regexp pattern string that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
+An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
 
 ### testResultsProcessor
 

--- a/docs/react/api-jest/builders/jest.md
+++ b/docs/react/api-jest/builders/jest.md
@@ -159,9 +159,9 @@ Run only tests with a name that matches the regex pattern. (https://jestjs.io/do
 
 ### testPathPattern
 
-Type: `string`
+Type: `array`
 
-A regexp pattern string that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
+An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
 
 ### testResultsProcessor
 

--- a/docs/web/api-jest/builders/jest.md
+++ b/docs/web/api-jest/builders/jest.md
@@ -159,9 +159,9 @@ Run only tests with a name that matches the regex pattern. (https://jestjs.io/do
 
 ### testPathPattern
 
-Type: `string`
+Type: `array`
 
-A regexp pattern string that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
+An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
 
 ### testResultsProcessor
 

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -4,6 +4,11 @@
       "version": "8.3.0",
       "description": "Update jest.config.js",
       "factory": "./src/migrations/update-8-3-0/update-8-3-0"
+    },
+    "update-8.7.0": {
+      "version": "8.7.0",
+      "description": "Update Jest testPathPattern option",
+      "factory": "./src/migrations/update-8-7-0/update-8-7-0"
     }
   }
 }

--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -61,6 +61,7 @@ describe('Jest Builder', () => {
               ]
             }
           }),
+          testPathPattern: [],
           watch: false
         },
         ['/root/jest.config.js']
@@ -75,7 +76,7 @@ describe('Jest Builder', () => {
         codeCoverage: false,
         runInBand: true,
         testNamePattern: 'should load',
-        testPathPattern: '/test/path',
+        testPathPattern: ['/test/path'],
         colors: false,
         reporters: ['/test/path'],
         verbose: false,
@@ -105,7 +106,7 @@ describe('Jest Builder', () => {
           coverage: false,
           runInBand: true,
           testNamePattern: 'should load',
-          testPathPattern: '/test/path',
+          testPathPattern: ['/test/path'],
           colors: false,
           reporters: ['/test/path'],
           verbose: false,
@@ -149,6 +150,7 @@ describe('Jest Builder', () => {
           findRelatedTests: true,
           runInBand: true,
           testNamePattern: 'should load',
+          testPathPattern: [],
           watch: false
         },
         ['/root/jest.config.js']
@@ -170,7 +172,7 @@ describe('Jest Builder', () => {
         passWithNoTests: true,
         silent: true,
         testNamePattern: 'test',
-        testPathPattern: '/test/path',
+        testPathPattern: ['/test/path'],
         colors: false,
         reporters: ['/test/path'],
         verbose: false,
@@ -211,7 +213,7 @@ describe('Jest Builder', () => {
           passWithNoTests: true,
           silent: true,
           testNamePattern: 'test',
-          testPathPattern: '/test/path',
+          testPathPattern: ['/test/path'],
           colors: false,
           verbose: false,
           reporters: ['/test/path'],
@@ -252,6 +254,7 @@ describe('Jest Builder', () => {
             }
           }),
           setupFilesAfterEnv: ['/root/test-setup.ts'],
+          testPathPattern: [],
           watch: false
         },
         ['/root/jest.config.js']
@@ -307,6 +310,7 @@ describe('Jest Builder', () => {
             }
           }),
           setupFilesAfterEnv: ['/root/test-setup.ts'],
+          testPathPattern: [],
           watch: false
         },
         ['/root/jest.config.js']

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -36,7 +36,7 @@ export interface JestBuilderOptions extends JsonObject {
   runInBand?: boolean;
   silent?: boolean;
   testNamePattern?: string;
-  testPathPattern?: string;
+  testPathPattern?: string[];
   colors?: boolean;
   reporters?: string[];
   verbose?: boolean;

--- a/packages/jest/src/builders/jest/schema.json
+++ b/packages/jest/src/builders/jest/schema.json
@@ -86,8 +86,11 @@
       "type": "string"
     },
     "testPathPattern": {
-      "description": "A regexp pattern string that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)",
-      "type": "string"
+      "description": "An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "colors": {
       "description": "Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)",

--- a/packages/jest/src/migrations/update-8-7-0/update-8-7-0.spec.ts
+++ b/packages/jest/src/migrations/update-8-7-0/update-8-7-0.spec.ts
@@ -1,0 +1,60 @@
+import { Tree } from '@angular-devkit/schematics';
+import { readJsonInTree } from '@nrwl/workspace/src/utils/ast-utils';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+
+describe('Update 8.7.0', () => {
+  let tree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(async () => {
+    tree = Tree.empty();
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/jest',
+      path.join(__dirname, '../../../migrations.json')
+    );
+  });
+
+  it('should convert testPathPattern option to an array', async () => {
+    tree.create(
+      'angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          test: {
+            architect: {
+              jest1: {
+                builder: '@nrwl/jest:jest',
+                options: {
+                  testPathPattern: 'some/test/path'
+                }
+              },
+              jest2: {
+                builder: '@nrwl/jest:jest',
+                options: {
+                  foo: 'bar'
+                }
+              },
+              jest3: {
+                builder: '@nrwl/jest:jest'
+              }
+            }
+          }
+        }
+      })
+    );
+
+    await schematicRunner
+      .runSchematicAsync('update-8.7.0', {}, tree)
+      .toPromise();
+
+    const angularJson = readJsonInTree(tree, 'angular.json');
+
+    expect(
+      angularJson.projects.test.architect.jest1.options.testPathPattern
+    ).toEqual(['some/test/path']);
+    expect(
+      angularJson.projects.test.architect.jest2.options.testPathPattern
+    ).toBeUndefined();
+  });
+});

--- a/packages/jest/src/migrations/update-8-7-0/update-8-7-0.ts
+++ b/packages/jest/src/migrations/update-8-7-0/update-8-7-0.ts
@@ -1,0 +1,20 @@
+import { Rule } from '@angular-devkit/schematics';
+import { updateWorkspace } from '@nrwl/workspace/src/utils/workspace';
+
+const convertToArray = updateWorkspace(workspace => {
+  workspace.projects.forEach(project => {
+    project.targets.forEach(target => {
+      if (
+        target.builder === '@nrwl/jest:jest' &&
+        target.options &&
+        target.options.testPathPattern
+      ) {
+        target.options.testPathPattern = [target.options.testPathPattern];
+      }
+    });
+  });
+});
+
+export default function(): Rule {
+  return convertToArray;
+}


### PR DESCRIPTION
Per https://github.com/facebook/jest/pull/5066, the testPathPattern parameter to the CLI is an array