### PR TITLE
feat(core): add filtering arguments to dep-graph CLI

### DIFF
--- a/docs/angular/cli/affected-dep-graph.md
+++ b/docs/angular/cli/affected-dep-graph.md
@@ -42,6 +42,12 @@ Open the dep graph of the workspace in the browser, and highlight the projects a
 nx affected:dep-graph --base=master~1 --head=master
 ```
 
+Open the dep graph of the workspace in the browser, highlight the projects affected, but exclude project-one and project-two:
+
+```bash
+nx affected:dep-graph --exclude=project-one,project-two
+```
+
 ## Options
 
 ### all
@@ -70,9 +76,13 @@ output file (e.g. --file=output.json or --file=dep-graph.html)
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas
 
-### filter
+### focus
 
-Use to limit the dependency graph to only show specific projects, list of projects delimited by commas.
+Use to show the dependency graph for a particular project and every node that is either an ancestor or a descendant.
+
+### groupByFolder
+
+Group projects by folder in dependency graph
 
 ### head
 

--- a/docs/angular/cli/dep-graph.md
+++ b/docs/angular/cli/dep-graph.md
@@ -30,16 +30,28 @@ Generate a static website with dep graph into an html file, accompanied by an as
 nx dep-graph --file=output.html
 ```
 
-Show the graph where every node is either an ancestor or a descendant of todos-feature-main.:
+Show the graph where every node is either an ancestor or a descendant of todos-feature-main:
 
 ```bash
-nx dep-graph --filter=todos-feature-main
+nx dep-graph --focus=todos-feature-main
 ```
 
-Exclude project-one and project-two from the dep graph.:
+Include project-one and project-two in the dep graph:
+
+```bash
+nx dep-graph --include=project-one,project-two
+```
+
+Exclude project-one and project-two from the dep graph:
 
 ```bash
 nx dep-graph --exclude=project-one,project-two
+```
+
+Show the graph where every node is either an ancestor or a descendant of todos-feature-main, but exclude project-one and project-two:
+
+```bash
+nx dep-graph --focus=todos-feature-main --exclude=project-one,project-two
 ```
 
 ## Options
@@ -52,9 +64,13 @@ List of projects delimited by commas to exclude from the dependency graph.
 
 output file (e.g. --file=output.json or --file=dep-graph.html)
 
-### filter
+### focus
 
-Use to limit the dependency graph to only show specific projects, list of projects delimited by commas.
+Use to show the dependency graph for a particular project and every node that is either an ancestor or a descendant.
+
+### groupByFolder
+
+Group projects by folder in dependency graph
 
 ### help
 

--- a/docs/react/cli/affected-dep-graph.md
+++ b/docs/react/cli/affected-dep-graph.md
@@ -42,6 +42,12 @@ Open the dep graph of the workspace in the browser, and highlight the projects a
 nx affected:dep-graph --base=master~1 --head=master
 ```
 
+Open the dep graph of the workspace in the browser, highlight the projects affected, but exclude project-one and project-two:
+
+```bash
+nx affected:dep-graph --exclude=project-one,project-two
+```
+
 ## Options
 
 ### all
@@ -70,9 +76,13 @@ output file (e.g. --file=output.json or --file=dep-graph.html)
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas
 
-### filter
+### focus
 
-Use to limit the dependency graph to only show specific projects, list of projects delimited by commas.
+Use to show the dependency graph for a particular project and every node that is either an ancestor or a descendant.
+
+### groupByFolder
+
+Group projects by folder in dependency graph
 
 ### head
 

--- a/docs/react/cli/dep-graph.md
+++ b/docs/react/cli/dep-graph.md
@@ -30,16 +30,28 @@ Generate a static website with dep graph into an html file, accompanied by an as
 nx dep-graph --file=output.html
 ```
 
-Show the graph where every node is either an ancestor or a descendant of todos-feature-main.:
+Show the graph where every node is either an ancestor or a descendant of todos-feature-main:
 
 ```bash
-nx dep-graph --filter=todos-feature-main
+nx dep-graph --focus=todos-feature-main
 ```
 
-Exclude project-one and project-two from the dep graph.:
+Include project-one and project-two in the dep graph:
+
+```bash
+nx dep-graph --include=project-one,project-two
+```
+
+Exclude project-one and project-two from the dep graph:
 
 ```bash
 nx dep-graph --exclude=project-one,project-two
+```
+
+Show the graph where every node is either an ancestor or a descendant of todos-feature-main, but exclude project-one and project-two:
+
+```bash
+nx dep-graph --focus=todos-feature-main --exclude=project-one,project-two
 ```
 
 ## Options
