### PR TITLE
fix(testing): add Cypress ESLint plugin

### DIFF
--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -19,6 +19,11 @@
       "version": "8.12.0-beta.1",
       "description": "Update Cypress to ^3.8.2",
       "factory": "./src/migrations/update-8-12-0/update-8-12-0"
+    },
+    "add-cypress-eslint-plugin-9.4.0": {
+      "version": "9.4.0-beta.1",
+      "description": "Add Cypress ESLint plugin",
+      "factory": "./src/migrations/update-9-4-0/add-cypress-eslint-plugin-9-4-0"
     }
   },
   "packageJsonUpdates": {

--- a/packages/cypress/src/migrations/update-9-4-0/add-cypress-eslint-plugin-9-4-0.spec.ts
+++ b/packages/cypress/src/migrations/update-9-4-0/add-cypress-eslint-plugin-9-4-0.spec.ts
@@ -1,0 +1,86 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { readJsonInTree, serializeJson } from '@nrwl/workspace';
+import * as path from 'path';
+
+describe('Add Cypress ESLint Plugin 9.4.0', () => {
+  let tree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(() => {
+    tree = Tree.empty();
+    tree.create(
+      'package.json',
+      serializeJson({
+        devDependencies: { '@nrwl/cypress': '9.3.0' },
+      })
+    );
+
+    tree.create(
+      'workspace.json',
+      serializeJson({
+        projects: {
+          'project-one-e2e': {
+            root: 'apps/project-one-e2e',
+            architect: {
+              e2e: {
+                builder: '@nrwl/cypress:cypress',
+              },
+            },
+          },
+          'project-two-e2e': {
+            root: 'apps/project-two-e2e',
+            architect: {
+              e2e: {
+                builder: '@nrwl/cypress:cypress',
+              },
+            },
+          },
+        },
+      })
+    );
+
+    tree.create(
+      'apps/project-one-e2e/.eslintrc',
+      serializeJson({
+        extends: '../../.eslintrc',
+      })
+    );
+
+    tree.create(
+      'apps/project-two-e2e/.eslintrc',
+      serializeJson({
+        extends: ['../../.eslintrc'],
+      })
+    );
+
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/cypress',
+      path.join(__dirname, '../../../migrations.json')
+    );
+  });
+
+  it('should add eslint-plugin-cypress devDependency', async () => {
+    const result = await schematicRunner
+      .runSchematicAsync('add-cypress-eslint-plugin-9.4.0', {}, tree)
+      .toPromise();
+
+    const { devDependencies } = readJsonInTree(result, '/package.json');
+    const projectOneEslintrcJson = readJsonInTree(
+      result,
+      'apps/project-one-e2e/.eslintrc'
+    );
+    const projectTwoEslintrcJson = readJsonInTree(
+      result,
+      'apps/project-two-e2e/.eslintrc'
+    );
+
+    expect(devDependencies['eslint-plugin-cypress']).toEqual('^2.10.3');
+    expect(projectOneEslintrcJson.extends).toContain(
+      'plugin:cypress/recommended'
+    );
+    expect(projectTwoEslintrcJson.extends).toContain(
+      'plugin:cypress/recommended'
+    );
+  });
+});

--- a/packages/cypress/src/migrations/update-9-4-0/add-cypress-eslint-plugin-9-4-0.ts
+++ b/packages/cypress/src/migrations/update-9-4-0/add-cypress-eslint-plugin-9-4-0.ts
@@ -1,0 +1,54 @@
+import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import {
+  addDepsToPackageJson,
+  formatFiles,
+  readJsonInTree,
+  updateJsonInTree,
+} from '@nrwl/workspace';
+
+async function addCypressPluginToEslintrc(host: Tree) {
+  const rules: Rule[] = [];
+  const { devDependencies } = readJsonInTree(host, 'package.json');
+
+  const eslintrcFilePaths = [];
+  if (devDependencies && devDependencies['@nrwl/cypress']) {
+    const workspaceJson = readJsonInTree(host, 'workspace.json');
+    Object.values<any>(workspaceJson.projects).forEach((project) => {
+      Object.values<any>(project.architect).forEach((target) => {
+        if (target.builder !== '@nrwl/cypress:cypress') {
+          return;
+        }
+
+        if (host.exists(`${project.root}/.eslintrc`)) {
+          eslintrcFilePaths.push(`${project.root}/.eslintrc`);
+        }
+      });
+    });
+
+    eslintrcFilePaths.forEach((eslintrcFilePath) => {
+      rules.push(
+        updateJsonInTree(eslintrcFilePath as string, (json) => {
+          if (json.extends) {
+            if (!Array.isArray(json.extends)) {
+              json.extends = [json.extends];
+            }
+
+            json.extends.push('plugin:cypress/recommended');
+          }
+
+          return json;
+        })
+      );
+    });
+  }
+
+  return chain(rules);
+}
+
+export default () => {
+  return chain([
+    addDepsToPackageJson({}, { 'eslint-plugin-cypress': '^2.10.3' }),
+    addCypressPluginToEslintrc,
+    formatFiles(),
+  ]);
+};

--- a/packages/cypress/src/schematics/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/schematics/cypress-project/cypress-project.spec.ts
@@ -236,5 +236,27 @@ describe('schematic:cypress-project', () => {
         });
       });
     });
+
+    describe('--linter', () => {
+      describe('eslint', () => {
+        it('should add eslint-plugin-cypress', async () => {
+          const tree = await runSchematic(
+            'cypress-project',
+            { name: 'my-app-e2e', project: 'my-app', linter: Linter.EsLint },
+            appTree
+          );
+          const packageJson = readJsonInTree(tree, 'package.json');
+          const eslintrcJson = readJsonInTree(
+            tree,
+            'apps/my-app-e2e/.eslintrc'
+          );
+
+          expect(
+            packageJson.devDependencies['eslint-plugin-cypress']
+          ).toBeTruthy();
+          expect(eslintrcJson.extends).toContain('plugin:cypress/recommended');
+        });
+      });
+    });
   });
 });

--- a/packages/cypress/src/utils/versions.ts
+++ b/packages/cypress/src/utils/versions.ts
@@ -1,2 +1,3 @@
 export const nxVersion = '*';
 export const cypressVersion = '^4.1.0';
+export const eslintPluginCypressVersion = '^2.10.3';


### PR DESCRIPTION
This fixes linting errors when using ESLint with a Cypress project that uses JavaScript.

## Current Behavior (This is the behavior we have today, before the PR is merged)

A freshly generated Cypress project with ESLint and JS will throw linting errors.

```
> nx run test-for-derek:lint 

Linting "test-for-derek"...

/Users/devinshoemaker/code/nx/playground/cypress-test/apps/test-for-derek/src/support/app.po.js
  1:34  error  'cy' is not defined  no-undef

/Users/devinshoemaker/code/nx/playground/cypress-test/apps/test-for-derek/src/integration/app.spec.js
  2:1   error  'describe' is not defined    no-undef
  3:5   error  'beforeEach' is not defined  no-undef
  3:22  error  'cy' is not defined          no-undef
  4:5   error  'it' is not defined          no-undef
  6:9   error  'cy' is not defined          no-undef

/Users/devinshoemaker/code/nx/playground/cypress-test/apps/test-for-derek/src/support/commands.js
  3:1  error  'Cypress' is not defined  no-undef
  4:5  error  'console' is not defined  no-undef

✖ 8 problems (8 errors, 0 warnings)

Lint errors found in the listed files.
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

A freshly generated Cypress project with ESLint and JS will not throw linting errors.