### PR TITLE
fix(misc): add missing packages to package group

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -33,12 +33,15 @@
     "packageGroup": [
       "@nrwl/workspace",
       "@nrwl/angular",
+      "@nrwl/bazel",
       "@nrwl/cypress",
       "@nrwl/express",
       "@nrwl/jest",
       "@nrwl/nest",
+      "@nrwl/next",
       "@nrwl/node",
       "@nrwl/react",
+      "@nrwl/storybook",
       "@nrwl/web"
     ]
   },


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Package group for `@nrwl/workspace` does not contain some packages.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Missing packages are added to `@nrwl/workspace/package.json`

## Issue
Fixes https://github.com/nrwl/nx/issues/2202