### PR TITLE
fix(core): runtime support for outputPath array on run-commands builder

### DIFF
--- a/docs/angular/api-linter/builders/lint.md
+++ b/docs/angular/api-linter/builders/lint.md
@@ -88,6 +88,6 @@ Hide output text.
 
 ### tsConfig
 
-Type: `string`
+Type: `string | array`
 
 The name of the TypeScript configuration file.

--- a/docs/angular/api-node/builders/build.md
+++ b/docs/angular/api-node/builders/build.md
@@ -24,7 +24,7 @@ Read buildable libraries from source instead of building them separately.
 
 Default: `all`
 
-Type: `string`
+Type: `string | array`
 
 Dependencies to keep external to the bundle. ("all" (default), "none", or an array of module names)
 

--- a/docs/angular/api-node/builders/execute.md
+++ b/docs/angular/api-node/builders/execute.md
@@ -30,7 +30,7 @@ The host to inspect the process on
 
 Default: `inspect`
 
-Type: `string`
+Type: `string | boolean`
 
 Ensures the app is starting with debugging
 

--- a/docs/angular/api-workspace/builders/run-commands.md
+++ b/docs/angular/api-workspace/builders/run-commands.md
@@ -178,7 +178,7 @@ You may specify a custom .env file path
 
 ### outputPath
 
-Type: `string`
+Type: `string | array`
 
 Tells Nx where the files will be created
 

--- a/docs/react/api-linter/builders/lint.md
+++ b/docs/react/api-linter/builders/lint.md
@@ -89,6 +89,6 @@ Hide output text.
 
 ### tsConfig
 
-Type: `string`
+Type: `string | array`
 
 The name of the TypeScript configuration file.

--- a/docs/react/api-node/builders/build.md
+++ b/docs/react/api-node/builders/build.md
@@ -25,7 +25,7 @@ Read buildable libraries from source instead of building them separately.
 
 Default: `all`
 
-Type: `string`
+Type: `string | array`
 
 Dependencies to keep external to the bundle. ("all" (default), "none", or an array of module names)
 

--- a/docs/react/api-node/builders/execute.md
+++ b/docs/react/api-node/builders/execute.md
@@ -31,7 +31,7 @@ The host to inspect the process on
 
 Default: `inspect`
 
-Type: `string`
+Type: `string | boolean`
 
 Ensures the app is starting with debugging
 

--- a/docs/react/api-workspace/builders/run-commands.md
+++ b/docs/react/api-workspace/builders/run-commands.md
@@ -179,7 +179,7 @@ You may specify a custom .env file path
 
 ### outputPath
 
-Type: `string`
+Type: `string | array`
 
 Tells Nx where the files will be created
 

--- a/packages/workspace/src/tasks-runner/utils.ts
+++ b/packages/workspace/src/tasks-runner/utils.ts
@@ -71,7 +71,7 @@ export function getOutputsForTargetAndConfiguration(
   }
 
   if (opts.outputPath) {
-    return [opts.outputPath];
+    return Array.isArray(opts.outputPath) ? opts.outputPath : [opts.outputPath];
   } else if (target === 'build') {
     return [`dist/${node.data.root}`];
   } else {

--- a/scripts/documentation/generate-builders-data.ts
+++ b/scripts/documentation/generate-builders-data.ts
@@ -111,11 +111,19 @@ function generateTemplate(
               option.default === undefined || option.default === ''
                 ? ''
                 : `Default: \`${option.default}\`\n`
-            }
-            Type: \`${option.type}\` ${
-          option.arrayOfType ? `of \`${option.arrayOfType}\`` : ''
-        } \n 
-            
+            }`;
+
+        if (option.types && option.types.length) {
+          template += dedent`
+              Type: \`${option.types.join(' | ')} \`\n`;
+        } else {
+          template += dedent`
+              Type: \`${option.type}\` ${
+            option.arrayOfType ? `of \`${option.arrayOfType}\`` : ''
+          } \n`;
+        }
+
+        template += dedent`  
             ${enumStr} 
             ${option.description}
           `;


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

Discussed with @vsavkin already, the schema for run-commands builder supports an array of strings for `outputPath`, but it was never supported at runtime. I have a use-case for this.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`outputPath` option for run-commands builder supports either a string or an array of strings.

## Issue

--------------------

Note: through this I also discovered that the documentation generator code is not taking into account options with multiple types, so I have addressed that in the most minimal way possible in this PR.

I would suggest taking a look at the code that handles doc generation to improve it to use e.g. `string[]` instead of `array`. All the info is available to the tool but it could do with some refactoring to make this flow through to the docs
