### PR TITLE
fix(core): change chunkify length to 50 to prevent windows crashes

### DIFF
--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -51,7 +51,7 @@ export function format(command: 'check' | 'write', args: yargs.Arguments) {
   }
 
   // Chunkify the patterns array to prevent crashing the windows terminal
-  const chunkList: string[][] = chunkify(patterns, 70);
+  const chunkList: string[][] = chunkify(patterns, 50);
 
   switch (command) {
     case 'write':


### PR DESCRIPTION
Issue 2362 requests a length of 50 as 70 was still causing issues
this pr addresses that by reducing
the length to 50

ISSUES CLOSED: #2362 

## Current Behavior (This is the behavior we have today, before the PR is merged)

Chunks are defined at a length of 70

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Chunks are defined at a length of 50

## Issue
#2362