### PR TITLE
fix(core): fix migration adding duplicate implicit dependencies

### DIFF
--- a/packages/workspace/src/migrations/update-8-12-0/add-implicit-e2e-deps.spec.ts
+++ b/packages/workspace/src/migrations/update-8-12-0/add-implicit-e2e-deps.spec.ts
@@ -41,4 +41,26 @@ describe('Update 8.12.0', () => {
       tags: []
     });
   });
+
+  it('should not add duplicate implicit dependencies for e2e projects', async () => {
+    tree = await callRule(
+      updateJsonInTree<NxJson>('nx.json', json => {
+        json.projects['my-app-e2e'].implicitDependencies = ['my-app'];
+        return json;
+      }),
+      tree
+    );
+    const result = await runMigration('add-implicit-e2e-deps', {}, tree);
+
+    const nxJson = readJsonInTree<NxJson>(result, 'nx.json');
+
+    expect(nxJson.projects['my-app-e2e']).toEqual({
+      tags: [],
+      implicitDependencies: ['my-app']
+    });
+
+    expect(nxJson.projects['my-non-existent-app-e2e']).toEqual({
+      tags: []
+    });
+  });
 });

--- a/packages/workspace/src/migrations/update-8-12-0/add-implicit-e2e-deps.ts
+++ b/packages/workspace/src/migrations/update-8-12-0/add-implicit-e2e-deps.ts
@@ -12,10 +12,13 @@ import { formatFiles } from '@nrwl/workspace/src/utils/rules/format-files';
 
 const addE2eImplicitDependencies = updateJsonInTree<NxJson>('nx.json', json => {
   Object.keys(json.projects).forEach(proj => {
-    if (proj.endsWith('-e2e') && json.projects[proj.replace(/-e2e$/, '')]) {
+    const implicitE2eName = proj.replace(/-e2e$/, '');
+    if (proj.endsWith('-e2e') && json.projects[implicitE2eName]) {
       json.projects[proj].implicitDependencies =
         json.projects[proj].implicitDependencies || [];
-      json.projects[proj].implicitDependencies.push(proj.replace(/-e2e$/, ''));
+      if (!json.projects[proj].implicitDependencies.includes(implicitE2eName)) {
+        json.projects[proj].implicitDependencies.push(implicitE2eName);
+      }
     }
   });
   return json;


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Migration adds duplicate implicit dependencies for e2e projects.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Migration does not adds duplicate implicit dependencies for e2e projects.

## Issue
