### PR TITLE
fix(generate): improve error handling on generate command

### DIFF
--- a/packages/workspace/src/schematics/remove/lib/update-tsconfig.ts
+++ b/packages/workspace/src/schematics/remove/lib/update-tsconfig.ts
@@ -23,16 +23,11 @@ export function updateTsconfig(schema: Schema) {
 
         const tsConfigPath = 'tsconfig.json';
         if (tree.exists(tsConfigPath)) {
-          let contents = tree.read(tsConfigPath).toString('utf-8');
-          try {
-              contents = JSON.parse(contents);
-          } catch (e) {
-              throw new Error(`Cannot parse ${tsConfigPath}: ${e.message}`);
-          }
-          delete contents.compilerOptions.paths[
+          const tsConfigJson = readJsonInTree(tree, tsConfigPath);
+          delete tsConfigJson.compilerOptions.paths[
             `@${nxJson.npmScope}/${project.root.substr(5)}`
           ];
-          tree.overwrite(tsConfigPath, serializeJson(contents));
+          tree.overwrite(tsConfigPath, serializeJson(tsConfigJson));
         }
 
         return tree;

--- a/packages/workspace/src/schematics/remove/lib/update-tsconfig.ts
+++ b/packages/workspace/src/schematics/remove/lib/update-tsconfig.ts
@@ -23,7 +23,12 @@ export function updateTsconfig(schema: Schema) {
 
         const tsConfigPath = 'tsconfig.json';
         if (tree.exists(tsConfigPath)) {
-          let contents = JSON.parse(tree.read(tsConfigPath).toString('utf-8'));
+          let contents = tree.read(tsConfigPath).toString('utf-8');
+          try {
+              contents = JSON.parse(contents);
+          } catch (e) {
+              throw new Error(`Cannot parse ${tsConfigPath}: ${e.message}`);
+          }
           delete contents.compilerOptions.paths[
             `@${nxJson.npmScope}/${project.root.substr(5)}`
           ];


### PR DESCRIPTION
Deliver better errors than `Unexpected token } in JSON at position X`
Fix issue #1047