### PR TITLE
feat(node): exclude node_modules from ts-loader

### DIFF
--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -37,6 +37,7 @@ export function getBaseWebpackPartial(
         {
           test: /\.(j|t)sx?$/,
           loader: `ts-loader`,
+          exclude: /node_modules/,
           options: {
             configFile: options.tsConfig,
             transpileOnly: true,


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`ts-loader` processes `node_modules`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`ts-loader` does not process `node_modules`

## Issue
