### PR TITLE
fix(node): install @nestjs/schematics as a dependency of @nrwl/nest

### DIFF
--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -29,12 +29,12 @@
     "migrations": "./migrations.json"
   },
   "peerDependencies": {
-    "@nrwl/workspace": "*",
-    "@nestjs/schematics": "^6.3.0"
+    "@nrwl/workspace": "*"
   },
   "dependencies": {
     "@nrwl/node": "*",
     "@nrwl/jest": "*",
-    "@angular-devkit/schematics": "~9.1.0"
+    "@angular-devkit/schematics": "~9.1.0",
+    "@nestjs/schematics": "^6.3.0"
   }
 }


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Creating a new workspace with angular+nest errors:

```
Cannot find module '@nestjs/schematics/package.json'
Require stack:
- /home/jason/projects/temp/nx-tests/nx930rc0test/node_modules/@angular/cli/node_modules/@angular-devkit/schematics/tools/node-module-engine-host.js
- /home/jason/projects/temp/nx-tests/nx930rc0test/node_modules/@angular/cli/node_modules/@angular-devkit/schematics/tools/workflow/node-workflow.js
- /home/jason/projects/temp/nx-tests/nx930rc0test/node_modules/@angular/cli/node_modules/@angular-devkit/schematics/tools/index.js
- /home/jason/projects/temp/nx-tests/nx930rc0test/node_modules/@angular/cli/utilities/json-schema.js
- /home/jason/projects/temp/nx-tests/nx930rc0test/node_modules/@angular/cli/models/command-runner.js
- /home/jason/projects/temp/nx-tests/nx930rc0test/node_modules/@angular/cli/lib/cli/index.js
- /home/jason/projects/temp/nx-tests/nx930rc0test/node_modules/@angular/cli/lib/init.js
- /home/jason/projects/temp/nx-tests/nx930rc0test/node_modules/@angular/cli/bin/ng
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Creating an angular+nest workspace succeeds.

## Issue
