### PR TITLE
fix(node): update library to only copy MD files in the root

### DIFF
--- a/packages/node/src/schematics/library/library.ts
+++ b/packages/node/src/schematics/library/library.ts
@@ -123,7 +123,7 @@ function addProject(options: NormalizedSchema): Rule {
           tsConfig: `${options.projectRoot}/tsconfig.lib.json`,
           packageJson: `${options.projectRoot}/package.json`,
           main: `${options.projectRoot}/src/index.ts`,
-          assets: [`${options.projectRoot}/**/*.md`]
+          assets: [`${options.projectRoot}/*.md`]
         }
       };
     }


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
By default copying of .MD files is included when generating a library. This was included as `**/*.md`. This means that MD files that are included in sub folders are then copied to the root when built.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
The asset string has been changed to `*.md` so that only root MD files are copied by default on newly created node library projects. 

## Issue
