### PR TITLE
feat(core): analyze tsconfig changes

### DIFF
--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph-models.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph-models.ts
@@ -1,5 +1,6 @@
 import { NxJson } from '../shared-interfaces';
 import { Change, FileChange } from '../file-utils';
+import { ProjectGraph } from '../project-graph';
 
 export interface AffectedProjectGraphContext {
   workspaceJson: any;
@@ -12,6 +13,7 @@ export interface TouchedProjectLocator<T extends Change = Change> {
     fileChanges: FileChange<T>[],
     workspaceJson?: any,
     nxJson?: NxJson<string[]>,
-    packageJson?: any
+    packageJson?: any,
+    projectGraph?: ProjectGraph
   ): string[];
 }

--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph.ts
@@ -19,6 +19,7 @@ import {
 import { normalizeNxJson } from '../normalize-nx-json';
 import { getTouchedProjectsInNxJson } from './locators/nx-json-changes';
 import { getTouchedProjectsInWorkspaceJson } from './locators/workspace-json-changes';
+import { getTouchedProjectsFromTsConfig } from './locators/tsconfig-json-changes';
 
 export function filterAffected(
   graph: ProjectGraph,
@@ -35,12 +36,13 @@ export function filterAffected(
     getTouchedNpmPackages,
     getImplicitlyTouchedProjectsByJsonChanges,
     getTouchedProjectsInNxJson,
-    getTouchedProjectsInWorkspaceJson
+    getTouchedProjectsInWorkspaceJson,
+    getTouchedProjectsFromTsConfig
   ];
   const touchedProjects = touchedProjectLocators.reduce(
     (acc, f) => {
       return acc.concat(
-        f(touchedFiles, workspaceJson, normalizedNxJson, packageJson)
+        f(touchedFiles, workspaceJson, normalizedNxJson, packageJson, graph)
       );
     },
     [] as string[]

--- a/packages/workspace/src/core/affected-project-graph/locators/tsconfig-json-changes.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/tsconfig-json-changes.spec.ts
@@ -1,0 +1,321 @@
+import { WholeFileChange } from '../../file-utils';
+import { jsonDiff } from '../../../utils/json-diff';
+import { getTouchedProjectsFromTsConfig } from './tsconfig-json-changes';
+import { DependencyType, ProjectGraph } from '../../project-graph';
+
+describe('getTouchedProjectsFromTsConfig', () => {
+  let graph: ProjectGraph;
+  beforeEach(() => {
+    graph = {
+      nodes: {
+        proj1: {
+          name: 'proj1',
+          type: 'app',
+          data: {
+            root: 'proj1',
+            files: []
+          }
+        },
+        proj2: {
+          name: 'proj2',
+          type: 'lib',
+          data: {
+            root: 'proj2',
+            files: []
+          }
+        }
+      },
+      dependencies: {
+        proj1: [
+          {
+            type: DependencyType.static,
+            source: 'proj1',
+            target: 'proj2'
+          }
+        ],
+        proj2: []
+      }
+    };
+  });
+  it('should not return changes when tsconfig.json is not touched', () => {
+    const result = getTouchedProjectsFromTsConfig(
+      [
+        {
+          file: 'source.ts',
+          ext: '.ts',
+          mtime: 0,
+          getChanges: () => [new WholeFileChange()]
+        }
+      ],
+      {},
+      {
+        npmScope: 'proj',
+        projects: {
+          proj1: {
+            tags: []
+          }
+        }
+      }
+    );
+    expect(result).toEqual([]);
+  });
+
+  describe('Whole File Changes', () => {
+    it('should return all projects for a whole file change', () => {
+      const result = getTouchedProjectsFromTsConfig(
+        [
+          {
+            file: 'tsconfig.json',
+            ext: '.json',
+            mtime: 0,
+            getChanges: () => [new WholeFileChange()]
+          }
+        ],
+        null,
+        null,
+        null,
+        graph
+      );
+      expect(result).toEqual(['proj1', 'proj2']);
+    });
+  });
+
+  describe('Changes to other compiler options', () => {
+    it('should return all projects', () => {
+      const result = getTouchedProjectsFromTsConfig(
+        [
+          {
+            file: 'tsconfig.json',
+            ext: '.json',
+            mtime: 0,
+            getChanges: () =>
+              jsonDiff(
+                {
+                  compilerOptions: {
+                    strict: false
+                  }
+                },
+                {
+                  compilerOptions: {
+                    strict: true
+                  }
+                }
+              )
+          }
+        ],
+        null,
+        null,
+        null,
+        graph
+      );
+      expect(result).toEqual(['proj1', 'proj2']);
+    });
+  });
+
+  describe('Adding new path mappings', () => {
+    it('should return projects pointed to by the path mappings', () => {
+      const result = getTouchedProjectsFromTsConfig(
+        [
+          {
+            file: 'tsconfig.json',
+            ext: '.json',
+            mtime: 0,
+            getChanges: () =>
+              jsonDiff(
+                {
+                  compilerOptions: {
+                    paths: {}
+                  }
+                },
+                {
+                  compilerOptions: {
+                    paths: {
+                      '@proj/proj1': ['proj1/index.ts']
+                    }
+                  }
+                }
+              )
+          }
+        ],
+        null,
+        null,
+        null,
+        graph
+      );
+      expect(result).toEqual(['proj1']);
+    });
+
+    it('should accept different types of paths', () => {
+      const result = getTouchedProjectsFromTsConfig(
+        [
+          {
+            file: 'tsconfig.json',
+            ext: '.json',
+            mtime: 0,
+            getChanges: () =>
+              jsonDiff(
+                {
+                  compilerOptions: {
+                    paths: {}
+                  }
+                },
+                {
+                  compilerOptions: {
+                    paths: {
+                      '@proj/proj1': ['./proj1/index.ts']
+                    }
+                  }
+                }
+              )
+          }
+        ],
+        null,
+        null,
+        null,
+        graph
+      );
+      expect(result).toEqual(['proj1']);
+    });
+  });
+
+  describe('Removing path mappings', () => {
+    it('should affect all projects if a project is removed', () => {
+      const result = getTouchedProjectsFromTsConfig(
+        [
+          {
+            file: 'tsconfig.json',
+            ext: '.json',
+            mtime: 0,
+            getChanges: () =>
+              jsonDiff(
+                {
+                  compilerOptions: {
+                    paths: {
+                      '@proj/proj1': ['proj1/index.ts']
+                    }
+                  }
+                },
+                {
+                  compilerOptions: {
+                    paths: {}
+                  }
+                }
+              )
+          }
+        ],
+        null,
+        null,
+        null,
+        graph
+      );
+      expect(result).toEqual(['proj1', 'proj2']);
+    });
+
+    it('should affect all projects if a path mapping is removed', () => {
+      const result = getTouchedProjectsFromTsConfig(
+        [
+          {
+            file: 'tsconfig.json',
+            ext: '.json',
+            mtime: 0,
+            getChanges: () =>
+              jsonDiff(
+                {
+                  compilerOptions: {
+                    paths: {
+                      '@proj/proj1': ['proj1/index.ts', 'proj1/index2.ts']
+                    }
+                  }
+                },
+                {
+                  compilerOptions: {
+                    paths: {
+                      '@proj/proj1': ['proj1/index.ts']
+                    }
+                  }
+                }
+              )
+          }
+        ],
+        null,
+        null,
+        null,
+        graph
+      );
+      expect(result).toContainEqual('proj1');
+      expect(result).toContainEqual('proj2');
+    });
+  });
+
+  describe('Modifying Path Mappings', () => {
+    it('should return projects that have path mappings modified within them', () => {
+      const result = getTouchedProjectsFromTsConfig(
+        [
+          {
+            file: 'tsconfig.json',
+            ext: '.json',
+            mtime: 0,
+            getChanges: () =>
+              jsonDiff(
+                {
+                  compilerOptions: {
+                    paths: {
+                      '@proj/proj1': ['proj1/index.ts']
+                    }
+                  }
+                },
+                {
+                  compilerOptions: {
+                    paths: {
+                      '@proj/proj1': ['proj1/index2.ts']
+                    }
+                  }
+                }
+              )
+          }
+        ],
+        null,
+        null,
+        null,
+        graph
+      );
+      expect(result).toContainEqual('proj1');
+      expect(result).not.toContainEqual('proj2');
+    });
+
+    it('should return both projects that the mappings used to point to and point to now', () => {
+      const result = getTouchedProjectsFromTsConfig(
+        [
+          {
+            file: 'tsconfig.json',
+            ext: '.json',
+            mtime: 0,
+            getChanges: () =>
+              jsonDiff(
+                {
+                  compilerOptions: {
+                    paths: {
+                      '@proj/proj1': ['proj1/index.ts']
+                    }
+                  }
+                },
+                {
+                  compilerOptions: {
+                    paths: {
+                      '@proj/proj1': ['proj2/index.ts']
+                    }
+                  }
+                }
+              )
+          }
+        ],
+        null,
+        null,
+        null,
+        graph
+      );
+      expect(result).toContainEqual('proj1');
+      expect(result).toContainEqual('proj2');
+    });
+  });
+});

--- a/packages/workspace/src/core/affected-project-graph/locators/tsconfig-json-changes.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/tsconfig-json-changes.ts
@@ -1,0 +1,92 @@
+import { join } from 'path';
+
+import { WholeFileChange } from '../../file-utils';
+import { DiffType, isJsonChange, JsonChange } from '../../../utils/json-diff';
+import { TouchedProjectLocator } from '../affected-project-graph-models';
+import {
+  getSortedProjectNodes,
+  onlyWorkspaceProjects,
+  ProjectGraphNode
+} from '../../project-graph';
+import { appRootPath } from '../../../utils/app-root';
+
+export const getTouchedProjectsFromTsConfig: TouchedProjectLocator<
+  WholeFileChange | JsonChange
+> = (touchedFiles, _a, _b, _c, graph): string[] => {
+  const tsConfigJsonChanges = touchedFiles.find(
+    change => change.file === 'tsconfig.json'
+  );
+  if (!tsConfigJsonChanges) {
+    return [];
+  }
+
+  const workspaceGraph = onlyWorkspaceProjects(graph);
+
+  const sortedNodes = getSortedProjectNodes(workspaceGraph.nodes);
+
+  const changes = tsConfigJsonChanges.getChanges();
+
+  if (!allChangesArePathChanges(changes)) {
+    return Object.keys(workspaceGraph.nodes);
+  }
+
+  const touched: string[] = [];
+  for (let i = 0; i < changes.length; i++) {
+    const change = changes[i];
+
+    if (change.path.length !== 4) {
+      continue;
+    }
+
+    // If a path is deleted, everything is touched
+    if (change.type === DiffType.Deleted) {
+      return Object.keys(workspaceGraph.nodes);
+    }
+    touched.push(...getProjectsAffectedByPaths(change, sortedNodes));
+  }
+  return touched;
+};
+
+function allChangesArePathChanges(
+  changes: Array<WholeFileChange | JsonChange>
+): changes is JsonChange[] {
+  return changes.every(isChangeToPathMappings);
+}
+
+/**
+ * Gets both previous project and current project of a particular change to tsconfig paths
+ */
+function getProjectsAffectedByPaths(
+  change: JsonChange,
+  sortedNodes: ProjectGraphNode[]
+) {
+  const result = [];
+
+  const paths: string[] = [change.value.lhs, change.value.rhs];
+  paths.forEach(path => {
+    sortedNodes.forEach(project => {
+      if (
+        path &&
+        project.data.root &&
+        join(appRootPath, path).startsWith(join(appRootPath, project.data.root))
+      ) {
+        result.push(project.name);
+      }
+    });
+  });
+
+  return result;
+}
+
+/**
+ * Change is possibly a change to path mappings
+ */
+function isChangeToPathMappings(
+  change: WholeFileChange | JsonChange
+): change is JsonChange {
+  return (
+    isJsonChange(change) &&
+    change.path[0] === 'compilerOptions' &&
+    (!change.path[1] || change.path[1] === 'paths')
+  );
+}

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -1,38 +1,15 @@
 import { resolveModuleByImport } from '../utils/typescript';
 import { normalizedProjectRoot } from './file-utils';
-import {
-  ProjectGraphNodeRecords,
-  ProjectType
-} from './project-graph/project-graph-models';
+import { ProjectGraphNodeRecords } from './project-graph/project-graph-models';
+import { getSortedProjectNodes, isWorkspaceProject } from './project-graph';
 
 export class TargetProjectLocator {
   _sortedNodeNames = [];
 
   constructor(private nodes: ProjectGraphNodeRecords) {
-    this._sortedNodeNames = Object.keys(nodes).sort((a, b) => {
-      // If a or b is not a nx project, leave them in the same spot
-      if (
-        !this._isNxProject(nodes[a].type) &&
-        !this._isNxProject(nodes[b].type)
-      ) {
-        return 0;
-      }
-      // sort all non-projects lower
-      if (
-        !this._isNxProject(nodes[a].type) &&
-        this._isNxProject(nodes[b].type)
-      ) {
-        return 1;
-      }
-      if (
-        this._isNxProject(nodes[a].type) &&
-        !this._isNxProject(nodes[b].type)
-      ) {
-        return -1;
-      }
-
-      return nodes[a].data.root.length > nodes[b].data.root.length ? -1 : 1;
-    });
+    this._sortedNodeNames = getSortedProjectNodes(nodes).map(
+      ({ name }) => name
+    );
   }
 
   findProjectWithImport(
@@ -50,7 +27,7 @@ export class TargetProjectLocator {
     return this._sortedNodeNames.find(projectName => {
       const p = this.nodes[projectName];
 
-      if (!this._isNxProject(p.type)) {
+      if (!isWorkspaceProject(p)) {
         return false;
       }
 
@@ -62,13 +39,5 @@ export class TargetProjectLocator {
         return normalizedImportExpr.startsWith(projectImport);
       }
     });
-  }
-
-  private _isNxProject(type: string) {
-    return (
-      type === ProjectType.app ||
-      type === ProjectType.lib ||
-      type === ProjectType.e2e
-    );
   }
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Tsconfig changes are not analyzed for affected 

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Tsconfig is analyzed for affected but the implicit dependency on tsconfig is not changed so it is opt in. 

Opt in by removing tsconfig from nx.json

## Issue
