### PR TITLE
fix(angular): properly generate storybook stories across barrel files

### DIFF
--- a/packages/angular/src/schematics/component-cypress-spec/component-cypress-spec.ts
+++ b/packages/angular/src/schematics/component-cypress-spec/component-cypress-spec.ts
@@ -22,6 +22,7 @@ import {
   getKnobType,
 } from '../component-story/component-story';
 import { applyWithSkipExisting } from '@nrwl/workspace/src/utils/ast-utils';
+import { join, normalize } from '@angular-devkit/core';
 
 export default function (schema: CreateComponentSpecFileSchema): Rule {
   return chain([createComponentSpecFile(schema)]);
@@ -45,8 +46,11 @@ export function createComponentSpecFile({
   return (tree: Tree, context: SchematicContext): Rule => {
     const e2eLibIntegrationFolderPath =
       getProjectConfig(tree, projectName + '-e2e').sourceRoot + '/integration';
-    const fullComponentPath =
-      libPath + '/' + componentPath + '/' + componentFileName + '.ts';
+    const fullComponentPath = join(
+      normalize(libPath),
+      componentPath,
+      `${componentFileName}.ts`
+    );
     const props = getInputPropertyDeclarations(tree, fullComponentPath).map(
       (node) => {
         const decoratorContent = findNodes(

--- a/packages/angular/src/schematics/component-story/component-story.ts
+++ b/packages/angular/src/schematics/component-story/component-story.ts
@@ -14,6 +14,7 @@ import {
   getSourceNodes,
   applyWithSkipExisting,
 } from '@nrwl/workspace/src/utils/ast-utils';
+import { join, normalize } from '@angular-devkit/core';
 
 export interface CreateComponentStoriesFileSchema {
   libPath: string;
@@ -35,7 +36,7 @@ export function createComponentStoriesFile({
   return (tree: Tree, context: SchematicContext): Rule => {
     const props = getInputDescriptors(
       tree,
-      libPath + '/' + componentPath + '/' + componentFileName + '.ts'
+      join(normalize(libPath), componentPath, `${componentFileName}.ts`)
     );
     return applyWithSkipExisting(url('./files'), [
       template({

--- a/packages/angular/src/schematics/storybook-configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/angular/src/schematics/storybook-configuration/__snapshots__/configuration.spec.ts.snap
@@ -22,6 +22,13 @@ Array [
   "/libs/test-ui-lib/src/lib/test-button/test-button.component.spec.ts",
   "/libs/test-ui-lib/src/lib/test-button/test-button.component.ts",
   "/libs/test-ui-lib/src/lib/test-button/test-button.component.stories.ts",
+  "/libs/test-ui-lib/src/lib/barrel/barrel.module.ts",
+  "/libs/test-ui-lib/src/lib/barrel/barrel-button/barrel-button.component.css",
+  "/libs/test-ui-lib/src/lib/barrel/barrel-button/barrel-button.component.html",
+  "/libs/test-ui-lib/src/lib/barrel/barrel-button/barrel-button.component.spec.ts",
+  "/libs/test-ui-lib/src/lib/barrel/barrel-button/barrel-button.component.ts",
+  "/libs/test-ui-lib/src/lib/barrel/barrel-button/index.ts",
+  "/libs/test-ui-lib/src/lib/barrel/barrel-button/barrel-button.component.stories.ts",
   "/libs/test-ui-lib/src/lib/nested/nested.module.ts",
   "/libs/test-ui-lib/src/lib/nested/nested-button/nested-button.component.css",
   "/libs/test-ui-lib/src/lib/nested/nested-button/nested-button.component.html",
@@ -50,6 +57,7 @@ Array [
   "/apps/test-ui-lib-e2e/src/support/index.ts",
   "/apps/test-ui-lib-e2e/src/integration/test-button/test-button.component.spec.ts",
   "/apps/test-ui-lib-e2e/src/integration/test-other/test-other.component.spec.ts",
+  "/apps/test-ui-lib-e2e/src/integration/barrel-button/barrel-button.component.spec.ts",
   "/apps/test-ui-lib-e2e/src/integration/nested-button/nested-button.component.spec.ts",
 ]
 `;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Previously when using barrel files to import components into `NgModules` the Nrwl Storybook schematic was unable to find the correct path to the actual Angular component for which it should generate a Storybook story.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Now it works across barrel files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #2813