### PR TITLE
fix(nx): storybook "staticDir" property items type

### DIFF
--- a/packages/storybook/src/builders/storybook/schema.json
+++ b/packages/storybook/src/builders/storybook/schema.json
@@ -41,7 +41,7 @@
       "type": "array",
       "description": "Directory where to load static files from, array of strings",
       "items": {
-        "type": "number"
+        "type": "string"
       }
     },
     "config": {


### PR DESCRIPTION
The `staticDir` should be an array of string but was defined as an array of number in the `schema.json`

## Current Behavior (This is the behavior we have today, before the PR is merged)
`nx run ui-lib:storybook` failed with `staticDir` option set

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
`nx run ui-lib:storybook` run with `staticDir` option set and will serve static dir

## Issue
The previous type defintion in `schema.json` for `staticDir` items was wrong