### PR TITLE
fix(core): include sorted node names in the project graph

### DIFF
--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -110,6 +110,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['myappName', 'mylibName'],
         dependencies: {}
       }
     );
@@ -163,6 +164,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['myapp2-mylib', 'myapp2Name', 'myappName'],
         dependencies: {}
       }
     );
@@ -240,6 +242,14 @@ describe('Enforce Module Boundaries', () => {
           }
         }
       },
+      nodeNames: [
+        'impl-both-domainsName',
+        'impl-domain2Name',
+        'impl2Name',
+        'untaggedName',
+        'apiName',
+        'implName'
+      ],
       dependencies: {}
     };
 
@@ -394,6 +404,7 @@ describe('Enforce Module Boundaries', () => {
               }
             }
           },
+          nodeNames: ['mylibName'],
           dependencies: {}
         }
       );
@@ -422,6 +433,7 @@ describe('Enforce Module Boundaries', () => {
               }
             }
           },
+          nodeNames: ['mylibName'],
           dependencies: {}
         }
       );
@@ -458,6 +470,7 @@ describe('Enforce Module Boundaries', () => {
               }
             }
           },
+          nodeNames: ['mylibName', 'otherName'],
           dependencies: {}
         }
       );
@@ -496,6 +509,7 @@ describe('Enforce Module Boundaries', () => {
               }
             }
           },
+          nodeNames: ['mylibName', 'otherName'],
           dependencies: {}
         }
       );
@@ -527,6 +541,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['mylibName'],
         dependencies: {}
       }
     );
@@ -569,6 +584,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['mylibName', 'utils'],
         dependencies: {}
       }
     );
