### PR TITLE
fix(nx): increases buffer size for git commands

### DIFF
--- a/packages/workspace/src/builders/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.ts
@@ -1,11 +1,12 @@
 import {
-  createBuilder,
   BuilderContext,
-  BuilderOutput
+  BuilderOutput,
+  createBuilder
 } from '@angular-devkit/architect';
-import { Observable } from 'rxjs';
-import { exec } from 'child_process';
 import { JsonObject } from '@angular-devkit/core';
+import { exec } from 'child_process';
+import { Observable } from 'rxjs';
+import { TEN_MEGABYTES } from '../../command-line/shared';
 
 try {
   require('dotenv').config();
@@ -136,7 +137,6 @@ function createProcess(
 ): Promise<boolean> {
   command = transformCommand(command, parsedArgs);
   return new Promise(res => {
-    const TEN_MEGABYTES = 1024 * 10000;
     const childProcess = exec(command, { maxBuffer: TEN_MEGABYTES });
     /**
      * Ensure the child process is killed when the parent exits

--- a/packages/workspace/src/command-line/shared.ts
+++ b/packages/workspace/src/command-line/shared.ts
@@ -19,6 +19,8 @@ import { output } from './output';
 
 const ignore = require('ignore');
 
+export const TEN_MEGABYTES = 1024 * 10000;
+
 export type ImplicitDependencyEntry = { [key: string]: '*' | string[] };
 export type NormalizedImplicitDependencyEntry = { [key: string]: string[] };
 export type ImplicitDependencies = {
@@ -141,7 +143,9 @@ function getUntrackedFiles(): string[] {
 }
 
 function getFilesUsingBaseAndHead(base: string, head: string): string[] {
-  const mergeBase = execSync(`git merge-base ${base} ${head}`)
+  const mergeBase = execSync(`git merge-base ${base} ${head}`, {
+    maxBuffer: TEN_MEGABYTES
+  })
     .toString()
     .trim();
   return parseGitOutput(`git diff --name-only ${mergeBase} ${head}`);
@@ -152,7 +156,7 @@ function getFilesFromShash(sha1: string, sha2: string): string[] {
 }
 
 function parseGitOutput(command: string): string[] {
-  return execSync(command)
+  return execSync(command, { maxBuffer: TEN_MEGABYTES })
     .toString('utf-8')
     .split('\n')
     .map(a => a.trim())


### PR DESCRIPTION
increases buffer size to 10MB

## Current Behavior (This is the behavior we have today, before the PR is merged)
Git commands with large command line output will error out

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Handle command line output up to 10MB

## Issue
fix #1886