### PR TITLE
feat(core): "cwd" option for commands runner

### DIFF
--- a/docs/angular/api-workspace/builders/run-commands.md
+++ b/docs/angular/api-workspace/builders/run-commands.md
@@ -30,17 +30,17 @@ Type: `string`
 
 Command to run in child process
 
-### envFile
-
-Type: `string`
-
-You may specify a custom .env file path if your file containing environment variables is located elsewhere.
-
 ### cwd
 
 Type: `string`
 
 Current working directory of the commands.
+
+### envFile
+
+Type: `string`
+
+You may specify a custom .env file path if your file containing environment variables is located elsewhere.
 
 ### outputPath
 

--- a/docs/angular/api-workspace/builders/run-commands.md
+++ b/docs/angular/api-workspace/builders/run-commands.md
@@ -36,6 +36,12 @@ Type: `string`
 
 You may specify a custom .env file path if your file containing environment variables is located elsewhere.
 
+### cwd
+
+Type: `string`
+
+Current working directory of the commands.
+
 ### outputPath
 
 Type: `string`

--- a/docs/react/api-workspace/builders/run-commands.md
+++ b/docs/react/api-workspace/builders/run-commands.md
@@ -31,17 +31,17 @@ Type: `string`
 
 Command to run in child process
 
-### envFile
-
-Type: `string`
-
-You may specify a custom .env file path if your file containing environment variables is located elsewhere.
-
 ### cwd
 
 Type: `string`
 
 Current working directory of the commands.
+
+### envFile
+
+Type: `string`
+
+You may specify a custom .env file path if your file containing environment variables is located elsewhere.
 
 ### outputPath
 

--- a/docs/react/api-workspace/builders/run-commands.md
+++ b/docs/react/api-workspace/builders/run-commands.md
@@ -37,6 +37,12 @@ Type: `string`
 
 You may specify a custom .env file path if your file containing environment variables is located elsewhere.
 
+### cwd
+
+Type: `string`
+
+Current working directory of the commands.
+
 ### outputPath
 
 Type: `string`

--- a/docs/web/api-workspace/builders/run-commands.md
+++ b/docs/web/api-workspace/builders/run-commands.md
@@ -31,17 +31,17 @@ Type: `string`
 
 Command to run in child process
 
-### envFile
-
-Type: `string`
-
-You may specify a custom .env file path if your file containing environment variables is located elsewhere.
-
 ### cwd
 
 Type: `string`
 
 Current working directory of the commands.
+
+### envFile
+
+Type: `string`
+
+You may specify a custom .env file path if your file containing environment variables is located elsewhere.
 
 ### outputPath
 

--- a/docs/web/api-workspace/builders/run-commands.md
+++ b/docs/web/api-workspace/builders/run-commands.md
@@ -37,6 +37,12 @@ Type: `string`
 
 You may specify a custom .env file path if your file containing environment variables is located elsewhere.
 
+### cwd
+
+Type: `string`
+
+Current working directory of the commands.
+
 ### outputPath
 
 Type: `string`

--- a/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
@@ -5,6 +5,7 @@ import { TestingArchitectHost } from '@angular-devkit/architect/testing';
 import { Architect } from '@angular-devkit/architect';
 import { join } from 'path';
 import { TEN_MEGABYTES } from '@nrwl/workspace/src/core/file-utils';
