### PR TITLE
feat(nx-plugin): properly implement and honor --unitTestRunner

### DIFF
--- a/docs/angular/api-nx-plugin/schematics/migration.md
+++ b/docs/angular/api-nx-plugin/schematics/migration.md
@@ -64,6 +64,16 @@ Type: `string`
 
 The name of the project.
 
+### unitTestRunner
+
+Default: `jest`
+
+Type: `string`
+
+Possible values: `jest`, `none`
+
+Test runner to use for unit tests
+
 ### version
 
 Alias(es): v

--- a/docs/angular/api-nx-plugin/schematics/schematic.md
+++ b/docs/angular/api-nx-plugin/schematics/schematic.md
@@ -53,3 +53,13 @@ Alias(es): p
 Type: `string`
 
 The name of the project.
+
+### unitTestRunner
+
+Default: `jest`
+
+Type: `string`
+
+Possible values: `jest`, `none`
+
+Test runner to use for unit tests

--- a/docs/react/api-nx-plugin/schematics/migration.md
+++ b/docs/react/api-nx-plugin/schematics/migration.md
@@ -64,6 +64,16 @@ Type: `string`
 
 The name of the project.
 
+### unitTestRunner
+
+Default: `jest`
+
+Type: `string`
+
+Possible values: `jest`, `none`
+
+Test runner to use for unit tests
+
 ### version
 
 Alias(es): v

--- a/docs/react/api-nx-plugin/schematics/schematic.md
+++ b/docs/react/api-nx-plugin/schematics/schematic.md
@@ -53,3 +53,13 @@ Alias(es): p
 Type: `string`
 
 The name of the project.
+
+### unitTestRunner
+
+Default: `jest`
+
+Type: `string`
+
+Possible values: `jest`, `none`
+
+Test runner to use for unit tests

--- a/packages/nx-plugin/src/schematics/builder/builder.spec.ts
+++ b/packages/nx-plugin/src/schematics/builder/builder.spec.ts
@@ -97,21 +97,23 @@ describe('NxPlugin builder', () => {
     );
   });
 
-  describe('--unitTestRunner none', () => {
-    it('should not generate unit test files', async () => {
-      const tree = await runSchematic(
-        'builder',
-        {
-          project: projectName,
-          name: 'my-builder',
-          unitTestRunner: 'none'
-        },
-        appTree
-      );
+  describe('--unitTestRunner', () => {
+    describe('none', () => {
+      it('should not generate unit test files', async () => {
+        const tree = await runSchematic(
+          'builder',
+          {
+            project: projectName,
+            name: 'my-builder',
+            unitTestRunner: 'none'
+          },
+          appTree
+        );
 
-      expect(
-        tree.exists('libs/my-plugin/src/builders/my-builder/builder.spec.ts')
-      ).toBeFalsy();
+        expect(
+          tree.exists('libs/my-plugin/src/builders/my-builder/builder.spec.ts')
+        ).toBeFalsy();
+      });
     });
   });
 });

--- a/packages/nx-plugin/src/schematics/migration/migration.spec.ts
+++ b/packages/nx-plugin/src/schematics/migration/migration.spec.ts
@@ -142,4 +142,30 @@ describe('NxPlugin migration', () => {
       }
     });
   });
+
+  describe('--unitTestRunner', () => {
+    it('should not generate test files', async () => {
+      const tree = await runSchematic(
+        'migration',
+        {
+          project: projectName,
+          name: 'my-migration',
+          version: '1.0.0',
+          unitTestRunner: 'none'
+        },
+        appTree
+      );
+
+      expect(
+        tree.exists(
+          'libs/my-plugin/src/migrations/my-migration/my-migration.ts'
+        )
+      ).toBeTruthy();
+      expect(
+        tree.exists(
+          'libs/my-plugin/src/migrations/my-migration/my-migration.spec.ts'
+        )
+      ).toBeFalsy();
+    });
+  });
 });

