### PR TITLE
Fix: ng add @nrwl/angular fails

### DIFF
--- a/packages/angular/collection.json
+++ b/packages/angular/collection.json
@@ -7,7 +7,7 @@
       "factory": "./src/schematics/init/init",
       "schema": "./src/schematics/init/schema.json",
       "description": "Initialize the @nrwl/angular plugin",
-      "aliaes": ["ng-add"],
+      "aliases": ["ng-add"],
       "hidden": true
     },
 


### PR DESCRIPTION
I love using Nx, but this is my first time looking behind the curtains, so hopefully I've done the right stuff here.  I was trying to create a new Nx workspace tonight, and noticed that running `ng add @nrwl/angular` fails and leaves the workspace in a bad state.

## Current Behavior

Running `ng add @nrwl/angular` installs the packages, but then errors out with `Cannot read property 'replace' of undefined`.  `angular.json` and `package.json` aren't updated as they should be.

Repro:

```
brianmcd@workdesktop:~/scratch$ yarn create nx-workspace example

... select an empty, Angular CLI project

brianmcd@workdesktop:~/scratch/example$ ng add @nrwl/angular
Installing packages for tooling via yarn.
yarn add v1.19.0
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.9: The platform "linux" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
warning "@nrwl/angular > jasmine-marbles@0.6.0" has unmet peer dependency "rxjs@^6.4.0".
warning "@nrwl/angular > @nrwl/cypress > fork-ts-checker-webpack-plugin@0.4.15" has unmet peer dependency "webpack@^2.3.0 || ^3.0.0 || ^4.0.0".
warning "@nrwl/angular > @nrwl/cypress > @cypress/webpack-preprocessor@4.1.0" has unmet peer dependency "webpack@^4.18.1".
warning "@nrwl/angular > @nrwl/cypress > @cypress/webpack-preprocessor > babel-loader@8.0.6" has unmet peer dependency "webpack@>=2".
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 145 new dependencies.
info Direct dependencies
└─ @nrwl/angular@8.6.0
info All dependencies
├─ @babel/core@7.6.2
├─ @babel/helper-builder-binary-assignment-operator-visitor@7.1.0
├─ @babel/helper-call-delegate@7.4.4
├─ @babel/helper-define-map@7.5.5

...cut out for brevity

├─ unicode-match-property-value-ecmascript@1.1.0
├─ unicode-property-aliases-ecmascript@1.0.5
├─ union-value@1.0.1
├─ unset-value@1.0.0
├─ upath@1.2.0
├─ urix@0.1.0
├─ use@3.1.1
└─ webpack-node-externals@1.7.2
Done in 3.33s.
Installed packages for tooling via yarn.
Cannot read property 'replace' of undefined
```

At this point, the workspace is not in a good state.

`angular.json` looks like this:

```json
{
  "version": 1,
  "projects": {},
  "cli": {
    "defaultCollection": "@nrwl/workspace"
  }
}
```

`package.json` is missing the Angular dependencies.

## Expected Behavior

It should succeed.