### PR TITLE
cleanup(repo): re-enable generating playground for all clis

### DIFF
--- a/e2e/create-playground.test.ts
+++ b/e2e/create-playground.test.ts
@@ -1,6 +1,6 @@
 import { ensureProject, forEachCli, newProject, runCLI } from './utils';
 
-forEachCli('angular', () => {
+forEachCli(() => {
   describe('create playground', () => {
     it('create playground', () => {
       newProject();


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

running

```
$ yarn create-playground
```

doesn't create the example workspace using the NX cli anymore. Folders are created, but remain empty.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

As shown in the tutorial video in CONTRIBUTING.md workspaces should be generated for all available CLIs