### PR TITLE
feat(core): add rule to enforce deps buildable-lib to buildable-lib

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -31,6 +31,7 @@ type Options = [
   {
     allow: string[];
     depConstraints: DepConstraint[];
+    enforceBuildableLibDependency: boolean;
   }
 ];
 export type MessageIds =
@@ -58,6 +59,7 @@ export default createESLintRule<Options, MessageIds>({
       {
         type: 'object',
         properties: {
+          enforceBuildableLibDependency: { type: 'boolean' },
           allow: [{ type: 'string' }],
           depConstraints: [
             {
@@ -88,10 +90,11 @@ export default createESLintRule<Options, MessageIds>({
   defaultOptions: [
     {
       allow: [],
-      depConstraints: []
+      depConstraints: [],
+      enforceBuildableLibDependency: false
     }
   ],
-  create(context, [{ allow, depConstraints }]) {
+  create(context, [{ allow, depConstraints, enforceBuildableLibDependency }]) {
     /**
      * Globally cached info about workspace
      */
@@ -183,6 +186,7 @@ export default createESLintRule<Options, MessageIds>({
 
           // buildable-lib is not allowed to import non-buildable-lib
           if (
+            enforceBuildableLibDependency === true &&
             sourceProject.type === ProjectType.lib &&
             targetProject.type === ProjectType.lib
           ) {

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -943,6 +943,131 @@ describe('Enforce Module Boundaries', () => {
       'Circular dependency between "mylibName" and "badcirclelibName" detected'
     );
   });
+
+  describe('buildable library imports', () => {
+    it('should error when buildable libraries import non-buildable libraries', () => {
+      const failures = runRule(
+        {},
+        `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
+        'import "@mycompany/nonBuildableLib"',
+        {
+          nodes: {
+            buildableLib: {
+              name: 'buildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/buildableLib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {
+                  build: {
+                    // defines a buildable lib
+                    builder: '@angular-devkit/build-ng-packagr:build'
+                  }
+                },
+                files: [createFile(`libs/buildableLib/src/main.ts`)]
+              }
+            },
+            nonBuildableLib: {
+              name: 'nonBuildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/nonBuildableLib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {},
+                files: [createFile(`libs/nonBuildableLib/src/main.ts`)]
+              }
+            }
+          },
+          dependencies: {}
+        }
+      );
+      expect(failures[0].message).toEqual(
+        'Buildable libs cannot import non-buildable libs'
+      );
+    });
+
+    it('should not error when buildable libraries import another buildable libraries', () => {
+      const failures = runRule(
+        {},
+        `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
+        'import "@mycompany/nonBuildableLib"',
+        {
+          nodes: {
+            buildableLib: {
+              name: 'buildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/buildableLib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {
+                  build: {
+                    // defines a buildable lib
+                    builder: '@angular-devkit/build-ng-packagr:build'
+                  }
+                },
+                files: [createFile(`libs/buildableLib/src/main.ts`)]
+              }
+            },
+            nonBuildableLib: {
+              name: 'nonBuildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/nonBuildableLib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {
+                  build: {
+                    // defines a buildable lib
+                    builder: '@angular-devkit/build-ng-packagr:build'
+                  }
+                },
+                files: [createFile(`libs/nonBuildableLib/src/main.ts`)]
+              }
+            }
+          },
+          dependencies: {}
+        }
+      );
+      expect(failures.length).toBe(0);
+    });
+
+    it('should ignore the buildable library verification if no architect is specified', () => {
+      const failures = runRule(
+        {},
+        `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
+        'import "@mycompany/nonBuildableLib"',
+        {
+          nodes: {
+            buildableLib: {
+              name: 'buildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/buildableLib',
+                tags: [],
+                implicitDependencies: [],
+                files: [createFile(`libs/buildableLib/src/main.ts`)]
+              }
+            },
+            nonBuildableLib: {
+              name: 'nonBuildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/nonBuildableLib',
+                tags: [],
+                implicitDependencies: [],
+                files: [createFile(`libs/nonBuildableLib/src/main.ts`)]
+              }
+            }
+          },
+          dependencies: {}
+        }
+      );
+      expect(failures.length).toBe(0);
+    });
+  });
 });
 
 const linter = new TSESLint.Linter();

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -945,9 +945,54 @@ describe('Enforce Module Boundaries', () => {
   });
 
   describe('buildable library imports', () => {
+    it('should ignore the buildable library verification if the enforceBuildableLibDependency is set to false', () => {
+      const failures = runRule(
+        {
+          enforceBuildableLibDependency: false
+        },
+        `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
+        'import "@mycompany/nonBuildableLib"',
+        {
+          nodes: {
+            buildableLib: {
+              name: 'buildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/buildableLib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {
+                  build: {
+                    // defines a buildable lib
+                    builder: '@angular-devkit/build-ng-packagr:build'
+                  }
+                },
+                files: [createFile(`libs/buildableLib/src/main.ts`)]
+              }
+            },
+            nonBuildableLib: {
+              name: 'nonBuildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/nonBuildableLib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {},
+                files: [createFile(`libs/nonBuildableLib/src/main.ts`)]
+              }
+            }
+          },
+          dependencies: {}
+        }
+      );
+      expect(failures.length).toBe(0);
+    });
+
     it('should error when buildable libraries import non-buildable libraries', () => {
       const failures = runRule(
-        {},
+        {
+          enforceBuildableLibDependency: true
+        },
         `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
         'import "@mycompany/nonBuildableLib"',
         {
@@ -990,7 +1035,9 @@ describe('Enforce Module Boundaries', () => {
 
     it('should not error when buildable libraries import another buildable libraries', () => {
       const failures = runRule(
-        {},
+        {
+          enforceBuildableLibDependency: true
+        },
         `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
         'import "@mycompany/nonBuildableLib"',
         {
@@ -1036,7 +1083,9 @@ describe('Enforce Module Boundaries', () => {
 
     it('should ignore the buildable library verification if no architect is specified', () => {
       const failures = runRule(
-        {},
+        {
+          enforceBuildableLibDependency: true
+        },
         `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
         'import "@mycompany/nonBuildableLib"',
         {

--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -42,8 +42,13 @@
     },
     "update-package-json-deps": {
       "version": "8.12.0-beta.1",
-      "description": "Add implicit e2e dependencies",
+      "description": "Update package.json dependencies",
       "factory": "./src/migrations/update-8-12-0/update-package-json-deps"
+    },
+    "update-enforce-boundary-lint-rule": {
+      "version": "8.12.0-beta.1",
+      "description": "Add enforceBuildableLibDependency flag to the nx enforce boundary lint rule",
+      "factory": "./src/migrations/update-8-12-0/update-enforce-boundary-lint-rule"
     }
   },
   "packageJsonUpdates": {

--- a/packages/workspace/src/migrations/update-8-12-0/update-enforce-boundary-lint-rule.spec.ts
+++ b/packages/workspace/src/migrations/update-8-12-0/update-enforce-boundary-lint-rule.spec.ts
@@ -1,0 +1,111 @@
+import { Tree } from '@angular-devkit/schematics';
+import { readJsonInTree } from '../../utils/ast-utils';
+import { serializeJson } from '../../utils/fileutils';
+import { runMigration } from '../../utils/testing';
+import { createEmptyWorkspace } from '../../utils/testing-utils';
+import {
+  _test_addWorkspaceFile,
+  WorkspaceFormat
+} from '@angular-devkit/core/src/workspace/core';
+import { NxJson } from '../../core/shared-interfaces';
+
+describe('Add update-enforce-boundary-lint rule', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = Tree.empty();
+
+    // Not invoking the createEmptyWorkspace(..) here as I want to
+    // customize the linter being used
+    _test_addWorkspaceFile('workspace.json', WorkspaceFormat.JSON);
+
+    tree.create(
+      '/workspace.json',
+      JSON.stringify({ version: 1, projects: {}, newProjectRoot: '' })
+    );
+    tree.create(
+      '/package.json',
+      JSON.stringify({
+        name: 'test-name',
+        dependencies: {},
+        devDependencies: {}
+      })
+    );
+    tree.create(
+      '/nx.json',
+      JSON.stringify(<NxJson>{ npmScope: 'proj', projects: {} })
+    );
+    tree.create(
+      '/tsconfig.json',
+      JSON.stringify({ compilerOptions: { paths: {} } })
+    );
+  });
+
+  describe('when using tslint', () => {
+    beforeEach(() => {
+      tree.create(
+        '/tslint.json',
+        JSON.stringify({
+          rules: {
+            'nx-enforce-module-boundaries': [
+              true,
+              {
+                npmScope: '<%= npmScope %>',
+                lazyLoad: [],
+                allow: []
+              }
+            ]
+          }
+        })
+      );
+    });
+
+    it('should add the proper enforceBuildableLibDependency flag', async () => {
+      const result = await runMigration(
+        'update-enforce-boundary-lint-rule',
+        {},
+        tree
+      );
+
+      const lintContent = readJsonInTree(result, 'tslint.json');
+      expect(
+        lintContent.rules['nx-enforce-module-boundaries'][1]
+          .enforceBuildableLibDependency
+      ).toBeTruthy();
+    });
+  });
+
+  describe('when using eslint', () => {
+    beforeEach(() => {
+      tree.create(
+        '/.eslintrc',
+        JSON.stringify({
+          rules: {
+            '@nrwl/nx/enforce-module-boundaries': [
+              true,
+              {
+                npmScope: '<%= npmScope %>',
+                lazyLoad: [],
+                allow: []
+              }
+            ]
+          }
+        })
+      );
+    });
+
+    it('should add the proper enforceBuildableLibDependency flag', async () => {
+      const result = await runMigration(
+        'update-enforce-boundary-lint-rule',
+        {},
+        tree
+      );
+
+      const lintContent = readJsonInTree(result, '.eslintrc');
+      expect(
+        lintContent.rules['@nrwl/nx/enforce-module-boundaries'][1]
+          .enforceBuildableLibDependency
+      ).toBeTruthy();
+    });
+  });
+});

--- a/packages/workspace/src/migrations/update-8-12-0/update-enforce-boundary-lint-rule.ts
+++ b/packages/workspace/src/migrations/update-8-12-0/update-enforce-boundary-lint-rule.ts
@@ -1,0 +1,41 @@
+import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import { updateJsonInTree } from '../../utils/ast-utils';
+
+export const addEnforceBuildablePackageTslintRule = (host: Tree) => {
+  if (host.exists('tslint.json')) {
+    return updateJsonInTree('tslint.json', json => {
+      const ruleName = 'nx-enforce-module-boundaries';
+      const rule = ruleName in json.rules ? json.rules[ruleName] : null;
+
+      if (Array.isArray(rule) && typeof rule[1] === 'object') {
+        // add flag
+        rule[1].enforceBuildableLibDependency = true;
+      }
+
+      return json;
+    });
+  }
+};
+
+export const addEnforceBuildablePackageEslintRule = (host: Tree) => {
+  if (host.exists('.eslintrc')) {
+    return updateJsonInTree('.eslintrc', json => {
+      const ruleName = '@nrwl/nx/enforce-module-boundaries';
+      const rule = ruleName in json.rules ? json.rules[ruleName] : null;
+
+      if (Array.isArray(rule) && typeof rule[1] === 'object') {
+        // add flag
+        rule[1].enforceBuildableLibDependency = true;
+      }
+
+      return json;
+    });
+  }
+};
+
+export default function(): Rule {
+  return chain([
+    addEnforceBuildablePackageTslintRule,
+    addEnforceBuildablePackageEslintRule
+  ]);
+}

--- a/packages/workspace/src/migrations/update-8-12-0/update-package-json-deps.ts
+++ b/packages/workspace/src/migrations/update-8-12-0/update-package-json-deps.ts
@@ -14,7 +14,7 @@ export default function(): Rule {
       path.join(__dirname, '../../..', 'migrations.json'),
       '8120'
     ),
-    addInstall,
+    // addInstall,
     formatFiles()
   ]);
 }

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -940,6 +940,131 @@ describe('Enforce Module Boundaries', () => {
       'Circular dependency between "mylibName" and "badcirclelibName" detected'
     );
   });
+
+  describe('buildable library imports', () => {
+    it('should error when buildable libraries import non-buildable libraries', () => {
+      const failures = runRule(
+        {},
+        `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
+        'import "@mycompany/nonBuildableLib"',
+        {
+          nodes: {
+            buildableLib: {
+              name: 'buildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/buildableLib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {
+                  build: {
+                    // defines a buildable lib
+                    builder: '@angular-devkit/build-ng-packagr:build'
+                  }
+                },
+                files: [createFile(`libs/buildableLib/src/main.ts`)]
+              }
+            },
+            nonBuildableLib: {
+              name: 'nonBuildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/nonBuildableLib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {},
+                files: [createFile(`libs/nonBuildableLib/src/main.ts`)]
+              }
+            }
+          },
+          dependencies: {}
+        }
+      );
+      expect(failures[0].getFailure()).toEqual(
+        'buildable libs cannot import non-buildable libs'
+      );
+    });
+
+    it('should not error when buildable libraries import another buildable libraries', () => {
+      const failures = runRule(
+        {},
+        `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
+        'import "@mycompany/nonBuildableLib"',
+        {
+          nodes: {
+            buildableLib: {
+              name: 'buildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/buildableLib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {
+                  build: {
+                    // defines a buildable lib
+                    builder: '@angular-devkit/build-ng-packagr:build'
+                  }
+                },
+                files: [createFile(`libs/buildableLib/src/main.ts`)]
+              }
+            },
+            nonBuildableLib: {
+              name: 'nonBuildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/nonBuildableLib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {
+                  build: {
+                    // defines a buildable lib
+                    builder: '@angular-devkit/build-ng-packagr:build'
+                  }
+                },
+                files: [createFile(`libs/nonBuildableLib/src/main.ts`)]
+              }
+            }
+          },
+          dependencies: {}
+        }
+      );
+      expect(failures.length).toBe(0);
+    });
+
+    it('should ignore the buildable library verification if no architect is specified', () => {
+      const failures = runRule(
+        {},
+        `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
+        'import "@mycompany/nonBuildableLib"',
+        {
+          nodes: {
+            buildableLib: {
+              name: 'buildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/buildableLib',
+                tags: [],
+                implicitDependencies: [],
+                files: [createFile(`libs/buildableLib/src/main.ts`)]
+              }
+            },
+            nonBuildableLib: {
+              name: 'nonBuildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/nonBuildableLib',
+                tags: [],
+                implicitDependencies: [],
+                files: [createFile(`libs/nonBuildableLib/src/main.ts`)]
+              }
+            }
+          },
+          dependencies: {}
+        }
+      );
+      expect(failures.length).toBe(0);
+    });
+  });
 });
 
 function createFile(f) {

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -942,9 +942,54 @@ describe('Enforce Module Boundaries', () => {
   });
 
   describe('buildable library imports', () => {
+    it('should ignore the buildable library verification if the enforceBuildableLibDependency is set to false', () => {
+      const failures = runRule(
+        {
+          enforceBuildableLibDependency: false
+        },
+        `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
+        'import "@mycompany/nonBuildableLib"',
+        {
+          nodes: {
+            buildableLib: {
+              name: 'buildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/buildableLib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {
+                  build: {
+                    // defines a buildable lib
+                    builder: '@angular-devkit/build-ng-packagr:build'
+                  }
+                },
+                files: [createFile(`libs/buildableLib/src/main.ts`)]
+              }
+            },
+            nonBuildableLib: {
+              name: 'nonBuildableLib',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/nonBuildableLib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {},
+                files: [createFile(`libs/nonBuildableLib/src/main.ts`)]
+              }
+            }
+          },
+          dependencies: {}
+        }
+      );
+      expect(failures.length).toBe(0);
+    });
+
     it('should error when buildable libraries import non-buildable libraries', () => {
       const failures = runRule(
-        {},
+        {
+          enforceBuildableLibDependency: true
+        },
         `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
         'import "@mycompany/nonBuildableLib"',
         {
@@ -987,7 +1032,9 @@ describe('Enforce Module Boundaries', () => {
 
     it('should not error when buildable libraries import another buildable libraries', () => {
       const failures = runRule(
-        {},
+        {
+          enforceBuildableLibDependency: true
+        },
         `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
         'import "@mycompany/nonBuildableLib"',
         {
@@ -1008,11 +1055,11 @@ describe('Enforce Module Boundaries', () => {
                 files: [createFile(`libs/buildableLib/src/main.ts`)]
               }
             },
-            nonBuildableLib: {
-              name: 'nonBuildableLib',
+            anotherBuildableLib: {
+              name: 'anotherBuildableLib',
               type: ProjectType.lib,
               data: {
-                root: 'libs/nonBuildableLib',
+                root: 'libs/anotherBuildableLib',
                 tags: [],
                 implicitDependencies: [],
                 architect: {
@@ -1021,7 +1068,7 @@ describe('Enforce Module Boundaries', () => {
                     builder: '@angular-devkit/build-ng-packagr:build'
                   }
                 },
-                files: [createFile(`libs/nonBuildableLib/src/main.ts`)]
+                files: [createFile(`libs/anotherBuildableLib/src/main.ts`)]
               }
             }
           },
@@ -1033,7 +1080,9 @@ describe('Enforce Module Boundaries', () => {
 
     it('should ignore the buildable library verification if no architect is specified', () => {
       const failures = runRule(
-        {},
+        {
+          enforceBuildableLibDependency: true
+        },
         `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
         'import "@mycompany/nonBuildableLib"',
         {

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -70,6 +70,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
   private readonly allow: string[];
+  private readonly enforceBuildableLibDependency: boolean = false; // for backwards compat
   private readonly depConstraints: DepConstraint[];
 
   constructor(
@@ -88,6 +89,9 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
     this.depConstraints = Array.isArray(this.getOptions()[0].depConstraints)
       ? this.getOptions()[0].depConstraints
       : [];
+
+    this.enforceBuildableLibDependency =
+      this.getOptions()[0].enforceBuildableLibDependency === true;
   }
 
   public visitImportDeclaration(node: ts.ImportDeclaration) {
@@ -177,6 +181,7 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
 
       // buildable-lib is not allowed to import non-buildable-lib
       if (
+        this.enforceBuildableLibDependency === true &&
         sourceProject.type === ProjectType.lib &&
         targetProject.type === ProjectType.lib
       ) {

--- a/packages/workspace/src/utils/lint.ts
+++ b/packages/workspace/src/utils/lint.ts
@@ -187,6 +187,7 @@ const globalTsLint = `
     "nx-enforce-module-boundaries": [
       true,
       {
+        "enforceBuildableLibDependency": true,
         "allow": [],
         "depConstraints": [
           { "sourceTag": "*", "onlyDependOnLibsWithTags": ["*"] }
@@ -221,6 +222,7 @@ const globalESLint = `
     "@nrwl/nx/enforce-module-boundaries": [
       "error",
       {
+        "enforceBuildableLibDependency": true,
         "allow": [],
         "depConstraints": [
           { "sourceTag": "*", "onlyDependOnLibsWithTags": ["*"] }

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -212,3 +212,18 @@ export function onlyLoadChildren(
 export function getSourceFilePath(sourceFileName: string, projectPath: string) {
   return normalize(sourceFileName).substring(projectPath.length + 1);
 }
+
+/**
+ * Verifies whether the given node has an architect builder attached
+ * @param projectGraph the node to verify
+ */
+export function hasArchitectBuildBuilder(
+  projectGraph: ProjectGraphNode
+): boolean {
+  return (
+    // can the architect not be defined? real use case?
+    projectGraph.data.architect &&
+    projectGraph.data.architect.build &&
+    projectGraph.data.architect.build.builder !== ''
+  );
+}


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Right now buildable (or publishable) can depend on non-buildable ones which is sub-optimal. The problem with depending on non-buildable libraries basically means "embedding" the src of the non-buildable lib into the buildable library, something which right now is not possible and could lead to confusion as well. Apart from that, it could also potentially mean to include the same non-buildable library multiple times in the case when it is being consumed by multiple buildable-libraries.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

This PR adds another check to the enforce boundary rule to not allow imports of non-buildable libs.
