### PR TITLE
feat(core): add cwd and outputPath options for run-commands schematic

### DIFF
--- a/docs/angular/api-workspace/schematics/run-commands.md
+++ b/docs/angular/api-workspace/schematics/run-commands.md
@@ -42,11 +42,23 @@ Type: `string`
 
 Command to run
 
+### cwd
+
+Type: `string`
+
+Current working directory of the command
+
 ### name
 
 Type: `string`
 
 Target name
+
+### outputs
+
+Type: `string`
+
+Comma-separated list of output paths
 
 ### project
 

--- a/docs/react/api-workspace/schematics/run-commands.md
+++ b/docs/react/api-workspace/schematics/run-commands.md
@@ -42,11 +42,23 @@ Type: `string`
 
 Command to run
 
+### cwd
+
+Type: `string`
+
+Current working directory of the command
+
 ### name
 
 Type: `string`
 
 Target name
+
+### outputs
+
+Type: `string`
+
+Comma-separated list of output paths
 
 ### project
 

--- a/packages/workspace/src/schematics/run-commands/run-commands.spec.ts
+++ b/packages/workspace/src/schematics/run-commands/run-commands.spec.ts
@@ -14,14 +14,22 @@ describe('run-commands', () => {
   it('should generate files', async () => {
     const tree = await runSchematic(
       'run-commands',
-      { name: 'custom', project: 'lib', command: 'echo 1' },
+      {
+        name: 'custom',
+        project: 'lib',
+        command: 'echo 1',
+        cwd: '/packages/foo',
+        outputs: '/dist/a, /dist/b, /dist/c',
+      },
       appTree
     );
     const workspaceJson = readJsonInTree(tree, '/workspace.json');
     expect(workspaceJson.projects['lib'].architect['custom']).toEqual({
       builder: '@nrwl/workspace:run-commands',
+      outputs: ['/dist/a', '/dist/b', '/dist/c'],
       options: {
         command: 'echo 1',
+        cwd: '/packages/foo',
       },
     });
   });

--- a/packages/workspace/src/schematics/run-commands/run-commands.ts
+++ b/packages/workspace/src/schematics/run-commands/run-commands.ts
@@ -11,8 +11,12 @@ export default function (schema: Schema): Rule {
     project.architect = project.architect || {};
     project.architect[schema.name] = {
       builder: '@nrwl/workspace:run-commands',
+      outputs: schema.outputs
+        ? schema.outputs.split(',').map((s) => s.trim())
+        : [],
       options: {
         command: schema.command,
+        cwd: schema.cwd,
       },
     };
     return json;

--- a/packages/workspace/src/schematics/run-commands/schema.d.ts
+++ b/packages/workspace/src/schematics/run-commands/schema.d.ts
@@ -2,4 +2,6 @@ export interface Schema {
   name: string;
   command: string;
   project: string;
+  cwd?: string;
+  outputs?: string;
 }

--- a/packages/workspace/src/schematics/run-commands/schema.json
+++ b/packages/workspace/src/schematics/run-commands/schema.json
@@ -28,6 +28,14 @@
       "description": "Command to run",
       "type": "string",
       "x-prompt": "What command would you like to run?"
+    },
+    "cwd": {
+      "description": "Current working directory of the command",
+      "type": "string"
+    },
+    "outputs": {
+      "description": "Comma-separated list of output paths",
+      "type": "string"
     }
   },
   "required": ["name", "command", "project"]


### PR DESCRIPTION
This PR adds `cwd` and `outputs` options to the `@nrwl/workspace:run-commands` schematic.

**Why?** This is useful for things like migrating [CRA to Nx](https://github.com/jaysoo/migrate-cra-to-nx/blob/main/MIGRATION.md).