### PR TITLE
fix(testing): fix cypress headless mode for some versions

### DIFF
--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -155,6 +155,7 @@ function initCypress(
   }
 
   options.exit = exit;
+  options.headed = !headless;
   options.headless = headless;
   options.record = record;
   options.key = key;


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Some versions of cypress do not work well with the `headless` option and still use `headed`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Both the `headless` and `headed` option should be passed for compatibility with all versions.

## Issue
