### PR TITLE
chore(repo): add --local to release and publish script

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -5,12 +5,34 @@
 
 VERSION=$1
 TAG=$2
+LOCALBUILD=$3
 PACKAGE_SOURCE=build/packages
 NPM_DEST=build/npm
 ORIG_DIRECTORY=`pwd`
+NPM_REGISTRY=`npm config get registry` # for local releases
 
 # We are running inside of a child_process, so we need to reauth
 npm adduser
+
+if [ "$LOCALBUILD" = "--local" ]; then
+  echo
+  echo "Publishing to npm registry $NPM_REGISTRY"
+
+  if [[ ! $NPM_REGISTRY == http://localhost* ]]; then
+    echo "------------------"
+    echo "💣 WARNING 💣 => $NPM_REGISTRY does not look like a local registry!"
+    echo "You may want to set registry with 'npm config set registry ...'"
+    echo "------------------"
+  fi
+  
+  read -p "Continue? (y/n)" -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
+  fi
+else
+  echo "Publishing to public npm"
+fi
 
 for package in $NPM_DEST/*/
 do
@@ -21,7 +43,12 @@ do
   PACKAGE_NAME=`node -e "console.log(require('./package.json').name)"`
 
   echo "Publishing ${PACKAGE_NAME}@${VERSION} --tag ${TAG}"
-  npm publish --tag $TAG --access public
+
+  if [ "$LOCALBUILD" = "--local" ]; then
+    npm publish --tag $TAG --access public --registry=NPM_REGISTRY
+  else
+    npm publish --tag $TAG --access public
+  fi
 
   cd $ORIG_DIRECTORY
 done


### PR DESCRIPTION
The best way to test fully test new Nx builds locally (especially migrations etc) is by releasing it to a local npm repo.

This PR adds some flags to the `nx-release.js` as well as `publish.sh` to automate some parts of the local release.

## How does it work

### Install Verdaccio & set it up

[Installing Verdaccio](https://verdaccio.org/docs/en/installation) is quite simple. Just add it as a global package:

```
$ npm install -g verdaccio
// or
$ yarn global add verdaccio
```

_(Using Docker could be an alternative. There's an official docker image for it)_

Run it with

```
$ verdaccio
```

![image](https://user-images.githubusercontent.com/542458/72509739-76ca6d80-3848-11ea-995e-0b69d5366ce5.png)

**Setup a dummy user:**
```
$ npm adduser --registry http://localhost:4873
```

You can just use username: `nrwl`, pwd:`nrwl` and email: `a@a.com`.

## Set the npm registry

Make your yarn & npm registry point to the local Verdaccio server with

```
$ npm config set registry http://localhost:4873
$ yarn config set registry http://localhost:4873/
```

You can always roll it back to the originals with

```
$ npm config delete registry
$ yarn config delete registry
```

I've created a simple script for that in case (which you can add to your PATH):

```
// setNpmReg.sh
#!/usr/bin/env bash

LOCALBUILD=$1

if [ "$LOCALBUILD" = "--local" ]; then
	echo "Setting registry to http://localhost:4873/"
	npm config set registry http://localhost:4873/
	yarn config set registry http://localhost:4873/
else
	npm config delete registry
	yarn config delete registry
	CURRENT_NPM_REGISTRY=`npm config get registry`
	CURRENT_YARN_REGISTRY=`yarn config get registry`
	
	echo "Reverting registries"
	echo "  > NPM:  $CURRENT_NPM_REGISTRY"
	echo "  > YARN: $CURRENT_YARN_REIGSTRY"
fi
```

## Releasing a new Nx version locally

First make sure you set the NPM / Yarn registry 

With this PR, to release a new version locally, just do

```
$ yarn nx-release 8.12.0-beta.104 --local
```

The release-it process will ask a couple of questions:

- Ready to release 8.12.0-beta.105? **=> y**
- Show staged files? **=> y** (or no, doesn't really matter)
- Commit (Release 8.12.0-beta.105)? **=> n**
- Tag (8.12.0-beta.105)? **=> n**
- Push? **=> n**
- Create a release on GitHub (Release 8.12.0-beta.105)? **=> n**

When asked for the credentials, just add the one of ur local repo (i.e. `nrwl:nrwl`)

You can then go to http://localhost:4873 which opens Verdaccio's web interface to see the published versions

![image](https://user-images.githubusercontent.com/542458/72510462-c8272c80-3849-11ea-9b90-d276f13b7c41.png)


### Want to delete all locally published packages (for whatever reason)?

All the packages are stored in Verdaccio's storage folder which (if you didn't change it) by default resides in `~/.local/share/verdaccio/storage`.

As a result, executing...
```
$ rm -rf ~/.local/share/verdaccio/storage/@nrwl/
```
...removes all `@nrwl` packages

