### PR TITLE
feat(core): add text filtering to dep-graph visualization

### DIFF
--- a/packages/workspace/src/core/dep-graph/dep-graph.css
+++ b/packages/workspace/src/core/dep-graph/dep-graph.css
@@ -253,3 +253,12 @@ g.affected ellipse {
   align-items: center;
   justify-content: center;
 }
+
+#textFilterInput {
+  flex: 1;
+  margin-right: 1.5em;
+}
+
+#textFilterButton {
+  flex: none;
+}

--- a/packages/workspace/src/core/dep-graph/dep-graph.html
+++ b/packages/workspace/src/core/dep-graph/dep-graph.html
@@ -45,6 +45,21 @@
             group by folder
           </label>
         </div>
+        <div class="sidebar-section">
+          <div class="flex">
+            <input id="textFilterInput" type="text" name="filter" />
+            <button id="textFilterButton">Filter</button>
+          </div>
+
+          <label>
+            <input
+              type="checkbox"
+              name="textFilterCheckbox"
+              value="includeInPath"
+            />
+            include projects in path
+          </label>
+        </div>
         <div id="project-lists"></div>
       </div>
     </div>
@@ -136,7 +151,7 @@
     window.graph = null;
     window.affected = null;
     window.focusedProject = null;
-    window.filteredProjects = null;
+    window.filteredProjects = [];
     window.groupByFolder = null;
     window.exclude = null;
   </script>

--- a/packages/workspace/src/core/dep-graph/dep-graph.js
+++ b/packages/workspace/src/core/dep-graph/dep-graph.js
@@ -496,6 +496,56 @@ window.filterProjects = () => {
   render();
 };
 
+function listenForTextFilterChanges() {
+  const textFilterInput = document.getElementById('textFilterInput');
+  const textFilterButton = document.getElementById('textFilterButton');
+
+  textFilterButton.addEventListener('click', () => {
+    filterProjectsByText(textFilterInput.value.toLowerCase());
+  });
+
+  textFilterInput.addEventListener('keyup', (event) => {
+    if (event.key === 'Enter') {
+      filterProjectsByText(textFilterInput.value.toLowerCase());
+    }
+  });
+}
+
+function filterProjectsByText(text) {
+  const checkboxes = Array.from(
+    document.querySelectorAll('input[name=projectName]')
+  );
+
+  checkboxes.forEach((checkbox) => (checkbox.checked = false));
+
+  const split = text.split(',').map((splitItem) => splitItem.trim());
+
+  const matchedProjects = checkboxes
+    .map((checkbox) => checkbox.value)
+    .filter(
+      (project) =>
+        split.findIndex((splitItem) => project.includes(splitItem)) > -1
+    );
+
+  const includeInPath = document.querySelector('input[name=textFilterCheckbox]')
+    .checked;
+
+  matchedProjects.forEach((project) => {
+    checkboxes.forEach((checkbox) => {
+      if (
+        checkbox.value === project ||
+        (includeInPath &&
+          (hasPath(project, checkbox.value, []) ||
+            hasPath(checkbox.value, project, [])))
+      ) {
+        checkbox.checked = true;
+      }
+    });
+  });
+
+  window.filterProjects();
+}
+
 setTimeout(() => {
   addProjectCheckboxes();
   checkForAffected();
@@ -519,6 +569,8 @@ setTimeout(() => {
   if (window.exclude.length > 0) {
     window.exclude.forEach((project) => excludeProject(project, false));
   }
+
+  listenForTextFilterChanges();
 
   filterProjects();
 });


### PR DESCRIPTION
## Current Behavior
Users may only focus or include/exclude projects using UI elements

## Expected Behavior
Users may include/exclude projects by entering a comma-separated list into a text search field. Optionally, users may choose to include all projects in the path of the matched projects.

