### PR TITLE
WIP: feat(nx): add generic task execution

### DIFF
--- a/docs/angular/api-workspace/npmscripts/affected-apps.md
+++ b/docs/angular/api-workspace/npmscripts/affected-apps.md
@@ -40,6 +40,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -67,6 +71,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/angular/api-workspace/npmscripts/affected-build.md
+++ b/docs/angular/api-workspace/npmscripts/affected-build.md
@@ -58,6 +58,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -97,6 +101,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/angular/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/angular/api-workspace/npmscripts/affected-dep-graph.md
@@ -46,6 +46,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -77,6 +81,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/angular/api-workspace/npmscripts/affected-e2e.md
+++ b/docs/angular/api-workspace/npmscripts/affected-e2e.md
@@ -58,6 +58,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -97,6 +101,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/angular/api-workspace/npmscripts/affected-libs.md
+++ b/docs/angular/api-workspace/npmscripts/affected-libs.md
@@ -40,6 +40,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -67,6 +71,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/angular/api-workspace/npmscripts/affected-lint.md
+++ b/docs/angular/api-workspace/npmscripts/affected-lint.md
@@ -58,6 +58,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -97,6 +101,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/angular/api-workspace/npmscripts/affected-test.md
+++ b/docs/angular/api-workspace/npmscripts/affected-test.md
@@ -58,6 +58,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -97,6 +101,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/angular/api-workspace/npmscripts/affected.md
+++ b/docs/angular/api-workspace/npmscripts/affected.md
@@ -64,6 +64,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -103,6 +107,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### target
 

--- a/docs/angular/api-workspace/npmscripts/format-check.md
+++ b/docs/angular/api-workspace/npmscripts/format-check.md
@@ -22,6 +22,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -49,6 +53,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/angular/api-workspace/npmscripts/format-write.md
+++ b/docs/angular/api-workspace/npmscripts/format-write.md
@@ -22,6 +22,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -49,6 +53,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/react/api-workspace/npmscripts/affected-apps.md
+++ b/docs/react/api-workspace/npmscripts/affected-apps.md
@@ -40,6 +40,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -67,6 +71,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/react/api-workspace/npmscripts/affected-build.md
+++ b/docs/react/api-workspace/npmscripts/affected-build.md
@@ -58,6 +58,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -97,6 +101,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/react/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/react/api-workspace/npmscripts/affected-dep-graph.md
@@ -46,6 +46,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -77,6 +81,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/react/api-workspace/npmscripts/affected-e2e.md
+++ b/docs/react/api-workspace/npmscripts/affected-e2e.md
@@ -58,6 +58,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -97,6 +101,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/react/api-workspace/npmscripts/affected-libs.md
+++ b/docs/react/api-workspace/npmscripts/affected-libs.md
@@ -40,6 +40,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -67,6 +71,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/react/api-workspace/npmscripts/affected-lint.md
+++ b/docs/react/api-workspace/npmscripts/affected-lint.md
@@ -58,6 +58,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -97,6 +101,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/react/api-workspace/npmscripts/affected-test.md
+++ b/docs/react/api-workspace/npmscripts/affected-test.md
@@ -58,6 +58,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -97,6 +101,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/react/api-workspace/npmscripts/affected.md
+++ b/docs/react/api-workspace/npmscripts/affected.md
@@ -64,6 +64,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -103,6 +107,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### target
 

