### PR TITLE
feat(react): --maxWorkers and --memoryLimit add tests and common fix

### DIFF
--- a/packages/web/src/utils/devserver.config.spec.ts
+++ b/packages/web/src/utils/devserver.config.spec.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs';
 import { WebBuildBuilderOptions } from '../builders/build/build.impl';
 import { WebDevServerOptions } from '../builders/dev-server/dev-server.impl';
 import { join } from 'path';
+import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 describe('getDevServerConfig', () => {
   let buildInput: WebBuildBuilderOptions;
@@ -440,6 +441,40 @@ describe('getDevServerConfig', () => {
         ) as any;
 
         expect(result.allowedHosts).toEqual([]);
+      });
+
+      describe('the max workers option', () => {
+        it('should set the maximum workers for the type checker', () => {
+          const result = getDevServerConfig(
+            root,
+            sourceRoot,
+            buildInput,
+            { ...serveInput, maxWorkers: 1 },
+            logger
+          ) as any;
+
+          const typeCheckerPlugin = result.plugins.find(
+            plugin => plugin instanceof ForkTsCheckerWebpackPlugin
+          ) as ForkTsCheckerWebpackPlugin;
+          expect(typeCheckerPlugin.options.workers).toEqual(1);
+        });
+      });
+
+      describe('the memory limit option', () => {
+        it('should set the memory limit for the type checker', () => {
+          const result = getDevServerConfig(
+            root,
+            sourceRoot,
+            buildInput,
+            { ...serveInput, memoryLimit: 1024 },
+            logger
+          ) as any;
+
+          const typeCheckerPlugin = result.plugins.find(
+            plugin => plugin instanceof ForkTsCheckerWebpackPlugin
+          ) as ForkTsCheckerWebpackPlugin;
+          expect(typeCheckerPlugin.options.memoryLimit).toEqual(1024);
+        });
       });
     });
   });

--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -23,7 +23,11 @@ export function getDevServerConfig(
   const webpackConfig: Configuration = getWebConfig(
     root,
     sourceRoot,
-    buildOptions,
+    {
+      ...buildOptions,
+      maxWorkers: serveOptions.maxWorkers,
+      memoryLimit: serveOptions.memoryLimit
+    },
     logger,
     true, // Don't need to support legacy browsers for dev.
     false


### PR DESCRIPTION
`nx serve -—maxWorkers=1 -—memoryLimit=1024`

Closes #2366

## Current Behavior (This is the behavior we have today, before the PR is merged)
I did little mistake and now is fixed. I added also 2 test to verify.

