### PR TITLE
fix(core): fix source map generation for production build

### DIFF
--- a/packages/web/src/utils/config.ts
+++ b/packages/web/src/utils/config.ts
@@ -97,7 +97,7 @@ export function getBaseWebpackPartial(
 
   if (isScriptOptimizeOn) {
     webpackConfig.optimization = {
-      minimizer: [createTerserPlugin(esm)],
+      minimizer: [createTerserPlugin(esm, !!options.sourceMap)],
       runtimeChunk: true
     };
   }
@@ -167,10 +167,11 @@ function getAliases(options: BuildBuilderOptions): { [key: string]: string } {
   );
 }
 
-export function createTerserPlugin(esm: boolean) {
+export function createTerserPlugin(esm: boolean, sourceMap: boolean) {
   return new TerserWebpackPlugin({
     parallel: true,
     cache: true,
+    sourceMap,
     terserOptions: {
       ecma: esm ? 6 : 5,
       safari10: true,


### PR DESCRIPTION
ISSUES CLOSED: #2802

## Current Behavior (This is the behavior we have today, before the PR is merged)
If `sourceMap` in workspace.json is set to a value other than false to generate source maps for production build, it shows some warnings which are saying the generated source maps are invalid after the build is finished.

```json
"configurations": {
  "production": {
    ...
    "optimization": true,
    "outputHashing": "all",
    "sourceMap": {
      "scripts": true,
      "hidden": true
    },
```
```bash
$ nx build <project> --prod
```
```
> nx run web:build:production 
Starting type checking service...
Using 6 workers with 2048MB memory limit
Hash: e0c2232e1fa3485acc4d
Built at: 2020-04-04 1:23:05 AM
Entrypoint main = runtime.3931bc0aeebe2d8b8ae7.js main.7f4c2d4a6e8220abaa3a.esm.js main.7f4c2d4a6e8220abaa3a.esm.js.map
Entrypoint polyfills = runtime.3931bc0aeebe2d8b8ae7.js polyfills.f7214edd7f63da46989c.esm.js
chunk    {0} runtime.3931bc0aeebe2d8b8ae7.js (runtime) 0 bytes ={1}= ={2}= [entry] [rendered]
chunk    {1} main.7f4c2d4a6e8220abaa3a.esm.js, main.7f4c2d4a6e8220abaa3a.esm.js.map (main) 221 KiB ={0}= [initial] [rendered]
chunk    {2} polyfills.f7214edd7f63da46989c.esm.js (polyfills) 239 KiB ={0}= [initial] [rendered]

WARNING in runtime.3931bc0aeebe2d8b8ae7.js contains invalid source map

WARNING in polyfills.f7214edd7f63da46989c.esm.js contains invalid source map
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Production builds should be completed with no warning.

## Issue
