### PR TITLE
docs(nx): update App component export in React tutorial

### DIFF
--- a/docs/react/tutorial/04-connect-to-api.md
+++ b/docs/react/tutorial/04-connect-to-api.md
@@ -5,7 +5,7 @@ Real-world applications do not live in isolation — they need APIs to talk 
 **Let's change our application to fetch the data from the API.**
 
 ```typescript jsx
-export const App = () => {
+const App = () => {
   const [todos, setTodos] = useState<Todo[]>([]);
 
   useEffect(() => {
@@ -39,6 +39,8 @@ export const App = () => {
     </>
   );
 };
+
+export default App
 ```
 
 !!!!!


### PR DESCRIPTION
The App component was a default export in previous steps. Changing it to a named export breaks the app. I've updated the example code here to use the default export pattern that was used in steps leading up to this point.

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

## Issue
