### PR TITLE
feat(core): compile only schematics realted source when using workspa…

### DIFF
--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -134,7 +134,7 @@ export function runNgNew(): string {
  * Sets up a new project in the temporary project path
  * for the currently selected CLI.
  */
-export function newProject() {
+export function newProject(): void {
   projName = uniq('proj');
   try {
     if (!directoryExists(tmpBackupProjPath())) {
@@ -165,8 +165,6 @@ export function newProject() {
     console.log(e.message);
     throw e;
   }
-
-  return { tmpProjPath: tmpProjPath() };
 }
 
 /**
@@ -176,9 +174,9 @@ export function newProject() {
  *
  * If one is not found, it creates a new project.
  */
-export function ensureProject() {
+export function ensureProject(): void {
   // if (!directoryExists(tmpProjPath())) {
-  return newProject();
+  newProject();
   // }
 }
 
@@ -351,7 +349,10 @@ export function createFile(f: string, content: string = ''): void {
   }
 }
 
-export function updateFile(f: string, content: string | Function): void {
+export function updateFile(
+  f: string,
+  content: string | ((content: string) => void)
+): void {
   ensureDirSync(path.dirname(tmpProjPath(f)));
   if (typeof content === 'string') {
     writeFileSync(tmpProjPath(f), content);

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -134,7 +134,7 @@ export function runNgNew(): string {
  * Sets up a new project in the temporary project path
  * for the currently selected CLI.
  */
-export function newProject(): void {
+export function newProject() {
   projName = uniq('proj');
   try {
     if (!directoryExists(tmpBackupProjPath())) {
@@ -165,6 +165,8 @@ export function newProject(): void {
     console.log(e.message);
     throw e;
   }
+
+  return { tmpProjPath: tmpProjPath() };
 }
 
 /**
@@ -174,9 +176,9 @@ export function newProject(): void {
  *
  * If one is not found, it creates a new project.
  */
-export function ensureProject(): void {
+export function ensureProject() {
   // if (!directoryExists(tmpProjPath())) {
-  newProject();
+  return newProject();
   // }
 }
 

--- a/e2e/workspace/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace/src/workspace-aux-commands.test.ts
@@ -200,7 +200,7 @@ forEachCli((cli) => {
 
   describe('workspace-schematic', () => {
     function setup() {
-      ensureProject();
+      const { tmpProjPath } = ensureProject();
 
       const custom = uniq('custom');
       const failing = uniq('custom-failing');
@@ -216,11 +216,11 @@ forEachCli((cli) => {
         `tools/schematics/${failing}/schema.json`
       );
 
-      return { custom, failing };
+      return { custom, failing, tmpProjPath };
     }
 
     it('should compile only schematic files', () => {
-      const { custom } = setup();
+      const { custom, tmpProjPath } = setup();
       const workspace = uniq('workspace');
 
       updateFile(
@@ -231,13 +231,17 @@ forEachCli((cli) => {
       );
 
       const dryRunOutput = runCommand(
-        `npm run workspace-schematic ${custom} ${workspace} -- --no-interactive --directory=dir --skipTsConfig=true -d`
+        `npm run workspace-schematic ${custom} ${workspace} -- --no-interactive -d`
       );
 
       expect(
-        exists(`dist/out-tsc/tools/schematics/${custom}/index.js`)
+        exists(
+          `${tmpProjPath}/dist/out-tsc/tools/schematics/${custom}/index.js`
+        )
       ).toEqual(true);
-      expect(exists(`dist/out-tsc/tools/utils/utils.js`)).toEqual(false);
+      expect(
+        exists(`${tmpProjPath}/dist/out-tsc/tools/utils/utils.js`)
+      ).toEqual(false);
     });
 
     it('should support workspace-specific schematics', async () => {


### PR DESCRIPTION
…ce-schematics

- this also improves  performance when invoking `nx workspace-schematic` (because less files need to be compiled)
- we are generating temp tsconfig, as using `exclude` capabilities as proposed in original issue would introduce bugs if one uses files outside `/schematics` folder ( our usecase at work for instance )

ISSUES CLOSED: #1215

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
