### PR TITLE
feat(core): add help,list and better DX to workspace-schematic

### DIFF
--- a/docs/angular/cli/workspace-schematic.md
+++ b/docs/angular/cli/workspace-schematic.md
@@ -22,7 +22,7 @@ List the available workspace-schematics
 
 ### name
 
-The name of your schematic`
+The name of your schematic
 
 ### version
 

--- a/docs/node/cli/workspace-schematic.md
+++ b/docs/node/cli/workspace-schematic.md
@@ -22,7 +22,7 @@ List the available workspace-schematics
 
 ### name
 
-The name of your schematic`
+The name of your schematic
 
 ### version
 

--- a/docs/react/cli/workspace-schematic.md
+++ b/docs/react/cli/workspace-schematic.md
@@ -22,7 +22,7 @@ List the available workspace-schematics
 
 ### name
 
-The name of your schematic`
+The name of your schematic
 
 ### version
 


### PR DESCRIPTION
ISSUES CLOSED: #2267

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Before
![2020-08-27 at 5 38 PM](https://user-images.githubusercontent.com/1223799/91463822-21e5df80-e88c-11ea-88dc-4ca98c58f23d.png)

![2020-08-27 at 5 39 PM](https://user-images.githubusercontent.com/1223799/91464198-9587ec80-e88c-11ea-88ec-008902aabac8.png)


## After

- better command help description
![image](https://user-images.githubusercontent.com/1223799/91706768-23125780-eb7f-11ea-9c78-e7290f4579f5.png)


- `-l`, `--list` support with better DX ( description + nicer terminal output)
![2020-08-27 at 5 35 PM](https://user-images.githubusercontent.com/1223799/91463579-daf7ea00-e88b-11ea-93a2-2979adebbb04.png)

- `--help`, `-h` support for called schematic

![image](https://user-images.githubusercontent.com/1223799/91706854-4210e980-eb7f-11ea-9f51-c6acbfa34da2.png)

![2020-08-27 at 5 34 PM](https://user-images.githubusercontent.com/1223799/91463460-b3a11d00-e88b-11ea-9859-89f4ba9f052d.png)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

### Additional Notes

- [x] I wasn't able to get proper `--help` support as yargs will consume default help of command chain (maybe I'm missing something)
- [ ] I'll need to add e2e tests 
  - ~can someone help me out with this ?~ figured on my own
  - ~blocked by https://github.com/nrwl/nx/pull/3621 (where are grouped e2e properly, after that is merged I'll add e2e to prevent conflicts)~
