### PR TITLE
fix(angular): storybook config schematic from generating stories when generateStories false

### DIFF
--- a/packages/angular/src/schematics/storybook-configuration/configuration.spec.ts
+++ b/packages/angular/src/schematics/storybook-configuration/configuration.spec.ts
@@ -10,6 +10,45 @@ describe('schematic:configuration', () => {
     appTree = await createTestUILib('test-ui-lib');
   });
 
+  it('should only configure storybook', async () => {
+    const tree = await runSchematic(
+      'storybook-configuration',
+      <StorybookConfigureSchema>{
+        name: 'test-ui-lib',
+        configureCypress: false,
+        generateCypressSpecs: false,
+        generateStories: false
+      },
+      appTree
+    );
+    expect(tree.exists('libs/test-ui-lib/.storybook/addons.js')).toBeTruthy();
+    expect(tree.exists('libs/test-ui-lib/.storybook/config.js')).toBeTruthy();
+    expect(
+      tree.exists('libs/test-ui-lib/.storybook/tsconfig.json')
+    ).toBeTruthy();
+    expect(tree.exists('apps/test-ui-lib-e2e/cypress.json')).toBeFalsy();
+    expect(
+      tree.exists(
+        'libs/test-ui-lib/src/lib/test-button/test-button.component.stories.ts'
+      )
+    ).toBeFalsy();
+    expect(
+      tree.exists(
+        'libs/test-ui-lib/src/lib/test-other/test-other.component.stories.ts'
+      )
+    ).toBeFalsy();
+    expect(
+      tree.exists(
+        'apps/test-ui-lib-e2e/src/integration/test-button/test-button.component.spec.ts'
+      )
+    ).toBeFalsy();
+    expect(
+      tree.exists(
+        'apps/test-ui-lib-e2e/src/integration/test-other/test-other.component.spec.ts'
+      )
+    ).toBeFalsy();
+  });
+
   it('should configure everything at once', async () => {
     const tree = await runSchematic(
       'storybook-configuration',

--- a/packages/angular/src/schematics/storybook-configuration/configuration.ts
+++ b/packages/angular/src/schematics/storybook-configuration/configuration.ts
@@ -2,19 +2,26 @@ import {
   chain,
   externalSchematic,
   Rule,
-  schematic
+  schematic,
+  noop
 } from '@angular-devkit/schematics';
 import { StorybookStoriesSchema } from '../stories/stories';
 import { StorybookConfigureSchema } from './schema';
 
 export default function(schema: StorybookConfigureSchema): Rule {
+  if (schema.generateCypressSpecs && !schema.generateStories) {
+    throw new Error(
+      'Cannot set generateCypressSpecs to true when generateStories is set to false.'
+    );
+  }
+
   return chain([
     externalSchematic('@nrwl/storybook', 'configuration', {
       name: schema.name,
       uiFramework: '@storybook/angular',
       configureCypress: schema.configureCypress
     }),
-    generateStories(schema)
+    schema.generateStories ? generateStories(schema) : noop()
   ]);
 }
 


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Running `ng g @nrwl/angular:storybook-configuration mylib --configure-cypress --generate-cypress-specs false --generate-stories false` for a new lib throws an error.

![Screen Shot 2020-01-26 at 9 00 40 PM](https://user-images.githubusercontent.com/14145352/73150257-124eb000-408b-11ea-89c5-673987bb1577.png)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Running `ng g @nrwl/angular:storybook-configuration mylib --configure-cypress --generate-cypress-specs false --generate-stories false` for a new lib completes successfully.

![Screen Shot 2020-01-26 at 9 20 28 PM](https://user-images.githubusercontent.com/14145352/73150279-2c888e00-408b-11ea-9a8d-7349b57bdc62.png)

Now, generating stories is skipped when `--generate-stories` is set to false.

## Issue

Closes #2383 