### PR TITLE
fix(node): use addDepsToPackageJson in @nrwl/express init schematics

### DIFF
--- a/packages/express/src/schematics/init/init.spec.ts
+++ b/packages/express/src/schematics/init/init.spec.ts
@@ -25,12 +25,15 @@ describe('init', () => {
     );
     const result = await runSchematic('init', {}, tree);
     const packageJson = readJsonInTree(result, 'package.json');
+    // add express
+    expect(packageJson.dependencies['express']).toBeDefined();
+    // move `@nrwl/express` to dev
     expect(packageJson.dependencies['@nrwl/express']).toBeUndefined();
     expect(packageJson.devDependencies['@nrwl/express']).toBeDefined();
+    // add express types
     expect(packageJson.devDependencies['@types/express']).toBeDefined();
+    // keep existing packages
     expect(packageJson.devDependencies[existing]).toBeDefined();
-    expect(packageJson.dependencies['express']).toBeDefined();
-    expect(packageJson.dependencies['@nrwl/express']).toBeUndefined();
     expect(packageJson.dependencies[existing]).toBeDefined();
   });
 

--- a/packages/express/src/schematics/init/init.ts
+++ b/packages/express/src/schematics/init/init.ts
@@ -3,6 +3,7 @@ import {
   addPackageWithInit,
   formatFiles,
   setDefaultCollection,
+  addDepsToPackageJson,
   updateJsonInTree,
 } from '@nrwl/workspace';
 import {
@@ -12,15 +13,9 @@ import {
 } from '../../utils/versions';
 import { Schema } from './schema';
 
-function updateDependencies(): Rule {
+function removeNrwlExpressFromDeps(): Rule {
   return updateJsonInTree('package.json', (json) => {
     delete json.dependencies['@nrwl/express'];
-    json.dependencies['express'] = expressVersion;
-    json.devDependencies = {
-      ...json.devDependencies,
-      '@types/express': expressTypingsVersion,
-      '@nrwl/express': nxVersion,
-    };
     return json;
   });
 }
@@ -32,7 +27,16 @@ export default function (schema: Schema) {
     schema.unitTestRunner === 'jest'
       ? addPackageWithInit('@nrwl/jest')
       : noop(),
-    updateDependencies(),
+    removeNrwlExpressFromDeps(),
+    addDepsToPackageJson(
+      {
+        express: expressVersion,
+      },
+      {
+        '@types/express': expressTypingsVersion,
+        '@nrwl/express': nxVersion,
+      }
+    ),
     formatFiles(schema),
   ]);
 }

--- a/packages/react/src/schematics/init/init.ts
+++ b/packages/react/src/schematics/init/init.ts
@@ -3,7 +3,6 @@ import { JsonObject } from '@angular-devkit/core';
 import {
   addPackageWithInit,
   setDefaultCollection,
-  updateJsonInTree,
   updateWorkspace,
   addDepsToPackageJson,
 } from '@nrwl/workspace';


### PR DESCRIPTION
## Current Behavior
When generating an express application with `nx g @nrwl/express:app` the types were not being installed.

## Expected Behavior
The Types should be installed when necessary after generating the express application.

## Related Issue(s)
Fixes #3103 
