### PR TITLE
fix(core): support --only-failed option with run-many command

### DIFF
--- a/packages/workspace/src/command-line/run-many.ts
+++ b/packages/workspace/src/command-line/run-many.ts
@@ -26,8 +26,11 @@ export function runMany(parsedArgs: yargs.Arguments): void {
     projectMap[proj.name] = proj;
   });
   const env = readEnvironment(nxArgs.target, projectMap);
+  const filteredProjects = Object.values(projects).filter(
+    (n) => !parsedArgs.onlyFailed || !env.workspaceResults.getResult(n.name)
+  );
   runCommand(
-    projects,
+    filteredProjects,
     projectGraph,
     env,
     nxArgs,


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

Using `--only-failed` with `nx run-many` still uses all projects

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Using `--only-failed` with `nx run-many` uses only failed projects

## Issue
