### PR TITLE
Remove empty space from describe name for components

### DIFF
--- a/packages/react/src/schematics/component/files/__fileName__.spec.tsx__tmpl__
+++ b/packages/react/src/schematics/component/files/__fileName__.spec.tsx__tmpl__
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 
 import <%= className %> from './<%= fileName %>';
 
-describe(' <%= className %>', () => {
+describe('<%= className %>', () => {
   it('should render successfully', () => {
     const { baseElement } = render(< <%= className %> />);
     expect(baseElement).toBeTruthy();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When creating a new component, in its spec file, the `describe` name includes an empty space at the beginning.

## Expected Behavior
`describe` name shouldn't have a empty space at the beginning.

## Related Issue(s)
Added on https://github.com/nrwl/nx/pull/1355.
