### PR TITLE
fix(core): handle projects build assets option being empty

### DIFF
--- a/packages/node/src/utils/config.spec.ts
+++ b/packages/node/src/utils/config.spec.ts
@@ -314,6 +314,17 @@ describe('getBaseWebpackPartial', () => {
         result.plugins.filter((plugin) => plugin instanceof CopyWebpackPlugin)
       ).toHaveLength(1);
     });
+
+    it('should not add a copy-webpack-plugin if the assets option is empty', () => {
+      const result = getBaseWebpackPartial({
+        ...input,
+        assets: [],
+      });
+
+      expect(
+        result.plugins.filter((plugin) => plugin instanceof CopyWebpackPlugin)
+      ).toHaveLength(0);
+    });
   });
 
   describe('the circular dependencies option', () => {

--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -98,7 +98,7 @@ export function getBaseWebpackPartial(
   }
 
   // process asset entries
-  if (options.assets) {
+  if (Array.isArray(options.assets) && options.assets.length > 0) {
     const copyWebpackPluginInstance = new CopyWebpackPlugin({
       patterns: options.assets.map((asset: any) => {
         return {

--- a/packages/web/src/utils/config.spec.ts
+++ b/packages/web/src/utils/config.spec.ts
@@ -293,6 +293,17 @@ describe('getBaseWebpackPartial', () => {
         result.plugins.filter((plugin) => plugin instanceof CopyWebpackPlugin)
       ).toHaveLength(1);
     });
+
+    it('should not add a copy-webpack-plugin if the assets option is empty', () => {
+      const result = getBaseWebpackPartial({
+        ...input,
+        assets: [],
+      });
+
+      expect(
+        result.plugins.filter((plugin) => plugin instanceof CopyWebpackPlugin)
+      ).toHaveLength(0);
+    });
   });
 
   describe('the circular dependencies option', () => {

--- a/packages/web/src/utils/config.ts
+++ b/packages/web/src/utils/config.ts
@@ -124,7 +124,7 @@ export function getBaseWebpackPartial(
     );
   }
 
-  if (options.assets) {
+  if (Array.isArray(options.assets) && options.assets.length > 0) {
     extraPlugins.push(createCopyPlugin(options.assets));
   }
 


### PR DESCRIPTION
ISSUES CLOSED: #3590

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If a projects build options omit the assets option or set it to an empty array CopyWebpackPlugin will throw a validation error and the build will fail.

This is a regression introduced in v10.1.0 (#3514)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Build should succeed with assets build option being empty or undefined

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3590
