### PR TITLE
fix(core): use cwd rather than __dirname for locating workspace root

### DIFF
--- a/packages/cli/bin/nx.ts
+++ b/packages/cli/bin/nx.ts
@@ -7,7 +7,7 @@ import { findWorkspaceRoot } from '../lib/find-workspace-root';
 import { initGlobal } from '../lib/init-global';
 import { initLocal } from '../lib/init-local';
 
-const workspace = findWorkspaceRoot(__dirname);
+const workspace = findWorkspaceRoot(process.cwd());
 
 if (workspace) {
   initLocal(workspace);


### PR DESCRIPTION
When the `node_modules` directory is a symlink `__dirname` resolves to the real file path rather than the the symlinked path.

Symlinking the node_modules in CI to allow us to cache the `node_modules` dir in a docker container. Our workflow is something like:
```
ln -s /opt/app/node_modules ./node_modules
yarn nx
```

Currently is silently fails due to `initGlobal()` being called twice, with the second call hitting the require cache and resulting in an immediate exit without error.