### PR TITLE
fix(core): use typescript module resolution for linting

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -5,13 +5,13 @@ import {
   findProjectUsingImport,
   findSourceProject,
   getSourceFilePath,
+  hasArchitectBuildBuilder,
   hasNoneOfTheseTags,
   isAbsoluteImportIntoAnotherProject,
   isCircular,
   isRelativeImportIntoAnotherProject,
   matchImportWithWildcard,
   onlyLoadChildren,
-  hasArchitectBuildBuilder,
 } from '@nrwl/workspace/src/utils/runtime-lint-utils';
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
@@ -22,7 +22,6 @@ import {
   ProjectType,
 } from '@nrwl/workspace/src/core/project-graph';
 import {
-  normalizedProjectRoot,
   readNxJson,
   readWorkspaceJson,
 } from '@nrwl/workspace/src/core/file-utils';
@@ -39,7 +38,6 @@ export type MessageIds =
   | 'noRelativeOrAbsoluteImportsAcrossLibraries'
   | 'noCircularDependencies'
   | 'noImportsOfApps'
-  | 'noDeepImportsIntoLibraries'
   | 'noImportOfNonBuildableLibraries'
   | 'noImportsOfLazyLoadedLibraries'
   | 'projectWithoutTagsCannotHaveDependencies'
@@ -77,10 +75,9 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      noRelativeOrAbsoluteImportsAcrossLibraries: `Library imports must start with @{{npmScope}}/`,
+      noRelativeOrAbsoluteImportsAcrossLibraries: `Libraries cannot be imported by a relative or absolute path`,
       noCircularDependencies: `Circular dependency between "{{sourceProjectName}}" and "{{targetProjectName}}" detected`,
       noImportsOfApps: 'Imports of apps are forbidden',
-      noDeepImportsIntoLibraries: 'Deep imports into libraries are forbidden',
       noImportOfNonBuildableLibraries:
         'Buildable libs cannot import non-buildable libs',
       noImportsOfLazyLoadedLibraries: `Imports of lazy-loaded libraries are forbidden`,
