### PR TITLE
[nextjs] Support loading environment variables from a `environmentFilePath` file

### DIFF
--- a/docs/angular/api-next/builders/dev-server.md
+++ b/docs/angular/api-next/builders/dev-server.md
@@ -26,6 +26,12 @@ Type: `boolean`
 
 Serve the application in the dev mode
 
+### environmentFilePath
+
+Type: `string`
+
+Load environment variables from a file.
+
 ### port
 
 Default: `4200`

--- a/docs/react/api-next/builders/dev-server.md
+++ b/docs/react/api-next/builders/dev-server.md
@@ -27,6 +27,12 @@ Type: `boolean`
 
 Serve the application in the dev mode
 
+### environmentFilePath
+
+Type: `string`
+
+Load environment variables from a file.
+
 ### port
 
 Default: `4200`

--- a/docs/web/api-next/builders/dev-server.md
+++ b/docs/web/api-next/builders/dev-server.md
@@ -27,6 +27,12 @@ Type: `boolean`
 
 Serve the application in the dev mode
 
+### environmentFilePath
+
+Type: `string`
+
+Load environment variables from a file.
+
 ### port
 
 Default: `4200`

--- a/packages/next/src/builders/dev-server/dev-server.impl.ts
+++ b/packages/next/src/builders/dev-server/dev-server.impl.ts
@@ -28,6 +28,7 @@ export interface NextBuildBuilderOptions extends JsonObject {
   quiet: boolean;
   buildTarget: string;
   customServerPath: string;
+  environmentFilePath: string;
 }
 
 export interface NextServerOptions {
@@ -56,6 +57,14 @@ function run(
   options: NextBuildBuilderOptions,
   context: BuilderContext
 ): Observable<BuilderOutput> {
+  if (options.environmentFilePath) {
+    const envFilePath = path.resolve(
+      context.workspaceRoot,
+      options.environmentFilePath
+    );
+    require('dotenv').config({ path: envFilePath });
+  }
+
   const buildTarget = targetFromTargetString(options.buildTarget);
 
   const build$ = !options.dev

--- a/packages/next/src/builders/dev-server/schema.json
+++ b/packages/next/src/builders/dev-server/schema.json
@@ -31,6 +31,11 @@
       "type": "string",
       "description": "Use a custom server script",
       "default": null
+    },
+    "environmentFilePath": {
+      "type": "string",
+      "description": "Load environment variables from a file.",
+      "default": null
     }
   },
   "required": []


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Environment variables are loaded only from a `.env` file in the current working directory.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

An `environmentFilePath` option can be specified, which is a path to a specific environment file. e.g. `apps/myapp/myapp.dev.env`:

```json
"serve": {
  "builder": "@nrwl/next:dev-server",
  "options": {
    "buildTarget": "myapp:build",
    "dev": true,
    "port": 3001,
    "environmentFilePath": "apps/myapp/myapp.dev.env"
  }
}
```

## Issue

Resolves #2199