### PR TITLE
feat(angular): add move schematic for workspace and angular collections

### DIFF
--- a/docs/angular/api-angular/schematics/move.md
+++ b/docs/angular/api-angular/schematics/move.md
@@ -1,0 +1,41 @@
+# move
+
+Move an Angular application or library to another folder
+
+## Usage
+
+```bash
+ng generate move ...
+```
+
+```bash
+ng g mv ... # same
+```
+
+By default, Nx will search for `move` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+ng g @nrwl/angular:move ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+ng g move ... --dry-run
+```
+
+## Options
+
+### destination
+
+Type: `string`
+
+The folder to move the Angular project into
+
+### projectName
+
+Type: `string`
+
+The name of the Angular project to move

--- a/docs/angular/api-workspace/schematics/move.md
+++ b/docs/angular/api-workspace/schematics/move.md
@@ -1,0 +1,41 @@
+# move
+
+Move an application or library to another folder
+
+## Usage
+
+```bash
+ng generate move ...
+```
+
+```bash
+ng g mv ... # same
+```
+
+By default, Nx will search for `move` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+ng g @nrwl/workspace:move ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+ng g move ... --dry-run
+```
+
+## Options
+
+### destination
+
+Type: `string`
+
+The folder to move the project into
+
+### projectName
+
+Type: `string`
+
+The name of the project to move

--- a/docs/react/api-angular/schematics/move.md
+++ b/docs/react/api-angular/schematics/move.md
@@ -1,0 +1,41 @@
+# move
+
+Move an Angular application or library to another folder
+
+## Usage
+
+```bash
+nx generate move ...
+```
+
+```bash
+nx g mv ... # same
+```
+
+By default, Nx will search for `move` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/angular:move ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g move ... --dry-run
+```
+
+## Options
+
+### destination
+
+Type: `string`
+
+The folder to move the Angular project into
+
+### projectName
+
+Type: `string`
+
+The name of the Angular project to move

--- a/docs/react/api-workspace/schematics/move.md
+++ b/docs/react/api-workspace/schematics/move.md
@@ -1,0 +1,41 @@
+# move
+
+Move an application or library to another folder
+
+## Usage
+
+```bash
+nx generate move ...
+```
+
+```bash
+nx g mv ... # same
+```
+
+By default, Nx will search for `move` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/workspace:move ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g move ... --dry-run
+```
+
+## Options
+
+### destination
+
+Type: `string`
+
+The folder to move the project into
+
+### projectName
+
+Type: `string`
+
+The name of the project to move

--- a/docs/web/api-angular/schematics/move.md
+++ b/docs/web/api-angular/schematics/move.md
@@ -1,0 +1,41 @@
+# move
+
+Move an Angular application or library to another folder
+
+## Usage
+
+```bash
+nx generate move ...
+```
+
+```bash
+nx g mv ... # same
+```
+
+By default, Nx will search for `move` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/angular:move ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g move ... --dry-run
+```
+
+## Options
+
+### destination
+
+Type: `string`
+
+The folder to move the Angular project into
+
+### projectName
+
+Type: `string`
+
+The name of the Angular project to move

--- a/docs/web/api-workspace/schematics/move.md
+++ b/docs/web/api-workspace/schematics/move.md
@@ -1,0 +1,41 @@
+# move
+
+Move an application or library to another folder
+
+## Usage
+
+```bash
+nx generate move ...
+```
+
+```bash
+nx g mv ... # same
+```
+
+By default, Nx will search for `move` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/workspace:move ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g move ... --dry-run
+```
+
+## Options
+
+### destination
+
+Type: `string`
+
+The folder to move the project into
+
+### projectName
+
+Type: `string`
+
+The name of the project to move

--- a/e2e/move.angular.test.ts
+++ b/e2e/move.angular.test.ts
@@ -1,0 +1,155 @@
+import { classify } from '@nrwl/workspace/src/utils/strings';
+import {
+  checkFilesExist,
+  forEachCli,
+  newProject,
+  readFile,
+  readJson,
+  runCLI,
+  uniq,
+  updateFile
+} from './utils';
+
+forEachCli(cli => {
+  describe('Move Angular Project', () => {
+    const workspace: string = cli === 'angular' ? 'angular' : 'workspace';
+
+    describe('Apps', () => {
+      let app1: string;
+      let app2: string;
+      let newPath: string;
+
+      beforeEach(() => {
+        app1 = uniq('app1');
+        app2 = uniq('app2');
+        newPath = `subfolder/${app2}`;
+        newProject();
+        runCLI(`generate @nrwl/angular:app ${app1}`);
+      });
+
+      /**
+       * Tries moving an app from ${app1} -> subfolder/${app2}
+       */
+      it('should work for apps', () => {
+        const moveOutput = runCLI(
+          `generate @nrwl/angular:move --projectName=${app1} --destination=${newPath}`
+        );
+
+        // just check the output
+        expect(moveOutput).toContain(`DELETE apps/${app1}`);
+        expect(moveOutput).toContain(`CREATE apps/${newPath}/browserslist`);
+        expect(moveOutput).toContain(`CREATE apps/${newPath}/jest.config.js`);
+        expect(moveOutput).toContain(
+          `CREATE apps/${newPath}/tsconfig.app.json`
+        );
+        expect(moveOutput).toContain(`CREATE apps/${newPath}/tsconfig.json`);
+        expect(moveOutput).toContain(
+          `CREATE apps/${newPath}/tsconfig.spec.json`
+        );
+        expect(moveOutput).toContain(`CREATE apps/${newPath}/tslint.json`);
+        expect(moveOutput).toContain(`CREATE apps/${newPath}/src/favicon.ico`);
+        expect(moveOutput).toContain(`CREATE apps/${newPath}/src/index.html`);
+        expect(moveOutput).toContain(`CREATE apps/${newPath}/src/main.ts`);
+        expect(moveOutput).toContain(`CREATE apps/${newPath}/src/polyfills.ts`);
+        expect(moveOutput).toContain(`CREATE apps/${newPath}/src/styles.css`);
+        expect(moveOutput).toContain(
+          `CREATE apps/${newPath}/src/test-setup.ts`
+        );
+        expect(moveOutput).toContain(
+          `CREATE apps/${newPath}/src/app/app.component.html`
+        );
+        expect(moveOutput).toContain(
+          `CREATE apps/${newPath}/src/app/app.module.ts`
+        );
+        expect(moveOutput).toContain(
+          `CREATE apps/${newPath}/src/assets/.gitkeep`
+        );
+        expect(moveOutput).toContain(
+          `CREATE apps/${newPath}/src/environments/environment.prod.ts`
+        );
+        expect(moveOutput).toContain(
+          `CREATE apps/${newPath}/src/environments/environment.ts`
+        );
+        expect(moveOutput).toContain(`UPDATE nx.json`);
+        expect(moveOutput).toContain(`UPDATE ${workspace}.json`);
+      });
+
+      /**
+       * Tries moving an e2e project from ${app1} -> ${newPath}
+       */
+      it('should work for e2e projects', () => {
+        const moveOutput = runCLI(
+          `generate @nrwl/angular:move --projectName=${app1}-e2e --destination=${newPath}-e2e`
+        );
+
+        // just check that the cypress.json is updated correctly
+        const cypressJsonPath = `apps/${newPath}-e2e/cypress.json`;
+        expect(moveOutput).toContain(`CREATE ${cypressJsonPath}`);
+        checkFilesExist(cypressJsonPath);
+        const cypressJson = readJson(cypressJsonPath);
+        expect(cypressJson.videosFolder).toEqual(
+          `../../../dist/cypress/apps/${newPath}-e2e/videos`
+        );
+        expect(cypressJson.screenshotsFolder).toEqual(
+          `../../../dist/cypress/apps/${newPath}-e2e/screenshots`
+        );
+      });
+    });
+
+    /**
+     * Tries moving a library from ${lib} -> shared/${lib}
+     */
+    it('should work for libraries', () => {
+      const lib1 = uniq('mylib');
+      const lib2 = uniq('mylib');
+      newProject();
+      runCLI(`generate @nrwl/angular:lib ${lib1}`);
+
+      /**
+       * Create a library which imports the module from the other lib
+       */
+
+      runCLI(`generate @nrwl/angular:lib ${lib2}`);
+
+      updateFile(
+        `libs/${lib2}/src/lib/${lib2}.module.ts`,
+        `import { ${classify(lib1)}Module } from '@proj/${lib1}';
+
+        export class ExtendedModule extends ${classify(lib1)}Module { }`
+      );
+
+      const moveOutput = runCLI(
+        `generate @nrwl/angular:move --projectName=${lib1} --destination=shared/${lib1}`
+      );
+
+      const newPath = `libs/shared/${lib1}`;
+      const newModule = `Shared${classify(lib1)}Module`;
+
+      const testSetupPath = `${newPath}/src/test-setup.ts`;
+      expect(moveOutput).toContain(`CREATE ${testSetupPath}`);
+      checkFilesExist(testSetupPath);
+
+      const modulePath = `${newPath}/src/lib/shared-${lib1}.module.ts`;
+      expect(moveOutput).toContain(`CREATE ${modulePath}`);
+      checkFilesExist(modulePath);
+      const moduleFile = readFile(modulePath);
+      expect(moduleFile).toContain(`export class ${newModule}`);
+
+      const indexPath = `${newPath}/src/index.ts`;
+      expect(moveOutput).toContain(`CREATE ${indexPath}`);
+      checkFilesExist(indexPath);
+      const index = readFile(indexPath);
+      expect(index).toContain(`export * from './lib/shared-${lib1}.module'`);
+
+      /**
+       * Check that the import in lib2 has been updated
+       */
+      const lib2FilePath = `libs/${lib2}/src/lib/${lib2}.module.ts`;
+      const lib2File = readFile(lib2FilePath);
+      expect(lib2File).toContain(
+        `import { ${newModule} } from '@proj/shared/${lib1}';`
+      );
+      expect(lib2File).toContain(`extends ${newModule}`);
+    });
+  });
+});

