### PR TITLE
feat(react): add option to generate js files instead of ts files

### DIFF
--- a/docs/angular/api-react/schematics/application.md
+++ b/docs/angular/api-react/schematics/application.md
@@ -76,6 +76,14 @@ Possible values: `cypress`, `none`
 
 Test runner to use for end to end (e2e) tests
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### linter
 
 Default: `tslint`

--- a/docs/angular/api-react/schematics/component.md
+++ b/docs/angular/api-react/schematics/component.md
@@ -70,6 +70,14 @@ Type: `boolean`
 
 When true, the component is exported from the project index.ts (if it exists).
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/angular/api-react/schematics/library.md
+++ b/docs/angular/api-react/schematics/library.md
@@ -58,6 +58,14 @@ Type: `string`
 
 A directory where the app is placed
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### linter
 
 Default: `tslint`

--- a/docs/angular/api-react/schematics/redux.md
+++ b/docs/angular/api-react/schematics/redux.md
@@ -44,6 +44,14 @@ Type: `string`
 
 The name of the folder used to contain/group the generated Redux files.
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/angular/api-react/schematics/storybook-configuration.md
+++ b/docs/angular/api-react/schematics/storybook-configuration.md
@@ -30,6 +30,14 @@ Type: `boolean`
 
 Run the cypress-configure schematic
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/angular/api-storybook/schematics/configuration.md
+++ b/docs/angular/api-storybook/schematics/configuration.md
@@ -30,6 +30,14 @@ Type: `boolean`
 
 Run the cypress-configure schematic
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/angular/api-storybook/schematics/cypress-project.md
+++ b/docs/angular/api-storybook/schematics/cypress-project.md
@@ -24,6 +24,14 @@ ng g cypress-project ... --dry-run
 
 ## Options
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/react/api-react/schematics/application.md
+++ b/docs/react/api-react/schematics/application.md
@@ -76,6 +76,14 @@ Possible values: `cypress`, `none`
 
 Test runner to use for end to end (e2e) tests
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### linter
 
 Default: `tslint`

--- a/docs/react/api-react/schematics/component.md
+++ b/docs/react/api-react/schematics/component.md
@@ -70,6 +70,14 @@ Type: `boolean`
 
 When true, the component is exported from the project index.ts (if it exists).
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/react/api-react/schematics/library.md
+++ b/docs/react/api-react/schematics/library.md
@@ -58,6 +58,14 @@ Type: `string`
 
 A directory where the app is placed
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### linter
 
 Default: `tslint`

--- a/docs/react/api-react/schematics/redux.md
+++ b/docs/react/api-react/schematics/redux.md
@@ -44,6 +44,14 @@ Type: `string`
 
 The name of the folder used to contain/group the generated Redux files.
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/react/api-react/schematics/storybook-configuration.md
+++ b/docs/react/api-react/schematics/storybook-configuration.md
@@ -30,6 +30,14 @@ Type: `boolean`
 
 Run the cypress-configure schematic
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/react/api-storybook/schematics/configuration.md
+++ b/docs/react/api-storybook/schematics/configuration.md
@@ -30,6 +30,14 @@ Type: `boolean`
 
 Run the cypress-configure schematic
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/react/api-storybook/schematics/cypress-project.md
+++ b/docs/react/api-storybook/schematics/cypress-project.md
@@ -24,6 +24,14 @@ nx g cypress-project ... --dry-run
 
 ## Options
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/web/api-react/schematics/application.md
+++ b/docs/web/api-react/schematics/application.md
@@ -76,6 +76,14 @@ Possible values: `cypress`, `none`
 
 Test runner to use for end to end (e2e) tests
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### linter
 
 Default: `tslint`

--- a/docs/web/api-react/schematics/component.md
+++ b/docs/web/api-react/schematics/component.md
@@ -70,6 +70,14 @@ Type: `boolean`
 
 When true, the component is exported from the project index.ts (if it exists).
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/web/api-react/schematics/library.md
+++ b/docs/web/api-react/schematics/library.md
@@ -58,6 +58,14 @@ Type: `string`
 
 A directory where the app is placed
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### linter
 
 Default: `tslint`

