### PR TITLE
feat(repo): only format documentation when generating documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "checkformat": "./scripts/check_format.sh",
     "checkimports": "node ./scripts/check-imports.js",
     "checkversions": "ts-node ./scripts/check-versions.ts",
-    "documentation": "./scripts/documentation/documentation.sh && yarn format && ./scripts/documentation/check-documentation.sh",
-    "prepush": "yarn checkcommit && yarn checkformat && yarn documentation"
+    "documentation": "./scripts/documentation/documentation.sh && ./scripts/documentation/check-documentation.sh",
+    "prepush": "yarn checkcommit && yarn documentation && yarn checkformat"
   },
   "devDependencies": {
     "@angular-devkit/architect": "0.803.14",

--- a/scripts/documentation/documentation.sh
+++ b/scripts/documentation/documentation.sh
@@ -4,3 +4,4 @@ echo "Generating API documentation"
 ts-node ./scripts/documentation/generate-builders-data.ts
 ts-node ./scripts/documentation/generate-schematics-data.ts
 ts-node ./scripts/documentation/generate-npmscripts-data.ts
+echo 'Done generating all Documentation'

--- a/scripts/documentation/generate-builders-data.ts
+++ b/scripts/documentation/generate-builders-data.ts
@@ -8,7 +8,11 @@ import {
   htmlSelectorFormat,
   pathFormat
 } from '@angular-devkit/schematics/src/formats';
-import { generateFile, sortAlphabeticallyFunction } from './utils';
+import {
+  generateJsonFile,
+  generateMarkdownFile,
+  sortAlphabeticallyFunction
+} from './utils';
 import {
   Configuration,
   getPackageConfigurations
@@ -126,8 +130,10 @@ Promise.all(
               builderList.map(b => generateTemplate(framework, b))
             )
             .then(markdownList =>
-              markdownList.forEach(template =>
-                generateFile(config.builderOutput, template)
+              Promise.all(
+                markdownList.map(template =>
+                  generateMarkdownFile(config.builderOutput, template)
+                )
               )
             )
             .then(() =>
@@ -142,11 +148,11 @@ Promise.all(
   console.log('Done generating Builders Documentation');
 });
 
-getPackageConfigurations().forEach(({ framework, configs }) => {
+getPackageConfigurations().forEach(async ({ framework, configs }) => {
   const builders = configs
     .filter(item => item.hasBuilders)
     .map(item => item.name);
-  fs.outputJsonSync(
+  await generateJsonFile(
     path.join(__dirname, '../../docs', framework, 'builders.json'),
     builders
   );

--- a/scripts/documentation/generate-schematics-data.ts
+++ b/scripts/documentation/generate-schematics-data.ts
@@ -8,7 +8,11 @@ import {
   htmlSelectorFormat,
   pathFormat
 } from '@angular-devkit/schematics/src/formats';
-import { generateFile, sortAlphabeticallyFunction } from './utils';
+import {
+  generateJsonFile,
+  generateMarkdownFile,
+  sortAlphabeticallyFunction
+} from './utils';
 import {
   Configuration,
   getPackageConfigurations
@@ -173,8 +177,10 @@ Promise.all(
                 .map(s => generateTemplate(framework, s))
             )
             .then(markdownList =>
-              markdownList.forEach(template =>
-                generateFile(config.schematicOutput, template)
+              Promise.all(
+                markdownList.map(template =>
+                  generateMarkdownFile(config.schematicOutput, template)
+                )
               )
             )
             .then(() => {
@@ -186,14 +192,14 @@ Promise.all(
     );
   })
 ).then(() => {
-  console.log('Finished Generating all Documentation');
+  console.log('Finished Generating Schematics Documentation');
 });
 
-getPackageConfigurations().forEach(({ framework, configs }) => {
+getPackageConfigurations().forEach(async ({ framework, configs }) => {
   const schematics = configs
     .filter(item => item.hasSchematics)
     .map(item => item.name);
-  fs.outputJsonSync(
+  await generateJsonFile(
     path.join(__dirname, '../../docs', framework, 'schematics.json'),
     schematics
   );

--- a/scripts/documentation/utils.ts
+++ b/scripts/documentation/utils.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { format, resolveConfig } from 'prettier';
 
 export function sortAlphabeticallyFunction(a: string, b: string): number {
   const nameA = a.toUpperCase(); // ignore upper and lowercase
@@ -14,14 +15,40 @@ export function sortAlphabeticallyFunction(a: string, b: string): number {
   return 0;
 }
 
-export function generateFile(
+export async function generateMarkdownFile(
   outputDirectory: string,
   templateObject: { name: string; template: string }
-): void {
+): Promise<void> {
+  const filePath = path.join(outputDirectory, `${templateObject.name}.md`);
   fs.outputFileSync(
-    path.join(outputDirectory, `${templateObject.name}.md`),
-    templateObject.template
+    filePath,
+    await formatWithPrettier(filePath, templateObject.template)
   );
+}
+
+export async function generateJsonFile(
+  filePath: string,
+  json: unknown
+): Promise<void> {
+  fs.outputFileSync(
+    filePath,
+    await formatWithPrettier(filePath, JSON.stringify(json))
+  );
+}
+
+export async function formatWithPrettier(filePath: string, content: string) {
+  let options: any = {
+    filepath: filePath
+  };
+  const resolvedOptions = await resolveConfig(filePath);
+  if (resolvedOptions) {
+    options = {
+      ...options,
+      ...resolvedOptions
+    };
+  }
+
+  return format(content, options);
 }
 
 export function getNxPackageDependencies(


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

All files are formatted during `yarn documentation`.

```sh
Done in 25.12s
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Documentation is formatted as its generated.

```sh
Done in 9.79s
```

## Issue