--- a/packages/nx-plugin/src/schematics/migration/migration.spec.ts
+++ b/packages/nx-plugin/src/schematics/migration/migration.spec.ts
@@ -144,28 +144,30 @@ describe('NxPlugin migration', () => {
   });
 
   describe('--unitTestRunner', () => {
-    it('should not generate test files', async () => {
-      const tree = await runSchematic(
-        'migration',
-        {
-          project: projectName,
-          name: 'my-migration',
-          version: '1.0.0',
-          unitTestRunner: 'none'
-        },
-        appTree
-      );
+    describe('none', () => {
+      it('should not generate test files', async () => {
+        const tree = await runSchematic(
+          'migration',
+          {
+            project: projectName,
+            name: 'my-migration',
+            version: '1.0.0',
+            unitTestRunner: 'none'
+          },
+          appTree
+        );
 
-      expect(
-        tree.exists(
-          'libs/my-plugin/src/migrations/my-migration/my-migration.ts'
-        )
-      ).toBeTruthy();
-      expect(
-        tree.exists(
-          'libs/my-plugin/src/migrations/my-migration/my-migration.spec.ts'
-        )
-      ).toBeFalsy();
+        expect(
+          tree.exists(
+            'libs/my-plugin/src/migrations/my-migration/my-migration.ts'
+          )
+        ).toBeTruthy();
+        expect(
+          tree.exists(
+            'libs/my-plugin/src/migrations/my-migration/my-migration.spec.ts'
+          )
+        ).toBeFalsy();
+      });
     });
   });
 });

--- a/packages/nx-plugin/src/schematics/migration/migration.ts
+++ b/packages/nx-plugin/src/schematics/migration/migration.ts
@@ -8,7 +8,9 @@ import {
   SchematicContext,
   template,
   Tree,
-  url
+  url,
+  filter,
+  noop
 } from '@angular-devkit/schematics';
 import {
   getProjectConfig,
@@ -75,6 +77,9 @@ function addFiles(options: NormalizedSchema): Rule {
         ...options,
         tmpl: ''
       }),
+      options.unitTestRunner === 'none'
+        ? filter(file => !file.endsWith('.spec.ts'))
+        : noop(),
       move(`${options.projectSourceRoot}/migrations`)
     ])
   );

--- a/packages/nx-plugin/src/schematics/migration/schema.d.ts
+++ b/packages/nx-plugin/src/schematics/migration/schema.d.ts
@@ -4,4 +4,5 @@ export interface Schema {
   description: string;
   version: string;
   packageJsonUpdates: boolean;
+  unitTestRunner: 'jest' | 'none';
 }

--- a/packages/nx-plugin/src/schematics/migration/schema.json
+++ b/packages/nx-plugin/src/schematics/migration/schema.json
@@ -43,6 +43,12 @@
       "description": "Whether or not to include package.json updates",
       "alias": "p",
       "default": false
+    },
+    "unitTestRunner": {
+      "type": "string",
+      "enum": ["jest", "none"],
+      "description": "Test runner to use for unit tests",
+      "default": "jest"
     }
   },
   "required": ["project", "version"]

--- a/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
@@ -163,38 +163,42 @@ describe('NxPlugin plugin', () => {
   });
 
   describe('--unitTestRunner', () => {
-    it('should not generate test files', async () => {
-      const externalSchematicSpy = jest.spyOn(
-        ngSchematics,
-        'externalSchematic'
-      );
-      const tree = await runSchematic(
-        'plugin',
-        { name: 'myPlugin', unitTestRunner: 'none' },
-        appTree
-      );
+    describe('none', () => {
+      it('should not generate test files', async () => {
+        const externalSchematicSpy = jest.spyOn(
+          ngSchematics,
+          'externalSchematic'
+        );
+        const tree = await runSchematic(
+          'plugin',
+          { name: 'myPlugin', unitTestRunner: 'none' },
+          appTree
+        );
 
-      expect(externalSchematicSpy).toBeCalledWith(
-        '@nrwl/node',
-        'lib',
-        expect.objectContaining({
-          unitTestRunner: 'none'
-        })
-      );
+        expect(externalSchematicSpy).toBeCalledWith(
+          '@nrwl/node',
+          'lib',
+          expect.objectContaining({
+            unitTestRunner: 'none'
+          })
+        );
 
-      expect(
-        tree.exists('libs/my-plugin/src/schematics/my-plugin/schematic.ts')
-      ).toBeTruthy();
-      expect(
-        tree.exists('libs/my-plugin/src/schematics/my-plugin/schematic.spec.ts')
-      ).toBeFalsy();
+        expect(
+          tree.exists('libs/my-plugin/src/schematics/my-plugin/schematic.ts')
+        ).toBeTruthy();
+        expect(
+          tree.exists(
+            'libs/my-plugin/src/schematics/my-plugin/schematic.spec.ts'
+          )
+        ).toBeFalsy();
 
-      expect(
-        tree.exists('libs/my-plugin/src/builders/build/builder.ts')
-      ).toBeTruthy();
-      expect(
-        tree.exists('libs/my-plugin/src/builders/build/builder.spec.ts')
-      ).toBeFalsy();
+        expect(
+          tree.exists('libs/my-plugin/src/builders/build/builder.ts')
+        ).toBeTruthy();
+        expect(
+          tree.exists('libs/my-plugin/src/builders/build/builder.spec.ts')
+        ).toBeFalsy();
+      });
     });
   });
 });

