### PR TITLE
chore(react): update React-related libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:all": "yarn linknpm fast && ./scripts/test_angular_runtime.sh && ./scripts/test.sh",
     "checkformat": "./scripts/check_format.sh",
     "checkimports": "node ./scripts/check-imports.js",
+    "checkversions": "ts-node ./scripts/check-versions.ts",
     "documentation": "./scripts/documentation/documentation.sh && yarn format && ./scripts/documentation/check-documentation.sh"
   },
   "devDependencies": {
@@ -181,7 +182,7 @@
     "rxjs": "~6.4.0",
     "sass": "1.22.9",
     "sass-loader": "7.2.0",
-    "semver": "5.4.1",
+    "semver": "6.3.0",
     "shelljs": "^0.8.3",
     "source-map": "0.7.3",
     "source-map-loader": "0.2.4",

--- a/packages/next/src/schematics/init/init.ts
+++ b/packages/next/src/schematics/init/init.ts
@@ -5,17 +5,23 @@ import {
   addPackageWithInit,
   updateWorkspace
 } from '@nrwl/workspace';
-import { frameworkVersion, pluginVersion } from '../../utils/versions';
+import {
+  nextVersion,
+  zeitNextCss,
+  zeitNextLess,
+  zeitNextSass,
+  zeitNextStylus
+} from '../../utils/versions';
 import { Schema } from './schema';
 
 export function addDependencies(): Rule {
   return addDepsToPackageJson(
     {
-      next: frameworkVersion,
-      '@zeit/next-css': pluginVersion,
-      '@zeit/next-sass': pluginVersion,
-      '@zeit/next-less': pluginVersion,
-      '@zeit/next-stylus': pluginVersion
+      next: nextVersion,
+      '@zeit/next-css': zeitNextCss,
+      '@zeit/next-sass': zeitNextLess,
+      '@zeit/next-less': zeitNextSass,
+      '@zeit/next-stylus': zeitNextStylus
     },
     {}
   );

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -1,3 +1,7 @@
 export const nxVersion = '*';
-export const frameworkVersion = '9.0.5';
-export const pluginVersion = '1.0.1';
+
+export const nextVersion = '9.0.5';
+export const zeitNextCss = '1.0.1';
+export const zeitNextSass = '1.0.1';
+export const zeitNextLess = '1.0.1';
+export const zeitNextStylus = '1.0.1';

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -10,10 +10,15 @@
       "description": "Update React workspace",
       "factory": "./src/migrations/update-8-5-0/update-workspace-8-5-0"
     },
-    "update-8-7-0.": {
+    "update-8-7-0": {
       "version": "8.7.0-beta.1",
       "description": "Update React libraries",
       "factory": "./src/migrations/update-8-7-0/update-8-7-0"
+    },
+    "update-8.9.0": {
+      "version": "8.9.0-beta.1",
+      "description": "Update React libraries",
+      "factory": "./src/migrations/update-8-9-0/update-8-9-0"
     }
   },
   "packageJsonUpdates": {
@@ -46,6 +51,59 @@
         },
         "@types/react-redux": {
           "version": "7.1.4",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "8.9.0": {
+      "version": "8.9.0-beta.1",
+      "packages": {
+        "react": {
+          "version": "16.12.0",
+          "alwaysAddToPackageJson": false
+        },
+        "react-dom": {
+          "version": "16.12.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react": {
+          "version": "16.9.13",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react-dom": {
+          "version": "16.9.4",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react-router-dom": {
+          "version": "5.1.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@testing-library/react": {
+          "version": "9.3.2",
+          "alwaysAddToPackageJson": false
+        },
+        "react-redux": {
+          "version": "7.1.3",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react-redux": {
+          "version": "7.1.5",
+          "alwaysAddToPackageJson": false
+        },
+        "eslint-plugin-import": {
+          "version": "2.18.2",
+          "alwaysAddToPackageJson": false
+        },
+        "eslint-plugin-jsx-a11y": {
+          "version": "6.2.3",
+          "alwaysAddToPackageJson": false
+        },
+        "eslint-plugin-react": {
+          "version": "7.16.0",
+          "alwaysAddToPackageJson": false
+        },
+        "eslint-plugin-react-hooks": {
+          "version": "2.3.0",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/react/src/migrations/update-8-3-0/update-8-3-0.ts
+++ b/packages/react/src/migrations/update-8-3-0/update-8-3-0.ts
@@ -20,7 +20,7 @@ import {
 } from 'typescript';
 import { ReplaceChange } from '@nrwl/workspace/src/utils/ast-utils';
 import { relative } from 'path';
-import { testingLibraryVersion } from '../../utils/versions';
+import { testingLibraryReactVersion } from '../../utils/versions';
 
 const ignore = require('ignore');
 
@@ -82,7 +82,7 @@ function updateDependencies(tree: Tree) {
     {
       dependencies: {},
       devDependencies: {
-        '@testing-library/react': testingLibraryVersion
+        '@testing-library/react': testingLibraryReactVersion
       }
     }
   );

--- a/packages/react/src/migrations/update-8-9-0/update-8-9-0.spec.ts
+++ b/packages/react/src/migrations/update-8-9-0/update-8-9-0.spec.ts
@@ -1,0 +1,76 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import {
+  updateJsonInTree,
+  readJsonInTree,
+  updateWorkspaceInTree,
+  readWorkspace,
+  getWorkspacePath
+} from '@nrwl/workspace';
+
+import * as path from 'path';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+
+describe('Update 8-9-0', () => {
+  let tree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(async () => {
+    tree = Tree.empty();
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/react',
+      path.join(__dirname, '../../../migrations.json')
+    );
+  });
+
+  it(`should update react to 16.12.0`, async () => {
+    tree.create(
+      'package.json',
+      JSON.stringify({
+        dependencies: {
+          react: '16.0.0'
+        }
+      })
+    );
+
+    tree = await schematicRunner
+      .runSchematicAsync('update-8.9.0', {}, tree)
+      .toPromise();
+
+    const packageJson = readJsonInTree(tree, '/package.json');
+    expect(packageJson.dependencies).toEqual({
+      react: '16.12.0'
+    });
+  });
+
+  it(`should replace redux-starter-kit with @reduxjs/toolkit`, async () => {
+    tree.create(
+      'package.json',
+      JSON.stringify({
+        dependencies: {
+          'redux-starter-kit': '0.8.0'
+        }
+      })
+    );
+
+    tree.create(
+      'apps/demo/src/main.tsx',
+      stripIndents`
+      import { configureStore } from 'redux-starter-kit';`
+    );
+
+    tree = await schematicRunner
+      .runSchematicAsync('update-8.9.0', {}, tree)
+      .toPromise();
+
+    const packageJson = readJsonInTree(tree, '/package.json');
+    expect(packageJson.dependencies).toEqual({
+      '@reduxjs/toolkit': '1.0.4'
+    });
+
+    const sourceCode = tree.read('apps/demo/src/main.tsx').toString();
+    expect(sourceCode).toContain(
+      `import { configureStore } from '@reduxjs/toolkit';`
+    );
+  });
+});

--- a/packages/react/src/migrations/update-8-9-0/update-8-9-0.ts
+++ b/packages/react/src/migrations/update-8-9-0/update-8-9-0.ts
@@ -1,0 +1,114 @@
+import * as ts from 'typescript';
+import {
+  chain,
+  noop,
+  Rule,
+  SchematicContext,
+  Tree
+} from '@angular-devkit/schematics';
+import {
+  insert,
+  readJsonInTree,
+  updateJsonInTree,
+  updatePackageJsonDependencies,
+  updatePackagesInPackageJson
+} from '@nrwl/workspace';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+import * as path from 'path';
+import { relative } from 'path';
+import { ReplaceChange } from '@nrwl/workspace/src/utils/ast-utils';
+
+const ignore = require('ignore');
+
+export default function update(): Rule {
+  return chain([
+    displayInformation,
+    updateDependencies,
+    updateImports,
+    updatePackagesInPackageJson(
+      path.join(__dirname, '../../../', 'migrations.json'),
+      '8.9.0'
+    )
+  ]);
+}
+
+function displayInformation(host: Tree, context: SchematicContext) {
+  const packageJson = readJsonInTree(host, '/package.json');
+  if (packageJson.dependencies['redux-starter-kit']) {
+    context.logger.info(stripIndents`
+    Redux Starter Kit been renamed to Redux Toolkit as of version 1.0.
+    
+    We are replacing your \`redux-starter-kit\` imports with \`@reduxjs/toolkit\`.
+    
+    See: https://github.com/reduxjs/redux-toolkit/releases/tag/v1.0.4
+  `);
+  }
+}
+
+function updateDependencies(host: Tree) {
+  const packageJson = readJsonInTree(host, '/package.json');
+  if (!packageJson.dependencies['redux-starter-kit']) {
+    return noop();
+  }
+
+  const removeOld = updateJsonInTree(
+    'package.json',
+    (json, context: SchematicContext) => {
+      json.dependencies = json.dependencies || {};
+      delete json.dependencies['redux-starter-kit'];
+      context.logger.info(`Removing \`redux-starter-kit\` as a dependency`);
+      return json;
+    }
+  );
+
+  const addNew = updatePackageJsonDependencies(
+    { '@reduxjs/toolkit': '1.0.4' },
+    {}
+  );
+
+  return chain([removeOld, addNew]);
+}
+
+function updateImports(host: Tree) {
+  let ig = ignore();
+
+  if (host.exists('.gitignore')) {
+    ig = ig.add(host.read('.gitignore').toString());
+  }
+
+  host.visit(path => {
+    if (ig.ignores(relative('/', path)) || !/\.tsx?$/.test(path)) {
+      return;
+    }
+
+    const sourceFile = ts.createSourceFile(
+      path,
+      host.read(path).toString(),
+      ts.ScriptTarget.Latest,
+      true
+    );
+    const changes = [];
+    sourceFile.statements.forEach(statement => {
+      if (
+        ts.isImportDeclaration(statement) &&
+        ts.isStringLiteral(statement.moduleSpecifier)
+      ) {
+        const nodeText = statement.moduleSpecifier.getText(sourceFile);
+        const modulePath = statement.moduleSpecifier
+          .getText(sourceFile)
+          .substr(1, nodeText.length - 2);
+        if (modulePath === 'redux-starter-kit') {
+          changes.push(
+            new ReplaceChange(
+              path,
+              statement.moduleSpecifier.getStart(sourceFile),
+              nodeText,
+              `'@reduxjs/toolkit'`
+            )
+          );
+        }
+      }
+    });
+    insert(host, path, changes);
+  });
+}

--- a/packages/react/src/schematics/application/application.ts
+++ b/packages/react/src/schematics/application/application.ts
@@ -38,7 +38,7 @@ import { CSS_IN_JS_DEPENDENCIES } from '../../utils/styled';
 import { addInitialRoutes } from '../../utils/ast-utils';
 import {
   babelPresetReactVersion,
-  reactRouterTypesVersion,
+  typesReactRouterDomVersion,
   reactRouterDomVersion
 } from '../../utils/versions';
 import { assertValidStyle } from '../../utils/assertion';
@@ -249,7 +249,7 @@ function addRouting(
         },
         addDepsToPackageJson(
           { 'react-router-dom': reactRouterDomVersion },
-          { '@types/react-router-dom': reactRouterTypesVersion }
+          { '@types/react-router-dom': typesReactRouterDomVersion }
         )
       ])
     : noop();

--- a/packages/react/src/schematics/component/component.ts
+++ b/packages/react/src/schematics/component/component.ts
@@ -23,7 +23,7 @@ import {
 } from '@nrwl/workspace/src/utils/ast-utils';
 import { CSS_IN_JS_DEPENDENCIES } from '../../utils/styled';
 import {
-  reactRouterTypesVersion,
+  typesReactRouterDomVersion,
   reactRouterDomVersion
 } from '../../utils/versions';
 import { assertValidStyle } from '../../utils/assertion';
@@ -45,7 +45,7 @@ export default function(schema: Schema): Rule {
       options.routing
         ? addDepsToPackageJson(
             { 'react-router-dom': reactRouterDomVersion },
-            { '@types/react-router-dom': reactRouterTypesVersion }
+            { '@types/react-router-dom': typesReactRouterDomVersion }
           )
         : noop(),
       formatFiles({ skipFormat: false })

--- a/packages/react/src/schematics/init/init.ts
+++ b/packages/react/src/schematics/init/init.ts
@@ -7,25 +7,26 @@ import {
 } from '@nrwl/workspace';
 import { Schema } from './schema';
 import {
-  frameworkVersion,
-  typesVersion,
-  domTypesVersion,
-  testingLibraryVersion,
-  nxVersion
+  reactVersion,
+  typesReactVersion,
+  typesReactDomVersion,
+  testingLibraryReactVersion,
+  nxVersion,
+  reactDomVersion
 } from '../../utils/versions';
 import { JsonObject } from '@angular-devkit/core';
 
 export function addDependencies(): Rule {
   return addDepsToPackageJson(
     {
-      react: frameworkVersion,
-      'react-dom': frameworkVersion
+      react: reactVersion,
+      'react-dom': reactDomVersion
     },
     {
       '@nrwl/react': nxVersion,
-      '@types/react': typesVersion,
-      '@types/react-dom': domTypesVersion,
-      '@testing-library/react': testingLibraryVersion
+      '@types/react': typesReactVersion,
+      '@types/react-dom': typesReactDomVersion,
+      '@testing-library/react': testingLibraryReactVersion
     }
   );
 }

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -40,7 +40,7 @@ import {
   findComponentImportPath
 } from '../../utils/ast-utils';
 import {
-  reactRouterTypesVersion,
+  typesReactRouterDomVersion,
   reactRouterDomVersion
 } from '../../utils/versions';
 import { assertValidStyle } from '../../utils/assertion';
@@ -191,7 +191,7 @@ function updateAppRoutes(
     return chain([
       addDepsToPackageJson(
         { 'react-router-dom': reactRouterDomVersion },
-        { '@types/react-router-dom': reactRouterTypesVersion }
+        { '@types/react-router-dom': typesReactRouterDomVersion }
       ),
       function addBrowserRouterToMain(host: Tree) {
         const { content, source } = readComponent(host, options.appMain);

--- a/packages/react/src/schematics/redux/files/__directory__/__fileName__.slice.ts__tmpl__
+++ b/packages/react/src/schematics/redux/files/__directory__/__fileName__.slice.ts__tmpl__
@@ -1,4 +1,4 @@
-import { createSlice, createSelector, Action, PayloadAction } from 'redux-starter-kit';
+import { createSlice, createSelector, Action, PayloadAction } from '@reduxjs/toolkit';
 import { ThunkAction } from 'redux-thunk';
 
 export const <%= constantName %>_FEATURE_KEY = '<%= propertyName %>';

--- a/packages/react/src/schematics/redux/redux.spec.ts
+++ b/packages/react/src/schematics/redux/redux.spec.ts
@@ -19,7 +19,7 @@ describe('lib', () => {
       appTree
     );
     const packageJson = readJsonInTree(tree, '/package.json');
-    expect(packageJson.dependencies['redux-starter-kit']).toBeDefined();
+    expect(packageJson.dependencies['@reduxjs/toolkit']).toBeDefined();
     expect(packageJson.dependencies['react-redux']).toBeDefined();
   });
 
@@ -56,7 +56,7 @@ describe('lib', () => {
       );
 
       const main = tree.read('/apps/my-app/src/main.tsx').toString();
-      expect(main).toContain('redux-starter-kit');
+      expect(main).toContain('@reduxjs/toolkit');
       expect(main).toContain('configureStore');
       expect(main).toContain('[THIRD_SLICE_FEATURE_KEY]: thirdSliceReducer,');
       expect(main).toContain(

--- a/packages/react/src/schematics/redux/redux.ts
+++ b/packages/react/src/schematics/redux/redux.ts
@@ -26,9 +26,9 @@ import { formatFiles, getWorkspace, names, toFileName } from '@nrwl/workspace';
 import * as path from 'path';
 import { addReduxStoreToMain, updateReduxStore } from '../../utils/ast-utils';
 import {
-  reactReduxTypesVersion,
+  typesReactReduxVersion,
   reactReduxVersion,
-  reduxStarterKitVersion
+  reduxjsToolkitVersion
 } from '../../utils/versions';
 
 export default function(schema: any): Rule {
@@ -58,9 +58,9 @@ function generateReduxFiles(options: NormalizedSchema) {
 function addReduxPackageDependencies(): Rule {
   return addDepsToPackageJson(
     {
-      'redux-starter-kit': reduxStarterKitVersion,
+      '@reduxjs/toolkit': reduxjsToolkitVersion,
       'react-redux': reactReduxVersion,
-      '@types/react-redux': reactReduxTypesVersion
+      '@types/react-redux': typesReactReduxVersion
     },
     {}
   );

--- a/packages/react/src/utils/ast-utils.spec.ts
+++ b/packages/react/src/utils/ast-utils.spec.ts
@@ -282,7 +282,7 @@ ReactDOM.render(<App/>, document.getElementById('root'));
     );
 
     const result = tree.read('/main.tsx').toString();
-    expect(result).toContain('redux-starter-kit');
+    expect(result).toContain('@reduxjs/toolkit');
     expect(result).toContain('const store = configureStore');
     expect(result).toContain('<Provider store={store}>');
   });
@@ -301,7 +301,7 @@ describe('updateReduxStore', () => {
 
   it('should update configureStore call', () => {
     const sourceCode = `
-import { configureStore } from 'redux-starter-kit';
+import { configureStore } from '@reduxjs/toolkit';
 const store = configureStore({
   reducer: {}
 });

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -351,7 +351,7 @@ export function addReduxStoreToMain(
     ...addGlobal(
       source,
       sourcePath,
-      `import { configureStore } from 'redux-starter-kit';
+      `import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';`
     ),
     new InsertChange(

--- a/packages/react/src/utils/lint.ts
+++ b/packages/react/src/utils/lint.ts
@@ -1,13 +1,18 @@
-import { EsLintPlugins } from './versions';
+import {
+  eslintPluginImportVersion,
+  eslintPluginReactVersion,
+  eslintPluginReactHooksVersion,
+  eslintPluginJsxA11yVersion
+} from './versions';
 import * as restrictedGlobals from 'confusing-browser-globals';
 
 export const extraEslintDependencies = {
   dependencies: {},
   devDependencies: {
-    'eslint-plugin-import': EsLintPlugins.importVersion,
-    'eslint-plugin-jsx-a11y': EsLintPlugins.jsxA11yVersion,
-    'eslint-plugin-react': EsLintPlugins.reactVersion,
-    'eslint-plugin-react-hooks': EsLintPlugins.reactHooksVersion
+    'eslint-plugin-import': eslintPluginImportVersion,
+    'eslint-plugin-jsx-a11y': eslintPluginJsxA11yVersion,
+    'eslint-plugin-react': eslintPluginReactVersion,
+    'eslint-plugin-react-hooks': eslintPluginReactHooksVersion
   }
 };
 

--- a/packages/react/src/utils/styled.ts
+++ b/packages/react/src/utils/styled.ts
@@ -1,7 +1,8 @@
 import {
-  emotionVersion,
+  emotionCoreVersion,
+  emotionStyledVersion,
   styledComponentsVersion,
-  styledComponentsTypesVersion
+  typesStyledComponentsVersion
 } from './versions';
 import { PackageDependencies } from './dependencies';
 
@@ -13,13 +14,13 @@ export const CSS_IN_JS_DEPENDENCIES: {
       'styled-components': styledComponentsVersion
     },
     devDependencies: {
-      '@types/styled-components': styledComponentsTypesVersion
+      '@types/styled-components': typesStyledComponentsVersion
     }
   },
   '@emotion/styled': {
     dependencies: {
-      '@emotion/styled': emotionVersion,
-      '@emotion/core': emotionVersion
+      '@emotion/styled': emotionStyledVersion,
+      '@emotion/core': emotionCoreVersion
     },
     devDependencies: {}
   }

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -1,28 +1,28 @@
 export const nxVersion = '*';
 
-export const frameworkVersion = '16.10.2';
-export const typesVersion = '16.9.6';
-export const domTypesVersion = '16.9.2';
+export const reactVersion = '16.12.0';
+export const reactDomVersion = '16.12.0';
+export const typesReactVersion = '16.9.13';
+export const typesReactDomVersion = '16.9.4';
 
-export const styledComponentsVersion = '4.4.0';
-export const styledComponentsTypesVersion = '4.1.19';
+export const styledComponentsVersion = '4.4.1';
+export const typesStyledComponentsVersion = '4.4.0';
 
-export const emotionVersion = '10.0.17';
+export const emotionStyledVersion = '10.0.23';
+export const emotionCoreVersion = '10.0.22';
 
 export const reactRouterDomVersion = '5.1.2';
-export const reactRouterTypesVersion = '5.1.0';
+export const typesReactRouterDomVersion = '5.1.2';
 
-export const testingLibraryVersion = '9.3.0';
+export const testingLibraryReactVersion = '9.3.2';
 
-export const babelPresetReactVersion = '7.0.0';
+export const babelPresetReactVersion = '7.7.4';
 
-export const reduxStarterKitVersion = '0.8.0';
-export const reactReduxVersion = '7.1.1';
-export const reactReduxTypesVersion = '7.1.4';
+export const reduxjsToolkitVersion = '1.0.4';
+export const reactReduxVersion = '7.1.3';
+export const typesReactReduxVersion = '7.1.5';
 
-export const EsLintPlugins = {
-  importVersion: '2.18.2',
-  jsxA11yVersion: '6.2.3',
-  reactVersion: '7.16.0',
-  reactHooksVersion: '2.1.2'
-};
+export const eslintPluginImportVersion = '2.18.2';
+export const eslintPluginJsxA11yVersion = '6.2.3';
+export const eslintPluginReactVersion = '7.16.0';
+export const eslintPluginReactHooksVersion = '2.3.0';

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -98,7 +98,7 @@
     "semver": "6.3.0",
     "source-map": "0.7.3",
     "source-map-loader": "0.2.4",
-    "source-map-support": "0.5.12",
+    "source-map-support": "0.5.13",
     "speed-measure-webpack-plugin": "1.3.1",
     "style-loader": "1.0.0",
     "stylus": "0.54.5",
@@ -108,13 +108,13 @@
     "terser-webpack-plugin": "1.4.1",
     "ts-loader": "5.4.5",
     "tsconfig-paths-webpack-plugin": "3.2.0",
-    "webpack": "4.39.2",
+    "webpack": "4.41.2",
     "webpack-dev-middleware": "3.7.0",
     "webpack-merge": "4.2.1",
     "webpack-sources": "1.4.3",
     "webpack-subresource-integrity": "1.1.0-rc.6",
     "worker-plugin": "3.2.0",
-    "webpack-dev-server": "3.1.14",
+    "webpack-dev-server": "3.9.0",
     "webpack-node-externals": "1.7.2"
   }
 }

--- a/scripts/check-versions.ts
+++ b/scripts/check-versions.ts
@@ -1,0 +1,121 @@
+/*
+ * This script checks if new versions of node modules are available.
+ * It uses naming conventions to transform constants to matching node module name.
+ *
+ * Usage:
+ *   yarn checkversions [file]
+ *
+ * Positional arg:
+ *   - [file]: relative or absolute file path to the versions file.
+ *
+ * Example:
+ *   yarn checkversions packages/react/src/utils/versions
+ */
+
+import { join } from 'path';
+import { gt } from 'semver';
+import chalk from 'chalk';
+import { dasherize } from '../packages/workspace/src/utils/strings';
+import * as shell from 'shelljs';
+import * as glob from 'glob';
+
+const excluded = ['nxVersion'];
+const scoped = [
+  'babel',
+  'emotion',
+  'reduxjs',
+  'testing-library',
+  'types',
+
+  'zeit'
+];
+
+try {
+  const files = process.argv[2]
+    ? [process.argv[2]]
+    : glob.sync('packages/**/*/versions.ts');
+  checkFiles(files);
+} catch (e) {
+  console.log(chalk.red(e.message));
+  process.exitCode = 1;
+}
+
+// -----------------------------------------------------------------------------
+
+function checkFiles(files: string[]) {
+  console.log(chalk.blue(`Checking versions in the following files...\n`));
+  console.log(`  - ${files.join('\n  - ')}\n`);
+  const maxFileNameLength = Math.max(...files.map(f => f.length));
+
+  files.forEach(f => {
+    const versions = getVersions(f);
+    const npmPackages = getPackages(versions);
+    const results = npmPackages.map(([p, v]) => getVersionData(p, v));
+    const logContext = `${f.padEnd(maxFileNameLength)}`;
+    results.forEach(r => {
+      if (r.outdated) {
+        console.log(
+          `${logContext} ❗ ${chalk.bold(
+            r.package
+          )} has new version ${chalk.bold(r.latest)} (current: ${r.prev})`
+        );
+      } else {
+        console.log(`${logContext} ✔️  ${r.package} is update to date`);
+      }
+    });
+  });
+}
+
+function getVersions(path: string) {
+  const versionsPath =
+    path.startsWith('.') || path.startsWith('packages')
+      ? join(__dirname, '..', path)
+      : path;
+  try {
+    return require(versionsPath);
+  } catch {
+    throw new Error(`Could not load ${path}. Please make sure it is valid.`);
+  }
+}
+
+function getPackages(versions: Record<string, string>): string[][] {
+  return Object.entries(versions).reduce(
+    (acc, [name, version]) => {
+      if (!excluded.includes(name)) {
+        const npmName = getNpmName(name);
+        acc.push([npmName, version]);
+      }
+      return acc;
+    },
+    [] as string[][]
+  );
+}
+
+function getNpmName(name: string): string {
+  const dashedName = dasherize(name.replace(/Version$/, ''));
+  const scope = scoped.find(s => dashedName.startsWith(`${s}-`));
+
+  if (scope) {
+    const rest = dashedName.split(`${scope}-`)[1];
+    return `@${scope}/${rest}`;
+  } else {
+    return dashedName;
+  }
+}
+
+function getVersionData(
+  p: string,
+  v: string
+): { package: string; outdated: boolean; latest: string; prev?: string } {
+  try {
+    const latest = JSON.parse(
+      shell.exec(`npm view ${p} version --json --silent`, { silent: true })
+    );
+    if (gt(latest, v)) {
+      return { package: p, outdated: true, latest, prev: v };
+    }
+  } catch {
+    // ignored
+  }
+  return { package: p, outdated: false, latest: v };
+}


### PR DESCRIPTION
Updates React libs and adds a script to check for outdated versions.

## Changes

- [x] Update react libs
- [x] Add script to check for new versions
- [x] Write migration for `redux-starter-kit` to `@redux/toolkit` and lib updates

## Examples of version checks

```
 yarn checkversions packages/react/src/utils/versions
```

![Screen Shot 2019-11-21 at 12 08 32 PM](https://user-images.githubusercontent.com/53559/69360288-46a38b80-0c58-11ea-96d9-aa70dfd210db.png)

```
# Use glob to detect version files
yarn checkversions
```
![Screen Shot 2019-11-25 at 1 06 12 PM](https://user-images.githubusercontent.com/53559/69566152-6f8f8d80-0f84-11ea-8a66-b54a3d2f8e74.png)

