### PR TITLE
fix(storybook): fix ng update for @nrwl/storybook

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -28,13 +28,7 @@
     "migrations": "./migrations.json"
   },
   "peerDependencies": {
-    "@nrwl/workspace": "*",
-    "@storybook/angular": "5.3.9",
-    "@storybook/react": "5.3.9",
-    "@storybook/core": "5.3.9",
-    "@storybook/addon-knobs": "5.3.9",
-    "babel-loader": "^8.0.6",
-    "@babel/core": "^7.5.4"
+    "@nrwl/workspace": "*"
   },
   "dependencies": {
     "@nrwl/cypress": "*",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`@nrwl/storybook`'s `peerDependencies` were causing `ng update` to complain for projects that do not use `react`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`@nrwl/storybook`'s `peerDependencies` are removed fixing warnings in `ng update` for projects that do not use `react`

## Issue
