### PR TITLE
fix(linter): ignore imports from npm packages for the dependency graph

### DIFF
--- a/packages/workspace/src/core/target-project-locator.spec.ts
+++ b/packages/workspace/src/core/target-project-locator.spec.ts
@@ -46,6 +46,7 @@ describe('findTargetProjectWithImport', () => {
       './nx.json': JSON.stringify(nxJson),
       './tsconfig.json': JSON.stringify(tsConfig),
       './libs/proj/index.ts': `import {a} from '@proj/my-second-proj';
+                              import {a} from '@proj/proj123-base';
                               import('@proj/project-3');
                               const a = { loadChildren: '@proj/proj4ab#a' };                     
       `,
@@ -192,6 +193,13 @@ describe('findTargetProjectWithImport', () => {
           files: [],
         },
       },
+      '@proj/proj123-base': {
+        name: '@proj/proj123-base',
+        type: 'npm',
+        data: {
+          files: [],
+        },
+      },
     };
 
     targetProjectLocator = new TargetProjectLocator(projects);
@@ -242,6 +250,13 @@ describe('findTargetProjectWithImport', () => {
       ctx.nxJson.npmScope
     );
     expect(parentProj).toEqual('proj1234');
+
+    const similarImportFromNpm = targetProjectLocator.findProjectWithImport(
+      '@proj/proj123-base',
+      'libs/proj/index.ts',
+      ctx.nxJson.npmScope
+    );
+    expect(similarImportFromNpm).toBeFalsy();
   });
 
   it('should be able to sort graph nodes', () => {
@@ -256,6 +271,7 @@ describe('findTargetProjectWithImport', () => {
       '@ng/core',
       '@ng/common',
       'npm-package',
+      '@proj/proj123-base',
     ]);
   });
 });

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -19,6 +19,11 @@ export class TargetProjectLocator {
   ) {
     const normalizedImportExpr = importExpr.split('#')[0];
 
+    const importedProject = this.nodes[normalizedImportExpr];
+    if (importedProject && !isWorkspaceProject(importedProject)) {
+      return false;
+    }
+
     const resolvedModule = resolveModuleByImport(
       normalizedImportExpr,
       filePath


### PR DESCRIPTION
Imports from npm packages should not be treated like workspace projects while building the
dependency graph.
Imports from npm packages with similar names to workspace projects should not
create false circular dependencies.

ISSUES CLOSED: #2980