### PR TITLE
fix(angular): show a nicer error when running nx in an angular workspace

### DIFF
--- a/packages/cli/lib/init-global.ts
+++ b/packages/cli/lib/init-global.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import * as fs from 'fs';
 import * as path from 'path';
 import { findWorkspaceRoot } from './find-workspace-root';
 import { output } from './output';
@@ -11,14 +12,34 @@ export function initGlobal() {
 
   if (workspace) {
     // Found a workspace root - hand off to the local copy of Nx
-    require(path.join(
+    const localNx = path.join(
       workspace.dir,
       'node_modules',
       '@nrwl',
       'cli',
       'bin',
       'nx.js'
-    ));
+    );
+    if (fs.existsSync(localNx)) {
+      require(localNx);
+    } else {
+      if (fs.existsSync(path.join(workspace.dir, 'node_modules'))) {
+        output.error({
+          title: `Could not find Nx in this workspace.`,
+          bodyLines: [
+            `To convert an Angular workspace to Nx run: ${chalk.bold.white(
+              `ng add @nrwl/workspace`
+            )}`,
+          ],
+        });
+      } else {
+        output.error({
+          title: `Could not find a node_modules folder in this workspace.`,
+          bodyLines: [`Have you run ${chalk.bold.white(`npm/yarn install`)}?`],
+        });
+      }
+      process.exit(1);
+    }
   } else {
     output.log({
       title: `The current directory isn't part of an Nx workspace.`,


### PR DESCRIPTION
Adds a slightly nicer error when we run in an Angular workspace by accident:

<img width="577" alt="Screenshot 2020-07-24 at 10 11 57" src="https://user-images.githubusercontent.com/439121/88376878-27846d00-cd96-11ea-8c8d-30b507df6a3e.png">


Fixes #2021 
