### PR TITLE
fix(repo): fix `yarn e2e create-playground`

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -7,9 +7,14 @@ mkdir -p tmp/angular
 mkdir -p tmp/nx
 
 if [ -n "$1" ]; then
-  jest --maxWorkers=1 ./build/e2e/$1.test.js
+  TEST_FILE="./build/e2e/$1.test.js"
+  COMMAND_FILE="./build/e2e/commands/$1.test.js"
+
+  if [ -f "$TEST_FILE" ]; then
+    jest --maxWorkers=1 $TEST_FILE
+  else
+    jest --maxWorkers=1 $COMMAND_FILE
+  fi
 else
   jest --maxWorkers=1 ./build/e2e/*.test.js
 fi
-
-


### PR DESCRIPTION
Path to jest commands files needs to be updated

### Current Behavior (This is the behavior we have today, before the PR is merged)

When you run `yarn e2e create-playground`, it executes the `e2e` script that points to the directory `./build/e2e/` without `create-playground.test.ts` file. The file is located in the `./build/e2e/commands` directory so the command fails:

```
if [ -n "$1" ]; then
  jest --maxWorkers=1 ./build/e2e/$1.test.js
else
  jest --maxWorkers=1 ./build/e2e/*.test.js
fi
```

### Expected Behavior (This is the new behavior we can expect after the PR is merged)

The path to `create-playground.test.ts` in `e2e` script should point to the directory `./build/e2e/commands` directory for command type files, and `./build/e2e/` for the "true" test files:

```
if [ -n "$1" ]; then
  TEST_FILE="./build/e2e/$1.test.js"
  COMMAND_FILE="./build/e2e/commands/$1.test.js"

  if [ -f "$TEST_FILE" ]; then
    jest --maxWorkers=1 $TEST_FILE
  else
    jest --maxWorkers=1 $COMMAND_FILE
  fi
else
  jest --maxWorkers=1 ./build/e2e/*.test.js
fi
```
