### PR TITLE
fix(node): add webpack-merge to @nrwl/node dependencies

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -47,6 +47,7 @@
     "ts-loader": "5.4.5",
     "tsconfig-paths-webpack-plugin": "3.2.0",
     "webpack": "4.41.2",
+    "webpack-merge": "4.2.1",
     "webpack-dev-server": "3.9.0",
     "webpack-node-externals": "1.7.2"
   }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`@nrwl/node` needs `webpack-merge` to build but does not add it as a `dependency`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`@nrwl/node` installs `webpack-merge` as a dependency and is able to build.

## Issue
Fixes #2169 