### PR TITLE
fix(react): pascalCaseFiles option not working for libs

### DIFF
--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -88,7 +88,8 @@ export default function(schema: Schema): Rule {
         skipTests: options.unitTestRunner === 'none',
         export: true,
         routing: options.routing,
-        js: options.js
+        js: options.js,
+        pascalCaseFiles: options.pascalCaseFiles
       }),
       updateLibPackageNpmScope(options),
       updateAppRoutes(options, context),


### PR DESCRIPTION
ISSUES CLOSED: #2488

`nx g @nrwl/react:lib test-lib --pascalCaseFiles` should now be working:

![image](https://user-images.githubusercontent.com/5975076/75272356-a3818580-57f5-11ea-94b5-b20b69023d75.png)
