### PR TITLE
fix(core): don't alter trailing newlines from `package.json` during migration

### DIFF
--- a/e2e/cli/src/cli.test.ts
+++ b/e2e/cli/src/cli.test.ts
@@ -252,6 +252,7 @@ forEachCli(() => {
       expect(packageJson.dependencies['migrate-child-package']).toEqual(
         '9.0.0'
       );
+      expect(readFile(`package.json`).endsWith(`}\n`)).toEqual(true);
 
       // creates migrations.json
       const migrationsJson = readJson(`migrations.json`);

--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -483,9 +483,12 @@ function updatePackageJson(
   }
 ) {
   const packageJsonPath = join(root, 'package.json');
-  const json = JSON.parse(
-    stripJsonComments(readFileSync(packageJsonPath).toString())
+  const packageJsonContent = readFileSync(packageJsonPath).toString();
+  const endOfFile = packageJsonContent.substring(
+    packageJsonContent.lastIndexOf('}') + 1,
+    packageJsonContent.length
   );
+  const json = JSON.parse(stripJsonComments(packageJsonContent));
   Object.keys(updatedPackages).forEach((p) => {
     if (json.devDependencies && json.devDependencies[p]) {
       json.devDependencies[p] = updatedPackages[p].version;
@@ -496,7 +499,7 @@ function updatePackageJson(
       json.dependencies[p] = updatedPackages[p].version;
     }
   });
-  writeFileSync(packageJsonPath, JSON.stringify(json, null, 2));
+  writeFileSync(packageJsonPath, JSON.stringify(json, null, 2) + endOfFile);
 }
 
 async function generateMigrationsJsonAndUpdatePackageJson(


### PR DESCRIPTION
ISSUES CLOSED: #3628
