### PR TITLE
fix(repo): renable e2e tests for node

### DIFF
--- a/e2e/node.test.ts
+++ b/e2e/node.test.ts
@@ -128,9 +128,9 @@ forEachCli(currentCLIName => {
           done();
         });
       });
-    }, 30000);
+    }, 60000);
 
-    fit('should have correct ts options for nest application', async () => {
+    it('should have correct ts options for nest application', async () => {
       if (currentCLIName === 'angular') {
         // Usually the tests use ensureProject() to setup the test workspace. But it will trigger
         // the nx workspace schematic which creates a tsconfig file containing the parameters
@@ -157,7 +157,7 @@ forEachCli(currentCLIName => {
       ); // respects "extends" inside tsconfigs
 
       expect(config.options.emitDecoratorMetadata).toEqual(true); // required by nest to function properly
-    }, 30000);
+    }, 60000);
 
     it('should be able to generate a nest application', async done => {
       ensureProject();
@@ -201,13 +201,14 @@ forEachCli(currentCLIName => {
 
       const process = spawn(
         'node',
-        ['./node_modules/.bin/nx', 'serve', nestapp],
+        ['./node_modules/@nrwl/cli/bin/nx', 'serve', nestapp],
         {
           cwd: tmpProjPath()
         }
       );
 
       process.stdout.on('data', async (data: Buffer) => {
+        console.log(data.toString());
         if (!data.toString().includes('Listening at http://localhost:3333')) {
           return;
         }
@@ -218,7 +219,7 @@ forEachCli(currentCLIName => {
           done();
         });
       });
-    }, 30000);
+    }, 60000);
 
     it('should be able to generate an empty application', async () => {
       ensureProject();
@@ -236,6 +237,6 @@ forEachCli(currentCLIName => {
         cwd: tmpProjPath()
       }).toString();
       expect(result).toContain('Hello World!');
-    }, 30000);
+    }, 60000);
   });
 });

--- a/packages/express/src/schematics/application/application.ts
+++ b/packages/express/src/schematics/application/application.ts
@@ -30,7 +30,7 @@ function addMainFile(options: NormalizedSchema): Rule {
       `/**
  * This is not a production server yet!
  * This is only a minimal backend to get started.
- **/
+ */
 
 import * as express from 'express';
 

--- a/packages/nest/src/schematics/application/application.ts
+++ b/packages/nest/src/schematics/application/application.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular-devkit/schematics';
 import { join, normalize, Path } from '@angular-devkit/core';
 import { Schema } from './schema';
-import { toFileName, updateJsonInTree } from '@nrwl/workspace';
+import { formatFiles, toFileName, updateJsonInTree } from '@nrwl/workspace';
 import init from '../init/init';
 
 interface NormalizedSchema extends Schema {
@@ -26,7 +26,7 @@ function addMainFile(options: NormalizedSchema): Rule {
       `/**
  * This is not a production server yet!
  * This is only a minimal backend to get started.
- **/
+ */
 
 import { NestFactory } from '@nestjs/core';
 
@@ -74,7 +74,8 @@ export default function(schema: Schema): Rule {
       updateJsonInTree(join(options.appProjectRoot, 'tsconfig.json'), json => {
         json.compilerOptions.emitDecoratorMetadata = true;
         return json;
-      })
+      }),
+      formatFiles(options)
     ])(host, context);
   };
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Node Tests are disabled because of a `fit`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Node tests are enabled again

## Issue
