### PR TITLE
fix: generated tsconfig path mapping for publishable libs (when generated in nested folders)

### DIFF
--- a/docs/angular/api-angular/schematics/library.md
+++ b/docs/angular/api-angular/schematics/library.md
@@ -36,11 +36,25 @@ Type: `boolean`
 
 Add a module spec file.
 
+### buildable
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a buildable library.
+
 ### directory
 
 Type: `string`
 
 A directory where the lib is placed
+
+### importPath
+
+Type: `string`
+
+The library name used to import it, like @myorg/my-awesome-lib. Must be a valid npm name.
 
 ### lazy
 
@@ -72,13 +86,11 @@ The prefix to apply to generated selectors.
 
 ### publishable
 
-Alias(es): buildable
-
 Default: `false`
 
 Type: `boolean`
 
-Generate a buildable library.
+Generate a publishable library.
 
 ### routing
 

--- a/docs/angular/api-nest/schematics/library.md
+++ b/docs/angular/api-nest/schematics/library.md
@@ -36,6 +36,14 @@ nx g lib mylib --directory=myapp
 
 ## Options
 
+### buildable
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a buildable library.
+
 ### controller
 
 Default: `false`
@@ -60,6 +68,12 @@ Type: `boolean`
 
 Add the Global decorator to the generated module.
 
+### importPath
+
+Type: `string`
+
+The library name used to import it, like @myorg/my-awesome-lib. Must be a valid npm name.
+
 ### linter
 
 Default: `tslint`
@@ -78,11 +92,9 @@ Library name
 
 ### publishable
 
-Alias(es): buildable
-
 Type: `boolean`
 
-Create a buildable library.
+Create a publishable library.
 
 ### service
 

--- a/docs/angular/api-node/schematics/library.md
+++ b/docs/angular/api-node/schematics/library.md
@@ -36,6 +36,14 @@ nx g lib mylib --directory=myapp
 
 ## Options
 
+### buildable
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a buildable library.
+
 ### directory
 
 Alias(es): d
@@ -43,6 +51,12 @@ Alias(es): d
 Type: `string`
 
 A directory where the lib is placed
+
+### importPath
+
+Type: `string`
+
+The library name used to import it, like @myorg/my-awesome-lib. Must be a valid npm name.
 
 ### linter
 
@@ -61,8 +75,6 @@ Type: `string`
 Library name
 
 ### publishable
-
-Alias(es): buildable
 
 Type: `boolean`
 

--- a/docs/angular/api-nx-plugin/schematics/plugin.md
+++ b/docs/angular/api-nx-plugin/schematics/plugin.md
@@ -27,7 +27,7 @@ nx g plugin ... --dry-run
 Generate libs/plugins/my-plugin:
 
 ```bash
-nx g plugin my-plugin --directory=plugins
+nx g plugin my-plugin --directory=plugins --importPath=@myorg/my-plugin
 ```
 
 ## Options
@@ -39,6 +39,12 @@ Alias(es): d
 Type: `string`
 
 A directory where the plugin is placed
+
+### importPath
+
+Type: `string`
+
+How the plugin will be published, like @myorg/my-awesome-plugin. Note this must be a valid npm name
 
 ### linter
 

--- a/docs/angular/api-react/schematics/library.md
+++ b/docs/angular/api-react/schematics/library.md
@@ -66,6 +66,12 @@ Type: `string`
 
 A directory where the lib is placed.
 
+### importPath
+
+Type: `string`
+
+The library name used to import it, like @myorg/my-awesome-lib
+
 ### js
 
 Default: `false`

--- a/docs/angular/api-react/schematics/library.md
+++ b/docs/angular/api-react/schematics/library.md
@@ -50,6 +50,14 @@ Type: `string`
 
 The application project to add the library route to.
 
+### buildable
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a buildable library.
+
 ### component
 
 Default: `true`
@@ -108,11 +116,9 @@ Use pascal case component file name (e.g. App.tsx).
 
 ### publishable
 
-Alias(es): buildable
-
 Type: `boolean`
 
-Create a buildable library.
+Create a publishable library.
 
 ### routing
 

--- a/docs/angular/api-workspace/schematics/library.md
+++ b/docs/angular/api-workspace/schematics/library.md
@@ -42,6 +42,12 @@ Type: `string`
 
 A directory where the lib is placed
 
+### importPath
+
+Type: `string`
+
+The library name used to import it, like @myorg/my-awesome-lib
+
 ### linter
 
 Default: `tslint`

--- a/docs/react/api-angular/schematics/library.md
+++ b/docs/react/api-angular/schematics/library.md
@@ -36,11 +36,25 @@ Type: `boolean`
 
 Add a module spec file.
 
+### buildable
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a buildable library.
+
 ### directory
 
 Type: `string`
 
 A directory where the lib is placed
+
+### importPath
+
+Type: `string`
+
+The library name used to import it, like @myorg/my-awesome-lib. Must be a valid npm name.
 
 ### lazy
 
@@ -72,13 +86,11 @@ The prefix to apply to generated selectors.
 
 ### publishable
 
-Alias(es): buildable
-
 Default: `false`
 
 Type: `boolean`
 
-Generate a buildable library.
+Generate a publishable library.
 
 ### routing
 

--- a/docs/react/api-nest/schematics/library.md
+++ b/docs/react/api-nest/schematics/library.md
@@ -36,6 +36,14 @@ nx g lib mylib --directory=myapp
 
 ## Options
 
