### PR TITLE
fix(misc): add prettier to create-nx-workspace sandbox

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -57,6 +57,7 @@ const tsVersion = 'TYPESCRIPT_VERSION';
 const cliVersion = 'NX_VERSION';
 const nxVersion = 'NX_VERSION';
 const angularCliVersion = 'ANGULAR_CLI_VERSION';
+const prettierVersion = 'PRETTIER_VERSION';
 
 const parsedArgs = yargsParser(process.argv, {
   string: ['cli', 'preset', 'appName'],
@@ -367,7 +368,8 @@ function createSandbox(
       dependencies: {
         '@nrwl/workspace': nxVersion,
         [cli.package]: cli.version,
-        typescript: tsVersion
+        typescript: tsVersion,
+        prettier: prettierVersion
       },
       license: 'MIT'
     })

--- a/scripts/nx-release.js
+++ b/scripts/nx-release.js
@@ -98,9 +98,10 @@ const { devDependencies } = JSON.parse(
 );
 const cliVersion = devDependencies['@angular/cli'];
 const typescriptVersion = devDependencies['typescript'];
+const prettierVersion = devDependencies['prettier'];
 
 console.log('Executing build script:');
-const buildCommand = `./scripts/package.sh ${parsedVersion.version} ${cliVersion} ${typescriptVersion}`;
+const buildCommand = `./scripts/package.sh ${parsedVersion.version} ${cliVersion} ${typescriptVersion} ${prettierVersion}`;
 console.log(`> ${buildCommand}`);
 childProcess.execSync(buildCommand, {
   stdio: [0, 1, 2]

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -6,6 +6,7 @@
 NX_VERSION=$1
 ANGULAR_CLI_VERSION=$2
 TYPESCRIPT_VERSION=$3
+PRETTIER_VERSION=$4
 
 if [[ $NX_VERSION == "--local" ]]; then
     NX_VERSION="*"
@@ -21,12 +22,14 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     sed -i "" "s|NX_VERSION|$NX_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
     sed -i "" "s|ANGULAR_CLI_VERSION|$ANGULAR_CLI_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
     sed -i "" "s|TYPESCRIPT_VERSION|$TYPESCRIPT_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
+    sed -i "" "s|PRETTIER_VERSION|$PRETTIER_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
 else
     sed -i "s|exports.nxVersion = '\*';|exports.nxVersion = '$NX_VERSION';|g" {react,next,web,jest,node,express,nest,cypress,storybook,angular,workspace}/src/utils/versions.js
     sed -i "s|\*|$NX_VERSION|g" {schematics,react,next,web,jest,node,express,nest,cypress,storybook,angular,workspace,cli,linter,bazel,insights,tao,eslint-plugin-nx,create-nx-workspace}/package.json
     sed -i "s|NX_VERSION|$NX_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
     sed -i "s|ANGULAR_CLI_VERSION|$ANGULAR_CLI_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
     sed -i "s|TYPESCRIPT_VERSION|$TYPESCRIPT_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
+    sed -i "s|PRETTIER_VERSION|$PRETTIER_VERSION|g" create-nx-workspace/bin/create-nx-workspace.js
 fi
 
 if [[ $NX_VERSION == "*" ]]; then


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`prettier` is needed to create a workspace (to run formatting) but is not available in the sandbox.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`prettier` is available in the sandbox and user is able to create a sandbox

## Issue