--- a/e2e/move.workspace.test.ts
+++ b/e2e/move.workspace.test.ts
@@ -1,0 +1,142 @@
+import { NxJson } from '@nrwl/workspace';
+import {
+  checkFilesExist,
+  exists,
+  forEachCli,
+  newProject,
+  readFile,
+  readJson,
+  runCLI,
+  uniq,
+  updateFile
+} from './utils';
+
+forEachCli(cli => {
+  describe('Move Project', () => {
+    const workspace: string = cli === 'angular' ? 'angular' : 'workspace';
+
+    /**
+     * Tries moving a library from ${lib}/data-access -> shared/${lib}/data-access
+     */
+    it('should work for libraries', () => {
+      const lib1 = uniq('mylib');
+      const lib2 = uniq('mylib');
+      newProject();
+      runCLI(`generate @nrwl/workspace:lib ${lib1}/data-access`);
+
+      updateFile(
+        `libs/${lib1}/data-access/src/lib/${lib1}-data-access.ts`,
+        `export function fromLibOne() { console.log('This is completely pointless'); }`
+      );
+
+      updateFile(
+        `libs/${lib1}/data-access/src/index.ts`,
+        `export * from './lib/${lib1}-data-access.ts'`
+      );
+
+      /**
+       * Create a library which imports a class from the other lib
+       */
+
+      runCLI(`generate @nrwl/workspace:lib ${lib2}/ui`);
+
+      updateFile(
+        `libs/${lib2}/ui/src/lib/${lib2}-ui.ts`,
+        `import { fromLibOne } from '@proj/${lib1}/data-access';
+
+        export const fromLibTwo = () => fromLibOne(); }`
+      );
+
+      const moveOutput = runCLI(
+        `generate @nrwl/workspace:move --projectName=${lib1}-data-access --destination=shared/${lib1}/data-access`
+      );
+
+      expect(moveOutput).toContain(`DELETE libs/${lib1}/data-access`);
+      expect(exists(`libs/${lib1}/data-access`)).toBeFalsy();
+
+      const newPath = `libs/shared/${lib1}/data-access`;
+      const newName = `shared-${lib1}-data-access`;
+
+      const readmePath = `${newPath}/README.md`;
+      expect(moveOutput).toContain(`CREATE ${readmePath}`);
+      checkFilesExist(readmePath);
+
+      const jestConfigPath = `${newPath}/jest.config.js`;
+      expect(moveOutput).toContain(`CREATE ${jestConfigPath}`);
+      checkFilesExist(jestConfigPath);
+      const jestConfig = readFile(jestConfigPath);
+      expect(jestConfig).toContain(`name: 'shared-${lib1}-data-access'`);
+      expect(jestConfig).toContain(`preset: '../../../../jest.config.js'`);
+      expect(jestConfig).toContain(
+        `coverageDirectory: '../../../../coverage/${newPath}'`
+      );
+
+      const tsConfigPath = `${newPath}/tsconfig.json`;
+      expect(moveOutput).toContain(`CREATE ${tsConfigPath}`);
+      checkFilesExist(tsConfigPath);
+      const tsConfig = readJson(tsConfigPath);
+      expect(tsConfig.extends).toEqual('../../../../tsconfig.json');
+
+      const tsConfigLibPath = `${newPath}/tsconfig.lib.json`;
+      expect(moveOutput).toContain(`CREATE ${tsConfigLibPath}`);
+      checkFilesExist(tsConfigLibPath);
+      const tsConfigLib = readJson(tsConfigLibPath);
+      expect(tsConfigLib.compilerOptions.outDir).toEqual(
+        '../../../../dist/out-tsc'
+      );
+
+      const tsConfigSpecPath = `${newPath}/tsconfig.spec.json`;
+      expect(moveOutput).toContain(`CREATE ${tsConfigSpecPath}`);
+      checkFilesExist(tsConfigSpecPath);
+      const tsConfigSpec = readJson(tsConfigSpecPath);
+      expect(tsConfigSpec.compilerOptions.outDir).toEqual(
+        '../../../../dist/out-tsc'
+      );
+
+      const indexPath = `${newPath}/src/index.ts`;
+      expect(moveOutput).toContain(`CREATE ${indexPath}`);
+      checkFilesExist(indexPath);
+
+      const rootClassPath = `${newPath}/src/lib/${lib1}-data-access.ts`;
+      expect(moveOutput).toContain(`CREATE ${rootClassPath}`);
+      checkFilesExist(rootClassPath);
+
+      expect(moveOutput).toContain('UPDATE nx.json');
+      const nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+      expect(nxJson.projects[`${lib1}-data-access`]).toBeUndefined();
+      expect(nxJson.projects[newName]).toEqual({
+        tags: []
+      });
+
+      expect(moveOutput).toContain('UPDATE tsconfig.json');
+      const rootTsConfig = readJson('tsconfig.json');
+      expect(
+        rootTsConfig.compilerOptions.paths[`@proj/${lib1}/data-access`]
+      ).toBeUndefined();
+      expect(
+        rootTsConfig.compilerOptions.paths[`@proj/shared/${lib1}/data-access`]
+      ).toEqual([`libs/shared/${lib1}/data-access/src/index.ts`]);
+
+      expect(moveOutput).toContain(`UPDATE ${workspace}.json`);
+      const workspaceJson = readJson(`${workspace}.json`);
+      expect(workspaceJson.projects[`${lib1}-data-access`]).toBeUndefined();
+      const project = workspaceJson.projects[newName];
+      expect(project).toBeTruthy();
+      expect(project.root).toBe(newPath);
+      expect(project.sourceRoot).toBe(`${newPath}/src`);
+      expect(project.architect.lint.options.tsConfig).toEqual([
+        `libs/shared/${lib1}/data-access/tsconfig.lib.json`,
+        `libs/shared/${lib1}/data-access/tsconfig.spec.json`
+      ]);
+
+      /**
+       * Check that the import in lib2 has been updated
+       */
+      const lib2FilePath = `libs/${lib2}/ui/src/lib/${lib2}-ui.ts`;
+      const lib2File = readFile(lib2FilePath);
+      expect(lib2File).toContain(
+        `import { fromLibOne } from '@proj/shared/${lib1}/data-access';`
+      );
+    });
+  });
+});

--- a/packages/angular/collection.json
+++ b/packages/angular/collection.json
@@ -81,6 +81,13 @@
       "schema": "./src/schematics/component-story/schema.json",
       "description": "Create a stories.ts file for a component",
       "hidden": true
