### PR TITLE
feat(core): update prettier to 1.19.1

### DIFF
--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -54,6 +54,11 @@
       "version": "9.0.0-beta.1",
       "description": "Update typescript to 3.6 and angular/cli to version 9",
       "factory": "./src/migrations/update-9-0-0/update-9-0-0"
+    },
+    "update-9-1-0": {
+      "version": "9.1.0-beta.1",
+      "description": "Update prettier to 1.19.1 with support for typescript 3.7",
+      "factory": "./src/migrations/update-9-0-0/update-9-0-0"
     }
   },
   "packageJsonUpdates": {
@@ -388,6 +393,14 @@
         "@schematics/angular": {
           "version": "~9.0.1",
           "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "9.0.0": {
+      "version": "9.0.0-beta.1",
+      "packages": {
+        "prettier": {
+          "version": "1.19.1"
         }
       }
     }

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -47,7 +47,7 @@
     ]
   },
   "peerDependencies": {
-    "prettier": "^1.18.2"
+    "prettier": "^1.19.1"
   },
   "dependencies": {
     "@angular-devkit/core": "~9.0.1",

--- a/packages/workspace/src/migrations/update-9-1-0/update-9-0-0.ts
+++ b/packages/workspace/src/migrations/update-9-1-0/update-9-0-0.ts
@@ -1,0 +1,12 @@
+import { chain } from '@angular-devkit/schematics';
+import { updatePackagesInPackageJson } from '@nrwl/workspace';
+import { join } from 'path';
+
+const updatePackages = updatePackagesInPackageJson(
+  join(__dirname, '../../../', 'migrations.json'),
+  '9.1.0'
+);
+
+export default function() {
+  return chain([updatePackages]);
+}

--- a/packages/workspace/src/utils/versions.ts
+++ b/packages/workspace/src/utils/versions.ts
@@ -2,7 +2,7 @@ export const nxVersion = '*';
 
 export const angularCliVersion = '9.0.1';
 export const typescriptVersion = '~3.7.4';
-export const prettierVersion = '1.18.2';
+export const prettierVersion = '1.19.1';
 export const typescriptESLintVersion = '2.19.2';
 export const eslintVersion = '6.1.0';
 export const eslintConfigPrettierVersion = '6.0.0';


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

Prettier is at 1.18 which does not support typescript 3.7

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Prettier is at 1.19 which does support typescript 3.7

## Issue
