### PR TITLE
fix(misc): update package.json only if needed

### DIFF
--- a/packages/jest/src/schematics/init/init.ts
+++ b/packages/jest/src/schematics/init/init.ts
@@ -1,5 +1,9 @@
 import { mergeWith, chain, url, Tree } from '@angular-devkit/schematics';
-import { addDepsToPackageJson, updateJsonInTree } from '@nrwl/workspace';
+import {
+  addDepsToPackageJson,
+  updateJsonInTree,
+  readJsonInTree
+} from '@nrwl/workspace';
 import {
   jestVersion,
   jestTypesVersion,
@@ -8,23 +12,48 @@ import {
 } from '../../utils/versions';
 import { Rule } from '@angular-devkit/schematics';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+import { noop } from 'rxjs';
 
-const updatePackageJson = chain([
-  addDepsToPackageJson(
-    {},
-    {
-      '@nrwl/jest': nxVersion,
-      jest: jestVersion,
-      '@types/jest': jestTypesVersion,
-      'ts-jest': tsJestVersion
-    }
-  ),
-  updateJsonInTree('package.json', json => {
-    json.dependencies = json.dependencies || {};
-    delete json.dependencies['@nrwl/jest'];
-    return json;
-  })
-]);
+/**
+ * verifies whether the given packageJson dependencies require an update
+ * given the deps & devDeps passed in
+ */
+const requiresAddingOfPackages = (packageJsonFile, deps, devDeps): boolean => {
+  let needsDepsUpdate = false;
+  let needsDevDepsUpdate = false;
+
+  if (Object.keys(deps).length > 0 && packageJsonFile.dependencies) {
+    needsDepsUpdate = !Object.keys(deps).find(
+      entry => packageJsonFile.dependencies[entry]
+    );
+  }
+
+  if (Object.keys(devDeps).length > 0 && packageJsonFile.dependencies) {
+    needsDevDepsUpdate = !Object.keys(devDeps).find(
+      entry => packageJsonFile.devDependencies[entry]
+    );
+  }
+
+  return needsDepsUpdate || needsDevDepsUpdate;
+};
+
+const removeNrwlJestFromDeps = (host: Tree) => {
+  // check whether to update the packge.json is necessary
+  const currentPackageJson = readJsonInTree(host, 'package.json');
+
+  if (
+    currentPackageJson.dependencies &&
+    currentPackageJson.dependencies['@nrwl/jest']
+  ) {
+    return updateJsonInTree('package.json', json => {
+      json.dependencies = json.dependencies || {};
+      delete json.dependencies['@nrwl/jest'];
+      return json;
+    });
+  } else {
+    return noop();
+  }
+};
 
 const createJestConfig = (host: Tree) => {
   if (!host.exists('jest.config.js')) {
@@ -46,5 +75,17 @@ const createJestConfig = (host: Tree) => {
 };
 
 export default function(): Rule {
-  return chain([createJestConfig, updatePackageJson]);
+  return chain([
+    createJestConfig,
+    addDepsToPackageJson(
+      {},
+      {
+        '@nrwl/jest': nxVersion,
+        jest: jestVersion,
+        '@types/jest': jestTypesVersion,
+        'ts-jest': tsJestVersion
+      }
+    ),
+    removeNrwlJestFromDeps
+  ]);
 }

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -9,7 +9,8 @@ import {
   Rule,
   Tree,
   SchematicContext,
-  DirEntry
+  DirEntry,
+  noop
 } from '@angular-devkit/schematics';
 import * as ts from 'typescript';
 import * as stripJsonComments from 'strip-json-comments';
@@ -534,30 +535,77 @@ export function readWorkspace(host: Tree): any {
   return readJsonInTree(host, path);
 }
 
+/**
+ * verifies whether the given packageJson dependencies require an update
+ * given the deps & devDeps passed in
+ */
+function requiresAddingOfPackages(packageJsonFile, deps, devDeps): boolean {
+  let needsDepsUpdate = false;
+  let needsDevDepsUpdate = false;
+
+  packageJsonFile.dependencies = packageJsonFile.dependencies || {};
+  packageJsonFile.devDependencies = packageJsonFile.devDependencies || {};
+
+  if (Object.keys(deps).length > 0) {
+    needsDepsUpdate = !Object.keys(deps).find(
+      entry => packageJsonFile.dependencies[entry]
+    );
+  }
+
+  if (Object.keys(devDeps).length > 0) {
+    needsDevDepsUpdate = !Object.keys(devDeps).find(
+      entry => packageJsonFile.devDependencies[entry]
+    );
+  }
+
+  return needsDepsUpdate || needsDevDepsUpdate;
+}
+
 let installAdded = false;
 
+/**
+ * Updates the package.json given the passed deps and/or devDeps. Only updates
+ * if the packages are not yet present
+ *
+ * @param host the schematic tree
+ * @param deps the package.json dependencies to add
+ * @param devDeps the package.json devDependencies to add
+ * @param addInstall default `true`; set to false to avoid installs
+ */
 export function addDepsToPackageJson(
   deps: any,
   devDeps: any,
   addInstall = true
 ): Rule {
-  return updateJsonInTree('package.json', (json, context: SchematicContext) => {
-    json.dependencies = {
-      ...(json.dependencies || {}),
-      ...deps,
-      ...(json.dependencies || {})
-    };
-    json.devDependencies = {
-      ...(json.devDependencies || {}),
-      ...devDeps,
-      ...(json.devDependencies || {})
-    };
-    if (addInstall && !installAdded) {
-      context.addTask(new NodePackageInstallTask());
-      installAdded = true;
+  return (host: Tree, context: SchematicContext) => {
+    const currentPackageJson = readJsonInTree(host, 'package.json');
+
+    if (requiresAddingOfPackages(currentPackageJson, deps, devDeps)) {
+      return updateJsonInTree(
+        'package.json',
+        (json, context: SchematicContext) => {
+          json.dependencies = {
+            ...(json.dependencies || {}),
+            ...deps,
+            ...(json.dependencies || {})
+          };
+          json.devDependencies = {
+            ...(json.devDependencies || {}),
+            ...devDeps,
+            ...(json.devDependencies || {})
+          };
+
+          if (addInstall && !installAdded) {
+            context.addTask(new NodePackageInstallTask());
+            installAdded = true;
+          }
+          return json;
+        }
+      );
+    } else {
+      return noop();
     }
-    return json;
-  });
+  };
 }
 
 export function updatePackageJsonDependencies(


### PR DESCRIPTION
Adjusts the schematic to only touch the package.json if really required.

ISSUES CLOSED: #2317

@FrozenPandaz could you give this a look. 

Two open questions related to this:

- the verification of whether the package.json should be touched could be moved directly to the `ast-utils.ts` class and integrated in the `addDepsToPackageJson`. Let me know what you think about that.
- how do we test this? Just verifying the schematic result tree for the `package.json` in the unit test doesn't really work. Alternatively we could add an e2e and verify the log output. that would work for sure