### PR TITLE
fix(web): use legacy decorators so they work with TypeScript.

### DIFF
--- a/packages/web/src/utils/babel-config.ts
+++ b/packages/web/src/utils/babel-config.ts
@@ -28,12 +28,12 @@ export function createBabelConfig(
     ],
     plugins: [
       require.resolve('babel-plugin-macros'),
+      // Must use legacy decorators to remain compatible with TypeScript.
+      [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
       [
-        // Allows decorators to be before export since it is consistent with TypeScript syntax.
-        require.resolve('@babel/plugin-proposal-decorators'),
-        { decoratorsBeforeExport: true }
-      ],
-      [require.resolve('@babel/plugin-proposal-class-properties')]
+        require.resolve('@babel/plugin-proposal-class-properties'),
+        { loose: true }
+      ]
     ]
   };
 }


### PR DESCRIPTION
Closes #1908

## Current Behavior (This is the behavior we have today, before the PR is merged)

Decorators use ES proposal syntax as opposed to TS syntax.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

TS decorators should work.


