### PR TITLE
fix(react): add React dependencies to package.json when adding a library

### DIFF
--- a/packages/react/src/schematics/init/init.spec.ts
+++ b/packages/react/src/schematics/init/init.spec.ts
@@ -19,10 +19,8 @@ describe('init', () => {
     );
     const result = await runSchematic('init', {}, tree);
     const packageJson = readJsonInTree(result, 'package.json');
-    expect(packageJson.dependencies['@nrwl/react']).toBeUndefined();
     expect(packageJson.dependencies['react']).toBeDefined();
     expect(packageJson.dependencies['react-dom']).toBeDefined();
-    expect(packageJson.devDependencies['@nrwl/react']).toBeDefined();
     expect(packageJson.devDependencies['@types/react']).toBeDefined();
     expect(packageJson.devDependencies['@types/react-dom']).toBeDefined();
     expect(packageJson.devDependencies['@testing-library/react']).toBeDefined();

--- a/packages/react/src/schematics/init/init.ts
+++ b/packages/react/src/schematics/init/init.ts
@@ -1,9 +1,11 @@
 import { chain, noop, Rule } from '@angular-devkit/schematics';
+import { JsonObject } from '@angular-devkit/core';
 import {
   addPackageWithInit,
   setDefaultCollection,
   updateJsonInTree,
   updateWorkspace,
+  addDepsToPackageJson,
 } from '@nrwl/workspace';
 import { Schema } from './schema';
 import {
@@ -14,26 +16,6 @@ import {
   typesReactDomVersion,
   typesReactVersion,
 } from '../../utils/versions';
-import { JsonObject } from '@angular-devkit/core';
-
-export function updateDependencies(): Rule {
-  return updateJsonInTree('package.json', (json) => {
-    delete json.dependencies['@nrwl/react'];
-    json.dependencies = {
-      ...json.dependencies,
-      react: reactVersion,
-      'react-dom': reactDomVersion,
-    };
-    json.devDependencies = {
-      ...json.devDependencies,
-      '@nrwl/react': nxVersion,
-      '@types/react': typesReactVersion,
-      '@types/react-dom': typesReactDomVersion,
-      '@testing-library/react': testingLibraryReactVersion,
-    };
-    return json;
-  });
-}
 
 function setDefault(): Rule {
   const updateReactWorkspace = updateWorkspace((workspace) => {
@@ -71,6 +53,17 @@ export default function (schema: Schema) {
       ? addPackageWithInit('@nrwl/cypress')
       : noop(),
     addPackageWithInit('@nrwl/web', schema),
-    updateDependencies(),
+    addDepsToPackageJson(
+      {
+        react: reactVersion,
+        'react-dom': reactDomVersion,
+      },
+      {
+        '@nrwl/react': nxVersion,
+        '@types/react': typesReactVersion,
+        '@types/react-dom': typesReactDomVersion,
+        '@testing-library/react': testingLibraryReactVersion,
+      }
+    ),
   ]);
 }

--- a/packages/react/src/schematics/library/library.spec.ts
+++ b/packages/react/src/schematics/library/library.spec.ts
@@ -43,6 +43,19 @@ describe('lib', () => {
       });
     });
 
+    it('should add react and react-dom packages to package.json if not already present', async () => {
+      const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+
+      const packageJson = readJsonInTree(tree, '/package.json');
+
+      expect(packageJson).toMatchObject({
+        dependencies: {
+          react: expect.anything(),
+          'react-dom': expect.anything(),
+        },
+      });
+    });
+
     it('should update root tsconfig.json', async () => {
       const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
       const tsconfigJson = readJsonInTree(tree, '/tsconfig.json');

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -44,6 +44,8 @@ import { extraEslintDependencies, reactEslintJson } from '../../utils/lint';
 import {
   reactRouterDomVersion,
   typesReactRouterDomVersion,
+  reactDomVersion,
+  reactVersion,
 } from '../../utils/versions';
 import { Schema } from './schema';
 import { libsDir } from '@nrwl/workspace/src/utils/ast-utils';
@@ -99,6 +101,13 @@ export default function (schema: Schema): Rule {
           })
         : noop(),
       options.publishable ? updateLibPackageNpmScope(options) : noop(),
+      addDepsToPackageJson(
+        {
+          react: reactVersion,
+          'react-dom': reactDomVersion,
+        },
+        {}
+      ),
       updateAppRoutes(options, context),
       initRootBabelConfig(),
       formatFiles(options),


### PR DESCRIPTION
This PR:
 * adds `react` and `react-dom` to the `package.json`  `dependencies` when generating a react library project
* has the `react` `init` schematic use `addDepsToPackageJson` to modify the deps and dev deps
* no longer moves `@nrwl/react` from `dependencies` to `devDependencies` (as per Jacks suggestion 😄 )

Resolves #2188