### PR TITLE
feat(angular): library builder to handle buildable libraries with deps

### DIFF
--- a/docs/angular/api-angular/builders/package.md
+++ b/docs/angular/api-angular/builders/package.md
@@ -1,0 +1,27 @@
+# package
+
+Build an Angular library
+
+Builder properties can be configured in angular.json when defining the builder, or when invoking it.
+
+## Properties
+
+### project
+
+Type: `string`
+
+The file path for the ng-packagr configuration file, relative to the current workspace.
+
+### tsConfig
+
+Type: `string`
+
+The full path for the TypeScript configuration file, relative to the current workspace.
+
+### watch
+
+Default: `false`
+
+Type: `boolean`
+
+Run build when files change.

--- a/docs/angular/builders.json
+++ b/docs/angular/builders.json
@@ -1,4 +1,5 @@
 [
+  "angular",
   "cypress",
   "express",
   "jest",

--- a/docs/react/api-angular/builders/package.md
+++ b/docs/react/api-angular/builders/package.md
@@ -1,0 +1,28 @@
+# package
+
+Build an Angular library
+
+Builder properties can be configured in workspace.json when defining the builder, or when invoking it.
+Read more about how to use builders and the CLI here: https://nx.dev/react/guides/cli.
+
+## Properties
+
+### project
+
+Type: `string`
+
+The file path for the ng-packagr configuration file, relative to the current workspace.
+
+### tsConfig
+
+Type: `string`
+
+The full path for the TypeScript configuration file, relative to the current workspace.
+
+### watch
+
+Default: `false`
+
+Type: `boolean`
+
+Run build when files change.

--- a/docs/react/builders.json
+++ b/docs/react/builders.json
@@ -1,4 +1,5 @@
 [
+  "angular",
   "cypress",
   "express",
   "jest",

--- a/docs/web/api-angular/builders/package.md
+++ b/docs/web/api-angular/builders/package.md
@@ -1,0 +1,28 @@
+# package
+
+Build an Angular library
+
+Builder properties can be configured in workspace.json when defining the builder, or when invoking it.
+Read more about how to use builders and the CLI here: https://nx.dev/web/guides/cli.
+
+## Properties
+
+### project
+
+Type: `string`
+
+The file path for the ng-packagr configuration file, relative to the current workspace.
+
+### tsConfig
+
+Type: `string`
+
+The full path for the TypeScript configuration file, relative to the current workspace.
+
+### watch
+
+Default: `false`
+
+Type: `boolean`
+
+Run build when files change.

--- a/docs/web/builders.json
+++ b/docs/web/builders.json
@@ -1,4 +1,5 @@
 [
+  "angular",
   "cypress",
   "express",
   "jest",

--- a/e2e/angular-package.test.ts
+++ b/e2e/angular-package.test.ts
@@ -1,0 +1,117 @@
+import { toClassName } from '@nrwl/workspace';
+import {
+  ensureProject,
+  forEachCli,
+  readJson,
+  runCLI,
+  uniq,
+  updateFile
+} from './utils';
+
+forEachCli('angular', cli => {
+  describe('Build Angular library', () => {
+    /**
+     * Graph:
+     *
+     *                 childLib
+     *               /
+     * parentLib =>
+     *               \
+     *                \
+     *                 childLib2
+     *
+     */
+    let parentLib: string;
+    let childLib: string;
+    let childLib2: string;
+
+    beforeEach(() => {
+      parentLib = uniq('parentlib');
+      childLib = uniq('childlib');
+      childLib2 = uniq('childlib2');
+
+      ensureProject();
+
+      runCLI(
+        `generate @nrwl/angular:library ${parentLib} --publishable=true --no-interactive`
+      );
+      runCLI(
+        `generate @nrwl/angular:library ${childLib} --publishable=true --no-interactive`
+      );
+      runCLI(
+        `generate @nrwl/angular:library ${childLib2} --publishable=true --no-interactive`
+      );
+
+      // create dependencies by importing
+      const createDep = (parent, children: string[]) => {
+        updateFile(
+          `libs/${parent}/src/lib/${parent}.module.ts`,
+          `
+              import { NgModule } from '@angular/core';
+              import { CommonModule } from '@angular/common';
+              ${children
+                .map(
+                  entry =>
+                    `import { ${toClassName(
+                      entry
+                    )}Module } from '@proj/${entry}';`
+                )
+                .join('\n')}
+              
+              @NgModule({
+                imports: [CommonModule, ${children
+                  .map(entry => `${toClassName(entry)}Module`)
+                  .join(',')}]
+              })
+              export class ${toClassName(parent)}Module {}          
+            `
+        );
+      };
+      debugger;
+
+      createDep(parentLib, [childLib, childLib2]);
+    });
+
+    it('should throw an error if the dependent library has not been built before building the parent lib', () => {
+      expect.assertions(2);
+
+      try {
+        runCLI(`build ${parentLib}`);
+      } catch (e) {
+        expect(e.stderr.toString()).toContain(
+          `Some of the library ${parentLib}'s dependencies have not been built yet. Please build these libraries before:`
+        );
+        expect(e.stderr.toString()).toContain(`${childLib}`);
+      }
+    });
+
+    it('should build the library when it does not have any deps', () => {
+      const parentLibOutput = runCLI(`build ${childLib}`);
+      expect(parentLibOutput).toContain(`Built @proj/${childLib}`);
+    });
+
+    it('should properly add references to any dependency into the parent package.json', () => {
+      const childLibOutput = runCLI(`build ${childLib}`);
+      const childLib2Output = runCLI(`build ${childLib2}`);
+      const parentLibOutput = runCLI(`build ${parentLib}`);
+
+      expect(childLibOutput).toContain(`Built @proj/${childLib}`);
+      expect(childLib2Output).toContain(`Built @proj/${childLib2}`);
+      expect(parentLibOutput).toContain(`Built @proj/${parentLib}`);
+
+      // assert package.json deps have been set
+      const assertPackageJson = (
+        parent: string,
+        lib: string,
+        version: string
+      ) => {
+        const jsonFile = readJson(`dist/libs/${parent}/package.json`);
+        const childDependencyVersion = jsonFile.dependencies[`@proj/${lib}`];
+        expect(childDependencyVersion).toBe(version);
+      };
+
+      assertPackageJson(parentLib, childLib, '0.0.1');
+      assertPackageJson(parentLib, childLib2, '0.0.1');
+    });
+  });
+});

--- a/packages/angular/builders.json
+++ b/packages/angular/builders.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "@angular-devkit/architect/src/builders-schema.json",
+  "builders": {
+    "package": {
+      "implementation": "./src/builders/package/package.impl",
+      "schema": "./src/builders/package/schema.json",
+      "description": "Build an Angular library"
+    }
+  }
+}

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -9,6 +9,11 @@
       "version": "8.5.0-beta.1",
       "description": "Upgrades Angular CLI to 8.3.0 and NgRx dependencies to version 8.2",
       "factory": "./src/migrations/update-8-5-0/upgrade-cli-8-3"
+    },
+    "change-angular-lib-builder": {
+      "version": "8.12.0-beta.1",
+      "description": "Changes Angular library builder to @nrwl/angular:package",
+      "factory": "./src/migrations/update-8-12-0/change-angular-lib-builder"
     }
   }
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -26,6 +26,7 @@
     "url": "https://github.com/nrwl/nx/issues"
   },
   "homepage": "https://nx.dev",
