### PR TITLE
fix(core): remove defaultProject in workspace when removing project

### DIFF
--- a/packages/workspace/src/schematics/remove/lib/update-workspace.spec.ts
+++ b/packages/workspace/src/schematics/remove/lib/update-workspace.spec.ts
@@ -66,9 +66,9 @@ describe('updateWorkspace Rule', () => {
     it('should delete the project', async () => {
       let workspace = JSON.parse(tree.read('workspace.json').toString());
       expect(workspace.projects['ng-app']).toBeDefined();
-  
+
       tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
-  
+
       workspace = JSON.parse(tree.read('workspace.json').toString());
       expect(workspace.projects['ng-app']).toBeUndefined();
     });
@@ -136,12 +136,12 @@ describe('updateWorkspace Rule', () => {
         skipFormat: false,
         forceRemove: false,
       };
-      
+
       let workspace = JSON.parse(tree.read('workspace.json').toString());
       expect(workspace.defaultProject).toBeDefined();
-  
+
       tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
-  
+
       workspace = JSON.parse(tree.read('workspace.json').toString());
       expect(workspace.defaultProject).toBeUndefined();
     });
@@ -155,12 +155,11 @@ describe('updateWorkspace Rule', () => {
 
       let workspace = JSON.parse(tree.read('workspace.json').toString());
       expect(workspace.defaultProject).toBeDefined();
-  
+
       tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
-  
+
       workspace = JSON.parse(tree.read('workspace.json').toString());
       expect(workspace.defaultProject).toBeDefined();
     });
   });
-
 });

