### PR TITLE
fix(linter): outputFile at non-existing directory path throws

### DIFF
--- a/e2e/linter.test.ts
+++ b/e2e/linter.test.ts
@@ -118,7 +118,7 @@ forEachCli('nx', () => {
       updateFile('.eslintrc', JSON.stringify(eslintrc, null, 2));
       updateFile(`apps/${myapp}/src/main.ts`, `console.log("should fail");`);
 
-      const outputFile = 'lint-output.json';
+      const outputFile = 'a/b/c/lint-output.json';
       expect(() => {
         checkFilesExist(outputFile);
       }).toThrow();

--- a/packages/linter/src/builders/lint/lint.impl.spec.ts
+++ b/packages/linter/src/builders/lint/lint.impl.spec.ts
@@ -344,14 +344,19 @@ describe('Linter Builder', () => {
     it('should attempt to write the lint results to the output file, if specified', async () => {
       setupMocks();
       jest.spyOn(fs, 'writeFileSync').mockImplementation();
+      jest.mock('@nrwl/workspace', () => ({
+        createDirectory: jest.fn()
+      }));
+      const { createDirectory } = require('@nrwl/workspace');
       await runBuilder({
         linter: 'eslint',
         config: './.eslintrc',
         files: ['includedFile1'],
-        outputFile: 'outputFile1'
+        outputFile: 'a/b/c/outputFile1'
       });
+      expect(createDirectory).toHaveBeenCalledWith('/root/a/b/c');
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        '/root/outputFile1',
+        '/root/a/b/c/outputFile1',
         formattedReports
       );
     });

--- a/packages/linter/src/builders/lint/lint.impl.ts
+++ b/packages/linter/src/builders/lint/lint.impl.ts
@@ -1,11 +1,12 @@
 import { createBuilder } from '@angular-devkit/architect';
 import { CLIEngine } from 'eslint';
-import { writeFileSync } from 'fs';
+import { writeFileSync, mkdirSync } from 'fs';
 import * as path from 'path';
 import { Schema } from './schema';
 import { BuilderContext } from '@angular-devkit/architect';
 import { createProgram } from './utility/ts-utils';
 import { lint, loadESLint } from './utility/eslint-utils';
+import { createDirectory } from '@nrwl/workspace';
 /**
  * Adapted from @angular-eslint/builder source
  */
@@ -110,10 +111,9 @@ async function run(options: Schema, context: BuilderContext): Promise<any> {
   context.logger.info(formattedResults);
 
   if (options.outputFile) {
-    writeFileSync(
-      path.join(context.workspaceRoot, options.outputFile),
-      formattedResults
-    );
+    const pathToFile = path.join(context.workspaceRoot, options.outputFile);
+    createDirectory(path.dirname(pathToFile));
+    writeFileSync(pathToFile, formattedResults);
   }
   if (bundledReport.warningCount > 0 && printInfo) {
     context.logger.warn('Lint warnings found in the listed files.\n');

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -13,7 +13,8 @@ export {
   updateJsonFile,
   readJsonFile,
   readWorkspaceConfigPath,
-  copyFile
+  copyFile,
+  createDirectory
 } from './src/utils/fileutils';
 export {
   offsetFromRoot,


### PR DESCRIPTION
ISSUES CLOSED: #2567 

## Current Behavior (This is the behavior we have today, before the PR is merged)

`nx lint frontend --outputFile="a/b/c/outputFile.txt"` will throw if the directory path doesn't exist

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

It should create the intermediate directory path to the file.