### PR TITLE
fix(nx-plugin): ignoring Additional Files from Affected Commands

### DIFF
--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -12,7 +12,11 @@ import {
   ProjectType,
   withDeps
 } from '../core/project-graph';
-import { calculateFileChanges, readEnvironment } from '../core/file-utils';
+import {
+  calculateFileChanges,
+  readEnvironment,
+  getIgnoredGlobs
+} from '../core/file-utils';
 import { printAffected } from './print-affected';
 import { projectHasTargetAndConfiguration } from '../utils/project-has-target-and-configuration';
 import { DefaultReporter } from '../tasks-runner/default-reporter';
@@ -25,7 +29,11 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
     ? projectGraph
     : filterAffected(
         projectGraph,
-        calculateFileChanges(parseFiles(nxArgs).files, nxArgs)
+        calculateFileChanges(
+          parseFiles(nxArgs).files,
+          nxArgs,
+          getIgnoredGlobs()
+        )
       );
   if (parsedArgs.withDeps) {
     affectedGraph = onlyWorkspaceProjects(

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -12,11 +12,7 @@ import {
   ProjectType,
   withDeps
 } from '../core/project-graph';
-import {
-  calculateFileChanges,
-  readEnvironment,
-  getIgnoredGlobs
-} from '../core/file-utils';
+import { calculateFileChanges, readEnvironment } from '../core/file-utils';
 import { printAffected } from './print-affected';
 import { projectHasTargetAndConfiguration } from '../utils/project-has-target-and-configuration';
 import { DefaultReporter } from '../tasks-runner/default-reporter';
@@ -29,11 +25,7 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
     ? projectGraph
     : filterAffected(
         projectGraph,
-        calculateFileChanges(
-          parseFiles(nxArgs).files,
-          nxArgs,
-          getIgnoredGlobs()
-        )
+        calculateFileChanges(parseFiles(nxArgs).files, nxArgs)
       );
   if (parsedArgs.withDeps) {
     affectedGraph = onlyWorkspaceProjects(

--- a/packages/workspace/src/core/file-utils.spec.ts
+++ b/packages/workspace/src/core/file-utils.spec.ts
@@ -1,6 +1,8 @@
 import { calculateFileChanges, WholeFileChange } from './file-utils';
 import { DiffType, JsonChange, jsonDiff } from '../utils/json-diff';
 
+const ignore = require('ignore');
+
 describe('calculateFileChanges', () => {
   it('should return a whole file change by default', () => {
     const changes = calculateFileChanges(
@@ -62,5 +64,19 @@ describe('calculateFileChanges', () => {
         rhs: '0.0.1'
       }
     });
+  });
+
+  it('should ignore *.md changes', () => {
+    const ig = ignore();
+    ig.add('*.md');
+    const changes = calculateFileChanges(
+      ['proj/readme.md'],
+      undefined,
+      (path, revision) => {
+        return revision === 'sha1' ? '' : 'const a = 0;';
+      },
+      ig
+    );
+    expect(changes.length).toEqual(0);
   });
 });

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -42,7 +42,7 @@ export function calculateFileChanges(
     f: string,
     r: void | string
   ) => string = defaultReadFileAtRevision,
-  ignore: any = null
+  ignore = getIgnoredGlobs()
 ): FileChange[] {
   if (ignore) {
     files = files.filter(f => !ignore.ignores(f));
@@ -144,7 +144,7 @@ export function allFilesInDir(
   return res;
 }
 
-export function getIgnoredGlobs() {
+function getIgnoredGlobs() {
   const ig = ignore();
   ig.add(readFileIfExisting(`${appRootPath}/.gitignore`));
   ig.add(readFileIfExisting(`${appRootPath}/.nxignore`));

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -42,7 +42,7 @@ export function calculateFileChanges(
     f: string,
     r: void | string
   ) => string = defaultReadFileAtRevision,
-  ignore?: any
+  ignore: any = null
 ): FileChange[] {
   if (ignore) {
     files = files.filter(f => !ignore.ignores(f));

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -41,8 +41,12 @@ export function calculateFileChanges(
   readFileAtRevision: (
     f: string,
     r: void | string
-  ) => string = defaultReadFileAtRevision
+  ) => string = defaultReadFileAtRevision,
+  ignore?: any
 ): FileChange[] {
+  if (ignore) {
+    files = files.filter(f => !ignore.ignores(f));
+  }
   return files.map(f => {
     const ext = extname(f);
     const _mtime = mtime(`${appRootPath}/${f}`);
@@ -140,7 +144,7 @@ export function allFilesInDir(
   return res;
 }
 
-function getIgnoredGlobs() {
+export function getIgnoredGlobs() {
   const ig = ignore();
   ig.add(readFileIfExisting(`${appRootPath}/.gitignore`));
   ig.add(readFileIfExisting(`${appRootPath}/.nxignore`));


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
.nxignore no effect

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
ignoring Additional Files from Affected Commands

## Issue
Close #2517