### PR TITLE
fix(core): migrate tsconfig references in eslintrc

### DIFF
--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -99,6 +99,11 @@
       "version": "10.0.0-beta.0",
       "description": "Migrate tsconfigs to solution style tsconfigs",
       "factory": "./src/migrations/update-10-0-0/solution-tsconfigs"
+    },
+    "migrate-eslintrc-tsconfig": {
+      "version": "10.0.1-beta.0",
+      "description": "Migrate .eslintrc files to reference new tsconfig",
+      "factory": "./src/migrations/update-10-0-1/migrate-eslintrc"
     }
   },
   "packageJsonUpdates": {

--- a/packages/workspace/src/migrations/update-10-0-1/migrate-eslintrc.spec.ts
+++ b/packages/workspace/src/migrations/update-10-0-1/migrate-eslintrc.spec.ts
@@ -1,0 +1,53 @@
+import { Tree } from '@angular-devkit/schematics';
+import { callRule, runMigration } from '../../utils/testing';
+import { readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
+
+describe('Eslintrc Migration', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = Tree.empty();
+    tree = await callRule(
+      updateJsonInTree('.eslintrc', () => ({
+        parserOptions: {
+          project: './tsconfig.json',
+        },
+      })),
+      tree
+    );
+    tree = await callRule(
+      updateJsonInTree('project1/.eslintrc', () => ({
+        parserOptions: {
+          project: '../tsconfig.json',
+        },
+      })),
+      tree
+    );
+    tree = await callRule(
+      updateJsonInTree('project2/.eslintrc', () => ({
+        parserOptions: {
+          project: './tsconfig.json',
+        },
+      })),
+      tree
+    );
+  });
+
+  it('should reference tsconfig.base.json', async () => {
+    const result = await runMigration('migrate-eslintrc-tsconfig', {}, tree);
+    const eslintrc = readJsonInTree(result, '.eslintrc');
+    expect(eslintrc.parserOptions.project).toEqual('./tsconfig.base.json');
+  });
+
+  it('should reference tsconfig.base.json from .eslintrc files not in the root', async () => {
+    const result = await runMigration('migrate-eslintrc-tsconfig', {}, tree);
+    const eslintrc = readJsonInTree(result, 'project1/.eslintrc');
+    expect(eslintrc.parserOptions.project).toEqual('../tsconfig.base.json');
+  });
+
+  it("should reference tsconfig.base.json in .eslintrc that don't reference the root tsconfig.json", async () => {
+    const result = await runMigration('migrate-eslintrc-tsconfig', {}, tree);
+    const eslintrc = readJsonInTree(result, 'project2/.eslintrc');
+    expect(eslintrc.parserOptions.project).toEqual('./tsconfig.json');
+  });
+});

--- a/packages/workspace/src/migrations/update-10-0-1/migrate-eslintrc.ts
+++ b/packages/workspace/src/migrations/update-10-0-1/migrate-eslintrc.ts
@@ -1,0 +1,31 @@
+import { basename, dirname, join } from '@angular-devkit/core';
+import { chain, Rule } from '@angular-devkit/schematics';
+import { formatFiles, updateJsonInTree } from '@nrwl/workspace';
+import { visitNotIgnoredFiles } from '../../utils/rules/visit-not-ignored-files';
+
+export default function (schema: any): Rule {
+  return chain([
+    visitNotIgnoredFiles((file, host, context) => {
+      if (basename(file) !== '.eslintrc') {
+        return;
+      }
+
+      return updateJsonInTree(file, (json) => {
+        const tsconfig = json?.parserOptions?.project;
+        if (tsconfig) {
+          const tsconfigPath = join(dirname(file), tsconfig);
+          if (tsconfigPath === 'tsconfig.json') {
+            json.parserOptions.project = json.parserOptions.project.replace(
+              /tsconfig.json$/,
+              'tsconfig.base.json'
+            );
+          }
+          return json;
+        } else {
+          return json;
+        }
+      });
+    }),
+    formatFiles(),
+  ]);
+}

--- a/packages/workspace/src/utils/rules/visit-not-ignored-files.ts
+++ b/packages/workspace/src/utils/rules/visit-not-ignored-files.ts
@@ -1,0 +1,42 @@
+import { join, normalize, Path } from '@angular-devkit/core';
+import {
+  callRule,
+  Rule,
+  SchematicContext,
+  Tree,
+} from '@angular-devkit/schematics';
+import ignore from 'ignore';
+
+export function visitNotIgnoredFiles(
+  visitor: (file: Path, host: Tree, context: SchematicContext) => void | Rule,
+  dir: Path = normalize('')
+): Rule {
+  return (host, context) => {
+    let ig;
+    if (host.exists('.gitignore')) {
+      ig = ignore();
+      ig.add(host.read('.gitignore').toString());
+    }
+    function visit(_dir: Path) {
+      if (_dir && ig?.ignores(_dir)) {
+        return;
+      }
+      const dirEntry = host.getDir(_dir);
+      dirEntry.subfiles.forEach((file) => {
+        if (ig?.ignores(join(_dir, file))) {
+          return;
+        }
+        const maybeRule = visitor(join(_dir, file), host, context);
+        if (maybeRule) {
+          callRule(maybeRule, host, context).subscribe();
+        }
+      });
+
+      dirEntry.subdirs.forEach((subdir) => {
+        visit(join(_dir, subdir));
+      });
+    }
+
+    visit(dir);
+  };
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`.eslintrc` files that reference the root `tsconfig.json` are not migrated to reference the new `tsconfig.base.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`.eslintrc` files that reference the root `tsconfig.json` are migrated to reference the new `tsconfig.base.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
