### PR TITLE
fix(angular): check for file to exist in decorate script

### DIFF
--- a/packages/workspace/src/schematics/utils/decorate-angular-cli.js__tmpl__
+++ b/packages/workspace/src/schematics/utils/decorate-angular-cli.js__tmpl__
@@ -63,7 +63,7 @@ function symlinkNgCLItoNxCLI() {
        * Such that it works in all shells and works with npx.
        */
       ['', '.cmd', '.ps1'].forEach(ext => {
-        fs.writeFileSync(ngPath + ext, fs.readFileSync(nxPath + ext));
+        if (fs.existsSync(nxPath + ext)) fs.writeFileSync(ngPath + ext, fs.readFileSync(nxPath + ext));
       });
     } else {
       // If unix-based, symlink


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running 'yarn' the error occurs on Windows:
```
NX ERROR Unable to create a symlink from the Angular CLI to the Nx CLI:ENOENT: no such file or directory, open './node_modules/.bin/nx.ps1'

NX ERROR Decoration of the Angular CLI did not complete successfully
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
No error

## Related Issue(s)
#3186 
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
Check for the file existence
