### PR TITLE
feat(core): scope project names to avoid conflicting names

### DIFF
--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
@@ -218,9 +218,9 @@ describe('project graph', () => {
 
     expect(affected).toEqual({
       nodes: {
-        'happy-nrwl': {
+        'npm:happy-nrwl': {
           type: 'npm',
-          name: 'happy-nrwl',
+          name: 'npm:happy-nrwl',
           data: expect.anything(),
         },
         util: {
@@ -245,7 +245,7 @@ describe('project graph', () => {
         },
       },
       dependencies: {
-        'happy-nrwl': [],
+        'npm:happy-nrwl': [],
         'demo-e2e': [
           {
             type: 'implicit',
@@ -261,7 +261,7 @@ describe('project graph', () => {
           },
         ],
         ui: [{ type: 'static', source: 'ui', target: 'util' }],
-        util: [{ type: 'static', source: 'util', target: 'happy-nrwl' }],
+        util: [{ type: 'static', source: 'util', target: 'npm:happy-nrwl' }],
       },
     });
   });
@@ -306,7 +306,7 @@ describe('project graph', () => {
     ]);
 
     expect(Object.keys(affected.nodes)).toEqual([
-      '@nrwl/workspace',
+      'npm:@nrwl/workspace',
       'api',
       'demo',
       'demo-e2e',

--- a/packages/workspace/src/core/affected-project-graph/locators/npm-packages.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/npm-packages.spec.ts
@@ -1,11 +1,13 @@
 import { getTouchedNpmPackages } from './npm-packages';
 import { NxJson } from '../../shared-interfaces';
-import { WholeFileChange } from '../..//file-utils';
+import { WholeFileChange } from '../../file-utils';
 import { DiffType } from '../../../utils/json-diff';
+import { ProjectGraph } from '../../project-graph';
 
 describe('getTouchedNpmPackages', () => {
   let workspaceJson;
   let nxJson: NxJson<string[]>;
+  let projectGraph: ProjectGraph;
   beforeEach(() => {
     workspaceJson = {
       projects: {
@@ -26,6 +28,36 @@ describe('getTouchedNpmPackages', () => {
       projects: {
         proj1: {},
         proj2: {},
+      },
+    };
+    projectGraph = {
+      nodes: {
+        proj1: {
+          type: 'app',
+          name: 'proj1',
+          data: {
+            files: [],
+          },
+        },
+        proj2: {
+          type: 'lib',
+          name: 'proj2',
+          data: {
+            files: [],
+          },
+        },
+        'npm:happy-nrwl': {
+          name: 'npm:happy-nrwl',
+          type: 'npm',
+          data: {
+            packageName: 'happy-nrwl',
+            files: [],
+          },
+        },
+      },
+      dependencies: {
+        proj1: [],
+        proj2: [],
       },
     };
   });
@@ -55,9 +87,10 @@ describe('getTouchedNpmPackages', () => {
         dependencies: {
           'happy-nrwl': '0.0.2',
         },
-      }
+      },
+      projectGraph
     );
-    expect(result).toEqual(['happy-nrwl']);
+    expect(result).toEqual(['npm:happy-nrwl']);
   });
 
   it('should handle package deletion', () => {
@@ -85,12 +118,21 @@ describe('getTouchedNpmPackages', () => {
         dependencies: {
           'happy-nrwl': '0.0.2',
         },
-      }
+      },
+      projectGraph
     );
     expect(result).toEqual(['proj1', 'proj2']);
   });
 
   it('should handle package addition', () => {
+    projectGraph.nodes['npm:awesome-nrwl'] = {
+      name: 'npm:awesome-nrwl',
+      type: 'npm',
+      data: {
+        packageName: 'awesome-nrwl',
+        files: [],
+      },
+    };
     const result = getTouchedNpmPackages(
       [
         {
@@ -116,12 +158,21 @@ describe('getTouchedNpmPackages', () => {
           'happy-nrwl': '0.0.2',
           'awesome-nrwl': '0.0.1',
         },
-      }
+      },
+      projectGraph
     );
-    expect(result).toEqual(['awesome-nrwl']);
+    expect(result).toEqual(['npm:awesome-nrwl']);
   });
 
   it('should handle whole file changes', () => {
+    projectGraph.nodes['npm:awesome-nrwl'] = {
+      name: 'npm:awesome-nrwl',
+      type: 'npm',
+      data: {
+        packageName: 'awesome-nrwl',
+        files: [],
+      },
+    };
     const result = getTouchedNpmPackages(
       [
         {
@@ -138,8 +189,9 @@ describe('getTouchedNpmPackages', () => {
           'happy-nrwl': '0.0.1',
           'awesome-nrwl': '0.0.1',
         },
-      }
+      },
+      projectGraph
     );
-    expect(result).toEqual(['happy-nrwl', 'awesome-nrwl']);
+    expect(result).toEqual(['npm:happy-nrwl', 'npm:awesome-nrwl']);
   });
 });

--- a/packages/workspace/src/core/project-graph/build-dependencies/explicit-npm-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/explicit-npm-dependencies.ts
@@ -2,6 +2,7 @@ import {
   AddProjectDependency,
   DependencyType,
   ProjectGraphContext,
+  ProjectGraphNode,
   ProjectGraphNodeRecords,
 } from '../project-graph-models';
 import { TypeScriptImportLocator } from './typescript-import-locator';
@@ -14,17 +15,23 @@ export function buildExplicitNpmDependencies(
 ) {
   const importLocator = new TypeScriptImportLocator(fileRead);
 
+  const npmProjects = Object.values(nodes).filter(
+    (node) => node.type === 'npm'
+  ) as ProjectGraphNode<{ packageName: string; version: string }>[];
+
   Object.keys(ctx.fileMap).forEach((source) => {
     Object.values(ctx.fileMap[source]).forEach((f) => {
       importLocator.fromFile(
         f.file,
         (importExpr: string, filePath: string, type: DependencyType) => {
-          const key = Object.keys(nodes).find((k) =>
-            isNpmPackageImport(k, importExpr)
+          const pkg = npmProjects.find((pkg) =>
+            isNpmPackageImport(pkg.data.packageName, importExpr)
           );
-          const target = nodes[key];
-          if (source && target && target.type === 'npm') {
-            addDependency(type, source, target.name);
+          if (pkg) {
+            const target = nodes[pkg.name];
+            if (source && target) {
+              addDependency(type, source, target.name);
+            }
           }
         }
       );
@@ -32,7 +39,7 @@ export function buildExplicitNpmDependencies(
   });
 }
 
-function isNpmPackageImport(p, e) {
+function isNpmPackageImport(p: string, e: string) {
   const toMatch = e
     .split(/[\/]/)
     .slice(0, p.startsWith('@') ? 2 : 1)

--- a/packages/workspace/src/core/project-graph/build-nodes/npm-packages.ts
+++ b/packages/workspace/src/core/project-graph/build-nodes/npm-packages.ts
@@ -14,9 +14,10 @@ export function buildNpmPackageNodes(
   Object.keys(deps).forEach((d) => {
     addNode({
       type: 'npm',
-      name: d,
+      name: `npm:${d}`,
       data: {
         version: deps[d],
+        packageName: d,
         files: [],
       },
     });

--- a/packages/workspace/src/core/project-graph/project-graph-builder.spec.ts
+++ b/packages/workspace/src/core/project-graph/project-graph-builder.spec.ts
@@ -63,6 +63,17 @@ describe('ProjectGraphBuilder', () => {
       },
     });
   });
+
+  it('should throw an error when there are projects with conflicting names', () => {
+    const builder = new ProjectGraphBuilder();
+    const projA = createNode('proj', 'app');
+    const projB = createNode('proj', 'lib');
+    builder.addNode(projA);
+
+    expect(() => {
+      builder.addNode(projB);
+    }).toThrow();
+  });
 });
 
 function createNode(name: string, type: string): ProjectGraphNode {

--- a/packages/workspace/src/core/project-graph/project-graph-builder.ts
+++ b/packages/workspace/src/core/project-graph/project-graph-builder.ts
@@ -22,6 +22,19 @@ export class ProjectGraphBuilder {
   }
 
   addNode(node: ProjectGraphNode) {
+    // Check if project with the same name already exists
+    if (this.nodes[node.name]) {
+      // Throw if existing project is of a different type
+      if (this.nodes[node.name].type !== node.type) {
+        throw new Error(
+          `Multiple projects are named "${node.name}". One is of type "${
+            node.type
+          }" and the other is of type "${
+            this.nodes[node.name].type
+          }". Please resolve the conflicting project names.`
+        );
+      }
+    }
     this.nodes[node.name] = node;
     this.dependencies[node.name] = {};
   }

--- a/packages/workspace/src/core/project-graph/project-graph.spec.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.spec.ts
@@ -139,11 +139,25 @@ describe('project graph', () => {
       'shared-util': { name: 'shared-util', type: 'lib' },
       'shared-util-data': { name: 'shared-util-data', type: 'lib' },
       'lazy-lib': { name: 'lazy-lib', type: 'lib' },
-      'happy-nrwl': { name: 'happy-nrwl', type: 'npm' },
-      express: { name: 'express', type: 'npm' },
+      'npm:happy-nrwl': {
+        name: 'npm:happy-nrwl',
+        type: 'npm',
+        data: {
+          packageName: 'happy-nrwl',
+        },
+      },
+      'npm:express': {
+        name: 'npm:express',
+        type: 'npm',
+        data: {
+          packageName: 'express',
+        },
+      },
     });
     expect(graph.dependencies).toMatchObject({
-      api: [{ type: DependencyType.static, source: 'api', target: 'express' }],
+      api: [
+        { type: DependencyType.static, source: 'api', target: 'npm:express' },
+      ],
       'demo-e2e': [
         { type: DependencyType.implicit, source: 'demo-e2e', target: 'demo' },
       ],
@@ -169,7 +183,7 @@ describe('project graph', () => {
         {
           type: DependencyType.static,
           source: 'shared-util',
-          target: 'happy-nrwl',
+          target: 'npm:happy-nrwl',
         },
       ],
     });

--- a/packages/workspace/src/utils/buildable-libs-utils.ts
+++ b/packages/workspace/src/utils/buildable-libs-utils.ts
@@ -276,16 +276,22 @@ export function updateBuildableProjectPackageJsonDependencies(
             'package.json'
           );
           depVersion = readJsonFile(depPackageJsonPath).version;
+
+          packageJson.dependencies[entry.name] = depVersion;
         } else if (entry.node.type === 'npm') {
           // If an npm dep is part of the workspace devDependencies, do not include it the library
-          if (!!workspacePackageJson.devDependencies?.[entry.name]) {
+          if (
+            !!workspacePackageJson.devDependencies?.[
+              entry.node.data.packageName
+            ]
+          ) {
             return;
           }
 
           depVersion = entry.node.data.version;
-        }
 
-        packageJson.dependencies[entry.name] = depVersion;
+          packageJson.dependencies[entry.node.data.packageName] = depVersion;
+        }
         updatePackageJson = true;
       } catch (e) {
         // skip if cannot find package.json


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

When a user creates a project with the same name as an `npm` dependency, the project graph will contain unexpected dependencies.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

When a user creates a project with the same name as an `npm` dependency, the workspace will be considered invalid.

## Issue
Fixes https://github.com/nrwl/nx/issues/2396

## Notes

I considered making it possible to have the same name on projects of different types but too many things reference a project by name such as:
* `nx build {projectName}`
* `implicitDependencies: [{projectName}]`