### PR TITLE
feat(nx-plugin): add migration schematic

### DIFF
--- a/docs/angular/api-nx-plugin/schematics/migration.md
+++ b/docs/angular/api-nx-plugin/schematics/migration.md
@@ -1,0 +1,73 @@
+# migration
+
+Create a migration for an Nx Plugin
+
+## Usage
+
+```bash
+nx generate migration ...
+```
+
+By default, Nx will search for `migration` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/nx-plugin:migration ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g migration ... --dry-run
+```
+
+### Examples
+
+Generate libs/my-plugin/src/migrations/my-migration:
+
+```bash
+nx g migration my-migration --project=my-plugin --version=1.0.0
+```
+
+## Options
+
+### description
+
+Alias(es): d
+
+Type: `string`
+
+Migration description
+
+### name
+
+Type: `string`
+
+Migration name
+
+### packageJsonUpdates
+
+Alias(es): p
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to include package.json updates
+
+### project
+
+Alias(es): p
+
+Type: `string`
+
+The name of the project.
+
+### version
+
+Alias(es): v
+
+Type: `string`
+
+Version to use for the migration

--- a/docs/react/api-nx-plugin/schematics/migration.md
+++ b/docs/react/api-nx-plugin/schematics/migration.md
@@ -1,0 +1,73 @@
+# migration
+
+Create a migration for an Nx Plugin
+
+## Usage
+
+```bash
+nx generate migration ...
+```
+
+By default, Nx will search for `migration` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/nx-plugin:migration ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g migration ... --dry-run
+```
+
+### Examples
+
+Generate libs/my-plugin/src/migrations/my-migration:
+
+```bash
+nx g migration my-migration --project=my-plugin --version=1.0.0
+```
+
+## Options
+
+### description
+
+Alias(es): d
+
+Type: `string`
+
+Migration description
+
+### name
+
+Type: `string`
+
+Migration name
+
+### packageJsonUpdates
+
+Alias(es): p
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to include package.json updates
+
+### project
+
+Alias(es): p
+
+Type: `string`
+
+The name of the project.
+
+### version
+
+Alias(es): v
+
+Type: `string`
+
+Version to use for the migration

--- a/packages/nx-plugin/collection.json
+++ b/packages/nx-plugin/collection.json
@@ -13,6 +13,11 @@
       "schema": "./src/schematics/e2e-project/schema.json",
       "description": "Create a e2e application for a Nx Plugin",
       "hidden": true
+    },
+    "migration": {
+      "factory": "./src/schematics/migration/migration",
+      "schema": "./src/schematics/migration/schema.json",
+      "description": "Create a migration for an Nx Plugin"
     }
   }
 }

--- a/packages/nx-plugin/src/schematics/migration/files/migration/__name__/__name__.spec.ts__tmpl__
+++ b/packages/nx-plugin/src/schematics/migration/files/migration/__name__/__name__.spec.ts__tmpl__
@@ -1,0 +1,36 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { readJsonInTree, serializeJson } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import * as path from 'path';
+
+describe('<%= name %>', () => {
+  let initialTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(async () => {
+    initialTree = createEmptyWorkspace(Tree.empty());
+
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/nx-plugin',
+      path.join(__dirname, '../../../migrations.json')
+    );
+
+    initialTree.overwrite(
+      'package.json',
+      serializeJson({
+        dependencies: {}
+      })
+    );
+  });
+
+  it(`should update dependencies`, async () => {
+    // eslint-disable-next-line require-atomic-updates
+    const result = await schematicRunner
+      .runSchematicAsync('<%= name %>', {}, initialTree)
+      .toPromise();
+
+    const { dependencies } = readJsonInTree(result, '/package.json');
+    expect(dependencies).toEqual({});
+  });
+});

--- a/packages/nx-plugin/src/schematics/migration/files/migration/__name__/__name__.ts__tmpl__
+++ b/packages/nx-plugin/src/schematics/migration/files/migration/__name__/__name__.ts__tmpl__
@@ -1,0 +1,12 @@
+import { chain, Rule } from '@angular-devkit/schematics';<% if (packageJsonUpdates) { %>
+import { updatePackagesInPackageJson } from '@nrwl/workspace';
+import * as path from 'path';<% } %>
+
+export default function update(): Rule {
+  return chain([<% if (packageJsonUpdates) { %>
+    updatePackagesInPackageJson(
+      path.join(__dirname, '../../../', 'migrations.json'),
+      '<%= version %>'
+    )
+  <% } %>]);
+}

