### PR TITLE
feat(node): add schematic for creating nestjs library

### DIFF
--- a/docs/angular/api-nest/schematics/library.md
+++ b/docs/angular/api-nest/schematics/library.md
@@ -1,0 +1,67 @@
+# library
+
+Create a nest library
+
+## Usage
+
+```bash
+ng generate library ...
+```
+
+```bash
+ng g lib ... # same
+```
+
+By default, Nx will search for `library` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+ng g @nrwl/nest:library ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+ng g library ... --dry-run
+```
+
+### Examples
+
+Generate libs/myapp/mylib:
+
+```bash
+ng g lib mylib --directory=myapp
+```
+
+## Options
+
+### directory
+
+Alias(es): d
+
+Type: `string`
+
+A directory where the library is placed
+
+### name
+
+Type: `string`
+
+Library name
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files
+
+### tags
+
+Alias(es): t
+
+Type: `string`
+
+Add tags to the library (used for linting)

--- a/docs/react/api-nest/schematics/library.md
+++ b/docs/react/api-nest/schematics/library.md
@@ -1,0 +1,67 @@
+# library
+
+Create a nest library
+
+## Usage
+
+```bash
+nx generate library ...
+```
+
+```bash
+nx g lib ... # same
+```
+
+By default, Nx will search for `library` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/nest:library ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g library ... --dry-run
+```
+
+### Examples
+
+Generate libs/myapp/mylib:
+
+```bash
+nx g lib mylib --directory=myapp
+```
+
+## Options
+
+### directory
+
+Alias(es): d
+
+Type: `string`
+
+A directory where the library is placed
+
+### name
+
+Type: `string`
+
+Library name
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files
+
+### tags
+
+Alias(es): t
+
+Type: `string`
+
+Add tags to the library (used for linting)

