### PR TITLE
feat(core): specify a custom .env file for workspace:run-commands

### DIFF
--- a/docs/angular/api-workspace/builders/run-commands.md
+++ b/docs/angular/api-workspace/builders/run-commands.md
@@ -30,6 +30,12 @@ Type: `string`
 
 Command to run in child process
 
+### envFile
+
+Type: `string`
+
+You may specify a custom .env file path if your file containing environment variables is located elsewhere.
+
 ### outputPath
 
 Type: `string`

--- a/docs/react/api-workspace/builders/run-commands.md
+++ b/docs/react/api-workspace/builders/run-commands.md
@@ -31,6 +31,12 @@ Type: `string`
 
 Command to run in child process
 
+### envFile
+
+Type: `string`
+
+You may specify a custom .env file path if your file containing environment variables is located elsewhere.
+
 ### outputPath
 
 Type: `string`

--- a/docs/web/api-workspace/builders/run-commands.md
+++ b/docs/web/api-workspace/builders/run-commands.md
@@ -31,6 +31,12 @@ Type: `string`
 
 Command to run in child process
 
+### envFile
+
+Type: `string`
+
+You may specify a custom .env file path if your file containing environment variables is located elsewhere.
+
 ### outputPath
 
 Type: `string`

--- a/packages/workspace/src/builders/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.ts
@@ -8,9 +8,18 @@ import { exec } from 'child_process';
 import { Observable } from 'rxjs';
 import { TEN_MEGABYTES } from '@nrwl/workspace/src/core/file-utils';
 
-try {
-  require('dotenv').config();
-} catch (e) {}
+function loadEnvVars(path?: string) {
+  if (path) {
+    const result = require('dotenv').config({ path });
+    if (result.error) {
+      throw result.error;
+    }
+  } else {
+    try {
+      require('dotenv').config();
+    } catch (e) {}
+  }
+}
 
 export interface RunCommandsBuilderOptions extends JsonObject {
   commands: { command: string }[];
@@ -18,6 +27,7 @@ export interface RunCommandsBuilderOptions extends JsonObject {
   parallel?: boolean;
   readyWhen?: string;
   args?: string;
+  envFile?: string;
   parsedArgs?: { [key: string]: string };
 }
 
@@ -27,6 +37,7 @@ function run(
   options: RunCommandsBuilderOptions,
   context: BuilderContext
 ): Observable<BuilderOutput> {
+  loadEnvVars(options.envFile);
   options.parsedArgs = parseArgs(options.args);
   return Observable.create(async observer => {
     if (!options.commands) {

--- a/packages/workspace/src/builders/run-commands/schema.json
+++ b/packages/workspace/src/builders/run-commands/schema.json
@@ -30,6 +30,10 @@
       "type": "string",
       "description": "Extra arguments. You can pass them as follows: ng run project:target --args='--wait=100'. You can them use {args.wait} syntax to interpolate them in the workspace config file."
     },
+    "envFile": {
+      "type": "string",
+      "description": "You may specify a custom .env file path if your file containing environment variables is located elsewhere."
+    },
     "color": {
       "type": "boolean",
       "description": "Use colors when showing output of command",


### PR DESCRIPTION
## Expected Behavior (This is the new behavior we can expect after the PR is merged)

By default `@nrwl/workspace:run-commands` looks for a `.env` file at the root level, and loads all the variables in there before running the command.

Sometimes, it might be useful to specify different `dotenv` depending on what environment you're targetting.

With this PR, you can specify a `envFile` option to `run-commands` which loads that instead of the root `.env`:

```json
       "sentry-push-sourcemaps-prod": {
          "builder": "@nrwl/workspace:run-commands",
          "options": {
            "commands": [
              {
                "envFile": "apps/my-app/environments/prod.env",
                "command": "nx run my-app --target=sentry-push-sourcemaps"
              }
            ]
          }
        },
```

## Issue
Closes #2199 