### PR TITLE
feat(core): add --target option to affected :libs and :apps

### DIFF
--- a/docs/angular/cli/affected-apps.md
+++ b/docs/angular/cli/affected-apps.md
@@ -1,6 +1,6 @@
 # affected:apps
 
-Print applications affected by changes
+Print or run task for applications affected by changes
 
 ## Usage
 
@@ -28,6 +28,12 @@ Print the names of all the apps affected by the last commit on master:
 
 ```bash
 nx affected:apps --base=master~1 --head=master
+```
+
+Run custom target for all affected apps:
+
+```bash
+nx nx affected:apps --target=custom-target
 ```
 
 ## Options
@@ -62,11 +68,23 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
+### maxParallel
+
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
+
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
+
+### parallel
+
+Default: `false`
+
+Parallelize the command
 
 ### plain
 
@@ -81,6 +99,10 @@ This is the name of the tasks runner configured in nx.json
 Default: `false`
 
 Rerun the tasks even when the results are available in the cache
+
+### target
+
+Task to run for affected projects
 
 ### uncommitted
 

--- a/docs/angular/cli/affected-libs.md
+++ b/docs/angular/cli/affected-libs.md
@@ -1,6 +1,6 @@
 # affected:libs
 
-Print libraries affected by changes
+Print or run task for libraries affected by changes
 
 ## Usage
 
@@ -28,6 +28,12 @@ Print the names of all the libs affected by the last commit on master:
 
 ```bash
 nx affected:libs --base=master~1 --head=master
+```
+
+Run custom target for all affected libs:
+
+```bash
+nx nx affected:libs --target=custom-target
 ```
 
 ## Options
@@ -62,11 +68,23 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
+### maxParallel
+
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
+
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
+
+### parallel
+
+Default: `false`
+
+Parallelize the command
 
 ### plain
 
@@ -81,6 +99,10 @@ This is the name of the tasks runner configured in nx.json
 Default: `false`
 
 Rerun the tasks even when the results are available in the cache
+
+### target
+
+Task to run for affected projects
 
 ### uncommitted
 

--- a/docs/angular/cli/migrate.md
+++ b/docs/angular/cli/migrate.md
@@ -4,6 +4,7 @@
 - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
 - Run migrations (e.g., nx migrate --run-migrations=migrations.json)
 
+
       ## Usage
       ```bash
       nx migrate

--- a/docs/react/cli/affected-apps.md
+++ b/docs/react/cli/affected-apps.md
@@ -1,6 +1,6 @@
 # affected:apps
 
-Print applications affected by changes
+Print or run task for applications affected by changes
 
 ## Usage
 
@@ -28,6 +28,12 @@ Print the names of all the apps affected by the last commit on master:
 
 ```bash
 nx affected:apps --base=master~1 --head=master
+```
+
+Run custom target for all affected apps:
+
+```bash
+nx nx affected:apps --target=custom-target
 ```
 
 ## Options
@@ -62,11 +68,23 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
+### maxParallel
+
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
+
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
+
+### parallel
+
+Default: `false`
+
+Parallelize the command
 
 ### plain
 
@@ -81,6 +99,10 @@ This is the name of the tasks runner configured in nx.json
 Default: `false`
 
 Rerun the tasks even when the results are available in the cache
+
+### target
+
+Task to run for affected projects
 
 ### uncommitted
 

--- a/docs/react/cli/affected-libs.md
+++ b/docs/react/cli/affected-libs.md
@@ -1,6 +1,6 @@
 # affected:libs
 
-Print libraries affected by changes
+Print or run task for libraries affected by changes
 
 ## Usage
 
@@ -28,6 +28,12 @@ Print the names of all the libs affected by the last commit on master:
 
 ```bash
 nx affected:libs --base=master~1 --head=master
