### PR TITLE
fix(nextjs): add missing node-sass dependency when using sass

### DIFF
--- a/packages/next/src/schematics/application/lib/add-style-dependencies.ts
+++ b/packages/next/src/schematics/application/lib/add-style-dependencies.ts
@@ -6,7 +6,8 @@ import {
   zeitNextCss,
   zeitNextLess,
   zeitNextSass,
-  zeitNextStylus
+  zeitNextStylus,
+  nodeSass
 } from '../../../utils/versions';
 
 const NEXT_SPECIFIC_STYLE_DEPENDENCIES = {
@@ -15,7 +16,9 @@ const NEXT_SPECIFIC_STYLE_DEPENDENCIES = {
     dependencies: {
       '@zeit/next-css': zeitNextCss
     },
-    devDependencies: {}
+    devDependencies: {
+      'node-sass': nodeSass
+    }
   },
   scss: {
     dependencies: {

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -3,5 +3,6 @@ export const nxVersion = '*';
 export const nextVersion = '9.3.3';
 export const zeitNextCss = '1.0.1';
 export const zeitNextSass = '1.0.1';
+export const nodeSass = '4.13.1';
 export const zeitNextLess = '1.0.1';
 export const zeitNextStylus = '1.0.1';


### PR DESCRIPTION
Because `node-sass` was listed as an optional peer dependency by the `sass-loader`, it was not getting added to `node_modules`, so the build would fail.

Closes #2574