--- a/docs/web/api-react/schematics/redux.md
+++ b/docs/web/api-react/schematics/redux.md
@@ -44,6 +44,14 @@ Type: `string`
 
 The name of the folder used to contain/group the generated Redux files.
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/web/api-react/schematics/storybook-configuration.md
+++ b/docs/web/api-react/schematics/storybook-configuration.md
@@ -30,6 +30,14 @@ Type: `boolean`
 
 Run the cypress-configure schematic
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/web/api-storybook/schematics/configuration.md
+++ b/docs/web/api-storybook/schematics/configuration.md
@@ -30,6 +30,14 @@ Type: `boolean`
 
 Run the cypress-configure schematic
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/docs/web/api-storybook/schematics/cypress-project.md
+++ b/docs/web/api-storybook/schematics/cypress-project.md
@@ -24,6 +24,14 @@ nx g cypress-project ... --dry-run
 
 ## Options
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### name
 
 Type: `string`

--- a/packages/cypress/src/schematics/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/schematics/cypress-project/cypress-project.ts
@@ -3,6 +3,7 @@ import {
   chain,
   mergeWith,
   move,
+  noop,
   Rule,
   template,
   url
@@ -19,6 +20,7 @@ import {
 import { offsetFromRoot } from '@nrwl/workspace';
 import { toFileName } from '@nrwl/workspace';
 import { Schema } from './schema';
+import { toJS } from '@nrwl/workspace/src/utils/rules/to-js';
 
 export interface CypressProjectSchema extends Schema {
   projectName: string;
@@ -33,9 +35,11 @@ function generateFiles(options: CypressProjectSchema): Rule {
         template({
           tmpl: '',
           ...options,
+          ext: options.js ? 'js' : 'ts',
           offsetFromRoot: offsetFromRoot(options.projectRoot)
         }),
-        move(options.projectRoot)
+        move(options.projectRoot),
+        options.js ? toJS() : noop()
       ])
     );
   };

--- a/packages/cypress/src/schematics/cypress-project/files/cypress.json
+++ b/packages/cypress/src/schematics/cypress-project/files/cypress.json
@@ -4,7 +4,7 @@
   "integrationFolder": "./src/integration",
   "modifyObstructiveCode": false,
   "pluginsFile": "./src/plugins/index",
-  "supportFile": "./src/support/index.ts",
+  "supportFile": "./src/support/index.<%= ext %>",
   "video": true,
   "videosFolder": "<%= offsetFromRoot %>dist/cypress/<%= projectRoot %>/videos",
   "screenshotsFolder": "<%= offsetFromRoot %>dist/cypress/<%= projectRoot %>/screenshots",

--- a/packages/cypress/src/schematics/cypress-project/files/tsconfig.e2e.json
+++ b/packages/cypress/src/schematics/cypress-project/files/tsconfig.e2e.json
@@ -4,5 +4,5 @@
     "sourceMap": false,
     "outDir": "<%= offsetFromRoot %>dist/out-tsc"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/packages/cypress/src/schematics/cypress-project/files/tsconfig.json
+++ b/packages/cypress/src/schematics/cypress-project/files/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["cypress", "node"]
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "**/*.js"]
 }

--- a/packages/cypress/src/schematics/cypress-project/schema.d.ts
+++ b/packages/cypress/src/schematics/cypress-project/schema.d.ts
@@ -5,4 +5,5 @@ export interface Schema {
   name: string;
   directory: string;
   linter: Linter;
+  js?: boolean;
 }

--- a/packages/cypress/src/schematics/cypress-project/schema.json
+++ b/packages/cypress/src/schematics/cypress-project/schema.json
@@ -29,6 +29,11 @@
       "type": "string",
       "enum": ["eslint", "tslint"],
       "default": "tslint"
+    },
+    "js": {
+      "description": "Generate JavaScript files rather than TypeScript files",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/react/src/schematics/application/application.spec.ts
+++ b/packages/react/src/schematics/application/application.spec.ts
@@ -549,4 +549,17 @@ describe('app', () => {
       });
     });
   });
+
+  describe('--js', () => {
+    it('generates JS files', async () => {
+      const tree = await runSchematic(
+        'app',
+        { name: 'myApp', js: true },
+        appTree
+      );
+
+      expect(tree.exists('/apps/my-app/src/app/app.js')).toBe(true);
+      expect(tree.exists('/apps/my-app/src/main.js')).toBe(true);
+    });
+  });
 });

