### PR TITLE
docs: add link to nxcloud when generating a new react/angular app

### DIFF
--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -97,13 +97,12 @@ const nrwlHomeTemplate = {
             </a>
         </li>
         <li class="col-span-2">
-            <a class="resource flex" href="https://connect.nrwl.io/">
-                <img
-                        height="36"
-                        alt="Nrwl Connect"
-                        src="https://connect.nrwl.io/assets/img/CONNECT_ColorIcon.png"
-                />
-                <span class="gutter-left">Nrwl Connect</span>
+            <a class="resource flex" href="https://nx.app/">
+                <svg width="36" height="36" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M120 15V30C103.44 30 90 43.44 90 60C90 76.56 76.56 90 60 90C43.44 90 30 103.44 30 120H15C6.72 120 0 113.28 0 105V15C0 6.72 6.72 0 15 0H105C113.28 0 120 6.72 120 15Z" fill="#0E2039"/>
+                  <path d="M120 30V105C120 113.28 113.28 120 105 120H30C30 103.44 43.44 90 60 90C76.56 90 90 76.56 90 60C90 43.44 103.44 30 120 30Z" fill="white"/>
+                </svg>
+                <span class="gutter-left">Nx Cloud</span>
             </a>
         </li>
     </ul>

--- a/packages/react/src/schematics/application/files/app/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/schematics/application/files/app/src/app/__fileName__.tsx__tmpl__
@@ -198,15 +198,12 @@ var innerJsx = `
         </a>
       </li>
       <li className="col-span-2">
-        <a className="resource flex" href="https://connect.nrwl.io/">
-          <img
-            height="36"
-            alt="Nrwl Connect"
-            src="https://connect.nrwl.io/assets/img/CONNECT_ColorIcon.png"
-          />
-          <span  className="gutter-left">
-            Nrwl Connect
-          </span>
+        <a className="resource flex" href="https://nx.app/">
+          <svg width="36" height="36" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M120 15V30C103.44 30 90 43.44 90 60C90 76.56 76.56 90 60 90C43.44 90 30 103.44 30 120H15C6.72 120 0 113.28 0 105V15C0 6.72 6.72 0 15 0H105C113.28 0 120 6.72 120 15Z" fill="#0E2039"/>
+            <path d="M120 30V105C120 113.28 113.28 120 105 120H30C30 103.44 43.44 90 60 90C76.56 90 90 76.56 90 60C90 43.44 103.44 30 120 30Z" fill="white"/>
+          </svg>
+          <span className="gutter-left">Nx Cloud</span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

We don't mention NxCloud in the generated app template.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

We should have a link to NxCloud in our angular/react app's template.
