### PR TITLE
feat(core): generate implicit dependencies for e2e projects

### DIFF
--- a/packages/angular/src/schematics/application/application.spec.ts
+++ b/packages/angular/src/schematics/application/application.spec.ts
@@ -50,6 +50,7 @@ describe('app', () => {
             tags: ['one', 'two']
           },
           'my-app-e2e': {
+            implicitDependencies: ['my-app'],
             tags: []
           }
         }
@@ -187,6 +188,7 @@ describe('app', () => {
             tags: ['one', 'two']
           },
           'my-dir-my-app-e2e': {
+            implicitDependencies: ['my-dir-my-app'],
             tags: []
           }
         }

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -26,7 +26,8 @@ import {
   toFileName,
   updateJsonInTree,
   updateWorkspace,
-  addLintFiles
+  addLintFiles,
+  NxJson
 } from '@nrwl/workspace';
 import { join, normalize } from '@angular-devkit/core';
 import init from '../init/init';
@@ -545,6 +546,9 @@ function updateProject(options: NormalizedSchema): Rule {
         };
         if (options.e2eTestRunner === 'protractor') {
           resultJson.projects[options.e2eProjectName] = { tags: [] };
+          resultJson.projects[options.e2eProjectName].implicitDependencies = [
+            options.name
+          ];
         }
         return resultJson;
       }),
@@ -697,14 +701,6 @@ export default function(schema: Schema): Rule {
       options.e2eTestRunner === 'protractor'
         ? updateE2eProject(options)
         : noop(),
-      options.e2eTestRunner === 'cypress'
-        ? externalSchematic('@nrwl/cypress', 'cypress-project', {
-            name: options.e2eProjectName,
-            directory: options.directory,
-            project: options.name,
-            linter: options.linter
-          })
-        : noop(),
       move(appProjectRoot, options.appProjectRoot),
       updateProject(options),
       updateComponentTemplate(options),
@@ -723,6 +719,14 @@ export default function(schema: Schema): Rule {
       options.unitTestRunner === 'karma'
         ? schematic('karma-project', {
             project: options.name
+          })
+        : noop(),
+      options.e2eTestRunner === 'cypress'
+        ? externalSchematic('@nrwl/cypress', 'cypress-project', {
+            name: options.e2eProjectName,
+            directory: options.directory,
+            project: options.name,
+            linter: options.linter
           })
         : noop(),
       options.backendProject ? addProxyConfig(options) : noop(),

--- a/packages/cypress/src/schematics/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/schematics/cypress-project/cypress-project.spec.ts
@@ -1,7 +1,7 @@
 import { Tree } from '@angular-devkit/schematics';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
 import { runSchematic } from '../../utils/testing';
-import { readJsonInTree, Linter } from '@nrwl/workspace';
+import { readJsonInTree, Linter, NxJson } from '@nrwl/workspace';
 
 describe('schematic:cypress-project', () => {
   let appTree: Tree;
@@ -86,6 +86,20 @@ describe('schematic:cypress-project', () => {
           tsConfig: ['apps/my-app-e2e/tsconfig.e2e.json'],
           exclude: ['**/node_modules/**', '!apps/my-app-e2e/**']
         }
+      });
+    });
+
+    it('should update nx.json', async () => {
+      const tree = await runSchematic(
+        'cypress-project',
+        { name: 'my-app-e2e', project: 'my-app', linter: Linter.EsLint },
+        appTree
+      );
+
+      const nxJson = readJsonInTree<NxJson>(tree, 'nx.json');
+      expect(nxJson.projects['my-app-e2e']).toEqual({
+        tags: [],
+        implicitDependencies: ['my-app']
       });
     });
 

--- a/packages/cypress/src/schematics/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/schematics/cypress-project/cypress-project.ts
@@ -48,7 +48,8 @@ function generateFiles(options: CypressProjectSchema): Rule {
 function updateNxJson(options: CypressProjectSchema): Rule {
   return updateJsonInTree<NxJson>('nx.json', json => {
     json.projects[options.projectName] = {
-      tags: []
+      tags: [],
+      implicitDependencies: [options.project]
     };
     return json;
   });

--- a/packages/next/src/schematics/application/application.spec.ts
+++ b/packages/next/src/schematics/application/application.spec.ts
@@ -37,7 +37,8 @@ describe('app', () => {
             tags: ['one', 'two']
           },
           'my-app-e2e': {
-            tags: []
+            tags: [],
+            implicitDependencies: ['my-app']
           }
         }
       });

--- a/packages/react/src/schematics/application/application.spec.ts
+++ b/packages/react/src/schematics/application/application.spec.ts
@@ -38,7 +38,8 @@ describe('app', () => {
             tags: ['one', 'two']
           },
           'my-app-e2e': {
-            tags: []
+            tags: [],
+            implicitDependencies: ['my-app']
           }
         }
       });
