### PR TITLE
docs(core): add docs for shared Nx commands

### DIFF
--- a/docs/angular/nx-commands/build.md
+++ b/docs/angular/nx-commands/build.md
@@ -1,0 +1,288 @@
+# build
+
+Compiles an application into an output directory named dist/ at the given output path. Must be executed from within a workspace directory.
+
+## Usage
+
+```bash
+nx build <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `build` command to the Angular CLI's `build` command.
+
+### Examples
+
+Compile a `production` build of the `myapp` project:
+
+```bash
+nx build myapp --prod
+```
+
+## Options
+
+The options below are common to the `build` command used within an Nx workspace. The Web and Angular-specifc build options are listed after these options.
+
+### baseHref
+
+Default: `/`
+
+Base url for the application being built.
+
+### commonChunk
+
+Use a separate bundle containing code used across multiple bundles.
+
+Default: `true`
+
+### budgets
+
+Budget thresholds to ensure parts of your application stay within boundaries which you set.
+
+### namedChunks
+
+Default: `true`
+
+Names the produced bundles according to their entry file
+
+### deployUrl
+
+URL where the application will be deployed.
+
+### es2015Polyfills
+
+Conditional polyfills loaded in browsers which do not support ES2015.
+
+### extractCss
+
+Extract css into a .css file
+
+### extractLicenses
+
+Extract all licenses in a separate file, in the case of production builds only.
+
+### index
+
+HTML File which will be contain the application
+
+### main
+
+The name of the main entry-point file.
+
+### tsConfig
+
+The name of the Typescript configuration file.
+
+### outputPath
+
+The output path of the generated files.
+
+### progress
+
+Log progress to the console while building.
+
+### optimization
+
+Enables optimization of the build output.
+
+### outputHashing
+
+Default: `none`
+
+Define the output filename cache-busting hashing mode.
+
+### scripts
+
+External Scripts which will be included before the main application entry.
+
+### showCircularDependencies
+
+Default: `true`
+
+Show circular dependency warnings on builds.
+
+### sourceMap
+
+Default: `true`
+
+Output sourcemaps.
+
+### statsJson
+
+Generates a 'stats.json' file which can be analyzed using tools such as: #webpack-bundle-analyzer' or https://webpack.github.io/
+analyse.
+
+### styles
+
+External Styles which will be included with the application
+
+### subresourceIntegrity
+
+Enables the use of subresource integrity validation.
+
+### vendorChunk
+
+Default: `true`
+
+Use a separate bundle containing only vendor libraries.
+
+### verbose
+
+Emits verbose output
+
+### watch
+
+Enable re-building when files change.
+
+### help
+
+Show help information
+
+### version
+
+Show version number
+
+## Web-Build Options
+
+### assets
+
+List of static application assets.
+
+### fileReplacements
+
+Replace files with other files in the build.
+
+### maxWorkers
+
+Number of workers to use for type checking.
+
+Default: `# of CPUS - 2`
+
+### memoryLimit
+
+Memory limit for type checking service process in MB.
+
+Default: `2048`
+
+### polyfills
+
+Polyfills to load before application
+
+### stylePreprocessorOptions
+
+Options to pass to style preprocessors.
+
+### webpackConfig
+
+Path to a function which takes a webpack config, some context and returns the resulting webpack config
+
+## Angular Options
+
+### aot
+
+Build using Ahead of Time compilation.
+
+### buildEventLog
+
+**EXPERIMENTAL** Output file path for Build Event Protocol events
+
+### buildOptimizer
+
+Enables `@angular-devkit/build-optimizer` optimizations when using the `--aot` option.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of angular.json.
+Each named target is accompanied by a configuration of option defaults for that target.
+Setting this explicitly overrides the "--prod" flag
+
+### crossOrigin
+
+Define the crossorigin attribute setting of elements that provide CORS support.
+
+### deleteOutputPath
+
+Delete the output path before building.
+
+### deployUrl
+
+URL where files will be deployed.
+
+### es5BrowserSupport
+
+Enables conditionally loaded ES2015 polyfills.
+
+### evalSourceMap
+
+Output in-file eval sourcemaps.
+
+### experimentalRollupPass
+
+Concatenate modules with Rollup before bundling them with Webpack.
+
+### forkTypeChecker
+
+Run the TypeScript type checker in a forked process.
+
+### i18nFile
+
+Localization file to use for i18n.
+
+### i18nFormat
+
+Format of the localization file specified with --i18n-file.
+
+### i18nLocale
+
+Locale to use for i18n.
+
+### i18nMissingTranslation
+
+How to handle missing translations for i18n.
+
+### localize
+
+### ngswConfigPath
+
+Path to ngsw-config.json.
+
+### poll
+
+Enable and define the file watching poll time period in milliseconds.
+
+### polyfills
+
+The full path for the polyfills file, relative to the current workspace.
+
+### preserveSymlinks
+
+Do not use the real path when resolving modules.
+
+### rebaseRootRelativeCssUrls
+
+Change root relative URLs in stylesheets to include base HREF and deploy URL. Use only for compatibility and transition. The behavior of this option is non-standard and will be removed in the next major release.
+
+### resourcesOutputPath
+
+The path where style resources will be placed, relative to outputPath.
+
+### serviceWorker
+
+Generates a service worker config for production builds.
+
+### skipAppShell
+
+Flag to prevent building an app shell.
+
+### vendorSourceMap
+
+Resolve vendor packages sourcemaps.
+
+### verbose
+
+Adds more details to output logging.
+
+### webWorkerTsConfig
+
+TypeScript configuration for Web Worker modules.

--- a/docs/angular/nx-commands/build.md
+++ b/docs/angular/nx-commands/build.md
@@ -4,8 +4,16 @@ Compiles an application into an output directory named dist/ at the given output
 
 ## Usage
 
