### PR TITLE
docs(core): generate nx commands supports blacklist

### DIFF
--- a/docs/angular/nx-commands/affected-build.md
+++ b/docs/angular/nx-commands/affected-build.md
@@ -96,7 +96,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/angular/nx-commands/affected-e2e.md
+++ b/docs/angular/nx-commands/affected-e2e.md
@@ -84,7 +84,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/angular/nx-commands/affected-lint.md
+++ b/docs/angular/nx-commands/affected-lint.md
@@ -84,7 +84,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/angular/nx-commands/affected-test.md
+++ b/docs/angular/nx-commands/affected-test.md
@@ -84,7 +84,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/angular/nx-commands/affected.md
+++ b/docs/angular/nx-commands/affected.md
@@ -102,7 +102,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/angular/nx-commands/run-many.md
+++ b/docs/angular/nx-commands/run-many.md
@@ -1,0 +1,101 @@
+# run-many
+
+Run task for multiple projects
+
+## Usage
+
+```bash
+nx run-many
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
+Test all projects.:
+
+```bash
+nx run-many --target=test --all
+```
+
+Test proj1 and proj2.:
+
+```bash
+nx run-many --target=test --projects=proj1,proj2
+```
+
+Test proj1 and proj2 in parallel.:
+
+```bash
+nx run-many --target=test --projects=proj1,proj2 --parallel --maxParallel=2
+```
+
+Build proj1 and proj2 and all their dependencies.:
+
+```bash
+nx run-many --target=test --projects=proj1,proj2 --with-deps
+```
+
+## Options
+
+### all
+
+All projects
+
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
+### help
+
+Show help
+
+### maxParallel
+
+Default: `3`
+
+Max number of parallel processes
+
+### only-failed
+
+Default: `false`
+
+Isolate projects which previously failed
+
+### parallel
+
+Default: `false`
+
+Parallelize the command
+
+### projects
+
+Projects to run (comma delimited)
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
+
+### skip-nx-cache
+
+Default: `false`
+
+Rerun the tasks even when the results are available in the cache
+
+### target
+
+Task to run for affected projects
+
+### verbose
+
+Print additional error stack trace on failure
+
+### version
+
+Show version number
+
+### with-deps
+
+Default: `false`
+
+Include dependencies of specified projects when computing what to run

--- a/docs/angular/nx-commands/run-many.md
+++ b/docs/angular/nx-commands/run-many.md
@@ -40,7 +40,7 @@ nx run-many --target=test --projects=proj1,proj2 --with-deps
 
 ### all
 
-All projects
+Run the target on all projects in the workspace
 
 ### configuration
 
@@ -54,13 +54,13 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
 Default: `false`
 
-Isolate projects which previously failed
+Only run the target on projects which previously failed
 
 ### parallel
 
@@ -74,7 +74,7 @@ Projects to run (comma delimited)
 
 ### runner
 
-This is the name of the tasks runner configured in nx.json
+Override the tasks runner in `nx.json`
 
 ### skip-nx-cache
 

--- a/docs/react/nx-commands/affected-build.md
+++ b/docs/react/nx-commands/affected-build.md
@@ -96,7 +96,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/react/nx-commands/affected-e2e.md
+++ b/docs/react/nx-commands/affected-e2e.md
@@ -84,7 +84,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/react/nx-commands/affected-lint.md
+++ b/docs/react/nx-commands/affected-lint.md
@@ -84,7 +84,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/react/nx-commands/affected-test.md
+++ b/docs/react/nx-commands/affected-test.md
@@ -84,7 +84,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/react/nx-commands/affected.md
+++ b/docs/react/nx-commands/affected.md
@@ -102,7 +102,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/react/nx-commands/run-many.md
+++ b/docs/react/nx-commands/run-many.md
@@ -1,0 +1,101 @@
+# run-many
+
+Run task for multiple projects
+
+## Usage
+
+```bash
+nx run-many
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
+Test all projects.:
+
+```bash
+nx run-many --target=test --all
+```
+
+Test proj1 and proj2.:
+
+```bash
+nx run-many --target=test --projects=proj1,proj2
+```
+
+Test proj1 and proj2 in parallel.:
+
+```bash
+nx run-many --target=test --projects=proj1,proj2 --parallel --maxParallel=2
+```
+
+Build proj1 and proj2 and all their dependencies.:
+
+```bash
+nx run-many --target=test --projects=proj1,proj2 --with-deps
+```
+
+## Options
+
+### all
+
+All projects
+
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
+### help
+
+Show help
+
+### maxParallel
+
+Default: `3`
+
+Max number of parallel processes
+
+### only-failed
+
+Default: `false`
+
+Isolate projects which previously failed
+
+### parallel
+
+Default: `false`
+
+Parallelize the command
+
+### projects
+
+Projects to run (comma delimited)
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
+
+### skip-nx-cache
+
+Default: `false`
+
+Rerun the tasks even when the results are available in the cache
+
+### target
+
+Task to run for affected projects
+
+### verbose
+
+Print additional error stack trace on failure
+
+### version
+
+Show version number
+
+### with-deps
+
+Default: `false`
+
+Include dependencies of specified projects when computing what to run

--- a/docs/react/nx-commands/run-many.md
+++ b/docs/react/nx-commands/run-many.md
@@ -40,7 +40,7 @@ nx run-many --target=test --projects=proj1,proj2 --with-deps
 
 ### all
 
-All projects
+Run the target on all projects in the workspace
 
 ### configuration
 
