### PR TITLE
fix(repo): registry is set incorrectly when using --local

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -45,7 +45,7 @@ do
   echo "Publishing ${PACKAGE_NAME}@${VERSION} --tag ${TAG}"
 
   if [ "$LOCALBUILD" = "--local" ]; then
-    npm publish --tag $TAG --access public --registry=NPM_REGISTRY
+    npm publish --tag $TAG --access public --registry=$NPM_REGISTRY
   else
     npm publish --tag $TAG --access public
   fi


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`yarn nx-release 999.9.9 --local` triggers
`npm WARN invalid config registry="NPM_REGISTRY"`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
No error should show

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3512 
