### PR TITLE
fix(nest): add default linter for new nest projects

### DIFF
--- a/packages/workspace/src/schematics/shared-new/shared-new.ts
+++ b/packages/workspace/src/schematics/shared-new/shared-new.ts
@@ -279,7 +279,10 @@ function setDefaultLinter(linter: string) {
     json.schematics['@nrwl/nx-plugin'] = {
       plugin: { linter },
     };
-    json.schematics['@nrwl/nest'] = { application: { linter } };
+    json.schematics['@nrwl/nest'] = {
+      application: { linter },
+      library: { linter }
+    };
     json.schematics['@nrwl/express'] = {
       application: { linter },
       library: { linter },

--- a/packages/workspace/src/schematics/shared-new/shared-new.ts
+++ b/packages/workspace/src/schematics/shared-new/shared-new.ts
@@ -281,7 +281,7 @@ function setDefaultLinter(linter: string) {
     };
     json.schematics['@nrwl/nest'] = {
       application: { linter },
-      library: { linter }
+      library: { linter },
     };
     json.schematics['@nrwl/express'] = {
       application: { linter },


### PR DESCRIPTION
## Current Behavior
Nest.js libraries are created with tslint

## Expected Behavior
Nest.js libraries are created with eslint

## Related Issue(s)
Fixes #3063 
