### PR TITLE
feat(misc): export mock builder context from workspace

### DIFF
--- a/packages/node/src/builders/execute/execute.impl.spec.ts
+++ b/packages/node/src/builders/execute/execute.impl.spec.ts
@@ -5,7 +5,10 @@ import {
 } from './execute.impl';
 import { of, from } from 'rxjs';
 import * as devkitArchitect from '@angular-devkit/architect';
-import { MockBuilderContext, getMockContext } from '../../utils/testing';
+
+import { MockBuilderContext } from '@nrwl/workspace/testing';
+
+import { getMockContext } from '../../utils/testing';
 
 jest.mock('child_process');
 let { fork } = require('child_process');

--- a/packages/node/src/utils/testing.ts
+++ b/packages/node/src/utils/testing.ts
@@ -1,13 +1,12 @@
 import { join } from 'path';
-import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+
+import { schema } from '@angular-devkit/core';
 import { Rule, Tree } from '@angular-devkit/schematics';
-import {
-  TestingArchitectHost,
-  TestLogger
-} from '@angular-devkit/architect/testing';
-import { schema, JsonObject } from '@angular-devkit/core';
-import { Architect, BuilderContext, Target } from '@angular-devkit/architect';
-import { ScheduleOptions } from '@angular-devkit/architect/src/api';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { Architect } from '@angular-devkit/architect';
+import { TestingArchitectHost } from '@angular-devkit/architect/testing';
+
+import { MockBuilderContext } from '@nrwl/workspace/testing';
 
 const testRunner = new SchematicTestRunner(
   '@nrwl/node',
@@ -40,75 +39,4 @@ export async function getMockContext() {
   const context = new MockBuilderContext(architect, architectHost);
   await context.addBuilderFromPackage(join(__dirname, '../..'));
   return context;
-}
-
-export class MockBuilderContext implements BuilderContext {
-  id: 0;
-
-  builder: any = {};
-  analytics = null;
-
-  target: Target = {
-    project: null,
-    target: null
-  };
-
-  get currentDirectory() {
-    return this.architectHost.currentDirectory;
-  }
-  get workspaceRoot() {
-    return this.architectHost.workspaceRoot;
-  }
-  logger = new TestLogger('test');
-  constructor(
-    private architect: Architect,
-    private architectHost: TestingArchitectHost
-  ) {}
-
-  async addBuilderFromPackage(path: string) {
-    return await this.architectHost.addBuilderFromPackage(path);
-  }
-
-  async addTarget(target: Target, builderName: string) {
-    return await this.architectHost.addTarget(target, builderName);
-  }
-
-  getBuilderNameForTarget(target: Target) {
-    return this.architectHost.getBuilderNameForTarget(target);
-  }
-
-  scheduleTarget(
-    target: Target,
-    overrides?: JsonObject,
-    scheduleOptions?: ScheduleOptions
-  ) {
-    return this.architect.scheduleTarget(target, overrides, scheduleOptions);
-  }
-
-  scheduleBuilder(
-    name: string,
-    overrides?: JsonObject,
-    scheduleOptions?: ScheduleOptions
-  ) {
-    return this.architect.scheduleBuilder(name, overrides, scheduleOptions);
-  }
-
-  getTargetOptions(target: Target) {
-    return this.architectHost.getOptionsForTarget(target);
-  }
-
-  validateOptions<T extends JsonObject = JsonObject>(
-    options: JsonObject,
-    builderName: string
-  ): Promise<T> {
-    return Promise.resolve<T>(options as T);
-  }
-
-  reportRunning() {}
-
-  reportStatus(status: string) {}
-
-  reportProgress(current: number, total?: number, status?: string) {}
-
-  addTeardown(teardown: () => Promise<void> | void) {}
 }

--- a/packages/storybook/src/builders/build-storybook/build-storybook.impl.spec.ts
+++ b/packages/storybook/src/builders/build-storybook/build-storybook.impl.spec.ts
@@ -1,7 +1,11 @@
-import { run as storybookBuilder } from './build-storybook.impl';
-import { MockBuilderContext, getMockContext } from '../../utils/testing';
 import { join } from 'path';
+
 import * as storybook from '@storybook/core/dist/server/build-static';
+
+import { MockBuilderContext } from '@nrwl/workspace/testing';
+
+import { getMockContext } from '../../utils/testing';
+import { run as storybookBuilder } from './build-storybook.impl';
 
 describe('Build storybook', () => {
   let context: MockBuilderContext;

--- a/packages/storybook/src/utils/testing.ts
+++ b/packages/storybook/src/utils/testing.ts
@@ -1,26 +1,17 @@
 import { join, sep } from 'path';
-import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import {
-  Tree,
-  Rule,
-  externalSchematic,
-  apply,
-  source
-} from '@angular-devkit/schematics';
-import { createEmptyWorkspace } from '@nrwl/workspace/src/utils/testing-utils';
-import {
-  BuilderContext,
-  Target,
-  Architect,
-  ScheduleOptions
-} from '@angular-devkit/architect';
-import {
-  TestLogger,
-  TestingArchitectHost
-} from '@angular-devkit/architect/testing';
-import { JsonObject, json, schema } from '@angular-devkit/core';
 import { tmpdir } from 'os';
 import { mkdtempSync } from 'fs';
+
+import { schema } from '@angular-devkit/core';
+import { externalSchematic, Rule, Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { Architect } from '@angular-devkit/architect';
+import { TestingArchitectHost } from '@angular-devkit/architect/testing';
+
+import {
+  createEmptyWorkspace,
+  MockBuilderContext
+} from '@nrwl/workspace/testing';
 
 const testRunner = new SchematicTestRunner(
   '@nrwl/storybook',
@@ -133,84 +124,4 @@ export async function getMockContext() {
   const context = new MockBuilderContext(architect, architectHost);
   await context.addBuilderFromPackage(join(__dirname, '../..'));
   return context;
-}
-
-export class MockBuilderContext implements BuilderContext {
-  id: 0;
-
-  builder: any = {};
-  analytics = null;
-
-  target: Target = {
-    project: null,
-    target: null
-  };
-
-  get currentDirectory() {
-    return this.architectHost.currentDirectory;
-  }
-  get workspaceRoot() {
-    return this.architectHost.workspaceRoot;
-  }
-  logger = new TestLogger('test');
-  constructor(
-    private architect: Architect,
-    private architectHost: TestingArchitectHost
-  ) {}
-
-  async addBuilderFromPackage(path: string) {
-    return await this.architectHost.addBuilderFromPackage(path);
-  }
-
-  async addTarget(target: Target, builderName: string) {
-    return await this.architectHost.addTarget(target, builderName);
-  }
-
-  getBuilderNameForTarget(target: Target) {
-    return this.architectHost.getBuilderNameForTarget(target);
-  }
-
-  scheduleTarget(
-    target: Target,
-    overrides?: JsonObject,
-    scheduleOptions?: ScheduleOptions
-  ) {
-    return this.architect.scheduleTarget(target, overrides, scheduleOptions);
-  }
-
-  scheduleBuilder(
-    name: string,
-    overrides?: JsonObject,
-    scheduleOptions?: ScheduleOptions
-  ) {
-    return this.architect.scheduleBuilder(name, overrides, scheduleOptions);
-  }
-
-  getTargetOptions(target: Target) {
-    return this.architectHost.getOptionsForTarget(target);
-  }
-
-  validateOptions<T extends JsonObject = JsonObject>(
-    options: JsonObject,
-    builderName: string
-  ): Promise<T> {
-    return Promise.resolve<T>(options as T);
-  }
-
-  reportRunning() {}
-
-  reportStatus(status: string) {}
-
-  reportProgress(current: number, total?: number, status?: string) {}
-
-  addTeardown(teardown: () => Promise<void> | void) {}
-
-  async getProjectMetadata(
-    target: Target | string
-  ): Promise<json.JsonObject | null> {
-    return (
-      this.architectHost &&
-      this.architectHost.getProjectMetadata(target as string)
-    );
-  }
 }

--- a/packages/web/src/builders/build/build.impl.spec.ts
+++ b/packages/web/src/builders/build/build.impl.spec.ts
@@ -1,12 +1,16 @@
+import { join } from 'path';
+
 import { workspaces } from '@angular-devkit/core';
-import { run, WebBuildBuilderOptions } from './build.impl';
 import { of } from 'rxjs';
 import * as buildWebpack from '@angular-devkit/build-webpack';
 jest.mock('tsconfig-paths-webpack-plugin');
 import TsConfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
+
+import { MockBuilderContext } from '@nrwl/workspace/testing';
+
+import { run, WebBuildBuilderOptions } from './build.impl';
 import * as webConfigUtils from '../../utils/web.config';
-import { getMockContext, MockBuilderContext } from '../../utils/testing';
-import { join } from 'path';
+import { getMockContext } from '../../utils/testing';
 import * as indexHtmlUtils from '../../utils/third-party/cli-files/utilities/index-file/write-index-html';
 
 describe('WebBuildBuilder', () => {

--- a/packages/web/src/builders/bundle/bundle.impl.spec.ts
+++ b/packages/web/src/builders/bundle/bundle.impl.spec.ts
@@ -1,10 +1,14 @@
+import { of } from 'rxjs';
+import { join } from 'path';
+
+import { workspaces } from '@angular-devkit/core';
+
+import * as f from '@nrwl/workspace/src/utils/fileutils';
+import { MockBuilderContext } from '@nrwl/workspace/testing';
+
 import * as impl from './bundle.impl';
 import * as rr from './run-rollup';
-import { of } from 'rxjs';
-import { getMockContext, MockBuilderContext } from '../../utils/testing';
-import { workspaces } from '@angular-devkit/core';
-import { join } from 'path';
-import * as f from '@nrwl/workspace/src/utils/fileutils';
+import { getMockContext } from '../../utils/testing';
 import { BundleBuilderOptions } from '../../utils/types';
 
 jest.mock('tsconfig-paths-webpack-plugin');

--- a/packages/web/src/utils/testing.ts
+++ b/packages/web/src/utils/testing.ts
@@ -1,17 +1,12 @@
 import { join } from 'path';
-import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+
+import { schema } from '@angular-devkit/core';
 import { Rule, Tree } from '@angular-devkit/schematics';
-import {
-  BuilderContext,
-  Architect,
-  Target,
-  ScheduleOptions
-} from '@angular-devkit/architect';
-import {
-  TestingArchitectHost,
-  TestLogger
-} from '@angular-devkit/architect/testing';
-import { schema, JsonObject } from '@angular-devkit/core';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { Architect } from '@angular-devkit/architect';
+import { TestingArchitectHost } from '@angular-devkit/architect/testing';
+
+import { MockBuilderContext } from '@nrwl/workspace/testing';
 
 const testRunner = new SchematicTestRunner(
   '@nrwl/web',
@@ -44,75 +39,4 @@ export async function getMockContext() {
   const context = new MockBuilderContext(architect, architectHost);
   await context.addBuilderFromPackage(join(__dirname, '../..'));
   return context;
-}
-
-export class MockBuilderContext implements BuilderContext {
-  id: 0;
-
-  builder: any = {};
-  analytics = null;
-
-  target: Target = {
-    project: null,
-    target: null
-  };
-
-  get currentDirectory() {
-    return this.architectHost.currentDirectory;
-  }
-  get workspaceRoot() {
-    return this.architectHost.workspaceRoot;
-  }
-  logger = new TestLogger('test');
-  constructor(
-    private architect: Architect,
-    private architectHost: TestingArchitectHost
-  ) {}
-
-  async addBuilderFromPackage(path: string) {
-    return await this.architectHost.addBuilderFromPackage(path);
-  }
-
-  async addTarget(target: Target, builderName: string) {
-    return await this.architectHost.addTarget(target, builderName);
-  }
-
-  getBuilderNameForTarget(target: Target) {
-    return this.architectHost.getBuilderNameForTarget(target);
-  }
-
-  scheduleTarget(
-    target: Target,
-    overrides?: JsonObject,
-    scheduleOptions?: ScheduleOptions
-  ) {
-    return this.architect.scheduleTarget(target, overrides, scheduleOptions);
-  }
-
-  scheduleBuilder(
-    name: string,
-    overrides?: JsonObject,
-    scheduleOptions?: ScheduleOptions
-  ) {
-    return this.architect.scheduleBuilder(name, overrides, scheduleOptions);
-  }
-
-  getTargetOptions(target: Target) {
-    return this.architectHost.getOptionsForTarget(target);
-  }
-
-  validateOptions<T extends JsonObject = JsonObject>(
-    options: JsonObject,
-    builderName: string
-  ): Promise<T> {
-    return Promise.resolve<T>(options as T);
-  }
-
-  reportRunning() {}
-
-  reportStatus(status: string) {}
-
-  reportProgress(current: number, total?: number, status?: string) {}
-
-  addTeardown(teardown: () => Promise<void> | void) {}
 }

--- a/packages/workspace/src/utils/testing-utils.ts
+++ b/packages/workspace/src/utils/testing-utils.ts
@@ -4,6 +4,13 @@ import {
   WorkspaceFormat
 } from '@angular-devkit/core/src/workspace/core';
 import { NxJson } from '@nrwl/workspace/src/core/shared-interfaces';
+import { Architect, BuilderContext, Target } from '@angular-devkit/architect';
+import {
+  TestingArchitectHost,
+  TestLogger
+} from '@angular-devkit/architect/testing';
+import { JsonObject } from '@angular-devkit/core';
+import { ScheduleOptions } from '@angular-devkit/architect/src/api';
 
 export function getFileContent(tree: Tree, path: string): string {
   const fileEntry = tree.get(path);
@@ -54,4 +61,79 @@ export function createEmptyWorkspace(tree: Tree): Tree {
     })
   );
   return tree;
+}
+
+/**
+ * Mock context which makes testing builders easier
+ */
+export class MockBuilderContext implements BuilderContext {
+  id: 0;
+
+  builder: any = {};
+  analytics = null;
+
+  target: Target = {
+    project: null,
+    target: null
+  };
+
+  logger = new TestLogger('test');
+
+  get currentDirectory() {
+    return this.architectHost.currentDirectory;
+  }
+  get workspaceRoot() {
+    return this.architectHost.workspaceRoot;
+  }
+  constructor(
+    private architect: Architect,
+    private architectHost: TestingArchitectHost
+  ) {}
+
+  async addBuilderFromPackage(path: string) {
+    return await this.architectHost.addBuilderFromPackage(path);
+  }
+
+  async addTarget(target: Target, builderName: string) {
+    return this.architectHost.addTarget(target, builderName);
+  }
+
+  getBuilderNameForTarget(target: Target) {
+    return this.architectHost.getBuilderNameForTarget(target);
+  }
+
+  scheduleTarget(
+    target: Target,
+    overrides?: JsonObject,
+    scheduleOptions?: ScheduleOptions
+  ) {
+    return this.architect.scheduleTarget(target, overrides, scheduleOptions);
+  }
+
+  scheduleBuilder(
+    name: string,
+    overrides?: JsonObject,
+    scheduleOptions?: ScheduleOptions
+  ) {
+    return this.architect.scheduleBuilder(name, overrides, scheduleOptions);
+  }
+
+  getTargetOptions(target: Target) {
+    return this.architectHost.getOptionsForTarget(target);
+  }
+
+  validateOptions<T extends JsonObject = JsonObject>(
+    options: JsonObject,
+    builderName: string
+  ): Promise<T> {
+    return Promise.resolve<T>(options as T);
+  }
+
+  reportRunning() {}
+
+  reportStatus(status: string) {}
+
+  reportProgress(current: number, total?: number, status?: string) {}
+
+  addTeardown(teardown: () => Promise<void> | void) {}
 }

--- a/packages/workspace/testing.ts
+++ b/packages/workspace/testing.ts
@@ -1,4 +1,5 @@
 export {
   createEmptyWorkspace,
-  getFileContent
+  getFileContent,
+  MockBuilderContext
 } from './src/utils/testing-utils';


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Every package creates a `MockBuilderContext`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`@nrwl/workspace/testing` exports `MockBuidlerContext`

Fixes issue with incompatible typing

## Issue