--- a/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
@@ -161,4 +161,40 @@ describe('NxPlugin plugin', () => {
       })
     );
   });
+
+  describe('--unitTestRunner', () => {
+    it('should not generate test files', async () => {
+      const externalSchematicSpy = jest.spyOn(
+        ngSchematics,
+        'externalSchematic'
+      );
+      const tree = await runSchematic(
+        'plugin',
+        { name: 'myPlugin', unitTestRunner: 'none' },
+        appTree
+      );
+
+      expect(externalSchematicSpy).toBeCalledWith(
+        '@nrwl/node',
+        'lib',
+        expect.objectContaining({
+          unitTestRunner: 'none'
+        })
+      );
+
+      expect(
+        tree.exists('libs/my-plugin/src/schematics/my-plugin/schematic.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('libs/my-plugin/src/schematics/my-plugin/schematic.spec.ts')
+      ).toBeFalsy();
+
+      expect(
+        tree.exists('libs/my-plugin/src/builders/build/builder.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists('libs/my-plugin/src/builders/build/builder.spec.ts')
+      ).toBeFalsy();
+    });
+  });
 });

--- a/packages/nx-plugin/src/schematics/plugin/plugin.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.ts
@@ -12,7 +12,9 @@ import {
   SchematicContext,
   template,
   Tree,
-  url
+  url,
+  filter,
+  noop
 } from '@angular-devkit/schematics';
 import {
   formatFiles,
@@ -44,7 +46,8 @@ export default function(schema: NormalizedSchema): Rule {
     return chain([
       externalSchematic('@nrwl/node', 'lib', {
         ...schema,
-        publishable: true
+        publishable: true,
+        unitTestRunner: options.unitTestRunner
       }),
       addFiles(options),
       updateWorkspaceJson(options),
@@ -113,18 +116,22 @@ function addFiles(options: NormalizedSchema): Rule {
           tmpl: '',
           offsetFromRoot: offsetFromRoot(options.projectRoot)
         }),
+        options.unitTestRunner === 'none'
+          ? filter(file => !file.endsWith('.spec.tsx'))
+          : noop(),
         move(options.projectRoot)
       ]),
       MergeStrategy.Overwrite
     ),
     schematic('schematic', {
       project: options.name,
-      name: options.name
+      name: options.name,
+      unitTestRunner: options.unitTestRunner
     }),
     schematic('builder', {
       project: options.name,
       name: 'build',
-      unitTestRunner: 'jest'
+      unitTestRunner: options.unitTestRunner
     })
   ]);
 }

--- a/packages/nx-plugin/src/schematics/plugin/plugin.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.ts
@@ -116,9 +116,6 @@ function addFiles(options: NormalizedSchema): Rule {
           tmpl: '',
           offsetFromRoot: offsetFromRoot(options.projectRoot)
         }),
-        options.unitTestRunner === 'none'
-          ? filter(file => !file.endsWith('.spec.tsx'))
-          : noop(),
         move(options.projectRoot)
       ]),
       MergeStrategy.Overwrite

--- a/packages/nx-plugin/src/schematics/schematic/schema.d.ts
+++ b/packages/nx-plugin/src/schematics/schematic/schema.d.ts
@@ -2,4 +2,5 @@ export interface Schema {
   project: string;
   name: string;
   description?: string;
+  unitTestRunner: 'jest' | 'none';
 }

