### PR TITLE
feat(react): copy README on buildable libs

### DIFF
--- a/e2e/react-package.test.ts
+++ b/e2e/react-package.test.ts
@@ -104,6 +104,12 @@ forEachCli('nx', (cli) => {
       checkFilesExist(`dist/libs/${childLib}/assets/hello.txt`);
     });
 
+    it('should copy the README to dist', () => {
+      const output = runCLI(`build ${childLib2}`);
+      expect(output).toContain(`Bundle complete`);
+      checkFilesExist(`dist/libs/${childLib2}/README.md`);
+    });
+
     it('should properly add references to any dependency into the parent package.json', () => {
       const childLibOutput = runCLI(`build ${childLib}`);
       const childLib2Output = runCLI(`build ${childLib2}`);

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -140,6 +140,13 @@ function addProject(options: NormalizedSchema): Rule {
           external,
           babelConfig: `@nrwl/react/plugins/bundle-babel`,
           rollupConfig: `@nrwl/react/plugins/bundle-rollup`,
+          assets: [
+            {
+              glob: 'README.md',
+              input: '.',
+              output: '.',
+            },
+          ],
         },
       };
     }


### PR DESCRIPTION
## Current Behavior

Right now, buildable react libs, when built, won't have their README copied to dist.

## Expected Behavior

Readme should finish in dist folder 