### PR TITLE
fix(storybook): allow import * as syntax in module file

### DIFF
--- a/packages/angular/src/schematics/stories/stories.spec.ts
+++ b/packages/angular/src/schematics/stories/stories.spec.ts
@@ -131,6 +131,12 @@ export async function createTestUILib(libName: string): Promise<Tree> {
     }),
     appTree
   );
+  const modulePath = `libs/${libName}/src/lib/${libName}.module.ts`;
+  appTree.overwrite(
+    modulePath,
+    `import * as ButtonExports from './test-button/test-button.component';
+    ${appTree.read(modulePath)}`
+  );
   appTree.overwrite(
     `libs/${libName}/src/lib/test-button/test-button.component.ts`,
     `

--- a/packages/angular/src/schematics/stories/stories.ts
+++ b/packages/angular/src/schematics/stories/stories.ts
@@ -80,11 +80,14 @@ export function createAllStories(
           const componentInfo = declaredComponents.map(componentName => {
             try {
               const importStatement = imports.find(statement => {
-                const importedIdentifiers = statement
+                const namedImports = statement
                   .getChildren()
                   .find(node => node.kind === SyntaxKind.ImportClause)
                   .getChildren()
-                  .find(node => node.kind === SyntaxKind.NamedImports)
+                  .find(node => node.kind === SyntaxKind.NamedImports);
+                if (namedImports === undefined) return false;
+
+                const importedIdentifiers = namedImports
                   .getChildren()
                   .find(node => node.kind === SyntaxKind.SyntaxList)
                   .getChildren()


### PR DESCRIPTION
ISSUES CLOSED: #2521

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
`import * as something from 'somewhere';` in the `module.ts` file used to generate stories will block any stories being generated.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Ignore those import lines.

## Issue
#2521 