### PR TITLE
Issue 1059: tsJestConfig overriding jest.config.ts global ts-jest config

### DIFF
--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -277,7 +277,9 @@ describe('Jest Builder', () => {
     beforeAll(() => {
       jest.doMock(
         '/root/jest.config.js',
-        () => ({ globals: { hereToStay: true } }),
+        () => ({
+          globals: { hereToStay: true, 'ts-jest': { diagnostics: false } }
+        }),
         { virtual: true }
       );
     });
@@ -296,6 +298,7 @@ describe('Jest Builder', () => {
           globals: JSON.stringify({
             hereToStay: true,
             'ts-jest': {
+              diagnostics: false,
               tsConfig: '/root/tsconfig.test.json',
               stringifyContentPathRegex: '\\.(html|svg)$',
               astTransformers: [

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -76,7 +76,10 @@ function run(
   const jestConfig: { globals: any } = require(options.jestConfig);
   const globals = jestConfig.globals || {};
   Object.assign(globals, {
-    'ts-jest': tsJestConfig
+    'ts-jest': {
+      ...(globals['ts-jest'] || {}),
+      ...tsJestConfig
+    }
   });
 
   const config: any = {


### PR DESCRIPTION
fix(testing): merge rather than replace `ts-jest` property on global config
resolves #1059

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

Any globals specified in jest.config.js are overridden due to reassignment of the `ts-jest` property of the globals object. This is a brute force reassignment, rather than a merging of globals defined in jest.config.js and those brought in via angular.json config.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Globals in jest.config.js will be properly merged with config brought in via angular.json. Critically, this will allow `diagnostics` to be set to false, which seems to be the primary use case that people are running into issues with.

## Issue

1059 