### PR TITLE
fix(node): add srcRootForCompilationRoot option for node package builder

### DIFF
--- a/docs/angular/api-node/builders/package.md
+++ b/docs/angular/api-node/builders/package.md
@@ -38,6 +38,12 @@ Type: `boolean`
 
 Output sourcemaps.
 
+### srcRootForCompilationRoot
+
+Type: `string`
+
+Sets the rootDir for TypeScript compilation. When not defined, it uses the project's root property
+
 ### tsConfig
 
 Type: `string`

--- a/docs/react/api-node/builders/package.md
+++ b/docs/react/api-node/builders/package.md
@@ -39,6 +39,12 @@ Type: `boolean`
 
 Output sourcemaps.
 
+### srcRootForCompilationRoot
+
+Type: `string`
+
+Sets the rootDir for TypeScript compilation. When not defined, it uses the project's root property
+
 ### tsConfig
 
 Type: `string`

--- a/packages/node/src/builders/package/package.impl.spec.ts
+++ b/packages/node/src/builders/package/package.impl.spec.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs-extra';
 jest.mock('@nrwl/workspace/src/utils/fileutils');
 import * as fsUtility from '@nrwl/workspace/src/utils/fileutils';
 import * as tsUtils from '@nrwl/workspace/src/utils/typescript';
+import * as ts from 'typescript';
 
 describe('NodePackageBuilder', () => {
   let testOptions: NodePackageBuilderOptions;
@@ -211,6 +212,43 @@ describe('NodePackageBuilder', () => {
             expect(fs.copy).toHaveBeenCalledWith(
               `${context.workspaceRoot}/lib/nodelib/src/CONTRIBUTING.md`,
               `${context.workspaceRoot}/${testOptions.outputPath}/CONTRIBUTING.md`
+            );
+            done();
+          },
+        });
+      });
+    });
+
+    describe('srcRootForCompilationRoot', () => {
+      let spy: jest.SpyInstance;
+      beforeEach(() => {
+        jest.clearAllMocks();
+        spy = jest.spyOn(ts, 'createCompilerHost');
+      });
+
+      it('should use srcRootForCompilationRoot when it is defined', (done) => {
+        testOptions.srcRootForCompilationRoot = 'libs/nodelib/src';
+
+        runNodePackageBuilder(testOptions, context).subscribe({
+          complete: () => {
+            expect(spy).toHaveBeenCalledWith(
+              expect.objectContaining({
+                rootDir: 'libs/nodelib/src',
+              })
+            );
+            done();
+          },
+        });
+      });
+      it('should not use srcRootForCompilationRoot when it is not defined', (done) => {
+        testOptions.srcRootForCompilationRoot = undefined;
+
+        runNodePackageBuilder(testOptions, context).subscribe({
+          complete: () => {
+            expect(spy).toHaveBeenCalledWith(
+              expect.objectContaining({
+                rootDir: 'libs/nodelib',
+              })
             );
             done();
           },

--- a/packages/node/src/builders/package/schema.json
+++ b/packages/node/src/builders/package/schema.json
@@ -41,6 +41,10 @@
     "packageJson": {
       "type": "string",
       "description": "The name of the package.json file"
+    },
+    "srcRootForCompilationRoot": {
+      "type": "string",
+      "description": "Sets the rootDir for TypeScript compilation. When not defined, it uses the project's root property"
     }
   },
   "required": ["tsConfig", "main"],

--- a/packages/node/src/builders/package/utils/compile-typescript-files.ts
+++ b/packages/node/src/builders/package/utils/compile-typescript-files.ts
@@ -70,7 +70,11 @@ export default function compileTypeScriptFiles(
 
   const tsconfig = readTsConfig(tsConfigPath);
   tsconfig.options.outDir = options.normalizedOutputPath;
-  tsconfig.options.rootDir = libRoot;
+  if (options.srcRootForCompilationRoot) {
+    tsconfig.options.rootDir = options.srcRootForCompilationRoot;
+  } else {
+    tsconfig.options.rootDir = libRoot;
+  }
 
   if (options.watch) {
     return createWatchProgram(tsconfig);

--- a/packages/node/src/builders/package/utils/models.ts
+++ b/packages/node/src/builders/package/utils/models.ts
@@ -9,6 +9,7 @@ export interface NodePackageBuilderOptions extends JsonObject {
   assets: Array<AssetGlob | string>;
   packageJson: string;
   updateBuildableProjectDepsInPackageJson?: boolean;
+  srcRootForCompilationRoot?: string;
 }
 
 export interface NormalizedBuilderOptions extends NodePackageBuilderOptions {

--- a/packages/node/src/migrations/update-10-1-0/remove-root-dir.spec.ts
+++ b/packages/node/src/migrations/update-10-1-0/remove-root-dir.spec.ts
@@ -77,5 +77,15 @@ describe('update 10.1.0', () => {
       exclude: ['**/*.spec.ts'],
       include: ['**/*.ts'],
     });
+
+    const workspace = JSON.parse(result.readContent('workspace.json'));
+    expect(workspace.projects['my-node-lib'].architect.build.options).toEqual({
+      outputPath: 'dist/libs/my-node-lib',
+      tsConfig: 'libs/my-node-lib/tsconfig.lib.json',
+      packageJson: 'libs/my-node-lib/package.json',
+      main: 'libs/my-node-lib/src/index.ts',
+      assets: ['libs/my-node-lib/*.md'],
+      srcRootForCompilationRoot: 'libs/my-node-lib/src',
+    });
   });
 });

--- a/packages/node/src/migrations/update-10-1-0/remove-root-dir.ts
+++ b/packages/node/src/migrations/update-10-1-0/remove-root-dir.ts
@@ -8,8 +8,11 @@ import {
   formatFiles,
   getWorkspace,
   getWorkspacePath,
+  readJsonInTree,
   updateJsonInTree,
+  updateWorkspace,
 } from '@nrwl/workspace';
+import { join } from 'path';
 
 function removeRootDirInTsConfig() {
   return async (host: Tree, _: SchematicContext) => {
@@ -18,13 +21,24 @@ function removeRootDirInTsConfig() {
     const rules = [];
 
     for (const [, projectDefinition] of workspace.projects) {
-      for (const [, testTarget] of projectDefinition.targets) {
-        if (testTarget.builder !== '@nrwl/node:package') {
+      for (const [, buildTarget] of projectDefinition.targets) {
+        if (buildTarget.builder !== '@nrwl/node:package') {
           continue;
         }
-        const tsConfigPath = testTarget.options.tsConfig as string;
+        const tsConfigPath = buildTarget.options.tsConfig as string;
         if (!host.exists(tsConfigPath)) {
           continue;
+        }
+
+        const tsConfig = readJsonInTree(host, tsConfigPath);
+        if (
+          tsConfig.compilerOptions.rootDir !== './' ||
+          tsConfig.compilerOptions.rootDir !== '.'
+        ) {
+          buildTarget.options.srcRootForCompilationRoot = join(
+            projectDefinition.root,
+            tsConfig.compilerOptions.rootDir
+          );
         }
 
         rules.push(
@@ -36,7 +50,7 @@ function removeRootDirInTsConfig() {
       }
     }
 
-    return chain(rules);
+    return chain([updateWorkspace(workspace), ...rules]);
   };
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
WIth the recent changes to the tsconfig.lib.json for the node:package builder, rootDir was removed. There is no way for users to specify the rootDir.

## Expected Behavior
a new property is added (`srcRootForCompilationRoot`). A migration also checks if the user already had a rootDir and creates the property for them in the workspace/angular.json

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
