### PR TITLE
fix(testing): fix the verbose option type for jest

### DIFF
--- a/docs/angular/api-jest/builders/jest.md
+++ b/docs/angular/api-jest/builders/jest.md
@@ -190,7 +190,7 @@ Divert all output to stderr.
 
 ### verbose
 
-Type: `string`
+Type: `boolean`
 
 Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)
 

--- a/docs/react/api-jest/builders/jest.md
+++ b/docs/react/api-jest/builders/jest.md
@@ -191,7 +191,7 @@ Divert all output to stderr.
 
 ### verbose
 
-Type: `string`
+Type: `boolean`
 
 Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)
 

--- a/docs/web/api-jest/builders/jest.md
+++ b/docs/web/api-jest/builders/jest.md
@@ -191,7 +191,7 @@ Divert all output to stderr.
 
 ### verbose
 
-Type: `string`
+Type: `boolean`
 
 Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)
 

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -39,8 +39,8 @@ export interface JestBuilderOptions extends JsonObject {
   testPathPattern?: string;
   colors?: boolean;
   reporters?: string[];
-  verbose?: false;
-  coverage?: false;
+  verbose?: boolean;
+  coverage?: boolean;
   coverageReporters?: string;
   coverageDirectory?: string;
   testResultsProcessor?: string;

--- a/packages/jest/src/builders/jest/schema.json
+++ b/packages/jest/src/builders/jest/schema.json
@@ -101,7 +101,8 @@
       }
     },
     "verbose": {
-      "description": "Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)"
+      "description": "Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)",
+      "type": "boolean"
     },
     "coverage": {
       "description": "Indicates that test coverage information should be collected and reported in the output. This option is also aliased by --collectCoverage. (https://jestjs.io/docs/en/cli#coverage)",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

The verbose flag is currently untyped. Output is not always verbose.

![image](https://user-images.githubusercontent.com/8104246/65804041-90875e00-e14e-11e9-9cbb-a9b9ea1aa7ac.png)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The verbose flag is typed to boolean. Output is verbose.

![image](https://user-images.githubusercontent.com/8104246/65804071-a85ee200-e14e-11e9-978b-5000c6a5444a.png)


## Issue
