### PR TITLE
fix(storybook): remove ng module import from angular stories

### DIFF
--- a/packages/angular/src/schematics/component-story/component-story.ts
+++ b/packages/angular/src/schematics/component-story/component-story.ts
@@ -1,7 +1,5 @@
 import {
-  apply,
   chain,
-  mergeWith,
   move,
   Rule,
   SchematicContext,
@@ -16,8 +14,6 @@ import { getSourceNodes } from '@nrwl/workspace/src/utils/ast-utils';
 
 export interface CreateComponentStoriesFileSchema {
   libPath: string;
-  moduleFileName: string;
-  ngModuleClassName: string;
   componentName: string;
   componentPath: string;
   componentFileName: string;
@@ -29,21 +25,11 @@ export default function(schema: CreateComponentStoriesFileSchema): Rule {
 
 export function createComponentStoriesFile({
   libPath,
-  moduleFileName,
-  ngModuleClassName,
   componentName,
   componentPath,
   componentFileName
 }: CreateComponentStoriesFileSchema): Rule {
   return (tree: Tree, context: SchematicContext): Rule => {
-    const relativeModulePath =
-      componentPath
-        .split('/')
-        .filter(segment => segment !== '.')
-        .map(() => '..')
-        .join('/') +
-      '/' +
-      moduleFileName.replace(/\.ts$/, '');
     const props = getInputDescriptors(
       tree,
       libPath + '/' + componentPath + '/' + componentFileName + '.ts'
@@ -52,8 +38,6 @@ export function createComponentStoriesFile({
       template({
         componentFileName: componentFileName,
         componentName: componentName,
-        relativeModulePath,
-        moduleName: ngModuleClassName,
         props,
         tmpl: ''
       }),

--- a/packages/angular/src/schematics/component-story/files/__componentFileName__.stories.ts__tmpl__
+++ b/packages/angular/src/schematics/component-story/files/__componentFileName__.stories.ts__tmpl__
@@ -1,5 +1,4 @@
 <% if(props.length > 0) { %>import { text, number, boolean } from '@storybook/addon-knobs';<% } %>
-import { <%=moduleName%> } from '<%=relativeModulePath%>';
 import { <%=componentName%> } from './<%=componentFileName%>';
 
 export default {

--- a/packages/angular/src/schematics/component-story/schema.json
+++ b/packages/angular/src/schematics/component-story/schema.json
@@ -11,12 +11,14 @@
     "moduleFileName": {
       "type": "string",
       "description": "File name of the module that declares this component",
-      "examples": ["ui-samples.module.ts"]
+      "examples": ["ui-samples.module.ts"],
+      "x-deprecated": true
     },
     "ngModuleClassName": {
       "type": "string",
       "description": "Class name of the module that declares this component",
-      "examples": ["UiSamplesModule"]
+      "examples": ["UiSamplesModule"],
+      "x-deprecated": true
     },
     "componentName": {
       "type": "string",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

The `ngModule` imports was removed but the import is still there.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The import is now removed as well.

## Issue
