### PR TITLE
fix(react): add styled-jsx to babel jest setup to avoid warnings

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -97,7 +97,11 @@ module.exports = withCSS({
       `
       );
 
-      await checkApp(appName, { checkLint: true, checkE2E: true });
+      await checkApp(appName, {
+        checkUnitTest: true,
+        checkLint: true,
+        checkE2E: false,
+      });
 
       // check that the configuration was consumed
       expect(readFile(`dist/apps/${appName}/.next/BUILD_ID`)).toEqual('fixed');
@@ -124,7 +128,11 @@ module.exports = withCSS({
       ` + readFile(mainPath)
       );
 
-      await checkApp(appName, { checkLint: false, checkE2E: false });
+      await checkApp(appName, {
+        checkUnitTest: false,
+        checkLint: false,
+        checkE2E: true,
+      });
     }, 120000);
 
     it('should compile when using a workspace and react lib written in TypeScript', async () => {
@@ -183,7 +191,11 @@ module.exports = withCSS({
           )
       );
 
-      await checkApp(appName, { checkLint: true, checkE2E: true });
+      await checkApp(appName, {
+        checkUnitTest: true,
+        checkLint: true,
+        checkE2E: false,
+      });
     }, 120000);
 
     it('should support --style=styled-components', async () => {
@@ -193,7 +205,11 @@ module.exports = withCSS({
         `generate @nrwl/next:app ${appName} --no-interactive --style=styled-components`
       );
 
-      await checkApp(appName, { checkLint: false, checkE2E: false });
+      await checkApp(appName, {
+        checkUnitTest: true,
+        checkLint: false,
+        checkE2E: false,
+      });
     }, 120000);
 
     it('should support --style=@emotion/styled', async () => {
@@ -203,7 +219,11 @@ module.exports = withCSS({
         `generate @nrwl/next:app ${appName} --no-interactive --style=@emotion/styled`
       );
 
-      await checkApp(appName, { checkLint: false, checkE2E: false });
+      await checkApp(appName, {
+        checkUnitTest: true,
+        checkLint: false,
+        checkE2E: false,
+      });
     }, 120000);
 
     it('should build with public folder', async () => {
@@ -224,19 +244,21 @@ module.exports = withCSS({
 
 async function checkApp(
   appName: string,
-  opts: { checkLint: boolean; checkE2E: boolean }
+  opts: { checkUnitTest: boolean; checkLint: boolean; checkE2E: boolean }
 ) {
   if (opts.checkLint) {
     const lintResults = runCLI(`lint ${appName}`);
     expect(lintResults).toContain('All files pass linting.');
   }
 
-  const testResults = await runCLIAsync(`test ${appName}`);
-  expect(testResults.combinedOutput).toContain(
-    'Test Suites: 1 passed, 1 total'
-  );
+  if (opts.checkUnitTest) {
+    const testResults = await runCLIAsync(`test ${appName}`);
+    expect(testResults.combinedOutput).toContain(
+      'Test Suites: 1 passed, 1 total'
+    );
+  }
 
-  if (supportUi()) {
+  if (opts.checkE2E) {
     const e2eResults = runCLI(`e2e ${appName}-e2e --headless`);
     expect(e2eResults).toContain('All specs passed!');
   }

--- a/packages/next/src/schematics/application/application.spec.ts
+++ b/packages/next/src/schematics/application/application.spec.ts
@@ -69,7 +69,14 @@ describe('app', () => {
       );
 
       const content = result.read('apps/my-app/pages/index.tsx').toString();
+
+      const babelJestConfig = readJsonInTree(
+        result,
+        'apps/my-app/babel-jest.config.json'
+      );
+
       expect(content).toMatch(/<style jsx>/);
+      expect(babelJestConfig.plugins).toContain('styled-jsx/babel');
     });
   });
 

--- a/packages/next/src/schematics/application/lib/add-jest.ts
+++ b/packages/next/src/schematics/application/lib/add-jest.ts
@@ -15,6 +15,7 @@ export function addJest(options: NormalizedSchema): Rule {
           supportTsx: true,
           skipSerializers: true,
           setupFile: 'none',
+          babelJest: true,
         }),
 
         updateJsonInTree(

--- a/packages/next/src/schematics/application/lib/update-jest-config.ts
+++ b/packages/next/src/schematics/application/lib/update-jest-config.ts
@@ -1,16 +1,25 @@
-import { noop, Rule } from '@angular-devkit/schematics';
+import { chain, noop, Rule } from '@angular-devkit/schematics';
 import { NormalizedSchema } from './normalize-options';
+import { updateBabelJestConfig } from '@nrwl/react/src/rules/update-babel-jest-config';
 
 export function updateJestConfig(options: NormalizedSchema): Rule {
   return options.unitTestRunner === 'none'
     ? noop()
-    : (host) => {
-        const configPath = `${options.appProjectRoot}/jest.config.js`;
-        const originalContent = host.read(configPath).toString();
-        const content = originalContent.replace(
-          'transform: {',
-          "transform: {\n    '^(?!.*\\\\.(js|jsx|ts|tsx|css|json)$)': '@nrwl/react/plugins/jest',"
-        );
-        host.overwrite(configPath, content);
-      };
+    : chain([
+        (host) => {
+          const configPath = `${options.appProjectRoot}/jest.config.js`;
+          const originalContent = host.read(configPath).toString();
+          const content = originalContent.replace(
+            'transform: {',
+            "transform: {\n    '^(?!.*\\\\.(js|jsx|ts|tsx|css|json)$)': '@nrwl/react/plugins/jest',"
+          );
+          host.overwrite(configPath, content);
+        },
+        updateBabelJestConfig(options.appProjectRoot, (json) => {
+          if (options.style === 'styled-jsx') {
+            json.plugins = (json.plugins || []).concat('styled-jsx/babel');
+          }
+          return json;
+        }),
+      ]);
 }

--- a/packages/react/src/rules/update-babel-jest-config.spec.ts
+++ b/packages/react/src/rules/update-babel-jest-config.spec.ts
@@ -1,0 +1,41 @@
+import { Tree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { readJsonInTree } from '@nrwl/workspace';
+import { updateBabelJestConfig } from './update-babel-jest-config';
+import { callRule } from '@nrwl/workspace/src/utils/testing';
+
+describe('updateBabelJestConfig', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = Tree.empty();
+    tree = createEmptyWorkspace(tree);
+  });
+
+  it('should update babel-jest.config.json', async () => {
+    tree.create('/apps/demo/babel-jest.config.json', JSON.stringify({}));
+
+    tree = await callRule(
+      updateBabelJestConfig('/apps/demo', (json) => {
+        json.plugins = ['test'];
+        return json;
+      }),
+      tree
+    );
+
+    const config = readJsonInTree(tree, '/apps/demo/babel-jest.config.json');
+    expect(config.plugins).toEqual(['test']);
+  });
+
+  it('should do nothing if project does not use babel jest', async () => {
+    tree = await callRule(
+      updateBabelJestConfig('/apps/demo', (json) => {
+        json.plugins = ['test'];
+        return json;
+      }),
+      tree
+    );
+
+    expect(tree.exists('/apps/demo/babel-jest.config.json')).toBe(false);
+  });
+});

--- a/packages/react/src/rules/update-babel-jest-config.ts
+++ b/packages/react/src/rules/update-babel-jest-config.ts
@@ -1,0 +1,16 @@
+import { noop, Tree } from '@angular-devkit/schematics';
+import { updateJsonInTree } from '@nrwl/workspace';
+
+type BabelJestConfigUpdater<T> = (json: T) => T;
+
+export function updateBabelJestConfig<T = any>(
+  projectRoot: string,
+  update: BabelJestConfigUpdater<T>
+) {
+  return (host: Tree) => {
+    const configPath = `${projectRoot}/babel-jest.config.json`;
+    return host.exists(configPath)
+      ? updateJsonInTree<T>(configPath, update)
+      : noop();
+  };
+}

--- a/packages/react/src/schematics/application/application.spec.ts
+++ b/packages/react/src/schematics/application/application.spec.ts
@@ -554,6 +554,22 @@ describe('app', () => {
       const packageJSON = readJsonInTree(tree, 'package.json');
       expect(packageJSON.dependencies['styled-jsx']).toBeDefined();
     });
+
+    it('should update babel config', async () => {
+      const tree = await runSchematic(
+        'app',
+        { name: 'myApp', style: 'styled-jsx' },
+        appTree
+      );
+
+      const babelrc = readJsonInTree(tree, 'apps/my-app/.babelrc');
+      const babelJestConfig = readJsonInTree(
+        tree,
+        'apps/my-app/babel-jest.config.json'
+      );
+      expect(babelrc.plugins).toContain('styled-jsx/babel');
+      expect(babelJestConfig.plugins).toContain('styled-jsx/babel');
+    });
   });
 
   describe('--routing', () => {

--- a/packages/react/src/schematics/application/lib/update-jest-config.ts
+++ b/packages/react/src/schematics/application/lib/update-jest-config.ts
@@ -1,5 +1,6 @@
 import { chain, noop, Rule } from '@angular-devkit/schematics';
-import { updateJestConfigContent } from '@nrwl/react/src/utils/jest-utils';
+import { updateBabelJestConfig } from '../../../rules/update-babel-jest-config';
+import { updateJestConfigContent } from '../../../utils/jest-utils';
 import { NormalizedSchema } from '../schema';
 import { offsetFromRoot, updateJsonInTree } from '@nrwl/workspace';
 
@@ -29,5 +30,11 @@ export function updateJestConfig(options: NormalizedSchema): Rule {
           const content = updateJestConfigContent(originalContent);
           host.overwrite(configPath, content);
         },
+        updateBabelJestConfig(options.appProjectRoot, (json) => {
+          if (options.style === 'styled-jsx') {
+            json.plugins = (json.plugins || []).concat('styled-jsx/babel');
+          }
+          return json;
+        }),
       ]);
 }

