### PR TITLE
Fix Jest resolver for SVG files

### DIFF
--- a/packages/jest/plugins/resolver.ts
+++ b/packages/jest/plugins/resolver.ts
@@ -44,7 +44,8 @@ module.exports = function(path: string, options: ResolveOptions) {
     ext === '.scss' ||
     ext === '.sass' ||
     ext === '.less' ||
-    ext === '.styl'
+    ext === '.styl' ||
+    ext === '.svg'
   ) {
     return require.resolve('identity-obj-proxy');
   }


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
`nx test` fails when testing an app which has SVGs in `.css` files or using UI frameworks such as Ionic/React.

```bash
$ yarn test
yarn run v1.19.0
$ nx test web
 FAIL  apps/web/src/app/app.spec.tsx
  ● Test suite failed to run

    Jest encountered an unexpected token

    This usually means that you are trying to import a file which Jest cannot parse, e.g. it's not plain JavaScript.

    By default, if Jest sees a Babel config, it will use that to transform your files, ignoring "node_modules".

    Here's what you can do:
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/en/configuration.html

    Details:

    /Users/puku0x/GitHub/nx/tmp/nx/proj/node_modules/ionicons/dist/ionicons/svg/ios-add.svg:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M368.5 240H272v-96.5c0-8.8-7.2-16-16-16s-16 7.2-16 16V240h-96.5c-8.8 0-16 7.2-16 16 0 4.4 1.8 8.4 4.7 11.3 2.9 2.9 6.9 4.7 11.3 4.7H240v96.5c0 4.4 1.8 8.4 4.7 11.3 2.9 2.9 6.9 4.7 11.3 4.7 8.8 0 16-7.2 16-16V272h96.5c8.8 0 16-7.2 16-16s-7.2-16-16-16z"/></svg>
                                                                                             ^

    SyntaxError: Unexpected token <

      at ScriptTransformer._transformAndBuildScript (../../node_modules/@jest/transform/build/ScriptTransformer.js:537:17)
      at ScriptTransformer.transform (../../node_modules/@jest/transform/build/ScriptTransformer.js:579:25)
      at Object.<anonymous> (../../node_modules/ionicons/icons/imports/add.js:2:8)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        2.826s
Ran all test suites.
error Command failed with exit code 1.

```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Components like below should pass the test without error.

```tsx
/**
  app.tsx

  After cloning master,
  $ yarn create-playground
  $ cd tmp/nx/proj
  $ yarn nx g @nrwl/react:app
  $ yarn add @ionic/react
*/
import React from 'react';
import {
  IonApp,
  IonContent,
  IonHeader,
  IonPage,
  IonTitle,
  IonToolbar
} from '@ionic/react';

/* Core CSS required for Ionic components to work properly */
import '@ionic/react/css/core.css';

/* Basic CSS for apps built with Ionic */
import '@ionic/react/css/normalize.css';
import '@ionic/react/css/structure.css';
import '@ionic/react/css/typography.css';

/* Optional CSS utils that can be commented out */
import '@ionic/react/css/padding.css';
import '@ionic/react/css/float-elements.css';
import '@ionic/react/css/text-alignment.css';
import '@ionic/react/css/text-transformation.css';
import '@ionic/react/css/flex-utils.css';
import '@ionic/react/css/display.css';

export const App = () => {
  return (
    <IonApp>
      <IonPage>
        <IonHeader>
          <IonToolbar>
            <IonTitle>Title</IonTitle>
          </IonToolbar>
        </IonHeader>
        <IonContent>
          <p>Welcome to web!</p>
        </IonContent>
      </IonPage>
    </IonApp>
  );
};

export default App;
```


## Issue
#1931