### PR TITLE
fix(nextjs): fix missing imports

### DIFF
--- a/packages/next/src/schematics/application/files/pages/__fileName__.tsx__tmpl__
+++ b/packages/next/src/schematics/application/files/pages/__fileName__.tsx__tmpl__
@@ -10,11 +10,11 @@ import React from 'react';
 %>
 
 import './<%= fileName %>.<%= style %>';
+<% }
+%>
+
 import { ReactComponent as NxLogo } from '../assets/nx-logo-white.svg';
 import { environment } from '../environments/environment';
-
-<% } 
-%>
 
 <% if (styledModule) { %>
 const StyledApp = styled.div`


### PR DESCRIPTION
## Current Behavior
page/index.tsx has no import of nx-logo and environment in styledModule templates.

## Expected Behavior
Template imports nx-logo and environment.

## Issue
#2494