--- a/packages/react/src/schematics/library/files/lib/.babelrc__tmpl__
+++ b/packages/react/src/schematics/library/files/lib/.babelrc__tmpl__
@@ -5,5 +5,6 @@
   ],
   "plugins": [
     <% if (style === 'styled-components') { %>["styled-components", { "pure": true, "ssr": true }]<% } %>
+    <% if (style === 'styled-jsx') { %>"styled-jsx/babel"<% } %>
   ]
 }

--- a/packages/react/src/schematics/library/library.spec.ts
+++ b/packages/react/src/schematics/library/library.spec.ts
@@ -473,12 +473,19 @@ describe('lib', () => {
       );
 
       const workspaceJson = readJsonInTree(tree, '/workspace.json');
+      const babelrc = readJsonInTree(tree, 'libs/my-lib/.babelrc');
+      const babelJestConfig = readJsonInTree(
+        tree,
+        'libs/my-lib/babel-jest.config.json'
+      );
 
       expect(workspaceJson.projects['my-lib'].architect.build).toMatchObject({
         options: {
           external: ['react', 'react-dom', 'styled-jsx'],
         },
       });
+      expect(babelrc.plugins).toContain('styled-jsx/babel');
+      expect(babelJestConfig.plugins).toContain('styled-jsx/babel');
     });
 
     it('should support style none', async () => {


### PR DESCRIPTION

## Expected Behavior

Jest tests show warnings when using `styled-jsx` in React app.

## Related Issue(s)
Jest tests should not show warnings when using `styled-jsx` in React app.