@@ -54,13 +54,13 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
 Default: `false`
 
-Isolate projects which previously failed
+Only run the target on projects which previously failed
 
 ### parallel
 
@@ -74,7 +74,7 @@ Projects to run (comma delimited)
 
 ### runner
 
-This is the name of the tasks runner configured in nx.json
+Override the tasks runner in `nx.json`
 
 ### skip-nx-cache
 

--- a/docs/web/nx-commands/affected-build.md
+++ b/docs/web/nx-commands/affected-build.md
@@ -96,7 +96,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/web/nx-commands/affected-e2e.md
+++ b/docs/web/nx-commands/affected-e2e.md
@@ -84,7 +84,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/web/nx-commands/affected-lint.md
+++ b/docs/web/nx-commands/affected-lint.md
@@ -84,7 +84,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/web/nx-commands/affected-test.md
+++ b/docs/web/nx-commands/affected-test.md
@@ -84,7 +84,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/web/nx-commands/affected.md
+++ b/docs/web/nx-commands/affected.md
@@ -102,7 +102,7 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 

--- a/docs/web/nx-commands/run-many.md
+++ b/docs/web/nx-commands/run-many.md
@@ -1,0 +1,101 @@
+# run-many
+
+Run task for multiple projects
+
+## Usage
+
+```bash
+nx run-many
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+### Examples
+
+Test all projects.:
+
+```bash
+nx run-many --target=test --all
+```
+
+Test proj1 and proj2.:
+
+```bash
+nx run-many --target=test --projects=proj1,proj2
+```
+
+Test proj1 and proj2 in parallel.:
+
+```bash
+nx run-many --target=test --projects=proj1,proj2 --parallel --maxParallel=2
+```
+
+Build proj1 and proj2 and all their dependencies.:
+
+```bash
+nx run-many --target=test --projects=proj1,proj2 --with-deps
+```
+
+## Options
+
+### all
+
+All projects
+
+### configuration
+
+This is the configuration to use when performing tasks on projects
+
+### help
+
+Show help
+
+### maxParallel
+
+Default: `3`
+
+Max number of parallel processes
+
+### only-failed
+
+Default: `false`
+
+Isolate projects which previously failed
+
+### parallel
+
+Default: `false`
+
+Parallelize the command
+
+### projects
+
+Projects to run (comma delimited)
+
+### runner
+
+This is the name of the tasks runner configured in nx.json
+
+### skip-nx-cache
+
+Default: `false`
+
+Rerun the tasks even when the results are available in the cache
+
+### target
+
+Task to run for affected projects
+
+### verbose
+
+Print additional error stack trace on failure
+
+### version
+
+Show version number
+
+### with-deps
+
+Default: `false`
+
+Include dependencies of specified projects when computing what to run

--- a/docs/web/nx-commands/run-many.md
+++ b/docs/web/nx-commands/run-many.md
@@ -40,7 +40,7 @@ nx run-many --target=test --projects=proj1,proj2 --with-deps
 
 ### all
 
-All projects
+Run the target on all projects in the workspace
 
 ### configuration
 
@@ -54,13 +54,13 @@ Show help
 
 Default: `3`
 
-Max number of parallel processes
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
 Default: `false`
 
-Isolate projects which previously failed
+Only run the target on projects which previously failed
 
 ### parallel
 
@@ -74,7 +74,7 @@ Projects to run (comma delimited)
 
 ### runner
 
-This is the name of the tasks runner configured in nx.json
+Override the tasks runner in `nx.json`
 
 ### skip-nx-cache
 

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -286,7 +286,9 @@ function withRunManyOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'Projects to run (comma delimited)',
       type: 'string'
     })
-    .option('all', { describe: 'All projects' })
+    .option('all', {
+      describe: 'Run the target on all projects in the workspace'
+    })
     .nargs('all', 0)
     .check(({ all, projects }) => {
       if ((all && projects) || (!all && !projects))
@@ -294,7 +296,7 @@ function withRunManyOptions(yargs: yargs.Argv): yargs.Argv {
       return true;
     })
     .options('runner', {
-      describe: 'This is the name of the tasks runner configured in nx.json',
+      describe: 'Override the tasks runner in `nx.json`',
       type: 'string'
     })
     .options('skip-nx-cache', {
@@ -315,7 +317,7 @@ function withRunManyOptions(yargs: yargs.Argv): yargs.Argv {
       default: false
     })
     .options('only-failed', {
-      describe: 'Isolate projects which previously failed',
+      describe: 'Only run the target on projects which previously failed',
       type: 'boolean',
       default: false
     })
@@ -370,7 +372,8 @@ function withParallel(yargs: yargs.Argv): yargs.Argv {
       default: false
     })
     .option('maxParallel', {
-      describe: 'Max number of parallel processes',
+      describe:
+        'Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.',
       type: 'number',
       default: 3
     });

--- a/packages/workspace/src/command-line/run-many.ts
+++ b/packages/workspace/src/command-line/run-many.ts
@@ -10,7 +10,7 @@ import {
 import { readEnvironment } from '../core/file-utils';
 import { DefaultReporter } from '../tasks-runner/default-reporter';
 import { projectHasTarget } from '../utils/project-graph-utils';
-import { output } from "../utils/output";
+import { output } from '../utils/output';
 
 export function runMany(parsedArgs: yargs.Arguments): void {
   const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides(


### PR DESCRIPTION
Update the script generating Nx commands by passing a black list and not guessing with the name of the command.

This allows us to be more precise on which command we want to generate the documentation for.