### PR TITLE
fix(core): fix decorate angular-cli script to work for production ins…

### DIFF
--- a/packages/workspace/src/schematics/utils/decorate-angular-cli.js__tmpl__
+++ b/packages/workspace/src/schematics/utils/decorate-angular-cli.js__tmpl__
@@ -25,7 +25,13 @@ const fs = require('fs');
 const os = require('os');
 const cp = require('child_process');
 const isWindows = os.platform() === 'win32';
-const { output } = require('@nrwl/workspace');
+let output;
+try {
+  output = require('@nrwl/workspace').output;
+} catch (e) {
+  console.warn('Angular CLI could not be decorated to enable computation caching. Please ensure @nrwl/workspace is installed.');
+  process.exit(0);
+}
 
 /**
  * Paths to files being patched


### PR DESCRIPTION
…talls

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`decorate-angular-cli` errors when `devDependencies` are not installed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`decorate-angular-cli` properly warns (and doesn't error) when `devDependencies` are not installed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/3179
