### PR TITLE
feat(core): allow bundled files after `main` bundle

### DIFF
--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -150,7 +150,9 @@ export function run(options: WebBuildBuilderOptions, context: BuilderContext) {
               deployUrl: options.deployUrl,
               scripts: options.scripts,
               styles: options.styles,
-              secondaryEntries: Object.keys(options.secondaryEntries)
+              secondaryEntries: options.secondaryEntries
+                ? Object.keys(options.secondaryEntries)
+                : undefined
             })
           : of(null)
         ).pipe(

--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -149,7 +149,8 @@ export function run(options: WebBuildBuilderOptions, context: BuilderContext) {
               baseHref: options.baseHref,
               deployUrl: options.deployUrl,
               scripts: options.scripts,
-              styles: options.styles
+              styles: options.styles,
+              secondaryEntries: Object.keys(options.secondaryEntries)
             })
           : of(null)
         ).pipe(

--- a/packages/web/src/builders/build/schema.json
+++ b/packages/web/src/builders/build/schema.json
@@ -7,6 +7,13 @@
       "type": "string",
       "description": "The name of the main entry-point file."
     },
+    "secondaryEntries": {
+      "type": "object",
+      "description": "Additional files to bundle and append after the main entry-point file.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "tsConfig": {
       "type": "string",
       "description": "The name of the Typescript configuration file."

--- a/packages/web/src/utils/normalize.ts
+++ b/packages/web/src/utils/normalize.ts
@@ -41,6 +41,12 @@ export function normalizeBuildOptions<T extends BuildBuilderOptions>(
   return {
     ...options,
     main: resolve(root, options.main),
+    secondaryEntries: options.secondaryEntries
+      ? Object.keys(options.secondaryEntries).reduce((entries, name) => {
+          entries[name] = resolve(root, options.secondaryEntries[name]);
+          return entries;
+        }, {})
+      : undefined,
     outputPath: resolve(root, options.outputPath),
     tsConfig: resolve(root, options.tsConfig),
     fileReplacements: normalizeFileReplacements(root, options.fileReplacements),

--- a/packages/web/src/utils/third-party/cli-files/utilities/index-file/write-index-html.ts
+++ b/packages/web/src/utils/third-party/cli-files/utilities/index-file/write-index-html.ts
@@ -39,6 +39,7 @@ export interface WriteIndexHtmlOptions {
   sri?: boolean;
   scripts?: ExtraEntryPoint[];
   styles?: ExtraEntryPoint[];
+  secondaryEntries?: ExtraEntryPoint[];
   postTransform?: IndexHtmlTransform;
   crossOrigin?: CrossOriginValue;
 }
@@ -57,6 +58,7 @@ export function writeIndexHtml({
   sri = false,
   scripts = [],
   styles = [],
+  secondaryEntries = [],
   postTransform,
   crossOrigin
 }: WriteIndexHtmlOptions): Observable<void> {
@@ -70,7 +72,7 @@ export function writeIndexHtml({
         deployUrl,
         crossOrigin,
         sri,
-        entrypoints: generateEntryPoints({ scripts, styles }),
+        entrypoints: generateEntryPoints({ scripts, styles, secondaryEntries }),
         files: filterAndMapBuildFiles(files, ['.js', '.css']),
         noModuleFiles: filterAndMapBuildFiles(noModuleFiles, '.js'),
         moduleFiles: filterAndMapBuildFiles(moduleFiles, '.js'),

--- a/packages/web/src/utils/third-party/cli-files/utilities/index-file/write-index-html.ts
+++ b/packages/web/src/utils/third-party/cli-files/utilities/index-file/write-index-html.ts
@@ -39,7 +39,7 @@ export interface WriteIndexHtmlOptions {
   sri?: boolean;
   scripts?: ExtraEntryPoint[];
   styles?: ExtraEntryPoint[];
-  secondaryEntries?: ExtraEntryPoint[];
+  secondaryEntries?: string[];
   postTransform?: IndexHtmlTransform;
   crossOrigin?: CrossOriginValue;
 }

--- a/packages/web/src/utils/third-party/cli-files/utilities/package-chunk-sort.ts
+++ b/packages/web/src/utils/third-party/cli-files/utilities/package-chunk-sort.ts
@@ -11,7 +11,7 @@ import { normalizeExtraEntryPoints } from '../models/webpack-configs/utils';
 export function generateEntryPoints(appConfig: {
   styles: ExtraEntryPoint[];
   scripts: ExtraEntryPoint[];
-  secondaryEntries: ExtraEntryPoint[];
+  secondaryEntries: string[];
 }) {
   // Add all styles/scripts, except lazy-loaded ones.
   const extraEntryPoints = (

--- a/packages/web/src/utils/third-party/cli-files/utilities/package-chunk-sort.ts
+++ b/packages/web/src/utils/third-party/cli-files/utilities/package-chunk-sort.ts
@@ -11,6 +11,7 @@ import { normalizeExtraEntryPoints } from '../models/webpack-configs/utils';
 export function generateEntryPoints(appConfig: {
   styles: ExtraEntryPoint[];
   scripts: ExtraEntryPoint[];
+  secondaryEntries: ExtraEntryPoint[];
 }) {
   // Add all styles/scripts, except lazy-loaded ones.
   const extraEntryPoints = (
@@ -37,7 +38,8 @@ export function generateEntryPoints(appConfig: {
     ...extraEntryPoints(appConfig.styles, 'styles'),
     ...extraEntryPoints(appConfig.scripts, 'scripts'),
     'vendor',
-    'main'
+    'main',
+    ...appConfig.secondaryEntries
   ];
 
   const duplicates = [

--- a/packages/web/src/utils/types.ts
+++ b/packages/web/src/utils/types.ts
@@ -15,6 +15,7 @@ export interface SourceMapOptions {
 
 export interface BuildBuilderOptions {
   main: string;
+  secondaryEntries?: { [name: string]: string };
   outputPath: string;
   tsConfig: string;
   watch?: boolean;

--- a/packages/web/src/utils/web.config.ts
+++ b/packages/web/src/utils/web.config.ts
@@ -43,11 +43,28 @@ export function getWebConfig(
   };
   return mergeWebpack([
     _getBaseWebpackPartial(options, esm, isScriptOptimizeOn),
+    getSecondaryEntriesPartial(options),
     getPolyfillsPartial(options, esm, isScriptOptimizeOn),
     getStylesPartial(wco),
     getCommonPartial(wco),
     getBrowserPartial(wco, options, isScriptOptimizeOn)
   ]);
+}
+
+function getSecondaryEntriesPartial(
+  options: WebBuildBuilderOptions
+): Configuration {
+  const config = {
+    entry: {} as { [key: string]: string[] }
+  };
+
+  if (options.secondaryEntries) {
+    Object.keys(options.secondaryEntries).forEach(name => {
+      config.entry[name] = [options.secondaryEntries[name]];
+    });
+  }
+
+  return config;
 }
 
 function getBrowserPartial(
@@ -63,6 +80,7 @@ function getBrowserPartial(
       subresourceIntegrity,
       scripts = [],
       styles = [],
+      secondaryEntries = {},
       index,
       baseHref
     } = options;
@@ -72,7 +90,11 @@ function getBrowserPartial(
         input: resolve(wco.root, index),
         output: basename(index),
         baseHref,
-        entrypoints: generateEntryPoints({ scripts, styles }),
+        entrypoints: generateEntryPoints({
+          scripts,
+          styles,
+          secondaryEntries: Object.keys(secondaryEntries)
+        }),
         deployUrl: deployUrl,
         sri: subresourceIntegrity,
         noModuleEntrypoints: ['polyfills-es5']


### PR DESCRIPTION
this adds support for splitting an application into multiple bundles, and loading main+secondaryEntries sequentially from the Html root.

## Issue

I'm trying to build an application where:

- `main.js` exposes a plugin system
- `plugin-a.js` registers parts of the application
- `plugin-b.js` registers other parts of the application
- etc.

And have each JS file be deployable to production independent of one another.

In order to accomplish this, I need a way to bundle the entire application while de-duplicating as many dependencies as possible. Specifying additional entrypoints during build phase supports this.