### PR TITLE
feat(linter): add maxWarnings option

### DIFF
--- a/docs/angular/api-linter/builders/lint.md
+++ b/docs/angular/api-linter/builders/lint.md
@@ -72,6 +72,14 @@ Possible values: `eslint`, `tslint`
 
 The tool to use for running lint checks.
 
+### maxWarnings
+
+Default: `-1`
+
+Type: `number`
+
+Number of warnings to trigger nonzero exit code - default: -1
+
 ### outputFile
 
 Type: `string`

--- a/docs/react/api-linter/builders/lint.md
+++ b/docs/react/api-linter/builders/lint.md
@@ -73,6 +73,14 @@ Possible values: `eslint`, `tslint`
 
 The tool to use for running lint checks.
 
+### maxWarnings
+
+Default: `-1`
+
+Type: `number`
+
+Number of warnings to trigger nonzero exit code - default: -1
+
 ### outputFile
 
 Type: `string`

--- a/packages/linter/src/builders/lint/lint.impl.spec.ts
+++ b/packages/linter/src/builders/lint/lint.impl.spec.ts
@@ -207,6 +207,7 @@ describe('Linter Builder', () => {
         outputFile: undefined,
         silent: false,
         tsConfig: undefined,
+        maxWarnings: -1,
       },
       expect.any(Set)
     );
@@ -487,6 +488,33 @@ describe('Linter Builder', () => {
       format: 'json',
       silent: true,
       force: false,
+    });
+    expect(output.success).toBeFalsy();
+  });
+  it('should be a failure if there are no errors, but warnings and maxWarnings is set to 0', async () => {
+    mockReports = [
+      {
+        errorCount: 0,
+        warningCount: 1,
+        results: [],
+        usedDeprecatedRules: [],
+      },
+      {
+        errorCount: 0,
+        warningCount: 0,
+        results: [],
+        usedDeprecatedRules: [],
+      },
+    ];
+    setupMocks();
+    const output = await runBuilder({
+      linter: 'eslint',
+      config: './.eslintrc',
+      files: ['includedFile1'],
+      format: 'json',
+      silent: true,
+      force: false,
+      maxWarnings: 1,
     });
     expect(output.success).toBeFalsy();
   });

--- a/packages/linter/src/builders/lint/lint.impl.ts
+++ b/packages/linter/src/builders/lint/lint.impl.ts
@@ -132,7 +132,11 @@ async function run(options: Schema, context: BuilderContext): Promise<any> {
   }
 
   return {
-    success: options.force || bundledReport.errorCount === 0,
+    success:
+      options.force ||
+      (bundledReport.errorCount === 0 &&
+        (options.maxWarnings === -1 ||
+          bundledReport.warningCount < options.maxWarnings)),
   };
 }
 

--- a/packages/linter/src/builders/lint/schema.d.ts
+++ b/packages/linter/src/builders/lint/schema.d.ts
@@ -11,6 +11,7 @@ export interface Schema {
   cache: boolean;
   outputFile: string;
   cacheLocation: string;
+  maxWarnings: number;
 }
 
 type Formatter =

--- a/packages/linter/src/builders/lint/schema.json
+++ b/packages/linter/src/builders/lint/schema.json
@@ -94,6 +94,11 @@
     "outputFile": {
       "type": "string",
       "description": "File to write report to."
+    },
+    "maxWarnings": {
+      "type": "number",
+      "description": "Number of warnings to trigger nonzero exit code - default: -1",
+      "default": -1
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)

The official eslint allows for a `maxWarnings` option, the nrwl builder does not atm.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

Have a `maxWarnings` option that allows to set the max allowed number of warnings.

## Issue

Fixes #2762