### PR TITLE
feat(nx): add init for bazel

### DIFF
--- a/packages/bazel/collection.json
+++ b/packages/bazel/collection.json
@@ -3,6 +3,13 @@
   "version": "0.1",
   "extends": [],
   "schematics": {
+    "init": {
+      "factory": "./src/schematics/init/init",
+      "schema": "./src/schematics/init/schema.json",
+      "aliases": ["ng-add"],
+      "description": "Add Bazel Files",
+      "hidden": true
+    },
     "sync": {
       "factory": "./src/schematics/sync/sync",
       "schema": "./src/schematics/sync/schema.json",

--- a/packages/bazel/src/schematics/init/files/root/.bazelrc
+++ b/packages/bazel/src/schematics/init/files/root/.bazelrc
@@ -1,0 +1,83 @@
+# Common Bazel settings for JavaScript/NodeJS workspaces
+# This rc file is automatically discovered when Bazel is run in this workspace,
+# see https://docs.bazel.build/versions/master/guide.html#bazelrc
+#
+# The full list of Bazel options: https://docs.bazel.build/versions/master/command-line-reference.html
+
+# Bazel will create symlinks from the workspace directory to output artifacts.
+# Build results will be placed in a directory called "dist/bin"
+# Other directories will be created like "dist/testlogs"
+# Be aware that this will still create a bazel-out symlink in
+# your project directory, which you must exclude from version control and your
+# editor's search path.
+build --symlink_prefix=dist/
+
+# To disable the symlinks altogether (including bazel-out) you can use
+# build --symlink_prefix=/
+# however this makes it harder to find outputs.
+
+# Specifies desired output mode for running tests.
+# Valid values are
+#   'summary' to output only test status summary
+#   'errors' to also print test logs for failed tests
+#   'all' to print logs for all tests
+#   'streamed' to output logs for all tests in real time
+#     (this will force tests to be executed locally one at a time regardless of --test_strategy value).
+test --test_output=errors
+
+# Support for debugging NodeJS tests
+# Add the Bazel option `--config=debug` to enable this
+# --test_output=streamed
+#     Stream stdout/stderr output from each test in real-time.
+#     See https://docs.bazel.build/versions/master/user-manual.html#flag--test_output for more details.
+# --test_strategy=exclusive
+#     Run one test at a time.
+# --test_timeout=9999
+#     Prevent long running tests from timing out
+#     See https://docs.bazel.build/versions/master/user-manual.html#flag--test_timeout for more details.
+# --nocache_test_results
+#     Always run tests
+# --node_options=--inspect-brk
+#     Pass the --inspect-brk option to all tests which enables the node inspector agent.
+#     See https://nodejs.org/de/docs/guides/debugging-getting-started/#command-line-options for more details.
+# --define=VERBOSE_LOGS=1
+#     Rules will output verbose logs if the VERBOSE_LOGS environment variable is set. `VERBOSE_LOGS` will be passed to
+#     `nodejs_binary` and `nodejs_test` via the default value of the `default_env_vars` attribute of those rules.
+# --define=DEBUG=1
+#     Rules may change their build outputs if the DEBUG environment variable is set. For example,
+#     mininfiers such as terser may make their output more human readable when this is set. `DEBUG` will be passed to
+#     `nodejs_binary` and `nodejs_test` via the default value of the `default_env_vars` attribute of those rules.
+test:debug --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results --define=VERBOSE_LOGS=1
+# Use bazel run with `--config=debug` to turn on the NodeJS inspector agent.
+# The node process will break before user code starts and wait for the debugger to connect.
+run:debug --define=VERBOSE_LOGS=1 -- --node_options=--inspect-brk
+# The following option will change the build output of certain rules such as terser and may not be desirable in all cases
+build:debug --define=DEBUG=1
+
+# Turn off legacy external runfiles
+# This prevents accidentally depending on this feature, which Bazel will remove.
+build --nolegacy_external_runfiles
+
+# Turn on the "Managed Directories" feature.
+# This allows Bazel to share the same node_modules directory with other tools
+# NB: this option was introduced in Bazel 0.26
+# See https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_allow_incremental_repository_updates
+common --experimental_allow_incremental_repository_updates
+
+# Turn on --incompatible_strict_action_env which was on by default
+# in Bazel 0.21.0 but turned off again in 0.22.0. Follow
+# https://github.com/bazelbuild/bazel/issues/7026 for more details.
+# This flag is needed to so that the bazel cache is not invalidated
+# when running bazel via `yarn bazel`.
+# See https://github.com/angular/angular/issues/27514.
+build --incompatible_strict_action_env
+run --incompatible_strict_action_env
+
+# Load any settings specific to the current user.
+# .bazelrc.user should appear in .gitignore so that settings are not shared with team members
+# This needs to be last statement in this
+# config, as the user configuration should be able to overwrite flags from this file.
+# See https://docs.bazel.build/versions/master/best-practices.html#bazelrc
+# (Note that we use .bazelrc.user so the file appears next to .bazelrc in directory listing,
+# rather than user.bazelrc as suggested in the Bazel docs)
+try-import %workspace%/.bazelrc.user

--- a/packages/bazel/src/schematics/init/files/root/patches/@ngtools+webpack+8.3.20.patch
+++ b/packages/bazel/src/schematics/init/files/root/patches/@ngtools+webpack+8.3.20.patch
@@ -1,0 +1,50 @@
+diff --git a/node_modules/@ngtools/webpack/src/loader.js b/node_modules/@ngtools/webpack/src/loader.js
+index bf6e8ae..ad943fe 100644
+--- a/node_modules/@ngtools/webpack/src/loader.js
++++ b/node_modules/@ngtools/webpack/src/loader.js
+@@ -30,9 +30,9 @@ function ngcLoader() {
+     // We must verify that the plugin is an instance of the right class.
+     // Throw an error if it isn't, that often means multiple @ngtools/webpack installs.
+     if (!(plugin instanceof angular_compiler_plugin_1.AngularCompilerPlugin) || !plugin.done) {
+-        throw new Error('Angular Compiler was detected but it was an instance of the wrong class.\n'
+-            + 'This likely means you have several @ngtools/webpack packages installed. '
+-            + 'You can check this with `npm ls @ngtools/webpack`, and then remove the extra copies.');
++        // throw new Error('Angular Compiler was detected but it was an instance of the wrong class.\n'
++        //     + 'This likely means you have several @ngtools/webpack packages installed. '
++        //     + 'You can check this with `npm ls @ngtools/webpack`, and then remove the extra copies.');
+     }
+     benchmark_1.time(timeLabel + '.ngcLoader.AngularCompilerPlugin');
+     plugin.done
+diff --git a/node_modules/@ngtools/webpack/src/ngcc_processor.js b/node_modules/@ngtools/webpack/src/ngcc_processor.js
+index 77f218a..d270644 100644
+--- a/node_modules/@ngtools/webpack/src/ngcc_processor.js
++++ b/node_modules/@ngtools/webpack/src/ngcc_processor.js
+@@ -49,6 +49,16 @@ class NgccProcessor {
+             this._processedModules.add(moduleName);
+             return;
+         }
++        // If the package.json is read only we should skip calling NGCC.
++        // With Bazel when running under sandbox the filesystem is read-only.
++        try {
++            fs_1.accessSync(packageJsonPath, fs_1.constants.W_OK);
++        }
++        catch (_a) {
++            // add it to processed so the second time round we skip this.
++            this._processedModules.add(moduleName);
++            return;
++        }
+         const timeLabel = `NgccProcessor.processModule.ngcc.process+${moduleName}`;
+         benchmark_1.time(timeLabel);
+         ngcc_1.process({
+@@ -88,6 +98,11 @@ class NgccProcessor {
+         }
+     }
+     findNodeModulesDirectory(startPoint) {
++        if (process.env.TEST_SRCDIR) {
++            // Check why with bazel build this is not resolved but is with bazel test
++            return path.join(require.resolve('npm/node_modules/@ngtools/webpack/package.json', '../../../'));
++        }
++
+         let current = startPoint;
+         while (path.dirname(current) !== current) {
+             const nodePath = path.join(current, 'node_modules');

--- a/packages/bazel/src/schematics/init/files/root/patches/BUILD.bazel
+++ b/packages/bazel/src/schematics/init/files/root/patches/BUILD.bazel
@@ -1,0 +1,4 @@
+filegroup(
+    name = "patches",
+    srcs = glob(["*.patch"]),
+)

--- a/packages/bazel/src/schematics/init/init.spec.ts
+++ b/packages/bazel/src/schematics/init/init.spec.ts
@@ -1,0 +1,53 @@
+import { Tree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { runSchematic } from '../utils/testing';
+import { readJsonInTree } from '@nrwl/workspace/src/utils/ast-utils';
+
+describe('@nrwl/bazel:sync', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = Tree.empty();
+    tree = createEmptyWorkspace(tree);
+    tree.create('.gitignore', '');
+  });
+
+  describe('.bazelrc', () => {
+    it('should be created', async () => {
+      const result = await runSchematic('init', {}, tree);
+
+      expect(result.exists('.bazelrc')).toEqual(true);
+    });
+  });
+
+  describe('patches', () => {
+    it('should be added', async () => {
+      const result = await runSchematic('init', {}, tree);
+
+      expect(result.exists('patches/BUILD.bazel')).toEqual(true);
+      expect(result.exists('patches/@ngtools+webpack+8.3.20.patch')).toEqual(
+        true
+      );
+    });
+  });
+
+  describe('@bazel dependencies', () => {
+    it('should be added', async () => {
+      const result = await runSchematic('init', {}, tree);
+
+      const packageJson = readJsonInTree(result, 'package.json');
+      expect(packageJson.devDependencies['@bazel/bazel']).toBeDefined();
+      expect(packageJson.devDependencies['@bazel/ibazel']).toBeDefined();
+      expect(packageJson.devDependencies['patch-package']).toBeDefined();
+    });
+  });
+
+  describe('.gitignore', () => {
+    it('should have "bazel-*" added', async () => {
+      const result = await runSchematic('init', {}, tree);
+
+      const gitignore = result.readContent('.gitignore');
+      expect(gitignore).toContain('bazel-*');
+    });
+  });
+});

--- a/packages/bazel/src/schematics/init/init.ts
+++ b/packages/bazel/src/schematics/init/init.ts
@@ -1,0 +1,99 @@
+import {
+  apply,
+  chain,
+  mergeWith,
+  Rule,
+  template,
+  url
+} from '@angular-devkit/schematics';
+import {
+  addDepsToPackageJson,
+  readJsonInTree,
+  updateJsonInTree
+} from '@nrwl/workspace';
+import ignore from 'ignore';
+import { bazelVersion, iBazelVersion, patchVersion } from '../utils/versions';
+import { noop } from 'rxjs';
+
+function updateGitIgnore(): Rule {
+  return host => {
+    if (!host.exists('.gitignore')) {
+      return;
+    }
+
+    const ig = ignore();
+    ig.add(host.read('.gitignore').toString());
+
+    if (!ig.ignores('bazel-out')) {
+      const content = `${host
+        .read('.gitignore')!
+        .toString('utf-8')
+        .trimRight()}\nbazel-*\n`;
+      host.overwrite('.gitignore', content);
+    }
+  };
+}
+
+const addRequiredPackages = addDepsToPackageJson(
+  {},
+  {
+    'patch-package': patchVersion,
+    '@bazel/bazel': bazelVersion,
+    '@bazel/ibazel': iBazelVersion
+  },
+  true
+);
+
+const addPostInstall = updateJsonInTree('package.json', json => {
+  if (!json.scripts) {
+    json.scripts = {};
+  }
+
+  if (
+    json.scripts['postinstall'] &&
+    json.scripts['postinstall'].includes('patch-package')
+  ) {
+    return json;
+  }
+
+  if (json.scripts.postinstall) {
+    if (!(json.scripts.postinstall as string).includes('patch-package')) {
+      json.scripts.postinstall = `patch-package && ${json.script.postinstall}`;
+    }
+  } else {
+    json.scripts.postinstall = 'patch-package';
+  }
+  return json;
+});
+
+function addFiles() {
+  return host => {
+    if (host.exists('patches/BUILD.bazel')) {
+      return noop;
+    }
+    return mergeWith(
+      apply(url('./files/root'), [
+        template({
+          tmpl: ''
+        }),
+        () => {
+          if (host.exists('BUILD.bazel')) {
+            host.delete('BUILD.bazel');
+          }
+        }
+      ])
+    );
+  };
+}
+
+export default (): Rule => {
+  return host => {
+    const packageJson = readJsonInTree(host, 'package.json');
+    return chain([
+      updateGitIgnore(),
+      !packageJson.devDependencies['@bazel/bazel'] ? addRequiredPackages : noop,
+      addPostInstall,
+      addFiles()
+    ]);
+  };
+};

--- a/packages/bazel/src/schematics/init/schema.json
+++ b/packages/bazel/src/schematics/init/schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxBazelInit",
+  "title": "Bazel Init Schema",
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/packages/bazel/src/schematics/utils/versions.ts
+++ b/packages/bazel/src/schematics/utils/versions.ts
@@ -1,0 +1,3 @@
+export const bazelVersion = '^1.2.0';
+export const iBazelVersion = '0.10.3';
+export const patchVersion = '^6.2.0';


### PR DESCRIPTION
Extracted the `init` part of https://github.com/nrwl/nx/pull/2133 and put it into a separate schematic.

## Current Behavior (This is the behavior we have today, before the PR is merged)

Bazel deps and .bazelrc are not added to the workspace.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Bazel deps and .bazelrc are added to the workspace.

## Issue
