### PR TITLE
fix(testing): resolve jestconfig and add globals.ts-jest if needed for migration

### DIFF
--- a/packages/jest/index.ts
+++ b/packages/jest/index.ts
@@ -2,7 +2,4 @@ export {
   addPropertyToJestConfig,
   removePropertyFromJestConfig,
 } from './src/utils/config/update-config';
-export {
-  jestConfigObjectAst,
-  jestConfigObject,
-} from './src/utils/config/functions';
+export { jestConfigObjectAst } from './src/utils/config/functions';

--- a/packages/jest/src/migrations/update-10-0-0/require-jest-config.ts
+++ b/packages/jest/src/migrations/update-10-0-0/require-jest-config.ts
@@ -1,0 +1,4 @@
+// export so that we can mock this return value
+export function getJestObject(path: string) {
+  return require(path);
+}

--- a/packages/jest/src/migrations/update-10-0-0/update-jest-configs.spec.ts
+++ b/packages/jest/src/migrations/update-10-0-0/update-jest-configs.spec.ts
@@ -5,8 +5,6 @@ import * as path from 'path';
 import { serializeJson } from '@nrwl/workspace';
 import { jestConfigObject } from '../../utils/config/functions';
 
-import { updateJestConfigForProjects } from './update-jest-configs';
-
 import { getJestObject } from './require-jest-config';
 jest.mock('./require-jest-config');
 const getJestObjectMock = getJestObject as jest.Mock<typeof getJestObject>;

--- a/packages/jest/src/migrations/update-10-0-0/update-jest-configs.spec.ts
+++ b/packages/jest/src/migrations/update-10-0-0/update-jest-configs.spec.ts
@@ -3,45 +3,62 @@ import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
 import * as path from 'path';
 import { serializeJson } from '@nrwl/workspace';
-import { jestConfigObject } from '../../..';
+import { jestConfigObject } from '../../utils/config/functions';
+
+import { updateJestConfigForProjects } from './update-jest-configs';
+
+import { getJestObject } from './require-jest-config';
+jest.mock('./require-jest-config');
+const getJestObjectMock = getJestObject as jest.Mock<typeof getJestObject>;
+
+const ngJestObject = {
+  name: 'test-jest',
+  preset: '../../jest.config.js',
+  coverageDirectory: '../../coverage/libs/test-jest',
+  globals: {
+    'existing-global': 'test',
+  },
+  snapshotSerializers: [
+    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
+    'jest-preset-angular/build/AngularSnapshotSerializer.js',
+    'jest-preset-angular/build/HTMLCommentSerializer.js',
+  ],
+};
+
+const reactJestObject = {
+  name: 'my-react-app',
+  preset: '../../jest.config.js',
+  transform: {
+    '^(?!.*\\\\.(js|jsx|ts|tsx|css|json)$)': '@nrwl/react/plugins/jest',
+    '^.+\\\\.[tj]sx?$': [
+      'babel-jest',
+      { cwd: __dirname, configFile: './babel-jest.config.json' },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+  coverageDirectory: '../../coverage/apps/my-react-app',
+};
 
 describe('update 10.0.0', () => {
   let initialTree: Tree;
   let schematicRunner: SchematicTestRunner;
-
   const jestConfig = String.raw`
-    module.exports = {    
-      name: 'test-jest',
-      preset: '../../jest.config.js',
-      coverageDirectory: '../../coverage/libs/test-jest',
-      globals: {
-        "existing-global": "test"
-      },
-      snapshotSerializers: [
-        'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
-        'jest-preset-angular/build/AngularSnapshotSerializer.js',
-        'jest-preset-angular/build/HTMLCommentSerializer.js'
-      ]
-    }
+    module.exports = ${JSON.stringify(ngJestObject)}
   `;
 
   const jestConfigReact = String.raw`
-  module.exports = {    
-      name: 'my-react-app',
-      preset: '../../jest.config.js',
-      transform: {
-        '^(?!.*\\\\.(js|jsx|ts|tsx|css|json)$)': '@nrwl/react/plugins/jest',
-        '^.+\\\\.[tj]sx?$': [
-          'babel-jest',
-          { cwd: __dirname, configFile: './babel-jest.config.json' }
-        ]
-      },
-      moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
-      coverageDirectory: '../../coverage/apps/my-react-app'
-    }
+  module.exports = ${JSON.stringify(reactJestObject)}
   `;
 
   beforeEach(() => {
+    getJestObjectMock.mockImplementation((path: string): any => {
+      if (path.includes('apps/products')) {
+        return ngJestObject;
+      } else if (path.includes('apps/cart')) {
+        return reactJestObject;
+      }
+    });
+
     initialTree = createEmptyWorkspace(Tree.empty());
 
     initialTree.create('apps/products/jest.config.js', jestConfig);

--- a/packages/jest/src/migrations/update-10-0-0/update-jest-configs.ts
+++ b/packages/jest/src/migrations/update-10-0-0/update-jest-configs.ts
@@ -13,6 +13,7 @@ import {
 } from '@nrwl/workspace';
 import { addPropertyToJestConfig } from '../../utils/config/update-config';
 import { getJestObject } from './require-jest-config';
+import { appRootPath } from '@nrwl/workspace/src/utils/app-root';
 
 function checkJestPropertyObject(object: unknown): object is object {
   return object !== null && object !== undefined;
@@ -43,7 +44,7 @@ function modifyJestConfig(
   }
 
   try {
-    const jestObject = getJestObject(jestConfig);
+    const jestObject = getJestObject(`${appRootPath}/${jestConfig}`);
 
     if (setupFile !== '') {
       // add set up env file

--- a/packages/jest/src/migrations/update-10-0-0/update-jest-configs.ts
+++ b/packages/jest/src/migrations/update-10-0-0/update-jest-configs.ts
@@ -115,7 +115,7 @@ function modifyJestConfig(
   }
 }
 
-export function updateJestConfigForProjects() {
+function updateJestConfigForProjects() {
   return async (host: Tree, context: SchematicContext) => {
     const workspace = await getWorkspace(host, getWorkspacePath(host));
 

--- a/packages/jest/src/schematics/jest-project/files/jest.config.js__tmpl__
+++ b/packages/jest/src/schematics/jest-project/files/jest.config.js__tmpl__
@@ -1,8 +1,7 @@
 module.exports = {
   name: '<%= project %>',
   preset: '<%= offsetFromRoot %>jest.config.js',<% if(setupFile !== 'none') { %>
-  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-  <% } %><% if (transformer === 'ts-jest') { %>
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],<% } %><% if (transformer === 'ts-jest') { %>
   globals: {
     'ts-jest': {
       tsConfig: '<rootDir>/tsconfig.spec.json',<%if (setupFile === 'angular') { %>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If a jest config has a require statement, or anything that's not a primitive JavaScript value in it, the migration will fail.

## Expected Behavior
We now `require()` the config so that node can resolve the values. 

Also adds `globals.ts-jest` to set the tsconfig even if there is no setupFile.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
