### PR TITLE
fix(nx): fix support for * in lint rules

### DIFF
--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -600,11 +600,12 @@ describe('Enforce Module Boundaries', () => {
 
   it('should not error about one level deep imports into library when exception is specified with a wildcard', () => {
     const failures = runRule(
-      { allow: ['@mycompany/other/*'] },
+      { allow: ['@mycompany/other/*', '@mycompany/another/*'] },
       `${process.cwd()}/proj/libs/mylib/src/main.ts`,
       `
       import "@mycompany/other/a/b";
       import "@mycompany/other/a";
+      import "@mycompany/another/a/b";
       `,
       [
         {
@@ -631,10 +632,23 @@ describe('Enforce Module Boundaries', () => {
             'libs/other/a/index.ts': 1,
             'libs/other/a/b.ts': 1
           }
+        },
+        {
+          name: 'anotherName',
+          root: 'libs/another',
+          type: ProjectType.lib,
+          tags: [],
+          implicitDependencies: [],
+          architect: {},
+          files: [`libs/another/a/index.ts`, `libs/another/a/b.ts`],
+          fileMTimes: {
+            'libs/another/a/index.ts': 1,
+            'libs/another/a/b.ts': 1
+          }
         }
       ]
     );
-    expect(failures.length).toEqual(1);
+    expect(failures.length).toEqual(2);
   });
 
   it('should respect regexp in allow option', () => {

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -49,7 +49,7 @@ export function matchImportWithWildcard(
   } else if (allowableImport.endsWith('/*')) {
     const prefix = allowableImport.substring(0, allowableImport.length - 1);
     if (!extractedImport.startsWith(prefix)) return false;
-    return extractedImport.substring(prefix.length).indexOf('/') > -1;
+    return extractedImport.substring(prefix.length).indexOf('/') === -1;
   } else if (allowableImport.indexOf('/**/') > -1) {
     const [prefix, suffix] = allowableImport.split('/**/');
     return (


### PR DESCRIPTION
## Current Behavior
One-level deep wildcard imports do not work correctly.

## Expected Behavior
One-level deep wildcard imports do work correctly.

## Issue
#2076 