### PR TITLE
chore(repo): use commitizen config in commit linting

### DIFF
--- a/scripts/commit-lint.js
+++ b/scripts/commit-lint.js
@@ -32,9 +32,9 @@ if (exitCode === 0) {
   );
   console.log('\ntype(scope): subject \n BLANK LINE \n body');
   console.log('\n');
-  console.log('possible types: chore|build|feat|fix|cleanup|docs');
+  console.log(`possible types: ${allowedTypes.join('|')}`);
   console.log(
-    'possible scopes: angular|bazel|core|docs|nextjs|nest|linter|node|react|storybook|testing|repo|misc (if unsure use "core")'
+    `possible scopes: ${allowedScopes.join('|')} (if unsure use "core")`
   );
   console.log(
     '\nEXAMPLE: \n' +

--- a/scripts/commit-lint.js
+++ b/scripts/commit-lint.js
@@ -1,14 +1,21 @@
 #!/usr/bin/env node
 
+const { types, scopes } = require('../.cz-config.js');
+
 console.log('🐟🐟🐟 Validating git commit message 🐟🐟🐟');
 const gitMessage = require('child_process')
   .execSync('git log -1 --no-merges')
   .toString()
   .trim();
 
-const matchCommit = /(chore|feat|fix|cleanup|docs)\((angular|bazel|core|docs|nextjs|nest|linter|node|nx-plugin|react|storybook|testing|repo|misc)\):\s(([a-z0-9:\-\s])+)/g.test(
-  gitMessage
-);
+const allowedTypes = types.map((type) => type.value);
+const allowedScopes = scopes.map((scope) => scope.name);
+
+const commitMsgRegex = `(${allowedTypes.join('|')})\\((${allowedScopes.join(
+  '|'
+)})\\):\\s(([a-z0-9:\-\s])+)`;
+
+const matchCommit = new RegExp(commitMsgRegex, 'g').test(gitMessage);
 const matchRevert = /Revert/gi.test(gitMessage);
 const matchRelease = /Release/gi.test(gitMessage);
 const exitCode = +!(matchRelease || matchRevert || matchCommit);


### PR DESCRIPTION
Use the commitizen configuration during the commit linting process to be aware of any types/scope
moification without requiring additional changes in the commit lint script

ISSUES CLOSED: #3313

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Every change on the commitizen configuration related to types and scopes require hard-coded changes to the ./scripts/commit-lint.js file.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Whenever the commitizen configuration is changed regarding types and scopes, the commit-lint.js script should automatically use this configuration to lint the commit messages.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3313 
