### PR TITLE
fix(nx): validate target and configuration in @nrwl/tao/run...

### DIFF
--- a/e2e/report.test.ts
+++ b/e2e/report.test.ts
@@ -1,32 +1,20 @@
 import { packagesWeCareAbout } from '@nrwl/workspace/src/command-line/report';
-import { ensureProject, forEachCli, runCLI } from './utils';
+import { ensureProject, forEachCli, runCommand } from './utils';
 
 const testTimeout = 120000;
 
-forEachCli('nx', () => {
+forEachCli(() => {
   describe('report', () => {
     it(
       `should report package versions`,
       async () => {
         ensureProject();
 
-        const reportOutput = runCLI('report');
+        const reportOutput = runCommand('npm run nx report');
 
         packagesWeCareAbout.forEach(p => {
           expect(reportOutput).toContain(p);
         });
-      },
-      testTimeout
-    );
-  });
-});
-
-forEachCli('angular', () => {
-  describe('report', () => {
-    it(
-      `shouldn't do anything at all`,
-      async () => {
-        // report is an Nx only command
       },
       testTimeout
     );

--- a/packages/tao/index.ts
+++ b/packages/tao/index.ts
@@ -49,12 +49,18 @@ export async function invokeCommand(
     case 'help':
     case '--help':
       return (await import('./src/commands/help')).help();
+
     default:
-      const projectName = commandArgs[0] ? commandArgs[0] : '';
+      const projectNameIncluded =
+        commandArgs[0] && !commandArgs[0].startsWith('-');
+      const projectName = projectNameIncluded ? commandArgs[0] : '';
       // this is to make `tao test mylib` same as `tao run mylib:test`
       return (await import('./src/commands/run')).run(
         root,
-        [`${projectName}:${command}`, ...commandArgs.slice(1)],
+        [
+          `${projectName}:${command}`,
+          ...(projectNameIncluded ? commandArgs.slice(1) : commandArgs)
+        ],
         isVerbose
       );
   }


### PR DESCRIPTION
…and provide better errors

e.g.

![image](https://user-images.githubusercontent.com/439121/66647414-bddd0d00-ec20-11e9-9132-cdf477ebede4.png)

Not sure if I need to provide an e2e test for this. It's a pretty small change. I'm also not sure *how* to e2e test this without arbitrarily testing another package like `@nrwl/react`
