### PR TITLE
fix(core): rename implicitDependencies during move

### DIFF
--- a/packages/workspace/src/schematics/move/lib/update-nx-json.ts
+++ b/packages/workspace/src/schematics/move/lib/update-nx-json.ts
@@ -9,6 +9,16 @@ import { getNewProjectName } from './utils';
  */
 export function updateNxJson(schema: Schema) {
   return updateJsonInTree<NxJson>('nx.json', (json) => {
+    Object.values(json.projects).forEach((project) => {
+      if (project.implicitDependencies) {
+        const index = project.implicitDependencies.indexOf(schema.projectName);
+        if (index !== -1) {
+          project.implicitDependencies[index] = getNewProjectName(
+            schema.destination
+          );
+        }
+      }
+    });
     json.projects[getNewProjectName(schema.destination)] = {
       ...json.projects[schema.projectName],
     };

--- a/packages/workspace/src/schematics/remove/lib/check-dependencies.ts
+++ b/packages/workspace/src/schematics/remove/lib/check-dependencies.ts
@@ -38,7 +38,7 @@ export function checkDependencies(schema: Schema): Rule {
 
     for (const dir of tree.getDir('/').subdirs) {
       if (ig.ignores(dir)) {
-        return;
+        continue;
       }
 
       tree.getDir(dir).visit((file: string) => {

--- a/packages/workspace/src/schematics/remove/lib/check-dependencies.ts
+++ b/packages/workspace/src/schematics/remove/lib/check-dependencies.ts
@@ -40,7 +40,8 @@ export function checkDependencies(schema: Schema): Rule {
       if (ig.ignores(dir)) {
         return;
       }
-      tree.getDir(dir).visit((file) => {
+
+      tree.getDir(dir).visit((file: string) => {
         files.push({
           file: path.relative(workspaceDir, file),
           ext: path.extname(file),

--- a/packages/workspace/src/schematics/remove/lib/update-nx-json.spec.ts
+++ b/packages/workspace/src/schematics/remove/lib/update-nx-json.spec.ts
@@ -5,6 +5,7 @@ import { createEmptyWorkspace } from '@nrwl/workspace/testing';
 import { callRule, runSchematic } from '../../../utils/testing';
 import { Schema } from '../schema';
 import { updateNxJson } from './update-nx-json';
+import { updateJsonInTree } from '@nrwl/workspace/src/utils/ast-utils';
 
 describe('updateNxJson Rule', () => {
   let tree: UnitTestTree;
@@ -15,13 +16,25 @@ describe('updateNxJson Rule', () => {
   });
 
   it('should update nx.json', async () => {
-    tree = await runSchematic('lib', { name: 'my-lib' }, tree);
+    tree = await runSchematic('lib', { name: 'my-lib1' }, tree);
+    tree = await runSchematic('lib', { name: 'my-lib2' }, tree);
 
     let nxJson = readJsonInTree(tree, '/nx.json');
-    expect(nxJson.projects['my-lib']).toBeDefined();
+    expect(nxJson.projects['my-lib1']).toBeDefined();
+
+    tree = (await callRule(
+      updateJsonInTree('nx.json', (json) => {
+        json.projects['my-lib2'].implicitDependencies = [
+          'my-lib1',
+          'my-other-lib',
+        ];
+        return json;
+      }),
+      tree
+    )) as UnitTestTree;
 
     const schema: Schema = {
-      projectName: 'my-lib',
+      projectName: 'my-lib1',
       skipFormat: false,
       forceRemove: false,
     };
@@ -29,6 +42,9 @@ describe('updateNxJson Rule', () => {
     tree = (await callRule(updateNxJson(schema), tree)) as UnitTestTree;
 
     nxJson = readJsonInTree(tree, '/nx.json');
-    expect(nxJson.projects['my-lib']).toBeUndefined();
+    expect(nxJson.projects['my-lib1']).toBeUndefined();
+    expect(nxJson.projects['my-lib2'].implicitDependencies).toEqual([
+      'my-other-lib',
+    ]);
   });
 });

--- a/packages/workspace/src/schematics/remove/lib/update-nx-json.ts
+++ b/packages/workspace/src/schematics/remove/lib/update-nx-json.ts
@@ -9,6 +9,15 @@ import { Schema } from '../schema';
 export function updateNxJson(schema: Schema) {
   return updateJsonInTree<NxJson>('nx.json', (json) => {
     delete json.projects[schema.projectName];
+
+    Object.values(json.projects).forEach((project) => {
+      if (project.implicitDependencies) {
+        project.implicitDependencies = project.implicitDependencies.filter(
+          (dep) => dep !== schema.projectName
+        );
+      }
+    });
+
     return json;
   });
 }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 export SELECTED_CLI=$SELECTED_CLI
-ts-node --project scripts/tsconfig.e2e.json ./scripts/e2e.ts $1
+ts-node --project scripts/tsconfig.e2e.json ./scripts/e2e.ts "$@"

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -86,6 +86,11 @@ export async function setup() {
 async function runTest() {
   let selectedProjects = process.argv[2];
 
+  let testNamePattern = '';
+  if (process.argv[3] === '-t' || process.argv[3] == '--testNamePattern') {
+    testNamePattern = `--testNamePattern "${process.argv[4]}"`;
+  }
+
   if (process.argv[3] === 'affected') {
     const affected = execSync(
       `nx print-affected --base=origin/master --select=projects`
@@ -116,7 +121,7 @@ async function runTest() {
       console.log('No tests to run');
     } else if (selectedProjects) {
       execSync(
-        `node --max-old-space-size=4000 ./node_modules/.bin/nx run-many --target=e2e --projects=${selectedProjects}`,
+        `node --max-old-space-size=4000 ./node_modules/.bin/nx run-many --target=e2e --projects=${selectedProjects} ${testNamePattern}`,
         {
           stdio: [0, 1, 2],
           env: { ...process.env, NX_TERMINAL_CAPTURE_STDERR: 'true' },
@@ -165,8 +170,8 @@ process.on('SIGINT', () => cleanUp(1));
 
 runTest()
   .then(() => {
-    process.exit(0);
     console.log('done');
+    process.exit(0);
   })
   .catch((e) => {
     console.error('error', e);


### PR DESCRIPTION
ISSUES CLOSED: #2906 

## Current Behavior (This is the behavior we have today, before the PR is merged)

Currently any implicitDependencies do not get renamed when using the move schematic. This is a manual process at the moment.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

implicitDependencies containing the name of the project we are renaming are updated accordingly.

## Issue

#2906 

### Note

This is my first contribution so let me know if I can do anything better! Thanks!
