### PR TITLE
feat(nest): update @nestjs/schematics dependency to 7

### DIFF
--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -35,6 +35,6 @@
     "@nrwl/node": "*",
     "@nrwl/jest": "*",
     "@angular-devkit/schematics": "~10.0.0",
-    "@nestjs/schematics": "^6.3.0"
+    "@nestjs/schematics": "^7.0.0"
   }
 }


### PR DESCRIPTION
## Current Behavior
The `@nrwl/nest` package depends on `@nestjs/schematics` v6.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `@nrwl/nest` package depends on `@nestjs/schematics` v7.


## Related Issue(s)

Nest deps got updated in #2921 and crossed paths with #2756. 