### PR TITLE
fix(core): rework where tmp tsconfigs are generated

### DIFF
--- a/packages/node/src/builders/package/package.impl.spec.ts
+++ b/packages/node/src/builders/package/package.impl.spec.ts
@@ -284,7 +284,12 @@ describe('NodeCompileBuilder', () => {
     });
 
     it('should call the tsc compiler with the modified tsconfig.json', done => {
-      let tmpTsConfigPath = join('libs/nodelib', 'tsconfig.nx-tmp');
+      let tmpTsConfigPath = join(
+        '/root',
+        'tmp',
+        'libs/nodelib',
+        'tsconfig.generated.json'
+      );
 
       runNodePackageBuilder(testOptions, context).subscribe({
         complete: () => {

--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -32,7 +32,7 @@ import {
   calculateProjectDependencies,
   checkDependentProjectsHaveBeenBuilt,
   DependentBuildableProjectNode,
-  readTsConfigWithRemappedPaths,
+  computeCompilerOptionsPaths,
   updateBuildableProjectPackageJsonDependencies
 } from '@nrwl/workspace/src/utils/buildable-libs-utils';
 
@@ -147,7 +147,7 @@ function createRollupOptions(
   context: BuilderContext,
   packageJson: any
 ): rollup.InputOptions {
-  const parsedTSConfig = readTsConfigWithRemappedPaths(
+  const compilerOptionPaths = computeCompilerOptionsPaths(
     options.tsConfig,
     dependencies
   );
@@ -162,7 +162,7 @@ function createRollupOptions(
           rootDir: options.entryRoot,
           allowJs: false,
           declaration: true,
-          paths: parsedTSConfig.compilerOptions.paths
+          paths: compilerOptionPaths
         }
       }
     }),


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

A tmp file is created within the project root

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

A tmp file is created within a tmp directory which is gitignored by defualt.

## Issue
Fixes #2790 