--- a/docs/react/api-workspace/npmscripts/format-check.md
+++ b/docs/react/api-workspace/npmscripts/format-check.md
@@ -22,6 +22,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -49,6 +53,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/react/api-workspace/npmscripts/format-write.md
+++ b/docs/react/api-workspace/npmscripts/format-write.md
@@ -22,6 +22,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -49,6 +53,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/web/api-workspace/npmscripts/affected-apps.md
+++ b/docs/web/api-workspace/npmscripts/affected-apps.md
@@ -40,6 +40,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -67,6 +71,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/web/api-workspace/npmscripts/affected-build.md
+++ b/docs/web/api-workspace/npmscripts/affected-build.md
@@ -58,6 +58,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -97,6 +101,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/web/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/web/api-workspace/npmscripts/affected-dep-graph.md
@@ -46,6 +46,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -77,6 +81,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/web/api-workspace/npmscripts/affected-e2e.md
+++ b/docs/web/api-workspace/npmscripts/affected-e2e.md
@@ -58,6 +58,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -97,6 +101,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/web/api-workspace/npmscripts/affected-libs.md
+++ b/docs/web/api-workspace/npmscripts/affected-libs.md
@@ -40,6 +40,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -67,6 +71,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/web/api-workspace/npmscripts/affected-lint.md
+++ b/docs/web/api-workspace/npmscripts/affected-lint.md
@@ -58,6 +58,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -97,6 +101,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/web/api-workspace/npmscripts/affected-test.md
+++ b/docs/web/api-workspace/npmscripts/affected-test.md
@@ -58,6 +58,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -97,6 +101,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/web/api-workspace/npmscripts/affected.md
+++ b/docs/web/api-workspace/npmscripts/affected.md
@@ -64,6 +64,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -103,6 +107,10 @@ Parallelize the command
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### target
 

--- a/docs/web/api-workspace/npmscripts/format-check.md
+++ b/docs/web/api-workspace/npmscripts/format-check.md
@@ -22,6 +22,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -49,6 +53,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/docs/web/api-workspace/npmscripts/format-write.md
+++ b/docs/web/api-workspace/npmscripts/format-write.md
@@ -22,6 +22,10 @@ All projects
 
 Base of the current branch (usually master)
 
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
 ### exclude
 
 Default: ``
@@ -49,6 +53,10 @@ Isolate projects which previously failed
 ### plain
 
 Produces a plain output for affected:apps and affected:libs
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
 
 ### uncommitted
 

