### PR TITLE
fix(node): fix node e2e test for circle

### DIFF
--- a/e2e/node.test.ts
+++ b/e2e/node.test.ts
@@ -228,6 +228,9 @@ forEachCli(currentCLIName => {
       const nodeapp = uniq('nodeapp');
 
       runCLI(`generate @nrwl/node:app ${nodeapp} --linter=${linter}`);
+
+      setMaxWorkers(nodeapp);
+
       const lintResults = runCLI(`lint ${nodeapp}`);
       expect(lintResults).toContain('All files pass linting.');
 


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

e2e test for empty node app is flaky because circle attempts to use 34 workers for type checking.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

circle uses 4 workers for type checking and the test is no longer flaky

## Issue
