### PR TITLE
fix(linter): fix issue with "files" option getting always excluded

### DIFF
--- a/docs/angular/migration/migration-angular.md
+++ b/docs/angular/migration/migration-angular.md
@@ -286,7 +286,7 @@ If you are using `Protractor` for E2E testing:
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
             "tsConfig": "apps/<app name>-e2e/tsconfig.e2e.json",
-            "exclude": ["**/node_modules/**", "!apps/<app name>-e2e/**"]
+            "exclude": ["**/node_modules/**", "!apps/<app name>-e2e/**/*"]
           }
         }
       }

--- a/packages/angular/src/schematics/application/application.spec.ts
+++ b/packages/angular/src/schematics/application/application.spec.ts
@@ -24,10 +24,10 @@ describe('app', () => {
 
       expect(
         workspaceJson.projects['my-app'].architect.lint.options.exclude
-      ).toEqual(['**/node_modules/**', '!apps/my-app/**']);
+      ).toEqual(['**/node_modules/**', '!apps/my-app/**/*']);
       expect(
         workspaceJson.projects['my-app-e2e'].architect.lint.options.exclude
-      ).toEqual(['**/node_modules/**', '!apps/my-app-e2e/**']);
+      ).toEqual(['**/node_modules/**', '!apps/my-app-e2e/**/*']);
     });
 
     it('should remove the e2e target on the application', async () => {
@@ -175,11 +175,11 @@ describe('app', () => {
 
       expect(
         workspaceJson.projects['my-dir-my-app'].architect.lint.options.exclude
-      ).toEqual(['**/node_modules/**', '!apps/my-dir/my-app/**']);
+      ).toEqual(['**/node_modules/**', '!apps/my-dir/my-app/**/*']);
       expect(
         workspaceJson.projects['my-dir-my-app-e2e'].architect.lint.options
           .exclude
-      ).toEqual(['**/node_modules/**', '!apps/my-dir/my-app-e2e/**']);
+      ).toEqual(['**/node_modules/**', '!apps/my-dir/my-app-e2e/**/*']);
     });
 
     it('should update nx.json', async () => {
@@ -456,7 +456,7 @@ describe('app', () => {
               builder: '@angular-devkit/build-angular:tslint',
               options: {
                 tsConfig: 'apps/my-app-e2e/tsconfig.e2e.json',
-                exclude: ['**/node_modules/**', '!apps/my-app-e2e/**'],
+                exclude: ['**/node_modules/**', '!apps/my-app-e2e/**/*'],
               },
             },
           },

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -510,7 +510,7 @@ function updateProject(options: NormalizedSchema): Rule {
               join(normalize(options.appProjectRoot), 'e2e/tsconfig.json')
         );
         fixedProject.architect.lint.options.exclude.push(
-          '!' + join(normalize(options.appProjectRoot), '**')
+          '!' + join(normalize(options.appProjectRoot), '**/*')
         );
 
         if (options.e2eTestRunner === 'none') {
@@ -618,7 +618,7 @@ function updateE2eProject(options: NormalizedSchema): Rule {
                 tsConfig: `${options.e2eProjectRoot}/tsconfig.e2e.json`,
                 exclude: [
                   '**/node_modules/**',
-                  '!' + join(normalize(options.e2eProjectRoot), '**'),
+                  '!' + join(normalize(options.e2eProjectRoot), '**/*'),
                 ],
               },
             },

--- a/packages/angular/src/schematics/library/library.spec.ts
+++ b/packages/angular/src/schematics/library/library.spec.ts
@@ -98,7 +98,7 @@ describe('lib', () => {
       ]);
       expect(
         workspaceJson.projects['my-lib'].architect.lint.options.exclude
-      ).toEqual(['**/node_modules/**', '!libs/my-lib/**']);
+      ).toEqual(['**/node_modules/**', '!libs/my-lib/**/*']);
     });
 
     it('should remove "build" target from workspace.json when a library is not publishable', async () => {
@@ -452,7 +452,7 @@ describe('lib', () => {
       ]);
       expect(
         workspaceJson.projects['my-dir-my-lib'].architect.lint.options.exclude
-      ).toEqual(['**/node_modules/**', '!libs/my-dir/my-lib/**']);
+      ).toEqual(['**/node_modules/**', '!libs/my-dir/my-lib/**/*']);
     });
 
     it('should update tsconfig.json', async () => {
@@ -966,7 +966,7 @@ describe('lib', () => {
       ]);
       expect(
         workspaceJson.projects['my-lib'].architect.lint.options.exclude
-      ).toEqual(['**/node_modules/**', '!libs/my-lib/**']);
+      ).toEqual(['**/node_modules/**', '!libs/my-lib/**/*']);
     });
   });
 

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -353,7 +353,7 @@ function updateProject(options: NormalizedSchema): Rule {
             path !== join(normalize(options.projectRoot), 'tsconfig.spec.json')
         );
         fixedProject.architect.lint.options.exclude.push(
-          '!' + join(normalize(options.projectRoot), '**')
+          '!' + join(normalize(options.projectRoot), '**/*')
         );
 
         json.projects[options.name] = fixedProject;

