### PR TITLE
feat(core): use TypeScript to resolve imported modules for dependencies

### DIFF
--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
@@ -12,6 +12,7 @@ jest.mock('../../utils/app-root', () => ({ appRootPath: '/root' }));
 describe('project graph', () => {
   let packageJson: any;
   let workspaceJson: any;
+  let tsConfigJson: any;
   let nxJson: NxJson;
   let filesJson: any;
   let filesAtMasterJson: any;
@@ -70,6 +71,15 @@ describe('project graph', () => {
         util: { tags: [] }
       }
     };
+    tsConfigJson = {
+      compilerOptions: {
+        baseUrl: '.',
+        paths: {
+          '@nrwl/ui': ['libs/ui/src/index.ts'],
+          '@nrwl/util': ['libs/util/src/index.ts']
+        }
+      }
+    };
     filesJson = {
       './apps/api/src/index.ts': stripIndents`
         console.log('starting server');
@@ -88,7 +98,8 @@ describe('project graph', () => {
       `,
       './package.json': JSON.stringify(packageJson),
       './nx.json': JSON.stringify(nxJson),
-      './workspace.json': JSON.stringify(workspaceJson)
+      './workspace.json': JSON.stringify(workspaceJson),
+      './tsconfig.json': JSON.stringify(tsConfigJson)
     };
     files = Object.keys(filesJson).map(f => ({
       file: f,

--- a/packages/workspace/src/core/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -5,8 +5,15 @@ import {
   ProjectGraphNodeRecords
 } from '../project-graph-models';
 import { TypeScriptImportLocator } from './typescript-import-locator';
-import { normalizedProjectRoot } from '../../file-utils';
+import * as ts from 'typescript';
+import { appRootPath } from '../../../utils/app-root';
+import { readTsConfig } from '../../../utils/typescript';
 
+let compilerHost: {
+  host: ts.CompilerHost;
+  options: ts.CompilerOptions;
+  moduleResolutionCache: ts.ModuleResolutionCache;
+};
 export function buildExplicitTypeScriptDependencies(
   ctx: ProjectGraphContext,
   nodes: ProjectGraphNodeRecords,
@@ -20,7 +27,7 @@ export function buildExplicitTypeScriptDependencies(
       importLocator.fromFile(
         f.file,
         (importExpr: string, filePath: string, type: DependencyType) => {
-          const target = findTargetProject(importExpr, nodes);
+          const target = findTargetProject(importExpr, nodes, f.file);
           if (source && target) {
             addDependency(type, source, target);
           }
@@ -29,15 +36,39 @@ export function buildExplicitTypeScriptDependencies(
     });
   });
 
-  function findTargetProject(importExpr, nodes) {
-    return Object.keys(nodes).find(projectName => {
-      const p = nodes[projectName];
-      const normalizedRoot = normalizedProjectRoot(p);
-      return (
-        importExpr === `@${ctx.nxJson.npmScope}/${normalizedRoot}` ||
-        importExpr.startsWith(`@${ctx.nxJson.npmScope}/${normalizedRoot}#`) ||
-        importExpr.startsWith(`@${ctx.nxJson.npmScope}/${normalizedRoot}/`)
-      );
-    });
+  function findTargetProject(importExpr, nodes, filePath) {
+    compilerHost = compilerHost || getCompilerHost();
+    const { options, host, moduleResolutionCache } = compilerHost;
+
+    importExpr = importExpr.split('#')[0];
+
+    const { resolvedModule } = ts.resolveModuleName(
+      importExpr,
+      filePath,
+      options,
+      host,
+      moduleResolutionCache
+    );
+
+    // module was not found in the workspace - return
+    if (!resolvedModule) {
+      return;
+    }
+
+    return Object.keys(nodes).find(projectName =>
+      resolvedModule.resolvedFileName
+        .replace(appRootPath, '')
+        .includes(nodes[projectName].data.root)
+    );
   }
+}
+
+function getCompilerHost() {
+  const { options } = readTsConfig(`${appRootPath}/tsconfig.json`);
+  const host = ts.createCompilerHost(options, true);
+  const moduleResolutionCache = ts.createModuleResolutionCache(
+    appRootPath,
+    host.getCanonicalFileName
+  );
+  return { options, host, moduleResolutionCache };
 }

--- a/packages/workspace/src/core/project-graph/project-graph.spec.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.spec.ts
@@ -13,6 +13,7 @@ describe('project graph', () => {
   let packageJson: any;
   let workspaceJson: any;
   let nxJson: NxJson;
+  let tsConfigJson: any;
   let filesJson: any;
   let files: FileData[];
 
@@ -48,6 +49,16 @@ describe('project graph', () => {
           sourceRoot: 'libs/shared/util/src',
           projectType: 'library'
         },
+        'shared-util-data': {
+          root: 'libs/shared/util/data',
+          sourceRoot: 'libs/shared/util/data/src',
+          projectType: 'library'
+        },
+        'lazy-lib': {
+          root: 'libs/lazy-lib',
+          sourceRoot: 'libs/lazy-lib',
+          projectType: 'library'
+        },
         api: {
           root: 'apps/api/',
           sourceRoot: 'apps/api/src',
@@ -62,7 +73,20 @@ describe('project graph', () => {
         demo: { tags: [], implicitDependencies: ['api'] },
         'demo-e2e': { tags: [] },
         ui: { tags: [] },
-        'shared-util': { tags: [] }
+        'shared-util': { tags: [] },
+        'shared-util-data': { tags: [] },
+        'lazy-lib': { tags: [] }
+      }
+    };
+    tsConfigJson = {
+      compilerOptions: {
+        baseUrl: '.',
+        paths: {
+          '@nrwl/shared/util': ['libs/shared/util/src/index.ts'],
+          '@nrwl/shared-util-data': ['libs/shared/util/data/src/index.ts'],
+          '@nrwl/ui': ['libs/ui/src/index.ts'],
+          '@nrwl/lazy-lib': ['libs/lazy-lib/src/index.ts']
+        }
       }
     };
     filesJson = {
@@ -71,6 +95,9 @@ describe('project graph', () => {
       `,
       './apps/demo/src/index.ts': stripIndents`
         import * as ui from '@nrwl/ui';
+        import * as data from '@nrwl/shared-util-data;
+
+        const s = { loadChildren: '@nrwl/lazy-lib#LAZY' }
       `,
       './apps/demo-e2e/src/integration/app.spec.ts': stripIndents`
         describe('whatever', () => {});
@@ -81,9 +108,16 @@ describe('project graph', () => {
       './libs/shared/util/src/index.ts': stripIndents`
         import * as happyNrwl from 'happy-nrwl';
       `,
+      './libs/shared/util/data/src/index.ts': stripIndents`
+        export const SHARED_DATA = 'shared data';
+      `,
+      './libs/lazy-lib/src/index.ts': stripIndents`
+        export const LAZY = 'lazy lib';
+      `,
       './package.json': JSON.stringify(packageJson),
       './nx.json': JSON.stringify(nxJson),
-      './workspace.json': JSON.stringify(workspaceJson)
+      './workspace.json': JSON.stringify(workspaceJson),
+      './tsconfig.json': JSON.stringify(tsConfigJson)
     };
     files = Object.keys(filesJson).map(f => ({
       file: f,
@@ -101,17 +135,28 @@ describe('project graph', () => {
       'demo-e2e': { name: 'demo-e2e', type: 'e2e' },
       demo: { name: 'demo', type: 'app' },
       ui: { name: 'ui', type: 'lib' },
-      'shared-util': { name: 'shared-util', type: 'lib' }
+      'shared-util': { name: 'shared-util', type: 'lib' },
+      'shared-util-data': { name: 'shared-util-data', type: 'lib' },
+      'lazy-lib': { name: 'lazy-lib', type: 'lib' }
     });
-
     expect(graph.dependencies).toMatchObject({
       'demo-e2e': [
         { type: DependencyType.implicit, source: 'demo-e2e', target: 'demo' }
       ],
-      demo: expect.arrayContaining([
-        { type: DependencyType.implicit, source: 'demo', target: 'api' },
-        { type: DependencyType.static, source: 'demo', target: 'ui' }
-      ]),
+      demo: [
+        { type: DependencyType.static, source: 'demo', target: 'ui' },
+        {
+          type: DependencyType.static,
+          source: 'demo',
+          target: 'shared-util-data'
+        },
+        {
+          type: DependencyType.dynamic,
+          source: 'demo',
+          target: 'lazy-lib'
+        },
+        { type: DependencyType.implicit, source: 'demo', target: 'api' }
+      ],
       ui: [{ type: DependencyType.static, source: 'ui', target: 'shared-util' }]
     });
   });


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
Modules are determined by their folder directory

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Modules are resolved using typescript's `resolveModuleName`

## Issue
Fixes #1093
Fixes #1361
Fixes #2053 