### PR TITLE
add customArgs to run-commands builder

### DIFF
--- a/docs/angular/api-workspace/builders/run-commands.md
+++ b/docs/angular/api-workspace/builders/run-commands.md
@@ -72,6 +72,36 @@ nx run frontend:create-script --args="--name=example"
 
 Notice the `--args="--name=example"` syntax: we can send custom arguments that will be interpolated into our commands via `{args.name}`
 
+##### Passing custom args
+
+Sometimes you need two variations of the same command and you want to send down an extra arg to the command. You can accomplish this with the `--customArgs` parameter.
+
+```json
+"generate-code": {
+    "builder": "@nrwl/workspace:run-commands",
+    "options": {
+        "commands": [
+            {
+            "command": "generate-code"
+            }
+        ],
+        "cwd": "apps/frontend"
+    }
+}
+```
+
+You can now run:
+
+```sh
+nx run frontend:generate-code
+```
+
+Which will run it only once, or if the `generate-code` binary allows it you can add `--watch`:
+
+```sh
+nx run frontend:generate-code --customArgs="--watch"
+```
+
 ##### Custom **done** conditions
 
 Normally, `run-commands` considers the commands done when all of them have finished running. If you don't need to wait until they're all done, you can set a special string, that considers the command finished the moment the string appears in `stdout` or `stderr`:
@@ -163,6 +193,12 @@ Type: `object[]`
 Type: `string`
 
 Command to run in child process
+
+### customArgs
+
+Type: `string`
+
+Custom arguments to append to the command
 
 ### cwd
 

--- a/docs/react/api-workspace/builders/run-commands.md
+++ b/docs/react/api-workspace/builders/run-commands.md
@@ -73,6 +73,36 @@ nx run frontend:create-script --args="--name=example"
 
 Notice the `--args="--name=example"` syntax: we can send custom arguments that will be interpolated into our commands via `{args.name}`
 
+##### Passing custom args
+
+Sometimes you need two variations of the same command and you want to send down an extra arg to the command. You can accomplish this with the `--customArgs` parameter.
+
+```json
+"generate-code": {
+    "builder": "@nrwl/workspace:run-commands",
+    "options": {
+        "commands": [
+            {
+            "command": "generate-code"
+            }
+        ],
+        "cwd": "apps/frontend"
+    }
+}
+```
+
+You can now run:
+
+```sh
+nx run frontend:generate-code
+```
+
+Which will run it only once, or if the `generate-code` binary allows it you can add `--watch`:
+
+```sh
+nx run frontend:generate-code --customArgs="--watch"
+```
+
 ##### Custom **done** conditions
 
 Normally, `run-commands` considers the commands done when all of them have finished running. If you don't need to wait until they're all done, you can set a special string, that considers the command finished the moment the string appears in `stdout` or `stderr`:
@@ -164,6 +194,12 @@ Type: `object[]`
 Type: `string`
 
 Command to run in child process
+
+### customArgs
+
+Type: `string`
+
+Custom arguments to append to the command
 
 ### cwd
 

--- a/packages/workspace/docs/run-commands-examples.md
+++ b/packages/workspace/docs/run-commands-examples.md
@@ -64,6 +64,36 @@ We run the above with:
 
 Notice the `--args="--name=example"` syntax: we can send custom arguments that will be interpolated into our commands via `{args.name}`
 
+##### Passing custom args
+
+Sometimes you need two variations of the same command and you want to send down an extra arg to the command. You can accomplish this with the `--customArgs` parameter.
+
+```json
+"generate-code": {
+    "builder": "@nrwl/workspace:run-commands",
+    "options": {
+        "commands": [
+            {
+            "command": "generate-code"
+            }
+        ],
+        "cwd": "apps/frontend"
+    }
+}
+```
+
+You can now run:
+
+```sh
+<%= cli %> run frontend:generate-code
+```
+
+Which will run it only once, or if the `generate-code` binary allows it you can add `--watch`:
+
+```sh
+<%= cli %> run frontend:generate-code --customArgs="--watch"
+```
+
 ##### Custom **done** conditions
 
 Normally, `run-commands` considers the commands done when all of them have finished running. If you don't need to wait until they're all done, you can set a special string, that considers the command finished the moment the string appears in `stdout` or `stderr`:

--- a/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.spec.ts
@@ -375,4 +375,28 @@ describe('Command Runner Builder', () => {
       );
     });
   });
+
+  describe('--customArgs', () => {
+    it('should append custom arguments', async () => {
+      const exec = spyOn(require('child_process'), 'exec').and.callThrough();
+      const run = await architect.scheduleBuilder(
+        '@nrwl/workspace:run-commands',
+        {
+          commands: [
+            {
+              command: `ls`
+            }
+          ],
+          customArgs: '-lah'
+        }
+      );
+
+      await run.result;
+
+      expect(exec).toHaveBeenCalledWith(`ls -lah`, {
+        maxBuffer: TEN_MEGABYTES,
+        env: { ...process.env, FORCE_COLOR: `false` }
+      });
+    });
+  });
 });

--- a/packages/workspace/src/builders/run-commands/schema.json
+++ b/packages/workspace/src/builders/run-commands/schema.json
@@ -40,6 +40,11 @@
       "description": "Use colors when showing output of command",
       "default": false
     },
+    "customArgs": {
+      "type": "string",
+      "description": "Custom arguments to append to the command",
+      "default": ""
+    },
     "outputPath": {
       "description": "Tells Nx where the files will be created",
       "oneOf": [


### PR DESCRIPTION
## Description

This PR adds the ability to append custom arguments to a command. Check the updated docs in this PR for more info:

### Passing custom args

Sometimes you need two variations of the same command and you want to send down an extra arg to the command. You can accomplish this with the `--customArgs` parameter.

```json
"generate-code": {
    "builder": "@nrwl/workspace:run-commands",
    "options": {
        "commands": [
            {
            "command": "generate-code"
            }
        ],
        "cwd": "apps/frontend"
    }
}
```

You can now run:

```sh
<%= cli %> run frontend:generate-code
```

Which will run it only once, or if the `generate-code` binary allows it you can add `--watch`:

```sh
<%= cli %> run frontend:generate-code --customArgs="--watch"
```