### PR TITLE
fix(testing): update jest builder to support testLocationInResults flag

### DIFF
--- a/docs/angular/api-jest/builders/jest.md
+++ b/docs/angular/api-jest/builders/jest.md
@@ -148,6 +148,12 @@ Type: `string`
 
 The name of the file to test.
 
+### testLocationInResults
+
+Type: `boolean`
+
+Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/en/cli#testlocationinresults)
+
 ### testNamePattern
 
 Alias(es): t

--- a/docs/react/api-jest/builders/jest.md
+++ b/docs/react/api-jest/builders/jest.md
@@ -149,6 +149,12 @@ Type: `string`
 
 The name of the file to test.
 
+### testLocationInResults
+
+Type: `boolean`
+
+Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/en/cli#testlocationinresults)
+
 ### testNamePattern
 
 Alias(es): t

--- a/docs/web/api-jest/builders/jest.md
+++ b/docs/web/api-jest/builders/jest.md
@@ -149,6 +149,12 @@ Type: `string`
 
 The name of the file to test.
 
+### testLocationInResults
+
+Type: `boolean`
+
+Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/en/cli#testlocationinresults)
+
 ### testNamePattern
 
 Alias(es): t

--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -183,7 +183,8 @@ describe('Jest Builder', () => {
         updateSnapshot: true,
         useStderr: true,
         watch: false,
-        watchAll: false
+        watchAll: false,
+        testLocationInResults: true
       });
       expect(await run.result).toEqual(
         jasmine.objectContaining({
@@ -223,7 +224,8 @@ describe('Jest Builder', () => {
           updateSnapshot: true,
           useStderr: true,
           watch: false,
-          watchAll: false
+          watchAll: false,
+          testLocationInResults: true
         },
         ['/root/jest.config.js']
       );

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -48,6 +48,7 @@ export interface JestBuilderOptions extends JsonObject {
   useStderr?: boolean;
   watch?: boolean;
   watchAll?: boolean;
+  testLocationInResults?: boolean;
 }
 
 export default createBuilder<JestBuilderOptions>(run);
@@ -96,6 +97,7 @@ function run(
     passWithNoTests: options.passWithNoTests,
     runInBand: options.runInBand,
     silent: options.silent,
+    testLocationInResults: options.testLocationInResults,
     testNamePattern: options.testNamePattern,
     testPathPattern: options.testPathPattern,
     colors: options.colors,

--- a/packages/jest/src/builders/jest/schema.json
+++ b/packages/jest/src/builders/jest/schema.json
@@ -139,6 +139,10 @@
     "watchAll": {
       "description": "Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/en/cli#watchall)",
       "type": "boolean"
+    },
+    "testLocationInResults": {
+      "description": "Adds a location field to test results.  Used to report location of a test in a reporter. { \"column\": 4, \"line\": 5 } (https://jestjs.io/docs/en/cli#testlocationinresults)",
+      "type": "boolean"
     }
   },
   "required": ["jestConfig", "tsConfig"]


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
Running `yarn affected:test` with a `--testLocationInResults` flag fails to run tests with an unknown option error.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Jest builder should accept the flag as valid and pass-thru to jest.

## Issue
#1527 