+  "builders": "./builders.json",
   "schematics": "./collection.json",
   "ng-update": {
     "requirements": {},

--- a/packages/angular/src/builders/package/package.impl.spec.ts
+++ b/packages/angular/src/builders/package/package.impl.spec.ts
@@ -1,0 +1,172 @@
+import { JsonObject } from '@angular-devkit/core';
+import { MockBuilderContext } from '@nrwl/workspace/testing';
+import { BuildAngularLibraryBuilderOptions, run } from './package.impl';
+import { getMockContext } from '../../utils/testing';
+import * as projectGraphUtils from '@nrwl/workspace/src/core/project-graph';
+import * as workspaceUtils from '@nrwl/workspace';
+import {
+  ProjectGraph,
+  ProjectType
+} from '@nrwl/workspace/src/core/project-graph';
+import * as fileUtils from '@nrwl/workspace/src/utils/fileutils';
+
+jest.mock('ng-packagr');
+import * as ngPackagrImport from 'ng-packagr';
+import * as ng from '@angular/compiler-cli';
+import { NgPackagr } from 'ng-packagr';
+
+class NgPackagrMock extends NgPackagr {
+  constructor() {
+    super(null);
+  }
+}
+
+describe('AngularLibraryWebBuildBuilder', () => {
+  let context: MockBuilderContext;
+  let testOptions: BuildAngularLibraryBuilderOptions & JsonObject;
+  let ngPackagrMock;
+
+  beforeEach(async () => {
+    context = await getMockContext();
+
+    // NgPackagr has some weird fluent API. I wonder whether
+    // I could simplify this mock
+    ngPackagrMock = new NgPackagrMock();
+    spyOn(ngPackagrMock, 'build').and.callFake(() => {
+      return Promise.resolve();
+    });
+    spyOn(ngPackagrMock, 'forProject').and.callThrough();
+    spyOn(ngPackagrMock, 'withTsConfig').and.callThrough();
+
+    spyOn(ngPackagrImport, 'ngPackagr').and.callFake(() => {
+      return ngPackagrMock;
+    });
+
+    // used for updating the json files
+    spyOn(fileUtils, 'writeJsonFile');
+    // parent tsconfig
+    spyOn(ng, 'readConfiguration').and.callFake(() => {
+      return {
+        options: {
+          paths: {
+            '@proj/buildable-child': []
+          }
+        }
+      };
+    });
+    spyOn(fileUtils, 'fileExists').and.returnValue(true);
+
+    context.target = {
+      project: 'buildable-parent',
+      target: null
+    };
+
+    testOptions = {
+      tsConfig: 'libs/publishable-parent/tsconfig.lib.json',
+      project: 'libs/publishable-parent/ng-package.json'
+    };
+  });
+
+  it('should invoke ng-packagr for a libary without any dependencies', async () => {
+    spyOn(projectGraphUtils, 'createProjectGraph').and.callFake(() => {
+      return {
+        nodes: {
+          'buildable-parent': {
+            type: ProjectType.lib,
+            name: 'buildable-parent',
+            data: { files: [], root: 'libs/buildable-parent' }
+          }
+        },
+        dependencies: {}
+      } as ProjectGraph;
+    });
+
+    // act
+    const result = await run(testOptions, context).toPromise();
+
+    expect(result.success).toBeTruthy();
+    expect(ngPackagrMock.build).toHaveBeenCalled();
+  });
+
+  describe('with dependent libraries', () => {
+    beforeEach(() => {
+      // create project graph with dependencies
+      spyOn(projectGraphUtils, 'createProjectGraph').and.callFake(() => {
+        return {
+          nodes: {
+            'buildable-parent': {
+              type: ProjectType.lib,
+              name: 'buildable-parent',
+              data: { files: [], root: 'libs/buildable-parent' }
+            },
+            'buildable-child': {
+              type: ProjectType.lib,
+              name: 'buildable-child',
+              data: {
+                files: [],
+                root: 'libs/buildable-child',
+                prefix: 'proj',
+                architect: {
+                  build: {
+                    builder: 'any builder'
+                  }
+                }
+              }
+            }
+          },
+          dependencies: {
+            'buildable-parent': [
+              {
+                type: ProjectType.lib,
+                target: 'buildable-child',
+                source: null
+              }
+            ],
+            'buildable-child': []
+          }
+        } as ProjectGraph;
+      });
+    });
+
+    it('should properly set the TSConfig paths', async () => {
+      spyOn(workspaceUtils, 'readJsonFile').and.returnValue({
+        name: '@proj/buildable-child',
+        version: '1.2.3'
+      });
+
+      // act
+      const result = await run(testOptions, context).toPromise();
+
+      // assert
+      expect(result.success).toBeTruthy();
+      expect(ngPackagrMock.withTsConfig).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          options: {
+            paths: { '@proj/buildable-child': ['dist/libs/buildable-child'] }
+          }
+        })
+      );
+    });
+
+    it('should update the package.json', async () => {
+      spyOn(workspaceUtils, 'readJsonFile').and.returnValue({
+        name: '@proj/buildable-child',
+        version: '1.2.3'
+      });
+
+      // act
+      const result = await run(testOptions, context).toPromise();
+
+      // assert
+      expect(result.success).toBeTruthy();
+      expect(fileUtils.writeJsonFile).toHaveBeenCalledWith(
+        'dist/libs/buildable-parent/package.json',
+        jasmine.objectContaining({
+          dependencies: {
+            '@proj/buildable-child': '1.2.3'
+          }
+        })
+      );
+    });
+  });
+});

