### PR TITLE
fix(testing): fix cypress 8.10 migration

### DIFF
--- a/packages/cypress/src/migrations/update-8-10-0/update-8-10-0.ts
+++ b/packages/cypress/src/migrations/update-8-10-0/update-8-10-0.ts
@@ -5,6 +5,6 @@ import { join } from 'path';
 export default () => {
   return updatePackagesInPackageJson(
     join(__dirname, '../../../migrations.json'),
-    '9.0.0'
+    '8.10.0'
   );
 };


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Cypress migration fails because it tries to find package updates for 9.0.0

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Cypress migration succeeds and updates packages for 8.10.0

## Issue
