### PR TITLE
fix(react): fix build options being overwritten by undefined serve options

### DIFF
--- a/packages/web/src/builders/dev-server/dev-server.impl.ts
+++ b/packages/web/src/builders/dev-server/dev-server.impl.ts
@@ -118,10 +118,16 @@ function run(
 
 function getBuildOptions(
   options: WebDevServerOptions,
-  context: BuilderContext,
-  overrides?: Partial<WebBuildBuilderOptions>
+  context: BuilderContext
 ): Observable<WebBuildBuilderOptions> {
   const target = targetFromTargetString(options.buildTarget);
+  const overrides: Partial<WebBuildBuilderOptions> = {};
+  if (options.maxWorkers) {
+    overrides.maxWorkers = options.maxWorkers;
+  }
+  if (options.memoryLimit) {
+    overrides.memoryLimit = options.memoryLimit;
+  }
   return from(
     Promise.all([
       context.getTargetOptions(target),

--- a/packages/web/src/utils/devserver.config.spec.ts
+++ b/packages/web/src/utils/devserver.config.spec.ts
@@ -448,8 +448,8 @@ describe('getDevServerConfig', () => {
           const result = getDevServerConfig(
             root,
             sourceRoot,
-            buildInput,
-            { ...serveInput, maxWorkers: 1 },
+            { ...buildInput, maxWorkers: 1 },
+            serveInput,
             logger
           ) as any;
 
@@ -465,8 +465,8 @@ describe('getDevServerConfig', () => {
           const result = getDevServerConfig(
             root,
             sourceRoot,
-            buildInput,
-            { ...serveInput, memoryLimit: 1024 },
+            { ...buildInput, memoryLimit: 1024 },
+            serveInput,
             logger
           ) as any;
 

--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -23,11 +23,7 @@ export function getDevServerConfig(
   const webpackConfig: Configuration = getWebConfig(
     root,
     sourceRoot,
-    {
-      ...buildOptions,
-      maxWorkers: serveOptions.maxWorkers,
-      memoryLimit: serveOptions.memoryLimit
-    },
+    buildOptions,
     logger,
     true, // Don't need to support legacy browsers for dev.
     false


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Build options for `maxWorkers` and `memoryLimit` were being overwritten by undefined serve options.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Build options for `maxWorkers` and `memoryLimit` should persist if there are no serve options for `maxWorkers` and `memoryLimit` respectively.

## Issue
