### PR TITLE
feat(nx): inclusion and exclusion capability added to nx dep-graph

### DIFF
--- a/docs/angular/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/angular/api-workspace/npmscripts/affected-dep-graph.md
@@ -64,6 +64,10 @@ output file (e.g. --file=output.json)
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas
 
+### filter
+
+Use to limit the dependency graph to only show specific projects, list of projects delimited by commas.
+
 ### head
 
 Latest commit of the current branch (usually HEAD)

--- a/docs/angular/api-workspace/npmscripts/dep-graph.md
+++ b/docs/angular/api-workspace/npmscripts/dep-graph.md
@@ -24,11 +24,31 @@ Save the dep graph into a json file:
 nx dep-graph --file=output.json
 ```
 
+Show the graph where every node is either an ancestor or a descendant of todos-feature-main.:
+
+```bash
+nx dep-graph --filter=todos-feature-main
+```
+
+Exclude project-one and project-two from the dep graph.:
+
+```bash
+nx dep-graph --exclude=project-one,project-two
+```
+
 ## Options
+
+### exclude
+
+List of projects delimited by commas to exclude from the dependency graph.
 
 ### file
 
 output file (e.g. --file=output.json)
+
+### filter
+
+Use to limit the dependency graph to only show specific projects, list of projects delimited by commas.
 
 ### help
 

--- a/docs/react/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/react/api-workspace/npmscripts/affected-dep-graph.md
@@ -64,6 +64,10 @@ output file (e.g. --file=output.json)
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas
 
+### filter
+
+Use to limit the dependency graph to only show specific projects, list of projects delimited by commas.
+
 ### head
 
 Latest commit of the current branch (usually HEAD)

--- a/docs/react/api-workspace/npmscripts/dep-graph.md
+++ b/docs/react/api-workspace/npmscripts/dep-graph.md
@@ -24,11 +24,31 @@ Save the dep graph into a json file:
 nx dep-graph --file=output.json
 ```
 
+Show the graph where every node is either an ancestor or a descendant of todos-feature-main.:
+
+```bash
+nx dep-graph --filter=todos-feature-main
+```
+
+Exclude project-one and project-two from the dep graph.:
+
+```bash
+nx dep-graph --exclude=project-one,project-two
+```
+
 ## Options
+
+### exclude
+
+List of projects delimited by commas to exclude from the dependency graph.
 
 ### file
 
 output file (e.g. --file=output.json)
+
+### filter
+
+Use to limit the dependency graph to only show specific projects, list of projects delimited by commas.
 
 ### help
 

--- a/docs/web/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/web/api-workspace/npmscripts/affected-dep-graph.md
@@ -64,6 +64,10 @@ output file (e.g. --file=output.json)
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas
 
+### filter
+
+Use to limit the dependency graph to only show specific projects, list of projects delimited by commas.
+
 ### head
 
 Latest commit of the current branch (usually HEAD)

--- a/docs/web/api-workspace/npmscripts/dep-graph.md
+++ b/docs/web/api-workspace/npmscripts/dep-graph.md
@@ -24,11 +24,31 @@ Save the dep graph into a json file:
 nx dep-graph --file=output.json
 ```
 
+Show the graph where every node is either an ancestor or a descendant of todos-feature-main.:
+
+```bash
+nx dep-graph --filter=todos-feature-main
+```
+
+Exclude project-one and project-two from the dep graph.:
+
+```bash
+nx dep-graph --exclude=project-one,project-two
+```
+
 ## Options
+
+### exclude
+
+List of projects delimited by commas to exclude from the dependency graph.
 
 ### file
 
 output file (e.g. --file=output.json)
+
+### filter
+
+Use to limit the dependency graph to only show specific projects, list of projects delimited by commas.
 
 ### help
 

--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -34,7 +34,7 @@ export function startServer(
 
   app.listen(4211, '127.0.0.1');
   output.note({
-    title: 'Dep graph started started at http://localhost:4211'
+    title: 'Dep graph started at http://localhost:4211'
   });
 
   opn('http://localhost:4211', {
@@ -43,13 +43,20 @@ export function startServer(
 }
 
 export function generateGraph(
-  args: { file?: string },
+  args: { file?: string; filter?: string[]; exclude?: string[] },
   affectedProjects: string[]
 ): void {
   const workspaceJson = readWorkspaceJson();
   const nxJson = readNxJson();
   const projects: ProjectNode[] = getProjectNodes(workspaceJson, nxJson);
   const deps = readDependencies(nxJson.npmScope, projects);
+
+  const renderProjects: ProjectNode[] = filterProjects(
+    deps,
+    projects,
+    args.filter,
+    args.exclude
+  );
 
   if (args.file) {
     writeFileSync(
@@ -65,6 +72,33 @@ export function generateGraph(
       )
     );
   } else {
-    startServer(projects, deps, affectedProjects);
+    startServer(renderProjects, deps, affectedProjects);
   }
+}
+
+export function filterProjects(deps, projects, filter, exclude) {
+  const filteredProjects = projects.filter(p => {
+    const filtered =
+      filter && filter.length > 0
+        ? filter.find(
+            f => hasPath(deps, f, p.name, []) || hasPath(deps, p.name, f, [])
+          )
+        : true;
+    return !exclude
+      ? filtered
+      : exclude && exclude.indexOf(p.name) === -1 && filtered;
+  });
+
+  return filteredProjects;
+}
+
+export function hasPath(deps, target, node, visited) {
+  if (target === node) return true;
+
+  for (let d of deps[node]) {
+    if (visited.indexOf(d.projectName) > -1) continue;
+    if (hasPath(deps, target, d.projectName, [...visited, d.projectName]))
+      return true;
+  }
+  return false;
 }

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -287,10 +287,23 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
 }
 
 function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
-  return yargs.option('file', {
-    describe: 'output file (e.g. --file=output.json)',
-    type: 'string'
-  });
+  return yargs
+    .option('file', {
+      describe: 'output file (e.g. --file=output.json)',
+      type: 'string'
+    })
+    .option('filter', {
+      describe:
+        'Use to limit the dependency graph to only show specific projects, list of projects delimited by commas.',
+      type: 'array',
+      coerce: parseCSV
+    })
+    .option('exclude', {
+      describe:
+        'List of projects delimited by commas to exclude from the dependency graph.',
+      type: 'array',
+      coerce: parseCSV
+    });
 }
 
 function parseCSV(args: string[]) {

--- a/scripts/documentation/generate-npmscripts-data.ts
+++ b/scripts/documentation/generate-npmscripts-data.ts
@@ -205,6 +205,15 @@ const examples = {
     {
       command: 'dep-graph --file=output.json',
       description: 'Save the dep graph into a json file'
+    },
+    {
+      command: 'dep-graph --filter=todos-feature-main',
+      description:
+        'Show the graph where every node is either an ancestor or a descendant of todos-feature-main.'
+    },
+    {
+      command: 'dep-graph --exclude=project-one,project-two',
+      description: 'Exclude project-one and project-two from the dep graph.'
     }
   ],
   'affected:dep-graph': [


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
No --filter or --exclude flags available from cli for dep-graph.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
`nx dep-graph --filter=todos-feature-main --exclude=shared-utils` will launch dep graph with all
ancestors and descendants of todos-feature-main and exclude the shared-utils library

## Issue
#1864 