+    },
+
+    "move": {
+      "factory": "./src/schematics/move/move",
+      "schema": "./src/schematics/move/schema.json",
+      "aliases": ["mv"],
+      "description": "Move an Angular application or library to another folder"
     }
   }
 }

--- a/packages/angular/src/schematics/move/lib/update-module-name.spec.ts
+++ b/packages/angular/src/schematics/move/lib/update-module-name.spec.ts
@@ -1,0 +1,115 @@
+import { Tree } from '@angular-devkit/schematics';
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { callRule, runSchematic } from '../../../utils/testing';
+import { Schema } from '../schema';
+import { updateModuleName } from './update-module-name';
+
+describe('updateModuleName Rule', () => {
+  let tree: UnitTestTree;
+  const schema: Schema = {
+    projectName: 'my-source',
+    destination: 'my-destination'
+  };
+
+  const modulePath = '/libs/my-destination/src/lib/my-destination.module.ts';
+  const moduleSpecPath =
+    '/libs/my-destination/src/lib/my-destination.module.spec.ts';
+  const indexPath = '/libs/my-destination/src/index.ts';
+  const importerPath = '/libs/my-importer/src/lib/my-importing-file.ts';
+
+  beforeEach(async () => {
+    tree = new UnitTestTree(Tree.empty());
+    tree = createEmptyWorkspace(tree) as UnitTestTree;
+
+    // fake a mid-move tree:
+    tree = await runSchematic('lib', { name: 'my-destination' }, tree);
+
+    tree.create(
+      '/libs/my-destination/src/lib/my-source.module.ts',
+      `import { NgModule } from '@angular/core';
+    import { CommonModule } from '@angular/common';
+    
+    @NgModule({
+      imports: [CommonModule]
+    })
+    export class MySourceModule {}`
+    );
+
+    tree.create(
+      '/libs/my-destination/src/lib/my-source.module.spec.ts',
+      `import { async, TestBed } from '@angular/core/testing';
+    import { MySourceModule } from './my-source.module';
+    
+    describe('MySourceModule', () => {
+      beforeEach(async(() => {
+        TestBed.configureTestingModule({
+          imports: [MySourceModule]
+        }).compileComponents();
+      }));
+    
+      it('should create', () => {
+        expect(MySourceModule).toBeDefined();
+      });
+    });`
+    );
+
+    tree.overwrite(
+      indexPath,
+      `export * from './lib/my-source.module';
+    `
+    );
+
+    tree.delete(modulePath);
+    tree.delete(moduleSpecPath);
+
+    tree = await runSchematic('lib', { name: 'my-importer' }, tree);
+
+    tree.create(
+      importerPath,
+      `import { MySourceModule } from '@proj/my-destination';
+    
+      export class MyExtendedSourceModule extends MySourceModule {}
+      `
+    );
+  });
+
+  it('should rename the module files and update the module name', async () => {
+    tree = (await callRule(updateModuleName(schema), tree)) as UnitTestTree;
+
+    expect(tree.files).toContain(modulePath);
+    expect(tree.files).toContain(moduleSpecPath);
+
+    const moduleFile = tree.read(modulePath).toString('utf-8');
+    expect(moduleFile).toContain(`export class MyDestinationModule {}`);
+
+    const moduleSpecFile = tree.read(moduleSpecPath).toString('utf-8');
+    expect(moduleSpecFile).toContain(
+      `import { MyDestinationModule } from './my-destination.module';`
+    );
+    expect(moduleSpecFile).toContain(`describe('MyDestinationModule', () => {`);
+    expect(moduleSpecFile).toContain(`imports: [MyDestinationModule]`);
+    expect(moduleSpecFile).toContain(
+      `expect(MyDestinationModule).toBeDefined();`
+    );
+  });
+
+  it('should update any references to the module', async () => {
+    tree = (await callRule(updateModuleName(schema), tree)) as UnitTestTree;
+
+    const importerFile = tree.read(importerPath).toString('utf-8');
+    expect(importerFile).toContain(
+      `import { MyDestinationModule } from '@proj/my-destination';`
+    );
+    expect(importerFile).toContain(
+      `export class MyExtendedSourceModule extends MyDestinationModule {}`
+    );
+  });
+
+  it('should update the index.ts file which exports the module', async () => {
+    tree = (await callRule(updateModuleName(schema), tree)) as UnitTestTree;
+
+    const indexFile = tree.read(indexPath).toString('utf-8');
+    expect(indexFile).toContain(`export * from './lib/my-destination.module';`);
+  });
+});

--- a/packages/angular/src/schematics/move/lib/update-module-name.ts
+++ b/packages/angular/src/schematics/move/lib/update-module-name.ts
@@ -1,0 +1,107 @@
+import { classify } from '@angular-devkit/core/src/utils/strings';
+import { SchematicContext, Tree } from '@angular-devkit/schematics';
+import { getWorkspace } from '@nrwl/workspace';
+import { getNewProjectName } from '@nrwl/workspace/src/schematics/move/lib/utils';
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Schema } from '../schema';
+
+/**
+ * Updates the Angular module name (including the spec file and index.ts)
+ *
+ * Again, if the user has deviated from the expected folder
+ * structure, they are very much on their own.
+ *
+ * @param schema The options provided to the schematic
+ */
+export function updateModuleName(schema: Schema) {
+  return (tree: Tree, _context: SchematicContext): Observable<Tree> => {
+    return from(getWorkspace(tree)).pipe(
+      map(workspace => {
+        const newProjectName = getNewProjectName(schema.destination);
+        const project = workspace.projects.get(newProjectName);
+
+        if (project.extensions['projectType'] === 'application') {
+          // Expect the module to be something like 'app.module.ts' regardless of the folder name,
+          // Therefore, nothing to do.
+          return tree;
+        }
+
+        const moduleName = {
+          from: classify(schema.projectName),
+          to: classify(newProjectName)
+        };
+
+        const findModuleName = new RegExp(moduleName.from, 'g');
+
+        const moduleFile = {
+          from: `${schema.projectName}.module`,
+          to: `${newProjectName}.module`
+        };
+
+        const replaceImport = new RegExp(moduleFile.from, 'g');
+
+        const filesToChange = [
+          {
+            from: `${project.sourceRoot}/lib/${moduleFile.from}.ts`,
+            to: `${project.sourceRoot}/lib/${moduleFile.to}.ts`
+          },
+          {
+            from: `${project.sourceRoot}/lib/${moduleFile.from}.spec.ts`,
+            to: `${project.sourceRoot}/lib/${moduleFile.to}.spec.ts`
+          }
+        ];
+
+        // Update the module file and its spec file
+        filesToChange.forEach(file => {
+          if (tree.exists(file.from)) {
+            let content = tree.read(file.from).toString('utf-8');
+
+            if (findModuleName.test(content)) {
+              content = content.replace(findModuleName, moduleName.to);
+            }
+
+            if (replaceImport.test(content)) {
+              content = content.replace(replaceImport, moduleFile.to);
+            }
+
+            tree.create(file.to, content);
+
+            tree.delete(file.from);
+          }
+        });
+
+        // Update any files which import the module
+        for (const [name, definition] of workspace.projects.entries()) {
+          if (name === newProjectName) {
+            continue;
+          }
+
+          const projectDir = tree.getDir(definition.root);
+          projectDir.visit(file => {
+            const contents = tree.read(file).toString('utf-8');
+            if (!findModuleName.test(contents)) {
+              return;
+            }
+
+            const updatedFile = tree
+              .read(file)
+              .toString()
+              .replace(findModuleName, moduleName.to);
+            tree.overwrite(file, updatedFile);
+          });
+        }
+
+        // Update the index file
+        const indexFile = `${project.sourceRoot}/index.ts`;
+        if (tree.exists(indexFile)) {
+          let content = tree.read(indexFile).toString('utf-8');
+          content = content.replace(replaceImport, moduleFile.to);
+          tree.overwrite(indexFile, content);
+        }
+
+        return tree;
+      })
+    );
+  };
+}

