### PR TITLE
fix(testing): allow passing in an array of coverage reporters

### DIFF
--- a/docs/angular/api-jest/builders/jest.md
+++ b/docs/angular/api-jest/builders/jest.md
@@ -62,7 +62,7 @@ The directory where Jest should output its coverage files.
 
 ### coverageReporters
 
-Type: `string`
+Type: `array`
 
 A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter
 

--- a/docs/react/api-jest/builders/jest.md
+++ b/docs/react/api-jest/builders/jest.md
@@ -63,7 +63,7 @@ The directory where Jest should output its coverage files.
 
 ### coverageReporters
 
-Type: `string`
+Type: `array`
 
 A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter
 

--- a/packages/jest/src/builders/jest/schema.json
+++ b/packages/jest/src/builders/jest/schema.json
@@ -120,7 +120,10 @@
     },
     "coverageReporters": {
       "description": "A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter",
-      "type": "string"
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "coverageDirectory": {
       "description": "The directory where Jest should output its coverage files.",


### PR DESCRIPTION
Current Behavior
<!-- This is the behavior we have today -->

`nx test some-app --codeCoverage --coverageReporters=json` 

throws the error:

```
Failed to write coverage reports:
ERROR: TypeError: coverageReporters.forEach is not a function
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It should allow passing in a list of reporters.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related PR:
https://github.com/nrwl/nx/pull/2645