### PR TITLE
fix(core): improve performance of project filtering on dep-graph

### DIFF
--- a/packages/workspace/src/core/dep-graph/dep-graph.css
+++ b/packages/workspace/src/core/dep-graph/dep-graph.css
@@ -241,3 +241,7 @@ g.affected ellipse {
   letter-spacing: 0.5px;
   margin-right: 0.4em;
 }
+
+.hide {
+  display: none;
+}

--- a/packages/workspace/src/core/dep-graph/dep-graph.html
+++ b/packages/workspace/src/core/dep-graph/dep-graph.html
@@ -21,6 +21,7 @@
             <button
               id="select-affected-button"
               onclick="window.selectAffectedProjects()"
+              class="hide"
             >
               Select Affected
             </button>


### PR DESCRIPTION
Also includes:
bug fix related to showing/hiding the 'Show Affected' button
bug fix to use 'root' rather than 'sourceRoot' to determine directory

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
On large projects, filtering projects can take 20-30 seconds to complete.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
On large projects, filtering projects takes less than 1 second.

## Issue
