### PR TITLE
docs(core): adjusts description on library schematics

### DIFF
--- a/docs/angular/api-angular/schematics/library.md
+++ b/docs/angular/api-angular/schematics/library.md
@@ -32,7 +32,7 @@ ng g library ... --dry-run
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the lib is placed
 
 ### lazy
 

--- a/docs/angular/api-node/schematics/library.md
+++ b/docs/angular/api-node/schematics/library.md
@@ -42,7 +42,7 @@ Alias(es): d
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the lib is placed
 
 ### linter
 

--- a/docs/angular/api-react/schematics/library.md
+++ b/docs/angular/api-react/schematics/library.md
@@ -56,7 +56,7 @@ Alias(es): d
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the lib is placed
 
 ### js
 

--- a/docs/angular/api-workspace/schematics/library.md
+++ b/docs/angular/api-workspace/schematics/library.md
@@ -40,7 +40,7 @@ ng g lib mylib --directory=myapp
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the lib is placed
 
 ### linter
 

--- a/docs/react/api-angular/schematics/library.md
+++ b/docs/react/api-angular/schematics/library.md
@@ -32,7 +32,7 @@ nx g library ... --dry-run
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the lib is placed
 
 ### lazy
 

--- a/docs/react/api-node/schematics/library.md
+++ b/docs/react/api-node/schematics/library.md
@@ -42,7 +42,7 @@ Alias(es): d
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the lib is placed
 
 ### linter
 

--- a/docs/react/api-react/schematics/library.md
+++ b/docs/react/api-react/schematics/library.md
@@ -56,7 +56,7 @@ Alias(es): d
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the lib is placed
 
 ### js
 

--- a/docs/react/api-workspace/schematics/library.md
+++ b/docs/react/api-workspace/schematics/library.md
@@ -40,7 +40,7 @@ nx g lib mylib --directory=myapp
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the lib is placed
 
 ### linter
 

--- a/docs/web/api-angular/schematics/library.md
+++ b/docs/web/api-angular/schematics/library.md
@@ -32,7 +32,7 @@ nx g library ... --dry-run
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the lib is placed
 
 ### lazy
 

--- a/docs/web/api-node/schematics/library.md
+++ b/docs/web/api-node/schematics/library.md
@@ -42,7 +42,7 @@ Alias(es): d
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the lib is placed
 
 ### linter
 

--- a/docs/web/api-react/schematics/library.md
+++ b/docs/web/api-react/schematics/library.md
@@ -56,7 +56,7 @@ Alias(es): d
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the lib is placed
 
 ### js
 

--- a/docs/web/api-workspace/schematics/library.md
+++ b/docs/web/api-workspace/schematics/library.md
@@ -40,7 +40,7 @@ nx g lib mylib --directory=myapp
 
 Type: `string`
 
-A directory where the app is placed
+A directory where the lib is placed
 
 ### linter
 

--- a/packages/angular/src/schematics/library/schema.json
+++ b/packages/angular/src/schematics/library/schema.json
@@ -15,7 +15,7 @@
     },
     "directory": {
       "type": "string",
-      "description": "A directory where the app is placed"
+      "description": "A directory where the lib is placed"
     },
     "publishable": {
       "type": "boolean",

--- a/packages/node/src/schematics/library/schema.json
+++ b/packages/node/src/schematics/library/schema.json
@@ -21,7 +21,7 @@
     },
     "directory": {
       "type": "string",
-      "description": "A directory where the app is placed",
+      "description": "A directory where the lib is placed",
       "alias": "d"
     },
     "linter": {

--- a/packages/react/src/schematics/library/schema.json
+++ b/packages/react/src/schematics/library/schema.json
@@ -25,7 +25,7 @@
     },
     "directory": {
       "type": "string",
-      "description": "A directory where the app is placed",
+      "description": "A directory where the lib is placed",
       "alias": "d"
     },
     "style": {

--- a/packages/workspace/src/schematics/library/schema.json
+++ b/packages/workspace/src/schematics/library/schema.json
@@ -21,7 +21,7 @@
     },
     "directory": {
       "type": "string",
-      "description": "A directory where the app is placed"
+      "description": "A directory where the lib is placed"
     },
     "linter": {
       "description": "The tool to use for running lint checks.",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

right now "where the app is placed" is displayed which might be confusing given we generate a
library

![image](https://user-images.githubusercontent.com/542458/74921505-2a85c680-53ce-11ea-93fc-d951c76d0c58.png)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

It should rather mention "libs"

## Issue
