### PR TITLE
fix(react): pass linter option properly to storybook cypress setup

### DIFF
--- a/docs/angular/api-react/schematics/storybook-configuration.md
+++ b/docs/angular/api-react/schematics/storybook-configuration.md
@@ -44,6 +44,16 @@ Type: `boolean`
 
 Generate JavaScript files rather than TypeScript files
 
+### linter
+
+Default: `tslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`
+
+The tool to use for running lint checks.
+
 ### name
 
 Type: `string`

--- a/docs/angular/api-storybook/schematics/configuration.md
+++ b/docs/angular/api-storybook/schematics/configuration.md
@@ -38,6 +38,16 @@ Type: `boolean`
 
 Generate JavaScript files rather than TypeScript files
 
+### linter
+
+Default: `tslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`
+
+The tool to use for running lint checks.
+
 ### name
 
 Type: `string`

--- a/docs/angular/api-storybook/schematics/cypress-project.md
+++ b/docs/angular/api-storybook/schematics/cypress-project.md
@@ -32,6 +32,16 @@ Type: `boolean`
 
 Generate JavaScript files rather than TypeScript files
 
+### linter
+
+Default: `tslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`
+
+The tool to use for running lint checks.
+
 ### name
 
 Type: `string`

--- a/docs/react/api-react/schematics/storybook-configuration.md
+++ b/docs/react/api-react/schematics/storybook-configuration.md
@@ -44,6 +44,16 @@ Type: `boolean`
 
 Generate JavaScript files rather than TypeScript files
 
+### linter
+
+Default: `tslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`
+
+The tool to use for running lint checks.
+
 ### name
 
 Type: `string`

--- a/docs/react/api-storybook/schematics/configuration.md
+++ b/docs/react/api-storybook/schematics/configuration.md
@@ -38,6 +38,16 @@ Type: `boolean`
 
 Generate JavaScript files rather than TypeScript files
 
+### linter
+
+Default: `tslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`
+
+The tool to use for running lint checks.
+
 ### name
 
 Type: `string`

--- a/docs/react/api-storybook/schematics/cypress-project.md
+++ b/docs/react/api-storybook/schematics/cypress-project.md
@@ -32,6 +32,16 @@ Type: `boolean`
 
 Generate JavaScript files rather than TypeScript files
 
+### linter
+
+Default: `tslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`
+
+The tool to use for running lint checks.
+
 ### name
 
 Type: `string`

--- a/packages/react/src/schematics/init/init.ts
+++ b/packages/react/src/schematics/init/init.ts
@@ -42,9 +42,11 @@ function setDefault(): Rule {
       jsonIdentity(workspace.extensions.schematics) || {};
     const reactSchematics =
       jsonIdentity(workspace.extensions.schematics['@nrwl/react']) || {};
+
     workspace.extensions.schematics = {
       ...workspace.extensions.schematics,
       '@nrwl/react': {
+        ...reactSchematics,
         application: {
           ...jsonIdentity(reactSchematics.application),
           babel: true

--- a/packages/react/src/schematics/storybook-configuration/configuration.ts
+++ b/packages/react/src/schematics/storybook-configuration/configuration.ts
@@ -25,7 +25,8 @@ export default function(schema: StorybookConfigureSchema): Rule {
       name: schema.name,
       uiFramework: '@storybook/react',
       configureCypress: schema.configureCypress,
-      js: schema.js
+      js: schema.js,
+      linter: schema.linter
     }),
     schema.generateStories ? generateStories(schema) : noop()
   ]);

--- a/packages/react/src/schematics/storybook-configuration/schema.d.ts
+++ b/packages/react/src/schematics/storybook-configuration/schema.d.ts
@@ -1,7 +1,10 @@
+import { Linter } from '@nrwl/workspace';
+
 export interface StorybookConfigureSchema {
   name: string;
   configureCypress: boolean;
   generateStories?: boolean;
   generateCypressSpecs?: boolean;
   js?: boolean;
+  linter?: Linter;
 }

--- a/packages/react/src/schematics/storybook-configuration/schema.json
+++ b/packages/react/src/schematics/storybook-configuration/schema.json
@@ -25,6 +25,12 @@
       "type": "boolean",
       "description": "Generate JavaScript files rather than TypeScript files",
       "default": false
+    },
+    "linter": {
+      "description": "The tool to use for running lint checks.",
+      "type": "string",
+      "enum": ["eslint", "tslint"],
+      "default": "tslint"
     }
   },
   "required": ["name"]

