### PR TITLE
feat(nx-plugin): use package and e2e folder instead of libs and apps in create-nx-plugin command

### DIFF
--- a/docs/shared/nx-plugin.md
+++ b/docs/shared/nx-plugin.md
@@ -23,15 +23,14 @@ After executing the above command, the following tree structure is created:
 
 ```treeview
 my-org/
-├── apps/
+├── e2e/
 │   └── my-plugin-e2e/
 │       ├── jest.config.js
 │       ├── tests/
 │       │   └── my-plugin.test.ts
 │       ├── tsconfig.json
 │       └── tsconfig.spec.json
-├── jest.config.js
-├── libs/
+├── packages/
 │   └── my-plugin/
 │       ├── README.md
 │       ├── builders.json
@@ -58,11 +57,12 @@ my-org/
 │       ├── tsconfig.json
 │       ├── tsconfig.lib.json
 │       └── tsconfig.spec.json
-├── nx.json
-├── package.json
 ├── tools
 │   ├── schematics/
 │   └── tsconfig.tools.json
+├── jest.config.js
+├── nx.json
+├── package.json
 ├── tsconfig.json
 ├── workspace.json
 └── yarn.lock
@@ -188,7 +188,7 @@ We'll go over a few parts of a test file below:
 ```typescript
 it('should create my-plugin', async (done) => {
   const plugin = uniq('my-plugin');
-  ensureNxProject('@my-org/my-plugin', 'dist/libs/my-plugin');
+  ensureNxProject('@my-org/my-plugin', 'dist/packages/my-plugin');
   await runNxCommandAsync(`generate @my-org/my-plugin:myPlugin ${plugin}`);
 
   const result = await runNxCommandAsync(`build ${plugin}`);
@@ -216,19 +216,19 @@ To make sure that assets are copied to the dist folder, open the `workspace.json
   "options": {
     // shortened...
     "assets": [
-      "libs/my-plugin/*.md",
+      "packages/my-plugin/*.md",
       {
-        "input": "./libs/my-plugin/src",
+        "input": "./packages/my-plugin/src",
         "glob": "**/*.!(ts)",
         "output": "./src"
       },
       {
-        "input": "./libs/my-plugin",
+        "input": "./packages/my-plugin",
         "glob": "collection.json",
         "output": "."
       },
       {
-        "input": "./libs/my-plugin",
+        "input": "./packages/my-plugin",
         "glob": "builders.json",
         "output": "."
       }
@@ -242,7 +242,7 @@ To make sure that assets are copied to the dist folder, open the `workspace.json
 To publish your plugin follow these steps:
 
 1. Build your plugin with the command `nx run my-plugin:build`
-1. `npm publish ./dist/libs/my-plugin` and follow the prompts from npm.
+1. `npm publish ./dist/package/my-plugin` and follow the prompts from npm.
 1. That's it!
 
 > Note: currently you will have to modify the `package.json` version by yourself or with a tool.

--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -91,7 +91,6 @@ function createNxPlugin(workspaceName, pluginName) {
 }
 
 function updateWorkspace(workspaceName: string) {
-  console.log(`updating workspace...`);
   const nxJsonPath = path.join(workspaceName, 'nx.json');
 
   const nxJson = JSON.parse(readFileSync(nxJsonPath).toString('UTF-8'));

--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 
-// we can import from '@nrwl/workspace' because it will require typescript
+// we can't import from '@nrwl/workspace' because it will require typescript
+// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { output } from '@nrwl/workspace/src/utils/output';
 import { dirSync } from 'tmp';
-import { writeFileSync } from 'fs-extra';
+import { writeFileSync, readFileSync, removeSync } from 'fs-extra';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import * as inquirer from 'inquirer';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
 import yargsParser = require('yargs-parser');
 import { determinePackageManager, showNxWarning } from './shared';
 
@@ -21,22 +24,6 @@ const parsedArgs = yargsParser(process.argv, {
     pluginName: 'plugin-name',
   },
   boolean: ['help'],
-});
-
-if (parsedArgs.help) {
-  showHelp();
-  process.exit(0);
-}
-
-const packageManager = determinePackageManager();
-determineWorkspaceName(parsedArgs).then((workspaceName) => {
-  return determinePluginName(parsedArgs).then((pluginName) => {
-    const tmpDir = createSandbox(packageManager);
-    createWorkspace(tmpDir, packageManager, parsedArgs, workspaceName);
-    createNxPlugin(workspaceName, pluginName);
-    commitChanges(workspaceName);
-    showNxWarning(workspaceName);
-  });
 });
 
 function createSandbox(packageManager: string) {
@@ -101,6 +88,23 @@ function createNxPlugin(workspaceName, pluginName) {
       stdio: [0, 1, 2],
     }
   );
+}
+
+function updateWorkspace(workspaceName: string) {
+  console.log(`updating workspace...`);
+  const nxJsonPath = path.join(workspaceName, 'nx.json');
+
+  const nxJson = JSON.parse(readFileSync(nxJsonPath).toString('UTF-8'));
+
+  nxJson['workspaceLayout'] = {
+    appsDir: 'e2e',
+    libsDir: 'packages',
+  };
+
+  writeFileSync(nxJsonPath, JSON.stringify(nxJson, undefined, 2));
+
+  removeSync(path.join(workspaceName, 'apps'));
+  removeSync(path.join(workspaceName, 'libs'));
 }
 
 function commitChanges(workspaceName) {
@@ -181,3 +185,20 @@ function showHelp() {
     pluginName     the name of the plugin to be created  
 `);
 }
+
+if (parsedArgs.help) {
+  showHelp();
+  process.exit(0);
+}
+
+const packageManager = determinePackageManager();
+determineWorkspaceName(parsedArgs).then((workspaceName) => {
+  return determinePluginName(parsedArgs).then((pluginName) => {
+    const tmpDir = createSandbox(packageManager);
+    createWorkspace(tmpDir, packageManager, parsedArgs, workspaceName);
+    updateWorkspace(workspaceName);
+    createNxPlugin(workspaceName, pluginName);
+    commitChanges(workspaceName);
+    showNxWarning(workspaceName);
+  });
+});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Creating a nx plugin workspace with `create-nx-plugin` will output a folder structure with `libs` and `apps`.

## Expected Behavior
`libs` and `apps` are replaced with `packages` and `e2e` respectfully. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #