### PR TITLE
[nextjs] support a custom hostname

### DIFF
--- a/docs/angular/api-next/builders/dev-server.md
+++ b/docs/angular/api-next/builders/dev-server.md
@@ -26,6 +26,12 @@ Type: `boolean`
 
 Serve the application in the dev mode
 
+### hostname
+
+Type: `string`
+
+Hostname on which the application is served.
+
 ### port
 
 Default: `4200`

--- a/docs/react/api-next/builders/dev-server.md
+++ b/docs/react/api-next/builders/dev-server.md
@@ -27,6 +27,12 @@ Type: `boolean`
 
 Serve the application in the dev mode
 
+### hostname
+
+Type: `string`
+
+Hostname on which the application is served.
+
 ### port
 
 Default: `4200`

--- a/docs/web/api-next/builders/dev-server.md
+++ b/docs/web/api-next/builders/dev-server.md
@@ -27,6 +27,12 @@ Type: `boolean`
 
 Serve the application in the dev mode
 
+### hostname
+
+Type: `string`
+
+Hostname on which the application is served.
+
 ### port
 
 Default: `4200`

--- a/packages/next/src/builders/dev-server/schema.json
+++ b/packages/next/src/builders/dev-server/schema.json
@@ -31,6 +31,11 @@
       "type": "string",
       "description": "Use a custom server script",
       "default": null
+    },
+    "hostname": {
+      "type": "string",
+      "description": "Hostname on which the application is served.",
+      "default": null
     }
   },
   "required": []


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

The `baseUrl` is always computed as [`http://localhost:${options.port}`](https://github.com/nrwl/nx/blob/02a5a0ef46fa12e71c84471801ffc8ff1a240b27/packages/next/src/builders/dev-server/dev-server.impl.ts#L101). This means that, when a `@nrwl/cypress:cypress` target launches Cypress, it always opens the application at `http://localhost:${options.port}`. This isn't always desirable because some applications _depend_ on being served on a non-localhost hostname, or on HTTPS, in order to behave properly.

For example, I use a reverse proxy to serve my app on `https://app.example.com`, which forwards traffic to `http://localhost:3001`. I want my Cypress tests to connect to `https://app.example.com`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

A new optional `baseUrl` option is available, which can be used to customize this value. For example:

```json
"serve": {
  "builder": "@nrwl/next:dev-server",
  "options": {
    "buildTarget": "myapp:build",
    "dev": true,
    "port": 3001,
    "baseUrl": "https://app.example.com"
  },
  "configurations": {
    "production": {
      "dev": false
    }
  }
},
```

## Issue

https://github.com/nrwl/nx/issues/2289