### PR TITLE
fix(core): consider overrides for output path

### DIFF
--- a/packages/workspace/src/tasks-runner/tasks-runner.ts
+++ b/packages/workspace/src/tasks-runner/tasks-runner.ts
@@ -7,7 +7,7 @@ import { NxJson } from '../core/shared-interfaces';
 export interface Task {
   id: string;
   target: Target;
-  overrides: Object;
+  overrides: any;
   hash?: string;
   projectRoot?: string;
   hashDetails?: {

--- a/packages/workspace/src/tasks-runner/utils.spec.ts
+++ b/packages/workspace/src/tasks-runner/utils.spec.ts
@@ -4,99 +4,180 @@ describe('utils', () => {
   describe('getOutputsForTargetAndConfiguration', () => {
     it('should return outputs when defined', () => {
       expect(
-        getOutputsForTargetAndConfiguration('build', 'production', {
-          name: 'myapp',
-          type: 'application',
-          data: {
-            architect: {
-              build: {
-                outputs: ['one', 'two'],
-              },
+        getOutputsForTargetAndConfiguration(
+          {
+            overrides: {},
+            target: {
+              project: 'myapp',
+              target: 'build',
+              configuration: 'production',
             },
-            files: [],
           },
-        })
+          {
+            name: 'myapp',
+            type: 'application',
+            data: {
+              architect: {
+                build: {
+                  outputs: ['one', 'two'],
+                },
+              },
+              files: [],
+            },
+          }
+        )
       ).toEqual(['one', 'two']);
     });
 
     it('should return configuration-specific outputPath when defined', () => {
       expect(
-        getOutputsForTargetAndConfiguration('build', 'production', {
-          name: 'myapp',
-          type: 'application',
-          data: {
-            architect: {
-              build: {
-                options: {
-                  outputPath: 'one',
-                },
-                configurations: {
-                  production: {
-                    outputPath: 'two',
+        getOutputsForTargetAndConfiguration(
+          {
+            overrides: {},
+            target: {
+              project: 'myapp',
+              target: 'build',
+              configuration: 'production',
+            },
+          },
+          {
+            name: 'myapp',
+            type: 'application',
+            data: {
+              architect: {
+                build: {
+                  options: {
+                    outputPath: 'one',
+                  },
+                  configurations: {
+                    production: {
+                      outputPath: 'two',
+                    },
                   },
                 },
               },
+              files: [],
             },
-            files: [],
-          },
-        })
+          }
+        )
       ).toEqual(['two']);
     });
 
     it('should return configuration-independent outputPath when defined', () => {
       expect(
-        getOutputsForTargetAndConfiguration('build', 'production', {
-          name: 'myapp',
-          type: 'application',
-          data: {
-            architect: {
-              build: {
-                options: {
-                  outputPath: 'one',
-                },
-                configurations: {
-                  production: {},
+        getOutputsForTargetAndConfiguration(
+          {
+            overrides: {},
+            target: {
+              project: 'myapp',
+              target: 'build',
+              configuration: 'production',
+            },
+          },
+          {
+            name: 'myapp',
+            type: 'application',
+            data: {
+              architect: {
+                build: {
+                  options: {
+                    outputPath: 'one',
+                  },
+                  configurations: {
+                    production: {},
+                  },
                 },
               },
+              files: [],
             },
-            files: [],
-          },
-        })
+          }
+        )
       ).toEqual(['one']);
     });
 
     it('should handle invalid configuration', () => {
       expect(
-        getOutputsForTargetAndConfiguration('build', 'production', {
-          name: 'myapp',
-          type: 'application',
-          data: {
-            architect: {
-              build: {
-                options: {
-                  outputPath: 'one',
+        getOutputsForTargetAndConfiguration(
+          {
+            overrides: {},
+            target: {
+              project: 'myapp',
+              target: 'build',
+              configuration: 'production',
+            },
+          },
+          {
+            name: 'myapp',
+            type: 'application',
+            data: {
+              architect: {
+                build: {
+                  options: {
+                    outputPath: 'one',
+                  },
                 },
               },
+              files: [],
             },
-            files: [],
-          },
-        })
+          }
+        )
       ).toEqual(['one']);
+    });
+
+    it('should handle overrides', () => {
+      expect(
+        getOutputsForTargetAndConfiguration(
+          {
+            overrides: {
+              outputPath: 'overrideOutputPath',
+            },
+            target: {
+              project: 'myapp',
+              target: 'build',
+              configuration: 'production',
+            },
+          },
+          {
+            name: 'myapp',
+            type: 'application',
+            data: {
+              architect: {
+                build: {
+                  options: {
+                    outputPath: 'one',
+                  },
+                },
+              },
+              files: [],
+            },
+          }
+        )
+      ).toEqual(['overrideOutputPath']);
     });
 
     it('should return default output path when nothing else is defined', () => {
       expect(
-        getOutputsForTargetAndConfiguration('build', 'production', {
-          name: 'myapp',
-          type: 'application',
-          data: {
-            root: 'root-myapp',
-            architect: {
-              build: {},
+        getOutputsForTargetAndConfiguration(
+          {
+            overrides: {},
+            target: {
+              project: 'myapp',
+              target: 'build',
+              configuration: 'production',
             },
-            files: [],
           },
-        })
+          {
+            name: 'myapp',
+            type: 'application',
+            data: {
+              root: 'root-myapp',
+              architect: {
+                build: {},
+              },
+              files: [],
+            },
+          }
+        )
       ).toEqual(['dist/root-myapp']);
     });
   });

--- a/packages/workspace/src/tasks-runner/utils.ts
+++ b/packages/workspace/src/tasks-runner/utils.ts
@@ -45,18 +45,17 @@ export function getCommand(cliCommand: string, isYarn: boolean, task: Task) {
 }
 
 export function getOutputs(p: Record<string, ProjectGraphNode>, task: Task) {
-  return getOutputsForTargetAndConfiguration(
-    task.target.target,
-    task.target.configuration,
-    p[task.target.project]
-  );
+  return getOutputsForTargetAndConfiguration(task, p[task.target.project]);
 }
 
 export function getOutputsForTargetAndConfiguration(
-  target: string,
-  configuration: string,
+  task: Pick<Task, 'target' | 'overrides'>,
   node: ProjectGraphNode
 ) {
+  if (task.overrides?.outputPath) {
+    return [task.overrides?.outputPath];
+  }
+  const { target, configuration } = task.target;
   const architect = node.data.architect[target];
   if (architect && architect.outputs) return architect.outputs;
 

--- a/packages/workspace/src/utils/buildable-libs-utils.ts
+++ b/packages/workspace/src/utils/buildable-libs-utils.ts
@@ -53,8 +53,10 @@ export function calculateProjectDependencies(
         return {
           name: libPackageJson.name, // i.e. @workspace/mylib
           outputs: getOutputsForTargetAndConfiguration(
-            context.target.target,
-            context.target.configuration,
+            {
+              overrides: {},
+              target: context.target,
+            },
             depNode
           ),
           node: depNode,
@@ -234,8 +236,10 @@ export function updateBuildableProjectPackageJsonDependencies(
   dependencies: DependentBuildableProjectNode[]
 ) {
   const outputs = getOutputsForTargetAndConfiguration(
-    context.target.target,
-    context.target.configuration,
+    {
+      overrides: {},
+      target: context.target,
+    },
     node
   );
 
@@ -268,8 +272,10 @@ export function updateBuildableProjectPackageJsonDependencies(
         let depVersion;
         if (entry.node.type === ProjectType.lib) {
           const outputs = getOutputsForTargetAndConfiguration(
-            context.target.target,
-            context.target.configuration,
+            {
+              overrides: {},
+              target: context.target,
+            },
             entry.node
           );
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

passing `outputPath` via the command line is not considered when locating the output directory

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

passing `outputPath` via the command line is considered when locating the output directory

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3152 
