### PR TITLE
chore(nx-plugin): fix linting errors and standardize structure

### DIFF
--- a/packages/nx-plugin/src/builders/e2e/e2e.impl.ts
+++ b/packages/nx-plugin/src/builders/e2e/e2e.impl.ts
@@ -4,17 +4,21 @@ import {
   scheduleTargetAndForget,
   targetFromTargetString,
 } from '@angular-devkit/architect';
-import { switchMap, concatMap } from 'rxjs/operators';
-import { Schema } from './schema';
 import { from } from 'rxjs';
+import { concatMap, switchMap } from 'rxjs/operators';
+import { Schema } from './schema';
 
 try {
   require('dotenv').config();
+  // eslint-disable-next-line no-empty
 } catch (e) {}
 
-export interface NxPluginE2EBuilderOptions extends Schema {}
+export type NxPluginE2EBuilderOptions = Schema;
 
-export default createBuilder(runNxPluginE2EBuilder);
+function buildTarget(context: BuilderContext, target: string) {
+  return scheduleTargetAndForget(context, targetFromTargetString(target));
+}
+
 export function runNxPluginE2EBuilder(
   options: NxPluginE2EBuilderOptions,
   context: BuilderContext
@@ -32,6 +36,4 @@ export function runNxPluginE2EBuilder(
   );
 }
 
-function buildTarget(context: BuilderContext, target: string) {
-  return scheduleTargetAndForget(context, targetFromTargetString(target));
-}
+export default createBuilder(runNxPluginE2EBuilder);

--- a/packages/nx-plugin/src/schematics/builder/builder.ts
+++ b/packages/nx-plugin/src/schematics/builder/builder.ts
@@ -1,99 +1,13 @@
-import {
-  apply,
-  chain,
-  filter,
-  mergeWith,
-  move,
-  noop,
-  Rule,
-  SchematicContext,
-  template,
-  Tree,
-  url,
-} from '@angular-devkit/schematics';
-import {
-  getProjectConfig,
-  names,
-  readNxJsonInTree,
-  toFileName,
-  updateJsonInTree,
-} from '@nrwl/workspace';
-import * as path from 'path';
-import { Schema } from './schema';
-
-export interface NormalizedSchema extends Schema {
-  fileName: string;
-  projectRoot: string;
-  projectSourceRoot: string;
-  npmScope: string;
-}
+import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import { addFiles } from './lib/add-files';
+import { normalizeOptions } from './lib/normalize-options';
+import { updateBuildersJson } from './lib/update-builders-json';
+import { NormalizedSchema } from './schema';
 
 export default function (schema: NormalizedSchema): Rule {
-  return (host: Tree, context: SchematicContext) => {
+  return (host: Tree) => {
     const options = normalizeOptions(host, schema);
 
     return chain([addFiles(options), updateBuildersJson(options)]);
   };
-}
-
-function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
-  const nxJson = readNxJsonInTree(host);
-  const npmScope = nxJson.npmScope;
-  const fileName = toFileName(options.name);
-
-  const { root: projectRoot, sourceRoot: projectSourceRoot } = getProjectConfig(
-    host,
-    options.project
-  );
-
-  let description: string;
-  if (options.description) {
-    description = options.description;
-  } else {
-    description = `${options.name} builder`;
-  }
-
-  const normalized: NormalizedSchema = {
-    ...options,
-    fileName,
-    description,
-    projectRoot,
-    projectSourceRoot,
-    npmScope,
-  };
-
-  return normalized;
-}
-
-function addFiles(options: NormalizedSchema): Rule {
-  return mergeWith(
-    apply(url(`./files/builder`), [
-      template({
-        ...options,
-        ...names(options.name),
-        tmpl: '',
-      }),
-      options.unitTestRunner === 'none'
-        ? filter((file) => !file.endsWith('.spec.ts'))
-        : noop(),
-      move(`${options.projectSourceRoot}/builders`),
-    ])
-  );
-}
-
-function updateBuildersJson(options: NormalizedSchema): Rule {
-  return updateJsonInTree(
-    path.join(options.projectRoot, 'builders.json'),
-    (json) => {
-      const builders = json.builders ? json.builders : {};
-      builders[options.name] = {
-        implementation: `./src/builders/${options.name}/builder`,
-        schema: `./src/builders/${options.name}/schema.json`,
-        description: options.description,
-      };
-      json.builders = builders;
-
-      return json;
-    }
-  );
 }

--- a/packages/nx-plugin/src/schematics/builder/lib/add-files.ts
+++ b/packages/nx-plugin/src/schematics/builder/lib/add-files.ts
@@ -1,0 +1,28 @@
+import {
+  apply,
+  filter,
+  mergeWith,
+  move,
+  noop,
+  Rule,
+  template,
+  url,
+} from '@angular-devkit/schematics';
+import { names } from '@nrwl/workspace';
+import { NormalizedSchema } from '../schema';
+
+export function addFiles(options: NormalizedSchema): Rule {
+  return mergeWith(
+    apply(url(`./files/builder`), [
+      template({
+        ...options,
+        ...names(options.name),
+        tmpl: '',
+      }),
+      options.unitTestRunner === 'none'
+        ? filter((file) => !file.endsWith('.spec.ts'))
+        : noop(),
+      move(`${options.projectSourceRoot}/builders`),
+    ])
+  );
+}

--- a/packages/nx-plugin/src/schematics/builder/lib/normalize-options.ts
+++ b/packages/nx-plugin/src/schematics/builder/lib/normalize-options.ts
@@ -1,0 +1,39 @@
+import { Tree } from '@angular-devkit/schematics';
+import {
+  getProjectConfig,
+  readNxJsonInTree,
+  toFileName,
+} from '@nrwl/workspace';
+import { NormalizedSchema, Schema } from '../schema';
+
+export function normalizeOptions(
+  host: Tree,
+  options: Schema
+): NormalizedSchema {
+  const nxJson = readNxJsonInTree(host);
+  const npmScope = nxJson.npmScope;
+  const fileName = toFileName(options.name);
+
+  const { root: projectRoot, sourceRoot: projectSourceRoot } = getProjectConfig(
+    host,
+    options.project
+  );
+
+  let description: string;
+  if (options.description) {
+    description = options.description;
+  } else {
+    description = `${options.name} builder`;
+  }
+
+  const normalized: NormalizedSchema = {
+    ...options,
+    fileName,
+    description,
+    projectRoot,
+    projectSourceRoot,
+    npmScope,
+  };
+
+  return normalized;
+}

