### PR TITLE
feat(web): enable devserver allowed hosts option

### DIFF
--- a/docs/angular/api-web/builders/dev-server.md
+++ b/docs/angular/api-web/builders/dev-server.md
@@ -6,6 +6,14 @@ Builder properties can be configured in angular.json when defining the builder, 
 
 ## Properties
 
+### allowedHosts
+
+Type: `string`
+
+Possible values: `host.com,host2.com`, `.host.com`
+
+This option allows you to whitelist services that are allowed to access the dev server.
+
 ### buildTarget
 
 Type: `string`

--- a/docs/react/api-web/builders/dev-server.md
+++ b/docs/react/api-web/builders/dev-server.md
@@ -7,6 +7,14 @@ Read more about how to use builders and the CLI here: https://nx.dev/react/guide
 
 ## Properties
 
+### allowedHosts
+
+Type: `string`
+
+Possible values: `host.com,host2.com`, `.host.com`
+
+This option allows you to whitelist services that are allowed to access the dev server.
+
 ### buildTarget
 
 Type: `string`

--- a/docs/web/api-web/builders/dev-server.md
+++ b/docs/web/api-web/builders/dev-server.md
@@ -7,6 +7,14 @@ Read more about how to use builders and the CLI here: https://nx.dev/web/guides/
 
 ## Properties
 
+### allowedHosts
+
+Type: `string`
+
+Possible values: `host.com,host2.com`, `.host.com`
+
+This option allows you to whitelist services that are allowed to access the dev server.
+
 ### buildTarget
 
 Type: `string`

--- a/packages/web/src/builders/dev-server/dev-server.impl.ts
+++ b/packages/web/src/builders/dev-server/dev-server.impl.ts
@@ -34,6 +34,7 @@ export interface WebDevServerOptions extends JsonObject {
   open: boolean;
   liveReload: boolean;
   watch: boolean;
+  allowedHosts: string;
 }
 
 export default createBuilder<WebDevServerOptions>(run);

--- a/packages/web/src/builders/dev-server/schema.json
+++ b/packages/web/src/builders/dev-server/schema.json
@@ -48,6 +48,11 @@
       "type": "boolean",
       "description": "Open the application in the browser.",
       "default": false
+    },
+    "allowedHosts": {
+      "type": "string",
+      "description": "This option allows you to whitelist services that are allowed to access the dev server.",
+      "enum": ["host.com,host2.com", ".host.com"]
     }
   }
 }

--- a/packages/web/src/utils/devserver.config.spec.ts
+++ b/packages/web/src/utils/devserver.config.spec.ts
@@ -49,7 +49,8 @@ describe('getDevServerConfig', () => {
       ssl: false,
       liveReload: true,
       open: false,
-      watch: true
+      watch: true,
+      allowedHosts: null
     };
 
     (<any>TsConfigPathsPlugin).mockImplementation(
@@ -395,6 +396,50 @@ describe('getDevServerConfig', () => {
         expect(result.proxy).toEqual({
           proxyConfig: 'proxyConfig'
         });
+      });
+    });
+
+    describe('allowed hosts', () => {
+      it('should have two allowed hosts', () => {
+        const { devServer: result } = getDevServerConfig(
+          root,
+          sourceRoot,
+          buildInput,
+          {
+            ...serveInput,
+            allowedHosts: 'host.com,subdomain.host.com'
+          },
+          logger
+        ) as any;
+
+        expect(result.allowedHosts).toEqual(['host.com', 'subdomain.host.com']);
+      });
+
+      it('should have one allowed host', () => {
+        const { devServer: result } = getDevServerConfig(
+          root,
+          sourceRoot,
+          buildInput,
+          {
+            ...serveInput,
+            allowedHosts: 'host.com'
+          },
+          logger
+        ) as any;
+
+        expect(result.allowedHosts).toEqual(['host.com']);
+      });
+
+      it('should not have allowed hosts', () => {
+        const { devServer: result } = getDevServerConfig(
+          root,
+          sourceRoot,
+          buildInput,
+          serveInput,
+          logger
+        ) as any;
+
+        expect(result.allowedHosts).toEqual([]);
       });
     });
   });

--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -92,7 +92,8 @@ function getDevServerPartial(
     },
     public: options.publicHost,
     publicPath: servePath,
-    contentBase: false
+    contentBase: false,
+    allowedHosts: []
   };
 
   if (options.ssl && options.sslKey && options.sslCert) {
@@ -101,6 +102,10 @@ function getDevServerPartial(
 
   if (options.proxyConfig) {
     config.proxy = getProxyConfig(root, options);
+  }
+
+  if (options.allowedHosts) {
+    config.allowedHosts = options.allowedHosts.split(',');
   }
 
   return config;


### PR DESCRIPTION
This option allows you to whitelist services that are allowed to access the dev server. for CLI usage pass the --allowed-hosts option a comma-delimited string.