### PR TITLE
fix(testing): pass cypressConfig values to Cypress.run()

### DIFF
--- a/packages/cypress/src/builders/cypress/cypress.impl.spec.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.spec.ts
@@ -78,7 +78,9 @@ describe('Cypress builder', () => {
       await run.stop();
       expect(cypressRun).toHaveBeenCalledWith(
         jasmine.objectContaining({
-          config: { baseUrl: 'http://localhost:4200' },
+          config: jasmine.objectContaining({
+            baseUrl: 'http://localhost:4200'
+          }),
           project: path.dirname(cypressBuilderOptions.cypressConfig)
         })
       );
@@ -98,7 +100,9 @@ describe('Cypress builder', () => {
       await run.stop();
       expect(cypressOpen).toHaveBeenCalledWith(
         jasmine.objectContaining({
-          config: { baseUrl: 'http://localhost:4200' },
+          config: jasmine.objectContaining({
+            baseUrl: 'http://localhost:4200'
+          }),
           project: path.dirname(cypressBuilderOptions.cypressConfig)
         })
       );
@@ -118,9 +122,9 @@ describe('Cypress builder', () => {
       await run.stop();
       expect(cypressRun).toHaveBeenCalledWith(
         jasmine.objectContaining({
-          config: {
+          config: jasmine.objectContaining({
             baseUrl: 'http://my-distant-host.com'
-          },
+          }),
           project: path.dirname(cypressBuilderOptions.cypressConfig)
         })
       );

--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -193,8 +193,22 @@ function getCypressConfigValues(
   options: CypressBuilderOptions,
   context: BuilderContext
 ): any {
+  const cypressBaseConfigPath = join(
+    context.workspaceRoot,
+    dirname(options.cypressConfig),
+    'cypress.json'
+  );
   const cypressConfigPath = join(context.workspaceRoot, options.cypressConfig);
-  return readJsonFile(cypressConfigPath);
+
+  if (cypressBaseConfigPath !== cypressConfigPath) {
+    // merge cypress.json + extending configuration file (for legacy check)
+    return {
+      ...readJsonFile(cypressBaseConfigPath),
+      ...readJsonFile(cypressConfigPath)
+    };
+  } else {
+    return readJsonFile(cypressBaseConfigPath);
+  }
 }
 
 function isLegacy(


### PR DESCRIPTION
see #1866 and #1878 

## Expected Behavior

The cypress builder `@nrwl/cypress:cypress` is passing the values of the file defined at the option `cypressConfig` to Cypress, even if the file is not named `cypress.json`.

If the configured file is not named `cypress.json`, the builder and Cypress are expecting a `cypress.json` in the same directory. Both files will be considered and the values are passed to Cypress (`cypress.json` has the lower priority if the same values are set).

## Current Behavior

The values of the config file defined at `cypressConfig` are ignored if the file is not named `cypress.json`. The builder is only passing the directory of the configured file to Cypress.