### PR TITLE
fix(docs): update ng for nx in documentation

### DIFF
--- a/docs/angular/api-workspace/builders/run-commands.md
+++ b/docs/angular/api-workspace/builders/run-commands.md
@@ -144,7 +144,7 @@ nx affected --target=generate-docs
 
 Type: `string`
 
-Extra arguments. You can pass them as follows: ng run project:target --args='--wait=100'. You can then use {args.wait} syntax to interpolate them in the workspace config file. See example [above](#chaining-commands-interpolating-args-and-setting-the-cwd)
+Extra arguments. You can pass them as follows: nx run project:target --args='--wait=100'. You can then use {args.wait} syntax to interpolate them in the workspace config file. See example [above](#chaining-commands-interpolating-args-and-setting-the-cwd)
 
 ### color
 

--- a/docs/angular/tutorial/10-computation-caching.md
+++ b/docs/angular/tutorial/10-computation-caching.md
@@ -5,7 +5,7 @@ Nx has built-in computation caching, which helps drastically improve the perform
 **To see it in action, run `nx build todos`:**
 
 ```bash
-> ng run todos:build
+> nx run todos:build
 Generating ES5 bundles for differential loading...
 ES5 bundle generation complete.
 
@@ -24,7 +24,7 @@ chunk {vendor} vendor-es5.js, vendor-es5.js.map (vendor) 2.75 MB [initial] [rend
 **Now, run `nx build todos` again, and you will see the results appearing instantly:**
 
 ```bash
-> ng run todos:build
+> nx run todos:build
 
 >  NX   NOTE  Cached Output:
 

--- a/docs/react/api-workspace/builders/run-commands.md
+++ b/docs/react/api-workspace/builders/run-commands.md
@@ -145,7 +145,7 @@ nx affected --target=generate-docs
 
 Type: `string`
 
-Extra arguments. You can pass them as follows: ng run project:target --args='--wait=100'. You can then use {args.wait} syntax to interpolate them in the workspace config file. See example [above](#chaining-commands-interpolating-args-and-setting-the-cwd)
+Extra arguments. You can pass them as follows: nx run project:target --args='--wait=100'. You can then use {args.wait} syntax to interpolate them in the workspace config file. See example [above](#chaining-commands-interpolating-args-and-setting-the-cwd)
 
 ### color
 

--- a/docs/shared/running-custom-commands.md
+++ b/docs/shared/running-custom-commands.md
@@ -38,7 +38,7 @@ Note: Replace `apps/my-app/tsconfig.app.json` with the appropriate `tsconfig.jso
 To run the builder for a single project:
 
 ```bash
-ng run my-app:compodoc
+nx run my-app:compodoc
 ```
 
 To run the builder for all affected projects:

--- a/packages/workspace/src/builders/run-commands/schema.json
+++ b/packages/workspace/src/builders/run-commands/schema.json
@@ -29,7 +29,7 @@
     },
     "args": {
       "type": "string",
-      "description": "Extra arguments. You can pass them as follows: ng run project:target --args='--wait=100'. You can then use {args.wait} syntax to interpolate them in the workspace config file. See example [above](#chaining-commands-interpolating-args-and-setting-the-cwd)"
+      "description": "Extra arguments. You can pass them as follows: nx run project:target --args='--wait=100'. You can then use {args.wait} syntax to interpolate them in the workspace config file. See example [above](#chaining-commands-interpolating-args-and-setting-the-cwd)"
     },
     "envFile": {
       "type": "string",


### PR DESCRIPTION
Got few places where `ng` was still used.