### PR TITLE
feat(misc): support formatting .mdx files

### DIFF
--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -20,7 +20,8 @@ const PRETTIER_EXTENSIONS = [
   'css',
   'html',
   'json',
-  'md'
+  'md',
+  'mdx'
 ];
 
 export function format(command: 'check' | 'write', args: yargs.Arguments) {


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`.mdx` files are excluded from formatting.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`.mdx` files are included in formatting. We're using Storybook at our organization and some of our stories are written in `.mdx` files using [Storybook Docs](https://github.com/storybookjs/storybook/tree/next/addons/docs).