### PR TITLE
cleanup(react): add e2e test for IE support and differential loading

### DIFF
--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -236,6 +236,36 @@ forEachCli('nx', () => {
       );
     }, 120000);
 
+    it('should generate app with legacy-ie support', async () => {
+      ensureProject();
+      const appName = uniq('app');
+
+      runCLI(
+        `generate @nrwl/react:app ${appName} --style=css --no-interactive`
+      );
+
+      // changing browser suporrt of this application
+      updateFile(`apps/${appName}/.browserslistrc`, `IE 11`);
+
+      await testGeneratedApp(appName, {
+        checkStyles: false,
+        checkProdBuild: true,
+        checkLinter: false,
+        checkE2E: false,
+      });
+
+      const filesToCheck = [
+        `dist/apps/${appName}/prod/polyfills.es5.js`,
+        `dist/apps/${appName}/prod/main.es5.js`,
+      ];
+
+      checkFilesExist(...filesToCheck);
+
+      expect(readFile(`dist/apps/${appName}/prod/index.html`)).toContain(
+        `<script src="main.esm.js" type="module"></script><script src="main.es5.js" nomodule defer></script>`
+      );
+    }, 120000);
+
     it('should be able to add a redux slice', async () => {
       ensureProject();
       const appName = uniq('app');

--- a/packages/web/src/utils/third-party/utils/build-browser-features.ts
+++ b/packages/web/src/utils/third-party/utils/build-browser-features.ts
@@ -32,7 +32,7 @@ export class BuildBrowserFeatures {
 
   /**
    * True, when one or more browsers requires ES5
-   * support and the scirpt target is ES2015 or greater.
+   * support and the script target is ES2015 or greater.
    */
   isDifferentialLoadingNeeded(): boolean {
     return this._es6TargetOrLater && this.isEs5SupportNeeded();


### PR DESCRIPTION
This just adds a missing E2E test verifying the differential build when `.browserslist` includes IE

This just adds a test, it does not modify current behaviour
