### PR TITLE
docs(docs): Add missing class todo in todos.component.html

### DIFF
--- a/docs/angular/tutorial/08-create-libs.md
+++ b/docs/angular/tutorial/08-create-libs.md
@@ -115,7 +115,7 @@ export class TodosComponent implements OnInit {
 
 ```html
 <ul>
-  <li *ngFor="let t of todos">{{ t.title }}</li>
+  <li *ngFor="let t of todos" class="todo">{{ t.title }}</li>
 </ul>
 ```
 


### PR DESCRIPTION
## Problem
Missing `class="todo"` in docs of `todos.component.html` section

## Solution
Fixes `todos.component.html` docs by adding missing `class="todo"`

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

## Expected Behavior

## Related Issue(s)

Fixes #
