### PR TITLE
feat(testing): reenable typechecking via forked process

### DIFF
--- a/e2e/cypress.test.ts
+++ b/e2e/cypress.test.ts
@@ -6,10 +6,8 @@ import {
   readFile,
   ensureProject,
   uniq,
-  newProject,
   forEachCli,
   supportUi,
-  workspaceConfigName,
   setMaxWorkers
 } from './utils';
 
@@ -46,7 +44,7 @@ forEachCli(currentCLIName => {
     if (supportUi()) {
       describe('running Cypress', () => {
         it('should execute e2e tests using Cypress', () => {
-          newProject();
+          ensureProject();
           const myapp = uniq('myapp');
           runCLI(
             `generate @nrwl/${nrwlPackageName}:app ${myapp} --e2eTestRunner=cypress --linter=${linter}`

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -38,6 +38,7 @@
     "@angular-devkit/architect": "0.803.14",
     "@angular-devkit/core": "8.3.14",
     "@cypress/webpack-preprocessor": "~4.1.0",
+    "fork-ts-checker-webpack-plugin": "^3.1.1",
     "tree-kill": "1.2.1",
     "ts-loader": "5.3.1",
     "tsconfig-paths-webpack-plugin": "3.2.0",

--- a/packages/cypress/src/plugins/preprocessor.spec.ts
+++ b/packages/cypress/src/plugins/preprocessor.spec.ts
@@ -21,7 +21,8 @@ describe('getWebpackConfig', () => {
       options: {
         configFile: './tsconfig.json',
         // https://github.com/TypeStrong/ts-loader/pull/685
-        experimentalWatchApi: true
+        experimentalWatchApi: true,
+        transpileOnly: true
       }
     });
   });

--- a/packages/cypress/src/plugins/preprocessor.ts
+++ b/packages/cypress/src/plugins/preprocessor.ts
@@ -1,6 +1,7 @@
 import * as wp from '@cypress/webpack-preprocessor';
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 import * as nodeExternals from 'webpack-node-externals';
+import * as ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
 export function preprocessTypescript(config: any) {
   if (!config.env.tsConfig) {
@@ -35,12 +36,18 @@ export function getWebpackConfig(config: any) {
           options: {
             configFile: config.env.tsConfig,
             // https://github.com/TypeStrong/ts-loader/pull/685
-            experimentalWatchApi: true
+            experimentalWatchApi: true,
+            transpileOnly: true
           }
         }
       ]
     },
-    plugins: [],
+    plugins: [
+      new ForkTsCheckerWebpackPlugin({
+        tsconfig: config.env.tsConfig,
+        useTypescriptIncrementalApi: false
+      })
+    ],
     externals: [nodeExternals()]
   };
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

An older version of `fork-ts-checker-webpack-plugin` was causing cypress to hang probably because a process was not being killed properly. Thus, we switched back to `ts-loader` to do type checking but that causes memory issues.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

We updated the version of `fork-ts-checker-webpack-plugin` and this one seems to have the bug fixed. Thus, we will switch back to using `fork-ts-checker-webpack-plugin` for type checking and to solve memory issues. :tada: 

## Issue
Fixes #1871 