### PR TITLE
feat(react) nx serve should has --maxWorkers --memoryLimit options

### DIFF
--- a/docs/angular/api-web/builders/dev-server.md
+++ b/docs/angular/api-web/builders/dev-server.md
@@ -34,6 +34,20 @@ Type: `boolean`
 
 Whether to reload the page on change, using live-reload.
 
+### maxWorkers
+
+Type: `number`
+
+Number of workers to use for type checking.
+
+### memoryLimit
+
+Default: `2048`
+
+Type: `number`
+
+Memory limit for type checking service process in MB.
+
 ### open
 
 Default: `false`

--- a/docs/react/api-web/builders/dev-server.md
+++ b/docs/react/api-web/builders/dev-server.md
@@ -35,6 +35,20 @@ Type: `boolean`
 
 Whether to reload the page on change, using live-reload.
 
+### maxWorkers
+
+Type: `number`
+
+Number of workers to use for type checking.
+
+### memoryLimit
+
+Default: `2048`
+
+Type: `number`
+
+Memory limit for type checking service process in MB.
+
 ### open
 
 Default: `false`

--- a/docs/web/api-web/builders/dev-server.md
+++ b/docs/web/api-web/builders/dev-server.md
@@ -35,6 +35,20 @@ Type: `boolean`
 
 Whether to reload the page on change, using live-reload.
 
+### maxWorkers
+
+Type: `number`
+
+Number of workers to use for type checking.
+
+### memoryLimit
+
+Default: `2048`
+
+Type: `number`
+
+Memory limit for type checking service process in MB.
+
 ### open
 
 Default: `false`

--- a/packages/web/src/builders/dev-server/dev-server.impl.ts
+++ b/packages/web/src/builders/dev-server/dev-server.impl.ts
@@ -35,7 +35,7 @@ export interface WebDevServerOptions extends JsonObject {
   liveReload: boolean;
   watch: boolean;
   allowedHosts: string;
-  maxWorkers?:number;
+  maxWorkers?: number;
   memoryLimit?: number;
 }
 

--- a/packages/web/src/builders/dev-server/dev-server.impl.ts
+++ b/packages/web/src/builders/dev-server/dev-server.impl.ts
@@ -35,6 +35,8 @@ export interface WebDevServerOptions extends JsonObject {
   liveReload: boolean;
   watch: boolean;
   allowedHosts: string;
+  maxWorkers?:number;
+  memoryLimit?: number;
 }
 
 export default createBuilder<WebDevServerOptions>(run);

--- a/packages/web/src/builders/dev-server/schema.json
+++ b/packages/web/src/builders/dev-server/schema.json
@@ -52,6 +52,16 @@
     "allowedHosts": {
       "type": "string",
       "description": "This option allows you to whitelist services that are allowed to access the dev server."
+    },
+    "memoryLimit": {
+      "type": "number",
+      "description": "Memory limit for type checking service process in MB.",
+      "default": 2048
+    },
+    "maxWorkers": {
+      "type": "number",
+      "description": "Number of workers to use for type checking.",
+      "default": "# of CPUS-2"
     }
   }
 }

--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -34,14 +34,17 @@ export function getDevServerConfig(
     serveOptions,
     buildOptions
   );
-  webpackConfig.plugins = [...webpackConfig.plugins,
+  webpackConfig.plugins = [
+    ...webpackConfig.plugins,
     new ForkTsCheckerWebpackPlugin({
-    memoryLimit:
-      serveOptions.memoryLimit ||
-      ForkTsCheckerWebpackPlugin.DEFAULT_MEMORY_LIMIT,
-    workers: serveOptions.maxWorkers || ForkTsCheckerWebpackPlugin.TWO_CPUS_FREE,
-    useTypescriptIncrementalApi: false
-  })];
+      memoryLimit:
+        serveOptions.memoryLimit ||
+        ForkTsCheckerWebpackPlugin.DEFAULT_MEMORY_LIMIT,
+      workers:
+        serveOptions.maxWorkers || ForkTsCheckerWebpackPlugin.TWO_CPUS_FREE,
+      useTypescriptIncrementalApi: false
+    })
+  ];
   if (serveOptions.liveReload) {
     webpackConfig.entry['main'].unshift(getLiveReloadEntry(serveOptions));
   }

--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -12,6 +12,7 @@ import { WebBuildBuilderOptions } from '../builders/build/build.impl';
 import { WebDevServerOptions } from '../builders/dev-server/dev-server.impl';
 import { buildServePath } from './serve-path';
 import { OptimizationOptions } from './types';
+import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 export function getDevServerConfig(
   root: string,
@@ -87,6 +88,15 @@ function getDevServerPartial(
       errors: !(scriptsOptimization || stylesOptimization),
       warnings: false
     },
+    plugins: [
+      new ForkTsCheckerWebpackPlugin({
+        memoryLimit:
+          options.memoryLimit ||
+          ForkTsCheckerWebpackPlugin.DEFAULT_MEMORY_LIMIT,
+        workers: options.maxWorkers || ForkTsCheckerWebpackPlugin.TWO_CPUS_FREE,
+        useTypescriptIncrementalApi: false
+      })
+    ],
     watchOptions: {
       poll: buildOptions.poll
     },

--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -34,6 +34,14 @@ export function getDevServerConfig(
     serveOptions,
     buildOptions
   );
+  webpackConfig.plugins = [...webpackConfig.plugins,
+    new ForkTsCheckerWebpackPlugin({
+    memoryLimit:
+      serveOptions.memoryLimit ||
+      ForkTsCheckerWebpackPlugin.DEFAULT_MEMORY_LIMIT,
+    workers: serveOptions.maxWorkers || ForkTsCheckerWebpackPlugin.TWO_CPUS_FREE,
+    useTypescriptIncrementalApi: false
+  })];
   if (serveOptions.liveReload) {
     webpackConfig.entry['main'].unshift(getLiveReloadEntry(serveOptions));
   }
@@ -88,15 +96,6 @@ function getDevServerPartial(
       errors: !(scriptsOptimization || stylesOptimization),
       warnings: false
     },
-    plugins: [
-      new ForkTsCheckerWebpackPlugin({
-        memoryLimit:
-          options.memoryLimit ||
-          ForkTsCheckerWebpackPlugin.DEFAULT_MEMORY_LIMIT,
-        workers: options.maxWorkers || ForkTsCheckerWebpackPlugin.TWO_CPUS_FREE,
-        useTypescriptIncrementalApi: false
-      })
-    ],
     watchOptions: {
       poll: buildOptions.poll
     },


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
`nx serve --maxWorkers=1` not working
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
`nx serve --maxWorkers or --memoryLimit` should work 
