### PR TITLE
fix(core): warn for invalid eslintrc

### DIFF
--- a/packages/workspace/src/migrations/update-10-0-1/migrate-eslintrc.spec.ts
+++ b/packages/workspace/src/migrations/update-10-0-1/migrate-eslintrc.spec.ts
@@ -50,4 +50,9 @@ describe('Eslintrc Migration', () => {
     const eslintrc = readJsonInTree(result, 'project2/.eslintrc');
     expect(eslintrc.parserOptions.project).toEqual('./tsconfig.json');
   });
+
+  it('should not fail for a non-json eslintrc', async () => {
+    tree.overwrite('project2/.eslintrc', 'not-json');
+    await runMigration('migrate-eslintrc-tsconfig', {}, tree);
+  });
 });

--- a/packages/workspace/src/migrations/update-10-0-1/migrate-eslintrc.ts
+++ b/packages/workspace/src/migrations/update-10-0-1/migrate-eslintrc.ts
@@ -10,21 +10,30 @@ export default function (schema: any): Rule {
         return;
       }
 
-      return updateJsonInTree(file, (json) => {
-        const tsconfig = json?.parserOptions?.project;
-        if (tsconfig) {
-          const tsconfigPath = join(dirname(file), tsconfig);
-          if (tsconfigPath === 'tsconfig.json') {
-            json.parserOptions.project = json.parserOptions.project.replace(
-              /tsconfig.json$/,
-              'tsconfig.base.json'
-            );
-          }
-          return json;
-        } else {
-          return json;
+      return (host, context) => {
+        try {
+          updateJsonInTree(file, (json) => {
+            const tsconfig = json?.parserOptions?.project;
+            if (tsconfig) {
+              const tsconfigPath = join(dirname(file), tsconfig);
+              if (tsconfigPath === 'tsconfig.json') {
+                json.parserOptions.project = json.parserOptions.project.replace(
+                  /tsconfig.json$/,
+                  'tsconfig.base.json'
+                );
+              }
+              return json;
+            } else {
+              return json;
+            }
+          })(host, context);
+        } catch (e) {
+          context.logger.warn(
+            `${file} could not be migrated because it is not valid JSON`
+          );
+          context.logger.error(e);
         }
-      });
+      };
     }),
     formatFiles(),
   ]);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Migration fails when `.eslintrc` is invalid.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Migration warns when `.eslintrc` is invalid.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/3416
