### PR TITLE
fix(core): add -d as alias for --dryRun for tao generate

### DIFF
--- a/packages/tao/src/commands/generate.ts
+++ b/packages/tao/src/commands/generate.ts
@@ -59,7 +59,8 @@ function parseGenerateOpts(
     minimist(args, {
       boolean: ['help', 'dryRun', 'debug', 'force', 'interactive'],
       alias: {
-        dryRun: 'dry-run'
+        dryRun: 'dry-run',
+        d: 'dryRun'
       },
       default: {
         debug: false,
@@ -102,6 +103,7 @@ function parseGenerateOpts(
   };
 
   delete schematicOptions.debug;
+  delete schematicOptions.d;
   delete schematicOptions.dryRun;
   delete schematicOptions.force;
   delete schematicOptions.interactive;


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`-d` is not an alias for dry run when generating code.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`-d` is an alias for `--dry-run` when generating code.

## Issue
