### PR TITLE
fix(core): don't generate test related things in README when no unitTestRunner

### DIFF
--- a/packages/workspace/src/schematics/library/files/lib/README.md
+++ b/packages/workspace/src/schematics/library/files/lib/README.md
@@ -1,7 +1,10 @@
 # <%= name %>
 
 This library was generated with [Nx](https://nx.dev).
+<% if(hasUnitTestRunner) { %>
 
 ## Running unit tests
 
 Run `ng test <%= name %>` to execute the unit tests via [Jest](https://jestjs.io).
+
+<% } %>

--- a/packages/workspace/src/schematics/library/library.ts
+++ b/packages/workspace/src/schematics/library/library.ts
@@ -74,7 +74,8 @@ function createFiles(options: NormalizedSchema): Rule {
         ...options,
         ...names(options.name),
         tmpl: '',
-        offsetFromRoot: offsetFromRoot(options.projectRoot)
+        offsetFromRoot: offsetFromRoot(options.projectRoot),
+        hasUnitTestRunner: options.unitTestRunner !== 'none'
       }),
       move(options.projectRoot)
     ])


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Right now when generating a workspace library and passing `unitTestRunner=none`, the generated
README still has the description on how to run unit tests.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

When no `unitTestRunner` has been chosen, the README should not contain any unit test
related info.

## Issue