### PR TITLE
fix(misc): fixed collection workspace module cannot be resolved

### DIFF
--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -62,13 +62,16 @@ function createWorkspace(
   ].join(' ');
 
   console.log(`new ${args} --preset=empty --collection=@nrwl/workspace`);
+  const executablePath = path.join(tmpDir, 'node_modules', '.bin', 'tao');
+  const collectionJsonPath = path.join(
+    tmpDir,
+    'node_modules',
+    '@nrwl',
+    'workspace',
+    'collection.json'
+  );
   execSync(
-    `"${path.join(
-      tmpDir,
-      'node_modules',
-      '.bin',
-      'tao'
-    )}" new ${args} --preset=empty --collection=@nrwl/workspace`,
+    `"${executablePath}" new ${args} --preset=empty --collection=${collectionJsonPath}`,
     {
       stdio: [0, 1, 2],
     }


### PR DESCRIPTION
when creating plugin through npx create-nx-plugin, it fails by throwing error
Collection @nrwl/workpsace cannot be resolved
this commit changes the collection arguments pointing to proper path of the
module in tmp directory

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running the below command fails
`NODE_DEBUG=MODULE npx create-nx-plugin@10.1.0 acme-org`
Note: I am running this command in an empty folder outside of nx git repo 'tmp' folder
The above command gives error like below
```
...
MODULE 6984: load "/tmp/tmp-6895HRT90PnmQY08/node_modules/ajv/lib/refs/json-schema-draft-06.json" for module "/tmp/tmp-6895HRT90PnmQY08/node_modules/ajv/lib/refs/json-schema-draft-06.json"
MODULE 6984: looking for "@nrwl/workspace/package.json" in ["/home/pradeep/my-nx-plugin/node_modules","/home/pradeep/node_modules","/home/node_modules","/node_modules","/home/pradeep/.node_modules","/home/pradeep/.node_libraries","/usr/lib/node"]
MODULE 6984: looking for "@nrwl/workspace/package.json" in ["/home/pradeep/my-nx-plugin/node_modules","/home/pradeep/node_modules","/home/node_modules","/node_modules","/home/pradeep/.node_modules","/home/pradeep/.node_libraries","/usr/lib/node"]
MODULE 6984: looking for "@nrwl/workspace" in ["/home/pradeep/my-nx-plugin/node_modules","/home/pradeep/node_modules","/home/node_modules","/node_modules","/home/pradeep/.node_modules","/home/pradeep/.node_libraries","/usr/lib/node"]
MODULE 6984: looking for "@nrwl/workspace" in ["/home/pradeep/my-nx-plugin/node_modules","/home/pradeep/node_modules","/home/node_modules","/node_modules","/home/pradeep/.node_modules","/home/pradeep/.node_libraries","/usr/lib/node"]
Collection "@nrwl/workspace" cannot be resolved.
(node:6895) UnhandledPromiseRejectionWarning: Error: Command failed: "/tmp/tmp-6895HRT90PnmQY08/node_modules/.bin/tao" new acme-org --preset=empty --collection=@nrwl/workspace
    at checkExecSyncError (child_process.js:616:11)
    at Object.execSync (child_process.js:652:15)
    at createWorkspace (/home/pradeep/.npm/_npx/6895/lib/node_modules/create-nx-plugin/bin/create-nx-plugin.js:51:21)
    at /home/pradeep/.npm/_npx/6895/lib/node_modules/create-nx-plugin/bin/create-nx-plugin.js:157:9
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:6895) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:6895) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
pradeep@DESKTOP-F6G5638:~/my-nx-plugin$
```
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should not give error
It was not able to resolve the collection.json of @nrwl/workspace module which is pointing to the empty folder
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