--- a/packages/angular/src/schematics/move/move.ts
+++ b/packages/angular/src/schematics/move/move.ts
@@ -1,0 +1,17 @@
+import { chain, externalSchematic } from '@angular-devkit/schematics';
+import { updateModuleName } from './lib/update-module-name';
+import { Schema } from './schema';
+
+/**
+ * Moves an Angular lib/app to another folder (and renames it in the process)
+ *
+ * @remarks It's important to note that `updateModuleName` is done after the update
+ * to the workspace, so it can't use the same tricks as the `@nrwl/workspace` rules
+ * to get the before and after names and paths.
+ */
+export default function(schema: Schema) {
+  return chain([
+    externalSchematic('@nrwl/workspace', 'move', schema),
+    updateModuleName(schema)
+  ]);
+}

--- a/packages/angular/src/schematics/move/schema.d.ts
+++ b/packages/angular/src/schematics/move/schema.d.ts
@@ -1,0 +1,4 @@
+export interface Schema {
+  projectName: string;
+  destination: string;
+}

--- a/packages/angular/src/schematics/move/schema.json
+++ b/packages/angular/src/schematics/move/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxAngularMove",
+  "title": "Nx Angular Move",
+  "description": "Move an Angular project to another folder in the workspace",
+  "type": "object",
+  "properties": {
+    "projectName": {
+      "type": "string",
+      "description": "The name of the Angular project to move"
+    },
+    "destination": {
+      "type": "string",
+      "description": "The folder to move the Angular project into"
+    }
+  },
+  "required": ["projectName", "destination"]
+}

--- a/packages/workspace/collection.json
+++ b/packages/workspace/collection.json
@@ -23,6 +23,13 @@
       "hidden": true
     },
 
+    "move": {
+      "factory": "./src/schematics/move/move",
+      "schema": "./src/schematics/move/schema.json",
+      "aliases": ["mv"],
+      "description": "Move an application or library to another folder"
+    },
+
     "ng-new": {
       "factory": "./src/schematics/ng-new/ng-new",
       "schema": "./src/schematics/ng-new/schema.json",

--- a/packages/workspace/src/schematics/move/lib/check-destination.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/check-destination.spec.ts
@@ -1,0 +1,60 @@
+import { Tree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { callRule, runSchematic } from '../../../utils/testing';
+import { Schema } from '../schema';
+import { checkDestination } from './check-destination';
+
+describe('checkDestination Rule', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createEmptyWorkspace(Tree.empty());
+    tree = await runSchematic('lib', { name: 'my-lib' }, tree);
+  });
+
+  it('should throw an error if the path is not explicit', async () => {
+    const schema: Schema = {
+      projectName: 'my-lib',
+      destination: '../apps/not-an-app'
+    };
+
+    await expect(callRule(checkDestination(schema), tree)).rejects.toThrow(
+      `Invalid destination: [${schema.destination}] - Please specify explicit path.`
+    );
+  });
+
+  it('should throw an error if the path already exists', async () => {
+    tree = await runSchematic('lib', { name: 'my-other-lib' }, tree);
+
+    const schema: Schema = {
+      projectName: 'my-lib',
+      destination: 'my-other-lib'
+    };
+
+    await expect(callRule(checkDestination(schema), tree)).rejects.toThrow(
+      `Invalid destination: [${schema.destination}] - Path is not empty.`
+    );
+  });
+
+  it('should NOT throw an error if the path is available', async () => {
+    const schema: Schema = {
+      projectName: 'my-lib',
+      destination: 'my-other-lib'
+    };
+
+    await expect(
+      callRule(checkDestination(schema), tree)
+    ).resolves.not.toThrow();
+  });
+
+  it('should normalize the destination', async () => {
+    const schema: Schema = {
+      projectName: 'my-lib',
+      destination: '/my-other-lib//wibble'
+    };
+
+    await callRule(checkDestination(schema), tree);
+
+    expect(schema.destination).toBe('my-other-lib/wibble');
+  });
+});

--- a/packages/workspace/src/schematics/move/lib/check-destination.ts
+++ b/packages/workspace/src/schematics/move/lib/check-destination.ts
@@ -1,0 +1,43 @@
+import { Rule, SchematicContext } from '@angular-devkit/schematics';
+import { Tree } from '@angular-devkit/schematics/src/tree/interface';
+import { getWorkspace } from '@nrwl/workspace';
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Schema } from '../schema';
+import { getDestination, normalizeSlashes } from './utils';
+
+/**
+ * Checks whether the destination folder is valid
+ *
+ * - must not be outside the workspace
+ * - must be a new folder
+ *
+ * @param schema The options provided to the schematic
+ */
+export function checkDestination(schema: Schema): Rule {
+  return (tree: Tree, _context: SchematicContext): Observable<Tree> => {
+    return from(getWorkspace(tree)).pipe(
+      map(workspace => {
+        const INVALID_DESTINATION = `Invalid destination: [${schema.destination}]`;
+
+        if (schema.destination.includes('..')) {
+          throw new Error(
+            `${INVALID_DESTINATION} - Please specify explicit path.`
+          );
+        }
+
+        const destination = getDestination(schema, workspace);
+
+        if (tree.getDir(destination).subfiles.length > 0) {
+          throw new Error(`${INVALID_DESTINATION} - Path is not empty.`);
+        }
+
+        if (schema.destination.startsWith('/')) {
+          schema.destination = normalizeSlashes(schema.destination.substr(1));
+        }
+
+        return tree;
+      })
+    );
+  };
+}

--- a/packages/workspace/src/schematics/move/lib/check-project-exists.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/check-project-exists.spec.ts
@@ -1,0 +1,37 @@
+import { Tree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { callRule, runSchematic } from '../../../utils/testing';
+import { Schema } from '../schema';
+import { checkProjectExists } from './check-project-exists';
+
+describe('checkProjectExists Rule', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createEmptyWorkspace(Tree.empty());
+  });
+
+  it('should throw an error if the project does NOT exist', async () => {
+    const schema: Schema = {
+      projectName: 'my-lib',
+      destination: 'my-destination'
+    };
+
+    await expect(callRule(checkProjectExists(schema), tree)).rejects.toThrow(
+      `Project not found in workspace: [${schema.projectName}]`
+    );
+  });
+
+  it('should NOT throw an error if the project exists', async () => {
+    tree = await runSchematic('lib', { name: 'my-lib' }, tree);
+
+    const schema: Schema = {
+      projectName: 'my-lib',
+      destination: 'my-destination'
+    };
+
+    await expect(
+      callRule(checkProjectExists(schema), tree)
+    ).resolves.not.toThrow();
+  });
+});

--- a/packages/workspace/src/schematics/move/lib/check-project-exists.ts
+++ b/packages/workspace/src/schematics/move/lib/check-project-exists.ts
@@ -1,0 +1,26 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { getWorkspace } from '@nrwl/workspace';
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Schema } from '../schema';
+
+/**
+ * Checks whether the project exists in the workspace.
+ *
+ * @param schema The options provided to the schematic
+ */
+export function checkProjectExists(schema: Schema): Rule {
+  return (tree: Tree, _context: SchematicContext): Observable<Tree> => {
+    return from(getWorkspace(tree)).pipe(
+      map(workspace => {
+        if (!workspace.projects.has(schema.projectName)) {
+          throw new Error(
+            `Project not found in workspace: [${schema.projectName}]`
+          );
+        }
+
+        return tree;
+      })
+    );
+  };
+}

--- a/packages/workspace/src/schematics/move/lib/move-project.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/move-project.spec.ts
@@ -1,0 +1,38 @@
+import { Tree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { runSchematic } from '../../../utils/testing';
+import { Schema } from '../schema';
+
+describe('moveProject Rule', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createEmptyWorkspace(Tree.empty());
+    tree = await runSchematic('lib', { name: 'my-lib' }, tree);
+  });
+
+  it('should copy all files and delete the source folder', async () => {
+    const schema: Schema = {
+      projectName: 'my-lib',
+      destination: 'my-destination'
+    };
+
+    // TODO - Currently this test will fail due to
+    //        https://github.com/angular/angular-cli/issues/16527
+    // host = await callRule(moveProject(schema), host);
+
+    // const destinationDir = host.getDir('libs/my-destination');
+    // let filesFound = false;
+    // destinationDir.visit(_file => {
+    //   filesFound = true;
+    // });
+    // expect(filesFound).toBeTruthy();
+
+    // const sourceDir = host.getDir('libs/my-lib');
+    // filesFound = false;
+    // sourceDir.visit(_file => {
+    //   filesFound = true;
+    // });
+    // expect(filesFound).toBeFalsy();
+  });
+});

