### PR TITLE
fix(core): perform package.json update if one of the deps is missing

### DIFF
--- a/packages/workspace/src/utils/ast-utils.spec.ts
+++ b/packages/workspace/src/utils/ast-utils.spec.ts
@@ -162,4 +162,31 @@ describe('addDepsToPackageJson', () => {
       testRunner.tasks.find(x => x.name === 'node-package')
     ).not.toBeDefined();
   });
+
+  it('should update the package.json if some of the dependencies are missing', async () => {
+    const devDeps = {
+      '@nrwl/jest': '1.2.3',
+      '@nrwl/workspace': '1.1.1'
+    };
+
+    appTree.overwrite(
+      '/package.json',
+      JSON.stringify({
+        dependencies: {},
+        devDependencies: {
+          '@nrwl/jest': '1.2.3'
+        }
+      })
+    );
+
+    const testRunner = new SchematicTestRunner('@nrwl/jest', null);
+
+    await testRunner
+      .callRule(() => {
+        return addDepsToPackageJson({}, devDeps);
+      }, appTree)
+      .toPromise();
+
+    expect(testRunner.tasks.find(x => x.name === 'node-package')).toBeDefined();
+  });
 });

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -547,14 +547,14 @@ function requiresAddingOfPackages(packageJsonFile, deps, devDeps): boolean {
   packageJsonFile.devDependencies = packageJsonFile.devDependencies || {};
 
   if (Object.keys(deps).length > 0) {
-    needsDepsUpdate = !Object.keys(deps).find(
-      entry => packageJsonFile.dependencies[entry]
+    needsDepsUpdate = Object.keys(deps).some(
+      entry => !packageJsonFile.dependencies[entry]
     );
   }
 
   if (Object.keys(devDeps).length > 0) {
-    needsDevDepsUpdate = !Object.keys(devDeps).find(
-      entry => packageJsonFile.devDependencies[entry]
+    needsDevDepsUpdate = Object.keys(devDeps).some(
+      entry => !packageJsonFile.devDependencies[entry]
     );
   }
 


### PR DESCRIPTION
When you create a workspace with web or react presets, Nx does not install additional eslint packages since `eslint` is already in `package.json`.

This PR updates the logic so if any of the requested dependencies is missing, then the add task will be executed.

## Current Behavior (This is the behavior we have today, before the PR is merged)

Running `create-nx-workspace myorg --preset=react` does not install eslint plugins so `yarn lint` fails.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`yarn lint` works