### PR TITLE
fix(core): do not run update task if package is not installed

### DIFF
--- a/packages/workspace/src/utils/update-task.ts
+++ b/packages/workspace/src/utils/update-task.ts
@@ -11,6 +11,7 @@ import {
 import { Observable } from 'rxjs';
 import { fork } from 'child_process';
 import { join } from 'path';
+import { readJsonInTree } from './ast-utils';
 
 let taskRegistered = false;
 
@@ -22,6 +23,10 @@ export function addUpdateTask(
   return (host: Tree, context: SchematicContext) => {
     // Workflow should always be there during ng update but not during tests.
     if (!context.engine.workflow) {
+      return;
+    }
+    const packageJson = readJsonInTree(host, 'package.json');
+    if (!packageJson.dependencies[pkg] && !packageJson.devDependencies[pkg]) {
       return;
     }
     if (!taskRegistered) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Migrations will try to run update on packages whether they are actually installed or not.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Migrations will not run updates on packages that are not installed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/3380