@@ -151,129 +148,112 @@ export default createESLintRule<Options, MessageIds>({
           return;
         }
 
+        const sourceProject = findSourceProject(projectGraph, sourceFilePath);
+        const targetProject = findProjectUsingImport(
+          projectGraph,
+          targetProjectLocator,
+          sourceFilePath,
+          imp
+        );
+
+        // If source or target are not part of an nx workspace, return.
+        if (!sourceProject || !targetProject) {
+          return;
+        }
+
         // check constraints between libs and apps
-        if (imp.startsWith(`@${npmScope}/`)) {
-          // we should find the name
-          const sourceProject = findSourceProject(projectGraph, sourceFilePath);
-          // findProjectUsingImport to take care of same prefix
-          const targetProject = findProjectUsingImport(
+        // check for circular dependency
+        if (isCircular(projectGraph, sourceProject, targetProject)) {
+          context.report({
+            node,
+            messageId: 'noCircularDependencies',
+            data: {
+              sourceProjectName: sourceProject.name,
+              targetProjectName: targetProject.name,
+            },
+          });
+          return;
+        }
+
+        // same project => allow
+        if (sourceProject === targetProject) {
+          return;
+        }
+
+        // cannot import apps
+        if (targetProject.type !== ProjectType.lib) {
+          context.report({
+            node,
+            messageId: 'noImportsOfApps',
+          });
+          return;
+        }
+
+        // buildable-lib is not allowed to import non-buildable-lib
+        if (
+          enforceBuildableLibDependency === true &&
+          sourceProject.type === ProjectType.lib &&
+          targetProject.type === ProjectType.lib
+        ) {
+          if (
+            hasArchitectBuildBuilder(sourceProject) &&
+            !hasArchitectBuildBuilder(targetProject)
+          ) {
+            context.report({
+              node,
+              messageId: 'noImportOfNonBuildableLibraries',
+            });
+            return;
+          }
+        }
+
+        // if we import a library using loadChildren, we should not import it using es6imports
+        if (
+          onlyLoadChildren(
             projectGraph,
-            targetProjectLocator,
-            sourceFilePath,
-            imp,
-            npmScope
-          );
+            sourceProject.name,
+            targetProject.name,
+            []
+          )
+        ) {
+          context.report({
+            node,
+            messageId: 'noImportsOfLazyLoadedLibraries',
+          });
+          return;
+        }
 
-          // something went wrong => return.
-          if (!sourceProject || !targetProject) {
-            return;
-          }
-
-          // check for circular dependency
-          if (isCircular(projectGraph, sourceProject, targetProject)) {
+        // check that dependency constraints are satisfied
+        if (depConstraints.length > 0) {
+          const constraints = findConstraintsFor(depConstraints, sourceProject);
+          // when no constrains found => error. Force the user to provision them.
+          if (constraints.length === 0) {
             context.report({
               node,
-              messageId: 'noCircularDependencies',
-              data: {
-                sourceProjectName: sourceProject.name,
-                targetProjectName: targetProject.name,
-              },
+              messageId: 'projectWithoutTagsCannotHaveDependencies',
             });
             return;
           }
 
-          // same project => allow
-          if (sourceProject === targetProject) {
-            return;
-          }
-
-          // cannot import apps
-          if (targetProject.type !== ProjectType.lib) {
-            context.report({
-              node,
-              messageId: 'noImportsOfApps',
-            });
-            return;
-          }
-
-          // buildable-lib is not allowed to import non-buildable-lib
-          if (
-            enforceBuildableLibDependency === true &&
-            sourceProject.type === ProjectType.lib &&
-            targetProject.type === ProjectType.lib
-          ) {
+          for (let constraint of constraints) {
             if (
-              hasArchitectBuildBuilder(sourceProject) &&
-              !hasArchitectBuildBuilder(targetProject)
+              hasNoneOfTheseTags(
+                targetProject,
+                constraint.onlyDependOnLibsWithTags || []
+              )
             ) {
+              const allowedTags = constraint.onlyDependOnLibsWithTags
+                .map((s) => `"${s}"`)
+                .join(', ');
               context.report({
                 node,
-                messageId: 'noImportOfNonBuildableLibraries',
+                messageId: 'tagConstraintViolation',
+                data: {
+                  sourceTag: constraint.sourceTag,
+                  allowedTags,
+                },
               });
               return;
-            }
-          }
-
-          // deep imports aren't allowed
-          if (imp !== `@${npmScope}/${normalizedProjectRoot(targetProject)}`) {
-            context.report({
-              node,
-              messageId: 'noDeepImportsIntoLibraries',
-            });
-            return;
-          }
-
-          // if we import a library using loadChildren, we should not import it using es6imports
-          if (
-            onlyLoadChildren(
-              projectGraph,
-              sourceProject.name,
-              targetProject.name,
-              []
-            )
-          ) {
-            context.report({
-              node,
-              messageId: 'noImportsOfLazyLoadedLibraries',
-            });
-            return;
-          }
-
-          // check that dependency constraints are satisfied
-          if (depConstraints.length > 0) {
-            const constraints = findConstraintsFor(
-              depConstraints,
-              sourceProject
-            );
-            // when no constrains found => error. Force the user to provision them.
-            if (constraints.length === 0) {
-              context.report({
-                node,
-                messageId: 'projectWithoutTagsCannotHaveDependencies',
-              });
-              return;
-            }
-
-            for (let constraint of constraints) {
-              if (
-                hasNoneOfTheseTags(
-                  targetProject,
-                  constraint.onlyDependOnLibsWithTags || []
-                )
-              ) {
-                const allowedTags = constraint.onlyDependOnLibsWithTags
-                  .map((s) => `"${s}"`)
-                  .join(', ');
-                context.report({
-                  node,
-                  messageId: 'tagConstraintViolation',
-                  data: {
-                    sourceTag: constraint.sourceTag,
-                    allowedTags,
-                  },
-                });
-                return;
-              }
             }
           }
         }

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -153,7 +153,8 @@ export default createESLintRule<Options, MessageIds>({
           projectGraph,
           targetProjectLocator,
           sourceFilePath,
-          imp
+          imp,
+          npmScope
         );
 
         // If source or target are not part of an nx workspace, return.

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -75,11 +75,11 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      noRelativeOrAbsoluteImportsAcrossLibraries: `Libraries cannot be imported by a relative or absolute path`,
+      noRelativeOrAbsoluteImportsAcrossLibraries: `Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope`,
       noCircularDependencies: `Circular dependency between "{{sourceProjectName}}" and "{{targetProjectName}}" detected`,
       noImportsOfApps: 'Imports of apps are forbidden',
       noImportOfNonBuildableLibraries:
-        'Buildable libs cannot import non-buildable libs',
+        'Buildable libraries cannot import non-buildable libraries',
       noImportsOfLazyLoadedLibraries: `Imports of lazy-loaded libraries are forbidden`,
       projectWithoutTagsCannotHaveDependencies: `A project without tags cannot depend on any libraries`,
       tagConstraintViolation: `A project tagged with "{{sourceTag}}" can only depend on libs tagged with {{allowedTags}}`,

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -37,6 +37,10 @@ const tsconfig = {
       '@mycompany/badcirclelib': ['libs/badcirclelib/src/index.ts'],
       '@mycompany/domain1': ['libs/domain1/src/index.ts'],
       '@mycompany/domain2': ['libs/domain2/src/index.ts'],
+      '@mycompany/buildableLib': ['libs/buildableLib/src/main.ts'],
+      '@nonBuildableScope/nonBuildableLib': [
+        'libs/nonBuildableLib/src/main.ts',
+      ],
     },
     types: ['node'],
   },
@@ -62,6 +66,8 @@ const fileSys = {
   './libs/badcirclelib/src/index.ts': '',
   './libs/domain1/src/index.ts': '',
   './libs/domain2/src/index.ts': '',
+  './libs/buildableLib/src/main.ts': '',
+  './libs/nonBuildableLib/src/main.ts': '',
   './tsconfig.json': JSON.stringify(tsconfig),
 };
 
@@ -463,7 +469,7 @@ describe('Enforce Module Boundaries', () => {
         }
       );
       expect(failures[0].message).toEqual(
-        'Library imports must start with @mycompany/'
+        'Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope'
       );
     });
 
@@ -501,7 +507,7 @@ describe('Enforce Module Boundaries', () => {
         }
       );
       expect(failures[0].message).toEqual(
-        'Library imports must start with @mycompany/'
+        'Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope'
       );
     });
   });
