### PR TITLE
chore(core): update nxtend GitHub URL

### DIFF
--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -2,7 +2,7 @@
   {
     "name": "@nxtend/ionic-react",
     "description": "An Nx plugin for developing Ionic React applications and libraries",
-    "url": "https://github.com/devinshoemaker/nxtend"
+    "url": "https://github.com/nxtend-team/nxtend"
   },
   {
     "name": "@angular-architects/ddd",


### PR DESCRIPTION
This plugin has transitioned to a GitHub organization, so this update is to reflect that.

## Current Behavior
The URL for @nxtend/ionic-react is outdated.

## Expected Behavior
The URL for @nxtend/ionic-react has the correct updated link.