--- a/packages/angular/src/builders/package/package.impl.ts
+++ b/packages/angular/src/builders/package/package.impl.ts
@@ -1,0 +1,218 @@
+import {
+  BuilderContext,
+  BuilderOutput,
+  createBuilder
+} from '@angular-devkit/architect';
+import { JsonObject } from '@angular-devkit/core';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+import * as ng from '@angular/compiler-cli';
+import { readJsonFile } from '@nrwl/workspace';
+import {
+  createProjectGraph,
+  ProjectGraphNode,
+  ProjectType
+} from '@nrwl/workspace/src/core/project-graph';
+import { fileExists, writeJsonFile } from '@nrwl/workspace/src/utils/fileutils';
+import { join, resolve } from 'path';
+import { from, Observable, of } from 'rxjs';
+import { map, mapTo, switchMap, tap } from 'rxjs/operators';
+
+export interface BuildAngularLibraryBuilderOptions {
+  /**
+   * The file path for the ng-packagr configuration file, relative to the current workspace.
+   */
+  project: string;
+  /**
+   * The full path for the TypeScript configuration file, relative to the current workspace.
+   */
+  tsConfig?: string;
+  /**
+   * Run build when files change.
+   */
+  watch?: boolean;
+}
+
+type DependentLibraryNode = {
+  scope: string;
+  outputPath: string;
+  node: ProjectGraphNode;
+};
+
+/**
+ * It is a prerequisite that dependent libraries have been built before the parent
+ * library. This function checks that
+ * @param context
+ */
+function checkDependentLibrariesHaveBeenBuilt(
+  context: BuilderContext,
+  projectDependencies: DependentLibraryNode[]
+) {
+  const depLibsToBuildFirst: DependentLibraryNode[] = [];
+
+  // verify whether all dependent libraries have been built
+  projectDependencies.forEach(libDep => {
+    // check wether dependent library has been built => that's necessary
+    const packageJsonPath = join(
+      context.workspaceRoot,
+      'dist',
+      libDep.node.data.root,
+      'package.json'
+    );
+
+    if (!fileExists(packageJsonPath)) {
+      depLibsToBuildFirst.push(libDep);
+    }
+  });
+
+  if (depLibsToBuildFirst.length > 0) {
+    context.logger.error(stripIndents`
+      Some of the library ${
+        context.target.project
+      }'s dependencies have not been built yet. Please build these libraries before:
+      ${depLibsToBuildFirst.map(x => ` - ${x.node.name}`).join('\n')}
+
+      Try: nx run-many --target build --projects ${context.target.project},...
+    `);
+
+    return { success: false };
+  } else {
+    return { success: true };
+  }
+}
+
+async function initializeNgPackagr(
+  options: BuildAngularLibraryBuilderOptions & JsonObject,
+  context: BuilderContext,
+  projectDependencies: DependentLibraryNode[]
+): Promise<import('ng-packagr').NgPackagr> {
+  const packager = (await import('ng-packagr')).ngPackagr();
+  packager.forProject(resolve(context.workspaceRoot, options.project));
+
+  if (options.tsConfig) {
+    // read the tsconfig and modify its path in memory to
+    // pass it on to ngpackagr
+    const parsedTSConfig = ng.readConfiguration(options.tsConfig);
+
+    // update the tsconfig.lib.json => we only do this in memory
+    // and pass it along to ng-packagr
+    projectDependencies.forEach(libDep => {
+      parsedTSConfig.options.paths[libDep.scope] = [
+        libDep.outputPath,
+        ...parsedTSConfig.options.paths[libDep.scope]
+      ];
+    });
+
+    packager.withTsConfig(parsedTSConfig);
+  }
+
+  return packager;
+}
+
+/**
+ * Given a target library, uses the project dep graph to find all its dependencies
+ * and calculates the `scope` name and output path
+ * @param targetProj the target library to build
+ */
+export function calculateLibraryDependencies(
+  context: BuilderContext
+): DependentLibraryNode[] {
+  const targetProj = context.target.project;
+  const projGraph = createProjectGraph();
+
+  const hasArchitectBuildBuilder = (projectGraph: ProjectGraphNode): boolean =>
+    projectGraph.data.architect &&
+    projectGraph.data.architect.build &&
+    projectGraph.data.architect.build.builder !== '';
+
+  // gather the library dependencies
+  return (projGraph.dependencies[targetProj] || [])
+    .map(dependency => {
+      const depNode = projGraph.nodes[dependency.target];
+
+      if (
+        depNode.type === ProjectType.lib &&
+        hasArchitectBuildBuilder(depNode)
+      ) {
+        const libPackageJson = readJsonFile(
+          join(context.workspaceRoot, depNode.data.root, 'package.json')
+        );
+
+        return {
+          scope: libPackageJson.name, // i.e. @wrkspace/mylib
+          outputPath: `dist/${depNode.data.root}`,
+          node: depNode
+        };
+      } else {
+        return null;
+      }
+    })
+    .filter(x => !!x);
+}
+
+/**
+ * Updates the peerDependencies section in the `dist/lib/xyz/package.json` with
+ * the proper dependency and version
+ */
+function updatePackageJsonDependencies(
+  context: BuilderContext,
+  libDependencies: DependentLibraryNode[]
+) {
+  const targetProject = context.target.project;
+
+  const projGraph = createProjectGraph();
+  const targetProjNode = projGraph.nodes[targetProject];
+
+  let distLibOutputPath = `dist/${targetProjNode.data.root}`;
+
+  // if we have dependencies, update the `dependencies` section of the package.json
+  const jsonOutputFile = `${distLibOutputPath}/package.json`;
+  if (libDependencies && libDependencies.length > 0) {
+    const outputJson = readJsonFile(jsonOutputFile);
+
+    outputJson.dependencies = outputJson.dependencies || {};
+
+    libDependencies.forEach(entry => {
+      if (!outputJson.dependencies[entry.scope]) {
+        // read the lib version (should we read the one from the dist?)
+        const packageJsonPath = join(
+          context.workspaceRoot,
+          entry.node.data.root,
+          'package.json'
+        );
+        const depNodePackageJson = readJsonFile(packageJsonPath);
+
+        outputJson.dependencies[entry.scope] = depNodePackageJson.version;
+      }
+    });
+
+    writeJsonFile(jsonOutputFile, outputJson);
+  }
+}
+
+export function run(
+  options: BuildAngularLibraryBuilderOptions & JsonObject,
+  context: BuilderContext
+): Observable<BuilderOutput> {
+  const dependencies = calculateLibraryDependencies(context);
+
+  return of(checkDependentLibrariesHaveBeenBuilt(context, dependencies)).pipe(
+    switchMap(result => {
+      if (result.success) {
+        return from(initializeNgPackagr(options, context, dependencies)).pipe(
+          switchMap(packager =>
+            options.watch ? packager.watch() : packager.build()
+          ),
+          tap(() => {
+            updatePackageJsonDependencies(context, dependencies);
+          }),
+          mapTo({ success: true })
+        );
+      } else {
+        // just pass on the result
+        return of(result);
+      }
+    })
+  );
+}
+
+export default createBuilder<Record<string, string> & any>(run);

