### PR TITLE
fix(docs): fix typos in decorate cli explanation

### DIFF
--- a/packages/workspace/src/schematics/utils/decorate-angular-cli.js__tmpl__
+++ b/packages/workspace/src/schematics/utils/decorate-angular-cli.js__tmpl__
@@ -1,5 +1,5 @@
 /**
- * This file decorate the Angular CLI with the Nx CLI to enable features such as computation caching,
+ * This file decorates the Angular CLI with the Nx CLI to enable features such as computation caching
  * and faster execution of tasks.
  *
  * It does this by:
@@ -11,7 +11,7 @@
  * The Nx CLI decorates the Angular CLI, so the Nx CLI is fully compatible with it.
  * Every command you run should work the same when using the Nx CLI, except faster.
  *
- * Because of symliking you can still type `ng build/test/lint` in the terminal. The ng command, in this case,
+ * Because of symlinking you can still type `ng build/test/lint` in the terminal. The ng command, in this case,
  * will point to nx, which will perform optimizations before invoking ng. So the Angular CLI is always invoked.
  * The Nx CLI simply does some optimizations before invoking the Angular CLI.
  *


### PR DESCRIPTION
There is no issue for this, and I'm calling it docs because it's kind of an explanation of what the decorate script does.
