### PR TITLE
fix(core): invalidate previous failed projects

### DIFF
--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -20,7 +20,6 @@ import { DefaultReporter } from '../tasks-runner/default-reporter';
 export function affected(command: string, parsedArgs: yargs.Arguments): void {
   const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides(parsedArgs);
 
-  const env = readEnvironment(nxArgs.target);
   const projectGraph = createProjectGraph();
   let affectedGraph = nxArgs.all
     ? projectGraph
@@ -33,11 +32,13 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
       withDeps(projectGraph, Object.values(affectedGraph.nodes))
     );
   }
-  const affectedProjects = Object.values(
-    parsedArgs.all ? projectGraph.nodes : affectedGraph.nodes
-  )
+  const projects = parsedArgs.all ? projectGraph.nodes : affectedGraph.nodes;
+  const env = readEnvironment(nxArgs.target, projects);
+  const affectedProjects = Object.values(projects)
     .filter(n => !parsedArgs.exclude.includes(n.name))
-    .filter(n => !parsedArgs.onlyFailed || !env.workspace.getResult(n.name));
+    .filter(
+      n => !parsedArgs.onlyFailed || !env.workspaceResults.getResult(n.name)
+    );
 
   try {
     switch (command) {

--- a/packages/workspace/src/command-line/run-many.ts
+++ b/packages/workspace/src/command-line/run-many.ts
@@ -14,9 +14,13 @@ import { DefaultReporter } from '../tasks-runner/default-reporter';
 
 export function runMany(parsedArgs: yargs.Arguments): void {
   const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides(parsedArgs);
-  const env = readEnvironment(nxArgs.target);
   const projectGraph = createProjectGraph();
   const projects = projectsToRun(nxArgs, projectGraph);
+  const projectMap: Record<string, ProjectGraphNode> = {};
+  projects.forEach(proj => {
+    projectMap[proj.name] = proj;
+  });
+  const env = readEnvironment(nxArgs.target, projectMap);
   runCommand(
     projects,
     projectGraph,

--- a/packages/workspace/src/command-line/run-one.ts
+++ b/packages/workspace/src/command-line/run-one.ts
@@ -9,9 +9,11 @@ export function runOne(opts: {
   configuration: string;
   overrides: any;
 }): void {
-  const env = readEnvironment(opts.target);
   const projectGraph = createProjectGraph();
   const projects = [projectGraph.nodes[opts.project]];
+  const env = readEnvironment(opts.target, {
+    [opts.project]: projectGraph.nodes[opts.project]
+  });
   runCommand(
     projects,
     projectGraph,

--- a/packages/workspace/src/command-line/workspace-results.spec.ts
+++ b/packages/workspace/src/command-line/workspace-results.spec.ts
@@ -2,14 +2,21 @@ import * as fs from 'fs';
 
 import { WorkspaceResults } from './workspace-results';
 import { serializeJson } from '../utils/fileutils';
-import { stripIndents } from '@angular-devkit/core/src/utils/literals';
-import { output } from '../utils/output';
+import { ProjectType } from '..//core/project-graph';
 
 describe('WorkspacesResults', () => {
   let results: WorkspaceResults;
 
   beforeEach(() => {
-    results = new WorkspaceResults('test');
+    results = new WorkspaceResults('test', {
+      proj: {
+        name: 'proj',
+        type: ProjectType.app,
+        data: {
+          files: []
+        }
+      }
+    });
   });
 
   it('should be instantiable', () => {
@@ -80,7 +87,15 @@ describe('WorkspacesResults', () => {
         })
       );
 
-      results = new WorkspaceResults('test');
+      results = new WorkspaceResults('test', {
+        proj: {
+          name: 'proj',
+          type: ProjectType.app,
+          data: {
+            files: []
+          }
+        }
+      });
 
       expect(fs.readFileSync).toHaveBeenCalledWith('dist/.nx-results', 'utf-8');
       expect(results.getResult('proj')).toBe(false);
@@ -90,7 +105,15 @@ describe('WorkspacesResults', () => {
       spyOn(fs, 'readFileSync').and.returnValue('invalid json');
 
       const runTests = () => {
-        results = new WorkspaceResults('test');
+        results = new WorkspaceResults('test', {
+          proj: {
+            name: 'proj',
+            type: ProjectType.app,
+            data: {
+              files: []
+            }
+          }
+        });
       };
 
       expect(runTests).not.toThrow();
@@ -107,9 +130,41 @@ describe('WorkspacesResults', () => {
         })
       );
 
-      results = new WorkspaceResults('build');
+      results = new WorkspaceResults('build', {
+        proj: {
+          name: 'proj',
+          type: ProjectType.app,
+          data: {
+            files: []
+          }
+        }
+      });
 
       expect(results.getResult('proj')).toBeUndefined();
+    });
+
+    it('should invalidate existing results when the project is not run', () => {
+      spyOn(fs, 'readFileSync').and.returnValue(
+        serializeJson({
+          command: 'test',
+          results: {
+            proj: true,
+            proj2: false
+          }
+        })
+      );
+
+      results = new WorkspaceResults('build', {
+        proj: {
+          name: 'proj',
+          type: ProjectType.app,
+          data: {
+            files: []
+          }
+        }
+      });
+
+      expect(results.hasFailure).toEqual(false);
     });
   });
 });

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -199,12 +199,15 @@ export function readWorkspaceFiles(): FileData[] {
   return files;
 }
 
-export function readEnvironment(target: string): Environment {
+export function readEnvironment(
+  target: string,
+  projects: Record<string, ProjectGraphNode>
+): Environment {
   const nxJson = readNxJson();
   const workspaceJson = readWorkspaceJson();
-  const workspace = new WorkspaceResults(target);
+  const workspaceResults = new WorkspaceResults(target, projects);
 
-  return { nxJson, workspaceJson, workspace };
+  return { nxJson, workspaceJson, workspaceResults };
 }
 
 /**

--- a/packages/workspace/src/core/shared-interfaces.ts
+++ b/packages/workspace/src/core/shared-interfaces.ts
@@ -1,3 +1,5 @@
+import { WorkspaceResults } from '@nrwl/workspace/src/command-line/workspace-results';
+
 export type ImplicitDependencyEntry<T = '*' | string[]> = {
   [key: string]: T | ImplicitJsonSubsetDependency<T>;
 };
@@ -28,5 +30,5 @@ export interface NxJsonProjectConfig {
 export interface Environment {
   nxJson: NxJson;
   workspaceJson: any;
-  workspace: any;
+  workspaceResults: WorkspaceResults;
 }

--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -14,7 +14,7 @@ type RunArgs = yargs.Arguments & ReporterArgs;
 export async function runCommand<T extends RunArgs>(
   projectsToRun: ProjectGraphNode[],
   projectGraph: ProjectGraph,
-  { nxJson, workspace }: Environment,
+  { nxJson, workspaceResults }: Environment,
   nxArgs: NxArgs,
   overrides: any,
   reporter: any
@@ -53,11 +53,11 @@ export async function runCommand<T extends RunArgs>(
     next: (event: any) => {
       switch (event.type) {
         case AffectedEventType.TaskComplete: {
-          workspace.setResult(event.task.target.project, event.success);
+          workspaceResults.setResult(event.task.target.project, event.success);
           break;
         }
         case AffectedEventType.TaskCacheRead: {
-          workspace.setResult(event.task.target.project, event.success);
+          workspaceResults.setResult(event.task.target.project, event.success);
           cached.push(event.task.target.project);
           break;
         }
@@ -68,15 +68,15 @@ export async function runCommand<T extends RunArgs>(
       // fix for https://github.com/nrwl/nx/issues/1666
       if (process.stdin['unref']) (process.stdin as any).unref();
 
-      workspace.saveResults();
+      workspaceResults.saveResults();
       reporter.printResults(
         nxArgs,
-        workspace.failedProjects,
-        workspace.startedWithFailedProjects,
+        workspaceResults.failedProjects,
+        workspaceResults.startedWithFailedProjects,
         cached
       );
 
-      if (workspace.hasFailure) {
+      if (workspaceResults.hasFailure) {
         process.exit(1);
       }
     }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Failed projects are not invalidated when they are not run again.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Failed projects are invalidated when they are not run again.

## Issue
Fixes #1271