### PR TITLE
fix(react): support default envName behavior for babel

### DIFF
--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -156,28 +156,18 @@ forEachCli('nx', () => {
         JSON.stringify(
           {
             presets: ['@nrwl/react/babel'],
+            plugins: [
+              [
+                'styled-components',
+                { pure: true, ssr: true, displayName: true },
+              ],
+            ],
             env: {
-              development: {
-                plugins: [
-                  [
-                    'styled-components',
-                    {
-                      pure: true,
-                      ssr: true,
-                      displayName: true,
-                    },
-                  ],
-                ],
-              },
               production: {
                 plugins: [
                   [
                     'styled-components',
-                    {
-                      pure: true,
-                      ssr: true,
-                      displayName: false,
-                    },
+                    { pure: true, ssr: true, displayName: false },
                   ],
                 ],
               },

--- a/packages/web/src/utils/config.spec.ts
+++ b/packages/web/src/utils/config.spec.ts
@@ -424,4 +424,45 @@ describe('getBaseWebpackPartial', () => {
       });
     });
   });
+
+  describe('babel loader', () => {
+    it('should set default options', () => {
+      const result = getBaseWebpackPartial({
+        ...input,
+        progress: true,
+      });
+
+      const rule = result.module.rules.find(
+        (r) => typeof r.loader === 'string' && r.loader.match(/babel-loader/)
+      );
+      expect(rule.options).toMatchObject({
+        rootMode: 'upward',
+        cwd: '/root/root/src',
+        envName: undefined,
+        babelrc: true,
+      });
+    });
+
+    it('should support envName overrides', () => {
+      const result = getBaseWebpackPartial(
+        {
+          ...input,
+          progress: true,
+        },
+        true,
+        true,
+        'production'
+      );
+
+      const rule = result.module.rules.find(
+        (r) => typeof r.loader === 'string' && r.loader.match(/babel-loader/)
+      );
+      expect(rule.options).toMatchObject({
+        rootMode: 'upward',
+        cwd: '/root/root/src',
+        envName: 'production',
+        babelrc: true,
+      });
+    });
+  });
 });

--- a/packages/web/src/utils/config.ts
+++ b/packages/web/src/utils/config.ts
@@ -55,7 +55,7 @@ export function getBaseWebpackPartial(
             rootMode: 'upward',
             cwd: join(options.root, options.sourceRoot),
             isModern: esm,
-            envName: configuration || 'development',
+            envName: configuration,
             babelrc: true,
             cacheDirectory: true,
             cacheCompression: false,


### PR DESCRIPTION

## Current Behavior

Cannot use `BABEL_ENV` or `NODE_ENV` to provide babel env -- only through `--configuration=...`. This is not the normal usage for babel.

## Expected Behavior

Can set either `BABEL_ENV` or `NODE_ENV`.
