### PR TITLE
fix(misc): resolve projects for linting using TypeScript

### DIFF
--- a/e2e/command-line.test.ts
+++ b/e2e/command-line.test.ts
@@ -44,7 +44,6 @@ forEachCli(() => {
         `
       import '../../../libs/${mylib}';
       import '@proj/${lazylib}';
-      import '@proj/${mylib}/deep';
       import '@proj/${myapp2}';
       import '@proj/${invalidtaglib}';
       import '@proj/${validtaglib}';
@@ -56,7 +55,6 @@ forEachCli(() => {
       const out = runCLI(`lint ${myapp}`, { silenceError: true });
       expect(out).toContain('library imports must start with @proj/');
       expect(out).toContain('imports of lazy-loaded libraries are forbidden');
-      expect(out).toContain('deep imports into libraries are forbidden');
       expect(out).toContain('imports of apps are forbidden');
       expect(out).toContain(
         'A project tagged with "validtag" can only depend on libs tagged with "validtag"'

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -141,8 +141,9 @@ export default createESLintRule<Options, MessageIds>({
           // findProjectUsingImport to take care of same prefix
           const targetProject = findProjectUsingImport(
             projectGraph,
-            npmScope,
-            imp
+            sourceFilePath,
+            imp,
+            npmScope
           );
 
           // something went wrong => return.

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -1,19 +1,72 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
-import * as parser from '@typescript-eslint/parser';
-import * as fs from 'fs';
-import enforceModuleBoundaries, {
-  RULE_NAME as enforceModuleBoundariesRuleName
-} from '../../src/rules/enforce-module-boundaries';
 import {
   DependencyType,
   ProjectGraph,
   ProjectType
 } from '@nrwl/workspace/src/core/project-graph';
+import { TSESLint } from '@typescript-eslint/experimental-utils';
+import * as parser from '@typescript-eslint/parser';
+import { vol } from 'memfs';
 import { extname } from 'path';
+import enforceModuleBoundaries, {
+  RULE_NAME as enforceModuleBoundariesRuleName
+} from '../../src/rules/enforce-module-boundaries';
+jest.mock('fs', () => require('memfs').fs);
+jest.mock('@nrwl/workspace/src/utils/app-root', () => ({
+  appRootPath: '/root'
+}));
+
+const tsconfig = {
+  compilerOptions: {
+    baseUrl: '.',
+    paths: {
+      '@mycompany/impl': ['libs/impl/src/index.ts'],
+      '@mycompany/untagged': ['libs/untagged/src/index.ts'],
+      '@mycompany/api': ['libs/api/src/index.ts'],
+      '@mycompany/impl-domain2': ['libs/impl-domain2/src/index.ts'],
+      '@mycompany/impl-both-domains': ['libs/impl-both-domains/src/index.ts'],
+      '@mycompany/impl2': ['libs/impl2/src/index.ts'],
+      '@mycompany/other': ['libs/other/src/index.ts'],
+      '@mycompany/other/a/b': ['libs/other/src/a/b.ts'],
+      '@mycompany/other/a': ['libs/other/src/a/index.ts'],
+      '@mycompany/another/a/b': ['libs/another/a/b.ts'],
+      '@mycompany/myapp': ['apps/myapp/src/index.ts'],
+      '@mycompany/mylib': ['libs/mylib/src/index.ts'],
+      '@mycompany/mylibName': ['libs/mylibName/src/index.ts'],
+      '@mycompany/anotherlibName': ['libs/anotherlibName/src/index.ts'],
+      '@mycompany/badcirclelib': ['libs/badcirclelib/src/index.ts'],
+      '@mycompany/domain1': ['libs/domain1/src/index.ts'],
+      '@mycompany/domain2': ['libs/domain2/src/index.ts']
+    },
+    types: ['node']
+  },
+  exclude: ['**/*.spec.ts'],
+  include: ['**/*.ts']
+};
+
+const fileSys = {
+  './libs/impl/src/index.ts': '',
+  './libs/untagged/src/index.ts': '',
+  './libs/api/src/index.ts': '',
+  './libs/impl-domain2/src/index.ts': '',
+  './libs/impl-both-domains/src/index.ts': '',
+  './libs/impl2/src/index.ts': '',
+  './libs/other/src/index.ts': '',
+  './libs/other/src/a/b.ts': '',
+  './libs/other/src/a/index.ts': '',
+  './libs/another/a/b.ts': '',
+  './apps/myapp/src/index.ts': '',
+  './libs/mylib/src/index.ts': '',
+  './libs/mylibName/src/index.ts': '',
+  './libs/anotherlibName/src/index.ts': '',
+  './libs/badcirclelib/src/index.ts': '',
+  './libs/domain1/src/index.ts': '',
+  './libs/domain2/src/index.ts': '',
+  './tsconfig.json': JSON.stringify(tsconfig)
+};
 
 describe('Enforce Module Boundaries', () => {
   beforeEach(() => {
-    spyOn(fs, 'writeFileSync');
+    vol.fromJSON(fileSys, '/root');
   });
 
   it('should not error when everything is in order', () => {
@@ -131,26 +184,15 @@ describe('Enforce Module Boundaries', () => {
             files: [createFile(`libs/api/src/index.ts`)]
           }
         },
-        implName: {
-          name: 'implName',
+        'impl-both-domainsName': {
+          name: 'impl-both-domainsName',
           type: ProjectType.lib,
           data: {
-            root: 'libs/impl',
-            tags: ['impl', 'domain1'],
+            root: 'libs/impl-both-domains',
+            tags: ['impl', 'domain1', 'domain2'],
             implicitDependencies: [],
             architect: {},
-            files: [createFile(`libs/impl/src/index.ts`)]
-          }
-        },
-        impl2Name: {
-          name: 'impl2Name',
-          type: ProjectType.lib,
-          data: {
-            root: 'libs/impl2',
-            tags: ['impl', 'domain1'],
-            implicitDependencies: [],
-            architect: {},
-            files: [createFile(`libs/impl2/src/index.ts`)]
+            files: [createFile(`libs/impl-both-domains/src/index.ts`)]
           }
         },
         'impl-domain2Name': {
@@ -164,15 +206,26 @@ describe('Enforce Module Boundaries', () => {
             files: [createFile(`libs/impl-domain2/src/index.ts`)]
           }
         },
-        'impl-both-domainsName': {
-          name: 'impl-both-domainsName',
+        impl2Name: {
+          name: 'impl2Name',
           type: ProjectType.lib,
           data: {
-            root: 'libs/impl-both-domains',
-            tags: ['impl', 'domain1', 'domain2'],
+            root: 'libs/impl2',
+            tags: ['impl', 'domain1'],
             implicitDependencies: [],
             architect: {},
-            files: [createFile(`libs/impl-both-domains/src/index.ts`)]
+            files: [createFile(`libs/impl2/src/index.ts`)]
+          }
+        },
+        implName: {
+          name: 'implName',
+          type: ProjectType.lib,
+          data: {
+            root: 'libs/impl',
+            tags: ['impl', 'domain1'],
+            implicitDependencies: [],
+            architect: {},
+            files: [createFile(`libs/impl/src/index.ts`)]
           }
         },
         untaggedName: {
@@ -198,6 +251,10 @@ describe('Enforce Module Boundaries', () => {
         { sourceTag: 'domain2', onlyDependOnLibsWithTags: ['domain2'] }
       ]
     };
+
+    beforeEach(() => {
+      vol.fromJSON(fileSys, '/root');
+    });
 
     it('should error when the target library does not have the right tag', () => {
       const failures = runRule(
@@ -478,211 +535,6 @@ describe('Enforce Module Boundaries', () => {
     expect(failures[0].message).toEqual(
       'Library imports must start with @mycompany/'
     );
-  });
-
-  it('should error about deep imports into libraries', () => {
-    const failures = runRule(
-      {},
-      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      `
-        import "@mycompany/other/src/blah"
-        import "@mycompany/other/src/sublib/blah"
-        `,
-      {
-        nodes: {
-          mylibName: {
-            name: 'mylibName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/mylib',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [
-                createFile(`libs/mylib/src/main.ts`),
-                createFile(`libs/mylib/src/another-file.ts`)
-              ]
-            }
-          },
-          otherName: {
-            name: 'otherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/other',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/other/src/blah.ts`)]
-            }
-          },
-          otherSublibName: {
-            name: 'otherSublibName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/other/sublib',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/other/sublib/src/blah.ts`)]
-            }
-          }
-        },
-        dependencies: {}
-      }
-    );
-    expect(failures[0].message).toEqual(
-      'Deep imports into libraries are forbidden'
-    );
-    expect(failures[1].message).toEqual(
-      'Deep imports into libraries are forbidden'
-    );
-  });
-
-  it('should not error about deep imports into library when fixed exception is set', () => {
-    const failures = runRule(
-      { allow: ['@mycompany/other/src/blah'] },
-      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      `
-        import "@mycompany/other/src/blah"
-        `,
-      {
-        nodes: {
-          mylibName: {
-            name: 'mylibName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/mylib',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [
-                createFile(`libs/mylib/src/main.ts`),
-                createFile(`libs/mylib/src/another-file.ts`)
-              ]
-            }
-          },
-          otherName: {
-            name: 'otherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/other',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/other/src/blah.ts`)]
-            }
-          }
-        },
-        dependencies: {}
-      }
-    );
-    expect(failures.length).toEqual(0);
-  });
-
-  it('should not error about deep imports into library when exception is specified with a wildcard', () => {
-    const failures = runRule(
-      { allow: ['@mycompany/other/**', '@mycompany/**/testing'] },
-      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      `
-        import "@mycompany/other/src/blah"
-        import "@mycompany/another/testing"
-        `,
-      {
-        nodes: {
-          mylibName: {
-            name: 'mylibName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/mylib',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/mylib/src/main.ts`)]
-            }
-          },
-          otherName: {
-            name: 'otherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/other',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/other/src/blah.ts`)]
-            }
-          },
-          anotherName: {
-            name: 'anotherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/another',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/anotherlib/testing.ts`)]
-            }
-          }
-        },
-        dependencies: {}
-      }
-    );
-    expect(failures.length).toEqual(0);
-  });
-
-  it('should not error about one level deep imports into library when exception is specified with a wildcard', () => {
-    const failures = runRule(
-      { allow: ['@mycompany/other/*'] },
-      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      `
-      import "@mycompany/other/a/b";
-      import "@mycompany/other/a";
-        `,
-      {
-        nodes: {
-          mylibName: {
-            name: 'mylibName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/mylib',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/mylib/src/main.ts`)]
-            }
-          },
-          otherName: {
-            name: 'otherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/other',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [
-                createFile(`libs/other/a/index.ts`),
-                createFile(`libs/other/a/b.ts`)
-              ]
-            }
-          },
-          anotherName: {
-            name: 'anotherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/another',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [
-                createFile(`libs/another/a/index.ts`),
-                createFile(`libs/another/a/b.ts`)
-              ]
-            }
-          }
-        },
-        dependencies: {}
-      }
-    );
-    expect(failures.length).toEqual(1);
   });
 
   it('should respect regexp in allow option', () => {

--- a/packages/workspace/src/core/project-graph/build-dependencies/find-target-project.spec.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/find-target-project.spec.ts
@@ -1,0 +1,147 @@
+import { fs, vol } from 'memfs';
+import { join } from 'path';
+import { ProjectGraphContext, ProjectGraphNode } from '../../project-graph';
+import { findTargetProjectWithImport } from './find-target-project';
+
+jest.mock('../../../utils/app-root', () => ({
+  appRootPath: '/root'
+}));
+jest.mock('fs', () => require('memfs').fs);
+
+describe('findTargetProjectWithImport', () => {
+  let ctx: ProjectGraphContext;
+  let projects: Record<string, ProjectGraphNode>;
+  let fsJson;
+  beforeEach(() => {
+    const workspaceJson = {
+      projects: {
+        proj1: {}
+      }
+    };
+    const nxJson = {
+      npmScope: 'proj',
+      projects: {
+        proj1: {}
+      }
+    };
+    const tsConfig = {
+      compilerOptions: {
+        baseUrl: '.',
+        paths: {
+          '@proj/proj1': ['libs/proj1/index.ts'],
+          '@proj/my-second-proj': ['libs/proj2/index.ts'],
+          '@proj/project-3': ['libs/proj3/index.ts']
+        }
+      }
+    };
+    fsJson = {
+      './workspace.json': JSON.stringify(workspaceJson),
+      './nx.json': JSON.stringify(nxJson),
+      './tsconfig.json': JSON.stringify(tsConfig),
+      './libs/proj1/index.ts': `import {a} from '@proj/my-second-proj';
+                              import('@proj/project-3');
+                              const a = { loadChildren: '@proj/proj4#a' };                     
+      `,
+      './libs/proj2/index.ts': `export const a = 2;`,
+      './libs/proj3/index.ts': `export const a = 3;`,
+      './libs/proj4/index.ts': `export const a = 4;`
+    };
+    vol.fromJSON(fsJson, '/root');
+
+    ctx = {
+      workspaceJson,
+      nxJson,
+      fileMap: {
+        proj1: [
+          {
+            file: 'libs/proj1/index.ts',
+            mtime: 0,
+            ext: '.ts'
+          }
+        ],
+        proj2: [
+          {
+            file: 'libs/proj2/index.ts',
+            mtime: 0,
+            ext: '.ts'
+          }
+        ],
+        proj3: [
+          {
+            file: 'libs/proj3/index.ts',
+            mtime: 0,
+            ext: '.ts'
+          }
+        ],
+        proj4: [
+          {
+            file: 'libs/proj4/index.ts',
+            mtime: 0,
+            ext: '.ts'
+          }
+        ]
+      }
+    };
+    projects = {
+      proj1: {
+        name: 'proj1',
+        type: 'lib',
+        data: {
+          root: 'libs/proj1',
+          files: []
+        }
+      },
+      proj2: {
+        name: 'proj2',
+        type: 'lib',
+        data: {
+          root: 'libs/proj2',
+          files: []
+        }
+      },
+      proj3: {
+        name: 'proj3',
+        type: 'lib',
+        data: {
+          root: 'libs/proj3',
+          files: []
+        }
+      },
+      proj4: {
+        name: 'proj4',
+        type: 'lib',
+        data: {
+          root: 'libs/proj4',
+          files: []
+        }
+      }
+    };
+  });
+  it('should be able to resolve a module by using tsConfig paths', () => {
+    const proj2 = findTargetProjectWithImport(
+      '@proj/my-second-proj',
+      'libs/proj1/index.ts',
+      ctx.nxJson.npmScope,
+      projects
+    );
+    const proj3 = findTargetProjectWithImport(
+      '@proj/project-3',
+      'libs/proj1/index.ts',
+      ctx.nxJson.npmScope,
+      projects
+    );
+
+    expect(proj2).toEqual('proj2');
+    expect(proj3).toEqual('proj3');
+  });
+  it('should be able to resolve a module using a normalized path', () => {
+    const proj4 = findTargetProjectWithImport(
+      '@proj/proj4',
+      'libs/proj1/index.ts',
+      ctx.nxJson.npmScope,
+      projects
+    );
+
+    expect(proj4).toEqual('proj4');
+  });
+});

--- a/packages/workspace/src/core/project-graph/build-dependencies/find-target-project.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/find-target-project.ts
@@ -1,0 +1,25 @@
+import { resolveModuleByImport } from '../../../utils/typescript';
+import { normalizedProjectRoot } from '../../file-utils';
+import { ProjectGraphNodeRecords } from '../project-graph-models';
+
+export function findTargetProjectWithImport(
+  importExpr: string,
+  filePath: string,
+  npmScope: string,
+  nodes: ProjectGraphNodeRecords
+) {
+  const normalizedImportExpr = importExpr.split('#')[0];
+
+  const resolvedModule = resolveModuleByImport(normalizedImportExpr, filePath);
+
+  return Object.keys(nodes).find(projectName => {
+    const p = nodes[projectName];
+    if (resolvedModule && resolvedModule.includes(p.data.root)) {
+      return true;
+    } else {
+      const normalizedRoot = normalizedProjectRoot(p);
+      const projectImport = `@${npmScope}/${normalizedRoot}`;
+      return normalizedImportExpr.startsWith(projectImport);
+    }
+  });
+}

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -1,15 +1,69 @@
+import { vol } from 'memfs';
+import { extname } from 'path';
 import { RuleFailure } from 'tslint';
 import * as ts from 'typescript';
-import * as fs from 'fs';
-
+import {
+  DependencyType,
+  ProjectGraph,
+  ProjectType
+} from '../core/project-graph';
 import { Rule } from './nxEnforceModuleBoundariesRule';
-import { DependencyType, ProjectGraph } from '../core/project-graph';
-import { ProjectType } from '../core/project-graph';
-import { extname } from 'path';
+
+jest.mock('fs', () => require('memfs').fs);
+jest.mock('../utils/app-root', () => ({ appRootPath: '/root' }));
+
+const tsconfig = {
+  compilerOptions: {
+    baseUrl: '.',
+    paths: {
+      '@mycompany/impl': ['libs/impl/src/index.ts'],
+      '@mycompany/untagged': ['libs/untagged/src/index.ts'],
+      '@mycompany/api': ['libs/api/src/index.ts'],
+      '@mycompany/impl-domain2': ['libs/impl-domain2/src/index.ts'],
+      '@mycompany/impl-both-domains': ['libs/impl-both-domains/src/index.ts'],
+      '@mycompany/impl2': ['libs/impl2/src/index.ts'],
+      '@mycompany/other': ['libs/other/src/index.ts'],
+      '@mycompany/other/a/b': ['libs/other/src/a/b.ts'],
+      '@mycompany/other/a': ['libs/other/src/a/index.ts'],
+      '@mycompany/another/a/b': ['libs/another/a/b.ts'],
+      '@mycompany/myapp': ['apps/myapp/src/index.ts'],
+      '@mycompany/mylib': ['libs/mylib/src/index.ts'],
+      '@mycompany/mylibName': ['libs/mylibName/src/index.ts'],
+      '@mycompany/anotherlibName': ['libs/anotherlibName/src/index.ts'],
+      '@mycompany/badcirclelib': ['libs/badcirclelib/src/index.ts'],
+      '@mycompany/domain1': ['libs/domain1/src/index.ts'],
+      '@mycompany/domain2': ['libs/domain2/src/index.ts']
+    },
+    types: ['node']
+  },
+  exclude: ['**/*.spec.ts'],
+  include: ['**/*.ts']
+};
+
+const fileSys = {
+  './libs/impl/src/index.ts': '',
+  './libs/untagged/src/index.ts': '',
+  './libs/api/src/index.ts': '',
+  './libs/impl-domain2/src/index.ts': '',
+  './libs/impl-both-domains/src/index.ts': '',
+  './libs/impl2/src/index.ts': '',
+  './libs/other/src/index.ts': '',
+  './libs/other/src/a/b.ts': '',
+  './libs/other/src/a/index.ts': '',
+  './libs/another/a/b.ts': '',
+  './apps/myapp/src/index.ts': '',
+  './libs/mylib/src/index.ts': '',
+  './libs/mylibName/src/index.ts': '',
+  './libs/anotherlibName/src/index.ts': '',
+  './libs/badcirclelib/src/index.ts': '',
+  './libs/domain1/src/index.ts': '',
+  './libs/domain2/src/index.ts': '',
+  './tsconfig.json': JSON.stringify(tsconfig)
+};
 
 describe('Enforce Module Boundaries', () => {
   beforeEach(() => {
-    spyOn(fs, 'writeFileSync');
+    vol.fromJSON(fileSys, '/root');
   });
 
   it('should not error when everything is in order', () => {
@@ -126,26 +180,15 @@ describe('Enforce Module Boundaries', () => {
             files: [createFile(`libs/api/src/index.ts`)]
           }
         },
-        implName: {
-          name: 'implName',
+        'impl-both-domainsName': {
+          name: 'impl-both-domainsName',
           type: ProjectType.lib,
           data: {
-            root: 'libs/impl',
-            tags: ['impl', 'domain1'],
+            root: 'libs/impl-both-domains',
+            tags: ['impl', 'domain1', 'domain2'],
             implicitDependencies: [],
             architect: {},
-            files: [createFile(`libs/impl/src/index.ts`)]
-          }
-        },
-        impl2Name: {
-          name: 'impl2Name',
-          type: ProjectType.lib,
-          data: {
-            root: 'libs/impl2',
-            tags: ['impl', 'domain1'],
-            implicitDependencies: [],
-            architect: {},
-            files: [createFile(`libs/impl2/src/index.ts`)]
+            files: [createFile(`libs/impl-both-domains/src/index.ts`)]
           }
         },
         'impl-domain2Name': {
@@ -159,15 +202,26 @@ describe('Enforce Module Boundaries', () => {
             files: [createFile(`libs/impl-domain2/src/index.ts`)]
           }
         },
-        'impl-both-domainsName': {
-          name: 'impl-both-domainsName',
+        impl2Name: {
+          name: 'impl2Name',
           type: ProjectType.lib,
           data: {
-            root: 'libs/impl-both-domains',
-            tags: ['impl', 'domain1', 'domain2'],
+            root: 'libs/impl2',
+            tags: ['impl', 'domain1'],
             implicitDependencies: [],
             architect: {},
-            files: [createFile(`libs/impl-both-domains/src/index.ts`)]
+            files: [createFile(`libs/impl2/src/index.ts`)]
+          }
+        },
+        implName: {
+          name: 'implName',
+          type: ProjectType.lib,
+          data: {
+            root: 'libs/impl',
+            tags: ['impl', 'domain1'],
+            implicitDependencies: [],
+            architect: {},
+            files: [createFile(`libs/impl/src/index.ts`)]
           }
         },
         untaggedName: {
@@ -193,6 +247,10 @@ describe('Enforce Module Boundaries', () => {
         { sourceTag: 'domain2', onlyDependOnLibsWithTags: ['domain2'] }
       ]
     };
+
+    beforeEach(() => {
+      vol.fromJSON(fileSys, '/root');
+    });
 
     it('should error when the target library does not have the right tag', () => {
       const failures = runRule(
@@ -474,212 +532,6 @@ describe('Enforce Module Boundaries', () => {
     expect(failures[0].getFailure()).toEqual(
       'library imports must start with @mycompany/'
     );
-  });
-
-  it('should error about deep imports into libraries', () => {
-    const failures = runRule(
-      {},
-      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      `
-      import "@mycompany/other/src/blah"
-      import "@mycompany/other/src/sublib/blah"
-      `,
-      {
-        nodes: {
-          mylibName: {
-            name: 'mylibName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/mylib',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [
-                createFile(`libs/mylib/src/main.ts`),
-                createFile(`libs/mylib/src/another-file.ts`)
-              ]
-            }
-          },
-          otherName: {
-            name: 'otherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/other',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/other/src/blah.ts`)]
-            }
-          },
-          otherSublibName: {
-            name: 'otherSublibName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/other/sublib',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/other/sublib/src/blah.ts`)]
-            }
-          }
-        },
-        dependencies: {}
-      }
-    );
-    expect(failures[0].getFailure()).toEqual(
-      'deep imports into libraries are forbidden'
-    );
-    expect(failures[1].getFailure()).toEqual(
-      'deep imports into libraries are forbidden'
-    );
-  });
-
-  it('should not error about deep imports into library when fixed exception is set', () => {
-    const failures = runRule(
-      { allow: ['@mycompany/other/src/blah'] },
-      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      `
-      import "@mycompany/other/src/blah"
-      `,
-      {
-        nodes: {
-          mylibName: {
-            name: 'mylibName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/mylib',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [
-                createFile(`libs/mylib/src/main.ts`),
-                createFile(`libs/mylib/src/another-file.ts`)
-              ]
-            }
-          },
-          otherName: {
-            name: 'otherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/other',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/other/src/blah.ts`)]
-            }
-          }
-        },
-        dependencies: {}
-      }
-    );
-    expect(failures.length).toEqual(0);
-  });
-
-  it('should not error about deep imports into library when exception is specified with a wildcard', () => {
-    const failures = runRule(
-      { allow: ['@mycompany/other/**', '@mycompany/**/testing'] },
-      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      `
-      import "@mycompany/other/src/blah"
-      import "@mycompany/another/testing"
-      `,
-      {
-        nodes: {
-          mylibName: {
-            name: 'mylibName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/mylib',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/mylib/src/main.ts`)]
-            }
-          },
-          otherName: {
-            name: 'otherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/other',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/other/src/blah.ts`)]
-            }
-          },
-          anotherName: {
-            name: 'anotherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/another',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/anotherlib/testing.ts`)]
-            }
-          }
-        },
-        dependencies: {}
-      }
-    );
-    expect(failures.length).toEqual(0);
-  });
-
-  it('should not error about one level deep imports into library when exception is specified with a wildcard', () => {
-    const failures = runRule(
-      { allow: ['@mycompany/other/*', '@mycompany/another/*'] },
-      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      `
-      import "@mycompany/other/a/b";
-      import "@mycompany/other/a";
-      import "@mycompany/another/a/b";
-      `,
-      {
-        nodes: {
-          mylibName: {
-            name: 'mylibName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/mylib',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/mylib/src/main.ts`)]
-            }
-          },
-          otherName: {
-            name: 'otherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/other',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [
-                createFile(`libs/other/a/index.ts`),
-                createFile(`libs/other/a/b.ts`)
-              ]
-            }
-          },
-          anotherName: {
-            name: 'anotherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/another',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [
-                createFile(`libs/another/a/index.ts`),
-                createFile(`libs/another/a/b.ts`)
-              ]
-            }
-          }
-        },
-        dependencies: {}
-      }
-    );
-    expect(failures.length).toEqual(2);
   });
 
   it('should respect regexp in allow option', () => {

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -124,15 +124,17 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
     // check constraints between libs and apps
     if (imp.startsWith(`@${this.npmScope}/`)) {
       // we should find the name
-      const sourceProject = findSourceProject(
-        this.projectGraph,
-        getSourceFilePath(this.getSourceFile().fileName, this.projectPath)
+      const filePath = getSourceFilePath(
+        this.getSourceFile().fileName,
+        this.projectPath
       );
+      const sourceProject = findSourceProject(this.projectGraph, filePath);
       // findProjectUsingImport to take care of same prefix
       const targetProject = findProjectUsingImport(
         this.projectGraph,
-        this.npmScope,
-        imp
+        filePath,
+        imp,
+        this.npmScope
       );
 
       // something went wrong => return.
@@ -160,16 +162,6 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
           node.getStart(),
           node.getWidth(),
           'imports of apps are forbidden'
-        );
-        return;
-      }
-
-      // deep imports aren't allowed
-      if (imp !== `@${this.npmScope}/${normalizedProjectRoot(targetProject)}`) {
-        this.addFailureAt(
-          node.getStart(),
-          node.getWidth(),
-          'deep imports into libraries are forbidden'
         );
         return;
       }

--- a/packages/workspace/src/utils/typescript.ts
+++ b/packages/workspace/src/utils/typescript.ts
@@ -1,5 +1,6 @@
-import * as ts from 'typescript';
 import { dirname } from 'path';
+import * as ts from 'typescript';
+import { appRootPath } from './app-root';
 
 export function readTsConfig(tsConfigPath: string) {
   const readResult = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
@@ -8,4 +9,45 @@ export function readTsConfig(tsConfigPath: string) {
     ts.sys,
     dirname(tsConfigPath)
   );
+}
+
+let compilerHost: {
+  host: ts.CompilerHost;
+  options: ts.CompilerOptions;
+  moduleResolutionCache: ts.ModuleResolutionCache;
+};
+
+/**
+ * Find a module based on it's import
+ *
+ * @param importExpr Import used to resolve to a module
+ * @param filePath
+ */
+export function resolveModuleByImport(importExpr: string, filePath: string) {
+  compilerHost = compilerHost || getCompilerHost();
+  const { options, host, moduleResolutionCache } = compilerHost;
+
+  const { resolvedModule } = ts.resolveModuleName(
+    importExpr,
+    filePath,
+    options,
+    host,
+    moduleResolutionCache
+  );
+
+  if (!resolvedModule) {
+    return;
+  } else {
+    return resolvedModule.resolvedFileName.replace(appRootPath, '');
+  }
+}
+
+function getCompilerHost() {
+  const { options } = readTsConfig(`${appRootPath}/tsconfig.json`);
+  const host = ts.createCompilerHost(options, true);
+  const moduleResolutionCache = ts.createModuleResolutionCache(
+    appRootPath,
+    host.getCanonicalFileName
+  );
+  return { options, host, moduleResolutionCache };
 }


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
Linting was checking the paths of imports based on file structure
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Linting should now use TypeScript resolution to find the imports

## Issue
Closes #2124