### PR TITLE
feat(react): add options to stop generation of components or styles

### DIFF
--- a/docs/angular/api-react/schematics/application.md
+++ b/docs/angular/api-react/schematics/application.md
@@ -142,7 +142,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/angular/api-react/schematics/component.md
+++ b/docs/angular/api-react/schematics/component.md
@@ -132,6 +132,6 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `none`
 
 The file extension to be used for style files.

--- a/docs/angular/api-react/schematics/library.md
+++ b/docs/angular/api-react/schematics/library.md
@@ -50,6 +50,14 @@ Type: `string`
 
 The application project to add the library route to
 
+### component
+
+Default: `true`
+
+Type: `boolean`
+
+Generate a default component
+
 ### directory
 
 Alias(es): d
@@ -128,7 +136,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/react/api-react/schematics/application.md
+++ b/docs/react/api-react/schematics/application.md
@@ -142,7 +142,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/react/api-react/schematics/component.md
+++ b/docs/react/api-react/schematics/component.md
@@ -132,6 +132,6 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `none`
 
 The file extension to be used for style files.

--- a/docs/react/api-react/schematics/library.md
+++ b/docs/react/api-react/schematics/library.md
@@ -50,6 +50,14 @@ Type: `string`
 
 The application project to add the library route to
 
+### component
+
+Default: `true`
+
+Type: `boolean`
+
+Generate a default component
+
 ### directory
 
 Alias(es): d
@@ -128,7 +136,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/web/api-react/schematics/application.md
+++ b/docs/web/api-react/schematics/application.md
@@ -142,7 +142,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/web/api-react/schematics/component.md
+++ b/docs/web/api-react/schematics/component.md
@@ -132,6 +132,6 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `none`
 
 The file extension to be used for style files.

--- a/docs/web/api-react/schematics/library.md
+++ b/docs/web/api-react/schematics/library.md
@@ -50,6 +50,14 @@ Type: `string`
 
 The application project to add the library route to
 
+### component
+
+Default: `true`
+
+Type: `boolean`
+
+Generate a default component
+
 ### directory
 
 Alias(es): d
@@ -128,7 +136,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `none`
 
 The file extension to be used for style files.
 

--- a/e2e/react.test.ts
+++ b/e2e/react.test.ts
@@ -99,6 +99,29 @@ forEachCli(currentCLIName => {
       );
     }, 120000);
 
+    it('should be able to generate a react lib with no components', async () => {
+      ensureProject();
+      const appName = uniq('app');
+      const libName = uniq('lib');
+
+      runCLI(
+        `generate @nrwl/react:app ${appName} --no-interactive --linter=${linter}`
+      );
+      runCLI(
+        `generate @nrwl/react:lib ${libName} --no-interactive --no-component`
+      );
+
+      setMaxWorkers(appName);
+
+      const mainPath = `apps/${appName}/src/main.tsx`;
+      updateFile(mainPath, `import '@proj/${libName}';\n` + readFile(mainPath));
+
+      const libTestResults = await runCLIAsync(`test ${libName}`);
+      expect(libTestResults.stderr).toBe('');
+
+      await testGeneratedApp(appName, { checkStyles: true, checkLinter: true });
+    }, 120000);
+
     it('should not create a dist folder if there is an error', async () => {
       ensureProject();
       const libName = uniq('lib');
@@ -145,6 +168,29 @@ forEachCli(currentCLIName => {
         checkStyles: false,
         checkLinter: true
       });
+    }, 120000);
+
+    it('should generate an app with no styles', async () => {
+      ensureProject();
+      const appName = uniq('app');
+
+      runCLI(
+        `generate @nrwl/react:app ${appName} --style none --no-interactive --linter=${linter}`
+      );
+
+      setMaxWorkers(appName);
+
+      await testGeneratedApp(appName, {
+        checkStyles: false,
+        checkLinter: true
+      });
+
+      expect(() => checkFilesExist(`dist/apps/${appName}/styles.css`)).toThrow(
+        /does not exist/
+      );
+      expect(readFile(`dist/apps/${appName}/index.html`)).not.toContain(
+        `<link rel="stylesheet" href="styles.css">`
+      );
     }, 120000);
 
     it('should be able to use JSX', async () => {

--- a/packages/react/src/schematics/application/application.spec.ts
+++ b/packages/react/src/schematics/application/application.spec.ts
@@ -396,6 +396,71 @@ describe('app', () => {
     });
   });
 
