### PR TITLE
fix(core): split namespace for library dependencies

### DIFF
--- a/e2e/angular-package.test.ts
+++ b/e2e/angular-package.test.ts
@@ -138,9 +138,14 @@ forEachCli('angular', (cli) => {
       expect(parentLibOutput).toContain(`Built @proj/${parentLib}`);
 
       const jsonFile = readJson(`dist/libs/${parentLib}/package.json`);
-      expect(jsonFile.dependencies).toMatchObject({
+      expect(jsonFile.dependencies).toEqual({
+        tslib: '^1.10.0',
         [`@proj/${childLib}`]: '0.0.1',
         [`@proj/${childLib2}`]: '0.0.1',
+      });
+      expect(jsonFile.peerDependencies).toEqual({
+        '@angular/common': '^9.1.0',
+        '@angular/core': '^9.1.0',
       });
     });
   });

--- a/packages/workspace/src/utils/buildable-libs-utils.ts
+++ b/packages/workspace/src/utils/buildable-libs-utils.ts
@@ -256,13 +256,9 @@ export function updateBuildableProjectPackageJsonDependencies(
 
   let updatePackageJson = false;
   dependencies.forEach((entry) => {
-    const entryName = entry.name.split(':');
-    /**
-     * Dependency names could potentially come in with `:` in them (ie. `npm:@npmscope/core`)
-     *
-     * We want to make sure that we do comparisons here without the first section (before `:`)
-     */
-    const packageName = entryName.length === 2 ? entryName[1] : entryName[0];
+    const packageName =
+      entry.node.type === 'npm' ? entry.node.data.packageName : entry.name;
+
     if (
       !hasDependency(packageJson, 'dependencies', packageName) &&
       !hasDependency(packageJson, 'devDependencies', packageName) &&

--- a/packages/workspace/src/utils/buildable-libs-utils.ts
+++ b/packages/workspace/src/utils/buildable-libs-utils.ts
@@ -256,10 +256,17 @@ export function updateBuildableProjectPackageJsonDependencies(
 
   let updatePackageJson = false;
   dependencies.forEach((entry) => {
+    const entryName = entry.name.split(':');
+    /**
+     * Dependency names could potentially come in with `:` in them (ie. `npm:@npmscope/core`)
+     *
+     * We want to make sure that we do comparisons here without the first section (before `:`)
+     */
+    const packageName = entryName.length === 2 ? entryName[1] : entryName[0];
     if (
-      !hasDependency(packageJson, 'dependencies', entry.name) &&
-      !hasDependency(packageJson, 'devDependencies', entry.name) &&
-      !hasDependency(packageJson, 'peerDependencies', entry.name)
+      !hasDependency(packageJson, 'dependencies', packageName) &&
+      !hasDependency(packageJson, 'devDependencies', packageName) &&
+      !hasDependency(packageJson, 'peerDependencies', packageName)
     ) {
       try {
         let depVersion;
@@ -277,7 +284,7 @@ export function updateBuildableProjectPackageJsonDependencies(
           );
           depVersion = readJsonFile(depPackageJsonPath).version;
 
-          packageJson.dependencies[entry.name] = depVersion;
+          packageJson.dependencies[packageName] = depVersion;
         } else if (entry.node.type === 'npm') {
           // If an npm dep is part of the workspace devDependencies, do not include it the library
           if (


### PR DESCRIPTION


_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
deps with npm are included twice for angular libs

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

npm deps have `npm:` included in their names, and we should not check that namespace when looking into the package.json

## Issue
