### PR TITLE
fix(angular): update defaults for NgRx schematics

### DIFF
--- a/docs/angular/api-angular/schematics/ngrx.md
+++ b/docs/angular/api-angular/schematics/ngrx.md
@@ -50,7 +50,7 @@ Create a Facade class for the the Feature.
 
 ### minimal
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 
@@ -118,7 +118,7 @@ Do not update the package.json with NgRx dependencies.
 
 ### syntax
 
-Default: `classes`
+Default: `creators`
 
 Type: `string`
 
@@ -128,7 +128,7 @@ Specifies whether to use class-based or creator functions for actions, reducers,
 
 ### useDataPersistence
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
 

--- a/docs/angular/guides/misc-ngrx.md
+++ b/docs/angular/guides/misc-ngrx.md
@@ -46,7 +46,7 @@ To get started with NgRx in an Angular application, you set up the root level st
 The example below shows you how to setup NgRx in the root of your application.
 
 ```bash
-ng g @nrwl/angular:ngrx app --module=apps/<appname>/src/app/app.module.ts --root --minimal
+ng g @nrwl/angular:ngrx app --module=apps/<appname>/src/app/app.module.ts --root
 ```
 
 The above command applies the following changes to the provided module:
@@ -75,7 +75,7 @@ To manage the feature state:
 - Provide a path to the `products` library module.
 
 ```bash
-ng g @nrwl/angular:ngrx products --module=libs/products/src/lib/products.module.ts --directory +state/products --syntax=creators --defaults
+ng g @nrwl/angular:ngrx products --module=libs/products/src/lib/products.module.ts --directory +state/products --defaults
 ```
 
 > Use the `--facade` option to generate an injectable Facade class along with the feature.

--- a/docs/react/api-angular/schematics/ngrx.md
+++ b/docs/react/api-angular/schematics/ngrx.md
@@ -50,7 +50,7 @@ Create a Facade class for the the Feature.
 
 ### minimal
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 
@@ -118,7 +118,7 @@ Do not update the package.json with NgRx dependencies.
 
 ### syntax
 
-Default: `classes`
+Default: `creators`
 
 Type: `string`
 
@@ -128,7 +128,7 @@ Specifies whether to use class-based or creator functions for actions, reducers,
 
 ### useDataPersistence
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
 

--- a/docs/web/api-angular/schematics/ngrx.md
+++ b/docs/web/api-angular/schematics/ngrx.md
@@ -50,7 +50,7 @@ Create a Facade class for the the Feature.
 
 ### minimal
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 
@@ -118,7 +118,7 @@ Do not update the package.json with NgRx dependencies.
 
 ### syntax
 
-Default: `classes`
+Default: `creators`
 
 Type: `string`
 
@@ -128,7 +128,7 @@ Specifies whether to use class-based or creator functions for actions, reducers,
 
 ### useDataPersistence
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
 