--- a/packages/angular/src/builders/package/schema.json
+++ b/packages/angular/src/builders/package/schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "ng-packagr Target",
+  "description": "ng-packagr target options for Build Architect. Use to build library projects.",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The file path for the ng-packagr configuration file, relative to the current workspace."
+    },
+    "tsConfig": {
+      "type": "string",
+      "description": "The full path for the TypeScript configuration file, relative to the current workspace."
+    },
+    "watch": {
+      "type": "boolean",
+      "description": "Run build when files change.",
+      "default": false
+    }
+  },
+  "additionalProperties": false,
+  "required": ["project"]
+}

--- a/packages/angular/src/migrations/update-8-12-0/change-angular-lib-builder.spec.ts
+++ b/packages/angular/src/migrations/update-8-12-0/change-angular-lib-builder.spec.ts
@@ -1,0 +1,68 @@
+import { Tree } from '@angular-devkit/schematics';
+import { readWorkspace } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { runMigration } from '@nrwl/workspace/src/utils/testing';
+import {
+  SchematicTestRunner,
+  UnitTestTree
+} from '@angular-devkit/schematics/testing';
+import { join } from 'path';
+
+describe('Update Angular library builder', () => {
+  let tree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(async () => {
+    tree = new UnitTestTree(Tree.empty());
+
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/workspace',
+      join(__dirname, '../../../migrations.json')
+    );
+  });
+
+  it('should overwrite the usual builder with @nrwl/angular:package', async () => {
+    tree.create(
+      'workspace.json',
+      JSON.stringify({
+        projects: {
+          ['buildable-lib']: {
+            projectType: 'library',
+            architect: {
+              build: {
+                builder: '@angular-devkit/build-ng-packagr:build'
+              }
+            }
+          },
+          ['anotherbuildable-lib']: {
+            projectType: 'library',
+            architect: {
+              build: {
+                builder: '@angular-devkit/build-ng-packagr:build'
+              }
+            }
+          },
+          ['nonbuildable-lib']: {
+            projectType: 'library',
+            architect: {}
+          }
+        }
+      })
+    );
+
+    await schematicRunner
+      .runSchematicAsync('change-angular-lib-builder', {}, tree)
+      .toPromise();
+
+    const config = readWorkspace(tree);
+    expect(config.projects['buildable-lib'].architect.build.builder).toBe(
+      '@nrwl/angular:package'
+    );
+    expect(
+      config.projects['anotherbuildable-lib'].architect.build.builder
+    ).toBe('@nrwl/angular:package');
+    expect(
+      config.projects['nonbuildable-lib'].architect.build
+    ).not.toBeDefined();
+  });
+});

