### PR TITLE
fix(core): cypress & fork ts checker plugin

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -39,8 +39,9 @@
     "@angular-devkit/core": "8.3.23",
     "@cypress/webpack-preprocessor": "~4.1.0",
     "tree-kill": "1.2.2",
-    "ts-loader": "5.3.1",
+    "ts-loader": "^5.3.1",
     "tsconfig-paths-webpack-plugin": "3.2.0",
-    "webpack-node-externals": "1.7.2"
+    "webpack-node-externals": "1.7.2",
+    "fork-ts-checker-webpack-plugin": "^3.1.1"
   }
 }

--- a/packages/cypress/src/plugins/preprocessor.spec.ts
+++ b/packages/cypress/src/plugins/preprocessor.spec.ts
@@ -21,7 +21,8 @@ describe('getWebpackConfig', () => {
       options: {
         configFile: './tsconfig.json',
         // https://github.com/TypeStrong/ts-loader/pull/685
-        experimentalWatchApi: true
+        experimentalWatchApi: true,
+        transpileOnly: true
       }
     });
   });

--- a/packages/cypress/src/plugins/preprocessor.ts
+++ b/packages/cypress/src/plugins/preprocessor.ts
@@ -1,6 +1,7 @@
 import * as wp from '@cypress/webpack-preprocessor';
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 import * as nodeExternals from 'webpack-node-externals';
+import * as ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
 export function preprocessTypescript(config: any) {
   if (!config.env.tsConfig) {
@@ -9,9 +10,10 @@ export function preprocessTypescript(config: any) {
     );
   }
 
-  return wp({
-    webpackOptions: getWebpackConfig(config)
-  });
+  return async (...args) =>
+    wp({
+      webpackOptions: getWebpackConfig(config)
+    })(...args);
 }
 
 export function getWebpackConfig(config: any) {
@@ -35,12 +37,18 @@ export function getWebpackConfig(config: any) {
           options: {
             configFile: config.env.tsConfig,
             // https://github.com/TypeStrong/ts-loader/pull/685
-            experimentalWatchApi: true
+            experimentalWatchApi: true,
+            transpileOnly: true
           }
         }
       ]
     },
-    plugins: [],
+    plugins: [
+      new ForkTsCheckerWebpackPlugin({
+        tsconfig: config.env.tsConfig,
+        useTypescriptIncrementalApi: false
+      })
+    ],
     externals: [nodeExternals()]
   };
 }

--- a/packages/cypress/src/schematics/cypress-project/files/src/plugins/index.js
+++ b/packages/cypress/src/schematics/cypress-project/files/src/plugins/index.js
@@ -17,6 +17,6 @@ module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
 
-  // Preprocess Typescript
+  // Preprocess Typescript file using Nx helper
   on('file:preprocessor', preprocessTypescript(config));
 };


### PR DESCRIPTION
## Current behaviour (This is the behaviour we have today, before the PR is merged)
The combination of `fork-ts-checker-webpack-plugin` and the use of `supportFile` property in the `cypress.json` file, was causing cypress to hang probably because a process was not being killed properly. Thus, we switched back to `ts-loader` to do type checking but that causes memory issues.

## Expected behaviour (This is the new behaviour we can expect after the PR is merged)
Because of the memory issues, we bringing back `fork-ts-checker-webpack-plugin` but adding a twist: compiling file by file instead of parallel.
That way Cypress is not hanging for a process that never end, and the memory issue should be resolved.


## Issue
fixes #2103
fixes #2217
fixes #2009