### PR TITLE
fix(core): add dep-graph assets to build output

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -95,7 +95,7 @@
               },
               {
                 "input": "packages/workspace",
-                "glob": "**/*.js",
+                "glob": "**/*.{js,css,html}",
                 "output": "/"
               },
               "LICENSE",


### PR DESCRIPTION
## Current Behavior

`dep-graph.html` and `dep-graph.css` don't get copied over to the build output.

Running dep-graph errors:

```
Error: ENOENT: no such file or directory, open '/home/jason/projects/temp/nx-tests/buildable-test/node_modules/@nrwl/workspace/src/core/dep-graph/dep-graph.html'
```

## Expected Behavior

Running dep-graph doesn't error.