### PR TITLE
fix(nextjs): add project deps to package.json when building nextjs apps

### DIFF
--- a/packages/next/src/builders/build/lib/create-package-json.ts
+++ b/packages/next/src/builders/build/lib/create-package-json.ts
@@ -3,7 +3,6 @@ import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { readJsonFile } from '@nrwl/workspace';
 import { NextBuildBuilderOptions } from '../../../utils/types';
-import { reactDomVersion, reactVersion } from '@nrwl/react/src/utils/versions';
 
 export async function createPackageJson(
   options: NextBuildBuilderOptions,
@@ -13,23 +12,13 @@ export async function createPackageJson(
     join(context.workspaceRoot, 'package.json')
   );
 
-  const allWorkspaceDeps = {
-    ...rootPackageJson.dependencies,
-    ...rootPackageJson.devDependencies,
-  };
-
   const outPackageJson = {
     name: context.target.project,
     version: '0.0.1',
     scripts: {
       start: 'next start',
     },
-    dependencies: {
-      next: allWorkspaceDeps.next,
-      react: allWorkspaceDeps.react || reactVersion,
-      'react-dom': allWorkspaceDeps['react-dom'] || reactDomVersion,
-    },
-    devDependencies: {},
+    dependencies: rootPackageJson.dependencies,
   };
 
   writeFileSync(


### PR DESCRIPTION
The fix makes the nextjs builder add the project dependencies to the dist package.json file

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The nextjs project get's built with only next, react and react-dom in the dist `package.json` file, and then fails after deployment because of the missing packages.

## Expected Behavior
The application dependencies are added to the dist `package.json`

## Related Issue(s)

Fixes #3062