### PR TITLE
fix(core): properly resolve tsconfig when serving from project root

### DIFF
--- a/packages/node/src/builders/build/build.impl.ts
+++ b/packages/node/src/builders/build/build.impl.ts
@@ -3,7 +3,7 @@ import { JsonObject, workspaces } from '@angular-devkit/core';
 import { runWebpack, BuildResult } from '@angular-devkit/build-webpack';
 
 import { Observable, from } from 'rxjs';
-import { resolve } from 'path';
+import { join, resolve } from 'path';
 import { map, concatMap } from 'rxjs/operators';
 import { getNodeWebpackConfig } from '../../utils/node.config';
 import { OUT_FILENAME } from '../../utils/config';
@@ -44,7 +44,7 @@ function run(
       context
     );
     options.tsConfig = createTmpTsConfig(
-      options.tsConfig,
+      join(context.workspaceRoot, options.tsConfig),
       context.workspaceRoot,
       target.data.root,
       dependencies

--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -21,7 +21,7 @@ import { writeIndexHtml } from '../../utils/third-party/cli-files/utilities/inde
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import { execSync } from 'child_process';
 import { Range, satisfies } from 'semver';
-import { basename } from 'path';
+import { basename, join } from 'path';
 import { createProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
@@ -84,7 +84,7 @@ export function run(options: WebBuildBuilderOptions, context: BuilderContext) {
       context
     );
     options.tsConfig = createTmpTsConfig(
-      options.tsConfig,
+      join(context.workspaceRoot, options.tsConfig),
       context.workspaceRoot,
       target.data.root,
       dependencies


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `ng serve` from an app's directory will not generate the right path for the generated tmp tsconfig.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `ng serve` from an app's directory will generate the right path for the generated tmp tsconfig.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/3316