--- a/docs/web/api-nest/schematics/library.md
+++ b/docs/web/api-nest/schematics/library.md
@@ -1,0 +1,67 @@
+# library
+
+Create a nest library
+
+## Usage
+
+```bash
+nx generate library ...
+```
+
+```bash
+nx g lib ... # same
+```
+
+By default, Nx will search for `library` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/nest:library ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g library ... --dry-run
+```
+
+### Examples
+
+Generate libs/myapp/mylib:
+
+```bash
+nx g lib mylib --directory=myapp
+```
+
+## Options
+
+### directory
+
+Alias(es): d
+
+Type: `string`
+
+A directory where the library is placed
+
+### name
+
+Type: `string`
+
+Library name
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files
+
+### tags
+
+Alias(es): t
+
+Type: `string`
+
+Add tags to the library (used for linting)

--- a/packages/nest/collection.json
+++ b/packages/nest/collection.json
@@ -16,6 +16,13 @@
       "schema": "./src/schematics/application/schema.json",
       "aliases": ["app"],
       "description": "Create a nest application"
+    },
+
+    "library": {
+      "factory": "./src/schematics/library/library",
+      "schema": "./src/schematics/library/schema.json",
+      "aliases": ["lib"],
+      "description": "Create a nest library"
     }
   }
 }

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -29,7 +29,8 @@
     "migrations": "./migrations.json"
   },
   "peerDependencies": {
-    "@nrwl/workspace": "*"
+    "@nrwl/workspace": "*",
+    "@nestjs/schematics": "~6.9.1"
   },
   "dependencies": {
     "@nrwl/node": "*",

--- a/packages/nest/src/schematics/library/library.spec.ts
+++ b/packages/nest/src/schematics/library/library.spec.ts
@@ -1,0 +1,221 @@
+import { externalSchematic, Tree } from '@angular-devkit/schematics';
+import { NxJson, readJsonInTree } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { runSchematic } from '../../utils/testing';
+
+describe('lib', () => {
+  let appTree: Tree;
+
+  beforeEach(() => {
+    appTree = Tree.empty();
+    appTree = createEmptyWorkspace(appTree);
+  });
+
+  describe('not nested', () => {
+    it('should update workspace.json', async () => {
+      const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+      const workspaceJson = readJsonInTree(tree, '/workspace.json');
+      expect(workspaceJson.projects['my-lib'].root).toEqual('libs/my-lib');
+      expect(workspaceJson.projects['my-lib'].architect.build).toBeUndefined();
+      expect(workspaceJson.projects['my-lib'].architect.lint).toEqual({
+        builder: '@angular-devkit/build-angular:tslint',
+        options: {
+          exclude: ['**/node_modules/**', '!libs/my-lib/**'],
+          tsConfig: [
+            'libs/my-lib/tsconfig.lib.json',
+            'libs/my-lib/tsconfig.spec.json'
+          ]
+        }
+      });
+      expect(workspaceJson.projects['my-lib'].architect.test).toEqual({
+        builder: '@nrwl/jest:jest',
+        options: {
+          jestConfig: 'libs/my-lib/jest.config.js',
+          tsConfig: 'libs/my-lib/tsconfig.spec.json'
+        }
+      });
+    });
+
+    it('should update nx.json', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', tags: 'one,two' },
+        appTree
+      );
+      const nxJson = readJsonInTree<NxJson>(tree, '/nx.json');
+      expect(nxJson).toEqual({
+        npmScope: 'proj',
+        projects: {
+          'my-lib': {
+            tags: ['one', 'two']
+          }
+        }
+      });
+    });
+
+    it('should update root tsconfig.json', async () => {
+      const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+      const tsconfigJson = readJsonInTree(tree, '/tsconfig.json');
+      expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
+        'libs/my-lib/src/index.ts'
+      ]);
+    });
+
+    it('should create a local tsconfig.json', async () => {
+      const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+      const tsconfigJson = readJsonInTree(tree, 'libs/my-lib/tsconfig.json');
+      expect(tsconfigJson).toEqual({
+        extends: '../../tsconfig.json',
+        compilerOptions: {
+          types: ['node', 'jest']
+        },
+        include: ['**/*.ts']
+      });
+    });
+
+    it('should extend the local tsconfig.json with tsconfig.spec.json', async () => {
+      const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+      const tsconfigJson = readJsonInTree(
+        tree,
+        'libs/my-lib/tsconfig.spec.json'
+      );
+      expect(tsconfigJson.extends).toEqual('./tsconfig.json');
+    });
+
+    it('should extend the local tsconfig.json with tsconfig.lib.json', async () => {
+      const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+      const tsconfigJson = readJsonInTree(
+        tree,
+        'libs/my-lib/tsconfig.lib.json'
+      );
+      expect(tsconfigJson.extends).toEqual('./tsconfig.json');
+    });
+
+    it('should generate files', async () => {
+      const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+      expect(tree.exists(`libs/my-lib/jest.config.js`)).toBeTruthy();
+      expect(tree.exists('libs/my-lib/src/index.ts')).toBeTruthy();
+      expect(tree.exists('libs/my-lib/src/lib/my-lib.module.ts')).toBeTruthy();
+      expect(tree.exists('libs/my-lib/src/lib/my-lib.service.ts')).toBeTruthy();
+      expect(
+        tree.exists('libs/my-lib/src/lib/my-lib.service.spec.ts')
+      ).toBeTruthy();
+    });
+  });
+
+  describe('nested', () => {
+    it('should update nx.json', async () => {
+      const tree = await runSchematic(
+        'lib',
+        {
+          name: 'myLib',
+          directory: 'myDir',
+          tags: 'one'
+        },
+        appTree
+      );
+      const nxJson = readJsonInTree<NxJson>(tree, '/nx.json');
+      expect(nxJson).toEqual({
+        npmScope: 'proj',
+        projects: {
+          'my-dir-my-lib': {
+            tags: ['one']
+          }
+        }
+      });
+
+      const tree2 = await runSchematic(
+        'lib',
+        {
+          name: 'myLib2',
+          directory: 'myDir',
+          tags: 'one,two'
+        },
+        tree
+      );
+      const nxJson2 = readJsonInTree<NxJson>(tree2, '/nx.json');
+      expect(nxJson2).toEqual({
+        npmScope: 'proj',
+        projects: {
+          'my-dir-my-lib': {
+            tags: ['one']
+          },
+          'my-dir-my-lib2': {
+            tags: ['one', 'two']
+          }
+        }
+      });
+    });
+
+    it('should generate files', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', directory: 'myDir' },
+        appTree
+      );
+      expect(tree.exists(`libs/my-dir/my-lib/jest.config.js`)).toBeTruthy();
+      expect(tree.exists('libs/my-dir/my-lib/src/index.ts')).toBeTruthy();
+      expect(
+        tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.module.ts')
+      ).toBeTruthy();
+    });
+
+    it('should update workspace.json', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', directory: 'myDir' },
+        appTree
+      );
+      const workspaceJson = readJsonInTree(tree, '/workspace.json');
+
+      expect(workspaceJson.projects['my-dir-my-lib'].root).toEqual(
+        'libs/my-dir/my-lib'
+      );
+      expect(workspaceJson.projects['my-dir-my-lib'].architect.lint).toEqual({
+        builder: '@angular-devkit/build-angular:tslint',
+        options: {
+          exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**'],
+          tsConfig: [
+            'libs/my-dir/my-lib/tsconfig.lib.json',
+            'libs/my-dir/my-lib/tsconfig.spec.json'
+          ]
+        }
+      });
+    });
+
+    it('should update tsconfig.json', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', directory: 'myDir' },
+        appTree
+      );
+      const tsconfigJson = readJsonInTree(tree, '/tsconfig.json');
+      expect(tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']).toEqual(
+        ['libs/my-dir/my-lib/src/index.ts']
+      );
+      expect(
+        tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']
+      ).toBeUndefined();
+    });
+
+    it('should create a local tsconfig.json', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', directory: 'myDir' },
+        appTree
+      );
+
+      const tsconfigJson = readJsonInTree(
+        tree,
+        'libs/my-dir/my-lib/tsconfig.json'
+      );
+      expect(tsconfigJson).toEqual({
+        extends: '../../../tsconfig.json',
+        compilerOptions: {
+          types: ['node', 'jest']
+        },
+        include: ['**/*.ts']
+      });
+    });
+  });
+});

--- a/packages/nest/src/schematics/library/library.ts
+++ b/packages/nest/src/schematics/library/library.ts
@@ -1,0 +1,136 @@
+import { normalize, Path } from '@angular-devkit/core';
+import {
+  asSource,
+  chain,
+  externalSchematic,
+  filter,
+  MergeStrategy,
+  mergeWith,
+  Rule,
+  SchematicContext,
+  Tree
+} from '@angular-devkit/schematics';
+import {
+  formatFiles,
+  getNpmScope,
+  renameDirSyncInTree,
+  toFileName
+} from '@nrwl/workspace';
+import { Schema } from './schema';
+
+export interface NormalizedSchema extends Schema {
+  name: string;
+  prefix: string;
+  fileName: string;
+  projectRoot: Path;
+  projectDirectory: string;
+  parsedTags: string[];
+}
+
+export default function(schema: NormalizedSchema): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    const options = normalizeOptions(host, schema);
+    return chain([
+      chain([
+        externalSchematic('@nrwl/workspace', 'lib', schema),
+        filter(file => !file.endsWith('.ts'))
+      ]),
+      mergeWith(
+        asSource(generateNestFiles(!!schema.directory, options)),
+        MergeStrategy.Overwrite
+      ),
+      formatFiles(options)
+    ]);
+  };
+}
+
+function generateNestFiles(isNested: boolean, options: NormalizedSchema): Rule {
+  return chain([
+    externalSchematic('@nestjs/schematics', 'library', {
+      ...{
+        name: options.name,
+        prefix: options.prefix
+      },
+      ...(isNested && {
+        path: options.projectDirectory
+      })
+    }),
+    adjustNestFilesToLibrary(options)
+  ]);
+}
+
+function adjustNestFilesToLibrary(options: NormalizedSchema): Rule {
+  return chain([
+    removeUnwantedNestFiles(options),
+    moveNestFilesToLibraryAndAddIndex(options)
+  ]);
+}
+
+function removeUnwantedNestFiles(options: NormalizedSchema): Rule {
+  return chain([
+    (tree: Tree) => {
+      const nestDirectory = options.directory
+        ? `${options.projectRoot}/${options.name}`
+        : options.projectRoot;
+      if (tree.exists('nest-cli.json')) {
+        tree.delete('nest-cli.json');
+      }
+      tree.delete(`${nestDirectory}/src/index.ts`);
+      if (options.directory) {
+        tree.delete(nestDirectory + '/tslint.json');
+      }
+    },
+    filter(file => !file.includes('tsconfig'))
+  ]);
+}
+
+function moveNestFilesToLibraryAndAddIndex(options: NormalizedSchema): Rule {
+  return (tree: Tree) => {
+    const libDirectory = options.projectRoot;
+    const nestDirectory = options.directory
+      ? `${options.projectRoot}/${options.name}`
+      : options.projectRoot;
+    renameDirSyncInTree(
+      tree,
+      `${nestDirectory}/src`,
+      `${libDirectory}/src/lib`,
+      err => {
+        if (err) {
+          throw err;
+        }
+      }
+    );
+    tree.create(
+      `${libDirectory}/src/index.ts`,
+      `export * from './lib/${options.fileName}.module';
+      export * from './lib/${options.fileName}.service';`
+    );
+    return tree;
+  };
+}
+
+function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
+  const name = toFileName(options.name);
+  const projectDirectory = options.directory
+    ? `${toFileName(options.directory)}/${name}`
+    : name;
+
+  const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
+  const fileName = projectName;
+  const projectRoot = normalize(`libs/${projectDirectory}`);
+  const defaultPrefix = getNpmScope(host);
+
+  const parsedTags = options.tags
+    ? options.tags.split(',').map(s => s.trim())
+    : [];
+
+  return {
+    ...options,
+    fileName,
+    prefix: defaultPrefix,
+    name: projectName,
+    projectRoot,
+    projectDirectory,
+    parsedTags
+  };
+}

--- a/packages/nest/src/schematics/library/schema.d.ts
+++ b/packages/nest/src/schematics/library/schema.d.ts
@@ -1,0 +1,6 @@
+export interface Schema {
+  name: string;
+  directory?: string;
+  skipFormat: boolean;
+  tags?: string;
+}

--- a/packages/nest/src/schematics/library/schema.json
+++ b/packages/nest/src/schematics/library/schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxNestLibrary",
+  "title": "Create a Nest Library for Nx",
+  "type": "object",
+  "examples": [
+    {
+      "command": "g lib mylib --directory=myapp",
+      "description": "Generate libs/myapp/mylib"
+    }
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Library name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the library?"
+    },
+    "directory": {
+      "type": "string",
+      "description": "A directory where the library is placed",
+      "alias": "d"
+    },
+    "tags": {
+      "type": "string",
+      "description": "Add tags to the library (used for linting)",
+      "alias": "t"
+    },
+    "skipFormat": {
+      "description": "Skip formatting files",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "required": ["name"]
+}


### PR DESCRIPTION
Add @nrwl/nest:library schematic.

ISSUES CLOSED: #2378

## Current Behavior (This is the behavior we have today, before the PR is merged)
There was no schematic for creating nestjs library in nx workspace.
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
`ng g @nrwl/nest:library myLib` will create library under `libs/my-lib` directory
## Issue
#2378 