### PR TITLE
fix(core): create-nx-workspace preset and cli params should work with spaces

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -404,26 +404,25 @@ function createApp(
   interactive: boolean,
   defaultBase: string
 ) {
-  // creating the app itself
-  const args = [
-    name,
-    ...process.argv
-      .slice(parsedArgs._[2] ? 3 : 2)
-      .filter(
-        (a) =>
-          !a.startsWith('--cli') &&
-          !a.startsWith('--preset') &&
-          !a.startsWith('--appName') &&
-          !a.startsWith('--app-name') &&
-          !a.startsWith('--style') &&
-          !a.startsWith('--nxCloud') &&
-          !a.startsWith('--nx-cloud') &&
-          !a.startsWith('--interactive') &&
-          !a.startsWith('--defaultBase') &&
-          !a.startsWith('--default-base')
-      ) // not used by the new command
-      .map((a) => `"${a}"`),
-  ].join(' ');
+  const filterArgs = [
+    '_',
+    'app-name',
+    'appName',
+    'cli',
+    'default-base',
+    'defaultBase',
+    'interactive',
+    'nx-cloud',
+    'nxCloud',
+    'preset',
+    'style',
+  ];
+
+  // These are the arguments that are passed to the schematic
+  const args = Object.keys(parsedArgs)
+    .filter((key) => !filterArgs.includes(key))
+    .map((key) => `--${key}=${parsedArgs[key]}`)
+    .join(' ');
 
   const appNameArg = appName ? ` --appName="${appName}"` : ``;
   const styleArg = style ? ` --style="${style}"` : ``;
@@ -434,7 +433,7 @@ function createApp(
   const defaultBaseArg = defaultBase ? ` --defaultBase="${defaultBase}"` : ``;
 
   console.log(
-    `new ${args} --preset="${preset}"${appNameArg}${styleArg}${nxCloudArg}${interactiveArg}${defaultBaseArg} --collection=@nrwl/workspace`
+    `new ${name} ${args} --preset="${preset}"${appNameArg}${styleArg}${nxCloudArg}${interactiveArg}${defaultBaseArg} --collection=@nrwl/workspace`
   );
   const executablePath = path.join(tmpDir, 'node_modules', '.bin', cli.command);
   const collectionJsonPath = path.join(
@@ -445,7 +444,7 @@ function createApp(
     'collection.json'
   );
   execSync(
-    `"${executablePath}" new ${args} --preset="${preset}"${appNameArg}${styleArg}${nxCloudArg}${interactiveArg}${defaultBaseArg} --collection=${collectionJsonPath}`,
+    `"${executablePath}" new ${name} ${args} --preset="${preset}"${appNameArg}${styleArg}${nxCloudArg}${interactiveArg}${defaultBaseArg} --collection=${collectionJsonPath}`,
     {
       stdio: [0, 1, 2],
     }


### PR DESCRIPTION
Follow up on #3077 that I accidentally closed by pushing an empty commit.

Fixes #3059 

@vsavkin after doing some experimentation with the command and passing params `--preset=empty` and `--preset empty` I figured that all is configured well, it only adds these extra parameters to the `ng` command. 

Not sure if this is considered a good solution but it seems to fix the issue.
