### PR TITLE
fix(nx): handle adding @nrwl/workspace to projects with camel case names

### DIFF
--- a/packages/workspace/src/schematics/init/init.ts
+++ b/packages/workspace/src/schematics/init/init.ts
@@ -545,7 +545,6 @@ function addInstallTask(options: Schema) {
 export default function(schema: Schema): Rule {
   const options = {
     ...schema,
-    name: toFileName(schema.name),
     npmScope: toFileName(schema.npmScope || schema.name)
   };
   const templateSource = apply(url('./files'), [


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Adding `@nrwl/workspace` to projects with names such as `myFunkyName` result in an error.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Adding `@nrwl/workspace` to projects with names such as `myFunkyName` succeeds.

## Issue
Fixes #1463 