### PR TITLE
refactor(nx): refactor affected to produce affected metadata

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -1,10 +1,10 @@
-import { ProjectType } from '@nrwl/workspace/src/command-line/affected-apps';
 import { readDependencies } from '@nrwl/workspace/src/command-line/deps-calculator';
 import {
   getProjectNodes,
   normalizedProjectRoot,
   readNxJson,
-  readWorkspaceJson
+  readWorkspaceJson,
+  ProjectType
 } from '@nrwl/workspace/src/command-line/shared';
 import { appRootPath } from '@nrwl/workspace/src/utils/app-root';
 import {

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -1,7 +1,7 @@
 import {
   ProjectNode,
   ProjectType
-} from '@nrwl/workspace/src/command-line/affected-apps';
+} from '@nrwl/workspace/src/command-line/shared';
 import {
   Dependency,
   DependencyType

--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -1,9 +1,13 @@
 import { readFileSync, writeFileSync } from 'fs';
 import * as http from 'http';
 import * as opn from 'opn';
-import { ProjectNode } from './affected-apps';
 import { Deps, readDependencies } from './deps-calculator';
-import { getProjectNodes, readNxJson, readWorkspaceJson } from './shared';
+import {
+  getProjectNodes,
+  readNxJson,
+  readWorkspaceJson,
+  ProjectNode
+} from './shared';
 
 export function startServer(
   projects: ProjectNode[],

--- a/packages/workspace/src/command-line/deps-calculator.spec.ts
+++ b/packages/workspace/src/command-line/deps-calculator.spec.ts
@@ -6,7 +6,7 @@ import {
   NxDepsJson,
   dependencies
 } from './deps-calculator';
-import { ProjectType, ProjectNode } from './affected-apps';
+import { ProjectType, ProjectNode } from './shared';
 import { serializeJson } from '../utils/fileutils';
 
 describe('DepsCalculator', () => {

--- a/packages/workspace/src/command-line/deps-calculator.ts
+++ b/packages/workspace/src/command-line/deps-calculator.ts
@@ -5,9 +5,9 @@ import {
   normalizedProjectRoot,
   getProjectMTime,
   mtime,
-  lastModifiedAmongProjectFiles
+  lastModifiedAmongProjectFiles,
+  ProjectNode
 } from './shared';
-import { ProjectNode } from './affected-apps';
 import { mkdirSync, readFileSync } from 'fs';
 import {
   fileExists,

--- a/packages/workspace/src/command-line/shared.spec.ts
+++ b/packages/workspace/src/command-line/shared.spec.ts
@@ -1,10 +1,13 @@
 import {
-  getImplicitDependencies,
   assertWorkspaceValidity,
+  createAffectedMetadata,
+  getImplicitDependencies,
   getProjectNodes,
-  NxJson
+  NxJson,
+  ProjectNode,
+  ProjectType
 } from './shared';
-import { ProjectType, ProjectNode } from './affected-apps';
+import { DependencyType, Deps } from './deps-calculator';
 
 describe('assertWorkspaceValidity', () => {
   let mockNxJson;
@@ -421,5 +424,218 @@ describe('getProjectNodes', () => {
         architect: {}
       }
     ]);
+  });
+});
+
+describe('createAffectedMetadata', () => {
+  let projectNodes: Partial<ProjectNode>[];
+  let dependencies: Deps;
+
+  beforeEach(() => {
+    projectNodes = [
+      {
+        name: 'app1'
+      },
+      {
+        name: 'app2'
+      },
+      {
+        name: 'app1-e2e'
+      },
+      {
+        name: 'customName-e2e'
+      },
+      {
+        name: 'lib1'
+      },
+      {
+        name: 'lib2'
+      }
+    ];
+    dependencies = {
+      'app1-e2e': [
+        {
+          projectName: 'app1',
+          type: DependencyType.implicit
+        }
+      ],
+      'customName-e2e': [
+        {
+          projectName: 'app2',
+          type: DependencyType.implicit
+        }
+      ],
+      app1: [
+        {
+          projectName: 'lib1',
+          type: DependencyType.es6Import
+        }
+      ],
+      app2: [
+        {
+          projectName: 'lib1',
+          type: DependencyType.es6Import
+        },
+        {
+          projectName: 'lib2',
+          type: DependencyType.es6Import
+        }
+      ],
+      lib1: [],
+      lib2: []
+    };
+  });
+
+  it('should translate project nodes array to map', () => {
+    expect(
+      createAffectedMetadata(projectNodes as ProjectNode[], dependencies, [])
+        .dependencyGraph.projects
+    ).toEqual({
+      app1: {
+        name: 'app1'
+      },
+      app2: {
+        name: 'app2'
+      },
+      'app1-e2e': {
+        name: 'app1-e2e'
+      },
+      'customName-e2e': {
+        name: 'customName-e2e'
+      },
+      lib1: {
+        name: 'lib1'
+      },
+      lib2: {
+        name: 'lib2'
+      }
+    });
+  });
+
+  it('should include the dependencies', () => {
+    expect(
+      createAffectedMetadata(projectNodes as ProjectNode[], dependencies, [])
+        .dependencyGraph.dependencies
+    ).toEqual(dependencies);
+  });
+
+  it('should find the roots', () => {
+    expect(
+      createAffectedMetadata(projectNodes as ProjectNode[], dependencies, [])
+        .dependencyGraph.roots
+    ).toEqual(['app1-e2e', 'customName-e2e']);
+  });
+
+  it('should set projects as touched', () => {
+    const { projectStates } = createAffectedMetadata(
+      projectNodes as ProjectNode[],
+      dependencies,
+      ['app1', 'lib2']
+    );
+    expect(projectStates.app1.touched).toEqual(true);
+    expect(projectStates.lib2.touched).toEqual(true);
+
+    expect(projectStates.lib1.touched).toEqual(false);
+    expect(projectStates.app2.touched).toEqual(false);
+    expect(projectStates['customName-e2e'].touched).toEqual(false);
+    expect(projectStates['app1-e2e'].touched).toEqual(false);
+  });
+
+  it('should set touched projects as affected', () => {
+    const { projectStates } = createAffectedMetadata(
+      projectNodes as ProjectNode[],
+      dependencies,
+      ['app1', 'lib2']
+    );
+    expect(projectStates.app1.affected).toEqual(true);
+    expect(projectStates.lib2.affected).toEqual(true);
+  });
+
+  it('should set dependents of touched projects as affected', () => {
+    const { projectStates } = createAffectedMetadata(
+      projectNodes as ProjectNode[],
+      dependencies,
+      ['app1']
+    );
+    expect(projectStates.app1.affected).toEqual(true);
+    expect(projectStates['app1-e2e'].affected).toEqual(true);
+
+    expect(projectStates.lib1.affected).toEqual(false);
+    expect(projectStates.lib2.affected).toEqual(false);
+    expect(projectStates.app2.affected).toEqual(false);
+    expect(projectStates['customName-e2e'].affected).toEqual(false);
+  });
+
+  it('should set dependents of touched projects as affected (2)', () => {
+    const { projectStates } = createAffectedMetadata(
+      projectNodes as ProjectNode[],
+      dependencies,
+      ['lib1']
+    );
+    expect(projectStates.app1.affected).toEqual(true);
+    expect(projectStates['app1-e2e'].affected).toEqual(true);
+    expect(projectStates.lib1.affected).toEqual(true);
+    expect(projectStates.app2.affected).toEqual(true);
+    expect(projectStates['customName-e2e'].affected).toEqual(true);
+
+    expect(projectStates.lib2.affected).toEqual(false);
+  });
+
+  it('should not set any projects as affected when none are touched', () => {
+    const { projectStates } = createAffectedMetadata(
+      projectNodes as ProjectNode[],
+      dependencies,
+      []
+    );
+    expect(projectStates.app1.affected).toEqual(false);
+    expect(projectStates.app2.affected).toEqual(false);
+    expect(projectStates.lib1.affected).toEqual(false);
+    expect(projectStates.lib2.affected).toEqual(false);
+    expect(projectStates['app1-e2e'].affected).toEqual(false);
+    expect(projectStates['customName-e2e'].affected).toEqual(false);
+  });
+
+  it('should handle circular dependencies', () => {
+    dependencies['lib2'].push({
+      projectName: 'app2',
+      type: DependencyType.es6Import
+    });
+    const metadata = createAffectedMetadata(
+      projectNodes as ProjectNode[],
+      dependencies,
+      ['lib2']
+    );
+    const { dependencyGraph, projectStates } = metadata;
+    expect(dependencyGraph.roots).toEqual(['app1-e2e', 'customName-e2e']);
+    expect(projectStates.app1.affected).toEqual(false);
+    expect(projectStates.app2.affected).toEqual(true);
+    expect(projectStates.lib1.affected).toEqual(false);
+    expect(projectStates.lib2.affected).toEqual(true);
+    expect(projectStates['app1-e2e'].affected).toEqual(false);
+    expect(projectStates['customName-e2e'].affected).toEqual(true);
+  });
+
+  it('should cases where there is no root', () => {
+    dependencies['lib1'].push({
+      projectName: 'app1-e2e',
+      type: DependencyType.es6Import
+    });
+    dependencies['lib2'].push({
+      projectName: 'customName-e2e',
+      type: DependencyType.es6Import
+    });
+    const metadata = createAffectedMetadata(
+      projectNodes as ProjectNode[],
+      dependencies,
+      ['app1-e2e', 'customName-e2e']
+    );
+    const { dependencyGraph, projectStates } = metadata;
+    expect(dependencyGraph.roots).toEqual([]);
+    expect(projectStates.app1.affected).toEqual(true);
+    expect(projectStates.app2.affected).toEqual(true);
+    expect(projectStates.lib1.affected).toEqual(true);
+    expect(projectStates.lib2.affected).toEqual(true);
+    expect(projectStates['app1-e2e'].affected).toEqual(true);
+    expect(projectStates['customName-e2e'].affected).toEqual(true);
   });
 });

--- a/packages/workspace/src/command-line/touched.spec.ts
+++ b/packages/workspace/src/command-line/touched.spec.ts
@@ -1,5 +1,5 @@
 import { touchedProjects } from './touched';
-import { ProjectType } from './affected-apps';
+import { ProjectType } from './shared';
 
 describe('touchedProjects', () => {
   it('should return the list of touchedProjects', () => {

--- a/packages/workspace/src/command-line/touched.ts
+++ b/packages/workspace/src/command-line/touched.ts
@@ -3,9 +3,9 @@ import {
   readWorkspaceJson,
   getProjectNodes,
   readNxJson,
-  getImplicitDependencies
+  getImplicitDependencies,
+  ProjectNode
 } from './shared';
-import { ProjectNode } from './affected-apps';
 
 export function touchedProjects(
   implicitDependencies: ImplicitDependencies,

--- a/packages/workspace/src/command-line/workspace-integrity-checks.spec.ts
+++ b/packages/workspace/src/command-line/workspace-integrity-checks.spec.ts
@@ -1,5 +1,5 @@
 import { WorkspaceIntegrityChecks } from './workspace-integrity-checks';
-import { ProjectType } from './affected-apps';
+import { ProjectType } from './shared';
 import chalk from 'chalk';
 
 describe('WorkspaceIntegrityChecks', () => {

--- a/packages/workspace/src/command-line/workspace-integrity-checks.ts
+++ b/packages/workspace/src/command-line/workspace-integrity-checks.ts
@@ -1,6 +1,5 @@
-import { ProjectNode } from './affected-apps';
 import { output, CLIErrorMessageConfig } from './output';
-import { workspaceFileName } from './shared';
+import { workspaceFileName, ProjectNode } from './shared';
 
 export class WorkspaceIntegrityChecks {
   constructor(private projectNodes: ProjectNode[], private files: string[]) {}

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -3,7 +3,7 @@ import * as ts from 'typescript';
 import * as fs from 'fs';
 
 import { Rule } from './nxEnforceModuleBoundariesRule';
-import { ProjectNode, ProjectType } from '../command-line/affected-apps';
+import { ProjectNode, ProjectType } from '../command-line/shared';
 import { DependencyType, Dependency } from '../command-line/deps-calculator';
 
 describe('Enforce Module Boundaries', () => {

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -1,13 +1,14 @@
 import * as Lint from 'tslint';
 import { IOptions } from 'tslint';
 import * as ts from 'typescript';
-import { ProjectNode, ProjectType } from '../command-line/affected-apps';
 import { readDependencies } from '../command-line/deps-calculator';
 import {
   getProjectNodes,
   normalizedProjectRoot,
   readNxJson,
-  readWorkspaceJson
+  readWorkspaceJson,
+  ProjectNode,
+  ProjectType
 } from '../command-line/shared';
 import { appRootPath } from '../utils/app-root';
 import {

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
-import { ProjectNode } from '../command-line/affected-apps';
 import { Dependency, DependencyType } from '../command-line/deps-calculator';
-import { normalizedProjectRoot } from '../command-line/shared';
+import { normalizedProjectRoot, ProjectNode } from '../command-line/shared';
 import { normalize } from '@angular-devkit/core';
 
 export type Deps = { [projectName: string]: Dependency[] };


### PR DESCRIPTION
##  Current Behavior (This is the behavior we have today, before the PR is merged)

Affected returns a `string[]` which does not give much info.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Affected returns an object which looks like the following:
https://github.com/nrwl/nx/pull/1913/files#diff-bdc063aab24bdf652e033fe0c4e9a8e4R70