### PR TITLE
fix(core): migrate implicitDependencies that reference tsconfig.json

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,7 +6,7 @@
       "dependencies": "*",
       "devDependencies": "*"
     },
-    "tsconfig.json": "*",
+    "tsconfig.base.json": "*",
     "tslint.json": "*",
     "nx.json": "*"
   },

--- a/packages/workspace/src/migrations/update-10-0-0/solution-tsconfigs.spec.ts
+++ b/packages/workspace/src/migrations/update-10-0-0/solution-tsconfigs.spec.ts
@@ -8,6 +8,14 @@ describe('Solution Tsconfigs Migration', () => {
   beforeEach(async () => {
     tree = Tree.empty();
     tree = await callRule(
+      updateJsonInTree('nx.json', () => ({
+        implicitDependencies: {
+          'tsconfig.json': '*',
+        },
+      })),
+      tree
+    );
+    tree = await callRule(
       updateJsonInTree('tsconfig.json', () => ({
         compilerOptions: {
           target: 'es2015',
@@ -52,6 +60,16 @@ describe('Solution Tsconfigs Migration', () => {
     const result = await runMigration('solution-tsconfigs', {}, tree);
     expect(result.exists('tsconfig.base.json')).toEqual(true);
     expect(result.exists('tsconfig.json')).toEqual(false);
+  });
+
+  it('should update implicit dependencies on tsconfig.json', async () => {
+    const result = await runMigration('solution-tsconfigs', {}, tree);
+    const json = readJsonInTree(result, 'nx.json');
+    expect(json).toEqual({
+      implicitDependencies: {
+        'tsconfig.base.json': '*',
+      },
+    });
   });
 
   it('should update tsconfig.base.json', async () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

implicit dependencies on `tsconfig.json` are not migrated to point to `tsconfig.base.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

implicit dependencies on `tsconfig.json` are migrated to point to `tsconfig.base.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
