### PR TITLE
fix(core): recalculate dep-graph when root files are touched

### DIFF
--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -97,6 +97,18 @@ function defaultReadFileAtRevision(
   }
 }
 
+export function getFileData(filePath: string): FileData {
+  const stat = fs.statSync(filePath);
+  return {
+    file: path
+      .relative(appRootPath, filePath)
+      .split(path.sep)
+      .join('/'),
+    ext: path.extname(filePath),
+    mtime: stat.mtimeMs
+  };
+}
+
 export function allFilesInDir(
   dirName: string,
   recurse: boolean = true
@@ -185,6 +197,13 @@ export function readNxJson(): NxJson {
 export function readWorkspaceFiles(): FileData[] {
   const workspaceJson = readWorkspaceJson();
   const files = [];
+
+  files.push(
+    getFileData(`${appRootPath}/package.json`),
+    getFileData(`${appRootPath}/${workspaceFileName()}`),
+    getFileData(`${appRootPath}/nx.json`),
+    getFileData(`${appRootPath}/tsconfig.json`)
+  );
 
   // Add known workspace files and directories
   files.push(...allFilesInDir(appRootPath, false));

--- a/packages/workspace/src/core/project-graph/project-graph.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync } from 'fs';
+import { mkdirSync } from 'fs';
 import { ProjectGraph } from './project-graph-models';
 import { ProjectGraphBuilder } from './project-graph-builder';
 import { appRootPath } from '../../utils/app-root';


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

The project graph is cached if only root files are changed.

This means the project graph does not contain new architect targets, implicitDependencies, node_modules, etc.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

## Issue
Fixes #2489