### PR TITLE
fix(repo): fix version in root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nrwl/nx-source",
-  "version": "9.4.0",
+  "version": "9.2.4",
   "description": "Extensible Dev Tools for Monorepos",
   "homepage": "https://nx.dev",
   "main": "index.js",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

version in root package.json is `9.4.0` from some left over changes from a local publish.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

version in root package.json in `9.2.3` as the latest stable version.

## Issue
