### PR TITLE
chore(libs): cypress version update to 3.6.1

### DIFF
--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -10,5 +10,20 @@
       "description": "Update Cypress Config",
       "factory": "./src/migrations/update-8-2-0/update-8-2-0"
     }
+  },
+  "packageJsonUpdates": {
+    "9.0.0": {
+      "version": "9.0.0-beta.1",
+      "packages": {
+        "@nrwl/cypress": {
+          "version": "9.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "cypress": {
+          "version": "9.0.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    }
   }
 }

--- a/packages/cypress/src/utils/versions.ts
+++ b/packages/cypress/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = '*';
-export const cypressVersion = '3.4.1';
+export const cypressVersion = '3.6.1';


### PR DESCRIPTION
Updating the Cypress dependency to the latest release: `3.6.1`.