### PR TITLE
feat(testing): add --ci-build-id option to cypress

### DIFF
--- a/docs/angular/api-cypress/builders/cypress.md
+++ b/docs/angular/api-cypress/builders/cypress.md
@@ -20,6 +20,12 @@ Possible values: `electron`, `chrome`, `chromium`, `canary`
 
 The browser to run tests in.
 
+### ciBuildId
+
+Type: `string`
+
+A unique identifier for a run to enable grouping or parallelization.
+
 ### copyFiles
 
 Type: `string`

--- a/docs/react/api-cypress/builders/cypress.md
+++ b/docs/react/api-cypress/builders/cypress.md
@@ -21,6 +21,12 @@ Possible values: `electron`, `chrome`, `chromium`, `canary`
 
 The browser to run tests in.
 
+### ciBuildId
+
+Type: `string`
+
+A unique identifier for a run to enable grouping or parallelization.
+
 ### copyFiles
 
 Type: `string`

--- a/docs/web/api-cypress/builders/cypress.md
+++ b/docs/web/api-cypress/builders/cypress.md
@@ -21,6 +21,12 @@ Possible values: `electron`, `chrome`, `chromium`, `canary`
 
 The browser to run tests in.
 
+### ciBuildId
+
+Type: `string`
+
+A unique identifier for a run to enable grouping or parallelization.
+
 ### copyFiles
 
 Type: `string`

--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -31,6 +31,7 @@ export interface CypressBuilderOptions extends JsonObject {
   env?: Record<string, string>;
   spec?: string;
   copyFiles?: string;
+  ciBuildId?: string;
 }
 
 try {
@@ -75,7 +76,8 @@ function run(
         baseUrl,
         options.browser,
         options.env,
-        options.spec
+        options.spec,
+        options.ciBuildId
       )
     ),
     options.watch ? tap(noop) : take(1),
@@ -106,6 +108,7 @@ function run(
  * @param browser
  * @param env
  * @param spec
+ * @param ciBuildId
  */
 function initCypress(
   cypressConfig: string,
@@ -118,7 +121,8 @@ function initCypress(
   baseUrl: string,
   browser?: string,
   env?: Record<string, string>,
-  spec?: string
+  spec?: string,
+  ciBuildId?: string
 ): Observable<BuilderOutput> {
   // Cypress expects the folder where a `cypress.json` is present
   const projectFolderPath = dirname(cypressConfig);
@@ -147,6 +151,7 @@ function initCypress(
   options.record = record;
   options.key = key;
   options.parallel = parallel;
+  options.ciBuildId = ciBuildId;
 
   return fromPromise<any>(
     !isWatching || headless ? Cypress.run(options) : Cypress.open(options)

--- a/packages/cypress/src/builders/cypress/schema.json
+++ b/packages/cypress/src/builders/cypress/schema.json
@@ -65,6 +65,10 @@
       "type": "string",
       "description": "DEPRECATED: A regex string that is used to choose what additional integration files to copy to the dist folder",
       "x-deprecated": true
+    },
+    "ciBuildId": {
+      "type": "string",
+      "description": "A unique identifier for a run to enable grouping or parallelization."
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
add --ci-build-id option to cypress in order to enable parallelization for some ci

https://github.com/cypress-io/cypress/blob/develop/cli/lib/exec/run.js#L29
