### PR TITLE
feat(storybook): support `--linter` in `cypress-project` schematic

### DIFF
--- a/docs/angular/api-storybook/schematics/cypress-project.md
+++ b/docs/angular/api-storybook/schematics/cypress-project.md
@@ -32,6 +32,16 @@ Type: `boolean`
 
 Generate JavaScript files rather than TypeScript files
 
+### linter
+
+Default: `tslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`
+
+The tool to use for running lint checks.
+
 ### name
 
 Type: `string`

--- a/docs/react/api-storybook/schematics/cypress-project.md
+++ b/docs/react/api-storybook/schematics/cypress-project.md
@@ -32,6 +32,16 @@ Type: `boolean`
 
 Generate JavaScript files rather than TypeScript files
 
+### linter
+
+Default: `tslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`
+
+The tool to use for running lint checks.
+
 ### name
 
 Type: `string`

--- a/packages/storybook/src/schematics/configuration/configuration.ts
+++ b/packages/storybook/src/schematics/configuration/configuration.ts
@@ -14,7 +14,8 @@ import {
   getProjectConfig,
   offsetFromRoot,
   readJsonFile,
-  updateWorkspace
+  updateWorkspace,
+  Linter
 } from '@nrwl/workspace';
 import { join, normalize } from '@angular-devkit/core';
 import { StorybookStoriesSchema } from '../../../../angular/src/schematics/stories/stories';
@@ -33,6 +34,7 @@ export default function(schema: StorybookConfigureSchema): Rule {
     schema.configureCypress
       ? schematic<CypressConfigureSchema>('cypress-project', {
           name: schema.name,
+          linter: Linter.TsLint,
           js: schema.js
         })
       : () => {}

--- a/packages/storybook/src/schematics/cypress-project/cypress-project.spec.ts
+++ b/packages/storybook/src/schematics/cypress-project/cypress-project.spec.ts
@@ -1,5 +1,6 @@
+import * as ngSchematics from '@angular-devkit/schematics';
 import { Tree } from '@angular-devkit/schematics';
-import { readJsonInTree, getProjectConfig } from '@nrwl/workspace';
+import { readJsonInTree, getProjectConfig, Linter } from '@nrwl/workspace';
 import { createTestUILib, runSchematic } from '../../utils/testing';
 
 describe('schematic:cypress-project', () => {
@@ -39,6 +40,48 @@ describe('schematic:cypress-project', () => {
     expect(project.architect.e2e.options.watch).toBeUndefined();
     expect(project.architect.e2e.configurations).toEqual({
       ci: { devServerTarget: `test-ui-lib:storybook:ci` }
+    });
+  });
+
+  describe('--linter', () => {
+    it('should generate tslint files', async () => {
+      const externalSchematicSpy = jest.spyOn(
+        ngSchematics,
+        'externalSchematic'
+      );
+      await runSchematic(
+        'cypress-project',
+        { name: 'test-ui-lib', linter: Linter.TsLint },
+        appTree
+      );
+
+      expect(externalSchematicSpy).toBeCalledWith(
+        '@nrwl/cypress',
+        'cypress-project',
+        expect.objectContaining({
+          linter: Linter.TsLint
+        })
+      );
+    });
+
+    it('should generate eslint files', async () => {
+      const externalSchematicSpy = jest.spyOn(
+        ngSchematics,
+        'externalSchematic'
+      );
+      await runSchematic(
+        'cypress-project',
+        { name: 'test-ui-lib', linter: Linter.EsLint },
+        appTree
+      );
+
+      expect(externalSchematicSpy).toBeCalledWith(
+        '@nrwl/cypress',
+        'cypress-project',
+        expect.objectContaining({
+          linter: Linter.EsLint
+        })
+      );
     });
   });
 });

--- a/packages/storybook/src/schematics/cypress-project/cypress-project.ts
+++ b/packages/storybook/src/schematics/cypress-project/cypress-project.ts
@@ -5,11 +5,16 @@ import {
   SchematicContext,
   Tree
 } from '@angular-devkit/schematics';
-import { getProjectConfig, updateWorkspaceInTree } from '@nrwl/workspace';
+import {
+  getProjectConfig,
+  Linter,
+  updateWorkspaceInTree
+} from '@nrwl/workspace';
 import { parseJsonAtPath, safeFileDelete } from '../../utils/utils';
 
 export interface CypressConfigureSchema {
   name: string;
+  linter: Linter;
   js?: boolean;
 }
 
@@ -19,6 +24,7 @@ export default function(schema: CypressConfigureSchema): Rule {
     externalSchematic('@nrwl/cypress', 'cypress-project', {
       name: e2eProjectName,
       project: schema.name,
+      linter: schema.linter,
       js: schema.js
     }),
     removeUnneededFiles(e2eProjectName, schema.js),

--- a/packages/storybook/src/schematics/cypress-project/schema.json
+++ b/packages/storybook/src/schematics/cypress-project/schema.json
@@ -11,6 +11,12 @@
         "index": 0
       }
     },
+    "linter": {
+      "description": "The tool to use for running lint checks.",
+      "type": "string",
+      "enum": ["eslint", "tslint"],
+      "default": "tslint"
+    },
     "js": {
       "type": "boolean",
       "description": "Generate JavaScript files rather than TypeScript files",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`@nrwl/cypress:cypress-project` supports `--linter`, however, `@nrwl/storybook:cypress-project` does not. This forces users into using TSLint for Cypress projects generated by the Storybook plugin as that is the default linter for that schematic.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`@nrwl/storybook:cypress-project` supports `--linter` so that users can choose between TSLint and ESLint.