--- a/packages/nx-plugin/src/schematics/builder/lib/update-builders-json.ts
+++ b/packages/nx-plugin/src/schematics/builder/lib/update-builders-json.ts
@@ -1,0 +1,21 @@
+import { Rule } from '@angular-devkit/schematics';
+import { updateJsonInTree } from '@nrwl/workspace';
+import * as path from 'path';
+import { NormalizedSchema } from '../schema';
+
+export function updateBuildersJson(options: NormalizedSchema): Rule {
+  return updateJsonInTree(
+    path.join(options.projectRoot, 'builders.json'),
+    (json) => {
+      const builders = json.builders ? json.builders : {};
+      builders[options.name] = {
+        implementation: `./src/builders/${options.name}/builder`,
+        schema: `./src/builders/${options.name}/schema.json`,
+        description: options.description,
+      };
+      json.builders = builders;
+
+      return json;
+    }
+  );
+}

--- a/packages/nx-plugin/src/schematics/builder/schema.d.ts
+++ b/packages/nx-plugin/src/schematics/builder/schema.d.ts
@@ -4,3 +4,10 @@ export interface Schema {
   description?: string;
   unitTestRunner: 'jest' | 'none';
 }
+
+export interface NormalizedSchema extends Schema {
+  fileName: string;
+  projectRoot: string;
+  projectSourceRoot: string;
+  npmScope: string;
+}

--- a/packages/nx-plugin/src/schematics/e2e-project/e2e.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/e2e.ts
@@ -1,144 +1,23 @@
-import { normalize } from '@angular-devkit/core';
-import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
-import {
-  apply,
-  chain,
-  externalSchematic,
-  mergeWith,
-  move,
-  Rule,
-  SchematicContext,
-  SchematicsException,
-  template,
-  Tree,
-  url,
-} from '@angular-devkit/schematics';
-import {
-  addProjectToNxJsonInTree,
-  getWorkspace,
-  offsetFromRoot,
-  readNxJsonInTree,
-  toPropertyName,
-  updateWorkspace,
-} from '@nrwl/workspace';
-import { join } from 'path';
+import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import { getWorkspace } from '@nrwl/workspace';
+import { addFiles } from './lib/add-files';
+import { addJest } from './lib/add-jest';
+import { normalizeOptions } from './lib/normalize-options';
+import { updateNxJson } from './lib/update-nx-json';
+import { updateWorkspaceJson } from './lib/update-workspace-json';
+import { validatePlugin } from './lib/validate-plugin';
 import { Schema } from './schema';
