### PR TITLE
feat(core): add nx-cloud to list of default packages to be migrated

### DIFF
--- a/packages/tao/src/commands/migrate.spec.ts
+++ b/packages/tao/src/commands/migrate.spec.ts
@@ -309,6 +309,10 @@ describe('Migration', () => {
           '@nrwl/nest': { version: '2.0.0', alwaysAddToPackageJson: false },
           '@nrwl/next': { version: '2.0.0', alwaysAddToPackageJson: false },
           '@nrwl/node': { version: '2.0.0', alwaysAddToPackageJson: false },
+          '@nrwl/nx-cloud': {
+            version: '2.0.0',
+            alwaysAddToPackageJson: false,
+          },
           '@nrwl/nx-plugin': {
             version: '2.0.0',
             alwaysAddToPackageJson: false,

--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -216,6 +216,7 @@ export class Migrator {
           '@nrwl/nest',
           '@nrwl/next',
           '@nrwl/node',
+          '@nrwl/nx-cloud',
           '@nrwl/nx-plugin',
           '@nrwl/react',
           '@nrwl/storybook',


### PR DESCRIPTION
`nx-cloud` is currently not migrated with the nx migrate latest command. Including this in the list of default packages will result in more expected behavior with less maintenance for the end-user.

## Current Behavior (This is the behavior we have today, before the PR is merged)

The `@nrwl/nx-cloud` package is not updated or migrated with the `nx migrate latest` command.

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

`@nrwl/nx-cloud` should be updated and migrated like all other `@nrwl/*` plugins/dependencies.