--- a/e2e/affected.test.ts
+++ b/e2e/affected.test.ts
@@ -143,13 +143,14 @@ forEachCli(() => {
 
       // affected:build should pass non-nx flags to the CLI
       const buildWithFlags = runCommand(
-        `npm run affected:build -- --files="libs/${mylib}/src/index.ts" --stats-json`
+        `npm run affected:build -- --files="libs/${mylib}/src/index.ts" -- --stats-json`
       );
 
       expect(buildWithFlags).toContain(`Running target build for projects:`);
       expect(buildWithFlags).toContain(`- ${myapp}`);
       expect(buildWithFlags).toContain(`- ${mypublishablelib}`);
-      expect(buildWithFlags).toContain('With flags: --stats-json=true');
+      expect(buildWithFlags).toContain('With flags:');
+      expect(buildWithFlags).toContain('--stats-json=true');
 
       if (supportUi()) {
         const e2e = runCommand(
@@ -221,7 +222,8 @@ forEachCli(() => {
       const lintWithJsonFormating = runCommand(
         `npm run affected:lint -- --files="libs/${mylib}/src/index.ts" -- --format json`
       );
-      expect(lintWithJsonFormating).toContain('With flags: --format json');
+      expect(lintWithJsonFormating).toContain('With flags:');
+      expect(lintWithJsonFormating).toContain('--format=json');
 
       const unitTestsExcluded = runCommand(
         `npm run affected:test -- --files="libs/${mylib}/src/index.ts" --exclude=${myapp},${mypublishablelib}`

--- a/packages/workspace/src/command-line/affected-apps.ts
+++ b/packages/workspace/src/command-line/affected-apps.ts
@@ -26,16 +26,17 @@ export function getAffectedProjects(
   ).map(project => project.name);
 }
 
-export function getAffectedProjectsWithTarget(
+export function getAffectedProjectsWithTargetAndConfiguration(
   affectedMetadata: AffectedMetadata,
-  target: string
-): string[] {
+  target: string,
+  configuration?: string
+): ProjectNode[] {
   return filterAffectedMetadata(
     affectedMetadata,
     project =>
       affectedMetadata.projectStates[project.name].affected &&
-      project.architect[target]
-  ).map(project => project.name);
+      projectHasTargetAndConfiguration(project, target, configuration)
+  );
 }
 
 export function getAllApps(affectedMetadata: AffectedMetadata): string[] {
@@ -58,14 +59,33 @@ export function getAllProjects(affectedMetadata: AffectedMetadata): string[] {
   );
 }
 
-export function getAllProjectsWithTarget(
+export function getAllProjectsWithTargetAndConfiguration(
   affectedMetadata: AffectedMetadata,
-  target: string
-): string[] {
-  return filterAffectedMetadata(
-    affectedMetadata,
-    project => project.architect[target]
-  ).map(project => project.name);
+  target: string,
+  configuration?: string
+): ProjectNode[] {
+  return filterAffectedMetadata(affectedMetadata, project =>
+    projectHasTargetAndConfiguration(project, target, configuration)
+  );
+}
+
+export function projectHasTargetAndConfiguration(
+  project: ProjectNode,
+  target: string,
+  configuration?: string
+) {
+  if (!project.architect[target]) {
+    return false;
+  }
+
+  if (!configuration) {
+    return !!project.architect[target];
+  } else {
+    return (
+      project.architect[target].configurations &&
+      project.architect[target].configurations[configuration]
+    );
+  }
 }
 
 function filterAffectedMetadata(

--- a/packages/workspace/src/command-line/affected.spec.ts
+++ b/packages/workspace/src/command-line/affected.spec.ts
@@ -1,0 +1,153 @@
+import { processArgs } from './affected';
+import { NxJson } from './shared';
+import defaultTasksRunner from '../tasks-runner/default-tasks-runner';
+import { TasksRunner } from '../tasks-runner/tasks-runner';
+
+describe('processArgs', () => {
+  let nxJson: NxJson;
+  let mockRunner: TasksRunner;
+
+  beforeEach(() => {
+    nxJson = {
+      npmScope: 'proj',
+      projects: {}
+    };
+    mockRunner = jest.fn();
+  });
+
+  it('should process nx specific arguments as affected args', () => {
+    expect(
+      processArgs(
+        {
+          files: [''],
+          notNxArg: true,
+          _: ['--override'],
+          $0: ''
+        },
+        nxJson
+      ).affectedArgs
+    ).toEqual({
+      files: ['']
+    });
+  });
+
+  it('should process non nx specific arguments as tasks runner args', () => {
+    expect(
+      processArgs(
+        {
+          files: [''],
+          notNxArg: true,
+          _: ['--override'],
+          $0: ''
+        },
+        nxJson
+      ).tasksRunnerOptions
+    ).toEqual({
+      notNxArg: true
+    });
+  });
+
+  it('should process delimited args as task overrides', () => {
+    expect(
+      processArgs(
+        {
+          files: [''],
+          notNxArg: true,
+          _: ['', '--override'],
+          $0: ''
+        },
+        nxJson
+      ).taskOverrides
+    ).toEqual({
+      override: true
+    });
+  });
+
+  it('should get a default tasks runner', () => {
+    expect(
+      processArgs(
+        {
+          files: [''],
+          notNxArg: true,
+          _: ['', '--override'],
+          $0: ''
+        },
+        nxJson
+      ).tasksRunner
+    ).toEqual(defaultTasksRunner);
+  });
+
+  it('should get a custom tasks runner', () => {
+    jest.mock('custom-runner', () => mockRunner, {
+      virtual: true
+    });
+    nxJson.tasksRunnerOptions = {
+      custom: {
+        runner: 'custom-runner'
+      }
+    };
+    expect(
+      processArgs(
+        {
+          files: [''],
+          notNxArg: true,
+          runner: 'custom',
+          _: ['', '--override'],
+          $0: ''
+        },
+        nxJson
+      ).tasksRunner
+    ).toEqual(mockRunner);
+  });
+
+  it('should get a custom tasks runner with options', () => {
+    jest.mock('custom-runner', () => mockRunner, {
+      virtual: true
+    });
+    nxJson.tasksRunnerOptions = {
+      custom: {
+        runner: 'custom-runner',
+        options: {
+          runnerOption: 'runner-option'
+        }
+      }
+    };
+    expect(
+      processArgs(
+        {
+          files: [''],
+          notNxArg: true,
+          runner: 'custom',
+          _: ['', '--override'],
+          $0: ''
+        },
+        nxJson
+      ).tasksRunnerOptions
+    ).toEqual({
+      runnerOption: 'runner-option',
+      notNxArg: true
+    });
+  });
+
+  it('should get a custom defined default tasks runner', () => {
+    jest.mock('custom-default-runner', () => mockRunner, {
+      virtual: true
+    });
+    nxJson.tasksRunnerOptions = {
+      default: {
+        runner: 'custom-default-runner'
+      }
+    };
+    expect(
+      processArgs(
+        {
+          files: [''],
+          notNxArg: true,
+          _: ['', '--override'],
+          $0: ''
+        },
+        nxJson
+      ).tasksRunner
+    ).toEqual(mockRunner);
+  });
+});

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -249,6 +249,15 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
       coerce: parseCSV,
       default: []
     })
+    .options('runner', {
+      describe: 'This is the name of the tasks runner configured in nx.json',
+      type: 'string'
+    })
+    .options('configuration', {
+      describe:
+        'This is the configuration to use when performing tasks on projects',
+      type: 'string'
+    })
     .options('only-failed', {
       describe: 'Isolate projects which previously failed',
       type: 'boolean',

--- a/packages/workspace/src/command-line/shared.ts
+++ b/packages/workspace/src/command-line/shared.ts
@@ -24,6 +24,12 @@ export interface NxJson {
   projects: {
     [projectName: string]: NxJsonProjectConfig;
   };
+  tasksRunnerOptions?: {
+    [tasksRunnerName: string]: {
+      runner: string;
+      options?: unknown;
+    };
+  };
 }
 
 export interface NxJsonProjectConfig {
@@ -443,6 +449,7 @@ export function createAffectedMetadata(
 ): AffectedMetadata {
   const projectStates: ProjectStates = {};
   const projects: ProjectMap = {};
+
   projectNodes.forEach(project => {
     projectStates[project.name] = {
       touched: false,

--- a/packages/workspace/src/command-line/workspace-results.spec.ts
+++ b/packages/workspace/src/command-line/workspace-results.spec.ts
@@ -22,7 +22,7 @@ describe('WorkspacesResults', () => {
 
   describe('success', () => {
     it('should return true when getting results', () => {
-      results.success('proj');
+      results.setResult('proj', true);
 
       expect(results.getResult('proj')).toBe(true);
     });
@@ -32,7 +32,7 @@ describe('WorkspacesResults', () => {
       spyOn(fs, 'unlinkSync');
       spyOn(fs, 'existsSync').and.returnValue(true);
 
-      results.success('proj');
+      results.setResult('proj', true);
       results.saveResults();
 
       expect(fs.writeSync).not.toHaveBeenCalled();
@@ -41,7 +41,7 @@ describe('WorkspacesResults', () => {
 
     it('should print results', () => {
       const projectName = 'proj';
-      results.success(projectName);
+      results.setResult(projectName, true);
       spyOn(output, 'success');
 
       const successTitle = 'Success';
@@ -60,7 +60,7 @@ describe('WorkspacesResults', () => {
       spyOn(output, 'success');
       spyOn(output, 'warn');
 
-      results.success(projectName);
+      results.setResult(projectName, true);
 
       const successTitle = 'Success';
 
@@ -85,7 +85,7 @@ describe('WorkspacesResults', () => {
 
   describe('fail', () => {
     it('should return false when getting results', () => {
-      results.fail('proj');
+      results.setResult('proj', false);
 
       expect(results.getResult('proj')).toBe(false);
     });
@@ -93,7 +93,7 @@ describe('WorkspacesResults', () => {
     it('should save results to file system', () => {
       spyOn(fs, 'writeFileSync');
 
-      results.fail('proj');
+      results.setResult('proj', false);
       results.saveResults();
 
       expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -109,7 +109,7 @@ describe('WorkspacesResults', () => {
 
     it('should print results', () => {
       const projectName = 'proj';
-      results.fail(projectName);
+      results.setResult(projectName, false);
       spyOn(output, 'error');
 
       const errorTitle = 'Fail';
@@ -128,7 +128,7 @@ describe('WorkspacesResults', () => {
 
     it('should tell the user that they can isolate only the failed tests', () => {
       const projectName = 'proj';
-      results.fail(projectName);
+      results.setResult(projectName, false);
       spyOn(output, 'error');
 
       const errorTitle = 'Fail';

--- a/packages/workspace/src/command-line/workspace-results.ts
+++ b/packages/workspace/src/command-line/workspace-results.ts
@@ -51,14 +51,6 @@ export class WorkspaceResults {
     return this.commandResults.results[projectName];
   }
 
-  fail(projectName: string) {
-    this.setResult(projectName, false);
-  }
-
-  success(projectName: string) {
-    this.setResult(projectName, true);
-  }
-
   saveResults() {
     if (Object.values<boolean>(this.commandResults.results).includes(false)) {
       writeJsonFile(RESULTS_FILE, this.commandResults);
@@ -120,7 +112,7 @@ export class WorkspaceResults {
     });
   }
 
-  private setResult(projectName: string, result: boolean) {
+  setResult(projectName: string, result: boolean) {
     this.commandResults.results[projectName] = result;
   }
 }

--- a/packages/workspace/src/tasks-runner/default-tasks-runner.spec.ts
+++ b/packages/workspace/src/tasks-runner/default-tasks-runner.spec.ts
@@ -1,0 +1,189 @@
+import defaultTasksRunner from './default-tasks-runner';
+import { AffectedEventType, Task } from './tasks-runner';
+jest.mock('npm-run-all', () => jest.fn());
+import * as runAll from 'npm-run-all';
+jest.mock('../command-line/shared', () => ({
+  cliCommand: () => 'nx'
+}));
+jest.mock('../utils/fileutils', () => ({
+  readJsonFile: () => ({
+    scripts: {
+      nx: 'nx'
+    }
+  })
+}));
+
+describe('defaultTasksRunner', () => {
+  let tasks: Task[];
+  beforeEach(() => {
+    tasks = [
+      {
+        id: 'task-1',
+        target: {
+          project: 'app-1',
+          target: 'target'
+        },
+        overrides: {}
+      },
+      {
+        id: 'task-2',
+        target: {
+          project: 'app-2',
+          target: 'target'
+        },
+        overrides: {}
+      }
+    ];
+  });
+
+  it('should run the correct commands through "npm-run-all"', done => {
+    runAll.mockImplementation(() => Promise.resolve());
+    defaultTasksRunner(tasks, {}).subscribe({
+      complete: () => {
+        expect(runAll).toHaveBeenCalledWith(
+          ['nx run app-1:target', 'nx run app-2:target'],
+          jasmine.anything()
+        );
+        done();
+      }
+    });
+  });
+
+  it('should run the correct commands through "npm-run-all" when tasks have a configuration', done => {
+    runAll.mockImplementation(() => Promise.resolve());
+    tasks = tasks.map(task => {
+      task.target.configuration = 'production';
+      return task;
+    });
+    defaultTasksRunner(tasks, {}).subscribe({
+      complete: () => {
+        expect(runAll).toHaveBeenCalledWith(
+          ['nx run app-1:target:production', 'nx run app-2:target:production'],
+          jasmine.anything()
+        );
+        done();
+      }
+    });
+  });
+
+  it('should run the correct commands through "npm-run-all" when tasks have overrides', done => {
+    runAll.mockImplementation(() => Promise.resolve());
+    tasks = tasks.map(task => {
+      task.overrides = {
+        override: 'override-value'
+      };
+      return task;
+    });
+    defaultTasksRunner(tasks, {}).subscribe({
+      complete: () => {
+        expect(runAll).toHaveBeenCalledWith(
+          [
+            'nx run app-1:target --override=override-value',
+            'nx run app-2:target --override=override-value'
+          ],
+          jasmine.anything()
+        );
+        done();
+      }
+    });
+  });
+
+  it('should run the correct commands through "npm-run-all" when tasks have configurations and overrides', done => {
+    runAll.mockImplementation(() => Promise.resolve());
+    tasks = tasks.map(task => {
+      task.target.configuration = 'production';
+      task.overrides = {
+        override: 'override-value'
+      };
+      return task;
+    });
+    defaultTasksRunner(tasks, {}).subscribe({
+      complete: () => {
+        expect(runAll).toHaveBeenCalledWith(
+          [
+            'nx run app-1:target:production --override=override-value',
+            'nx run app-2:target:production --override=override-value'
+          ],
+          jasmine.anything()
+        );
+        done();
+      }
+    });
+  });
+
+  it('should pass the right options when options are passed', done => {
+    runAll.mockImplementation(() => Promise.resolve());
+    defaultTasksRunner(tasks, {
+      parallel: true,
+      maxParallel: 5
+    }).subscribe({
+      complete: () => {
+        expect(runAll).toHaveBeenCalledWith(
+          jasmine.any(Array),
+          jasmine.objectContaining({
+            parallel: true,
+            maxParallel: 5
+          })
+        );
+        done();
+      }
+    });
+  });
+
+  it('should run emit task complete events when "run-all-prerender" resolves', done => {
+    runAll.mockImplementation(() => Promise.resolve());
+    let i = 0;
+    const expected = [
+      {
+        task: tasks[0],
+        type: AffectedEventType.TaskComplete,
+        success: true
+      },
+      {
+        task: tasks[1],
+        type: AffectedEventType.TaskComplete,
+        success: true
+      }
+    ];
+    defaultTasksRunner(tasks, {}).subscribe({
+      next: event => {
+        expect(event).toEqual(expected[i++]);
+      },
+      complete: done
+    });
+  });
+
+  it('should run emit task complete events when "run-all-prerender" rejects', done => {
+    runAll.mockImplementation(() =>
+      Promise.reject({
+        results: [
+          {
+            code: 0
+          },
+          {
+            code: 1
+          }
+        ]
+      })
+    );
+    let i = 0;
+    const expected = [
+      {
+        task: tasks[0],
+        type: AffectedEventType.TaskComplete,
+        success: true
+      },
+      {
+        task: tasks[1],
+        type: AffectedEventType.TaskComplete,
+        success: false
+      }
+    ];
+    defaultTasksRunner(tasks, {}).subscribe({
+      next: event => {
+        expect(event).toEqual(expected[i++]);
+      },
+      complete: done
+    });
+  });
+});

--- a/packages/workspace/src/tasks-runner/default-tasks-runner.ts
+++ b/packages/workspace/src/tasks-runner/default-tasks-runner.ts
@@ -1,0 +1,121 @@
+import * as runAll from 'npm-run-all';
+import { Observable } from 'rxjs';
+import { basename } from 'path';
+import {
+  AffectedEventType,
+  Task,
+  TaskCompleteEvent,
+  TasksRunner
+} from './tasks-runner';
+import { cliCommand } from '../command-line/shared';
+import { output } from '../command-line/output';
+import { readJsonFile } from '../utils/fileutils';
+
+const commonCommands = ['build', 'test', 'lint', 'e2e', 'deploy'];
+
+export interface DefaultTasksRunnerOptions {
+  parallel?: boolean;
+  maxParallel?: number;
+}
+
+export const defaultTasksRunner: TasksRunner<DefaultTasksRunnerOptions> = (
+  tasks: Task[],
+  options: DefaultTasksRunnerOptions
+): Observable<TaskCompleteEvent> => {
+  const additionalTaskOverrides = getLegacyTaskOverrides(options);
+  tasks.forEach(task => {
+    task.overrides = {
+      ...task.overrides,
+      ...additionalTaskOverrides
+    };
+  });
+  const commands = getCommands(tasks);
+  return new Observable(subscriber => {
+    runAll(commands, {
+      parallel: options.parallel || false,
+      maxParallel: options.maxParallel || 3,
+      continueOnError: true,
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr
+    })
+      .then(() => {
+        tasks.forEach(task => {
+          subscriber.next({
+            task: task,
+            type: AffectedEventType.TaskComplete,
+            success: true
+          });
+        });
+      })
+      .catch(e => {
+        e.results.forEach((result, i) => {
+          subscriber.next({
+            task: tasks[i],
+            type: AffectedEventType.TaskComplete,
+            success: result.code === 0
+          });
+        });
+      })
+      .finally(() => {
+        subscriber.complete();
+        // fix for https://github.com/nrwl/nx/issues/1666
+        if (process.stdin['unref']) (process.stdin as any).unref();
+      });
+  });
+};
+
+export default defaultTasksRunner;
+
+function getLegacyTaskOverrides(options: any) {
+  const legacyTaskOverrides = { ...options };
+  delete legacyTaskOverrides.maxParallel;
+  delete legacyTaskOverrides['max-parallel'];
+  delete legacyTaskOverrides.parallel;
+  delete legacyTaskOverrides.verbose;
+  return legacyTaskOverrides;
+}
+
+function getCommands(tasks: Task[]) {
+  const cli = cliCommand();
+  assertPackageJsonScriptExists(cli);
+  const isYarn = basename(process.env.npm_execpath || 'npm').startsWith('yarn');
+  return tasks.map(task => {
+    const args = Object.entries(task.overrides)
+      .map(([prop, value]) => `--${prop}=${value}`)
+      .join(' ');
+    return commonCommands.includes(task.target.target)
+      ? `${cli}${isYarn ? '' : ' --'} ${task.target.target} ${
+          task.target.project
+        } ${
+          task.target.configuration
+            ? `--configuration ${task.target.configuration} `
+            : ''
+        }${args}`
+      : `${cli}${isYarn ? '' : ' --'} run ${task.target.project}:${
+          task.target.target
+        }${task.target.configuration ? `:${task.target.configuration}` : ''}${
+          args ? ' ' + args : ''
+        }`;
+  });
+}
+
+function assertPackageJsonScriptExists(cli: string) {
+  // Make sure the `package.json` has the `nx: "nx"` command needed by `npm-run-all`
+  const packageJson = readJsonFile('./package.json');
+  if (!packageJson.scripts || !packageJson.scripts[cli]) {
+    output.error({
+      title: `The "scripts" section of your 'package.json' must contain "${cli}": "${cli}"`,
+      bodyLines: [
+        output.colors.gray('...'),
+        ' "scripts": {',
+        output.colors.gray('  ...'),
+        `   "${cli}": "${cli}"`,
+        output.colors.gray('  ...'),
+        ' }',
+        output.colors.gray('...')
+      ]
+    });
+    return process.exit(1);
+  }
+}

--- a/packages/workspace/src/tasks-runner/tasks-runner.ts
+++ b/packages/workspace/src/tasks-runner/tasks-runner.ts
@@ -1,0 +1,37 @@
+import { Observable } from 'rxjs';
+import { Target } from '@angular-devkit/architect';
+
+import { DependencyGraph } from '../command-line/shared';
+
+export interface Task {
+  id: string;
+  target: Target;
+  overrides: Object;
+}
+
+export enum AffectedEventType {
+  TaskComplete = '[Task] Complete'
+}
+
+export interface AffectedEvent {
+  task: Task;
+  type: AffectedEventType;
+}
+
+export interface TaskCompleteEvent extends AffectedEvent {
+  type: AffectedEventType.TaskComplete;
+  success: boolean;
+}
+
+export type TasksRunner<T = unknown> = (
+  tasks: Task[],
+  options?: T,
+  context?: {
+    dependencyGraph: DependencyGraph;
+    tasksMap: {
+      [projectName: string]: {
+        [targetName: string]: Task;
+      };
+    };
+  }
+) => Observable<AffectedEvent>;

--- a/packages/workspace/src/utils/fileutils.ts
+++ b/packages/workspace/src/utils/fileutils.ts
@@ -123,3 +123,7 @@ export function renameSync(
     cb(e);
   }
 }
+
+export function isRelativePath(path: string): boolean {
+  return path.startsWith('./') || path.startsWith('../');
+}


### PR DESCRIPTION
# WIP

This PR is still in progress but below is the information for the intentions of the PR.

## Current Behavior (This is the behavior we have today, before the PR is merged)

Task execution is currently handled by `npm-run-all` and unconfigurable to the user. There are limitations to what can be done through `npm-run-all` under the hood.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

This PR enables configuration of custom `TasksRunners`. The _default_ TasksRunner right now still uses `npm-run-all`.

### TasksRunners

A TasksRunner is a function with the following signature:

```ts
function customTasksRunner(tasks: Task[], options: any): Observable<BuildEvent> {
  // Run Tasks
}
```

### Future work

#### 🚀Remote Task Execution

The next step of this effort is that Nrwl is working on a task runner which will execute tasks remotely which will allow users to distribute their builds across multiple machines!

#### Ecosystem

This opens up an ecosystem of custom task runners. Users can create their own to suit their needs in general. We will also move the default task runner more extensible to allow an ecosystem to develop more easily.

## Issue
