### PR TITLE
feat(repo): add update-playground script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "e2e": "./scripts/e2e.sh",
     "e2e-rerun": "./scripts/e2e-rerun.sh",
     "create-playground": "./scripts/e2e.sh create-playground",
+    "update-playground": "./scripts/update-playground.sh",
     "e2e-ci1": "./scripts/e2e-ci1.sh",
     "e2e-ci2": "./scripts/e2e-ci2.sh",
     "format": "./scripts/format.sh",

--- a/scripts/update-playground.sh
+++ b/scripts/update-playground.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+./scripts/build.sh
+
+echo 'Updating all playground projects...'
+
+# Update NX playground
+rm -rf tmp/nx/proj/node_modules/@nrwl
+cp -r build/packages tmp/nx/proj/node_modules/@nrwl
+
+# Update Angular playground
+rm -rf tmp/angular/proj/node_modules/@nrwl
+cp -r build/packages tmp/angular/proj/node_modules/@nrwl


### PR DESCRIPTION
After creating a new playground, you can now run `yarn update-playground` to update with the latest
changes to NX without deleting and recreating the whole playground

## Current Behavior (This is the behavior we have today, before the PR is merged)

To update the playground you'd need to call the `yarn copy` script and pass it the full folder path for each playground project.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

There is now a quick script `yarn update-playground` that builds and copies the artefacts in both the `nx` and `angular` playground projects.