### PR TITLE
fix(web): resolve issue where different core-js versions exist in the same workspace

### DIFF
--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -214,12 +214,7 @@ export function copyMissingPackages(): void {
     '@testing-library',
 
     // For testing webpack config with babel-loader
-    '@babel/core',
-    '@babel/preset-env',
-    '@babel/preset-react',
-    '@babel/preset-typescript',
-    '@babel/plugin-proposal-class-properties',
-    '@babel/plugin-proposal-decorators',
+    '@babel',
     'babel-loader',
     'babel-plugin-macros',
     'eslint-plugin-import',

--- a/packages/web/src/utils/config.ts
+++ b/packages/web/src/utils/config.ts
@@ -1,6 +1,6 @@
 import * as webpack from 'webpack';
 import { Configuration, ProgressPlugin, Stats } from 'webpack';
-import { dirname } from 'path';
+import { dirname, resolve } from 'path';
 import { LicenseWebpackPlugin } from 'license-webpack-plugin';
 import * as CopyWebpackPlugin from 'copy-webpack-plugin';
 import * as TerserWebpackPlugin from 'terser-webpack-plugin';
@@ -63,6 +63,9 @@ export function getBaseWebpackPartial(
           mainFields
         })
       ],
+      // Search closest node_modules first, and then fallback to to default node module resolution scheme.
+      // This ensures we are pulling the correct versions of dependencies, such as `core-js`.
+      modules: [resolve(__dirname, '..', '..', 'node_modules'), 'node_modules'],
       mainFields
     },
     performance: {


### PR DESCRIPTION
Fix issue with different version of core-js in the hoisted `node_modules` folder.

If the workspace has `core-js@2` installed, then the web builder would fail at the polyfill step since all of the `core-js` paths are different.

## Current Behavior (This is the behavior we have today, before the PR is merged)

Serving and building web/react apps fail.s

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Serving and building web/react apps works.

## Issue

Closes #2086