### PR TITLE
fix(repo): extend the timeout for plugin e2e tests

### DIFF
--- a/e2e/nx-plugin.test.ts
+++ b/e2e/nx-plugin.test.ts
@@ -64,7 +64,7 @@ forEachCli(currentCLIName => {
       expectTestsPass(results);
 
       done();
-    }, 75000);
+    }, 150000);
 
     describe('--directory', () => {
       it('should create a plugin in the specified directory', () => {


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Plugin e2e tests often timeout

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Plugin e2e tests does not timeout as often.

## Issue
