### PR TITLE
feat(storybook): add docsMode support

### DIFF
--- a/docs/angular/api-storybook/builders/build.md
+++ b/docs/angular/api-storybook/builders/build.md
@@ -6,6 +6,14 @@ Builder properties can be configured in angular.json when defining the builder, 
 
 ## Properties
 
+### docsMode
+
+Default: `false`
+
+Type: `boolean`
+
+Build a documentation-only site using addon-docs.
+
 ### outputPath
 
 Type: `string`

--- a/docs/react/api-storybook/builders/build.md
+++ b/docs/react/api-storybook/builders/build.md
@@ -7,6 +7,14 @@ Read more about how to use builders and the CLI here: https://nx.dev/react/guide
 
 ## Properties
 
+### docsMode
+
+Default: `false`
+
+Type: `boolean`
+
+Build a documentation-only site using addon-docs.
+
 ### outputPath
 
 Type: `string`

--- a/docs/web/api-storybook/builders/build.md
+++ b/docs/web/api-storybook/builders/build.md
@@ -7,6 +7,14 @@ Read more about how to use builders and the CLI here: https://nx.dev/web/guides/
 
 ## Properties
 
+### docsMode
+
+Default: `false`
+
+Type: `boolean`
+
+Build a documentation-only site using addon-docs.
+
 ### outputPath
 
 Type: `string`

--- a/packages/storybook/src/builders/build-storybook/build-storybook.impl.ts
+++ b/packages/storybook/src/builders/build-storybook/build-storybook.impl.ts
@@ -27,6 +27,8 @@ export interface StorybookBuilderOptions extends JsonObject {
   uiFramework: string;
   config: StorybookConfig;
   quiet?: boolean;
+  outputPath?: string;
+  docsMode?: boolean;
 }
 
 try {
@@ -85,8 +87,8 @@ async function storybookOptionMapper(
     configDir: storybookConfig,
     ...frameworkOptions,
     frameworkPresets: [...(frameworkOptions.frameworkPresets || [])],
-
-    watch: false
+    watch: false,
+    docsMode: builderOptions.docsMode
   };
   optionsWithFramework.config;
   return optionsWithFramework;

--- a/packages/storybook/src/builders/build-storybook/schema.json
+++ b/packages/storybook/src/builders/build-storybook/schema.json
@@ -47,6 +47,11 @@
         }
       ]
     },
+    "docsMode": {
+      "type": "boolean",
+      "description": "Build a documentation-only site using addon-docs.",
+      "default": false
+    },
     "quiet": {
       "type": "boolean",
       "description": "Suppress verbose build output.",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
Build storybook using the `--docs` flag is not possible at the moment.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
New option on the storybook schematic that allows building stories using documentation addon.

## Issue
no issue