### PR TITLE
chore(core): nx plugin submission @nxtend/capacitor

### DIFF
--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -2,7 +2,12 @@
   {
     "name": "@nxtend/ionic-react",
     "description": "An Nx plugin for developing Ionic React applications and libraries",
-    "url": "https://github.com/nxtend-team/nxtend"
+    "url": "https://github.com/nxtend-team/nxtend/tree/master/libs/ionic-react"
+  },
+  {
+    "name": "@nxtend/capacitor",
+    "description": "An Nx plugin for developing cross-platform applications using Capacitor",
+    "url": "https://github.com/nxtend-team/nxtend/tree/master/libs/capacitor"
   },
   {
     "name": "@angular-architects/ddd",


### PR DESCRIPTION
This adds the new `@nxtend/capacitor` plugin to the approved plugin list, and updates the existing `@nxtend/ionic-react` URL.