### PR TITLE
fix(core): honor workspace layout with workspace move schematic

### DIFF
--- a/e2e/workspace/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace/src/workspace-aux-commands.test.ts
@@ -15,6 +15,8 @@ import {
   uniq,
   updateFile,
   workspaceConfigName,
+  setCurrentProjName,
+  runCreateWorkspace,
 } from '@nrwl/e2e/utils';
 
 forEachCli((cli) => {
@@ -727,6 +729,147 @@ forEachCli((cli) => {
        * Check that the import in lib2 has been updated
        */
       const lib2FilePath = `libs/${lib2}/ui/src/lib/${lib2}-ui.ts`;
+      const lib2File = readFile(lib2FilePath);
+      expect(lib2File).toContain(
+        `import { fromLibOne } from '@proj/shared/${lib1}/data-access';`
+      );
+    });
+
+    it('should work for custom workspace layouts', () => {
+      const lib1 = uniq('mylib');
+      const lib2 = uniq('mylib');
+      const lib3 = uniq('mylib');
+      newProject();
+
+      let nxJson = readJson('nx.json');
+      nxJson.workspaceLayout = { libsDir: 'packages' };
+      updateFile('nx.json', JSON.stringify(nxJson));
+
+      runCLI(`generate @nrwl/workspace:lib ${lib1}/data-access`);
+
+      updateFile(
+        `packages/${lib1}/data-access/src/lib/${lib1}-data-access.ts`,
+        `export function fromLibOne() { console.log('This is completely pointless'); }`
+      );
+
+      updateFile(
+        `packages/${lib1}/data-access/src/index.ts`,
+        `export * from './lib/${lib1}-data-access.ts'`
+      );
+
+      /**
+       * Create a library which imports a class from lib1
+       */
+
+      runCLI(`generate @nrwl/workspace:lib ${lib2}/ui`);
+
+      updateFile(
+        `packages/${lib2}/ui/src/lib/${lib2}-ui.ts`,
+        `import { fromLibOne } from '@proj/${lib1}/data-access';
+
+        export const fromLibTwo = () => fromLibOne(); }`
+      );
+
+      /**
+       * Create a library which has an implicit dependency on lib1
+       */
+
+      runCLI(`generate @nrwl/workspace:lib ${lib3}`);
+      nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+      nxJson.projects[lib3].implicitDependencies = [`${lib1}-data-access`];
+      updateFile(`nx.json`, JSON.stringify(nxJson));
+
+      /**
+       * Now try to move lib1
+       */
+
+      const moveOutput = runCLI(
+        `generate @nrwl/workspace:move --project ${lib1}-data-access shared/${lib1}/data-access`
+      );
+
+      expect(moveOutput).toContain(`DELETE packages/${lib1}/data-access`);
+      expect(exists(`packages/${lib1}/data-access`)).toBeFalsy();
+
+      const newPath = `packages/shared/${lib1}/data-access`;
+      const newName = `shared-${lib1}-data-access`;
+
+      const readmePath = `${newPath}/README.md`;
+      expect(moveOutput).toContain(`CREATE ${readmePath}`);
+      checkFilesExist(readmePath);
+
+      const jestConfigPath = `${newPath}/jest.config.js`;
+      expect(moveOutput).toContain(`CREATE ${jestConfigPath}`);
+      checkFilesExist(jestConfigPath);
+      const jestConfig = readFile(jestConfigPath);
+      expect(jestConfig).toContain(`name: 'shared-${lib1}-data-access'`);
+      expect(jestConfig).toContain(`preset: '../../../../jest.config.js'`);
+      expect(jestConfig).toContain(
+        `coverageDirectory: '../../../../coverage/${newPath}'`
+      );
+
+      const tsConfigPath = `${newPath}/tsconfig.json`;
+      expect(moveOutput).toContain(`CREATE ${tsConfigPath}`);
+      checkFilesExist(tsConfigPath);
+
+      const tsConfigLibPath = `${newPath}/tsconfig.lib.json`;
+      expect(moveOutput).toContain(`CREATE ${tsConfigLibPath}`);
+      checkFilesExist(tsConfigLibPath);
+      const tsConfigLib = readJson(tsConfigLibPath);
+      expect(tsConfigLib.compilerOptions.outDir).toEqual(
+        '../../../../dist/out-tsc'
+      );
+
+      const tsConfigSpecPath = `${newPath}/tsconfig.spec.json`;
+      expect(moveOutput).toContain(`CREATE ${tsConfigSpecPath}`);
+      checkFilesExist(tsConfigSpecPath);
+      const tsConfigSpec = readJson(tsConfigSpecPath);
+      expect(tsConfigSpec.compilerOptions.outDir).toEqual(
+        '../../../../dist/out-tsc'
+      );
+
+      const indexPath = `${newPath}/src/index.ts`;
+      expect(moveOutput).toContain(`CREATE ${indexPath}`);
+      checkFilesExist(indexPath);
+
+      const rootClassPath = `${newPath}/src/lib/${lib1}-data-access.ts`;
+      expect(moveOutput).toContain(`CREATE ${rootClassPath}`);
+      checkFilesExist(rootClassPath);
+
+      expect(moveOutput).toContain('UPDATE nx.json');
+      nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+      expect(nxJson.projects[`${lib1}-data-access`]).toBeUndefined();
+      expect(nxJson.projects[newName]).toEqual({
+        tags: [],
+      });
+      expect(nxJson.projects[lib3].implicitDependencies).toEqual([
+        `shared-${lib1}-data-access`,
+      ]);
+
+      expect(moveOutput).toContain('UPDATE tsconfig.base.json');
+      const rootTsConfig = readJson('tsconfig.base.json');
+      expect(
+        rootTsConfig.compilerOptions.paths[`@proj/${lib1}/data-access`]
+      ).toBeUndefined();
+      expect(
+        rootTsConfig.compilerOptions.paths[`@proj/shared/${lib1}/data-access`]
+      ).toEqual([`packages/shared/${lib1}/data-access/src/index.ts`]);
+
+      expect(moveOutput).toContain(`UPDATE ${workspace}.json`);
+      const workspaceJson = readJson(`${workspace}.json`);
+      expect(workspaceJson.projects[`${lib1}-data-access`]).toBeUndefined();
+      const project = workspaceJson.projects[newName];
+      expect(project).toBeTruthy();
+      expect(project.root).toBe(newPath);
+      expect(project.sourceRoot).toBe(`${newPath}/src`);
+      expect(project.architect.lint.options.tsConfig).toEqual([
+        `packages/shared/${lib1}/data-access/tsconfig.lib.json`,
+        `packages/shared/${lib1}/data-access/tsconfig.spec.json`,
+      ]);
+
+      /**
+       * Check that the import in lib2 has been updated
+       */
+      const lib2FilePath = `packages/${lib2}/ui/src/lib/${lib2}-ui.ts`;
       const lib2File = readFile(lib2FilePath);
       expect(lib2File).toContain(
         `import { fromLibOne } from '@proj/shared/${lib1}/data-access';`

--- a/packages/workspace/src/schematics/move/lib/check-destination.ts
+++ b/packages/workspace/src/schematics/move/lib/check-destination.ts
@@ -26,7 +26,7 @@ export function checkDestination(schema: Schema): Rule {
           );
         }
 
-        const destination = getDestination(schema, workspace);
+        const destination = getDestination(schema, workspace, tree);
 
         if (tree.getDir(destination).subfiles.length > 0) {
           throw new Error(`${INVALID_DESTINATION} - Path is not empty.`);

--- a/packages/workspace/src/schematics/move/lib/move-project.ts
+++ b/packages/workspace/src/schematics/move/lib/move-project.ts
@@ -16,7 +16,7 @@ export function moveProject(schema: Schema) {
       map((workspace) => {
         const project = workspace.projects.get(schema.projectName);
 
-        const destination = getDestination(schema, workspace);
+        const destination = getDestination(schema, workspace, tree);
         const dir = tree.getDir(project.root);
         dir.visit((file) => {
           const newPath = file.replace(project.root, destination);

--- a/packages/workspace/src/schematics/move/lib/update-cypress-json.ts
+++ b/packages/workspace/src/schematics/move/lib/update-cypress-json.ts
@@ -24,7 +24,7 @@ export function updateCypressJson(schema: Schema): Rule {
     return from(getWorkspace(tree)).pipe(
       map((workspace) => {
         const project = workspace.projects.get(schema.projectName);
-        const destination = getDestination(schema, workspace);
+        const destination = getDestination(schema, workspace, tree);
 
         const cypressJsonPath = path.join(destination, 'cypress.json');
 

--- a/packages/workspace/src/schematics/move/lib/update-imports.ts
+++ b/packages/workspace/src/schematics/move/lib/update-imports.ts
@@ -9,6 +9,7 @@ import { from, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Schema } from '../schema';
 import { normalizeSlashes } from './utils';
+import { ProjectType } from '@nrwl/workspace/src/utils/project-type';
 
 /**
  * Updates all the imports in the workspace and modifies the tsconfig appropriately.
@@ -20,6 +21,9 @@ export function updateImports(schema: Schema) {
     return from(getWorkspace(tree)).pipe(
       map((workspace) => {
         const nxJson = readJsonInTree<NxJson>(tree, 'nx.json');
+        const libsDir = nxJson.workspaceLayout?.libsDir
+          ? nxJson.workspaceLayout.libsDir
+          : 'libs';
         const project = workspace.projects.get(schema.projectName);
 
         if (project.extensions['projectType'] === 'application') {
@@ -29,7 +33,7 @@ export function updateImports(schema: Schema) {
 
         const projectRef = {
           from: normalizeSlashes(
-            `@${nxJson.npmScope}/${project.root.substr(5)}`
+            `@${nxJson.npmScope}/${project.root.substr(libsDir.length + 1)}`
           ),
           to: normalizeSlashes(`@${nxJson.npmScope}/${schema.destination}`),
         };
@@ -57,7 +61,7 @@ export function updateImports(schema: Schema) {
         }
 
         const projectRoot = {
-          from: project.root.substr(5),
+          from: project.root.substr(libsDir.length + 1),
           to: schema.destination,
         };
 

--- a/packages/workspace/src/schematics/move/lib/update-jest-config.ts
+++ b/packages/workspace/src/schematics/move/lib/update-jest-config.ts
@@ -19,7 +19,7 @@ export function updateJestConfig(schema: Schema): Rule {
     return from(getWorkspace(tree)).pipe(
       map((workspace) => {
         const project = workspace.projects.get(schema.projectName);
-        const destination = getDestination(schema, workspace);
+        const destination = getDestination(schema, workspace, tree);
         const newProjectName = getNewProjectName(schema.destination);
 
         const jestConfigPath = path.join(destination, 'jest.config.js');

--- a/packages/workspace/src/schematics/move/lib/update-project-root-files.ts
+++ b/packages/workspace/src/schematics/move/lib/update-project-root-files.ts
@@ -20,7 +20,7 @@ export function updateProjectRootFiles(schema: Schema): Rule {
     return from(getWorkspace(tree)).pipe(
       map((workspace) => {
         const project = workspace.projects.get(schema.projectName);
-        const destination = getDestination(schema, workspace);
+        const destination = getDestination(schema, workspace, tree);
 
         const newRelativeRoot = path
           .relative(path.join(appRootPath, destination), appRootPath)

--- a/packages/workspace/src/schematics/move/lib/update-workspace.ts
+++ b/packages/workspace/src/schematics/move/lib/update-workspace.ts
@@ -1,3 +1,4 @@
+import { SchematicContext, Tree } from '@angular-devkit/schematics';
 import { updateWorkspaceInTree } from '@nrwl/workspace';
 import { Schema } from '../schema';
 import { getDestination, getNewProjectName } from './utils';
@@ -12,38 +13,40 @@ import { getDestination, getNewProjectName } from './utils';
  * @param schema The options provided to the schematic
  */
 export function updateWorkspace(schema: Schema) {
-  return updateWorkspaceInTree((workspace) => {
-    const project = workspace.projects[schema.projectName];
-    const newProjectName = getNewProjectName(schema.destination);
+  return (tree: Tree, _context: SchematicContext) => {
+    return updateWorkspaceInTree((workspace) => {
+      const project = workspace.projects[schema.projectName];
+      const newProjectName = getNewProjectName(schema.destination);
 
-    // update root path refs in that project only
-    const oldProject = JSON.stringify(project);
-    const newProject = oldProject.replace(
-      new RegExp(project.root, 'g'),
-      getDestination(schema, workspace)
-    );
+      // update root path refs in that project only
+      const oldProject = JSON.stringify(project);
+      const newProject = oldProject.replace(
+        new RegExp(project.root, 'g'),
+        getDestination(schema, workspace, tree)
+      );
 
-    // rename
-    delete workspace.projects[schema.projectName];
-    workspace.projects[newProjectName] = JSON.parse(newProject);
+      // rename
+      delete workspace.projects[schema.projectName];
+      workspace.projects[newProjectName] = JSON.parse(newProject);
 
-    // update target refs
-    const strWorkspace = JSON.stringify(workspace);
-    workspace = JSON.parse(
-      strWorkspace.replace(
-        new RegExp(`${schema.projectName}:`, 'g'),
-        `${newProjectName}:`
-      )
-    );
+      // update target refs
+      const strWorkspace = JSON.stringify(workspace);
+      workspace = JSON.parse(
+        strWorkspace.replace(
+          new RegExp(`${schema.projectName}:`, 'g'),
+          `${newProjectName}:`
+        )
+      );
 
-    // update default project (if necessary)
-    if (
-      workspace.defaultProject &&
-      workspace.defaultProject === schema.projectName
-    ) {
-      workspace.defaultProject = newProjectName;
-    }
+      // update default project (if necessary)
+      if (
+        workspace.defaultProject &&
+        workspace.defaultProject === schema.projectName
+      ) {
+        workspace.defaultProject = newProjectName;
+      }
 
-    return workspace;
-  });
+      return workspace;
+    });
+  };
 }

--- a/packages/workspace/src/schematics/move/lib/utils.ts
+++ b/packages/workspace/src/schematics/move/lib/utils.ts
@@ -1,6 +1,27 @@
 import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
+import { Tree } from '@angular-devkit/schematics';
+import { NxJson } from '@nrwl/workspace/src/core/shared-interfaces';
+import { readJsonInTree } from '@nrwl/workspace/src/utils/ast-utils';
 import * as path from 'path';
 import { Schema } from '../schema';
+
+/**
+ * This helper function retrieves the users workspace layout from
+ * `nx.json`. If the user does not have this property defined then
+ * we assume the default `apps/` and `libs/` layout.
+ *
+ * @param host The host tree
+ */
+export function getWorkspaceLayout(
+  host: Tree
+): { appsDir?: string; libsDir?: string } {
+  const nxJson = readJsonInTree<NxJson>(host, 'nx.json');
+  const workspaceLayout = nxJson.workspaceLayout
+    ? nxJson.workspaceLayout
+    : { appsDir: 'apps', libsDir: 'libs' };
+
+  return workspaceLayout;
+}
 
 /**
  * This helper function ensures that we don't move libs or apps
@@ -14,7 +35,8 @@ import { Schema } from '../schema';
  */
 export function getDestination(
   schema: Schema,
-  workspace: WorkspaceDefinition | any
+  workspace: WorkspaceDefinition | any,
+  host: Tree
 ): string {
   const project = workspace.projects.get
     ? workspace.projects.get(schema.projectName)
@@ -23,9 +45,11 @@ export function getDestination(
     ? project.extensions['projectType']
     : project.projectType;
 
-  let rootFolder = 'libs';
+  const workspaceLayout = getWorkspaceLayout(host);
+
+  let rootFolder = workspaceLayout.libsDir;
   if (projectType === 'application') {
-    rootFolder = 'apps';
+    rootFolder = workspaceLayout.appsDir;
   }
   return path.join(rootFolder, schema.destination).split(path.sep).join('/');
 }


### PR DESCRIPTION
## Current Behavior
The `@nx/workspace:move` schematic does not check the users workspace layout configuration and assumes the `apps/` and `libs/` dir.

If the user manually updates their workspace layout and then attempts to use the `move` schematic then their preferences will be ignored.

If the user the user manually changes their workspace layout, generates a new application or library, and then attempts to use the `move` schematic on the newly generated project then an error is thrown. 

## Expected Behavior
As a user with a custom workspace layout, I should be able to use the `@nrwl/workspace:move` schematic.

## Related Issue

Fixes https://github.com/nrwl/nx/issues/3354