### PR TITLE
fix(nextjs): add missing references config to tsconfig

### DIFF
--- a/packages/next/src/schematics/application/files/tsconfig.json__tmpl__
+++ b/packages/next/src/schematics/application/files/tsconfig.json__tmpl__
@@ -12,5 +12,12 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["**/*.ts", "**/*.tsx", "next-env.d.ts"]
+  "exclude": ["node_modules"],
+  "include": [],
+  "files": [],
+  "references": [
+      {
+          "path": "./tsconfig.spec.json"
+      }
+  ]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When you generate a new Next application the tsconfig.json is missing the reference to the tsconfig.lib.json file

## Expected Behavior
tsconfig has a reference property which links the tsconfig with tsconfig.spec.json