### PR TITLE
fix(angular): correct typo in NgRx reducer template

### DIFF
--- a/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.reducer.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.reducer.ts__tmpl__
@@ -9,7 +9,7 @@ export const <%= className.toUpperCase() %>_FEATURE_KEY = '<%= propertyName %>';
 export interface State extends EntityState<<%= className %>Entity> {
   selectedId ?: string | number;          // which <%= className %> record has been selected
   loaded      : boolean;                  // has the <%= className %> list been loaded
-  error      ?: string | null;            // last none error (if any)
+  error      ?: string | null;            // last known error (if any)
 }
 
 export interface <%= className %>PartialState {


### PR DESCRIPTION
"None" is a type-o and should be "known". This PR fixes that one single word.