### PR TITLE
fix(web): package builder correctly copies assets on Windows

### DIFF
--- a/packages/web/src/builders/package/package.impl.spec.ts
+++ b/packages/web/src/builders/package/package.impl.spec.ts
@@ -1,3 +1,6 @@
+const mockCopyPlugin = jest.fn();
+jest.mock('rollup-plugin-copy', () => mockCopyPlugin);
+
 import { of, throwError } from 'rxjs';
 import { join } from 'path';
 
@@ -58,6 +61,28 @@ describe('WebPackagebuilder', () => {
           name: 'Example',
         },
       ]);
+    });
+
+    it(`should always use forward slashes for asset paths`, () => {
+      createRollupOptions(
+        {
+          ...normalizePackageOptions(testOptions, '/root', '/root/src'),
+          assets: [
+            {
+              glob: 'README.md',
+              input: 'C:\\windows\\path',
+              output: '.',
+            },
+          ],
+        },
+        [],
+        context,
+        { name: 'example' },
+        '/root/src'
+      );
+      expect(mockCopyPlugin).toHaveBeenCalledWith({
+        targets: [{ dest: '/root/dist/ui', src: 'C:/windows/path/README.md' }],
+      });
     });
   });
 });

--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -294,8 +294,8 @@ function convertCopyAssetsToRollupOptions(
 ): RollupCopyAssetOption[] {
   return assets
     ? assets.map((a) => ({
-        src: join(a.input, a.glob),
-        dest: join(outputPath, a.output),
+        src: join(a.input, a.glob).replace(/\\/g, '/'),
+        dest: join(outputPath, a.output).replace(/\\/g, '/'),
       }))
     : undefined;
 }


### PR DESCRIPTION
On Windows, the paths were using backslashes and this was causing `globby` inside `rollup-plugin-copy` to not match any pattern, and thus ignoring all assets during the build. This commit ensures that all paths passed to `rollup-plugin-copy` use only forward slashes.