### PR TITLE
fix(core): forbid project dependencies onto self

### DIFF
--- a/packages/workspace/src/command-line/project-graph/project-graph-builder.spec.ts
+++ b/packages/workspace/src/command-line/project-graph/project-graph-builder.spec.ts
@@ -24,6 +24,7 @@ describe('ProjectGraphBuilder', () => {
     builder.addDependency(DependencyType.static, myapp.name, libB.name);
     builder.addDependency(DependencyType.static, libB.name, libC.name);
     builder.addDependency(DependencyType.static, libB.name, libC.name); // Idempotency
+    builder.addDependency(DependencyType.static, libB.name, libB.name);
     builder.addDependency(DependencyType.static, libC.name, happyNrwl.name);
 
     const graph = builder.build();

--- a/packages/workspace/src/command-line/project-graph/project-graph-builder.ts
+++ b/packages/workspace/src/command-line/project-graph/project-graph-builder.ts
@@ -30,6 +30,9 @@ export class ProjectGraphBuilder {
     sourceProjectName: string,
     targetProjectName: string
   ) {
+    if (sourceProjectName === targetProjectName) {
+      return;
+    }
     if (!this.nodes[sourceProjectName]) {
       throw new Error(`Source project does not exist: ${sourceProjectName}`);
     }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Projects are able to depend on itself which makes graph traversal very problematic.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Projects are not able to depend on itself.

## Issue