--- a/packages/workspace/src/schematics/remove/lib/update-workspace.spec.ts
+++ b/packages/workspace/src/schematics/remove/lib/update-workspace.spec.ts
@@ -13,19 +13,104 @@ describe('updateWorkspace Rule', () => {
   beforeEach(async () => {
     tree = new UnitTestTree(Tree.empty());
     tree = createEmptyWorkspace(tree) as UnitTestTree;
+  });
 
-    schema = {
-      projectName: 'ng-app',
-      skipFormat: false,
-      forceRemove: false,
-    };
+  describe('delete project', async () => {
+    beforeEach(async () => {
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
 
-    tree = (await callRule(
-      updateWorkspaceInTree((workspace) => {
-        return {
-          version: 1,
-          projects: {
-            'ng-app': {
+      tree = (await callRule(
+        updateWorkspaceInTree((workspace) => {
+          return {
+            version: 1,
+            projects: {
+              'ng-app': {
+                projectType: 'application',
+                schematics: {},
+                root: 'apps/ng-app',
+                sourceRoot: 'apps/ng-app/src',
+                prefix: 'happyorg',
+                architect: {
+                  build: {
+                    builder: '@angular-devkit/build-angular:browser',
+                    options: {},
+                  },
+                },
+              },
+              'ng-app-e2e': {
+                root: 'apps/ng-app-e2e',
+                sourceRoot: 'apps/ng-app-e2e/src',
+                projectType: 'application',
+                architect: {
+                  e2e: {
+                    builder: '@nrwl/cypress:cypress',
+                    options: {
+                      cypressConfig: 'apps/ng-app-e2e/cypress.json',
+                      tsConfig: 'apps/ng-app-e2e/tsconfig.e2e.json',
+                      devServerTarget: 'ng-app:serve',
+                    },
+                  },
+                },
+              },
+            },
+          };
+        }),
+        tree
+      )) as UnitTestTree;
+    });
+
+    it('should delete the project', async () => {
+      let workspace = JSON.parse(tree.read('workspace.json').toString());
+      expect(workspace.projects['ng-app']).toBeDefined();
+  
+      tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
+  
+      workspace = JSON.parse(tree.read('workspace.json').toString());
+      expect(workspace.projects['ng-app']).toBeUndefined();
+    });
+  });
+
+  describe('defaultProject', () => {
+    beforeEach(async () => {
+      tree = (await callRule(
+        updateWorkspaceInTree((workspace) => {
+          return {
+            version: 1,
+            projects: {
+              'ng-app': {
+                projectType: 'application',
+                schematics: {},
+                root: 'apps/ng-app',
+                sourceRoot: 'apps/ng-app/src',
+                prefix: 'happyorg',
+                architect: {
+                  build: {
+                    builder: '@angular-devkit/build-angular:browser',
+                    options: {},
+                  },
+                },
+              },
+              'ng-app-e2e': {
+                root: 'apps/ng-app-e2e',
+                sourceRoot: 'apps/ng-app-e2e/src',
+                projectType: 'application',
+                architect: {
+                  e2e: {
+                    builder: '@nrwl/cypress:cypress',
+                    options: {
+                      cypressConfig: 'apps/ng-app-e2e/cypress.json',
+                      tsConfig: 'apps/ng-app-e2e/tsconfig.e2e.json',
+                      devServerTarget: 'ng-app:serve',
+                    },
+                  },
+                },
+              },
+            },
+            'ng-other-app': {
               projectType: 'application',
               schematics: {},
               root: 'apps/ng-app',
@@ -38,35 +123,44 @@ describe('updateWorkspace Rule', () => {
                 },
               },
             },
-            'ng-app-e2e': {
-              root: 'apps/ng-app-e2e',
-              sourceRoot: 'apps/ng-app-e2e/src',
-              projectType: 'application',
-              architect: {
-                e2e: {
-                  builder: '@nrwl/cypress:cypress',
-                  options: {
-                    cypressConfig: 'apps/ng-app-e2e/cypress.json',
-                    tsConfig: 'apps/ng-app-e2e/tsconfig.e2e.json',
-                    devServerTarget: 'ng-app:serve',
-                  },
-                },
-              },
-            },
-          },
-        };
-      }),
-      tree
-    )) as UnitTestTree;
+            defaultProject: 'ng-app',
+          };
+        }),
+        tree
+      )) as UnitTestTree;
+    });
+
+    it('should remove defaultProject if it matches the project being deleted', async () => {
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+      
+      let workspace = JSON.parse(tree.read('workspace.json').toString());
+      expect(workspace.defaultProject).toBeDefined();
+  
+      tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
+  
+      workspace = JSON.parse(tree.read('workspace.json').toString());
+      expect(workspace.defaultProject).toBeUndefined();
+    });
+
+    it('should not remove defaultProject if it does not match the project being deleted', async () => {
+      schema = {
+        projectName: 'ng-other-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      let workspace = JSON.parse(tree.read('workspace.json').toString());
+      expect(workspace.defaultProject).toBeDefined();
+  
+      tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
+  
+      workspace = JSON.parse(tree.read('workspace.json').toString());
+      expect(workspace.defaultProject).toBeDefined();
+    });
   });
 
-  it('should delete the project', async () => {
-    let workspace = JSON.parse(tree.read('workspace.json').toString());
-    expect(workspace.projects['ng-app']).toBeDefined();
-
-    tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
-
-    workspace = JSON.parse(tree.read('workspace.json').toString());
-    expect(workspace.projects['ng-app']).toBeUndefined();
-  });
 });

--- a/packages/workspace/src/schematics/remove/lib/update-workspace.ts
+++ b/packages/workspace/src/schematics/remove/lib/update-workspace.ts
@@ -8,13 +8,20 @@ import { updateWorkspaceInTree, getWorkspacePath } from '@nrwl/workspace';
  * @param schema The options provided to the schematic
  */
 export function updateWorkspace(schema: Schema) {
-  return updateWorkspaceInTree((workspace, context: SchematicContext, host: Tree) => {
-    delete workspace.projects[schema.projectName];
-    if (workspace.defaultProject && workspace.defaultProject === schema.projectName) {
-      delete workspace.defaultProject;
-      const workspacePath = getWorkspacePath(host);
-      context.logger.warn(`Default project was removed in ${workspacePath} because it was "${schema.projectName}". If you want a default project you should define a new one.`);
+  return updateWorkspaceInTree(
+    (workspace, context: SchematicContext, host: Tree) => {
+      delete workspace.projects[schema.projectName];
+      if (
+        workspace.defaultProject &&
+        workspace.defaultProject === schema.projectName
+      ) {
+        delete workspace.defaultProject;
+        const workspacePath = getWorkspacePath(host);
+        context.logger.warn(
+          `Default project was removed in ${workspacePath} because it was "${schema.projectName}". If you want a default project you should define a new one.`
+        );
+      }
+      return workspace;
     }
-    return workspace;
-  });
+  );
 }

--- a/packages/workspace/src/schematics/remove/lib/update-workspace.ts
+++ b/packages/workspace/src/schematics/remove/lib/update-workspace.ts
@@ -1,5 +1,6 @@
-import { updateWorkspaceInTree } from '@nrwl/workspace';
 import { Schema } from '../schema';
+import { SchematicContext, Tree } from '@angular-devkit/schematics';
+import { updateWorkspaceInTree, getWorkspacePath } from '@nrwl/workspace';
 
 /**
  * Deletes the project from the workspace file
@@ -7,8 +8,13 @@ import { Schema } from '../schema';
  * @param schema The options provided to the schematic
  */
 export function updateWorkspace(schema: Schema) {
-  return updateWorkspaceInTree((workspace) => {
+  return updateWorkspaceInTree((workspace, context: SchematicContext, host: Tree) => {
     delete workspace.projects[schema.projectName];
+    if (workspace.defaultProject && workspace.defaultProject === schema.projectName) {
+      delete workspace.defaultProject;
+      const workspacePath = getWorkspacePath(host);
+      context.logger.warn(`Default project was removed in ${workspacePath} because it was "${schema.projectName}". If you want a default project you should define a new one.`);
+    }
     return workspace;
   });
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Deleting the project listed as `defaultProject` in the workspace file leaves the CLI in an unusable state

## Expected Behavior
If the default project is removed, this removes the `defaultProject` setting and displays a warning to the user

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3511
