### PR TITLE
fix(core): generated proper cli command in lib readme

### DIFF
--- a/packages/workspace/src/schematics/library/files/lib/README.md
+++ b/packages/workspace/src/schematics/library/files/lib/README.md
@@ -5,6 +5,6 @@ This library was generated with [Nx](https://nx.dev).
 
 ## Running unit tests
 
-Run `ng test <%= name %>` to execute the unit tests via [Jest](https://jestjs.io).
+Run `<%= cliCommand %> test <%= name %>` to execute the unit tests via [Jest](https://jestjs.io).
 
 <% } %>

--- a/packages/workspace/src/schematics/library/library.spec.ts
+++ b/packages/workspace/src/schematics/library/library.spec.ts
@@ -2,6 +2,7 @@ import { Tree } from '@angular-devkit/schematics';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
 import { readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
 import { NxJson } from '@nrwl/workspace';
+
 import { runSchematic } from '../../utils/testing';
 
 describe('lib', () => {
@@ -102,9 +103,14 @@ describe('lib', () => {
 
     it('should generate files', async () => {
       const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+
       expect(tree.exists(`libs/my-lib/jest.config.js`)).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/index.ts')).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/lib/my-lib.ts')).toBeTruthy();
+      expect(tree.exists('libs/my-lib/README.md')).toBeTruthy();
+
+      const ReadmeContent = tree.readContent('libs/my-lib/README.md');
+      expect(ReadmeContent).toContain('nx test my-lib');
     });
   });
 

--- a/packages/workspace/src/schematics/library/library.ts
+++ b/packages/workspace/src/schematics/library/library.ts
@@ -22,6 +22,7 @@ import { formatFiles } from '@nrwl/workspace';
 import { offsetFromRoot } from '@nrwl/workspace';
 import { generateProjectLint, addLintFiles } from '../../utils/lint';
 import { addProjectToNxJsonInTree, libsDir } from '../../utils/ast-utils';
+import { cliCommand } from '../../core/file-utils';
 
 export interface NormalizedSchema extends Schema {
   name: string;
@@ -79,6 +80,7 @@ function createFiles(options: NormalizedSchema): Rule {
       template({
         ...options,
         ...names(options.name),
+        cliCommand: cliCommand(),
         tmpl: '',
         offsetFromRoot: offsetFromRoot(options.projectRoot),
         hasUnitTestRunner: options.unitTestRunner !== 'none',


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

@nrwl node,workspace library plugins generate README with `ng` instead of `nx` if `workspace.json` is used

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx @nrwl/workspace:lib foo`

 creates README.md with `Run ‘nx test foo’ to execute the unit tests via …..`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
