### PR TITLE
feat(misc): pass outputFile and format flags to eslint builder

### DIFF
--- a/docs/angular/api-linter/builders/lint.md
+++ b/docs/angular/api-linter/builders/lint.md
@@ -34,11 +34,11 @@ Fixes linting errors (may overwrite linted files).
 
 ### format
 
-Default: `prose`
+Default: `stylish`
 
 Type: `string`
 
-Output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist).
+ESLint Output formatter (https://eslint.org/docs/user-guide/formatters).
 
 ### linter
 
@@ -49,6 +49,12 @@ Type: `string`
 Possible values: `eslint`, `tslint`
 
 The tool to use for running lint checks.
+
+### outputFile
+
+Type: `string`
+
+Output file for formatted output.
 
 ### tsConfig
 

--- a/docs/react/api-linter/builders/lint.md
+++ b/docs/react/api-linter/builders/lint.md
@@ -35,11 +35,11 @@ Fixes linting errors (may overwrite linted files).
 
 ### format
 
-Default: `prose`
+Default: `stylish`
 
 Type: `string`
 
-Output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist).
+ESLint Output formatter (https://eslint.org/docs/user-guide/formatters).
 
 ### linter
 
@@ -50,6 +50,12 @@ Type: `string`
 Possible values: `eslint`, `tslint`
 
 The tool to use for running lint checks.
+
+### outputFile
+
+Type: `string`
+
+Output file for formatted output.
 
 ### tsConfig
 

--- a/docs/web/api-linter/builders/lint.md
+++ b/docs/web/api-linter/builders/lint.md
@@ -35,11 +35,11 @@ Fixes linting errors (may overwrite linted files).
 
 ### format
 
-Default: `prose`
+Default: `stylish`
 
 Type: `string`
 
-Output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist).
+ESLint Output formatter (https://eslint.org/docs/user-guide/formatters).
 
 ### linter
 
@@ -50,6 +50,12 @@ Type: `string`
 Possible values: `eslint`, `tslint`
 
 The tool to use for running lint checks.
+
+### outputFile
+
+Type: `string`
+
+Output file for formatted output.
 
 ### tsConfig
 

--- a/packages/linter/src/builders/lint/lint.impl.ts
+++ b/packages/linter/src/builders/lint/lint.impl.ts
@@ -11,8 +11,7 @@ function run(options: any, context: BuilderContext): Observable<BuilderOutput> {
     delete options.linter;
     options.eslintConfig = options.config;
     delete options.config;
-    // Use whatever the default formatter is
-    delete options.format;
+
     return from(
       context.scheduleBuilder('@angular-eslint/builder:lint', options, {
         logger: patchedLogger(context)

--- a/packages/linter/src/builders/lint/schema.json
+++ b/packages/linter/src/builders/lint/schema.json
@@ -26,25 +26,30 @@
         }
       ]
     },
+    "outputFile": {
+      "type": "string",
+      "description": "Output file for formatted output."
+    },
     "format": {
       "type": "string",
-      "description": "Output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist).",
-      "default": "prose",
+      "description": "ESLint Output formatter (https://eslint.org/docs/user-guide/formatters).",
+      "default": "stylish",
       "anyOf": [
         {
           "enum": [
-            "checkstyle",
-            "codeFrame",
-            "filesList",
-            "json",
-            "junit",
-            "msbuild",
-            "pmd",
-            "prose",
             "stylish",
-            "tap",
-            "verbose",
-            "vso"
+            "compact",
+            "codeframe",
+            "unix",
+            "visualstudio",
+            "table",
+            "checkstyle",
+            "html",
+            "jslint-xml",
+            "json",
+            "json-with-metadata",
+            "junit",
+            "tap"
           ]
         },
         { "minLength": 1 }


### PR DESCRIPTION
Fixes https://github.com/nrwl/nx/issues/2435

Requires an upstream change to `@angular/eslint` via https://github.com/angular-eslint/angular-eslint/pull/37

Requires a new release of `@angular/eslint` and a subsequent update to `packages/linter/package.json` since the `"@angular-eslint/builder"` dependency will need to be bumped up.