### PR TITLE
feat(core): allow non-double output of web html file

### DIFF
--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -50,6 +50,12 @@ export function run(options: WebBuildBuilderOptions, context: BuilderContext) {
       : options.optimization && options.optimization.scripts
       ? options.optimization.scripts
       : false;
+  const isHtmlOptimizeOn =
+    typeof options.optimization === 'boolean'
+      ? options.optimization
+      : options.optimization && options.optimization.html
+      ? options.optimization.html
+      : false;
 
   // Node versions 12.2-12.8 has a bug where prod builds will hang for 2-3 minutes
   // after the program exits.
@@ -78,7 +84,8 @@ export function run(options: WebBuildBuilderOptions, context: BuilderContext) {
             options,
             context.logger,
             true,
-            isScriptOptimizeOn
+            isScriptOptimizeOn,
+            isHtmlOptimizeOn
           ),
           // ES5 build for legacy browsers.
           isScriptOptimizeOn
@@ -88,7 +95,8 @@ export function run(options: WebBuildBuilderOptions, context: BuilderContext) {
                 options,
                 context.logger,
                 false,
-                isScriptOptimizeOn
+                isScriptOptimizeOn,
+                isHtmlOptimizeOn
               )
             : undefined
         ]
@@ -132,13 +140,6 @@ export function run(options: WebBuildBuilderOptions, context: BuilderContext) {
       ),
       switchMap(([result1, result2 = { success: true, emittedFiles: [] }]) => {
         const success = [result1, result2].every(result => result.success);
-        const isHtmlOptimizeOn =
-          typeof options.optimization === 'boolean'
-            ? options.optimization
-            : options.optimization && options.optimization.html
-            ? options.optimization.html
-            : false;
-
         return (isHtmlOptimizeOn
           ? writeIndexHtml({
               host,

--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -132,7 +132,14 @@ export function run(options: WebBuildBuilderOptions, context: BuilderContext) {
       ),
       switchMap(([result1, result2 = { success: true, emittedFiles: [] }]) => {
         const success = [result1, result2].every(result => result.success);
-        return (options.optimization
+        const isHtmlOptimizeOn =
+          typeof options.optimization === 'boolean'
+            ? options.optimization
+            : options.optimization && options.optimization.html
+            ? options.optimization.html
+            : false;
+
+        return (isHtmlOptimizeOn
           ? writeIndexHtml({
               host,
               outputPath: devkitJoin(

--- a/packages/web/src/builders/build/schema.json
+++ b/packages/web/src/builders/build/schema.json
@@ -154,6 +154,11 @@
               "type": "boolean",
               "description": "Enables optimization of the styles output.",
               "default": true
+            },
+            "html": {
+              "type": "boolean",
+              "description": "Enables optimization of the html output.",
+              "default": true
             }
           },
           "additionalProperties": false

--- a/packages/web/src/utils/devserver.config.spec.ts
+++ b/packages/web/src/utils/devserver.config.spec.ts
@@ -31,7 +31,8 @@ describe('getDevServerConfig', () => {
       },
       optimization: {
         scripts: false,
-        styles: false
+        styles: false,
+        html: false
       },
       styles: [],
       scripts: [],
@@ -184,7 +185,8 @@ describe('getDevServerConfig', () => {
             ...buildInput,
             optimization: {
               scripts: true,
-              styles: false
+              styles: false,
+              html: false
             }
           },
           serveInput,
@@ -202,7 +204,8 @@ describe('getDevServerConfig', () => {
             ...buildInput,
             optimization: {
               scripts: false,
-              styles: true
+              styles: true,
+              html: false
             }
           },
           serveInput,
@@ -220,7 +223,8 @@ describe('getDevServerConfig', () => {
             ...buildInput,
             optimization: {
               scripts: true,
-              styles: true
+              styles: true,
+              html: false
             }
           },
           serveInput,
@@ -238,7 +242,8 @@ describe('getDevServerConfig', () => {
             ...buildInput,
             optimization: {
               scripts: false,
-              styles: false
+              styles: false,
+              html: false
             }
           },
           serveInput,
@@ -256,7 +261,8 @@ describe('getDevServerConfig', () => {
             ...buildInput,
             optimization: {
               scripts: true,
-              styles: true
+              styles: true,
+              html: false
             }
           },
           serveInput,
@@ -331,7 +337,8 @@ describe('getDevServerConfig', () => {
             ...buildInput,
             optimization: {
               scripts: true,
-              styles: true
+              styles: true,
+              html: false
             }
           },
           serveInput,

--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -26,6 +26,7 @@ export function getDevServerConfig(
     buildOptions,
     logger,
     true, // Don't need to support legacy browsers for dev.
+    false,
     false
   );
   (webpackConfig as any).devServer = getDevServerPartial(

--- a/packages/web/src/utils/normalize.ts
+++ b/packages/web/src/utils/normalize.ts
@@ -128,7 +128,8 @@ export function normalizeWebBuildOptions(
       typeof options.optimization !== 'object'
         ? {
             scripts: options.optimization,
-            styles: options.optimization
+            styles: options.optimization,
+            html: options.optimization
           }
         : options.optimization,
     sourceMap:

--- a/packages/web/src/utils/types.ts
+++ b/packages/web/src/utils/types.ts
@@ -4,6 +4,7 @@ import { Path } from '@angular-devkit/core';
 export interface OptimizationOptions {
   scripts: boolean;
   styles: boolean;
+  html: boolean;
 }
 
 export interface SourceMapOptions {

--- a/packages/web/src/utils/web.config.spec.ts
+++ b/packages/web/src/utils/web.config.spec.ts
@@ -29,7 +29,8 @@ describe('getWebConfig', () => {
       },
       optimization: {
         scripts: false,
-        styles: false
+        styles: false,
+        html: false
       },
       styles: [],
       scripts: [],

--- a/packages/web/src/utils/web.config.ts
+++ b/packages/web/src/utils/web.config.ts
@@ -20,7 +20,8 @@ export function getWebConfig(
   options: WebBuildBuilderOptions,
   logger: LoggerApi,
   esm?: boolean,
-  isScriptOptimizeOn?: boolean
+  isScriptOptimizeOn?: boolean,
+  isHtmlOptimizeOn?: boolean
 ) {
   const tsConfig = readTsConfig(options.tsConfig);
 
@@ -46,18 +47,18 @@ export function getWebConfig(
     getPolyfillsPartial(options, esm, isScriptOptimizeOn),
     getStylesPartial(wco),
     getCommonPartial(wco),
-    getBrowserPartial(wco, options, isScriptOptimizeOn)
+    getBrowserPartial(wco, options, isHtmlOptimizeOn)
   ]);
 }
 
 function getBrowserPartial(
   wco: any,
   options: WebBuildBuilderOptions,
-  isScriptOptimizeOn: boolean
+  isHtmlOptimizeOn: boolean
 ) {
   const config = getBrowserConfig(wco);
 
-  if (!isScriptOptimizeOn) {
+  if (!isHtmlOptimizeOn) {
     const {
       deployUrl,
       subresourceIntegrity,


### PR DESCRIPTION
added `html` optimization parameter to determine whether index file should be optimized. this fixes the previous ternary statement which could never be `falsey` due to the `normalize.ts` converting this property to an object