### PR TITLE
fix(node): change the default port to 0 for node:execute

### DIFF
--- a/docs/angular/api-node/builders/execute.md
+++ b/docs/angular/api-node/builders/execute.md
@@ -36,7 +36,7 @@ Ensures the app is starting with debugging
 
 ### port
 
-Default: `7777`
+Default: `0`
 
 Type: `number`
 

--- a/docs/react/api-node/builders/execute.md
+++ b/docs/react/api-node/builders/execute.md
@@ -37,7 +37,7 @@ Ensures the app is starting with debugging
 
 ### port
 
-Default: `7777`
+Default: `0`
 
 Type: `number`
 

--- a/docs/web/api-node/builders/execute.md
+++ b/docs/web/api-node/builders/execute.md
@@ -37,7 +37,7 @@ Ensures the app is starting with debugging
 
 ### port
 
-Default: `7777`
+Default: `0`
 
 Type: `number`
 

--- a/packages/node/src/builders/execute/schema.json
+++ b/packages/node/src/builders/execute/schema.json
@@ -22,7 +22,7 @@
     },
     "port": {
       "type": "number",
-      "default": 7777,
+      "default": 0,
       "description": "The port to inspect the process on. Setting port to 0 will assign random free ports to all forked processes."
     },
     "watch": {


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
By default, the `@nrwl/node:execute` builder has `watch` defaulted to `true`. This means that any change to code will rerun the process. When this happens the old inspect process hasn't freed the port in time and we get the following error:
```
Starting inspector on localhost:7777 failed: address already in use
```
## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Setting the port to 0 by default will allow the process to use any port that is available. This will make sure that the process will not crash if it cannot get access to a port. 

## Issue
ISSUES CLOSED: #1728