### PR TITLE
feat(angular): add --project alias, default argv source and example to move schemas

### DIFF
--- a/docs/angular/api-angular/schematics/move.md
+++ b/docs/angular/api-angular/schematics/move.md
@@ -26,6 +26,14 @@ Show what will be generated without writing to disk:
 ng g move ... --dry-run
 ```
 
+### Examples
+
+Move libs/my-feature-lib to libs/shared/my-feature-lib:
+
+```bash
+ng g @nrwl/angular:move --project my-feature-lib shared/my-feature-lib
+```
+
 ## Options
 
 ### destination
@@ -35,6 +43,8 @@ Type: `string`
 The folder to move the Angular project into
 
 ### projectName
+
+Alias(es): project
 
 Type: `string`
 

--- a/docs/angular/api-workspace/schematics/move.md
+++ b/docs/angular/api-workspace/schematics/move.md
@@ -26,6 +26,14 @@ Show what will be generated without writing to disk:
 ng g move ... --dry-run
 ```
 
+### Examples
+
+Move libs/my-feature-lib to libs/shared/my-feature-lib:
+
+```bash
+ng g @nrwl/workspace:move --project my-feature-lib shared/my-feature-lib
+```
+
 ## Options
 
 ### destination
@@ -35,6 +43,8 @@ Type: `string`
 The folder to move the project into
 
 ### projectName
+
+Alias(es): project
 
 Type: `string`
 

--- a/docs/react/api-angular/schematics/move.md
+++ b/docs/react/api-angular/schematics/move.md
@@ -26,6 +26,14 @@ Show what will be generated without writing to disk:
 nx g move ... --dry-run
 ```
 
+### Examples
+
+Move libs/my-feature-lib to libs/shared/my-feature-lib:
+
+```bash
+nx g @nrwl/angular:move --project my-feature-lib shared/my-feature-lib
+```
+
 ## Options
 
 ### destination
@@ -35,6 +43,8 @@ Type: `string`
 The folder to move the Angular project into
 
 ### projectName
+
+Alias(es): project
 
 Type: `string`
 

--- a/docs/react/api-workspace/schematics/move.md
+++ b/docs/react/api-workspace/schematics/move.md
@@ -26,6 +26,14 @@ Show what will be generated without writing to disk:
 nx g move ... --dry-run
 ```
 
+### Examples
+
+Move libs/my-feature-lib to libs/shared/my-feature-lib:
+
+```bash
+nx g @nrwl/workspace:move --project my-feature-lib shared/my-feature-lib
+```
+
 ## Options
 
 ### destination
@@ -35,6 +43,8 @@ Type: `string`
 The folder to move the project into
 
 ### projectName
+
+Alias(es): project
 
 Type: `string`
 

--- a/docs/web/api-angular/schematics/move.md
+++ b/docs/web/api-angular/schematics/move.md
@@ -26,6 +26,14 @@ Show what will be generated without writing to disk:
 nx g move ... --dry-run
 ```
 
+### Examples
+
+Move libs/my-feature-lib to libs/shared/my-feature-lib:
+
+```bash
+nx g @nrwl/angular:move --project my-feature-lib shared/my-feature-lib
+```
+
 ## Options
 
 ### destination
@@ -35,6 +43,8 @@ Type: `string`
 The folder to move the Angular project into
 
 ### projectName
+
+Alias(es): project
 
 Type: `string`
 

--- a/docs/web/api-workspace/schematics/move.md
+++ b/docs/web/api-workspace/schematics/move.md
@@ -26,6 +26,14 @@ Show what will be generated without writing to disk:
 nx g move ... --dry-run
 ```
 
+### Examples
+
+Move libs/my-feature-lib to libs/shared/my-feature-lib:
+
+```bash
+nx g @nrwl/workspace:move --project my-feature-lib shared/my-feature-lib
+```
+
 ## Options
 
 ### destination
@@ -35,6 +43,8 @@ Type: `string`
 The folder to move the project into
 
 ### projectName
+
+Alias(es): project
 
 Type: `string`
 

--- a/e2e/move.angular.test.ts
+++ b/e2e/move.angular.test.ts
@@ -32,7 +32,7 @@ forEachCli(cli => {
        */
       it('should work for apps', () => {
         const moveOutput = runCLI(
-          `generate @nrwl/angular:move --projectName=${app1} --destination=${newPath}`
+          `generate @nrwl/angular:move --project ${app1} ${newPath}`
         );
 
         // just check the output

--- a/e2e/move.workspace.test.ts
+++ b/e2e/move.workspace.test.ts
@@ -48,7 +48,7 @@ forEachCli(cli => {
       );
 
       const moveOutput = runCLI(
-        `generate @nrwl/workspace:move --projectName=${lib1}-data-access --destination=shared/${lib1}/data-access`
+        `generate @nrwl/workspace:move --project ${lib1}-data-access shared/${lib1}/data-access`
       );
 
       expect(moveOutput).toContain(`DELETE libs/${lib1}/data-access`);

--- a/packages/angular/src/schematics/move/schema.json
+++ b/packages/angular/src/schematics/move/schema.json
@@ -4,14 +4,25 @@
   "title": "Nx Angular Move",
   "description": "Move an Angular project to another folder in the workspace",
   "type": "object",
+  "examples": [
+    {
+      "command": "g @nrwl/angular:move --project my-feature-lib shared/my-feature-lib",
+      "description": "Move libs/my-feature-lib to libs/shared/my-feature-lib"
+    }
+  ],
   "properties": {
     "projectName": {
       "type": "string",
+      "alias": "project",
       "description": "The name of the Angular project to move"
     },
     "destination": {
       "type": "string",
-      "description": "The folder to move the Angular project into"
+      "description": "The folder to move the Angular project into",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
     }
   },
   "required": ["projectName", "destination"]

--- a/packages/workspace/src/schematics/move/schema.json
+++ b/packages/workspace/src/schematics/move/schema.json
@@ -4,14 +4,25 @@
   "title": "Nx Move",
   "description": "Move a project to another folder in the workspace",
   "type": "object",
+  "examples": [
+    {
+      "command": "g @nrwl/workspace:move --project my-feature-lib shared/my-feature-lib",
+      "description": "Move libs/my-feature-lib to libs/shared/my-feature-lib"
+    }
+  ],
   "properties": {
     "projectName": {
       "type": "string",
+      "alias": "project",
       "description": "The name of the project to move"
     },
     "destination": {
       "type": "string",
-      "description": "The folder to move the project into"
+      "description": "The folder to move the project into",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
     }
   },
   "required": ["projectName", "destination"]


### PR DESCRIPTION
Just a small update to the `mv` schemas which adds an example and enables:

`nx g @nrwl/angular:mv --project my-lib shared/my-lib`