### PR TITLE
chore(repo): improve PR submission process

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -1,0 +1,78 @@
+module.exports = {
+  types: [
+    { value: 'feat', name: 'feat:     A new feature' },
+    { value: 'fix', name: 'fix:      A bug fix' },
+    { value: 'docs', name: 'docs:     Documentation only changes' },
+    {
+      value: 'cleanup',
+      name:
+        'cleanup:  A code change that neither fixes a bug nor adds a feature'
+    },
+    {
+      value: 'chore',
+      name: "chore:    Other changes that don't modify src or test files"
+    }
+  ],
+
+  scopes: [
+    { name: 'angular', description: 'anything Angular specific' },
+    { name: 'bazel', description: 'anything Bazel specific' },
+    { name: 'core', description: 'anything Nx core specific' },
+    { name: 'docs', description: 'anything related to docs infrastructure' },
+    { name: 'nextjs', description: 'anything Next specific' },
+    { name: 'node', description: 'anything Node specific' },
+    { name: 'react', description: 'anything React specific' },
+    { name: 'storybook', description: 'anything Storybook specific' },
+    {
+      name: 'testing',
+      description: 'anything testing specific (e.g., jest or cypress)'
+    },
+    {
+      name: 'repo',
+      description: 'anything related to managing the repo itself'
+    },
+    { name: 'misc', description: 'misc stuff' }
+  ],
+
+  allowTicketNumber: true,
+  isTicketNumberRequired: false,
+  ticketNumberPrefix: 'TICKET-',
+  ticketNumberRegExp: '\\d{1,5}',
+
+  // it needs to match the value for field type. Eg.: 'fix'
+  /*
+  scopeOverrides: {
+    fix: [
+      {name: 'merge'},
+      {name: 'style'},
+      {name: 'e2eTest'},
+      {name: 'unitTest'}
+    ]
+  },
+  */
+  // override the messages, defaults are as follows
+  messages: {
+    type: "Select the type of change that you're committing:",
+    scope: '\nDenote the SCOPE of this change (optional):',
+    // used if allowCustomScopes is true
+    customScope: 'Denote the SCOPE of this change:',
+    subject: 'Write a SHORT, IMPERATIVE tense description of the change:\n',
+    body:
+      'Provide a LONGER description of the change (optional). Use "|" to break new line:\n',
+    breaking: 'List any BREAKING CHANGES (optional):\n',
+    footer:
+      'List any ISSUES CLOSED by this change (optional). E.g.: #31, #34:\n',
+    confirmCommit: 'Are you sure you want to proceed with the commit above?'
+  },
+
+  allowCustomScopes: false,
+  allowBreakingChanges: ['feat', 'fix'],
+  // skip any questions you want
+  skipQuestions: [],
+
+  // limit subject length
+  subjectLimit: 100
+  // breaklineChar: '|', // It is supported for fields body and footer.
+  // footerPrefix : 'ISSUES CLOSED:'
+  // askForBreakingChangeFirst : true, // default is false
+};

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,11 +112,11 @@ You can file new issues by filling out our [issue form](https://github.com/nrwl/
 
 Please follow the following guidelines:
 
-- Make sure unit tests pass
-- Make sure e2e tests pass (this can take a while, so you can always let CI check those)
+- Make sure unit tests pass (`yarn test`)
+- Make sure e2e tests pass (this can take a while, so you can always let CI check those) (`yarn e2e`)
 - Make sure you run `yarn format`
-- For documentation, check for spelling and grammatical errors.
-- Update your commit message to follow the guidelines below
+- Update documentation with `yarn documentation`. For documentation, check for spelling and grammatical errors.
+- Update your commit message to follow the guidelines below (use `yarn commit` to automate compliance)
 
 #### Commit Message Guidelines
 

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "checkformat": "./scripts/check_format.sh",
     "checkimports": "node ./scripts/check-imports.js",
     "checkversions": "ts-node ./scripts/check-versions.ts",
-    "documentation": "./scripts/documentation/documentation.sh && yarn format && ./scripts/documentation/check-documentation.sh"
+    "documentation": "./scripts/documentation/documentation.sh && yarn format && ./scripts/documentation/check-documentation.sh",
+    "prepush": "yarn checkcommit && yarn checkformat && yarn documentation"
   },
   "devDependencies": {
-    "axios": "^0.19.0",
     "@angular-devkit/architect": "0.803.14",
     "@angular-devkit/build-angular": "0.803.14",
     "@angular-devkit/build-ng-packagr": "0.803.14",
@@ -67,11 +67,11 @@
     "@ngrx/store-devtools": "8.5.0",
     "@ngtools/webpack": "8.3.14",
     "@schematics/angular": "8.3.14",
-    "@testing-library/react": "9.3.0",
-    "@storybook/core": "^5.2.5",
-    "@storybook/angular": "^5.2.5",
-    "@storybook/react": "^5.2.5",
     "@storybook/addon-knobs": "^5.2.5",
+    "@storybook/angular": "^5.2.5",
+    "@storybook/core": "^5.2.5",
+    "@storybook/react": "^5.2.5",
+    "@testing-library/react": "9.3.0",
     "@types/express": "4.17.0",
     "@types/fast-levenshtein": "^0.0.1",
     "@types/jasmine": "~2.8.6",
@@ -95,6 +95,7 @@
     "angular": "1.6.6",
     "app-root-path": "^2.0.1",
     "autoprefixer": "9.6.1",
+    "axios": "^0.19.0",
     "babel-loader": "8.0.6",
     "babel-plugin-macros": "2.6.1",
     "babel-plugin-transform-async-to-promises": "0.8.14",
@@ -112,6 +113,7 @@
     "cosmiconfig": "^4.0.0",
     "cypress": "3.4.1",
     "cz-conventional-changelog": "^3.0.2",
+    "cz-customizable": "^6.2.0",
     "document-register-element": "^1.13.1",
     "dotenv": "6.2.0",
     "eslint": "6.1.0",
@@ -239,7 +241,7 @@
   },
   "config": {
     "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
+      "path": "./node_modules/cz-customizable"
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6772,6 +6772,18 @@ cz-conventional-changelog@^3.0.2:
   optionalDependencies:
     "@commitlint/load" ">6.1.1"
 
+cz-customizable@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/cz-customizable/-/cz-customizable-6.2.0.tgz#4591bef5eae9fcef44bf024259723979404cdee0"
+  integrity sha512-6fBA8pbwApTY20Q5aDkWgJcg5wCmbwlcnccUFyBQypN8AoRJ0Vt4pLehai0/P2Xr29t2UDYoNGOUDhi4eoR0JQ==
+  dependencies:
+    editor "1.0.0"
+    find-config "^1.0.0"
+    inquirer "^6.3.1"
+    lodash "^4.17.11"
+    temp "^0.9.0"
+    word-wrap "^1.2.3"
+
 d@1, d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
@@ -7387,6 +7399,11 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+editor@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
+  integrity sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -8392,6 +8409,13 @@ find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
     commondir "^1.0.1"
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
+
+find-config@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/find-config/-/find-config-1.0.0.tgz#eafa2b9bc07fa9c90e9a0c3ef9cecf1cc800f530"
+  integrity sha1-6vorm8B/qckOmgw++c7PHMgA9TA=
+  dependencies:
+    user-home "^2.0.0"
 
 find-node-modules@2.0.0:
   version "2.0.0"
@@ -9595,19 +9619,19 @@ humanize-ms@^1.2.1:
     ms "^2.0.0"
 
 husky@^3.0.3:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-3.0.5.tgz#d7db27c346645a8dc52df02aa534a377ad7925e0"
-  integrity sha512-cKd09Jy9cDyNIvAdN2QQAP/oA21sle4FWXjIMDttailpLAYZuBE7WaPmhrkj+afS8Sj9isghAtFvWSQ0JiwOHg==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-3.1.0.tgz#5faad520ab860582ed94f0c1a77f0f04c90b57c0"
+  integrity sha512-FJkPoHHB+6s4a+jwPqBudBDvYZsoQW5/HBuMSehC8qDiCe50kpcxeqFoDSlow+9I6wg47YxBoT3WxaURlrDIIQ==
   dependencies:
     chalk "^2.4.2"
+    ci-info "^2.0.0"
     cosmiconfig "^5.2.1"
     execa "^1.0.0"
     get-stdin "^7.0.0"
-    is-ci "^2.0.0"
     opencollective-postinstall "^2.0.2"
     pkg-dir "^4.2.0"
     please-upgrade-node "^3.2.0"
-    read-pkg "^5.1.1"
+    read-pkg "^5.2.0"
     run-node "^1.0.0"
     slash "^3.0.0"
 
@@ -9856,7 +9880,7 @@ inquirer@6.5.1:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-inquirer@^6.2.0, inquirer@^6.4.1:
+inquirer@^6.2.0, inquirer@^6.3.1, inquirer@^6.4.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
   integrity sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
@@ -15030,7 +15054,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-read-pkg@^5.0.0, read-pkg@^5.1.1:
+read-pkg@^5.0.0, read-pkg@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
   integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
@@ -15625,7 +15649,7 @@ right-pad@^1.0.1:
   resolved "https://registry.yarnpkg.com/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
   integrity sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=
 
-rimraf@2.6.3:
+rimraf@2.6.3, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -17127,6 +17151,13 @@ telejson@^3.0.2:
     lodash "^4.17.15"
     memoizerific "^1.11.3"
 
+temp@^0.9.0:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.1.tgz#2d666114fafa26966cd4065996d7ceedd4dd4697"
+  integrity sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==
+  dependencies:
+    rimraf "~2.6.2"
+
 tempfile@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/tempfile/-/tempfile-1.1.1.tgz#5bcc4eaecc4ab2c707d8bc11d99ccc9a2cb287f2"
@@ -17922,6 +17953,13 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+user-home@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
+  integrity sha1-nHC/2Babwdy/SGBODwS4tJzenp8=
+  dependencies:
+    os-homedir "^1.0.0"
+
 useragent@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/useragent/-/useragent-2.3.0.tgz#217f943ad540cb2128658ab23fc960f6a88c9972"
@@ -18525,7 +18563,7 @@ windows-release@^3.1.0:
   dependencies:
     execa "^1.0.0"
 
-word-wrap@^1.0.3:
+word-wrap@^1.0.3, word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==


### PR DESCRIPTION
Add cz-customizable to restrict scopes
Add a prepush hook with husky

## Current Behavior (This is the behavior we have today, before the PR is merged)
Devs submitting a PR need to remember to:
- Run `yarn format`
- Run `yarn documentation`
- Format commit messages correctly

If they forget, they get no feedback until after CI has run.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
- `yarn commit` will list the valid types and scopes so that the commit messages will be guaranteed valid
- `git push` will trigger a local check of `yarn checkcommit`, `yarn checkformat` and `yarn documentation` so that devs can fix before pushing.
