### PR TITLE
feat(core): add peerdependency cypress for nrwl/cypress

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -32,7 +32,8 @@
     "migrations": "./migrations.json"
   },
   "peerDependencies": {
-    "@nrwl/workspace": "*"
+    "@nrwl/workspace": "*",
+    "cypress": "^3.8.2"
   },
   "dependencies": {
     "@angular-devkit/architect": "0.803.23",


### PR DESCRIPTION
Adding Cypress as peerdependencies for @nrwl/cypress package. This allows you not having to add Cypress as a dependency for the workspace itself. Just use the Cypress version supported by the Nx package.