### PR TITLE
feat(core): make create-project-graph async

### DIFF
--- a/packages/bazel/src/schematics/sync/sync.ts
+++ b/packages/bazel/src/schematics/sync/sync.ts
@@ -184,8 +184,8 @@ function createRootBuildFile() {
 const runInit = schematic<{}>('init', {});
 
 export default (): Rule => {
-  return (host: Tree) => {
-    const projectGraph = getProjectGraphFromHost(host);
+  return async (host: Tree) => {
+    const projectGraph = await getProjectGraphFromHost(host);
 
     return chain([
       runInit,

--- a/packages/node/src/builders/package/package.impl.spec.ts
+++ b/packages/node/src/builders/package/package.impl.spec.ts
@@ -69,7 +69,7 @@ describe('NodePackageBuilder', () => {
 
   describe('Without library dependencies', () => {
     beforeEach(() => {
-      spyOn(projectGraph, 'createProjectGraph').and.callFake(() => {
+      spyOn(projectGraph, 'createProjectGraphAsync').and.callFake(async () => {
         return {
           nodes: {
             nodelib: {
@@ -260,7 +260,7 @@ describe('NodePackageBuilder', () => {
   describe('building with dependencies', () => {
     beforeEach(() => {
       // fake that dep project has been built
-      spyOn(projectGraph, 'createProjectGraph').and.callFake(() => {
+      spyOn(projectGraph, 'createProjectGraphAsync').and.callFake(async () => {
         return {
           nodes: {
             nodelib: {

--- a/packages/react/src/migrations/update-9-4-0/babelrc-9-4-0.ts
+++ b/packages/react/src/migrations/update-9-4-0/babelrc-9-4-0.ts
@@ -22,10 +22,10 @@ let addedEmotionPreset = false;
  * - For any projects that are not migrated, display a message so users are not surprised.
  */
 export default function update(): Rule {
-  return (host: Tree, context: SchematicContext) => {
+  return async (host: Tree, context: SchematicContext) => {
     const updates = [];
     const conflicts: Array<[string, string]> = [];
-    const projectGraph = getFullProjectGraphFromHost(host);
+    const projectGraph = await getFullProjectGraphFromHost(host);
     if (host.exists('/babel.config.json')) {
       context.logger.info(
         `

--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -18,7 +18,7 @@ import {
   readJsonFile,
   writeJsonFile,
 } from '@nrwl/workspace/src/utils/fileutils';
-import { createProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import { createProjectGraphAsync } from '@nrwl/workspace/src/core/project-graph';
 
 import {
   calculateProjectDependencies,
@@ -65,14 +65,18 @@ export function run(
   rawOptions: PackageBuilderOptions,
   context: BuilderContext
 ): Observable<BuilderOutput> {
-  const projGraph = createProjectGraph();
-  const { target, dependencies } = calculateProjectDependencies(
-    projGraph,
-    context
-  );
-
-  return from(getSourceRoot(context)).pipe(
-    switchMap((sourceRoot) => {
+  return from(createProjectGraphAsync()).pipe(
+    concatMap((projectGraph) =>
+      getSourceRoot(context).then((sourceRoot) => ({
+        sourceRoot,
+        projectGraph,
+      }))
+    ),
+    switchMap(({ projectGraph, sourceRoot }) => {
+      const { target, dependencies } = calculateProjectDependencies(
+        projectGraph,
+        context
+      );
       if (!checkDependentProjectsHaveBeenBuilt(context, dependencies)) {
         return of({ success: false });
       }

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -6,7 +6,7 @@ import { runCommand } from '../tasks-runner/run-command';
 import { NxArgs, splitArgsIntoNxArgsAndOverrides, RawNxArgs } from './utils';
 import { filterAffected } from '../core/affected-project-graph';
 import {
-  createProjectGraph,
+  createProjectGraphAsync,
   onlyWorkspaceProjects,
   ProjectGraphNode,
   ProjectType,
@@ -17,10 +17,10 @@ import { printAffected } from './print-affected';
 import { projectHasTarget } from '../utils/project-graph-utils';
 import { DefaultReporter } from '../tasks-runner/default-reporter';
 
-export function affected(
+export async function affected(
   command: 'apps' | 'libs' | 'dep-graph' | 'print-affected' | 'affected',
   parsedArgs: yargs.Arguments & RawNxArgs
-): void {
+) {
   const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides(
     parsedArgs,
     'affected',
@@ -29,7 +29,7 @@ export function affected(
     }
   );
 
-  const projectGraph = createProjectGraph();
+  const projectGraph = await createProjectGraphAsync();
   let affectedGraph = nxArgs.all
     ? projectGraph
     : filterAffected(

--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -5,7 +5,7 @@ import * as opn from 'opn';
 import { join, normalize, parse } from 'path';
 import * as url from 'url';
 import {
-  createProjectGraph,
+  createProjectGraphAsync,
   onlyWorkspaceProjects,
   ProjectGraph,
   ProjectGraphNode,
@@ -139,7 +139,7 @@ function filterGraph(
   return filteredGraph;
 }
 
-export function generateGraph(
+export async function generateGraph(
   args: {
     file?: string;
     host?: string;
@@ -148,8 +148,8 @@ export function generateGraph(
     groupByFolder?: boolean;
   },
   affectedProjects: string[]
-): void {
-  let graph = onlyWorkspaceProjects(createProjectGraph());
+) {
+  let graph = onlyWorkspaceProjects(await createProjectGraphAsync());
 
   const projects = Object.values(graph.nodes) as ProjectGraphNode[];
   projects.sort((a, b) => {

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -4,7 +4,7 @@ import * as resolve from 'resolve';
 import { getProjectRoots, parseFiles } from './shared';
 import { fileExists } from '../utils/fileutils';
 import {
-  createProjectGraph,
+  createProjectGraphAsync,
   onlyWorkspaceProjects,
 } from '../core/project-graph';
 import { filterAffected } from '../core/affected-project-graph';
@@ -28,10 +28,13 @@ const PRETTIER_EXTENSIONS = [
 
 const MATCH_ALL_PATTERN = `**/*.{${PRETTIER_EXTENSIONS.join(',')}}`;
 
-export function format(command: 'check' | 'write', args: yargs.Arguments) {
+export async function format(
+  command: 'check' | 'write',
+  args: yargs.Arguments
+) {
   const { nxArgs } = splitArgsIntoNxArgsAndOverrides(args, 'affected');
 
-  const patterns = getPatterns({ ...args, ...nxArgs } as any).map(
+  const patterns = (await getPatterns({ ...args, ...nxArgs } as any)).map(
     (p) => `"${p}"`
   );
 
@@ -48,7 +51,9 @@ export function format(command: 'check' | 'write', args: yargs.Arguments) {
   }
 }
 
-function getPatterns(args: NxArgs & { libsAndApps: boolean; _: string[] }) {
+async function getPatterns(
+  args: NxArgs & { libsAndApps: boolean; _: string[] }
+) {
   const allFilesPattern = [MATCH_ALL_PATTERN];
 
   try {
@@ -67,14 +72,14 @@ function getPatterns(args: NxArgs & { libsAndApps: boolean; _: string[] }) {
         PRETTIER_EXTENSIONS.map((ext) => '.' + ext).includes(path.extname(f))
       );
 
-    return args.libsAndApps ? getPatternsFromApps(patterns) : patterns;
+    return args.libsAndApps ? await getPatternsFromApps(patterns) : patterns;
   } catch (e) {
     return allFilesPattern;
   }
 }
 
-function getPatternsFromApps(affectedFiles: string[]): string[] {
-  const graph = onlyWorkspaceProjects(createProjectGraph());
+async function getPatternsFromApps(affectedFiles: string[]): Promise<string[]> {
+  const graph = onlyWorkspaceProjects(await createProjectGraphAsync());
   const affectedGraph = filterAffected(
     graph,
     calculateFileChanges(affectedFiles)

--- a/packages/workspace/src/command-line/lint.ts
+++ b/packages/workspace/src/command-line/lint.ts
@@ -1,5 +1,5 @@
 import {
-  createProjectGraph,
+  createProjectGraphAsync,
   onlyWorkspaceProjects,
 } from '../core/project-graph';
 import { WorkspaceIntegrityChecks } from './workspace-integrity-checks';
@@ -7,8 +7,8 @@ import { readWorkspaceFiles, workspaceLayout } from '../core/file-utils';
 import { output } from '../utils/output';
 import * as path from 'path';
 
-export function workspaceLint() {
-  const graph = onlyWorkspaceProjects(createProjectGraph());
+export async function workspaceLint() {
+  const graph = onlyWorkspaceProjects(await createProjectGraphAsync());
 
   const cliErrorOutputConfigs = new WorkspaceIntegrityChecks(
     graph,

--- a/packages/workspace/src/command-line/run-many.ts
+++ b/packages/workspace/src/command-line/run-many.ts
@@ -2,7 +2,7 @@ import * as yargs from 'yargs';
 import { runCommand } from '../tasks-runner/run-command';
 import { NxArgs, splitArgsIntoNxArgsAndOverrides } from './utils';
 import {
-  createProjectGraph,
+  createProjectGraphAsync,
   isWorkspaceProject,
   onlyWorkspaceProjects,
   ProjectGraph,
@@ -14,12 +14,12 @@ import { DefaultReporter } from '../tasks-runner/default-reporter';
 import { projectHasTarget } from '../utils/project-graph-utils';
 import { output } from '../utils/output';
 
-export function runMany(parsedArgs: yargs.Arguments): void {
+export async function runMany(parsedArgs: yargs.Arguments) {
   const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides(
     parsedArgs,
     'run-many'
   );
-  const projectGraph = createProjectGraph();
+  const projectGraph = await createProjectGraphAsync();
   const projects = projectsToRun(nxArgs, projectGraph);
   const projectMap: Record<string, ProjectGraphNode> = {};
   projects.forEach((proj) => {

--- a/packages/workspace/src/command-line/run-one.ts
+++ b/packages/workspace/src/command-line/run-one.ts
@@ -1,16 +1,16 @@
 import { runCommand } from '../tasks-runner/run-command';
-import { createProjectGraph, ProjectGraph } from '../core/project-graph';
+import { createProjectGraphAsync, ProjectGraph } from '../core/project-graph';
 import { readEnvironment } from '../core/file-utils';
 import { EmptyReporter } from '../tasks-runner/empty-reporter';
 import { splitArgsIntoNxArgsAndOverrides } from './utils';
 import { projectHasTarget } from '../utils/project-graph-utils';
 
-export function runOne(opts: {
+export async function runOne(opts: {
   project: string;
   target: string;
   configuration: string;
   parsedArgs: any;
-}): void {
+}) {
   const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides(
     {
       ...opts.parsedArgs,
@@ -20,7 +20,7 @@ export function runOne(opts: {
     'run-one'
   );
 
-  const projectGraph = createProjectGraph();
+  const projectGraph = await createProjectGraphAsync();
   const { projects, projectsMap } = getProjects(
     projectGraph,
     nxArgs.withDeps,

--- a/packages/workspace/src/command-line/shared.ts
+++ b/packages/workspace/src/command-line/shared.ts
@@ -1,5 +1,8 @@
 import { execSync } from 'child_process';
-import { createProjectGraph, ProjectGraphNode } from '../core/project-graph';
+import {
+  createProjectGraphAsync,
+  ProjectGraphNode,
+} from '../core/project-graph';
 import { NxJson } from '../core/shared-interfaces';
 import { readWorkspaceJson, TEN_MEGABYTES } from '../core/file-utils';
 import { NxArgs } from './utils';
@@ -59,15 +62,6 @@ function parseGitOutput(command: string): string[] {
     .split('\n')
     .map((a) => a.trim())
     .filter((a) => a.length > 0);
-}
-
-// TODO: remove it in Nx 10
-export function getProjectNodes(
-  workspaceJson: any,
-  nxJson: NxJson
-): ProjectGraphNode[] {
-  const graph = createProjectGraph(workspaceJson, nxJson);
-  return Object.values(graph.nodes);
 }
 
 export function getProjectRoots(projectNames: string[]): string[] {

--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
@@ -2,7 +2,7 @@ import { extname } from 'path';
 import { jsonDiff } from '../../utils/json-diff';
 import { vol } from 'memfs';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
-import { createProjectGraph } from '../project-graph';
+import { createProjectGraphAsync } from '../project-graph';
 import { filterAffected } from './affected-project-graph';
 import { FileData, WholeFileChange } from '../file-utils';
 import { NxJson } from '../shared-interfaces';
@@ -133,8 +133,8 @@ describe('project graph', () => {
     vol.fromJSON(filesJson, '/root');
   });
 
-  it('should create nodes and dependencies with workspace projects', () => {
-    const graph = createProjectGraph();
+  it('should create nodes and dependencies with workspace projects', async () => {
+    const graph = await createProjectGraphAsync();
     const affected = filterAffected(graph, [
       {
         file: 'something-for-api.txt',
@@ -198,8 +198,8 @@ describe('project graph', () => {
     });
   });
 
-  it('should create nodes and dependencies with npm packages', () => {
-    const graph = createProjectGraph();
+  it('should create nodes and dependencies with npm packages', async () => {
+    const graph = await createProjectGraphAsync();
     const updatedPackageJson = {
       ...packageJson,
       dependencies: {
@@ -266,8 +266,8 @@ describe('project graph', () => {
     });
   });
 
-  it('should support implicit JSON file dependencies (some projects)', () => {
-    const graph = createProjectGraph();
+  it('should support implicit JSON file dependencies (some projects)', async () => {
+    const graph = await createProjectGraphAsync();
     const updatedPackageJson = {
       ...packageJson,
       scripts: {
@@ -287,8 +287,8 @@ describe('project graph', () => {
     expect(Object.keys(affected.nodes)).toEqual(['demo', 'demo-e2e', 'api']);
   });
 
-  it('should support implicit JSON file dependencies (all projects)', () => {
-    const graph = createProjectGraph();
+  it('should support implicit JSON file dependencies (all projects)', async () => {
+    const graph = await createProjectGraphAsync();
     const updatedPackageJson = {
       ...packageJson,
       devDependencies: {

--- a/packages/workspace/src/core/project-graph/index.ts
+++ b/packages/workspace/src/core/project-graph/index.ts
@@ -1,4 +1,4 @@
-export { createProjectGraph } from './project-graph';
+export { createProjectGraph, createProjectGraphAsync } from './project-graph';
 export { BuildDependencies } from './build-dependencies';
 export { BuildNodes } from './build-nodes';
 export { ProjectGraphBuilder } from './project-graph-builder';

--- a/packages/workspace/src/core/project-graph/project-graph.spec.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.spec.ts
@@ -3,7 +3,7 @@ jest.mock('fs', () => require('memfs').fs);
 jest.mock('../../utils/app-root', () => ({ appRootPath: '/root' }));
 
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
-import { createProjectGraph } from './project-graph';
+import { createProjectGraphAsync } from './project-graph';
 import { DependencyType } from './project-graph-models';
 import { NxJson } from '../shared-interfaces';
 import { defaultFileHasher } from '@nrwl/workspace/src/core/hasher/file-hasher';
@@ -129,8 +129,8 @@ describe('project graph', () => {
     vol.fromJSON(filesJson, '/root');
   });
 
-  it('should create nodes and dependencies with workspace projects', () => {
-    const graph = createProjectGraph();
+  it('should create nodes and dependencies with workspace projects', async () => {
+    const graph = await createProjectGraphAsync();
 
     expect(graph.nodes).toMatchObject({
       api: { name: 'api', type: 'app' },
@@ -191,7 +191,7 @@ describe('project graph', () => {
   });
 
   it('should update the graph if the workspace file changes ', async () => {
-    let graph = createProjectGraph();
+    let graph = await createProjectGraphAsync();
     expect(graph.nodes).toMatchObject({
       demo: { name: 'demo', type: 'app' },
     });
@@ -202,19 +202,19 @@ describe('project graph', () => {
 
     defaultFileHasher.init();
 
-    graph = createProjectGraph();
+    graph = await createProjectGraphAsync();
     expect(graph.nodes).toMatchObject({
       demo: { name: 'demo', type: 'lib' },
     });
   });
 
-  it('should handle circular dependencies', () => {
+  it('should handle circular dependencies', async () => {
     fs.writeFileSync(
       '/root/libs/shared/util/src/index.ts',
       `import * as ui from '@nrwl/ui';`
     );
 
-    const graph = createProjectGraph();
+    const graph = await createProjectGraphAsync();
 
     expect(graph.dependencies['shared-util']).toEqual([
       {

--- a/packages/workspace/src/schematics/remove/lib/check-dependencies.ts
+++ b/packages/workspace/src/schematics/remove/lib/check-dependencies.ts
@@ -8,7 +8,7 @@ import { getWorkspacePath } from '@nrwl/workspace/src/utils/cli-config-utils';
 import ignore from 'ignore';
 import * as path from 'path';
 import {
-  createProjectGraph,
+  createProjectGraphAsync,
   onlyWorkspaceProjects,
   ProjectGraph,
   reverse,
@@ -28,7 +28,7 @@ export function checkDependencies(schema: Schema): Rule {
   }
   let ig = ignore();
 
-  return (tree: Tree): Tree => {
+  return async (tree: Tree) => {
     if (tree.exists('.gitignore')) {
       ig = ig.add(tree.read('.gitignore').toString());
     }
@@ -49,7 +49,7 @@ export function checkDependencies(schema: Schema): Rule {
       });
     }
 
-    const graph: ProjectGraph = createProjectGraph(
+    const graph: ProjectGraph = await createProjectGraphAsync(
       readWorkspace(tree),
       readNxJsonInTree(tree),
       files,
@@ -63,7 +63,7 @@ export function checkDependencies(schema: Schema): Rule {
     const deps = reverseGraph.dependencies[schema.projectName] || [];
 
     if (deps.length === 0) {
-      return tree;
+      return;
     }
 
     throw new Error(

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -22,7 +22,7 @@ import * as stripJsonComments from 'strip-json-comments';
 import { serializeJson } from './fileutils';
 import { getWorkspacePath } from './cli-config-utils';
 import {
-  createProjectGraph,
+  createProjectGraphAsync,
   onlyWorkspaceProjects,
   ProjectGraph,
 } from '../core/project-graph';
@@ -397,11 +397,13 @@ export function readJsonInTree<T = any>(host: Tree, path: string): T {
 /**
  * Method for utilizing the project graph in schematics
  */
-export function getProjectGraphFromHost(host: Tree): ProjectGraph {
-  return onlyWorkspaceProjects(getFullProjectGraphFromHost(host));
+export async function getProjectGraphFromHost(
+  host: Tree
+): Promise<ProjectGraph> {
+  return onlyWorkspaceProjects(await getFullProjectGraphFromHost(host));
 }
 
-export function getFullProjectGraphFromHost(host: Tree): ProjectGraph {
+export function getFullProjectGraphFromHost(host: Tree): Promise<ProjectGraph> {
   const workspaceJson = readJsonInTree(host, getWorkspacePath(host));
   const nxJson = readJsonInTree<NxJson>(host, '/nx.json');
 
@@ -430,7 +432,7 @@ export function getFullProjectGraphFromHost(host: Tree): ProjectGraph {
     );
   });
 
-  return createProjectGraph(
+  return createProjectGraphAsync(
     workspaceJson,
     nxJson,
     workspaceFiles,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There is synchronous version of `createProjectGraph` that limits performance improvements that we can do.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There is an asynchronous version of `createProjectGraph` as well as the synchronous one that is there today.

The synchronous version seems to need to exist for linters that don't have a good way of asynchronous setup.

Otherwise, all usages of `createProjectGraph` have been switched over to `createProjectGraphAsync`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
