### PR TITLE
fix(nx): fix resolution conflicts with RxJS 6.4.0

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -2,6 +2,9 @@
   "name": "@nrwl/workspace",
   "version": "0.0.1",
   "description": "Extensible Dev Tools for Monorepos",
+  "scripts": {
+    "postinstall": "rimraf ./node_modules/listr/node_modules/rxjs"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nrwl/nx.git"
@@ -50,7 +53,8 @@
     "ignore": "5.0.4",
     "npm-run-all": "4.1.5",
     "opn": "^5.3.0",
-    "rxjs": "^6.4.0",
+    "rxjs": "6.4.0",
+    "rxjs-compat": "6.4.0",
     "semver": "5.4.1",
     "strip-json-comments": "2.0.1",
     "tmp": "0.0.33",


### PR DESCRIPTION
This PR pins RxJS to 6.4.0, and adds rxjs-compat 6.4.0 as a dependency
It also removes rxjs from the node_modules of listr to prevent multiple resolved copies

Closes #2013
Closes #2018

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

## Issue