@@ -605,6 +621,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['mylibName', 'otherName'],
         dependencies: {
           mylibName: [
             {
@@ -651,6 +668,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['mylibName', 'myappName'],
         dependencies: {}
       }
     );
@@ -698,6 +716,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['anotherlibName', 'mylibName', 'myappName'],
         dependencies: {
           mylibName: [
             {
@@ -766,6 +785,12 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: [
+          'badcirclelibName',
+          'anotherlibName',
+          'mylibName',
+          'myappName'
+        ],
         dependencies: {
           mylibName: [
             {

--- a/packages/workspace/src/command-line/workspace-integrity-checks.spec.ts
+++ b/packages/workspace/src/command-line/workspace-integrity-checks.spec.ts
@@ -21,6 +21,7 @@ describe('WorkspaceIntegrityChecks', () => {
               }
             }
           },
+          nodeNames: ['project1'],
           dependencies: {}
         },
         ['libs/project1/src/index.ts']
@@ -55,6 +56,7 @@ describe('WorkspaceIntegrityChecks', () => {
               }
             }
           },
+          nodeNames: ['project1', 'projec2'],
           dependencies: {}
         },
         ['libs/project2/src/index.ts']
@@ -89,6 +91,7 @@ describe('WorkspaceIntegrityChecks', () => {
               }
             }
           },
+          nodeNames: ['project1'],
           dependencies: {}
         },
         ['libs/project1/src/index.ts', 'libs/project2/src/index.ts']

--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
@@ -172,6 +172,7 @@ describe('project graph', () => {
           data: expect.anything()
         }
       },
+      nodeNames: [],
       dependencies: {
         'demo-e2e': [
           {
@@ -242,6 +243,7 @@ describe('project graph', () => {
           data: expect.anything()
         }
       },
+      nodeNames: [],
       dependencies: {
         'demo-e2e': [
           {

--- a/packages/workspace/src/core/project-graph/build-dependencies/build-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/build-dependencies.ts
@@ -8,6 +8,7 @@ export interface BuildDependencies {
   (
     ctx: ProjectGraphContext,
     nodes: ProjectGraphNodeRecords,
+    nodeNames: string[],
     addDependency: AddProjectDependency,
     fileRead: (s: string) => string
   ): void;

--- a/packages/workspace/src/core/project-graph/build-dependencies/explicit-npm-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/explicit-npm-dependencies.ts
@@ -9,6 +9,7 @@ import { TypeScriptImportLocator } from './typescript-import-locator';
 export function buildExplicitNpmDependencies(
   ctx: ProjectGraphContext,
   nodes: ProjectGraphNodeRecords,
+  nodeNames: string[],
   addDependency: AddProjectDependency,
   fileRead: (s: string) => string
 ) {
@@ -19,9 +20,7 @@ export function buildExplicitNpmDependencies(
       importLocator.fromFile(
         f.file,
         (importExpr: string, filePath: string, type: DependencyType) => {
-          const key = Object.keys(nodes).find(k =>
-            isNpmPackageImport(k, importExpr)
-          );
+          const key = nodeNames.find(k => isNpmPackageImport(k, importExpr));
           const target = nodes[key];
           if (source && target && target.type === 'npm') {
             addDependency(type, source, target.name);

--- a/packages/workspace/src/core/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -10,6 +10,7 @@ import { findTargetProjectWithImport } from './find-target-project';
 export function buildExplicitTypeScriptDependencies(
   ctx: ProjectGraphContext,
   nodes: ProjectGraphNodeRecords,
+  nodeNames: string[],
   addDependency: AddProjectDependency,
   fileRead: (s: string) => string
 ) {
@@ -24,7 +25,8 @@ export function buildExplicitTypeScriptDependencies(
             importExpr,
             f.file,
             ctx.nxJson.npmScope,
-            nodes
+            nodes,
+            nodeNames
           );
           if (source && target) {
             addDependency(type, source, target);

--- a/packages/workspace/src/core/project-graph/build-dependencies/find-target-project.spec.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/find-target-project.spec.ts
@@ -11,6 +11,7 @@ jest.mock('fs', () => require('memfs').fs);
 describe('findTargetProjectWithImport', () => {
   let ctx: ProjectGraphContext;
   let projects: Record<string, ProjectGraphNode>;
+  let projectNames: string[];
   let fsJson;
   beforeEach(() => {
     const workspaceJson = {
@@ -116,19 +117,22 @@ describe('findTargetProjectWithImport', () => {
         }
       }
     };
+    projectNames = ['proj1', 'proj2', 'proj3', 'proj4'];
   });
   it('should be able to resolve a module by using tsConfig paths', () => {
     const proj2 = findTargetProjectWithImport(
       '@proj/my-second-proj',
       'libs/proj1/index.ts',
       ctx.nxJson.npmScope,
-      projects
+      projects,
+      projectNames
     );
     const proj3 = findTargetProjectWithImport(
       '@proj/project-3',
       'libs/proj1/index.ts',
       ctx.nxJson.npmScope,
-      projects
+      projects,
+      projectNames
     );
 
     expect(proj2).toEqual('proj2');
@@ -139,7 +143,8 @@ describe('findTargetProjectWithImport', () => {
       '@proj/proj4',
       'libs/proj1/index.ts',
       ctx.nxJson.npmScope,
-      projects
+      projects,
+      projectNames
     );
 
     expect(proj4).toEqual('proj4');

--- a/packages/workspace/src/core/project-graph/build-dependencies/find-target-project.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/find-target-project.ts
@@ -6,13 +6,14 @@ export function findTargetProjectWithImport(
   importExpr: string,
   filePath: string,
   npmScope: string,
-  nodes: ProjectGraphNodeRecords
+  nodes: ProjectGraphNodeRecords,
+  nodeNames: string[]
 ) {
   const normalizedImportExpr = importExpr.split('#')[0];
 
   const resolvedModule = resolveModuleByImport(normalizedImportExpr, filePath);
 
-  return Object.keys(nodes).find(projectName => {
+  return nodeNames.find(projectName => {
     const p = nodes[projectName];
     if (resolvedModule && resolvedModule.includes(p.data.root)) {
       return true;

--- a/packages/workspace/src/core/project-graph/build-dependencies/implicit-project-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/implicit-project-dependencies.ts
@@ -8,6 +8,7 @@ import {
 export function buildImplicitProjectDependencies(
   ctx: ProjectGraphContext,
   nodes: ProjectGraphNodeRecords,
+  nodeNames: string[],
   addDependency: AddProjectDependency,
   fileRead: (s: string) => string
 ) {

--- a/packages/workspace/src/core/project-graph/build-nodes/build-nodes.ts
+++ b/packages/workspace/src/core/project-graph/build-nodes/build-nodes.ts
@@ -1,9 +1,14 @@
-import { AddProjectNode, ProjectGraphContext } from '../project-graph-models';
+import {
+  AddProjectNode,
+  ProjectGraphContext,
+  AddProjectNodeNames
+} from '../project-graph-models';
 
 export interface BuildNodes {
   (
     ctx: ProjectGraphContext,
     addNode: AddProjectNode,
+    addNodeName: AddProjectNodeNames,
     fileRead: (s: string) => string
   ): void;
 }

--- a/packages/workspace/src/core/project-graph/build-nodes/npm-packages.ts
+++ b/packages/workspace/src/core/project-graph/build-nodes/npm-packages.ts
@@ -1,9 +1,14 @@
 import * as stripJsonComments from 'strip-json-comments';
-import { ProjectGraphContext, AddProjectNode } from '../project-graph-models';
+import {
+  ProjectGraphContext,
+  AddProjectNode,
+  AddProjectNodeNames
+} from '../project-graph-models';
 
 export function buildNpmPackageNodes(
   ctx: ProjectGraphContext,
   addNode: AddProjectNode,
+  addNodeNames: AddProjectNodeNames,
   fileRead: (s: string) => string
 ) {
   const packageJson = JSON.parse(stripJsonComments(fileRead('package.json')));
@@ -12,6 +17,7 @@ export function buildNpmPackageNodes(
     ...packageJson.devDependencies
   };
   Object.keys(deps).forEach(d => {
+    addNodeNames(d);
     addNode({
       type: 'npm',
       name: d,

--- a/packages/workspace/src/core/project-graph/build-nodes/workspace-projects.ts
+++ b/packages/workspace/src/core/project-graph/build-nodes/workspace-projects.ts
@@ -1,8 +1,13 @@
-import { AddProjectNode, ProjectGraphContext } from '../project-graph-models';
+import {
+  AddProjectNode,
+  ProjectGraphContext,
+  AddProjectNodeNames
+} from '../project-graph-models';
 
 export function buildWorkspaceProjectNodes(
   ctx: ProjectGraphContext,
   addNode: AddProjectNode,
+  addNodeNames: AddProjectNodeNames,
   fileRead: (s: string) => string
 ) {
   const toAdd = [];
@@ -33,11 +38,16 @@ export function buildWorkspaceProjectNodes(
   });
 
   // Sort by root directory length (do we need this?)
-  toAdd.sort((a, b) => {
-    if (!a.data.root) return -1;
-    if (!b.data.root) return -1;
-    return a.data.root.length > b.data.root.length ? -1 : 1;
-  });
+  const nodeNames = toAdd
+    .sort((a, b) => {
+      if (!a.data.root) return -1;
+      if (!b.data.root) return -1;
+      return a.data.root.length > b.data.root.length ? -1 : 1;
+    })
+    .map(node => {
+      return node.name;
+    });
+  addNodeNames(nodeNames);
 
   toAdd.forEach(n => {
     addNode({

--- a/packages/workspace/src/core/project-graph/operators.spec.ts
+++ b/packages/workspace/src/core/project-graph/operators.spec.ts
@@ -9,6 +9,7 @@ const graph: ProjectGraph = {
     lib2: { name: 'lib2', type: 'lib', data: null },
     lib3: { name: 'lib3', type: 'lib', data: null }
   },
+  nodeNames: [],
   dependencies: {
     'app1-e2e': [
       {
@@ -57,6 +58,7 @@ describe('reverse', () => {
         lib2: { name: 'lib2', type: 'lib', data: null },
         lib3: { name: 'lib3', type: 'lib', data: null }
       },
+      nodeNames: [],
       dependencies: {
         app1: [
           {
@@ -133,6 +135,7 @@ describe('withDeps', () => {
           data: null
         }
       },
+      nodeNames: [],
       dependencies: {
         lib2: [
           {
@@ -180,6 +183,7 @@ describe('filterNodes', () => {
         'app1-e2e': { name: 'app1-e2e', type: 'app', data: null },
         app1: { name: 'app1', type: 'app', data: null }
       },
+      nodeNames: [],
       dependencies: {
         'app1-e2e': [
           {

--- a/packages/workspace/src/core/project-graph/project-graph-builder.ts
+++ b/packages/workspace/src/core/project-graph/project-graph-builder.ts
@@ -7,6 +7,7 @@ import {
 
 export class ProjectGraphBuilder {
   readonly nodes: Record<string, ProjectGraphNode> = {};
+  readonly nodeNames: string[] = [];
   readonly dependencies: Record<
     string,
     Record<string, ProjectGraphDependency>
@@ -23,6 +24,14 @@ export class ProjectGraphBuilder {
 
   addNode(node: ProjectGraphNode) {
     this.nodes[node.name] = node;
+  }
+
+  addNodeNames(nodeNames: string | string[]) {
+    if (typeof nodeNames === 'string') {
+      this.nodeNames.push(nodeNames);
+    } else {
+      this.nodeNames.push(...nodeNames);
+    }
   }
 
   addDependency(
@@ -53,6 +62,7 @@ export class ProjectGraphBuilder {
   build(): ProjectGraph {
     return {
       nodes: this.nodes as ProjectGraph['nodes'],
+      nodeNames: this.nodeNames,
       dependencies: Object.keys(this.dependencies).reduce(
         (acc, k) => {
           acc[k] = Object.values(this.dependencies[k]);

--- a/packages/workspace/src/core/project-graph/project-graph-models.ts
+++ b/packages/workspace/src/core/project-graph/project-graph-models.ts
@@ -4,6 +4,7 @@ import { NxJson } from '../shared-interfaces';
 
 export interface ProjectGraph {
   nodes: Record<string, ProjectGraphNode>;
+  nodeNames: string[];
   dependencies: Record<string, ProjectGraphDependency[]>;
 }
 
@@ -22,6 +23,8 @@ export interface ProjectGraphNode<T extends {} = {}> {
 export type ProjectGraphNodeRecords = Record<string, ProjectGraphNode>;
 
 export type AddProjectNode = (node: ProjectGraphNode) => void;
+
+export type AddProjectNodeNames = (nodeNames: string | string[]) => void;
 
 export interface ProjectGraphDependency {
   type: DependencyType | string;

--- a/packages/workspace/src/core/project-graph/project-graph.spec.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.spec.ts
@@ -178,6 +178,21 @@ describe('project graph', () => {
     });
   });
 
+  it('should have a ordered (based on root length) array of project names', () => {
+    const graph = createProjectGraph();
+    expect(graph.nodeNames).toEqual([
+      'shared-util-data',
+      'shared-util',
+      'demo-e2e',
+      'lazy-lib',
+      'demo',
+      'api',
+      'ui',
+      'happy-nrwl',
+      '@nrwl/workspace'
+    ]);
+  });
+
   it('should handle circular dependencies', () => {
     fs.writeFileSync(
       '/root/libs/shared/util/src/index.ts',

--- a/packages/workspace/src/core/project-graph/project-graph.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.ts
@@ -61,10 +61,23 @@ export function createProjectGraph(
       buildExplicitNpmDependencies
     ];
 
-    buildNodesFns.forEach(f => f(ctx, builder.addNode.bind(builder), fileRead));
+    buildNodesFns.forEach(f =>
+      f(
+        ctx,
+        builder.addNode.bind(builder),
+        builder.addNodeNames.bind(builder),
+        fileRead
+      )
+    );
 
     buildDependenciesFns.forEach(f =>
-      f(ctx, builder.nodes, builder.addDependency.bind(builder), fileRead)
+      f(
+        ctx,
+        builder.nodes,
+        builder.nodeNames,
+        builder.addDependency.bind(builder),
+        fileRead
+      )
     );
 
     const projectGraph = builder.build();

--- a/packages/workspace/src/tasks-runner/task-orderer.spec.ts
+++ b/packages/workspace/src/tasks-runner/task-orderer.spec.ts
@@ -5,6 +5,7 @@ describe('TaskStages', () => {
   it('should return empty for an empty array', () => {
     const stages = new TaskOrderer('build', {
       nodes: {},
+      nodeNames: [],
       dependencies: {}
     }).splitTasksIntoStages([]);
     expect(stages).toEqual([]);
@@ -13,6 +14,7 @@ describe('TaskStages', () => {
   it('should split tasks into stages based on their dependencies', () => {
     const stages = new TaskOrderer('build', {
       nodes: {},
+      nodeNames: [],
       dependencies: {
         child1: [],
         child2: [],

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -106,6 +106,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['myappName', 'mylibName'],
         dependencies: {}
       }
     );
@@ -159,6 +160,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['myapp2-mylib', 'myapp2Name', 'myappName'],
         dependencies: {}
       }
     );
@@ -236,6 +238,14 @@ describe('Enforce Module Boundaries', () => {
           }
         }
       },
+      nodeNames: [
+        'impl-both-domainsName',
+        'impl-domain2Name',
+        'impl2Name',
+        'untaggedName',
+        'apiName',
+        'implName'
+      ],
       dependencies: {}
     };
 
@@ -390,6 +400,7 @@ describe('Enforce Module Boundaries', () => {
               }
             }
           },
+          nodeNames: ['mylibName'],
           dependencies: {}
         }
       );
@@ -418,6 +429,7 @@ describe('Enforce Module Boundaries', () => {
               }
             }
           },
+          nodeNames: ['mylibName'],
           dependencies: {}
         }
       );
@@ -454,6 +466,7 @@ describe('Enforce Module Boundaries', () => {
               }
             }
           },
+          nodeNames: ['mylibName', 'otherName'],
           dependencies: {}
         }
       );
@@ -493,6 +506,7 @@ describe('Enforce Module Boundaries', () => {
               }
             }
           },
+          nodeNames: ['mylibName', 'otherName'],
           dependencies: {}
         }
       );
@@ -524,6 +538,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['mylibName'],
         dependencies: {}
       }
     );
@@ -566,6 +581,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['mylibName', 'utils'],
         dependencies: {}
       }
     );
@@ -602,6 +618,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['mylibName', 'otherName'],
         dependencies: {
           mylibName: [
             {
@@ -648,6 +665,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['mylibName', 'myappName'],
         dependencies: {}
       }
     );
@@ -695,6 +713,7 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: ['anotherlibName', 'mylibName', 'myappName'],
         dependencies: {
           mylibName: [
             {
@@ -763,6 +782,12 @@ describe('Enforce Module Boundaries', () => {
             }
           }
         },
+        nodeNames: [
+          'badcirclelibName',
+          'anotherlibName',
+          'mylibName',
+          'myappName'
+        ],
         dependencies: {
           mylibName: [
             {

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -142,7 +142,8 @@ export function findProjectUsingImport(
     imp,
     filePath,
     npmScope,
-    projectGraph.nodes
+    projectGraph.nodes,
+    projectGraph.nodeNames
   );
   return projectGraph.nodes[target];
 }


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
Project nodes are sorted by property name in an Object. This works for node versions > 10 (ie 12+). Guarantee of property order was added with es2015 and node 12+ fully implements the spec. 
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Project graph names should be ordered with something that is guaranteed to keep the ordering in all node versions

## Issue


---
Opening as draft to check e2es