### PR TITLE
fix(angular): fix path for secondary entrypoints

### DIFF
--- a/e2e/angular-package.test.ts
+++ b/e2e/angular-package.test.ts
@@ -42,6 +42,44 @@ forEachCli('angular', (cli) => {
         `generate @nrwl/angular:library ${childLib2} --publishable=true --no-interactive`
       );
 
+      // create secondary entrypoint
+      updateFile(
+        `libs/${childLib}/sub/package.json`,
+        `
+          {
+            "ngPackage": {}
+          }
+        `
+      );
+      updateFile(
+        `libs/${childLib}/sub/src/lib/sub.module.ts`,
+        `
+          import { NgModule } from '@angular/core';
+          import { CommonModule } from '@angular/common';
+          @NgModule({ imports: [CommonModule] })
+          export class SubModule {}
+        `
+      );
+
+      updateFile(
+        `libs/${childLib}/sub/src/public_api.ts`,
+        `export * from './lib/sub.module';`
+      );
+
+      updateFile(
+        `libs/${childLib}/sub/src/index.ts`,
+        `export * from './public_api';`
+      );
+
+      updateFile(`tsconfig.json`, (s) => {
+        return s.replace(
+          `"@proj/${childLib}": ["libs/${childLib}/src/index.ts"],`,
+          `"@proj/${childLib}": ["libs/${childLib}/src/index.ts"],
+      "@proj/${childLib}/sub": ["libs/${childLib}/sub/src/index.ts"],
+        `
+        );
+      });
+
       // create dependencies by importing
       const createDep = (parent, children: string[]) => {
         updateFile(
@@ -57,11 +95,12 @@ forEachCli('angular', (cli) => {
                     )}Module } from '@proj/${entry}';`
                 )
                 .join('\n')}
+              import { SubModule } from '@proj/${childLib}/sub';
               
               @NgModule({
                 imports: [CommonModule, ${children
                   .map((entry) => `${toClassName(entry)}Module`)
-                  .join(',')}]
+                  .join(',')}, SubModule]
               })
               export class ${toClassName(parent)}Module {}          
             `

--- a/packages/workspace/src/utils/buildable-libs-utils.spec.ts
+++ b/packages/workspace/src/utils/buildable-libs-utils.spec.ts
@@ -1,0 +1,33 @@
+import {
+  DependentBuildableProjectNode,
+  updatePaths,
+} from './buildable-libs-utils';
+
+describe('updatePaths', () => {
+  const deps: DependentBuildableProjectNode[] = [
+    { name: '@proj/lib', node: {} as any, outputs: ['dist/libs/lib'] },
+  ];
+
+  it('should add path', () => {
+    const paths: Record<string, string[]> = {
+      '@proj/test': ['libs/test/src/index.ts'],
+    };
+    updatePaths(deps, paths);
+    expect(paths).toEqual({
+      '@proj/lib': ['dist/libs/lib'],
+      '@proj/test': ['libs/test/src/index.ts'],
+    });
+  });
+
+  it('should replace paths', () => {
+    const paths: Record<string, string[]> = {
+      '@proj/lib': ['libs/lib/src/index.ts'],
+      '@proj/lib/sub': ['libs/lib/sub/src/index.ts'],
+    };
+    updatePaths(deps, paths);
+    expect(paths).toEqual({
+      '@proj/lib': ['dist/libs/lib'],
+      '@proj/lib/sub': ['dist/libs/lib/sub'],
+    });
+  });
+});

--- a/packages/workspace/src/utils/buildable-libs-utils.ts
+++ b/packages/workspace/src/utils/buildable-libs-utils.ts
@@ -197,11 +197,19 @@ export function checkDependentProjectsHaveBeenBuilt(
 
 export function updatePaths(
   dependencies: DependentBuildableProjectNode[],
-  paths: { [k: string]: string[] }
+  paths: Record<string, string[]>
 ) {
+  const pathsKeys = Object.keys(paths);
   dependencies.forEach((dep) => {
     if (dep.outputs && dep.outputs.length > 0) {
       paths[dep.name] = dep.outputs;
+      // check for secondary entrypoints, only available for ng-packagr projects
+      for (const path of pathsKeys) {
+        if (path.startsWith(`${dep.name}/`)) {
+          const [, nestedPart] = path.split(`${dep.name}/`);
+          paths[path] = dep.outputs.map((o) => `${o}/${nestedPart}`);
+        }
+      }
     }
   });
 }


### PR DESCRIPTION
Secondary entrypoint path need to be adjusted to use the prebuild dist.

## Current Behavior (This is the behavior we have today, before the PR is merged)
Secondary entrypoints are not adjusted.
```json
{
 "paths": {
    "@nx-test/liba": ["dist/libs/liba"],
    "@nx-test/liba/sub": ["libs/liba/sub/src/index.ts"]
  }
}
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Secondary entrypoints should be adjusted.
```json
{
 "paths": {
    "@nx-test/liba": ["dist/libs/liba"],
    "@nx-test/liba/sub": ["dist/libs/liba/sub"]
  }
}
```

## Issue
#1765