### PR TITLE
fix(angular): extend angular version range to anything higher than 9.1

### DIFF
--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -1,5 +1,5 @@
 export const nxVersion = '*';
-export const angularVersion = '9.1.0';
+export const angularVersion = '^9.1.0';
 export const angularDevkitVersion = '0.901.0';
 export const angularJsVersion = '1.6.6';
 export const ngrxVersion = '9.0.0';


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Using `ng add @nrwl/angular` sets the version of angular framework to `9.1.0`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Using `ng add @nrwl/angular` sets the latest 9.x version of angular higher than 9.1.0.

## Issue
Fixes https://github.com/nrwl/nx/issues/2751