--- a/e2e/ngrx.test.ts
+++ b/e2e/ngrx.test.ts
@@ -18,7 +18,7 @@ forEachCli(() => {
 
       // Generate root ngrx state management
       runCLI(
-        `generate @nrwl/angular:ngrx users --module=apps/${myapp}/src/app/app.module.ts --root`
+        `generate @nrwl/angular:ngrx users --module=apps/${myapp}/src/app/app.module.ts --root --minimal=false --syntax=classes --useDataPersistence=true`
       );
       const packageJson = readJson('package.json');
       expect(packageJson.dependencies['@ngrx/store']).toBeDefined();
@@ -30,7 +30,7 @@ forEachCli(() => {
       // Generate feature library and ngrx state within that library
       runCLI(`g @nrwl/angular:lib ${mylib} --prefix=fl`);
       runCLI(
-        `generate @nrwl/angular:ngrx flights --module=libs/${mylib}/src/lib/${mylib}.module.ts --facade`
+        `generate @nrwl/angular:ngrx flights --module=libs/${mylib}/src/lib/${mylib}.module.ts --facade --syntax=classes`
       );
 
       expect(runCLI(`build ${myapp}`)).toContain(
@@ -51,7 +51,7 @@ forEachCli(() => {
 
       // Generate root ngrx state management
       runCLI(
-        `generate @nrwl/angular:ngrx users --module=apps/${myapp}/src/app/app.module.ts --root --minimal --syntax=creators`
+        `generate @nrwl/angular:ngrx users --module=apps/${myapp}/src/app/app.module.ts --root`
       );
       const packageJson = readJson('package.json');
       expect(packageJson.dependencies['@ngrx/entity']).toBeDefined();
@@ -65,7 +65,7 @@ forEachCli(() => {
       // Generate feature library and ngrx state within that library
       runCLI(`g @nrwl/angular:lib ${mylib} --prefix=fl`);
 
-      const flags = `--facade --syntax=creators --useDataPersistence=false --barrels`;
+      const flags = `--facade --barrels`;
       runCLI(
         `generate @nrwl/angular:ngrx flights --module=libs/${mylib}/src/lib/${mylib}.module.ts ${flags}`
       );

--- a/packages/angular/src/schematics/ngrx/ngrx.spec.ts
+++ b/packages/angular/src/schematics/ngrx/ngrx.spec.ts
@@ -29,7 +29,9 @@ describe('ngrx', () => {
       {
         name: 'state',
         module: 'apps/myapp/src/app/app.module.ts',
-        onlyEmptyRoot: true
+        onlyEmptyRoot: true,
+        minimal: false,
+        root: true
       },
       appTree
     );
@@ -77,7 +79,8 @@ describe('ngrx', () => {
       {
         name: 'app',
         module: 'apps/myapp/src/app/app.module.ts',
-        root: true
+        root: true,
+        minimal: false
       },
       appTree
     );
@@ -124,7 +127,8 @@ describe('ngrx', () => {
         name: 'app',
         module: 'apps/myapp/src/app/app.module.ts',
         root: true,
-        facade: true
+        facade: true,
+        minimal: false
       },
       appTree
     );
@@ -180,7 +184,8 @@ describe('ngrx', () => {
       'ngrx',
       {
         name: 'state',
-        module: 'apps/myapp/src/app/app.module.ts'
+        module: 'apps/myapp/src/app/app.module.ts',
+        minimal: false
       },
       appTree
     );
@@ -201,7 +206,8 @@ describe('ngrx', () => {
       {
         name: 'state',
         module: 'apps/myapp/src/app/app.module.ts',
-        directory: 'myCustomState'
+        directory: 'myCustomState',
+        minimal: false
       },
       appTree
     );
@@ -223,7 +229,8 @@ describe('ngrx', () => {
         name: 'state',
         module: 'apps/myapp/src/app/app.module.ts',
         onlyAddFiles: true,
-        facade: true
+        facade: true,
+        minimal: false
       },
       appTree
     );
@@ -253,7 +260,8 @@ describe('ngrx', () => {
         module: 'apps/myapp/src/app/app.module.ts',
         onlyAddFiles: false,
         skipImport: true,
-        facade: true
+        facade: true,
+        minimal: false
       },
       appTree
     );
@@ -519,7 +527,8 @@ import {
         'ngrx',
         {
           name: 'super-users',
-          module: appConfig.appModule
+          module: appConfig.appModule,
+          minimal: false
         },
         appTree
       );
@@ -549,7 +558,9 @@ import {
           name: 'users',
           module: appConfig.appModule,
           syntax: 'creators',
-          facade: true
+          minimal: false,
+          facade: true,
+          useDataPersistance: false
         },
         appTree
       );
@@ -588,7 +599,7 @@ import {
 
       [
         `import { createEffect, Actions, ofType } from '@ngrx/effects';`,
-        'this.dataPersistence.fetch(UsersActions.loadUsers, {'
+        'fetch({'
       ].forEach(text => {
         expect(content).toContain(text);
       });
@@ -645,7 +656,7 @@ import {
           module: appConfig.appModule,
           syntax: 'creators',
           facade: true,
-          useDataPersistence: false
+          minimal: false
         },
         appTree
       );
@@ -701,7 +712,10 @@ import {
       {
         name: featureName,
         module: appConfig.appModule,
-        facade: withFacade
+        facade: withFacade,
+        syntax: 'classes',
+        minimal: false,
+        useDataPersistance: true
       },
       appTree
     );

--- a/packages/angular/src/schematics/ngrx/ngrx.ts
+++ b/packages/angular/src/schematics/ngrx/ngrx.ts
@@ -54,9 +54,10 @@ export default function generateNgrxCollection(_options: Schema): Rule {
       options.onlyAddFiles = true;
     }
 
-    const fileGeneration = !options.onlyEmptyRoot
-      ? [generateNgrxFilesFromTemplates(options)]
-      : [];
+    const fileGeneration =
+      !options.onlyEmptyRoot || (!options.root && options.minimal)
+        ? [generateNgrxFilesFromTemplates(options)]
+        : [];
 
     const moduleModification = !options.onlyAddFiles
       ? [

--- a/packages/angular/src/schematics/ngrx/rules/add-imports-to-module.ts
+++ b/packages/angular/src/schematics/ngrx/rules/add-imports-to-module.ts
@@ -70,7 +70,10 @@ export function addImportsToModule(context: RequestContext): Rule {
     const hasRouter = sourceText.indexOf('RouterModule') > -1;
     const hasNxModule = sourceText.includes('NxModule.forRoot()');
 
-    if (context.options.onlyEmptyRoot || context.options.minimal) {
+    if (
+      (context.options.onlyEmptyRoot || context.options.minimal) &&
+      context.options.root
+    ) {
       insert(host, modulePath, [
         addImport.apply(this, storeModule),
         addImport.apply(this, effectsModule),

--- a/packages/angular/src/schematics/ngrx/schema.json
+++ b/packages/angular/src/schematics/ngrx/schema.json
@@ -47,7 +47,7 @@
     },
     "minimal": {
       "type": "boolean",
-      "default": false,
+      "default": true,
       "description": "Only register the root state management setup or feature state."
     },
     "onlyEmptyRoot": {
@@ -68,12 +68,12 @@
     "syntax": {
       "type": "string",
       "enum": ["classes", "creators"],
-      "default": "classes",
+      "default": "creators",
       "description": "Specifies whether to use class-based or creator functions for actions, reducers, and effects."
     },
     "useDataPersistence": {
       "type": "boolean",
-      "default": true,
+      "default": false,
       "description": "Generate NgRx Effects with the DataPersistence helper service. Set to false to use plain effects data persistence operators."
     },
     "barrels": {


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

By default, the root Store and Effects modules are registered, with a generated feature
By default, the action classes syntax is used for scaffolding
By default, the DataPersistence class in injected and used in Effects

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

By default, only the root Store and Effects modules are registered
By default, the creator functions are used for scaffolding with schematics
By default, the DataPersistence operators are used in Effects

## Issue
