### PR TITLE
feat(storybook): add docs mode option to dev server builder

### DIFF
--- a/docs/angular/api-storybook/builders/storybook.md
+++ b/docs/angular/api-storybook/builders/storybook.md
@@ -6,6 +6,14 @@ Builder properties can be configured in angular.json when defining the builder, 
 
 ## Properties
 
+### docsMode
+
+Default: `false`
+
+Type: `boolean`
+
+Build a documentation-only site using addon-docs.
+
 ### host
 
 Default: `localhost`

--- a/docs/react/api-storybook/builders/storybook.md
+++ b/docs/react/api-storybook/builders/storybook.md
@@ -7,6 +7,14 @@ Read more about how to use builders and the CLI here: https://nx.dev/react/guide
 
 ## Properties
 
+### docsMode
+
+Default: `false`
+
+Type: `boolean`
+
+Build a documentation-only site using addon-docs.
+
 ### host
 
 Default: `localhost`

--- a/packages/storybook/src/builders/build-storybook/build-storybook.impl.ts
+++ b/packages/storybook/src/builders/build-storybook/build-storybook.impl.ts
@@ -88,7 +88,6 @@ async function storybookOptionMapper(
     ...frameworkOptions,
     frameworkPresets: [...(frameworkOptions.frameworkPresets || [])],
     watch: false,
-    docsMode: builderOptions.docsMode,
   };
   optionsWithFramework.config;
   return optionsWithFramework;

--- a/packages/storybook/src/builders/storybook/schema.json
+++ b/packages/storybook/src/builders/storybook/schema.json
@@ -78,6 +78,11 @@
         }
       ]
     },
+    "docsMode": {
+      "type": "boolean",
+      "description": "Build a documentation-only site using addon-docs.",
+      "default": false
+    },
     "quiet": {
       "type": "boolean",
       "description": "Suppress verbose build output.",

--- a/packages/storybook/src/builders/storybook/storybook.impl.ts
+++ b/packages/storybook/src/builders/storybook/storybook.impl.ts
@@ -33,6 +33,7 @@ export interface StorybookBuilderOptions extends JsonObject {
   sslKey?: string;
   staticDir?: number[];
   watch?: boolean;
+  docsMode?: boolean;
 }
 
 try {


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

The `storybook` builder doesn't have the docs mode option, but the `build-storybook` builder does.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Be able to serve Storybook in docs mode with your dev server.