### PR TITLE
docs(docs): fix fixutres typo on react and angular docs

### DIFF
--- a/docs/angular/guides/react-and-angular.md
+++ b/docs/angular/guides/react-and-angular.md
@@ -61,7 +61,7 @@ happynrwl/
 │       ├── src/
 │       │   ├── integrations/
 │       │   │   └── app.spec.ts
-│       │   ├── fixutres/
+│       │   ├── fixtures/
 │       │   ├── plugins/
 │       │   └── support/
 │       ├── cypress.json

--- a/docs/angular/guides/react.md
+++ b/docs/angular/guides/react.md
@@ -70,7 +70,7 @@ happynrwl/
 │   │   ├── src/
 │   │   │   ├── integrations/
 │   │   │   │   └── app.spec.ts
-│   │   │   ├── fixutres/
+│   │   │   ├── fixtures/
 │   │   │   ├── plugins/
 │   │   │   └── support/
 │   │   ├── cypress.json

--- a/docs/react/guides/nextjs.md
+++ b/docs/react/guides/nextjs.md
@@ -49,7 +49,7 @@ happynrwl/
 │   │   ├── src/
 │   │   │   ├── integrations/
 │   │   │   │   └── app.spec.ts
-│   │   │   ├── fixutres/
+│   │   │   ├── fixtures/
 │   │   │   ├── plugins/
 │   │   │   └── support/
 │   │   ├── cypress.json


### PR DESCRIPTION
The typo `fixutres` was present in some files.
Couldn't live with it.