+  describe('--style none', () => {
+    it('should not generate any styles', async () => {
+      const tree = await runSchematic(
+        'app',
+        { name: 'myApp', style: 'none' },
+        appTree
+      );
+
+      expect(tree.exists('apps/my-app/src/app/app.tsx')).toBeTruthy();
+      expect(tree.exists('apps/my-app/src/app/app.spec.tsx')).toBeTruthy();
+      expect(tree.exists('apps/my-app/src/app/app.css')).toBeFalsy();
+      expect(tree.exists('apps/my-app/src/app/app.scss')).toBeFalsy();
+      expect(tree.exists('apps/my-app/src/app/app.styl')).toBeFalsy();
+
+      const content = tree.read('apps/my-app/src/app/app.tsx').toString();
+      expect(content).not.toContain('styled-components');
+      expect(content).not.toContain('<StyledApp>');
+      expect(content).not.toContain('@emotion/styled');
+      expect(content).not.toContain('<StyledApp>');
+
+      //for imports
+      expect(content).not.toContain('app.styl');
+      expect(content).not.toContain('app.css');
+      expect(content).not.toContain('app.scss');
+    });
+
+    it('should set defaults when style: none', async () => {
+      const tree = await runSchematic(
+        'app',
+        {
+          name: 'myApp',
+          style: 'none'
+        },
+        appTree
+      );
+
+      const workspaceJson = readJsonInTree(tree, '/workspace.json');
+      expect(workspaceJson.schematics['@nrwl/react']).toMatchObject({
+        application: {
+          style: 'none'
+        },
+        component: {
+          style: 'none'
+        },
+        library: {
+          style: 'none'
+        }
+      });
+    });
+
+    it('should exclude styles from workspace.json', async () => {
+      const tree = await runSchematic(
+        'app',
+        { name: 'myApp', style: 'none' },
+        appTree
+      );
+
+      const workspaceJson = readJsonInTree(tree, 'workspace.json');
+
+      expect(
+        workspaceJson.projects['my-app'].architect.build.options.styles
+      ).toEqual([]);
+    });
+  });
+
   describe('--style styled-components', () => {
     it('should use styled-components as the styled API library', async () => {
       const tree = await runSchematic(

--- a/packages/react/src/schematics/application/application.ts
+++ b/packages/react/src/schematics/application/application.ts
@@ -52,6 +52,7 @@ interface NormalizedSchema extends Schema {
   parsedTags: string[];
   fileName: string;
   styledModule: null | string;
+  hasStyles: boolean;
 }
 
 export default function(schema: Schema): Rule {
@@ -89,7 +90,7 @@ function createApplicationFiles(options: NormalizedSchema): Rule {
         tmpl: '',
         offsetFromRoot: offsetFromRoot(options.appProjectRoot)
       }),
-      options.styledModule
+      options.styledModule || !options.hasStyles
         ? filter(file => !file.endsWith(`.${options.style}`))
         : noop(),
       options.unitTestRunner === 'none'
@@ -138,9 +139,10 @@ function addProject(options: NormalizedSchema): Rule {
           join(options.appProjectRoot, 'src/favicon.ico'),
           join(options.appProjectRoot, 'src/assets')
         ],
-        styles: options.styledModule
-          ? []
-          : [join(options.appProjectRoot, `src/styles.${options.style}`)],
+        styles:
+          options.styledModule || !options.hasStyles
+            ? []
+            : [join(options.appProjectRoot, `src/styles.${options.style}`)],
         scripts: [],
         webpackConfig: '@nrwl/react/plugins/webpack'
       },
@@ -327,7 +329,7 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
 
   const fileName = options.pascalCaseFiles ? 'App' : 'app';
 
-  const styledModule = /^(css|scss|less|styl)$/.test(options.style)
+  const styledModule = /^(css|scss|less|styl|none)$/.test(options.style)
     ? null
     : options.style;
 
@@ -342,7 +344,8 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
     e2eProjectName,
     parsedTags,
     fileName,
-    styledModule
+    styledModule,
+    hasStyles: options.style !== 'none'
   };
 }
 

--- a/packages/react/src/schematics/application/files/app/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/schematics/application/files/app/src/app/__fileName__.tsx__tmpl__
@@ -3,11 +3,14 @@ import React, { Component } from 'react';
 <% } else { %>
 import React from 'react';
 <% } %>
-<% if (styledModule) {
-  var wrapper = 'StyledApp';
-%>import styled from '<%= styledModule %>';<% } else {
-  var wrapper = 'div';
-%>import './<%= fileName %>.<%= style %>';<% } %>
+
+<% if (hasStyles) {
+  if (styledModule) {
+    var wrapper = 'StyledApp';
+  %>import styled from '<%= styledModule %>';<% } else {
+    var wrapper = 'div';
+  %>import './<%= fileName %>.<%= style %>';<% } 
+} else { var wrapper = 'div'; }%>
 
 import { ReactComponent as Logo } from './logo.svg';
 import star from './star.svg';
@@ -252,12 +255,12 @@ export class App extends Component {
 <% } else { %>
 export const App = () => {
   /*
-   * Replace the elements below with your own.
+   * Replace the elements below with your own. <% if (hasStyles) { %>
    *
-   * Note: The corresponding styles are in the ./<%= fileName %>.<%= style %> file.
+   * Note: The corresponding styles are in the ./<%= fileName %>.<%= style %> file. <% } %> 
    */
   return (
-    <<%= wrapper %><% if (!styledModule) {%> className="app"<% } %>>
+    <<%= wrapper %><% if (!styledModule && hasStyles) {%> className="app"<% } %>>
       <%= innerJsx %>
     </<%= wrapper %>>
   );

--- a/packages/react/src/schematics/application/schema.d.ts
+++ b/packages/react/src/schematics/application/schema.d.ts
@@ -1,8 +1,9 @@
 import { Linter } from '@nrwl/workspace';
+import { SupportedStyles } from 'packages/react/typings/style';
 
 export interface Schema {
   name: string;
-  style?: string;
+  style?: SupportedStyles;
   skipFormat: boolean;
   directory?: string;
   tags?: string;

--- a/packages/react/src/schematics/application/schema.json
+++ b/packages/react/src/schematics/application/schema.json
@@ -61,6 +61,10 @@
           {
             "value": "@emotion/styled",
             "label": "emotion           [ https://emotion.sh            ]"
+          },
+          {
+            "value": "none",
+            "label": "None"
           }
         ]
       }

--- a/packages/react/src/schematics/component/component.spec.ts
+++ b/packages/react/src/schematics/component/component.spec.ts
@@ -84,6 +84,36 @@ describe('component', () => {
     });
   });
 
