### PR TITLE
fix(angular): add the root directory to the "resolvePaths" option when creating the NodeWorkflow

### DIFF
--- a/packages/workspace/src/command-line/workspace-schematic.ts
+++ b/packages/workspace/src/command-line/workspace-schematic.ts
@@ -135,6 +135,7 @@ function createWorkflow(dryRun: boolean) {
     root,
     dryRun,
     registry: new schema.CoreSchemaRegistry(formats.standardFormats),
+    resolvePaths: [root],
   });
 }
 


### PR DESCRIPTION
## Current Behavior
Nx workspace schematics can't load externalSchematics because the collections cannot be resolved.

## Expected Behavior
Nx workspace schematics are now able to find collections for externalSchematics

## Related Issue(s)
Fixes #3233 
