### PR TITLE
fix(nx): affected maximum call stack size exceeded when circular dependencies

### DIFF
--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -222,13 +222,13 @@ function visit(
 ) {
   const visited = new Set<string>();
   function _visit(projectName: string) {
-    affectedMetadata.dependencyGraph.dependencies[projectName].forEach(dep => {
-      _visit(dep.projectName);
-    });
     if (visited.has(projectName)) {
       return;
     }
     visited.add(projectName);
+    affectedMetadata.dependencyGraph.dependencies[projectName].forEach(dep => {
+      _visit(dep.projectName);
+    });
     visitor(affectedMetadata.dependencyGraph.projects[projectName]);
   }
   affectedMetadata.dependencyGraph.roots.forEach(root => {


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

## Issue
```javascript
RangeError: Maximum call stack size exceeded
    at _visit (/Users/jimmy/Documents/GitHub/mlab/node_modules/@nrwl/workspace/src/command-line/affected.js:119:20)
    at /Users/jimmy/Documents/GitHub/mlab/node_modules/@nrwl/workspace/src/command-line/affected.js:127:10
    at Array.forEach (<anonymous>)
    at _visit (/Users/jimmy/Documents/GitHub/mlab/node_modules/@nrwl/workspace/src/command-line/affected.js:125:66)
    at /Users/jimmy/Documents/GitHub/mlab/node_modules/@nrwl/workspace/src/command-line/affected.js:127:10
    at Array.forEach (<anonymous>)
    at _visit (/Users/jimmy/Documents/GitHub/mlab/node_modules/@nrwl/workspace/src/command-line/affected.js:125:66)
    at /Users/jimmy/Documents/GitHub/mlab/node_modules/@nrwl/workspace/src/command-line/affected.js:127:10
    at Array.forEach (<anonymous>)
    at _visit (/Users/jimmy/Documents/GitHub/mlab/node_modules/@nrwl/workspace/src/command-line/affected.js:125:66)
```