### PR TITLE
fix(linter): fix performance issues with boundaries lint checks

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -76,7 +76,7 @@ export default createESLintRule<Options, MessageIds>({
     ],
     messages: {
       noRelativeOrAbsoluteImportsAcrossLibraries: `Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope`,
-      noCircularDependencies: `Circular dependency between "{{sourceProjectName}}" and "{{targetProjectName}}" detected. The path is: "{{path}}"`,
+      noCircularDependencies: `Circular dependency between "{{sourceProjectName}}" and "{{targetProjectName}}" detected. The path is: {{path}}`,
       noImportsOfApps: 'Imports of apps are forbidden',
       noImportOfNonBuildableLibraries:
         'Buildable libraries cannot import non-buildable libraries',

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -177,7 +177,7 @@ export default createESLintRule<Options, MessageIds>({
             data: {
               sourceProjectName: sourceProject.name,
               targetProjectName: targetProject.name,
-              path: circularPath.reduce((acc, v) => `${acc}->${v}`, '')
+              path: circularPath.reduce((acc, v) => `${acc} -> ${v.name}`, sourceProject.name)
             }
           });
           return;

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -76,7 +76,7 @@ export default createESLintRule<Options, MessageIds>({
     ],
     messages: {
       noRelativeOrAbsoluteImportsAcrossLibraries: `Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope`,
-      noCircularDependencies: `Circular dependency between "{{sourceProjectName}}" and "{{targetProjectName}}" detected. The path is: {{path}}`,
+      noCircularDependencies: `Circular dependency between "{{sourceProjectName}}" and "{{targetProjectName}}" detected: {{path}}`,
       noImportsOfApps: 'Imports of apps are forbidden',
       noImportOfNonBuildableLibraries:
         'Buildable libraries cannot import non-buildable libraries',

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -169,7 +169,11 @@ export default createESLintRule<Options, MessageIds>({
 
         // check constraints between libs and apps
         // check for circular dependency
-        const circularPath = checkCircularPath(projectGraph, sourceProject, targetProject);
+        const circularPath = checkCircularPath(
+          projectGraph,
+          sourceProject,
+          targetProject
+        );
         if (circularPath.length !== 0) {
           context.report({
             node,
@@ -177,8 +181,11 @@ export default createESLintRule<Options, MessageIds>({
             data: {
               sourceProjectName: sourceProject.name,
               targetProjectName: targetProject.name,
-              path: circularPath.reduce((acc, v) => `${acc} -> ${v.name}`, sourceProject.name)
-            }
+              path: circularPath.reduce(
+                (acc, v) => `${acc} -> ${v.name}`,
+                sourceProject.name
+              ),
+            },
           });
           return;
         }

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -717,7 +717,7 @@ describe('Enforce Module Boundaries', () => {
       }
     );
     expect(failures[0].message).toEqual(
-      'Circular dependency between "anotherlibName" and "mylibName" detected. The path is: anotherlibName -> mylibName -> anotherlibName'
+      'Circular dependency between "anotherlibName" and "mylibName" detected: anotherlibName -> mylibName -> anotherlibName'
     );
   });
 
@@ -799,7 +799,7 @@ describe('Enforce Module Boundaries', () => {
       }
     );
     expect(failures[0].message).toEqual(
-      'Circular dependency between "mylibName" and "badcirclelibName" detected. The path is: mylibName -> badcirclelibName -> anotherlibName -> mylibName'
+      'Circular dependency between "mylibName" and "badcirclelibName" detected: mylibName -> badcirclelibName -> anotherlibName -> mylibName'
     );
   });
 

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -717,7 +717,7 @@ describe('Enforce Module Boundaries', () => {
       }
     );
     expect(failures[0].message).toEqual(
-      'Circular dependency between "anotherlibName" and "mylibName" detected'
+      'Circular dependency between "anotherlibName" and "mylibName" detected. The path is: anotherlibName -> mylibName -> anotherlibName'
     );
   });
 
@@ -799,7 +799,7 @@ describe('Enforce Module Boundaries', () => {
       }
     );
     expect(failures[0].message).toEqual(
-      'Circular dependency between "mylibName" and "badcirclelibName" detected'
+      'Circular dependency between "mylibName" and "badcirclelibName" detected. The path is: mylibName -> badcirclelibName -> anotherlibName -> mylibName'
     );
   });
 

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -714,7 +714,7 @@ describe('Enforce Module Boundaries', () => {
       }
     );
     expect(failures[0].getFailure()).toEqual(
-      'Circular dependency between "anotherlibName" and "mylibName" detected. The path is: anotherlibName -> mylibName -> anotherlibName'
+      'Circular dependency between "anotherlibName" and "mylibName" detected: anotherlibName -> mylibName -> anotherlibName'
     );
   });
 
