### PR TITLE
fix(core): use file full path in git show

### DIFF
--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -87,7 +87,7 @@ function defaultReadFileAtRevision(
   try {
     return !revision
       ? readFileSync(file).toString()
-      : execSync(`git show ${revision}:${file}`, {
+      : execSync(`git show ${revision}:${appRootPath}/${file}`, {
           maxBuffer: TEN_MEGABYTES
         })
           .toString()


### PR DESCRIPTION
Use file full path in git show to identify affected files to fix an issue when nx workspace is not at the root of git repository

## Current Behavior (This is the behavior we have today, before the PR is merged)
When NX workspace is not located at the root of git repository and we run affected commands using git repository (with --origin and --base options), we end up with the following kind of error message and the whole workspace is considered affected.
`fatal: Path 'src/subfolder/package.json' exists, but not 'package.json'.`
`Did you mean 'origin/master:src/subfolder/package.json' aka 'origin/master:./package.json'?`


## Expected Behavior (This is the new behavior we can expect after the PR is merged)
The affected commands properly identifies affected projects even when NX workspace is not located at the root of git repository. (and error message is not shown anymore)


## Issue
Closes #2292