### PR TITLE
fix(nx): affected --all should not parse for affected files

### DIFF
--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -67,9 +67,8 @@ export function affected(
 ): void {
   const workspaceResults = new WorkspaceResults(parsedArgs.target);
 
-  const touchedFiles = parseFiles(parsedArgs).files;
   const affectedMetadata = getAffectedMetadata(
-    touchedFiles,
+    parsedArgs.all ? [] : parseFiles(parsedArgs).files,
     parsedArgs.withDeps
   );
 


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`nx affected:lint --all` fails with git error when repository does not gave `master` branched. Common case in CI when doing shallow clones.

Running `nx affected:lint --all` fails with error bellow when there is no master branch.
```
Error: Command failed: git merge-base master HEAD
fatal: Not a valid object name master

    at checkExecSyncError (child_process.js:621:11)
    at Object.execSync (child_process.js:657:15)
    at getFilesUsingBaseAndHead (/ng-app/node_modules/@nrwl/workspace/src/command-line/shared.js:108:39)
    at Object.parseFiles (/ng-app/node_modules/@nrwl/workspace/src/command-line/shared.js:93:20)
    at Object.affected (/ng-app/node_modules/@nrwl/workspace/src/command-line/affected.js:16:35)
    at Object.handler (/ng-app/node_modules/@nrwl/workspace/src/command-line/nx-commands.js:66:138)
    at Object.runCommand (/ng-app/node_modules/@nrwl/workspace/node_modules/yargs/lib/command.js:235:44)
    at Object.parseArgs [as _parseArgs] (/ng-app/node_modules/@nrwl/workspace/node_modules/yargs/yargs.js:1022:30)
    at Object.get [as argv] (/ng-app/node_modules/@nrwl/workspace/node_modules/yargs/yargs.js:965:21)
    at Object.<anonymous> (/ng-app/node_modules/@nrwl/cli/bin/nx.js:38:26)
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`nx affected:lint --all` should not trigger `git merge-base master HEAD`
Instead affected should just use all libs/apps from `nx.json` without checking affected files via `git merge-base`.

## Issue

Closes #1988