### PR TITLE
fix(nextjs): fix SVG import for generated Next app

### DIFF
--- a/e2e/commands/create-nx-workspace.test.ts
+++ b/e2e/commands/create-nx-workspace.test.ts
@@ -40,7 +40,7 @@ describe('create-nx-workspace', () => {
     await addReact(workspaceDir);
     await execCommand(
       `Generate a React app`,
-      `ng g @nrwl/react:app reactapp --linter=eslint --style=css --no-router`,
+      `ng g @nrwl/react:app reactapp --style=css --no-router`,
       workspaceDir
     );
     await execCommand(`Building angular app`, `ng build ngapp`, workspaceDir);

--- a/e2e/next.test.ts
+++ b/e2e/next.test.ts
@@ -16,9 +16,7 @@ forEachCli('nx', () => {
       ensureProject();
       const appName = uniq('app');
 
-      runCLI(
-        `generate @nrwl/next:app ${appName} --no-interactive --linter=eslint`
-      );
+      runCLI(`generate @nrwl/next:app ${appName} --no-interactive`);
 
       const proxyConf = {
         '/external-api': {
@@ -81,9 +79,7 @@ forEachCli('nx', () => {
       const appName = uniq('app');
       const libName = uniq('lib');
 
-      runCLI(
-        `generate @nrwl/next:app ${appName} --no-interactive --linter=eslint`
-      );
+      runCLI(`generate @nrwl/next:app ${appName} --no-interactive`);
 
       runCLI(`generate @nrwl/react:lib ${libName} --no-interactive`);
 
@@ -111,9 +107,7 @@ module.exports = {
       const appName = uniq('app');
       const libName = uniq('lib');
 
-      runCLI(
-        `generate @nrwl/next:app ${appName} --no-interactive --linter=eslint`
-      );
+      runCLI(`generate @nrwl/next:app ${appName} --no-interactive`);
       runCLI(`generate @nrwl/react:lib ${libName} --no-interactive`);
 
       const mainPath = `apps/${appName}/pages/index.tsx`;
@@ -138,9 +132,7 @@ module.exports = {
       const tsLibName = uniq('tslib');
       const tsxLibName = uniq('tsxlib');
 
-      runCLI(
-        `generate @nrwl/next:app ${appName} --no-interactive --linter=eslint`
-      );
+      runCLI(`generate @nrwl/next:app ${appName} --no-interactive`);
       runCLI(`generate @nrwl/react:lib ${tsxLibName} --no-interactive`);
       runCLI(`generate @nrwl/workspace:lib ${tsLibName} --no-interactive`);
 
@@ -191,6 +183,26 @@ module.exports = {
       );
 
       await checkApp(appName, { checkLint: true });
+    }, 120000);
+
+    it('should support --style=styled-components', async () => {
+      const appName = uniq('app');
+
+      runCLI(
+        `generate @nrwl/next:app ${appName} --no-interactive --style=styled-components`
+      );
+
+      await checkApp(appName, { checkLint: false });
+    }, 120000);
+
+    it('should support --style=@emotion/styled', async () => {
+      const appName = uniq('app');
+
+      runCLI(
+        `generate @nrwl/next:app ${appName} --no-interactive --style=@emotion/styled`
+      );
+
+      await checkApp(appName, { checkLint: false });
     }, 120000);
   });
 });

--- a/packages/next/src/schematics/application/files/pages/__fileName__.tsx__tmpl__
+++ b/packages/next/src/schematics/application/files/pages/__fileName__.tsx__tmpl__
@@ -10,11 +10,11 @@ import React from 'react';
 %>
 
 import './<%= fileName %>.<%= style %>';
+
+<% }
+%>
 import { ReactComponent as NxLogo } from '../assets/nx-logo-white.svg';
 import { environment } from '../environments/environment';
-
-<% } 
-%>
 
 <% if (styledModule) { %>
 const StyledApp = styled.div`

--- a/packages/react/src/schematics/application/application.spec.ts
+++ b/packages/react/src/schematics/application/application.spec.ts
@@ -361,6 +361,27 @@ describe('app', () => {
     expect(appContent).not.toMatch(/extends Component/);
   });
 
+  it('should add .eslintrc and dependencies', async () => {
+    const tree = await runSchematic(
+      'app',
+      { name: 'myApp', linter: 'eslint' },
+      appTree
+    );
+
+    const eslintJson = readJsonInTree(tree, '/apps/my-app/.eslintrc');
+    const packageJson = readJsonInTree(tree, '/package.json');
+
+    expect(eslintJson.plugins).toEqual(
+      expect.arrayContaining(['react', 'react-hooks'])
+    );
+    expect(packageJson).toMatchObject({
+      devDependencies: {
+        'eslint-plugin-react': expect.anything(),
+        'eslint-plugin-react-hooks': expect.anything()
+      }
+    });
+  });
+
   describe('--class-component', () => {
     it('should generate class components', async () => {
       const tree = await runSchematic(
@@ -524,29 +545,6 @@ describe('app', () => {
         },
         library: {
           style: 'styled-components'
-        }
-      });
-    });
-  });
-
-  describe('--linter=eslint', () => {
-    it('should add .eslintrc and dependencies', async () => {
-      const tree = await runSchematic(
-        'app',
-        { name: 'myApp', linter: 'eslint' },
-        appTree
-      );
-
-      const eslintJson = readJsonInTree(tree, '/apps/my-app/.eslintrc');
-      const packageJson = readJsonInTree(tree, '/package.json');
-
-      expect(eslintJson.plugins).toEqual(
-        expect.arrayContaining(['react', 'react-hooks'])
-      );
-      expect(packageJson).toMatchObject({
-        devDependencies: {
-          'eslint-plugin-react': expect.anything(),
-          'eslint-plugin-react-hooks': expect.anything()
         }
       });
     });


### PR DESCRIPTION
* Moved the imports out of `if-else` in template to styled-components/emotion also gets it.
* Cleaned up React e2e tests to remove `--linter=eslint` (since we only support eslint now)

Closes #2494