### PR TITLE
fix(core): do not print warnings for print-affected

### DIFF
--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -20,7 +20,10 @@ import { DefaultReporter } from '../tasks-runner/default-reporter';
 export function affected(command: string, parsedArgs: yargs.Arguments): void {
   const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides(
     parsedArgs,
-    'affected'
+    'affected',
+    {
+      printWarnings: command !== 'print-affected' && !parsedArgs.plain,
+    }
   );
 
   const projectGraph = createProjectGraph();

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -72,7 +72,8 @@ const ignoreArgs = ['$0', '_'];
 
 export function splitArgsIntoNxArgsAndOverrides(
   args: yargs.Arguments,
-  mode: 'run-one' | 'run-many' | 'affected'
+  mode: 'run-one' | 'run-many' | 'affected' | 'print-affected',
+  options = { printWarnings: true }
 ): { nxArgs: NxArgs; overrides: yargs.Arguments } {
   const nxSpecific =
     mode === 'run-one' ? runOne : mode === 'run-many' ? runMany : runAffected;
@@ -103,7 +104,9 @@ export function splitArgsIntoNxArgsAndOverrides(
   }
 
   if (mode === 'affected') {
-    printArgsWarning(nxArgs);
+    if (options.printWarnings) {
+      printArgsWarning(nxArgs);
+    }
     if (
       !nxArgs.files &&
       !nxArgs.uncommitted &&


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`print-affected` prints warnings which makes it hard to parse.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`print-affected` does not print warnings making it easier to parse

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/3473
