### PR TITLE
fix(nx): added lint check to make sure that scoped paths are mapped correctly

### DIFF
--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -883,6 +883,46 @@ describe('Enforce Module Boundaries', () => {
       'Circular dependency between "mylibName" and "badcirclelibName" detected'
     );
   });
+
+  it('should error when it cannot match a scoped import to a root folder path', () => {
+    const failures = runRule(
+      {},
+      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
+      `
+      import "@mycompany/mylib";
+      import "@mycompany/utils/data";
+      // should error because the import doesnt match a root folder
+      import "@mycompany/utils-data";
+      `,
+      [
+        {
+          name: 'mylibName',
+          root: 'libs/mylib',
+          type: ProjectType.lib,
+          tags: [],
+          implicitDependencies: [],
+          architect: {},
+          files: [`libs/mylib/src/main.ts`],
+          fileMTimes: {
+            'libs/mylib/src/main.ts': 1
+          }
+        },
+        {
+          name: 'utils-data',
+          root: 'libs/utils/data',
+          type: ProjectType.lib,
+          tags: [],
+          implicitDependencies: [],
+          architect: {},
+          files: [`libs/utils/data/a.ts`],
+          fileMTimes: {
+            'libs/utils/data/a.ts': 1
+          }
+        }
+      ]
+    );
+    expect(failures.length).toEqual(1);
+  });
 });
 
 const linter = new TSESLint.Linter();

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -890,6 +890,46 @@ describe('Enforce Module Boundaries', () => {
       'Circular dependency between "mylibName" and "badcirclelibName" detected'
     );
   });
+
+  it('should error when it cannot match a scoped import to a root folder path', () => {
+    const failures = runRule(
+      {},
+      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
+      `
+      import "@mycompany/mylib";
+      import "@mycompany/utils/data";
+      // should error because the import doesnt match a root folder
+      import "@mycompany/utils-data";
+      `,
+      [
+        {
+          name: 'mylibName',
+          root: 'libs/mylib',
+          type: ProjectType.lib,
+          tags: [],
+          implicitDependencies: [],
+          architect: {},
+          files: [`libs/mylib/src/main.ts`],
+          fileMTimes: {
+            'libs/mylib/src/main.ts': 1
+          }
+        },
+        {
+          name: 'utils-data',
+          root: 'libs/utils/data',
+          type: ProjectType.lib,
+          tags: [],
+          implicitDependencies: [],
+          architect: {},
+          files: [`libs/utils/data/a.ts`],
+          fileMTimes: {
+            'libs/utils/data/a.ts': 1
+          }
+        }
+      ]
+    );
+    expect(failures.length).toEqual(1);
+  });
 });
 
 function runRule(


### PR DESCRIPTION
This checks that scoped imported libs are properly mapped to the libs folder structure


## Current Behavior (This is the behavior we have today, before the PR is merged)
If a scoped imported path after the scope does not match the folder structure, no error is shown.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
A linting error should now appear if we cannot find the proper lib path. 

## Issue
fix #2124