### PR TITLE
feat(node): add memory limit option

### DIFF
--- a/docs/angular/api-node/builders/build.md
+++ b/docs/angular/api-node/builders/build.md
@@ -66,6 +66,12 @@ Type: `number`
 
 Number of workers to use for type checking. (defaults to # of CPUS - 2)
 
+### memoryLimit
+
+Type: `number`
+
+Memory limit for type checking service process in MB. (defaults to 2048)
+
 ### optimization
 
 Default: `false`

--- a/docs/react/api-node/builders/build.md
+++ b/docs/react/api-node/builders/build.md
@@ -67,6 +67,12 @@ Type: `number`
 
 Number of workers to use for type checking. (defaults to # of CPUS - 2)
 
+### memoryLimit
+
+Type: `number`
+
+Memory limit for type checking service process in MB. (defaults to 2048)
+
 ### optimization
 
 Default: `false`

--- a/packages/node/src/builders/build/schema.json
+++ b/packages/node/src/builders/build/schema.json
@@ -87,6 +87,10 @@
       "type": "number",
       "description": "Number of workers to use for type checking. (defaults to # of CPUS - 2)"
     },
+    "memoryLimit": {
+      "type": "number",
+      "description": "Memory limit for type checking service process in MB. (defaults to 2048)"
+    },
     "fileReplacements": {
       "description": "Replace files with other files in the build.",
       "type": "array",

--- a/packages/node/src/utils/config.spec.ts
+++ b/packages/node/src/utils/config.spec.ts
@@ -275,6 +275,20 @@ describe('getBaseWebpackPartial', () => {
     });
   });
 
+  describe('the memory limit option', () => {
+    it('should set the memory limit for the type checker', () => {
+      const result = getBaseWebpackPartial({
+        ...input,
+        memoryLimit: 512
+      });
+
+      const typeCheckerPlugin = result.plugins.find(
+        plugin => plugin instanceof ForkTsCheckerWebpackPlugin
+      ) as ForkTsCheckerWebpackPlugin;
+      expect(typeCheckerPlugin.options.memoryLimit).toEqual(512);
+    });
+  });
+
   describe('the assets option', () => {
     it('should add a copy-webpack-plugin', () => {
       const result = getBaseWebpackPartial({

--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -65,6 +65,9 @@ export function getBaseWebpackPartial(
     plugins: [
       new ForkTsCheckerWebpackPlugin({
         tsconfig: options.tsConfig,
+        memoryLimit:
+          options.memoryLimit ||
+          ForkTsCheckerWebpackPlugin.DEFAULT_MEMORY_LIMIT,
         workers: options.maxWorkers || ForkTsCheckerWebpackPlugin.TWO_CPUS_FREE,
         useTypescriptIncrementalApi: false
       })

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -26,6 +26,7 @@ export interface BuildBuilderOptions {
   optimization?: boolean | OptimizationOptions;
   showCircularDependencies?: boolean;
   maxWorkers?: number;
+  memoryLimit?: number;
   poll?: number;
 
   fileReplacements: FileReplacement[];


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`--memoryLimit` is not an option for the node builder.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`--memoryLimit` is an option for the node builder to limit the amount of memory each worker is allocated.

## Issue
Fixes #2716