### PR TITLE
docs(nx-plugin): add documentation for exported functions and provide written doc

### DIFF
--- a/docs/map.json
+++ b/docs/map.json
@@ -180,6 +180,11 @@
           {
             "name": "Changes between Nx 7 and Nx 8",
             "id": "nx7-to-nx8"
+          },
+          {
+            "name": "Creating a Nx Plugin",
+            "id": "creating-a-nx-plugin",
+            "file": "shared/nx-plugin"
           }
         ]
       }
@@ -330,6 +335,11 @@
             "name": "Imposing Constraints on the Dependency Graph",
             "id": "monorepo-tags",
             "file": "shared/monorepo-tags"
+          },
+          {
+            "name": "Creating a Nx Plugin",
+            "id": "creating-a-nx-plugin",
+            "file": "shared/nx-plugin"
           }
         ]
       }
@@ -489,6 +499,11 @@
             "name": "Imposing Constraints on the Dependency Graph",
             "id": "monorepo-tags",
             "file": "shared/monorepo-tags"
+          },
+          {
+            "name": "Creating a Nx Plugin",
+            "id": "creating-a-nx-plugin",
+            "file": "shared/nx-plugin"
           }
         ]
       }

--- a/docs/map.json
+++ b/docs/map.json
@@ -130,6 +130,11 @@
             "file": "shared/tools-workspace-schematics"
           },
           {
+            "name": "Nx Plugins",
+            "id": "nx-plugin",
+            "file": "shared/nx-plugin"
+          },
+          {
             "name": "Rebuilding and Retesting What is Affected",
             "id": "monorepo-affected",
             "file": "shared/monorepo-affected"
@@ -180,11 +185,6 @@
           {
             "name": "Changes between Nx 7 and Nx 8",
             "id": "nx7-to-nx8"
-          },
-          {
-            "name": "Creating a Nx Plugin",
-            "id": "creating-a-nx-plugin",
-            "file": "shared/nx-plugin"
           }
         ]
       }
@@ -317,6 +317,11 @@
             "file": "shared/tools-workspace-schematics"
           },
           {
+            "name": "Nx Plugins",
+            "id": "nx-plugin",
+            "file": "shared/nx-plugin"
+          },
+          {
             "name": "Rebuilding and Retesting What is Affected",
             "id": "monorepo-affected",
             "file": "shared/monorepo-affected"
@@ -335,11 +340,6 @@
             "name": "Imposing Constraints on the Dependency Graph",
             "id": "monorepo-tags",
             "file": "shared/monorepo-tags"
-          },
-          {
-            "name": "Creating a Nx Plugin",
-            "id": "creating-a-nx-plugin",
-            "file": "shared/nx-plugin"
           }
         ]
       }
@@ -481,6 +481,11 @@
             "file": "shared/tools-workspace-schematics"
           },
           {
+            "name": "Nx Plugins",
+            "id": "nx-plugin",
+            "file": "shared/nx-plugin"
+          },
+          {
             "name": "Rebuilding and Retesting What is Affected",
             "id": "monorepo-affected",
             "file": "shared/monorepo-affected"
@@ -499,11 +504,6 @@
             "name": "Imposing Constraints on the Dependency Graph",
             "id": "monorepo-tags",
             "file": "shared/monorepo-tags"
-          },
-          {
-            "name": "Creating a Nx Plugin",
-            "id": "creating-a-nx-plugin",
-            "file": "shared/nx-plugin"
           }
         ]
       }

