### PR TITLE
feat(core): generate static website with dep-graph --file=foldername.html

### DIFF
--- a/docs/angular/cli/affected-dep-graph.md
+++ b/docs/angular/cli/affected-dep-graph.md
@@ -30,6 +30,12 @@ Save the dep graph of the workspace in a json file, and highlight the projects a
 nx affected:dep-graph --base=master --head=HEAD --file=output.json
 ```
 
+Generate a static website with dep graph data in an html file, highlighting the projects affected by the changes between master and HEAD (e.g., PR):
+
+```bash
+nx affected:dep-graph --base=master --head=HEAD --file=output.html
+```
+
 Open the dep graph of the workspace in the browser, and highlight the projects affected by the last commit on master:
 
 ```bash
@@ -58,7 +64,7 @@ Exclude certain projects from being processed
 
 ### file
 
-output file (e.g. --file=output.json)
+output file (e.g. --file=output.json or --file=dep-graph.html)
 
 ### files
 

--- a/docs/angular/cli/dep-graph.md
+++ b/docs/angular/cli/dep-graph.md
@@ -24,6 +24,12 @@ Save the dep graph into a json file:
 nx dep-graph --file=output.json
 ```
 
+Generate a static website with dep graph into an html file, accompanied by an asset folder called static:
+
+```bash
+nx dep-graph --file=output.html
+```
+
 Show the graph where every node is either an ancestor or a descendant of todos-feature-main.:
 
 ```bash
@@ -44,7 +50,7 @@ List of projects delimited by commas to exclude from the dependency graph.
 
 ### file
 
-output file (e.g. --file=output.json)
+output file (e.g. --file=output.json or --file=dep-graph.html)
 
 ### filter
 

--- a/docs/angular/cli/migrate.md
+++ b/docs/angular/cli/migrate.md
@@ -4,6 +4,7 @@
 - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
 - Run migrations (e.g., nx migrate --run-migrations=migrations.json)
 
+
       ## Usage
       ```bash
       nx migrate

--- a/docs/react/cli/affected-dep-graph.md
+++ b/docs/react/cli/affected-dep-graph.md
@@ -30,6 +30,12 @@ Save the dep graph of the workspace in a json file, and highlight the projects a
 nx affected:dep-graph --base=master --head=HEAD --file=output.json
 ```
 
+Generate a static website with dep graph data in an html file, highlighting the projects affected by the changes between master and HEAD (e.g., PR):
+
+```bash
+nx affected:dep-graph --base=master --head=HEAD --file=output.html
+```
+
 Open the dep graph of the workspace in the browser, and highlight the projects affected by the last commit on master:
 
 ```bash
@@ -58,7 +64,7 @@ Exclude certain projects from being processed
 
 ### file
 
-output file (e.g. --file=output.json)
+output file (e.g. --file=output.json or --file=dep-graph.html)
 
 ### files
 

--- a/docs/react/cli/dep-graph.md
+++ b/docs/react/cli/dep-graph.md
@@ -24,6 +24,12 @@ Save the dep graph into a json file:
 nx dep-graph --file=output.json
 ```
 
+Generate a static website with dep graph into an html file, accompanied by an asset folder called static:
+
+```bash
+nx dep-graph --file=output.html
+```
+
 Show the graph where every node is either an ancestor or a descendant of todos-feature-main.:
 
 ```bash
@@ -44,7 +50,7 @@ List of projects delimited by commas to exclude from the dependency graph.
 
 ### file
 
-output file (e.g. --file=output.json)
+output file (e.g. --file=output.json or --file=dep-graph.html)
 
 ### filter
 

--- a/docs/react/cli/migrate.md
+++ b/docs/react/cli/migrate.md
@@ -4,6 +4,7 @@
 - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
 - Run migrations (e.g., nx migrate --run-migrations=migrations.json)
 
+
       ## Usage
       ```bash
       nx migrate

--- a/e2e/workspace-aux-commands.test.ts
+++ b/e2e/workspace-aux-commands.test.ts
@@ -355,6 +355,10 @@ forEachCli((cli) => {
       expect(jsonFileContents2.criticalPath).toContain('mylib');
       expect(jsonFileContents2.criticalPath).not.toContain('mylib2');
     }, 1000000);
