### PR TITLE
feat(angular): update angularjs to 1.7.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@zeit/next-sass": "1.0.1",
     "@zeit/next-stylus": "1.0.1",
     "ajv": "6.10.2",
-    "angular": "1.6.6",
+    "angular": "1.7.9",
     "app-root-path": "^2.0.1",
     "autoprefixer": "9.7.4",
     "axios": "^0.19.0",

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -1,7 +1,7 @@
 export const nxVersion = '*';
 export const angularVersion = '^9.1.0';
 export const angularDevkitVersion = '0.901.0';
-export const angularJsVersion = '1.6.6';
+export const angularJsVersion = '1.7.9';
 export const ngrxVersion = '9.0.0';
 export const rxjsVersion = '~6.5.4';
 export const jestPresetAngularVersion = '8.1.2';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5467,10 +5467,10 @@ amphtml-validator@1.0.30:
     commander "2.15.1"
     promise "8.0.1"
 
-angular@1.6.6:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.6.tgz#fd5a3cfb437ce382d854ee01120797978527cb64"
-  integrity sha1-/Vo8+0N844LYVO4BEgeXl4Uny2Q=
+angular@1.7.9:
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/angular/-/angular-1.7.9.tgz#e52616e8701c17724c3c238cfe4f9446fd570bc4"
+  integrity sha512-5se7ZpcOtu0MBFlzGv5dsM1quQDoDeUTwZrWjGtTNA7O88cD8TEk5IEKCTDa3uECV9XnvKREVUr7du1ACiWGFQ==
 
 ansi-align@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

AngularJS 1.6.6 is installed when generating update module and downgrade module which as a security vulnerability.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

AngularJS 1.7.9 is installed which has patches for the security vulnerability.

There's no migration for this because migrations for those breaking changes is difficult.

## Issue
