### PR TITLE
fix(node): remove rootDir for node libs

### DIFF
--- a/docs/angular/api-node/builders/package.md
+++ b/docs/angular/api-node/builders/package.md
@@ -22,7 +22,7 @@ The name of the main entry-point file.
 
 Type: `string`
 
-The output path of the generated files.
+The output path for copying asset files.
 
 ### packageJson
 

--- a/docs/react/api-node/builders/package.md
+++ b/docs/react/api-node/builders/package.md
@@ -23,7 +23,7 @@ The name of the main entry-point file.
 
 Type: `string`
 
-The output path of the generated files.
+The output path for copying asset files.
 
 ### packageJson
 

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -275,9 +275,8 @@ forEachCli((currentCLIName) => {
         extends: './tsconfig.json',
         compilerOptions: {
           module: 'commonjs',
-          outDir: '../../dist/out-tsc',
+          outDir: '../../dist',
           declaration: true,
-          rootDir: './src',
           types: ['node'],
         },
         exclude: ['**/*.spec.ts'],

--- a/packages/node/migrations.json
+++ b/packages/node/migrations.json
@@ -4,6 +4,11 @@
       "version": "9.2.0-beta.1",
       "description": "Set buildLibsFromSource property to true to not break existing projects.",
       "factory": "./src/migrations/update-9-2-0/set-build-libs-from-source"
+    },
+    "update-node-lib-tsconfigs": {
+      "version": "10.0.7",
+      "description": "Set the outdir of tsconfigs for buildable libraries and remove the rootDir",
+      "factory": "./src/migrations/update-10-0-0/update-node-lib-tsconfigs"
     }
   }
 }

