### PR TITLE
fix(testing): issue passing coverageRepoters commandline

### DIFF
--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -107,7 +107,6 @@ function run(
     testPathPattern: options.testPathPattern,
     colors: options.colors,
     verbose: options.verbose,
-    coverageReporters: options.coverageReporters,
     coverageDirectory: options.coverageDirectory,
     testResultsProcessor: options.testResultsProcessor,
     updateSnapshot: options.updateSnapshot,
@@ -139,6 +138,12 @@ function run(
 
   if (options.reporters && options.reporters.length > 0) {
     config.reporters = options.reporters;
+  }
+  
+  if(options.coverageReporters) {
+    // coverageReporters is an array of string in jest
+    // https://jestjs.io/docs/en/configuration#coveragereporters-arraystring
+    config.coverageReporters: [options.coverageReporters],
   }
 
   return from(runCLI(config, [options.jestConfig])).pipe(

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -19,6 +19,7 @@ import { runCLI } from 'jest';
 if (process.env.NODE_ENV == null || process.env.NODE_ENV == undefined) {
   (process.env as any).NODE_ENV = 'test';
 }
+
 export interface JestBuilderOptions extends JsonObject {
   codeCoverage?: boolean;
   config?: string;

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -144,7 +144,7 @@ function run(
   if(options.coverageReporters) {
     // coverageReporters is an array of string in jest
     // https://jestjs.io/docs/en/configuration#coveragereporters-arraystring
-    config.coverageReporters: [options.coverageReporters],
+    config.coverageReporters = [options.coverageReporters],
   }
 
   return from(runCLI(config, [options.jestConfig])).pipe(


### PR DESCRIPTION
In Jest coverageReporters are an array of strings (https://jestjs.io/docs/en/configuration#coveragereporters-arraystring). In here it is an optional string. 

## Current Behavior (This is the behavior we have today, before the PR is merged)
When passing a string value for the coverageReporters to the command line, it results into the following error:

Failed to write coverage reports:
        ERROR: TypeError: coverageReporters.forEach is not a function
        STACK: TypeError: coverageReporters.forEach is not a function

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Use the provided coverageReporter

## Issue