--- a/packages/workspace/src/schematics/move/lib/move-project.ts
+++ b/packages/workspace/src/schematics/move/lib/move-project.ts
@@ -1,0 +1,32 @@
+import { SchematicContext, Tree } from '@angular-devkit/schematics';
+import { getWorkspace } from '@nrwl/workspace';
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Schema } from '../schema';
+import { getDestination } from './utils';
+
+/**
+ * Moves a project to the given destination path
+ *
+ * @param schema The options provided to the schematic
+ */
+export function moveProject(schema: Schema) {
+  return (tree: Tree, _context: SchematicContext): Observable<Tree> => {
+    return from(getWorkspace(tree)).pipe(
+      map(workspace => {
+        const project = workspace.projects.get(schema.projectName);
+
+        const destination = getDestination(schema, workspace);
+        const dir = tree.getDir(project.root);
+        dir.visit(file => {
+          const newPath = file.replace(project.root, destination);
+          tree.create(newPath, tree.read(file));
+        });
+
+        tree.delete(project.root);
+
+        return tree;
+      })
+    );
+  };
+}

--- a/packages/workspace/src/schematics/move/lib/update-cypress-json.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-cypress-json.spec.ts
@@ -1,0 +1,66 @@
+import { Tree } from '@angular-devkit/schematics';
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
+import { readJsonInTree } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { callRule, runSchematic } from '../../../utils/testing';
+import { Schema } from '../schema';
+import { updateCypressJson } from './update-cypress-json';
+
+describe('updateCypressJson Rule', () => {
+  let tree: UnitTestTree;
+
+  beforeEach(async () => {
+    tree = new UnitTestTree(Tree.empty());
+    tree = createEmptyWorkspace(tree) as UnitTestTree;
+  });
+
+  it('should handle cypress.json not existing', async () => {
+    tree = await runSchematic('lib', { name: 'my-lib' }, tree);
+
+    expect(tree.files).not.toContain('/libs/my-destination/cypress.json');
+
+    const schema: Schema = {
+      projectName: 'my-lib',
+      destination: 'my-destination'
+    };
+
+    await expect(
+      callRule(updateCypressJson(schema), tree)
+    ).resolves.not.toThrow();
+  });
+
+  it('should update the videos and screenshots folders', async () => {
+    const cypressJson = {
+      fileServerFolder: '.',
+      fixturesFolder: './src/fixtures',
+      integrationFolder: './src/integration',
+      pluginsFile: './src/plugins/index',
+      supportFile: false,
+      video: true,
+      videosFolder: '../../dist/cypress/libs/my-lib/videos',
+      screenshotsFolder: '../../dist/cypress/libs/my-lib/screenshots',
+      chromeWebSecurity: false
+    };
+
+    tree = await runSchematic('lib', { name: 'my-lib' }, tree);
+    tree.create(
+      '/libs/my-destination/cypress.json',
+      JSON.stringify(cypressJson)
+    );
+
+    expect(tree.files).toContain('/libs/my-destination/cypress.json');
+
+    const schema: Schema = {
+      projectName: 'my-lib',
+      destination: 'my-destination'
+    };
+
+    tree = (await callRule(updateCypressJson(schema), tree)) as UnitTestTree;
+
+    expect(readJsonInTree(tree, '/libs/my-destination/cypress.json')).toEqual({
+      ...cypressJson,
+      videosFolder: '../../dist/cypress/libs/my-destination/videos',
+      screenshotsFolder: '../../dist/cypress/libs/my-destination/screenshots'
+    });
+  });
+});

--- a/packages/workspace/src/schematics/move/lib/update-cypress-json.ts
+++ b/packages/workspace/src/schematics/move/lib/update-cypress-json.ts
@@ -1,0 +1,54 @@
+import { Rule, SchematicContext } from '@angular-devkit/schematics';
+import { Tree } from '@angular-devkit/schematics/src/tree/interface';
+import { getWorkspace } from '@nrwl/workspace';
+import * as path from 'path';
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Schema } from '../schema';
+import { getDestination } from './utils';
+
+interface PartialCypressJson {
+  videosFolder: string;
+  screenshotsFolder: string;
+}
+
+/**
+ * Updates the videos and screenshots folders in the cypress.json if it exists (i.e. we're moving an e2e project)
+ *
+ * (assume relative paths have been updated previously)
+ *
+ * @param schema The options provided to the schematic
+ */
+export function updateCypressJson(schema: Schema): Rule {
+  return (tree: Tree, _context: SchematicContext): Observable<Tree> => {
+    return from(getWorkspace(tree)).pipe(
+      map(workspace => {
+        const project = workspace.projects.get(schema.projectName);
+        const destination = getDestination(schema, workspace);
+
+        const cypressJsonPath = path.join(destination, 'cypress.json');
+
+        if (!tree.exists(cypressJsonPath)) {
+          // nothing to do
+          return tree;
+        }
+
+        const cypressJson = JSON.parse(
+          tree.read(cypressJsonPath).toString('utf-8')
+        ) as PartialCypressJson;
+        cypressJson.videosFolder = cypressJson.videosFolder.replace(
+          project.root,
+          destination
+        );
+        cypressJson.screenshotsFolder = cypressJson.screenshotsFolder.replace(
+          project.root,
+          destination
+        );
+
+        tree.overwrite(cypressJsonPath, JSON.stringify(cypressJson));
+
+        return tree;
+      })
+    );
+  };
+}

--- a/packages/workspace/src/schematics/move/lib/update-imports.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-imports.spec.ts
@@ -1,0 +1,63 @@
+import { Tree } from '@angular-devkit/schematics';
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
+import { readJsonInTree } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { callRule, runSchematic } from '../../../utils/testing';
+import { Schema } from '../schema';
+import { updateImports } from './update-imports';
+
+describe('updateImports Rule', () => {
+  let tree: UnitTestTree;
+  let schema: Schema;
+
+  beforeEach(async () => {
+    tree = new UnitTestTree(Tree.empty());
+    tree = createEmptyWorkspace(tree) as UnitTestTree;
+
+    schema = {
+      projectName: 'my-source',
+      destination: 'my-destination'
+    };
+  });
+
+  it('should update project refs', async () => {
+    // this is a bit of a cheat - we expect to run this rule on an intermediate state
+    // tree where the workspace hasn't been updated yet, so just create libs representing
+    // source and destination to make sure that the workspace has libraries with those names.
+    tree = await runSchematic('lib', { name: 'my-destination' }, tree);
+    tree = await runSchematic('lib', { name: 'my-source' }, tree);
+
+    tree = await runSchematic('lib', { name: 'my-importer' }, tree);
+    const importerFilePath = 'libs/my-importer/src/importer.ts';
+    tree.create(
+      importerFilePath,
+      `
+      import { MyClass } from '@proj/my-source';
+
+      export MyExtendedClass extends MyClass {};
+    `
+    );
+
+    tree = (await callRule(updateImports(schema), tree)) as UnitTestTree;
+
+    expect(tree.read(importerFilePath).toString()).toContain(
+      `import { MyClass } from '@proj/my-destination';`
+    );
+  });
+
+  it('should update project ref in the tsconfig file', async () => {
+    tree = await runSchematic('lib', { name: 'my-source' }, tree);
+
+    let tsConfig = readJsonInTree(tree, '/tsconfig.json');
+    expect(tsConfig.compilerOptions.paths).toEqual({
+      '@proj/my-source': ['libs/my-source/src/index.ts']
+    });
+
+    tree = (await callRule(updateImports(schema), tree)) as UnitTestTree;
+
+    tsConfig = readJsonInTree(tree, '/tsconfig.json');
+    expect(tsConfig.compilerOptions.paths).toEqual({
+      '@proj/my-destination': ['libs/my-destination/src/index.ts']
+    });
+  });
+});