--- a/packages/nx-plugin/src/schematics/migration/migration.spec.ts
+++ b/packages/nx-plugin/src/schematics/migration/migration.spec.ts
@@ -1,0 +1,145 @@
+import * as ngSchematics from '@angular-devkit/schematics';
+import { Tree } from '@angular-devkit/schematics';
+import { readJsonInTree, readWorkspace } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { runSchematic } from '../../utils/testing';
+
+describe('NxPlugin migration', () => {
+  let appTree: Tree;
+  let projectName: string;
+
+  beforeEach(async () => {
+    projectName = 'my-plugin';
+    appTree = createEmptyWorkspace(ngSchematics.Tree.empty());
+    appTree = await runSchematic('plugin', { name: projectName }, appTree);
+  });
+
+  it('should update the workspace.json file', async () => {
+    const tree = await runSchematic(
+      'migration',
+      {
+        project: projectName,
+        version: '1.0.0'
+      },
+      appTree
+    );
+    const workspace = await readWorkspace(tree);
+    const project = workspace.projects['my-plugin'];
+    expect(project.root).toEqual('libs/my-plugin');
+    expect(project.architect.build.options.assets).toContainEqual({
+      input: './libs/my-plugin',
+      glob: 'migrations.json',
+      output: '.'
+    });
+  });
+
+  it('should generate files', async () => {
+    const tree = await runSchematic(
+      'migration',
+      {
+        project: projectName,
+        name: 'my-migration',
+        description: 'my-migration description',
+        version: '1.0.0'
+      },
+      appTree
+    );
+
+    const migrationsJson = readJsonInTree(
+      tree,
+      'libs/my-plugin/migrations.json'
+    );
+    const packageJson = readJsonInTree(tree, 'libs/my-plugin/package.json');
+
+    expect(
+      tree.exists('libs/my-plugin/src/migrations/my-migration/my-migration.ts')
+    ).toBeTruthy();
+    expect(
+      tree.exists(
+        'libs/my-plugin/src/migrations/my-migration/my-migration.spec.ts'
+      )
+    ).toBeTruthy();
+
+    expect(migrationsJson.schematics['my-migration'].version).toEqual('1.0.0');
+    expect(migrationsJson.schematics['my-migration'].description).toEqual(
+      'my-migration description'
+    );
+    expect(migrationsJson.schematics['my-migration'].factory).toEqual(
+      './src/migrations/my-migration/my-migration'
+    );
+    expect(migrationsJson.packageJsonUpdates).toBeFalsy();
+
+    expect(packageJson['ng-update'].migrations).toEqual('./migrations.json');
+  });
+
+  it('should generate files with default name', async () => {
+    const tree = await runSchematic(
+      'migration',
+      {
+        project: projectName,
+        description: 'my-migration description',
+        version: '1.0.0'
+      },
+      appTree
+    );
+
+    const migrationsJson = readJsonInTree(
+      tree,
+      'libs/my-plugin/migrations.json'
+    );
+
+    expect(
+      tree.exists('libs/my-plugin/src/migrations/update-1.0.0/update-1.0.0.ts')
+    ).toBeTruthy();
+
+    expect(migrationsJson.schematics['update-1.0.0'].factory).toEqual(
+      './src/migrations/update-1.0.0/update-1.0.0'
+    );
+  });
+
+  it('should generate files with default description', async () => {
+    const tree = await runSchematic(
+      'migration',
+      {
+        project: projectName,
+        name: 'my-migration',
+        version: '1.0.0'
+      },
+      appTree
+    );
+
+    const migrationsJson = readJsonInTree(
+      tree,
+      'libs/my-plugin/migrations.json'
+    );
+
+    expect(migrationsJson.schematics['my-migration'].description).toEqual(
+      'my-migration'
+    );
+  });
+
+  it('should generate files with package.json updates', async () => {
+    const tree = await runSchematic(
+      'migration',
+      {
+        project: projectName,
+        name: 'my-migration',
+        version: '1.0.0',
+        packageJsonUpdates: true
+      },
+      appTree
+    );
+
+    const migrationsJson = readJsonInTree(
+      tree,
+      'libs/my-plugin/migrations.json'
+    );
+
+    expect(migrationsJson.packageJsonUpdates).toEqual({
+      ['1.0.0']: {
+        version: '1.0.0',
+        packages: {}
+      }
+    });
+  });
+});

