### PR TITLE
feat(core): improved console output for nx migrate

### DIFF
--- a/packages/node/src/migrations/update-9-2-0/set-build-libs-from-source.ts
+++ b/packages/node/src/migrations/update-9-2-0/set-build-libs-from-source.ts
@@ -6,6 +6,10 @@ export default function update(): Rule {
     updateWorkspaceInTree(workspaceJson => {
       Object.entries<any>(workspaceJson.projects).forEach(
         ([projectName, project]) => {
+          if (!project.architect) {
+            return;
+          }
+
           Object.entries<any>(project.architect).forEach(
             ([targetName, targetConfig]) => {
               if (targetConfig.builder === '@nrwl/node:build') {

--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -1,6 +1,9 @@
 import { logging, normalize, virtualFs } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
+import { TaskExecutor } from '@angular-devkit/schematics';
 import { BaseWorkflow } from '@angular-devkit/schematics/src/workflow';
+import { BuiltinTaskExecutor } from '@angular-devkit/schematics/tasks/node';
+import { NodePackageName } from '@angular-devkit/schematics/tasks/node-package/options';
 import { NodeModulesEngineHost } from '@angular-devkit/schematics/tools';
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
@@ -11,9 +14,6 @@ import { dirSync } from 'tmp';
 import { getLogger } from '../shared/logger';
 import { convertToCamelCase, handleErrors } from '../shared/params';
 import minimist = require('minimist');
-import { NodePackageName } from '@angular-devkit/schematics/tasks/node-package/options';
-import { TaskExecutor } from '@angular-devkit/schematics';
-import { BuiltinTaskExecutor } from '@angular-devkit/schematics/tasks/node';
 
 export type MigrationsJson = {
   version: string;
@@ -515,23 +515,23 @@ async function generateMigrationsJsonAndUpdatePackageJson(
     if (migrations.length > 0) {
       createMigrationsFile(root, migrations);
 
-      logger.info(`The migrate command has run successfully.`);
+      logger.info(`NX The migrate command has run successfully.`);
       logger.info(`- package.json has been updated`);
       logger.info(`- migrations.json has been generated`);
 
-      logger.info(`Next steps:`);
+      logger.info(`NX Next steps:`);
       logger.info(
         `- Make sure package.json changes make sense and then run 'npm install' or 'yarn'`
       );
       logger.info(`- Run 'nx migrate --run-migrations=migrations.json'`);
     } else {
-      logger.info(`The migrate command has run successfully.`);
+      logger.info(`NX The migrate command has run successfully.`);
       logger.info(`- package.json has been updated`);
       logger.info(
         `- there are no migrations to run, so migrations.json has not been created.`
       );
 
-      logger.info(`Next steps:`);
+      logger.info(`NX Next steps:`);
       logger.info(
         `- Make sure package.json changes make sense and then run 'npm install' or 'yarn'`
       );
@@ -539,7 +539,7 @@ async function generateMigrationsJsonAndUpdatePackageJson(
   } catch (e) {
     const startVersion = versions(root, {})('@nrwl/workspace');
     logger.error(
-      `The migrate command failed. Try the following to migrate your workspace:`
+      `NX The migrate command failed. Try the following to migrate your workspace:`
     );
     logger.error(`> npm install --save-dev @nrwl/workspace@latest`);
     logger.error(
@@ -600,7 +600,7 @@ class MigrationEngineHost extends NodeModulesEngineHost {
       if (!pkgJsonSchematics) {
         pkgJsonSchematics = packageJson['ng-update'];
         if (!pkgJsonSchematics) {
-          throw new Error(`Could find migrations in package: "${name}"`);
+          throw new Error(`Could not find migrations in package: "${name}"`);
         }
       }
       if (typeof pkgJsonSchematics != 'string') {

--- a/packages/tao/src/shared/logger.ts
+++ b/packages/tao/src/shared/logger.ts
@@ -1,14 +1,34 @@
 import { logging, terminal } from '@angular-devkit/core';
 import { createConsoleLogger } from '@angular-devkit/core/node';
 
+const NX_PREFIX = `${terminal.cyan('>')} ${terminal.inverse(
+  terminal.bold(terminal.cyan(' NX '))
+)}`;
+
+const NX_ERROR = terminal.inverse(terminal.bold(terminal.red(' ERROR ')));
+
 let logger: logging.Logger;
-export const getLogger = (isVerbose: boolean = false) => {
+export const getLogger = (isVerbose: boolean = false): logging.Logger => {
   if (!logger) {
     logger = createConsoleLogger(isVerbose, process.stdout, process.stderr, {
       warn: s => terminal.bold(terminal.yellow(s)),
-      error: s => terminal.bold(terminal.red(s)),
-      fatal: s => terminal.bold(terminal.red(s))
+      error: s => {
+        if (s.startsWith('NX ')) {
+          return `\n${NX_ERROR} ${terminal.bold(terminal.red(s.substr(3)))}\n`;
+        }
+
+        return terminal.bold(terminal.red(s));
+      },
+      fatal: s => terminal.bold(terminal.red(s)),
+      info: s => {
+        if (s.startsWith('NX ')) {
+          return `\n${NX_PREFIX} ${terminal.bold(s.substr(3))}\n`;
+        }
+
+        return terminal.white(s);
+      }
     });
   }
+
   return logger;
 };


### PR DESCRIPTION
Improved console output for `nx migrate`. Hopefully this highlights the need to run `npm install` slightly better. e.g.

![image](https://user-images.githubusercontent.com/439121/80203668-6d0e8e00-861f-11ea-8fe9-6860331a56b5.png)


I've also included a small fix to the `@nrwl/node:set-build-libs-from-source` migration, that doesn't really warrant it's own PR.