### PR TITLE
feat(misc): add color option to run-commands

### DIFF
--- a/docs/angular/api-workspace/builders/run-commands.md
+++ b/docs/angular/api-workspace/builders/run-commands.md
@@ -12,6 +12,14 @@ Type: `string`
 
 Extra arguments. You can pass them as follows: ng run project:target --args='--wait=100'. You can them use {args.wait} syntax to interpolate them in the workspace config file.
 
+### color
+
+Default: `false`
+
+Type: `boolean`
+
+Use colors when showing output of command
+
 ### commands
 
 Type: `array` of `object`

--- a/docs/react/api-workspace/builders/run-commands.md
+++ b/docs/react/api-workspace/builders/run-commands.md
@@ -13,6 +13,14 @@ Type: `string`
 
 Extra arguments. You can pass them as follows: ng run project:target --args='--wait=100'. You can them use {args.wait} syntax to interpolate them in the workspace config file.
 
+### color
+
+Default: `false`
+
+Type: `boolean`
+
+Use colors when showing output of command
+
 ### commands
 
 Type: `array` of `object`

--- a/docs/web/api-workspace/builders/run-commands.md
+++ b/docs/web/api-workspace/builders/run-commands.md
@@ -13,6 +13,14 @@ Type: `string`
 
 Extra arguments. You can pass them as follows: ng run project:target --args='--wait=100'. You can them use {args.wait} syntax to interpolate them in the workspace config file.
 
+### color
+
+Default: `false`
+
+Type: `boolean`
+
+Use colors when showing output of command
+
 ### commands
 
 Type: `array` of `object`

--- a/packages/workspace/src/builders/run-commands/schema.json
+++ b/packages/workspace/src/builders/run-commands/schema.json
@@ -29,6 +29,11 @@
     "args": {
       "type": "string",
       "description": "Extra arguments. You can pass them as follows: ng run project:target --args='--wait=100'. You can them use {args.wait} syntax to interpolate them in the workspace config file."
+    },
+    "color": {
+      "type": "boolean",
+      "description": "Use colors when showing output of command",
+      "default": false
     }
   },
   "required": ["commands"]


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Colors do not show up when using `@nrwl/workspace:run-commands`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Colors show up when using `@nrwl/workspace:run-commands`

## Issue
Fixes #2240 