### PR TITLE
fix(node): pass builder options on to the serve target

### DIFF
--- a/packages/node/src/builders/execute/execute.impl.ts
+++ b/packages/node/src/builders/execute/execute.impl.ts
@@ -150,8 +150,9 @@ function startBuild(
       }
     }),
     concatMap(
-      () =>
+      options =>
         scheduleTargetAndForget(context, target, {
+          ...options,
           watch: true
         }) as Observable<NodeBuildEvent>
     )


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Right now the options specified in the builder are not passed onto the serve target.
As a result things like `showCircularDependencies` settings don't have an effect when serving the node app

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

options specified in the build target should be propagated to the serve target as well.

## Issue

ISSUES CLOSED: #1649