### PR TITLE
fix(core): fix module resolution in project locator

### DIFF
--- a/packages/workspace/src/utils/typescript.ts
+++ b/packages/workspace/src/utils/typescript.ts
@@ -2,6 +2,8 @@ import { dirname } from 'path';
 import * as ts from 'typescript';
 import { appRootPath } from './app-root';
 
+const normalizedAppRoot = appRootPath.replace(/\\/g, '/');
+
 export function readTsConfig(tsConfigPath: string) {
   const readResult = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
   return ts.parseJsonConfigFileContent(
@@ -38,7 +40,7 @@ export function resolveModuleByImport(importExpr: string, filePath: string) {
   if (!resolvedModule) {
     return;
   } else {
-    return resolvedModule.resolvedFileName.replace(`${appRootPath}/`, '');
+    return resolvedModule.resolvedFileName.replace(`${normalizedAppRoot}/`, '');
   }
 }
 


### PR DESCRIPTION
On windows, there is a bug in project module resolution, caused by path separator.  TypeScript resolveModuleName will always return a posix normalized path, so our appRootPath needs to be normalized for string replacement.

I came across the issue when trying to run dep-graph, but other areas (ex: affected:*) which rely on TargetProjectLocator are going to be impacted.

findProjectWithImport is using typescript utils to resolve modules by import expressions.  appRootPath on windows is using the windows separator `\`, while TypeScript resolveModuleName is returning a module with resolvedFileName containing posix separator `/`.

Since (angular.json) project root path's are relative, the condition is not met, and it relies on npmScope - https://github.com/nrwl/nx/blob/b55a1a96dd74fc1ecc209eb4f42959933102bd75/packages/workspace/src/core/target-project-locator.ts#L34

## Current Behavior (This is the behavior we have today, before the PR is merged)
resolveModuleByImport returns project files with absolute path.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
resolveModuleByImport should return project files with relative path (appRootPath removed).

## Issue

I have not tested, but these might be related:

https://github.com/nrwl/nx/issues/2472

https://github.com/nrwl/nx/issues/2820
