### PR TITLE
feat(nest): add schematic that wraps @nestjs/schematics:module

### DIFF
--- a/docs/angular/api-nest/schematics/module.md
+++ b/docs/angular/api-nest/schematics/module.md
@@ -1,0 +1,65 @@
+# module
+
+Create a new nest module
+
+## Usage
+
+```bash
+nx generate module ...
+```
+
+```bash
+nx g m ... # same
+```
+
+By default, Nx will search for `module` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/nest:module ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g module ... --dry-run
+```
+
+## Options
+
+### flat
+
+Default: `false`
+
+Type: `boolean`
+
+Create module at the source root rather than its own directory.
+
+### name
+
+Type: `string`
+
+Module name
+
+### path
+
+Default: `/`
+
+Type: `string`
+
+The path to create the module.
+
+### project
+
+Type: `string`
+
+The name of the project
+
+### skipImport
+
+Default: `false`
+
+Type: `boolean`
+
+Flag to skip the module import.

--- a/docs/react/api-nest/schematics/module.md
+++ b/docs/react/api-nest/schematics/module.md
@@ -1,0 +1,65 @@
+# module
+
+Create a new nest module
+
+## Usage
+
+```bash
+nx generate module ...
+```
+
+```bash
+nx g m ... # same
+```
+
+By default, Nx will search for `module` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/nest:module ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g module ... --dry-run
+```
+
+## Options
+
+### flat
+
+Default: `false`
+
+Type: `boolean`
+
+Create module at the source root rather than its own directory.
+
+### name
+
+Type: `string`
+
+Module name
+
+### path
+
+Default: `/`
+
+Type: `string`
+
+The path to create the module.
+
+### project
+
+Type: `string`
+
+The name of the project
+
+### skipImport
+
+Default: `false`
+
+Type: `boolean`
+
+Flag to skip the module import.

--- a/packages/nest/collection.json
+++ b/packages/nest/collection.json
@@ -23,6 +23,13 @@
       "schema": "./src/schematics/library/schema.json",
       "aliases": ["lib"],
       "description": "Create a new nest library"
+    },
+
+    "module": {
+      "factory": "./src/schematics/module/module",
+      "schema": "./src/schematics/module/schema.json",
+      "aliases": ["m"],
+      "description": "Create a new nest module"
     }
   }
 }

--- a/packages/nest/src/schematics/module/module.spec.ts
+++ b/packages/nest/src/schematics/module/module.spec.ts
@@ -1,0 +1,106 @@
+import { Tree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { runSchematic } from '../../utils/testing';
+
+describe('init', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = Tree.empty();
+    tree = createEmptyWorkspace(tree);
+    tree = await runSchematic('app', { name: 'my-app' }, tree);
+  });
+
+  it('should create and import a module', async () => {
+    const result = await runSchematic(
+      'module',
+      {
+        name: 'my-mod',
+        project: 'my-app',
+      },
+      tree
+    );
+    expect(
+      result.readContent('apps/my-app/src/app/my-mod/my-mod.module.ts')
+    ).toContain(`import { Module } from '@nestjs/common';`);
+    expect(result.readContent('apps/my-app/src/app/app.module.ts')).toContain(
+      `import { MyModModule } from './my-mod/my-mod.module';`
+    );
+  });
+
+  it('should create and import a flat module', async () => {
+    const result = await runSchematic(
+      'module',
+      {
+        name: 'my-mod',
+        project: 'my-app',
+        flat: true,
+      },
+      tree
+    );
+
+    expect(
+      result.readContent('apps/my-app/src/app/my-mod.module.ts')
+    ).toContain(`import { Module } from '@nestjs/common';`);
+    expect(result.readContent('apps/my-app/src/app/app.module.ts')).toContain(
+      `import { MyModModule } from './my-mod.module';`
+    );
+  });
+
+  it('should create and import a module from a different path', async () => {
+    const result = await runSchematic(
+      'module',
+      {
+        name: 'my-mod',
+        project: 'my-app',
+        path: 'my-path',
+      },
+      tree
+    );
+
+    expect(
+      result.readContent('apps/my-app/src/app/my-path/my-mod/my-mod.module.ts')
+    ).toContain(`import { Module } from '@nestjs/common';`);
+    expect(result.readContent('apps/my-app/src/app/app.module.ts')).toContain(
+      `import { MyModModule } from './my-path/my-mod/my-mod.module';`
+    );
+  });
+
+  it('should create and import a flat module from a different path', async () => {
+    const result = await runSchematic(
+      'module',
+      {
+        name: 'my-mod',
+        project: 'my-app',
+        path: 'my-path',
+        flat: true,
+      },
+      tree
+    );
+
+    expect(
+      result.readContent('apps/my-app/src/app/my-path/my-mod.module.ts')
+    ).toContain(`import { Module } from '@nestjs/common';`);
+    expect(result.readContent('apps/my-app/src/app/app.module.ts')).toContain(
+      `import { MyModModule } from './my-path/my-mod.module';`
+    );
+  });
+
+  it('should create a module and skip the import', async () => {
+    const result = await runSchematic(
+      'module',
+      {
+        name: 'my-mod',
+        project: 'my-app',
+        skipImport: true,
+      },
+      tree
+    );
+    expect(
+      result.readContent('apps/my-app/src/app/my-mod/my-mod.module.ts')
+    ).toContain(`import { Module } from '@nestjs/common';`);
+    expect(
+      result.readContent('apps/my-app/src/app/app.module.ts')
+    ).not.toContain(`import { MyModModule } from './my-mod/my-mod.module';`);
+  });
+});

--- a/packages/nest/src/schematics/module/module.ts
+++ b/packages/nest/src/schematics/module/module.ts
@@ -1,0 +1,24 @@
+import {
+  chain,
+  externalSchematic,
+  Rule,
+  Tree,
+} from '@angular-devkit/schematics';
+import { getProjectConfig } from '@nrwl/workspace';
+import * as path from 'path';
+import { Schema } from './schema';
+
+export default function (options: Schema): Rule {
+  return (host: Tree) => {
+    const config = getProjectConfig(host, options.project);
+    return chain([
+      externalSchematic('@nestjs/schematics', 'module', {
+        ...options,
+        sourceRoot: path.join(
+          config.sourceRoot,
+          config.projectType === 'library' ? 'lib' : 'app'
+        ),
+      }),
+    ]);
+  };
+}

--- a/packages/nest/src/schematics/module/schema.d.ts
+++ b/packages/nest/src/schematics/module/schema.d.ts
@@ -1,0 +1,7 @@
+export interface Schema {
+  name: string;
+  project: string;
+  path?: string;
+  flat: boolean;
+  skipImport: boolean;
+}

--- a/packages/nest/src/schematics/module/schema.json
+++ b/packages/nest/src/schematics/module/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxNestInit",
+  "title": "Add Nest Module",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Module name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the module?"
+    },
+    "project": {
+      "type": "string",
+      "description": "The name of the project"
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path to create the module.",
+      "default": "/"
+    },
+    "skipImport": {
+      "type": "boolean",
+      "description": "Flag to skip the module import.",
+      "default": false
+    },
+    "flat": {
+      "type": "boolean",
+      "description": "Create module at the source root rather than its own directory.",
+      "default": false
+    }
+  },
+  "required": ["name", "project"]
+}


### PR DESCRIPTION
This PR create a schematic that wraps `@nestjs/schematics:module`.

Related issue #2959 

Depends on #2921 as it depends on a [fix](https://github.com/nestjs/schematics/commit/2c732fb2718d7b33adfe64415d315aceee497c44) that landed in `@nestjs/schematics` v7.