### PR TITLE
fix(misc): parse args for format command

### DIFF
--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -8,7 +8,7 @@ import { createProjectGraph } from '../core/project-graph';
 import { filterAffected } from '../core/affected-project-graph';
 import { calculateFileChanges } from '../core/file-utils';
 import * as yargs from 'yargs';
-import { NxArgs } from './utils';
+import { NxArgs, splitArgsIntoNxArgsAndOverrides } from './utils';
 
 const PRETTIER_EXTENSIONS = [
   'ts',
@@ -26,8 +26,13 @@ const PRETTIER_EXTENSIONS = [
 export function format(command: 'check' | 'write', args: yargs.Arguments) {
   let patterns: string[];
 
+  const { nxArgs } = splitArgsIntoNxArgsAndOverrides(args);
+
   try {
-    patterns = getPatterns(args as any);
+    patterns = getPatterns({
+      ...args,
+      ...nxArgs
+    } as any);
   } catch (e) {
     output.error({
       title: e.message,


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Args are not parsed for the format command thus not setting default values for base

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Args are parsed for the format command, setting values for base, and not formatting all files for `yarn format`

## Issue
Fixes #2284
Fixes #2471 
Fixes #2541 