### PR TITLE
cleanup(core): export setDefaultCollection from @nrwl/workspace

### DIFF
--- a/packages/angular/src/schematics/init/init.ts
+++ b/packages/angular/src/schematics/init/init.ts
@@ -10,6 +10,7 @@ import {
   addDepsToPackageJson,
   formatFiles,
   readJsonInTree,
+  setDefaultCollection,
   updateJsonInTree,
   updateWorkspace,
 } from '@nrwl/workspace';
@@ -22,7 +23,6 @@ import {
 import { Schema } from './schema';
 import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
-import { setDefaultCollection } from '@nrwl/workspace/src/utils/rules/workspace';
 
 const updateDependencies = addDepsToPackageJson(
   {

--- a/packages/express/src/schematics/init/init.ts
+++ b/packages/express/src/schematics/init/init.ts
@@ -2,6 +2,7 @@ import { chain, noop, Rule } from '@angular-devkit/schematics';
 import {
   addPackageWithInit,
   formatFiles,
+  setDefaultCollection,
   updateJsonInTree,
 } from '@nrwl/workspace';
 import {
@@ -10,7 +11,6 @@ import {
   nxVersion,
 } from '../../utils/versions';
 import { Schema } from './schema';
-import { setDefaultCollection } from '@nrwl/workspace/src/utils/rules/workspace';
 
 function updateDependencies(): Rule {
   return updateJsonInTree('package.json', (json) => {

--- a/packages/nest/src/schematics/init/init.ts
+++ b/packages/nest/src/schematics/init/init.ts
@@ -3,6 +3,7 @@ import {
   addDepsToPackageJson,
   addPackageWithInit,
   formatFiles,
+  setDefaultCollection,
   updateJsonInTree,
 } from '@nrwl/workspace';
 import { Schema } from './schema';
@@ -12,7 +13,6 @@ import {
   nxVersion,
   reflectMetadataVersion,
 } from '../../utils/versions';
-import { setDefaultCollection } from '@nrwl/workspace/src/utils/rules/workspace';
 
 export const updateDependencies = addDepsToPackageJson(
   {

--- a/packages/next/src/schematics/init/init.ts
+++ b/packages/next/src/schematics/init/init.ts
@@ -1,8 +1,11 @@
 import { chain, noop } from '@angular-devkit/schematics';
-import { addDepsToPackageJson, addPackageWithInit } from '@nrwl/workspace';
+import {
+  addDepsToPackageJson,
+  addPackageWithInit,
+  setDefaultCollection,
+} from '@nrwl/workspace';
 import { nextVersion } from '../../utils/versions';
 import { Schema } from './schema';
-import { setDefaultCollection } from '@nrwl/workspace/src/utils/rules/workspace';
 import {
   reactDomVersion,
   reactVersion,

--- a/packages/node/src/schematics/init/init.ts
+++ b/packages/node/src/schematics/init/init.ts
@@ -2,11 +2,11 @@ import { chain, noop, Rule } from '@angular-devkit/schematics';
 import {
   addPackageWithInit,
   formatFiles,
+  setDefaultCollection,
   updateJsonInTree,
 } from '@nrwl/workspace';
 import { nxVersion } from '../../utils/versions';
 import { Schema } from './schema';
-import { setDefaultCollection } from '@nrwl/workspace/src/utils/rules/workspace';
 
 function updateDependencies(): Rule {
   return updateJsonInTree('package.json', (json) => {

--- a/packages/react/src/schematics/init/init.ts
+++ b/packages/react/src/schematics/init/init.ts
@@ -1,6 +1,7 @@
 import { chain, noop, Rule } from '@angular-devkit/schematics';
 import {
   addPackageWithInit,
+  setDefaultCollection,
   updateJsonInTree,
   updateWorkspace,
 } from '@nrwl/workspace';
@@ -14,7 +15,6 @@ import {
   typesReactVersion,
 } from '../../utils/versions';
 import { JsonObject } from '@angular-devkit/core';
-import { setDefaultCollection } from '@nrwl/workspace/src/utils/rules/workspace';
 
 export function updateDependencies(): Rule {
   return updateJsonInTree('package.json', (json) => {

--- a/packages/web/src/schematics/init/init.ts
+++ b/packages/web/src/schematics/init/init.ts
@@ -2,6 +2,7 @@ import { chain, noop, Rule } from '@angular-devkit/schematics';
 import {
   addPackageWithInit,
   formatFiles,
+  setDefaultCollection,
   updateJsonInTree,
 } from '@nrwl/workspace';
 import { Schema } from './schema';
@@ -9,7 +10,6 @@ import {
   documentRegisterElementVersion,
   nxVersion,
 } from '../../utils/versions';
-import { setDefaultCollection } from '@nrwl/workspace/src/utils/rules/workspace';
 
 function updateDependencies(): Rule {
   return updateJsonInTree('package.json', (json) => {

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -68,6 +68,7 @@ export { formatFiles } from './src/utils/rules/format-files';
 export { deleteFile } from './src/utils/rules/deleteFile';
 export * from './src/utils/rules/ng-add';
 export { updateKarmaConf } from './src/utils/rules/update-karma-conf';
+export { setDefaultCollection } from './src/utils/rules/workspace';
 import * as strings from './src/utils/strings';
 export { checkAndCleanWithSemver } from './src/utils/version-utils';
 export { updatePackagesInPackageJson } from './src/utils/update-packages-in-package-json';


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`setDefaultCollection` is not exported from the root barrel file in `@nrwl/workspace` which requires an Nx Plugin author to import from `@nrwl/workspace/src/utils/rules/workspace`.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

To be able to import `setDefaultCollection` from `@nrwl/workspace`.

## Issue