+  describe('--style none', () => {
+    it('should generate component files without styles', async () => {
+      const tree = await runSchematic(
+        'component',
+        { name: 'hello', project: projectName, style: 'none' },
+        appTree
+      );
+      expect(tree.exists('libs/my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
+      expect(
+        tree.exists('libs/my-lib/src/lib/hello/hello.spec.tsx')
+      ).toBeTruthy();
+      expect(tree.exists('libs/my-lib/src/lib/hello/hello.css')).toBeFalsy();
+      expect(tree.exists('libs/my-lib/src/lib/hello/hello.scss')).toBeFalsy();
+      expect(tree.exists('libs/my-lib/src/lib/hello/hello.styl')).toBeFalsy();
+
+      const content = tree
+        .read('libs/my-lib/src/lib/hello/hello.tsx')
+        .toString();
+      expect(content).not.toContain('styled-components');
+      expect(content).not.toContain('<StyledHello>');
+      expect(content).not.toContain('@emotion/styled');
+      expect(content).not.toContain('<StyledHello>');
+
+      //for imports
+      expect(content).not.toContain('hello.styl');
+      expect(content).not.toContain('hello.css');
+      expect(content).not.toContain('hello.scss');
+    });
+  });
+
   describe('--style styled-components', () => {
     it('should use styled-components as the styled API library', async () => {
       const tree = await runSchematic(

--- a/packages/react/src/schematics/component/component.ts
+++ b/packages/react/src/schematics/component/component.ts
@@ -34,6 +34,7 @@ interface NormalizedSchema extends Schema {
   fileName: string;
   className: string;
   styledModule: null | string;
+  hasStyles: boolean;
 }
 
 export default function(schema: Schema): Rule {
@@ -71,7 +72,7 @@ function createComponentFiles(options: NormalizedSchema): Rule {
           tmpl: ''
         }),
         options.skipTests ? filter(file => !/.*spec.tsx/.test(file)) : noop(),
-        options.styledModule
+        options.styledModule || !options.hasStyles
           ? filter(file => !file.endsWith(`.${options.style}`))
           : noop(),
         move(directory),
@@ -146,7 +147,7 @@ function normalizeOptions(
     options.project
   );
   const directory = options.flat ? '' : options.directory || fileName;
-  const styledModule = /^(css|scss|less|styl)$/.test(options.style)
+  const styledModule = /^(css|scss|less|styl|none)$/.test(options.style)
     ? null
     : options.style;
 
@@ -160,6 +161,7 @@ function normalizeOptions(
     ...options,
     directory,
     styledModule,
+    hasStyles: options.style !== 'none',
     className,
     fileName: componentFileName,
     projectSourceRoot

--- a/packages/react/src/schematics/component/files/__directory__/__fileName__.tsx__tmpl__
+++ b/packages/react/src/schematics/component/files/__directory__/__fileName__.tsx__tmpl__
@@ -7,15 +7,18 @@ import React from 'react';
 <% if (routing) { %>
 import { Route, Link } from 'react-router-dom';
 <% } %>
-<% if (styledModule) {
-  var wrapper = 'Styled' + className;
-%>
-import styled from '<%= styledModule %>';
-<% } else {
-  var wrapper = 'div';
-%>
-import './<%= fileName %>.<%= style %>';
-<% } %>
+
+<% if (hasStyles) {
+   if (styledModule) {
+    var wrapper = 'Styled' + className;
+  %>
+  import styled from '<%= styledModule %>';
+  <% } else {
+    var wrapper = 'div';
+  %>
+  import './<%= fileName %>.<%= style %>';
+  <% }
+} else { var wrapper = 'div'; } %>
 
 /* eslint-disable-next-line */
 export interface <%= className %>Props {

--- a/packages/react/src/schematics/component/schema.d.ts
+++ b/packages/react/src/schematics/component/schema.d.ts
@@ -1,7 +1,9 @@
+import { SupportedStyles } from 'packages/react/typings/style';
+
 export interface Schema {
   name: string;
   project: string;
-  style?: string;
+  style?: SupportedStyles;
   skipTests?: boolean;
   directory?: string;
   export?: boolean;

--- a/packages/react/src/schematics/component/schema.json
+++ b/packages/react/src/schematics/component/schema.json
@@ -61,6 +61,10 @@
           {
             "value": "@emotion/styled",
             "label": "emotion           [ https://emotion.sh            ]"
+          },
+          {
+            "value": "none",
+            "label": "None"
           }
         ]
       }

--- a/packages/react/src/schematics/library/library.spec.ts
+++ b/packages/react/src/schematics/library/library.spec.ts
@@ -245,6 +245,45 @@ describe('lib', () => {
     });
   });
 
+  describe('--style none', () => {
+    it('should not use styles when style none', async () => {
+      const result = await runSchematic(
+        'lib',
+        { name: 'myLib', style: 'none' },
+        appTree
+      );
+
+      expect(result.exists('libs/my-lib/src/lib/my-lib.tsx')).toBeTruthy();
+      expect(result.exists('libs/my-lib/src/lib/my-lib.spec.tsx')).toBeTruthy();
+      expect(result.exists('libs/my-lib/src/lib/my-lib.css')).toBeFalsy();
+      expect(result.exists('libs/my-lib/src/lib/my-lib.scss')).toBeFalsy();
+      expect(result.exists('libs/my-lib/src/lib/my-lib.styl')).toBeFalsy();
+
+      const content = result.read('libs/my-lib/src/lib/my-lib.tsx').toString();
+      expect(content).not.toContain('styled-components');
+      expect(content).not.toContain('<StyledApp>');
+      expect(content).not.toContain('@emotion/styled');
+      expect(content).not.toContain('<StyledApp>');
+
+      //for imports
+      expect(content).not.toContain('app.styl');
+      expect(content).not.toContain('app.css');
+      expect(content).not.toContain('app.scss');
+    });
+  });
+
+  describe('--no-component', () => {
+    it('should not generate components or styles', async () => {
+      const result = await runSchematic(
+        'lib',
+        { name: 'myLib', component: false },
+        appTree
+      );
+
+      expect(result.exists('libs/my-lib/src/lib')).toBeFalsy();
+    });
+  });
+
   describe('--unit-test-runner none', () => {
     it('should not generate test configuration', async () => {
       const resultTree = await runSchematic(
@@ -375,6 +414,26 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-lib'].architect.build).toMatchObject({
         options: {
           external: ['react', 'react-dom', '@emotion/styled', '@emotion/core']
+        }
+      });
+    });
+
+    it('should support style none', async () => {
+      const tree = await runSchematic(
+        'lib',
+        {
+          name: 'myLib',
+          publishable: true,
+          style: 'none'
+        },
+        appTree
+      );
+
+      const workspaceJson = readJsonInTree(tree, '/workspace.json');
+
+      expect(workspaceJson.projects['my-lib'].architect.build).toMatchObject({
+        options: {
+          external: ['react', 'react-dom']
         }
       });
     });

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -63,6 +63,9 @@ export default function(schema: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const options = normalizeOptions(host, schema, context);
 
+    if (!options.component) {
+      options.style = 'none';
+    }
     return chain([
       addLintFiles(options.projectRoot, options.linter, {
         localConfig: reactEslintJson,
@@ -80,17 +83,19 @@ export default function(schema: Schema): Rule {
             skipSerializers: true
           })
         : noop(),
-      externalSchematic('@nrwl/react', 'component', {
-        name: options.name,
-        project: options.name,
-        flat: true,
-        style: options.style,
-        skipTests: options.unitTestRunner === 'none',
-        export: true,
-        routing: options.routing,
-        js: options.js,
-        pascalCaseFiles: options.pascalCaseFiles
-      }),
+      options.component
+        ? externalSchematic('@nrwl/react', 'component', {
+            name: options.name,
+            project: options.name,
+            flat: true,
+            style: options.style,
+            skipTests: options.unitTestRunner === 'none',
+            export: true,
+            routing: options.routing,
+            js: options.js,
+            pascalCaseFiles: options.pascalCaseFiles
+          })
+        : noop(),
       updateLibPackageNpmScope(options),
       updateAppRoutes(options, context),
       formatFiles(options)
@@ -114,8 +119,9 @@ function addProject(options: NormalizedSchema): Rule {
       if (
         options.style !== 'css' &&
         options.style !== 'scss' &&
-        options.style !== 'style' &&
-        options.style !== 'less'
+        options.style !== 'styl' &&
+        options.style !== 'less' &&
+        options.style !== 'none'
       ) {
         external.push(
           ...Object.keys(CSS_IN_JS_DEPENDENCIES[options.style].dependencies)

--- a/packages/react/src/schematics/library/schema.d.ts
+++ b/packages/react/src/schematics/library/schema.d.ts
@@ -1,9 +1,10 @@
 import { Linter } from '@nrwl/workspace';
+import { SupportedStyles } from 'packages/react/typings/style';
 
 export interface Schema {
   name: string;
   directory?: string;
-  style?: string;
+  style?: SupportedStyles;
   skipTsConfig: boolean;
   skipFormat: boolean;
   tags?: string;
@@ -12,6 +13,7 @@ export interface Schema {
   appProject?: string;
   unitTestRunner: 'jest' | 'none';
   linter: Linter;
+  component?: boolean;
   publishable?: boolean;
   js?: boolean;
 }

--- a/packages/react/src/schematics/library/schema.json
+++ b/packages/react/src/schematics/library/schema.json
@@ -57,6 +57,10 @@
           {
             "value": "@emotion/styled",
             "label": "emotion           [ https://emotion.sh            ]"
+          },
+          {
+            "value": "none",
+            "label": "None"
           }
         ]
       }
@@ -106,6 +110,11 @@
     "publishable": {
       "type": "boolean",
       "description": "Create a publishable library. A \"build\" architect will be added for this project the workspace configuration."
+    },
+    "component": {
+      "type": "boolean",
+      "description": "Generate a default component",
+      "default": true
     },
     "js": {
       "type": "boolean",

--- a/packages/react/src/utils/assertion.ts
+++ b/packages/react/src/utils/assertion.ts
@@ -4,7 +4,8 @@ const VALID_STYLES = [
   'less',
   'styl',
   'styled-components',
-  '@emotion/styled'
+  '@emotion/styled',
+  'none'
 ];
 export function assertValidStyle(style: string): void {
   if (VALID_STYLES.indexOf(style) === -1) {

--- a/packages/react/typings/style.d.ts
+++ b/packages/react/typings/style.d.ts
@@ -1,0 +1,8 @@
+export type SupportedStyles =
+  | 'css'
+  | 'scss'
+  | 'styl'
+  | 'less'
+  | 'styled-components'
+  | '@emotion/styled'
+  | 'none';


### PR DESCRIPTION
ISSUES CLOSED: #2184

When generating react **apps** , **components** or `libs`:

You can now pass `--styles='none'` to stop generation of any styling for the component

When generating react `libs`:

You can pass `--no-component` or `--component=false` to stop generation of any component or style files.