### PR TITLE
feat(docs): show entity type and entity container's type

### DIFF
--- a/docs/angular/api-linter/builders/lint.md
+++ b/docs/angular/api-linter/builders/lint.md
@@ -88,6 +88,6 @@ Hide output text.
 
 ### tsConfig
 
-Type: `string | array`
+Type: `string | string[]`
 
 The name of the TypeScript configuration file.

--- a/docs/angular/api-next/builders/build.md
+++ b/docs/angular/api-next/builders/build.md
@@ -8,7 +8,7 @@ Builder properties can be configured in angular.json when defining the builder, 
 
 ### fileReplacements
 
-Type: `array` of `object`
+Type: `object[]`
 
 Replace files with other files in the build.
 

--- a/docs/angular/api-node/builders/build.md
+++ b/docs/angular/api-node/builders/build.md
@@ -24,7 +24,7 @@ Read buildable libraries from source instead of building them separately.
 
 Default: `all`
 
-Type: `string | array`
+Type: `string | string[]`
 
 Dependencies to keep external to the bundle. ("all" (default), "none", or an array of module names)
 
@@ -38,7 +38,7 @@ Extract all licenses in a separate file, in the case of production builds only.
 
 ### fileReplacements
 
-Type: `array` of `object`
+Type: `object[]`
 
 Replace files with other files in the build.
 

--- a/docs/angular/api-web/builders/build.md
+++ b/docs/angular/api-web/builders/build.md
@@ -72,7 +72,7 @@ Extract all licenses in a separate file, in the case of production builds only.
 
 ### fileReplacements
 
-Type: `array` of `object`
+Type: `object[]`
 
 Replace files with other files in the build.
 

--- a/docs/angular/api-web/builders/package.md
+++ b/docs/angular/api-web/builders/package.md
@@ -34,7 +34,7 @@ CSS files will be extracted to the output folder.
 
 ### globals
 
-Type: `array` of `object`
+Type: `object[]`
 
 A mapping of node modules to their UMD global names. Used by the UMD bundle
 

--- a/docs/angular/api-workspace/builders/run-commands.md
+++ b/docs/angular/api-workspace/builders/run-commands.md
@@ -156,7 +156,7 @@ Use colors when showing output of command
 
 ### commands
 
-Type: `array` of `object`
+Type: `object[]`
 
 #### command
 
@@ -178,7 +178,7 @@ You may specify a custom .env file path
 
 ### outputPath
 
-Type: `string | array`
+Type: `string | string[]`
 
 Tells Nx where the files will be created
 

--- a/docs/react/api-linter/builders/lint.md
+++ b/docs/react/api-linter/builders/lint.md
@@ -89,6 +89,6 @@ Hide output text.
 
 ### tsConfig
 
-Type: `string | array`
+Type: `string | string[]`
 
 The name of the TypeScript configuration file.

--- a/docs/react/api-next/builders/build.md
+++ b/docs/react/api-next/builders/build.md
@@ -9,7 +9,7 @@ Read more about how to use builders and the CLI here: https://nx.dev/react/guide
 
 ### fileReplacements
 
-Type: `array` of `object`
+Type: `object[]`
 
 Replace files with other files in the build.
 

--- a/docs/react/api-node/builders/build.md
+++ b/docs/react/api-node/builders/build.md
@@ -25,7 +25,7 @@ Read buildable libraries from source instead of building them separately.
 
 Default: `all`
 
-Type: `string | array`
+Type: `string | string[]`
 
 Dependencies to keep external to the bundle. ("all" (default), "none", or an array of module names)
 
@@ -39,7 +39,7 @@ Extract all licenses in a separate file, in the case of production builds only.
 
 ### fileReplacements
 
-Type: `array` of `object`
+Type: `object[]`
 
 Replace files with other files in the build.
 

--- a/docs/react/api-web/builders/build.md
+++ b/docs/react/api-web/builders/build.md
@@ -73,7 +73,7 @@ Extract all licenses in a separate file, in the case of production builds only.
 
 ### fileReplacements
 
-Type: `array` of `object`
+Type: `object[]`
 
 Replace files with other files in the build.
 

--- a/docs/react/api-web/builders/package.md
+++ b/docs/react/api-web/builders/package.md
@@ -35,7 +35,7 @@ CSS files will be extracted to the output folder.
 
 ### globals
 
-Type: `array` of `object`
+Type: `object[]`
 
 A mapping of node modules to their UMD global names. Used by the UMD bundle
 

--- a/docs/react/api-workspace/builders/run-commands.md
+++ b/docs/react/api-workspace/builders/run-commands.md
@@ -157,7 +157,7 @@ Use colors when showing output of command
 
 ### commands
 
-Type: `array` of `object`
+Type: `object[]`
 
 #### command
 
@@ -179,7 +179,7 @@ You may specify a custom .env file path
 
 ### outputPath
 
-Type: `string | array`
+Type: `string | string[]`
 
 Tells Nx where the files will be created
 

--- a/scripts/documentation/generate-builders-data.ts
+++ b/scripts/documentation/generate-builders-data.ts
@@ -114,13 +114,18 @@ function generateTemplate(
             }`;
 
         if (option.types && option.types.length) {
+          const displayTypeList = option.types.map(type =>
+            type === 'array' ? `${option.type}[]` : type
+          );
           template += dedent`
-              Type: \`${option.types.join(' | ')} \`\n`;
+              Type: \`${displayTypeList.join(' | ')} \`\n`;
         } else {
           template += dedent`
-              Type: \`${option.type}\` ${
-            option.arrayOfType ? `of \`${option.arrayOfType}\`` : ''
-          } \n`;
+              Type: ${
+                option.arrayOfType
+                  ? `\`${option.arrayOfType}[]\``
+                  : `\`${option.type}\``
+              } \n`;
         }
 
         template += dedent`  

--- a/scripts/documentation/json-parser.ts
+++ b/scripts/documentation/json-parser.ts
@@ -152,10 +152,6 @@ export async function parseJsonSchemaToOptions(
         ? xDeprecated
         : undefined;
 
-    const xUserAnalytics = current['x-user-analytics'];
-    const userAnalytics =
-      typeof xUserAnalytics == 'number' ? xUserAnalytics : undefined;
-
     const option: NxOption = {
       name,
       description:
@@ -167,7 +163,6 @@ export async function parseJsonSchemaToOptions(
       aliases,
       ...(format !== undefined ? { format } : {}),
       hidden,
-      ...(userAnalytics ? { userAnalytics } : {}),
       ...(deprecated !== undefined ? { deprecated } : {}),
       ...(positional !== undefined ? { positional } : {})
     };


### PR DESCRIPTION
Documentation now supports to show options with multiple associated types. Like `string` and `string[]`.
