### PR TITLE
feat(testing): pass reporter and reporterOptions to cypress builder

### DIFF
--- a/docs/angular/api-cypress/builders/cypress.md
+++ b/docs/angular/api-cypress/builders/cypress.md
@@ -92,6 +92,18 @@ Type: `boolean`
 
 Whether or not Cypress should record the results of the tests
 
+### reporter
+
+Type: `string`
+
+The reporter used during cypress run
+
+### reporterOptions
+
+Type: `string`
+
+The reporter options used. Supported options depend on the reporter.
+
 ### spec
 
 Type: `string`

--- a/docs/react/api-cypress/builders/cypress.md
+++ b/docs/react/api-cypress/builders/cypress.md
@@ -93,6 +93,18 @@ Type: `boolean`
 
 Whether or not Cypress should record the results of the tests
 
+### reporter
+
+Type: `string`
+
+The reporter used during cypress run
+
+### reporterOptions
+
+Type: `string`
+
+The reporter options used. Supported options depend on the reporter.
+
 ### spec
 
 Type: `string`

--- a/packages/cypress/src/builders/cypress/cypress.impl.spec.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.spec.ts
@@ -210,7 +210,30 @@ describe('Cypress builder', () => {
       .then(() => {
         expect(cypressRun).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            ignoreTestFiles: cypressBuilderOptions.ignoreTestFiles,
+            ignoreTestFiles: cfg.ignoreTestFiles,
+          })
+        );
+        expect(cypressOpen).not.toHaveBeenCalled();
+        done();
+      });
+
+    fakeEventEmitter.emit('exit', 0); // Passing tsc command
+  });
+
+  it('should call `Cypress.run` with a reporter and reporterOptions', async (done) => {
+    const cfg = {
+      ...cypressBuilderOptions,
+      reporter: 'junit',
+      reporterOptions: 'mochaFile=reports/results-[hash].xml,toConsole=true',
+    };
+
+    cypressBuilderRunner(cfg, mockedBuilderContext)
+      .toPromise()
+      .then(() => {
+        expect(cypressRun).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            reporter: cfg.reporter,
+            reporterOptions: cfg.reporterOptions,
           })
         );
         expect(cypressOpen).not.toHaveBeenCalled();
@@ -305,7 +328,7 @@ describe('Cypress builder', () => {
   });
 
   test('when devServerTarget option present and baseUrl option is absent, baseUrl should come from devServerTarget', async (done) => {
-    const result = await cypressBuilderRunner(
+    await cypressBuilderRunner(
       cypressBuilderOptions,
       mockedBuilderContext
     ).toPromise();

--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -35,6 +35,8 @@ export interface CypressBuilderOptions extends JsonObject {
   ciBuildId?: string;
   group?: string;
   ignoreTestFiles?: string;
+  reporter?: string;
+  reporterOptions?: string;
 }
 
 try {
@@ -85,7 +87,10 @@ export function cypressBuilderRunner(
         options.env,
         options.spec,
         options.ciBuildId,
-        options.group
+        options.group,
+        options.ignoreTestFiles,
+        options.reporter,
+        options.reporterOptions
       )
     ),
     options.watch ? tap(noop) : take(1),
@@ -134,7 +139,9 @@ function initCypress(
   spec?: string,
   ciBuildId?: string,
   group?: string,
-  ignoreTestFiles?: string
+  ignoreTestFiles?: string,
+  reporter?: string,
+  reporterOptions?: string
 ): Observable<BuilderOutput> {
   // Cypress expects the folder where a `cypress.json` is present
   const projectFolderPath = dirname(cypressConfig);
@@ -168,6 +175,8 @@ function initCypress(
   options.ciBuildId = ciBuildId;
   options.group = group;
   options.ignoreTestFiles = ignoreTestFiles;
+  options.reporter = reporter;
+  options.reporterOptions = reporterOptions;
 
   return fromPromise<any>(
     !isWatching || headless ? Cypress.run(options) : Cypress.open(options)

--- a/packages/cypress/src/builders/cypress/schema.json
+++ b/packages/cypress/src/builders/cypress/schema.json
@@ -76,6 +76,14 @@
     "ignoreTestFiles": {
       "type": "string",
       "description": "A String or Array of glob patterns used to ignore test files that would otherwise be shown in your list of tests. Cypress uses minimatch with the options: {dot: true, matchBase: true}. We suggest using https://globster.xyz to test what files would match."
+    },
+    "reporter": {
+      "type": "string",
+      "description": "The reporter used during cypress run"
+    },
+    "reporterOptions": {
+      "type": "string",
+      "description": "The reporter options used. Supported options depend on the reporter."
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
ISSUES CLOSED: #2800

## Current Behavior
reporter and reporterOptions have to be set via env
## Expected Behavior
reporter and reporterOptions can be set without setting them via env

## Related Issue(s)
#2800

Fixes #2800