### PR TITLE
fix(nx): use same prettier version

### DIFF
--- a/docs/angular/fundamentals/build-full-stack-applications.md
+++ b/docs/angular/fundamentals/build-full-stack-applications.md
@@ -108,7 +108,7 @@ interface Todo {
   template: `
     <h1>Todos</h1>
     <ul>
-      <li *ngFor="let t of (todos | async)">{{ t.title }}</li>
+      <li *ngFor="let t of todos | async">{{ t.title }}</li>
     </ul>
   `
 })
@@ -294,7 +294,7 @@ import { Todo } from '@myorg/data';
   template: `
     <h1>Todos</h1>
     <ul>
-      <li *ngFor="let t of (todos | async)">{{ t.title }}</li>
+      <li *ngFor="let t of todos | async">{{ t.title }}</li>
     </ul>
   `
 })

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "npm-run-all": "^4.1.5",
     "opn": "^5.3.0",
     "precise-commits": "1.0.2",
-    "prettier": "1.16.4",
+    "prettier": "1.18.2",
     "react": "16.9.0",
     "react-dom": "16.9.0",
     "react-router-dom": "5.0.1",

--- a/packages/angular/spec/data-persistence.spec.ts
+++ b/packages/angular/spec/data-persistence.spec.ts
@@ -65,7 +65,7 @@ class RootCmp {}
 @Component({
   template: `
     Todo [
-    <div *ngIf="(todo | async) as t">ID {{ t.id }} User {{ t.user }}</div>
+    <div *ngIf="todo | async as t">ID {{ t.id }} User {{ t.user }}</div>
     ]
   `
 })

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -360,9 +360,7 @@ function updateComponentTemplate(options: NormalizedSchema): Rule {
 function updateComponentSpec(options: NormalizedSchema) {
   return (host: Tree) => {
     if (options.skipTests !== true) {
-      const componentSpecPath = `${
-        options.appProjectRoot
-      }/src/app/app.component.spec.ts`;
+      const componentSpecPath = `${options.appProjectRoot}/src/app/app.component.spec.ts`;
       const componentSpecSource = host
         .read(componentSpecPath)!
         .toString('utf-8');
@@ -594,9 +592,7 @@ function updateE2eProject(options: NormalizedSchema): Rule {
           }
         };
 
-        project.architect.e2e.options.protractorConfig = `${
-          options.e2eProjectRoot
-        }/protractor.conf.js`;
+        project.architect.e2e.options.protractorConfig = `${options.e2eProjectRoot}/protractor.conf.js`;
 
         json.projects[options.e2eProjectName] = project;
         delete json.projects[options.name].architect.e2e;

--- a/packages/linter/src/builders/lint/lint.impl.ts
+++ b/packages/linter/src/builders/lint/lint.impl.ts
@@ -32,9 +32,7 @@ function run(options: any, context: BuilderContext): Observable<BuilderOutput> {
   }
 
   throw new Error(
-    `"${
-      options.linter
-    }" is not a supported linter option: use either eslint or tslint`
+    `"${options.linter}" is not a supported linter option: use either eslint or tslint`
   );
 }
 

--- a/packages/node/src/builders/build/build.impl.ts
+++ b/packages/node/src/builders/build/build.impl.ts
@@ -74,9 +74,7 @@ async function getSourceRoot(context: BuilderContext) {
     return workspace.projects.get(context.target.project).sourceRoot;
   } else {
     context.reportStatus('Error');
-    const message = `${
-      context.target.project
-    } does not have a sourceRoot. Please define one.`;
+    const message = `${context.target.project} does not have a sourceRoot. Please define one.`;
     context.logger.error(message);
     throw new Error(message);
   }

--- a/packages/react/src/schematics/component/component.ts
+++ b/packages/react/src/schematics/component/component.ts
@@ -115,9 +115,7 @@ function addExportsToBarrel(options: NormalizedSchema): Rule {
                 indexSourceFile,
                 indexFilePath,
                 options.directory
-                  ? `export * from './lib/${options.directory}/${
-                      options.fileName
-                    }';`
+                  ? `export * from './lib/${options.directory}/${options.fileName}';`
                   : `export * from './lib/${options.fileName}';`
               )
             );

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -162,9 +162,7 @@ function updateAppRoutes(
 
     if (!componentImportPath) {
       throw new Error(
-        `Could not find App component in ${
-          options.appMain
-        } (Hint: you can omit --appProject, or make sure App exists)`
+        `Could not find App component in ${options.appMain} (Hint: you can omit --appProject, or make sure App exists)`
       );
     }
 
@@ -278,9 +276,7 @@ function normalizeOptions(
 
     if (appProjectConfig.projectType !== 'application') {
       throw new Error(
-        `appProject expected type of "application" but got "${
-          appProjectConfig.projectType
-        }"`
+        `appProject expected type of "application" but got "${appProjectConfig.projectType}"`
       );
     }
 

--- a/packages/react/src/schematics/redux/redux.ts
+++ b/packages/react/src/schematics/redux/redux.ts
@@ -183,9 +183,7 @@ async function normalizeOptions(
     const appConfig = getProjectConfig(host, options.appProject);
     if (appConfig.projectType !== 'application') {
       throw new Error(
-        `Expected ${options.appProject} to be an application but got ${
-          appConfig.projectType
-        }`
+        `Expected ${options.appProject} to be an application but got ${appConfig.projectType}`
       );
     }
     appProjectSourcePath = appConfig.sourceRoot;

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -283,9 +283,7 @@ export function addRoute(
       new InsertChange(
         sourcePath,
         firstRoute.getEnd(),
-        `<Route path="${options.routePath}" component={${
-          options.componentName
-        }} />`
+        `<Route path="${options.routePath}" component={${options.componentName}} />`
       )
     );
 
@@ -296,9 +294,7 @@ export function addRoute(
           new InsertChange(
             sourcePath,
             parentLi.getEnd(),
-            `<li><Link to="${options.routePath}">${
-              options.componentName
-            }</Link></li>`
+            `<li><Link to="${options.routePath}">${options.componentName}</Link></li>`
           )
         );
       } else {
@@ -438,9 +434,7 @@ export function updateReduxStore(
     ...addGlobal(
       source,
       sourcePath,
-      `import { ${feature.keyName}, ${feature.reducerName} } from '${
-        feature.modulePath
-      }';`
+      `import { ${feature.keyName}, ${feature.reducerName} } from '${feature.modulePath}';`
     ),
     new InsertChange(
       sourcePath,

--- a/packages/schematics/migrations/update-6-0-0/update-6-0-0.ts
+++ b/packages/schematics/migrations/update-6-0-0/update-6-0-0.ts
@@ -301,9 +301,7 @@ function moveE2eTests(host: Tree, context: SchematicContext) {
         );
         context.logger.warn(err.message);
         context.logger.warn(
-          `If there are e2e tests for the ${key} project, we recommend manually moving them to ${
-            p.root
-          }-e2e/src.`
+          `If there are e2e tests for the ${key} project, we recommend manually moving them to ${p.root}-e2e/src.`
         );
       });
     }
@@ -591,15 +589,9 @@ const updateworkspaceJson = updateWorkspaceInTree(json => {
       case 'application':
         project.prefix = prefix;
 
-        project.architect.build.options.tsConfig = `${
-          project.root
-        }/tsconfig.app.json`;
-        project.architect.test.options.karmaConfig = `${
-          project.root
-        }/karma.conf.js`;
-        project.architect.test.options.tsConfig = `${
-          project.root
-        }/tsconfig.spec.json`;
+        project.architect.build.options.tsConfig = `${project.root}/tsconfig.app.json`;
+        project.architect.test.options.karmaConfig = `${project.root}/karma.conf.js`;
+        project.architect.test.options.tsConfig = `${project.root}/tsconfig.spec.json`;
 
         project.architect.test.options.main = `${project.sourceRoot}/test.ts`;
 
@@ -630,12 +622,8 @@ const updateworkspaceJson = updateWorkspaceInTree(json => {
         project.prefix = prefix;
 
         project.projectType = 'library';
-        project.architect.test.options.karmaConfig = `${
-          project.root
-        }/karma.conf.js`;
-        project.architect.test.options.tsConfig = `${
-          project.root
-        }/tsconfig.spec.json`;
+        project.architect.test.options.karmaConfig = `${project.root}/karma.conf.js`;
+        project.architect.test.options.tsConfig = `${project.root}/tsconfig.spec.json`;
         project.architect.test.options.main = `${project.sourceRoot}/test.ts`;
 
         project.architect.lint.options.tsConfig = [
@@ -660,9 +648,7 @@ const updateworkspaceJson = updateWorkspaceInTree(json => {
         project.sourceRoot = `${project.root}/src`;
         project.prefix = prefix;
 
-        project.architect.e2e.options.protractorConfig = `${
-          project.root
-        }/protractor.conf.js`;
+        project.architect.e2e.options.protractorConfig = `${project.root}/protractor.conf.js`;
         project.architect.lint.options.tsConfig = [
           `${project.root}/tsconfig.e2e.json`
         ];

--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -108,9 +108,7 @@ export class Migrator {
     } catch (e) {
       if (e.message.indexOf('No matching version') > -1) {
         throw new Error(
-          `${
-            e.message
-          }\nRun migrate with --to="package1@version1,package2@version2"`
+          `${e.message}\nRun migrate with --to="package1@version1,package2@version2"`
         );
       } else {
         throw e;

--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -57,9 +57,7 @@ export function run(options: WebBuildBuilderOptions, context: BuilderContext) {
   const supportedRange = new Range('10 || >=12.9');
   if (!satisfies(nodeVersion, supportedRange)) {
     throw new Error(
-      `Node version ${nodeVersion} is not supported. Supported range is "${
-        supportedRange.raw
-      }".`
+      `Node version ${nodeVersion} is not supported. Supported range is "${supportedRange.raw}".`
     );
   }
   return from(getSourceRoot(context, host))

--- a/packages/web/src/utils/source-root.ts
+++ b/packages/web/src/utils/source-root.ts
@@ -12,9 +12,7 @@ export async function getSourceRoot(context: BuilderContext, host: Host<{}>) {
     return workspace.projects.get(context.target.project).sourceRoot;
   } else {
     context.reportStatus('Error');
-    const message = `${
-      context.target.project
-    } does not have a sourceRoot. Please define one.`;
+    const message = `${context.target.project} does not have a sourceRoot. Please define one.`;
     context.logger.error(message);
     throw new Error(message);
   }

--- a/packages/workspace/src/builders/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.ts
@@ -78,9 +78,7 @@ async function runInParallel(options: RunCommandsBuilderOptions) {
     const r = await Promise.race(procs);
     if (!r.result) {
       process.stderr.write(
-        `Warning: @nrwl/run-command command "${
-          r.command
-        }" exited with non-zero status code`
+        `Warning: @nrwl/run-command command "${r.command}" exited with non-zero status code`
       );
       return false;
     } else {
@@ -92,9 +90,7 @@ async function runInParallel(options: RunCommandsBuilderOptions) {
     if (failed.length > 0) {
       failed.forEach(f => {
         process.stderr.write(
-          `Warning: @nrwl/run-command command "${
-            f.command
-          }" exited with non-zero status code`
+          `Warning: @nrwl/run-command command "${f.command}" exited with non-zero status code`
         );
       });
       return false;

--- a/packages/workspace/src/schematics/init/init.ts
+++ b/packages/workspace/src/schematics/init/init.ts
@@ -518,9 +518,7 @@ function checkCanConvertToWorkspace(options: Schema) {
           `Make sure the ${e2eKey}.architect.e2e.options.protractorConfig is valid or the ${e2eKey} project is removed from angular.json.`
         );
         throw new Error(
-          `An e2e project was specified but ${
-            e2eApp.architect.e2e.options.protractorConfig
-          } could not be found.`
+          `An e2e project was specified but ${e2eApp.architect.e2e.options.protractorConfig} could not be found.`
         );
       }
 

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -150,9 +150,7 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
 
       // check for circular dependency
       if (isCircular(this.deps, sourceProject, targetProject)) {
-        const error = `Circular dependency between "${
-          sourceProject.name
-        }" and "${targetProject.name}" detected`;
+        const error = `Circular dependency between "${sourceProject.name}" and "${targetProject.name}" detected`;
         this.addFailureAt(node.getStart(), node.getWidth(), error);
         return;
       }
@@ -221,9 +219,7 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
             const allowedTags = constraint.onlyDependOnLibsWithTags
               .map(s => `"${s}"`)
               .join(', ');
-            const error = `A project tagged with "${
-              constraint.sourceTag
-            }" can only depend on libs tagged with ${allowedTags}`;
+            const error = `A project tagged with "${constraint.sourceTag}" can only depend on libs tagged with ${allowedTags}`;
             this.addFailureAt(node.getStart(), node.getWidth(), error);
             return;
           }

--- a/packages/workspace/src/utils/rules/deleteFile.ts
+++ b/packages/workspace/src/utils/rules/deleteFile.ts
@@ -4,9 +4,7 @@ import { forEach, FileEntry, Rule } from '@angular-devkit/schematics';
  * Remove a file from the Virtual Schematic Tree
  */
 export function deleteFile(from: string): Rule {
-  return forEach(
-    (entry: FileEntry): FileEntry | null => {
-      return entry.path === from ? null : entry;
-    }
-  );
+  return forEach((entry: FileEntry): FileEntry | null => {
+    return entry.path === from ? null : entry;
+  });
 }

--- a/packages/workspace/src/utils/update-task.ts
+++ b/packages/workspace/src/utils/update-task.ts
@@ -86,9 +86,7 @@ function createRunUpdateTask(): TaskExecutorFactory<UpdateTaskOptions> {
                 obs.next();
                 obs.complete();
               } else {
-                const message = `${
-                  options.package
-                } migration failed, see above.`;
+                const message = `${options.package} migration failed, see above.`;
                 obs.error(new Error(message));
               }
             });

--- a/scripts/documentation/generate-schematics-data.ts
+++ b/scripts/documentation/generate-schematics-data.ts
@@ -82,9 +82,7 @@ function generateTemplate(
   }
 
   template += dedent`
-  By default, Nx will search for \`${
-    schematic.name
-  }\` in the default collection provisioned in \`${filename}\`.\n
+  By default, Nx will search for \`${schematic.name}\` in the default collection provisioned in \`${filename}\`.\n
   You can specify the collection explicitly as follows:  
   \`\`\`bash
   ${cliCommand} g ${schematic.collectionName}:${schematic.name} ...
@@ -181,9 +179,7 @@ Promise.all(
             )
             .then(() => {
               console.log(
-                `Documentation from ${config.root} generated to ${
-                  config.schematicOutput
-                }`
+                `Documentation from ${config.root} generated to ${config.schematicOutput}`
               );
             });
         })

--- a/scripts/nx-release.js
+++ b/scripts/nx-release.js
@@ -83,9 +83,7 @@ function parseVersion(version) {
 const parsedVersion = parseVersion(parsedArgs._[2]);
 if (!parsedVersion.isValid) {
   console.error(
-    `\nError:\nThe specified version is not valid. You specified: "${
-      parsedVersion.version
-    }"`
+    `\nError:\nThe specified version is not valid. You specified: "${parsedVersion.version}"`
   );
   console.error(
     `Please run "yarn nx-release --help" for details on the acceptable version format.\n`
@@ -102,9 +100,7 @@ const cliVersion = devDependencies['@angular/cli'];
 const typescriptVersion = devDependencies['typescript'];
 
 console.log('Executing build script:');
-const buildCommand = `./scripts/package.sh ${
-  parsedVersion.version
-} ${cliVersion} ${typescriptVersion}`;
+const buildCommand = `./scripts/package.sh ${parsedVersion.version} ${cliVersion} ${typescriptVersion}`;
 console.log(`> ${buildCommand}`);
 childProcess.execSync(buildCommand, {
   stdio: [0, 1, 2]
@@ -205,9 +201,7 @@ releaseIt(options)
      * We always use either "latest" or "next" (i.e. no separate tags for alpha, beta etc)
      */
     const npmTag = parsedVersion.isPrerelease ? 'next' : 'latest';
-    const npmPublishCommand = `./scripts/publish.sh ${
-      output.version
-    } ${npmTag}`;
+    const npmPublishCommand = `./scripts/publish.sh ${output.version} ${npmTag}`;
     console.log('Executing publishing script for all packages:');
     console.log(`> ${npmPublishCommand}`);
     console.log(

--- a/yarn.lock
+++ b/yarn.lock
@@ -11793,10 +11793,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@1.16.4:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
-  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+prettier@1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-error@^2.0.2:
   version "2.1.1"


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
prettier is installed in two different version. (1.16.4 and 1.18.2)
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
prettier is installed with the same version (1.18.2)
## Issue
Closes #1863 