### PR TITLE
fix(core): make prettier a peerDependency to respect installed versio…

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -42,6 +42,9 @@
       "@nrwl/web"
     ]
   },
+  "peerDependencies": {
+    "prettier": "^1.18.2"
+  },
   "dependencies": {
     "@angular-devkit/core": "9.0.0-rc.5",
     "@angular-devkit/schematics": "9.0.0-rc.5",
@@ -56,7 +59,6 @@
     "tmp": "0.0.33",
     "yargs-parser": "10.0.0",
     "yargs": "^11.0.0",
-    "prettier": "1.18.2",
     "chalk": "2.4.2",
     "@nrwl/cli": "*"
   }


### PR DESCRIPTION
…n of prettier

## Current Behavior (This is the behavior we have today, before the PR is merged)

Workspace installed version of `prettier` (specified in `package.json` is not used during `nx format:write`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Workspace installed version of `prettier` is used during `nx format:write`

## Issue
Closes #1863 
Fixes #2159 