### PR TITLE
fix(core): update @nrwl/workspace migration versions for CLI/DevKit to 9.0.1

### DIFF
--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -350,11 +350,43 @@
       "version": "9.0.0-beta.1",
       "packages": {
         "@angular/cli": {
-          "version": "9.0.0",
+          "version": "9.0.1",
           "alwaysAddToPackageJson": false
         },
         "typescript": {
           "version": "~3.7.4",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular-devkit/architect": {
+          "version": "0.900.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular-devkit/build-angular": {
+          "version": "0.900.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular-devkit/build-ng-packagr": {
+          "version": "0.900.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular-devkit/build-webpack": {
+          "version": "0.900.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular-devkit/build-optimizer": {
+          "version": "0.900.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular-devkit/core": {
+          "version": "9.0.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular-devkit/schematics": {
+          "version": "9.0.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@schematics/angular": {
+          "version": "9.0.1",
           "alwaysAddToPackageJson": false
         }
       }


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

When migrations run `@angular-devkit/build-angular` is changed to `0.803.23`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

When migrations run `@angular-devkit/build-angular` is changed to `0.900.1`

## Issue