--- a/packages/workspace/src/schematics/move/lib/update-imports.ts
+++ b/packages/workspace/src/schematics/move/lib/update-imports.ts
@@ -1,0 +1,83 @@
+import { SchematicContext, Tree } from '@angular-devkit/schematics';
+import {
+  getWorkspace,
+  NxJson,
+  readJsonInTree,
+  serializeJson
+} from '@nrwl/workspace';
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Schema } from '../schema';
+import { normalizeSlashes } from './utils';
+
+/**
+ * Updates all the imports in the workspace and modifies the tsconfig appropriately.
+ *
+ * @param schema The options provided to the schematic
+ */
+export function updateImports(schema: Schema) {
+  return (tree: Tree, _context: SchematicContext): Observable<Tree> => {
+    return from(getWorkspace(tree)).pipe(
+      map(workspace => {
+        const nxJson = readJsonInTree<NxJson>(tree, 'nx.json');
+        const project = workspace.projects.get(schema.projectName);
+
+        if (project.extensions['projectType'] === 'application') {
+          // These shouldn't be imported anywhere?
+          return tree;
+        }
+
+        const projectRef = {
+          from: normalizeSlashes(
+            `@${nxJson.npmScope}/${project.root.substr(5)}`
+          ),
+          to: normalizeSlashes(`@${nxJson.npmScope}/${schema.destination}`)
+        };
+
+        const replaceProjectRef = new RegExp(projectRef.from, 'g');
+
+        for (const [name, definition] of workspace.projects.entries()) {
+          if (name === schema.projectName) {
+            continue;
+          }
+
+          const projectDir = tree.getDir(definition.root);
+          projectDir.visit(file => {
+            const contents = tree.read(file).toString('utf-8');
+            if (!replaceProjectRef.test(contents)) {
+              return;
+            }
+
+            const updatedFile = tree
+              .read(file)
+              .toString()
+              .replace(replaceProjectRef, projectRef.to);
+            tree.overwrite(file, updatedFile);
+          });
+        }
+
+        const projectRoot = {
+          from: project.root.substr(5),
+          to: schema.destination
+        };
+
+        const tsConfigPath = 'tsconfig.json';
+        if (tree.exists(tsConfigPath)) {
+          let contents = JSON.parse(tree.read(tsConfigPath).toString('utf-8'));
+          const path = contents.compilerOptions.paths[
+            projectRef.from
+          ] as string[];
+
+          contents.compilerOptions.paths[projectRef.to] = path.map(x =>
+            x.replace(new RegExp(projectRoot.from, 'g'), projectRoot.to)
+          );
+          delete contents.compilerOptions.paths[projectRef.from];
+
+          tree.overwrite(tsConfigPath, serializeJson(contents));
+        }
+
+        return tree;
+      })
+    );
+  };
+}

--- a/packages/workspace/src/schematics/move/lib/update-jest-config.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-jest-config.spec.ts
@@ -1,0 +1,57 @@
+import { Tree } from '@angular-devkit/schematics';
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { callRule, runSchematic } from '../../../utils/testing';
+import { Schema } from '../schema';
+import { updateJestConfig } from './update-jest-config';
+
+describe('updateJestConfig Rule', () => {
+  let tree: UnitTestTree;
+
+  beforeEach(async () => {
+    tree = new UnitTestTree(Tree.empty());
+    tree = createEmptyWorkspace(tree) as UnitTestTree;
+  });
+
+  it('should handle jest config not existing', async () => {
+    tree = await runSchematic('lib', { name: 'my-source' }, tree);
+
+    const schema: Schema = {
+      projectName: 'my-source',
+      destination: 'my-destination'
+    };
+
+    await expect(
+      callRule(updateJestConfig(schema), tree)
+    ).resolves.not.toThrow();
+  });
+
+  it('should update the name and coverage directory', async () => {
+    const jestConfig = `module.exports = {
+      name: 'my-source',
+      preset: '../../jest.config.js',
+      coverageDirectory: '../../coverage/libs/my-source',
+      snapshotSerializers: [
+        'jest-preset-angular/AngularSnapshotSerializer.js',
+        'jest-preset-angular/HTMLCommentSerializer.js'
+      ]
+    };`;
+    const jestConfigPath = '/libs/my-destination/jest.config.js';
+
+    tree = await runSchematic('lib', { name: 'my-source' }, tree);
+    tree.create(jestConfigPath, jestConfig);
+
+    const schema: Schema = {
+      projectName: 'my-source',
+      destination: 'my-destination'
+    };
+
+    tree = (await callRule(updateJestConfig(schema), tree)) as UnitTestTree;
+
+    const jestConfigAfter = tree.read(jestConfigPath).toString();
+    expect(jestConfigAfter).toContain(`name: 'my-destination'`);
+    expect(jestConfigAfter).toContain(
+      `coverageDirectory: '../../coverage/libs/my-destination'`
+    );
+  });
+});

--- a/packages/workspace/src/schematics/move/lib/update-jest-config.ts
+++ b/packages/workspace/src/schematics/move/lib/update-jest-config.ts
@@ -1,0 +1,46 @@
+import { Rule, SchematicContext } from '@angular-devkit/schematics';
+import { Tree } from '@angular-devkit/schematics/src/tree/interface';
+import { getWorkspace } from '@nrwl/workspace';
+import * as path from 'path';
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Schema } from '../schema';
+import { getDestination, getNewProjectName } from './utils';
+
+/**
+ * Updates the project name and coverage folder in the jest.config.js if it exists
+ *
+ * (assume relative paths have been updated previously)
+ *
+ * @param schema The options provided to the schematic
+ */
+export function updateJestConfig(schema: Schema): Rule {
+  return (tree: Tree, _context: SchematicContext): Observable<Tree> => {
+    return from(getWorkspace(tree)).pipe(
+      map(workspace => {
+        const project = workspace.projects.get(schema.projectName);
+        const destination = getDestination(schema, workspace);
+        const newProjectName = getNewProjectName(schema.destination);
+
+        const jestConfigPath = path.join(destination, 'jest.config.js');
+
+        if (!tree.exists(jestConfigPath)) {
+          // nothing to do
+          return tree;
+        }
+
+        const oldContent = tree.read(jestConfigPath).toString('utf-8');
+
+        const findName = new RegExp(schema.projectName, 'g');
+        const findDir = new RegExp(project.root, 'g');
+
+        const newContent = oldContent
+          .replace(findName, newProjectName)
+          .replace(findDir, destination);
+        tree.overwrite(jestConfigPath, newContent);
+
+        return tree;
+      })
+    );
+  };
+}

--- a/packages/workspace/src/schematics/move/lib/update-nx-json.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-nx-json.spec.ts
@@ -1,0 +1,34 @@
+import { Tree } from '@angular-devkit/schematics';
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
+import { readJsonInTree } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { callRule, runSchematic } from '../../../utils/testing';
+import { Schema } from '../schema';
+import { updateNxJson } from './update-nx-json';
+
+describe('updateNxJson Rule', () => {
+  let tree: UnitTestTree;
+
+  beforeEach(async () => {
+    tree = new UnitTestTree(Tree.empty());
+    tree = createEmptyWorkspace(tree) as UnitTestTree;
+  });
+
+  it('should update nx.json', async () => {
+    tree = await runSchematic('lib', { name: 'my-source' }, tree);
+
+    const schema: Schema = {
+      projectName: 'my-source',
+      destination: 'my-destination'
+    };
+
+    tree = (await callRule(updateNxJson(schema), tree)) as UnitTestTree;
+
+    const nxJson = readJsonInTree(tree, '/nx.json');
+
+    expect(nxJson.projects['my-source']).toBeUndefined();
+    expect(nxJson.projects['my-destination']).toEqual({
+      tags: []
+    });
+  });
+});

--- a/packages/workspace/src/schematics/move/lib/update-nx-json.ts
+++ b/packages/workspace/src/schematics/move/lib/update-nx-json.ts
@@ -1,0 +1,18 @@
+import { NxJson, updateJsonInTree } from '@nrwl/workspace';
+import { Schema } from '../schema';
+import { getNewProjectName } from './utils';
+
+/**
+ * Updates the nx.json file by renaming the project
+ *
+ * @param schema The options provided to the schematic
+ */
+export function updateNxJson(schema: Schema) {
+  return updateJsonInTree<NxJson>('nx.json', json => {
+    json.projects[getNewProjectName(schema.destination)] = {
+      ...json.projects[schema.projectName]
+    };
+    delete json.projects[schema.projectName];
+    return json;
+  });
+}

