### PR TITLE
fix(angular): remove prod tsconfig for non-publishable lib

### DIFF
--- a/packages/angular/src/schematics/library/library.spec.ts
+++ b/packages/angular/src/schematics/library/library.spec.ts
@@ -118,6 +118,18 @@ describe('lib', () => {
       ).not.toBeDefined();
     });
 
+    it('should remove tsconfib.lib.prod.json when library is not publishable', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', publishable: false },
+        appTree
+      );
+
+      const libProdConfig = tree.read('libs/my-lib/tsconfig.lib.prod.json');
+
+      expect(libProdConfig).toBeFalsy();
+    });
+
     it('should update nx.json', async () => {
       const tree = await runSchematic(
         'lib',

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -258,6 +258,7 @@ function updateProject(options: NormalizedSchema): Rule {
     if (!options.publishable) {
       host.delete(path.join(options.projectRoot, 'ng-package.json'));
       host.delete(path.join(options.projectRoot, 'package.json'));
+      host.delete(path.join(options.projectRoot, 'tsconfig.lib.prod.json'));
     }
 
     host.delete(path.join(options.projectRoot, 'karma.conf.js'));


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

A `tsconfig.lib.prod.json` is retained for non-publishable libs

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

A `tsconfig.lib.prod.json` is not retained for non-publishable libs

## Issue

Closes #2765 