+import { SchemaValidationException } from '@angular-devkit/core/src/json/schema';
 
 function readFile(f: string) {
   return readFileSync(f)
@@ -23,8 +24,7 @@ describe('Command Runner Builder', () => {
     await testArchitectHost.addBuilderFromPackage(join(__dirname, '../../..'));
   });
 
-  // TODO re-enable test when https://github.com/angular/angular-cli/pull/14315 is merged
-  xit('should error when no commands are given', async () => {
+  it('should error when no commands are given', async () => {
     try {
       const run = await architect.scheduleBuilder(
         '@nrwl/workspace:run-commands',
@@ -33,14 +33,14 @@ describe('Command Runner Builder', () => {
       await run.output.toPromise();
       fail('should throw');
     } catch (e) {
-      expect(e).toEqual(
-        `ERROR: Bad builder config for @nrwl/run-command - "command" option is required`
+      expect(e.message).toContain(`Schema validation failed`);
+      expect(e.message).toContain(
+        `path "" should have required property 'commands'`
       );
     }
   });
 
-  // TODO re-enable test when https://github.com/angular/angular-cli/pull/14315 is merged
-  xit('should error when no command is given', async () => {
+  it('should error when no command is given', async () => {
     try {
       const run = await architect.scheduleBuilder(
         '@nrwl/workspace:run-commands',
@@ -51,8 +51,9 @@ describe('Command Runner Builder', () => {
       await run.result;
       fail('should throw');
     } catch (e) {
-      expect(e).toEqual(
-        `ERROR: Bad builder config for @nrwl/run-command - "command" option is required`
+      expect(e.message).toContain(`Schema validation failed`);
+      expect(e.message).toContain(
+        `path ".commands[0]" should have required property 'command'`
       );
     }
   });
@@ -268,6 +269,40 @@ describe('Command Runner Builder', () => {
         maxBuffer: TEN_MEGABYTES,
         env: { ...process.env, FORCE_COLOR: `true` }
       });
+    });
+
+    it('should run the task in the specified working directory', async () => {
+      const f = fileSync().name;
+      let run = await architect.scheduleBuilder(
+        '@nrwl/workspace:run-commands',
+        {
+          commands: [
+            {
+              command: `pwd >> ${f}`
+            }
+          ]
+        }
+      );
+
+      let result = await run.result;
+
+      expect(result).toEqual(jasmine.objectContaining({ success: true }));
+      expect(readFile(f)).toContain('nx');
+      expect(readFile(f)).not.toContain('packages');
+
+      run = await architect.scheduleBuilder('@nrwl/workspace:run-commands', {
+        commands: [
+          {
+            command: `pwd >> ${f}`
+          }
+        ],
+        cwd: 'packages'
+      });
+
+      result = await run.result;
+
+      expect(result).toEqual(jasmine.objectContaining({ success: true }));
+      expect(readFile(f)).toContain('nx/packages');
     });
   });
 

--- a/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
@@ -5,7 +5,6 @@ import { TestingArchitectHost } from '@angular-devkit/architect/testing';
 import { Architect } from '@angular-devkit/architect';
 import { join } from 'path';
 import { TEN_MEGABYTES } from '@nrwl/workspace/src/core/file-utils';
-import { SchemaValidationException } from '@angular-devkit/core/src/json/schema';
 
 function readFile(f: string) {
   return readFileSync(f)

--- a/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
@@ -269,40 +269,36 @@ describe('Command Runner Builder', () => {
         env: { ...process.env, FORCE_COLOR: `true` }
       });
     });
+  });
 
-    it('should run the task in the specified working directory', async () => {
-      const f = fileSync().name;
-      let run = await architect.scheduleBuilder(
-        '@nrwl/workspace:run-commands',
+  it('should run the task in the specified working directory', async () => {
+    const f = fileSync().name;
+    let run = await architect.scheduleBuilder('@nrwl/workspace:run-commands', {
+      commands: [
         {
-          commands: [
-            {
-              command: `pwd >> ${f}`
-            }
-          ]
+          command: `pwd >> ${f}`
         }
-      );
-
-      let result = await run.result;
-
-      expect(result).toEqual(jasmine.objectContaining({ success: true }));
-      expect(readFile(f)).toContain('nx');
-      expect(readFile(f)).not.toContain('packages');
-
-      run = await architect.scheduleBuilder('@nrwl/workspace:run-commands', {
-        commands: [
-          {
-            command: `pwd >> ${f}`
-          }
-        ],
-        cwd: 'packages'
-      });
-
-      result = await run.result;
-
-      expect(result).toEqual(jasmine.objectContaining({ success: true }));
-      expect(readFile(f)).toContain('nx/packages');
+      ]
     });
+
+    let result = await run.result;
+
+    expect(result).toEqual(jasmine.objectContaining({ success: true }));
+    expect(readFile(f)).not.toContain('/packages');
+
+    run = await architect.scheduleBuilder('@nrwl/workspace:run-commands', {
+      commands: [
+        {
+          command: `pwd >> ${f}`
+        }
+      ],
+      cwd: 'packages'
+    });
+
+    result = await run.result;
+
+    expect(result).toEqual(jasmine.objectContaining({ success: true }));
+    expect(readFile(f)).toContain('/packages');
   });
 
   describe('dotenv', () => {

--- a/packages/workspace/src/builders/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.ts
@@ -26,6 +26,7 @@ export interface RunCommandsBuilderOptions extends JsonObject {
   color?: boolean;
   parallel?: boolean;
   readyWhen?: string;
+  cwd?: string;
   args?: string;
   envFile?: string;
   parsedArgs?: { [key: string]: string };
@@ -83,7 +84,8 @@ async function runInParallel(options: RunCommandsBuilderOptions) {
       c.command,
       options.readyWhen,
       options.parsedArgs,
-      options.color
+      options.color,
+      options.cwd
     ).then(result => ({
       result,
       command: c.command
@@ -127,7 +129,8 @@ async function runSerially(
           c.command,
           options.readyWhen,
           options.parsedArgs,
-          options.color
+          options.color,
+          options.cwd
         );
         return !success ? c.command : null;
       } else {
@@ -150,13 +153,15 @@ function createProcess(
   command: string,
   readyWhen: string,
   parsedArgs: { [key: string]: string },
-  color: boolean
+  color: boolean,
+  cwd: string
 ): Promise<boolean> {
   command = transformCommand(command, parsedArgs);
   return new Promise(res => {
     const childProcess = exec(command, {
       maxBuffer: TEN_MEGABYTES,
-      env: { ...process.env, FORCE_COLOR: `${color}` }
+      env: { ...process.env, FORCE_COLOR: `${color}` },
+      cwd
     });
     /**
      * Ensure the child process is killed when the parent exits

--- a/packages/workspace/src/builders/run-commands/schema.json
+++ b/packages/workspace/src/builders/run-commands/schema.json
@@ -52,7 +52,12 @@
           }
         }
       ]
+    },
+    "cwd": {
+      "type": "string",
+      "description": "Current working directory of the commands."
     }
   },
-  "required": ["commands"]
+  "required": ["commands"],
+  "additionalProperties": false
 }

--- a/packages/workspace/src/builders/run-commands/schema.json
+++ b/packages/workspace/src/builders/run-commands/schema.json
@@ -58,6 +58,5 @@
       "description": "Current working directory of the commands."
     }
   },
-  "required": ["commands"],
-  "additionalProperties": false
+  "required": ["commands"]
 }


### PR DESCRIPTION
Adds a `cwd` option to the `@nrwl/workspace:run-commands` builder:
``` 
"print-working-directory": {
          "builder": "@nrwl/workspace:run-commands",
          "options": {
            "commands": [
              {
                "command": "pwd"
              }
            ],
            "cwd": "apps/frontend/src"
          }
        }
```
(conceptually the same as the `cwd` option when creating a [child process](https://nodejs.org/api/child_process.html) in Node)