+
+    it.todo(
+      'dep-graph should output a deployable static website in an html file accompanied by a folder with static assets'
+    );
   });
 
   describe('Move Angular Project', () => {

--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -123,6 +123,12 @@ export function generateGraph(
         title: `JSON output created in ${folder}`,
         bodyLines: [filename],
       });
+    } else {
+      output.error({
+        title: `Please specify a filename with either .json or .html extension.`,
+        bodyLines: [`You provided --file=${args.file}`],
+      });
+      process.exit(1);
     }
   } else {
     startServer(

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -26,9 +26,9 @@ export const commandsObject = yargs
   .command(
     'run [project][:target][:configuration] [options, ...]',
     `
-    Run a target for a project 
-    (e.g., nx run myapp:serve:production). 
-    
+    Run a target for a project
+    (e.g., nx run myapp:serve:production).
+
     You can also use the infix notation to run a target:
     (e.g., nx serve myapp --configuration=production)
     `
@@ -37,7 +37,7 @@ export const commandsObject = yargs
     'generate [schematic-collection:][schematic] [options, ...]',
     `
     Generate code
-    (e.g., nx generate @nrwl/web:app myapp). 
+    (e.g., nx generate @nrwl/web:app myapp).
     `
   )
   .command(
@@ -175,8 +175,8 @@ export const commandsObject = yargs
   .command(
     'migrate',
     `Creates a migrations file or runs migrations from the migrations file.
-- Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)      
-- Run migrations (e.g., nx migrate --run-migrations=migrations.json)      
+- Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
+- Run migrations (e.g., nx migrate --run-migrations=migrations.json)
     `,
     (yargs) => yargs,
     () => {
@@ -332,7 +332,8 @@ function withRunManyOptions(yargs: yargs.Argv): yargs.Argv {
 function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
   return yargs
     .option('file', {
-      describe: 'output file (e.g. --file=output.json)',
+      describe:
+        'output file (e.g. --file=output.json or --file=dep-graph.html)',
       type: 'string',
     })
     .option('filter', {

--- a/scripts/documentation/generate-cli-data.ts
+++ b/scripts/documentation/generate-cli-data.ts
@@ -260,6 +260,11 @@ const examples = {
       description: 'Save the dep graph into a json file',
     },
     {
+      command: 'dep-graph --file=output.html',
+      description:
+        'Generate a static website with dep graph into an html file, accompanied by an asset folder called static',
+    },
+    {
       command: 'dep-graph --filter=todos-feature-main',
       description:
         'Show the graph where every node is either an ancestor or a descendant of todos-feature-main.',
@@ -285,6 +290,12 @@ const examples = {
         'affected:dep-graph --base=master --head=HEAD --file=output.json',
       description:
         'Save the dep graph of the workspace in a json file, and highlight the projects affected by the changes between master and HEAD (e.g., PR)',
+    },
+    {
+      command:
+        'affected:dep-graph --base=master --head=HEAD --file=output.html',
+      description:
+        'Generate a static website with dep graph data in an html file, highlighting the projects affected by the changes between master and HEAD (e.g., PR)',
     },
     {
       command: 'affected:dep-graph --base=master~1 --head=master',
@@ -418,9 +429,9 @@ Promise.all(
       let template = dedent`
       # ${command.command}
       ${command.description}
-      
+
       ## Usage
-      \`\`\`bash 
+      \`\`\`bash
       nx ${command.command}
       \`\`\`
 


### PR DESCRIPTION
## Current Behavior

I can only either run it in the browser locally or output the json which I'm honestly not sure what to do with. I can also give the `--file` arg any file extension but always get the same json.

## Expected Behavior

I'd like to be able to deploy the dep-graph website (the one we get when we run `nx dep-graph` and related commands) to wherever.

I'd also expect dep-graph with `--file` to fail if an unsupported extension is provided. Asking for a png (like in #2056) but getting a png file with json inside is very strange DX.

## My changes

### Support for html output

With these changes we'll be able to run something like

```bash
nx affected:dep-graph --base=master --head=HEAD --file=output.html
```

This will now generate a static website with the dep graph data, highlighting the projects affected by the changes between master and HEAD (e.g., PR). It will create a folder with the filename provided, in this example the folder would be called `output`.

This also applies to all other `dep-graph` commands. The website generated matches the one that usually runs locally using the `dep-graph` commands.

See #3048 for more context.

**NOTE: I have not written tests for this new behaviour, I'm not entirely sure how to approach that but I'm willing to make the effort if this implementation will be considered acceptable.**

### Display error if not `json` or `html`

Additionally the `dep-graph --file=*` command now errors out if an unsupported extension is provided.

## Issues
Closes #3048, #2005