### PR TITLE
fix(core): default to whole file change type

### DIFF
--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -21,8 +21,12 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
 
   const env = readEnvironment(nxArgs.target);
   const projectGraph = createProjectGraph();
-  const fileChanges = readFileChanges(nxArgs);
-  let affectedGraph = filterAffected(projectGraph, fileChanges);
+  let affectedGraph = nxArgs.all
+    ? projectGraph
+    : filterAffected(
+        projectGraph,
+        calculateFileChanges(parseFiles(nxArgs).files, nxArgs)
+      );
   if (parsedArgs.withDeps) {
     affectedGraph = onlyWorkspaceProjects(
       withDeps(projectGraph, Object.values(affectedGraph.nodes))
@@ -43,7 +47,7 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
         if (parsedArgs.plain) {
           console.log(apps.join(' '));
         } else {
-          printArgsWarning(parsedArgs);
+          printArgsWarning(nxArgs);
           if (apps.length) {
             output.log({
               title: 'Affected apps:',
@@ -60,7 +64,7 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
         if (parsedArgs.plain) {
           console.log(libs.join(' '));
         } else {
-          printArgsWarning(parsedArgs);
+          printArgsWarning(nxArgs);
           if (libs.length) {
             output.log({
               title: 'Affected libs:',
@@ -72,7 +76,7 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
 
       case 'dep-graph':
         const projectNames = affectedProjects.map(p => p.name);
-        printArgsWarning(parsedArgs);
+        printArgsWarning(nxArgs);
         generateGraph(parsedArgs as any, projectNames);
         break;
 
@@ -99,7 +103,7 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
           affectedProjects,
           nxArgs
         );
-        printArgsWarning(parsedArgs);
+        printArgsWarning(nxArgs);
         runCommand(
           projectWithTargetAndConfig,
           projectGraph,
@@ -114,16 +118,6 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
     printError(e, parsedArgs.verbose);
     process.exit(1);
   }
-}
-
-function readFileChanges(nxArgs: NxArgs) {
-  // Do we still need this `--all` option?
-  if (nxArgs.all) {
-    return [];
-  }
-
-  const files = parseFiles(nxArgs).files;
-  return calculateFileChanges(files, nxArgs.base, nxArgs.head);
 }
 
 function allProjectsWithTargetAndConfiguration(

--- a/packages/workspace/src/command-line/shared.ts
+++ b/packages/workspace/src/command-line/shared.ts
@@ -1,22 +1,14 @@
 import { execSync } from 'child_process';
 import { output } from '../utils/output';
 import { createProjectGraph, ProjectGraphNode } from '../core/project-graph';
-import { NxArgs } from './utils';
 import { NxJson } from '../core/shared-interfaces';
 import { readWorkspaceJson, TEN_MEGABYTES } from '../core/file-utils';
+import { NxArgs } from './utils';
 
 export function printArgsWarning(options: NxArgs) {
   const { files, uncommitted, untracked, base, head, all } = options;
 
-  if (
-    !files &&
-    !uncommitted &&
-    !untracked &&
-    !base &&
-    !head &&
-    !all &&
-    options._.length < 2
-  ) {
+  if (!files && !uncommitted && !untracked && !base && !head && !all) {
     output.note({
       title: `Affected criteria defaulted to --base=${output.bold(
         'master'
@@ -68,20 +60,6 @@ export function parseFiles(options: NxArgs): { files: string[] } {
         ])
       )
     };
-  } else if (options._.length >= 2) {
-    return {
-      files: getFilesFromShash(options._[1], options._[2])
-    };
-  } else {
-    return {
-      files: Array.from(
-        new Set([
-          ...getFilesUsingBaseAndHead('master', 'HEAD'),
-          ...getUncommittedFiles(),
-          ...getUntrackedFiles()
-        ])
-      )
-    };
   }
 }
 
@@ -100,10 +78,6 @@ function getFilesUsingBaseAndHead(base: string, head: string): string[] {
     .toString()
     .trim();
   return parseGitOutput(`git diff --name-only --relative ${mergeBase} ${head}`);
-}
-
-function getFilesFromShash(sha1: string, sha2: string): string[] {
-  return parseGitOutput(`git diff --name-only --relative ${sha1} ${sha2}`);
 }
 
 function parseGitOutput(command: string): string[] {

--- a/packages/workspace/src/command-line/utils.spec.ts
+++ b/packages/workspace/src/command-line/utils.spec.ts
@@ -4,15 +4,29 @@ describe('splitArgs', () => {
   it('should split nx specific arguments into nxArgs', () => {
     expect(
       splitArgsIntoNxArgsAndOverrides({
-        files: [''],
+        base: 'sha1',
+        head: 'sha2',
         notNxArg: true,
         _: ['--override'],
         $0: ''
       }).nxArgs
     ).toEqual({
-      _: ['--override'],
-      projects: [],
-      files: ['']
+      base: 'sha1',
+      head: 'sha2',
+      projects: []
+    });
+  });
+
+  it('should default to having a base of master', () => {
+    expect(
+      splitArgsIntoNxArgsAndOverrides({
+        notNxArg: true,
+        _: ['--override'],
+        $0: ''
+      }).nxArgs
+    ).toEqual({
+      base: 'master',
+      projects: []
     });
   });
 
@@ -25,6 +39,24 @@ describe('splitArgs', () => {
         $0: ''
       }).overrides
     ).toEqual({
+      notNxArg: true,
+      override: true
+    });
+  });
+
+  it('should add other args to nx args', () => {
+    const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides({
+      notNxArg: true,
+      _: ['sha1', 'sha2', '--override'],
+      $0: ''
+    });
+
+    expect(nxArgs).toEqual({
+      base: 'sha1',
+      head: 'sha2',
+      projects: []
+    });
+    expect(overrides).toEqual({
       notNxArg: true,
       override: true
     });

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -30,8 +30,7 @@ const dummyOptions: NxArgs = {
   withDeps: false,
   'with-deps': false,
   projects: [],
-  select: '',
-  _: []
+  select: ''
 } as any;
 
 const nxSpecific = Object.keys(dummyOptions);
@@ -61,7 +60,6 @@ export interface NxArgs {
   'with-deps'?: boolean;
   projects?: string[];
   select?: string;
-  _: string[];
 }
 
 const ignoreArgs = ['$0', '_'];
@@ -85,6 +83,21 @@ export function splitArgsIntoNxArgsAndOverrides(
     nxArgs.projects = [];
   } else {
     nxArgs.projects = args.projects.split(',').map((p: string) => p.trim());
+  }
+
+  if (
+    !nxArgs.files &&
+    !nxArgs.uncommitted &&
+    !nxArgs.untracked &&
+    !nxArgs.base &&
+    !nxArgs.head &&
+    !nxArgs.all &&
+    args._.length >= 2
+  ) {
+    nxArgs.base = args._[0];
+    nxArgs.head = args._[1];
+  } else if (!nxArgs.base) {
+    nxArgs.base = 'master';
   }
 
   return { nxArgs, overrides };

--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph-models.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph-models.ts
@@ -1,7 +1,17 @@
 import { NxJson } from '../shared-interfaces';
+import { Change, FileChange } from '../file-utils';
 
 export interface AffectedProjectGraphContext {
   workspaceJson: any;
   nxJson: NxJson<string[]>;
   touchedProjects: string[];
+}
+
+export interface TouchedProjectLocator<T extends Change = Change> {
+  (
+    fileChanges: FileChange<T>[],
+    workspaceJson?: any,
+    nxJson?: NxJson<string[]>,
+    packageJson?: any
+  ): string[];
 }

--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
@@ -4,7 +4,7 @@ import { vol } from 'memfs';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import { createProjectGraph } from '../project-graph';
 import { filterAffected } from './affected-project-graph';
-import { FileData } from '../file-utils';
+import { FileData, WholeFileChange } from '../file-utils';
 import { NxJson } from '../shared-interfaces';
 
 jest.mock('fs', () => require('memfs').fs);
@@ -140,13 +140,13 @@ describe('project graph', () => {
         file: 'something-for-api.txt',
         ext: '.txt',
         mtime: 1,
-        getChanges: () => ['SOMETHING CHANGED']
+        getChanges: () => [new WholeFileChange()]
       },
       {
         file: 'libs/ui/src/index.ts',
         ext: '.ts',
         mtime: 1,
-        getChanges: () => ['SOMETHING CHANGED']
+        getChanges: () => [new WholeFileChange()]
       }
     ]);
     expect(affected).toEqual({

--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph.ts
@@ -1,5 +1,10 @@
 import { ProjectGraph, ProjectGraphBuilder, reverse } from '../project-graph';
-import { FileChange, readNxJson, readWorkspaceJson } from '../file-utils';
+import {
+  FileChange,
+  readNxJson,
+  readPackageJson,
+  readWorkspaceJson
+} from '../file-utils';
 import { NxJson } from '../shared-interfaces';
 import {
   getImplicitlyTouchedProjects,
@@ -7,18 +12,22 @@ import {
 } from './locators/workspace-projects';
 import { getTouchedNpmPackages } from './locators/npm-packages';
 import { getImplicitlyTouchedProjectsByJsonChanges } from './locators/implicit-json-changes';
-import { AffectedProjectGraphContext } from './affected-project-graph-models';
+import {
+  AffectedProjectGraphContext,
+  TouchedProjectLocator
+} from './affected-project-graph-models';
 import { normalizeNxJson } from '../normalize-nx-json';
 
 export function filterAffected(
   graph: ProjectGraph,
   touchedFiles: FileChange[],
   workspaceJson: any = readWorkspaceJson(),
-  nxJson: NxJson = readNxJson()
+  nxJson: NxJson = readNxJson(),
+  packageJson: any = readPackageJson()
 ): ProjectGraph {
   const normalizedNxJson = normalizeNxJson(nxJson);
   // Additional affected logic should be in this array.
-  const touchedProjectLocators = [
+  const touchedProjectLocators: TouchedProjectLocator[] = [
     getTouchedProjects,
     getImplicitlyTouchedProjects,
     getTouchedNpmPackages,
@@ -26,7 +35,9 @@ export function filterAffected(
   ];
   const touchedProjects = touchedProjectLocators.reduce(
     (acc, f) => {
-      return acc.concat(f(workspaceJson, normalizedNxJson, touchedFiles));
+      return acc.concat(
+        f(touchedFiles, workspaceJson, normalizedNxJson, packageJson)
+      );
     },
     [] as string[]
   );

--- a/packages/workspace/src/core/affected-project-graph/locators/implicit-json-changes.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/implicit-json-changes.spec.ts
@@ -1,0 +1,73 @@
+import { getImplicitlyTouchedProjectsByJsonChanges } from './implicit-json-changes';
+import { NxJson } from '../../shared-interfaces';
+import { WholeFileChange } from '../../file-utils';
+import { DiffType } from '../../../utils/json-diff';
+
+describe('getImplicitlyTouchedProjectsByJsonChanges', () => {
+  let workspaceJson;
+  let nxJson: NxJson<string[]>;
+  beforeEach(() => {
+    workspaceJson = {
+      projects: {
+        proj1: {},
+        proj2: {}
+      }
+    };
+    nxJson = {
+      implicitDependencies: {
+        'package.json': {
+          dependencies: ['proj1'],
+          some: {
+            'deep-field': ['proj2']
+          }
+        }
+      },
+      npmScope: 'scope',
+      projects: {
+        proj1: {},
+        proj2: {}
+      }
+    };
+  });
+
+  it('should handle json changes', () => {
+    const result = getImplicitlyTouchedProjectsByJsonChanges(
+      [
+        {
+          file: 'package.json',
+          mtime: 0,
+          ext: '.json',
+          getChanges: () => [
+            {
+              type: DiffType.Modified,
+              path: ['some', 'deep-field'],
+              value: {
+                lhs: 'before',
+                rhs: 'after'
+              }
+            }
+          ]
+        }
+      ],
+      workspaceJson,
+      nxJson
+    );
+    expect(result).toEqual(['proj2']);
+  });
+
+  it('should handle whole file changes', () => {
+    const result = getImplicitlyTouchedProjectsByJsonChanges(
+      [
+        {
+          file: 'package.json',
+          mtime: 0,
+          ext: '.json',
+          getChanges: () => [new WholeFileChange()]
+        }
+      ],
+      workspaceJson,
+      nxJson
+    );
+    expect(result).toEqual(['proj1', 'proj2']);
+  });
+});

--- a/packages/workspace/src/core/affected-project-graph/locators/npm-packages.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/npm-packages.spec.ts
@@ -1,0 +1,84 @@
+import { getTouchedNpmPackages } from './npm-packages';
+import { NxJson } from '../../shared-interfaces';
+import { WholeFileChange } from '../..//file-utils';
+import { DiffType } from '../../../utils/json-diff';
+
+describe('getImplicitlyTouchedProjectsByJsonChanges', () => {
+  let workspaceJson;
+  let nxJson: NxJson<string[]>;
+  beforeEach(() => {
+    workspaceJson = {
+      projects: {
+        proj1: {},
+        proj2: {}
+      }
+    };
+    nxJson = {
+      implicitDependencies: {
+        'package.json': {
+          dependencies: ['proj1'],
+          some: {
+            'deep-field': ['proj2']
+          }
+        }
+      },
+      npmScope: 'scope',
+      projects: {
+        proj1: {},
+        proj2: {}
+      }
+    };
+  });
+
+  it('should handle json changes', () => {
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          mtime: 0,
+          ext: '.json',
+          getChanges: () => [
+            {
+              type: DiffType.Modified,
+              path: ['dependencies', 'happy-nrwl'],
+              value: {
+                lhs: '0.0.1',
+                rhs: '0.0.2'
+              }
+            }
+          ]
+        }
+      ],
+      workspaceJson,
+      nxJson,
+      {
+        dependencies: {
+          'happy-nrwl': '0.0.2'
+        }
+      }
+    );
+    expect(result).toEqual(['happy-nrwl']);
+  });
+
+  it('should handle whole file changes', () => {
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          mtime: 0,
+          ext: '.json',
+          getChanges: () => [new WholeFileChange()]
+        }
+      ],
+      workspaceJson,
+      nxJson,
+      {
+        dependencies: {
+          'happy-nrwl': '0.0.1',
+          'awesome-nrwl': '0.0.1'
+        }
+      }
+    );
+    expect(result).toEqual(['happy-nrwl', 'awesome-nrwl']);
+  });
+});

--- a/packages/workspace/src/core/affected-project-graph/locators/workspace-projects.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/workspace-projects.ts
@@ -1,11 +1,9 @@
-import { NxJson } from '../../shared-interfaces';
-import { FileChange } from '../../file-utils';
+import { TouchedProjectLocator } from '../affected-project-graph-models';
 
-export function getTouchedProjects(
-  workspaceJson: any,
-  nxJson: NxJson,
-  touchedFiles: FileChange[]
-): string[] {
+export const getTouchedProjects: TouchedProjectLocator = (
+  touchedFiles,
+  workspaceJson
+): string[] => {
   return touchedFiles
     .map(f => {
       return Object.keys(workspaceJson.projects).find(projectName => {
@@ -14,13 +12,13 @@ export function getTouchedProjects(
       });
     })
     .filter(Boolean);
-}
+};
 
-export function getImplicitlyTouchedProjects(
-  workspaceJson: any,
-  nxJson: NxJson,
-  fileChanges: FileChange[]
-): string[] {
+export const getImplicitlyTouchedProjects: TouchedProjectLocator = (
+  fileChanges,
+  workspaceJson,
+  nxJson
+): string[] => {
   if (!nxJson.implicitDependencies) {
     return [];
   }
@@ -38,12 +36,10 @@ export function getImplicitlyTouchedProjects(
     }
 
     // File change affects all projects, just return all projects.
-    if (projects === '*') {
-      return Object.keys(workspaceJson.projects);
-    } else if (Array.isArray(projects)) {
+    if (Array.isArray(projects)) {
       touched.push(...projects);
     }
   }
 
   return touched;
-}
+};

--- a/packages/workspace/src/core/file-utils.spec.ts
+++ b/packages/workspace/src/core/file-utils.spec.ts
@@ -1,0 +1,66 @@
+import { calculateFileChanges, WholeFileChange } from './file-utils';
+import { DiffType, JsonChange, jsonDiff } from '../utils/json-diff';
+
+describe('calculateFileChanges', () => {
+  it('should return a whole file change by default', () => {
+    const changes = calculateFileChanges(
+      ['proj/index.ts'],
+      undefined,
+      (path, revision) => {
+        return revision === 'sha1' ? '' : 'const a = 0;';
+      }
+    );
+
+    expect(changes[0].getChanges()).toEqual([new WholeFileChange()]);
+  });
+
+  it('should return a json changes for json files', () => {
+    const changes = calculateFileChanges(
+      ['package.json'],
+      {
+        base: 'sha1',
+        head: 'sha2'
+      },
+      (path, revision) => {
+        return revision === 'sha1'
+          ? JSON.stringify({
+              dependencies: {
+                'happy-nrwl': '0.0.1',
+                'not-awesome-nrwl': '0.0.1'
+              }
+            })
+          : JSON.stringify({
+              dependencies: {
+                'happy-nrwl': '0.0.2',
+                'awesome-nrwl': '0.0.1'
+              }
+            });
+      }
+    );
+
+    expect(changes[0].getChanges()).toContainEqual({
+      type: DiffType.Modified,
+      path: ['dependencies', 'happy-nrwl'],
+      value: {
+        lhs: '0.0.1',
+        rhs: '0.0.2'
+      }
+    });
+    expect(changes[0].getChanges()).toContainEqual({
+      type: DiffType.Deleted,
+      path: ['dependencies', 'not-awesome-nrwl'],
+      value: {
+        lhs: '0.0.1',
+        rhs: undefined
+      }
+    });
+    expect(changes[0].getChanges()).toContainEqual({
+      type: DiffType.Added,
+      path: ['dependencies', 'awesome-nrwl'],
+      value: {
+        lhs: undefined,
+        rhs: '0.0.1'
+      }
+    });
+  });
+});

--- a/packages/workspace/src/core/project-graph/project-graph.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.ts
@@ -9,6 +9,7 @@ import {
   writeJsonFile
 } from '../../utils/fileutils';
 import {
+  defaultFileRead,
   FileData,
   mtime,
   readNxJson,
@@ -85,10 +86,6 @@ export function createProjectGraph(
 interface ProjectGraphCache {
   projectGraph: ProjectGraph;
   fileMap: FileMap;
-}
-
-function defaultFileRead(filePath: string) {
-  return readFileSync(`${appRootPath}/${filePath}`, 'UTF-8');
 }
 
 const nxDepsPath = `${appRootPath}/dist/nxdeps.json`;

--- a/packages/workspace/src/utils/json-diff.spec.ts
+++ b/packages/workspace/src/utils/json-diff.spec.ts
@@ -32,4 +32,39 @@ describe('jsonDiff', () => {
       ])
     );
   });
+
+  it('should work well for package.json', () => {
+    const result = jsonDiff(
+      {
+        dependencies: {
+          'happy-nrwl': '0.0.1',
+          'not-awesome-nrwl': '0.0.1'
+        }
+      },
+      {
+        dependencies: {
+          'happy-nrwl': '0.0.2',
+          'awesome-nrwl': '0.0.1'
+        }
+      }
+    );
+
+    expect(result).toContainEqual({
+      type: DiffType.Modified,
+      path: ['dependencies', 'happy-nrwl'],
+      value: { lhs: '0.0.1', rhs: '0.0.2' }
+    });
+
+    expect(result).toContainEqual({
+      type: DiffType.Deleted,
+      path: ['dependencies', 'not-awesome-nrwl'],
+      value: { lhs: '0.0.1', rhs: undefined }
+    });
+
+    expect(result).toContainEqual({
+      type: DiffType.Added,
+      path: ['dependencies', 'awesome-nrwl'],
+      value: { lhs: undefined, rhs: '0.0.1' }
+    });
+  });
 });

--- a/packages/workspace/src/utils/json-diff.ts
+++ b/packages/workspace/src/utils/json-diff.ts
@@ -1,10 +1,12 @@
+import { Change } from '../core/file-utils';
+
 export enum DiffType {
-  Deleted,
-  Added,
-  Modified
+  Deleted = 'JsonPropertyDeleted',
+  Added = 'JsonPropertyAdded',
+  Modified = 'JsonPropertyModified'
 }
 
-export interface JsonValueDiff {
+export interface JsonChange extends Change {
   type: DiffType;
   path: string[];
   value: {
@@ -13,8 +15,16 @@ export interface JsonValueDiff {
   };
 }
 
-export function jsonDiff(lhs: any, rhs: any): JsonValueDiff[] {
-  const result: JsonValueDiff[] = [];
+export function isJsonChange(change: Change): change is JsonChange {
+  return (
+    change.type === DiffType.Added ||
+    change.type === DiffType.Deleted ||
+    change.type === DiffType.Modified
+  );
+}
+
+export function jsonDiff(lhs: any, rhs: any): JsonChange[] {
+  const result: JsonChange[] = [];
   const seenInLhs = new Set<string>();
 
   walkJsonTree(lhs, [], (path, lhsValue) => {
@@ -67,7 +77,7 @@ export function jsonDiff(lhs: any, rhs: any): JsonValueDiff[] {
 }
 
 // Depth-first walk down JSON tree.
-function walkJsonTree(
+export function walkJsonTree(
   json: any,
   currPath: string[],
   visitor: (path: string[], value: any) => boolean


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`yarn affected:apps` (no other args) errors with:

```sh
 jason@pop-os  ~/projects/nx-example   master ●  yarn affected:apps                             
yarn run v1.19.0
$ nx affected:apps
/home/jason/projects/nx-example/node_modules/yargs/yargs.js:1109
      else throw err
           ^

TypeError: Cannot read property 'length' of undefined
    at Object.parseFiles (/home/jason/projects/nx-example/node_modules/@nrwl/workspace/src/command-line/shared.js:64:24)
    at readFileChanges (/home/jason/projects/nx-example/node_modules/@nrwl/workspace/src/command-line/affected.js:94:28)
    at Object.affected (/home/jason/projects/nx-example/node_modules/@nrwl/workspace/src/command-line/affected.js:17:25)
    at Object.exports.commandsObject.yargs.usage.command.command.command.command.command.args [as handler] (/home/jason/projects/nx-example/node_modules/@nrwl/workspace/src/command-line/nx-commands.js:63:113)
    at Object.runCommand (/home/jason/projects/nx-example/node_modules/yargs/lib/command.js:235:44)
    at Object.parseArgs [as _parseArgs] (/home/jason/projects/nx-example/node_modules/yargs/yargs.js:1022:30)
    at Object.get [as argv] (/home/jason/projects/nx-example/node_modules/yargs/yargs.js:965:21)
    at Object.initLocal (/home/jason/projects/nx-example/node_modules/@nrwl/cli/lib/init-local.js:18:26)
    at Object.<anonymous> (/home/jason/projects/nx-example/node_modules/@nrwl/cli/bin/nx.js:12:18)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

JSON diff is also not calculated properly

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`yarn affected:apps` (no other args) defaults to `--base master --head HEAD` and JSON diff is calculated properly.

## Issue
