### PR TITLE
fix(linter): fix exclude pattern in eslint schematics

### DIFF
--- a/packages/cypress/src/schematics/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/schematics/cypress-project/cypress-project.spec.ts
@@ -83,7 +83,7 @@ describe('schematic:cypress-project', () => {
         options: {
           linter: 'eslint',
           tsConfig: ['apps/my-app-e2e/tsconfig.e2e.json'],
-          exclude: ['**/node_modules/**', '!apps/my-app-e2e/**'],
+          exclude: ['**/node_modules/**', '!apps/my-app-e2e/**/*'],
         },
       });
     });

--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -79,6 +79,11 @@
       "version": "9.4.0-beta.1",
       "description": "Remove config builder option when using eslint to enable automatic detection",
       "factory": "./src/migrations/update-9-4-0/update-eslint-config"
+    },
+    "update-eslint-exclude": {
+      "version": "9.4.0-beta.1",
+      "description": "Fix exclude patterns to ensure it does not break linting when a files option is defined",
+      "factory": "./src/migrations/update-9-4-0/update-eslint-exclude"
     }
   },
   "packageJsonUpdates": {

--- a/packages/workspace/src/migrations/update-9-4-0/update-eslint-exclude.spec.ts
+++ b/packages/workspace/src/migrations/update-9-4-0/update-eslint-exclude.spec.ts
@@ -1,0 +1,114 @@
+import { Tree } from '@angular-devkit/schematics';
+import { readWorkspace } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { callRule, runMigration } from '../../utils/testing';
+import { updateWorkspace } from '@nrwl/workspace/src/utils/workspace';
+
+describe('Update eslint exclude pattern for 9.4.0', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = Tree.empty();
+    tree = createEmptyWorkspace(tree);
+    tree = await callRule(
+      updateWorkspace((workspace) => {
+        workspace.projects.add({
+          name: 'proj1',
+          root: 'apps/proj1',
+          architect: {
+            lint: {
+              builder: '@angular-devkit/build-angular:tslint',
+              options: {
+                exclude: ['**/node_modules/**', '!apps/proj1/**'],
+              },
+            },
+          },
+        });
+        workspace.projects.add({
+          name: 'proj2',
+          root: 'apps/proj2',
+          architect: {
+            lint: {
+              builder: '@nrwl/linter:lint',
+              options: {
+                linter: 'eslint',
+                exclude: ['!apps/proj2/**', '**/node_modules/**'],
+              },
+            },
+          },
+        });
+        workspace.projects.add({
+          name: 'proj3',
+          root: 'apps/proj3',
+          architect: {
+            lint: {
+              builder: '@nrwl/linter:lint',
+              options: {
+                linter: 'tslint',
+                exclude: ['!apps/proj3/*', '**/node_modules/**'],
+              },
+            },
+          },
+        });
+        workspace.projects.add({
+          name: 'proj4',
+          root: 'libs/proj4',
+          architect: {
+            lint: {
+              builder: '@nrwl/linter:lint',
+              options: {
+                linter: 'eslint',
+                exclude: [
+                  '**/node_modules/**',
+                  'libs/proj4/**',
+                  '!libs/proj4/**',
+                ],
+              },
+            },
+          },
+        });
+        workspace.projects.add({
+          name: 'proj5',
+          root: 'apps/proj5',
+          architect: {
+            lint: {
+              builder: '@nrwl/linter:lint',
+              options: {
+                exclude: ['**/node_modules/**', '!apps/proj5/**'],
+              },
+            },
+          },
+        });
+      }),
+      tree
+    );
+  });
+
+  it('should fix the exclude option when using eslint', async () => {
+    const result = await runMigration('update-eslint-exclude', {}, tree);
+
+    const json = readWorkspace(result);
+
+    expect(json.projects.proj1.architect.lint.options.exclude).toEqual([
+      '**/node_modules/**',
+      '!apps/proj1/**',
+    ]);
+    expect(json.projects.proj2.architect.lint.options.exclude).toEqual([
+      '!apps/proj2/**/*',
+      '**/node_modules/**',
+    ]);
+    expect(json.projects.proj3.architect.lint.options.exclude).toEqual([
+      '!apps/proj3/*',
+      '**/node_modules/**',
+    ]);
+    expect(json.projects.proj4.architect.lint.options.exclude).toEqual([
+      '**/node_modules/**',
+      'libs/proj4/**',
+      '!libs/proj4/**/*',
+    ]);
+    expect(json.projects.proj5.architect.lint.options.exclude).toEqual([
+      '**/node_modules/**',
+      '!apps/proj5/**/*',
+    ]);
+  });
+});

--- a/packages/workspace/src/migrations/update-9-4-0/update-eslint-exclude.ts
+++ b/packages/workspace/src/migrations/update-9-4-0/update-eslint-exclude.ts
@@ -1,0 +1,25 @@
+import { chain, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { formatFiles, updateWorkspaceInTree } from '@nrwl/workspace';
+
+function updateExcludePattern(host: Tree, context: SchematicContext) {
+  return updateWorkspaceInTree((json) => {
+    Object.keys(json.projects).forEach((name) => {
+      const p = json.projects[name];
+      const faultyPattern = `!${p.root}/**`;
+      if (
+        p.architect?.lint.builder === '@nrwl/linter:lint' &&
+        p.architect?.lint.options?.exclude.includes(faultyPattern)
+      ) {
+        const index: number = p.architect?.lint.options?.exclude.indexOf(
+          faultyPattern
+        );
+        p.architect.lint.options.exclude[index] = faultyPattern + '/*';
+      }
+    });
+    return json;
+  });
+}
+
+export default function () {
+  return chain([updateExcludePattern, formatFiles()]);
+}

--- a/packages/workspace/src/utils/lint.ts
+++ b/packages/workspace/src/utils/lint.ts
@@ -42,7 +42,7 @@ export function generateProjectLint(
         // nested configurations.
         linter: 'eslint',
         tsConfig: [tsConfigPath],
-        exclude: ['**/node_modules/**', '!' + projectRoot + '/**'],
+        exclude: ['**/node_modules/**', '!' + projectRoot + '/**/*'],
       },
     };
   } else {


### PR DESCRIPTION
Nx currently uses this default glob pattern for tslint and eslint exclusions: "exclude": ["**/node_modules/**", "!apps/<app name>/**"]

This is because the linters use the TS programs in the app to decide what to lint. But if the app imports a lib, we don't want to lint that lib as well, as it should be lintable separately. So we use the above pattern to exclude any files outside of the app root.

But if we add a files:["**/*.ts"] option, we'd expect the linting to happen on all the files in the app root - which currently doesn't work - all files get excluded.

To fix this, the exclude pattern needs to be changed to: "exclude": ["**/node_modules/**", "!apps/<app name>/**/*"]