### PR TITLE
fix(testing): fix race condition in tests for parallel commands runner

### DIFF
--- a/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
@@ -87,10 +87,10 @@ describe('Command Runner Builder', () => {
         {
           commands: [
             {
-              command: `sleep 0.2 && echo 1 >> ${f}`
+              command: `echo 1 >> ${f}`
             },
             {
-              command: `sleep 0.1 && echo 2 >> ${f}`
+              command: `echo 2 >> ${f}`
             }
           ],
           parallel: true
@@ -99,7 +99,9 @@ describe('Command Runner Builder', () => {
       const result = await run.result;
 
       expect(result).toEqual(jasmine.objectContaining({ success: true }));
-      expect(readFile(f)).toEqual('21');
+      const contents = readFile(f);
+      expect(contents).toContain(1);
+      expect(contents).toContain(2);
     });
   });
 

--- a/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
@@ -60,7 +60,8 @@ describe('Command Runner Builder', () => {
   describe('no readyCondition', () => {
     it('should run commands serially', async () => {
       const f = fileSync().name;
-      const run = await architect.scheduleBuilder(
+      const exec = spyOn(require('child_process'), 'exec').and.callThrough();
+      const scheduleRun = await architect.scheduleBuilder(
         '@nrwl/workspace:run-commands',
         {
           commands: [
@@ -74,6 +75,9 @@ describe('Command Runner Builder', () => {
           parallel: false
         }
       );
+      const processesCreated = exec.calls.count();
+      expect(processesCreated).toBeLessThan(2);
+      const run = await scheduleRun;
       const result = await run.result;
 
       expect(result).toEqual(jasmine.objectContaining({ success: true }));
@@ -82,7 +86,8 @@ describe('Command Runner Builder', () => {
 
     it('should run commands in parallel', async () => {
       const f = fileSync().name;
-      const run = await architect.scheduleBuilder(
+      const exec = spyOn(require('child_process'), 'exec').and.callThrough();
+      const scheduleRun = await architect.scheduleBuilder(
         '@nrwl/workspace:run-commands',
         {
           commands: [
@@ -96,8 +101,10 @@ describe('Command Runner Builder', () => {
           parallel: true
         }
       );
+      const processesCreated = exec.calls.count();
+      expect(processesCreated).toBe(2);
+      const run = await scheduleRun;
       const result = await run.result;
-
       expect(result).toEqual(jasmine.objectContaining({ success: true }));
       const contents = readFile(f);
       expect(contents).toContain(1);

--- a/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
@@ -75,8 +75,10 @@ describe('Command Runner Builder', () => {
           parallel: false
         }
       );
+      //wait a tick for the serial runner to schedule the first task
+      await Promise.resolve();
       const processesCreated = exec.calls.count();
-      expect(processesCreated).toBeLessThan(2);
+      expect(processesCreated).toBe(1);
       const run = await scheduleRun;
       const result = await run.result;
 


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Test would occasionally fail.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Test should consistently pass now.

## Issue

The previous setup was as follows:
- **command_1** was sleeping for 0.2 seconds before running
- **command_2** was sleeping for 0.1 seconds before running
The idea was that, if truly running in parallel, the second commands would finish before the first, because it was sleeping for less.

But as @jaysoo pointed out, if they're running in parallel we can't guarantee order, even with `sleep`.

## Fix (checked-in / part of this PR)

Instead of checking the order in which the commands were executed we now:
- invoke the commands runner synchronously
- immediately checked if there were 2 calls to spawn the processes
- wait for the promise/tasks to finish and check whether they both appended to the file (we do not check for order, just presence)

To prove above strategy works, it's also been added to the `serial` runner tests, and it indeed just prints 0 (as the initial promise it creates is a null one, only once that resolves it schedules the first task in the queue)