### PR TITLE
fix(storybook): add support for .ts extension in storybook webpack configuration template

### DIFF
--- a/packages/storybook/src/schematics/configuration/lib-files/.storybook/webpack.config.js__tmpl__
+++ b/packages/storybook/src/schematics/configuration/lib-files/.storybook/webpack.config.js__tmpl__
@@ -4,6 +4,7 @@ module.exports = async ({ config, mode }) => {
   config = await rootWebpackConfig({ config, mode });
   <% if(uiFramework === '@storybook/react') { %>
   config.resolve.extensions.push('.tsx');
+  config.resolve.extensions.push('.ts');
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
     loader: require.resolve('babel-loader'),


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
Compiling issues, see #2259 

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
can import from `.ts` files in `.stories.tsx`

## Issue
Closes #2259