### PR TITLE
feat(react): provide only umd & esm bundles when packaging

### DIFF
--- a/e2e/react-package.test.ts
+++ b/e2e/react-package.test.ts
@@ -79,13 +79,16 @@ forEachCli('nx', cli => {
       const childLib2Output = runCLI(`build ${childLib2}`);
       const parentLibOutput = runCLI(`build ${parentLib}`);
 
-      expect(childLibOutput).toContain(`${childLib}.esm5.js`);
+      expect(childLibOutput).toContain(`${childLib}.esm.js`);
+      expect(childLibOutput).toContain(`${childLib}.umd.js`);
       expect(childLibOutput).toContain(`Bundle complete`);
 
-      expect(childLib2Output).toContain(`${childLib2}.esm5.js`);
+      expect(childLib2Output).toContain(`${childLib2}.esm.js`);
+      expect(childLib2Output).toContain(`${childLib2}.umd.js`);
       expect(childLib2Output).toContain(`Bundle complete`);
 
-      expect(parentLibOutput).toContain(`${parentLib}.esm5.js`);
+      expect(parentLibOutput).toContain(`${parentLib}.esm.js`);
+      expect(parentLibOutput).toContain(`${parentLib}.umd.js`);
       expect(parentLibOutput).toContain(`Bundle complete`);
 
       const jsonFile = readJson(`dist/libs/${parentLib}/package.json`);

--- a/e2e/react.test.ts
+++ b/e2e/react.test.ts
@@ -52,11 +52,30 @@ forEachCli(currentCLIName => {
       expect(libTestResults.stdout).toContain('Bundle complete.');
 
       checkFilesExist(
+        `dist/libs/${libName}/package.json`,
         `dist/libs/${libName}/index.d.ts`,
-        `dist/libs/${libName}/${libName}.esm5.js`,
-        `dist/libs/${libName}/${libName}.esm2015.js`,
+        `dist/libs/${libName}/${libName}.esm.js`,
         `dist/libs/${libName}/${libName}.umd.js`
       );
+    }, 120000);
+
+    it('should not create a dist folder if there is an error', async () => {
+      ensureProject();
+      const libName = uniq('lib');
+
+      runCLI(
+        `generate @nrwl/react:lib ${libName} --publishable --no-interactive`
+      );
+
+      const mainPath = `libs/${libName}/src/lib/${libName}.tsx`;
+      updateFile(mainPath, readFile(mainPath) + `\n console.log(a);`); // should error - "a" will be undefined
+
+      await expect(runCLIAsync(`build ${libName}`)).rejects.toThrow(
+        /Bundle failed/
+      );
+      expect(() => {
+        checkFilesExist(`dist/libs/${libName}/package.json`);
+      }).toThrow();
     }, 120000);
 
     it('should generate app with routing', async () => {

--- a/packages/web/src/builders/package/package.impl.spec.ts
+++ b/packages/web/src/builders/package/package.impl.spec.ts
@@ -63,6 +63,7 @@ describe('WebPackagebuilder', () => {
           success: true
         });
       });
+      spyOn(context.logger, 'info');
 
       const result = await impl.run(testOptions, context).toPromise();
 
@@ -79,17 +80,13 @@ describe('WebPackagebuilder', () => {
           },
           {
             format: 'esm',
-            file: '/root/dist/ui/example.esm2015.js',
-            name: 'Example'
-          },
-          {
-            format: 'esm',
-            file: '/root/dist/ui/example.esm5.js',
+            file: '/root/dist/ui/example.esm.js',
             name: 'Example'
           }
         ])
       );
       expect(result.success).toBe(true);
+      expect(context.logger.info).toHaveBeenCalledWith('Bundle complete.');
     });
 
     it('should return failure when one run fails', async () => {
@@ -99,10 +96,12 @@ describe('WebPackagebuilder', () => {
           success: count++ === 0
         });
       });
-
+      spyOn(context.logger, 'error');
       const result = await impl.run(testOptions, context).toPromise();
 
       expect(result.success).toBe(false);
+      expect(f.writeJsonFile).not.toHaveBeenCalled();
+      expect(context.logger.error).toHaveBeenCalledWith('Bundle failed.');
     });
 
     it('updates package.json', async () => {
@@ -111,7 +110,6 @@ describe('WebPackagebuilder', () => {
           success: true
         });
       });
-
       await impl.run(testOptions, context).toPromise();
 
       expect(f.writeJsonFile).toHaveBeenCalled();
@@ -120,8 +118,7 @@ describe('WebPackagebuilder', () => {
       expect(content).toMatchObject({
         name: 'example',
         main: './example.umd.js',
-        module: './example.esm5.js',
-        es2015: './example.esm2015.js',
+        module: './example.esm.js',
         typings: './index.d.ts'
       });
     });

--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -6,15 +6,7 @@ import {
 } from '@angular-devkit/architect';
 import { JsonObject } from '@angular-devkit/core';
 import { from, Observable, of } from 'rxjs';
-import {
-  map,
-  mergeScan,
-  switchMap,
-  tap,
-  last,
-  mergeMap,
-  scan
-} from 'rxjs/operators';
+import { switchMap, tap, last, mergeMap, catchError } from 'rxjs/operators';
 import { runRollup } from './run-rollup';
 import { createBabelConfig as _createBabelConfig } from '../../utils/babel-config';
 import * as autoprefixer from 'autoprefixer';
@@ -169,14 +161,10 @@ export function run(
         context.logger.info('Bundling...');
         return from(rollupOptions).pipe(
           mergeMap(options => runRollup(options)),
-          scan(
-            (acc, result) => {
-              return {
-                success: acc.success && result.success
-              };
-            },
-            { success: true }
-          ),
+          catchError(e => {
+            console.error(e);
+            return of({ success: false });
+          }),
           last(),
           tap({
             next: result => {

--- a/packages/web/src/builders/package/run-rollup.ts
+++ b/packages/web/src/builders/package/run-rollup.ts
@@ -5,10 +5,6 @@ import { catchError, map, switchMap } from 'rxjs/operators';
 export function runRollup(options: rollup.RollupOptions) {
   return from(rollup.rollup(options)).pipe(
     switchMap(bundle => from(bundle.write(options.output))),
-    map(() => ({ success: true })),
-    catchError(e => {
-      console.error(e);
-      return of({ success: false });
-    })
+    map(() => ({ success: true }))
   );
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

When building libraries for the web, we export 3 bundles:
- umd 
- esm2015
- esm5

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

We don't really need to transpile at all (the consumer of the library can be responsible for that). Instead, we should just be exporting a UMD bundle (for backwards compatibility) and a ESM bundle.

## Issue
Closes #2496 - because we don't need to set a `targets` anymore, which works around a [babel bug](https://github.com/babel/babel/issues/10808)