### PR TITLE
feat(storybook): configure assets dir to Storybook static dir

### DIFF
--- a/packages/storybook/src/schematics/configuration/configuration.ts
+++ b/packages/storybook/src/schematics/configuration/configuration.ts
@@ -107,6 +107,7 @@ function addStorybookTask(projectName: string, uiFramework: string): Rule {
       options: {
         uiFramework,
         port: 4400,
+        staticDir: [`${projectConfig.root}/src/assets`],
         config: {
           configFolder: `${projectConfig.root}/.storybook`
         }


### PR DESCRIPTION
If you are used to Nx dir layout, you'll find it natural to create and use a `assets` dir.

I'd say not having to know the config options for Storybook in order to use it is good developer experience.

Your thoughts?