### PR TITLE
fix(misc): fix project tslint generation

### DIFF
--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -29,6 +29,11 @@
       "version": "8.5.0-beta.1",
       "description": "Fix the exclude paths in tsconfig.lib.json files for Jest projects",
       "factory": "./src/migrations/update-8-5-0/fix-tsconfig-lib-json"
+    },
+    "fix-tslint-json": {
+      "version": "8.10.0-beta.1",
+      "description": "Fix rules in `tslint.json`",
+      "factory": "./src/migrations/update-8-10-0/fix-tslint-json"
     }
   },
   "packageJsonUpdates": {

--- a/packages/workspace/src/migrations/update-8-10-0/fix-tslint-json.spec.ts
+++ b/packages/workspace/src/migrations/update-8-10-0/fix-tslint-json.spec.ts
@@ -1,0 +1,92 @@
+import { chain, Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { join } from 'path';
+import {
+  readJsonInTree,
+  updateJsonInTree,
+  updateWorkspaceInTree
+} from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import {
+  callRule,
+  createLibWithTests,
+  runMigration
+} from '../../utils/testing';
+import { updateWorkspace } from '@nrwl/workspace/src/utils/workspace';
+
+describe('Update 8.10.0', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = Tree.empty();
+    tree = createEmptyWorkspace(tree);
+  });
+
+  it('should fix projects with invalid tslint configs', async () => {
+    tree = await callRule(
+      chain([
+        updateWorkspace(workspace => {
+          workspace.projects.add({
+            name: 'proj-with-invalid-tslint',
+            root: 'proj-with-invalid-tslint'
+          });
+        }),
+        updateJsonInTree('proj-with-invalid-tslint/tslint.json', () => ({
+          rules: []
+        }))
+      ]),
+      tree
+    );
+
+    const result = await runMigration('fix-tslint-json', {}, tree);
+
+    expect(
+      readJsonInTree(result, 'proj-with-invalid-tslint/tslint.json').rules
+    ).toEqual({});
+  });
+
+  it('should fix projects with valid tslint configs', async () => {
+    tree = await callRule(
+      chain([
+        updateWorkspace(workspace => {
+          workspace.projects.add({
+            name: 'proj-with-valid-tslint',
+            root: 'proj-with-valid-tslint'
+          });
+        }),
+        updateJsonInTree('proj-with-valid-tslint/tslint.json', () => ({
+          rules: {
+            rule: [true]
+          }
+        }))
+      ]),
+      tree
+    );
+
+    const result = await runMigration('fix-tslint-json', {}, tree);
+
+    expect(
+      readJsonInTree(result, 'proj-with-valid-tslint/tslint.json').rules
+    ).toEqual({
+      rule: [true]
+    });
+  });
+
+  it('should not add tslint configs to projects without tslint configs', async () => {
+    tree = await callRule(
+      chain([
+        updateWorkspace(workspace => {
+          workspace.projects.add({
+            name: 'proj-without-tslint',
+            root: 'proj-without-tslint'
+          });
+        })
+      ]),
+      tree
+    );
+
+    const result = await runMigration('fix-tslint-json', {}, tree);
+
+    expect(result.exists('proj-without-tslint/tslint.json')).toEqual(false);
+  });
+});

--- a/packages/workspace/src/migrations/update-8-10-0/fix-tslint-json.ts
+++ b/packages/workspace/src/migrations/update-8-10-0/fix-tslint-json.ts
@@ -1,0 +1,49 @@
+import {
+  chain,
+  Rule,
+  SchematicContext,
+  Tree
+} from '@angular-devkit/schematics';
+import { join, normalize } from '@angular-devkit/core';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+
+import { updateJsonInTree } from '../../utils/ast-utils';
+import { getWorkspace } from '../../utils/workspace';
+
+async function fixTslints(host: Tree) {
+  const workspace = await getWorkspace(host);
+  const rules: Rule[] = [];
+  workspace.projects.forEach(proj => {
+    const tslintPath = join(normalize(proj.root), 'tslint.json');
+    if (host.exists(tslintPath)) {
+      rules.push(
+        updateJsonInTree(tslintPath, (json, context) => {
+          if (Array.isArray(json.rules)) {
+            if (json.rules.length === 0) {
+              json.rules = {};
+            } else {
+              context.logger.warn(
+                `"rules" in "${tslintPath}" is an array but should be an object.`
+              );
+            }
+          }
+          return json;
+        })
+      );
+    }
+  });
+
+  return chain(rules);
+}
+
+function showInfo(host: Tree, context: SchematicContext) {
+  context.logger.info(stripIndents`
+    Nx generated invalid tslint configurations in a prior version.
+    
+    These invalid configurations will be fixed.
+  `);
+}
+
+export default function(): Rule {
+  return chain([showInfo, fixTslints]);
+}

--- a/packages/workspace/src/schematics/library/library.spec.ts
+++ b/packages/workspace/src/schematics/library/library.spec.ts
@@ -222,7 +222,7 @@ describe('lib', () => {
       const tslintJson = readJsonInTree(tree, 'libs/my-dir/my-lib/tslint.json');
       expect(tslintJson).toEqual({
         extends: '../../../tslint.json',
-        rules: []
+        rules: {}
       });
     });
   });

--- a/packages/workspace/src/utils/lint.ts
+++ b/packages/workspace/src/utils/lint.ts
@@ -77,7 +77,7 @@ export function addLintFiles(
           join(projectRoot as any, `tslint.json`),
           JSON.stringify({
             extends: `${offsetFromRoot(projectRoot)}tslint.json`,
-            rules: []
+            rules: {}
           })
         );
       }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`tslint.json` files in projects are created with `rules: []` which isn't proper configuration for tslint.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`tslint.json` files in projects are created with `rules: {}` which is proper configuration for tslint.

There's a migration to fix the ones which were generated incorrectly... if they have not been touched.

## Issue