--- a/packages/nx-plugin/src/schematics/schematic/schema.json
+++ b/packages/nx-plugin/src/schematics/schematic/schema.json
@@ -32,6 +32,12 @@
       "type": "string",
       "description": "Schematic description",
       "alias": "d"
+    },
+    "unitTestRunner": {
+      "type": "string",
+      "enum": ["jest", "none"],
+      "description": "Test runner to use for unit tests",
+      "default": "jest"
     }
   },
   "required": ["project", "name"]

--- a/packages/nx-plugin/src/schematics/schematic/schematic.spec.ts
+++ b/packages/nx-plugin/src/schematics/schematic/schematic.spec.ts
@@ -109,25 +109,27 @@ describe('NxPlugin schematic', () => {
   });
 
   describe('--unitTestRunner', () => {
-    it('should generate files', async () => {
-      const tree = await runSchematic(
-        'schematic',
-        {
-          project: projectName,
-          name: 'my-schematic',
-          unitTestRunner: 'none'
-        },
-        appTree
-      );
+    describe('none', () => {
+      it('should generate files', async () => {
+        const tree = await runSchematic(
+          'schematic',
+          {
+            project: projectName,
+            name: 'my-schematic',
+            unitTestRunner: 'none'
+          },
+          appTree
+        );
 
-      expect(
-        tree.exists('libs/my-plugin/src/schematics/my-schematic/schematic.ts')
-      ).toBeTruthy();
-      expect(
-        tree.exists(
-          'libs/my-plugin/src/schematics/my-schematic/schematic.spec.ts'
-        )
-      ).toBeFalsy();
+        expect(
+          tree.exists('libs/my-plugin/src/schematics/my-schematic/schematic.ts')
+        ).toBeTruthy();
+        expect(
+          tree.exists(
+            'libs/my-plugin/src/schematics/my-schematic/schematic.spec.ts'
+          )
+        ).toBeFalsy();
+      });
     });
   });
 });

--- a/packages/nx-plugin/src/schematics/schematic/schematic.spec.ts
+++ b/packages/nx-plugin/src/schematics/schematic/schematic.spec.ts
@@ -107,4 +107,27 @@ describe('NxPlugin schematic', () => {
       'my-schematic custom description'
     );
   });
+
+  describe('--unitTestRunner', () => {
+    it('should generate files', async () => {
+      const tree = await runSchematic(
+        'schematic',
+        {
+          project: projectName,
+          name: 'my-schematic',
+          unitTestRunner: 'none'
+        },
+        appTree
+      );
+
+      expect(
+        tree.exists('libs/my-plugin/src/schematics/my-schematic/schematic.ts')
+      ).toBeTruthy();
+      expect(
+        tree.exists(
+          'libs/my-plugin/src/schematics/my-schematic/schematic.spec.ts'
+        )
+      ).toBeFalsy();
+    });
+  });
 });

--- a/packages/nx-plugin/src/schematics/schematic/schematic.spec.ts
+++ b/packages/nx-plugin/src/schematics/schematic/schematic.spec.ts
@@ -110,7 +110,7 @@ describe('NxPlugin schematic', () => {
 
   describe('--unitTestRunner', () => {
     describe('none', () => {
-      it('should generate files', async () => {
+      it('should not generate files', async () => {
         const tree = await runSchematic(
           'schematic',
           {

--- a/packages/nx-plugin/src/schematics/schematic/schematic.ts
+++ b/packages/nx-plugin/src/schematics/schematic/schematic.ts
@@ -8,7 +8,9 @@ import {
   SchematicContext,
   template,
   Tree,
-  url
+  url,
+  filter,
+  noop
 } from '@angular-devkit/schematics';
 import {
   getProjectConfig,
@@ -80,6 +82,9 @@ function addFiles(options: NormalizedSchema): Rule {
         ...names(options.name),
         tmpl: ''
       }),
+      options.unitTestRunner === 'none'
+        ? filter(file => !file.endsWith('.spec.ts'))
+        : noop(),
       move(`${options.projectSourceRoot}/schematics`)
     ])
   );


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`@nrwl/nx-plugin` has a `unitTestRunner` property that is not being honored.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`@nrwl/nx-plugin` does not generate unit test configurations or files when `--unitTestRunner=none` is passed.