### PR TITLE
fix(testing): allow jest --bail flag type to be either boolean or number

### DIFF
--- a/docs/angular/api-jest/builders/jest.md
+++ b/docs/angular/api-jest/builders/jest.md
@@ -10,7 +10,7 @@ Builder properties can be configured in angular.json when defining the builder, 
 
 Alias(es): b
 
-Type: `number`
+Type: `number | boolean`
 
 Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/en/cli#bail)
 

--- a/docs/react/api-jest/builders/jest.md
+++ b/docs/react/api-jest/builders/jest.md
@@ -11,7 +11,7 @@ Read more about how to use builders and the CLI here: https://nx.dev/react/guide
 
 Alias(es): b
 
-Type: `number`
+Type: `number | boolean`
 
 Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/en/cli#bail)
 

--- a/packages/jest/src/builders/jest/schema.d.ts
+++ b/packages/jest/src/builders/jest/schema.d.ts
@@ -8,7 +8,7 @@ export interface JestBuilderOptions extends JsonObject {
   testFile?: string;
   setupFile?: string;
   tsConfig: string;
-  bail?: number;
+  bail?: boolean | number;
   ci?: boolean;
   color?: boolean;
   clearCache?: boolean;

--- a/packages/jest/src/builders/jest/schema.json
+++ b/packages/jest/src/builders/jest/schema.json
@@ -39,7 +39,7 @@
     "bail": {
       "alias": "b",
       "description": "Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/en/cli#bail)",
-      "type": "number"
+      "oneOf": [{ "type": "number" }, { "type": "boolean" }]
     },
     "ci": {
       "description": "Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/en/cli#ci)",


### PR DESCRIPTION
## Current Behavior

The actual jest CLI defaults `--bail` to 1, which would bail all test suites when it fails one.
For our builder we always need to pass the value `--bail 1`, which isn't consistent.

## Expected Behavior
The user should be able to leave the option off (default), or pass the boolean version `--bail`, or pass the number version `--bail ${n}`, e.g. `--bail 3`

## Related Issue(s)
No related issue
