### PR TITLE
fix(react): do not include package.json in libs without publishable flag

### DIFF
--- a/e2e/react.test.ts
+++ b/e2e/react.test.ts
@@ -28,6 +28,9 @@ forEachCli(currentCLIName => {
       );
       runCLI(`generate @nrwl/react:lib ${libName} --no-interactive`);
 
+      // Libs should not include package.json by default
+      checkFilesDoNotExist(`libs/${libName}/package.json`);
+
       const mainPath = `apps/${appName}/src/main.tsx`;
       updateFile(mainPath, `import '@proj/${libName}';\n` + readFile(mainPath));
 

--- a/packages/react/src/schematics/library/library.spec.ts
+++ b/packages/react/src/schematics/library/library.spec.ts
@@ -92,6 +92,7 @@ describe('lib', () => {
 
     it('should generate files', async () => {
       const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+      expect(tree.exists('libs/my-lib/package.json')).toBeFalsy();
       expect(tree.exists(`libs/my-lib/jest.config.js`)).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/index.ts')).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/lib/my-lib.tsx')).toBeTruthy();

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -96,7 +96,7 @@ export default function(schema: Schema): Rule {
             pascalCaseFiles: options.pascalCaseFiles
           })
         : noop(),
-      updateLibPackageNpmScope(options),
+      options.publishable ? updateLibPackageNpmScope(options) : noop(),
       updateAppRoutes(options, context),
       formatFiles(options)
     ])(host, context);


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
Package.json is created for react libs without the `--publishable` flag. 

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Package.json should only be created when `--publishable` is used with the generate command.

## Issue