@@ -796,7 +796,7 @@ describe('Enforce Module Boundaries', () => {
       }
     );
     expect(failures[0].getFailure()).toEqual(
-      'Circular dependency between "mylibName" and "badcirclelibName" detected. The path is: mylibName -> badcirclelibName -> anotherlibName -> mylibName'
+      'Circular dependency between "mylibName" and "badcirclelibName" detected: mylibName -> badcirclelibName -> anotherlibName -> mylibName'
     );
   });
 

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -714,7 +714,7 @@ describe('Enforce Module Boundaries', () => {
       }
     );
     expect(failures[0].getFailure()).toEqual(
-      'Circular dependency between "anotherlibName" and "mylibName" detected'
+      'Circular dependency between "anotherlibName" and "mylibName" detected. The path is: anotherlibName -> mylibName -> anotherlibName'
     );
   });
 
@@ -796,7 +796,7 @@ describe('Enforce Module Boundaries', () => {
       }
     );
     expect(failures[0].getFailure()).toEqual(
-      'Circular dependency between "mylibName" and "badcirclelibName" detected'
+      'Circular dependency between "mylibName" and "badcirclelibName" detected. The path is: mylibName -> badcirclelibName -> anotherlibName -> mylibName'
     );
   });
 

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -16,7 +16,7 @@ import {
   hasArchitectBuildBuilder,
   hasNoneOfTheseTags,
   isAbsoluteImportIntoAnotherProject,
-  isCircular,
+  checkCircularPath,
   isRelativeImportIntoAnotherProject,
   matchImportWithWildcard,
   onlyLoadChildren,
@@ -161,8 +161,10 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
     }
 
     // check for circular dependency
-    if (isCircular(this.projectGraph, sourceProject, targetProject)) {
-      const error = `Circular dependency between "${sourceProject.name}" and "${targetProject.name}" detected`;
+    const circularPath = checkCircularPath(this.projectGraph, sourceProject, targetProject);
+    if (circularPath.length !== 0) {
+      const path = circularPath.reduce((acc, v) => `${acc}->${v}`, '');
+      const error = `Circular dependency between "${sourceProject.name}" and "${targetProject.name}" detected. The path is: ${path}`;
       this.addFailureAt(node.getStart(), node.getWidth(), error);
       return;
     }

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -171,7 +171,7 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
         (acc, v) => `${acc} -> ${v.name}`,
         sourceProject.name
       );
-      const error = `Circular dependency between "${sourceProject.name}" and "${targetProject.name}" detected. The path is: ${path}`;
+      const error = `Circular dependency between "${sourceProject.name}" and "${targetProject.name}" detected: ${path}`;
       this.addFailureAt(node.getStart(), node.getWidth(), error);
       return;
     }

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -161,9 +161,16 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
     }
 
     // check for circular dependency
