### PR TITLE
fix(testing): remove --coverage option from jest builder

### DIFF
--- a/docs/angular/api-jest/builders/jest.md
+++ b/docs/angular/api-jest/builders/jest.md
@@ -52,12 +52,6 @@ Type: `string`
 
 The path to a Jest config file specifying how to find and execute tests. If no rootDir is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration
 
-### coverage
-
-Type: `boolean`
-
-Indicates that test coverage information should be collected and reported in the output. This option is also aliased by --collectCoverage. (https://jestjs.io/docs/en/cli#coverage)
-
 ### coverageDirectory
 
 Type: `string`

--- a/docs/react/api-jest/builders/jest.md
+++ b/docs/react/api-jest/builders/jest.md
@@ -53,12 +53,6 @@ Type: `string`
 
 The path to a Jest config file specifying how to find and execute tests. If no rootDir is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration
 
-### coverage
-
-Type: `boolean`
-
-Indicates that test coverage information should be collected and reported in the output. This option is also aliased by --collectCoverage. (https://jestjs.io/docs/en/cli#coverage)
-
 ### coverageDirectory
 
 Type: `string`

--- a/docs/web/api-jest/builders/jest.md
+++ b/docs/web/api-jest/builders/jest.md
@@ -53,12 +53,6 @@ Type: `string`
 
 The path to a Jest config file specifying how to find and execute tests. If no rootDir is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration
 
-### coverage
-
-Type: `boolean`
-
-Indicates that test coverage information should be collected and reported in the output. This option is also aliased by --collectCoverage. (https://jestjs.io/docs/en/cli#coverage)
-
 ### coverageDirectory
 
 Type: `string`

--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -81,7 +81,6 @@ describe('Jest Builder', () => {
         colors: false,
         reporters: ['/test/path'],
         verbose: false,
-        coverage: false,
         coverageReporters: 'test',
         coverageDirectory: '/test/path',
         watch: false
@@ -179,7 +178,6 @@ describe('Jest Builder', () => {
         colors: false,
         reporters: ['/test/path'],
         verbose: false,
-        coverage: false,
         coverageReporters: 'test',
         coverageDirectory: '/test/path',
         testResultsProcessor: 'results-processor',

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -43,7 +43,6 @@ export interface JestBuilderOptions extends JsonObject {
   colors?: boolean;
   reporters?: string[];
   verbose?: boolean;
-  coverage?: boolean;
   coverageReporters?: string;
   coverageDirectory?: string;
   testResultsProcessor?: string;

--- a/packages/jest/src/builders/jest/schema.json
+++ b/packages/jest/src/builders/jest/schema.json
@@ -107,10 +107,6 @@
       "description": "Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)",
       "type": "boolean"
     },
-    "coverage": {
-      "description": "Indicates that test coverage information should be collected and reported in the output. This option is also aliased by --collectCoverage. (https://jestjs.io/docs/en/cli#coverage)",
-      "type": "boolean"
-    },
     "coverageReporters": {
       "description": "A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter",
       "type": "string"


### PR DESCRIPTION
the --coverage option was not being used in the builder at all, so provided no change in behavior.
The --codeCoverage option should be used instead

ISSUES CLOSED: #2564
