### PR TITLE
Builder missing a hyphen

### DIFF
--- a/docs/angular/guides/nx7-to-nx8.md
+++ b/docs/angular/guides/nx7-to-nx8.md
@@ -73,7 +73,7 @@ All Web schematics such as `app` and `lib` have been moved to `@nrwl/web` which 
 The builders for building and serving Web apps has been moved to `@nrwl/web` and can be specified as follows:
 
 - `@nrwl/builders:web-build` is now `@nrwl/web:build`
-- `@nrwl/builders:web-dev-server` is now `@nrwl/web:devserver`
+- `@nrwl/builders:web-dev-server` is now `@nrwl/web:dev-server`
 
 ### Nest
 


### PR DESCRIPTION
"builder": "@nrwl/web:dev-server" is generated in the workspace.json in a create-nx-workspace app