@@ -52,9 +64,13 @@ List of projects delimited by commas to exclude from the dependency graph.
 
 output file (e.g. --file=output.json or --file=dep-graph.html)
 
-### filter
+### focus
 
-Use to limit the dependency graph to only show specific projects, list of projects delimited by commas.
+Use to show the dependency graph for a particular project and every node that is either an ancestor or a descendant.
+
+### groupByFolder
+
+Group projects by folder in dependency graph
 
 ### help
 

--- a/e2e/workspace/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace/src/workspace-aux-commands.test.ts
@@ -376,9 +376,77 @@ forEachCli((cli) => {
       expect(jsonFileContents2.criticalPath).not.toContain('mylib2');
     }, 1000000);
 
-    it.todo(
-      'dep-graph should output a deployable static website in an html file accompanied by a folder with static assets'
-    );
+    it('dep-graph should focus requested project', () => {
+      runCommand(
+        `npm run dep-graph -- --focus=myapp --file=project-graph.json`
+      );
+
+      expect(() => checkFilesExist('project-graph.json')).not.toThrow();
+
+      const jsonFileContents = readJson('project-graph.json');
+      const projectNames = Object.keys(jsonFileContents.graph.nodes);
+
+      expect(projectNames).toContain('myapp');
+      expect(projectNames).toContain('mylib');
+      expect(projectNames).toContain('mylib2');
+      expect(projectNames).toContain('myapp-e2e');
+
+      expect(projectNames).not.toContain('myapp2');
+      expect(projectNames).not.toContain('myapp3');
+      expect(projectNames).not.toContain('myapp2-e2e');
+      expect(projectNames).not.toContain('myapp3-e2e');
+    }, 1000000);
+
+    it('dep-graph should exclude requested projects', () => {
+      runCommand(
+        `npm run dep-graph -- --exclude=myapp-e2e,myapp2-e2e,myapp3-e2e --file=project-graph.json`
+      );
+
+      expect(() => checkFilesExist('project-graph.json')).not.toThrow();
+
+      const jsonFileContents = readJson('project-graph.json');
+      const projectNames = Object.keys(jsonFileContents.graph.nodes);
+
+      expect(projectNames).toContain('myapp');
+      expect(projectNames).toContain('mylib');
+      expect(projectNames).toContain('mylib2');
+      expect(projectNames).toContain('myapp2');
+      expect(projectNames).toContain('myapp3');
+
+      expect(projectNames).not.toContain('myapp-e2e');
+      expect(projectNames).not.toContain('myapp2-e2e');
+      expect(projectNames).not.toContain('myapp3-e2e');
+    }, 1000000);
+
+    it('dep-graph should exclude requested projects that were included by a focus', () => {
+      runCommand(
+        `npm run dep-graph -- --focus=myapp --exclude=myapp-e2e --file=project-graph.json`
+      );
+
+      expect(() => checkFilesExist('project-graph.json')).not.toThrow();
+
+      const jsonFileContents = readJson('project-graph.json');
+      const projectNames = Object.keys(jsonFileContents.graph.nodes);
+
+      expect(projectNames).toContain('myapp');
+      expect(projectNames).toContain('mylib');
+      expect(projectNames).toContain('mylib2');
+
+      expect(projectNames).not.toContain('myapp-e2e');
+      expect(projectNames).not.toContain('myapp2');
+      expect(projectNames).not.toContain('myapp3');
+      expect(projectNames).not.toContain('myapp2-e2e');
+      expect(projectNames).not.toContain('myapp3-e2e');
+    }, 1000000);
+
+    it('dep-graph should output a deployable static website in an html file accompanied by a folder with static assets', () => {
+      runCommand(`npm run dep-graph -- --file=project-graph.html`);
+
+      expect(() => checkFilesExist('project-graph.html')).not.toThrow();
+      expect(() => checkFilesExist('static/dep-graph.css')).not.toThrow();
+      expect(() => checkFilesExist('static/dep-graph.js')).not.toThrow();
+      expect(() => checkFilesExist('static/vendor.js')).not.toThrow();
+    });
   });
 
   describe('Move Angular Project', () => {

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -336,17 +336,20 @@ function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
         'output file (e.g. --file=output.json or --file=dep-graph.html)',
       type: 'string',
     })
