### PR TITLE
chore(web): update sass to ^1.26.3

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -92,7 +92,7 @@
     "rollup-plugin-peer-deps-external": "^2.2.2",
     "rollup-plugin-postcss": "^3.1.1",
     "rollup-plugin-typescript2": "^0.27.1",
-    "sass": "1.22.9",
+    "sass": "^1.26.3",
     "sass-loader": "8.0.2",
     "semver": "6.3.0",
     "source-map": "0.7.3",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

In `@nrwl/web`, the version for `sass` is pinned.

https://github.com/nrwl/nx/blob/83865747e9baa9fdc075396c1dca6c072fcb814b/packages/web/package.json#L94

This results in two issues:

1. The version declared is relatively outdated, i.e., released "a year ago" according to npm, which is missing multiple meaningful features in the Sass ecosystem such as modules.
2. In Nx projects, we consistently have to use the `"resolutions"` key strategy in `package.json`, to keep this dev dependency aligned with our other tooling.

## Expected Behavior

Ideally, `sass` would use a looser semver scope within `@nrwl/web` to avoid having to update its version via the `"resolutions"` key strategy workspace after workspace, and `sass` would be up-to-date at least to the latest minor version released, which coincidentally is what Nx depends on at the root of the repo.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3475
