### PR TITLE
feat(nx-plugin): export `patchPackageJsonForPlugin(...)`

### DIFF
--- a/packages/nx-plugin/src/utils/testing-utils/nx-project.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/nx-project.ts
@@ -20,7 +20,10 @@ function runNxNewCommand(args?: string, silent?: boolean) {
   );
 }
 
-function patchPackageJsonForPlugin(npmPackageName: string, distPath: string) {
+export function patchPackageJsonForPlugin(
+  npmPackageName: string,
+  distPath: string
+) {
   const p = JSON.parse(readFileSync(tmpProjPath('package.json')).toString());
   p.devDependencies[npmPackageName] = `file:${appRootPath}/${distPath}`;
   writeFileSync(tmpProjPath('package.json'), JSON.stringify(p, null, 2));


### PR DESCRIPTION
## Current Behavior
This function cannot be imported into a project from the `@nrwl/nx-plugin` package.

## Expected Behavior
This function cannot be imported into a project from the `@nrwl/nx-plugin` package. This function could be useful to Nx plugin developers that need to write an e2e for a plugin that depends on another plugin in the same workspace.
