### PR TITLE
fix(nx-plugin): add plugin under directory option

### DIFF
--- a/packages/nx-plugin/src/schematics/e2e-project/e2e.spec.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/e2e.spec.ts
@@ -1,11 +1,6 @@
 import { Tree } from '@angular-devkit/schematics';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
-import {
-  updateWorkspace,
-  readJsonInTree,
-  readWorkspace,
-  getWorkspace,
-} from '@nrwl/workspace';
+import { updateWorkspace, readWorkspace, getWorkspace } from '@nrwl/workspace';
 import { runSchematic } from '../../utils/testing';
 
 describe('NxPlugin e2e-project', () => {
@@ -58,6 +53,22 @@ describe('NxPlugin e2e-project', () => {
     expect(
       tree.exists('apps/my-plugin-e2e/tests/my-plugin.test.ts')
     ).toBeTruthy();
+  });
+
+  it('should set project root with the directory option', async () => {
+    const tree = await runSchematic(
+      'e2e-project',
+      {
+        pluginName: 'my-plugin',
+        pluginOutputPath: `dist/libs/namespace/my-plugin`,
+        npmPackageName: '@proj/namespace-my-plugin',
+        projectDirectory: 'namespace/my-plugin',
+      },
+      appTree
+    );
+    const workspace = await readWorkspace(tree);
+    const project = workspace.projects['my-plugin-e2e'];
+    expect(project.root).toBe('apps/namespace/my-plugin-e2e');
   });
 
   it('should update the nxJson', async () => {

--- a/packages/nx-plugin/src/schematics/e2e-project/lib/normalize-options.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/lib/normalize-options.ts
@@ -5,12 +5,24 @@ import { appsDir } from '@nrwl/workspace/src/utils/ast-utils';
 import { join } from 'path';
 import { NxPluginE2ESchema, Schema } from '../schema';
 
+function normalizeProjectRoot(
+  host: Tree,
+  options: Schema,
+  projectName: string
+) {
+  const { projectDirectory } = options;
+  if (!projectDirectory) {
+    return join(normalize(appsDir(host)), projectName);
+  }
+  return join(normalize(appsDir(host)), `${projectDirectory}-e2e`);
+}
+
 export function normalizeOptions(
   host: Tree,
   options: Schema
 ): NxPluginE2ESchema {
   const projectName = `${options.pluginName}-e2e`;
-  const projectRoot = join(normalize(appsDir(host)), projectName);
+  const projectRoot = normalizeProjectRoot(host, options, projectName);
   const npmScope = readNxJsonInTree(host).npmScope;
   const pluginPropertyName = toPropertyName(options.pluginName);
   return {

--- a/packages/nx-plugin/src/schematics/e2e-project/schema.d.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/schema.d.ts
@@ -1,5 +1,6 @@
 export interface Schema {
   pluginName: string;
+  projectDirectory: string;
   npmPackageName: string;
   pluginOutputPath: string;
   jestConfig: string;

--- a/packages/nx-plugin/src/schematics/e2e-project/schema.json
+++ b/packages/nx-plugin/src/schematics/e2e-project/schema.json
@@ -5,7 +5,11 @@
   "properties": {
     "pluginName": {
       "type": "string",
-      "description": "the name of the pluging to be tested"
+      "description": "the name of the plugin to be tested"
+    },
+    "projectDirectory": {
+      "type": "string",
+      "description": "the directory where the plugin is placed"
     },
     "npmPackageName": {
       "type": "string",

--- a/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
@@ -65,6 +65,23 @@ describe('NxPlugin plugin', () => {
     });
   });
 
+  it('should place the plugin in a directory', async () => {
+    const tree = await runSchematic(
+      'plugin',
+      {
+        name: 'myPlugin',
+        directory: 'plugins',
+        importPath: '@project/plugins-my-plugin',
+      },
+      appTree
+    );
+    const workspace = await readWorkspace(tree);
+    const project = workspace.projects['plugins-my-plugin'];
+    const projectE2e = workspace.projects['plugins-my-plugin-e2e'];
+    expect(project.root).toEqual('libs/plugins/my-plugin');
+    expect(projectE2e.root).toEqual('apps/plugins/my-plugin-e2e');
+  });
+
   it('should update the tsconfig.lib.json file', async () => {
     const tree = await runSchematic(
       'plugin',

--- a/packages/nx-plugin/src/schematics/plugin/plugin.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.ts
@@ -12,10 +12,10 @@ import { addFiles } from './lib/add-files';
 import { normalizeOptions } from './lib/normalize-options';
 import { updateTsConfig } from './lib/update-tsconfig';
 import { updateWorkspaceJson } from './lib/update-workspace-json';
-import { NormalizedSchema } from './schema';
+import { Schema } from './schema';
 
-export default function (schema: NormalizedSchema): Rule {
-  return (host: Tree) => {
+export default function (schema: Schema): Rule {
+  return (host: Tree, context: SchematicContext) => {
     const options = normalizeOptions(host, schema);
 
     return chain([
@@ -30,6 +30,7 @@ export default function (schema: NormalizedSchema): Rule {
       updateTsConfig(options),
       schematic('e2e-project', {
         pluginName: options.name,
+        projectDirectory: options.projectDirectory,
         pluginOutputPath: `dist/${libsDir(host)}/${options.projectDirectory}`,
         npmPackageName: options.npmPackageName,
       }),


### PR DESCRIPTION
`nx generate @nrwl/nx-plugin:plugin` is not respecting directory option for e2e app

ISSUES CLOSED: #3347

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Discussed in issue

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Discussed in issue

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3347
