### PR TITLE
fix(react): remove package.json when publishable is `false`

### DIFF
--- a/packages/react/src/schematics/library/library.spec.ts
+++ b/packages/react/src/schematics/library/library.spec.ts
@@ -92,6 +92,7 @@ describe('lib', () => {
 
     it('should generate files', async () => {
       const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+      expect(tree.exists('libs/my-lib/package.json')).toBeFalsy();
       expect(tree.exists(`libs/my-lib/jest.config.js`)).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/index.ts')).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/lib/my-lib.tsx')).toBeTruthy();

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -96,7 +96,7 @@ export default function(schema: Schema): Rule {
             pascalCaseFiles: options.pascalCaseFiles
           })
         : noop(),
-      updateLibPackageNpmScope(options),
+      options.publishable ? updateLibPackageNpmScope(options) : noop(),
       updateAppRoutes(options, context),
       formatFiles(options)
     ])(host, context);


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

The tree contains a `package.json` file when `publishable` is `false`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

When `publishable` is set to `false` no `package.json` file is needed.