### PR TITLE
feat(core): adds host binding option to dep-graph command

### DIFF
--- a/docs/angular/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/angular/api-workspace/npmscripts/affected-dep-graph.md
@@ -76,6 +76,10 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
+### host
+
+Bind the dep graph server to a specific ip address.
+
 ### only-failed
 
 Default: `false`

--- a/docs/angular/api-workspace/npmscripts/dep-graph.md
+++ b/docs/angular/api-workspace/npmscripts/dep-graph.md
@@ -54,6 +54,10 @@ Use to limit the dependency graph to only show specific projects, list of projec
 
 Show help
 
+### host
+
+Bind the dep graph server to a specific ip address.
+
 ### version
 
 Show version number

--- a/docs/react/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/react/api-workspace/npmscripts/affected-dep-graph.md
@@ -76,6 +76,10 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
+### host
+
+Bind the dep graph server to a specific ip address.
+
 ### only-failed
 
 Default: `false`

--- a/docs/react/api-workspace/npmscripts/dep-graph.md
+++ b/docs/react/api-workspace/npmscripts/dep-graph.md
@@ -54,6 +54,10 @@ Use to limit the dependency graph to only show specific projects, list of projec
 
 Show help
 
+### host
+
+Bind the dep graph server to a specific ip address.
+
 ### version
 
 Show version number

--- a/docs/web/api-workspace/npmscripts/affected-dep-graph.md
+++ b/docs/web/api-workspace/npmscripts/affected-dep-graph.md
@@ -76,6 +76,10 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
+### host
+
+Bind the dep graph server to a specific ip address.
+
 ### only-failed
 
 Default: `false`

--- a/docs/web/api-workspace/npmscripts/dep-graph.md
+++ b/docs/web/api-workspace/npmscripts/dep-graph.md
@@ -54,6 +54,10 @@ Use to limit the dependency graph to only show specific projects, list of projec
 
 Show help
 
+### host
+
+Bind the dep graph server to a specific ip address.
+
 ### version
 
 Show version number

--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -11,7 +11,7 @@ import { output } from '../utils/output';
 import { join } from 'path';
 
 export function generateGraph(
-  args: { file?: string; filter?: string[]; exclude?: string[] },
+  args: { file?: string; filter?: string[]; exclude?: string[]; host?: string },
   affectedProjects: string[]
 ): void {
   const graph = onlyWorkspaceProjects(createProjectGraph());
@@ -36,14 +36,20 @@ export function generateGraph(
       )
     );
   } else {
-    startServer(renderProjects, graph, affectedProjects);
+    startServer(
+      renderProjects,
+      graph,
+      affectedProjects,
+      args.host || '127.0.0.1'
+    );
   }
 }
 
 function startServer(
   projects: ProjectGraphNode[],
   graph: ProjectGraph,
-  affected: string[]
+  affected: string[],
+  host: string
 ) {
   const f = readFileSync(
     join(__dirname, '../core/dep-graph/dep-graph.html')
@@ -64,12 +70,13 @@ function startServer(
     res.end(html);
   });
 
-  app.listen(4211, '127.0.0.1');
+  app.listen(4211, host);
+
   output.note({
-    title: 'Dep graph started at http://localhost:4211'
+    title: `Dep graph started at http://${host}:4211`
   });
 
-  opn('http://localhost:4211', {
+  opn(`http://${host}:4211`, {
     wait: false
   });
 }

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -332,6 +332,10 @@ function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
         'List of projects delimited by commas to exclude from the dependency graph.',
       type: 'array',
       coerce: parseCSV
+    })
+    .option('host', {
+      describe: 'Bind the dep graph server to a specific ip address.',
+      type: 'string'
     });
 }
 


### PR DESCRIPTION
## Current Behavior
The dep-graph server uses the 127.0.0.1 ip address.

## Expected Behavior
Having an option to overrule the bind address. So it's possible to run dep-graph inside a docker dev enviroment

## Issue
N/A