+```
+
+Run custom target for all affected libs:
+
+```bash
+nx nx affected:libs --target=custom-target
 ```
 
 ## Options
@@ -62,11 +68,23 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
+### maxParallel
+
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
+
 ### only-failed
 
 Default: `false`
 
 Isolate projects which previously failed
+
+### parallel
+
+Default: `false`
+
+Parallelize the command
 
 ### plain
 
@@ -81,6 +99,10 @@ This is the name of the tasks runner configured in nx.json
 Default: `false`
 
 Rerun the tasks even when the results are available in the cache
+
+### target
+
+Task to run for affected projects
 
 ### uncommitted
 

--- a/docs/react/cli/migrate.md
+++ b/docs/react/cli/migrate.md
@@ -4,6 +4,7 @@
 - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
 - Run migrations (e.g., nx migrate --run-migrations=migrations.json)
 
+
       ## Usage
       ```bash
       nx migrate

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -46,38 +46,46 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
   try {
     switch (command) {
       case 'apps':
-        const apps = affectedProjects
-          .filter((p) => p.type === ProjectType.app)
-          .map((p) => p.name);
-        if (parsedArgs.plain) {
-          console.log(apps.join(' '));
-        } else {
-          printArgsWarning(nxArgs);
-          if (apps.length) {
-            output.log({
-              title: 'Affected apps:',
-              bodyLines: apps.map((app) => `${output.colors.gray('-')} ${app}`),
-            });
-          }
-        }
-        break;
+      case 'libs': {
+        const projectTypeToFilter =
+          command === 'apps' ? ProjectType.app : ProjectType.lib;
 
-      case 'libs':
-        const libs = affectedProjects
-          .filter((p) => p.type === ProjectType.lib)
-          .map((p) => p.name);
+        const projects = affectedProjects.filter(
+          (p) => p.type === projectTypeToFilter
+        );
+
         if (parsedArgs.plain) {
-          console.log(libs.join(' '));
+          const affectedProjectsNames = projects.map((p) => p.name);
+          console.log(affectedProjectsNames.join(' '));
+        } else if (nxArgs.target) {
+          const libsWithTarget = allProjectsWithTarget(projects, nxArgs);
+
+          runCommand(
+            libsWithTarget,
+            projectGraph,
+            env,
+            nxArgs,
+            overrides,
+            new DefaultReporter(),
+            null
+          );
         } else {
+          const affectedProjectsNames = projects.map((p) => p.name);
+
           printArgsWarning(nxArgs);
-          if (libs.length) {
+          if (affectedProjectsNames.length) {
+            const title = `Affected ${command === 'apps' ? 'apps' : 'libs'}:`;
             output.log({
-              title: 'Affected libs:',
-              bodyLines: libs.map((lib) => `${output.colors.gray('-')} ${lib}`),
+              title,
+              bodyLines: affectedProjectsNames.map(
+                (lib) => `${output.colors.gray('-')} ${lib}`
+              ),
             });
           }
         }
+
         break;
+      }
 
       case 'dep-graph':
         const projectNames = affectedProjects.map((p) => p.name);

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -26,9 +26,9 @@ export const commandsObject = yargs
   .command(
     'run [project][:target][:configuration] [options, ...]',
     `
-    Run a target for a project 
-    (e.g., nx run myapp:serve:production). 
-    
+    Run a target for a project
+    (e.g., nx run myapp:serve:production).
+
     You can also use the infix notation to run a target:
     (e.g., nx serve myapp --configuration=production)
     `
@@ -37,7 +37,7 @@ export const commandsObject = yargs
     'generate [schematic-collection:][schematic] [options, ...]',
     `
     Generate code
-    (e.g., nx generate @nrwl/web:app myapp). 
+    (e.g., nx generate @nrwl/web:app myapp).
     `
   )
   .command(
@@ -54,14 +54,14 @@ export const commandsObject = yargs
   )
   .command(
     'affected:apps',
-    'Print applications affected by changes',
-    withAffectedOptions,
+    'Print or run task for applications affected by changes',
+    (yargs) => withAffectedOptions(withParallel(withTarget(yargs))),
     (args) => affected('apps', { ...args })
   )
   .command(
     'affected:libs',
-    'Print libraries affected by changes',
-    withAffectedOptions,
+    'Print or run task for libraries affected by changes',
+    (yargs) => withAffectedOptions(withParallel(withTarget(yargs))),
     (args) =>
       affected('libs', {
         ...args,
@@ -175,8 +175,8 @@ export const commandsObject = yargs
   .command(
     'migrate',
     `Creates a migrations file or runs migrations from the migrations file.
-- Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)      
-- Run migrations (e.g., nx migrate --run-migrations=migrations.json)      
+- Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
+- Run migrations (e.g., nx migrate --run-migrations=migrations.json)
     `,
     (yargs) => yargs,
     () => {

--- a/scripts/documentation/generate-cli-data.ts
+++ b/scripts/documentation/generate-cli-data.ts
@@ -230,6 +230,10 @@ const examples = {
       description:
         'Print the names of all the apps affected by the last commit on master',
     },
+    {
+      command: 'nx affected:apps --target=custom-target',
+      description: 'Run custom target for all affected apps',
+    },
   ],
   'affected:libs': [
     {
@@ -246,6 +250,10 @@ const examples = {
       command: 'affected:libs --base=master~1 --head=master',
       description:
         'Print the names of all the libs affected by the last commit on master',
+    },
+    {
+      command: 'nx affected:libs --target=custom-target',
+      description: 'Run custom target for all affected libs',
     },
   ],
   'format:write': [],
@@ -418,9 +426,9 @@ Promise.all(
       let template = dedent`
       # ${command.command}
       ${command.description}
-      
+
       ## Usage
-      \`\`\`bash 
+      \`\`\`bash
       nx ${command.command}
       \`\`\`
 


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

When I run `nx affected:libs --target=deploy` or `nx affected:apps --target=deploy` it only list the affected libs or apps.

![image](https://user-images.githubusercontent.com/7026066/64743805-f1643480-d4c6-11e9-986c-ef1ac7335efa.png)

Nothing more happens.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The parameter ` --target` is not present on `affected:libs` or `affected:apps`. It exists for all the stuff in your workspace `nx affected --target=deploy` but is going "deploy" my apps and libraries and if I want only deploy my libraries and I can't do that.

The option `--target` should available for both `:libs` and `:apps`

## Issue
ISSUES CLOSED: #1830

## Other Information

This PR adds the option `--target` to the command `affected:libs` and `affected:apps`. It's implemented without introducing any breaking change and works in the following way:

- `nx affected:libs` will still print the affected libs formatted
- `nx affected:libs --plain` will still print the affected libs in plain format
- `nx affected:libs --target=test` will run the test of the affected libs
- `nx affected:libs --plain --target=test`, will print the affected libs in plain format, doesn't make sense to set both parameters and the `--plain` option will have the priority


