### PR TITLE
fix(nx): add support for regexp in `allow` option of enforce-module-boundaries lint rule

### DIFF
--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -644,6 +644,43 @@ describe('Enforce Module Boundaries', () => {
     expect(failures.length).toEqual(1);
   });
 
+  it('should respect regexp in allow option', () => {
+    const failures = runRule(
+      { allow: ['^.*/utils/.*$'] },
+      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
+      `
+      import "../../utils/a";
+      `,
+      [
+        {
+          name: 'mylibName',
+          root: 'libs/mylib',
+          type: ProjectType.lib,
+          tags: [],
+          implicitDependencies: [],
+          architect: {},
+          files: [`libs/mylib/src/main.ts`],
+          fileMTimes: {
+            'libs/mylib/src/main.ts': 1
+          }
+        },
+        {
+          name: 'utils',
+          root: 'libs/utils',
+          type: ProjectType.lib,
+          tags: [],
+          implicitDependencies: [],
+          architect: {},
+          files: [`libs/utils/a.ts`],
+          fileMTimes: {
+            'libs/utils/a.ts': 1
+          }
+        }
+      ]
+    );
+    expect(failures.length).toEqual(0);
+  });
+
   it('should error on importing a lazy-loaded library', () => {
     const failures = runRule(
       {},

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -637,6 +637,43 @@ describe('Enforce Module Boundaries', () => {
     expect(failures.length).toEqual(1);
   });
 
+  it('should respect regexp in allow option', () => {
+    const failures = runRule(
+      { allow: ['^.*/utils/.*$'] },
+      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
+      `
+      import "../../utils/a";
+      `,
+      [
+        {
+          name: 'mylibName',
+          root: 'libs/mylib',
+          type: ProjectType.lib,
+          tags: [],
+          implicitDependencies: [],
+          architect: {},
+          files: [`libs/mylib/src/main.ts`],
+          fileMTimes: {
+            'libs/mylib/src/main.ts': 1
+          }
+        },
+        {
+          name: 'utils',
+          root: 'libs/utils',
+          type: ProjectType.lib,
+          tags: [],
+          implicitDependencies: [],
+          architect: {},
+          files: [`libs/utils/a.ts`],
+          fileMTimes: {
+            'libs/utils/a.ts': 1
+          }
+        }
+      ]
+    );
+    expect(failures.length).toEqual(0);
+  });
+
   it('should error on importing a lazy-loaded library', () => {
     const failures = runRule(
       {},

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -56,7 +56,7 @@ export function matchImportWithWildcard(
       extractedImport.startsWith(prefix) && extractedImport.endsWith(suffix)
     );
   } else {
-    return extractedImport === allowableImport;
+    return new RegExp(allowableImport).test(extractedImport);
   }
 }
 


### PR DESCRIPTION
We previously support regexp (to some extent) in the `allow` option of the enforce boundaries lint rule. This was changed when we fixed deep imports, so this PR adds the regpexp support back.

Closes #1943
