### PR TITLE
fix(react): fix console log during unit test

### DIFF
--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -113,7 +113,7 @@ export function run(
         context.logger.info('Bundling...');
         return runRollup(rollupOptions).pipe(
           catchError((e) => {
-            console.error(e);
+            context.logger.error(`Error during bundle: ${e}`);
             return of({ success: false });
           }),
           last(),


### PR DESCRIPTION
When running yarn test a console.error would print "Ooops" from a test.
Logging has been updated to use context logger not console to match other code.

## Current Behavior (This is the behavior we have today, before the PR is merged)
Logs console error

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Logs context logger error