### PR TITLE
fix(core): custom schematic windows path normalization

### DIFF
--- a/packages/tao/src/commands/generate.ts
+++ b/packages/tao/src/commands/generate.ts
@@ -189,6 +189,7 @@ async function createWorkflow(
     packageManager: await detectPackageManager(fsHost),
     root: normalize(root),
     registry: new schema.CoreSchemaRegistry(formats.standardFormats),
+    resolvePaths: [process.cwd(), root],
   });
   const _params = opts.schematicOptions._;
   delete opts.schematicOptions._;

--- a/packages/workspace/src/command-line/workspace-schematic.ts
+++ b/packages/workspace/src/command-line/workspace-schematic.ts
@@ -135,7 +135,7 @@ function createWorkflow(dryRun: boolean) {
     root,
     dryRun,
     registry: new schema.CoreSchemaRegistry(formats.standardFormats),
-    resolvePaths: [root],
+    resolvePaths: [process.cwd(), rootDirectory],
   });
 }
 


### PR DESCRIPTION
## Issue: 

Running a workspace schematic under Windows fails with `Error: Collection "@nrwl/angular" cannot be resolved.`

## Explanation: 

Related PR: https://github.com/nrwl/nx/pull/3252

[We normalize the appRoot before creating the NodeWorkflow](https://github.com/nrwl/nx/blob/master/packages/workspace/src/command-line/workspace-schematic.ts#L131) which breaks some paths on Windows machines.

`normalize(...)` comes from the angular-cli devkit, and has a bug where it converts windows path to unix. For example:

`C:\Users\matei\repo` turns to --> `/C/Users/matei/repo`

So part of this fix:
- I am sending the app root directly to the `NodeWorkflow`
- I am also sending `process.cwd()` and `__dirname`, as per [the Angular CLI's source](https://github.com/angular/angular-cli/blob/master/packages/angular/cli/models/schematic-command.ts#L257)

---

Fixes #3233 