### PR TITLE
chore(repo): add stale issues check to github workflow

### DIFF
--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -1,0 +1,25 @@
+on:
+  schedule:
+    - cron: "* */12 * * *"
+name: Stale Bot workflow
+jobs:
+  build:
+    name: stale
+    runs-on: ubuntu-latest
+    steps:
+      - name: stale
+        id: stale
+        uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: -1
+          stale-issue-label: "status: stale"
+          operations-per-run: 300
+          remove-stale-when-updated: true
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it hasn't had any recent activity. It will be closed in 14 days if no further activity occurs.
+            If we missed this issue please reply to keep it active.
+            Thanks for being a part of the Nrwl community! 🙏
+          exempt-issue-labels: |
+            community


### PR DESCRIPTION
This PR adds a workflow to check for stale issues. 

- Issues are labeled stale after 30 days.
- Issues are closed after 14 days if no further activity occurs.
    * For now this is disabled so current stale issues are not closed automatically.
- Some labels are whitelisted to never go stale.