### PR TITLE
fix(react): fix differential loading in ES6 only Web/React apps

### DIFF
--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -297,8 +297,6 @@ forEachCli('nx', () => {
         `dist/apps/${appName}/runtime.js`,
         `dist/apps/${appName}/polyfills.esm.js`,
         `dist/apps/${appName}/main.esm.js`,
-        `dist/apps/${appName}/polyfills.es5.js`,
-        `dist/apps/${appName}/main.es5.js`,
       ];
       if (opts.checkStyles) {
         filesToCheck.push(`dist/apps/${appName}/styles.css`);

--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -40,8 +40,6 @@ forEachCli((currentCLIName) => {
         `dist/apps/${appName}/runtime.js`,
         `dist/apps/${appName}/polyfills.esm.js`,
         `dist/apps/${appName}/main.esm.js`,
-        `dist/apps/${appName}/polyfills.es5.js`,
-        `dist/apps/${appName}/main.es5.js`,
         `dist/apps/${appName}/styles.css`
       );
       expect(readFile(`dist/apps/${appName}/index.html`)).toContain(


### PR DESCRIPTION
## Current Behavior
Currently, creating a React app, that only supports modern browsers and does not require ES5 code transformations still produces an ES5 differential loading build and related HTML scripts for `--prod`

**.browserlistrc**
```
last 1 Chrome version
last 1 Firefox version
last 2 Edge major versions
last 2 Safari major version
last 2 iOS major versions
Firefox ESR
not IE 9-11
```

**index.html**
```html
  <script src="runtime.365178a7a0f8f038a0f1.js" type="module"></script>
  <script src="runtime.ea86ecefbed611ddfe95.js" nomodule defer></script>
  <script src="polyfills.c5c4fdadab70353ad788.esm.js" type="module"></script>
  <script src="polyfills.4e05765e8b625a625564.es5.js" nomodule defer></script>
  <script src="main.78d8d47626f700b652f7.esm.js" type="module"></script>
  <script src="main.b594145c3d1b9fb56209.es5.js" nomodule defer></script>
```

## Expected Behavior
With this aggressively modern browserlist config it should produce:

**.browserlistrc**
```
last 1 Chrome version
last 1 Firefox version
last 2 Edge major versions
last 2 Safari major version
last 2 iOS major versions
Firefox ESR
not IE 9-11
```

**index.html**
```html
  <script src="runtime.365178a7a0f8f038a0f1.js" type="module"></script>
  <script src="polyfills.c5c4fdadab70353ad788.esm.js" type="module"></script>
  <script src="main.78d8d47626f700b652f7.esm.js" type="module"></script>
```

This PR fixes the logic in `@nrwl/web/src/builders/build/build.impl.ts` to correctly produce only the modern build.

