### PR TITLE
WIP fix(repo): fix e2e tests

### DIFF
--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -272,7 +272,6 @@ export function copyMissingPackages(): void {
     'browserslist',
     'license-webpack-plugin',
     'webpack-subresource-integrity',
-    'copy-webpack-plugin',
     'autoprefixer',
     'mini-css-extract-plugin',
     'postcss-import',


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`copy-webpack-plugin` is copied into the e2e workspace `node_modules`. This causes some sort of version mismatch.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`copy-webpack-plugin` is not copied into the e2e worskpace `node_modules`. This fixes the version mismatch
