### PR TITLE
fix(angular): check for spec files when generating a library

### DIFF
--- a/packages/angular/src/schematics/library/lib/update-project.ts
+++ b/packages/angular/src/schematics/library/lib/update-project.ts
@@ -26,11 +26,26 @@ export function updateProject(options: NormalizedSchema): Rule {
   return chain([
     (host: Tree, _context: SchematicContext): Tree => {
       const libRoot = `${options.projectRoot}/src/lib/`;
+      const serviceSpecPath = path.join(
+        libRoot,
+        `${options.name}.service.spec.ts`
+      );
+      const componentSpecPath = path.join(
+        libRoot,
+        `${options.name}.component.spec.ts`
+      );
 
       host.delete(path.join(libRoot, `${options.name}.service.ts`));
-      host.delete(path.join(libRoot, `${options.name}.service.spec.ts`));
+
+      if (host.exists(serviceSpecPath)) {
+        host.delete(serviceSpecPath);
+      }
+
       host.delete(path.join(libRoot, `${options.name}.component.ts`));
-      host.delete(path.join(libRoot, `${options.name}.component.spec.ts`));
+
+      if (host.exists(componentSpecPath)) {
+        host.delete(path.join(libRoot, `${options.name}.component.spec.ts`));
+      }
 
       if (!options.publishable) {
         host.delete(path.join(options.projectRoot, 'ng-package.json'));


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Generating a library that defaults to spec files not being generated fails.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generating a library that defaults to spec files not being generated completes successfully.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3286 
