### PR TITLE
fix(linter): Using @typescript-eslint/no-unused-expressions instead

### DIFF
--- a/packages/react/src/utils/lint.ts
+++ b/packages/react/src/utils/lint.ts
@@ -108,14 +108,7 @@ export const reactEslintJson = {
     'no-restricted-globals': ['error'].concat(restrictedGlobals),
     'no-unexpected-multiline': 'warn',
     'no-unreachable': 'warn',
-    'no-unused-expressions': [
-      'error',
-      {
-        allowShortCircuit: true,
-        allowTernary: true,
-        allowTaggedTemplates: true,
-      },
-    ],
+    "no-unused-expressions": 'off',
     'no-unused-labels': 'warn',
     'no-useless-computed-key': 'warn',
     'no-useless-concat': 'warn',
@@ -260,5 +253,13 @@ export const reactEslintJson = {
     ],
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'warn',
+    '@typescript-eslint/no-unused-expressions': [
+      'error',
+      {
+        'allowShortCircuit': true,
+        'allowTernary': true,
+        'allowTaggedTemplates': true
+      }
+    ],
   },
 };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

optional chained function call shows lint errors.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
optional chained function calls should not show lint errors

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3296
