### PR TITLE
Normalize appRootPath to prevent issues on Windows

### DIFF
--- a/packages/workspace/src/utils/app-root.ts
+++ b/packages/workspace/src/utils/app-root.ts
@@ -1,8 +1,11 @@
 import { fileExists } from './fileutils';
 import * as path from 'path';
 
-// TODO: vsavkin normalize the path
-export const appRootPath = pathInner(__dirname);
+function normalizeBackslashes(dir) {
+	return dir.replace(/\\/g,'/')
+}
+
+export const appRootPath = normalizeBackslashes(pathInner(__dirname));
 
 function pathInner(dir: string): string {
   if (path.dirname(dir) === dir) return process.cwd();


### PR DESCRIPTION
workspace/utils/app-root - appRootPath constant was un-normalized until now.
This lead to issues with dep-graph on Windows systems.

Fixes path-based detection https://github.com/nrwl/nx/issues/2955