### PR TITLE
fix(core): file-utils workspaceFileName now returns proper file name

### DIFF
--- a/packages/web/src/builders/package/run-rollup.ts
+++ b/packages/web/src/builders/package/run-rollup.ts
@@ -8,7 +8,11 @@ export function runRollup(options: rollup.RollupOptions) {
       const outputOptions = Array.isArray(options.output)
         ? options.output
         : [options.output];
-      return from(Promise.all(outputOptions.map(o => bundle.write(o))));
+      return from(
+        Promise.all(
+          (<Array<rollup.OutputOptions>>outputOptions).map(o => bundle.write(o))
+        )
+      );
     }),
     map(() => ({ success: true }))
   );

--- a/packages/workspace/src/command-line/workspace-integrity-checks.spec.ts
+++ b/packages/workspace/src/command-line/workspace-integrity-checks.spec.ts
@@ -68,7 +68,7 @@ describe('WorkspaceIntegrityChecks', () => {
               '-'
             )} Cannot find project 'project1' in 'libs/project1'`
           ],
-          title: 'The angular.json file is out of sync'
+          title: 'The workspace.json file is out of sync'
         }
       ]);
     });

--- a/packages/workspace/src/core/affected-project-graph/locators/workspace-json-changes.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/workspace-json-changes.spec.ts
@@ -3,7 +3,7 @@ import { WholeFileChange } from '../../file-utils';
 import { DiffType } from '../../../utils/json-diff';
 
 describe('getTouchedProjectsInWorkspaceJson', () => {
-  it('should not return changes when angular.json is not touched', () => {
+  it('should not return changes when workspace.json is not touched', () => {
     const result = getTouchedProjectsInWorkspaceJson(
       [
         {
@@ -30,7 +30,7 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
     const result = getTouchedProjectsInWorkspaceJson(
       [
         {
-          file: 'angular.json',
+          file: 'workspace.json',
           ext: '.json',
           mtime: 0,
           getChanges: () => [new WholeFileChange()]
@@ -55,7 +55,7 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
     const result = getTouchedProjectsInWorkspaceJson(
       [
         {
-          file: 'angular.json',
+          file: 'workspace.json',
           ext: '.json',
           mtime: 0,
           getChanges: () => [
@@ -85,11 +85,11 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
     expect(result).toEqual(['proj1', 'proj2']);
   });
 
-  it('should return projects added in angular.json', () => {
+  it('should return projects added in workspace.json', () => {
     const result = getTouchedProjectsInWorkspaceJson(
       [
         {
-          file: 'angular.json',
+          file: 'workspace.json',
           ext: '.json',
           mtime: 0,
           getChanges: () => [
@@ -126,11 +126,11 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
     expect(result).toEqual(['proj1']);
   });
 
-  it('should affect all projects if a project is removed from angular.json', () => {
+  it('should affect all projects if a project is removed from workspace.json', () => {
     const result = getTouchedProjectsInWorkspaceJson(
       [
         {
-          file: 'angular.json',
+          file: 'workspace.json',
           ext: '.json',
           mtime: 0,
           getChanges: () => [
@@ -161,11 +161,11 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
     expect(result).toEqual(['proj1', 'proj2']);
   });
 
-  it('should return projects modified in angular.json', () => {
+  it('should return projects modified in workspace.json', () => {
     const result = getTouchedProjectsInWorkspaceJson(
       [
         {
-          file: 'angular.json',
+          file: 'workspace.json',
           ext: '.json',
           mtime: 0,
           getChanges: () => [

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -6,7 +6,7 @@ import { extname } from 'path';
 import { NxArgs } from '../command-line/utils';
 import { WorkspaceResults } from '../command-line/workspace-results';
 import { appRootPath } from '../utils/app-root';
-import { readJsonFile } from '../utils/fileutils';
+import { readJsonFile, fileExists } from '../utils/fileutils';
 import { jsonDiff } from '../utils/json-diff';
 import { ProjectGraphNode } from './project-graph';
 import { Environment, NxJson } from './shared-interfaces';
@@ -172,11 +172,7 @@ export function cliCommand() {
 }
 
 export function workspaceFileName() {
-  const packageJson = readPackageJson();
-  if (
-    packageJson.devDependencies['@angular/cli'] ||
-    packageJson.dependencies['@angular/cli']
-  ) {
+  if (fileExists(`${appRootPath}/angular.json`)) {
     return 'angular.json';
   } else {
     return 'workspace.json';


### PR DESCRIPTION
This PR picks up where https://github.com/nrwl/nx/pull/2594 left off and fixed all unit tests - thanks to @scallacs original efforts - this one had plagued us for awhile.

## Current Behavior

workspaceFileName() returns 'angular.json' when @angular/cli is in package.json devDependencies even if workspace.json is used.

## Expected Behavior

workspaceFileName() should return `workspace.json` if Nx was configured that way or `angular.json` if it's configured using angular cli.

## Issue

closes https://github.com/nrwl/nx/issues/2253