### PR TITLE
feat(core): add user-friendly error on invalid input

### DIFF
--- a/packages/workspace/src/schematics/move/lib/update-imports.ts
+++ b/packages/workspace/src/schematics/move/lib/update-imports.ts
@@ -88,7 +88,14 @@ export function updateImports(schema: Schema) {
           const path = tsConfig.compilerOptions.paths[
             projectRef.from
           ] as string[];
-
+          if (!path) {
+            throw new Error(
+              [
+                `unable to find "${projectRef.from}" in`,
+                `${tsConfigPath} compilerOptions.paths`,
+              ].join(' ')
+            );
+          }
           const updatedPath = path.map((x) =>
             x.replace(new RegExp(projectRoot.from, 'g'), projectRoot.to)
           );


### PR DESCRIPTION
Prevent cryptic error of `TypeError: Cannot read property 'map' of undefined`, which doesn't guide the user towards success

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

`TypeError: Cannot read property 'map' of undefined` on bad input

## Expected Behavior

Guidance on what was incorrect

## Related Issue(s)

#3354, #3318 

Fixes #

n/a