### PR TITLE
fix(nx): [storybook] skip existing stories and cypress specs

### DIFF
--- a/e2e/storybook.test.ts
+++ b/e2e/storybook.test.ts
@@ -76,7 +76,7 @@ forEachCli(() => {
             `generate @nrwl/angular:storybook-configuration ${mylib} --configureCypress --generateStories --generateCypressSpecs --no-interactive`
           );
           runCLI(
-            `generate @nrwl/storybook:configuration ${mylib} --no-interactive`
+            `generate @nrwl/angular:stories ${mylib} --generateCypressSpecs --no-interactive`
           );
 
           writeFileSync(

--- a/packages/angular/src/schematics/component-cypress-spec/component-cypress-spec.ts
+++ b/packages/angular/src/schematics/component-cypress-spec/component-cypress-spec.ts
@@ -16,7 +16,11 @@ import {
   PropertyDeclaration,
   SyntaxKind
 } from 'typescript';
-import { getTsSourceFile, getDecoratorMetadata } from '../../utils/ast-utils';
+import {
+  getTsSourceFile,
+  getDecoratorMetadata,
+  applyWithSkipExisting
+} from '../../utils/ast-utils';
 import {
   getInputPropertyDeclarations,
   getKnobType
@@ -67,20 +71,16 @@ export function createComponentSpecFile({
       }
     );
     const componentSelector = getComponentSelector(tree, fullComponentPath);
-    return chain([
-      mergeWith(
-        apply(url('./files'), [
-          template({
-            projectName,
-            componentFileName: componentFileName,
-            componentName: componentName,
-            componentSelector,
-            props,
-            tmpl: ''
-          }),
-          move(e2eLibIntegrationFolderPath + '/' + componentPath)
-        ])
-      )
+    return applyWithSkipExisting(url('./files'), [
+      template({
+        projectName,
+        componentFileName: componentFileName,
+        componentName: componentName,
+        componentSelector,
+        props,
+        tmpl: ''
+      }),
+      move(e2eLibIntegrationFolderPath + '/' + componentPath)
     ]);
   };
 }

--- a/packages/angular/src/schematics/component-story/component-story.ts
+++ b/packages/angular/src/schematics/component-story/component-story.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular-devkit/schematics';
 import { findNodes } from '@nrwl/workspace';
 import { PropertyDeclaration, SyntaxKind } from 'typescript';
-import { getTsSourceFile } from '../../utils/ast-utils';
+import { getTsSourceFile, applyWithSkipExisting } from '../../utils/ast-utils';
 import { getSourceNodes } from '@nrwl/workspace/src/utils/ast-utils';
 
 export interface CreateComponentStoriesFileSchema {
@@ -48,20 +48,16 @@ export function createComponentStoriesFile({
       tree,
       libPath + '/' + componentPath + '/' + componentFileName + '.ts'
     );
-    return chain([
-      mergeWith(
-        apply(url('./files'), [
-          template({
-            componentFileName: componentFileName,
-            componentName: componentName,
-            relativeModulePath,
-            moduleName: ngModuleClassName,
-            props,
-            tmpl: ''
-          }),
-          move(libPath + '/' + componentPath)
-        ])
-      )
+    return applyWithSkipExisting(url('./files'), [
+      template({
+        componentFileName: componentFileName,
+        componentName: componentName,
+        relativeModulePath,
+        moduleName: ngModuleClassName,
+        props,
+        tmpl: ''
+      }),
+      move(libPath + '/' + componentPath)
     ]);
   };
 }

--- a/packages/angular/src/utils/ast-utils.ts
+++ b/packages/angular/src/utils/ast-utils.ts
@@ -8,7 +8,16 @@ import {
   InsertChange,
   RemoveChange
 } from '@nrwl/workspace/src/utils/ast-utils';
-import { Tree, SchematicsException } from '@angular-devkit/schematics';
+import {
+  Tree,
+  SchematicsException,
+  Source,
+  Rule,
+  SchematicContext,
+  mergeWith,
+  apply,
+  forEach
+} from '@angular-devkit/schematics';
 import * as path from 'path';
 import { toFileName } from '@nrwl/workspace/src/utils/name-utils';
 
@@ -646,4 +655,22 @@ export function getTsSourceFile(host: Tree, path: string): ts.SourceFile {
   );
 
   return source;
+}
+
+export function applyWithSkipExisting(source: Source, rules: Rule[]): Rule {
+  return (tree: Tree, _context: SchematicContext) => {
+    const rule = mergeWith(
+      apply(source, [
+        ...rules,
+        forEach(fileEntry => {
+          if (tree.exists(fileEntry.path)) {
+            return null;
+          }
+          return fileEntry;
+        })
+      ])
+    );
+
+    return rule(tree, _context);
+  };
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
If stories have already been generated for a library, running the `stories` schematic will fail.  (New stories will not be generated.)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
If a stories file or cypress spec file already exists, skip it.  Otherwise, generate the stories file or spec file.

## Issue
Fixes #2090 