### PR TITLE
fix(core): adjust nx migrate log

### DIFF
--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -530,6 +530,11 @@ async function generateMigrationsJsonAndUpdatePackageJson(
       logger.info(
         `- there are no migrations to run, so migrations.json has not been created.`
       );
+
+      logger.info(`Next steps:`);
+      logger.info(
+        `- Make sure package.json changes make sense and then run 'npm install' or 'yarn'`
+      );
     }
   } catch (e) {
     const startVersion = versions(root, {})('@nrwl/workspace');


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Right now if we run `nx migrate` and no migration has been produced, the console doesn't print any log about having to run `npm i` or `yarn`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The log about that should be printed as the `package.json` might have been modified, thus requiring an npm install.
