### PR TITLE
fix(core): support `lint` command

### DIFF
--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -8,6 +8,7 @@ import {
   ensureProject,
   uniq,
   forEachCli,
+  runCLIAsync,
 } from '@nrwl/e2e/utils';
 
 forEachCli('nx', () => {
@@ -107,7 +108,7 @@ forEachCli('nx', () => {
       expect(cacheInfo).toContain(`${myapp}/src/app/app.spec.tsx`);
     }, 1000000);
 
-    it('linting should generate an output file with a specific format', () => {
+    it('linting should generate an output file with a specific format', async () => {
       newProject();
       const myapp = uniq('myapp');
 
@@ -122,7 +123,7 @@ forEachCli('nx', () => {
       expect(() => {
         checkFilesExist(outputFile);
       }).toThrow();
-      const stdout = runCLI(
+      const { stdout } = await runCLIAsync(
         `lint ${myapp} --output-file="${outputFile}" --format=json`,
         {
           silenceError: true,

--- a/e2e/workspace/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace/src/workspace-aux-commands.test.ts
@@ -83,6 +83,21 @@ forEachCli((cli) => {
       );
     }, 1000000);
 
+    it('nx lint should pass all projects', () => {
+      ensureProject();
+
+      const myapp = uniq('myapp');
+      const mylib = uniq('mylib');
+
+      runCLI(`generate @nrwl/angular:app ${myapp}`);
+      runCLI(`generate @nrwl/angular:lib ${mylib}`);
+
+      const stdout = runCommand(`npm run nx lint`);
+      expect(stdout).toContain(`Linting "${myapp}"...`);
+      expect(stdout).toContain(`Linting "${myapp}-e2e"...`);
+      expect(stdout).toContain(`Linting "${mylib}"...`);
+    }, 1000000);
+
     describe('nx lint', () => {
       afterAll(() => {
         newProject();

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -126,6 +126,22 @@ export const commandsObject = yargs
       })
   )
   .command(
+    'lint [project]',
+    'Run linting in a given project',
+    (yargs) =>
+      withRunManyOptions(withParallel(yargs)).positional('project', {
+        describe: 'Optional name of the project to lint',
+      }),
+    (args) => {
+      const { project, ...options } = args;
+      runMany({
+        ...options,
+        target: 'lint',
+        ...(project ? { projects: project } : { all: true }),
+      });
+    }
+  )
+  .command(
     'dep-graph',
     'Graph dependencies within workspace',
     (yargs) => withDepGraphOptions(yargs),
@@ -138,12 +154,11 @@ export const commandsObject = yargs
     (args) => format('check', args)
   )
   .command(
-    'format:write',
+    ['format:write', 'format'],
     'Overwrite un-formatted files',
     withFormatOptions,
     (args) => format('write', args)
   )
-  .alias('format:write', 'format')
   .command(
     'workspace-lint [files..]',
     'Lint workspace or list of files.  Note: To exclude files from this lint rule, you can add them to the ".nxignore" file',
@@ -301,11 +316,6 @@ function withRunManyOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'Run the target on all projects in the workspace',
     })
     .nargs('all', 0)
-    .check(({ all, projects }) => {
-      if ((all && projects) || (!all && !projects))
-        throw new Error('You must provide either --all or --projects');
-      return true;
-    })
     .options('runner', {
       describe: 'Override the tasks runner in `nx.json`',
       type: 'string',

--- a/packages/workspace/src/command-line/supported-nx-commands.ts
+++ b/packages/workspace/src/command-line/supported-nx-commands.ts
@@ -7,6 +7,7 @@ export const supportedNxCommands = [
   'affected:e2e',
   'affected:dep-graph',
   'affected:lint',
+  'lint',
   'print-affected',
   'dep-graph',
   'format',


### PR DESCRIPTION
This command behaves similarly to `ng lint` by linting all available projects or one specific project if passed as argument.
