### PR TITLE
fix(testing): add coverage as alias of code-coverage

### DIFF
--- a/docs/angular/api-jest/builders/jest.md
+++ b/docs/angular/api-jest/builders/jest.md
@@ -28,6 +28,8 @@ Deletes the Jest cache directory and then exits without running tests. Will dele
 
 ### codeCoverage
 
+Alias(es): coverage
+
 Type: `boolean`
 
 Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)

--- a/docs/react/api-jest/builders/jest.md
+++ b/docs/react/api-jest/builders/jest.md
@@ -29,6 +29,8 @@ Deletes the Jest cache directory and then exits without running tests. Will dele
 
 ### codeCoverage
 
+Alias(es): coverage
+
 Type: `boolean`
 
 Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)

--- a/packages/jest/src/builders/jest/schema.json
+++ b/packages/jest/src/builders/jest/schema.json
@@ -5,7 +5,8 @@
   "properties": {
     "codeCoverage": {
       "description": "Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)",
-      "type": "boolean"
+      "type": "boolean",
+      "aliases": ["coverage"]
     },
     "config": {
       "description": "The path to a Jest config file specifying how to find and execute tests. If no rootDir is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

`--coverage` was removed in #2569

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`--coverage` is an alias for `code-coverage` for `jest`.

## Issue
Fixes #3005