### PR TITLE
fix(core): fix issues running move schematic in windows

### DIFF
--- a/packages/angular/src/schematics/move/lib/update-module-name.ts
+++ b/packages/angular/src/schematics/move/lib/update-module-name.ts
@@ -32,7 +32,7 @@ export function updateModuleName(schema: Schema) {
           to: classify(newProjectName)
         };
 
-        const findModuleName = new RegExp(moduleName.from, 'g');
+        const findModuleName = new RegExp(`\\b${moduleName.from}`, 'g');
 
         const moduleFile = {
           from: `${schema.projectName}.module`,

--- a/packages/workspace/src/schematics/move/lib/update-jest-config.ts
+++ b/packages/workspace/src/schematics/move/lib/update-jest-config.ts
@@ -31,11 +31,11 @@ export function updateJestConfig(schema: Schema): Rule {
 
         const oldContent = tree.read(jestConfigPath).toString('utf-8');
 
-        const findName = new RegExp(schema.projectName, 'g');
+        const findName = new RegExp(`'${schema.projectName}'`, 'g');
         const findDir = new RegExp(project.root, 'g');
 
         const newContent = oldContent
-          .replace(findName, newProjectName)
+          .replace(findName, `'${newProjectName}'`)
           .replace(findDir, destination);
         tree.overwrite(jestConfigPath, newContent);
 

--- a/packages/workspace/src/schematics/move/lib/update-project-root-files.ts
+++ b/packages/workspace/src/schematics/move/lib/update-project-root-files.ts
@@ -22,14 +22,14 @@ export function updateProjectRootFiles(schema: Schema): Rule {
         const project = workspace.projects.get(schema.projectName);
         const destination = getDestination(schema, workspace);
 
-        const newRelativeRoot = path.relative(
-          path.join(appRootPath, destination),
-          appRootPath
-        );
-        const oldRelativeRoot = path.relative(
-          path.join(appRootPath, project.root),
-          appRootPath
-        );
+        const newRelativeRoot = path
+          .relative(path.join(appRootPath, destination), appRootPath)
+          .split(path.sep)
+          .join('/');
+        const oldRelativeRoot = path
+          .relative(path.join(appRootPath, project.root), appRootPath)
+          .split(path.sep)
+          .join('/');
 
         if (newRelativeRoot === oldRelativeRoot) {
           // nothing to do

--- a/packages/workspace/src/schematics/move/lib/utils.ts
+++ b/packages/workspace/src/schematics/move/lib/utils.ts
@@ -27,7 +27,10 @@ export function getDestination(
   if (projectType === 'application') {
     rootFolder = 'apps';
   }
-  return path.join(rootFolder, schema.destination);
+  return path
+    .join(rootFolder, schema.destination)
+    .split(path.sep)
+    .join('/');
 }
 
 /**


### PR DESCRIPTION
This PR fixes a few issues encountered while running move schematics in a windows environment.

## Current Behavior

### Error when running the schematic
When running `move` schematic in windows environment we end up with an error.

For example:
Command `ng g move --projectName api-interfaces shared/api-interfaces`
Error `Unexpected token s in JSON at position 14`

This is because the `getDestination` utility method returns a path with backslash separator on windows (example: `libs\shared\api-interfaces` ) and this causes `JSON.parse` method used later in `updateWorkspace` to identify `\s` as a special character and to throw an error.

### Incorrect extends property for project's root files
After running `move` command on windows, `tslint.json`, `tsconfig.json` and `jest.config.js` `extends` property are not correctly pointing to the respective parent's files.

This issue is also related to the fact that backslash separators are used instead of slash.

### Substrings are replaced in jest.config.js file
_(This issue is not specific to Windows environments)_

When running the move command, all occurences of the library name are replaced in jest.config.js which results in incorrect configuration.
For example:
`ng g move --projectName ui shared/ui`
Results in: (see the **bshared/uild**)
```
snapshotSerializers: [
    'jest-preset-angular/bshared/uild/AngularSnapshotSerializer.js',
    'jest-preset-angular/bshared/uild/HTMLCommentSerializer.js'
  ]
```

### Substrings are replaced when renaming Angular module import
_(This issue is not specific to Windows environments)_

When running `move` schematic, the replacement of the main module name occurs even on substrings of modules.
For example when moving interceptors library, the `Interceptor` module should be renamed to `NewInterceptor`.
If we have somewhere strings like `@UseInterceptors` or `AuthInterceptors`, then the command will rename them to `@UseNewInterceptors` and `AuthNewInterceptors` which is not the expected behavior.

## Expected Behavior
- When running move schematic in windows environment, the command should run without error.
- The extends properties of project root files should be correct,
- Only the project name should be replaced in jest.config.ts
- Only the actual module import should be replaced.


## Issue
Fixes #2590
