### PR TITLE
feat(web): pass through builder options to custom rollup config

### DIFF
--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -244,7 +244,7 @@ export function createRollupOptions(
     };
 
     return options.rollupConfig
-      ? require(options.rollupConfig)(rollupConfig)
+      ? require(options.rollupConfig)(rollupConfig, options)
       : rollupConfig;
   });
 }


### PR DESCRIPTION
# problem

Just as the default rollup config is a function of builder options, so too should-be/could-be userland rollup configuration

# solution

Pass in full options to userland rollup config function

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
