### PR TITLE
fix(testing): issue passing coverageRepoters commandline

### DIFF
--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -111,7 +111,7 @@ describe('Jest Builder', () => {
           colors: false,
           reporters: ['/test/path'],
           verbose: false,
-          coverageReporters: 'test',
+          coverageReporters: ['test'],
           coverageDirectory: '/test/path',
           watch: false
         },
@@ -220,7 +220,7 @@ describe('Jest Builder', () => {
           colors: false,
           verbose: false,
           reporters: ['/test/path'],
-          coverageReporters: 'test',
+          coverageReporters: ['test'],
           coverageDirectory: '/test/path',
           testResultsProcessor: 'results-processor',
           updateSnapshot: true,

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -107,7 +107,6 @@ function run(
     testPathPattern: options.testPathPattern,
     colors: options.colors,
     verbose: options.verbose,
-    coverageReporters: options.coverageReporters,
     coverageDirectory: options.coverageDirectory,
     testResultsProcessor: options.testResultsProcessor,
     updateSnapshot: options.updateSnapshot,
@@ -139,6 +138,11 @@ function run(
 
   if (options.reporters && options.reporters.length > 0) {
     config.reporters = options.reporters;
+  }
+
+  if (options.coverageReporters) {
+    // In Jest coverageReporters is an array of strings
+    config.coverageReporters = [options.coverageReporters];
   }
 
   return from(runCLI(config, [options.jestConfig])).pipe(


### PR DESCRIPTION
In Jest coverageReporters are an array of strings (https://jestjs.io/docs/en/configuration#coveragereporters-arraystring). In here it is an optional string. 

## Current Behavior (This is the behavior we have today, before the PR is merged)
When passing a string value for the coverageReporters to the command line, it results into the following error:

Failed to write coverage reports:
        ERROR: TypeError: coverageReporters.forEach is not a function
        STACK: TypeError: coverageReporters.forEach is not a function

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Use the provided coverageReporter

## Issue