### PR TITLE
fix(testing): fix race condition in tests for parallel commands runner

### DIFF
--- a/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
@@ -87,10 +87,10 @@ describe('Command Runner Builder', () => {
         {
           commands: [
             {
-              command: `sleep 0.2 && echo 1 >> ${f}`
+              command: `echo 1 >> ${f}`
             },
             {
-              command: `sleep 0.1 && echo 2 >> ${f}`
+              command: `echo 2 >> ${f}`
             }
           ],
           parallel: true
@@ -99,7 +99,9 @@ describe('Command Runner Builder', () => {
       const result = await run.result;
 
       expect(result).toEqual(jasmine.objectContaining({ success: true }));
-      expect(readFile(f)).toEqual('21');
+      const contents = readFile(f);
+      expect(contents).toContain(1);
+      expect(contents).toContain(2);
     });
   });
 


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Test would occasionally fail.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Test should consistently pass now.

## Issue

The previous setup was as follows:
- **command_1** was sleeping for 0.2 seconds before running
- **command_2** was sleeping for 0.1 seconds before running
The idea was that, if truly running in parallel, the second commands would finish before the first, because it was sleeping for less.

But as @jaysoo pointed out, if they're running in parallel we can't guarantee order, even with `sleep`.

## Fix

Maybe I'm missing something, but unless we extend the sleep duration of the first command to a much larger number (or at least the first larger number where we stop noticing failures), there's no way to truly test that the two commands are really running in parallel. 

So we are now just checking for the presence of the outputs in the file, and not the order in which they were written in.