### PR TITLE
fix(command-line): update dep-graph render logic to show full graph

### DIFF
--- a/packages/workspace/src/command-line/dep-graph/dep-graph.html
+++ b/packages/workspace/src/command-line/dep-graph/dep-graph.html
@@ -146,9 +146,11 @@
 
     render(d3.select('svg g'), g);
 
+    svg.attr('height', g.graph().height + 40);
+    svg.attr('width', g.graph().width + 100);
+
     var xCenterOffset = (svg.attr('width') - g.graph().width) / 2;
     svgGroup.attr('transform', 'translate(' + xCenterOffset + ', 20)');
-    svg.attr('height', g.graph().height + 40);
   }
 </script>
 <form onsubmit="return window.filter()">


### PR DESCRIPTION
adds width attribute to svg on render call based on graph size

fix #1938

## Current Behavior (This is the behavior we have today, before the PR is merged)
The dependency graph cuts off at 1024px and doesn't show the full dependency graph. This is because the width isn't calculated from the graph to update to svg attribute like how height is. 
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
This PR updates the width calculation to happen on render() calls whilst moving the xCenterOffset calculation to happen below this new width calculation. Now the dependency graph can be seen in full and have the offset correctly calculated. 
## Issue 
#1938 