### PR TITLE
 feat(node): add runtimeArgs for execute builder

### DIFF
--- a/docs/angular/api-node/builders/execute.md
+++ b/docs/angular/api-node/builders/execute.md
@@ -42,6 +42,12 @@ Type: `number`
 
 The port to inspect the process on. Setting port to 0 will assign random free ports to all forked processes.
 
+### runtimeArgs
+
+Type: `array`
+
+Extra args passed to the node process
+
 ### waitUntilTargets
 
 Type: `array`

--- a/docs/react/api-node/builders/execute.md
+++ b/docs/react/api-node/builders/execute.md
@@ -43,6 +43,12 @@ Type: `number`
 
 The port to inspect the process on. Setting port to 0 will assign random free ports to all forked processes.
 
+### runtimeArgs
+
+Type: `array`
+
+Extra args passed to the node process
+
 ### waitUntilTargets
 
 Type: `array`

--- a/docs/web/api-node/builders/execute.md
+++ b/docs/web/api-node/builders/execute.md
@@ -43,6 +43,12 @@ Type: `number`
 
 The port to inspect the process on. Setting port to 0 will assign random free ports to all forked processes.
 
+### runtimeArgs
+
+Type: `array`
+
+Extra args passed to the node process
+
 ### waitUntilTargets
 
 Type: `array`

--- a/packages/node/src/builders/execute/execute.impl.spec.ts
+++ b/packages/node/src/builders/execute/execute.impl.spec.ts
@@ -38,6 +38,7 @@ describe('NodeExecuteBuilder', () => {
     testOptions = {
       inspect: true,
       args: [],
+      runtimeArgs: [],
       buildTarget: 'nodeapp:build',
       port: 9229,
       waitUntilTargets: [],
@@ -152,6 +153,27 @@ describe('NodeExecuteBuilder', () => {
             '--inspect=localhost:1234'
           ]
         });
+      });
+    });
+  });
+
+  describe('--runtimeArgs', () => {
+    it('should add runtime args to the node process', async () => {
+      await nodeExecuteBuilderHandler(
+        {
+          ...testOptions,
+          runtimeArgs: ['-r', 'node-register']
+        },
+        context
+      ).toPromise();
+      expect(fork).toHaveBeenCalledWith('outfile.js', [], {
+        execArgv: [
+          '-r',
+          'source-map-support/register',
+          '-r',
+          'node-register',
+          '--inspect=localhost:9229'
+        ]
       });
     });
   });

--- a/packages/node/src/builders/execute/execute.impl.ts
+++ b/packages/node/src/builders/execute/execute.impl.ts
@@ -26,6 +26,7 @@ export const enum InspectType {
 
 export interface NodeExecuteBuilderOptions extends JsonObject {
   inspect: boolean | InspectType;
+  runtimeArgs: string[];
   args: string[];
   waitUntilTargets: string[];
   buildTarget: string;
@@ -77,7 +78,7 @@ function runProcess(event: NodeBuildEvent, options: NodeExecuteBuilderOptions) {
 }
 
 function getExecArgv(options: NodeExecuteBuilderOptions) {
-  const args = ['-r', 'source-map-support/register'];
+  const args = ['-r', 'source-map-support/register', ...options.runtimeArgs];
 
   if (options.inspect === true) {
     options.inspect = InspectType.Inspect;

--- a/packages/node/src/builders/execute/schema.json
+++ b/packages/node/src/builders/execute/schema.json
@@ -43,6 +43,14 @@
       "description": "Ensures the app is starting with debugging",
       "default": "inspect"
     },
+    "runtimeArgs": {
+      "type": "array",
+      "description": "Extra args passed to the node process",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
     "args": {
       "type": "array",
       "description": "Extra args when starting the app",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
There is no way to add arguments to the node process while using the `@nrwl/node:execute` builder. All args are passed to the program that will run, rather than the process that starts it. 

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Allows for runtime args to be added for the process

## Issue
 Closes #2215