### PR TITLE
fix(angular): use isObservable to prevent errors due to rxjs version …

### DIFF
--- a/packages/angular/src/runtime/nx/data-persistence.ts
+++ b/packages/angular/src/runtime/nx/data-persistence.ts
@@ -3,7 +3,7 @@ import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { Actions, ofType } from '@ngrx/effects';
 import { ROUTER_NAVIGATION, RouterNavigationAction } from '@ngrx/router-store';
 import { Action, Store, ActionCreator } from '@ngrx/store';
-import { Observable, of } from 'rxjs';
+import { isObservable, Observable, of } from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -436,7 +436,7 @@ function findSnapshot(
 }
 
 function wrapIntoObservable<O>(obj: Observable<O> | O | void): Observable<O> {
-  if (!!obj && obj instanceof Observable) {
+  if (isObservable(obj)) {
     return obj;
   } else if (!obj) {
     return of();


### PR DESCRIPTION
…mismatch

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Having multiple copies of `rxjs` in `node_modules` will cause `wrapInObservable` to not wrap observables and cause `Effects` to complain.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`wrapInObservable` will be able to accurately determine that an `Observable` from another copy of `rxjs` is an observable and  wrap it appropriately.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
