### PR TITLE
feat(nextjs): adds dependencies to builder

### DIFF
--- a/docs/angular/api-next/builders/build.md
+++ b/docs/angular/api-next/builders/build.md
@@ -6,6 +6,12 @@ Builder properties can be configured in angular.json when defining the builder, 
 
 ## Properties
 
+### dependencies
+
+Type: `array`
+
+Adds more dependencies from root package json into the build.
+
 ### fileReplacements
 
 Type: `object[]`

--- a/docs/react/api-next/builders/build.md
+++ b/docs/react/api-next/builders/build.md
@@ -7,6 +7,12 @@ Read more about how to use builders and the CLI here: https://nx.dev/react/guide
 
 ## Properties
 
+### dependencies
+
+Type: `array`
+
+Adds more dependencies from root package json into the build.
+
 ### fileReplacements
 
 Type: `object[]`

--- a/packages/next/src/builders/build/build.impl.spec.ts
+++ b/packages/next/src/builders/build/build.impl.spec.ts
@@ -27,6 +27,7 @@ describe('Next.js Builder', () => {
           with: 'apps/wibble/src/environment.prod.ts',
         },
       ],
+      dependencies: [],
     };
 
     jest.spyOn(build, 'default').mockReturnValue(Promise.resolve());

--- a/packages/next/src/builders/build/lib/create-package-json.ts
+++ b/packages/next/src/builders/build/lib/create-package-json.ts
@@ -18,6 +18,13 @@ export async function createPackageJson(
     ...rootPackageJson.devDependencies,
   };
 
+  const pickedDependencies = options.dependencies.reduce((acc, value) => {
+    if (allWorkspaceDeps[value]) {
+      acc[value] = allWorkspaceDeps[value];
+    }
+    return acc;
+  }, {});
+
   const outPackageJson = {
     name: context.target.project,
     version: '0.0.1',
@@ -28,6 +35,7 @@ export async function createPackageJson(
       next: allWorkspaceDeps.next,
       react: allWorkspaceDeps.react || reactVersion,
       'react-dom': allWorkspaceDeps['react-dom'] || reactDomVersion,
+      ...pickedDependencies,
     },
     devDependencies: {},
   };

--- a/packages/next/src/builders/build/schema.json
+++ b/packages/next/src/builders/build/schema.json
@@ -29,6 +29,14 @@
         "required": ["replace", "with"]
       },
       "default": []
+    },
+    "dependencies": {
+      "description": "Adds more dependencies from root package json into the build.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
     }
   },
   "required": []

--- a/packages/next/src/schematics/application/application.spec.ts
+++ b/packages/next/src/schematics/application/application.spec.ts
@@ -115,6 +115,7 @@ describe('app', () => {
     expect(architectConfig.build.options).toEqual({
       root: 'apps/my-app',
       outputPath: 'dist/apps/my-app',
+      dependencies: [],
     });
   });
 

--- a/packages/next/src/schematics/application/lib/add-project.spec.ts
+++ b/packages/next/src/schematics/application/lib/add-project.spec.ts
@@ -44,6 +44,7 @@ describe('addProject Rule', () => {
       options: {
         outputPath: 'dist/apps/todos',
         root: '/apps/todos',
+        dependencies: [],
       },
     });
   });

--- a/packages/next/src/schematics/application/lib/add-project.ts
+++ b/packages/next/src/schematics/application/lib/add-project.ts
@@ -14,6 +14,7 @@ export function addProject(options: NormalizedSchema): Rule {
       options: {
         root: options.appProjectRoot,
         outputPath: join(normalize('dist'), options.appProjectRoot),
+        dependencies: [],
       },
       // This has to be here so `nx serve [app] --prod` will work. Otherwise
       // a missing configuration error will be thrown.

--- a/packages/next/src/utils/config.spec.ts
+++ b/packages/next/src/utils/config.spec.ts
@@ -72,6 +72,7 @@ describe('Next.js webpack config builder', () => {
           root: 'apps/wibble',
           outputPath: 'dist/apps/wibble',
           fileReplacements: [],
+          dependencies: [],
         },
         { workspaceRoot: '/root' } as any
       );

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -34,6 +34,7 @@ export interface NextBuildBuilderOptions extends JsonObject {
   root: string;
   outputPath: string;
   fileReplacements: FileReplacement[];
+  dependencies: string[];
 }
 
 export interface NextServeBuilderOptions extends JsonObject {


### PR DESCRIPTION
This commit should surface a new option `dependencies` in the builder.
We can pass an array of
package names to be taken from the root package.json and merged into the output of the build.

BREAKING CHANGE:
not sure – first time contributor :)

ISSUES CLOSED: 3062

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Right now we are producing a `package.json` with hard-coded dependencies when building a next.js app.

## Expected Behavior
This will surface a `dependencies` key in the configuration of the builder in order for the user to pass an optional list of dependencies to be taken from the root `package.json`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3062