-    const circularPath = checkCircularPath(this.projectGraph, sourceProject, targetProject);
+    const circularPath = checkCircularPath(
+      this.projectGraph,
+      sourceProject,
+      targetProject
+    );
     if (circularPath.length !== 0) {
-      const path = circularPath.reduce((acc, v) => `${acc} -> ${v.name}`, sourceProject.name);
+      const path = circularPath.reduce(
+        (acc, v) => `${acc} -> ${v.name}`,
+        sourceProject.name
+      );
       const error = `Circular dependency between "${sourceProject.name}" and "${targetProject.name}" detected. The path is: ${path}`;
       this.addFailureAt(node.getStart(), node.getWidth(), error);
       return;

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -163,7 +163,7 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
     // check for circular dependency
     const circularPath = checkCircularPath(this.projectGraph, sourceProject, targetProject);
     if (circularPath.length !== 0) {
-      const path = circularPath.reduce((acc, v) => `${acc}->${v}`, '');
+      const path = circularPath.reduce((acc, v) => `${acc} -> ${v.name}`, sourceProject.name);
       const error = `Circular dependency between "${sourceProject.name}" and "${targetProject.name}" detected. The path is: ${path}`;
       this.addFailureAt(node.getStart(), node.getWidth(), error);
       return;

--- a/packages/workspace/src/utils/runtime-lint-utils.spec.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.spec.ts
@@ -12,8 +12,8 @@ describe('should find the path between nodes', () => {
     const graph = {
       nodes: ['A', 'B'],
       dependencies: {
-        'A': ['B']
-      }
+        A: ['B'],
+      },
     };
 
     const g = transformGraph(graph);
@@ -23,7 +23,6 @@ describe('should find the path between nodes', () => {
   });
 
   it('should find direct path', () => {
-
     /*
 
     A -> B
@@ -33,8 +32,8 @@ describe('should find the path between nodes', () => {
     const graph = {
       nodes: ['A', 'B'],
       dependencies: {
-        'A': ['B']
-      }
+        A: ['B'],
+      },
     };
 
     const g = transformGraph(graph);
@@ -44,7 +43,6 @@ describe('should find the path between nodes', () => {
   });
 
   it('should find indirect path', () => {
-
     /*
 
     A -> B -> E -> F
@@ -59,8 +57,8 @@ describe('should find the path between nodes', () => {
         A: ['B'],
         B: ['C', 'E'],
         C: ['D'],
-        E: ['F']
-      }
+        E: ['F'],
+      },
     };
 
     const g = transformGraph(graph);
@@ -70,7 +68,6 @@ describe('should find the path between nodes', () => {
   });
 
   it('should find indirect path in a graph that has a simple cycle', () => {
-
     /*
 
     A -> B -> C -> F
@@ -86,8 +83,8 @@ describe('should find the path between nodes', () => {
         B: ['C'],
         C: ['D', 'F'],
         D: ['E'],
-        E: ['A']
-      }
+        E: ['A'],
+      },
     };
 
     const g = transformGraph(graph);
@@ -97,7 +94,6 @@ describe('should find the path between nodes', () => {
   });
 
   it('should find indirect path in a graph that has a cycle', () => {
-
     /*
 
     B <- A ->  D -> E
@@ -112,8 +108,8 @@ describe('should find the path between nodes', () => {
         A: ['B', 'D'],
         B: ['C'],
         C: ['A'],
-        D: ['E']
-      }
+        D: ['E'],
+      },
     };
 
     const g = transformGraph(graph);
@@ -123,7 +119,6 @@ describe('should find the path between nodes', () => {
   });
 
   it('should find indirect path in a graph with inner and outer cycles', () => {
-
     /*
 
         A  -->  B
@@ -144,8 +139,8 @@ describe('should find the path between nodes', () => {
         E: ['B'],
         F: ['H'],
         G: ['C'],
-        H: ['G', 'E']
-      }
+        H: ['G', 'E'],
+      },
     };
 
     const g = transformGraph(graph);
@@ -163,14 +158,14 @@ describe('should find the path between nodes', () => {
 
 interface SimplifiedGraph {
   nodes: Array<string>;
-  dependencies: Record<string, Array<string>>
+  dependencies: Record<string, Array<string>>;
 }
 
 function transformGraph(graph: SimplifiedGraph): ProjectGraph {
   const nodes = graph.nodes.reduce((acc, name) => {
     return {
       ...acc,
-      [name]: { name, type: 'app' }
+      [name]: { name, type: 'app' },
     };
   }, {});
 
@@ -181,19 +176,19 @@ function transformGraph(graph: SimplifiedGraph): ProjectGraph {
 
     return {
       ...acc,
-      [dep]: targets
+      [dep]: targets,
     };
   }, {});
 
   return {
     nodes,
-    dependencies
+    dependencies,
   };
 }
 
-function getPath(graph: ProjectGraph, node: { from: string, to: string }) {
+function getPath(graph: ProjectGraph, node: { from: string; to: string }) {
   const src = graph.nodes[node.to];
   const dest = graph.nodes[node.from];
   const path = checkCircularPath(graph, src, dest);
-  return path.map(n => n.name);
+  return path.map((n) => n.name);
 }

--- a/packages/workspace/src/utils/runtime-lint-utils.spec.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.spec.ts
@@ -1,0 +1,190 @@
+import { checkCircularPath } from './runtime-lint-utils';
+
+function transformGraph(graph) {
+  const nodes = graph.nodes.reduce((acc, name) => {
+    return {
+      ...acc,
+      [name]: { name }
+    };
+  }, {});
+
+  const dependencies = Object.keys(graph.dependencies).reduce((acc, dep) => {
+    const targets = graph.dependencies[dep].reduce((acc, name) => {
+      return [...acc, { source: dep, target: name }];
+    }, []);
+
+    return {
+      ...acc,
+      [dep]: targets
+    };
+  }, {});
+
+  return {
+    nodes,
+    dependencies
+  };
+}
+
+function getPath(graph, node) {
+  return checkCircularPath(graph as any, { name: node.to } as any, { name: node.from } as any);
+}
+
+describe('should find the path between nodes', () => {
+  it('should return empty path when when there are no connecting edges', () => {
+    /*
+
+    A -> B -> C - > E
+
+     */
+
+    const graph = {
+      nodes: ['A', 'B', 'C', 'E'],
+      dependencies: {
+        'A': ['B'],
+        'B': ['C'],
+        'C': ['E']
+      }
+    };
+
+    const g = transformGraph(graph);
+    const path = getPath(g, { from: 'B', to: 'A' });
+
+    expect(path).toEqual([]);
+  });
+
+  it('should find direct path', () => {
+    /*
+
+    A -> B -> C - > E
+
+    */
+
+    const graph = {
+      nodes: ['A', 'B', 'C'],
+      dependencies: {
+        'A': ['B']
+      }
+    };
+
+    const g = transformGraph(graph);
+    const path = getPath(g, { from: 'A', to: 'B' });
+
+    expect(path).toEqual(['A', 'B']);
+  });
+
+  it('should find indirect path', () => {
+
+    /*
+
+    A -> B -> E -> F
+         \
+          C -> D
+
+    */
+
+    const graph = {
+      nodes: ['A', 'B', 'C', 'D', 'E', 'F'],
+      dependencies: {
+        A: ['B'],
+        B: ['C', 'E'],
+        C: ['D'],
+        E: ['F']
+      }
+    };
+
+    const g = transformGraph(graph);
+    const path = getPath(g, { from: 'A', to: 'F' });
+
+    expect(path).toEqual(['A', 'B', 'E', 'F']);
+  });
+
+  it('should find indirect path in a graph that has a simple cycle', () => {
+
+    /*
+
+    A -> B -> C -> F
+     \       /
+      E <-- D
+
+    */
+
+    const graph = {
+      nodes: ['A', 'B', 'C', 'D', 'E', 'F'],
+      dependencies: {
+        A: ['B'],
+        B: ['C'],
+        C: ['D', 'F'],
+        D: ['E'],
+        E: ['A']
+      }
+    };
+
+    const g = transformGraph(graph);
+    const path = getPath(g, { from: 'A', to: 'F' });
+
+    expect(path).toEqual(['A', 'B', 'C', 'F']);
+  });
+
+  it('should find indirect path in a graph that has a cycle', () => {
+    /*
+
+    B <- A ->  D -> E
+     \  /^
+      C
+
+    */
+
+    const graph = {
+      nodes: ['A', 'B', 'C', 'D', 'E'],
+      dependencies: {
+        A: ['B', 'D'],
+        B: ['C'],
+        C: ['A'],
+        D: ['E']
+      }
+    };
+
+    const g = transformGraph(graph);
+    const path = getPath(g, { from: 'A', to: 'E' });
+
+    expect(path).toEqual(['A', 'D', 'E']);
+  });
+
+  it('should find indirect path in a graph with inner and outer cycles', () => {
+
+    /*
+
+        A  -->  B
+      /^  \   /^ \
+     C    D  E   F
+     ^\  /   ^\  /
+       G  <--  H
+
+    */
+
+    const graph = {
+      nodes: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'],
+      dependencies: {
+        A: ['B', 'D'],
+        B: ['F'],
+        C: ['A'],
+        D: ['G'],
+        E: ['B'],
+        F: ['H'],
+        G: ['C'],
+        H: ['G', 'E']
+      }
+    };
+
+    const g = transformGraph(graph);
+
+    const path1 = getPath(g, { from: 'A', to: 'H' });
+    expect(path1).toEqual(['A', 'B', 'F', 'H']);
+
+    const path2 = getPath(g, { from: 'A', to: 'G' });
+    expect(path2).toEqual(['A', 'D', 'G']);
+
+    const path3 = getPath(g, { from: 'B', to: 'D' });
+    expect(path3).toEqual(['B', 'F', 'H', 'G', 'C', 'A', 'D']);
+  });
+});

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -2,7 +2,8 @@ import { normalize } from '@angular-devkit/core';
 import * as path from 'path';
 import { FileData } from '../core/file-utils';
 import {
-  DependencyType, isWorkspaceProject,
+  DependencyType,
+  isWorkspaceProject,
   ProjectGraph,
   ProjectGraphDependency,
   ProjectGraphNode,
@@ -156,27 +157,29 @@ export function checkCircularPath(
 }
 
 interface Reach {
-  graph: ProjectGraph,
-  matrix: Record<string, Array<string>>,
-  adjList: Record<string, Array<string>>
+  graph: ProjectGraph;
+  matrix: Record<string, Array<string>>;
+  adjList: Record<string, Array<string>>;
 }
 
 const reach: Reach = {
   graph: null,
   matrix: null,
-  adjList: null
+  adjList: null,
 };
 
 function buildMatrix(graph: ProjectGraph) {
   const dependencies = graph.dependencies;
-  const nodes = Object.keys(graph.nodes).filter(s => isWorkspaceProject(graph.nodes[s]));
+  const nodes = Object.keys(graph.nodes).filter((s) =>
+    isWorkspaceProject(graph.nodes[s])
+  );
   const adjList = {};
   const matrix = {};
 
   const initMatrixValues = nodes.reduce((acc, value) => {
     return {
       ...acc,
-      [value]: false
+      [value]: false,
     };
   }, {});
 
@@ -207,11 +210,15 @@ function buildMatrix(graph: ProjectGraph) {
 
   return {
     matrix,
-    adjList
+    adjList,
   };
 }
 
-function getPath(graph: ProjectGraph, sourceProjectName: string, targetProjectName: string): Array<ProjectGraphNode> {
+function getPath(
+  graph: ProjectGraph,
+  sourceProjectName: string,
+  targetProjectName: string
+): Array<ProjectGraphNode> {
   if (sourceProjectName === targetProjectName) return [];
 
   if (reach.graph !== graph) {
@@ -234,16 +241,16 @@ function getPath(graph: ProjectGraph, sourceProjectName: string, targetProjectNa
     if (current === targetProjectName) break;
 
     adjList[current]
-      .filter(adj => visited.indexOf(adj) === -1)
-      .filter(adj => reach.matrix[adj][targetProjectName])
-      .forEach(adj => {
+      .filter((adj) => visited.indexOf(adj) === -1)
+      .filter((adj) => reach.matrix[adj][targetProjectName])
+      .forEach((adj) => {
         visited.push(adj);
         queue.push([adj, [...path]]);
       });
   }
 
   if (path.length > 1) {
-    return path.map(n => graph.nodes[n]);
+    return path.map((n) => graph.nodes[n]);
   } else {
     return [];
   }


### PR DESCRIPTION
## Current Behavior
The circular dependencies check can be very flow in large projects. This is because we traverse the same graph over and over again. Instead of doing this, we can use dynamic programming and cache traversed sub-paths. 

## Expected Behavior
The number of total traversals should become O(EdgesInProjectGraph).

Fixes #
#3393