--- a/packages/workspace/src/schematics/move/lib/update-project-root-files.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-project-root-files.spec.ts
@@ -1,0 +1,47 @@
+import { Tree } from '@angular-devkit/schematics';
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { callRule, runSchematic } from '../../../utils/testing';
+import { Schema } from '../schema';
+import { updateProjectRootFiles } from './update-project-root-files';
+
+describe('updateProjectRootFiles Rule', () => {
+  let tree: UnitTestTree;
+
+  beforeEach(async () => {
+    tree = new UnitTestTree(Tree.empty());
+    tree = createEmptyWorkspace(tree) as UnitTestTree;
+  });
+
+  it('should update the relative root in files at the root of the project', async () => {
+    const testFile = `module.exports = {
+      name: 'my-source',
+      preset: '../../jest.config.js',
+      coverageDirectory: '../../coverage/libs/my-source',
+      snapshotSerializers: [
+        'jest-preset-angular/AngularSnapshotSerializer.js',
+        'jest-preset-angular/HTMLCommentSerializer.js'
+      ]
+    };`;
+    const testFilePath = '/libs/subfolder/my-destination/jest.config.js';
+
+    tree = await runSchematic('lib', { name: 'my-source' }, tree);
+    tree.create(testFilePath, testFile);
+
+    const schema: Schema = {
+      projectName: 'my-source',
+      destination: 'subfolder/my-destination'
+    };
+
+    tree = (await callRule(
+      updateProjectRootFiles(schema),
+      tree
+    )) as UnitTestTree;
+
+    const testFileAfter = tree.read(testFilePath).toString();
+    expect(testFileAfter).toContain(`preset: '../../../jest.config.js'`);
+    expect(testFileAfter).toContain(
+      `coverageDirectory: '../../../coverage/libs/my-source'`
+    );
+  });
+});

--- a/packages/workspace/src/schematics/move/lib/update-project-root-files.ts
+++ b/packages/workspace/src/schematics/move/lib/update-project-root-files.ts
@@ -1,0 +1,58 @@
+import { Rule, SchematicContext } from '@angular-devkit/schematics';
+import { Tree } from '@angular-devkit/schematics/src/tree/interface';
+import { getWorkspace } from '@nrwl/workspace';
+import { appRootPath } from '@nrwl/workspace/src/utils/app-root';
+import * as path from 'path';
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Schema } from '../schema';
+import { getDestination } from './utils';
+
+/**
+ * Updates the files in the root of the project
+ *
+ * Typically these are config files which point outside of the project folder
+ *
+ * @param schema The options provided to the schematic
+ */
+export function updateProjectRootFiles(schema: Schema): Rule {
+  return (tree: Tree, _context: SchematicContext): Observable<Tree> => {
+    return from(getWorkspace(tree)).pipe(
+      map(workspace => {
+        const project = workspace.projects.get(schema.projectName);
+        const destination = getDestination(schema, workspace);
+
+        const newRelativeRoot = path.relative(
+          path.join(appRootPath, destination),
+          appRootPath
+        );
+        const oldRelativeRoot = path.relative(
+          path.join(appRootPath, project.root),
+          appRootPath
+        );
+
+        if (newRelativeRoot === oldRelativeRoot) {
+          // nothing to do
+          return tree;
+        }
+
+        const dots = /\./g;
+        const regex = new RegExp(oldRelativeRoot.replace(dots, '\\.'), 'g');
+
+        const isRootFile = new RegExp(`${schema.destination}/[^/]+.js*`);
+        const projectDir = tree.getDir(destination);
+        projectDir.visit(file => {
+          if (!isRootFile.test(file)) {
+            return;
+          }
+
+          const oldContent = tree.read(file).toString();
+          const newContent = oldContent.replace(regex, newRelativeRoot);
+          tree.overwrite(file, newContent);
+        });
+
+        return tree;
+      })
+    );
+  };
+}

--- a/packages/workspace/src/schematics/move/lib/update-workspace.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-workspace.spec.ts
@@ -1,0 +1,210 @@
+import { Tree } from '@angular-devkit/schematics';
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { callRule } from '../../../utils/testing';
+import { Schema } from '../schema';
+import { updateWorkspace } from './update-workspace';
+
+describe('updateWorkspace Rule', () => {
+  let tree: UnitTestTree;
+
+  beforeEach(async () => {
+    tree = new UnitTestTree(Tree.empty());
+    tree = createEmptyWorkspace(tree) as UnitTestTree;
+
+    const workspace = {
+      version: 1,
+      projects: {
+        'my-source': {
+          projectType: 'application',
+          root: 'apps/my-source',
+          sourceRoot: 'apps/my-source/src',
+          prefix: 'app',
+          architect: {
+            build: {
+              builder: '@angular-devkit/build-angular:browser',
+              options: {
+                outputPath: 'dist/apps/my-source',
+                index: 'apps/my-source/src/index.html',
+                main: 'apps/my-source/src/main.ts',
+                polyfills: 'apps/my-source/src/polyfills.ts',
+                tsConfig: 'apps/my-source/tsconfig.app.json',
+                aot: false,
+                assets: [
+                  'apps/my-source/src/favicon.ico',
+                  'apps/my-source/src/assets'
+                ],
+                styles: ['apps/my-source/src/styles.scss'],
+                scripts: []
+              },
+              configurations: {
+                production: {
+                  fileReplacements: [
+                    {
+                      replace: 'apps/my-source/src/environments/environment.ts',
+                      with:
+                        'apps/my-source/src/environments/environment.prod.ts'
+                    }
+                  ],
+                  optimization: true,
+                  outputHashing: 'all',
+                  sourceMap: false,
+                  extractCss: true,
+                  namedChunks: false,
+                  aot: true,
+                  extractLicenses: true,
+                  vendorChunk: false,
+                  buildOptimizer: true,
+                  budgets: [
+                    {
+                      type: 'initial',
+                      maximumWarning: '2mb',
+                      maximumError: '5mb'
+                    },
+                    {
+                      type: 'anyComponentStyle',
+                      maximumWarning: '6kb',
+                      maximumError: '10kb'
+                    }
+                  ]
+                }
+              }
+            },
+            serve: {
+              builder: '@angular-devkit/build-angular:dev-server',
+              options: {
+                browserTarget: 'my-source:build'
+              },
+              configurations: {
+                production: {
+                  browserTarget: 'my-source:build:production'
+                }
+              }
+            },
+            'extract-i18n': {
+              builder: '@angular-devkit/build-angular:extract-i18n',
+              options: {
+                browserTarget: 'my-source:build'
+              }
+            },
+            lint: {
+              builder: '@angular-devkit/build-angular:tslint',
+              options: {
+                tsConfig: [
+                  'apps/my-source/tsconfig.app.json',
+                  'apps/my-source/tsconfig.spec.json'
+                ],
+                exclude: ['**/node_modules/**', '!apps/my-source/**']
+              }
+            },
+            test: {
+              builder: '@nrwl/jest:jest',
+              options: {
+                jestConfig: 'apps/my-source/jest.config.js',
+                tsConfig: 'apps/my-source/tsconfig.spec.json',
+                setupFile: 'apps/my-source/src/test-setup.ts'
+              }
+            }
+          }
+        },
+        'my-source-e2e': {
+          root: 'apps/my-source-e2e',
+          sourceRoot: 'apps/my-source-e2e/src',
+          projectType: 'application',
+          architect: {
+            e2e: {
+              builder: '@nrwl/cypress:cypress',
+              options: {
+                cypressConfig: 'apps/my-source-e2e/cypress.json',
+                tsConfig: 'apps/my-source-e2e/tsconfig.e2e.json',
+                devServerTarget: 'my-source:serve'
+              },
+              configurations: {
+                production: {
+                  devServerTarget: 'my-source:serve:production'
+                }
+              }
+            },
+            lint: {
+              builder: '@angular-devkit/build-angular:tslint',
+              options: {
+                tsConfig: ['apps/my-source-e2e/tsconfig.e2e.json'],
+                exclude: ['**/node_modules/**', '!apps/my-source-e2e/**']
+              }
+            }
+          }
+        }
+      },
+      defaultProject: 'my-source'
+    };
+
+    tree.overwrite('workspace.json', JSON.stringify(workspace));
+  });
+
+  it('should rename the project', async () => {
+    const schema: Schema = {
+      projectName: 'my-source',
+      destination: 'subfolder/my-destination'
+    };
+
+    tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
+
+    const workspace = JSON.parse(tree.read('workspace.json').toString());
+
+    expect(workspace.projects['my-source']).toBeUndefined();
+    expect(workspace.projects['subfolder-my-destination']).toBeDefined();
+  });
+
+  it('should update the default project', async () => {
+    const schema: Schema = {
+      projectName: 'my-source',
+      destination: 'subfolder/my-destination'
+    };
+
+    tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
+
+    const workspace = JSON.parse(tree.read('workspace.json').toString());
+
+    expect(workspace.defaultProject).toBe('subfolder-my-destination');
+  });
+
+  it('should update paths in only the intended project', async () => {
+    const schema: Schema = {
+      projectName: 'my-source',
+      destination: 'subfolder/my-destination'
+    };
+
+    tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
+
+    const workspace = JSON.parse(tree.read('workspace.json').toString());
+
+    const actualProject = workspace.projects['subfolder-my-destination'];
+    expect(actualProject).toBeDefined();
+    expect(actualProject.root).toBe('apps/subfolder/my-destination');
+    expect(actualProject.root).toBe('apps/subfolder/my-destination');
+
+    const similarProject = workspace.projects['my-source-e2e'];
+    expect(similarProject).toBeDefined();
+    expect(similarProject.root).toBe('apps/my-source-e2e');
+  });
+
+  it('should update build targets', async () => {
+    const schema: Schema = {
+      projectName: 'my-source',
+      destination: 'subfolder/my-destination'
+    };
+
+    tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
+
+    const workspace = JSON.parse(tree.read('workspace.json').toString());
+
+    const e2eProject = workspace.projects['my-source-e2e'];
+    expect(e2eProject).toBeDefined();
+    expect(e2eProject.architect.e2e.options.devServerTarget).toBe(
+      'subfolder-my-destination:serve'
+    );
+    expect(
+      e2eProject.architect.e2e.configurations.production.devServerTarget
+    ).toBe('subfolder-my-destination:serve:production');
+  });
+});

