### PR TITLE
fix(storybook): remove ng module import from angular stories

### DIFF
--- a/packages/angular/src/schematics/component-story/files/__componentFileName__.stories.ts__tmpl__
+++ b/packages/angular/src/schematics/component-story/files/__componentFileName__.stories.ts__tmpl__
@@ -8,7 +8,7 @@ export default {
 
 export const primary = () => ({
   moduleMetadata: {
-    imports: []
+    imports: [<%= moduleName %>]
   },
   component: <%=componentName%>,
   props: {<% for (let prop of props) { %>


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

The ngModule is imported into the `.stories.ts` file but not into the ngModule metadata.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The ngModule is imported into the ngModule metadata.

## Issue
