### PR TITLE
fix(node): set tsconfig target to es2015 for nest apps

### DIFF
--- a/e2e/node.test.ts
+++ b/e2e/node.test.ts
@@ -160,6 +160,7 @@ forEachCli(currentCLIName => {
       ); // respects "extends" inside tsconfigs
 
       expect(config.options.emitDecoratorMetadata).toEqual(true); // required by nest to function properly
+      expect(config.options.target).toEqual(ts.ScriptTarget.ES2015); // required by nest swagger to function properly
       cleanup();
     }, 120000);
 

--- a/packages/nest/src/schematics/application/application.spec.ts
+++ b/packages/nest/src/schematics/application/application.spec.ts
@@ -1,6 +1,7 @@
 import { Tree } from '@angular-devkit/schematics';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
 import { runSchematic } from '../../utils/testing';
+import { readJsonInTree } from '@nrwl/workspace';
 
 describe('app', () => {
   let appTree: Tree;
@@ -16,5 +17,11 @@ describe('app', () => {
       `await NestFactory.create(AppModule);`
     );
     expect(tree.exists('apps/my-node-app/src/app/app.module.ts')).toBeTruthy();
+  });
+
+  it('should have es2015 as the tsconfig target', async () => {
+    const tree = await runSchematic('app', { name: 'myNodeApp' }, appTree);
+    const tsconfig = readJsonInTree(tree, 'apps/my-node-app/tsconfig.json');
+    expect(tsconfig.compilerOptions.target).toBe('es2015');
   });
 });

--- a/packages/nest/src/schematics/application/application.ts
+++ b/packages/nest/src/schematics/application/application.ts
@@ -73,6 +73,7 @@ export default function(schema: Schema): Rule {
       addAppFiles(options),
       updateJsonInTree(join(options.appProjectRoot, 'tsconfig.json'), json => {
         json.compilerOptions.emitDecoratorMetadata = true;
+        json.compilerOptions.target = 'es2015';
         return json;
       }),
       formatFiles(options)


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
Nest applications have `es5` set as the target for newly created apps. 

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Nest applications should have `es2015` set as the target to allow for additional capabilities with various nest packages. 

## Issue
closes #1283
closes #1002