### PR TITLE
fix(nextjs): add styled components and emotion to Next.js preset options

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -300,7 +300,7 @@ function determineStyle(preset: Preset, parsedArgs: any) {
     }
   ];
 
-  if (preset === Preset.ReactWithExpress || preset === Preset.React) {
+  if ([Preset.ReactWithExpress, Preset.React, Preset.NextJs].includes(preset)) {
     choices.push(
       {
         value: 'styled-components',


### PR DESCRIPTION
ISSUES CLOSED: #2058

## Current Behavior
`npx create-nx-workspace` does not show `styled-components` or `emotion` as style options for the Next.js preset 😢

## Expected Behavior
`npx create-nx-workspace` DOES show `styled-components` and `emotion` as style options for the Next.js preset 🎉
