### PR TITLE
fix(core): fix directory grouping on dep-graph

### DIFF
--- a/packages/workspace/src/core/dep-graph/dep-graph.js
+++ b/packages/workspace/src/core/dep-graph/dep-graph.js
@@ -10,7 +10,7 @@ function groupProjectsByDirectory(projects) {
 
   projects.forEach((project) => {
     const split = project.data.root.split('/');
-    const directory = split.slice(1, -2).join('/');
+    const directory = split.slice(1, -1).join('/');
 
     if (!groups.hasOwnProperty(directory)) {
       groups[directory] = [];


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
dep-graph visualization does not group directories in sidebar consistently

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
dep-graph visualization groups directories in sidebar correctly
## Issue
