### PR TITLE
docs(resources): add nx video course links

### DIFF
--- a/docs/angular/getting-started/resources.md
+++ b/docs/angular/getting-started/resources.md
@@ -17,7 +17,7 @@
 
 ### Videos
 
-- [Video course on using Nx Workspaces](https://angularplaybook.com/p/nx-workspaces)
+- [Video course on using Nx Workspaces](https://connect.nrwl.io/app/courses/nx-workspaces/intro)
 
 ### Talks
 

--- a/docs/react/getting-started/resources.md
+++ b/docs/react/getting-started/resources.md
@@ -13,6 +13,10 @@
 - [Nx blog posts](https://blog.nrwl.io/react/home)
 - [Effective React Development with Nx](https://go.nrwl.io/effective-react-development-with-nx-new-book)
 
+## Videos
+
+- [Video course on using Nx Workspaces](https://connect.nrwl.io/app/courses/nx-workspaces/intro)
+
 ## Misc
 
 - [nx-examples](https://github.com/nrwl/nx-examples) repo has branches for different nx comments to display expected behavior and example app and libraries.

--- a/docs/web/getting-started/resources.md
+++ b/docs/web/getting-started/resources.md
@@ -13,6 +13,10 @@
 - [Nx blog posts](https://blog.nrwl.io/nx/home)
 - [Enterprise Monorepo Patterns Book](https://go.nrwl.io/angular-enterprise-monorepo-patterns-new-book?utm_campaign=Book%3A%20Monorepo%20Patterns%2C%20Jan%202019&utm_source=Github&utm_medium=Banner%20Ad)
 
+## Videos
+
+- [Video course on using Nx Workspaces](https://connect.nrwl.io/app/courses/nx-workspaces/intro)
+
 ## Misc
 
 - [nx-examples](https://github.com/nrwl/nx-examples) repo has branches for different nx comments to display expected behavior and example app and libraries. Check out the branch (workspace, ngrx...) to see what gets created for you. More info on readme.

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -74,6 +74,14 @@ const nrwlHomeTemplate = {
         <li class="col-span-2">
             <a
                     class="resource flex"
+                    href="https://connect.nrwl.io/app/courses/nx-workspaces/intro"
+            >
+                Nx video course
+            </a>
+        </li>
+        <li class="col-span-2">
+            <a
+                    class="resource flex"
                     href="https://nx.dev/angular/getting-started/what-is-nx"
             >
                 Nx video tutorial

--- a/packages/next/src/schematics/application/files/pages/__fileName__.tsx__tmpl__
+++ b/packages/next/src/schematics/application/files/pages/__fileName__.tsx__tmpl__
@@ -176,6 +176,14 @@ var innerJsx = `
       Here are some links to help you get started.
     </p>
     <ul className="resources">
+        <li className="col-span-2">
+          <a
+            className="resource flex"
+            href="https://connect.nrwl.io/app/courses/nx-workspaces/intro"
+          >
+            Nx video course
+          </a>
+        </li>
       <li className="col-span-2">
         <a
           className="resource flex"

--- a/packages/react/src/schematics/application/files/app/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/schematics/application/files/app/src/app/__fileName__.tsx__tmpl__
@@ -172,6 +172,14 @@ var innerJsx = `
     </p>
     <ul className="resources">
       <li className="col-span-2">
+        <li className="col-span-2">
+          <a
+            className="resource flex"
+            href="https://connect.nrwl.io/app/courses/nx-workspaces/intro"
+          >
+            Nx video course
+          </a>
+        </li>
         <a
           className="resource flex"
           href="https://nx.dev/react/getting-started/what-is-nx"

--- a/packages/web/src/schematics/application/files/app/src/app/app.element.ts__tmpl__
+++ b/packages/web/src/schematics/application/files/app/src/app/app.element.ts__tmpl__
@@ -32,6 +32,14 @@ export class AppElement extends HTMLElement {
         <li class="col-span-2">
             <a
                     class="resource flex"
+                    href="https://connect.nrwl.io/app/courses/nx-workspaces/intro"
+            >
+                Nx video course
+            </a>
+        </li>
+        <li class="col-span-2">
+            <a
+                    class="resource flex"
                     href="https://nx.dev/angular/getting-started/what-is-nx"
             >
                 Nx video tutorial


### PR DESCRIPTION
Add nx video course link to the documentation and the different application schematic templates.