### PR TITLE
fix(testing): update maxWorkers jest builder option to support string type

### DIFF
--- a/docs/angular/api-jest/builders/jest.md
+++ b/docs/angular/api-jest/builders/jest.md
@@ -94,7 +94,7 @@ Prints the test results in JSON. This mode will send all other test output and u
 
 Alias(es): w
 
-Type: `number`
+Type: `number | string`
 
 Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/en/cli#maxworkers-num)
 

--- a/docs/react/api-jest/builders/jest.md
+++ b/docs/react/api-jest/builders/jest.md
@@ -95,7 +95,7 @@ Prints the test results in JSON. This mode will send all other test output and u
 
 Alias(es): w
 
-Type: `number`
+Type: `number | string`
 
 Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/en/cli#maxworkers-num)
 

--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -271,6 +271,7 @@ describe('Jest Builder', () => {
             },
           }),
           maxWorkers: '50%',
+          testPathPattern: [],
         },
         ['/root/jest.config.js']
       );

--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -246,6 +246,36 @@ describe('Jest Builder', () => {
       );
     });
 
+    it('should support passing string type for maxWorkers option to jestCLI', async () => {
+      const run = await architect.scheduleBuilder('@nrwl/jest:jest', {
+        jestConfig: './jest.config.js',
+        tsConfig: './tsconfig.test.json',
+        maxWorkers: '50%',
+      });
+      expect(await run.result).toEqual(
+        jasmine.objectContaining({
+          success: true,
+        })
+      );
+      expect(runCLI).toHaveBeenCalledWith(
+        {
+          _: [],
+          globals: JSON.stringify({
+            'ts-jest': {
+              tsConfig: '/root/tsconfig.test.json',
+              stringifyContentPathRegex: '\\.(html|svg)$',
+              astTransformers: [
+                'jest-preset-angular/build/InlineFilesTransformer',
+                'jest-preset-angular/build/StripStylesTransformer',
+              ],
+            },
+          }),
+          maxWorkers: '50%',
+        },
+        ['/root/jest.config.js']
+      );
+    });
+
     it('should send the main to runCLI', async () => {
       const run = await architect.scheduleBuilder('@nrwl/jest:jest', {
         jestConfig: './jest.config.js',

--- a/packages/jest/src/builders/jest/schema.d.ts
+++ b/packages/jest/src/builders/jest/schema.d.ts
@@ -14,7 +14,7 @@ export interface JestBuilderOptions extends JsonObject {
   clearCache?: boolean;
   findRelatedTests?: string;
   json?: boolean;
-  maxWorkers?: number;
+  maxWorkers?: number | string;
   onlyChanged?: boolean;
   outputFile?: string;
   passWithNoTests?: boolean;

--- a/packages/jest/src/builders/jest/schema.json
+++ b/packages/jest/src/builders/jest/schema.json
@@ -61,7 +61,7 @@
     "maxWorkers": {
       "alias": "w",
       "description": "Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/en/cli#maxworkers-num)",
-      "type": "number"
+      "oneOf": [{ "type": "number" }, { "type": "string" }]
     },
     "onlyChanged": {
       "alias": "o",


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Running tests using the jest builder, with `maxWorkers` option with a `string` value specified, results in the following error:
```
Cannot parse arguments. See below for the reasons.
    Argument --maxWorkers could not be parsed using value "50%".Valid type(s) is: number
```

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

The `maxWorkers` option does not error when passed a `string` value.

Jest supports both number and string args for the maxWorkers option, per their latest docs. This
updates the options for the jest builder to support both number and string types. Also updates the
docs accordingly.

## Issue
Closes #2871 