--- a/packages/react/src/schematics/application/files/app/tsconfig.app.json
+++ b/packages/react/src/schematics/application/files/app/tsconfig.app.json
@@ -5,5 +5,5 @@
     "types": []
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
 }

--- a/packages/react/src/schematics/application/files/app/tsconfig.json
+++ b/packages/react/src/schematics/application/files/app/tsconfig.json
@@ -11,5 +11,5 @@
     "<%= offsetFromRoot %>node_modules/@nrwl/react/typings/cssmodule.d.ts",
     "<%= offsetFromRoot %>node_modules/@nrwl/react/typings/image.d.ts"
   ],
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
 }

--- a/packages/react/src/schematics/application/schema.d.ts
+++ b/packages/react/src/schematics/application/schema.d.ts
@@ -13,4 +13,5 @@ export interface Schema {
   classComponent?: boolean;
   routing?: boolean;
   skipWorkspaceJson?: boolean;
+  js?: boolean;
 }

--- a/packages/react/src/schematics/application/schema.json
+++ b/packages/react/src/schematics/application/schema.json
@@ -115,6 +115,11 @@
       "description": "Use class components instead of functional component",
       "alias": "C",
       "default": false
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files",
+      "default": false
     }
   },
   "required": []

--- a/packages/react/src/schematics/component/component.ts
+++ b/packages/react/src/schematics/component/component.ts
@@ -27,6 +27,7 @@ import {
   reactRouterDomVersion
 } from '../../utils/versions';
 import { assertValidStyle } from '../../utils/assertion';
+import { toJS } from '@nrwl/workspace/src/utils/rules/to-js';
 
 interface NormalizedSchema extends Schema {
   projectSourceRoot: Path;
@@ -73,7 +74,8 @@ function createComponentFiles(options: NormalizedSchema): Rule {
         options.styledModule
           ? filter(file => !file.endsWith(`.${options.style}`))
           : noop(),
-        move(directory)
+        move(directory),
+        options.js ? toJS() : noop()
       ])
     );
   };
@@ -97,7 +99,10 @@ function addExportsToBarrel(options: NormalizedSchema): Rule {
       workspace.projects.get(options.project).extensions.type === 'application';
     return options.export && !isApp
       ? (host: Tree) => {
-          const indexFilePath = join(options.projectSourceRoot, 'index.ts');
+          const indexFilePath = join(
+            options.projectSourceRoot,
+            options.js ? 'index.js' : 'index.ts'
+          );
           const buffer = host.read(indexFilePath);
           if (!!buffer) {
             const indexSource = buffer!.toString('utf-8');

--- a/packages/react/src/schematics/component/schema.d.ts
+++ b/packages/react/src/schematics/component/schema.d.ts
@@ -8,4 +8,5 @@ export interface Schema {
   pascalCaseFiles?: boolean;
   classComponent?: boolean;
   routing?: boolean;
+  js?: boolean;
 }

--- a/packages/react/src/schematics/component/schema.json
+++ b/packages/react/src/schematics/component/schema.json
@@ -97,6 +97,11 @@
     "routing": {
       "type": "boolean",
       "description": "Generate a library with routes."
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files",
+      "default": false
     }
   },
   "required": ["name", "project"]

--- a/packages/react/src/schematics/library/files/lib/tsconfig.json
+++ b/packages/react/src/schematics/library/files/lib/tsconfig.json
@@ -11,5 +11,5 @@
     "<%= offsetFromRoot %>node_modules/@nrwl/react/typings/cssmodule.d.ts",
     "<%= offsetFromRoot %>node_modules/@nrwl/react/typings/image.d.ts"
   ],
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
 }

--- a/packages/react/src/schematics/library/files/lib/tsconfig.lib.json
+++ b/packages/react/src/schematics/library/files/lib/tsconfig.lib.json
@@ -5,5 +5,5 @@
     "types": []
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
 }

--- a/packages/react/src/schematics/library/library.spec.ts
+++ b/packages/react/src/schematics/library/library.spec.ts
@@ -71,7 +71,7 @@ describe('lib', () => {
           '../../node_modules/@nrwl/react/typings/cssmodule.d.ts',
           '../../node_modules/@nrwl/react/typings/image.d.ts'
         ],
-        include: ['**/*.ts', '**/*.tsx']
+        include: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx']
       });
     });
 
