### PR TITLE
feat(core): add support to environment variables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ You can then go to `tmp/nx` (this is set up to use Nx CLI) or `tmp/angular` (thi
 
 ```bash
 yarn create-playground
-cd tmp/nx
+cd tmp/nx/proj
 nx g @nrwl/express:app backend
 nx build backend
 ```

--- a/docs/map.json
+++ b/docs/map.json
@@ -554,6 +554,11 @@
             "name": "Imposing Constraints on the Dependency Graph",
             "id": "monorepo-tags",
             "file": "shared/monorepo-tags"
+          },
+          {
+            "name": "Using Environment Variables",
+            "id": "environment-variables",
+            "file": "react/guides/environment-variables"
           }
         ]
       }

--- a/docs/react/guides/environment-variables.md
+++ b/docs/react/guides/environment-variables.md
@@ -1,0 +1,37 @@
+# Environment Variables
+
+Environment variables are global system variables accessible by all the processes running under the Operating System (OS). Environment variables are useful to store system-wide values such as the directories to search for executable programs (PATH), OS version, Network Information, and custom variables. These env variables are passed at build time and used at the runtime of an app.
+
+## How to Use
+
+It's important to note that NX will only include in the process default and NX prefixed env vars such as: `NODE_ENV` or `NX_CUSTOM_VAR`.
+
+Defining environment variables can vary between OSes. It’s also important to know that this is temporary for the life of the shell session.
+
+**Unix systems**
+
+In Unix systems, we need to pass the env vars before passing the (or other) commands \
+
+Let's say we want to build with development mode, with env vars we can do that like so:
+
+```bash
+NODE_ENV=development nx build myapp
+```
+
+And if we want to add a custom env var for the command above, it would look like:
+
+```bash
+NODE_ENV=development NX_BUILD_NUMBER=123 nx build myapp
+```
+
+**Windows (cmd.exe)**
+
+```bash
+set "NODE_ENV=development" && nx build myapp
+```
+
+**Windows (Powershell)**
+
+```bash
+($env:NODE_ENV = "development") -and (nx build myapp)
+```

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -9,6 +9,11 @@ import {
 import { ensureDirSync } from 'fs-extra';
 import * as path from 'path';
 
+interface RunCmdOpts {
+  silenceError?: boolean;
+  env?: Record<string, string>;
+}
+
 export let cli;
 
 export function uniq(prefix: string) {
@@ -208,6 +213,7 @@ export function copyMissingPackages(): void {
     'cypress',
     'jest',
     '@types/jest',
+    '@types/node',
     'jest-preset-angular',
     'identity-obj-proxy',
     'karma',
@@ -339,13 +345,14 @@ function copyNodeModule(name: string) {
 
 export function runCommandAsync(
   command: string,
-  opts = {
-    silenceError: false
+  opts: RunCmdOpts = {
+    silenceError: false,
+    env: process.env
   }
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     exec(
-      command,
+      `${command}`,
       {
         cwd: tmpProjPath()
       },
@@ -361,8 +368,9 @@ export function runCommandAsync(
 
 export function runCLIAsync(
   command: string,
-  opts = {
-    silenceError: false
+  opts: RunCmdOpts = {
+    silenceError: false,
+    env: process.env
   }
 ): Promise<{ stdout: string; stderr: string }> {
   return runCommandAsync(
@@ -373,13 +381,15 @@ export function runCLIAsync(
 
 export function runNgAdd(
   command?: string,
-  opts = {
-    silenceError: false
+  opts: RunCmdOpts = {
+    silenceError: false,
+    env: process.env
   }
 ): string {
   try {
     return execSync(`./node_modules/.bin/ng ${command}`, {
-      cwd: tmpProjPath()
+      cwd: tmpProjPath(),
+      env: opts.env
     })
       .toString()
       .replace(
@@ -398,13 +408,15 @@ export function runNgAdd(
 
 export function runCLI(
   command?: string,
-  opts = {
-    silenceError: false
+  opts: RunCmdOpts = {
+    silenceError: false,
+    env: process.env
   }
 ): string {
   try {
     const r = execSync(`node ./node_modules/@nrwl/cli/bin/nx.js ${command}`, {
-      cwd: tmpProjPath()
+      cwd: tmpProjPath(),
+      env: opts.env
     })
       .toString()
       .replace(

--- a/packages/react/src/schematics/application/files/app/tsconfig.app.json
+++ b/packages/react/src/schematics/application/files/app/tsconfig.app.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
-    "types": []
+    "types": ["node"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]

--- a/packages/react/src/schematics/library/files/lib/tsconfig.lib.json
+++ b/packages/react/src/schematics/library/files/lib/tsconfig.lib.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
-    "types": []
+    "types": ["node"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]

--- a/packages/web/src/schematics/application/files/app/tsconfig.app.json
+++ b/packages/web/src/schematics/application/files/app/tsconfig.app.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
-    "types": []
+    "types": ["node"]
   },
   "exclude": ["**/*.spec.ts"],
   "include": ["**/*.ts"]


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
When passing environment variables for apps to access in the `process.env`, e.g `NODE_ENV=production nx serve APP_NAME`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
When passing environment variables to the build and/or running, e.g `NODE_ENV=production nx serve APP_NAME` the expectation is that we can access the env variables in the `process.env` like so `process.env.NODE_ENV`.

## Issue
Closes #1848
