### PR TITLE
cleanup(nx-plugin): remove comment in migration test template

### DIFF
--- a/packages/nx-plugin/src/schematics/migration/files/migration/__name__/__name__.spec.ts__tmpl__
+++ b/packages/nx-plugin/src/schematics/migration/files/migration/__name__/__name__.spec.ts__tmpl__
@@ -25,7 +25,6 @@ describe('<%= name %>', () => {
   });
 
   it(`should update dependencies`, async () => {
-    // eslint-disable-next-line require-atomic-updates
     const result = await schematicRunner
       .runSchematicAsync('<%= name %>', {}, initialTree)
       .toPromise();


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

There is a comment in the `nx-plugin` migration schematic test template that is unnecessary. 

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The comment does not exist.

I have tested this with both ESLint and TSLint and have not had any issues. 

## Issue