+### buildable
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a buildable library.
+
 ### controller
 
 Default: `false`
@@ -60,6 +68,12 @@ Type: `boolean`
 
 Add the Global decorator to the generated module.
 
+### importPath
+
+Type: `string`
+
+The library name used to import it, like @myorg/my-awesome-lib. Must be a valid npm name.
+
 ### linter
 
 Default: `tslint`
@@ -78,11 +92,9 @@ Library name
 
 ### publishable
 
-Alias(es): buildable
-
 Type: `boolean`
 
-Create a buildable library.
+Create a publishable library.
 
 ### service
 

--- a/docs/react/api-node/schematics/library.md
+++ b/docs/react/api-node/schematics/library.md
@@ -36,6 +36,14 @@ nx g lib mylib --directory=myapp
 
 ## Options
 
+### buildable
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a buildable library.
+
 ### directory
 
 Alias(es): d
@@ -43,6 +51,12 @@ Alias(es): d
 Type: `string`
 
 A directory where the lib is placed
+
+### importPath
+
+Type: `string`
+
+The library name used to import it, like @myorg/my-awesome-lib. Must be a valid npm name.
 
 ### linter
 
@@ -61,8 +75,6 @@ Type: `string`
 Library name
 
 ### publishable
-
-Alias(es): buildable
 
 Type: `boolean`
 

--- a/docs/react/api-nx-plugin/schematics/plugin.md
+++ b/docs/react/api-nx-plugin/schematics/plugin.md
@@ -27,7 +27,7 @@ nx g plugin ... --dry-run
 Generate libs/plugins/my-plugin:
 
 ```bash
-nx g plugin my-plugin --directory=plugins
+nx g plugin my-plugin --directory=plugins --importPath=@myorg/my-plugin
 ```
 
 ## Options
@@ -39,6 +39,12 @@ Alias(es): d
 Type: `string`
 
 A directory where the plugin is placed
+
+### importPath
+
+Type: `string`
+
+How the plugin will be published, like @myorg/my-awesome-plugin. Note this must be a valid npm name
 
 ### linter
 

--- a/docs/react/api-react/schematics/library.md
+++ b/docs/react/api-react/schematics/library.md
@@ -50,6 +50,14 @@ Type: `string`
 
 The application project to add the library route to.
 
+### buildable
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a buildable library.
+
 ### component
 
 Default: `true`
@@ -65,6 +73,12 @@ Alias(es): d
 Type: `string`
 
 A directory where the lib is placed.
+
+### importPath
+
+Type: `string`
+
+The library name used to import it, like @myorg/my-awesome-lib
 
 ### js
 
@@ -102,11 +116,9 @@ Use pascal case component file name (e.g. App.tsx).
 
 ### publishable
 
-Alias(es): buildable
-
 Type: `boolean`
 
-Create a buildable library.
+Create a publishable library.
 
 ### routing
 

--- a/docs/react/api-workspace/schematics/library.md
+++ b/docs/react/api-workspace/schematics/library.md
@@ -42,6 +42,12 @@ Type: `string`
 
 A directory where the lib is placed
 
+### importPath
+
+Type: `string`
+
+The library name used to import it, like @myorg/my-awesome-lib
+
 ### linter
 
 Default: `tslint`

