### PR TITLE
fix: invalid projects cause run-many to exit

### DIFF
--- a/packages/workspace/src/command-line/run-tasks/default-reporter.ts
+++ b/packages/workspace/src/command-line/run-tasks/default-reporter.ts
@@ -17,7 +17,7 @@ export class DefaultReporter {
       if (affectedArgs.configuration) {
         description += ` that are configured for "${affectedArgs.configuration}"`;
       }
-      output.logSingleLine(`No projects ${description} were affected`);
+      output.logSingleLine(`No projects ${description} were run`);
       return;
     }
 

--- a/packages/workspace/src/command-line/run-tasks/run-many.ts
+++ b/packages/workspace/src/command-line/run-tasks/run-many.ts
@@ -101,6 +101,8 @@ export function getProjectsToRun(
         title: `the following do not have configuration for "${target}"`,
         bodyLines: noConfig.map(p => '- ' + p)
       });
+
+      process.exit(1);
     }
   } else {
     found = allProjects;


### PR DESCRIPTION
 - when a project is invalid, display error and exit
 - when a project doesn't have configuration, display warning and continue
 - when no projects have configuration, do not mention "affected"