### PR TITLE
fix(nx-plugin): don't add duplicate migrations.json asset entries

### DIFF
--- a/packages/nx-plugin/src/schematics/migration/migration.ts
+++ b/packages/nx-plugin/src/schematics/migration/migration.ts
@@ -1,4 +1,4 @@
-import { JsonArray } from '@angular-devkit/core';
+import { JsonArray, JsonObject } from '@angular-devkit/core';
 import {
   apply,
   chain,
@@ -89,7 +89,12 @@ function updateWorkspaceJson(options: NormalizedSchema): Rule {
   return updateWorkspace((workspace) => {
     const targets = workspace.projects.get(options.project).targets;
     const build = targets.get('build');
-    if (build) {
+    if (
+      build &&
+      (build.options.assets as JsonArray).filter(
+        (asset) => (asset as JsonObject).glob === 'migrations.json'
+      ).length === 0
+    ) {
       (build.options.assets as JsonArray).push(
         ...[
           {


### PR DESCRIPTION
## Current Behavior
`nx g @nrwl/nx-plugin:migration` will add a `migrations.json` asset entry to `workspace.json` every time the schematic is executed, even if it already exists.

## Expected Behavior
`nx g @nrwl/nx-plugin:migration` will only add a `migrations.json` asset entry to `workspace.json` if it does not already exist.