--- a/packages/angular/src/migrations/update-8-12-0/change-angular-lib-builder.ts
+++ b/packages/angular/src/migrations/update-8-12-0/change-angular-lib-builder.ts
@@ -1,0 +1,30 @@
+import {
+  chain,
+  Rule,
+  SchematicContext,
+  Tree
+} from '@angular-devkit/schematics';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+import { formatFiles } from '@nrwl/workspace/src/utils/rules/format-files';
+import { readWorkspaceJson, updateWorkspaceInTree } from '@nrwl/workspace';
+
+export default function(): Rule {
+  return chain([
+    updateWorkspaceInTree(config => {
+      Object.keys(config.projects).forEach(name => {
+        if (
+          config.projects[name].architect &&
+          config.projects[name].architect.build &&
+          config.projects[name].architect.build.builder ===
+            '@angular-devkit/build-ng-packagr:build'
+        ) {
+          config.projects[name].architect.build.builder =
+            '@nrwl/angular:package';
+        }
+      });
+      return config;
+    }),
+    ,
+    formatFiles()
+  ]);
+}

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -340,6 +340,9 @@ function updateProject(options: NormalizedSchema): Rule {
 
         if (!options.publishable) {
           delete fixedProject.architect.build;
+        } else {
+          // adjust the builder path to our custom one
+          fixedProject.architect.build.builder = '@nrwl/angular:package';
         }
 
         delete fixedProject.architect.test;

--- a/packages/angular/src/utils/testing.ts
+++ b/packages/angular/src/utils/testing.ts
@@ -2,7 +2,13 @@ import { join } from 'path';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import { Tree, Rule, externalSchematic } from '@angular-devkit/schematics';
 import { names, toFileName } from '@nrwl/workspace/src/utils/name-utils';
-import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import {
+  createEmptyWorkspace,
+  MockBuilderContext
+} from '@nrwl/workspace/testing';
+import { TestingArchitectHost } from '@angular-devkit/architect/testing';
+import { schema } from '@angular-devkit/core';
+import { Architect } from '@angular-devkit/architect';
 
 const testRunner = new SchematicTestRunner(
   '@nrwl/angular',
@@ -165,4 +171,24 @@ export function createLib(tree: Tree, libName: string): Tree {
   `
   );
   return tree;
+}
+
+export async function getTestArchitect() {
+  const architectHost = new TestingArchitectHost('/root', '/root');
+  const registry = new schema.CoreSchemaRegistry();
+  registry.addPostTransform(schema.transforms.addUndefinedDefaults);
+
+  const architect = new Architect(architectHost, registry);
+
+  await architectHost.addBuilderFromPackage(join(__dirname, '../..'));
+
+  return [architect, architectHost] as [Architect, TestingArchitectHost];
+}
+
+export async function getMockContext() {
+  const [architect, architectHost] = await getTestArchitect();
+
+  const context = new MockBuilderContext(architect, architectHost);
+  await context.addBuilderFromPackage(join(__dirname, '../..'));
+  return context;
 }


### PR DESCRIPTION
Adds a new builder `@nrwl/angular:library-build`.

 that makes sure using building buildable (aka publishable) libraries depending on other buildable libraries work as expected, without limiting the current dx with auto-reload when using libraries within apps.

## Current Behavior (This is the behavior we have today, before the PR is merged)

Right now when one buildable (aka) publishable library imports another buildable library, one has to manually fix the `tsconfig` and adjust the `paths` s.t. they point to the `dist` of the depending buildable library. Otherwise the build fails.

That cannot be done statically however, because otherwise running `yarn start` and importing a library in an application won't work (in watch mode). Rather one would have to either rebuild the library manually after each change or run the library with `--watch` independently.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

This PR introduces a new Angular library builder `@nrwl/angular:library-build` with the following features:

- uses Nx dependency graph to determine dependencies & automatically updates the `tsconfig.json` paths and adds the dependent library to the parent's `package.json` file.
- human friendly error message when a dependent library has not been built before

## For the Reviewer

Generate an angular workspace with the following library graph:

```
                           
                childLib
              /             
parentLib =>     
              \             
               \            
                childLib2
```

The e2e test `angular-package.test.ts` runs through the main test cases.