### PR TITLE
fix(react): allow env to work in .babelrc for projects

### DIFF
--- a/packages/web/babel.ts
+++ b/packages/web/babel.ts
@@ -5,6 +5,8 @@
 module.exports = function (api: any, options: {}) {
   api.assertVersion(7);
 
+  const isModern = api.caller((caller) => caller.isModern);
+
   return {
     presets: [
       // Support module/nomodule pattern.
@@ -17,7 +19,7 @@ module.exports = function (api: any, options: {}) {
           corejs: 3,
           // Do not transform modules to CJS
           modules: false,
-          targets: api.env('legacy') ? undefined : { esmodules: true },
+          targets: isModern ? { esmodules: true } : undefined,
           bugfixes: true,
           // Exclude transforms that make all code slower
           exclude: ['transform-typeof-symbol'],

--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -11,10 +11,10 @@ import { getWebConfig } from '../../utils/web.config';
 import { BuildBuilderOptions } from '../../utils/types';
 import {
   bufferCount,
+  concatMap,
   map,
   mergeScan,
   switchMap,
-  concatMap,
 } from 'rxjs/operators';
 import { getSourceRoot } from '../../utils/source-root';
 import { writeIndexHtml } from '../../utils/third-party/cli-files/utilities/index-file/write-index-html';
@@ -119,7 +119,8 @@ export function run(options: WebBuildBuilderOptions, context: BuilderContext) {
             options,
             context.logger,
             true,
-            isScriptOptimizeOn
+            isScriptOptimizeOn,
+            context.target.configuration
           ),
           // ES5 build for legacy browsers.
           isScriptOptimizeOn &&
@@ -130,7 +131,8 @@ export function run(options: WebBuildBuilderOptions, context: BuilderContext) {
                 options,
                 context.logger,
                 false,
-                isScriptOptimizeOn
+                isScriptOptimizeOn,
+                context.target.configuration
               )
             : undefined,
         ]

--- a/packages/web/src/utils/config.spec.ts
+++ b/packages/web/src/utils/config.spec.ts
@@ -49,7 +49,7 @@ describe('getBaseWebpackPartial', () => {
       );
       expect(rule).toBeTruthy();
 
-      expect(rule.loader).toEqual('babel-loader');
+      expect(rule.loader).toContain('babel-loader');
     });
 
     it('should split typescript type checking into a separate workers', () => {
@@ -157,26 +157,6 @@ describe('getBaseWebpackPartial', () => {
     it('should include es2015 in mainFields if typescript is set es2015', () => {
       const result = getBaseWebpackPartial(input, true);
       expect(result.resolve.mainFields).toContain('es2015');
-    });
-  });
-
-  describe('ES modules', () => {
-    it('should override preset-env target for esm', () => {
-      const result = getBaseWebpackPartial(input, true);
-
-      expect(
-        (result.module.rules.find((rule) => rule.loader === 'babel-loader')
-          .options as any).envName
-      ).toMatch('modern');
-    });
-
-    it('should not override preset-env target for es5', () => {
-      const result = getBaseWebpackPartial(input, false);
-
-      expect(
-        (result.module.rules.find((rule) => rule.loader === 'babel-loader')
-          .options as any).envName
-      ).toMatch('legacy');
     });
   });
 

--- a/packages/web/src/utils/config.ts
+++ b/packages/web/src/utils/config.ts
@@ -19,7 +19,8 @@ const IGNORED_WEBPACK_WARNINGS = [
 export function getBaseWebpackPartial(
   options: BuildBuilderOptions,
   esm?: boolean,
-  isScriptOptimizeOn?: boolean
+  isScriptOptimizeOn?: boolean,
+  configuration?: string
 ): Configuration {
   const extensions = ['.ts', '.tsx', '.mjs', '.js', '.jsx'];
   const mainFields = [...(esm ? ['es2015'] : []), 'module', 'main'];
@@ -48,12 +49,13 @@ export function getBaseWebpackPartial(
       rules: [
         {
           test: /\.([jt])sx?$/,
-          loader: `babel-loader`,
+          loader: join(__dirname, 'web-babel-loader'),
           exclude: /node_modules/,
           options: {
             rootMode: 'upward',
             cwd: join(options.root, options.sourceRoot),
-            envName: esm ? 'modern' : 'legacy',
+            isModern: esm,
+            envName: configuration || 'development',
             babelrc: true,
             cacheDirectory: true,
             cacheCompression: false,

--- a/packages/web/src/utils/web-babel-loader.ts
+++ b/packages/web/src/utils/web-babel-loader.ts
@@ -1,0 +1,15 @@
+module.exports = require('babel-loader').custom((babel) => {
+  return {
+    customOptions({ isModern, ...loader }) {
+      return {
+        custom: { isModern },
+        loader,
+      };
+    },
+    config(cfg, { customOptions: { isModern } }) {
+      // Add hint to our babel preset so it can handle modern vs legacy bundles.
+      cfg.options.caller.isModern = isModern;
+      return cfg.options;
+    },
+  };
+});

--- a/packages/web/src/utils/web.config.ts
+++ b/packages/web/src/utils/web.config.ts
@@ -22,7 +22,8 @@ export function getWebConfig(
   options: WebBuildBuilderOptions,
   logger: LoggerApi,
   esm?: boolean,
-  isScriptOptimizeOn?: boolean
+  isScriptOptimizeOn?: boolean,
+  configuration?: string
 ) {
   const tsConfig = readTsConfig(options.tsConfig);
 
@@ -44,7 +45,7 @@ export function getWebConfig(
     tsConfigPath: options.tsConfig,
   };
   return mergeWebpack([
-    _getBaseWebpackPartial(options, esm, isScriptOptimizeOn),
+    _getBaseWebpackPartial(options, esm, isScriptOptimizeOn, configuration),
     getPolyfillsPartial(options, esm, isScriptOptimizeOn),
     getStylesPartial(wco, options),
     getCommonPartial(wco),
@@ -88,9 +89,15 @@ function getBrowserPartial(
 function _getBaseWebpackPartial(
   options: WebBuildBuilderOptions,
   esm: boolean,
-  isScriptOptimizeOn: boolean
+  isScriptOptimizeOn: boolean,
+  configuration?: string
 ) {
-  let partial = getBaseWebpackPartial(options, esm, isScriptOptimizeOn);
+  let partial = getBaseWebpackPartial(
+    options,
+    esm,
+    isScriptOptimizeOn,
+    configuration
+  );
   delete partial.resolve.mainFields;
   return partial;
 }


### PR DESCRIPTION
We are currently setting babel env to legacy/modern for the differential loading use case. This is overriding the `NODE_ENV` value when users use `env` inside `.babelrc` -- since `BABEL_ENV` takes precedence over `NODE_ENV`.

This PR uses babel's caller API, in combination with a custom load that wraps `babel-loader` to pass a `isModern` custom option.

## Current Behavior
Cannot use `env` in `.babelrc` file.

## Expected Behavior
Can use `env` in `.babelrc` file.

Closes #3351