--- a/packages/storybook/src/schematics/configuration/configuration.ts
+++ b/packages/storybook/src/schematics/configuration/configuration.ts
@@ -33,7 +33,8 @@ export default function(schema: StorybookConfigureSchema): Rule {
     schema.configureCypress
       ? schematic<CypressConfigureSchema>('cypress-project', {
           name: schema.name,
-          js: schema.js
+          js: schema.js,
+          linter: schema.linter
         })
       : () => {}
   ]);

--- a/packages/storybook/src/schematics/configuration/schema.d.ts
+++ b/packages/storybook/src/schematics/configuration/schema.d.ts
@@ -1,6 +1,9 @@
+import { Linter } from '@nrwl/workspace';
+
 export interface StorybookConfigureSchema {
   name: string;
   uiFramework: string;
   configureCypress: boolean;
+  linter: Linter;
   js?: boolean;
 }

--- a/packages/storybook/src/schematics/configuration/schema.json
+++ b/packages/storybook/src/schematics/configuration/schema.json
@@ -22,6 +22,12 @@
       "description": "Run the cypress-configure schematic",
       "x-prompt": "Configure a cypress e2e app to run against the storybook instance?"
     },
+    "linter": {
+      "description": "The tool to use for running lint checks.",
+      "type": "string",
+      "enum": ["eslint", "tslint"],
+      "default": "tslint"
+    },
     "js": {
       "type": "boolean",
       "description": "Generate JavaScript files rather than TypeScript files",

--- a/packages/storybook/src/schematics/cypress-project/cypress-project.ts
+++ b/packages/storybook/src/schematics/cypress-project/cypress-project.ts
@@ -7,10 +7,12 @@ import {
 } from '@angular-devkit/schematics';
 import { getProjectConfig, updateWorkspaceInTree } from '@nrwl/workspace';
 import { parseJsonAtPath, safeFileDelete } from '../../utils/utils';
+import { Linter } from '@nrwl/workspace';
 
 export interface CypressConfigureSchema {
   name: string;
   js?: boolean;
+  linter: Linter;
 }
 
 export default function(schema: CypressConfigureSchema): Rule {
@@ -19,7 +21,8 @@ export default function(schema: CypressConfigureSchema): Rule {
     externalSchematic('@nrwl/cypress', 'cypress-project', {
       name: e2eProjectName,
       project: schema.name,
-      js: schema.js
+      js: schema.js,
+      linter: schema.linter
     }),
     removeUnneededFiles(e2eProjectName, schema.js),
     addBaseUrlToCypressConfig(e2eProjectName),

--- a/packages/storybook/src/schematics/cypress-project/schema.json
+++ b/packages/storybook/src/schematics/cypress-project/schema.json
@@ -15,6 +15,12 @@
       "type": "boolean",
       "description": "Generate JavaScript files rather than TypeScript files",
       "default": false
+    },
+    "linter": {
+      "description": "The tool to use for running lint checks.",
+      "type": "string",
+      "enum": ["eslint", "tslint"],
+      "default": "tslint"
     }
   },
   "required": ["name"]

--- a/packages/workspace/src/schematics/shared-new/shared-new.ts
+++ b/packages/workspace/src/schematics/shared-new/shared-new.ts
@@ -239,8 +239,10 @@ function setDefaultLinter(linter: string) {
     json.schematics['@nrwl/cypress'] = { 'cypress-project': { linter } };
     json.schematics['@nrwl/react'] = {
       application: { linter },
-      library: { linter }
+      library: { linter },
+      'storybook-configuration': { linter }
     };
+
     json.schematics['@nrwl/next'] = {
       application: { linter }
     };


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

When generating a new storybook configuration for a library with a Cypress setup, the Cypress setup uses tslint, rather than eslint. this leads to an issue because tslint requires the `angular-devkit/build-angular` package which isn't available in a React workspace (and shouldn't be).

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

- the Cypress test setup uses eslint
- a default linter option is configured for the `@nrwl/react:storybook-configuration` in the `workspace.json`

## Issue
