### PR TITLE
fix(storybook): add install after adding @nrwl/storybook

### DIFF
--- a/packages/storybook/src/utils/versions.ts
+++ b/packages/storybook/src/utils/versions.ts
@@ -1,3 +1,4 @@
+export const nxVersion = '*';
 export const storybookVersion = '5.3.9';
 export const babelCoreVersion = '7.8.3';
 export const babelLoaderVersion = '8.0.6';


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Storybook deps are not installed after using `ng g @nrwl/angular:storybook-configuration`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Storybook deps are installed after using `ng g @nrwl/angular:storybook-configuration`

## Issue
