### PR TITLE
feat(storybook): improve webpack DX by adding proper types and jsdoc

### DIFF
--- a/packages/storybook/src/schematics/configuration/lib-files/.storybook/webpack.config.js__tmpl__
+++ b/packages/storybook/src/schematics/configuration/lib-files/.storybook/webpack.config.js__tmpl__
@@ -1,6 +1,10 @@
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const rootWebpackConfig = require('<%= offsetFromRoot %>../.storybook/webpack.config');
-// Export a function. Accept the base config as the only param.
+/**
+ * Export a function. Accept the base config as the only param.
+ *
+ * @param {Parameters<typeof rootWebpackConfig>[0]} options
+ */
 module.exports = async ({ config, mode }) => {
   config = await rootWebpackConfig({ config, mode });
 
@@ -13,9 +17,8 @@ module.exports = async ({ config, mode }) => {
     : (config.resolve.plugins = [tsPaths])
 
   <% if(uiFramework === '@storybook/react') { %>
-  config.resolve.extensions.push('.tsx');
-  config.resolve.extensions.push('.ts');
-    
+  config.resolve.extensions.push('.ts', '.tsx');
+
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
     loader: require.resolve('babel-loader'),

--- a/packages/storybook/src/schematics/configuration/root-files/.storybook/webpack.config.js
+++ b/packages/storybook/src/schematics/configuration/root-files/.storybook/webpack.config.js
@@ -1,9 +1,10 @@
-// Export a function. Accept the base config as the only param.
+/**
+ * Export a function. Accept the base config as the only param.
+ * @param {Object} options
+ * @param {Required<import('webpack').Configuration>} options.config
+ * @param {'DEVELOPMENT' | 'PRODUCTION'} options.mode - change the build configuration. 'PRODUCTION' is used when building the static version of storybook.
+ */
 module.exports = async ({ config, mode }) => {
-  // `mode` has a value of 'DEVELOPMENT' or 'PRODUCTION'
-  // You can change the configuration based on that.
-  // 'PRODUCTION' is used when building the static version of storybook.
-
   // Make whatever fine-grained changes you need
 
   // Return the altered config

--- a/packages/storybook/src/schematics/init/init.spec.ts
+++ b/packages/storybook/src/schematics/init/init.spec.ts
@@ -43,6 +43,7 @@ describe('init', () => {
       expect(
         packageJson.devDependencies['@storybook/addon-knobs']
       ).toBeDefined();
+      expect(packageJson.devDependencies['@types/webpack']).toBeDefined();
 
       // angular specific
       expect(packageJson.devDependencies['@storybook/angular']).toBeDefined();

--- a/packages/storybook/src/schematics/init/init.ts
+++ b/packages/storybook/src/schematics/init/init.ts
@@ -15,6 +15,7 @@ import {
   storybookVersion,
   nxVersion,
   babelPresetTypescriptVersion,
+  webpackTypesVersion,
 } from '../../utils/versions';
 import { Schema } from './schema';
 
@@ -27,6 +28,7 @@ function checkDependenciesInstalled(schema: Schema): Rule {
     // base deps
     devDependencies['@nrwl/storybook'] = nxVersion;
     devDependencies['@storybook/addon-knobs'] = storybookVersion;
+    devDependencies['@types/webpack'] = webpackTypesVersion;
 
     if (schema.uiFramework === '@storybook/angular') {
       devDependencies['@storybook/angular'] = storybookVersion;

--- a/packages/storybook/src/utils/versions.ts
+++ b/packages/storybook/src/utils/versions.ts
@@ -3,3 +3,4 @@ export const storybookVersion = '5.3.9';
 export const babelCoreVersion = '7.9.6';
 export const babelLoaderVersion = '8.1.0';
 export const babelPresetTypescriptVersion = '7.9.0';
+export const webpackTypesVersion = '4.41.21';


### PR DESCRIPTION
## Current Behavior
If we use type checking for vanilla js and config options, there are manual steps needed to make those work.

## Expected Behavior
we should provide best possible DX everywhere if possible, even for configuration

## Related Issue(s)

Fixes #
