### PR TITLE
fix(core): return single level roots as is without slicing

### DIFF
--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -249,11 +249,12 @@ export function mtime(filePath: string): number {
 
 export function normalizedProjectRoot(p: ProjectGraphNode): string {
   if (p.data && p.data.root) {
-    return p.data.root
-      .split('/')
-      .filter(v => !!v)
-      .slice(1)
-      .join('/');
+    const path = p.data.root.split('/').filter(v => !!v);
+    if (path.length === 1) {
+      return path[0];
+    }
+    // Remove the first part of the path, usually 'libs'
+    return path.slice(1).join('/');
   } else {
     return '';
   }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

If a project's root has only a single level in it's path, it is improperly labeled as a dependency of some projects.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

A project with a single level root is not improperly labeled as dependencies of projects.

## Issue
Fixes https://github.com/nrwl/nx/issues/2778