### PR TITLE
Update 08-create-libs.md

### DIFF
--- a/docs/angular/tutorial/08-create-libs.md
+++ b/docs/angular/tutorial/08-create-libs.md
@@ -91,7 +91,7 @@ myorg/
 └── tslint.json
 ```
 
-**Add a `todos` input to `libs/src/lib/todos/todos.component.ts`.**
+**Add a `todos` input to `libs/ui/src/lib/todos/todos.component.ts`.**
 
 ```typescript
 import { Component, OnInit, Input } from '@angular/core';


### PR DESCRIPTION
fix(nx): fix incorrect path in doc


## Current Behavior
Current path in tutorial is 'libs/src/lib/todos/todos.component.ts', which does not exist.

## Expected Behavior
Instead, the path should be `libs/ui/src/lib/todos/todos.component.ts`

