### PR TITLE
fix(testing): fix migration for cypress

### DIFF
--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -9,18 +9,19 @@
       "version": "8.2.0-beta.1",
       "description": "Update Cypress Config",
       "factory": "./src/migrations/update-8-2-0/update-8-2-0"
+    },
+    "update-9.0.0": {
+      "version": "9.0.0-beta.1",
+      "description": "Update Cypress to 3.6.1",
+      "factory": "./src/migrations/update-9-0-0/update-9-0-0"
     }
   },
   "packageJsonUpdates": {
     "9.0.0": {
       "version": "9.0.0-beta.1",
       "packages": {
-        "@nrwl/cypress": {
-          "version": "9.0.0",
-          "alwaysAddToPackageJson": false
-        },
         "cypress": {
-          "version": "9.0.0",
+          "version": "3.6.1",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/cypress/src/migrations/update-9-0-0/update-9-0-0.ts
+++ b/packages/cypress/src/migrations/update-9-0-0/update-9-0-0.ts
@@ -1,0 +1,10 @@
+import { updatePackagesInPackageJson } from '@nrwl/workspace';
+
+import { join } from 'path';
+
+export default () => {
+  return updatePackagesInPackageJson(
+    join(__dirname, '../../../migrations.json'),
+    '9.0.0'
+  );
+};


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

The migration for Cypress is written incorrectly.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The migration for Cypress is fixed.

Unfortunately, it's too late for `8.9` so I added it for `9.0.0` migration :man_shrugging: 

## Issue
