### PR TITLE
fix(docs): fix react nx console link

### DIFF
--- a/docs/react/tutorial/06-proxy.md
+++ b/docs/react/tutorial/06-proxy.md
@@ -68,7 +68,7 @@ Options:
   --help                  Show available options for project target.
 ```
 
-It helps with good editor integration (see [VSCode Support](https://nx.dev/nx-console)).
+It helps with good editor integration (see [VSCode Support](https://nx.dev/react/cli/console)).
 
 But, most importantly, it provides a holistic dev experience regardless of the tools used, and enables advanced build features like distributed computation caching and distributed builds).
 


### PR DESCRIPTION
Update the url targeting Nx Console documentation for the new version.