### PR TITLE
fix(storybook): replace storybook cypress e2e architect configuration

### DIFF
--- a/packages/storybook/src/schematics/cypress-project/cypress-project.spec.ts
+++ b/packages/storybook/src/schematics/cypress-project/cypress-project.spec.ts
@@ -37,6 +37,8 @@ describe('schematic:cypress-project', () => {
     );
     expect(project.architect.e2e.options.headless).toBeUndefined();
     expect(project.architect.e2e.options.watch).toBeUndefined();
-    expect(project.architect.e2e.configurations.headless).toBeUndefined();
+    expect(project.architect.e2e.configurations).toEqual({
+      ci: { devServerTarget: `test-ui-lib:storybook:ci` }
+    });
   });
 });

--- a/packages/storybook/src/schematics/cypress-project/cypress-project.ts
+++ b/packages/storybook/src/schematics/cypress-project/cypress-project.ts
@@ -79,6 +79,11 @@ function updateAngularJsonBuilder(
       options: <any>{
         ...e2eTarget.options,
         devServerTarget: `${targetProjectName}:storybook`
+      },
+      configurations: {
+        ci: {
+          devServerTarget: `${targetProjectName}:storybook:ci`
+        }
       }
     };
     return workspace;


### PR DESCRIPTION
Generating a ui library with storybook and cypress creates an e2e architect with a production
configuration (when storybook doesn't have a production configuration) that specifies a serve target (when storybook has no serve target). This PR will replace the configuration with the default storybook configuration i.e. "ci".

## Current Behavior (This is the behavior we have today, before the PR is merged)

Generating a storybook ui library with cypress creates the e2e architect:
```
"e2e": {
  "builder": "@nrwl/cypress:cypress",
  "options": {
    "cypressConfig": "apps/shared-ui-core-components-e2e/cypress.json",
    "tsConfig": "apps/shared-ui-core-components-e2e/tsconfig.e2e.json",
    "devServerTarget": "shared-ui-core-components:storybook"
  },
  "configurations": {
    "production": {
      "devServerTarget": "shared-ui-core-components:serve:production"
    }
  }
},
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Generating a storybook ui library with cypress creates the e2e architect:

```
"e2e": {
  "builder": "@nrwl/cypress:cypress",
  "options": {
    "cypressConfig": "apps/shared-ui-core-components-e2e/cypress.json",
    "tsConfig": "apps/shared-ui-core-components-e2e/tsconfig.e2e.json",
    "devServerTarget": "shared-ui-core-components:storybook"
  },
  "configurations": {
    "ci": {
      "quite": true
    }
  }
},
```
