### PR TITLE
fix(node): remove directory prompt from node apps

### DIFF
--- a/packages/express/src/schematics/application/schema.json
+++ b/packages/express/src/schematics/application/schema.json
@@ -15,8 +15,7 @@
     },
     "directory": {
       "description": "The directory of the new application.",
-      "type": "string",
-      "x-prompt": "In which directory should the node application be generated?"
+      "type": "string"
     },
     "skipFormat": {
       "description": "Skip formatting files",

--- a/packages/nest/src/schematics/application/schema.json
+++ b/packages/nest/src/schematics/application/schema.json
@@ -15,8 +15,7 @@
     },
     "directory": {
       "description": "The directory of the new application.",
-      "type": "string",
-      "x-prompt": "In which directory should the node application be generated?"
+      "type": "string"
     },
     "skipFormat": {
       "description": "Skip formatting files",

--- a/packages/node/src/schematics/application/schema.json
+++ b/packages/node/src/schematics/application/schema.json
@@ -15,8 +15,7 @@
     },
     "directory": {
       "description": "The directory of the new application.",
-      "type": "string",
-      "x-prompt": "In which directory should the node application be generated?"
+      "type": "string"
     },
     "skipFormat": {
       "description": "Skip formatting files",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Only node applications ask what directory they should be placed in.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

We cleaned up a lot of these prompts before but I guess node applications are still prompting for the directory. This prompt is now removed.

## Issue
