### PR TITLE
fix(core): fix default export of tasks-runners v2

### DIFF
--- a/packages/workspace/src/tasks-runner/tasks-runner-v2.ts
+++ b/packages/workspace/src/tasks-runner/tasks-runner-v2.ts
@@ -1,5 +1,9 @@
+import { defaultTasksRunner } from './default-tasks-runner';
+
 export {
   DefaultTasksRunnerOptions,
   RemoteCache,
   defaultTasksRunner as tasksRunnerV2
 } from './default-tasks-runner';
+
+export default defaultTasksRunner;


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Workspaces that have caching configured using the import of `tasks-runner-v2` were broken with the change of the default tasks-runner because there is no default export.

```ts
require('@nrwl/workspace/src/tasks-runner/tasks-runner-v2').default === undefined;
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Workspaces that have caching configured using the import of `tasks-runner-v2` were broken with the change of the default tasks-runner because there is no default export.

```ts
typeof require('@nrwl/workspace/src/tasks-runner/tasks-runner-v2').default === 'function';
```

## Issue
Fixes #2655 