### PR TITLE
fix(testing): set NODE_ENV to 'test' when running jest

### DIFF
--- a/e2e/jest.test.ts
+++ b/e2e/jest.test.ts
@@ -67,5 +67,23 @@ forEachCli(() => {
       expect(appResult.stderr).toContain('Test Suites: 1 passed, 1 total');
       done();
     }, 45000);
+
+    it('should set the NODE_ENV to `test`', async done => {
+      ensureProject();
+      const mylib = uniq('mylib');
+      runCLI(`generate @nrwl/workspace:lib ${mylib} --unit-test-runner jest`);
+
+      updateFile(
+        `libs/${mylib}/src/lib/${mylib}.spec.ts`,
+        `
+        test('can access jest global', () => {
+          expect(process.env.NODE_ENV).toBe('test');
+        });
+        `
+      );
+      const appResult = await runCLIAsync(`test ${mylib} --no-watch`);
+      expect(appResult.stderr).toContain('Test Suites: 1 passed, 1 total');
+      done();
+    }, 45000);
   });
 });

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -16,6 +16,9 @@ try {
 
 import { runCLI } from 'jest';
 
+if (process.env.NODE_ENV == null || process.env.NODE_ENV == undefined) {
+  (process.env as any).NODE_ENV = 'test';
+}
 export interface JestBuilderOptions extends JsonObject {
   codeCoverage?: boolean;
   config?: string;


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
NODE_ENV is not set to `test` when running Jest. This is not the same behaviour as running jest through the command line. 
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
NODE_ENV is now set to `test` when running tests that utilize jest.
## Issue
Fixes #977
