### PR TITLE
chore(core): nx plugin submission nx-deploy-it

### DIFF
--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -18,5 +18,10 @@
     "name": "@flowaccount/nx-serverless",
     "description": "Nx plugin for node/angular-universal schematics and deployment builders in an Nx workspace",
     "url": "https://github.com/flowaccount/nx-plugins"
+  },
+  {
+    "name": "@dev-thought/nx-deploy-it",
+    "description": "Nx plugin to deploy applications on your favorite cloud provider",
+    "url": "https://github.com/Dev-Thought/nx-plugins/tree/master/libs/nx-deploy-it"
   }
 ]


### PR DESCRIPTION
Thanks nrwl for this fantastic plugin system!

I have just rewritten my plugin to it, and I am happy to be able to ship version 1.0.0 of nx-deploy-it.
It provides the power of infrastructure as code in a way that fits perfectly in the NX workspace. Infrastructure as code in typescript!

The current support is Azure, Google Cloud Platform, and AWS as a provider and the applications angular and NestJs. But everything is built extensible with adapters, so it is easy to integrate additional provider or application types.

The possibilities are endless here. You could even create shared IaC modules ins libs and use the dep-graph from NX.

I hope this plugin will help the community to understand better how important infrastructure as code is and allows getting easier access to it.