### PR TITLE
fix(storybook): only install the necessary package dependencies

### DIFF
--- a/docs/angular/api-storybook/schematics/configuration.md
+++ b/docs/angular/api-storybook/schematics/configuration.md
@@ -58,6 +58,6 @@ Library name
 
 Type: `string`
 
-Possible values: `@storybook/angular`, `@storybook/react`, `@storybook/web`
+Possible values: `@storybook/angular`, `@storybook/react`
 
 Storybook UI Framework to use

--- a/docs/react/api-storybook/schematics/configuration.md
+++ b/docs/react/api-storybook/schematics/configuration.md
@@ -58,6 +58,6 @@ Library name
 
 Type: `string`
 
-Possible values: `@storybook/angular`, `@storybook/react`, `@storybook/web`
+Possible values: `@storybook/angular`, `@storybook/react`
 
 Storybook UI Framework to use

--- a/packages/storybook/src/schematics/configuration/configuration.ts
+++ b/packages/storybook/src/schematics/configuration/configuration.ts
@@ -25,7 +25,9 @@ import { toJS } from '@nrwl/workspace/src/utils/rules/to-js';
 
 export default function (schema: StorybookConfigureSchema): Rule {
   return chain([
-    schematic('ng-add', {}),
+    schematic('ng-add', {
+      uiFramework: schema.uiFramework,
+    }),
     createRootStorybookDir(schema.name, schema.js),
     createLibStorybookDir(schema.name, schema.uiFramework, schema.js),
     configureTsConfig(schema.name),

--- a/packages/storybook/src/schematics/configuration/schema.json
+++ b/packages/storybook/src/schematics/configuration/schema.json
@@ -14,7 +14,7 @@
     "uiFramework": {
       "type": "string",
       "description": "Storybook UI Framework to use",
-      "enum": ["@storybook/angular", "@storybook/react", "@storybook/web"],
+      "enum": ["@storybook/angular", "@storybook/react"],
       "x-prompt": "What UI framework plugin should storybook use?"
     },
     "configureCypress": {

--- a/packages/storybook/src/schematics/init/init.spec.ts
+++ b/packages/storybook/src/schematics/init/init.spec.ts
@@ -14,28 +14,87 @@ describe('init', () => {
     appTree = createEmptyWorkspace(appTree);
   });
 
-  it('should add dependencies into `package.json` file', async () => {
-    const existing = 'existing';
-    const existingVersion = '1.0.0';
-    await callRule(
-      addDepsToPackageJson(
-        { '@nrwl/storybook': storybookVersion, [existing]: existingVersion },
-        { [existing]: existingVersion },
-        false
-      ),
-      appTree
-    );
-    const tree = await runSchematic('init', {}, appTree);
-    const packageJson = readJsonInTree(tree, 'package.json');
-    expect(packageJson.devDependencies['@nrwl/storybook']).toBeDefined();
-    expect(packageJson.devDependencies['@storybook/angular']).toBeDefined();
-    expect(packageJson.devDependencies['@storybook/react']).toBeDefined();
-    expect(packageJson.devDependencies['@storybook/addon-knobs']).toBeDefined();
-    expect(packageJson.devDependencies[existing]).toBeDefined();
-    expect(packageJson.devDependencies['@babel/core']).toBeDefined();
-    expect(packageJson.devDependencies['babel-loader']).toBeDefined();
-    expect(packageJson.dependencies['@nrwl/storybook']).toBeUndefined();
-    expect(packageJson.dependencies[existing]).toBeDefined();
+  describe('dependencies for package.json', () => {
+    it('should add angular related dependencies when using Angular as uiFramework', async () => {
+      const existing = 'existing';
+      const existingVersion = '1.0.0';
+      await callRule(
+        addDepsToPackageJson(
+          { '@nrwl/storybook': storybookVersion, [existing]: existingVersion },
+          { [existing]: existingVersion },
+          false
+        ),
+        appTree
+      );
+      const tree = await runSchematic(
+        'init',
+        {
+          uiFramework: '@storybook/angular',
+        },
+        appTree
+      );
+      const packageJson = readJsonInTree(tree, 'package.json');
+
+      // general deps
+      expect(packageJson.devDependencies['@nrwl/storybook']).toBeDefined();
+      expect(packageJson.dependencies['@nrwl/storybook']).toBeUndefined();
+      expect(packageJson.dependencies[existing]).toBeDefined();
+      expect(packageJson.devDependencies[existing]).toBeDefined();
+      expect(
+        packageJson.devDependencies['@storybook/addon-knobs']
+      ).toBeDefined();
+
+      // angular specific
+      expect(packageJson.devDependencies['@storybook/angular']).toBeDefined();
+      expect(packageJson.devDependencies['@angular/forms']).toBeDefined();
+
+      // react specific
+      expect(packageJson.devDependencies['@storybook/react']).not.toBeDefined();
+      expect(packageJson.devDependencies['@babel/core']).not.toBeDefined();
+      expect(packageJson.devDependencies['babel-loader']).not.toBeDefined();
+    });
+
+    it('should add react related dependencies when using React as uiFramework', async () => {
+      console.log('test');
+      const existing = 'existing';
+      const existingVersion = '1.0.0';
+      await callRule(
+        addDepsToPackageJson(
+          { '@nrwl/storybook': storybookVersion, [existing]: existingVersion },
+          { [existing]: existingVersion },
+          false
+        ),
+        appTree
+      );
+      const tree = await runSchematic(
+        'init',
+        {
+          uiFramework: '@storybook/react',
+        },
+        appTree
+      );
+      const packageJson = readJsonInTree(tree, 'package.json');
+
+      // general deps
+      expect(packageJson.devDependencies['@nrwl/storybook']).toBeDefined();
+      expect(packageJson.dependencies['@nrwl/storybook']).toBeUndefined();
+      expect(packageJson.dependencies[existing]).toBeDefined();
+      expect(packageJson.devDependencies[existing]).toBeDefined();
+      expect(
+        packageJson.devDependencies['@storybook/addon-knobs']
+      ).toBeDefined();
+
+      // react specific
+      expect(packageJson.devDependencies['@storybook/react']).toBeDefined();
+      expect(packageJson.devDependencies['@babel/core']).toBeDefined();
+      expect(packageJson.devDependencies['babel-loader']).toBeDefined();
+
+      // angular specific
+      expect(
+        packageJson.devDependencies['@storybook/angular']
+      ).not.toBeDefined();
+      expect(packageJson.devDependencies['@angular/forms']).not.toBeDefined();
+    });
   });
 
   it('should add build-storybook to cacheable operations', async () => {

--- a/packages/storybook/src/schematics/init/schema.d.ts
+++ b/packages/storybook/src/schematics/init/schema.d.ts
@@ -1,1 +1,3 @@
-export interface Schema {}
+export interface Schema {
+  uiFramework: '@storybook/angular' | '@storybook/react';
+}

--- a/packages/storybook/src/schematics/init/schema.json
+++ b/packages/storybook/src/schematics/init/schema.json
@@ -3,5 +3,12 @@
   "id": "Nx Storybook Project Schematics Schema",
   "title": "Add Storybook Configuration to the workspace",
   "type": "object",
-  "properties": {}
+  "properties": {
+    "uiFramework": {
+      "type": "string",
+      "description": "Storybook UI Framework to use",
+      "enum": ["@storybook/angular", "@storybook/react"],
+      "x-prompt": "What UI framework plugin should storybook use?"
+    }
+  }
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Currently when configuring storybook for a React library, also Angular based dependencies get installed.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Only the minimum required package dependencies should be installed when setting up Storybook

## Notes

Waiting on #2831 to go in first
