### PR TITLE
fix(angular): support ng-add with missing e2e, lint, test targets

### DIFF
--- a/packages/workspace/src/schematics/init/init.spec.ts
+++ b/packages/workspace/src/schematics/init/init.spec.ts
@@ -183,4 +183,48 @@ describe('workspace', () => {
     const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
     expect(tree.exists('/apps/myApp/tsconfig.app.json')).toBe(true);
   });
+
+  it('should work with missing e2e, lint, or test targets', async () => {
+    appTree.create('/package.json', JSON.stringify({}));
+    appTree.create(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        defaultProject: 'myApp',
+        projects: {
+          myApp: {
+            root: '',
+            sourceRoot: 'src',
+            architect: {
+              build: {
+                options: {
+                  tsConfig: 'tsconfig.app.json'
+                },
+                configurations: {}
+              }
+            }
+          }
+        }
+      })
+    );
+    appTree.create(
+      '/tsconfig.app.json',
+      '{"extends": "../tsconfig.json", "compilerOptions": {}}'
+    );
+    appTree.create(
+      '/tsconfig.spec.json',
+      '{"extends": "../tsconfig.json", "compilerOptions": {}}'
+    );
+    appTree.create('/tsconfig.json', '{"compilerOptions": {}}');
+    appTree.create('/tslint.json', '{"rules": {}}');
+    appTree.create('/e2e/protractor.conf.js', '// content');
+    appTree.create('/src/app/app.module.ts', '// content');
+    appTree.create('/karma.conf.js', '// content');
+
+    const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
+
+    expect(tree.exists('/apps/myApp/tsconfig.app.json')).toBe(true);
+    expect(tree.exists('/apps/myApp/karma.conf.js')).toBe(true);
+    expect(tree.exists('/karma.conf.js')).toBe(true);
+  });
 });


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

Running `ng add @nrwl/workspace` with missing architect targets for `e2e`, `lint`, or `test` fails.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Running `ng add @nrwl/workspace` with missing architect targets for `e2e`, `lint`, or `test` continues.

## Issue

Closes #2024 
