### PR TITLE
fix(core): update workspaceFileName() to determine actual configuration

### DIFF
--- a/packages/workspace/src/command-line/workspace-integrity-checks.spec.ts
+++ b/packages/workspace/src/command-line/workspace-integrity-checks.spec.ts
@@ -68,7 +68,7 @@ describe('WorkspaceIntegrityChecks', () => {
               '-'
             )} Cannot find project 'project1' in 'libs/project1'`
           ],
-          title: 'The angular.json file is out of sync'
+          title: 'The workspace.json file is out of sync'
         }
       ]);
     });

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -5,7 +5,7 @@ import { extname } from 'path';
 import { jsonDiff } from '../utils/json-diff';
 import { readFileSync } from 'fs';
 import { execSync } from 'child_process';
-import { readJsonFile } from '../utils/fileutils';
+import { readJsonFile, fileExists } from '../utils/fileutils';
 import { Environment, NxJson } from './shared-interfaces';
 import { ProjectGraphNode } from './project-graph';
 import { WorkspaceResults } from '../command-line/workspace-results';
@@ -172,15 +172,10 @@ export function cliCommand() {
 }
 
 export function workspaceFileName() {
-  const packageJson = readPackageJson();
-  if (
-    packageJson.devDependencies['@angular/cli'] ||
-    packageJson.dependencies['@angular/cli']
-  ) {
+  if (fileExists(`${appRootPath}/angular.json`)) {
     return 'angular.json';
-  } else {
-    return 'workspace.json';
   }
+  return 'workspace.json';
 }
 
 export function defaultFileRead(filePath: string) {


### PR DESCRIPTION
filename (#2253)

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

workspaceFileName() returns 'angular.json' when @angular/cli is in package.json dependencies even if we use workspace.json file

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

workspaceFileName() must returns 'workspace.json' if file exists event if @angular/cli is in package.json dependencies

## Issue

Fixes #2253 
