### PR TITLE
fix(core): move setMaxWorkers responsibility to runCLI

### DIFF
--- a/e2e/cypress.test.ts
+++ b/e2e/cypress.test.ts
@@ -1,16 +1,14 @@
 import {
   checkFilesExist,
+  ensureProject,
+  forEachCli,
+  newProject,
+  readFile,
   readJson,
   runCLI,
-  updateFile,
-  readFile,
-  ensureProject,
-  uniq,
-  newProject,
-  forEachCli,
   supportUi,
-  workspaceConfigName,
-  setMaxWorkers
+  uniq,
+  updateFile
 } from './utils';
 
 forEachCli(currentCLIName => {
@@ -51,10 +49,6 @@ forEachCli(currentCLIName => {
           runCLI(
             `generate @nrwl/${nrwlPackageName}:app ${myapp} --e2eTestRunner=cypress --linter=${linter}`
           );
-
-          if (currentCLIName === 'nx') {
-            setMaxWorkers(myapp);
-          }
 
           expect(runCLI(`e2e ${myapp}-e2e --headless --no-watch`)).toContain(
             'All specs passed!'

--- a/e2e/node.test.ts
+++ b/e2e/node.test.ts
@@ -1,29 +1,27 @@
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import { execSync, fork, spawn } from 'child_process';
 import * as http from 'http';
 import * as path from 'path';
 import * as treeKill from 'tree-kill';
 import * as ts from 'typescript';
 import {
+  checkFilesDoNotExist,
+  checkFilesExist,
+  cleanup,
+  copyMissingPackages,
   ensureProject,
+  forEachCli,
+  readFile,
   readJson,
   runCLI,
   runCLIAsync,
-  uniq,
-  updateFile,
-  forEachCli,
-  checkFilesExist,
-  tmpProjPath,
-  workspaceConfigName,
-  cleanup,
   runNew,
   runNgAdd,
-  copyMissingPackages,
-  setMaxWorkers,
-  newProject,
-  checkFilesDoNotExist
+  tmpProjPath,
+  uniq,
+  updateFile,
+  workspaceConfigName
 } from './utils';
-import { stripIndents } from '@angular-devkit/core/src/utils/literals';
-import { readFile } from './utils';
 
 function getData(): Promise<any> {
   return new Promise(resolve => {
@@ -49,8 +47,6 @@ forEachCli(currentCLIName => {
       const nodeapp = uniq('nodeapp');
 
       runCLI(`generate @nrwl/node:app ${nodeapp} --linter=${linter}`);
-
-      setMaxWorkers(nodeapp);
 
       const lintResults = runCLI(`lint ${nodeapp}`);
       expect(lintResults).toContain('All files pass linting.');
@@ -190,8 +186,6 @@ forEachCli(currentCLIName => {
       ensureProject();
       const nestapp = uniq('nestapp');
       runCLI(`generate @nrwl/nest:app ${nestapp} --linter=${linter}`);
-
-      setMaxWorkers(nestapp);
 
       const lintResults = runCLI(`lint ${nestapp}`);
       expect(lintResults).toContain('All files pass linting.');
@@ -420,8 +414,6 @@ forEachCli(currentCLIName => {
       ensureProject();
 
       runCLI(`generate @nrwl/express:app ${app}`);
-      setMaxWorkers(app);
-
       runCLI(`generate @nrwl/node:lib ${parentLib} --publishable=true`);
       runCLI(`generate @nrwl/node:lib ${childLib} --publishable=true`);
       runCLI(`generate @nrwl/node:lib ${childLib2} --publishable=true`);

--- a/e2e/react-package.test.ts
+++ b/e2e/react-package.test.ts
@@ -4,7 +4,6 @@ import {
   forEachCli,
   readJson,
   runCLI,
-  setMaxWorkers,
   uniq,
   updateFile
 } from './utils';
@@ -35,7 +34,6 @@ forEachCli('nx', cli => {
       ensureProject();
 
       runCLI(`generate @nrwl/react:app ${app}`);
-      setMaxWorkers(app);
 
       runCLI(
         `generate @nrwl/react:library ${parentLib} --buildable --no-interactive`

--- a/e2e/react.test.ts
+++ b/e2e/react.test.ts
@@ -1,20 +1,19 @@
+import { serializeJson } from '@nrwl/workspace';
 import {
+  checkFilesDoNotExist,
+  checkFilesExist,
   ensureProject,
+  forEachCli,
+  readFile,
+  readJson,
+  renameFile,
   runCLI,
+  runCLIAsync,
+  supportUi,
   uniq,
   updateFile,
-  readFile,
-  runCLIAsync,
-  checkFilesExist,
-  renameFile,
-  readJson,
-  forEachCli,
-  supportUi,
-  workspaceConfigName,
-  setMaxWorkers,
-  checkFilesDoNotExist
+  workspaceConfigName
 } from './utils';
-import { serializeJson } from '@nrwl/workspace';
 
 forEachCli(currentCLIName => {
   const linter = currentCLIName === 'angular' ? 'tslint' : 'eslint';
@@ -29,8 +28,6 @@ forEachCli(currentCLIName => {
         `generate @nrwl/react:app ${appName} --no-interactive --linter=${linter}`
       );
       runCLI(`generate @nrwl/react:lib ${libName} --no-interactive`);
-
-      setMaxWorkers(appName);
 
       const mainPath = `apps/${appName}/src/main.tsx`;
       updateFile(mainPath, `import '@proj/${libName}';\n` + readFile(mainPath));
@@ -111,8 +108,6 @@ forEachCli(currentCLIName => {
         `generate @nrwl/react:lib ${libName} --no-interactive --no-component`
       );
 
-      setMaxWorkers(appName);
-
       const mainPath = `apps/${appName}/src/main.tsx`;
       updateFile(mainPath, `import '@proj/${libName}';\n` + readFile(mainPath));
 
@@ -149,8 +144,6 @@ forEachCli(currentCLIName => {
         `generate @nrwl/react:app ${appName} --routing --no-interactive --linter=${linter}`
       );
 
-      setMaxWorkers(appName);
-
       await testGeneratedApp(appName, { checkStyles: true, checkLinter: true });
     }, 120000);
 
@@ -161,8 +154,6 @@ forEachCli(currentCLIName => {
       runCLI(
         `generate @nrwl/react:app ${appName} --style styled-components --no-interactive --linter=${linter}`
       );
-
-      setMaxWorkers(appName);
 
       await testGeneratedApp(appName, {
         checkStyles: false,
@@ -177,8 +168,6 @@ forEachCli(currentCLIName => {
       runCLI(
         `generate @nrwl/react:app ${appName} --style none --no-interactive --linter=${linter}`
       );
-
-      setMaxWorkers(appName);
 
       await testGeneratedApp(appName, {
         checkStyles: false,
@@ -202,8 +191,6 @@ forEachCli(currentCLIName => {
         `generate @nrwl/react:app ${appName} --no-interactive --linter=${linter}`
       );
       runCLI(`generate @nrwl/react:lib ${libName} --no-interactive`);
-
-      setMaxWorkers(appName);
 
       renameFile(
         `apps/${appName}/src/main.tsx`,

--- a/e2e/web.test.ts
+++ b/e2e/web.test.ts
@@ -6,7 +6,6 @@ import {
   readFile,
   runCLI,
   runCLIAsync,
-  setMaxWorkers,
   supportUi,
   uniq,
   updateFile
@@ -22,8 +21,6 @@ forEachCli(currentCLIName => {
       runCLI(
         `generate @nrwl/web:app ${appName} --no-interactive --linter=${linter}`
       );
-
-      setMaxWorkers(appName);
 
       const lintResults = runCLI(`lint ${appName}`);
       expect(lintResults).toContain('All files pass linting.');
@@ -134,8 +131,6 @@ forEachCli(currentCLIName => {
       const newCode = `const envVars = [process.env.NODE_ENV, process.env.NX_BUILD, process.env.NX_API];`;
 
       runCLI(`generate @nrwl/web:app ${appName} --no-interactive`);
-
-      setMaxWorkers(appName);
 
       const content = readFile(main);
 

--- a/e2e/workspace.test.ts
+++ b/e2e/workspace.test.ts
@@ -1,5 +1,5 @@
+import { NxJson } from '@nrwl/workspace';
 import {
-  cli,
   ensureProject,
   forEachCli,
   listFiles,
@@ -9,12 +9,10 @@ import {
   rmDist,
   runCLI,
   runCommand,
-  setMaxWorkers,
   uniq,
   updateFile,
   workspaceConfigName
 } from './utils';
-import { NxJson } from '@nrwl/workspace';
 
 let originalCIValue: any;
 
@@ -40,7 +38,6 @@ forEachCli(cliName => {
       const mylib1 = uniq('mylib1');
       const mylib2 = uniq('mylib1');
       runCLI(`generate @nrwl/react:app ${myapp}`);
-      setMaxWorkers(myapp);
       runCLI(`generate @nrwl/react:lib ${mylib1} --publishable`);
       runCLI(`generate @nrwl/react:lib ${mylib2} --publishable`);
 


### PR DESCRIPTION
This moves the responsibility of setting the maxWorkers option to the `runCLI` function. This means that (hopefully) it will be much harder to forget to set it in e2e tests.

Technically this method is a _tiny_ bit slower than before as I've just decided to update it on all the projects when we see a generate. I _could_ probably try to extract the `appName` from the command, but that seemed more brittle than just going through the project list and updating those builders we know will need to be updated.

For most e2e tests this will only mean updating one project anyway so it shouldn't make a noticeable difference. 🤷‍♀️