### PR TITLE
fix(core): handle removed npm package for affected logic

### DIFF
--- a/packages/workspace/src/core/affected-project-graph/locators/npm-packages.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/npm-packages.spec.ts
@@ -3,7 +3,7 @@ import { NxJson } from '../../shared-interfaces';
 import { WholeFileChange } from '../..//file-utils';
 import { DiffType } from '../../../utils/json-diff';
 
-describe('getImplicitlyTouchedProjectsByJsonChanges', () => {
+describe('getTouchedNpmPackages', () => {
   let workspaceJson;
   let nxJson: NxJson<string[]>;
   beforeEach(() => {
@@ -44,6 +44,15 @@ describe('getImplicitlyTouchedProjectsByJsonChanges', () => {
               value: {
                 lhs: '0.0.1',
                 rhs: '0.0.2'
+              }
+            },
+            // If it's deleted then it should not exist in project graph.
+            {
+              type: DiffType.Deleted,
+              path: ['dependencies', 'sad-nrwl'],
+              value: {
+                lhs: '0.0.1',
+                rhs: undefined
               }
             }
           ]

--- a/packages/workspace/src/core/affected-project-graph/locators/npm-packages.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/npm-packages.ts
@@ -12,7 +12,8 @@ export const getTouchedNpmPackages: TouchedProjectLocator<
     changes.forEach(c => {
       if (
         isJsonChange(c) &&
-        (c.path[0] === 'dependencies' || c.path[0] === 'devDependencies')
+        (c.path[0] === 'dependencies' || c.path[0] === 'devDependencies') &&
+        c.value.rhs // If rhs is blank then dep was deleted and does not exist in project graph
       ) {
         touched.push(c.path[1]);
       } else if (isWholeFileChange(c)) {


### PR DESCRIPTION
**This PR fixes the error when an npm package is removed from 'package.json' in a feature branch.

There are additional considerations though. For example, if I don't touch my project source, but I delete a dependency from `package.json`, then should the project that imports the deleted dep be marked as affected? I think it should, but this PR does not handle that case.**