--- a/packages/cypress/src/schematics/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/schematics/cypress-project/cypress-project.spec.ts
@@ -51,7 +51,7 @@ describe('schematic:cypress-project', () => {
         builder: '@angular-devkit/build-angular:tslint',
         options: {
           tsConfig: ['apps/my-app-e2e/tsconfig.e2e.json'],
-          exclude: ['**/node_modules/**', '!apps/my-app-e2e/**'],
+          exclude: ['**/node_modules/**', '!apps/my-app-e2e/**/*'],
         },
       });
       expect(project.architect.e2e).toEqual({
@@ -83,7 +83,7 @@ describe('schematic:cypress-project', () => {
         options: {
           linter: 'eslint',
           tsConfig: ['apps/my-app-e2e/tsconfig.e2e.json'],
-          exclude: ['**/node_modules/**', '!apps/my-app-e2e/**'],
+          exclude: ['**/node_modules/**', '!apps/my-app-e2e/**/*'],
         },
       });
     });
@@ -160,7 +160,7 @@ describe('schematic:cypress-project', () => {
           builder: '@angular-devkit/build-angular:tslint',
           options: {
             tsConfig: ['apps/my-dir/my-app-e2e/tsconfig.e2e.json'],
-            exclude: ['**/node_modules/**', '!apps/my-dir/my-app-e2e/**'],
+            exclude: ['**/node_modules/**', '!apps/my-dir/my-app-e2e/**/*'],
           },
         });
 

--- a/packages/nest/src/schematics/library/library.spec.ts
+++ b/packages/nest/src/schematics/library/library.spec.ts
@@ -21,7 +21,7 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-lib'].architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          exclude: ['**/node_modules/**', '!libs/my-lib/**'],
+          exclude: ['**/node_modules/**', '!libs/my-lib/**/*'],
           tsConfig: [
             'libs/my-lib/tsconfig.lib.json',
             'libs/my-lib/tsconfig.spec.json',
@@ -268,7 +268,7 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-dir-my-lib'].architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**'],
+          exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**/*'],
           tsConfig: [
             'libs/my-dir/my-lib/tsconfig.lib.json',
             'libs/my-dir/my-lib/tsconfig.spec.json',

--- a/packages/node/src/schematics/application/application.spec.ts
+++ b/packages/node/src/schematics/application/application.spec.ts
@@ -59,7 +59,7 @@ describe('app', () => {
             'apps/my-node-app/tsconfig.app.json',
             'apps/my-node-app/tsconfig.spec.json',
           ],
-          exclude: ['**/node_modules/**', '!apps/my-node-app/**'],
+          exclude: ['**/node_modules/**', '!apps/my-node-app/**/*'],
         },
       });
       expect(workspaceJson.projects['my-node-app-e2e']).toBeUndefined();
