### PR TITLE
fix(misc): remove deprecated jest builder options from schematic

### DIFF
--- a/docs/angular/api-nx-plugin/builders/e2e.md
+++ b/docs/angular/api-nx-plugin/builders/e2e.md
@@ -22,4 +22,4 @@ the target Nx Plugin project and build
 
 Type: `string`
 
-Spec tsconfig file
+[Deprecated] Spec tsconfig file

--- a/docs/react/api-nx-plugin/builders/e2e.md
+++ b/docs/react/api-nx-plugin/builders/e2e.md
@@ -23,4 +23,4 @@ the target Nx Plugin project and build
 
 Type: `string`
 
-Spec tsconfig file
+[Deprecated] Spec tsconfig file

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -34,6 +34,11 @@
       "version": "10.1.0-beta.4",
       "description": "Update jest to v26",
       "factory": "./src/migrations/update-10-1-0/update-10-1-0"
+    },
+    "update-10.2.0": {
+      "version": "10.2.0",
+      "description": "Remove deprecated jest builder options",
+      "factory": "./src/migrations/update-10-2-0/update-10-2-0"
     }
   },
   "packageJsonUpdates": {

--- a/packages/jest/src/builders/jest/schema.d.ts
+++ b/packages/jest/src/builders/jest/schema.d.ts
@@ -7,7 +7,6 @@ export interface JestBuilderOptions extends JsonObject {
   jestConfig: string;
   testFile?: string;
   setupFile?: string;
-  tsConfig: string;
   bail?: boolean | number;
   ci?: boolean;
   color?: boolean;

--- a/packages/jest/src/migrations/update-10-2-0/update-10-2-0.spec.ts
+++ b/packages/jest/src/migrations/update-10-2-0/update-10-2-0.spec.ts
@@ -1,0 +1,78 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { serializeJson } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import * as path from 'path';
+
+describe('update 10.2.0', () => {
+  let initialTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(() => {
+    initialTree = createEmptyWorkspace(Tree.empty());
+
+    initialTree.overwrite(
+      'workspace.json',
+      serializeJson({
+        version: 1,
+        projects: {
+          products: {
+            root: 'apps/products',
+            sourceRoot: 'apps/products/src',
+            architect: {
+              build: {
+                builder: '@angular-devkit/build-angular:browser',
+              },
+              test: {
+                builder: '@nrwl/jest:jest',
+                options: {
+                  jestConfig: 'apps/products/jest.config.js',
+                  tsConfig: 'apps/products/tsconfig.spec.json',
+                  setupFile: 'apps/products/src/test-setup.ts',
+                  passWithNoTests: true,
+                },
+              },
+            },
+          },
+          cart: {
+            root: 'apps/cart',
+            sourceRoot: 'apps/cart/src',
+            architect: {
+              build: {
+                builder: '@nrwl/web:build',
+              },
+              test: {
+                builder: '@nrwl/jest:jest',
+                options: {
+                  jestConfig: 'apps/cart/jest.config.js',
+                  passWithNoTests: true,
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/jest',
+      path.join(__dirname, '../../../migrations.json')
+    );
+  });
+
+  it('should remove setupFile and tsconfig in test architect from workspace.json', async (done) => {
+    const result = await schematicRunner
+      .runSchematicAsync('update-10.2.0', {}, initialTree)
+      .toPromise();
+
+    const updatedWorkspace = JSON.parse(result.readContent('workspace.json'));
+    expect(updatedWorkspace.projects.products.architect.test.options).toEqual({
+      jestConfig: expect.anything(),
+      passWithNoTests: expect.anything(),
+    });
+    expect(updatedWorkspace.projects.cart.architect.test.options).toEqual({
+      jestConfig: expect.anything(),
+      passWithNoTests: expect.anything(),
+    });
+    done();
+  });
+});

--- a/packages/jest/src/migrations/update-10-2-0/update-10-2-0.ts
+++ b/packages/jest/src/migrations/update-10-2-0/update-10-2-0.ts
@@ -1,0 +1,33 @@
+import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import {
+  formatFiles,
+  getWorkspace,
+  getWorkspacePath,
+  updateWorkspace,
+} from '@nrwl/workspace';
+
+function removeDeprecatedJestBuilderOptions() {
+  return async (host: Tree) => {
+    const workspace = await getWorkspace(host, getWorkspacePath(host));
+
+    for (const [, projectDefinition] of workspace.projects) {
+      for (const [, testTarget] of projectDefinition.targets) {
+        if (testTarget.builder !== '@nrwl/jest:jest') {
+          continue;
+        }
+
+        const updatedOptions = { ...testTarget.options };
+        delete updatedOptions.setupFile;
+        delete updatedOptions.tsConfig;
+
+        testTarget.options = updatedOptions;
+      }
+    }
+
+    return updateWorkspace(workspace);
+  };
+}
+
+export default function update(): Rule {
+  return chain([removeDeprecatedJestBuilderOptions(), formatFiles()]);
+}

--- a/packages/jest/src/schematics/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/schematics/jest-project/jest-project.spec.ts
@@ -67,8 +67,6 @@ describe('jestProject', () => {
       builder: '@nrwl/jest:jest',
       options: {
         jestConfig: 'libs/lib1/jest.config.js',
-        setupFile: 'libs/lib1/src/test-setup.ts',
-        tsConfig: 'libs/lib1/tsconfig.spec.json',
         passWithNoTests: true,
       },
     });

--- a/packages/jest/src/schematics/jest-project/lib/update-workspace.ts
+++ b/packages/jest/src/schematics/jest-project/lib/update-workspace.ts
@@ -10,16 +10,9 @@ export function updateWorkspace(options: JestProjectSchema): Rule {
       builder: '@nrwl/jest:jest',
       options: {
         jestConfig: join(normalize(projectConfig.root), 'jest.config.js'),
-        tsConfig: join(normalize(projectConfig.root), 'tsconfig.spec.json'),
         passWithNoTests: true,
       },
     };
-    if (options.setupFile !== 'none') {
-      projectConfig.architect.test.options.setupFile = join(
-        normalize(projectConfig.root),
-        'src/test-setup.ts'
-      );
-    }
     if (projectConfig.architect.lint) {
       projectConfig.architect.lint.options.tsConfig = [
         ...projectConfig.architect.lint.options.tsConfig,

--- a/packages/nest/src/schematics/library/library.spec.ts
+++ b/packages/nest/src/schematics/library/library.spec.ts
@@ -33,7 +33,6 @@ describe('lib', () => {
         builder: '@nrwl/jest:jest',
         options: {
           jestConfig: 'libs/my-lib/jest.config.js',
-          tsConfig: 'libs/my-lib/tsconfig.spec.json',
           passWithNoTests: true,
         },
       });

--- a/packages/node/src/schematics/library/library.spec.ts
+++ b/packages/node/src/schematics/library/library.spec.ts
@@ -32,7 +32,6 @@ describe('lib', () => {
         builder: '@nrwl/jest:jest',
         options: {
           jestConfig: 'libs/my-lib/jest.config.js',
-          tsConfig: 'libs/my-lib/tsconfig.spec.json',
           passWithNoTests: true,
         },
       });

--- a/packages/nx-plugin/migrations.json
+++ b/packages/nx-plugin/migrations.json
@@ -1,3 +1,9 @@
 {
-  "schematics": {}
+  "schematics": {
+    "update-10.2.0": {
+      "version": "10.2.0",
+      "description": "Remove deprecated jest builder options",
+      "factory": "./src/migrations/update-10-2-0/update-10-2-0"
+    }
+  }
 }

--- a/packages/nx-plugin/src/builders/e2e/e2e.impl.ts
+++ b/packages/nx-plugin/src/builders/e2e/e2e.impl.ts
@@ -27,7 +27,6 @@ export function runNxPluginE2EBuilder(
     switchMap(() => {
       return from(
         context.scheduleBuilder('@nrwl/jest:jest', {
-          tsConfig: options.tsSpecConfig,
           jestConfig: options.jestConfig,
           watch: false,
         })

--- a/packages/nx-plugin/src/builders/e2e/schema.d.ts
+++ b/packages/nx-plugin/src/builders/e2e/schema.d.ts
@@ -3,5 +3,4 @@ import { JsonObject } from '@angular-devkit/core';
 export interface Schema extends JsonObject {
   target: string;
   jestConfig: string;
-  tsSpecConfig: string;
 }

--- a/packages/nx-plugin/src/builders/e2e/schema.json
+++ b/packages/nx-plugin/src/builders/e2e/schema.json
@@ -13,8 +13,9 @@
     },
     "tsSpecConfig": {
       "type": "string",
-      "description": "Spec tsconfig file"
+      "description": "[Deprecated] Spec tsconfig file",
+      "x-deprecated": true
     }
   },
-  "required": ["target", "jestConfig", "tsSpecConfig"]
+  "required": ["target", "jestConfig"]
 }

--- a/packages/nx-plugin/src/migrations/update-10-2-0/update-10-2-0.spec.ts
+++ b/packages/nx-plugin/src/migrations/update-10-2-0/update-10-2-0.spec.ts
@@ -1,0 +1,61 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { serializeJson } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import * as path from 'path';
+
+describe('update 10.2.0', () => {
+  let initialTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(() => {
+    initialTree = createEmptyWorkspace(Tree.empty());
+
+    initialTree.overwrite(
+      'workspace.json',
+      serializeJson({
+        version: 1,
+        projects: {
+          'my-plugin-e2e': {
+            projectType: 'application',
+            root: 'apps/my-plugin-e2e',
+            sourceRoot: 'apps/my-plugin-e2e/src',
+            architect: {
+              e2e: {
+                builder: '@nrwl/nx-plugin:e2e',
+                options: {
+                  target: 'my-plugin:build',
+                  npmPackageName: '@repo/my-plugin',
+                  pluginOutputPath: 'dist/libs/my-plugin',
+                  jestConfig: 'apps/my-plugin-e2e/jest.config.js',
+                  tsSpecConfig: 'apps/my-plugin-e2e/tsconfig.spec.json',
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/jest',
+      path.join(__dirname, '../../../migrations.json')
+    );
+  });
+
+  it('should remove setupFile and tsconfig in test architect from workspace.json', async (done) => {
+    const result = await schematicRunner
+      .runSchematicAsync('update-10.2.0', {}, initialTree)
+      .toPromise();
+
+    const updatedWorkspace = JSON.parse(result.readContent('workspace.json'));
+    expect(
+      updatedWorkspace.projects['my-plugin-e2e'].architect.e2e.options
+    ).toEqual({
+      target: expect.anything(),
+      npmPackageName: expect.anything(),
+      pluginOutputPath: expect.anything(),
+      jestConfig: expect.anything(),
+    });
+    done();
+  });
+});

--- a/packages/nx-plugin/src/migrations/update-10-2-0/update-10-2-0.ts
+++ b/packages/nx-plugin/src/migrations/update-10-2-0/update-10-2-0.ts
@@ -1,0 +1,32 @@
+import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import {
+  formatFiles,
+  getWorkspace,
+  getWorkspacePath,
+  updateWorkspace,
+} from '@nrwl/workspace';
+
+function removeDeprecatedJestBuilderOptions() {
+  return async (host: Tree) => {
+    const workspace = await getWorkspace(host, getWorkspacePath(host));
+
+    for (const [, projectDefinition] of workspace.projects) {
+      for (const [, testTarget] of projectDefinition.targets) {
+        if (testTarget.builder !== '@nrwl/nx-plugin:e2e') {
+          continue;
+        }
+
+        const updatedOptions = { ...testTarget.options };
+        delete updatedOptions.tsSpecConfig;
+
+        testTarget.options = updatedOptions;
+      }
+    }
+
+    return updateWorkspace(workspace);
+  };
+}
+
+export default function update(): Rule {
+  return chain([removeDeprecatedJestBuilderOptions(), formatFiles()]);
+}

--- a/packages/nx-plugin/src/schematics/e2e-project/e2e.spec.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/e2e.spec.ts
@@ -130,7 +130,6 @@ describe('NxPlugin e2e-project', () => {
     const project = workspace.projects.get('my-plugin-e2e');
     expect(project.targets.get('e2e')).toMatchObject({
       options: expect.objectContaining({
-        tsSpecConfig: 'apps/my-plugin-e2e/tsconfig.spec.json',
         jestConfig: 'apps/my-plugin-e2e/jest.config.js',
       }),
     });

--- a/packages/nx-plugin/src/schematics/e2e-project/lib/add-jest.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/lib/add-jest.ts
@@ -17,10 +17,7 @@ export function addJest(options: NxPluginE2ESchema): Rule {
       const e2eOptions = project.targets.get('e2e').options;
       project.targets.get('e2e').options = {
         ...e2eOptions,
-        ...{
-          jestConfig: testOptions.jestConfig,
-          tsSpecConfig: testOptions.tsConfig,
-        },
+        jestConfig: testOptions.jestConfig,
       };
 
       // remove the jest build target

--- a/packages/nx-plugin/src/schematics/e2e-project/schema.d.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/schema.d.ts
@@ -4,7 +4,6 @@ export interface Schema {
   npmPackageName: string;
   pluginOutputPath: string;
   jestConfig: string;
-  tsSpecConfig: string;
 }
 
 export interface NxPluginE2ESchema extends Schema {

--- a/packages/nx-plugin/src/schematics/e2e-project/schema.json
+++ b/packages/nx-plugin/src/schematics/e2e-project/schema.json
@@ -25,7 +25,8 @@
     },
     "tsSpecConfig": {
       "type": "string",
-      "description": "Spec tsconfig file"
+      "description": "[Deprecated] Spec tsconfig file",
+      "x-deprecated": true
     }
   },
   "required": ["pluginName", "npmPackageName"]

--- a/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
@@ -60,7 +60,6 @@ describe('NxPlugin plugin', () => {
       builder: '@nrwl/jest:jest',
       options: {
         jestConfig: 'libs/my-plugin/jest.config.js',
-        tsConfig: 'libs/my-plugin/tsconfig.spec.json',
         passWithNoTests: true,
       },
     });


### PR DESCRIPTION
## Current Behavior
Jest schematic adds deprecated options to project config in `workspace.json`

## Expected Behavior
Jest schematic does NOT add deprecated options to project config in `workspace.json`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3505