### PR TITLE
fix(repo): reorder CI ci to run most valuable steps first

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
     working_directory: ~/repo
     environment:
       # install Cypress in Linux-like cache folder
-      CYPRESS_CACHE_FOLDER: "~/.cache/Cypress"
+      CYPRESS_CACHE_FOLDER: '~/.cache/Cypress'
 
     docker:
       - image: circleci/node:12-browsers
@@ -78,20 +78,20 @@ jobs:
     steps:
       - setup
       - run:
+          name: Run Unit Tests
+          command: yarn test:all
+      - run:
+          name: Check Documentation
+          command: yarn documentation
+      - run:
+          name: Check Imports
+          command: yarn checkimports
+      - run:
           name: Check Formatting
           command: yarn checkformat
       - run:
           name: Check Commit Message Format
           command: yarn checkcommit
-      - run:
-          name: Check Imports
-          command: yarn checkimports
-      - run:
-          name: Check Documentation
-          command: yarn documentation
-      - run:
-          name: Run Unit Tests
-          command: yarn test:all
   e2e-nx-1:
     executor: default
     steps:


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

Most valuable steps such as unit tests are run after less-valuable steps such as checking the commit format.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Most valuable steps such as unit tests are run first so that less-valuable failures such as checking the commit format do not block the CI process from providing valuable information.

## Issue
