### PR TITLE
feat: reworks run-many and with-deps

### DIFF
--- a/e2e/run-many.test.ts
+++ b/e2e/run-many.test.ts
@@ -1,6 +1,15 @@
-import { ensureProject, uniq, runCLI, forEachCli } from './utils';
+import { ensureProject, updateFile, uniq, runCLI, forEachCli } from './utils';
 
 let originalCIValue: any;
+
+const DEBUG = false;
+const l = (str: string) => {
+  if (DEBUG) {
+    console.log(str);
+  }
+
+  return str;
+};
 
 forEachCli(() => {
   /**
@@ -19,30 +28,72 @@ forEachCli(() => {
   describe('Run Many', () => {
     it('should build specific and all projects', () => {
       ensureProject();
-      const mylib = uniq('mylib');
-      const mylib2 = uniq('mylib2');
-      const mylib3 = uniq('mylib3');
-      runCLI(`generate @nrwl/angular:lib ${mylib} --publishable`);
-      runCLI(`generate @nrwl/angular:lib ${mylib2} --publishable`);
-      runCLI(`generate @nrwl/angular:lib ${mylib3} --publishable`);
+      const libA = uniq('liba-rand');
+      const libB = uniq('libb-rand');
+      const libC = uniq('libc-rand');
+      const libD = uniq('libd-rand');
 
-      const buildParallel = runCLI(
-        `run-many --target=build --projects="${mylib},${mylib2}" --parallel`
+      l(runCLI(`generate @nrwl/angular:lib ${libA} --publishable`));
+      l(runCLI(`generate @nrwl/angular:lib ${libB} --publishable`));
+      l(runCLI(`generate @nrwl/angular:lib ${libC} --publishable`));
+      l(runCLI(`generate @nrwl/angular:lib ${libD}`));
+
+      l('=======> libA depends on libC');
+      updateFile(
+        `libs/${libA}/src/lib/${libA}.module.spec.ts`,
+        `
+              import '@proj/${libC}';
+              describe('sample test', () => {
+                it('should test', () => {
+                  expect(1).toEqual(1);
+                });
+              });
+            `
+      );
+
+      l('=======> testing run many starting');
+
+      const buildParallel = l(
+        runCLI(
+          `run-many --target=build --projects="${libC},${libB}" --parallel`
+        )
       );
       expect(buildParallel).toContain(`Running target build for projects:`);
-      expect(buildParallel).toContain(`- ${mylib}`);
-      expect(buildParallel).toContain(`- ${mylib2}`);
-      expect(buildParallel).not.toContain(`- ${mylib3}`);
+      expect(buildParallel).not.toContain(`- ${libA}`);
+      expect(buildParallel).toContain(`- ${libB}`);
+      expect(buildParallel).toContain(`- ${libC}`);
+      expect(buildParallel).not.toContain(`- ${libD}`);
       expect(buildParallel).toContain('Running target "build" succeeded');
 
-      const buildAllParallel = runCLI(
-        `run-many --target=build --all --parallel`
-      );
+      l('=======> testing run many complete');
+
+      l('=======> testing run many --all starting');
+      const buildAllParallel = l(runCLI(`run-many --target=build --all`));
       expect(buildAllParallel).toContain(`Running target build for projects:`);
-      expect(buildAllParallel).toContain(`- ${mylib}`);
-      expect(buildAllParallel).toContain(`- ${mylib2}`);
-      expect(buildAllParallel).toContain(`- ${mylib3}`);
+      expect(buildAllParallel).toContain(`- ${libA}`);
+      expect(buildAllParallel).toContain(`- ${libB}`);
+      expect(buildAllParallel).toContain(`- ${libC}`);
+      expect(buildAllParallel).not.toContain(`- ${libD}`);
       expect(buildAllParallel).toContain('Running target "build" succeeded');
+
+      l('=======> testing run many --all complete');
+
+      l('=======> testing run many --with-deps');
+
+      const buildWithDeps = l(
+        runCLI(
+          `run-many --target=build --projects="${libA}" --with-deps --parallel`
+        )
+      );
+      expect(buildWithDeps).toContain(`Running target build for projects:`);
+      expect(buildWithDeps).toContain(`- ${libA}`);
+      expect(buildWithDeps).toContain(`"build" "${libC}"`);
+      expect(buildWithDeps).not.toContain(`- ${libB}`);
+      expect(buildWithDeps).not.toContain(`- ${libC}`);
+      expect(buildWithDeps).not.toContain(`- ${libD}`);
+      expect(buildWithDeps).toContain('Running target "build" succeeded');
+
+      l('=======> testing run many --with-deps complete');
     }, 1000000);
   });
 });

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -316,6 +316,11 @@ function withRunManyOptions(yargs: yargs.Argv): yargs.Argv {
         'This is the configuration to use when performing tasks on projects',
       type: 'string'
     })
+    .options('with-deps', {
+      describe:
+        'Include dependencies of specified projects when computing what to run',
+      type: 'boolean'
+    })
     .options('only-failed', {
       describe: 'Isolate projects which previously failed',
       type: 'boolean',

--- a/packages/workspace/src/command-line/run-tasks/getAffectedProjects.ts
+++ b/packages/workspace/src/command-line/run-tasks/getAffectedProjects.ts
@@ -1,0 +1,1 @@
+import { ProjectMetadata, ProjectNode } from '../shared';

--- a/packages/workspace/src/command-line/run-tasks/run-command.ts
+++ b/packages/workspace/src/command-line/run-tasks/run-command.ts
@@ -27,7 +27,7 @@ export function runCommand<T extends RunArgs>(
   projectsToRun: ProjectNode[],
   dependencyGraph: DependencyGraph,
   { nxArgs, overrides, targetArgs }: Arguments<T>,
-  { nxJson, workspace }: Environment
+  { nxJson, workspaceResults }: Environment
 ) {
   const reporter = new DefaultReporter();
   reporter.beforeRun(projectsToRun.map(p => p.name), nxArgs, overrides);
@@ -72,7 +72,7 @@ export function runCommand<T extends RunArgs>(
     next: (event: TaskCompleteEvent) => {
       switch (event.type) {
         case AffectedEventType.TaskComplete: {
-          workspace.setResult(event.task.target.project, event.success);
+          workspaceResults.setResult(event.task.target.project, event.success);
         }
       }
     },
@@ -81,14 +81,14 @@ export function runCommand<T extends RunArgs>(
       // fix for https://github.com/nrwl/nx/issues/1666
       if (process.stdin['unref']) (process.stdin as any).unref();
 
-      workspace.saveResults();
+      workspaceResults.saveResults();
       reporter.printResults(
         nxArgs,
-        workspace.failedProjects,
-        workspace.startedWithFailedProjects
+        workspaceResults.failedProjects,
+        workspaceResults.startedWithFailedProjects
       );
 
-      if (workspace.hasFailure) {
+      if (workspaceResults.hasFailure) {
         process.exit(1);
       }
     }

--- a/packages/workspace/src/command-line/run-tasks/utils.ts
+++ b/packages/workspace/src/command-line/run-tasks/utils.ts
@@ -1,14 +1,7 @@
 import * as yargsParser from 'yargs-parser';
 import * as yargs from 'yargs';
-import {
-  getProjectNodes,
-  NxJson,
-  ProjectNode,
-  readNxJson,
-  readWorkspaceJson
-} from '../shared';
+import { NxJson, ProjectNode, readNxJson, readWorkspaceJson } from '../shared';
 import { WorkspaceResults } from '../workspace-results';
-import { output } from '../output';
 
 export interface Arguments<T extends yargs.Arguments> {
   nxArgs: T;
@@ -65,13 +58,13 @@ export function projectHasTargetAndConfiguration(
 export interface Environment {
   nxJson: NxJson;
   workspaceJson: any;
-  workspace: any;
+  workspaceResults: any;
 }
 
 export function readEnvironment(target: string): Environment {
   const nxJson = readNxJson();
   const workspaceJson = readWorkspaceJson();
-  const workspace = new WorkspaceResults(target);
+  const workspaceResults = new WorkspaceResults(target);
 
-  return { nxJson, workspaceJson, workspace };
+  return { nxJson, workspaceJson, workspaceResults };
 }

--- a/packages/workspace/src/command-line/shared.spec.ts
+++ b/packages/workspace/src/command-line/shared.spec.ts
@@ -488,12 +488,8 @@ describe('createAffectedMetadata', () => {
 
   it('should translate project nodes array to map', () => {
     expect(
-      createProjectMetadata(
-        projectNodes as ProjectNode[],
-        dependencies,
-        [],
-        false
-      ).dependencyGraph.projects
+      createProjectMetadata(projectNodes as ProjectNode[], dependencies, [])
+        .dependencyGraph.projects
     ).toEqual({
       app1: {
         name: 'app1'
@@ -518,23 +514,15 @@ describe('createAffectedMetadata', () => {
 
   it('should include the dependencies', () => {
     expect(
-      createProjectMetadata(
-        projectNodes as ProjectNode[],
-        dependencies,
-        [],
-        false
-      ).dependencyGraph.dependencies
+      createProjectMetadata(projectNodes as ProjectNode[], dependencies, [])
+        .dependencyGraph.dependencies
     ).toEqual(dependencies);
   });
 
   it('should find the roots', () => {
     expect(
-      createProjectMetadata(
-        projectNodes as ProjectNode[],
-        dependencies,
-        [],
-        false
-      ).dependencyGraph.roots
+      createProjectMetadata(projectNodes as ProjectNode[], dependencies, [])
+        .dependencyGraph.roots
     ).toEqual(['app1-e2e', 'customName-e2e']);
   });
 
@@ -542,8 +530,7 @@ describe('createAffectedMetadata', () => {
     const { projectStates } = createProjectMetadata(
       projectNodes as ProjectNode[],
       dependencies,
-      ['app1', 'lib2'],
-      false
+      ['app1', 'lib2']
     );
     expect(projectStates.app1.touched).toEqual(true);
     expect(projectStates.lib2.touched).toEqual(true);
@@ -558,8 +545,7 @@ describe('createAffectedMetadata', () => {
     const { projectStates } = createProjectMetadata(
       projectNodes as ProjectNode[],
       dependencies,
-      ['app1', 'lib2'],
-      false
+      ['app1', 'lib2']
     );
     expect(projectStates.app1.affected).toEqual(true);
     expect(projectStates.lib2.affected).toEqual(true);
@@ -569,8 +555,7 @@ describe('createAffectedMetadata', () => {
     const { projectStates } = createProjectMetadata(
       projectNodes as ProjectNode[],
       dependencies,
-      ['app1'],
-      false
+      ['app1']
     );
     expect(projectStates.app1.affected).toEqual(true);
     expect(projectStates['app1-e2e'].affected).toEqual(true);
@@ -585,8 +570,7 @@ describe('createAffectedMetadata', () => {
     const { projectStates } = createProjectMetadata(
       projectNodes as ProjectNode[],
       dependencies,
-      ['lib1'],
-      false
+      ['lib1']
     );
     expect(projectStates.app1.affected).toEqual(true);
     expect(projectStates['app1-e2e'].affected).toEqual(true);
@@ -601,8 +585,7 @@ describe('createAffectedMetadata', () => {
     const { projectStates } = createProjectMetadata(
       projectNodes as ProjectNode[],
       dependencies,
-      [],
-      false
+      []
     );
     expect(projectStates.app1.affected).toEqual(false);
     expect(projectStates.app2.affected).toEqual(false);
@@ -620,8 +603,7 @@ describe('createAffectedMetadata', () => {
     const metadata = createProjectMetadata(
       projectNodes as ProjectNode[],
       dependencies,
-      ['lib2'],
-      false
+      ['lib2']
     );
     const { dependencyGraph, projectStates } = metadata;
     expect(dependencyGraph.roots).toEqual(['app1-e2e', 'customName-e2e']);
@@ -645,8 +627,7 @@ describe('createAffectedMetadata', () => {
     const metadata = createProjectMetadata(
       projectNodes as ProjectNode[],
       dependencies,
-      ['app1-e2e', 'customName-e2e'],
-      false
+      ['app1-e2e', 'customName-e2e']
     );
     const { dependencyGraph, projectStates } = metadata;
     expect(dependencyGraph.roots).toEqual([]);

--- a/packages/workspace/src/tasks-runner/tasks-runner.ts
+++ b/packages/workspace/src/tasks-runner/tasks-runner.ts
@@ -23,15 +23,17 @@ export interface TaskCompleteEvent extends AffectedEvent {
   success: boolean;
 }
 
+export interface TasksRunnerContext {
+  dependencyGraph: DependencyGraph;
+  tasksMap: {
+    [projectName: string]: {
+      [targetName: string]: Task;
+    };
+  };
+}
+
 export type TasksRunner<T = unknown> = (
   tasks: Task[],
   options?: T,
-  context?: {
-    dependencyGraph: DependencyGraph;
-    tasksMap: {
-      [projectName: string]: {
-        [targetName: string]: Task;
-      };
-    };
-  }
+  context?: TasksRunnerContext
 ) => Observable<AffectedEvent>;

--- a/scripts/e2e-ci1.sh
+++ b/scripts/e2e-ci1.sh
@@ -6,6 +6,8 @@ rm -rf tmp
 mkdir -p tmp/angular
 mkdir -p tmp/nx
 
+# Please keep this in alphabetical order
+# This should be every file under e2e except for utils.js up to next.test.ts
 export SELECTED_CLI=$1  
 jest --maxWorkers=1 ./build/e2e/affected.test.js &&
 jest --maxWorkers=1 ./build/e2e/command-line.test.js &&

--- a/scripts/e2e-ci2.sh
+++ b/scripts/e2e-ci2.sh
@@ -6,6 +6,8 @@ rm -rf tmp
 mkdir -p tmp/angular
 mkdir -p tmp/nx
 
+# Please keep this in alphabetical order
+# This should be every file under e2e except for utils.js after ng-add.test.ts
 export SELECTED_CLI=$1  
 jest --maxWorkers=1 ./build/e2e/ng-add.test.js &&
 jest --maxWorkers=1 ./build/e2e/ngrx.test.js &&
@@ -13,6 +15,7 @@ jest --maxWorkers=1 ./build/e2e/node.test.js &&
 jest --maxWorkers=1 ./build/e2e/print-affected.test.js &&
 jest --maxWorkers=1 ./build/e2e/react.test.js &&
 jest --maxWorkers=1 ./build/e2e/report.test.js &&
+jest --maxWorkers=1 ./build/e2e/run-many.test.js &&
+jest --maxWorkers=1 ./build/e2e/storybook.test.js &&
 jest --maxWorkers=1 ./build/e2e/upgrade-module.test.js &&
-jest --maxWorkers=1 ./build/e2e/web.test.js &&
-jest --maxWorkers=1 ./build/e2e/storybook.test.js
+jest --maxWorkers=1 ./build/e2e/web.test.js


### PR DESCRIPTION
 - after understanding the mental model behind affected better, reworked run-many to fit it
   - refactored `AffectedMetadata` to be `ProjectMetadata`
   - added the ability to pass in touched projects, as well as touched files
   - rewired run-many to use that instead of reproducing various bits
  - this includes @FrozenPandaz's adding run-many test to run with the CI
  - fixes an issue with --all where it would run all other projects, not just projects that can run for the given target
 - reworked with-deps
   - --with-deps is now a function a reporter can call, to get a list of precondition tasks to a given set of tasks
   - supporting this in run many, also adds support for print-affected