### PR TITLE
fix(nx): update dep-graph render logic to show full graph

### DIFF
--- a/packages/workspace/src/command-line/dep-graph/dep-graph.html
+++ b/packages/workspace/src/command-line/dep-graph/dep-graph.html
@@ -146,9 +146,11 @@
 
     render(d3.select('svg g'), g);
 
+    svg.attr('height', g.graph().height + 40);
+    svg.attr('width', g.graph().width + 100);
+
     var xCenterOffset = (svg.attr('width') - g.graph().width) / 2;
     svgGroup.attr('transform', 'translate(' + xCenterOffset + ', 20)');
-    svg.attr('height', g.graph().height + 40);
   }
 </script>
 <form onsubmit="return window.filter()">


### PR DESCRIPTION
adds width attribute to svg on render call based on graph size

fix #1938

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
Dependency currently does not take into account graph size for width and uses the hard coded 1024 default size. 
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Svg should adjust size based on the graph size 
## Issue

#1938 