### PR TITLE
docs(nx): fix lazy loading command

### DIFF
--- a/docs/angular/guides/misc-lazy-loading.md
+++ b/docs/angular/guides/misc-lazy-loading.md
@@ -9,7 +9,7 @@ You can use libraries across the app using two strategies:
 
 Even a medium size application has code that doesn't need to load until later. Lazing loading this code help with the bundle size, as a a result, with the startup time of your application.
 
-To learn how to use lazy loading, run `ng g @nrwl/angular:lib todo-list-shell --router --lazy --parentModule=apps/todos/src/app/app.module.ts`.
+To learn how to use lazy loading, run `ng g @nrwl/angular:lib todo-list-shell --routing --lazy --parentModule=apps/todos/src/app/app.module.ts`.
 
 _**Explanation**_
 


### PR DESCRIPTION
The command to create a lib with lazy loading incorrectly had the tribute --router instead of --routing

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

## Issue
