### PR TITLE
feat(nextjs): update nextjs and related packages to current version

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -34,6 +34,19 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "10.1.0": {
+      "version": "10.1.0-beta.0",
+      "packages": {
+        "next": {
+          "version": "9.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "node-sass": {
+          "version": "4.14.1",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/next/src/migrations/update-10-1-0/update-10-1-0.ts
+++ b/packages/next/src/migrations/update-10-1-0/update-10-1-0.ts
@@ -1,0 +1,13 @@
+import { chain, Rule } from '@angular-devkit/schematics';
+import { formatFiles, updatePackagesInPackageJson } from '@nrwl/workspace';
+import * as path from 'path';
+
+export default function update(): Rule {
+  return chain([
+    updatePackagesInPackageJson(
+      path.join(__dirname, '../../../', 'migrations.json'),
+      '10.1.0'
+    ),
+    formatFiles(),
+  ]);
+}

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -1,9 +1,9 @@
 export const nxVersion = '*';
 
-export const nextVersion = '9.3.3';
+export const nextVersion = '9.5.1';
 export const zeitNextCss = '1.0.1';
 export const zeitNextSass = '1.0.1';
-export const nodeSass = '4.13.1';
+export const nodeSass = '4.14.1';
 export const zeitNextLess = '1.0.1';
 export const zeitNextStylus = '1.0.1';
 export const emotionServerVersion = '10.0.27';


### PR DESCRIPTION
This just updates NextJS to 9.5.1 and node-sass to 4.14.1, along with a migration.
