### PR TITLE
fix(@nrwl/workspace): Account for files with paths

### DIFF
--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -42,7 +42,9 @@ export {
   findNodes,
   updatePackageJsonDependencies,
   getProjectGraphFromHost,
-  readWorkspace
+  readWorkspace,
+  renameSyncInTree,
+  renameDirSyncInTree
 } from './src/utils/ast-utils';
 
 export {

--- a/packages/workspace/src/utils/ast-utils.spec.ts
+++ b/packages/workspace/src/utils/ast-utils.spec.ts
@@ -1,5 +1,12 @@
-import { readJsonInTree } from './ast-utils';
-import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import {
+  readJsonInTree,
+  renameSyncInTree,
+  renameDirSyncInTree
+} from './ast-utils';
+import {
+  SchematicTestRunner,
+  UnitTestTree
+} from '@angular-devkit/schematics/testing';
 import { join } from 'path';
 import { Tree } from '@angular-devkit/schematics';
 import { serializeJson } from './fileutils';
@@ -43,5 +50,77 @@ describe('readJsonInTree', () => {
     expect(() => readJsonInTree(tree, 'data.json')).toThrow(
       'Cannot parse data.json: Unexpected token d in JSON at position 2'
     );
+  });
+});
+
+describe('renameSyncInTree', () => {
+  let tree: UnitTestTree;
+
+  beforeEach(() => {
+    tree = new UnitTestTree(Tree.empty());
+  });
+
+  it('should rename a file in the tree', () => {
+    const content = 'my content';
+    tree.create('/a', content);
+    renameSyncInTree(tree, '/a', '/b', err => {
+      expect(err).toBeFalsy();
+      expect(content).toEqual(tree.readContent('/b'));
+    });
+  });
+
+  it('should rename a file in the tree to a nested dir', () => {
+    const content = 'my content';
+    tree.create('/a', content);
+    renameSyncInTree(tree, '/a', '/x/y/z/b', err => {
+      expect(err).toBeFalsy();
+      expect(content).toEqual(tree.readContent('/x/y/z/b'));
+    });
+  });
+});
+
+describe('renameDirSyncInTree', () => {
+  let tree: UnitTestTree;
+
+  beforeEach(() => {
+    tree = new UnitTestTree(Tree.empty());
+  });
+
+  it('should rename a dir in the tree', () => {
+    const content = 'my content';
+    tree.create('/dir/a', content);
+    tree.create('/dir/b', content);
+    renameDirSyncInTree(tree, 'dir', '/newdir', err => {
+      expect(err).toBeFalsy();
+      expect(tree.files).toContain('/newdir/a');
+      expect(tree.files).toContain('/newdir/b');
+      expect(tree.files).not.toContain('/dir/a');
+      expect(tree.files).not.toContain('/dir/b');
+    });
+  });
+
+  it('should rename a dir in the tree, with sub dirs', () => {
+    const content = 'my content';
+    tree.create('/dir/a', content);
+    tree.create('/dir/b', content);
+    tree.create('/dir/sub1/c', content);
+    tree.create('/dir/sub1/d', content);
+    tree.create('/dir/sub1/sub2/e', content);
+    tree.create('/dir/sub1/sub2/f', content);
+    renameDirSyncInTree(tree, 'dir', '/newdir', err => {
+      expect(err).toBeFalsy();
+      expect(tree.files).toContain('/newdir/a');
+      expect(tree.files).toContain('/newdir/b');
+      expect(tree.files).not.toContain('/dir/a');
+      expect(tree.files).not.toContain('/dir/b');
+      expect(tree.files).toContain('/newdir/sub1/c');
+      expect(tree.files).toContain('/newdir/sub1/d');
+      expect(tree.files).not.toContain('/dir/sub1/c');
+      expect(tree.files).not.toContain('/dir/sub1/d');
+      expect(tree.files).toContain('/newdir/sub1/sub2/e');
+      expect(tree.files).toContain('/newdir/sub1/sub2/f');
+      expect(tree.files).not.toContain('/dir/sub1/sub2/e');
+      expect(tree.files).not.toContain('/dir/sub1/sub2/f');
+    });
   });
 });


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Running `ng add @nrwl/workspace` to update a CLI workspace when files such as `tsconfig.app.json` are in a directory such as `src` causes the schematic to error out.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Running the above command will move the file(s) to the appropriate location.

## Issue
