### PR TITLE
fix(angular): changes the styleext setting of the component schematic…

### DIFF
--- a/packages/angular/src/schematics/library/library.spec.ts
+++ b/packages/angular/src/schematics/library/library.spec.ts
@@ -910,7 +910,7 @@ describe('lib', () => {
 
       expect(workspaceJson.projects['my-lib'].schematics).toEqual({
         '@nrwl/angular:component': {
-          styleext: 'scss'
+          style: 'scss'
         }
       });
     });

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -333,7 +333,7 @@ function updateProject(options: NormalizedSchema): Rule {
           fixedProject.schematics = {
             ...fixedProject.schematics,
             '@nrwl/angular:component': {
-              styleext: options.style
+              style: options.style
             }
           };
         }


### PR DESCRIPTION
… to style

the styleext setting to define the component style extension was removed in Angular 9.

ISSUES CLOSED: #2475 

## Current Behavior (This is the behavior we have today, before the PR is merged)
When generating a new library it uses styleext instead of style for the component schematic.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Setting the style property instead of the styleext.

## Issue
#2475 (Don't know if it fully resolves this issue.)