### PR TITLE
fix(schematics): updated simpleModuleName support when directory is provided 

### DIFF
--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -136,7 +136,7 @@ function addLoadChildren(options: NormalizedSchema): Rule {
         `{path: '${toFileName(
           options.fileName
         )}', loadChildren: () => import('@${npmScope}/${
-          options.projectDirectory
+          options.simpleModuleName ? options.name : options.projectDirectory
         }').then(module => module.${options.moduleName})}`
       )
     ]);
@@ -195,7 +195,7 @@ function addChildren(options: NormalizedSchema): Rule {
       true
     );
     const constName = `${toPropertyName(options.fileName)}Routes`;
-    const importPath = `@${npmScope}/${options.projectDirectory}`;
+    const importPath = `@${npmScope}/${options.simpleModuleName ? options.name : options.projectDirectory}`;
 
     insert(host, options.parentModule, [
       insertImport(
@@ -224,7 +224,7 @@ function updateNgPackage(options: NormalizedSchema): Rule {
     return noop();
   }
   const dest = `${offsetFromRoot(options.projectRoot)}dist/libs/${
-    options.projectDirectory
+    options.simpleModuleName ? options.name : options.projectDirectory
   }`;
   return chain([
     updateJsonInTree(`${options.projectRoot}/ng-package.json`, json => {
@@ -400,7 +400,7 @@ function updateTsConfig(options: NormalizedSchema): Rule {
       return updateJsonInTree('tsconfig.json', json => {
         const c = json.compilerOptions;
         delete c.paths[options.name];
-        c.paths[`@${nxJson.npmScope}/${options.projectDirectory}`] = [
+        c.paths[`@${nxJson.npmScope}/${options.simpleModuleName ? options.name : options.projectDirectory}`] = [
           `libs/${options.projectDirectory}/src/index.ts`
         ];
         return json;


### PR DESCRIPTION
> fix(schematics): updated simpleModuleName support when directory is provided 

> Closes #2034

# Context of the problem

Running `@nrwl/angular` schematic for creating new library 

> Example: `ng g @nrwl/angular:lib --name=awesomeLib --publishable=true --prefix=com.company.poc --routing=true --lazy=true --parentModule=./apps/demo/src/app/app-routing.module.ts
 --directory=com/company/poc --simpleModuleName=true --style=scss`

The command schematic respects the `--simpleModuleName=true` for 

-  case when generating name of library module (which generates `awesome-lib.module.ts`)
but

## Current Behavior (This is the behavior we have today, before the PR is merged)
- in `tsconfig.json`  file 

`"paths": {
      "@myworkspace/com/company/poc/awesome-lib": [
        "libs/com/company/poc/awesome-lib/src/index.ts"
      ]
    }`

- in `app-routing.module.ts` file 

` RouterModule.forRoot([
      {
        path: 'awesome-lib',
        loadChildren: () =>
          import('@myworkspace/com/company/poc/awesome-lib').then(
            module => module.AwesomeLibModule
          )
      }
    ])`

- and for any place where we might want to import the module as

`import { AwesomeLibModule } from '@myworkspace/com/company/poc/awesome-lib';`

directory com/company/poc is added in all the named scope.
instead 

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
- in `tsconfig.json`  file 

`"paths": {
      "@myworkspace/awesome-lib": [
        "libs/com/company/poc/awesome-lib/src/index.ts"
      ]
    }`

- in `app-routing.module.ts` file 

` RouterModule.forRoot([
      {
        path: 'awesome-lib',
        loadChildren: () =>
          import('@myworkspace/awesome-lib').then(
            module => module.AwesomeLibModule
          )
      }
    ])`

- and for any place where we might want to import the module as

`import { AwesomeLibModule } from '@myworkspace/awesome-lib';`

should be generated.
## Issue
#2034