### PR TITLE
fix(nx-plugin): remove function `copyNodeModules` from `ensureNxProject`

### DIFF
--- a/packages/nx-plugin/src/utils/testing-utils/nx-project.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/nx-project.ts
@@ -73,5 +73,4 @@ export function ensureNxProject(
 ): void {
   ensureDirSync(tmpProjPath());
   newNxProject(npmPackageName, pluginDistPath);
-  copyNodeModules(['@nrwl']);
 }


### PR DESCRIPTION
The function `copyNodeModules` deletes a plugin inside `node_modules/@nrwl` if it's being developed for `@nrwl` workspace. The function runs as part of `ensureNxProject` and is safe to remove as @nrwl related modules will be installed as dependencies from npm. The plugin beind developed will be linked from the main workspace.
