### PR TITLE
fix(angular): allow for existing .prettierignore when adding Nx

### DIFF
--- a/packages/workspace/src/schematics/init/init.spec.ts
+++ b/packages/workspace/src/schematics/init/init.spec.ts
@@ -228,6 +228,63 @@ describe('workspace', () => {
       expect(tree.exists('/apps/myApp/karma.conf.js')).toBe(true);
       expect(tree.exists('/karma.conf.js')).toBe(true);
     });
+
+    it('should work with existing .prettierignore file', async () => {
+      appTree.create('/package.json', JSON.stringify({}));
+      appTree.create('/.prettierignore', '# existing ignore rules');
+      appTree.create(
+        '/angular.json',
+        JSON.stringify({
+          version: 1,
+          defaultProject: 'myApp',
+          projects: {
+            myApp: {
+              root: '',
+              sourceRoot: 'src',
+              architect: {
+                build: {
+                  options: {
+                    tsConfig: 'tsconfig.app.json',
+                  },
+                  configurations: {},
+                },
+                test: {
+                  options: {
+                    tsConfig: 'tsconfig.spec.json',
+                  },
+                },
+                lint: {
+                  options: {
+                    tsConfig: 'tsconfig.app.json',
+                  },
+                },
+                e2e: {
+                  options: {
+                    protractorConfig: 'e2e/protractor.conf.js',
+                  },
+                },
+              },
+            },
+          },
+        })
+      );
+      appTree.create(
+        '/tsconfig.app.json',
+        '{"extends": "../tsconfig.json", "compilerOptions": {}}'
+      );
+      appTree.create(
+        '/tsconfig.spec.json',
+        '{"extends": "../tsconfig.json", "compilerOptions": {}}'
+      );
+      appTree.create('/tsconfig.base.json', '{"compilerOptions": {}}');
+      appTree.create('/tslint.json', '{"rules": {}}');
+      appTree.create('/e2e/protractor.conf.js', '// content');
+      appTree.create('/src/app/app.module.ts', '// content');
+      const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
+
+      const prettierIgnore = tree.read('/.prettierignore').toString();
+      expect(prettierIgnore).toBe('# existing ignore rules');
+    });
   });
 
   describe('preserve angular cli layout', () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `ng add @nrwl/workspace` in an Angular CLI workspace with an existing .prettierignore causes an error

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `ng add @nrwl/workspace` in an Angular CLI workspace with an existing .prettierignore continues without error

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3192 