--- a/packages/workspace/src/schematics/move/lib/update-workspace.ts
+++ b/packages/workspace/src/schematics/move/lib/update-workspace.ts
@@ -1,0 +1,49 @@
+import { updateWorkspaceInTree } from '@nrwl/workspace';
+import { Schema } from '../schema';
+import { getDestination, getNewProjectName } from './utils';
+
+/**
+ * Updates the project in the workspace file
+ *
+ * - update all references to the old root path
+ * - change the project name
+ * - change target references
+ *
+ * @param schema The options provided to the schematic
+ */
+export function updateWorkspace(schema: Schema) {
+  return updateWorkspaceInTree(workspace => {
+    const project = workspace.projects[schema.projectName];
+    const newProjectName = getNewProjectName(schema.destination);
+
+    // update root path refs in that project only
+    const oldProject = JSON.stringify(project);
+    const newProject = oldProject.replace(
+      new RegExp(project.root, 'g'),
+      getDestination(schema, workspace)
+    );
+
+    // rename
+    delete workspace.projects[schema.projectName];
+    workspace.projects[newProjectName] = JSON.parse(newProject);
+
+    // update target refs
+    const strWorkspace = JSON.stringify(workspace);
+    workspace = JSON.parse(
+      strWorkspace.replace(
+        new RegExp(`${schema.projectName}:`, 'g'),
+        `${newProjectName}:`
+      )
+    );
+
+    // update default project (if necessary)
+    if (
+      workspace.defaultProject &&
+      workspace.defaultProject === schema.projectName
+    ) {
+      workspace.defaultProject = newProjectName;
+    }
+
+    return workspace;
+  });
+}

--- a/packages/workspace/src/schematics/move/lib/utils.ts
+++ b/packages/workspace/src/schematics/move/lib/utils.ts
@@ -1,0 +1,52 @@
+import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
+import * as path from 'path';
+import { Schema } from '../schema';
+
+/**
+ * This helper function ensures that we don't move libs or apps
+ * outside of the folders they should be in.
+ *
+ * This will break if someone isn't using the default libs/apps
+ * folders. In that case, they're on their own :/
+ *
+ * @param schema
+ * @param workspace
+ */
+export function getDestination(
+  schema: Schema,
+  workspace: WorkspaceDefinition | any
+): string {
+  const project = workspace.projects.get
+    ? workspace.projects.get(schema.projectName)
+    : workspace.projects[schema.projectName];
+  const projectType = project.extensions
+    ? project.extensions['projectType']
+    : project.projectType;
+
+  let rootFolder = 'libs';
+  if (projectType === 'application') {
+    rootFolder = 'apps';
+  }
+  return path.join(rootFolder, schema.destination);
+}
+
+/**
+ * Replaces slashes with dashes
+ *
+ * @param path
+ */
+export function getNewProjectName(path: string): string {
+  return path.replace(/\//g, '-');
+}
+
+/**
+ * Normalizes slashes (removes duplicates)
+ *
+ * @param input
+ */
+export function normalizeSlashes(input: string): string {
+  return input
+    .split('/')
+    .filter(x => !!x)
+    .join('/');
+}

--- a/packages/workspace/src/schematics/move/move.ts
+++ b/packages/workspace/src/schematics/move/move.ts
@@ -1,0 +1,25 @@
+import { chain } from '@angular-devkit/schematics';
+import { checkDestination } from './lib/check-destination';
+import { checkProjectExists } from './lib/check-project-exists';
+import { moveProject } from './lib/move-project';
+import { updateCypressJson } from './lib/update-cypress-json';
+import { updateImports } from './lib/update-imports';
+import { updateJestConfig } from './lib/update-jest-config';
+import { updateNxJson } from './lib/update-nx-json';
+import { updateProjectRootFiles } from './lib/update-project-root-files';
+import { updateWorkspace } from './lib/update-workspace';
+import { Schema } from './schema';
+
+export default function(schema: Schema) {
+  return chain([
+    checkProjectExists(schema),
+    checkDestination(schema),
+    moveProject(schema), // we MUST move the project first, if we don't we get a "This should never happen" error 🤦‍♀️
+    updateProjectRootFiles(schema),
+    updateCypressJson(schema),
+    updateJestConfig(schema),
+    updateNxJson(schema),
+    updateImports(schema),
+    updateWorkspace(schema) // Have to do this last because all previous rules need the information in here
+  ]);
+}

--- a/packages/workspace/src/schematics/move/schema.d.ts
+++ b/packages/workspace/src/schematics/move/schema.d.ts
@@ -1,0 +1,4 @@
+export interface Schema {
+  projectName: string;
+  destination: string;
+}

--- a/packages/workspace/src/schematics/move/schema.json
+++ b/packages/workspace/src/schematics/move/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxWorkspaceMove",
+  "title": "Nx Move",
+  "description": "Move a project to another folder in the workspace",
+  "type": "object",
+  "properties": {
+    "projectName": {
+      "type": "string",
+      "description": "The name of the project to move"
+    },
+    "destination": {
+      "type": "string",
+      "description": "The folder to move the project into"
+    }
+  },
+  "required": ["projectName", "destination"]
+}

--- a/scripts/e2e-ci1.sh
+++ b/scripts/e2e-ci1.sh
@@ -20,5 +20,7 @@ jest --maxWorkers=1 ./build/e2e/jest.test.js &&
 jest --maxWorkers=1 ./build/e2e/karma.test.js &&
 jest --maxWorkers=1 ./build/e2e/list.test.js &&
 jest --maxWorkers=1 ./build/e2e/migrate.test.js &&
+jest --maxWorkers=1 ./build/e2e/move.angular.test.js &&
+jest --maxWorkers=1 ./build/e2e/move.workspace.test.js &&
 jest --maxWorkers=1 ./build/e2e/new.test.js &&
 jest --maxWorkers=1 ./build/e2e/next.test.js


### PR DESCRIPTION
This adds the ability to move libraries and applications from one folder to another, renaming the app/lib in the process and updating any references throughout the repo as needed.

I have almost certainly missed something, but this is ready for beta use, imo.

I've foregone spec files in favour of e2e tests, but I can go back and write some if need be...