+The `build` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx build <project> [options]
+```
+
+```bash
+nx run <project>:build [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/angular/nx-commands/e2e.md
+++ b/docs/angular/nx-commands/e2e.md
@@ -1,0 +1,135 @@
+# generate
+
+Builds and serves an app, then runs end-to-end tests using the configured E2E test runner.
+
+## Usage
+
+```bash
+nx e2e <project>
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `e2e` command to the Angular CLI's `e2e` command.
+
+### Examples
+
+Run E2E test with a custom base url:
+
+```bash
+nx e2e myapp-e2e --base-url http://localhost:4201
+```
+
+Run E2E test with a specific target:
+
+```bash
+nx e2e myapp-e2e --configuration smoke
+```
+
+## Common Options
+
+The options below are common to the E2E commands used within an Nx workspace. Cypress and Protractor-specifc options are listed below.
+
+### baseUrl
+
+Use this to pass directly the address of your distant server address with the port running your application.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of angular.json. Each named target is accompanied by a configuration of option defaults for that target. Setting this explicitly overrides the `--prod` option.
+
+### devServerTarget
+
+Dev server target to run tests against.
+
+### prod
+
+Shorthand for `--configuration=production`. When true, sets the build configuration to the production target. By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
+
+### version
+
+Show version number
+
+## Cypress Options
+
+### browser
+
+The browser to run tests in.
+
+### ci-build-id
+
+A unique identifier for a run to enable grouping or parallelization.
+
+### ci-build-id
+
+A unique identifier for a run to enable grouping or parallelization.
+
+### cypress-config
+
+The path of the Cypress configuration json file.
+
+### exit
+
+Whether or not the Cypress Test Runner will stay open after running tests in a spec file
+
+### group
+
+A named group for recorded runs in the Cypress dashboard.
+
+### headless
+
+Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode.
+
+### help
+
+Shows a help message for this command in the console.
+
+### key
+
+The key cypress should use to run tests in parallel/record the run (CI only).
+
+### parallel
+
+Whether or not Cypress should run its tests in parallel (CI only).
+
+### record
+
+Whether or not Cypress should record the results of the tests
+
+### spec
+
+A comma delimited glob string that is provided to the Cypress runner to specify which spec files to run. For example: '**examples/**,**actions.spec**
+
+### ts-config
+
+The path of the Cypress tsconfig configuration json file.
+
+## Protractor Options
+
+### element-explorer
+
+Start Protractor's Element Explorer for debugging.
+
+### host
+
+Host to listen on.
+
+### port
+
+The port to use to serve the application.
+
+### protractor-config
+
+The name of the Protractor configuration file.
+
+### specs
+
+Override specs in the protractor config.
+
+### suite
+
+Override suite in the protractor config.
+
+### webdriver-update
+
+Try to update webdriver.

--- a/docs/angular/nx-commands/e2e.md
+++ b/docs/angular/nx-commands/e2e.md
@@ -4,8 +4,16 @@ Builds and serves an app, then runs end-to-end tests using the configured E2E te
 
 ## Usage
 
+The `e2e` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx e2e <project>
+```
+
+```bash
+nx run <project>:e2e
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/angular/nx-commands/generate.md
+++ b/docs/angular/nx-commands/generate.md
@@ -1,0 +1,71 @@
+# generate
+
+Runs a schematic that generates and/or modifies files based on a schematic from a collection.
+
+## Usage
+
+```bash
+nx generate <collection:schematic>
+```
+
+```bash
+nx g <schematic>
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `generate` command to the Angular CLI's `generate` command.
+
+### Examples
+
+Generate a new Angular application:
+
+```bash
+nx generate @nrwl/node:app myapp
+```
+
+Generate a new React application:
+
+```bash
+nx generate @nrwl/react:app myapp
+```
+
+Generate a new Node application:
+
+```bash
+nx generate @nrwl/node:app myapp
+```
+
+## Options
+
+### defaults
+
+Default: `false`
+
+When true, disables interactive input prompts for options with a default.
+
+### dryRun
+
+Default: `false`
+
+When true, disables interactive input prompts for options with a default.
+
+### force
+
+Default: `false`
+
+When true, forces overwriting of existing files.
+
+### interactive
+
+Default: `true`
+
+When false, disables interactive input prompts.
+
+### help
+
+Show help and display available schematics in the default collection.
+
+### version
+
+Show version number

--- a/docs/angular/nx-commands/lint.md
+++ b/docs/angular/nx-commands/lint.md
@@ -4,8 +4,16 @@ Runs linting tools on application code in a given project folder using the confi
 
 ## Usage
 
+The `lint` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx lint <project> [options]
+```
+
+```bash
+nx run <project>:lint [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/angular/nx-commands/lint.md
+++ b/docs/angular/nx-commands/lint.md
@@ -1,0 +1,99 @@
+# lint
+
+Runs linting tools on application code in a given project folder using the configured linter.
+
+## Usage
+
+```bash
+nx lint <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `lint` command to the Angular CLI's `lint` command.
+
+### Examples
+
+Run lint checks for the `myapp` project and fix linter errors:
+
+```bash
+nx lint myapp --fix
+```
+
+## Common Options
+
+The options below are common to the `lint` command used within an Nx workspace. The ESLint and Angular-specifc lint options are listed after these options.
+
+### exclude
+
+Files to exclude from linting.
+
+### files
+
+Files to include in linting.
+
+### fix
+
+Fixes linting errors (may overwrite linted files).
+
+### force
+
+Succeeds even if there was linting errors.
+
+### format
+
+ESLint Output formatter (https://eslint.org/docs/user-guide/formatters). (default: stylish)
+
+### silent
+
+Hide output text.
+
+### tsConfig
+
+The name of the TypeScript configuration file.
+
+### help
+
+Show help information
+
+### version
+
+Show version number
+
+## ESLint Options
+
+### cache
+
+Only check changed files.
+
+### cacheLocation
+
+Path to the cache file or directory.
+
+### config
+
+The name of the configuration file.
+
+### linter
+
+The tool to use for running lint checks.
+
+Default: `tslint`
+
+### outputFile
+
+File to write report to.
+
+## Angular-TSLint Options
+
+### configuration (-c)
+
+The linting configuration to use.
+
+### tslint-config
+
+The name of the TSLint configuration file.
+
+### type-check
+
+Controls the type check for linting.

--- a/docs/angular/nx-commands/run.md
+++ b/docs/angular/nx-commands/run.md
@@ -1,0 +1,41 @@
+# run
+
+Runs an Architect target with an optional custom builder configuration defined in your project.
+
+## Usage
+
+```bash
+nx run <target> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `run` command to the Angular CLI's `run` command.
+
+### Examples
+
+Run the `build` target for the `myapp` :
+
+```bash
+nx run myapp:build
+```
+
+Run the `build` target for the `myapp` project with a `production` configuration:
+
+```bash
+nx run myapp:build:production
+```
+
+## Options
+
+### configuration (-c)
+
+A named builder configuration, defined in the "configurations" section of the workspace configuration file. The builder uses the named configuration to run the given target.
+
+### help
+
+Show help
+
+### version
+
+Show version number

--- a/docs/angular/nx-commands/serve.md
+++ b/docs/angular/nx-commands/serve.md
@@ -1,0 +1,193 @@
+# serve
+
+Builds and serves an application, rebuilding on file changes.
+
+## Usage
+
+```bash
+nx serve <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `serve` command to the Angular CLI's `serve` command.
+
+### Examples
+
+Serve the `myapp` project:
+
+```bash
+nx serve myapp
+```
+
+## Common Options
+
+The options below are common to the `serve` command used within an Nx workspace. The Web and Angular-specifc serve options are listed after these options.
+
+### allowedHosts
+
+This option allows you to whitelist services that are allowed to access the dev server.
+
+### host
+
+Host to listen on.
+
+Default: `localhost`
+
+### liveReload
+
+Whether to reload the page on change, using live-reload.
+
+Default: `true`
+
+### open (-o)
+
+Open the application in the browser.
+
+### port
+
+Port to listen on.
+
+Default: `4200`
+
+### publicHost
+
+Public URL where the application will be served
+
+### ssl
+
+Serve using HTTPS.
+
+### sslKey
+
+SSL key to use for serving HTTPS.
+
+### sslCert
+
+SSL certificate to use for serving HTTPS.
+
+### watch
+
+Watches for changes and rebuilds application
+
+Default: `true`
+
+### help
+
+Show help
+
+### version
+
+Show version number
+
+## Web-Serve Options
+
+### buildTarget
+
+Target which builds the application
+
+### memoryLimit
+
+Memory limit for type checking service process in MB.
+
+### maxWorkers
+
+Number of workers to use for type checking.
+
+## Angular-Serve Options
+
+### aot
+
+Build using Ahead of Time compilation.
+
+### base-href
+
+Base url for the application being built.
+
+### browser-target
+
+Target to serve.
+
+### build-event-log
+
+**EXPERIMENTAL** Output file path for Build Event Protocol events.
+
+### common-chunk
+
+Use a separate bundle containing code used across multiple bundles.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of the workspace configuration.
+Each named target is accompanied by a configuration of option defaults for that target.
+Setting this explicitly overrides the `--prod` flag
+
+### deploy-url
+
+URL where files will be deployed.
+
+### disable-host-check
+
+Don't verify connected clients are part of allowed hosts.
+
+### eval-source-map
+
+Output in-file eval sourcemaps.
+
+### hmr
+
+Enable hot module replacement.
+
+### hmr-warning
+
+Show a warning when the `--hmr` option is enabled.
+
+### optimization
+
+Enables optimization of the build output.
+
+### poll
+
+Enable and define the file watching poll time period in milliseconds.
+
+### prod
+
+Shorthand for `--configuration=production`.
+When true, sets the build configuration to the production target.
+By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
+
+### progress
+
+Log progress to the console while building.
+
+### proxy-config
+
+Proxy configuration file.
+
+### public-host
+
+The URL that the browser client (or live-reload client, if enabled) should use to connect to the development server. Use for a complex dev server setup, such as one with reverse proxies.
+
+### serve-path
+
+The pathname where the app will be served.
+
+### serve-path-default-warning
+
+Show a warning when deploy-url/base-href use unsupported serve path values.
+
+### source-map
+
+Output sourcemaps.
+
+### vendor-chunk
+
+Use a separate bundle containing only vendor libraries.
+
+### vendor-source-map
+
+Resolve vendor packages sourcemaps.
+
+### verbose
+
+Adds more details to output logging.

--- a/docs/angular/nx-commands/serve.md
+++ b/docs/angular/nx-commands/serve.md
@@ -4,8 +4,16 @@ Builds and serves an application, rebuilding on file changes.
 
 ## Usage
 
+The `serve` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx serve <project> [options]
+```
+
+```bash
+nx run <project>:serve [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/angular/nx-commands/test.md
+++ b/docs/angular/nx-commands/test.md
@@ -4,8 +4,16 @@ Runs unit tests in a project using the configured unit test runner.
 
 ## Usage
 
+The `test` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx test <project> [options]
+```
+
+```bash
+nx run <project>:test [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/angular/nx-commands/test.md
+++ b/docs/angular/nx-commands/test.md
@@ -1,0 +1,252 @@
+# test
+
+Runs unit tests in a project using the configured unit test runner.
+
+## Usage
+
+```bash
+nx test <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `test` command to the Angular CLI's `test` command.
+
+### Examples
+
+Run unit tests:
+
+```bash
+nx test myapp
+```
+
+## Common Options
+
+The options below are common to the `test` command used within an Nx workspace. The Jest and Karma-specifc test options are listed after these options.
+
+### codeCoverage
+
+Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)
+
+### tsConfig
+
+The path to the Typescript configuration file.
+
+### watch
+
+Watch files for changes and rerun tests.
+
+### help
+
+Show help information.
+
+### version
+
+Show version number
+
+## Jest Options
+
+### bail
+
+Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/en/cli#bail)
+
+### ci
+
+Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/en/cli#ci)
+
+### color
+
+Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/en/cli#colors)
+
+### colors
+
+Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)
+
+### coverageReporters
+
+A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter
+
+### coverageDirectory
+
+An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
+
+### config
+
+The path to a Jest config file specifying how to find and execute tests. If no rootDir is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration
+
+### clearCache
+
+Deletes the Jest cache directory and then exits without running tests. Will delete Jest's default cache directory. _Note: clearing the cache will reduce performance_.
+
+### findRelatedTests
+
+Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/en/cli#findrelatedtests-spaceseparatedlistofsourcefiles)
+
+### jestConfig
+
+The path of the Jest configuration. (https://jestjs.io/docs/en/configuration)
+
+### json
+
+Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/en/cli#json)
+
+### maxWorkers
+
+Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/en/cli#maxworkers-num)
+
+### onlyChanged
+
+Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment. (https://jestjs.io/docs/en/cli#onlychanged)
+
+### outputFile
+
+Write test results to a file when the --json option is also specified. (https://jestjs.io/docs/en/cli#outputfile-filename)
+
+### passWithNoTests
+
+Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/en/cli#passwithnotests)
+
+### reporters
+
+Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/en/cli#reporters)
+
+### runInBand
+
+Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/en/cli#runinband)
+
+### setupFile
+
+The name of a setup file used by Jest. (https://jestjs.io/docs/en/configuration#setupfilesafterenv-array)
+
+### silent
+
+Prevent tests from printing messages through the console. (https://jestjs.io/docs/en/cli#silent)
+
+### testFile
+
+The name of the file to test.
+
+### testNamePattern
+
+Run only tests with a name that matches the regex pattern. (https://jestjs.io/docs/en/cli#testnamepattern-regex)
+
+### testPathPattern
+
+An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
+
+### testLocationInResults
+
+Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/en/cli#testlocationinresults)
+
+### testResultsProcessor
+
+Node module that implements a custom results processor. (https://jestjs.io/docs/en/configuration#testresultsprocessor-string)
+
+### updateSnapshot
+
+Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern. (https://jestjs.io/docs/en/cli#updatesnapshot)
+
+### useStderr
+
+Divert all output to stderr.
+
+### verbose
+
+Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)
+
+### watchAll
+
+Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/en/cli#watchall)
+
+## Karma Options
+
+### browsers
+
+Override which browsers tests are run against.
+
+### codeCoverage
+
+Output a code coverage report.
+
+### codeCoverageExclude
+
+Globs to exclude from code coverage.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of angular.json.
+Each named target is accompanied by a configuration of option defaults for that target.
+Setting this explicitly overrides the `--prod` flag.
+
+### environment
+
+Defines the build environment.
+
+### evalSourceMap
+
+Output in-file eval sourcemaps.
+
+### help
+
+Shows a help message for this command in the console.
+
+### include
+
+Globs of files to include, relative to workspace or project root.
+
+There are 2 special cases:
+
+- when a path to directory is provided, all spec files ending ".spec.@(ts|tsx)" will be included
+- when a path to a file is provided, and a matching spec file exists it will be included instead
+
+### karmaConfig
+
+The name of the Karma configuration file.
+
+### main
+
+The name of the main entry-point file.
+
+### poll
+
+Enable and define the file watching poll time period in milliseconds.
+
+### polyfills
+
+The name of the polyfills file.
+
+### preserveSymlinks
+
+Do not use the real path when resolving modules.
+
+### prod
+
+Shorthand for "--configuration=production". When true, sets the build configuration to the production target. By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
+
+### progress
+
+Log progress to the console while building.
+
+### reporters
+
+Karma reporters to use. Directly passed to the karma runner.
+
+### sourceMap
+
+Output sourcemaps.
+
+### tsCconfig
+
+The name of the TypeScript configuration file.
+
+### vendorSourceMap
+
+Resolve vendor packages sourcemaps.
+
+### watch
+
+Run build when files change.
+
+### webWorkerTsConfig
+
+TypeScript configuration for Web Worker modules.

--- a/docs/react/nx-commands/build.md
+++ b/docs/react/nx-commands/build.md
@@ -1,0 +1,288 @@
+# build
+
+Compiles an application into an output directory named dist/ at the given output path. Must be executed from within a workspace directory.
+
+## Usage
+
+```bash
+nx build <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `build` command to the Angular CLI's `build` command.
+
+### Examples
+
+Compile a `production` build of the `myapp` project:
+
+```bash
+nx build myapp --prod
+```
+
+## Options
+
+The options below are common to the `build` command used within an Nx workspace. The Web and Angular-specifc build options are listed after these options.
+
+### baseHref
+
+Default: `/`
+
+Base url for the application being built.
+
+### commonChunk
+
+Use a separate bundle containing code used across multiple bundles.
+
+Default: `true`
+
+### budgets
+
+Budget thresholds to ensure parts of your application stay within boundaries which you set.
+
+### namedChunks
+
+Default: `true`
+
+Names the produced bundles according to their entry file
+
+### deployUrl
+
+URL where the application will be deployed.
+
+### es2015Polyfills
+
+Conditional polyfills loaded in browsers which do not support ES2015.
+
+### extractCss
+
+Extract css into a .css file
+
+### extractLicenses
+
+Extract all licenses in a separate file, in the case of production builds only.
+
+### index
+
+HTML File which will be contain the application
+
+### main
+
+The name of the main entry-point file.
+
+### tsConfig
+
+The name of the Typescript configuration file.
+
+### outputPath
+
+The output path of the generated files.
+
+### progress
+
+Log progress to the console while building.
+
+### optimization
+
+Enables optimization of the build output.
+
+### outputHashing
+
+Default: `none`
+
+Define the output filename cache-busting hashing mode.
+
+### scripts
+
+External Scripts which will be included before the main application entry.
+
+### showCircularDependencies
+
+Default: `true`
+
+Show circular dependency warnings on builds.
+
+### sourceMap
+
+Default: `true`
+
+Output sourcemaps.
+
+### statsJson
+
+Generates a 'stats.json' file which can be analyzed using tools such as: #webpack-bundle-analyzer' or https://webpack.github.io/
+analyse.
+
+### styles
+
+External Styles which will be included with the application
+
+### subresourceIntegrity
+
+Enables the use of subresource integrity validation.
+
+### vendorChunk
+
+Default: `true`
+
+Use a separate bundle containing only vendor libraries.
+
+### verbose
+
+Emits verbose output
+
+### watch
+
+Enable re-building when files change.
+
+### help
+
+Show help information
+
+### version
+
+Show version number
+
+## Web-Build Options
+
+### assets
+
+List of static application assets.
+
+### fileReplacements
+
+Replace files with other files in the build.
+
+### maxWorkers
+
+Number of workers to use for type checking.
+
+Default: `# of CPUS - 2`
+
+### memoryLimit
+
+Memory limit for type checking service process in MB.
+
+Default: `2048`
+
+### polyfills
+
+Polyfills to load before application
+
+### stylePreprocessorOptions
+
+Options to pass to style preprocessors.
+
+### webpackConfig
+
+Path to a function which takes a webpack config, some context and returns the resulting webpack config
+
+## Angular Options
+
+### aot
+
+Build using Ahead of Time compilation.
+
+### buildEventLog
+
+**EXPERIMENTAL** Output file path for Build Event Protocol events
+
+### buildOptimizer
+
+Enables `@angular-devkit/build-optimizer` optimizations when using the `--aot` option.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of angular.json.
+Each named target is accompanied by a configuration of option defaults for that target.
+Setting this explicitly overrides the "--prod" flag
+
+### crossOrigin
+
+Define the crossorigin attribute setting of elements that provide CORS support.
+
+### deleteOutputPath
+
+Delete the output path before building.
+
+### deployUrl
+
+URL where files will be deployed.
+
+### es5BrowserSupport
+
+Enables conditionally loaded ES2015 polyfills.
+
+### evalSourceMap
+
+Output in-file eval sourcemaps.
+
+### experimentalRollupPass
+
+Concatenate modules with Rollup before bundling them with Webpack.
+
+### forkTypeChecker
+
+Run the TypeScript type checker in a forked process.
+
+### i18nFile
+
+Localization file to use for i18n.
+
+### i18nFormat
+
+Format of the localization file specified with --i18n-file.
+
+### i18nLocale
+
+Locale to use for i18n.
+
+### i18nMissingTranslation
+
+How to handle missing translations for i18n.
+
+### localize
+
+### ngswConfigPath
+
+Path to ngsw-config.json.
+
+### poll
+
+Enable and define the file watching poll time period in milliseconds.
+
+### polyfills
+
+The full path for the polyfills file, relative to the current workspace.
+
+### preserveSymlinks
+
+Do not use the real path when resolving modules.
+
+### rebaseRootRelativeCssUrls
+
+Change root relative URLs in stylesheets to include base HREF and deploy URL. Use only for compatibility and transition. The behavior of this option is non-standard and will be removed in the next major release.
+
+### resourcesOutputPath
+
+The path where style resources will be placed, relative to outputPath.
+
+### serviceWorker
+
+Generates a service worker config for production builds.
+
+### skipAppShell
+
+Flag to prevent building an app shell.
+
+### vendorSourceMap
+
+Resolve vendor packages sourcemaps.
+
+### verbose
+
+Adds more details to output logging.
+
+### webWorkerTsConfig
+
+TypeScript configuration for Web Worker modules.

--- a/docs/react/nx-commands/build.md
+++ b/docs/react/nx-commands/build.md
@@ -4,8 +4,16 @@ Compiles an application into an output directory named dist/ at the given output
 
 ## Usage
 
+The `build` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx build <project> [options]
+```
+
+```bash
+nx run <project>:build [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/react/nx-commands/e2e.md
+++ b/docs/react/nx-commands/e2e.md
@@ -1,0 +1,135 @@
+# generate
+
+Builds and serves an app, then runs end-to-end tests using the configured E2E test runner.
+
+## Usage
+
+```bash
+nx e2e <project>
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `e2e` command to the Angular CLI's `e2e` command.
+
+### Examples
+
+Run E2E test with a custom base url:
+
+```bash
+nx e2e myapp-e2e --base-url http://localhost:4201
+```
+
+Run E2E test with a specific target:
+
+```bash
+nx e2e myapp-e2e --configuration smoke
+```
+
+## Common Options
+
+The options below are common to the E2E commands used within an Nx workspace. Cypress and Protractor-specifc options are listed below.
+
+### baseUrl
+
+Use this to pass directly the address of your distant server address with the port running your application.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of angular.json. Each named target is accompanied by a configuration of option defaults for that target. Setting this explicitly overrides the `--prod` option.
+
+### devServerTarget
+
+Dev server target to run tests against.
+
+### prod
+
+Shorthand for `--configuration=production`. When true, sets the build configuration to the production target. By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
+
+### version
+
+Show version number
+
+## Cypress Options
+
+### browser
+
+The browser to run tests in.
+
+### ci-build-id
+
+A unique identifier for a run to enable grouping or parallelization.
+
+### ci-build-id
+
+A unique identifier for a run to enable grouping or parallelization.
+
+### cypress-config
+
+The path of the Cypress configuration json file.
+
+### exit
+
+Whether or not the Cypress Test Runner will stay open after running tests in a spec file
+
+### group
+
+A named group for recorded runs in the Cypress dashboard.
+
+### headless
+
+Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode.
+
+### help
+
+Shows a help message for this command in the console.
+
+### key
+
+The key cypress should use to run tests in parallel/record the run (CI only).
+
+### parallel
+
+Whether or not Cypress should run its tests in parallel (CI only).
+
+### record
+
+Whether or not Cypress should record the results of the tests
+
+### spec
+
+A comma delimited glob string that is provided to the Cypress runner to specify which spec files to run. For example: '**examples/**,**actions.spec**
+
+### ts-config
+
+The path of the Cypress tsconfig configuration json file.
+
+## Protractor Options
+
+### element-explorer
+
+Start Protractor's Element Explorer for debugging.
+
+### host
+
+Host to listen on.
+
+### port
+
+The port to use to serve the application.
+
+### protractor-config
+
+The name of the Protractor configuration file.
+
+### specs
+
+Override specs in the protractor config.
+
+### suite
+
+Override suite in the protractor config.
+
+### webdriver-update
+
+Try to update webdriver.

--- a/docs/react/nx-commands/e2e.md
+++ b/docs/react/nx-commands/e2e.md
@@ -4,8 +4,16 @@ Builds and serves an app, then runs end-to-end tests using the configured E2E te
 
 ## Usage
 
+The `e2e` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx e2e <project>
+```
+
+```bash
+nx run <project>:e2e
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/react/nx-commands/generate.md
+++ b/docs/react/nx-commands/generate.md
@@ -1,0 +1,71 @@
+# generate
+
+Runs a schematic that generates and/or modifies files based on a schematic from a collection.
+
+## Usage
+
+```bash
+nx generate <collection:schematic>
+```
+
+```bash
+nx g <schematic>
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `generate` command to the Angular CLI's `generate` command.
+
+### Examples
+
+Generate a new Angular application:
+
+```bash
+nx generate @nrwl/node:app myapp
+```
+
+Generate a new React application:
+
+```bash
+nx generate @nrwl/react:app myapp
+```
+
+Generate a new Node application:
+
+```bash
+nx generate @nrwl/node:app myapp
+```
+
+## Options
+
+### defaults
+
+Default: `false`
+
+When true, disables interactive input prompts for options with a default.
+
+### dryRun
+
+Default: `false`
+
+When true, disables interactive input prompts for options with a default.
+
+### force
+
+Default: `false`
+
+When true, forces overwriting of existing files.
+
+### interactive
+
+Default: `true`
+
+When false, disables interactive input prompts.
+
+### help
+
+Show help and display available schematics in the default collection.
+
+### version
+
+Show version number

--- a/docs/react/nx-commands/lint.md
+++ b/docs/react/nx-commands/lint.md
@@ -4,8 +4,16 @@ Runs linting tools on application code in a given project folder using the confi
 
 ## Usage
 
+The `lint` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx lint <project> [options]
+```
+
+```bash
+nx run <project>:lint [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/react/nx-commands/lint.md
+++ b/docs/react/nx-commands/lint.md
@@ -1,0 +1,99 @@
+# lint
+
+Runs linting tools on application code in a given project folder using the configured linter.
+
+## Usage
+
+```bash
+nx lint <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `lint` command to the Angular CLI's `lint` command.
+
+### Examples
+
+Run lint checks for the `myapp` project and fix linter errors:
+
+```bash
+nx lint myapp --fix
+```
+
+## Common Options
+
+The options below are common to the `lint` command used within an Nx workspace. The ESLint and Angular-specifc lint options are listed after these options.
+
+### exclude
+
+Files to exclude from linting.
+
+### files
+
+Files to include in linting.
+
+### fix
+
+Fixes linting errors (may overwrite linted files).
+
+### force
+
+Succeeds even if there was linting errors.
+
+### format
+
+ESLint Output formatter (https://eslint.org/docs/user-guide/formatters). (default: stylish)
+
+### silent
+
+Hide output text.
+
+### tsConfig
+
+The name of the TypeScript configuration file.
+
+### help
+
+Show help information
+
+### version
+
+Show version number
+
+## ESLint Options
+
+### cache
+
+Only check changed files.
+
+### cacheLocation
+
+Path to the cache file or directory.
+
+### config
+
+The name of the configuration file.
+
+### linter
+
+The tool to use for running lint checks.
+
+Default: `tslint`
+
+### outputFile
+
+File to write report to.
+
+## Angular-TSLint Options
+
+### configuration (-c)
+
+The linting configuration to use.
+
+### tslint-config
+
+The name of the TSLint configuration file.
+
+### type-check
+
+Controls the type check for linting.

--- a/docs/react/nx-commands/run.md
+++ b/docs/react/nx-commands/run.md
@@ -1,0 +1,41 @@
+# run
+
+Runs an Architect target with an optional custom builder configuration defined in your project.
+
+## Usage
+
+```bash
+nx run <target> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `run` command to the Angular CLI's `run` command.
+
+### Examples
+
+Run the `build` target for the `myapp` :
+
+```bash
+nx run myapp:build
+```
+
+Run the `build` target for the `myapp` project with a `production` configuration:
+
+```bash
+nx run myapp:build:production
+```
+
+## Options
+
+### configuration (-c)
+
+A named builder configuration, defined in the "configurations" section of the workspace configuration file. The builder uses the named configuration to run the given target.
+
+### help
+
+Show help
+
+### version
+
+Show version number

--- a/docs/react/nx-commands/serve.md
+++ b/docs/react/nx-commands/serve.md
@@ -1,0 +1,193 @@
+# serve
+
+Builds and serves an application, rebuilding on file changes.
+
+## Usage
+
+```bash
+nx serve <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `serve` command to the Angular CLI's `serve` command.
+
+### Examples
+
+Serve the `myapp` project:
+
+```bash
+nx serve myapp
+```
+
+## Common Options
+
+The options below are common to the `serve` command used within an Nx workspace. The Web and Angular-specifc serve options are listed after these options.
+
+### allowedHosts
+
+This option allows you to whitelist services that are allowed to access the dev server.
+
+### host
+
+Host to listen on.
+
+Default: `localhost`
+
+### liveReload
+
+Whether to reload the page on change, using live-reload.
+
+Default: `true`
+
+### open (-o)
+
+Open the application in the browser.
+
+### port
+
+Port to listen on.
+
+Default: `4200`
+
+### publicHost
+
+Public URL where the application will be served
+
+### ssl
+
+Serve using HTTPS.
+
+### sslKey
+
+SSL key to use for serving HTTPS.
+
+### sslCert
+
+SSL certificate to use for serving HTTPS.
+
+### watch
+
+Watches for changes and rebuilds application
+
+Default: `true`
+
+### help
+
+Show help
+
+### version
+
+Show version number
+
+## Web-Serve Options
+
+### buildTarget
+
+Target which builds the application
+
+### memoryLimit
+
+Memory limit for type checking service process in MB.
+
+### maxWorkers
+
+Number of workers to use for type checking.
+
+## Angular-Serve Options
+
+### aot
+
+Build using Ahead of Time compilation.
+
+### base-href
+
+Base url for the application being built.
+
+### browser-target
+
+Target to serve.
+
+### build-event-log
+
+**EXPERIMENTAL** Output file path for Build Event Protocol events.
+
+### common-chunk
+
+Use a separate bundle containing code used across multiple bundles.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of the workspace configuration.
+Each named target is accompanied by a configuration of option defaults for that target.
+Setting this explicitly overrides the `--prod` flag
+
+### deploy-url
+
+URL where files will be deployed.
+
+### disable-host-check
+
+Don't verify connected clients are part of allowed hosts.
+
+### eval-source-map
+
+Output in-file eval sourcemaps.
+
+### hmr
+
+Enable hot module replacement.
+
+### hmr-warning
+
+Show a warning when the `--hmr` option is enabled.
+
+### optimization
+
+Enables optimization of the build output.
+
+### poll
+
+Enable and define the file watching poll time period in milliseconds.
+
+### prod
+
+Shorthand for `--configuration=production`.
+When true, sets the build configuration to the production target.
+By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
+
+### progress
+
+Log progress to the console while building.
+
+### proxy-config
+
+Proxy configuration file.
+
+### public-host
+
+The URL that the browser client (or live-reload client, if enabled) should use to connect to the development server. Use for a complex dev server setup, such as one with reverse proxies.
+
+### serve-path
+
+The pathname where the app will be served.
+
+### serve-path-default-warning
+
+Show a warning when deploy-url/base-href use unsupported serve path values.
+
+### source-map
+
+Output sourcemaps.
+
+### vendor-chunk
+
+Use a separate bundle containing only vendor libraries.
+
+### vendor-source-map
+
+Resolve vendor packages sourcemaps.
+
+### verbose
+
+Adds more details to output logging.

--- a/docs/react/nx-commands/serve.md
+++ b/docs/react/nx-commands/serve.md
@@ -4,8 +4,16 @@ Builds and serves an application, rebuilding on file changes.
 
 ## Usage
 
+The `serve` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx serve <project> [options]
+```
+
+```bash
+nx run <project>:serve [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/react/nx-commands/test.md
+++ b/docs/react/nx-commands/test.md
@@ -4,8 +4,16 @@ Runs unit tests in a project using the configured unit test runner.
 
 ## Usage
 
+The `test` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx test <project> [options]
+```
+
+```bash
+nx run <project>:test [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/react/nx-commands/test.md
+++ b/docs/react/nx-commands/test.md
@@ -1,0 +1,252 @@
+# test
+
+Runs unit tests in a project using the configured unit test runner.
+
+## Usage
+
+```bash
+nx test <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `test` command to the Angular CLI's `test` command.
+
+### Examples
+
+Run unit tests:
+
+```bash
+nx test myapp
+```
+
+## Common Options
+
+The options below are common to the `test` command used within an Nx workspace. The Jest and Karma-specifc test options are listed after these options.
+
+### codeCoverage
+
+Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)
+
+### tsConfig
+
+The path to the Typescript configuration file.
+
+### watch
+
+Watch files for changes and rerun tests.
+
+### help
+
+Show help information.
+
+### version
+
+Show version number
+
+## Jest Options
+
+### bail
+
+Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/en/cli#bail)
+
+### ci
+
+Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/en/cli#ci)
+
+### color
+
+Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/en/cli#colors)
+
+### colors
+
+Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)
+
+### coverageReporters
+
+A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter
+
+### coverageDirectory
+
+An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
+
+### config
+
+The path to a Jest config file specifying how to find and execute tests. If no rootDir is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration
+
+### clearCache
+
+Deletes the Jest cache directory and then exits without running tests. Will delete Jest's default cache directory. _Note: clearing the cache will reduce performance_.
+
+### findRelatedTests
+
+Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/en/cli#findrelatedtests-spaceseparatedlistofsourcefiles)
+
+### jestConfig
+
+The path of the Jest configuration. (https://jestjs.io/docs/en/configuration)
+
+### json
+
+Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/en/cli#json)
+
+### maxWorkers
+
+Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/en/cli#maxworkers-num)
+
+### onlyChanged
+
+Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment. (https://jestjs.io/docs/en/cli#onlychanged)
+
+### outputFile
+
+Write test results to a file when the --json option is also specified. (https://jestjs.io/docs/en/cli#outputfile-filename)
+
+### passWithNoTests
+
+Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/en/cli#passwithnotests)
+
+### reporters
+
+Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/en/cli#reporters)
+
+### runInBand
+
+Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/en/cli#runinband)
+
+### setupFile
+
+The name of a setup file used by Jest. (https://jestjs.io/docs/en/configuration#setupfilesafterenv-array)
+
+### silent
+
+Prevent tests from printing messages through the console. (https://jestjs.io/docs/en/cli#silent)
+
+### testFile
+
+The name of the file to test.
+
+### testNamePattern
+
+Run only tests with a name that matches the regex pattern. (https://jestjs.io/docs/en/cli#testnamepattern-regex)
+
+### testPathPattern
+
+An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
+
+### testLocationInResults
+
+Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/en/cli#testlocationinresults)
+
+### testResultsProcessor
+
+Node module that implements a custom results processor. (https://jestjs.io/docs/en/configuration#testresultsprocessor-string)
+
+### updateSnapshot
+
+Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern. (https://jestjs.io/docs/en/cli#updatesnapshot)
+
+### useStderr
+
+Divert all output to stderr.
+
+### verbose
+
+Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)
+
+### watchAll
+
+Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/en/cli#watchall)
+
+## Karma Options
+
+### browsers
+
+Override which browsers tests are run against.
+
+### codeCoverage
+
+Output a code coverage report.
+
+### codeCoverageExclude
+
+Globs to exclude from code coverage.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of angular.json.
+Each named target is accompanied by a configuration of option defaults for that target.
+Setting this explicitly overrides the `--prod` flag.
+
+### environment
+
+Defines the build environment.
+
+### evalSourceMap
+
+Output in-file eval sourcemaps.
+
+### help
+
+Shows a help message for this command in the console.
+
+### include
+
+Globs of files to include, relative to workspace or project root.
+
+There are 2 special cases:
+
+- when a path to directory is provided, all spec files ending ".spec.@(ts|tsx)" will be included
+- when a path to a file is provided, and a matching spec file exists it will be included instead
+
+### karmaConfig
+
+The name of the Karma configuration file.
+
+### main
+
+The name of the main entry-point file.
+
+### poll
+
+Enable and define the file watching poll time period in milliseconds.
+
+### polyfills
+
+The name of the polyfills file.
+
+### preserveSymlinks
+
+Do not use the real path when resolving modules.
+
+### prod
+
+Shorthand for "--configuration=production". When true, sets the build configuration to the production target. By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
+
+### progress
+
+Log progress to the console while building.
+
+### reporters
+
+Karma reporters to use. Directly passed to the karma runner.
+
+### sourceMap
+
+Output sourcemaps.
+
+### tsCconfig
+
+The name of the TypeScript configuration file.
+
+### vendorSourceMap
+
+Resolve vendor packages sourcemaps.
+
+### watch
+
+Run build when files change.
+
+### webWorkerTsConfig
+
+TypeScript configuration for Web Worker modules.

--- a/docs/shared/nx-commands/build.md
+++ b/docs/shared/nx-commands/build.md
@@ -1,0 +1,288 @@
+# build
+
+Compiles an application into an output directory named dist/ at the given output path. Must be executed from within a workspace directory.
+
+## Usage
+
+```bash
+nx build <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `build` command to the Angular CLI's `build` command.
+
+### Examples
+
+Compile a `production` build of the `myapp` project:
+
+```bash
+nx build myapp --prod
+```
+
+## Options
+
+The options below are common to the `build` command used within an Nx workspace. The Web and Angular-specifc build options are listed after these options.
+
+### baseHref
+
+Default: `/`
+
+Base url for the application being built.
+
+### commonChunk
+
+Use a separate bundle containing code used across multiple bundles.
+
+Default: `true`
+
+### budgets
+
+Budget thresholds to ensure parts of your application stay within boundaries which you set.
+
+### namedChunks
+
+Default: `true`
+
+Names the produced bundles according to their entry file
+
+### deployUrl
+
+URL where the application will be deployed.
+
+### es2015Polyfills
+
+Conditional polyfills loaded in browsers which do not support ES2015.
+
+### extractCss
+
+Extract css into a .css file
+
+### extractLicenses
+
+Extract all licenses in a separate file, in the case of production builds only.
+
+### index
+
+HTML File which will be contain the application
+
+### main
+
+The name of the main entry-point file.
+
+### tsConfig
+
+The name of the Typescript configuration file.
+
+### outputPath
+
+The output path of the generated files.
+
+### progress
+
+Log progress to the console while building.
+
+### optimization
+
+Enables optimization of the build output.
+
+### outputHashing
+
+Default: `none`
+
+Define the output filename cache-busting hashing mode.
+
+### scripts
+
+External Scripts which will be included before the main application entry.
+
+### showCircularDependencies
+
+Default: `true`
+
+Show circular dependency warnings on builds.
+
+### sourceMap
+
+Default: `true`
+
+Output sourcemaps.
+
+### statsJson
+
+Generates a 'stats.json' file which can be analyzed using tools such as: #webpack-bundle-analyzer' or https://webpack.github.io/
+analyse.
+
+### styles
+
+External Styles which will be included with the application
+
+### subresourceIntegrity
+
+Enables the use of subresource integrity validation.
+
+### vendorChunk
+
+Default: `true`
+
+Use a separate bundle containing only vendor libraries.
+
+### verbose
+
+Emits verbose output
+
+### watch
+
+Enable re-building when files change.
+
+### help
+
+Show help information
+
+### version
+
+Show version number
+
+## Web-Build Options
+
+### assets
+
+List of static application assets.
+
+### fileReplacements
+
+Replace files with other files in the build.
+
+### maxWorkers
+
+Number of workers to use for type checking.
+
+Default: `# of CPUS - 2`
+
+### memoryLimit
+
+Memory limit for type checking service process in MB.
+
+Default: `2048`
+
+### polyfills
+
+Polyfills to load before application
+
+### stylePreprocessorOptions
+
+Options to pass to style preprocessors.
+
+### webpackConfig
+
+Path to a function which takes a webpack config, some context and returns the resulting webpack config
+
+## Angular Options
+
+### aot
+
+Build using Ahead of Time compilation.
+
+### buildEventLog
+
+**EXPERIMENTAL** Output file path for Build Event Protocol events
+
+### buildOptimizer
+
+Enables `@angular-devkit/build-optimizer` optimizations when using the `--aot` option.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of angular.json.
+Each named target is accompanied by a configuration of option defaults for that target.
+Setting this explicitly overrides the "--prod" flag
+
+### crossOrigin
+
+Define the crossorigin attribute setting of elements that provide CORS support.
+
+### deleteOutputPath
+
+Delete the output path before building.
+
+### deployUrl
+
+URL where files will be deployed.
+
+### es5BrowserSupport
+
+Enables conditionally loaded ES2015 polyfills.
+
+### evalSourceMap
+
+Output in-file eval sourcemaps.
+
+### experimentalRollupPass
+
+Concatenate modules with Rollup before bundling them with Webpack.
+
+### forkTypeChecker
+
+Run the TypeScript type checker in a forked process.
+
+### i18nFile
+
+Localization file to use for i18n.
+
+### i18nFormat
+
+Format of the localization file specified with --i18n-file.
+
+### i18nLocale
+
+Locale to use for i18n.
+
+### i18nMissingTranslation
+
+How to handle missing translations for i18n.
+
+### localize
+
+### ngswConfigPath
+
+Path to ngsw-config.json.
+
+### poll
+
+Enable and define the file watching poll time period in milliseconds.
+
+### polyfills
+
+The full path for the polyfills file, relative to the current workspace.
+
+### preserveSymlinks
+
+Do not use the real path when resolving modules.
+
+### rebaseRootRelativeCssUrls
+
+Change root relative URLs in stylesheets to include base HREF and deploy URL. Use only for compatibility and transition. The behavior of this option is non-standard and will be removed in the next major release.
+
+### resourcesOutputPath
+
+The path where style resources will be placed, relative to outputPath.
+
+### serviceWorker
+
+Generates a service worker config for production builds.
+
+### skipAppShell
+
+Flag to prevent building an app shell.
+
+### vendorSourceMap
+
+Resolve vendor packages sourcemaps.
+
+### verbose
+
+Adds more details to output logging.
+
+### webWorkerTsConfig
+
+TypeScript configuration for Web Worker modules.

--- a/docs/shared/nx-commands/build.md
+++ b/docs/shared/nx-commands/build.md
@@ -4,8 +4,16 @@ Compiles an application into an output directory named dist/ at the given output
 
 ## Usage
 
+The `build` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx build <project> [options]
+```
+
+```bash
+nx run <project>:build [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/shared/nx-commands/e2e.md
+++ b/docs/shared/nx-commands/e2e.md
@@ -1,0 +1,135 @@
+# generate
+
+Builds and serves an app, then runs end-to-end tests using the configured E2E test runner.
+
+## Usage
+
+```bash
+nx e2e <project>
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `e2e` command to the Angular CLI's `e2e` command.
+
+### Examples
+
+Run E2E test with a custom base url:
+
+```bash
+nx e2e myapp-e2e --base-url http://localhost:4201
+```
+
+Run E2E test with a specific target:
+
+```bash
+nx e2e myapp-e2e --configuration smoke
+```
+
+## Common Options
+
+The options below are common to the E2E commands used within an Nx workspace. Cypress and Protractor-specifc options are listed below.
+
+### baseUrl
+
+Use this to pass directly the address of your distant server address with the port running your application.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of angular.json. Each named target is accompanied by a configuration of option defaults for that target. Setting this explicitly overrides the `--prod` option.
+
+### devServerTarget
+
+Dev server target to run tests against.
+
+### prod
+
+Shorthand for `--configuration=production`. When true, sets the build configuration to the production target. By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
+
+### version
+
+Show version number
+
+## Cypress Options
+
+### browser
+
+The browser to run tests in.
+
+### ci-build-id
+
+A unique identifier for a run to enable grouping or parallelization.
+
+### ci-build-id
+
+A unique identifier for a run to enable grouping or parallelization.
+
+### cypress-config
+
+The path of the Cypress configuration json file.
+
+### exit
+
+Whether or not the Cypress Test Runner will stay open after running tests in a spec file
+
+### group
+
+A named group for recorded runs in the Cypress dashboard.
+
+### headless
+
+Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode.
+
+### help
+
+Shows a help message for this command in the console.
+
+### key
+
+The key cypress should use to run tests in parallel/record the run (CI only).
+
+### parallel
+
+Whether or not Cypress should run its tests in parallel (CI only).
+
+### record
+
+Whether or not Cypress should record the results of the tests
+
+### spec
+
+A comma delimited glob string that is provided to the Cypress runner to specify which spec files to run. For example: '**examples/**,**actions.spec**
+
+### ts-config
+
+The path of the Cypress tsconfig configuration json file.
+
+## Protractor Options
+
+### element-explorer
+
+Start Protractor's Element Explorer for debugging.
+
+### host
+
+Host to listen on.
+
+### port
+
+The port to use to serve the application.
+
+### protractor-config
+
+The name of the Protractor configuration file.
+
+### specs
+
+Override specs in the protractor config.
+
+### suite
+
+Override suite in the protractor config.
+
+### webdriver-update
+
+Try to update webdriver.

--- a/docs/shared/nx-commands/e2e.md
+++ b/docs/shared/nx-commands/e2e.md
@@ -4,8 +4,16 @@ Builds and serves an app, then runs end-to-end tests using the configured E2E te
 
 ## Usage
 
+The `e2e` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx e2e <project>
+```
+
+```bash
+nx run <project>:e2e
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/shared/nx-commands/generate.md
+++ b/docs/shared/nx-commands/generate.md
@@ -1,0 +1,71 @@
+# generate
+
+Runs a schematic that generates and/or modifies files based on a schematic from a collection.
+
+## Usage
+
+```bash
+nx generate <collection:schematic>
+```
+
+```bash
+nx g <schematic>
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `generate` command to the Angular CLI's `generate` command.
+
+### Examples
+
+Generate a new Angular application:
+
+```bash
+nx generate @nrwl/node:app myapp
+```
+
+Generate a new React application:
+
+```bash
+nx generate @nrwl/react:app myapp
+```
+
+Generate a new Node application:
+
+```bash
+nx generate @nrwl/node:app myapp
+```
+
+## Options
+
+### defaults
+
+Default: `false`
+
+When true, disables interactive input prompts for options with a default.
+
+### dryRun
+
+Default: `false`
+
+When true, disables interactive input prompts for options with a default.
+
+### force
+
+Default: `false`
+
+When true, forces overwriting of existing files.
+
+### interactive
+
+Default: `true`
+
+When false, disables interactive input prompts.
+
+### help
+
+Show help and display available schematics in the default collection.
+
+### version
+
+Show version number

--- a/docs/shared/nx-commands/lint.md
+++ b/docs/shared/nx-commands/lint.md
@@ -4,8 +4,16 @@ Runs linting tools on application code in a given project folder using the confi
 
 ## Usage
 
+The `lint` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx lint <project> [options]
+```
+
+```bash
+nx run <project>:lint [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/shared/nx-commands/lint.md
+++ b/docs/shared/nx-commands/lint.md
@@ -1,0 +1,99 @@
+# lint
+
+Runs linting tools on application code in a given project folder using the configured linter.
+
+## Usage
+
+```bash
+nx lint <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `lint` command to the Angular CLI's `lint` command.
+
+### Examples
+
+Run lint checks for the `myapp` project and fix linter errors:
+
+```bash
+nx lint myapp --fix
+```
+
+## Common Options
+
+The options below are common to the `lint` command used within an Nx workspace. The ESLint and Angular-specifc lint options are listed after these options.
+
+### exclude
+
+Files to exclude from linting.
+
+### files
+
+Files to include in linting.
+
+### fix
+
+Fixes linting errors (may overwrite linted files).
+
+### force
+
+Succeeds even if there was linting errors.
+
+### format
+
+ESLint Output formatter (https://eslint.org/docs/user-guide/formatters). (default: stylish)
+
+### silent
+
+Hide output text.
+
+### tsConfig
+
+The name of the TypeScript configuration file.
+
+### help
+
+Show help information
+
+### version
+
+Show version number
+
+## ESLint Options
+
+### cache
+
+Only check changed files.
+
+### cacheLocation
+
+Path to the cache file or directory.
+
+### config
+
+The name of the configuration file.
+
+### linter
+
+The tool to use for running lint checks.
+
+Default: `tslint`
+
+### outputFile
+
+File to write report to.
+
+## Angular-TSLint Options
+
+### configuration (-c)
+
+The linting configuration to use.
+
+### tslint-config
+
+The name of the TSLint configuration file.
+
+### type-check
+
+Controls the type check for linting.

--- a/docs/shared/nx-commands/run.md
+++ b/docs/shared/nx-commands/run.md
@@ -1,0 +1,41 @@
+# run
+
+Runs an Architect target with an optional custom builder configuration defined in your project.
+
+## Usage
+
+```bash
+nx run <target> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `run` command to the Angular CLI's `run` command.
+
+### Examples
+
+Run the `build` target for the `myapp` :
+
+```bash
+nx run myapp:build
+```
+
+Run the `build` target for the `myapp` project with a `production` configuration:
+
+```bash
+nx run myapp:build:production
+```
+
+## Options
+
+### configuration (-c)
+
+A named builder configuration, defined in the "configurations" section of the workspace configuration file. The builder uses the named configuration to run the given target.
+
+### help
+
+Show help
+
+### version
+
+Show version number

--- a/docs/shared/nx-commands/serve.md
+++ b/docs/shared/nx-commands/serve.md
@@ -1,0 +1,193 @@
+# serve
+
+Builds and serves an application, rebuilding on file changes.
+
+## Usage
+
+```bash
+nx serve <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `serve` command to the Angular CLI's `serve` command.
+
+### Examples
+
+Serve the `myapp` project:
+
+```bash
+nx serve myapp
+```
+
+## Common Options
+
+The options below are common to the `serve` command used within an Nx workspace. The Web and Angular-specifc serve options are listed after these options.
+
+### allowedHosts
+
+This option allows you to whitelist services that are allowed to access the dev server.
+
+### host
+
+Host to listen on.
+
+Default: `localhost`
+
+### liveReload
+
+Whether to reload the page on change, using live-reload.
+
+Default: `true`
+
+### open (-o)
+
+Open the application in the browser.
+
+### port
+
+Port to listen on.
+
+Default: `4200`
+
+### publicHost
+
+Public URL where the application will be served
+
+### ssl
+
+Serve using HTTPS.
+
+### sslKey
+
+SSL key to use for serving HTTPS.
+
+### sslCert
+
+SSL certificate to use for serving HTTPS.
+
+### watch
+
+Watches for changes and rebuilds application
+
+Default: `true`
+
+### help
+
+Show help
+
+### version
+
+Show version number
+
+## Web-Serve Options
+
+### buildTarget
+
+Target which builds the application
+
+### memoryLimit
+
+Memory limit for type checking service process in MB.
+
+### maxWorkers
+
+Number of workers to use for type checking.
+
+## Angular-Serve Options
+
+### aot
+
+Build using Ahead of Time compilation.
+
+### base-href
+
+Base url for the application being built.
+
+### browser-target
+
+Target to serve.
+
+### build-event-log
+
+**EXPERIMENTAL** Output file path for Build Event Protocol events.
+
+### common-chunk
+
+Use a separate bundle containing code used across multiple bundles.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of the workspace configuration.
+Each named target is accompanied by a configuration of option defaults for that target.
+Setting this explicitly overrides the `--prod` flag
+
+### deploy-url
+
+URL where files will be deployed.
+
+### disable-host-check
+
+Don't verify connected clients are part of allowed hosts.
+
+### eval-source-map
+
+Output in-file eval sourcemaps.
+
+### hmr
+
+Enable hot module replacement.
+
+### hmr-warning
+
+Show a warning when the `--hmr` option is enabled.
+
+### optimization
+
+Enables optimization of the build output.
+
+### poll
+
+Enable and define the file watching poll time period in milliseconds.
+
+### prod
+
+Shorthand for `--configuration=production`.
+When true, sets the build configuration to the production target.
+By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
+
+### progress
+
+Log progress to the console while building.
+
+### proxy-config
+
+Proxy configuration file.
+
+### public-host
+
+The URL that the browser client (or live-reload client, if enabled) should use to connect to the development server. Use for a complex dev server setup, such as one with reverse proxies.
+
+### serve-path
+
+The pathname where the app will be served.
+
+### serve-path-default-warning
+
+Show a warning when deploy-url/base-href use unsupported serve path values.
+
+### source-map
+
+Output sourcemaps.
+
+### vendor-chunk
+
+Use a separate bundle containing only vendor libraries.
+
+### vendor-source-map
+
+Resolve vendor packages sourcemaps.
+
+### verbose
+
+Adds more details to output logging.

--- a/docs/shared/nx-commands/serve.md
+++ b/docs/shared/nx-commands/serve.md
@@ -4,8 +4,16 @@ Builds and serves an application, rebuilding on file changes.
 
 ## Usage
 
+The `serve` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx serve <project> [options]
+```
+
+```bash
+nx run <project>:serve [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/shared/nx-commands/test.md
+++ b/docs/shared/nx-commands/test.md
@@ -4,8 +4,16 @@ Runs unit tests in a project using the configured unit test runner.
 
 ## Usage
 
+The `test` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx test <project> [options]
+```
+
+```bash
+nx run <project>:test [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/shared/nx-commands/test.md
+++ b/docs/shared/nx-commands/test.md
@@ -1,0 +1,252 @@
+# test
+
+Runs unit tests in a project using the configured unit test runner.
+
+## Usage
+
+```bash
+nx test <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `test` command to the Angular CLI's `test` command.
+
+### Examples
+
+Run unit tests:
+
+```bash
+nx test myapp
+```
+
+## Common Options
+
+The options below are common to the `test` command used within an Nx workspace. The Jest and Karma-specifc test options are listed after these options.
+
+### codeCoverage
+
+Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)
+
+### tsConfig
+
+The path to the Typescript configuration file.
+
+### watch
+
+Watch files for changes and rerun tests.
+
+### help
+
+Show help information.
+
+### version
+
+Show version number
+
+## Jest Options
+
+### bail
+
+Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/en/cli#bail)
+
+### ci
+
+Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/en/cli#ci)
+
+### color
+
+Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/en/cli#colors)
+
+### colors
+
+Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)
+
+### coverageReporters
+
+A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter
+
+### coverageDirectory
+
+An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
+
+### config
+
+The path to a Jest config file specifying how to find and execute tests. If no rootDir is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration
+
+### clearCache
+
+Deletes the Jest cache directory and then exits without running tests. Will delete Jest's default cache directory. _Note: clearing the cache will reduce performance_.
+
+### findRelatedTests
+
+Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/en/cli#findrelatedtests-spaceseparatedlistofsourcefiles)
+
+### jestConfig
+
+The path of the Jest configuration. (https://jestjs.io/docs/en/configuration)
+
+### json
+
+Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/en/cli#json)
+
+### maxWorkers
+
+Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/en/cli#maxworkers-num)
+
+### onlyChanged
+
+Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment. (https://jestjs.io/docs/en/cli#onlychanged)
+
+### outputFile
+
+Write test results to a file when the --json option is also specified. (https://jestjs.io/docs/en/cli#outputfile-filename)
+
+### passWithNoTests
+
+Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/en/cli#passwithnotests)
+
+### reporters
+
+Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/en/cli#reporters)
+
+### runInBand
+
+Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/en/cli#runinband)
+
+### setupFile
+
+The name of a setup file used by Jest. (https://jestjs.io/docs/en/configuration#setupfilesafterenv-array)
+
+### silent
+
+Prevent tests from printing messages through the console. (https://jestjs.io/docs/en/cli#silent)
+
+### testFile
+
+The name of the file to test.
+
+### testNamePattern
+
+Run only tests with a name that matches the regex pattern. (https://jestjs.io/docs/en/cli#testnamepattern-regex)
+
+### testPathPattern
+
+An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
+
+### testLocationInResults
+
+Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/en/cli#testlocationinresults)
+
+### testResultsProcessor
+
+Node module that implements a custom results processor. (https://jestjs.io/docs/en/configuration#testresultsprocessor-string)
+
+### updateSnapshot
+
+Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern. (https://jestjs.io/docs/en/cli#updatesnapshot)
+
+### useStderr
+
+Divert all output to stderr.
+
+### verbose
+
+Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)
+
+### watchAll
+
+Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/en/cli#watchall)
+
+## Karma Options
+
+### browsers
+
+Override which browsers tests are run against.
+
+### codeCoverage
+
+Output a code coverage report.
+
+### codeCoverageExclude
+
+Globs to exclude from code coverage.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of angular.json.
+Each named target is accompanied by a configuration of option defaults for that target.
+Setting this explicitly overrides the `--prod` flag.
+
+### environment
+
+Defines the build environment.
+
+### evalSourceMap
+
+Output in-file eval sourcemaps.
+
+### help
+
+Shows a help message for this command in the console.
+
+### include
+
+Globs of files to include, relative to workspace or project root.
+
+There are 2 special cases:
+
+- when a path to directory is provided, all spec files ending ".spec.@(ts|tsx)" will be included
+- when a path to a file is provided, and a matching spec file exists it will be included instead
+
+### karmaConfig
+
+The name of the Karma configuration file.
+
+### main
+
+The name of the main entry-point file.
+
+### poll
+
+Enable and define the file watching poll time period in milliseconds.
+
+### polyfills
+
+The name of the polyfills file.
+
+### preserveSymlinks
+
+Do not use the real path when resolving modules.
+
+### prod
+
+Shorthand for "--configuration=production". When true, sets the build configuration to the production target. By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
+
+### progress
+
+Log progress to the console while building.
+
+### reporters
+
+Karma reporters to use. Directly passed to the karma runner.
+
+### sourceMap
+
+Output sourcemaps.
+
+### tsCconfig
+
+The name of the TypeScript configuration file.
+
+### vendorSourceMap
+
+Resolve vendor packages sourcemaps.
+
+### watch
+
+Run build when files change.
+
+### webWorkerTsConfig
+
+TypeScript configuration for Web Worker modules.

--- a/docs/web/nx-commands/build.md
+++ b/docs/web/nx-commands/build.md
@@ -1,0 +1,288 @@
+# build
+
+Compiles an application into an output directory named dist/ at the given output path. Must be executed from within a workspace directory.
+
+## Usage
+
+```bash
+nx build <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `build` command to the Angular CLI's `build` command.
+
+### Examples
+
+Compile a `production` build of the `myapp` project:
+
+```bash
+nx build myapp --prod
+```
+
+## Options
+
+The options below are common to the `build` command used within an Nx workspace. The Web and Angular-specifc build options are listed after these options.
+
+### baseHref
+
+Default: `/`
+
+Base url for the application being built.
+
+### commonChunk
+
+Use a separate bundle containing code used across multiple bundles.
+
+Default: `true`
+
+### budgets
+
+Budget thresholds to ensure parts of your application stay within boundaries which you set.
+
+### namedChunks
+
+Default: `true`
+
+Names the produced bundles according to their entry file
+
+### deployUrl
+
+URL where the application will be deployed.
+
+### es2015Polyfills
+
+Conditional polyfills loaded in browsers which do not support ES2015.
+
+### extractCss
+
+Extract css into a .css file
+
+### extractLicenses
+
+Extract all licenses in a separate file, in the case of production builds only.
+
+### index
+
+HTML File which will be contain the application
+
+### main
+
+The name of the main entry-point file.
+
+### tsConfig
+
+The name of the Typescript configuration file.
+
+### outputPath
+
+The output path of the generated files.
+
+### progress
+
+Log progress to the console while building.
+
+### optimization
+
+Enables optimization of the build output.
+
+### outputHashing
+
+Default: `none`
+
+Define the output filename cache-busting hashing mode.
+
+### scripts
+
+External Scripts which will be included before the main application entry.
+
+### showCircularDependencies
+
+Default: `true`
+
+Show circular dependency warnings on builds.
+
+### sourceMap
+
+Default: `true`
+
+Output sourcemaps.
+
+### statsJson
+
+Generates a 'stats.json' file which can be analyzed using tools such as: #webpack-bundle-analyzer' or https://webpack.github.io/
+analyse.
+
+### styles
+
+External Styles which will be included with the application
+
+### subresourceIntegrity
+
+Enables the use of subresource integrity validation.
+
+### vendorChunk
+
+Default: `true`
+
+Use a separate bundle containing only vendor libraries.
+
+### verbose
+
+Emits verbose output
+
+### watch
+
+Enable re-building when files change.
+
+### help
+
+Show help information
+
+### version
+
+Show version number
+
+## Web-Build Options
+
+### assets
+
+List of static application assets.
+
+### fileReplacements
+
+Replace files with other files in the build.
+
+### maxWorkers
+
+Number of workers to use for type checking.
+
+Default: `# of CPUS - 2`
+
+### memoryLimit
+
+Memory limit for type checking service process in MB.
+
+Default: `2048`
+
+### polyfills
+
+Polyfills to load before application
+
+### stylePreprocessorOptions
+
+Options to pass to style preprocessors.
+
+### webpackConfig
+
+Path to a function which takes a webpack config, some context and returns the resulting webpack config
+
+## Angular Options
+
+### aot
+
+Build using Ahead of Time compilation.
+
+### buildEventLog
+
+**EXPERIMENTAL** Output file path for Build Event Protocol events
+
+### buildOptimizer
+
+Enables `@angular-devkit/build-optimizer` optimizations when using the `--aot` option.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of angular.json.
+Each named target is accompanied by a configuration of option defaults for that target.
+Setting this explicitly overrides the "--prod" flag
+
+### crossOrigin
+
+Define the crossorigin attribute setting of elements that provide CORS support.
+
+### deleteOutputPath
+
+Delete the output path before building.
+
+### deployUrl
+
+URL where files will be deployed.
+
+### es5BrowserSupport
+
+Enables conditionally loaded ES2015 polyfills.
+
+### evalSourceMap
+
+Output in-file eval sourcemaps.
+
+### experimentalRollupPass
+
+Concatenate modules with Rollup before bundling them with Webpack.
+
+### forkTypeChecker
+
+Run the TypeScript type checker in a forked process.
+
+### i18nFile
+
+Localization file to use for i18n.
+
+### i18nFormat
+
+Format of the localization file specified with --i18n-file.
+
+### i18nLocale
+
+Locale to use for i18n.
+
+### i18nMissingTranslation
+
+How to handle missing translations for i18n.
+
+### localize
+
+### ngswConfigPath
+
+Path to ngsw-config.json.
+
+### poll
+
+Enable and define the file watching poll time period in milliseconds.
+
+### polyfills
+
+The full path for the polyfills file, relative to the current workspace.
+
+### preserveSymlinks
+
+Do not use the real path when resolving modules.
+
+### rebaseRootRelativeCssUrls
+
+Change root relative URLs in stylesheets to include base HREF and deploy URL. Use only for compatibility and transition. The behavior of this option is non-standard and will be removed in the next major release.
+
+### resourcesOutputPath
+
+The path where style resources will be placed, relative to outputPath.
+
+### serviceWorker
+
+Generates a service worker config for production builds.
+
+### skipAppShell
+
+Flag to prevent building an app shell.
+
+### vendorSourceMap
+
+Resolve vendor packages sourcemaps.
+
+### verbose
+
+Adds more details to output logging.
+
+### webWorkerTsConfig
+
+TypeScript configuration for Web Worker modules.

--- a/docs/web/nx-commands/build.md
+++ b/docs/web/nx-commands/build.md
@@ -4,8 +4,16 @@ Compiles an application into an output directory named dist/ at the given output
 
 ## Usage
 
+The `build` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx build <project> [options]
+```
+
+```bash
+nx run <project>:build [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/web/nx-commands/e2e.md
+++ b/docs/web/nx-commands/e2e.md
@@ -1,0 +1,135 @@
+# generate
+
+Builds and serves an app, then runs end-to-end tests using the configured E2E test runner.
+
+## Usage
+
+```bash
+nx e2e <project>
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `e2e` command to the Angular CLI's `e2e` command.
+
+### Examples
+
+Run E2E test with a custom base url:
+
+```bash
+nx e2e myapp-e2e --base-url http://localhost:4201
+```
+
+Run E2E test with a specific target:
+
+```bash
+nx e2e myapp-e2e --configuration smoke
+```
+
+## Common Options
+
+The options below are common to the E2E commands used within an Nx workspace. Cypress and Protractor-specifc options are listed below.
+
+### baseUrl
+
+Use this to pass directly the address of your distant server address with the port running your application.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of angular.json. Each named target is accompanied by a configuration of option defaults for that target. Setting this explicitly overrides the `--prod` option.
+
+### devServerTarget
+
+Dev server target to run tests against.
+
+### prod
+
+Shorthand for `--configuration=production`. When true, sets the build configuration to the production target. By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
+
+### version
+
+Show version number
+
+## Cypress Options
+
+### browser
+
+The browser to run tests in.
+
+### ci-build-id
+
+A unique identifier for a run to enable grouping or parallelization.
+
+### ci-build-id
+
+A unique identifier for a run to enable grouping or parallelization.
+
+### cypress-config
+
+The path of the Cypress configuration json file.
+
+### exit
+
+Whether or not the Cypress Test Runner will stay open after running tests in a spec file
+
+### group
+
+A named group for recorded runs in the Cypress dashboard.
+
+### headless
+
+Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode.
+
+### help
+
+Shows a help message for this command in the console.
+
+### key
+
+The key cypress should use to run tests in parallel/record the run (CI only).
+
+### parallel
+
+Whether or not Cypress should run its tests in parallel (CI only).
+
+### record
+
+Whether or not Cypress should record the results of the tests
+
+### spec
+
+A comma delimited glob string that is provided to the Cypress runner to specify which spec files to run. For example: '**examples/**,**actions.spec**
+
+### ts-config
+
+The path of the Cypress tsconfig configuration json file.
+
+## Protractor Options
+
+### element-explorer
+
+Start Protractor's Element Explorer for debugging.
+
+### host
+
+Host to listen on.
+
+### port
+
+The port to use to serve the application.
+
+### protractor-config
+
+The name of the Protractor configuration file.
+
+### specs
+
+Override specs in the protractor config.
+
+### suite
+
+Override suite in the protractor config.
+
+### webdriver-update
+
+Try to update webdriver.

--- a/docs/web/nx-commands/e2e.md
+++ b/docs/web/nx-commands/e2e.md
@@ -4,8 +4,16 @@ Builds and serves an app, then runs end-to-end tests using the configured E2E te
 
 ## Usage
 
+The `e2e` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx e2e <project>
+```
+
+```bash
+nx run <project>:e2e
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/web/nx-commands/generate.md
+++ b/docs/web/nx-commands/generate.md
@@ -1,0 +1,71 @@
+# generate
+
+Runs a schematic that generates and/or modifies files based on a schematic from a collection.
+
+## Usage
+
+```bash
+nx generate <collection:schematic>
+```
+
+```bash
+nx g <schematic>
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `generate` command to the Angular CLI's `generate` command.
+
+### Examples
+
+Generate a new Angular application:
+
+```bash
+nx generate @nrwl/node:app myapp
+```
+
+Generate a new React application:
+
+```bash
+nx generate @nrwl/react:app myapp
+```
+
+Generate a new Node application:
+
+```bash
+nx generate @nrwl/node:app myapp
+```
+
+## Options
+
+### defaults
+
+Default: `false`
+
+When true, disables interactive input prompts for options with a default.
+
+### dryRun
+
+Default: `false`
+
+When true, disables interactive input prompts for options with a default.
+
+### force
+
+Default: `false`
+
+When true, forces overwriting of existing files.
+
+### interactive
+
+Default: `true`
+
+When false, disables interactive input prompts.
+
+### help
+
+Show help and display available schematics in the default collection.
+
+### version
+
+Show version number

--- a/docs/web/nx-commands/lint.md
+++ b/docs/web/nx-commands/lint.md
@@ -4,8 +4,16 @@ Runs linting tools on application code in a given project folder using the confi
 
 ## Usage
 
+The `lint` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx lint <project> [options]
+```
+
+```bash
+nx run <project>:lint [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/web/nx-commands/lint.md
+++ b/docs/web/nx-commands/lint.md
@@ -1,0 +1,99 @@
+# lint
+
+Runs linting tools on application code in a given project folder using the configured linter.
+
+## Usage
+
+```bash
+nx lint <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `lint` command to the Angular CLI's `lint` command.
+
+### Examples
+
+Run lint checks for the `myapp` project and fix linter errors:
+
+```bash
+nx lint myapp --fix
+```
+
+## Common Options
+
+The options below are common to the `lint` command used within an Nx workspace. The ESLint and Angular-specifc lint options are listed after these options.
+
+### exclude
+
+Files to exclude from linting.
+
+### files
+
+Files to include in linting.
+
+### fix
+
+Fixes linting errors (may overwrite linted files).
+
+### force
+
+Succeeds even if there was linting errors.
+
+### format
+
+ESLint Output formatter (https://eslint.org/docs/user-guide/formatters). (default: stylish)
+
+### silent
+
+Hide output text.
+
+### tsConfig
+
+The name of the TypeScript configuration file.
+
+### help
+
+Show help information
+
+### version
+
+Show version number
+
+## ESLint Options
+
+### cache
+
+Only check changed files.
+
+### cacheLocation
+
+Path to the cache file or directory.
+
+### config
+
+The name of the configuration file.
+
+### linter
+
+The tool to use for running lint checks.
+
+Default: `tslint`
+
+### outputFile
+
+File to write report to.
+
+## Angular-TSLint Options
+
+### configuration (-c)
+
+The linting configuration to use.
+
+### tslint-config
+
+The name of the TSLint configuration file.
+
+### type-check
+
+Controls the type check for linting.

--- a/docs/web/nx-commands/run.md
+++ b/docs/web/nx-commands/run.md
@@ -1,0 +1,41 @@
+# run
+
+Runs an Architect target with an optional custom builder configuration defined in your project.
+
+## Usage
+
+```bash
+nx run <target> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `run` command to the Angular CLI's `run` command.
+
+### Examples
+
+Run the `build` target for the `myapp` :
+
+```bash
+nx run myapp:build
+```
+
+Run the `build` target for the `myapp` project with a `production` configuration:
+
+```bash
+nx run myapp:build:production
+```
+
+## Options
+
+### configuration (-c)
+
+A named builder configuration, defined in the "configurations" section of the workspace configuration file. The builder uses the named configuration to run the given target.
+
+### help
+
+Show help
+
+### version
+
+Show version number

--- a/docs/web/nx-commands/serve.md
+++ b/docs/web/nx-commands/serve.md
@@ -1,0 +1,193 @@
+# serve
+
+Builds and serves an application, rebuilding on file changes.
+
+## Usage
+
+```bash
+nx serve <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `serve` command to the Angular CLI's `serve` command.
+
+### Examples
+
+Serve the `myapp` project:
+
+```bash
+nx serve myapp
+```
+
+## Common Options
+
+The options below are common to the `serve` command used within an Nx workspace. The Web and Angular-specifc serve options are listed after these options.
+
+### allowedHosts
+
+This option allows you to whitelist services that are allowed to access the dev server.
+
+### host
+
+Host to listen on.
+
+Default: `localhost`
+
+### liveReload
+
+Whether to reload the page on change, using live-reload.
+
+Default: `true`
+
+### open (-o)
+
+Open the application in the browser.
+
+### port
+
+Port to listen on.
+
+Default: `4200`
+
+### publicHost
+
+Public URL where the application will be served
+
+### ssl
+
+Serve using HTTPS.
+
+### sslKey
+
+SSL key to use for serving HTTPS.
+
+### sslCert
+
+SSL certificate to use for serving HTTPS.
+
+### watch
+
+Watches for changes and rebuilds application
+
+Default: `true`
+
+### help
+
+Show help
+
+### version
+
+Show version number
+
+## Web-Serve Options
+
+### buildTarget
+
+Target which builds the application
+
+### memoryLimit
+
+Memory limit for type checking service process in MB.
+
+### maxWorkers
+
+Number of workers to use for type checking.
+
+## Angular-Serve Options
+
+### aot
+
+Build using Ahead of Time compilation.
+
+### base-href
+
+Base url for the application being built.
+
+### browser-target
+
+Target to serve.
+
+### build-event-log
+
+**EXPERIMENTAL** Output file path for Build Event Protocol events.
+
+### common-chunk
+
+Use a separate bundle containing code used across multiple bundles.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of the workspace configuration.
+Each named target is accompanied by a configuration of option defaults for that target.
+Setting this explicitly overrides the `--prod` flag
+
+### deploy-url
+
+URL where files will be deployed.
+
+### disable-host-check
+
+Don't verify connected clients are part of allowed hosts.
+
+### eval-source-map
+
+Output in-file eval sourcemaps.
+
+### hmr
+
+Enable hot module replacement.
+
+### hmr-warning
+
+Show a warning when the `--hmr` option is enabled.
+
+### optimization
+
+Enables optimization of the build output.
+
+### poll
+
+Enable and define the file watching poll time period in milliseconds.
+
+### prod
+
+Shorthand for `--configuration=production`.
+When true, sets the build configuration to the production target.
+By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
+
+### progress
+
+Log progress to the console while building.
+
+### proxy-config
+
+Proxy configuration file.
+
+### public-host
+
+The URL that the browser client (or live-reload client, if enabled) should use to connect to the development server. Use for a complex dev server setup, such as one with reverse proxies.
+
+### serve-path
+
+The pathname where the app will be served.
+
+### serve-path-default-warning
+
+Show a warning when deploy-url/base-href use unsupported serve path values.
+
+### source-map
+
+Output sourcemaps.
+
+### vendor-chunk
+
+Use a separate bundle containing only vendor libraries.
+
+### vendor-source-map
+
+Resolve vendor packages sourcemaps.
+
+### verbose
+
+Adds more details to output logging.

--- a/docs/web/nx-commands/serve.md
+++ b/docs/web/nx-commands/serve.md
@@ -4,8 +4,16 @@ Builds and serves an application, rebuilding on file changes.
 
 ## Usage
 
+The `serve` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx serve <project> [options]
+```
+
+```bash
+nx run <project>:serve [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/web/nx-commands/test.md
+++ b/docs/web/nx-commands/test.md
@@ -4,8 +4,16 @@ Runs unit tests in a project using the configured unit test runner.
 
 ## Usage
 
+The `test` command is a built-in alias to the [run command](/angular/nx-commands/run).
+
+These two commands are equivalent:
+
 ```bash
 nx test <project> [options]
+```
+
+```bash
+nx run <project>:test [options]
 ```
 
 Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.

--- a/docs/web/nx-commands/test.md
+++ b/docs/web/nx-commands/test.md
@@ -1,0 +1,252 @@
+# test
+
+Runs unit tests in a project using the configured unit test runner.
+
+## Usage
+
+```bash
+nx test <project> [options]
+```
+
+Install `@nrwl/cli` globally to invoke the command directly using `nx`, or use `npm run nx` or `yarn nx`.
+
+> When used within an Nx workspace with the Angular CLI as the primary CLI, the Nx CLI delegates the `test` command to the Angular CLI's `test` command.
+
+### Examples
+
+Run unit tests:
+
+```bash
+nx test myapp
+```
+
+## Common Options
+
+The options below are common to the `test` command used within an Nx workspace. The Jest and Karma-specifc test options are listed after these options.
+
+### codeCoverage
+
+Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)
+
+### tsConfig
+
+The path to the Typescript configuration file.
+
+### watch
+
+Watch files for changes and rerun tests.
+
+### help
+
+Show help information.
+
+### version
+
+Show version number
+
+## Jest Options
+
+### bail
+
+Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/en/cli#bail)
+
+### ci
+
+Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/en/cli#ci)
+
+### color
+
+Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/en/cli#colors)
+
+### colors
+
+Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)
+
+### coverageReporters
+
+A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter
+
+### coverageDirectory
+
+An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
+
+### config
+
+The path to a Jest config file specifying how to find and execute tests. If no rootDir is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration
+
+### clearCache
+
+Deletes the Jest cache directory and then exits without running tests. Will delete Jest's default cache directory. _Note: clearing the cache will reduce performance_.
+
+### findRelatedTests
+
+Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/en/cli#findrelatedtests-spaceseparatedlistofsourcefiles)
+
+### jestConfig
+
+The path of the Jest configuration. (https://jestjs.io/docs/en/configuration)
+
+### json
+
+Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/en/cli#json)
+
+### maxWorkers
+
+Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/en/cli#maxworkers-num)
+
+### onlyChanged
+
+Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment. (https://jestjs.io/docs/en/cli#onlychanged)
+
+### outputFile
+
+Write test results to a file when the --json option is also specified. (https://jestjs.io/docs/en/cli#outputfile-filename)
+
+### passWithNoTests
+
+Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/en/cli#passwithnotests)
+
+### reporters
+
+Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/en/cli#reporters)
+
+### runInBand
+
+Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/en/cli#runinband)
+
+### setupFile
+
+The name of a setup file used by Jest. (https://jestjs.io/docs/en/configuration#setupfilesafterenv-array)
+
+### silent
+
+Prevent tests from printing messages through the console. (https://jestjs.io/docs/en/cli#silent)
+
+### testFile
+
+The name of the file to test.
+
+### testNamePattern
+
+Run only tests with a name that matches the regex pattern. (https://jestjs.io/docs/en/cli#testnamepattern-regex)
+
+### testPathPattern
+
+An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
+
+### testLocationInResults
+
+Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/en/cli#testlocationinresults)
+
+### testResultsProcessor
+
+Node module that implements a custom results processor. (https://jestjs.io/docs/en/configuration#testresultsprocessor-string)
+
+### updateSnapshot
+
+Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern. (https://jestjs.io/docs/en/cli#updatesnapshot)
+
+### useStderr
+
+Divert all output to stderr.
+
+### verbose
+
+Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)
+
+### watchAll
+
+Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/en/cli#watchall)
+
+## Karma Options
+
+### browsers
+
+Override which browsers tests are run against.
+
+### codeCoverage
+
+Output a code coverage report.
+
+### codeCoverageExclude
+
+Globs to exclude from code coverage.
+
+### configuration (-c)
+
+A named build target, as specified in the "configurations" section of angular.json.
+Each named target is accompanied by a configuration of option defaults for that target.
+Setting this explicitly overrides the `--prod` flag.
+
+### environment
+
+Defines the build environment.
+
+### evalSourceMap
+
+Output in-file eval sourcemaps.
+
+### help
+
+Shows a help message for this command in the console.
+
+### include
+
+Globs of files to include, relative to workspace or project root.
+
+There are 2 special cases:
+
+- when a path to directory is provided, all spec files ending ".spec.@(ts|tsx)" will be included
+- when a path to a file is provided, and a matching spec file exists it will be included instead
+
+### karmaConfig
+
+The name of the Karma configuration file.
+
+### main
+
+The name of the main entry-point file.
+
+### poll
+
+Enable and define the file watching poll time period in milliseconds.
+
+### polyfills
+
+The name of the polyfills file.
+
+### preserveSymlinks
+
+Do not use the real path when resolving modules.
+
+### prod
+
+Shorthand for "--configuration=production". When true, sets the build configuration to the production target. By default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.
+
+### progress
+
+Log progress to the console while building.
+
+### reporters
+
+Karma reporters to use. Directly passed to the karma runner.
+
+### sourceMap
+
+Output sourcemaps.
+
+### tsCconfig
+
+The name of the TypeScript configuration file.
+
+### vendorSourceMap
+
+Resolve vendor packages sourcemaps.
+
+### watch
+
+Run build when files change.
+
+### webWorkerTsConfig
+
+TypeScript configuration for Web Worker modules.

--- a/scripts/documentation/generate-nx-commands-data.ts
+++ b/scripts/documentation/generate-nx-commands-data.ts
@@ -359,7 +359,15 @@ const examples = {
   ]
 };
 
-const unwantedCommands = ['run', 'generate'];
+const sharedCommands = [
+  'build',
+  'e2e',
+  'generate',
+  'lint',
+  'run',
+  'serve',
+  'test'
+];
 
 console.log('Generating Nx Commands Documentation');
 Promise.all(
@@ -467,12 +475,38 @@ Promise.all(
     const nxCommands = getCommands(commandsObject);
     await Promise.all(
       Object.keys(nxCommands)
-        .filter(name => !unwantedCommands.includes(name))
+        .filter(name => !sharedCommands.includes(name))
         .map(name => parseCommandInstance(name, nxCommands[name]))
         .map(command => generateMarkdown(command))
         .map(templateObject =>
           generateMarkdownFile(commandsOutputDirectory, templateObject)
         )
+    );
+
+    await Promise.all(
+      sharedCommands.map(command => {
+        const sharedCommandsDirectory = path.join(
+          __dirname,
+          '../../docs/shared/nx-commands'
+        );
+        const sharedCommandsOutputDirectory = path.join(
+          __dirname,
+          '../../docs/',
+          framework,
+          'nx-commands'
+        );
+        const templateObject = {
+          name: command,
+          template: fs
+            .readFileSync(path.join(sharedCommandsDirectory, `${command}.md`))
+            .toString('utf-8')
+        };
+
+        return generateMarkdownFile(
+          sharedCommandsOutputDirectory,
+          templateObject
+        );
+      })
     );
   })
 ).then(() => {


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

Nx commands shared with the Angular CLI are not listed in the side menu on https://nx.dev/angular/nx-commands/affected

- build
- serve
- test
- lint
- e2e
- generate
- run

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Nx commands shared with the Angular CLI are listed in the side menu on https://nx.dev/angular/nx-commands/affected

This also updates the documentation script to copy each one one of shared nx-commands markdown into the respective frameworks (Angular, React, Web).

In the future, we could look at generating more of this information from the builders metadata.

## Issue
