### PR TITLE
fix(core): use file path inside git repository in git show command

### DIFF
--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -89,9 +89,17 @@ function defaultReadFileAtRevision(
   revision: void | string
 ): string {
   try {
+    const fileFullPath = `${appRootPath}${path.sep}${file}`;
+    const gitRepositoryPath = execSync('git rev-parse --show-toplevel')
+      .toString()
+      .trim();
+    const filePathInGitRepository = path
+      .relative(gitRepositoryPath, fileFullPath)
+      .split(path.sep)
+      .join('/');
     return !revision
       ? readFileSync(file).toString()
-      : execSync(`git show ${revision}:${file}`, {
+      : execSync(`git show ${revision}:${filePathInGitRepository}`, {
           maxBuffer: TEN_MEGABYTES
         })
           .toString()


### PR DESCRIPTION
Use file's relative path inside git repository when running `git show` to identify affected .json files to fix an issue when nx workspace is not at the root of git repository

## Current Behavior (This is the behavior we have today, before the PR is merged)
When NX workspace is not located at the root of git repository and we run affected commands using git repository (with --base option), we end up with the following kind of error message.
```
fatal: Path 'src/nx-repository-folder/package.json' exists, but not 'package.json'.
Did you mean 'origin/master:src/nx-repository-folder/package.json' aka 'origin/master:./package.json'?
```

It seems this problem occurs for .json files only.
When `defaultReadFileAtRevision` is executed, `git show` command is used with the file name. 
In the case that NX workspace is not located at the root of git repository, the file path does not match the one inside the git repository which shows the above error.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
The `git show` command is used with the file's relative path inside git repository folder and therefore the git command properly identifies the file even when NX workspace is not located at the root of git repository. (and error message is not shown anymore)

## Issue
Closes #2292