### PR TITLE
fix(angular): allow creating an app named 'app' or lib named 'lib'

### DIFF
--- a/packages/angular/src/schematics/application/application.spec.ts
+++ b/packages/angular/src/schematics/application/application.spec.ts
@@ -140,6 +140,12 @@ describe('app', () => {
       expect(result.exists('apps/my-app/src/main.ts')).toEqual(true);
       expect(result.exists('apps/my-app-e2e/protractor.conf.js')).toEqual(true);
     });
+
+    it('should set projectType to application', async () => {
+      const tree = await runSchematic('app', { name: 'app' }, appTree);
+      const workspaceJson = readJsonInTree(tree, '/workspace.json');
+      expect(workspaceJson.projects['app'].projectType).toEqual('application');
+    });
   });
 
   describe('nested', () => {

--- a/packages/workspace/src/utils/cli-config-utils.spec.ts
+++ b/packages/workspace/src/utils/cli-config-utils.spec.ts
@@ -1,0 +1,25 @@
+import { replaceAppNameWithPath } from './cli-config-utils';
+
+describe('replaceAppNameWithPath', () => {
+  describe('when node is `application`', () => {
+    describe('and appName is `app`', () => {
+      it('still returns the node', () => {
+        const node = 'application';
+        const appName = 'app';
+        const root = 'apps/app';
+        expect(replaceAppNameWithPath(node, appName, root)).toEqual(node);
+      });
+    });
+  });
+
+  describe('when node is `library`', () => {
+    describe('and appName is `lib`', () => {
+      it('still returns the node', () => {
+        const node = 'library';
+        const appName = 'lib';
+        const root = 'libs/lib';
+        expect(replaceAppNameWithPath(node, appName, root)).toEqual(node);
+      });
+    });
+  });
+});

--- a/packages/workspace/src/utils/cli-config-utils.ts
+++ b/packages/workspace/src/utils/cli-config-utils.ts
@@ -39,7 +39,11 @@ export function replaceAppNameWithPath(
       `([^a-z0-9]*(${appName}))|((${appName})[^a-z0-9:]*)`,
       'gi'
     );
-    if (!!node.match(matchPattern)) {
+    if (
+      !!node.match(matchPattern) &&
+      node !== 'application' &&
+      node !== 'library'
+    ) {
       const r = node.replace(appName, root);
       return r.startsWith('/apps') || r.startsWith('/libs')
         ? r.substring(1)


### PR DESCRIPTION
Currently when trying to create an app named 'app' or a lib named 'lib', the schematics inject the
'projectType' as 'apps/application' or lib as 'libs/library', breaking the Angular build.

fix #1844

## Current Behavior (This is the behavior we have today, before the PR is merged)

When creating an Angular application with the name `app`, the `angular.json` is updated but the new application has a `projectType` of `apps/application`. This breaks when trying to `yarn build app` since the `projectType` should be `application`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

If creating an Angular application with the name `app`, `angular.json`'s `projectType` should be `application`.

## Issue

#1844
