### PR TITLE
fix(nextjs): default fileReplacements relative to workspace root

### DIFF
--- a/packages/next/src/schematics/application/application.spec.ts
+++ b/packages/next/src/schematics/application/application.spec.ts
@@ -110,8 +110,8 @@ describe('app', () => {
       production: {
         fileReplacements: [
           {
-            replace: 'environments/environment.ts',
-            with: 'environments/environment.prod.ts'
+            replace: 'apps/my-app/environments/environment.ts',
+            with: 'apps/my-app/environments/environment.prod.ts'
           }
         ]
       }

--- a/packages/next/src/schematics/application/lib/add-project.spec.ts
+++ b/packages/next/src/schematics/application/lib/add-project.spec.ts
@@ -1,0 +1,58 @@
+import { normalize } from '@angular-devkit/core';
+import { Tree } from '@angular-devkit/schematics';
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
+import { Linter, readJsonInTree } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { callRule } from '../../../utils/testing';
+import { addProject } from './add-project';
+import { NormalizedSchema } from './normalize-options';
+
+describe('addProject Rule', () => {
+  let tree: Tree;
+  let schema: NormalizedSchema;
+
+  beforeEach(async () => {
+    tree = createEmptyWorkspace(Tree.empty());
+
+    schema = {
+      name: 'todos',
+      skipFormat: false,
+      unitTestRunner: 'jest',
+      e2eTestRunner: 'cypress',
+      linter: Linter.EsLint,
+      classComponent: false,
+      projectName: 'todos',
+      appProjectRoot: normalize('/apps/todos'),
+      e2eProjectName: 'todos-e2e',
+      e2eProjectRoot: normalize('/apps/todos-e2e'),
+      parsedTags: [],
+      fileName: 'index',
+      styledModule: null
+    };
+  });
+
+  it('should add the build configuration correctly', async () => {
+    tree = (await callRule(addProject(schema), tree)) as UnitTestTree;
+
+    const workspaceJson = readJsonInTree(tree, '/workspace.json');
+
+    const project = workspaceJson.projects[schema.name];
+    expect(project.architect.build).toEqual({
+      builder: '@nrwl/next:build',
+      configurations: {
+        production: {
+          fileReplacements: [
+            {
+              replace: '/apps/todos/environments/environment.ts',
+              with: '/apps/todos/environments/environment.prod.ts'
+            }
+          ]
+        }
+      },
+      options: {
+        outputPath: 'dist/apps/todos',
+        root: '/apps/todos'
+      }
+    });
+  });
+});

--- a/packages/next/src/schematics/application/lib/add-project.ts
+++ b/packages/next/src/schematics/application/lib/add-project.ts
@@ -19,8 +19,14 @@ export function addProject(options: NormalizedSchema): Rule {
         production: {
           fileReplacements: [
             {
-              replace: `environments/environment.ts`,
-              with: `environments/environment.prod.ts`
+              replace: join(
+                options.appProjectRoot,
+                `environments/environment.ts`
+              ),
+              with: join(
+                options.appProjectRoot,
+                `environments/environment.prod.ts`
+              )
             }
           ]
         }


### PR DESCRIPTION
Small fix to change the default file replacement paths in the nextjs application schematic. They should be relative to the workspace root.

I've also added a small test for the rule that changed.