### PR TITLE
fix(workspace): git-hasher does not work with RM

### DIFF
--- a/packages/workspace/src/core/hasher/git-hasher.spec.ts
+++ b/packages/workspace/src/core/hasher/git-hasher.spec.ts
@@ -72,6 +72,14 @@ describe('git-hasher', () => {
       `${dir}/a.txt`,
       `${dir}/newa.txt`,
     ]);
+    
+    run(`mv a.txt moda.txt`);
+    run('echo modified >> moda.txt`);
+    expect([...getFileHashes(dir).keys()]).toEqual([
+      `${dir}/moda.txt`,
+      `${dir}/newa.txt`,
+    ]);
+        
   });
 
   it('should handle spaces in filenames', () => {

--- a/packages/workspace/src/core/hasher/git-hasher.ts
+++ b/packages/workspace/src/core/hasher/git-hasher.ts
@@ -36,7 +36,7 @@ function parseGitStatus(output: string): Map<string, string> {
         .filter((r) => !!r);
       if (changeType && filenames && filenames.length > 0) {
         // the before filename we mark as deleted, so we remove it from the map
-        if (changeType === 'R') {
+        if (changeType[0] === 'R') {
           changes.set(filenames[0], 'D');
         }
         changes.set(filenames[filenames.length - 1], changeType);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

If I both move and modify a file, the output in git status -s will be `RM` while the parsing of the output checks for the whole status to be equal to `R`, which it isn't; so I check only the first letter to be `R`.

## Current Behavior
<!-- This is the behavior we have today -->

I move and modify a file, then I tried to run `nx run my-plugin:build` and it didn't work, because it couldn't find the original file (the one before moving).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `RM` status should now be parsed correctly.

## Related Issue(s)


I have not even used `nx` yet, I'm just trying to get it to work, so I wouldn't mind a thorough review.