--- a/packages/nx-plugin/src/schematics/migration/migration.ts
+++ b/packages/nx-plugin/src/schematics/migration/migration.ts
@@ -1,0 +1,148 @@
+import { JsonArray } from '@angular-devkit/core';
+import {
+  apply,
+  chain,
+  mergeWith,
+  move,
+  Rule,
+  SchematicContext,
+  template,
+  Tree,
+  url
+} from '@angular-devkit/schematics';
+import {
+  getProjectConfig,
+  toFileName,
+  updateJsonInTree,
+  updateWorkspace
+} from '@nrwl/workspace';
+import * as path from 'path';
+import { Schema } from './schema';
+
+export interface NormalizedSchema extends Schema {
+  projectRoot: string;
+  projectSourceRoot: string;
+}
+
+export default function(schema: NormalizedSchema): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    const options = normalizeOptions(host, schema);
+
+    return chain([
+      addFiles(options),
+      updateMigrationsJson(options),
+      updateWorkspaceJson(options),
+      updatePackageJson(options)
+    ]);
+  };
+}
+
+function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
+  let name: string;
+  if (options.name) {
+    name = toFileName(options.name);
+  } else {
+    name = toFileName(`update-${options.version}`);
+  }
+
+  let description: string;
+  if (options.description) {
+    description = options.description;
+  } else {
+    description = name;
+  }
+
+  const { root: projectRoot, sourceRoot: projectSourceRoot } = getProjectConfig(
+    host,
+    options.project
+  );
+
+  const normalized: NormalizedSchema = {
+    ...options,
+    name,
+    description,
+    projectRoot,
+    projectSourceRoot
+  };
+
+  return normalized;
+}
+
+function addFiles(options: NormalizedSchema): Rule {
+  return mergeWith(
+    apply(url(`./files/migration`), [
+      template({
+        ...options,
+        tmpl: ''
+      }),
+      move(`${options.projectSourceRoot}/migrations`)
+    ])
+  );
+}
+
+function updateWorkspaceJson(options: NormalizedSchema): Rule {
+  return updateWorkspace(workspace => {
+    const targets = workspace.projects.get(options.project).targets;
+    const build = targets.get('build');
+    if (build) {
+      (build.options.assets as JsonArray).push(
+        ...[
+          {
+            input: `./${options.projectRoot}`,
+            glob: 'migrations.json',
+            output: '.'
+          }
+        ]
+      );
+    }
+  });
+}
+
+function updateMigrationsJson(options: NormalizedSchema): Rule {
+  return updateJsonInTree(
+    path.join(options.projectRoot, 'migrations.json'),
+    json => {
+      const schematics = json.schematics ? json.schematics : {};
+      schematics[options.name] = {
+        version: options.version,
+        description: options.description,
+        factory: `./src/migrations/${options.name}/${options.name}`
+      };
+      json.schematics = schematics;
+
+      if (options.packageJsonUpdates) {
+        const packageJsonUpdatesObj = json.packageJsonUpdates
+          ? json.packageJsonUpdates
+          : {};
+        if (!packageJsonUpdatesObj[options.version]) {
+          packageJsonUpdatesObj[options.version] = {
+            version: options.version,
+            packages: {}
+          };
+        }
+        json.packageJsonUpdates = packageJsonUpdatesObj;
+      }
+
+      return json;
+    }
+  );
+}
+
+function updatePackageJson(options: NormalizedSchema): Rule {
+  return updateJsonInTree(
+    path.join(options.projectRoot, 'package.json'),
+    json => {
+      if (!json['ng-update'] || !json['ng-update'].migrations) {
+        if (json['ng-update']) {
+          json['ng-update'].migrations = './migrations.json';
+        } else {
+          json['ng-update'] = {
+            migrations: './migrations.json'
+          };
+        }
+      }
+
+      return json;
+    }
+  );
+}

--- a/packages/nx-plugin/src/schematics/migration/schema.d.ts
+++ b/packages/nx-plugin/src/schematics/migration/schema.d.ts
@@ -1,0 +1,7 @@
+export interface Schema {
+  project: string;
+  name: string;
+  description: string;
+  version: string;
+  packageJsonUpdates: boolean;
+}

--- a/packages/nx-plugin/src/schematics/migration/schema.json
+++ b/packages/nx-plugin/src/schematics/migration/schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxPluginMigration",
+  "title": "Create a Migration for an Nx Plugin",
+  "type": "object",
+  "examples": [
+    {
+      "command": "g migration my-migration --project=my-plugin --version=1.0.0",
+      "description": "Generate libs/my-plugin/src/migrations/my-migration"
+    }
+  ],
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "alias": "p",
+      "$default": {
+        "$source": "projectName"
+      },
+      "x-prompt": "What is the name of the project for the migration?"
+    },
+    "name": {
+      "type": "string",
+      "description": "Migration name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
+    "description": {
+      "type": "string",
+      "description": "Migration description",
+      "alias": "d"
+    },
+    "version": {
+      "type": "string",
+      "description": "Version to use for the migration",
+      "alias": "v",
+      "x-prompt": "What version would you like to use for the migration?"
+    },
+    "packageJsonUpdates": {
+      "type": "boolean",
+      "description": "Whether or not to include package.json updates",
+      "alias": "p",
+      "default": false
+    }
+  },
+  "required": ["project", "version"]
+}


### PR DESCRIPTION
This change adds a new schematic that generates a migration for an Nx plugin. The user can specify the version for the migration, and optionally add a custom name, description, and whether or not to include package.json updates.

Examples:

```
nx g @nrwl/nx-plugin:migration --project=ionic-react --version=1.2.0
```

```
nx g @nrwl/nx-plugin:migration fix-files-1.2.0 --project=ionic-react --version=1.2.0
```