### PR TITLE
fix(linter): eslint version should match >= 6.1.0

### DIFF
--- a/packages/linter/src/builders/lint/lint.impl.ts
+++ b/packages/linter/src/builders/lint/lint.impl.ts
@@ -36,7 +36,7 @@ async function run(options: Schema, context: BuilderContext): Promise<any> {
     !version ||
     version.length < 2 ||
     Number(version[0]) < 6 ||
-    Number(version[1]) < 1
+    (Number(version[0]) === 6 && Number(version[1]) < 1)
   ) {
     throw new Error('ESLint must be version 6.1 or higher.');
   }


### PR DESCRIPTION
## Current Behavior

If we try to use a major version of `eslint` above `6`, that has a minor version of `0`, we get an error message saying `ESLint must be version 6.1 or higher.`.

## Expected Behavior

We can now use major versions of `eslint` above `6` regardless of their minor version.

## Issue

Closes #3001