@@ -228,7 +228,7 @@ describe('lib', () => {
           '../../../node_modules/@nrwl/react/typings/cssmodule.d.ts',
           '../../../node_modules/@nrwl/react/typings/image.d.ts'
         ],
-        include: ['**/*.ts', '**/*.tsx']
+        include: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx']
       });
     });
   });
@@ -351,6 +351,21 @@ describe('lib', () => {
       const packageJson = readJsonInTree(tree, '/libs/my-lib/package.json');
 
       expect(packageJson.name).toEqual('my-lib');
+    });
+  });
+
+  describe('--js', () => {
+    it('should generate JS files', async () => {
+      const tree = await runSchematic(
+        'lib',
+        {
+          name: 'myLib',
+          js: true
+        },
+        appTree
+      );
+
+      expect(tree.exists('/libs/my-lib/src/index.js')).toBe(true);
     });
   });
 });

--- a/packages/react/src/schematics/library/schema.d.ts
+++ b/packages/react/src/schematics/library/schema.d.ts
@@ -13,4 +13,5 @@ export interface Schema {
   unitTestRunner: 'jest' | 'none';
   linter: Linter;
   publishable?: boolean;
+  js?: boolean;
 }

--- a/packages/react/src/schematics/library/schema.json
+++ b/packages/react/src/schematics/library/schema.json
@@ -106,6 +106,11 @@
     "publishable": {
       "type": "boolean",
       "description": "Create a publishable library. A \"build\" architect will be added for this project the workspace configuration."
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/react/src/schematics/redux/redux.ts
+++ b/packages/react/src/schematics/redux/redux.ts
@@ -30,6 +30,7 @@ import {
   reactReduxVersion,
   reduxjsToolkitVersion
 } from '../../utils/versions';
+import { toJS } from '@nrwl/workspace/src/utils/rules/to-js';
 
 export default function(schema: any): Rule {
   return async (host: Tree, context: SchematicContext) => {
@@ -49,7 +50,8 @@ export default function(schema: any): Rule {
 function generateReduxFiles(options: NormalizedSchema) {
   const templateSource = apply(url('./files'), [
     template({ ...options, tmpl: '' }),
-    move(options.filesPath)
+    move(options.filesPath),
+    options.js ? toJS() : noop()
   ]);
 
   return mergeWith(templateSource);
@@ -68,7 +70,10 @@ function addReduxPackageDependencies(): Rule {
 
 function addExportsToBarrel(options: NormalizedSchema): Rule {
   return (host: Tree) => {
-    const indexFilePath = path.join(options.projectSourcePath, 'index.ts');
+    const indexFilePath = path.join(
+      options.projectSourcePath,
+      options.js ? 'index.js' : 'index.ts'
+    );
 
     const buffer = host.read(indexFilePath);
     if (!!buffer) {
@@ -187,7 +192,10 @@ async function normalizeOptions(
       );
     }
     appProjectSourcePath = appConfig.sourceRoot;
-    appMainFilePath = path.join(appProjectSourcePath, 'main.tsx');
+    appMainFilePath = path.join(
+      appProjectSourcePath,
+      options.js ? 'main.js' : 'main.tsx'
+    );
     if (!host.exists(appMainFilePath)) {
       throw new Error(
         `Could not find ${appMainFilePath} during store configuration`

--- a/packages/react/src/schematics/redux/schema.d.ts
+++ b/packages/react/src/schematics/redux/schema.d.ts
@@ -5,6 +5,7 @@ export interface Schema {
   project: string;
   directory: string;
   appProject: string;
+  js?: string;
 }
 
 interface NormalizedSchema extends Schema {

--- a/packages/react/src/schematics/redux/schema.json
+++ b/packages/react/src/schematics/redux/schema.json
@@ -30,6 +30,11 @@
       "type": "string",
       "description": "The application project to add the slice to.",
       "alias": "a"
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/react/src/schematics/storybook-configuration/configuration.ts
+++ b/packages/react/src/schematics/storybook-configuration/configuration.ts
@@ -6,7 +6,8 @@ export default function(schema: StorybookConfigureSchema): Rule {
     externalSchematic('@nrwl/storybook', 'configuration', {
       name: schema.name,
       uiFramework: '@storybook/react',
-      configureCypress: schema.configureCypress
+      configureCypress: schema.configureCypress,
+      js: schema.js
     })
   ]);
 }

--- a/packages/react/src/schematics/storybook-configuration/schema.d.ts
+++ b/packages/react/src/schematics/storybook-configuration/schema.d.ts
@@ -1,4 +1,5 @@
 export interface StorybookConfigureSchema {
   name: string;
   configureCypress: boolean;
+  js?: boolean;
 }

--- a/packages/react/src/schematics/storybook-configuration/schema.json
+++ b/packages/react/src/schematics/storybook-configuration/schema.json
@@ -15,6 +15,11 @@
       "type": "boolean",
       "description": "Run the cypress-configure schematic",
       "x-prompt": "Configure a cypress e2e app to run against the storybook instance?"
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/storybook/src/schematics/configuration/schema.d.ts
+++ b/packages/storybook/src/schematics/configuration/schema.d.ts
@@ -2,4 +2,5 @@ export interface StorybookConfigureSchema {
   name: string;
   uiFramework: string;
   configureCypress: boolean;
+  js?: boolean;
 }

--- a/packages/storybook/src/schematics/configuration/schema.json
+++ b/packages/storybook/src/schematics/configuration/schema.json
@@ -21,6 +21,11 @@
       "type": "boolean",
       "description": "Run the cypress-configure schematic",
       "x-prompt": "Configure a cypress e2e app to run against the storybook instance?"
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/storybook/src/schematics/cypress-project/cypress-project.ts
+++ b/packages/storybook/src/schematics/cypress-project/cypress-project.ts
@@ -10,6 +10,7 @@ import { parseJsonAtPath, safeFileDelete } from '../../utils/utils';
 
 export interface CypressConfigureSchema {
   name: string;
+  js?: boolean;
 }
 
 export default function(schema: CypressConfigureSchema): Rule {
@@ -17,24 +18,26 @@ export default function(schema: CypressConfigureSchema): Rule {
   return chain([
     externalSchematic('@nrwl/cypress', 'cypress-project', {
       name: e2eProjectName,
-      project: schema.name
+      project: schema.name,
+      js: schema.js
     }),
-    removeUnneededFiles(e2eProjectName),
+    removeUnneededFiles(e2eProjectName, schema.js),
     addBaseUrlToCypressConfig(e2eProjectName),
     updateAngularJsonBuilder(e2eProjectName, schema.name)
   ]);
 }
 
-function removeUnneededFiles(projectName: string): Rule {
+function removeUnneededFiles(projectName: string, js: boolean): Rule {
   return (tree: Tree, context: SchematicContext): Tree => {
     safeFileDelete(
       tree,
       getProjectConfig(tree, projectName).sourceRoot +
-        '/integration/app.spec.ts'
+        (js ? '/integration/app.spec.js' : '/integration/app.spec.ts')
     );
     safeFileDelete(
       tree,
-      getProjectConfig(tree, projectName).sourceRoot + '/support/app.po.ts'
+      getProjectConfig(tree, projectName).sourceRoot +
+        (js ? '/support/app.po.js' : '/support/app.po.ts')
     );
 
     return tree;

--- a/packages/storybook/src/schematics/cypress-project/schema.json
+++ b/packages/storybook/src/schematics/cypress-project/schema.json
@@ -10,6 +10,11 @@
         "$source": "argv",
         "index": 0
       }
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/workspace/src/utils/rules/to-js.ts
+++ b/packages/workspace/src/utils/rules/to-js.ts
@@ -1,0 +1,23 @@
+import { transpile, JsxEmit, ScriptTarget } from 'typescript';
+import { forEach, Rule, when } from '@angular-devkit/schematics';
+import { normalize } from '@angular-devkit/core';
+
+export function toJS(): Rule {
+  return forEach(
+    when(
+      path => path.endsWith('.ts') || path.endsWith('.tsx'),
+      entry => {
+        const original = entry.content.toString('utf-8');
+        const result = transpile(original, {
+          allowJs: true,
+          jsx: JsxEmit.Preserve,
+          target: ScriptTarget.ESNext
+        });
+        return {
+          content: Buffer.from(result, 'utf-8'),
+          path: normalize(entry.path.replace(/\.tsx?$/, '.js'))
+        };
+      }
+    )
+  );
+}


### PR DESCRIPTION
Add `--js` option to React apps and libs, and also Cypress projects (because e2e project should be consistently using JS).

```
nx g app demo --js
nx g lib ui --js
```

This will transform all TS and TSX files to JS files.