### PR TITLE
feat(react): make React schematics use babel-jest by default

### DIFF
--- a/docs/angular/api-react/schematics/application.md
+++ b/docs/angular/api-react/schematics/application.md
@@ -48,16 +48,6 @@ nx g app myapp --routing
 
 ## Options
 
-### babelJest
-
-Alias(es): babel-jest
-
-Default: `false`
-
-Type: `boolean`
-
-Use babel-jest instead of ts-jest
-
 ### classComponent
 
 Alias(es): C

--- a/docs/angular/api-react/schematics/library.md
+++ b/docs/angular/api-react/schematics/library.md
@@ -50,16 +50,6 @@ Type: `string`
 
 The application project to add the library route to
 
-### babelJest
-
-Alias(es): babel-jest
-
-Default: `false`
-
-Type: `boolean`
-
-Use babel-jest instead of ts-jest
-
 ### component
 
 Default: `true`

--- a/docs/react/api-react/schematics/application.md
+++ b/docs/react/api-react/schematics/application.md
@@ -48,16 +48,6 @@ nx g app myapp --routing
 
 ## Options
 
-### babelJest
-
-Alias(es): babel-jest
-
-Default: `false`
-
-Type: `boolean`
-
-Use babel-jest instead of ts-jest
-
 ### classComponent
 
 Alias(es): C

--- a/docs/react/api-react/schematics/library.md
+++ b/docs/react/api-react/schematics/library.md
@@ -50,16 +50,6 @@ Type: `string`
 
 The application project to add the library route to
 
-### babelJest
-
-Alias(es): babel-jest
-
-Default: `false`
-
-Type: `boolean`
-
-Use babel-jest instead of ts-jest
-
 ### component
 
 Default: `true`

--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -199,25 +199,6 @@ forEachCli((currentCLIName) => {
       );
     }, 120000);
 
-    it('should be able to use babel-jest', async () => {
-      ensureProject();
-      const appName = uniq('app');
-      const libName = uniq('lib');
-
-      runCLI(
-        `generate @nrwl/react:app ${appName} --no-interactive --babelJest`
-      );
-      runCLI(
-        `generate @nrwl/react:lib ${libName} --no-interactive --babelJest`
-      );
-
-      const appTestResults = await runCLIAsync(`test ${appName}`);
-      expect(appTestResults.stderr).toContain('Test Suites: 1 passed, 1 total');
-
-      const libTestResults = await runCLIAsync(`test ${libName}`);
-      expect(libTestResults.stderr).toContain('Test Suites: 1 passed, 1 total');
-    }, 120000);
-
     it('should be able to add a redux slice', async () => {
       ensureProject();
       const appName = uniq('app');

--- a/packages/react/src/schematics/application/lib/add-jest.ts
+++ b/packages/react/src/schematics/application/lib/add-jest.ts
@@ -8,7 +8,7 @@ export function addJest(options: NormalizedSchema): Rule {
         supportTsx: true,
         skipSerializers: true,
         setupFile: 'none',
-        babelJest: options.babelJest,
+        babelJest: true,
       })
     : noop();
 }

--- a/packages/react/src/schematics/application/schema.json
+++ b/packages/react/src/schematics/application/schema.json
@@ -97,12 +97,6 @@
       "description": "Test runner to use for unit tests",
       "default": "jest"
     },
-    "babelJest": {
-      "type": "boolean",
-      "alias": "babel-jest",
-      "description": "Use babel-jest instead of ts-jest",
-      "default": false
-    },
     "e2eTestRunner": {
       "type": "string",
       "enum": ["cypress", "none"],

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -84,7 +84,7 @@ export default function (schema: Schema): Rule {
             setupFile: 'none',
             supportTsx: true,
             skipSerializers: true,
-            babelJest: options.babelJest,
+            babelJest: true,
           })
         : noop(),
       options.component

--- a/packages/react/src/schematics/library/schema.json
+++ b/packages/react/src/schematics/library/schema.json
@@ -77,12 +77,6 @@
       "description": "Test runner to use for unit tests",
       "default": "jest"
     },
-    "babelJest": {
-      "type": "boolean",
-      "alias": "babel-jest",
-      "description": "Use babel-jest instead of ts-jest",
-      "default": false
-    },
     "tags": {
       "type": "string",
       "description": "Add tags to the library (used for linting)",


### PR DESCRIPTION
The babelJest option was removed from the React application
and library schematics and set to true by default

Resolves #2365 because going forward React projects (apps + libraries) would not use `ts-jest` but rather a properly configured `babel-jest`
Resolves #1720 for React projects at least