### PR TITLE
fix(core): remove extra style argument passed to create-nx-workspace

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -393,6 +393,7 @@ function createApp(
           !a.startsWith('--preset') &&
           !a.startsWith('--appName') &&
           !a.startsWith('--app-name') &&
+          !a.startsWith('--style') &&
           !a.startsWith('--interactive')
       ) // not used by the new command
       .map(a => `"${a}"`)


### PR DESCRIPTION
ISSUES CLOSED: #2427

## Current Behavior (This is the behavior we have today, before the PR is merged)
`npx create-nx-workspace@latest todo --preset=react --appName="webapp" --style=scss"` throws and error:

```
Schematic input does not validate against the Schema: {"style":["scss","scss"],"preset":"react","appName":"webapp","--":[{"name":"collection","possible":[]}],"name":"todo"}
Errors:

  Data path ".style" should be string.
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
It should create the workspace with out errors


## Issue
#2427 
There was an extra `style` argument passed to `new` which ended up being combined into and array which then failed validation, because it was expecting a string for `style`

Following example of removing arguments like `preset` and `appName`, this PR removes the extraneous style argument as well.