### PR TITLE
docs(angular): fixed link to page nx and cli

### DIFF
--- a/docs/angular/tutorial/01-create-application.md
+++ b/docs/angular/tutorial/01-create-application.md
@@ -78,7 +78,7 @@ nx serve todos
 
 ## Note on `nx serve` and `ng serve`
 
-Internally, the Nx CLI delegates to the Angular CLI when running commands or generating code. The `nx serve` command produces the same result as `ng serve`, and `nx build` produces the same results as `ng build`. However, the Nx CLI supports advanced capabilities that aren't supported by the Angular CLI. For instance, Nx's computation cache only works when using the Nx CLI. In other words, using `nx` instead `ng` will result in the same output, but often will perform a lot better. [Read more about Nx CLI and Angular CLI.](`/angular/cli/nx-and-cli)
+Internally, the Nx CLI delegates to the Angular CLI when running commands or generating code. The `nx serve` command produces the same result as `ng serve`, and `nx build` produces the same results as `ng build`. However, the Nx CLI supports advanced capabilities that aren't supported by the Angular CLI. For instance, Nx's computation cache only works when using the Nx CLI. In other words, using `nx` instead `ng` will result in the same output, but often will perform a lot better. [Read more about Nx CLI and Angular CLI.](/angular/cli/nx-and-cli)
 
 Depending on how your dev env is set up, the command above might result in `Command 'nx' not found`.
 


### PR DESCRIPTION
Was introducing the tool to a friend, I clicked on the link "learn more about nx cli and angular
cli", which resulted in a blank page;  there was `%60` in the URL. After decodeURI, I thought it
would have the "grave accent" (used in template string) that should not be there. Therefore I removed it.