### PR TITLE
feat(react): remove IE 11 from default config in React/Web Schematics

### DIFF
--- a/packages/react/src/schematics/application/files/app/.browserslistrc__tmpl__
+++ b/packages/react/src/schematics/application/files/app/.browserslistrc__tmpl__
@@ -7,6 +7,10 @@
 #
 # If you need to support different browsers in production, you may tweak the list below.
 
-> 0.2%
-not dead
-not op_mini all
+last 1 Chrome version
+last 1 Firefox version
+last 2 Edge major versions
+last 2 Safari major version
+last 2 iOS major versions
+Firefox ESR
+not IE 9-11 # For IE 9-11 support, remove 'not'.

--- a/packages/web/src/schematics/application/files/app/browserslist
+++ b/packages/web/src/schematics/application/files/app/browserslist
@@ -4,6 +4,10 @@
 #
 # If you need to support different browsers in production, you may tweak the list below.
 
-> 0.2%
-not dead
-not op_mini all
+last 1 Chrome version
+last 1 Firefox version
+last 2 Edge major versions
+last 2 Safari major version
+last 2 iOS major versions
+Firefox ESR
+not IE 9-11 # For IE 9-11 support, remove 'not'.


### PR DESCRIPTION
## Current Behavior
The current default `.browserlistrc` from generating a React application from `@nrwl/react` or `@nrwl/web` schematics looks like:

```
> 0.2%
not dead
not op_mini all
```

Which supports:
```
and_chr 81
and_ff 68
and_qq 10.4
and_uc 12.12
chrome 83
chrome 81
chrome 80
chrome 79
chrome 49
edge 18
firefox 77
firefox 76
ie 11
ios_saf 13.4-13.5
ios_saf 13.3
ios_saf 13.0-13.1
ios_saf 12.2-12.4
ios_saf 12.0-12.1
opera 68
safari 13.1
safari 13
safari 12.1
samsung 12.0
samsung 11.1-11.2
```

## Expected Behavior
This PR changes the default `.browserlistrc` to

```
last 1 Chrome version
last 1 Firefox version
last 2 Edge major versions
last 2 Safari major version
last 2 iOS major versions
Firefox ESR
not IE 9-11 # For IE 9-11 support, remove 'not'.
```

Which explicitly removes IE and limits the browser support to the more expected:

```
chrome 83
edge 83
edge 81
firefox 78
firefox 68
ios_saf 13.4-13.5
ios_saf 13.3
ios_saf 13.2
ios_saf 13.0-13.1
ios_saf 12.2-12.4
ios_saf 12.0-12.1
safari 13.1
safari 13
safari 12.1
safari 12
```

