### PR TITLE
fix(nx): fix affected logic for app tsconfigs

### DIFF
--- a/packages/workspace/src/command-line/shared.ts
+++ b/packages/workspace/src/command-line/shared.ts
@@ -173,7 +173,7 @@ export function parseFiles(options: YargsAffectedOptions): { files: string[] } {
 }
 
 function getUncommittedFiles(): string[] {
-  return parseGitOutput(`git diff --name-only HEAD .`);
+  return parseGitOutput(`git diff --name-only --relative HEAD .`);
 }
 
 function getUntrackedFiles(): string[] {
@@ -186,11 +186,11 @@ function getFilesUsingBaseAndHead(base: string, head: string): string[] {
   })
     .toString()
     .trim();
-  return parseGitOutput(`git diff --name-only ${mergeBase} ${head}`);
+  return parseGitOutput(`git diff --name-only --relative ${mergeBase} ${head}`);
 }
 
 function getFilesFromShash(sha1: string, sha2: string): string[] {
-  return parseGitOutput(`git diff --name-only ${sha1} ${sha2}`);
+  return parseGitOutput(`git diff --name-only --relative ${sha1} ${sha2}`);
 }
 
 function parseGitOutput(command: string): string[] {

--- a/packages/workspace/src/command-line/touched.spec.ts
+++ b/packages/workspace/src/command-line/touched.spec.ts
@@ -78,9 +78,9 @@ describe('touchedProjects', () => {
         {
           name: 'app1Name',
           root: 'apps/app1',
-          files: ['app1.ts'],
+          files: ['apps/app1/app1.ts'],
           fileMTimes: {
-            'app1.ts': 1
+            'apps/app1/app1.ts': 1
           },
           tags: [],
           implicitDependencies: [],
@@ -90,9 +90,9 @@ describe('touchedProjects', () => {
         {
           name: 'app2Name',
           root: 'apps/app2',
-          files: ['app2.ts'],
+          files: ['apps/app2/app2.ts'],
           fileMTimes: {
-            'app2.ts': 1
+            'apps/app2/app2.ts': 1
           },
           tags: [],
           implicitDependencies: [],
@@ -102,9 +102,9 @@ describe('touchedProjects', () => {
         {
           name: 'lib1Name',
           root: 'libs/lib1',
-          files: ['lib1.ts'],
+          files: ['libs/lib1/lib1.ts'],
           fileMTimes: {
-            'lib1.ts': 1
+            'libs/lib1/lib1.ts': 1
           },
           tags: [],
           implicitDependencies: [],
@@ -114,9 +114,9 @@ describe('touchedProjects', () => {
         {
           name: 'lib2Name',
           root: 'libs/lib2',
-          files: ['lib2.ts'],
+          files: ['libs/lib2/lib2.ts'],
           fileMTimes: {
-            'lib2.ts': 1
+            'libs/lib2/lib2.ts': 1
           },
           tags: [],
           implicitDependencies: [],
@@ -124,7 +124,7 @@ describe('touchedProjects', () => {
           type: ProjectType.lib
         }
       ],
-      ['gitrepo/some/path/inside/nx/libs/lib2/lib2.ts', 'apps/app2/app2.ts']
+      ['libs/lib2/lib2.ts', 'apps/app2/app2.ts']
     );
 
     expect(tp).toEqual(['app2Name', 'lib2Name']);
@@ -254,7 +254,7 @@ describe('touchedProjects', () => {
           type: ProjectType.lib
         }
       ],
-      ['gitrepo/some/path/Jenkinsfile']
+      ['Jenkinsfile']
     );
 
     expect(tp).toEqual(['app1Name', 'app2Name']);

--- a/packages/workspace/src/command-line/touched.ts
+++ b/packages/workspace/src/command-line/touched.ts
@@ -1,3 +1,5 @@
+import { join } from 'path';
+
 import {
   ImplicitDependencies,
   readWorkspaceJson,
@@ -6,6 +8,7 @@ import {
   getImplicitDependencies,
   ProjectNode
 } from './shared';
+import { appRootPath } from '../utils/app-root';
 
 export function touchedProjects(
   implicitDependencies: ImplicitDependencies,
@@ -40,7 +43,7 @@ function implicitlyTouchedProjects(
   return Array.from(
     Object.entries(implicitDependencies.files).reduce(
       (projectSet, [file, projectNames]) => {
-        if (touchedFiles.find(tf => tf.endsWith(file))) {
+        if (touchedFiles.find(tf => tf === file)) {
           projectNames.forEach(projectName => {
             projectSet.add(projectName);
           });
@@ -59,9 +62,7 @@ function directlyTouchedProjects(
   return projects
     .filter(project => {
       return touchedFiles.some(file => {
-        return project.files.some(projectFile => {
-          return file.endsWith(projectFile);
-        });
+        return project.files.some(projectFile => projectFile === file);
       });
     })
     .map(project => project.name);


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Touching `apps/app1/tsconfig.json` makes it seem like `/tsconfig.json` was touched and affects everything.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Touching `apps/app1/tsconfig.json` affects only `app1`.

## Issue
Fixes https://github.com/nrwl/nx/issues/985