### PR TITLE
docs(testing): fix jest builder documentation regarding coverageDirectory key

### DIFF
--- a/docs/angular/api-jest/builders/jest.md
+++ b/docs/angular/api-jest/builders/jest.md
@@ -58,7 +58,7 @@ The path to a Jest config file specifying how to find and execute tests. If no r
 
 Type: `string`
 
-An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
+The directory where Jest should output its coverage files.
 
 ### coverageReporters
 

--- a/docs/react/api-jest/builders/jest.md
+++ b/docs/react/api-jest/builders/jest.md
@@ -59,7 +59,7 @@ The path to a Jest config file specifying how to find and execute tests. If no r
 
 Type: `string`
 
-An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
+The directory where Jest should output its coverage files.
 
 ### coverageReporters
 

--- a/packages/jest/src/builders/jest/schema.json
+++ b/packages/jest/src/builders/jest/schema.json
@@ -123,7 +123,7 @@
       "type": "string"
     },
     "coverageDirectory": {
-      "description": "An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.",
+      "description": "The directory where Jest should output its coverage files.",
       "type": "string"
     },
     "testResultsProcessor": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Navigating to https://nx.dev/angular/plugins/jest/builders/jest#coveragedirectory shows documentation matching the first paragraph from https://jestjs.io/docs/en/configuration#coveragepathignorepatterns-arraystring

NX documentation:
![image](https://user-images.githubusercontent.com/7547875/88579369-4e55d400-d020-11ea-91a1-3a019be87348.png)
Jest documentation:
![image](https://user-images.githubusercontent.com/7547875/88579417-60377700-d020-11ea-9d20-dace0c282090.png)

## Expected Behavior
Navigating to https://nx.dev/angular/plugins/jest/builders/jest#coveragedirectory shows documentation matching https://jestjs.io/docs/en/configuration#coveragedirectory-string


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3420
