### PR TITLE
chore(nx): bump nestjs version

### DIFF
--- a/packages/nest/migrations.json
+++ b/packages/nest/migrations.json
@@ -1,3 +1,38 @@
 {
-  "schematics": {}
+  "schematics": {},
+  "packageJsonUpdates": {
+    "8.7.0": {
+      "version": "8.7.0-beta.1",
+      "packages": {
+        "@nrwl/nest": {
+          "version": "8.7.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@nestjs/common": {
+          "version": "^6.8.3",
+          "alwaysAddToPackageJson": false
+        },
+        "@nestjs/core": {
+          "version": "^6.8.3",
+          "alwaysAddToPackageJson": false
+        },
+        "@nestjs/platform-express": {
+          "version": "^6.8.3",
+          "alwaysAddToPackageJson": false
+        },
+        "@nestjs/schematics": {
+          "version": "^6.7.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@nestjs/testing": {
+          "version": "^6.8.3",
+          "alwaysAddToPackageJson": false
+        },
+        "reflect-metadata": {
+          "version": "^0.1.13",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    }
+  }
 }

--- a/packages/nest/src/utils/versions.ts
+++ b/packages/nest/src/utils/versions.ts
@@ -1,6 +1,6 @@
 export const nxVersion = '*';
 
-export const nestJsVersion = '^6.2.4';
-export const nestJsSchematicsVersion = '^6.3.0';
+export const nestJsVersion = '^6.8.3';
+export const nestJsSchematicsVersion = '^6.7.0';
 
-export const reflectMetadataVersion = '^0.1.12';
+export const reflectMetadataVersion = '^0.1.13';


### PR DESCRIPTION
Bumping the current NestJS dependency versions to `6.8.3`.