### PR TITLE
chore(core): nx plugin submission @nxpm/schematics

### DIFF
--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -48,5 +48,10 @@
     "name": "@twittwer/compodoc",
     "description": "Nx Plugin to integrate the generation of documentation with Compodoc in the Nx workflow",
     "url": "https://github.com/twittwer/nx-tools/tree/master/libs/compodoc#readme"
+  },
+  {
+    "name": "@nxpm/schematics",
+    "description": "Nx Plugin for creating a publishable schematics library",
+    "url": "https://github.com/nxpm/nxpm/tree/master/libs/schematics"
   }
 ]


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

@nxpm/schematics is not in the list of approved plugins :(

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

@nxpm/schematics is in the list of approved plugins :)

