### PR TITLE
fix(linter): exit node process successfully when maxWarnings is set

### DIFF
--- a/packages/linter/src/builders/lint/lint.impl.spec.ts
+++ b/packages/linter/src/builders/lint/lint.impl.spec.ts
@@ -518,6 +518,6 @@ describe('Linter Builder', () => {
       force: false,
       maxWarnings: 1,
     });
-    expect(output.success).toBeFalsy();
+    expect(output.success).toBeTruthy();
   });
 });

--- a/packages/linter/src/builders/lint/lint.impl.spec.ts
+++ b/packages/linter/src/builders/lint/lint.impl.spec.ts
@@ -493,7 +493,7 @@ describe('Linter Builder', () => {
     });
     expect(output.success).toBeFalsy();
   });
-  it('should be a failure if there are no errors, but warnings and maxWarnings is set to 0', async () => {
+  it('should be a failure if there are no errors, but there are more warnings than allowed by maxWarnings', async () => {
     mockReports = [
       {
         errorCount: 0,
@@ -503,7 +503,7 @@ describe('Linter Builder', () => {
       },
       {
         errorCount: 0,
-        warningCount: 0,
+        warningCount: 1,
         results: [],
         usedDeprecatedRules: [],
       },
@@ -518,6 +518,6 @@ describe('Linter Builder', () => {
       force: false,
       maxWarnings: 1,
     });
-    expect(output.success).toBeTruthy();
+    expect(output.success).toBeFalsy();
   });
 });

--- a/packages/linter/src/builders/lint/lint.impl.ts
+++ b/packages/linter/src/builders/lint/lint.impl.ts
@@ -140,7 +140,7 @@ async function run(options: Schema, context: BuilderContext): Promise<any> {
       options.force ||
       (bundledReport.errorCount === 0 &&
         (options.maxWarnings === -1 ||
-          bundledReport.warningCount < options.maxWarnings)),
+          bundledReport.warningCount <= options.maxWarnings)),
   };
 }
 


### PR DESCRIPTION
ISSUES CLOSED: #3644