@@ -127,7 +127,7 @@ describe('app', () => {
             'apps/my-dir/my-node-app/tsconfig.app.json',
             'apps/my-dir/my-node-app/tsconfig.spec.json',
           ],
-          exclude: ['**/node_modules/**', '!apps/my-dir/my-node-app/**'],
+          exclude: ['**/node_modules/**', '!apps/my-dir/my-node-app/**/*'],
         },
       });
 

--- a/packages/node/src/schematics/library/library.spec.ts
+++ b/packages/node/src/schematics/library/library.spec.ts
@@ -21,7 +21,7 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-lib'].architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          exclude: ['**/node_modules/**', '!libs/my-lib/**'],
+          exclude: ['**/node_modules/**', '!libs/my-lib/**/*'],
           tsConfig: [
             'libs/my-lib/tsconfig.lib.json',
             'libs/my-lib/tsconfig.spec.json',
@@ -159,7 +159,7 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-dir-my-lib'].architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**'],
+          exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**/*'],
           tsConfig: [
             'libs/my-dir/my-lib/tsconfig.lib.json',
             'libs/my-dir/my-lib/tsconfig.spec.json',

--- a/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
@@ -44,7 +44,7 @@ describe('NxPlugin plugin', () => {
     expect(project.architect.lint).toEqual({
       builder: '@angular-devkit/build-angular:tslint',
       options: {
-        exclude: ['**/node_modules/**', '!libs/my-plugin/**'],
+        exclude: ['**/node_modules/**', '!libs/my-plugin/**/*'],
         tsConfig: [
           'libs/my-plugin/tsconfig.lib.json',
           'libs/my-plugin/tsconfig.spec.json',

--- a/packages/react/src/schematics/application/application.spec.ts
+++ b/packages/react/src/schematics/application/application.spec.ts
@@ -294,7 +294,7 @@ describe('app', () => {
     expect(workspaceJson.projects['my-app'].architect.lint).toEqual({
       builder: '@angular-devkit/build-angular:tslint',
       options: {
-        exclude: ['**/node_modules/**', '!apps/my-app/**'],
+        exclude: ['**/node_modules/**', '!apps/my-app/**/*'],
         tsConfig: [
           'apps/my-app/tsconfig.app.json',
           'apps/my-app/tsconfig.spec.json',

--- a/packages/react/src/schematics/library/library.spec.ts
+++ b/packages/react/src/schematics/library/library.spec.ts
@@ -20,7 +20,7 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-lib'].architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          exclude: ['**/node_modules/**', '!libs/my-lib/**'],
+          exclude: ['**/node_modules/**', '!libs/my-lib/**/*'],
           tsConfig: [
             'libs/my-lib/tsconfig.lib.json',
             'libs/my-lib/tsconfig.spec.json',
@@ -184,7 +184,7 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-dir-my-lib'].architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**'],
+          exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**/*'],
           tsConfig: [
             'libs/my-dir/my-lib/tsconfig.lib.json',
             'libs/my-dir/my-lib/tsconfig.spec.json',

--- a/packages/web/src/schematics/application/application.spec.ts
+++ b/packages/web/src/schematics/application/application.spec.ts
@@ -282,7 +282,7 @@ describe('app', () => {
     expect(workspaceJson.projects['my-app'].architect.lint).toEqual({
       builder: '@angular-devkit/build-angular:tslint',
       options: {
-        exclude: ['**/node_modules/**', '!apps/my-app/**'],
+        exclude: ['**/node_modules/**', '!apps/my-app/**/*'],
         tsConfig: [
           'apps/my-app/tsconfig.app.json',
           'apps/my-app/tsconfig.spec.json',

--- a/packages/workspace/src/migrations/update-8-2-0/update-8-2-0.spec.ts
+++ b/packages/workspace/src/migrations/update-8-2-0/update-8-2-0.spec.ts
@@ -40,7 +40,7 @@ describe('Update 8.2.0', () => {
       builder: '@angular-devkit/build-angular:tslint',
       options: {
         tsConfig: ['my-app/tsconfig.json'],
-        exclude: ['**/node_modules/**', '!my-app/**'],
+        exclude: ['**/node_modules/**', '!my-app/**/*'],
       },
     });
   });

--- a/packages/workspace/src/migrations/update-8-2-0/update-8-2-0.ts
+++ b/packages/workspace/src/migrations/update-8-2-0/update-8-2-0.ts
@@ -9,7 +9,7 @@ const addExcludes = updateWorkspace((workspace) => {
       if (target.builder !== '@angular-devkit/build-angular:tslint') {
         return;
       }
-      const exceptRootGlob = '!' + join(normalize(project.root), '**');
+      const exceptRootGlob = '!' + join(normalize(project.root), '**/*');
 
       if (!target.options.exclude) {
         target.options.exclude = [];

--- a/packages/workspace/src/schematics/library/library.spec.ts
+++ b/packages/workspace/src/schematics/library/library.spec.ts
@@ -22,7 +22,7 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-lib'].architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          exclude: ['**/node_modules/**', '!libs/my-lib/**'],
+          exclude: ['**/node_modules/**', '!libs/my-lib/**/*'],
           tsConfig: [
             'libs/my-lib/tsconfig.lib.json',
             'libs/my-lib/tsconfig.spec.json',
@@ -172,7 +172,7 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-dir-my-lib'].architect.lint).toEqual({
         builder: '@angular-devkit/build-angular:tslint',
         options: {
-          exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**'],
+          exclude: ['**/node_modules/**', '!libs/my-dir/my-lib/**/*'],
           tsConfig: [
             'libs/my-dir/my-lib/tsconfig.lib.json',
             'libs/my-dir/my-lib/tsconfig.spec.json',

--- a/packages/workspace/src/schematics/move/lib/update-workspace.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-workspace.spec.ts
@@ -94,7 +94,7 @@ describe('updateWorkspace Rule', () => {
                   'apps/my-source/tsconfig.app.json',
                   'apps/my-source/tsconfig.spec.json',
                 ],
-                exclude: ['**/node_modules/**', '!apps/my-source/**'],
+                exclude: ['**/node_modules/**', '!apps/my-source/**/*'],
               },
             },
             test: {
@@ -129,7 +129,7 @@ describe('updateWorkspace Rule', () => {
               builder: '@angular-devkit/build-angular:tslint',
               options: {
                 tsConfig: ['apps/my-source-e2e/tsconfig.e2e.json'],
-                exclude: ['**/node_modules/**', '!apps/my-source-e2e/**'],
+                exclude: ['**/node_modules/**', '!apps/my-source-e2e/**/*'],
               },
             },
           },

--- a/packages/workspace/src/utils/lint.ts
+++ b/packages/workspace/src/utils/lint.ts
@@ -30,7 +30,7 @@ export function generateProjectLint(
       builder: '@angular-devkit/build-angular:tslint',
       options: {
         tsConfig: [tsConfigPath],
-        exclude: ['**/node_modules/**', '!' + projectRoot + '/**'],
+        exclude: ['**/node_modules/**', '!' + projectRoot + '/**/*'],
       },
     };
   } else if (linter === Linter.EsLint) {
@@ -42,7 +42,7 @@ export function generateProjectLint(
         // nested configurations.
         linter: 'eslint',
         tsConfig: [tsConfigPath],
-        exclude: ['**/node_modules/**', '!' + projectRoot + '/**'],
+        exclude: ['**/node_modules/**', '!' + projectRoot + '/**/*'],
       },
     };
   } else {


### PR DESCRIPTION
Nx currently uses this default glob pattern for tslint and eslint exclusions: `"exclude": ["**/node_modules/**", "!apps/<app name>/**"]`

This is because the linters use the TS programs in the app to decide what to lint. But if the app imports a lib, we don't want to lint that lib as well, as it should be lintable separately. So we use the above pattern to exclude any files outside of the app root.

But if we add a `files:["**/*.ts"]` option, we'd expect the linting to happen on all the files in the app root - which currently doesn't work - all files get excluded.

To fix this, the exclude pattern needs to be changed to: `"exclude": ["**/node_modules/**", "!apps/<app name>/**"]`