### PR TITLE
fix(misc): add formatting to all migrations

### DIFF
--- a/packages/angular/src/migrations/update-8-3-0/upgrade-ngrx-8-0.ts
+++ b/packages/angular/src/migrations/update-8-3-0/upgrade-ngrx-8-0.ts
@@ -64,5 +64,5 @@ function updateNgrx(updateDeps: TaskId[]) {
 
 export default function() {
   const { rule: updateCLIRule, tasks } = updateCLI();
-  return chain([updateCLIRule, updateNgrx(tasks)]);
+  return chain([updateCLIRule, updateNgrx(tasks), formatFiles()]);
 }

--- a/packages/angular/src/migrations/update-8-5-0/upgrade-cli-8-3.ts
+++ b/packages/angular/src/migrations/update-8-5-0/upgrade-cli-8-3.ts
@@ -66,5 +66,10 @@ function updateNgrx(updateDeps: TaskId[]) {
 
 export default function() {
   const { rule: updateCLIRule, tasks } = updateCLI();
-  return chain([updateAngular, updateCLIRule, updateNgrx(tasks)]);
+  return chain([
+    updateAngular,
+    updateCLIRule,
+    updateNgrx(tasks),
+    formatFiles()
+  ]);
 }

--- a/packages/angular/src/migrations/update-9-0-0/add-postinstall.ts
+++ b/packages/angular/src/migrations/update-9-0-0/add-postinstall.ts
@@ -1,25 +1,29 @@
-import { updateJsonInTree } from '@nrwl/workspace';
+import { formatFiles, updateJsonInTree } from '@nrwl/workspace';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+import { chain } from '@angular-devkit/schematics';
 
 export default function() {
-  return updateJsonInTree('package.json', (json, context) => {
-    json.scripts = json.scripts || {};
-    if (json.scripts.postinstall) {
-      context.logger.warn(
-        stripIndents`
+  return chain([
+    updateJsonInTree('package.json', (json, context) => {
+      json.scripts = json.scripts || {};
+      if (json.scripts.postinstall) {
+        context.logger.warn(
+          stripIndents`
             ---------------------------------------------------------------------------------------
             Angular Ivy requires you to run ngcc after every npm install.
             The easiest way to accomplish this is to update your postinstall script to invoke ngcc.
             ---------------------------------------------------------------------------------------
           `
-      );
-    } else {
-      context.logger.info(
-        stripIndents`A "postinstall" script has been added to package.json to run ngcc.`
-      );
-      json.scripts.postinstall =
-        'ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points';
-    }
-    return json;
-  });
+        );
+      } else {
+        context.logger.info(
+          stripIndents`A "postinstall" script has been added to package.json to run ngcc.`
+        );
+        json.scripts.postinstall =
+          'ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points';
+      }
+      return json;
+    }),
+    formatFiles()
+  ]);
 }

--- a/packages/angular/src/migrations/update-9-0-0/update-9-0-0.ts
+++ b/packages/angular/src/migrations/update-9-0-0/update-9-0-0.ts
@@ -1,5 +1,5 @@
 import { chain, SchematicContext } from '@angular-devkit/schematics';
-import { addUpdateTask } from '@nrwl/workspace';
+import { addUpdateTask, formatFiles } from '@nrwl/workspace';
 import { RunSchematicTask } from '@angular-devkit/schematics/tasks';
 import { join } from 'path';
 
@@ -14,7 +14,8 @@ export default function() {
     );
     return chain([
       addUpdateTask('@angular/core', '9.0.0', [postInstallTask]),
-      addUpdateTask('@angular/cli', '9.0.1', [postInstallTask])
+      addUpdateTask('@angular/cli', '9.0.1', [postInstallTask]),
+      formatFiles()
     ]);
   };
 }

--- a/packages/cypress/src/migrations/update-8-1-0/update-8-1-0.ts
+++ b/packages/cypress/src/migrations/update-8-1-0/update-8-1-0.ts
@@ -4,7 +4,7 @@ import {
   SchematicContext,
   Tree
 } from '@angular-devkit/schematics';
-import { updateJsonInTree } from '@nrwl/workspace';
+import { formatFiles, updateJsonInTree } from '@nrwl/workspace';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 
 function displayInformation(host: Tree, context: SchematicContext) {
@@ -28,6 +28,7 @@ export default function(): Rule {
 
       return json;
     }),
-    displayInformation
+    displayInformation,
+    formatFiles()
   ]);
 }

--- a/packages/cypress/src/migrations/update-8-10-0/update-8-10-0.ts
+++ b/packages/cypress/src/migrations/update-8-10-0/update-8-10-0.ts
@@ -1,10 +1,14 @@
-import { updatePackagesInPackageJson } from '@nrwl/workspace';
+import { formatFiles, updatePackagesInPackageJson } from '@nrwl/workspace';
 
 import { join } from 'path';
+import { chain } from '@angular-devkit/schematics';
 
 export default () => {
-  return updatePackagesInPackageJson(
-    join(__dirname, '../../../migrations.json'),
-    '8.10.0'
-  );
+  return chain([
+    updatePackagesInPackageJson(
+      join(__dirname, '../../../migrations.json'),
+      '8.10.0'
+    ),
+    formatFiles()
+  ]);
 };

--- a/packages/cypress/src/migrations/update-8-12-0/update-8-12-0.ts
+++ b/packages/cypress/src/migrations/update-8-12-0/update-8-12-0.ts
@@ -1,10 +1,14 @@
-import { updatePackagesInPackageJson } from '@nrwl/workspace';
+import { formatFiles, updatePackagesInPackageJson } from '@nrwl/workspace';
 
 import { join } from 'path';
+import { chain } from '@angular-devkit/schematics';
 
 export default () => {
-  return updatePackagesInPackageJson(
-    join(__dirname, '../../../migrations.json'),
-    '8.12.0'
-  );
+  return chain([
+    updatePackagesInPackageJson(
+      join(__dirname, '../../../migrations.json'),
+      '8.12.0'
+    ),
+    formatFiles()
+  ]);
 };

--- a/packages/jest/src/migrations/update-8-7-0/update-8-7-0.ts
+++ b/packages/jest/src/migrations/update-8-7-0/update-8-7-0.ts
@@ -1,5 +1,6 @@
-import { Rule } from '@angular-devkit/schematics';
+import { chain, Rule } from '@angular-devkit/schematics';
 import { updateWorkspace } from '@nrwl/workspace/src/utils/workspace';
+import { formatFiles } from '@nrwl/workspace';
 
 const convertToArray = updateWorkspace(workspace => {
   workspace.projects.forEach(project => {
@@ -16,5 +17,5 @@ const convertToArray = updateWorkspace(workspace => {
 });
 
 export default function(): Rule {
-  return convertToArray;
+  return chain([convertToArray, formatFiles()]);
 }

--- a/packages/nest/src/migrations/update-8-7-0/update-8-7-0.ts
+++ b/packages/nest/src/migrations/update-8-7-0/update-8-7-0.ts
@@ -1,10 +1,13 @@
-import { Rule } from '@angular-devkit/schematics';
-import { updatePackagesInPackageJson } from '@nrwl/workspace';
+import { chain, Rule } from '@angular-devkit/schematics';
+import { formatFiles, updatePackagesInPackageJson } from '@nrwl/workspace';
 import * as path from 'path';
 
 export default function update(): Rule {
-  return updatePackagesInPackageJson(
-    path.join(__dirname, '../../../', 'migrations.json'),
-    '8.7.0'
-  );
+  return chain([
+    updatePackagesInPackageJson(
+      path.join(__dirname, '../../../', 'migrations.json'),
+      '8.7.0'
+    ),
+    formatFiles()
+  ]);
 }

--- a/packages/next/src/migrations/update-8-10-0/update-8-10-0.ts
+++ b/packages/next/src/migrations/update-8-10-0/update-8-10-0.ts
@@ -1,10 +1,13 @@
-import { Rule } from '@angular-devkit/schematics';
-import { updatePackagesInPackageJson } from '@nrwl/workspace';
+import { chain, Rule } from '@angular-devkit/schematics';
+import { formatFiles, updatePackagesInPackageJson } from '@nrwl/workspace';
 import * as path from 'path';
 
 export default function update(): Rule {
-  return updatePackagesInPackageJson(
-    path.join(__dirname, '../../../', 'migrations.json'),
-    '8.10.0'
-  );
+  return chain([
+    updatePackagesInPackageJson(
+      path.join(__dirname, '../../../', 'migrations.json'),
+      '8.10.0'
+    ),
+    formatFiles()
+  ]);
 }

--- a/packages/next/src/migrations/update-9-2-0/create-next-config.spec.ts
+++ b/packages/next/src/migrations/update-9-2-0/create-next-config.spec.ts
@@ -63,7 +63,10 @@ describe('create-next-config-9.2.0', () => {
 
     // Creates config for Next apps
     const content = tree.read('apps/demo1/next.config.js').toString();
-    expect(content).toContain('withStylus(withLess(withSass(withCSS({');
+    expect(content).toContain('withStylus(');
+    expect(content).toContain('withLess(');
+    expect(content).toContain('withSass(');
+    expect(content).toContain('withCSS(');
 
     // Doesn't create config for non-Next apps
     expect(tree.exists('apps/demo2/next.config.js')).toBe(false);

--- a/packages/node/src/migrations/update-9-2-0/set-build-libs-from-source.ts
+++ b/packages/node/src/migrations/update-9-2-0/set-build-libs-from-source.ts
@@ -1,23 +1,26 @@
-import { Rule } from '@angular-devkit/schematics';
-import { updateWorkspaceInTree } from '@nrwl/workspace';
+import { chain, Rule } from '@angular-devkit/schematics';
+import { formatFiles, updateWorkspaceInTree } from '@nrwl/workspace';
 
 export default function update(): Rule {
-  return updateWorkspaceInTree(workspaceJson => {
-    Object.entries<any>(workspaceJson.projects).forEach(
-      ([projectName, project]) => {
-        Object.entries<any>(project.architect).forEach(
-          ([targetName, targetConfig]) => {
-            if (targetConfig.builder === '@nrwl/node:build') {
-              const architect =
-                workspaceJson.projects[projectName].architect[targetName];
-              if (architect && architect.options) {
-                architect.options.buildLibsFromSource = true;
+  return chain([
+    updateWorkspaceInTree(workspaceJson => {
+      Object.entries<any>(workspaceJson.projects).forEach(
+        ([projectName, project]) => {
+          Object.entries<any>(project.architect).forEach(
+            ([targetName, targetConfig]) => {
+              if (targetConfig.builder === '@nrwl/node:build') {
+                const architect =
+                  workspaceJson.projects[projectName].architect[targetName];
+                if (architect && architect.options) {
+                  architect.options.buildLibsFromSource = true;
+                }
               }
             }
-          }
-        );
-      }
-    );
-    return workspaceJson;
-  });
+          );
+        }
+      );
+      return workspaceJson;
+    }),
+    formatFiles()
+  ]);
 }

--- a/packages/react/src/migrations/update-8-10-0/update-8-10-0.ts
+++ b/packages/react/src/migrations/update-8-10-0/update-8-10-0.ts
@@ -6,6 +6,7 @@ import {
   Tree
 } from '@angular-devkit/schematics';
 import {
+  formatFiles,
   offsetFromRoot,
   readWorkspace,
   updateJsonInTree,
@@ -45,8 +46,8 @@ function displayInformation(host: Tree, context: SchematicContext) {
 
 function addCustomTypings(host: Tree) {
   const workspace = readWorkspace(host);
-  return chain(
-    Object.keys(workspace.projects).map(k => {
+  return chain([
+    ...Object.keys(workspace.projects).map(k => {
       const p = workspace.projects[k];
       if (p.projectType !== 'application') {
         return noop();
@@ -68,8 +69,9 @@ function addCustomTypings(host: Tree) {
       } else {
         return noop();
       }
-    })
-  );
+    }),
+    formatFiles()
+  ]);
 }
 
 function updateBuilderWebpackOption(json) {

--- a/packages/react/src/migrations/update-8-10-1/fix-react-tsconfig-8-10-1.ts
+++ b/packages/react/src/migrations/update-8-10-1/fix-react-tsconfig-8-10-1.ts
@@ -1,5 +1,5 @@
 import { chain, noop, Rule, Tree } from '@angular-devkit/schematics';
-import { readWorkspace, updateJsonInTree } from '@nrwl/workspace';
+import { formatFiles, readWorkspace, updateJsonInTree } from '@nrwl/workspace';
 import * as path from 'path';
 
 const ignore = require('ignore');
@@ -7,8 +7,8 @@ const ignore = require('ignore');
 export default function update(): Rule {
   return (host: Tree) => {
     const workspace = readWorkspace(host);
-    return chain(
-      Object.keys(workspace.projects).map(k => {
+    return chain([
+      ...Object.keys(workspace.projects).map(k => {
         const p = workspace.projects[k];
         if (p.projectType !== 'application') {
           return noop();
@@ -23,8 +23,9 @@ export default function update(): Rule {
         } else {
           return noop();
         }
-      })
-    );
+      }),
+      formatFiles()
+    ]);
   };
 }
 

--- a/packages/react/src/migrations/update-8-12-0/fix-react-files-8-12-0.ts
+++ b/packages/react/src/migrations/update-8-12-0/fix-react-files-8-12-0.ts
@@ -1,12 +1,17 @@
 import { chain, Rule } from '@angular-devkit/schematics';
-import { addDepsToPackageJson, updateWorkspaceInTree } from '@nrwl/workspace';
+import {
+  addDepsToPackageJson,
+  formatFiles,
+  updateWorkspaceInTree
+} from '@nrwl/workspace';
 
 const ignore = require('ignore');
 
 export default function update(): Rule {
   return chain([
     updateWorkspaceInTree(updateBuilderWebpackOption),
-    addDepsToPackageJson({}, { '@babel/preset-react': '7.8.3' })
+    addDepsToPackageJson({}, { '@babel/preset-react': '7.8.3' }),
+    formatFiles()
   ]);
 }
 

--- a/packages/react/src/migrations/update-8-12-0/update-8-12-0.ts
+++ b/packages/react/src/migrations/update-8-12-0/update-8-12-0.ts
@@ -1,10 +1,13 @@
-import { Rule } from '@angular-devkit/schematics';
-import { updatePackagesInPackageJson } from '@nrwl/workspace';
+import { chain, Rule } from '@angular-devkit/schematics';
+import { formatFiles, updatePackagesInPackageJson } from '@nrwl/workspace';
 import * as path from 'path';
 
 export default function update(): Rule {
-  return updatePackagesInPackageJson(
-    path.join(__dirname, '../../../', 'migrations.json'),
-    '8.12.0'
-  );
+  return chain([
+    updatePackagesInPackageJson(
+      path.join(__dirname, '../../../', 'migrations.json'),
+      '8.12.0'
+    ),
+    formatFiles()
+  ]);
 }

--- a/packages/react/src/migrations/update-8-5-0/update-workspace-8-5-0.ts
+++ b/packages/react/src/migrations/update-8-5-0/update-workspace-8-5-0.ts
@@ -1,24 +1,27 @@
-import { Rule } from '@angular-devkit/schematics';
-import { updateWorkspaceInTree } from '@nrwl/workspace';
+import { chain, Rule } from '@angular-devkit/schematics';
+import { formatFiles, updateWorkspaceInTree } from '@nrwl/workspace';
 
 export default function update(): Rule {
-  return updateWorkspaceInTree(config => {
-    const a = [];
-    const b = [];
-    Object.keys(config.schematics).forEach(name => {
-      if (name === '@nrwl/react' && config.schematics[name].application) {
-        a.push(config.schematics[name]);
-      }
-      if (name === '@nrwl/react:application') {
-        b.push(config.schematics[name]);
-      }
-    });
-    a.forEach(x => {
-      delete x.application.babel;
-    });
-    b.forEach(x => {
-      delete x.babel;
-    });
-    return config;
-  });
+  return chain([
+    updateWorkspaceInTree(config => {
+      const a = [];
+      const b = [];
+      Object.keys(config.schematics).forEach(name => {
+        if (name === '@nrwl/react' && config.schematics[name].application) {
+          a.push(config.schematics[name]);
+        }
+        if (name === '@nrwl/react:application') {
+          b.push(config.schematics[name]);
+        }
+      });
+      a.forEach(x => {
+        delete x.application.babel;
+      });
+      b.forEach(x => {
+        delete x.babel;
+      });
+      return config;
+    }),
+    formatFiles()
+  ]);
 }

--- a/packages/react/src/migrations/update-8-7-0/update-8-7-0.ts
+++ b/packages/react/src/migrations/update-8-7-0/update-8-7-0.ts
@@ -4,7 +4,11 @@ import {
   SchematicContext,
   Tree
 } from '@angular-devkit/schematics';
-import { readJsonInTree, updatePackagesInPackageJson } from '@nrwl/workspace';
+import {
+  formatFiles,
+  readJsonInTree,
+  updatePackagesInPackageJson
+} from '@nrwl/workspace';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import * as path from 'path';
 
@@ -14,7 +18,8 @@ export default function update(): Rule {
     updatePackagesInPackageJson(
       path.join(__dirname, '../../../', 'migrations.json'),
       '8.7.0'
-    )
+    ),
+    formatFiles()
   ]);
 }
 

--- a/packages/react/src/migrations/update-8-9-0/update-8-9-0.ts
+++ b/packages/react/src/migrations/update-8-9-0/update-8-9-0.ts
@@ -7,6 +7,7 @@ import {
   Tree
 } from '@angular-devkit/schematics';
 import {
+  formatFiles,
   insert,
   readJsonInTree,
   updateJsonInTree,
@@ -28,7 +29,8 @@ export default function update(): Rule {
     updatePackagesInPackageJson(
       path.join(__dirname, '../../../', 'migrations.json'),
       '8.9.0'
-    )
+    ),
+    formatFiles()
   ]);
 }
 

--- a/packages/storybook/src/migrations/update-8-8-2/update-builder-8-8-2.ts
+++ b/packages/storybook/src/migrations/update-8-8-2/update-builder-8-8-2.ts
@@ -3,7 +3,8 @@ import {
   updateWorkspaceInTree,
   readWorkspaceJson,
   readWorkspace,
-  updateJsonInTree
+  updateJsonInTree,
+  formatFiles
 } from '@nrwl/workspace';
 
 export default function update(): Rule {
@@ -56,6 +57,7 @@ export default function update(): Rule {
         }
       });
       return chain(tsconfigUpdateRules);
-    }
+    },
+    formatFiles()
   ]);
 }

--- a/packages/storybook/src/migrations/update-9-0-0/update-9-0-0.ts
+++ b/packages/storybook/src/migrations/update-9-0-0/update-9-0-0.ts
@@ -1,5 +1,5 @@
 import { chain } from '@angular-devkit/schematics';
-import { updatePackagesInPackageJson } from '@nrwl/workspace';
+import { formatFiles, updatePackagesInPackageJson } from '@nrwl/workspace';
 import { join } from 'path';
 
 const updatePackages = updatePackagesInPackageJson(
@@ -8,5 +8,5 @@ const updatePackages = updatePackagesInPackageJson(
 );
 
 export default function() {
-  return chain([updatePackages]);
+  return chain([updatePackages, formatFiles()]);
 }

--- a/packages/storybook/src/migrations/update-9-2-0/update-9-2-0.ts
+++ b/packages/storybook/src/migrations/update-9-2-0/update-9-2-0.ts
@@ -1,6 +1,7 @@
 import { chain } from '@angular-devkit/schematics';
 import { addCacheableOperation } from '../../schematics/init/init';
+import { formatFiles } from '@nrwl/workspace';
 
 export default function() {
-  return chain([addCacheableOperation]);
+  return chain([addCacheableOperation, formatFiles()]);
 }

--- a/packages/web/src/migrations/update-8-5-0/update-builder-8-5-0.ts
+++ b/packages/web/src/migrations/update-8-5-0/update-builder-8-5-0.ts
@@ -1,21 +1,24 @@
-import { Rule } from '@angular-devkit/schematics';
-import { updateWorkspaceInTree } from '@nrwl/workspace';
+import { chain, Rule } from '@angular-devkit/schematics';
+import { formatFiles, updateWorkspaceInTree } from '@nrwl/workspace';
 
 export default function update(): Rule {
-  return updateWorkspaceInTree(config => {
-    const filteredProjects = [];
-    Object.keys(config.projects).forEach(name => {
-      if (
-        config.projects[name].architect &&
-        config.projects[name].architect.build &&
-        config.projects[name].architect.build.builder === '@nrwl/web:build'
-      ) {
-        filteredProjects.push(config.projects[name]);
-      }
-    });
-    filteredProjects.forEach(p => {
-      delete p.architect.build.options.differentialLoading;
-    });
-    return config;
-  });
+  return chain([
+    updateWorkspaceInTree(config => {
+      const filteredProjects = [];
+      Object.keys(config.projects).forEach(name => {
+        if (
+          config.projects[name].architect &&
+          config.projects[name].architect.build &&
+          config.projects[name].architect.build.builder === '@nrwl/web:build'
+        ) {
+          filteredProjects.push(config.projects[name]);
+        }
+      });
+      filteredProjects.forEach(p => {
+        delete p.architect.build.options.differentialLoading;
+      });
+      return config;
+    }),
+    formatFiles()
+  ]);
 }

--- a/packages/web/src/migrations/update-9-0-0/update-builder-9-0-0.ts
+++ b/packages/web/src/migrations/update-9-0-0/update-builder-9-0-0.ts
@@ -1,21 +1,24 @@
-import { Rule } from '@angular-devkit/schematics';
-import { updateWorkspaceInTree } from '@nrwl/workspace';
+import { chain, Rule } from '@angular-devkit/schematics';
+import { formatFiles, updateWorkspaceInTree } from '@nrwl/workspace';
 
 export default function update(): Rule {
-  return updateWorkspaceInTree(workspaceJson => {
-    Object.entries<any>(workspaceJson.projects).forEach(
-      ([projectName, project]) => {
-        Object.entries<any>(project.architect).forEach(
-          ([targetName, targetConfig]) => {
-            if (targetConfig.builder === '@nrwl/web:bundle') {
-              workspaceJson.projects[projectName].architect[
-                targetName
-              ].builder = '@nrwl/web:package';
+  return chain([
+    updateWorkspaceInTree(workspaceJson => {
+      Object.entries<any>(workspaceJson.projects).forEach(
+        ([projectName, project]) => {
+          Object.entries<any>(project.architect).forEach(
+            ([targetName, targetConfig]) => {
+              if (targetConfig.builder === '@nrwl/web:bundle') {
+                workspaceJson.projects[projectName].architect[
+                  targetName
+                ].builder = '@nrwl/web:package';
+              }
             }
-          }
-        );
-      }
-    );
-    return workspaceJson;
-  });
+          );
+        }
+      );
+      return workspaceJson;
+    }),
+    formatFiles()
+  ]);
 }

--- a/packages/web/src/migrations/update-9-2-0/set-build-libs-from-source.ts
+++ b/packages/web/src/migrations/update-9-2-0/set-build-libs-from-source.ts
@@ -1,23 +1,26 @@
-import { Rule } from '@angular-devkit/schematics';
-import { updateWorkspaceInTree } from '@nrwl/workspace';
+import { chain, Rule } from '@angular-devkit/schematics';
+import { formatFiles, updateWorkspaceInTree } from '@nrwl/workspace';
 
 export default function update(): Rule {
-  return updateWorkspaceInTree(workspaceJson => {
-    Object.entries<any>(workspaceJson.projects).forEach(
-      ([projectName, project]) => {
-        Object.entries<any>(project.architect).forEach(
-          ([targetName, targetConfig]) => {
-            if (targetConfig.builder === '@nrwl/web:build') {
-              const architect =
-                workspaceJson.projects[projectName].architect[targetName];
-              if (architect && architect.options) {
-                architect.options.buildLibsFromSource = true;
+  return chain([
+    updateWorkspaceInTree(workspaceJson => {
+      Object.entries<any>(workspaceJson.projects).forEach(
+        ([projectName, project]) => {
+          Object.entries<any>(project.architect).forEach(
+            ([targetName, targetConfig]) => {
+              if (targetConfig.builder === '@nrwl/web:build') {
+                const architect =
+                  workspaceJson.projects[projectName].architect[targetName];
+                if (architect && architect.options) {
+                  architect.options.buildLibsFromSource = true;
+                }
               }
             }
-          }
-        );
-      }
-    );
-    return workspaceJson;
-  });
+          );
+        }
+      );
+      return workspaceJson;
+    }),
+    formatFiles()
+  ]);
 }

--- a/packages/workspace/src/migrations/update-8-10-0/fix-tslint-json.ts
+++ b/packages/workspace/src/migrations/update-8-10-0/fix-tslint-json.ts
@@ -9,6 +9,7 @@ import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 
 import { updateJsonInTree } from '../../utils/ast-utils';
 import { getWorkspace } from '../../utils/workspace';
+import { formatFiles } from '@nrwl/workspace';
 
 async function fixTslints(host: Tree) {
   const workspace = await getWorkspace(host);
@@ -32,6 +33,8 @@ async function fixTslints(host: Tree) {
       );
     }
   });
+
+  rules.push(formatFiles());
 
   return chain(rules);
 }

--- a/packages/workspace/src/migrations/update-8-12-0/update-package-json-deps.ts
+++ b/packages/workspace/src/migrations/update-8-12-0/update-package-json-deps.ts
@@ -14,7 +14,6 @@ export default function(): Rule {
       path.join(__dirname, '../../..', 'migrations.json'),
       '8120'
     ),
-    // addInstall,
     formatFiles()
   ]);
 }

--- a/packages/workspace/src/migrations/update-8-2-0/update-8-2-0.ts
+++ b/packages/workspace/src/migrations/update-8-2-0/update-8-2-0.ts
@@ -1,5 +1,7 @@
 import { updateWorkspace } from '../../utils/workspace';
 import { join, JsonArray, normalize } from '@angular-devkit/core';
+import { formatFiles } from '@nrwl/workspace';
+import { chain } from '@angular-devkit/schematics';
 
 const addExcludes = updateWorkspace(workspace => {
   workspace.projects.forEach(project => {
@@ -21,5 +23,5 @@ const addExcludes = updateWorkspace(workspace => {
 });
 
 export default function() {
-  return addExcludes;
+  return chain([addExcludes, formatFiles()]);
 }

--- a/packages/workspace/src/migrations/update-8-3-0/rename-lint.ts
+++ b/packages/workspace/src/migrations/update-8-3-0/rename-lint.ts
@@ -1,4 +1,6 @@
 import { updateJsonInTree } from '../../utils/ast-utils';
+import { formatFiles } from '@nrwl/workspace';
+import { chain } from '@angular-devkit/schematics';
 
 const updateLint = updateJsonInTree('package.json', json => {
   if (
@@ -15,5 +17,5 @@ const updateLint = updateJsonInTree('package.json', json => {
 });
 
 export default function() {
-  return updateLint;
+  return chain([updateLint, formatFiles()]);
 }

--- a/packages/workspace/src/migrations/update-8-3-0/update-cypress-to-34.ts
+++ b/packages/workspace/src/migrations/update-8-3-0/update-cypress-to-34.ts
@@ -1,4 +1,4 @@
-import { updateJsonInTree } from '@nrwl/workspace';
+import { formatFiles, updateJsonInTree } from '@nrwl/workspace';
 import { chain, SchematicContext } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 
@@ -16,5 +16,5 @@ const addInstall = (_: any, context: SchematicContext) => {
 };
 
 export default function() {
-  return chain([updateCypress, addInstall]);
+  return chain([updateCypress, addInstall, formatFiles()]);
 }

--- a/packages/workspace/src/migrations/update-8-4-0/add-nx-script.ts
+++ b/packages/workspace/src/migrations/update-8-4-0/add-nx-script.ts
@@ -1,4 +1,6 @@
 import { updateJsonInTree } from '../../utils/ast-utils';
+import { chain } from '@angular-devkit/schematics';
+import { formatFiles } from '@nrwl/workspace';
 
 const addNxScript = updateJsonInTree('package.json', json => {
   if (json.scripts && !json.scripts.nx) {
@@ -8,5 +10,5 @@ const addNxScript = updateJsonInTree('package.json', json => {
 });
 
 export default function() {
-  return addNxScript;
+  return chain([addNxScript, formatFiles()]);
 }

--- a/packages/workspace/src/migrations/update-8-5-0/fix-tsconfig-lib-json.ts
+++ b/packages/workspace/src/migrations/update-8-5-0/fix-tsconfig-lib-json.ts
@@ -1,32 +1,36 @@
-import { Tree, SchematicContext } from '@angular-devkit/schematics';
+import { Tree, SchematicContext, chain } from '@angular-devkit/schematics';
 import { readWorkspace, readJsonInTree } from '../../utils/ast-utils';
+import { formatFiles } from '@nrwl/workspace';
 
 export default function() {
-  return (host: Tree) => {
-    const config = readWorkspace(host);
+  return chain([
+    (host: Tree) => {
+      const config = readWorkspace(host);
 
-    const configsToUpdate = [];
-    Object.keys(config.projects).forEach(name => {
-      const project = config.projects[name];
-      if (
-        project.projectType === 'library' &&
-        project.architect &&
-        project.architect.test &&
-        project.architect.test.builder === '@nrwl/jest:jest' &&
-        project.architect.test.options &&
-        project.architect.test.options.setupFile ===
-          project.sourceRoot + '/test-setup.ts'
-      ) {
-        configsToUpdate.push(project.root + '/tsconfig.lib.json');
-      }
-    });
+      const configsToUpdate = [];
+      Object.keys(config.projects).forEach(name => {
+        const project = config.projects[name];
+        if (
+          project.projectType === 'library' &&
+          project.architect &&
+          project.architect.test &&
+          project.architect.test.builder === '@nrwl/jest:jest' &&
+          project.architect.test.options &&
+          project.architect.test.options.setupFile ===
+            project.sourceRoot + '/test-setup.ts'
+        ) {
+          configsToUpdate.push(project.root + '/tsconfig.lib.json');
+        }
+      });
 
-    configsToUpdate.forEach(config => {
-      const tsconfig = readJsonInTree(host, config);
-      if (tsconfig.exclude && tsconfig.exclude[0] === 'src/test.ts') {
-        tsconfig.exclude[0] = 'src/test-setup.ts';
-        host.overwrite(config, JSON.stringify(tsconfig));
-      }
-    });
-  };
+      configsToUpdate.forEach(config => {
+        const tsconfig = readJsonInTree(host, config);
+        if (tsconfig.exclude && tsconfig.exclude[0] === 'src/test.ts') {
+          tsconfig.exclude[0] = 'src/test-setup.ts';
+          host.overwrite(config, JSON.stringify(tsconfig));
+        }
+      });
+    },
+    formatFiles()
+  ]);
 }

--- a/packages/workspace/src/migrations/update-9-0-0/update-9-0-0.ts
+++ b/packages/workspace/src/migrations/update-9-0-0/update-9-0-0.ts
@@ -1,5 +1,5 @@
 import { chain } from '@angular-devkit/schematics';
-import { updatePackagesInPackageJson } from '@nrwl/workspace';
+import { formatFiles, updatePackagesInPackageJson } from '@nrwl/workspace';
 import { join } from 'path';
 
 const updatePackages = updatePackagesInPackageJson(
@@ -8,5 +8,5 @@ const updatePackages = updatePackagesInPackageJson(
 );
 
 export default function() {
-  return chain([updatePackages]);
+  return chain([updatePackages, formatFiles()]);
 }

--- a/packages/workspace/src/migrations/update-9-1-0/update-9-1-0.ts
+++ b/packages/workspace/src/migrations/update-9-1-0/update-9-1-0.ts
@@ -1,5 +1,5 @@
 import { chain } from '@angular-devkit/schematics';
-import { updatePackagesInPackageJson } from '@nrwl/workspace';
+import { formatFiles, updatePackagesInPackageJson } from '@nrwl/workspace';
 import { join } from 'path';
 
 const updatePackages = updatePackagesInPackageJson(
@@ -7,5 +7,5 @@ const updatePackages = updatePackagesInPackageJson(
   '9.1.0'
 );
 export default function() {
-  return chain([updatePackages]);
+  return chain([updatePackages, formatFiles()]);
 }

--- a/packages/workspace/src/migrations/update-9-1-0/update-lint-config.ts
+++ b/packages/workspace/src/migrations/update-9-1-0/update-lint-config.ts
@@ -1,5 +1,5 @@
-import { SchematicContext, Tree } from '@angular-devkit/schematics';
-import { readWorkspace, updateJsonInTree } from '@nrwl/workspace';
+import { chain, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { formatFiles, readWorkspace, updateJsonInTree } from '@nrwl/workspace';
 
 function updateLintConfigurations(host: Tree, context: SchematicContext) {
   const workspaceJson = readWorkspace(host);
@@ -52,5 +52,5 @@ function updateJson(visitor, path, host, context) {
 }
 
 export default function() {
-  return updateLintConfigurations;
+  return chain([updateLintConfigurations, formatFiles()]);
 }

--- a/packages/workspace/src/migrations/update-9-2-0/update-9-2-0.ts
+++ b/packages/workspace/src/migrations/update-9-2-0/update-9-2-0.ts
@@ -1,5 +1,5 @@
 import { chain } from '@angular-devkit/schematics';
-import { updateJsonInTree } from '@nrwl/workspace';
+import { formatFiles, updateJsonInTree } from '@nrwl/workspace';
 
 const addCacheableOperations = updateJsonInTree('nx.json', nxJson => {
   nxJson.tasksRunnerOptions = nxJson.tasksRunnerOptions || {};
@@ -47,5 +47,5 @@ const addCacheableOperations = updateJsonInTree('nx.json', nxJson => {
 });
 
 export default function() {
-  return chain([addCacheableOperations]);
+  return chain([addCacheableOperations, formatFiles()]);
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

A lot of migrations are missing a step to format files. This puts the repo in a state that does not pass formatting checks after migrations.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Formatting has been added to all migrations so that repos do not end up in a state that does not pass formatting checks.

## Issue
Fixes #2685 