### PR TITLE
fix(storybook): Fix an invalid dependency version for @babel/core

### DIFF
--- a/packages/storybook/src/schematics/init/init.ts
+++ b/packages/storybook/src/schematics/init/init.ts
@@ -5,7 +5,11 @@ import {
   Tree
 } from '@angular-devkit/schematics';
 import { readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
-import { babelLoaderVersion, storybookVersion } from '../../utils/versions';
+import {
+  babelLoaderVersion,
+  babelCoreVersion,
+  storybookVersion
+} from '../../utils/versions';
 import { Schema } from './schema';
 
 function checkDependenciesInstalled(): Rule {
@@ -19,7 +23,7 @@ function checkDependenciesInstalled(): Rule {
       devDependencies['@storybook/react'] = storybookVersion;
       devDependencies['@storybook/addon-knobs'] = storybookVersion;
       devDependencies['babel-loader'] = babelLoaderVersion;
-      devDependencies['@babel/core'] = babelLoaderVersion;
+      devDependencies['@babel/core'] = babelCoreVersion;
     }
     if (
       !packageJson.dependencies['@angular/forms'] &&


### PR DESCRIPTION
fix(storybook): Fix an invalid dependency version for @babel/core

## Current Behavior
The Storybook schematic imports the wrong version variable for the **@babel/core** package.
It is re-using the babelLoaderVersion meant for **babel-loader** instead of the babelCoreVersion it should be using.

This in turn points to a version of **@babel/core** that doesn't exist, breaking this schematic silently.

## Expected Behavior
The BabelCoreVersion should be used, allowing the install to succeed again.

## Issue
Fixes #2665

This is a very quick edit and PR made from my phone, sorry if I missed anything.