### PR TITLE
fix(storybook): fix storybook peer dependencies

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -31,7 +31,7 @@
     "@nrwl/workspace": "*",
     "@storybook/angular": "^5.2.5",
     "@storybook/react": "^5.2.5",
-    "@storybook/web": "^5.2.5",
+    "@storybook/core": "^5.2.5",
     "@storybook/addon-knobs": "^5.2.5",
     "babel-loader": "^8.0.6",
     "@babel/core": "^7.5.4"


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`@nrwl/storybook` peer depends on `@storybook/web` which does not exist.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`@nrwl/storybook` peer depends on `@storybook/core`.

## Issue
Fixes https://github.com/nrwl/nx/issues/2203