### PR TITLE
docs(docs): fix grammar in @nxtend/ionic-react description

### DIFF
--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "@nxtend/ionic-react",
-    "description": "An Nx plugin for developing Ionic React applications and libraries.",
+    "description": "An Nx plugin for developing Ionic React applications and libraries",
     "url": "https://github.com/devinshoemaker/nxtend"
   },
   {

--- a/docs/react/tutorial/05-add-node-app.md
+++ b/docs/react/tutorial/05-add-node-app.md
@@ -31,7 +31,7 @@ Nx is an open platform with plugins for many modern tools and frameworks. **To s
 
 >  NX  Community plugins:
 
-  @nxtend/ionic-react - An Nx plugin for developing Ionic React applications and libraries.
+  @nxtend/ionic-react - An Nx plugin for developing Ionic React applications and libraries
   @angular-architects/ddd - Nx plugin for structuring a monorepo with domains and layers
   ...
 ```

--- a/docs/shared/plugins-overview.md
+++ b/docs/shared/plugins-overview.md
@@ -35,7 +35,7 @@ Use the `nx list` command to see installed and available plugins. Both Nrwl main
 
 >  NX  Community plugins:
 
-  @nxtend/ionic-react - An Nx plugin for developing Ionic React applications and libraries.
+  @nxtend/ionic-react - An Nx plugin for developing Ionic React applications and libraries
   @angular-architects/ddd - Nx plugin for structuring a monorepo with domains and layers
   @offeringsolutions/nx-karma-to-jest - Nx plugin for replacing karma with jest in an Nx workspace
   @flowaccount/nx-serverless - Nx plugin for node/angular-universal schematics and deployment builders in an Nx workspace


### PR DESCRIPTION
This change makes the description of the @nxtend/ionic-react Nx plugin grammatically consistent with the other plugins.

The Nrwl team seems pretty strict with their commit messages, so hopefully, this fits the changes at hand.

## Current Behavior (This is the behavior we have today, before the PR is merged)

The grammatical inconsistency of the community Nx plugin descriptions drives me crazy. 😄

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The grammar of the community Nx plugin descriptions is consistent and clean. 😎