-import { appsDir } from '@nrwl/workspace/src/utils/ast-utils';
-
-export interface NxPluginE2ESchema extends Schema {
-  projectRoot: string;
-  projectName: string;
-  pluginPropertyName: string;
-  npmScope: string;
-}
 
 export default function (options: Schema): Rule {
-  return async (host: Tree, context: SchematicContext) => {
+  return async (host: Tree) => {
     const workspace = await getWorkspace(host);
     validatePlugin(workspace, options.pluginName);
     const normalizedOptions = normalizeOptions(host, options);
     return chain([
-      updateFiles(normalizedOptions),
+      addFiles(normalizedOptions),
       updateNxJson(normalizedOptions),
       updateWorkspaceJson(normalizedOptions),
       addJest(normalizedOptions),
     ]);
   };
-}
-
-function validatePlugin(workspace: WorkspaceDefinition, pluginName: string) {
-  const project = workspace.projects.get(pluginName);
-  if (!project) {
-    throw new SchematicsException(
-      `Project name "${pluginName}" doesn't not exist.`
-    );
-  }
-}
-
-function normalizeOptions(host: Tree, options: Schema): NxPluginE2ESchema {
-  const projectName = `${options.pluginName}-e2e`;
-  const projectRoot = join(normalize(appsDir(host)), projectName);
-  const npmScope = readNxJsonInTree(host).npmScope;
-  const pluginPropertyName = toPropertyName(options.pluginName);
-  return {
-    ...options,
-    projectName,
-    pluginPropertyName,
-    projectRoot,
-    npmScope,
-  };
-}
-
-function updateNxJson(options: NxPluginE2ESchema): Rule {
-  return addProjectToNxJsonInTree(options.projectName, {
-    tags: [],
-    implicitDependencies: [options.pluginName],
-  });
-}
-
-function updateWorkspaceJson(options: NxPluginE2ESchema): Rule {
-  return chain([
-    async (host, context) => {
-      const workspace = await getWorkspace(host);
-      workspace.projects.add({
-        name: options.projectName,
-        root: options.projectRoot,
-        projectType: 'application',
-        sourceRoot: `${options.projectRoot}/src`,
-        targets: {
-          e2e: {
-            builder: '@nrwl/nx-plugin:e2e',
-            options: {
-              target: `${options.pluginName}:build`,
-              npmPackageName: options.npmPackageName,
-              pluginOutputPath: options.pluginOutputPath,
-            },
-          },
-        },
-      });
-      return updateWorkspace(workspace);
-    },
-  ]);
-}
-
-function updateFiles(options: NxPluginE2ESchema): Rule {
-  return mergeWith(
-    apply(url('./files'), [
-      template({
-        tmpl: '',
-        ...options,
-        offsetFromRoot: offsetFromRoot(options.projectRoot),
-      }),
-      move(options.projectRoot),
-    ])
-  );
-}
-
-function addJest(options: NxPluginE2ESchema): Rule {
-  return chain([
-    externalSchematic('@nrwl/jest', 'jest-project', {
-      project: options.projectName,
-      setupFile: 'none',
-      supportTsx: false,
-      skipSerializers: true,
-    }),
-    async (host, context) => {
-      const workspace = await getWorkspace(host);
-      const project = workspace.projects.get(options.projectName);
-      const testOptions = project.targets.get('test').options;
-      const e2eOptions = project.targets.get('e2e').options;
-      project.targets.get('e2e').options = {
-        ...e2eOptions,
-        ...{
-          jestConfig: testOptions.jestConfig,
-          tsSpecConfig: testOptions.tsConfig,
-        },
-      };
-
-      // remove the jest build target
-      project.targets.delete('test');
-
-      return updateWorkspace(workspace);
-    },
-  ]);
 }

--- a/packages/nx-plugin/src/schematics/e2e-project/lib/add-files.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/lib/add-files.ts
@@ -1,0 +1,23 @@
+import {
+  apply,
+  mergeWith,
+  move,
+  Rule,
+  template,
+  url,
+} from '@angular-devkit/schematics';
+import { offsetFromRoot } from '@nrwl/workspace';
+import { NxPluginE2ESchema } from '../schema';
+
+export function addFiles(options: NxPluginE2ESchema): Rule {
+  return mergeWith(
+    apply(url('./files'), [
+      template({
+        tmpl: '',
+        ...options,
+        offsetFromRoot: offsetFromRoot(options.projectRoot),
+      }),
+      move(options.projectRoot),
+    ])
+  );
+}

--- a/packages/nx-plugin/src/schematics/e2e-project/lib/add-jest.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/lib/add-jest.ts
@@ -1,0 +1,32 @@
+import { chain, externalSchematic, Rule } from '@angular-devkit/schematics';
+import { getWorkspace, updateWorkspace } from '@nrwl/workspace';
+import { NxPluginE2ESchema } from '../schema';
+
+export function addJest(options: NxPluginE2ESchema): Rule {
+  return chain([
+    externalSchematic('@nrwl/jest', 'jest-project', {
+      project: options.projectName,
+      setupFile: 'none',
+      supportTsx: false,
+      skipSerializers: true,
+    }),
+    async (host) => {
+      const workspace = await getWorkspace(host);
+      const project = workspace.projects.get(options.projectName);
+      const testOptions = project.targets.get('test').options;
+      const e2eOptions = project.targets.get('e2e').options;
+      project.targets.get('e2e').options = {
+        ...e2eOptions,
+        ...{
+          jestConfig: testOptions.jestConfig,
+          tsSpecConfig: testOptions.tsConfig,
+        },
+      };
+
+      // remove the jest build target
+      project.targets.delete('test');
+
+      return updateWorkspace(workspace);
+    },
+  ]);
+}

--- a/packages/nx-plugin/src/schematics/e2e-project/lib/normalize-options.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/lib/normalize-options.ts
@@ -1,0 +1,23 @@
+import { normalize } from '@angular-devkit/core';
+import { Tree } from '@angular-devkit/schematics';
+import { readNxJsonInTree, toPropertyName } from '@nrwl/workspace';
+import { appsDir } from '@nrwl/workspace/src/utils/ast-utils';
+import { join } from 'path';
+import { NxPluginE2ESchema, Schema } from '../schema';
+
+export function normalizeOptions(
+  host: Tree,
+  options: Schema
+): NxPluginE2ESchema {
+  const projectName = `${options.pluginName}-e2e`;
+  const projectRoot = join(normalize(appsDir(host)), projectName);
+  const npmScope = readNxJsonInTree(host).npmScope;
+  const pluginPropertyName = toPropertyName(options.pluginName);
+  return {
+    ...options,
+    projectName,
+    pluginPropertyName,
+    projectRoot,
+    npmScope,
+  };
+}

--- a/packages/nx-plugin/src/schematics/e2e-project/lib/update-nx-json.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/lib/update-nx-json.ts
@@ -1,0 +1,10 @@
+import { Rule } from '@angular-devkit/schematics';
+import { addProjectToNxJsonInTree } from '@nrwl/workspace';
+import { NxPluginE2ESchema } from '../schema';
+
+export function updateNxJson(options: NxPluginE2ESchema): Rule {
+  return addProjectToNxJsonInTree(options.projectName, {
+    tags: [],
+    implicitDependencies: [options.pluginName],
+  });
+}

--- a/packages/nx-plugin/src/schematics/e2e-project/lib/update-workspace-json.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/lib/update-workspace-json.ts
@@ -1,0 +1,28 @@
+import { chain, Rule } from '@angular-devkit/schematics';
+import { getWorkspace, updateWorkspace } from '@nrwl/workspace';
+import { NxPluginE2ESchema } from '../schema';
+
+export function updateWorkspaceJson(options: NxPluginE2ESchema): Rule {
+  return chain([
+    async (host, context) => {
+      const workspace = await getWorkspace(host);
+      workspace.projects.add({
+        name: options.projectName,
+        root: options.projectRoot,
+        projectType: 'application',
+        sourceRoot: `${options.projectRoot}/src`,
+        targets: {
+          e2e: {
+            builder: '@nrwl/nx-plugin:e2e',
+            options: {
+              target: `${options.pluginName}:build`,
+              npmPackageName: options.npmPackageName,
+              pluginOutputPath: options.pluginOutputPath,
+            },
+          },
+        },
+      });
+      return updateWorkspace(workspace);
+    },
+  ]);
+}

--- a/packages/nx-plugin/src/schematics/e2e-project/lib/validate-plugin.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/lib/validate-plugin.ts
@@ -1,0 +1,14 @@
+import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
+import { SchematicsException } from '@angular-devkit/schematics';
+
+export function validatePlugin(
+  workspace: WorkspaceDefinition,
+  pluginName: string
+) {
+  const project = workspace.projects.get(pluginName);
+  if (!project) {
+    throw new SchematicsException(
+      `Project name "${pluginName}" doesn't not exist.`
+    );
+  }
+}

--- a/packages/nx-plugin/src/schematics/e2e-project/schema.d.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/schema.d.ts
@@ -1,9 +1,14 @@
-import { Linter } from '@nrwl/workspace';
-
 export interface Schema {
   pluginName: string;
   npmPackageName: string;
   pluginOutputPath: string;
   jestConfig: string;
   tsSpecConfig: string;
+}
+
+export interface NxPluginE2ESchema extends Schema {
+  projectRoot: string;
+  projectName: string;
+  pluginPropertyName: string;
+  npmScope: string;
 }

--- a/packages/nx-plugin/src/schematics/migration/lib/add-files.ts
+++ b/packages/nx-plugin/src/schematics/migration/lib/add-files.ts
@@ -1,0 +1,26 @@
+import {
+  apply,
+  filter,
+  mergeWith,
+  move,
+  noop,
+  Rule,
+  template,
+  url,
+} from '@angular-devkit/schematics';
+import { NormalizedSchema } from '../schema';
+
+export function addFiles(options: NormalizedSchema): Rule {
+  return mergeWith(
+    apply(url(`./files/migration`), [
+      template({
+        ...options,
+        tmpl: '',
+      }),
+      options.unitTestRunner === 'none'
+        ? filter((file) => !file.endsWith('.spec.ts'))
+        : noop(),
+      move(`${options.projectSourceRoot}/migrations`),
+    ])
+  );
+}

--- a/packages/nx-plugin/src/schematics/migration/lib/normalize-options.ts
+++ b/packages/nx-plugin/src/schematics/migration/lib/normalize-options.ts
@@ -1,0 +1,37 @@
+import { Tree } from '@angular-devkit/schematics';
+import { getProjectConfig, toFileName } from '@nrwl/workspace';
+import { NormalizedSchema, Schema } from '../schema';
+
+export function normalizeOptions(
+  host: Tree,
+  options: Schema
+): NormalizedSchema {
+  let name: string;
+  if (options.name) {
+    name = toFileName(options.name);
+  } else {
+    name = toFileName(`update-${options.version}`);
+  }
+
+  let description: string;
+  if (options.description) {
+    description = options.description;
+  } else {
+    description = name;
+  }
+
+  const { root: projectRoot, sourceRoot: projectSourceRoot } = getProjectConfig(
+    host,
+    options.project
+  );
+
+  const normalized: NormalizedSchema = {
+    ...options,
+    name,
+    description,
+    projectRoot,
+    projectSourceRoot,
+  };
+
+  return normalized;
+}

--- a/packages/nx-plugin/src/schematics/migration/lib/update-migratiions-json.ts
+++ b/packages/nx-plugin/src/schematics/migration/lib/update-migratiions-json.ts
@@ -1,0 +1,34 @@
+import { Rule } from '@angular-devkit/schematics';
+import { updateJsonInTree } from '@nrwl/workspace';
+import * as path from 'path';
+import { NormalizedSchema } from '../schema';
+
+export function updateMigrationsJson(options: NormalizedSchema): Rule {
+  return updateJsonInTree(
+    path.join(options.projectRoot, 'migrations.json'),
+    (json) => {
+      const schematics = json.schematics ? json.schematics : {};
+      schematics[options.name] = {
+        version: options.version,
+        description: options.description,
+        factory: `./src/migrations/${options.name}/${options.name}`,
+      };
+      json.schematics = schematics;
+
+      if (options.packageJsonUpdates) {
+        const packageJsonUpdatesObj = json.packageJsonUpdates
+          ? json.packageJsonUpdates
+          : {};
+        if (!packageJsonUpdatesObj[options.version]) {
+          packageJsonUpdatesObj[options.version] = {
+            version: options.version,
+            packages: {},
+          };
+        }
+        json.packageJsonUpdates = packageJsonUpdatesObj;
+      }
+
+      return json;
+    }
+  );
+}

--- a/packages/nx-plugin/src/schematics/migration/lib/update-package-json.ts
+++ b/packages/nx-plugin/src/schematics/migration/lib/update-package-json.ts
@@ -1,0 +1,23 @@
+import { Rule } from '@angular-devkit/schematics';
+import { updateJsonInTree } from '@nrwl/workspace';
+import * as path from 'path';
+import { NormalizedSchema } from '../schema';
+
+export function updatePackageJson(options: NormalizedSchema): Rule {
+  return updateJsonInTree(
+    path.join(options.projectRoot, 'package.json'),
+    (json) => {
+      if (!json['ng-update'] || !json['ng-update'].migrations) {
+        if (json['ng-update']) {
+          json['ng-update'].migrations = './migrations.json';
+        } else {
+          json['ng-update'] = {
+            migrations: './migrations.json',
+          };
+        }
+      }
+
+      return json;
+    }
+  );
+}

--- a/packages/nx-plugin/src/schematics/migration/lib/update-workspace-json.ts
+++ b/packages/nx-plugin/src/schematics/migration/lib/update-workspace-json.ts
@@ -1,0 +1,27 @@
+import { JsonArray, JsonObject } from '@angular-devkit/core';
+import { Rule } from '@angular-devkit/schematics';
+import { updateWorkspace } from '@nrwl/workspace';
+import { NormalizedSchema } from '../schema';
+
+export function updateWorkspaceJson(options: NormalizedSchema): Rule {
+  return updateWorkspace((workspace) => {
+    const targets = workspace.projects.get(options.project).targets;
+    const build = targets.get('build');
+    if (
+      build &&
+      (build.options.assets as JsonArray).filter(
+        (asset) => (asset as JsonObject).glob === 'migrations.json'
+      ).length === 0
+    ) {
+      (build.options.assets as JsonArray).push(
+        ...[
+          {
+            input: `./${options.projectRoot}`,
+            glob: 'migrations.json',
+            output: '.',
+          },
+        ]
+      );
+    }
+  });
+}

--- a/packages/nx-plugin/src/schematics/migration/migration.ts
+++ b/packages/nx-plugin/src/schematics/migration/migration.ts
@@ -1,33 +1,13 @@
-import { JsonArray, JsonObject } from '@angular-devkit/core';
-import {
-  apply,
-  chain,
-  mergeWith,
-  move,
-  Rule,
-  SchematicContext,
-  template,
-  Tree,
-  url,
-  filter,
-  noop,
-} from '@angular-devkit/schematics';
-import {
-  getProjectConfig,
-  toFileName,
-  updateJsonInTree,
-  updateWorkspace,
-} from '@nrwl/workspace';
-import * as path from 'path';
-import { Schema } from './schema';
-
-export interface NormalizedSchema extends Schema {
-  projectRoot: string;
-  projectSourceRoot: string;
-}
+import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import { addFiles } from './lib/add-files';
+import { normalizeOptions } from './lib/normalize-options';
+import { updateMigrationsJson } from './lib/update-migratiions-json';
+import { updatePackageJson } from './lib/update-package-json';
+import { updateWorkspaceJson } from './lib/update-workspace-json';
+import { NormalizedSchema } from './schema';
 
 export default function (schema: NormalizedSchema): Rule {
-  return (host: Tree, context: SchematicContext) => {
+  return (host: Tree) => {
     const options = normalizeOptions(host, schema);
 
     return chain([
@@ -37,122 +17,4 @@ export default function (schema: NormalizedSchema): Rule {
       updatePackageJson(options),
     ]);
   };
-}
-
-function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
-  let name: string;
-  if (options.name) {
-    name = toFileName(options.name);
-  } else {
-    name = toFileName(`update-${options.version}`);
-  }
-
-  let description: string;
-  if (options.description) {
-    description = options.description;
-  } else {
-    description = name;
-  }
-
-  const { root: projectRoot, sourceRoot: projectSourceRoot } = getProjectConfig(
-    host,
-    options.project
-  );
-
-  const normalized: NormalizedSchema = {
-    ...options,
-    name,
-    description,
-    projectRoot,
-    projectSourceRoot,
-  };
-
-  return normalized;
-}
-
-function addFiles(options: NormalizedSchema): Rule {
-  return mergeWith(
-    apply(url(`./files/migration`), [
-      template({
-        ...options,
-        tmpl: '',
-      }),
-      options.unitTestRunner === 'none'
-        ? filter((file) => !file.endsWith('.spec.ts'))
-        : noop(),
-      move(`${options.projectSourceRoot}/migrations`),
-    ])
-  );
-}
-
-function updateWorkspaceJson(options: NormalizedSchema): Rule {
-  return updateWorkspace((workspace) => {
-    const targets = workspace.projects.get(options.project).targets;
-    const build = targets.get('build');
-    if (
-      build &&
-      (build.options.assets as JsonArray).filter(
-        (asset) => (asset as JsonObject).glob === 'migrations.json'
-      ).length === 0
-    ) {
-      (build.options.assets as JsonArray).push(
-        ...[
-          {
-            input: `./${options.projectRoot}`,
-            glob: 'migrations.json',
-            output: '.',
-          },
-        ]
-      );
-    }
-  });
-}
-
-function updateMigrationsJson(options: NormalizedSchema): Rule {
-  return updateJsonInTree(
-    path.join(options.projectRoot, 'migrations.json'),
-    (json) => {
-      const schematics = json.schematics ? json.schematics : {};
-      schematics[options.name] = {
-        version: options.version,
-        description: options.description,
-        factory: `./src/migrations/${options.name}/${options.name}`,
-      };
-      json.schematics = schematics;
-
-      if (options.packageJsonUpdates) {
-        const packageJsonUpdatesObj = json.packageJsonUpdates
-          ? json.packageJsonUpdates
-          : {};
-        if (!packageJsonUpdatesObj[options.version]) {
-          packageJsonUpdatesObj[options.version] = {
-            version: options.version,
-            packages: {},
-          };
-        }
-        json.packageJsonUpdates = packageJsonUpdatesObj;
-      }
-
-      return json;
-    }
-  );
-}
-
-function updatePackageJson(options: NormalizedSchema): Rule {
-  return updateJsonInTree(
-    path.join(options.projectRoot, 'package.json'),
-    (json) => {
-      if (!json['ng-update'] || !json['ng-update'].migrations) {
-        if (json['ng-update']) {
-          json['ng-update'].migrations = './migrations.json';
-        } else {
-          json['ng-update'] = {
-            migrations: './migrations.json',
-          };
-        }
-      }
-
-      return json;
-    }
-  );
 }

--- a/packages/nx-plugin/src/schematics/migration/schema.d.ts
+++ b/packages/nx-plugin/src/schematics/migration/schema.d.ts
@@ -6,3 +6,8 @@ export interface Schema {
   packageJsonUpdates: boolean;
   unitTestRunner: 'jest' | 'none';
 }
+
+export interface NormalizedSchema extends Schema {
+  projectRoot: string;
+  projectSourceRoot: string;
+}

--- a/packages/nx-plugin/src/schematics/plugin/lib/add-files.ts
+++ b/packages/nx-plugin/src/schematics/plugin/lib/add-files.ts
@@ -1,0 +1,52 @@
+import { normalize } from '@angular-devkit/core';
+import {
+  apply,
+  chain,
+  MergeStrategy,
+  mergeWith,
+  move,
+  Rule,
+  schematic,
+  template,
+  url,
+} from '@angular-devkit/schematics';
+import { names, offsetFromRoot } from '@nrwl/workspace';
+import { allFilesInDirInHost } from '@nrwl/workspace/src/utils/ast-utils';
+import { NormalizedSchema } from '../schema';
+
+export function addFiles(options: NormalizedSchema): Rule {
+  return chain([
+    (host) => {
+      allFilesInDirInHost(
+        host,
+        normalize(`${options.projectRoot}/src/lib`)
+      ).forEach((file) => {
+        host.delete(file);
+      });
+
+      return host;
+    },
+    mergeWith(
+      apply(url(`./files/plugin`), [
+        template({
+          ...options,
+          ...names(options.name),
+          tmpl: '',
+          offsetFromRoot: offsetFromRoot(options.projectRoot),
+        }),
+        move(options.projectRoot),
+      ]),
+      MergeStrategy.Overwrite
+    ),
+    schematic('schematic', {
+      project: options.name,
+      name: options.name,
+      unitTestRunner: options.unitTestRunner,
+    }),
+    schematic('builder', {
+      project: options.name,
+      name: 'build',
+      unitTestRunner: options.unitTestRunner,
+    }),
+  ]);
+}

--- a/packages/nx-plugin/src/schematics/plugin/lib/normalize-options.ts
+++ b/packages/nx-plugin/src/schematics/plugin/lib/normalize-options.ts
@@ -1,0 +1,43 @@
+import { normalize } from '@angular-devkit/core';
+import { Tree } from '@angular-devkit/schematics';
+import { readNxJsonInTree, toFileName } from '@nrwl/workspace';
+import { libsDir } from '@nrwl/workspace/src/utils/ast-utils';
+import { getFileTemplate } from '../../../utils/get-file-template';
+import { NormalizedSchema, Schema } from '../schema';
+
+export function normalizeOptions(
+  host: Tree,
+  options: Schema
+): NormalizedSchema {
+  const nxJson = readNxJsonInTree(host);
+  const npmScope = nxJson.npmScope;
+  const name = toFileName(options.name);
+  const projectDirectory = options.directory
+    ? `${toFileName(options.directory)}/${name}`
+    : name;
+
+  const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
+  const fileName = projectName;
+  const projectRoot = normalize(`${libsDir(host)}/${projectDirectory}`);
+
+  const parsedTags = options.tags
+    ? options.tags.split(',').map((s) => s.trim())
+    : [];
+  const npmPackageName = `@${npmScope}/${name}`;
+
+  const fileTemplate = getFileTemplate();
+
+  const normalized: NormalizedSchema = {
+    ...options,
+    fileName,
+    npmScope,
+    name: projectName,
+    projectRoot,
+    projectDirectory,
+    parsedTags,
+    npmPackageName,
+    fileTemplate,
+  };
+
+  return normalized;
+}

--- a/packages/nx-plugin/src/schematics/plugin/lib/update-tsconfig.ts
+++ b/packages/nx-plugin/src/schematics/plugin/lib/update-tsconfig.ts
@@ -1,0 +1,16 @@
+import { Rule, Tree } from '@angular-devkit/schematics';
+import { getProjectConfig, updateJsonInTree } from '@nrwl/workspace';
+import { NormalizedSchema } from '../schema';
+
+export function updateTsConfig(options: NormalizedSchema): Rule {
+  return (host: Tree) => {
+    const projectConfig = getProjectConfig(host, options.name);
+    return updateJsonInTree(
+      `${projectConfig.root}/tsconfig.lib.json`,
+      (json) => {
+        json.compilerOptions.rootDir = '.';
+        return json;
+      }
+    );
+  };
+}

--- a/packages/nx-plugin/src/schematics/plugin/lib/update-workspace-json.ts
+++ b/packages/nx-plugin/src/schematics/plugin/lib/update-workspace-json.ts
@@ -1,0 +1,32 @@
+import { JsonArray } from '@angular-devkit/core';
+import { Rule } from '@angular-devkit/schematics';
+import { updateWorkspace } from '@nrwl/workspace';
+import { NormalizedSchema } from '../schema';
+
+export function updateWorkspaceJson(options: NormalizedSchema): Rule {
+  return updateWorkspace((workspace) => {
+    const targets = workspace.projects.get(options.name).targets;
+    const build = targets.get('build');
+    if (build) {
+      (build.options.assets as JsonArray).push(
+        ...[
+          {
+            input: `./${options.projectRoot}/src`,
+            glob: '**/*.!(ts)',
+            output: './src',
+          },
+          {
+            input: `./${options.projectRoot}`,
+            glob: 'collection.json',
+            output: '.',
+          },
+          {
+            input: `./${options.projectRoot}`,
+            glob: 'builders.json',
+            output: '.',
+          },
+        ]
+      );
+    }
+  });
+}

--- a/packages/nx-plugin/src/schematics/plugin/plugin.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.ts
@@ -1,49 +1,21 @@
-import { JsonArray, normalize, Path } from '@angular-devkit/core';
-import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import {
-  apply,
   chain,
   externalSchematic,
-  MergeStrategy,
-  mergeWith,
-  move,
   Rule,
   schematic,
   SchematicContext,
-  template,
   Tree,
-  url,
-  filter,
-  noop,
 } from '@angular-devkit/schematics';
-import {
-  formatFiles,
-  getProjectConfig,
-  names,
-  offsetFromRoot,
-  readNxJsonInTree,
-  toFileName,
-  updateJsonInTree,
-  updateWorkspace,
-} from '@nrwl/workspace';
-import {
-  allFilesInDirInHost,
-  libsDir,
-} from '@nrwl/workspace/src/utils/ast-utils';
-import { Schema } from './schema';
-export interface NormalizedSchema extends Schema {
-  name: string;
-  fileName: string;
-  projectRoot: Path;
-  projectDirectory: string;
-  parsedTags: string[];
-  npmScope: string;
-  npmPackageName: string;
-  fileTemplate: string;
-}
+import { formatFiles } from '@nrwl/workspace';
+import { libsDir } from '@nrwl/workspace/src/utils/ast-utils';
+import { addFiles } from './lib/add-files';
+import { normalizeOptions } from './lib/normalize-options';
+import { updateTsConfig } from './lib/update-tsconfig';
+import { updateWorkspaceJson } from './lib/update-workspace-json';
+import { NormalizedSchema } from './schema';
 
 export default function (schema: NormalizedSchema): Rule {
-  return (host: Tree, context: SchematicContext) => {
+  return (host: Tree) => {
     const options = normalizeOptions(host, schema);
 
     return chain([
@@ -63,122 +35,4 @@ export default function (schema: NormalizedSchema): Rule {
       formatFiles(options),
     ]);
   };
-}
-
-function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
-  const nxJson = readNxJsonInTree(host);
-  const npmScope = nxJson.npmScope;
-  const name = toFileName(options.name);
-  const projectDirectory = options.directory
-    ? `${toFileName(options.directory)}/${name}`
-    : name;
-
-  const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
-  const fileName = projectName;
-  const projectRoot = normalize(`${libsDir(host)}/${projectDirectory}`);
-
-  const parsedTags = options.tags
-    ? options.tags.split(',').map((s) => s.trim())
-    : [];
-  const npmPackageName = `@${npmScope}/${name}`;
-
-  const fileTemplate = getFileTemplate();
-
-  const normalized: NormalizedSchema = {
-    ...options,
-    fileName,
-    npmScope,
-    name: projectName,
-    projectRoot,
-    projectDirectory,
-    parsedTags,
-    npmPackageName,
-    fileTemplate,
-  };
-
-  return normalized;
-}
-
-function addFiles(options: NormalizedSchema): Rule {
-  return chain([
-    (host) => {
-      allFilesInDirInHost(
-        host,
-        normalize(`${options.projectRoot}/src/lib`)
-      ).forEach((file) => {
-        host.delete(file);
-      });
-
-      return host;
-    },
-    mergeWith(
-      apply(url(`./files/plugin`), [
-        template({
-          ...options,
-          ...names(options.name),
-          tmpl: '',
-          offsetFromRoot: offsetFromRoot(options.projectRoot),
-        }),
-        move(options.projectRoot),
-      ]),
-      MergeStrategy.Overwrite
-    ),
-    schematic('schematic', {
-      project: options.name,
-      name: options.name,
-      unitTestRunner: options.unitTestRunner,
-    }),
-    schematic('builder', {
-      project: options.name,
-      name: 'build',
-      unitTestRunner: options.unitTestRunner,
-    }),
-  ]);
-}
-
-function updateWorkspaceJson(options: NormalizedSchema): Rule {
-  return updateWorkspace((workspace) => {
-    const targets = workspace.projects.get(options.name).targets;
-    const build = targets.get('build');
-    if (build) {
-      (build.options.assets as JsonArray).push(
-        ...[
-          {
-            input: `./${options.projectRoot}/src`,
-            glob: '**/*.!(ts)',
-            output: './src',
-          },
-          {
-            input: `./${options.projectRoot}`,
-            glob: 'collection.json',
-            output: '.',
-          },
-          {
-            input: `./${options.projectRoot}`,
-            glob: 'builders.json',
-            output: '.',
-          },
-        ]
-      );
-    }
-  });
-}
-
-function updateTsConfig(options: NormalizedSchema): Rule {
-  return (host: Tree, context: SchematicContext) => {
-    const projectConfig = getProjectConfig(host, options.name);
-    return updateJsonInTree(
-      `${projectConfig.root}/tsconfig.lib.json`,
-      (json) => {
-        json.compilerOptions.rootDir = '.';
-        return json;
-      }
-    );
-  };
-}
-
-function getFileTemplate() {
-  return stripIndents`
-    const variable = "<%= projectName %>";
-  `;
 }

--- a/packages/nx-plugin/src/schematics/plugin/schema.d.ts
+++ b/packages/nx-plugin/src/schematics/plugin/schema.d.ts
@@ -9,3 +9,14 @@ export interface Schema {
   unitTestRunner: 'jest' | 'none';
   linter: Linter;
 }
+
+export interface NormalizedSchema extends Schema {
+  name: string;
+  fileName: string;
+  projectRoot: Path;
+  projectDirectory: string;
+  parsedTags: string[];
+  npmScope: string;
+  npmPackageName: string;
+  fileTemplate: string;
+}

--- a/packages/nx-plugin/src/schematics/schematic/lib/add-files.ts
+++ b/packages/nx-plugin/src/schematics/schematic/lib/add-files.ts
@@ -1,0 +1,28 @@
+import {
+  apply,
+  filter,
+  mergeWith,
+  move,
+  noop,
+  Rule,
+  template,
+  url,
+} from '@angular-devkit/schematics';
+import { names } from '@nrwl/workspace';
+import { NormalizedSchema } from '../schema';
+
+export function addFiles(options: NormalizedSchema): Rule {
+  return mergeWith(
+    apply(url(`./files/schematic`), [
+      template({
+        ...options,
+        ...names(options.name),
+        tmpl: '',
+      }),
+      options.unitTestRunner === 'none'
+        ? filter((file) => !file.endsWith('.spec.ts'))
+        : noop(),
+      move(`${options.projectSourceRoot}/schematics`),
+    ])
+  );
+}

--- a/packages/nx-plugin/src/schematics/schematic/lib/normalize-options.ts
+++ b/packages/nx-plugin/src/schematics/schematic/lib/normalize-options.ts
@@ -1,0 +1,46 @@
+import { Tree } from '@angular-devkit/schematics';
+import {
+  getProjectConfig,
+  readNxJsonInTree,
+  toFileName,
+} from '@nrwl/workspace';
+import { getFileTemplate } from '../../../utils/get-file-template';
+import { NormalizedSchema, Schema } from '../schema';
+
+export function normalizeOptions(
+  host: Tree,
+  options: Schema
+): NormalizedSchema {
+  const nxJson = readNxJsonInTree(host);
+  const npmScope = nxJson.npmScope;
+  const fileName = toFileName(options.name);
+
+  const { root: projectRoot, sourceRoot: projectSourceRoot } = getProjectConfig(
+    host,
+    options.project
+  );
+
+  const npmPackageName = `@${npmScope}/${fileName}`;
+
+  const fileTemplate = getFileTemplate();
+
+  let description: string;
+  if (options.description) {
+    description = options.description;
+  } else {
+    description = `${options.name} schematic`;
+  }
+
+  const normalized: NormalizedSchema = {
+    ...options,
+    fileName,
+    description,
+    projectRoot,
+    projectSourceRoot,
+    npmScope,
+    npmPackageName,
+    fileTemplate,
+  };
+
+  return normalized;
+}

--- a/packages/nx-plugin/src/schematics/schematic/lib/update-collection-json.ts
+++ b/packages/nx-plugin/src/schematics/schematic/lib/update-collection-json.ts
@@ -1,0 +1,21 @@
+import { Rule } from '@angular-devkit/schematics';
+import { updateJsonInTree } from '@nrwl/workspace';
+import * as path from 'path';
+import { NormalizedSchema } from '../schema';
+
+export function updateCollectionJson(options: NormalizedSchema): Rule {
+  return updateJsonInTree(
+    path.join(options.projectRoot, 'collection.json'),
+    (json) => {
+      const schematics = json.schematics ? json.schematics : {};
+      schematics[options.name] = {
+        factory: `./src/schematics/${options.name}/schematic`,
+        schema: `./src/schematics/${options.name}/schema.json`,
+        description: options.description,
+      };
+      json.schematics = schematics;
+
+      return json;
+    }
+  );
+}

--- a/packages/nx-plugin/src/schematics/schematic/schema.d.ts
+++ b/packages/nx-plugin/src/schematics/schematic/schema.d.ts
@@ -4,3 +4,12 @@ export interface Schema {
   description?: string;
   unitTestRunner: 'jest' | 'none';
 }
+
+export interface NormalizedSchema extends Schema {
+  fileName: string;
+  projectRoot: string;
+  projectSourceRoot: string;
+  npmScope: string;
+  npmPackageName: string;
+  fileTemplate: string;
+}

--- a/packages/nx-plugin/src/schematics/schematic/schematic.ts
+++ b/packages/nx-plugin/src/schematics/schematic/schematic.ts
@@ -1,114 +1,13 @@
-import { stripIndents } from '@angular-devkit/core/src/utils/literals';
-import {
-  apply,
-  chain,
-  mergeWith,
-  move,
-  Rule,
-  SchematicContext,
-  template,
-  Tree,
-  url,
-  filter,
-  noop,
-} from '@angular-devkit/schematics';
-import {
-  getProjectConfig,
-  names,
-  readNxJsonInTree,
-  toFileName,
-  updateJsonInTree,
-} from '@nrwl/workspace';
-import * as path from 'path';
-import { Schema } from './schema';
-
-export interface NormalizedSchema extends Schema {
-  fileName: string;
-  projectRoot: string;
-  projectSourceRoot: string;
-  npmScope: string;
-  npmPackageName: string;
-  fileTemplate: string;
-}
+import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import { addFiles } from './lib/add-files';
+import { normalizeOptions } from './lib/normalize-options';
+import { updateCollectionJson } from './lib/update-collection-json';
+import { NormalizedSchema } from './schema';
 
 export default function (schema: NormalizedSchema): Rule {
-  return (host: Tree, context: SchematicContext) => {
+  return (host: Tree) => {
     const options = normalizeOptions(host, schema);
 
     return chain([addFiles(options), updateCollectionJson(options)]);
   };
-}
-
-function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
-  const nxJson = readNxJsonInTree(host);
-  const npmScope = nxJson.npmScope;
-  const fileName = toFileName(options.name);
-
-  const { root: projectRoot, sourceRoot: projectSourceRoot } = getProjectConfig(
-    host,
-    options.project
-  );
-
-  const npmPackageName = `@${npmScope}/${fileName}`;
-
-  const fileTemplate = getFileTemplate();
-
-  let description: string;
-  if (options.description) {
-    description = options.description;
-  } else {
-    description = `${options.name} schematic`;
-  }
-
-  const normalized: NormalizedSchema = {
-    ...options,
-    fileName,
-    description,
-    projectRoot,
-    projectSourceRoot,
-    npmScope,
-    npmPackageName,
-    fileTemplate,
-  };
-
-  return normalized;
-}
-
-function addFiles(options: NormalizedSchema): Rule {
-  return mergeWith(
-    apply(url(`./files/schematic`), [
-      template({
-        ...options,
-        ...names(options.name),
-        tmpl: '',
-      }),
-      options.unitTestRunner === 'none'
-        ? filter((file) => !file.endsWith('.spec.ts'))
-        : noop(),
-      move(`${options.projectSourceRoot}/schematics`),
-    ])
-  );
-}
-
-function updateCollectionJson(options: NormalizedSchema): Rule {
-  return updateJsonInTree(
-    path.join(options.projectRoot, 'collection.json'),
-    (json) => {
-      const schematics = json.schematics ? json.schematics : {};
-      schematics[options.name] = {
-        factory: `./src/schematics/${options.name}/schematic`,
-        schema: `./src/schematics/${options.name}/schema.json`,
-        description: options.description,
-      };
-      json.schematics = schematics;
-
-      return json;
-    }
-  );
-}
-
-function getFileTemplate() {
-  return stripIndents`
-    const variable = "<%= projectName %>";
-  `;
 }

--- a/packages/nx-plugin/src/utils/get-file-template.ts
+++ b/packages/nx-plugin/src/utils/get-file-template.ts
@@ -1,0 +1,7 @@
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+
+export function getFileTemplate() {
+  return stripIndents`
+      const variable = "<%= projectName %>";
+    `;
+}


### PR DESCRIPTION
## Current Behavior
The nx-plugin package produces a lot of linting errors.

## Expected Behavior
The nx-plugin package should not produce linting errors.

I'm very open to feedback on this PR, and also understand if it doesn't get merged at all. I was poking around the code base and figured I'd do some TLC on the `nx-plugin` package and fix some linting errors and clean up the code. I find the recent structural changes to the `react` package to be easy to digest, so I applied the same pattern here.