### PR TITLE
fix(misc): allow --js flag to be passed to @nrwl/web:lib schematic

### DIFF
--- a/docs/angular/api-workspace/schematics/library.md
+++ b/docs/angular/api-workspace/schematics/library.md
@@ -48,6 +48,14 @@ Type: `string`
 
 The library name used to import it, like @myorg/my-awesome-lib
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### linter
 
 Default: `eslint`

--- a/docs/react/api-workspace/schematics/library.md
+++ b/docs/react/api-workspace/schematics/library.md
@@ -48,6 +48,14 @@ Type: `string`
 
 The library name used to import it, like @myorg/my-awesome-lib
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
 ### linter
 
 Default: `eslint`

--- a/packages/workspace/src/schematics/library/library.spec.ts
+++ b/packages/workspace/src/schematics/library/library.spec.ts
@@ -302,4 +302,43 @@ describe('lib', () => {
       expect.assertions(1);
     });
   });
+
+  describe('--js flag', () => {
+    it('should generate js files instead of ts files', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', js: true },
+        appTree
+      );
+      expect(tree.exists(`libs/my-lib/jest.config.js`)).toBeTruthy();
+      expect(tree.exists('libs/my-lib/src/index.js')).toBeTruthy();
+      expect(tree.exists('libs/my-lib/src/lib/my-lib.js')).toBeTruthy();
+    });
+
+    it('should update root tsconfig.json with a js file path', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', js: true },
+        appTree
+      );
+      const tsconfigJson = readJsonInTree(tree, '/tsconfig.base.json');
+      expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
+        'libs/my-lib/src/index.js',
+      ]);
+    });
+
+    it('should generate js files for nested libs as well', async () => {
+      const tree = await runSchematic(
+        'lib',
+        { name: 'myLib', directory: 'myDir', js: true },
+        appTree
+      );
+      expect(tree.exists(`libs/my-dir/my-lib/jest.config.js`)).toBeTruthy();
+      expect(tree.exists('libs/my-dir/my-lib/src/index.js')).toBeTruthy();
+      expect(
+        tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.js')
+      ).toBeTruthy();
+      expect(tree.exists('libs/my-dir/my-lib/src/index.js')).toBeTruthy();
+    });
+  });
 });

--- a/packages/workspace/src/schematics/library/schema.d.ts
+++ b/packages/workspace/src/schematics/library/schema.d.ts
@@ -11,4 +11,5 @@ export interface Schema {
   linter: Linter;
   testEnvironment: 'jsdom' | 'node';
   importPath?: string;
+  js?: boolean;
 }

--- a/packages/workspace/src/schematics/library/schema.json
+++ b/packages/workspace/src/schematics/library/schema.json
@@ -59,6 +59,11 @@
     "importPath": {
       "type": "string",
       "description": "The library name used to import it, like @myorg/my-awesome-lib"
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files",
+      "default": false
     }
   },
   "required": ["name"]


### PR DESCRIPTION
##  Current Behavior
Running `nx g @nrwl/web:lib myLib --js` produces an error `Could not match option 'js' to the @nrwl/web:library schema.`

## Expected Behavior
That running `nx g @nrwl/web:lib myLib --js` would be able to run and generate a web library in js instead of ts.

## Related Issue(s)
Fixes #2985