--- a/docs/shared/nx-plugin.md
+++ b/docs/shared/nx-plugin.md
@@ -1,18 +1,24 @@
-# Creating a Nx Plugin
+# Nx Plugins
+
+Nx plugins are npm packages that contain schematics and builders to extend a Nx workspace. Schematics are blueprints to create new files from templates, and builders execute those files. These plugins also update the `nx.json` when generating new libs or apps.
+
+This guide will explain how to generate a new plugin, build on it, test it and publish it.
+
+> A list of plugins that is maintained by Nrwl is found in the [Nrwl/nx repo](https://github.com/nrwl/nx/tree/master/packages).
 
 ## Generating a Plugin
 
-To get started with building a Nx Plugin, you can run the following command:
+To get started with building a Nx Plugin, run the following command:
 
 ```bash
 npx create-nx-plugin my-org --pluginName my-plugin
 ```
 
-This command will create a brand new workspace, and set up a pre-configured plugin with the specified name.
+This command creates a brand new workspace, and sets up a pre-configured plugin with the specified name.
 
 ## Workspace Structure
 
-After executing the above command, the following tree structure will be created:
+After executing the above command, the following tree structure is created:
 
 ```treeview
 my-org/
@@ -61,20 +67,20 @@ my-org/
 └── yarn.lock
 ```
 
-> If you do not want to create a new workspace, you can install install the `@nrwl/nx-plugin` dependency in an already existing workspace with npm or yarn. Then run `nx g @nrwl/nx-plugin:plugin [pluginName]`.
+> If you do not want to create a new workspace, install the `@nrwl/nx-plugin` dependency in an already existing workspace with npm or yarn. Then run `nx g @nrwl/nx-plugin:plugin [pluginName]`.
 
-Whenever a new plugin is created, it will include a default schematic, builder, and e2e app.
+A new plugin is created with a default schematic, builder, and e2e app.
 
 ## Schematic
 
-The generated schematic will contain boilerplate that will do the following:
+The generated schematic contains boilerplate that will do the following:
 
-- Normalize a schema (the options that the schematic will accept)
-- Update the `workspace.json` (or `angular.json` if you would like your plugin be used in a Angular CLI workspace)
+- Normalize a schema (the options that the schematic accepts)
+- Update the `workspace.json` (or `angular.json` if the plugin is used in a Angular CLI workspace)
 - Add the plugin's project to the `nx.json` file
 - Add files to the disk using templates
 
-To change the type of project the plugin will generate, you can change the `projectType` const with the `ProjectType` enum. This will ensure that generated projects with your plugin will go in to the correct workspace directory (`libs/` or `apps/`).
+To change the type of project the plugin generates, change the `projectType` const with the `ProjectType` enum. This ensures that generated projects with the plugin will go in to the correct workspace directory (`libs/` or `apps/`).
 
 ```typescript
 const projectType = ProjectType.Library;
@@ -84,13 +90,13 @@ const projectType = ProjectType.Library;
 
 ### Schematic options
 
-There will be a generated `schema.d.ts` file that will contain all the options that the schematic supports. By default, we include `directory`, `tags`, and `name` as the options. If you need to add more, please update this file and the `schema.json` file.
+The `schema.d.ts` file contains all the options that the schematic supports. By default, it includes `directory`, `tags`, and `name` as the options. If more options need to be added, please update this file and the `schema.json` file.
 
-> Note: The `schema.d.ts` file is used for type checking inside your implementation file. It should match the properties in `schema.json`.
+> Note: The `schema.d.ts` file is used for type checking inside the implementation file. It should match the properties in `schema.json`.
 
 ### Adding more schematics
 
-To add more schematics to your plugin, create a new folder that contains a implementation file, a `schema.json` file, and a `schema.d.ts` file. After, edit the `collection.json` file and add your new schematic there.
+To add more schematics to the plugin, create a new folder that contains a implementation file, a `schema.json` file, and a `schema.d.ts` file. After, edit the `collection.json` file and add the new schematic there.
 
 ```json
 {
@@ -113,17 +119,17 @@ To add more schematics to your plugin, create a new folder that contains a imple
 }
 ```
 
-To read more about schematics and how they work, you can go to the documentation at [angular.io/guide/schematics-authoring](https://angular.io/guide/schematics-authoring)
+For more information on how schematics work, see [angular.io/guide/schematics-authoring](https://angular.io/guide/schematics-authoring)
 
 ### Schematic Testing
 
-The schematic spec file will include boilerplate to help you get started with testing. This includes setting up a empty workspace, and the schematic test runner.
+The schematic spec file includes boilerplate to help get started with testing. This includes setting up a empty workspace, and the schematic test runner.
 
 Full E2Es are supported (and recommended) and will run everything on the file system like a user would.
 
 ## Builder
 
-The generated builder is set up to just emit output. It's up to you to decide what you would like to actually want the builder to do. Some examples of what a builder can do are:
+The default builder is set up to just emit a console log. Some examples of what a builder can do are:
 
 - Use the .NET core compiler (or something similar)
 - Compile Stencil/Svelte/Vue components
@@ -133,7 +139,7 @@ The generated builder is set up to just emit output. It's up to you to decide wh
 
 ### Adding more builders
 
-Adding more builders to your plugin is exactly the same as adding more schematics. Create a new folder then add a implementation, `schema.json` and `schema.d.ts` files. Then edit the `builders.json` file in the root of your plugin project.
+Adding more builders to the plugin is exactly the same as adding more schematics. Create a new folder and add a implementation, `schema.json` and `schema.d.ts` files. Then edit the `builders.json` file in the root of the plugin project.
 
 ```json
 {
@@ -154,27 +160,27 @@ Adding more builders to your plugin is exactly the same as adding more schematic
 }
 ```
 
-> Note: to use your new builder in any target (inside the `workspace.json` or `angular.json`), you would use the following `@my-org/my-plugin:newBuilder`
+> Note: to use builders in any target (inside the `workspace.json` or `angular.json`), use the following syntax `@my-org/my-plugin:newBuilder`
 
-To read more about builders and how they work, you can go to the documentation at [angular.io/guide/cli-builder](https://angular.io/guide/cli-builder)
+For more information on how builders work, see [angular.io/guide/cli-builder](https://angular.io/guide/cli-builder)
 
 ### Builder testing
 
 The builder spec file contains boilerplate to set up the `CoreSchemaRegistry`, `TestingArchitectHost` and adds the builder from a package.json.
 
-There are some additional comments to help with these tests. To read more about testing builders, you can go to the [angular.io/guide/cli-builder#testing-a-builder](https://angular.io/guide/cli-builder#testing-a-builder) docs.
+There are some additional comments to help with these tests. For more information about testing builders, see [angular.io/guide/cli-builder#testing-a-builder](https://angular.io/guide/cli-builder#testing-a-builder).
 
 Full E2Es are supported (and recommended) and will run everything on the file system like a user would.
 
-## E2Es
+## Testing your plugin
 
-One of the biggest benefits that the Nx Plugin package provides is support for E2E testing your plugin.
+One of the biggest benefits that the Nx Plugin package provides is support for E2E testing.
 
-When running a E2E, we create a temporary E2E directory in the root of your workspace. This temporary directory is a blank Nx workspace, and will have your plugin's built package installed locally.
+When the E2E app runs, a temporary E2E directory is created in the root of the workspace. This directory is a blank Nx workspace, and will have the plugin's built package installed locally.
 
 ### E2E Testing file
 
-When a new plugin is generated, a test file will be created in the `my-plugin-e2e` app. Inside this test file, there is already tests for making sure that the builder ran, checking if directories are created with the `--directory` option, and checking if tags are added to `nx.json`.
+When the plugin is generated, a test file is created in the `my-plugin-e2e` app. Inside this test file, there are already tests for making sure that the builder ran, checking if directories are created with the `--directory` option, and checking if tags are added to `nx.json`.
 
 We'll go over a few parts of a test file below:
 
@@ -197,11 +203,11 @@ it('should create my-plugin', async done => {
 
 There are additional functions that the `@nrwl/nx-plugin/testing` package exports. Most of them are file utilities to manipulate and read files in the E2E directory.
 
-## Assets
+## Including Assets
 
-Sometimes you might want to include some assets with your plugin. This might be a image or some additional binaries.
+Sometimes you might want to include some assets with the plugin. This might be a image or some additional binaries.
 
-To make sure that assets are copied to the dist folder, open the `workspace.json` (or `angular.json`) file, and find the plugin's project. Inside the `build` property, you can add additional assets. By default, we include all `.md` files in the root, all non-ts files in folders, and the `collection.json` and `builders.json` files.
+To make sure that assets are copied to the dist folder, open the `workspace.json` (or `angular.json`) file, and find the plugin's project. Inside the `build` property, add additional assets. By default, all `.md` files in the root, all non-ts files in folders, and the `collection.json` and `builders.json` files are included.
 
 ```json
 "build": {
@@ -236,13 +242,13 @@ To publish your plugin follow these steps:
 
 1. Build your plugin with the command `nx run my-plugin:build`
 1. `npm publish ./dist/libs/my-plugin` and follow the prompts from npm.
-1. Thats it!
+1. That's it!
 
 > Note: currently you will have to modify the `package.json` version by yourself or with a tool.
 
 After that, you can then install your plugin like any other npm package,
-`npm i -D @my-org/my-plugin`.
+`npm i -D @my-org/my-plugin` or `yarn add -D @my-org/my-plugin`.
 
-### Nx listing
+### Listing your Nx Plugin
 
 If you would like your plugin to be included with the `nx list` command, open up an issue on the [Nrwl/nx repo](https://github.com/nrwl/nx/issues/new) and let's discuss!

--- a/docs/shared/nx-plugin.md
+++ b/docs/shared/nx-plugin.md
@@ -1,0 +1,248 @@
+# Creating a Nx Plugin
+
+## Generating a Plugin
+
+To get started with building a Nx Plugin, you can run the following command:
+
+```bash
+npx create-nx-plugin my-org --pluginName my-plugin
+```
+
+This command will create a brand new workspace, and set up a pre-configured plugin with the specified name.
+
+## Workspace Structure
+
+After executing the above command, the following tree structure will be created:
+
+```treeview
+my-org/
+├── apps/
+│   └── my-plugin-e2e/
+│       ├── jest.config.js
+│       ├── tests/
+│       │   └── my-plugin.test.ts
+│       ├── tsconfig.json
+│       └── tsconfig.spec.json
+├── jest.config.js
+├── libs/
+│   └── my-plugin/
+│       ├── README.md
+│       ├── builders.json
+│       ├── collection.json
+│       ├── jest.config.js
+│       ├── package.json
+│       ├── src/
+│       │   ├── builders/
+│       │   │   └── my-plugin/
+│       │   │       ├── builder.spec.ts
+│       │   │       ├── builder.ts
+│       │   │       ├── schema.d.ts
+│       │   │       └── schema.json
+│       │   ├── index.ts
+│       │   └── schematics/
+│       │       └── my-plugin/
+│       │           ├── files/
+│       │           │   └── src/
+│       │           │       └── index.ts.template
+│       │           ├── schema.d.ts
+│       │           ├── schema.json
+│       │           ├── schematic.spec.ts
+│       │           └── schematic.ts
+│       ├── tsconfig.json
+│       ├── tsconfig.lib.json
+│       └── tsconfig.spec.json
+├── nx.json
+├── package.json
+├── tools
+│   ├── schematics/
+│   └── tsconfig.tools.json
+├── tsconfig.json
+├── workspace.json
+└── yarn.lock
+```
+
+> If you do not want to create a new workspace, you can install install the `@nrwl/nx-plugin` dependency in an already existing workspace with npm or yarn. Then run `nx g @nrwl/nx-plugin:plugin [pluginName]`.
+
+Whenever a new plugin is created, it will include a default schematic, builder, and e2e app.
+
+## Schematic
+
+The generated schematic will contain boilerplate that will do the following:
+
+- Normalize a schema (the options that the schematic will accept)
+- Update the `workspace.json` (or `angular.json` if you would like your plugin be used in a Angular CLI workspace)
+- Add the plugin's project to the `nx.json` file
+- Add files to the disk using templates
+
+To change the type of project the plugin will generate, you can change the `projectType` const with the `ProjectType` enum. This will ensure that generated projects with your plugin will go in to the correct workspace directory (`libs/` or `apps/`).
+
+```typescript
+const projectType = ProjectType.Library;
+// OR
+// const projectType = ProjectType.Application;
+```
+
+### Schematic options
+
+There will be a generated `schema.d.ts` file that will contain all the options that the schematic supports. By default, we include `directory`, `tags`, and `name` as the options. If you need to add more, please update this file and the `schema.json` file.
+
+> Note: The `schema.d.ts` file is used for type checking inside your implementation file. It should match the properties in `schema.json`.
+
+### Adding more schematics
+
+To add more schematics to your plugin, create a new folder that contains a implementation file, a `schema.json` file, and a `schema.d.ts` file. After, edit the `collection.json` file and add your new schematic there.
+
+```json
+{
+  "$schema": "../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "name": "my-plugin",
+  "version": "0.0.1",
+  "schematics": {
+    "myPlugin": {
+      "factory": "./src/schematics/my-plugin/schematic",
+      "schema": "./src/schematics/my-plugin/schema.json",
+      "description": "my-plugin schematic"
+    },
+    // new schematic
+    "added-schematic": {
+      "factory": "./src/schematics/added-schematic/schematic",
+      "schema": "./src/schematics/added-schematic/schema.json",
+      "description": "added-schematic schematic"
+    }
+  }
+}
+```
+
+To read more about schematics and how they work, you can go to the documentation at [angular.io/guide/schematics-authoring](https://angular.io/guide/schematics-authoring)
+
+### Schematic Testing
+
+The schematic spec file will include boilerplate to help you get started with testing. This includes setting up a empty workspace, and the schematic test runner.
+
+Full E2Es are supported (and recommended) and will run everything on the file system like a user would.
+
+## Builder
+
+The generated builder is set up to just emit output. It's up to you to decide what you would like to actually want the builder to do. Some examples of what a builder can do are:
+
+- Use the .NET core compiler (or something similar)
+- Compile Stencil/Svelte/Vue components
+- Deploy an app on a CDN
+- Publish to NPM
+- and many more!
+
+### Adding more builders
+
+Adding more builders to your plugin is exactly the same as adding more schematics. Create a new folder then add a implementation, `schema.json` and `schema.d.ts` files. Then edit the `builders.json` file in the root of your plugin project.
+
+```json
+{
+  "$schema": "../../node_modules/@angular-devkit/architect/src/builders-schema.json",
+  "builders": {
+    "build": {
+      "implementation": "./src/builders/my-plugin/builder",
+      "schema": "./src/builders/my-plugin/schema.json",
+      "description": "my-plugin builder"
+    },
+    // new builder
+    "newBuilder": {
+      "implementation": "./src/builders/new-builder/builder",
+      "schema": "./src/builders/new-builder/schema.json",
+      "description": "new-builder builder"
+    }
+  }
+}
+```
+
+> Note: to use your new builder in any target (inside the `workspace.json` or `angular.json`), you would use the following `@my-org/my-plugin:newBuilder`
+
+To read more about builders and how they work, you can go to the documentation at [angular.io/guide/cli-builder](https://angular.io/guide/cli-builder)
+
+### Builder testing
+
+The builder spec file contains boilerplate to set up the `CoreSchemaRegistry`, `TestingArchitectHost` and adds the builder from a package.json.
+
+There are some additional comments to help with these tests. To read more about testing builders, you can go to the [angular.io/guide/cli-builder#testing-a-builder](https://angular.io/guide/cli-builder#testing-a-builder) docs.
+
+Full E2Es are supported (and recommended) and will run everything on the file system like a user would.
+
+## E2Es
+
+One of the biggest benefits that the Nx Plugin package provides is support for E2E testing your plugin.
+
+When running a E2E, we create a temporary E2E directory in the root of your workspace. This temporary directory is a blank Nx workspace, and will have your plugin's built package installed locally.
+
+### E2E Testing file
+
+When a new plugin is generated, a test file will be created in the `my-plugin-e2e` app. Inside this test file, there is already tests for making sure that the builder ran, checking if directories are created with the `--directory` option, and checking if tags are added to `nx.json`.
+
+We'll go over a few parts of a test file below:
+
+```typescript
+it('should create my-plugin', async done => {
+  const plugin = uniq('my-plugin');
+  ensureNxProject('@my-org/my-plugin', 'dist/libs/my-plugin');
+  await runNxCommandAsync(`generate @my-org/my-plugin:myPlugin ${plugin}`);
+
+  const result = await runNxCommandAsync(`build ${plugin}`);
+  expect(result.stdout).toContain('Builder ran');
+
+  done();
+});
+```
+
+- The `uniq` function creates a random name with the prefix and a random number.
+- The `ensureNxProject` is the function that will create the temporary directory. It takes two arguments, the plugin package name and the dist directory of when it's built.
+- The `runNxCommandAsync` will execute a `nx` command in the E2E directory.
+
+There are additional functions that the `@nrwl/nx-plugin/testing` package exports. Most of them are file utilities to manipulate and read files in the E2E directory.
+
+## Assets
+
+Sometimes you might want to include some assets with your plugin. This might be a image or some additional binaries.
+
+To make sure that assets are copied to the dist folder, open the `workspace.json` (or `angular.json`) file, and find the plugin's project. Inside the `build` property, you can add additional assets. By default, we include all `.md` files in the root, all non-ts files in folders, and the `collection.json` and `builders.json` files.
+
+```json
+"build": {
+  "builder": "@nrwl/node:package",
+  "options": {
+    // shortened...
+    "assets": [
+      "libs/my-plugin/*.md",
+      {
+        "input": "./libs/my-plugin/src",
+        "glob": "**/*.!(ts)",
+        "output": "./src"
+      },
+      {
+        "input": "./libs/my-plugin",
+        "glob": "collection.json",
+        "output": "."
+      },
+      {
+        "input": "./libs/my-plugin",
+        "glob": "builders.json",
+        "output": "."
+      }
+    ]
+  }
+}
+```
+
+## Publishing your Nx Plugin
+
+To publish your plugin follow these steps:
+
+1. Build your plugin with the command `nx run my-plugin:build`
+1. `npm publish ./dist/libs/my-plugin` and follow the prompts from npm.
+1. Thats it!
+
+> Note: currently you will have to modify the `package.json` version by yourself or with a tool.
+
+After that, you can then install your plugin like any other npm package,
+`npm i -D @my-org/my-plugin`.
+
+### Nx listing
+
+If you would like your plugin to be included with the `nx list` command, open up an issue on the [Nrwl/nx repo](https://github.com/nrwl/nx/issues/new) and let's discuss!

--- a/packages/nx-plugin/src/builders/e2e/e2e.impl.spec.ts
+++ b/packages/nx-plugin/src/builders/e2e/e2e.impl.spec.ts
@@ -31,7 +31,6 @@ describe('NxPluginE2EBuilder', () => {
     contextBuilderSpy = jest
       .spyOn(context, 'scheduleBuilder')
       .mockImplementation((name, overrides) => {
-        console.log('hello');
         return new Promise((res, rej) => {
           res({
             result: of({ success: true }).toPromise(),

--- a/packages/nx-plugin/src/schematics/plugin/files/plugin/src/builders/__fileName__/builder.spec.ts__tmpl__
+++ b/packages/nx-plugin/src/schematics/plugin/files/plugin/src/builders/__fileName__/builder.spec.ts__tmpl__
@@ -24,8 +24,7 @@ describe('Command Runner Builder', () => {
 
   it('can run', async () => {
     // A "run" can have multiple outputs, and contains progress information.
-    const run = await architect.scheduleBuilder('@<%= npmScope %>/<%= fileName %>:build', options);  // We pass the logger for checking later.
-
+    const run = await architect.scheduleBuilder('@<%= npmScope %>/<%= fileName %>:build', options);
     // The "result" member (of type BuilderOutput) is the next output.
     const output = await run.result;
 

--- a/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
@@ -2,7 +2,8 @@ import { exec } from 'child_process';
 import { tmpProjPath } from './paths';
 
 /**
- * Run a command asynchronously
+ * Run a command asynchronously inside the e2e directory.
+ *
  * @param command
  * @param opts
  */
@@ -29,7 +30,7 @@ export function runCommandAsync(
 }
 
 /**
- * Run a nx command asynchronously
+ * Run a nx command asynchronously inside the e2e directory
  * @param command
  * @param opts
  */

--- a/packages/nx-plugin/src/utils/testing-utils/commands.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/commands.ts
@@ -2,9 +2,11 @@ import { execSync } from 'child_process';
 import { tmpProjPath } from './paths';
 
 /**
- * Run a nx command
+ * Run a nx command inside the e2e directory
  * @param command
  * @param opts
+ *
+ * @see tmpProjPath
  */
 export function runNxCommand(
   command?: string,

--- a/packages/nx-plugin/src/utils/testing-utils/nx-project.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/nx-project.ts
@@ -28,11 +28,17 @@ function patchPackageJsonForPlugin(npmPackageName: string, distPath: string) {
 /**
  * Generate a unique name for running CLI commands
  * @param prefix
+ *
+ * @returns `'<prefix><random number>'`
  */
 export function uniq(prefix: string) {
   return `${prefix}${Math.floor(Math.random() * 10000000)}`;
 }
 
+/**
+ * Run yarn install in the e2e directory
+ * @param silent silent output from the install
+ */
 export function runYarnInstall(silent: boolean = true) {
   const install = execSync('yarn install', {
     cwd: tmpProjPath(),
@@ -42,8 +48,10 @@ export function runYarnInstall(silent: boolean = true) {
 }
 
 /**
- * Sets up a new project in the temporary project path
- * for the currently selected CLI.
+ * Creates a new nx project in the e2e directory
+ *
+ * @param npmPackageName package name to test
+ * @param pluginDistPath dist path where the plugin was outputted to
  */
 export function newNxProject(
   npmPackageName: string,
@@ -56,10 +64,8 @@ export function newNxProject(
 }
 
 /**
- * Ensures that a project has been setup
- * in the temporary project path
- *
- * If one is not found, it creates a new project.
+ * Ensures that a project has been setup in the e2e directory
+ * It will also copy `@nrwl` packages to the e2e directory
  */
 export function ensureNxProject(
   npmPackageName?: string,

--- a/packages/nx-plugin/src/utils/testing-utils/paths.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/paths.ts
@@ -1,9 +1,21 @@
+/**
+ * The directory where the e2e workspace resides in.
+ *
+ * @param path path within the e2e directory
+ * @returns `'${process.cwd()}/tmp/nx-e2e/proj/<path>'`
+ */
 export function tmpProjPath(path?: string) {
   return path
     ? `${process.cwd()}/tmp/nx-e2e/proj/${path}`
     : `${process.cwd()}/tmp/nx-e2e/proj`;
 }
 
+/**
+ * The workspace backup directory. This is used for caching of the creation of the workspace.
+ *
+ * @param path path within the e2e directory
+ * @returns `'${process.cwd()}/tmp/nx-e2e/proj-backup/<path>'`
+ */
 export function tmpBackupProjPath(path?: string) {
   return path
     ? `${process.cwd()}/tmp/nx-e2e/proj-backup/${path}`

--- a/packages/nx-plugin/src/utils/testing-utils/utils.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/utils.ts
@@ -1,14 +1,14 @@
 import {
+  copySync,
   ensureDirSync,
   readdirSync,
   readFileSync,
   removeSync,
   renameSync,
   statSync,
-  writeFileSync,
-  copySync
+  writeFileSync
 } from 'fs-extra';
-import { dirname } from 'path';
+import { dirname, isAbsolute } from 'path';
 import { tmpProjPath } from './paths';
 
 /**
@@ -26,73 +26,129 @@ export function copyNodeModules(modules: string[]) {
 }
 
 /**
- * Assert output from a asynchronous CLI command
- * @param output: Output from an asynchronous command
+ * Assert test output from a asynchronous CLI command.
+ *
+ * @param output Output from an asynchronous command
  */
-export function expectTestsPass(v: { stdout: string; stderr: string }) {
-  expect(v.stderr).toContain('Ran all test suites');
-  expect(v.stderr).not.toContain('fail');
+export function expectTestsPass(output: { stdout: string; stderr: string }) {
+  expect(output.stderr).toContain('Ran all test suites');
+  expect(output.stderr).not.toContain('fail');
 }
 
-export function updateFile(f: string, content: string | Function): void {
-  ensureDirSync(dirname(tmpProjPath(f)));
+// type callback =
+
+/**
+ * Update a file's content in the e2e directory.
+ *
+ * If the `content` param is a callback, it will provide the original file content as an argument.
+ *
+ * @param file Path of the file in the e2e directory
+ * @param content Content to replace the original content with
+ */
+export function updateFile(
+  file: string,
+  content: string | ((originalFileContent: string) => string)
+): void {
+  ensureDirSync(dirname(tmpProjPath(file)));
   if (typeof content === 'string') {
-    writeFileSync(tmpProjPath(f), content);
+    writeFileSync(tmpProjPath(file), content);
   } else {
     writeFileSync(
-      tmpProjPath(f),
-      content(readFileSync(tmpProjPath(f)).toString())
+      tmpProjPath(file),
+      content(readFileSync(tmpProjPath(file)).toString())
     );
   }
 }
 
-export function renameFile(f: string, newPath: string): void {
+/**
+ * Rename a file or directory within the e2e directory.
+ * @param path Original path
+ * @param newPath New path
+ */
+export function renameFile(path: string, newPath: string): void {
   ensureDirSync(dirname(tmpProjPath(newPath)));
-  renameSync(tmpProjPath(f), tmpProjPath(newPath));
+  renameSync(tmpProjPath(path), tmpProjPath(newPath));
 }
 
-export function checkFilesExist(...expectedFiles: string[]) {
-  expectedFiles.forEach(f => {
-    const ff = f.startsWith('/') ? f : tmpProjPath(f);
-    if (!exists(ff)) {
-      throw new Error(`File '${ff}' does not exist`);
+/**
+ * Check if the file or directory exists.
+ *
+ * If a path starts with `/` or `C:/`, it will check it as absolute. Otherwise it will check within the e2e directory.
+ *
+ * @param expectedPaths Files or directories to check
+ * @usage `checkFileExists('file1', 'file2', '/var/user/file')`
+ */
+export function checkFilesExist(...expectedPaths: string[]) {
+  expectedPaths.forEach(path => {
+    const filePath = isAbsolute(path) ? path : tmpProjPath(path);
+    if (!exists(filePath)) {
+      throw new Error(`'${filePath}' does not exist`);
     }
   });
 }
 
+/**
+ * Get a list of all files within a directory.
+ * @param dirName Directory name within the e2e directory.
+ */
 export function listFiles(dirName: string) {
   return readdirSync(tmpProjPath(dirName));
 }
 
-export function readJson(f: string): any {
-  return JSON.parse(readFile(f));
+/**
+ * Read a JSON file.
+ * @param path Path to the JSON file. Absolute or relative to the e2e directory.
+ */
+export function readJson(path: string): any {
+  return JSON.parse(readFile(path));
 }
 
-export function readFile(f: string) {
-  const ff = f.startsWith('/') ? f : tmpProjPath(f);
-  return readFileSync(ff).toString();
+/**
+ * Read a file.
+ * @param path Path to the file. Absolute or relative to the e2e directory.
+ */
+export function readFile(path: string) {
+  const filePath = isAbsolute(path) ? path : tmpProjPath(path);
+  return readFileSync(filePath).toString();
 }
 
+/**
+ * Deletes the e2e directory
+ */
 export function cleanup() {
   removeSync(tmpProjPath());
 }
 
+/**
+ * Remove the dist folder from the e2e directory
+ */
 export function rmDist() {
   removeSync(`${tmpProjPath()}/dist`);
 }
 
+/**
+ * Get the currend `cwd` in the process
+ */
 export function getCwd(): string {
   return process.cwd();
 }
 
-export function directoryExists(filePath: string): boolean {
+/**
+ * Check if a directory exists
+ * @param directoryPath Path to directory
+ */
+export function directoryExists(directoryPath: string): boolean {
   try {
-    return statSync(filePath).isDirectory();
+    return statSync(directoryPath).isDirectory();
   } catch (err) {
     return false;
   }
 }
 
+/**
+ * Check if a file exists.
+ * @param filePath Path to file
+ */
 export function fileExists(filePath: string): boolean {
   try {
     return statSync(filePath).isFile();
@@ -101,10 +157,18 @@ export function fileExists(filePath: string): boolean {
   }
 }
 
-export function exists(filePath: string): boolean {
-  return directoryExists(filePath) || fileExists(filePath);
+/**
+ * Check if a file or directory exists.
+ * @param path Path to file or directory
+ */
+export function exists(path: string): boolean {
+  return directoryExists(path) || fileExists(path);
 }
 
+/**
+ * Get the size of a file on disk
+ * @param filePath Path to the file
+ */
 export function getSize(filePath: string): number {
   return statSync(filePath).size;
 }


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
Documentation is missing from exported functions in nx-plugin. No docs written.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Documentation is added to exported functions and a written doc is provided to go through all the functions of the package. 

## Issue
