### PR TITLE
fix(testing): cypress builder - baseUrl option take precedence if present

### DIFF
--- a/packages/cypress/src/builders/cypress/cypress.impl.spec.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.spec.ts
@@ -268,6 +268,32 @@ describe('Cypress builder', () => {
     done();
   });
 
+  test('when devServerTarget AND baseUrl options are both present, baseUrl should take precidence', async (done) => {
+    const options: CypressBuilderOptions = {
+      ...cypressBuilderOptions,
+      baseUrl: 'test-url-from-options',
+    };
+    const result = await cypressBuilderRunner(
+      options,
+      mockedBuilderContext
+    ).toPromise();
+    expect(cypressRun.calls.mostRecent().args[0].config.baseUrl).toBe(
+      'test-url-from-options'
+    );
+    done();
+  });
+
+  test('when devServerTarget option present and baseUrl option is absent, baseUrl should come from devServerTarget', async (done) => {
+    const result = await cypressBuilderRunner(
+      cypressBuilderOptions,
+      mockedBuilderContext
+    ).toPromise();
+    expect(cypressRun.calls.mostRecent().args[0].config.baseUrl).toBe(
+      'http://localhost:4200'
+    );
+    done();
+  });
+
   describe('legacy', () => {
     beforeEach(() => {
       cypressConfig = {

--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -64,7 +64,9 @@ export function cypressBuilderRunner(
 
   return (!legacy
     ? options.devServerTarget
-      ? startDevServer(options.devServerTarget, options.watch, context)
+      ? startDevServer(options.devServerTarget, options.watch, context).pipe(
+          map((devServerBaseUrl) => options.baseUrl || devServerBaseUrl)
+        )
       : of(options.baseUrl)
     : legacyCompile(options, context)
   ).pipe(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If `devServerTarget` AND `baseUrl` options are set, the baseUrl that cypress will use is determined by the `devServerTarget`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
If `devServerTarget` AND `baseUrl` options are set, the baseUrl that cypress will use should be the `baseUrl` option.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
