### PR TITLE
fix(angular): replace addAll with setAll

### DIFF
--- a/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.reducer.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.reducer.ts__tmpl__
@@ -29,7 +29,7 @@ const <%= propertyName %>Reducer = createReducer(
     state => ({ ...state, loaded: false, error: null })
   ),
   on(<%= className %>Actions.load<%= className %>Success,
-    (state, { <%= propertyName %> }) => <%= propertyName %>Adapter.addAll(<%= propertyName %>, { ...state, loaded: true })
+    (state, { <%= propertyName %> }) => <%= propertyName %>Adapter.setAll(<%= propertyName %>, { ...state, loaded: true })
   ),
   on(<%= className %>Actions.load<%= className %>Failure,
     (state, { error }) => ({ ...state, error })

--- a/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.selectors.spec.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.selectors.spec.ts__tmpl__
@@ -14,7 +14,7 @@ describe('<%= className %> Selectors', () => {
 
   beforeEach(() => {
     state = {
-      <%= propertyName %>: <%= propertyName %>Adapter.addAll([
+      <%= propertyName %>: <%= propertyName %>Adapter.setAll([
         create<%= className %>Entity( 'PRODUCT-AAA' ),
         create<%= className %>Entity( 'PRODUCT-BBB' ),
         create<%= className %>Entity( 'PRODUCT-CCC' )


### PR DESCRIPTION
ngrx is deprecating addAll for setAll. so this replaces addAll with setAll.

ISSUES CLOSED: #3698

## Current Behavior
using a method marked for deprecation

## Expected Behavior
latest method

## Related Issue(s)
Fixes #3698