-    .option('filter', {
+    .option('focus', {
       describe:
-        'Use to limit the dependency graph to only show specific projects, list of projects delimited by commas.',
-      type: 'array',
-      coerce: parseCSV,
+        'Use to show the dependency graph for a particular project and every node that is either an ancestor or a descendant.',
+      type: 'string',
     })
     .option('exclude', {
       describe:
         'List of projects delimited by commas to exclude from the dependency graph.',
       type: 'array',
       coerce: parseCSV,
+    })
+    .option('groupByFolder', {
+      describe: 'Group projects by folder in dependency graph',
+      type: 'boolean',
     })
     .option('host', {
       describe: 'Bind the dep graph server to a specific ip address.',

--- a/packages/workspace/src/core/dep-graph/dep-graph.css
+++ b/packages/workspace/src/core/dep-graph/dep-graph.css
@@ -245,3 +245,11 @@ g.affected ellipse {
 .hide {
   display: none;
 }
+
+#no-projects-chosen {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}

--- a/packages/workspace/src/core/dep-graph/dep-graph.html
+++ b/packages/workspace/src/core/dep-graph/dep-graph.html
@@ -28,7 +28,10 @@
             <button id="select-all-button" onclick="window.selectAllProjects()">
               Select All
             </button>
-            <button id="deselect-all-button" onclick="window.deselectAllProjects()">
+            <button
+              id="deselect-all-button"
+              onclick="window.deselectAllProjects()"
+            >
               Deselect All
             </button>
           </div>
@@ -47,6 +50,9 @@
     </div>
 
     <div id="main-content">
+      <div id="no-projects-chosen">
+        <h4>Please select projects in the sidebar.</h4>
+      </div>
       <svg id="svg-canvas" width="960" height="600">
         <defs>
           <filter
@@ -129,6 +135,10 @@
     window.projects = null;
     window.graph = null;
     window.affected = null;
+    window.focusedProject = null;
+    window.filteredProjects = null;
+    window.groupByFolder = null;
+    window.exclude = null;
   </script>
 
   <script src="vendor.js"></script>

--- a/scripts/documentation/generate-cli-data.ts
+++ b/scripts/documentation/generate-cli-data.ts
@@ -265,13 +265,23 @@ const examples = {
         'Generate a static website with dep graph into an html file, accompanied by an asset folder called static',
     },
     {
-      command: 'dep-graph --filter=todos-feature-main',
+      command: 'dep-graph --focus=todos-feature-main',
       description:
-        'Show the graph where every node is either an ancestor or a descendant of todos-feature-main.',
+        'Show the graph where every node is either an ancestor or a descendant of todos-feature-main',
+    },
+    {
+      command: 'dep-graph --include=project-one,project-two',
+      description: 'Include project-one and project-two in the dep graph',
     },
     {
       command: 'dep-graph --exclude=project-one,project-two',
-      description: 'Exclude project-one and project-two from the dep graph.',
+      description: 'Exclude project-one and project-two from the dep graph',
+    },
+    {
+      command:
+        'dep-graph --focus=todos-feature-main --exclude=project-one,project-two',
+      description:
+        'Show the graph where every node is either an ancestor or a descendant of todos-feature-main, but exclude project-one and project-two',
     },
   ],
   'affected:dep-graph': [
@@ -301,6 +311,11 @@ const examples = {
       command: 'affected:dep-graph --base=master~1 --head=master',
       description:
         'Open the dep graph of the workspace in the browser, and highlight the projects affected by the last commit on master',
+    },
+    {
+      command: 'affected:dep-graph --exclude=project-one,project-two',
+      description:
+        'Open the dep graph of the workspace in the browser, highlight the projects affected, but exclude project-one and project-two',
     },
   ],
   'workspace-schematic': [],


### PR DESCRIPTION
BREAKING CHANGE:
Dependency graph will now default to having no projects selected if run without filtering arguments

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The dependency graph, by default, selects all projects to visualize when it is first loaded and has no options to configure filtering from the CLI.

## Expected Behavior
The dependency graph, by default, selects no projects to visualize when it is first loaded and has CLI options to configure what projects are selected.

## Motivation
Rendering all projects by default is very slow for large projects and not useful given how large the graph becomes. By changing the behavior to not render all projects by default, we can speed up the first load and allow the user to choose which projects to render. By providing these options at the CLI as well, we can also help the user select proejcts ahead of time rather than checking boxes in the browser.

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
