### PR TITLE
fix(testing): do not add cypress-eslint-plugin if eslint not used

### DIFF
--- a/packages/cypress/src/migrations/update-9-4-0/add-cypress-eslint-plugin-9-4-0.ts
+++ b/packages/cypress/src/migrations/update-9-4-0/add-cypress-eslint-plugin-9-4-0.ts
@@ -1,4 +1,4 @@
-import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import { chain, noop, Rule, Tree } from '@angular-devkit/schematics';
 import {
   addDepsToPackageJson,
   formatFiles,
@@ -47,9 +47,19 @@ async function addCypressPluginToEslintrc(host: Tree) {
 }
 
 export default () => {
-  return chain([
-    addDepsToPackageJson({}, { 'eslint-plugin-cypress': '^2.10.3' }),
-    addCypressPluginToEslintrc,
-    formatFiles(),
-  ]);
+  return (host: Tree) => {
+    const packageJson = readJsonInTree(host, 'package.json');
+    if (
+      packageJson.devDependencies?.eslint ||
+      packageJson.dependencies?.eslint
+    ) {
+      return chain([
+        addDepsToPackageJson({}, { 'eslint-plugin-cypress': '^2.10.3' }),
+        addCypressPluginToEslintrc,
+        formatFiles(),
+      ]);
+    } else {
+      return noop();
+    }
+  };
 };


### PR DESCRIPTION
## Current Behavior

`cypress-eslint-plugin` is added even if `eslint` is not used.

## Expected Behavior

`cypress-eslint-plugin` is not used if `eslint` is not used.