### PR TITLE
fix(misc): fix nx migrate to execute run-schematic tasks

### DIFF
--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -13,6 +13,7 @@ import { convertToCamelCase, handleErrors } from '../shared/params';
 import minimist = require('minimist');
 import { NodePackageName } from '@angular-devkit/schematics/tasks/node-package/options';
 import { TaskExecutor } from '@angular-devkit/schematics';
+import { BuiltinTaskExecutor } from '@angular-devkit/schematics/tasks/node';
 
 export type MigrationsJson = {
   version: string;
@@ -573,14 +574,12 @@ class MigrationEngineHost extends NodeModulesEngineHost {
           });
         })
     });
+
+    this.registerTaskExecutor(BuiltinTaskExecutor.RunSchematic);
   }
 
   protected _resolveCollectionPath(name: string): string {
     let collectionPath: string | undefined = undefined;
-
-    try {
-      return super._resolveCollectionPath(name);
-    } catch {}
 
     if (name.startsWith('.') || name.startsWith('/')) {
       name = resolve(name);


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`nx migrate` is broken because the wrong collection is resolved.

`nx migrate` is not capable of running schematics with tasks

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`nx migrate` resolves the correct collection

`nx migrate` is capable of running schematics with tasks

## Issue
