### PR TITLE
fix(core): set default linter for schematics in newly created workspaces

### DIFF
--- a/packages/workspace/src/schematics/shared-new/shared-new.ts
+++ b/packages/workspace/src/schematics/shared-new/shared-new.ts
@@ -240,7 +240,13 @@ function setDefaultLinter(linter: string) {
       application: { linter }
     };
     json.schematics['@nrwl/web'] = { application: { linter } };
-    json.schematics['@nrwl/node'] = { application: { linter } };
+    json.schematics['@nrwl/node'] = {
+      application: { linter },
+      library: { linter }
+    };
+    json.schematics['@nrwl/nx-plugin'] = {
+      plugin: { linter }
+    };
     json.schematics['@nrwl/nest'] = { application: { linter } };
     json.schematics['@nrwl/express'] = { application: { linter } };
     return json;


### PR DESCRIPTION

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
When creating a new workspace with `nx`, the default linter for `@nrwl/node:library` and `@nrwl/nx-plugin:plugin` are tslint. 

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
eslint is added as a default for `@nrwl/node:library` and `@nrwl/nx-plugin:plugin` when creating workspaces with `nx`.

## Issue
