### PR TITLE
feat(core): update prettier to 2.0.4

### DIFF
--- a/e2e/node.test.ts
+++ b/e2e/node.test.ts
@@ -336,10 +336,10 @@ forEachCli(currentCLIName => {
                 preset: '../../jest.config.js',
                 testEnvironment: 'node',
                  transform: {
-                '^.+\\.[tj]sx?$': 'ts-jest'
+                '^.+\\.[tj]sx?$': 'ts-jest',
                 },
                 moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
-                coverageDirectory: '../../coverage/libs/${nestlib}'
+                coverageDirectory: '../../coverage/libs/${nestlib}',
             };
             `
       );

--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -69,6 +69,11 @@
       "version": "9.2.0-beta.1",
       "description": "Add cacheable operations to nx.json",
       "factory": "./src/migrations/update-9-2-0/update-9-2-0"
+    },
+    "update-9-3-0": {
+      "version": "9.3.0-beta.1",
+      "description": "Update prettier to v2",
+      "factory": "./src/migrations/update-9-3-0/update-9-3-0"
     }
   },
   "packageJsonUpdates": {
@@ -538,6 +543,14 @@
         "@angular/service-worker": {
           "version": "~9.1.0",
           "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "9.3.0": {
+      "version": "9.3.0-beta.1",
+      "packages": {
+        "prettier": {
+          "version": "2.0.4"
         }
       }
     }

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -47,7 +47,7 @@
     ]
   },
   "peerDependencies": {
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.4"
   },
   "dependencies": {
     "@angular-devkit/core": "~9.1.0",

--- a/packages/workspace/src/migrations/update-9-3-0/update-9-3-0.ts
+++ b/packages/workspace/src/migrations/update-9-3-0/update-9-3-0.ts
@@ -1,0 +1,11 @@
+import { chain } from '@angular-devkit/schematics';
+import { formatFiles, updatePackagesInPackageJson } from '@nrwl/workspace';
+import { join } from 'path';
+
+const updatePackages = updatePackagesInPackageJson(
+  join(__dirname, '../../../', 'migrations.json'),
+  '9.3.0'
+);
+export default function() {
+  return chain([updatePackages, formatFiles()]);
+}

--- a/packages/workspace/src/utils/versions.ts
+++ b/packages/workspace/src/utils/versions.ts
@@ -2,7 +2,7 @@ export const nxVersion = '*';
 
 export const angularCliVersion = '9.1.0';
 export const typescriptVersion = '~3.8.3';
-export const prettierVersion = '1.19.1';
+export const prettierVersion = '2.0.4';
 export const typescriptESLintVersion = '2.19.2';
 export const eslintVersion = '6.8.0';
 export const eslintConfigPrettierVersion = '6.0.0';


### PR DESCRIPTION
ISSUES CLOSED: #2710

Updates the workspace prettier version to 2.0.4 and runs formatting during the migration.