@@ -534,7 +540,7 @@ describe('Enforce Module Boundaries', () => {
 
     expect(failures.length).toEqual(1);
     expect(failures[0].message).toEqual(
-      'Library imports must start with @mycompany/'
+      'Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope'
     );
   });
 
@@ -847,7 +853,7 @@ describe('Enforce Module Boundaries', () => {
           enforceBuildableLibDependency: true,
         },
         `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
-        'import "@mycompany/nonBuildableLib"',
+        'import "@nonBuildableScope/nonBuildableLib"',
         {
           nodes: {
             buildableLib: {
@@ -882,7 +888,7 @@ describe('Enforce Module Boundaries', () => {
         }
       );
       expect(failures[0].message).toEqual(
-        'Buildable libs cannot import non-buildable libs'
+        'Buildable libraries cannot import non-buildable libraries'
       );
     });
 

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -12,6 +12,17 @@ export class TargetProjectLocator {
     );
   }
 
+  /**
+   * Find a project based on its import
+   *
+   * @param importExpr
+   * @param filePath
+   * @param npmScope
+   *  Npm scope shouldn't be used finding a project, but, to improve backward
+   *  compatibility, we fallback to checking the scope.
+   *  This happens in cases where someone has the dist output in their tsconfigs
+   *  and typescript will find the dist before the src.
+   */
   findProjectWithImport(
     importExpr: string,
     filePath: string,

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -34,6 +34,10 @@ const tsconfig = {
       '@mycompany/badcirclelib': ['libs/badcirclelib/src/index.ts'],
       '@mycompany/domain1': ['libs/domain1/src/index.ts'],
       '@mycompany/domain2': ['libs/domain2/src/index.ts'],
+      '@mycompany/buildableLib': ['libs/buildableLib/src/main.ts'],
+      '@nonBuildableScope/nonBuildableLib': [
+        'libs/nonBuildableLib/src/main.ts',
+      ],
     },
     types: ['node'],
   },
@@ -59,6 +63,8 @@ const fileSys = {
   './libs/badcirclelib/src/index.ts': '',
   './libs/domain1/src/index.ts': '',
   './libs/domain2/src/index.ts': '',
+  './libs/buildableLib/src/main.ts': '',
+  './libs/nonBuildableLib/src/main.ts': '',
   './tsconfig.json': JSON.stringify(tsconfig),
 };
 
@@ -459,7 +465,7 @@ describe('Enforce Module Boundaries', () => {
         }
       );
       expect(failures[0].getFailure()).toEqual(
-        'library imports must start with @mycompany/'
+        'libraries cannot be imported by a relative or absolute path, and must begin with a npm scope'
       );
     });
 
@@ -498,7 +504,7 @@ describe('Enforce Module Boundaries', () => {
         }
       );
       expect(failures[0].getFailure()).toEqual(
-        'library imports must start with @mycompany/'
+        'libraries cannot be imported by a relative or absolute path, and must begin with a npm scope'
       );
     });
   });
@@ -531,7 +537,7 @@ describe('Enforce Module Boundaries', () => {
 
     expect(failures.length).toEqual(1);
     expect(failures[0].getFailure()).toEqual(
-      'library imports must start with @mycompany/'
+      'libraries cannot be imported by a relative or absolute path, and must begin with a npm scope'
     );
   });
 
@@ -844,7 +850,7 @@ describe('Enforce Module Boundaries', () => {
           enforceBuildableLibDependency: true,
         },
         `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
-        'import "@mycompany/nonBuildableLib"',
+        'import "@nonBuildableScope/nonBuildableLib"',
         {
           nodes: {
             buildableLib: {
@@ -879,7 +885,7 @@ describe('Enforce Module Boundaries', () => {
         }
       );
       expect(failures[0].getFailure()).toEqual(
-        'buildable libs cannot import non-buildable libs'
+        'buildable libraries cannot import non-buildable libraries'
       );
     });
 

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -144,7 +144,8 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
       this.projectGraph,
       this.targetProjectLocator,
       filePath,
-      imp
+      imp,
+      this.npmScope
     );
 
     // If source or target are not part of an nx workspace, return.

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -129,7 +129,7 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
       this.addFailureAt(
         node.getStart(),
         node.getWidth(),
-        `libraries cannot be imported by a relative or absolute path`
+        `libraries cannot be imported by a relative or absolute path, and must begin with a npm scope`
       );
       return;
     }

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -135,14 +135,11 @@ export function findProjectUsingImport(
   projectGraph: ProjectGraph,
   targetProjectLocator: TargetProjectLocator,
   filePath: string,
-  imp: string,
-  npmScope: string
+  imp: string
 ) {
-  const target = targetProjectLocator.findProjectWithImport(
-    imp,
-    filePath,
-    npmScope
-  );
+  // Npm scope shouldn't be used in linting anymore.
+  // We should just be able to find the import with typescript
+  const target = targetProjectLocator.findProjectWithImport(imp, filePath, '');
   return projectGraph.nodes[target];
 }
 

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -135,11 +135,21 @@ export function findProjectUsingImport(
   projectGraph: ProjectGraph,
   targetProjectLocator: TargetProjectLocator,
   filePath: string,
-  imp: string
+  imp: string,
+  npmScope: string
 ) {
-  // Npm scope shouldn't be used in linting anymore.
-  // We should just be able to find the import with typescript
-  const target = targetProjectLocator.findProjectWithImport(imp, filePath, '');
+  /**
+   *  Npm scope shouldn't be used in linting anymore, BUT, to improve backward
+   *  compatibility, we fallback to checking the scope.
+   *
+   *  This happens in cases where someone has the dist output in their tsconfigs
+   *  and typescript will find the dist before the src.
+   */
+  const target = targetProjectLocator.findProjectWithImport(
+    imp,
+    filePath,
+    npmScope
+  );
   return projectGraph.nodes[target];
 }
 

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -138,13 +138,6 @@ export function findProjectUsingImport(
   imp: string,
   npmScope: string
 ) {
-  /**
-   *  Npm scope shouldn't be used in linting anymore, BUT, to improve backward
-   *  compatibility, we fallback to checking the scope.
-   *
-   *  This happens in cases where someone has the dist output in their tsconfigs
-   *  and typescript will find the dist before the src.
-   */
   const target = targetProjectLocator.findProjectWithImport(
     imp,
     filePath,


### PR DESCRIPTION
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)
During linting, we check the import with the hardcoded `npmScope`. This was OK, until someone added another scope to their projects and linting stopped working.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
We now use the TypeScript module resolution to find all projects within a workspace. We do not use string comparison anymore. 

This also means that deep imports are opt in, because you have to specifically set the tsconfig.json to allow deep imports. 

## Issue