@@ -109,7 +110,8 @@ describe('app', () => {
             tags: ['one', 'two']
           },
           'my-dir-my-app-e2e': {
-            tags: []
+            tags: [],
+            implicitDependencies: ['my-dir-my-app']
           }
         }
       });

--- a/packages/web/src/schematics/application/application.spec.ts
+++ b/packages/web/src/schematics/application/application.spec.ts
@@ -38,7 +38,8 @@ describe('app', () => {
             tags: ['one', 'two']
           },
           'my-app-e2e': {
-            tags: []
+            tags: [],
+            implicitDependencies: ['my-app']
           }
         }
       });
@@ -108,7 +109,8 @@ describe('app', () => {
             tags: ['one', 'two']
           },
           'my-dir-my-app-e2e': {
-            tags: []
+            tags: [],
+            implicitDependencies: ['my-dir-my-app']
           }
         }
       });

--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -34,6 +34,11 @@
       "version": "8.10.0-beta.1",
       "description": "Fix rules in `tslint.json`",
       "factory": "./src/migrations/update-8-10-0/fix-tslint-json"
+    },
+    "add-implicit-e2e-deps": {
+      "version": "8.12.0-beta.1",
+      "description": "Add implicit e2e dependencies",
+      "factory": "./src/migrations/update-8-12-0/add-implicit-e2e-deps"
     }
   },
   "packageJsonUpdates": {

--- a/packages/workspace/src/core/project-graph/build-dependencies/implicit-project-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/implicit-project-dependencies.ts
@@ -18,6 +18,8 @@ export function buildImplicitProjectDependencies(
         addDependency(DependencyType.implicit, source, target);
       });
     }
+
+    // TODO(v10): remove this because implicit dependencies are generated now..
     if (source.endsWith('-e2e')) {
       const target = source.replace(/-e2e$/, '');
       // Only add if expected source actually exists, otherwise this will error out.

--- a/packages/workspace/src/migrations/update-8-12-0/add-implicit-e2e-deps.spec.ts
+++ b/packages/workspace/src/migrations/update-8-12-0/add-implicit-e2e-deps.spec.ts
@@ -1,0 +1,44 @@
+import { Tree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '../../utils/testing-utils';
+import { callRule, runMigration } from '../../utils/testing';
+import { readJsonInTree, updateJsonInTree } from '../../utils/ast-utils';
+import { NxJson } from '../../core/shared-interfaces';
+
+describe('Update 8.12.0', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = Tree.empty();
+    tree = createEmptyWorkspace(tree);
+    tree = await callRule(
+      updateJsonInTree<NxJson>('nx.json', json => {
+        json.projects['my-app'] = {
+          tags: []
+        };
+        json.projects['my-app-e2e'] = {
+          tags: []
+        };
+        json.projects['my-non-existent-app-e2e'] = {
+          tags: []
+        };
+        return json;
+      }),
+      tree
+    );
+  });
+
+  it('should add implicit dependencies for e2e projects', async () => {
+    const result = await runMigration('add-implicit-e2e-deps', {}, tree);
+
+    const nxJson = readJsonInTree<NxJson>(result, 'nx.json');
+
+    expect(nxJson.projects['my-app-e2e']).toEqual({
+      tags: [],
+      implicitDependencies: ['my-app']
+    });
+
+    expect(nxJson.projects['my-non-existent-app-e2e']).toEqual({
+      tags: []
+    });
+  });
+});

--- a/packages/workspace/src/migrations/update-8-12-0/add-implicit-e2e-deps.ts
+++ b/packages/workspace/src/migrations/update-8-12-0/add-implicit-e2e-deps.ts
@@ -1,0 +1,34 @@
+import {
+  chain,
+  Rule,
+  SchematicContext,
+  Tree
+} from '@angular-devkit/schematics';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+
+import { updateJsonInTree } from '../../utils/ast-utils';
+import { NxJson } from '../../core/shared-interfaces';
+import { formatFiles } from '@nrwl/workspace/src/utils/rules/format-files';
+
+const addE2eImplicitDependencies = updateJsonInTree<NxJson>('nx.json', json => {
+  Object.keys(json.projects).forEach(proj => {
+    if (proj.endsWith('-e2e') && json.projects[proj.replace(/-e2e$/, '')]) {
+      json.projects[proj].implicitDependencies =
+        json.projects[proj].implicitDependencies || [];
+      json.projects[proj].implicitDependencies.push(proj.replace(/-e2e$/, ''));
+    }
+  });
+  return json;
+});
+
+function showInfo(host: Tree, context: SchematicContext) {
+  context.logger.info(stripIndents`
+    Nx no longer infers implicit dependencies between e2e projects and their source projects based on name.
+    
+    These dependencies have been added to nx.json.
+  `);
+}
+
+export default function(): Rule {
+  return chain([showInfo, addE2eImplicitDependencies, formatFiles()]);
+}


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Nx infers implicit dependencies between e2e projects and their source project.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

E2e projects have implicit dependencies to their source project when being generated.

A migration has been added to add these implicit dependencies to `nx.json`

## Issue
Fixes #1182