### PR TITLE
fix(web): use missing `umdName` option in `package` builder

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -24,6 +24,7 @@ module.exports = {
     { name: 'node', description: 'anything Node specific' },
     { name: 'nx-plugin', description: 'anything Nx Plugin specific' },
     { name: 'react', description: 'anything React specific' },
+    { name: 'web', description: 'anything Web specific' },
     { name: 'linter', description: 'anything Linter specific' },
     { name: 'storybook', description: 'anything Storybook specific' },
     {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,6 +170,7 @@ The scope must be one of the following:
 - node - anything Node specific
 - linter - anything Linter specific
 - react - anything React specific
+- web - anything Web specific
 - storybook - anything Storybook specific
 - testing - anything testing specific (e.g., jest or cypress)
 - repo - anything related to managing the repo itself

--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -237,7 +237,7 @@ export function createRollupOptions(
         globals,
         format: config.format,
         file: `${options.outputPath}/${context.target.project}.${config.extension}.js`,
-        name: toClassName(context.target.project),
+        name: options.umdName || toClassName(context.target.project),
       },
       external: (id) => externalPackages.includes(id),
       plugins,

--- a/packages/web/src/utils/types.ts
+++ b/packages/web/src/utils/types.ts
@@ -58,6 +58,7 @@ export interface PackageBuilderOptions {
   watch?: boolean;
   assets?: any[];
   updateBuildableProjectDepsInPackageJson?: boolean;
+  umdName?: string;
 }
 
 export interface AssetGlobPattern extends JsonObject {


### PR DESCRIPTION
## Current Behavior
In [options](https://nx.dev/react/plugins/web/builders/package#umdname)  for package builder we have mentioned that we can use `umdName`, but adding this options does not have any effect.

## Expected Behavior
Adding `umdName` in builder options it will correctly create UMD with `umdName`

No related issues found

---

PS: added `web` scope in commitizen config