### PR TITLE
refactor(nx): change workspace-schematic output format to be …

### DIFF
--- a/e2e/command-line.test.ts
+++ b/e2e/command-line.test.ts
@@ -195,15 +195,15 @@ forEachCli(() => {
         `npm run workspace-schematic ${custom} ${workspace} -- --no-interactive --directory=dir -d`
       );
       expect(exists(`libs/dir/${workspace}/src/index.ts`)).toEqual(false);
-      expect(dryRunOutput).toContain(`update ${workspaceConfigName()}`);
-      expect(dryRunOutput).toContain('update nx.json');
+      expect(dryRunOutput).toContain(`UPDATE ${workspaceConfigName()}`);
+      expect(dryRunOutput).toContain('UPDATE nx.json');
 
       const output = runCommand(
         `npm run workspace-schematic ${custom} ${workspace} -- --no-interactive --directory=dir`
       );
       checkFilesExist(`libs/dir/${workspace}/src/index.ts`);
-      expect(output).toContain(`update ${workspaceConfigName()}`);
-      expect(output).toContain('update nx.json');
+      expect(output).toContain(`UPDATE ${workspaceConfigName()}`);
+      expect(output).toContain('UPDATE nx.json');
 
       const another = uniq('another');
       runCLI(`g workspace-schematic ${another} --no-interactive`);
@@ -220,7 +220,7 @@ forEachCli(() => {
       const promptOutput = runCommand(
         `npm run workspace-schematic ${custom} mylib2 --dry-run`
       );
-      expect(promptOutput).toContain('update nx.json');
+      expect(promptOutput).toContain('UPDATE nx.json');
     }, 1000000);
 
     describe('dep-graph', () => {


### PR DESCRIPTION
…consistent with Angular CLI

Any schematic that modifies the Virtual Tree using the `workspace-schematic` command will output
changes to the Virtual Tree in a consistent format with the Angular CLI `generate` command.

#1870

## Current Behavior (This is the behavior we have today, before the PR is merged)

The output formatting is inconsistent. The Virtual Tree change logs are not color-coded, nor is the operation type uppercased. Also, there is no log output when the `--dry-run` flag is used, even though the `--dry-run` itself works correctly and the schematic does not affect the filesystem.

Here is the output from the `workspace-schematic` command.
![image](https://user-images.githubusercontent.com/12140467/65413362-3488a680-dde9-11e9-8cbc-56e9f86fb4db.png)


Here is the output from the `genereate` command.
![image](https://user-images.githubusercontent.com/12140467/65413236-ebd0ed80-dde8-11e9-87ef-300eb666a38d.png)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

When running `nx workspace-schematic <name>`, the console output formatting from changes made to the Virtual Tree should be consistent with the formatting used by the Angular CLI when running `ng generate <name>`.

## Issue
#1870 