### PR TITLE
fix(testing): add migration for jest to migration.json

### DIFF
--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -19,6 +19,11 @@
       "version": "9.0.1-beta.1",
       "description": "Correctly sets passWithNoTests option",
       "factory": "./src/migrations/update-9-0-1/update-9-0-1"
+    },
+    "update-9.2.0": {
+      "version": "9.2.0-beta.3",
+      "description": "Update jest to v25",
+      "factory": "./src/migrations/update-9-2-0/update-9-2-0"
     }
   },
   "packageJsonUpdates": {


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

The update to jest 25 is not registered in migration.json so it does not work with `ng update`

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The update is registered in migration.json so it does work with `ng update`.

## Issue
