### PR TITLE
fix(react): file name and style are properly shown when creating a new react app

### DIFF
--- a/packages/react/src/schematics/application/files/app/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/schematics/application/files/app/src/app/__fileName__.tsx__tmpl__
@@ -255,7 +255,7 @@ export const App = () => {
   /*
    * Replace the elements below with your own.
    *
-   * Note: The corresponding styles are in the ./${fileName}.${style} file.
+   * Note: The corresponding styles are in the ./<%= fileName %>.<%= style %> file.
    */
   return (
     <<%= wrapper %><% if (!styledModule) {%> className="app"<% } %>>


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
App comment did not show the file or style extension properly
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
File and style extension are populated properly now

## Issue
fix #2049