### PR TITLE
fix(core): align webpack version with @angular-devkit one

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -107,7 +107,7 @@
     "terser-webpack-plugin": "2.3.1",
     "ts-loader": "5.4.5",
     "tsconfig-paths-webpack-plugin": "3.2.0",
-    "webpack": "4.41.2",
+    "webpack": "4.39.2",
     "webpack-dev-middleware": "3.7.0",
     "webpack-merge": "4.2.1",
     "webpack-sources": "1.4.3",


### PR DESCRIPTION
Otherwise when having a repo with an Angular and react project we'll get an error "TypeError:
compilation.getAsset is not a function"

## Current Behavior (This is the behavior we have today, before the PR is merged)

When having a React and Angular app in a single repo, building the react app results in an error

```
TypeError: compilation.getAsset is not a function
    at /home/nrwlian/tryupgrade/node_modules/@nrwl/web/node_modules/webpack/lib/SourceMapDevToolPlugin.js:178:33
    at Array.forEach (<anonymous>)
    at /home/nrwlian/tryupgrade/node_modules/@nrwl/web/node_modules/webpack/lib/SourceMapDevToolPlugin.js:177:12
    at SyncHook.eval [as call] (eval at create (/home/nrwlian/tryupgrade/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:7:1)
    at SyncHook.lazyCompileHook (/home/nrwlian/tryupgrade/node_modules/tapable/lib/Hook.js:154:20)
    at /home/nrwlian/tryupgrade/node_modules/webpack/lib/Compilation.js:1375:42
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/home/nrwlian/tryupgrade/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at AsyncSeriesHook.lazyCompileHook (/home/nrwlian/tryupgrade/node_modules/tapable/lib/Hook.js:154:20)
    at /home/nrwlian/tryupgrade/node_modules/webpack/lib/Compilation.js:1371:36
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/home/nrwlian/tryupgrade/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at AsyncSeriesHook.lazyCompileHook (/home/nrwlian/tryupgrade/node_modules/tapable/lib/Hook.js:154:20)
    at /home/nrwlian/tryupgrade/node_modules/webpack/lib/Compilation.js:1367:32
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/home/nrwlian/tryupgrade/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at AsyncSeriesHook.lazyCompileHook (/home/nrwlian/tryupgrade/node_modules/tapable/lib/Hook.js:154:20)
    at Compilation.seal (/home/nrwlian/tryupgrade/node_modules/webpack/lib/Compilation.js:1304:27)
    at /home/nrwlian/tryupgrade/node_modules/webpack/lib/Compiler.js:665:18
```

It apparently boils down to different versions of `webpack`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The React app should build without issues.

## Notes

@jaysoo Do you see any potential problems with downgrading `webpack` from `4.41.2`? Asking you as you upgraded it with #2089 

