### PR TITLE
fix(angular): add migration to update to angular 9.1.0

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -25,6 +25,11 @@
       "version": "9.0.0-beta.1",
       "description": "Upgrades Angular and Angular CLI to 9.0.0",
       "factory": "./src/migrations/update-9-0-0/update-9-0-0"
+    },
+    "update-9-2-2": {
+      "version": "9.2.2-beta.1",
+      "description": "Upgrades Angular to 9.1.0",
+      "factory": "./src/migrations/update-9-2-2/update-9-2-2"
     }
   }
 }

--- a/packages/angular/src/migrations/update-9-2-2/update-9-2-2.ts
+++ b/packages/angular/src/migrations/update-9-2-2/update-9-2-2.ts
@@ -1,0 +1,10 @@
+import { chain, SchematicContext } from '@angular-devkit/schematics';
+import { addUpdateTask, formatFiles } from '@nrwl/workspace';
+import { RunSchematicTask } from '@angular-devkit/schematics/tasks';
+import { join } from 'path';
+
+export default function() {
+  return (_, context: SchematicContext) => {
+    return chain([addUpdateTask('@angular/core', '^9.1.0'), formatFiles()]);
+  };
+}


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

There is no migration to angular 9.1.0 which is needed for compatibility with typescript 3.8. 

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

angular is migrated to 9.1.0 which is needed for compatibility with typescript 3.8

## Issue
