### PR TITLE
fix(angular): correctly add provider to module if last element was ob…

### DIFF
--- a/packages/angular/src/utils/ast-utils.spec.ts
+++ b/packages/angular/src/utils/ast-utils.spec.ts
@@ -1,0 +1,112 @@
+import { InsertChange } from '@nrwl/workspace/src/utils/ast-utils';
+import { createSourceFile, ScriptTarget } from 'typescript';
+import { addProviderToModule } from './ast-utils';
+
+describe('ast-utils', () => {
+  describe('_addSymbolToNgModuleMetadata', () => {
+    const moduleImport = `import { NgModule } from '@angular/core';`;
+    const fileName = 'app.module.ts';
+    const createTemplate = (content: string, close: string) => ({
+      start: content.length,
+      text: content + close
+    });
+    const createStockModule = (content: string) =>
+      createSourceFile(fileName, content, ScriptTarget.Latest, true);
+
+    it('should add provider to module without existing providers', () => {
+      const toAdd = 'MyProvider';
+
+      const { start, text } = createTemplate(
+        moduleImport + '@NgModule({',
+        '})'
+      );
+      const source = createStockModule(text);
+      const change = addProviderToModule(source, fileName, toAdd);
+      const expectedChange = [
+        new InsertChange(fileName, start, `  providers: [${toAdd}]\n`)
+      ];
+
+      expect(change).toEqual(expectedChange);
+    });
+
+    it('should add provider to module with existing empty providers', () => {
+      const toAdd = 'MyProvider';
+
+      const { start, text } = createTemplate(
+        moduleImport + '@NgModule({providers:[',
+        ']})'
+      );
+      const source = createStockModule(text);
+      const change = addProviderToModule(source, fileName, toAdd);
+      const expectedChange = [new InsertChange(fileName, start, toAdd)];
+
+      expect(change).toEqual(expectedChange);
+    });
+
+    it('should add provider to module with existing providers', () => {
+      const toAdd = 'MyProvider';
+
+      let template = createTemplate(
+        moduleImport + '@NgModule({providers:[ProviderOne,ProviderTwo',
+        ']})'
+      );
+      let source = createStockModule(template.text);
+      let change = addProviderToModule(source, fileName, toAdd);
+      let expectedChange = [
+        new InsertChange(fileName, template.start, `, ${toAdd}`)
+      ];
+
+      expect(change).toEqual(expectedChange);
+
+      template = createTemplate(
+        moduleImport +
+          '@NgModule({providers:[{provide:MyClass,useExisting:MyExistingClass}',
+        ']})'
+      );
+      source = createStockModule(template.text);
+      change = addProviderToModule(source, fileName, toAdd);
+      expectedChange = [
+        new InsertChange(fileName, template.start, `, ${toAdd}`)
+      ];
+
+      expect(change).toEqual(expectedChange);
+
+      template = createTemplate(
+        moduleImport + '@NgModule({providers:[someCondition ? MyProvider : []',
+        ']})'
+      );
+      source = createStockModule(template.text);
+      change = addProviderToModule(source, fileName, toAdd);
+      expectedChange = [
+        new InsertChange(fileName, template.start, `, ${toAdd}`)
+      ];
+
+      expect(change).toEqual(expectedChange);
+
+      template = createTemplate(
+        moduleImport +
+          '@NgModule({providers:[[NestedProvider1, NestedProvider2]',
+        ']})'
+      );
+      source = createStockModule(template.text);
+      change = addProviderToModule(source, fileName, toAdd);
+      expectedChange = [
+        new InsertChange(fileName, template.start, `, ${toAdd}`)
+      ];
+
+      expect(change).toEqual(expectedChange);
+
+      template = createTemplate(
+        moduleImport + '@NgModule({providers:[...ExistingProviders',
+        ']})'
+      );
+      source = createStockModule(template.text);
+      change = addProviderToModule(source, fileName, toAdd);
+      expectedChange = [
+        new InsertChange(fileName, template.start, `, ${toAdd}`)
+      ];
+
+      expect(change).toEqual(expectedChange);
+    });
+  });
+});

--- a/packages/angular/src/utils/ast-utils.ts
+++ b/packages/angular/src/utils/ast-utils.ts
@@ -216,7 +216,8 @@ function _addSymbolToNgModuleMetadata(
     return [];
   }
 
-  if (Array.isArray(node)) {
+  const isArray = Array.isArray(node);
+  if (isArray) {
     const nodeArray = (node as {}) as Array<ts.Node>;
     const symbolsArray = nodeArray.map(node => node.getText());
     if (symbolsArray.includes(expression)) {
@@ -228,7 +229,7 @@ function _addSymbolToNgModuleMetadata(
 
   let toInsert: string;
   let position = node.getEnd();
-  if (node.kind == ts.SyntaxKind.ObjectLiteralExpression) {
+  if (!isArray && node.kind == ts.SyntaxKind.ObjectLiteralExpression) {
     // We haven't found the field in the metadata declaration. Insert a new
     // field.
     const expr = node as ts.ObjectLiteralExpression;
@@ -248,7 +249,7 @@ function _addSymbolToNgModuleMetadata(
         toInsert = `, ${metadataField}: [${expression}]`;
       }
     }
-  } else if (node.kind == ts.SyntaxKind.ArrayLiteralExpression) {
+  } else if (!isArray && node.kind == ts.SyntaxKind.ArrayLiteralExpression) {
     // We found the field but it's empty. Insert it just before the `]`.
     position--;
     toInsert = `${expression}`;


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Using `addProviderToModule` with an existing list of providers and the last element being an object would incorrectly add the provider to the object. For example:
```
// An existing module
providers: [
  {
     provide: REDUCER_TOKEN,
     useFactory: getReducers,
  }
]
```
Using `insert(tree, modulePath, addProviderToModule(source, modulePath, 'MyProvider'))` in a schematic would produce:
```
providers: [
  {
      provide: REDUCER_TOKEN,
      useFactory: getReducers,
      providers: [MyProvider],
   }
]
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The provider will be added correctly like so:
```
providers: [
  {
      provide: REDUCER_TOKEN,
      useFactory: getReducers,
   },
  MyProvider
]
```
