### PR TITLE
fix(misc): add message suggesting to install a plugin in an empty workspace

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -500,8 +500,8 @@ function pointToTutorialAndCourse(preset: Preset) {
           `In order to add functionality to an empty workspace, you need to install a plugin.`,
           `For example: @nrwl/angular, @nrwl/nest, @nrwl/node, @nrwl/react or @nrwl/web`,
         ],
-      })
-      break
+      });
+      break;
     case Preset.React:
     case Preset.ReactWithExpress:
     case Preset.NextJs:

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -492,6 +492,16 @@ async function askAboutNxCloud(parsedArgs: any) {
 function pointToTutorialAndCourse(preset: Preset) {
   const title = `First time using Nx? Check out this interactive Nx tutorial.`;
   switch (preset) {
+    case Preset.Empty:
+      output.addVerticalSeparator();
+      output.note({
+        title: `First time using Nx?`,
+        bodyLines: [
+          `In order to add functionality to an empty workspace, you need to install a plugin.`,
+          `For example: @nrwl/angular, @nrwl/nest, @nrwl/node, @nrwl/react or @nrwl/web`,
+        ],
+      })
+      break
     case Preset.React:
     case Preset.ReactWithExpress:
     case Preset.NextJs:


### PR DESCRIPTION
## Current Behavior
When installing an empty workspace there is not message that you should install a plugin to add actual functionality to you workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
There should be a message suggesting the user to install a plugin.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related issue #2953 where people suggest we add a message when creating empty workspaces.


Please let me know if you like to see any changes in the language.
