### PR TITLE
chore(repo): update husky prepush configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "checkformat": "./scripts/check_format.sh",
     "checkimports": "node ./scripts/check-imports.js",
     "checkversions": "ts-node ./scripts/check-versions.ts",
-    "documentation": "./scripts/documentation/documentation.sh && ./scripts/documentation/check-documentation.sh",
-    "prepush": "yarn checkcommit && yarn documentation && yarn checkformat"
+    "documentation": "./scripts/documentation/documentation.sh && ./scripts/documentation/check-documentation.sh"
   },
   "devDependencies": {
     "@angular-devkit/architect": "0.803.22",
@@ -250,6 +249,11 @@
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-customizable"
+    }
+  },
+  "husky": {
+    "hooks": {
+      "pre-push": "yarn checkcommit && yarn documentation && yarn checkformat"
     }
   }
 }


### PR DESCRIPTION
Using a package.json prepush script with Husky will be deprecated:

```
Warning: Setting pre-push script in package.json > scripts will be deprecated
Please move it to husky.hooks in package.json, a .huskyrc file, or a husky.config.js file
Or run ./node_modules/.bin/husky-upgrade for automatic update

See https://github.com/typicode/husky for usage
```

Quickly upgraded it to the new way of configuring prepush hooks