--- a/e2e/angular/src/angular-package.test.ts
+++ b/e2e/angular/src/angular-package.test.ts
@@ -33,13 +33,13 @@ forEachCli('angular', (cli) => {
       newProject();
 
       runCLI(
-        `generate @nrwl/angular:library ${parentLib} --publishable=true --no-interactive`
+        `generate @nrwl/angular:library ${parentLib} --publishable=true --importPath=@proj/${parentLib} --no-interactive`
       );
       runCLI(
-        `generate @nrwl/angular:library ${childLib} --publishable=true --no-interactive`
+        `generate @nrwl/angular:library ${childLib} --publishable=true --importPath=@proj/${childLib} --no-interactive`
       );
       runCLI(
-        `generate @nrwl/angular:library ${childLib2} --publishable=true --no-interactive`
+        `generate @nrwl/angular:library ${childLib2} --publishable=true --importPath=@proj/${childLib2} --no-interactive`
       );
 
       // create secondary entrypoint

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -266,7 +266,9 @@ forEachCli((currentCLIName) => {
       ensureProject();
 
       const nodeLib = uniq('nodelib');
-      runCLI(`generate @nrwl/node:lib ${nodeLib} --publishable`);
+      runCLI(
+        `generate @nrwl/node:lib ${nodeLib} --publishable --importPath=@proj/${nodeLib}`
+      );
       checkFilesExist(`libs/${nodeLib}/package.json`);
       const tslibConfig = readJson(`libs/${nodeLib}/tsconfig.lib.json`);
       expect(tslibConfig).toEqual({
@@ -303,12 +305,16 @@ forEachCli((currentCLIName) => {
       const nglib = uniq('nglib');
 
       // Generating two libraries just to have a lot of files to copy
-      runCLI(`generate @nrwl/node:lib ${nodelib} --publishable`);
+      runCLI(
+        `generate @nrwl/node:lib ${nodelib} --publishable --importPath=@proj/${nodelib}`
+      );
       /**
        * The angular lib contains a lot sub directories that would fail without
        * `nodir: true` in the package.impl.ts
        */
-      runCLI(`generate @nrwl/angular:lib ${nglib} --publishable`);
+      runCLI(
+        `generate @nrwl/angular:lib ${nglib} --publishable --importPath=@proj/${nglib}`
+      );
       const workspace = readJson(workspaceConfigName());
       workspace.projects[nodelib].architect.build.options.assets.push({
         input: `./dist/libs/${nglib}`,
@@ -428,9 +434,9 @@ forEachCli((currentCLIName) => {
       ensureProject();
 
       runCLI(`generate @nrwl/express:app ${app}`);
-      runCLI(`generate @nrwl/node:lib ${parentLib} --publishable=true`);
-      runCLI(`generate @nrwl/node:lib ${childLib} --publishable=true`);
-      runCLI(`generate @nrwl/node:lib ${childLib2} --publishable=true`);
+      runCLI(`generate @nrwl/node:lib ${parentLib} --buildable=true`);
+      runCLI(`generate @nrwl/node:lib ${childLib} --buildable=true`);
+      runCLI(`generate @nrwl/node:lib ${childLib2} --buildable=true`);
 
       // create dependencies by importing
       const createDep = (parent, children: string[]) => {

--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -19,7 +19,9 @@ forEachCli((currentCLIName) => {
       ensureProject();
       const plugin = uniq('plugin');
 
-      runCLI(`generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter}`);
+      runCLI(
+        `generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter} --importPath=@proj/${plugin}`
+      );
       const lintResults = runCLI(`lint ${plugin}`);
       expect(lintResults).toContain('All files pass linting.');
 
@@ -62,7 +64,9 @@ forEachCli((currentCLIName) => {
     it(`should run the plugin's e2e tests`, async (done) => {
       ensureProject();
       const plugin = uniq('plugin');
-      runCLI(`generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter}`);
+      runCLI(
+        `generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter} --importPath=@proj/${plugin}`
+      );
       const results = await runCLIAsync(`e2e ${plugin}-e2e`);
       expect(results.stdout).toContain('Compiling TypeScript files');
       expectTestsPass(results);
@@ -75,7 +79,9 @@ forEachCli((currentCLIName) => {
       const plugin = uniq('plugin');
       const version = '1.0.0';
 
-      runCLI(`generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter}`);
+      runCLI(
+        `generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter} --importPath=@proj/${plugin}`
+      );
       runCLI(
         `generate @nrwl/nx-plugin:migration --project=${plugin} --version=${version} --packageJsonUpdates=false`
       );
@@ -112,7 +118,9 @@ forEachCli((currentCLIName) => {
       const plugin = uniq('plugin');
       const schematic = uniq('schematic');
 
-      runCLI(`generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter}`);
+      runCLI(
+        `generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter} --importPath=@proj/${plugin}`
+      );
       runCLI(
         `generate @nrwl/nx-plugin:schematic ${schematic} --project=${plugin}`
       );
@@ -152,7 +160,9 @@ forEachCli((currentCLIName) => {
       const plugin = uniq('plugin');
       const builder = uniq('builder');
 
-      runCLI(`generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter}`);
+      runCLI(
+        `generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter} --importPath=@proj/${plugin}`
+      );
       runCLI(`generate @nrwl/nx-plugin:builder ${builder} --project=${plugin}`);
 
       const lintResults = runCLI(`lint ${plugin}`);
@@ -190,7 +200,7 @@ forEachCli((currentCLIName) => {
         ensureProject();
         const plugin = uniq('plugin');
         runCLI(
-          `generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter} --directory subdir`
+          `generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter} --directory subdir --importPath=@proj/${plugin}`
         );
         checkFilesExist(`libs/subdir/${plugin}/package.json`);
         const workspace = readJson(workspaceConfigName());
@@ -206,7 +216,7 @@ forEachCli((currentCLIName) => {
         ensureProject();
         const plugin = uniq('plugin');
         runCLI(
-          `generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter} --tags=e2etag,e2ePackage`
+          `generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter} --tags=e2etag,e2ePackage --importPath=@proj/${plugin}`
         );
         const nxJson = readJson('nx.json');
         expect(nxJson.projects[plugin].tags).toEqual(['e2etag', 'e2ePackage']);

--- a/e2e/react/src/react-package.test.ts
+++ b/e2e/react/src/react-package.test.ts
@@ -37,13 +37,13 @@ forEachCli('nx', (cli) => {
       runCLI(`generate @nrwl/react:app ${app}`);
 
       runCLI(
-        `generate @nrwl/react:library ${parentLib} --buildable --no-interactive`
+        `generate @nrwl/react:library ${parentLib} --publishable --importPath=@proj/${parentLib} --no-interactive`
       );
       runCLI(
-        `generate @nrwl/react:library ${childLib} --buildable --no-interactive`
+        `generate @nrwl/react:library ${childLib} --publishable --importPath=@proj/${childLib} --no-interactive`
       );
       runCLI(
-        `generate @nrwl/react:library ${childLib2} --buildable --no-interactive`
+        `generate @nrwl/react:library ${childLib2} --publishable --importPath=@proj/${childLib2} --no-interactive`
       );
 
       // create dependencies by importing

--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -52,7 +52,7 @@ forEachCli('nx', () => {
       const libName = uniq('lib');
 
       runCLI(
-        `generate @nrwl/react:lib ${libName} --publishable --no-interactive`
+        `generate @nrwl/react:lib ${libName} --publishable --importPath=@proj/${libName} --no-interactive`
       );
 
       const libTestResults = await runCLIAsync(
@@ -113,7 +113,7 @@ forEachCli('nx', () => {
       const libName = uniq('lib');
 
       runCLI(
-        `generate @nrwl/react:lib ${libName} --publishable --no-interactive`
+        `generate @nrwl/react:lib ${libName} --publishable --importPath=@proj/${libName} --no-interactive`
       );
 
       const mainPath = `libs/${libName}/src/lib/${libName}.tsx`;

--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -38,8 +38,8 @@ forEachCli((cliName) => {
       const mylib1 = uniq('mylib1');
       const mylib2 = uniq('mylib1');
       runCLI(`generate @nrwl/react:app ${myapp}`);
-      runCLI(`generate @nrwl/react:lib ${mylib1} --publishable`);
-      runCLI(`generate @nrwl/react:lib ${mylib2} --publishable`);
+      runCLI(`generate @nrwl/react:lib ${mylib1} --buildable`);
+      runCLI(`generate @nrwl/react:lib ${mylib2} --buildable`);
 
       updateFile(
         `apps/${myapp}/src/main.ts`,
@@ -80,9 +80,9 @@ forEachCli((cliName) => {
       const libD = uniq('libd-rand');
 
       runCLI(`generate @nrwl/angular:app ${appA}`);
-      runCLI(`generate @nrwl/angular:lib ${libA} --publishable --defaults`);
-      runCLI(`generate @nrwl/angular:lib ${libB} --publishable --defaults`);
-      runCLI(`generate @nrwl/angular:lib ${libC} --publishable --defaults`);
+      runCLI(`generate @nrwl/angular:lib ${libA} --buildable --defaults`);
+      runCLI(`generate @nrwl/angular:lib ${libB} --buildable --defaults`);
+      runCLI(`generate @nrwl/angular:lib ${libC} --buildable --defaults`);
       runCLI(`generate @nrwl/angular:lib ${libD} --defaults`);
 
       // libA depends on libC
@@ -206,7 +206,9 @@ forEachCli((cliName) => {
       runCLI(`generate @nrwl/angular:app ${myapp2}`);
       runCLI(`generate @nrwl/angular:lib ${mylib}`);
       runCLI(`generate @nrwl/angular:lib ${mylib2}`);
-      runCLI(`generate @nrwl/angular:lib ${mypublishablelib} --publishable`);
+      runCLI(
+        `generate @nrwl/angular:lib ${mypublishablelib} --publishable --importPath=@proj/${mypublishablelib}`
+      );
 
       updateFile(
         `apps/${myapp}/src/app/app.component.spec.ts`,
@@ -434,7 +436,7 @@ forEachCli((cliName) => {
       runCLI(`generate @nrwl/react:app ${myapp2}`);
       runCLI(`generate @nrwl/react:lib ${mylib}`);
       runCLI(`generate @nrwl/react:lib ${mylib2}`);
-      runCLI(`generate @nrwl/react:lib ${mypublishablelib} --publishable`);
+      runCLI(`generate @nrwl/react:lib ${mypublishablelib} --buildable`);
 
       updateFile(
         `apps/${myapp}/src/main.tsx`,

--- a/packages/angular/src/schematics/library/lib/normalize-options.ts
+++ b/packages/angular/src/schematics/library/lib/normalize-options.ts
@@ -1,6 +1,6 @@
 import { Tree } from '@angular-devkit/schematics';
-import { getNpmScope, toClassName, toFileName } from '@nrwl/workspace';
-import { libsDir } from '@nrwl/workspace/src/utils/ast-utils';
+import { getNpmScope, toClassName, toFileName, NxJson } from '@nrwl/workspace';
+import { libsDir, readJsonInTree } from '@nrwl/workspace/src/utils/ast-utils';
 import { Schema } from '../schema';
 import { NormalizedSchema } from './normalized-schema';
 
@@ -24,6 +24,9 @@ export function normalizeOptions(
   const modulePath = `${projectRoot}/src/lib/${fileName}.module.ts`;
   const defaultPrefix = getNpmScope(host);
 
+  const importPath =
+    options.importPath || `@${defaultPrefix}/${projectDirectory}`;
+
   return {
     ...options,
     prefix: options.prefix ? options.prefix : defaultPrefix,
@@ -35,5 +38,6 @@ export function normalizeOptions(
     modulePath,
     parsedTags,
     fileName,
+    importPath,
   };
 }

--- a/packages/angular/src/schematics/library/lib/update-lib-package-npm-scope.ts
+++ b/packages/angular/src/schematics/library/lib/update-lib-package-npm-scope.ts
@@ -1,12 +1,10 @@
 import { Rule, Tree } from '@angular-devkit/schematics';
-import { getNpmScope, updateJsonInTree } from '@nrwl/workspace';
+import { updateJsonInTree } from '@nrwl/workspace';
 import { NormalizedSchema } from './normalized-schema';
 
 export function updateLibPackageNpmScope(options: NormalizedSchema): Rule {
-  return (host: Tree) => {
-    return updateJsonInTree(`${options.projectRoot}/package.json`, (json) => {
-      json.name = `@${getNpmScope(host)}/${options.name}`;
-      return json;
-    });
-  };
+  return updateJsonInTree(`${options.projectRoot}/package.json`, (json) => {
+    json.name = options.importPath;
+    return json;
+  });
 }

--- a/packages/angular/src/schematics/library/lib/update-ng-package.ts
+++ b/packages/angular/src/schematics/library/lib/update-ng-package.ts
@@ -4,7 +4,7 @@ import { libsDir } from '@nrwl/workspace/src/utils/ast-utils';
 import { NormalizedSchema } from './normalized-schema';
 
 export function updateNgPackage(host: Tree, options: NormalizedSchema): Rule {
-  if (!options.publishable) {
+  if (!(options.publishable || options.buildable)) {
     return noop();
   }
   const dest = `${offsetFromRoot(options.projectRoot)}dist/${libsDir(host)}/${

--- a/packages/angular/src/schematics/library/lib/update-project.ts
+++ b/packages/angular/src/schematics/library/lib/update-project.ts
@@ -47,7 +47,7 @@ export function updateProject(options: NormalizedSchema): Rule {
         host.delete(path.join(libRoot, `${options.name}.component.spec.ts`));
       }
 
-      if (!options.publishable) {
+      if (!options.publishable && !options.buildable) {
         host.delete(path.join(options.projectRoot, 'ng-package.json'));
         host.delete(path.join(options.projectRoot, 'package.json'));
         host.delete(path.join(options.projectRoot, 'tsconfig.lib.prod.json'));
@@ -138,7 +138,7 @@ export function updateProject(options: NormalizedSchema): Rule {
           };
         }
 
-        if (!options.publishable) {
+        if (!options.publishable && !options.buildable) {
           delete fixedProject.architect.build;
         } else {
           // adjust the builder path to our custom one

--- a/packages/angular/src/schematics/library/lib/update-tsconfig.ts
+++ b/packages/angular/src/schematics/library/lib/update-tsconfig.ts
@@ -2,23 +2,30 @@ import {
   chain,
   Rule,
   SchematicContext,
+  SchematicsException,
   Tree,
 } from '@angular-devkit/schematics';
-import { NxJson, readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
-import { libsDir } from '@nrwl/workspace/src/utils/ast-utils';
+import { updateJsonInTree } from '@nrwl/workspace';
 import { NormalizedSchema } from './normalized-schema';
 
 export function updateTsConfig(options: NormalizedSchema): Rule {
   return chain([
     (host: Tree, context: SchematicContext) => {
-      const nxJson = readJsonInTree<NxJson>(host, 'nx.json');
       return updateJsonInTree('tsconfig.base.json', (json) => {
         const c = json.compilerOptions;
         c.paths = c.paths || {};
         delete c.paths[options.name];
-        c.paths[`@${nxJson.npmScope}/${options.projectDirectory}`] = [
-          `${libsDir(host)}/${options.projectDirectory}/src/index.ts`,
+
+        if (c.paths[options.importPath]) {
+          throw new SchematicsException(
+            `You already have a library using the import path "${options.importPath}". Make sure to specify a unique one.`
+          );
+        }
+
+        c.paths[options.importPath] = [
+          `libs/${options.projectDirectory}/src/index.ts`,
         ];
+
         return json;
       })(host, context);
     },

--- a/packages/angular/src/schematics/library/schema.d.ts
+++ b/packages/angular/src/schematics/library/schema.d.ts
@@ -7,7 +7,9 @@ export interface Schema {
   addModuleSpec?: boolean;
   directory?: string;
   sourceDir?: string;
+  buildable: boolean;
   publishable: boolean;
+  importPath?: string;
 
   spec?: boolean;
   flat?: boolean;

--- a/packages/angular/src/schematics/library/schema.json
+++ b/packages/angular/src/schematics/library/schema.json
@@ -20,8 +20,12 @@
     "publishable": {
       "type": "boolean",
       "default": false,
-      "description": "Generate a buildable library.",
-      "alias": "buildable"
+      "description": "Generate a publishable library."
+    },
+    "buildable": {
+      "type": "boolean",
+      "default": false,
+      "description": "Generate a buildable library."
     },
     "prefix": {
       "type": "string",
@@ -104,6 +108,10 @@
       "enum": ["karma", "jest", "none"],
       "description": "Test runner to use for unit tests",
       "default": "jest"
+    },
+    "importPath": {
+      "type": "string",
+      "description": "The library name used to import it, like @myorg/my-awesome-lib. Must be a valid npm name."
     }
   },
   "required": []

--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -80,9 +80,11 @@ function createWorkspace(
 }
 
 function createNxPlugin(workspaceName, pluginName) {
-  console.log(`nx generate @nrwl/nx-plugin:plugin ${pluginName}`);
+  console.log(
+    `nx generate @nrwl/nx-plugin:plugin ${pluginName} --importPath=${workspaceName}/${pluginName}`
+  );
   execSync(
-    `node ./node_modules/@nrwl/cli/bin/nx.js generate @nrwl/nx-plugin:plugin ${pluginName}`,
+    `node ./node_modules/@nrwl/cli/bin/nx.js generate @nrwl/nx-plugin:plugin ${pluginName} --importPath=${workspaceName}/${pluginName}`,
     {
       cwd: workspaceName,
       stdio: [0, 1, 2],

--- a/packages/nest/src/schematics/library/library.spec.ts
+++ b/packages/nest/src/schematics/library/library.spec.ts
@@ -366,7 +366,7 @@ describe('lib', () => {
     it('should update package.json', async () => {
       const publishableTree = await runSchematic(
         'lib',
-        { name: 'mylib', publishable: true },
+        { name: 'mylib', publishable: true, importPath: '@proj/mylib' },
         appTree
       );
 

--- a/packages/nest/src/schematics/library/library.ts
+++ b/packages/nest/src/schematics/library/library.ts
@@ -175,7 +175,7 @@ function updateTsConfig(options: NormalizedSchema): Rule {
 }
 
 function addProject(options: NormalizedSchema): Rule {
-  if (!options.publishable) {
+  if (!options.publishable && !options.buildable) {
     return noop();
   }
 

--- a/packages/nest/src/schematics/library/schema.d.ts
+++ b/packages/nest/src/schematics/library/schema.d.ts
@@ -8,6 +8,7 @@ export interface Schema {
   tags?: string;
   unitTestRunner: 'jest' | 'none';
   linter: Linter;
+  buildable: boolean;
   publishable?: boolean;
   global?: boolean;
   service?: boolean;

--- a/packages/nest/src/schematics/library/schema.json
+++ b/packages/nest/src/schematics/library/schema.json
@@ -53,8 +53,16 @@
     },
     "publishable": {
       "type": "boolean",
-      "description": "Create a buildable library.",
-      "alias": "buildable"
+      "description": "Create a publishable library."
+    },
+    "buildable": {
+      "type": "boolean",
+      "default": false,
+      "description": "Generate a buildable library."
+    },
+    "importPath": {
+      "type": "string",
+      "description": "The library name used to import it, like @myorg/my-awesome-lib. Must be a valid npm name."
     },
     "global": {
       "type": "boolean",

--- a/packages/node/src/schematics/library/files/lib/package.json__tmpl__
+++ b/packages/node/src/schematics/library/files/lib/package.json__tmpl__
@@ -1,4 +1,4 @@
 {
-  "name": "@<%= prefix %>/<%= name %>",
+  "name": "<%= importPath %>",
   "version": "0.0.1"
 }

--- a/packages/node/src/schematics/library/library.spec.ts
+++ b/packages/node/src/schematics/library/library.spec.ts
@@ -185,6 +185,26 @@ describe('lib', () => {
       ).toBeUndefined();
     });
 
+    it('should throw an exception when not passing importPath when using --publishable', async () => {
+      expect.assertions(1);
+
+      try {
+        const tree = await runSchematic(
+          'lib',
+          {
+            name: 'myLib',
+            directory: 'myDir',
+            publishable: true,
+          },
+          appTree
+        );
+      } catch (e) {
+        expect(e.message).toContain(
+          'For publishable libs you have to provide a proper "--importPath" which needs to be a valid npm package name (e.g. my-awesome-lib or @myorg/my-lib)'
+        );
+      }
+    });
+
     it('should create a local tsconfig.json', async () => {
       const tree = await runSchematic(
         'lib',
@@ -236,11 +256,39 @@ describe('lib', () => {
     });
   });
 
+  describe('buildable package', () => {
+    it('should have a builder defined', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', buildable: true },
+        appTree
+      );
+      const workspaceJson = readJsonInTree(tree, '/workspace.json');
+
+      expect(workspaceJson.projects['my-lib'].root).toEqual('libs/my-lib');
+
+      expect(workspaceJson.projects['my-lib'].architect.build).toBeDefined();
+    });
+  });
+
   describe('publishable package', () => {
+    it('should have a builder defined', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', publishable: true, importPath: '@proj/mylib' },
+        appTree
+      );
+      const workspaceJson = readJsonInTree(tree, '/workspace.json');
+
+      expect(workspaceJson.projects['my-lib'].root).toEqual('libs/my-lib');
+
+      expect(workspaceJson.projects['my-lib'].architect.build).toBeDefined();
+    });
+
     it('should update package.json', async () => {
       const publishableTree = await runSchematic(
         'lib',
-        { name: 'mylib', publishable: true },
+        { name: 'mylib', publishable: true, importPath: '@proj/mylib' },
         appTree
       );
 
@@ -250,6 +298,61 @@ describe('lib', () => {
       );
 
       expect(packageJsonContent.name).toEqual('@proj/mylib');
+    });
+  });
+
+  describe('--importPath', () => {
+    it('should update the package.json & tsconfig with the given import path', async () => {
+      const tree = await runSchematic(
+        'lib',
+        {
+          name: 'myLib',
+          publishable: true,
+          directory: 'myDir',
+          importPath: '@myorg/lib',
+        },
+        appTree
+      );
+      const packageJson = readJsonInTree(
+        tree,
+        'libs/my-dir/my-lib/package.json'
+      );
+      const tsconfigJson = readJsonInTree(tree, '/tsconfig.base.json');
+
+      expect(packageJson.name).toBe('@myorg/lib');
+      expect(
+        tsconfigJson.compilerOptions.paths[packageJson.name]
+      ).toBeDefined();
+    });
+
+    it('should fail if the same importPath has already been used', async () => {
+      const tree1 = await runSchematic(
+        'lib',
+        {
+          name: 'myLib1',
+          publishable: true,
+          importPath: '@myorg/lib',
+        },
+        appTree
+      );
+
+      try {
+        await runSchematic(
+          'lib',
+          {
+            name: 'myLib2',
+            publishable: true,
+            importPath: '@myorg/lib',
+          },
+          tree1
+        );
+      } catch (e) {
+        expect(e.message).toContain(
+          'You already have a library using the import path'
+        );
+      }
+
+      expect.assertions(1);
     });
   });
 });

--- a/packages/node/src/schematics/library/schema.d.ts
+++ b/packages/node/src/schematics/library/schema.d.ts
@@ -8,6 +8,8 @@ export interface Schema {
   tags?: string;
   unitTestRunner: 'jest' | 'none';
   linter: Linter;
+  buildable?: boolean;
   publishable?: boolean;
+  importPath?: string;
   testEnvironment: 'jsdom' | 'node';
 }

--- a/packages/node/src/schematics/library/schema.json
+++ b/packages/node/src/schematics/library/schema.json
@@ -53,8 +53,16 @@
     },
     "publishable": {
       "type": "boolean",
-      "description": "Create a publishable library.",
-      "alias": "buildable"
+      "description": "Create a publishable library."
+    },
+    "buildable": {
+      "type": "boolean",
+      "default": false,
+      "description": "Generate a buildable library."
+    },
+    "importPath": {
+      "type": "string",
+      "description": "The library name used to import it, like @myorg/my-awesome-lib. Must be a valid npm name."
     },
     "testEnvironment": {
       "type": "string",

--- a/packages/nx-plugin/src/schematics/builder/builder.spec.ts
+++ b/packages/nx-plugin/src/schematics/builder/builder.spec.ts
@@ -11,7 +11,11 @@ describe('NxPlugin builder', () => {
   beforeEach(async () => {
     projectName = 'my-plugin';
     appTree = createEmptyWorkspace(ngSchematics.Tree.empty());
-    appTree = await runSchematic('plugin', { name: projectName }, appTree);
+    appTree = await runSchematic(
+      'plugin',
+      { name: projectName, importPath: '@proj/my-plugin' },
+      appTree
+    );
   });
 
   it('should generate files', async () => {

--- a/packages/nx-plugin/src/schematics/migration/migration.spec.ts
+++ b/packages/nx-plugin/src/schematics/migration/migration.spec.ts
@@ -11,7 +11,11 @@ describe('NxPlugin migration', () => {
   beforeEach(async () => {
     projectName = 'my-plugin';
     appTree = createEmptyWorkspace(ngSchematics.Tree.empty());
-    appTree = await runSchematic('plugin', { name: projectName }, appTree);
+    appTree = await runSchematic(
+      'plugin',
+      { name: projectName, importPath: '@proj/my-plugin' },
+      appTree
+    );
   });
 
   it('should update the workspace.json file', async () => {

--- a/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
@@ -10,7 +10,11 @@ describe('NxPlugin plugin', () => {
   });
 
   it('should update the workspace.json file', async () => {
-    const tree = await runSchematic('plugin', { name: 'myPlugin' }, appTree);
+    const tree = await runSchematic(
+      'plugin',
+      { name: 'myPlugin', importPath: '@proj/my-plugin' },
+      appTree
+    );
     const workspace = await readWorkspace(tree);
     const project = workspace.projects['my-plugin'];
     expect(project.root).toEqual('libs/my-plugin');
@@ -62,7 +66,11 @@ describe('NxPlugin plugin', () => {
   });
 
   it('should update the tsconfig.lib.json file', async () => {
-    const tree = await runSchematic('plugin', { name: 'myPlugin' }, appTree);
+    const tree = await runSchematic(
+      'plugin',
+      { name: 'myPlugin', importPath: '@proj/my-plugin' },
+      appTree
+    );
     const tsLibConfig = readJsonInTree(
       tree,
       'libs/my-plugin/tsconfig.lib.json'
@@ -71,7 +79,11 @@ describe('NxPlugin plugin', () => {
   });
 
   it('should create schematic and builder files', async () => {
-    const tree = await runSchematic('plugin', { name: 'myPlugin' }, appTree);
+    const tree = await runSchematic(
+      'plugin',
+      { name: 'myPlugin', importPath: '@proj/my-plugin' },
+      appTree
+    );
     expect(tree.exists('libs/my-plugin/collection.json')).toBeTruthy();
     expect(tree.exists('libs/my-plugin/builders.json')).toBeTruthy();
     expect(
@@ -118,7 +130,11 @@ describe('NxPlugin plugin', () => {
       it('should not generate test files', async () => {
         const tree = await runSchematic(
           'plugin',
-          { name: 'myPlugin', unitTestRunner: 'none' },
+          {
+            name: 'myPlugin',
+            importPath: '@proj/my-plugin',
+            unitTestRunner: 'none',
+          },
           appTree
         );
 

--- a/packages/nx-plugin/src/schematics/plugin/plugin.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.ts
@@ -22,6 +22,7 @@ export default function (schema: NormalizedSchema): Rule {
       externalSchematic('@nrwl/node', 'lib', {
         ...schema,
         publishable: true,
+        importPath: schema.importPath,
         unitTestRunner: options.unitTestRunner,
       }),
       addFiles(options),

--- a/packages/nx-plugin/src/schematics/plugin/schema.d.ts
+++ b/packages/nx-plugin/src/schematics/plugin/schema.d.ts
@@ -3,6 +3,7 @@ import { Linter } from '@nrwl/workspace';
 export interface Schema {
   name: string;
   directory?: string;
+  importPath: string;
   skipTsConfig: boolean;
   skipFormat: boolean;
   tags?: string;

--- a/packages/nx-plugin/src/schematics/plugin/schema.json
+++ b/packages/nx-plugin/src/schematics/plugin/schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "g plugin my-plugin --directory=plugins",
+      "command": "g plugin my-plugin --directory=plugins --importPath=@myorg/my-plugin",
       "description": "Generate libs/plugins/my-plugin"
     }
   ],
@@ -23,6 +23,10 @@
       "type": "string",
       "description": "A directory where the plugin is placed",
       "alias": "d"
+    },
+    "importPath": {
+      "type": "string",
+      "description": "How the plugin will be published, like @myorg/my-awesome-plugin. Note this must be a valid npm name"
     },
     "linter": {
       "description": "The tool to use for running lint checks.",
@@ -52,5 +56,5 @@
       "description": "Do not update tsconfig.json for development experience."
     }
   },
-  "required": ["name"]
+  "required": ["name", "importPath"]
 }

--- a/packages/nx-plugin/src/schematics/schematic/schematic.spec.ts
+++ b/packages/nx-plugin/src/schematics/schematic/schematic.spec.ts
@@ -11,7 +11,11 @@ describe('NxPlugin schematic', () => {
   beforeEach(async () => {
     projectName = 'my-plugin';
     appTree = createEmptyWorkspace(ngSchematics.Tree.empty());
-    appTree = await runSchematic('plugin', { name: projectName }, appTree);
+    appTree = await runSchematic(
+      'plugin',
+      { name: projectName, importPath: '@proj/my-plugin' },
+      appTree
+    );
   });
 
   it('should generate files', async () => {

--- a/packages/react/src/schematics/library/schema.d.ts
+++ b/packages/react/src/schematics/library/schema.d.ts
@@ -16,5 +16,7 @@ export interface Schema {
   linter: Linter;
   component?: boolean;
   publishable?: boolean;
+  buildable?: boolean;
+  importPath?: string;
   js?: boolean;
 }

--- a/packages/react/src/schematics/library/schema.json
+++ b/packages/react/src/schematics/library/schema.json
@@ -113,8 +113,16 @@
     },
     "publishable": {
       "type": "boolean",
-      "description": "Create a buildable library.",
-      "alias": "buildable"
+      "description": "Create a publishable library."
+    },
+    "buildable": {
+      "type": "boolean",
+      "default": false,
+      "description": "Generate a buildable library."
+    },
+    "importPath": {
+      "type": "string",
+      "description": "The library name used to import it, like @myorg/my-awesome-lib"
     },
     "component": {
       "type": "boolean",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -68,6 +68,7 @@
     "yargs": "^11.0.0",
     "chalk": "2.4.2",
     "@nrwl/cli": "*",
-    "axios": "0.19.2"
+    "axios": "0.19.2",
+    "speakingurl": "14.0.1"
   }
 }

--- a/packages/workspace/src/schematics/library/library.spec.ts
+++ b/packages/workspace/src/schematics/library/library.spec.ts
@@ -255,4 +255,49 @@ describe('lib', () => {
       ).toEqual(['libs/my-lib/tsconfig.lib.json']);
     });
   });
+
+  describe('--importPath', () => {
+    it('should update the tsconfig with the given import path', async () => {
+      const tree = await runSchematic(
+        'lib',
+        {
+          name: 'myLib',
+          directory: 'myDir',
+          importPath: '@myorg/lib',
+        },
+        appTree
+      );
+      const tsconfigJson = readJsonInTree(tree, '/tsconfig.base.json');
+
+      expect(tsconfigJson.compilerOptions.paths['@myorg/lib']).toBeDefined();
+    });
+
+    it('should fail if the same importPath has already been used', async () => {
+      const tree1 = await runSchematic(
+        'lib',
+        {
+          name: 'myLib1',
+          importPath: '@myorg/lib',
+        },
+        appTree
+      );
+
+      try {
+        await runSchematic(
+          'lib',
+          {
+            name: 'myLib2',
+            importPath: '@myorg/lib',
+          },
+          tree1
+        );
+      } catch (e) {
+        expect(e.message).toContain(
+          'You already have a library using the import path'
+        );
+      }
+
+      expect.assertions(1);
+    });
+  });
 });

--- a/packages/workspace/src/schematics/library/library.ts
+++ b/packages/workspace/src/schematics/library/library.ts
@@ -28,6 +28,7 @@ export interface NormalizedSchema extends Schema {
   projectRoot: string;
   projectDirectory: string;
   parsedTags: string[];
+  importPath?: string;
 }
 
 function addProject(options: NormalizedSchema): Rule {

--- a/packages/workspace/src/schematics/library/schema.d.ts
+++ b/packages/workspace/src/schematics/library/schema.d.ts
@@ -10,4 +10,5 @@ export interface Schema {
   unitTestRunner: 'jest' | 'none';
   linter: Linter;
   testEnvironment: 'jsdom' | 'node';
+  importPath?: string;
 }

--- a/packages/workspace/src/schematics/library/schema.json
+++ b/packages/workspace/src/schematics/library/schema.json
@@ -54,6 +54,10 @@
       "enum": ["jsdom", "node"],
       "description": "The test environment to use if unitTestRunner is set to jest",
       "default": "jsdom"
+    },
+    "importPath": {
+      "type": "string",
+      "description": "The library name used to import it, like @myorg/my-awesome-lib"
     }
   },
   "required": ["name"]


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Right now the generated path mappings for nested libraries get generated as follows:

```
"@my-org/platform/core": ["libs/platform/core/src/index.ts"],
"@my-org/platform/common": ["libs/platform/common/src/index.ts"]
```

The above works fine as long as the library isn't a buildable one. Buildable libraries have their own `package.json` where the package name would look like `@my-org/platform-core`. NPM package names cannot have multiple nestings, but rather just `<scope>/<package-name>`. As a result the Nx generated path mapping would differ from the one when the package gets published, which is a problem.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The path mappings generated in the `tsconfig.json` should match the one of the published package.

## Issue

#2794 
