### PR TITLE
fix(nest): remove the default main file from @nrwl/node:lib

### DIFF
--- a/packages/nest/src/schematics/library/library.spec.ts
+++ b/packages/nest/src/schematics/library/library.spec.ts
@@ -87,6 +87,16 @@ describe('lib', () => {
       );
     });
 
+    it('should remove the default file from @nrwl/node:lib', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', global: true },
+        appTree
+      );
+      expect(tree.exists('libs/my-lib/src/lib/my-lib.spec.ts')).toBeFalsy();
+      expect(tree.exists('libs/my-lib/src/lib/my-lib.ts')).toBeFalsy();
+    });
+
     it('should provide the controller and service', async () => {
       const tree = await runSchematic(
         'lib',

--- a/packages/nest/src/schematics/library/library.ts
+++ b/packages/nest/src/schematics/library/library.ts
@@ -52,6 +52,7 @@ export default function (schema: NormalizedSchema): Rule {
       addProject(options),
       formatFiles(options),
       deleteFile(`/${options.projectRoot}/src/lib/${options.fileName}.spec.ts`),
+      deleteFile(`/${options.projectRoot}/src/lib/${options.fileName}.ts`),
     ]);
   };
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

When running `nx g @nrwl/nest:lib` there was a left-over file generated by `@nrwl/node:lib`, the spec file was deleted but the actual file not.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

This patch makes sure the file gets removed.

## Issue
