### PR TITLE
fix(testing): add a guard to not accidently publish to the registry

### DIFF
--- a/e2e/local-registry/setup.ts
+++ b/e2e/local-registry/setup.ts
@@ -4,7 +4,7 @@ import { getDirectories } from '../utils';
 
 const asyncExec = promisify(exec);
 
-process.env.PUBLISHED_VERSION = `9999.0.0`;
+process.env.PUBLISHED_VERSION = `9999.0.1`;
 
 async function spawnLocalRegistry() {
   const localRegistryProcess = spawn('npx', [
@@ -40,6 +40,13 @@ async function updateVersion(packagePath) {
 }
 
 async function publishPackage(packagePath) {
+  if (process.env.npm_config_registry.indexOf('http://localhost') === -1) {
+    throw Error(`
+      ------------------
+      💣 ERROR 💣 => $NPM_REGISTRY does not look like a local registry'
+      ------------------
+    `);
+  }
   await asyncExec(`npm publish`, {
     cwd: packagePath,
     env: process.env,

--- a/scripts/create-playground.sh
+++ b/scripts/create-playground.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-./scripts/link.sh 9999.0.0
+./scripts/link.sh 9999.0.1
 
 rm -rf tmp
 mkdir -p tmp/angular
 mkdir -p tmp/nx
 
-PUBLISHED_VERSION=9999.0.0 NPM_CONFIG_REGISTRY=http://localhost:4872/ jest --maxWorkers=1  -c "./build/e2e/jest-config.js" ./build/e2e/commands/create-playground.test.js
+PUBLISHED_VERSION=9999.0.1 npm_config_registry=http://localhost:4872/ jest --maxWorkers=1  -c "./build/e2e/jest-config.js" ./build/e2e/commands/create-playground.test.js

--- a/scripts/e2e-ci1.sh
+++ b/scripts/e2e-ci1.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-./scripts/link.sh 9999.0.0
+./scripts/link.sh 9999.0.1
 
 rm -rf tmp
 mkdir -p tmp/angular
 mkdir -p tmp/nx
 
 export SELECTED_CLI=$1
-PUBLISHED_VERSION=9999.0.0 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 "./build/e2e/(angular|cli|workspace|workspace-aux-commands|cypress).test.js" 
+PUBLISHED_VERSION=9999.0.1 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 "./build/e2e/(angular|cli|workspace|workspace-aux-commands|cypress).test.js" 

--- a/scripts/e2e-ci2.sh
+++ b/scripts/e2e-ci2.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-./scripts/link.sh 9999.0.0
+./scripts/link.sh 9999.0.1
 
 rm -rf tmp
 mkdir -p tmp/angular
 mkdir -p tmp/nx
 
 export SELECTED_CLI=$1
-PUBLISHED_VERSION=9999.0.0 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 "./build/e2e/(jest|karma|next|nx-plugin|downgrade-module).test.js"
+PUBLISHED_VERSION=9999.0.1 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 "./build/e2e/(jest|karma|next|nx-plugin|downgrade-module).test.js"

--- a/scripts/e2e-ci3.sh
+++ b/scripts/e2e-ci3.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-./scripts/link.sh 9999.0.0
+./scripts/link.sh 9999.0.1
 
 rm -rf tmp
 mkdir -p tmp/angular
 mkdir -p tmp/nx
 
 export SELECTED_CLI=$1
-PUBLISHED_VERSION=9999.0.0 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 "./build/e2e/(storybook|upgrade-module|web|angular-package|react-package|ngrx).test.js"
+PUBLISHED_VERSION=9999.0.1 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 "./build/e2e/(storybook|upgrade-module|web|angular-package|react-package|ngrx).test.js"

--- a/scripts/e2e-ci4.sh
+++ b/scripts/e2e-ci4.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-./scripts/link.sh 9999.0.0
+./scripts/link.sh 9999.0.1
 
 rm -rf tmp
 mkdir -p tmp/angular
 mkdir -p tmp/nx
 
 export SELECTED_CLI=$1
-PUBLISHED_VERSION=9999.0.0 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 "./build/e2e/(ng-add|node|react).test.js"
+PUBLISHED_VERSION=9999.0.1 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 "./build/e2e/(ng-add|node|react).test.js"

--- a/scripts/e2e-rerun.sh
+++ b/scripts/e2e-rerun.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-./scripts/link.sh 9999.0.0
+./scripts/link.sh 9999.0.1
 
 rm -rf tmp/nx/proj/node_modules/@nrwl
 rm -rf tmp/angular/proj/node_modules/@nrwl
@@ -8,9 +8,9 @@ cp -r node_modules/@nrwl tmp/nx/proj/node_modules/@nrwl
 cp -r node_modules/@nrwl tmp/angular/proj/node_modules/@nrwl
 
 if [ -n "$1" ]; then
-  PUBLISHED_VERSION=9999.0.0 NPM_CONFIG_REGISTRY=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 ./build/e2e/$1.test.js
+  PUBLISHED_VERSION=9999.0.1 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 ./build/e2e/$1.test.js
 else
-  PUBLISHED_VERSION=9999.0.0 NPM_CONFIG_REGISTRY=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 ./build/e2e
+  PUBLISHED_VERSION=9999.0.1 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 ./build/e2e
 fi
 
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-./scripts/link.sh 9999.0.0
+./scripts/link.sh 9999.0.1
 
 rm -rf tmp
 mkdir -p tmp/angular
@@ -10,10 +10,10 @@ if [ -n "$1" ]; then
   COMMAND_FILE="./build/e2e/commands/$1.test.js"
 
   if [ -f "$TEST_FILE" ]; then
-    PUBLISHED_VERSION=9999.0.0 NPM_CONFIG_REGISTRY=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 $TEST_FILE
+    PUBLISHED_VERSION=9999.0.1 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 $TEST_FILE
   else
-    PUBLISHED_VERSION=9999.0.0 NPM_CONFIG_REGISTRY=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 $COMMAND_FILE
+    PUBLISHED_VERSION=9999.0.1 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 $COMMAND_FILE
   fi
 else
-  PUBLISHED_VERSION=9999.0.0 NPM_CONFIG_REGISTRY=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 ./build/e2e/*.test.js
+  PUBLISHED_VERSION=9999.0.1 npm_config_registry=http://localhost:4872/ jest -c "./build/e2e/jest-config.js" --maxWorkers=1 ./build/e2e/*.test.js
 fi


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Allows linux systems to publish version 9999.0.0 to the actual npm registry

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Don't let it do that

## Issue
