### PR TITLE
feat(core): use custom output logging for configuration errors

### DIFF
--- a/packages/workspace/src/core/assert-workspace-validity.ts
+++ b/packages/workspace/src/core/assert-workspace-validity.ts
@@ -1,26 +1,40 @@
 import { workspaceFileName } from './file-utils';
-import { ImplicitJsonSubsetDependency } from '@nrwl/workspace/src/core/shared-interfaces';
+import {
+  ImplicitJsonSubsetDependency,
+  NxJson,
+} from '@nrwl/workspace/src/core/shared-interfaces';
+import { output } from '../utils/output';
 
-export function assertWorkspaceValidity(workspaceJson, nxJson) {
+export function assertWorkspaceValidity(workspaceJson, nxJson: NxJson) {
   const workspaceJsonProjects = Object.keys(workspaceJson.projects);
   const nxJsonProjects = Object.keys(nxJson.projects);
 
   if (minus(workspaceJsonProjects, nxJsonProjects).length > 0) {
-    throw new Error(
-      `${workspaceFileName()} and nx.json are out of sync. The following projects are missing in nx.json: ${minus(
-        workspaceJsonProjects,
-        nxJsonProjects
-      ).join(', ')}`
-    );
+    output.error({
+      title: 'Configuration Error',
+      bodyLines: [
+        `${workspaceFileName()} and nx.json are out of sync. The following projects are missing in nx.json: ${minus(
+          workspaceJsonProjects,
+          nxJsonProjects
+        ).join(', ')}`,
+      ],
+    });
+
+    process.exit(1);
   }
 
   if (minus(nxJsonProjects, workspaceJsonProjects).length > 0) {
-    throw new Error(
-      `${workspaceFileName()} and nx.json are out of sync. The following projects are missing in ${workspaceFileName()}: ${minus(
-        nxJsonProjects,
-        workspaceJsonProjects
-      ).join(', ')}`
-    );
+    output.error({
+      title: 'Configuration Error',
+      bodyLines: [
+        `${workspaceFileName()} and nx.json are out of sync. The following projects are missing in ${workspaceFileName()}: ${minus(
+          nxJsonProjects,
+          workspaceJsonProjects
+        ).join(', ')}`,
+      ],
+    });
+
+    process.exit(1);
   }
 
   const projects = {
@@ -81,7 +95,12 @@ export function assertWorkspaceValidity(workspaceJson, nxJson) {
     message += str;
   });
 
-  throw new Error(message);
+  output.error({
+    title: 'Configuration Error',
+    bodyLines: [message],
+  });
+
+  process.exit(1);
 }
 
 function detectAndSetInvalidProjectValues(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When angular.json/workspace.json is out of sync, or there is an implicitDependency in nx.json that is invalid, we throw an error message with a stack trace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When angular.json/workspace.json is out of sync, or there is an implicitDependency in nx.json that is invalid, we log a custom error message using a standardized format.

![image](https://user-images.githubusercontent.com/42211/86633565-6ba20000-bf96-11ea-807a-35b659c15208.png)

