### PR TITLE
fix(core): print args warning when base is not passed

### DIFF
--- a/e2e/workspace/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace/src/workspace-aux-commands.test.ts
@@ -179,7 +179,9 @@ forEachCli((cli) => {
       expect(stdout).not.toContain(`apps/${myapp}/src/app/app.component.ts`);
 
       runCommand('npm run format:write -- --all');
-      expect(runCommand('npm run -s format:check -- --all')).toEqual('');
+      expect(runCommand('npm run -s format:check -- --all')).not.toContain(
+        `apps/${myapp}/src/main.ts`
+      );
     });
 
     it('should support workspace-specific schematics', async () => {

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -1,7 +1,7 @@
 import * as yargs from 'yargs';
 import { generateGraph } from './dep-graph';
 import { output } from '../utils/output';
-import { parseFiles, printArgsWarning } from './shared';
+import { parseFiles } from './shared';
 import { runCommand } from '../tasks-runner/run-command';
 import { NxArgs, splitArgsIntoNxArgsAndOverrides } from './utils';
 import { filterAffected } from '../core/affected-project-graph';
@@ -52,7 +52,6 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
         if (parsedArgs.plain) {
           console.log(apps.join(' '));
         } else {
-          printArgsWarning(nxArgs);
           if (apps.length) {
             output.log({
               title: 'Affected apps:',
@@ -69,7 +68,6 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
         if (parsedArgs.plain) {
           console.log(libs.join(' '));
         } else {
-          printArgsWarning(nxArgs);
           if (libs.length) {
             output.log({
               title: 'Affected libs:',
@@ -81,7 +79,6 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
 
       case 'dep-graph':
         const projectNames = affectedProjects.map((p) => p.name);
-        printArgsWarning(nxArgs);
         generateGraph(parsedArgs as any, projectNames);
         break;
 
@@ -108,7 +105,6 @@ export function affected(command: string, parsedArgs: yargs.Arguments): void {
           affectedProjects,
           nxArgs
         );
-        printArgsWarning(nxArgs);
         runCommand(
           projectsWithTarget,
           projectGraph,

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 import * as path from 'path';
 import * as resolve from 'resolve';
-import { getProjectRoots, parseFiles, printArgsWarning } from './shared';
+import { getProjectRoots, parseFiles } from './shared';
 import { fileExists } from '../utils/fileutils';
 import { output } from '../utils/output';
 import { createProjectGraph } from '../core/project-graph';
@@ -71,7 +71,6 @@ function getPatterns(args: NxArgs & { libsAndApps: boolean; _: string[] }) {
       return allFilesPattern;
     }
 
-    printArgsWarning(args);
     const p = parseFiles(args);
     let patterns = p.files
       .filter((f) => fileExists(f))

--- a/packages/workspace/src/command-line/shared.ts
+++ b/packages/workspace/src/command-line/shared.ts
@@ -1,36 +1,8 @@
 import { execSync } from 'child_process';
-import { output } from '../utils/output';
 import { createProjectGraph, ProjectGraphNode } from '../core/project-graph';
 import { NxJson } from '../core/shared-interfaces';
 import { readWorkspaceJson, TEN_MEGABYTES } from '../core/file-utils';
-import { NxArgs, getAffectedConfig } from './utils';
-
-export function printArgsWarning(options: NxArgs) {
-  const { files, uncommitted, untracked, base, head, all } = options;
-  const affectedConfig = getAffectedConfig();
-
-  if (!files && !uncommitted && !untracked && !base && !head && !all) {
-    output.note({
-      title: `Affected criteria defaulted to --base=${output.bold(
-        `${affectedConfig.defaultBase}`
-      )} --head=${output.bold('HEAD')}`,
-    });
-  }
-
-  if (all) {
-    output.warn({
-      title: `Running affected:* commands with --all can result in very slow builds.`,
-      bodyLines: [
-        output.bold('--all') +
-          ' is not meant to be used for any sizable project or to be used in CI.',
-        '',
-        output.colors.gray(
-          'Learn more about checking only what is affected: '
-        ) + 'https://nx.dev/guides/monorepo-affected.',
-      ],
-    });
-  }
-}
+import { NxArgs } from './utils';
 
 export function parseFiles(options: NxArgs): { files: string[] } {
   const { files, uncommitted, untracked, base, head } = options;

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -2,6 +2,7 @@ import * as yargsParser from 'yargs-parser';
 import * as yargs from 'yargs';
 import * as fileUtils from '../core/file-utils';
 import { NxAffectedConfig } from '../core/shared-interfaces';
+import { output } from '../utils/output';
 
 const runOne = [
   'target',
@@ -102,6 +103,7 @@ export function splitArgsIntoNxArgsAndOverrides(
   }
 
   if (mode === 'affected') {
+    printArgsWarning(nxArgs);
     if (
       !nxArgs.files &&
       !nxArgs.uncommitted &&
@@ -139,5 +141,32 @@ export function getAffectedConfig(): NxAffectedConfig {
     return {
       defaultBase,
     };
+  }
+}
+
+function printArgsWarning(options: NxArgs) {
+  const { files, uncommitted, untracked, base, head, all } = options;
+  const affectedConfig = getAffectedConfig();
+
+  if (!files && !uncommitted && !untracked && !base && !head && !all) {
+    output.note({
+      title: `Affected criteria defaulted to --base=${output.bold(
+        `${affectedConfig.defaultBase}`
+      )} --head=${output.bold('HEAD')}`,
+    });
+  }
+
+  if (all) {
+    output.warn({
+      title: `Running affected:* commands with --all can result in very slow builds.`,
+      bodyLines: [
+        output.bold('--all') +
+          ' is not meant to be used for any sizable project or to be used in CI.',
+        '',
+        output.colors.gray(
+          'Learn more about checking only what is affected: '
+        ) + 'https://nx.dev/guides/monorepo-affected.',
+      ],
+    });
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The warning for defaulting affected args does not show up.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The warning for defaulting affected args does show up.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
