### PR TITLE
fix(testing):  fix generating cypress-project with no project specified

### DIFF
--- a/packages/cypress/src/schematics/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/schematics/cypress-project/cypress-project.spec.ts
@@ -221,5 +221,20 @@ describe('schematic:cypress-project', () => {
         );
       });
     });
+
+    describe('--project', () => {
+      describe('none', () => {
+        it('should not add any implicit dependencies', async () => {
+          const tree = await runSchematic(
+            'cypress-project',
+            { name: 'my-app-e2e' },
+            appTree
+          );
+
+          const nxJson = readJsonInTree(tree, 'nx.json');
+          expect(nxJson.projects['my-app-e2e']).toEqual({ tags: [] });
+        });
+      });
+    });
   });
 });

--- a/packages/cypress/src/schematics/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/schematics/cypress-project/cypress-project.ts
@@ -51,8 +51,14 @@ function updateNxJson(options: CypressProjectSchema): Rule {
   return updateJsonInTree<NxJson>('nx.json', (json) => {
     json.projects[options.projectName] = {
       tags: [],
-      implicitDependencies: [options.project],
     };
+
+    if (options.project) {
+      json.projects[options.projectName].implicitDependencies = [
+        options.project,
+      ];
+    }
+
     return json;
   });
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

If a Cypress project is generated without a project specified then it will cause issues with the modified `nx.json` because the projects `implicitDependencies` will contain a `null`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

I am able to generate a Cypress project without a project specified.

## Issue
