### PR TITLE
feat(testing): set transpileOnly=true ...

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -38,6 +38,7 @@
     "@angular-devkit/architect": "0.803.3",
     "@angular-devkit/core": "8.3.3",
     "@cypress/webpack-preprocessor": "~4.1.0",
+    "fork-ts-checker-webpack-plugin": "^0.4.9",
     "tree-kill": "1.2.1",
     "ts-loader": "5.3.1",
     "tsconfig-paths-webpack-plugin": "3.2.0",

--- a/packages/cypress/src/plugins/preprocessor.spec.ts
+++ b/packages/cypress/src/plugins/preprocessor.spec.ts
@@ -21,7 +21,9 @@ describe('getWebpackConfig', () => {
       options: {
         configFile: './tsconfig.json',
         // https://github.com/TypeStrong/ts-loader/pull/685
-        experimentalWatchApi: true
+        experimentalWatchApi: true,
+        // https://github.com/cypress-io/cypress/issues/2316
+        transpileOnly: true
       }
     });
   });

--- a/packages/cypress/src/plugins/preprocessor.ts
+++ b/packages/cypress/src/plugins/preprocessor.ts
@@ -2,6 +2,8 @@ import * as wp from '@cypress/webpack-preprocessor';
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 import * as nodeExternals from 'webpack-node-externals';
 
+import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
 export function preprocessTypescript(config: any) {
   if (!config.env.tsConfig) {
     throw new Error(
@@ -35,11 +37,18 @@ export function getWebpackConfig(config: any) {
           options: {
             configFile: config.env.tsConfig,
             // https://github.com/TypeStrong/ts-loader/pull/685
-            experimentalWatchApi: true
+            experimentalWatchApi: true,
+            // https://github.com/cypress-io/cypress/issues/2316
+            transpileOnly: true
           }
         }
       ]
     },
+    plugins: [
+      new ForkTsCheckerWebpackPlugin({
+        tsconfig: config.env.tsConfig
+      })
+    ],
     externals: [nodeExternals()]
   };
 }


### PR DESCRIPTION
see #1871 

## Current Behavior (This is the behavior we have today, before the PR is merged)

After upgrading to the latest version of the `@nrwl/cypress:cypress` builder, `8.5.0`, my cypress tests start to fail with an `JavaScript heap out of memory` error.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Cypress execution is using the `fork-ts-checker-webpack-plugin` plugin and the `transpileOnly` flag is set to `true` to avoid `JavaScript heap out of memory` errors. See [this](https://github.com/cypress-io/cypress/issues/2316#issuecomment-516824284) comment.