### PR TITLE
feat(angular): respect useDataPersistence flag when creating ngrx efffects

### DIFF
--- a/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.effects.spec.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.effects.spec.ts__tmpl__
@@ -6,7 +6,7 @@ import { EffectsModule } from '@ngrx/effects';
 import {StoreModule} from '@ngrx/store';
 import {provideMockActions} from '@ngrx/effects/testing';
 
-import { NxModule, DataPersistence } from '@nrwl/angular';
+import { NxModule, <% if (useDataPersistence) { %>DataPersistence<% } %> } from '@nrwl/angular';
 import { hot } from '@nrwl/angular/testing';
 
 import { <%= className %>Effects } from './<%= fileName %>.effects';
@@ -25,7 +25,7 @@ describe('<%= className %>Effects', () => {
       ],
       providers: [
         <%= className %>Effects,
-        DataPersistence,
+        <% if (useDataPersistence) { %>DataPersistence,<% } %>
         provideMockActions(() => actions)
       ],
     });

--- a/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.effects.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.effects.ts__tmpl__
@@ -1,25 +1,46 @@
 import { Injectable } from '@angular/core';
-import { Effect, Actions } from '@ngrx/effects';
-import { DataPersistence } from '@nrwl/angular';
+import { Effect, Actions <% if (!useDataPersistence) { %>,ofType<% }%> } from '@ngrx/effects';
+import { <% if (useDataPersistence) { %>DataPersistence<% } else { %>fetch<% } %> } from '@nrwl/angular';
 
 import { <%= className %>PartialState  } from './<%= fileName %>.reducer';
 import { Load<%= className %>, <%= className %>Loaded, <%= className %>LoadError, <%= className %>ActionTypes } from './<%= fileName %>.actions';
 
 @Injectable()
 export class <%= className %>Effects {
- @Effect() load<%= className %>$ = this.dataPersistence.fetch(<%= className %>ActionTypes.Load<%= className %>, {
-   run: (action: Load<%= className %>, state: <%= className %>PartialState) => {
-     // Your custom REST 'load' logic goes here. For now just return an empty list...
-     return new <%= className %>Loaded([]);
-   },
+ @Effect() load<%= className %>$ =
 
-   onError: (action: Load<%= className %>, error) => {
-     console.error('Error', error);
-     return new <%= className %>LoadError(error);
-   }
- });
+ <% if (useDataPersistence) { %>
+ this.dataPersistence.fetch(<%= className %>ActionTypes.Load<%= className %>, {
+    run: (action: Load<%= className %>, state: <%= className %>PartialState) => {
+      // Your custom REST 'load' logic goes here. For now just return an empty list...
+      return new <%= className %>Loaded([]);
+    },
+
+    onError: (action: Load<%= className %>, error) => {
+      console.error('Error', error);
+      return new <%= className %>LoadError(error);
+    }
+  });
+ <% } else { %>
+  this.actions$.pipe(
+     ofType(<%= className %>ActionTypes.Load<%= className %>),
+     fetch({
+        run: (action: Load<%= className %>, state: <%= className %>PartialState) => {
+          // Your custom REST 'load' logic goes here. For now just return an empty list...
+          return new <%= className %>Loaded([]);
+        },
+
+        onError: (action: Load<%= className %>, error) => {
+          console.error('Error', error);
+          return new <%= className %>LoadError(error);
+        }
+      })
+  );
+ <% } %>
+
+
 
  constructor(
    private actions$: Actions,
-   private dataPersistence: DataPersistence<<%= className %>PartialState>) { }
+   <% if (useDataPersistence) { %>private dataPersistence: DataPersistence<<%= className %>PartialState><% } %>) { }
 }

--- a/packages/angular/src/schematics/ngrx/ngrx.spec.ts
+++ b/packages/angular/src/schematics/ngrx/ngrx.spec.ts
@@ -560,7 +560,7 @@ import {
           syntax: 'creators',
           minimal: false,
           facade: true,
-          useDataPersistance: false,
+          useDataPersistence: false,
         },
         appTree
       );
@@ -702,10 +702,40 @@ import {
     });
   });
 
+  describe('classes syntax', () => {
+    it('should use fetch operator when useDataPersistence is set to false', async () => {
+      const appConfig = getAppConfig();
+      const tree = await runSchematic(
+        'ngrx',
+        {
+          name: 'users',
+          module: appConfig.appModule,
+          syntax: 'classes',
+          minimal: false,
+          facade: true,
+          useDataPersistence: false,
+        },
+        appTree
+      );
+
+      const statePath = `${findModuleParent(appConfig.appModule)}/+state`;
+      const content = tree.readContent(`${statePath}/users.effects.ts`);
+
+      [`{ fetch }`, `, ofType`, `ofType(UsersActionTypes.LoadUsers),`].forEach(
+        (text) => {
+          expect(content).toContain(text);
+        }
+      );
+
+      expect(content).not.toContain('dataPersistence.fetch');
+    });
+  });
+
   async function buildNgrxTree(
     appConfig: AppConfig,
     featureName: string = 'user',
-    withFacade = false
+    withFacade = false,
+    useDataPersistence = true
   ): Promise<UnitTestTree> {
     return await runSchematic(
       'ngrx',
@@ -715,7 +745,7 @@ import {
         facade: withFacade,
         syntax: 'classes',
         minimal: false,
-        useDataPersistance: true,
+        useDataPersistence,
       },
       appTree
     );


### PR DESCRIPTION
ISSUES CLOSED: #2448

## Current Behavior
useDataPersistence only works for the creator syntax.

## Expected Behavior
 This PR will add the ability to use the classes syntax without nrwls datapersistence

## Related Issue(s)
#2448

