### PR TITLE
fix(react): exposed the crossOrigin option for web builder options

### DIFF
--- a/docs/angular/api-web/builders/build.md
+++ b/docs/angular/api-web/builders/build.md
@@ -42,6 +42,12 @@ Type: `boolean`
 
 Use a separate bundle containing code used across multiple bundles.
 
+### crossOrigin
+
+Type: `string`
+
+The crossorigin attribute to use for generated javascript script tags. One of 'none' | 'anonymous' | 'use-credentials'
+
 ### deployUrl
 
 Type: `string`

--- a/docs/react/api-web/builders/build.md
+++ b/docs/react/api-web/builders/build.md
@@ -43,6 +43,12 @@ Type: `boolean`
 
 Use a separate bundle containing code used across multiple bundles.
 
+### crossOrigin
+
+Type: `string`
+
+The crossorigin attribute to use for generated javascript script tags. One of 'none' | 'anonymous' | 'use-credentials'
+
 ### deployUrl
 
 Type: `string`

--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -21,6 +21,7 @@ import {
   calculateProjectDependencies,
   createTmpTsConfig
 } from '@nrwl/workspace/src/utils/buildable-libs-utils';
+import { CrossOriginValue } from '../../utils/third-party/cli-files/utilities/index-file/augment-index-html';
 
 export interface WebBuildBuilderOptions extends BuildBuilderOptions {
   index: string;
@@ -29,6 +30,7 @@ export interface WebBuildBuilderOptions extends BuildBuilderOptions {
   deployUrl: string;
 
   extractCss?: boolean;
+  crossOrigin?: CrossOriginValue;
 
   polyfills?: string;
   es2015Polyfills?: string;
@@ -152,6 +154,7 @@ export function run(options: WebBuildBuilderOptions, context: BuilderContext) {
         const success = [result1, result2].every(result => result.success);
         return (options.optimization
           ? writeIndexHtml({
+              crossOrigin: options.crossOrigin,
               host,
               outputPath: devkitJoin(
                 normalize(options.outputPath),

--- a/packages/web/src/builders/build/schema.json
+++ b/packages/web/src/builders/build/schema.json
@@ -3,6 +3,10 @@
   "description": "Web application build target options for Build Facade",
   "type": "object",
   "properties": {
+    "crossOrigin": {
+      "type": "string",
+      "description": "The crossorigin attribute to use for generated javascript script tags.  One of 'none' | 'anonymous' | 'use-credentials'"
+    },
     "main": {
       "type": "string",
       "description": "The name of the main entry-point file."


### PR DESCRIPTION
ISSUES CLOSED: #2419

## Current Behavior (This is the behavior we have today, before the PR is merged)
crossOrigin option is not available for web builder

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
crossOrigin option can be optionally specified 

## Issue