--- a/packages/node/src/builders/package/package.impl.spec.ts
+++ b/packages/node/src/builders/package/package.impl.spec.ts
@@ -91,12 +91,7 @@ describe('NodePackageBuilder', () => {
             fork
           ).toHaveBeenCalledWith(
             `${context.workspaceRoot}/node_modules/typescript/bin/tsc`,
-            [
-              '-p',
-              join(context.workspaceRoot, testOptions.tsConfig),
-              '--outDir',
-              join(context.workspaceRoot, testOptions.outputPath),
-            ],
+            ['-p', join(context.workspaceRoot, testOptions.tsConfig)],
             { stdio: [0, 1, 2, 'ipc'] }
           );
 
@@ -296,15 +291,11 @@ describe('NodePackageBuilder', () => {
 
       runNodePackageBuilder(testOptions, context).subscribe({
         complete: () => {
-          expect(fork).toHaveBeenCalledWith(
+          expect(
+            fork
+          ).toHaveBeenCalledWith(
             `${context.workspaceRoot}/node_modules/typescript/bin/tsc`,
-            [
-              '-p',
-              tmpTsConfigPath,
-              // join(context.workspaceRoot, testOptions.tsConfig),
-              '--outDir',
-              join(context.workspaceRoot, testOptions.outputPath),
-            ],
+            ['-p', tmpTsConfigPath],
             { stdio: [0, 1, 2, 'ipc'] }
           );
 

--- a/packages/node/src/builders/package/package.impl.ts
+++ b/packages/node/src/builders/package/package.impl.ts
@@ -153,7 +153,7 @@ function normalizeOptions(
 
   // Relative path for the dist directory
   const tsconfig = readJsonFile(join(context.workspaceRoot, options.tsConfig));
-  const rootDir = tsconfig.compilerOptions.rootDir || '';
+  const rootDir = tsconfig.compilerOptions?.rootDir || '';
   const mainFileDir = dirname(options.main);
   const tsconfigDir = dirname(options.tsConfig);
 
@@ -184,7 +184,7 @@ function compileTypeScriptFiles(
   removeSync(options.normalizedOutputPath);
   let tsConfigPath = join(context.workspaceRoot, options.tsConfig);
 
-  return Observable.create((subscriber: Subscriber<BuilderOutput>) => {
+  return new Observable((subscriber: Subscriber<BuilderOutput>) => {
     if (projectDependencies.length > 0) {
       const libRoot = projGraph.nodes[context.target.project].data.root;
       tsConfigPath = createTmpTsConfig(
@@ -196,7 +196,7 @@ function compileTypeScriptFiles(
     }
 
     try {
-      let args = ['-p', tsConfigPath, '--outDir', options.normalizedOutputPath];
+      let args = ['-p', tsConfigPath];
 
       if (options.sourceMap) {
         args.push('--sourceMap');

--- a/packages/node/src/builders/package/schema.json
+++ b/packages/node/src/builders/package/schema.json
@@ -13,7 +13,7 @@
     },
     "outputPath": {
       "type": "string",
-      "description": "The output path of the generated files."
+      "description": "The output path for copying asset files."
     },
     "watch": {
       "type": "boolean",

--- a/packages/node/src/migrations/update-10-0-0/update-node-lib-tsconfigs.spec.ts
+++ b/packages/node/src/migrations/update-10-0-0/update-node-lib-tsconfigs.spec.ts
@@ -1,0 +1,101 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { serializeJson } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import * as path from 'path';
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+
+describe('update 10.0.0', () => {
+  let initialTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(() => {
+    initialTree = createEmptyWorkspace(Tree.empty());
+    initialTree.create(
+      'libs/products/tsconfig.lib.json',
+      stripIndents`
+      {
+        "compilerOptions": {
+          "rootDir": "./src",
+          "outDir": "../../dist/out-tsc"
+        }
+      }
+    `
+    );
+    initialTree.create(
+      'libs/nested/cart/tsconfig.lib.json',
+      stripIndents`
+      {
+        "compilerOptions": {
+          "rootDir": "./src",
+          "outDir": "../../dist/out-tsc"
+        }
+      }
+    `
+    );
+
+    initialTree.overwrite(
+      'workspace.json',
+      serializeJson({
+        version: 1,
+        projects: {
+          products: {
+            root: 'libs/products',
+            sourceRoot: 'libs/products/src',
+            architect: {
+              build: {
+                builder: '@nrwl/node:package',
+                options: {
+                  outputPath: 'dist/libs/products',
+                  tsConfig: 'libs/products/tsconfig.lib.json',
+                  packageJson: 'libs/products/package.json',
+                  main: 'libs/products/src/index.ts',
+                  assets: ['libs/products/*.md'],
+                },
+              },
+            },
+          },
+          cart: {
+            root: 'libs/nested/cart',
+            sourceRoot: 'libs/nested/cart/src',
+            architect: {
+              build: {
+                builder: '@nrwl/node:package',
+                options: {
+                  outputPath: 'dist/libs/nested/cart',
+                  tsConfig: 'libs/nested/cart/tsconfig.lib.json',
+                  packageJson: 'libs/nested/cart/package.json',
+                  main: 'libs/nested/cart/src/index.ts',
+                  assets: ['libs/nested/cart/*.md'],
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/node',
+      path.join(__dirname, '../../../migrations.json')
+    );
+  });
+
+  it('should update tsconfig.lib.json for projects that have @nrwl/node:package', async () => {
+    const result = await schematicRunner
+      .runSchematicAsync('update-node-lib-tsconfigs', {}, initialTree)
+      .toPromise();
+
+    const tsConfig = JSON.parse(
+      result.readContent('libs/products/tsconfig.lib.json')
+    );
+    expect(tsConfig.compilerOptions.rootDir).toBeUndefined();
+    expect(tsConfig.compilerOptions.outDir).toEqual('../../dist');
+
+    const tsConfig2 = JSON.parse(
+      result.readContent('libs/nested/cart/tsconfig.lib.json')
+    );
+    expect(tsConfig2.compilerOptions.rootDir).toBeUndefined();
+    expect(tsConfig2.compilerOptions.outDir).toEqual('../../../dist');
+  });
+});

--- a/packages/node/src/migrations/update-10-0-0/update-node-lib-tsconfigs.ts
+++ b/packages/node/src/migrations/update-10-0-0/update-node-lib-tsconfigs.ts
@@ -1,0 +1,42 @@
+import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import { offsetFromRoot } from '@nrwl/workspace';
+import {
+  getWorkspace,
+  getWorkspacePath,
+  updateJsonInTree,
+} from '@nrwl/workspace';
+
+function checkTsConfigPath(configPath: unknown): configPath is string {
+  return typeof configPath === 'string';
+}
+
+async function updateTsConfigDists(host: Tree) {
+  const updates: Rule[] = [];
+
+  const workspace = await getWorkspace(host, getWorkspacePath(host));
+  for (const [, projectDefinition] of workspace.projects) {
+    for (const [, testTarget] of projectDefinition.targets) {
+      if (testTarget.builder !== '@nrwl/node:package') {
+        continue;
+      }
+
+      if (checkTsConfigPath(testTarget.options.tsConfig)) {
+        updates.push(
+          updateJsonInTree(testTarget.options.tsConfig, (json) => {
+            delete json.compilerOptions?.rootDir;
+            json.compilerOptions.outDir = `${offsetFromRoot(
+              projectDefinition.root
+            )}dist`;
+
+            return json;
+          })
+        );
+      }
+    }
+  }
+  return chain(updates);
+}
+
+export default function update(): Rule {
+  return chain([updateTsConfigDists]);
+}

--- a/packages/node/src/schematics/library/files/lib/tsconfig.lib.json
+++ b/packages/node/src/schematics/library/files/lib/tsconfig.lib.json
@@ -2,9 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "<%= offsetFromRoot %>dist/out-tsc",
+    "outDir": "<%= offsetFromRoot %>dist",
     "declaration": true,
-    "rootDir": "./src",
     "types": ["node"]
   },
   "exclude": ["**/*.spec.ts"],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Buildable node libs have rootDir in their configs. This breaks with a solution style tsconfig (like in this repo). 

## Expected Behavior
Remove the rootDir and change the outDir to read from the tsconfig.json for the `@nrwl/node:package` builder.

## Other
Should a new property be added to the package schema so that it can override the tsconfig outDir property? The outputPath after this change will only affect the asset copy placement.
