### PR TITLE
fix(core): fix runNxNewCommand so plugin e2e tests will work.

### DIFF
--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -55,12 +55,11 @@ forEachCli((currentCLIName) => {
       done();
     }, 45000);
 
-    // TODO: vsavkin reenable
     // the test invoke ensureNxProject, which points to @nrwl/workspace collection
     // which walks up the directory to find it in the next repo itself, so it
     // doesn't use the collection we are building
     // we should change it to point to the right collection using relative path
-    xit(`should run the plugin's e2e tests`, async (done) => {
+    it(`should run the plugin's e2e tests`, async (done) => {
       ensureProject();
       const plugin = uniq('plugin');
       runCLI(`generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter}`);

--- a/packages/nx-plugin/src/utils/testing-utils/nx-project.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/nx-project.ts
@@ -10,7 +10,7 @@ function runNxNewCommand(args?: string, silent?: boolean) {
   return execSync(
     `node ${require.resolve(
       '@nrwl/tao'
-    )} new proj --no-interactive --skip-install --collection=@nrwl/workspace --npmScope=proj ${
+    )} new proj --no-interactive --skip-install --collection=@nrwl/workspace --npmScope=proj --preset=empty ${
       args || ''
     }`,
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10323,7 +10323,7 @@ fs-extra@8.1.0, fs-extra@^8.0.1, fs-extra@^8.1.0:
 
 fs-extra@9.0.0, fs-extra@^9.0.0:
   version "9.0.0"
-  resolved "http://localhost:4873/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
   integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
   dependencies:
     at-least-node "^1.0.0"


### PR DESCRIPTION
Fixes runNxNewCommand so plugin e2e tests will work by passing --preset=empty to new proj.

ISSUES CLOSED: #3253 

## Current Behavior
Currently all plugin e2e tests will fail when trying to create a new temporary Nx project.

## Expected Behavior
These e2e tests should be able to pass.
