### PR TITLE
fix(angular): do not error during migration when encountering a prettierrc

### DIFF
--- a/packages/workspace/src/schematics/init/init.spec.ts
+++ b/packages/workspace/src/schematics/init/init.spec.ts
@@ -229,61 +229,128 @@ describe('workspace', () => {
       expect(tree.exists('/karma.conf.js')).toBe(true);
     });
 
-    it('should work with existing .prettierignore file', async () => {
-      appTree.create('/package.json', JSON.stringify({}));
-      appTree.create('/.prettierignore', '# existing ignore rules');
-      appTree.create(
-        '/angular.json',
-        JSON.stringify({
-          version: 1,
-          defaultProject: 'myApp',
-          projects: {
-            myApp: {
-              root: '',
-              sourceRoot: 'src',
-              architect: {
-                build: {
-                  options: {
-                    tsConfig: 'tsconfig.app.json',
+    describe('prettier', () => {
+      it('should work with existing .prettierignore file', async () => {
+        appTree.create('/package.json', JSON.stringify({}));
+        appTree.create(
+          '/angular.json',
+          JSON.stringify({
+            version: 1,
+            defaultProject: 'myApp',
+            projects: {
+              myApp: {
+                root: '',
+                sourceRoot: 'src',
+                architect: {
+                  build: {
+                    options: {
+                      tsConfig: 'tsconfig.app.json',
+                    },
+                    configurations: {},
                   },
-                  configurations: {},
-                },
-                test: {
-                  options: {
-                    tsConfig: 'tsconfig.spec.json',
+                  test: {
+                    options: {
+                      tsConfig: 'tsconfig.spec.json',
+                    },
                   },
-                },
-                lint: {
-                  options: {
-                    tsConfig: 'tsconfig.app.json',
+                  lint: {
+                    options: {
+                      tsConfig: 'tsconfig.app.json',
+                    },
                   },
-                },
-                e2e: {
-                  options: {
-                    protractorConfig: 'e2e/protractor.conf.js',
+                  e2e: {
+                    options: {
+                      protractorConfig: 'e2e/protractor.conf.js',
+                    },
                   },
                 },
               },
             },
-          },
-        })
-      );
-      appTree.create(
-        '/tsconfig.app.json',
-        '{"extends": "../tsconfig.json", "compilerOptions": {}}'
-      );
-      appTree.create(
-        '/tsconfig.spec.json',
-        '{"extends": "../tsconfig.json", "compilerOptions": {}}'
-      );
-      appTree.create('/tsconfig.base.json', '{"compilerOptions": {}}');
-      appTree.create('/tslint.json', '{"rules": {}}');
-      appTree.create('/e2e/protractor.conf.js', '// content');
-      appTree.create('/src/app/app.module.ts', '// content');
-      const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
+          })
+        );
+        appTree.create(
+          '/tsconfig.app.json',
+          '{"extends": "../tsconfig.json", "compilerOptions": {}}'
+        );
+        appTree.create(
+          '/tsconfig.spec.json',
+          '{"extends": "../tsconfig.json", "compilerOptions": {}}'
+        );
+        appTree.create('/tsconfig.base.json', '{"compilerOptions": {}}');
+        appTree.create('/tslint.json', '{"rules": {}}');
+        appTree.create('/e2e/protractor.conf.js', '// content');
+        appTree.create('/src/app/app.module.ts', '// content');
+        appTree.create('/.prettierignore', '# existing ignore rules');
 
-      const prettierIgnore = tree.read('/.prettierignore').toString();
-      expect(prettierIgnore).toBe('# existing ignore rules');
+        const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
+
+        const prettierIgnore = tree.read('/.prettierignore').toString();
+        expect(prettierIgnore).toBe('# existing ignore rules');
+      });
+
+      it('should work with existing .prettierrc file', async () => {
+        const config = {
+          semi: true,
+          trailingComma: 'none',
+          singleQuote: true,
+          printWidth: 80,
+        };
+
+        appTree.create('/.prettierrc', JSON.stringify(config));
+        appTree.create('/package.json', JSON.stringify({}));
+        appTree.create(
+          '/angular.json',
+          JSON.stringify({
+            version: 1,
+            defaultProject: 'myApp',
+            projects: {
+              myApp: {
+                root: '',
+                sourceRoot: 'src',
+                architect: {
+                  build: {
+                    options: {
+                      tsConfig: 'tsconfig.app.json',
+                    },
+                    configurations: {},
+                  },
+                  test: {
+                    options: {
+                      tsConfig: 'tsconfig.spec.json',
+                    },
+                  },
+                  lint: {
+                    options: {
+                      tsConfig: 'tsconfig.app.json',
+                    },
+                  },
+                  e2e: {
+                    options: {
+                      protractorConfig: 'e2e/protractor.conf.js',
+                    },
+                  },
+                },
+              },
+            },
+          })
+        );
+        appTree.create(
+          '/tsconfig.app.json',
+          '{"extends": "../tsconfig.json", "compilerOptions": {}}'
+        );
+        appTree.create(
+          '/tsconfig.spec.json',
+          '{"extends": "../tsconfig.json", "compilerOptions": {}}'
+        );
+        appTree.create('/tsconfig.base.json', '{"compilerOptions": {}}');
+        appTree.create('/tslint.json', '{"rules": {}}');
+        appTree.create('/e2e/protractor.conf.js', '// content');
+        appTree.create('/src/app/app.module.ts', '// content');
+
+        const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
+        const prettierRc = tree.read('/.prettierrc').toJSON();
+        expect(prettierRc).toStrictEqual(config);
+      });
     });
   });
 

--- a/packages/workspace/src/schematics/init/init.ts
+++ b/packages/workspace/src/schematics/init/init.ts
@@ -519,6 +519,11 @@ function createAdditionalFiles(options: Schema): Rule {
             '.prettierrc',
             serializeJson(DEFAULT_NRWL_PRETTIER_CONFIG)
           );
+        } else {
+          host.overwrite(
+            '.prettierrc',
+            serializeJson(existingPrettierConfig.config)
+          );
         }
       }),
       mapTo(host)

--- a/packages/workspace/src/utils/common.ts
+++ b/packages/workspace/src/utils/common.ts
@@ -1,4 +1,3 @@
-import { Rule } from '@angular-devkit/schematics';
 import { Options } from 'prettier';
 import * as cosmiconfig from 'cosmiconfig';
 


### PR DESCRIPTION
This is a WIP. Currently I cannot get the test to pass. Running the migration locally works like a charm.
While we are at it, maybe we should update cosmiconfig to v7. Nx is using v4!

If anybody has an idea on how to fix the test, feel free to adjust the PR or get in touch with me :)

## Current Behavior
When encountering prettier configuration during ng -> nx migration, the migration fails

## Expected Behavior
When encountering prettier configuration during ng -> nx migration, use existing one

## Related Issue(s)
#2155

Fixes #2155
