### PR TITLE
build(nx): add run-many to ci tests

### DIFF
--- a/scripts/e2e-ci1.sh
+++ b/scripts/e2e-ci1.sh
@@ -6,6 +6,8 @@ rm -rf tmp
 mkdir -p tmp/angular
 mkdir -p tmp/nx
 
+# Please keep this in alphabetical order
+# This should be every file under e2e except for utils.js up to next.test.ts
 export SELECTED_CLI=$1  
 jest --maxWorkers=1 ./build/e2e/affected.test.js &&
 jest --maxWorkers=1 ./build/e2e/command-line.test.js &&

--- a/scripts/e2e-ci2.sh
+++ b/scripts/e2e-ci2.sh
@@ -6,6 +6,8 @@ rm -rf tmp
 mkdir -p tmp/angular
 mkdir -p tmp/nx
 
+# Please keep this in alphabetical order
+# This should be every file under e2e except for utils.js after ng-add.test.ts
 export SELECTED_CLI=$1  
 jest --maxWorkers=1 ./build/e2e/ng-add.test.js &&
 jest --maxWorkers=1 ./build/e2e/ngrx.test.js &&
@@ -13,6 +15,7 @@ jest --maxWorkers=1 ./build/e2e/node.test.js &&
 jest --maxWorkers=1 ./build/e2e/print-affected.test.js &&
 jest --maxWorkers=1 ./build/e2e/react.test.js &&
 jest --maxWorkers=1 ./build/e2e/report.test.js &&
+jest --maxWorkers=1 ./build/e2e/run-many.test.js &&
+jest --maxWorkers=1 ./build/e2e/storybook.test.js &&
 jest --maxWorkers=1 ./build/e2e/upgrade-module.test.js &&
-jest --maxWorkers=1 ./build/e2e/web.test.js &&
-jest --maxWorkers=1 ./build/e2e/storybook.test.js
+jest --maxWorkers=1 ./build/e2e/web.test.js


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

run-many.test.ts does not run in CI

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

run-many.test.ts runs in CI

## Issue
