### PR TITLE
feat(core): optimize project locator perf

### DIFF
--- a/packages/workspace/src/core/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -14,7 +14,7 @@ export function buildExplicitTypeScriptDependencies(
   fileRead: (s: string) => string
 ) {
   const importLocator = new TypeScriptImportLocator(fileRead);
-  const targetProjectLocator = new TargetProjectLocator(nodes);
+  const targetProjectLocator = new TargetProjectLocator(nodes, fileRead);
   Object.keys(ctx.fileMap).forEach((source) => {
     Object.values(ctx.fileMap[source]).forEach((f) => {
       importLocator.fromFile(

--- a/packages/workspace/src/core/target-project-locator.spec.ts
+++ b/packages/workspace/src/core/target-project-locator.spec.ts
@@ -1,5 +1,4 @@
 import { fs, vol } from 'memfs';
-import { join } from 'path';
 import {
   ProjectGraphContext,
   ProjectGraphNode,
@@ -197,6 +196,34 @@ describe('findTargetProjectWithImport', () => {
     targetProjectLocator = new TargetProjectLocator(projects);
   });
 
+  it('should be able to resolve a module by using relative paths', () => {
+    const res1 = targetProjectLocator.findProjectWithImport(
+      './class.ts',
+      'libs/proj/index.ts',
+      ctx.nxJson.npmScope
+    );
+    const res2 = targetProjectLocator.findProjectWithImport(
+      '../index.ts',
+      'libs/proj/src/index.ts',
+      ctx.nxJson.npmScope
+    );
+    const res3 = targetProjectLocator.findProjectWithImport(
+      '../proj/../proj2/index.ts',
+      'libs/proj/index.ts',
+      ctx.nxJson.npmScope
+    );
+    const res4 = targetProjectLocator.findProjectWithImport(
+      '../proj/../index.ts',
+      'libs/proj/src/index.ts',
+      ctx.nxJson.npmScope
+    );
+
+    expect(res1).toEqual('proj');
+    expect(res2).toEqual('proj');
+    expect(res3).toEqual('proj2');
+    expect(res4).toEqual('proj');
+  });
+
   it('should be able to resolve a module by using tsConfig paths', () => {
     const proj2 = targetProjectLocator.findProjectWithImport(
       '@proj/my-second-proj',
@@ -242,20 +269,5 @@ describe('findTargetProjectWithImport', () => {
       ctx.nxJson.npmScope
     );
     expect(parentProj).toEqual('proj1234');
-  });
-
-  it('should be able to sort graph nodes', () => {
-    expect(targetProjectLocator._sortedNodeNames).toEqual([
-      'proj1234-child',
-      'proj1234',
-      'proj123',
-      'proj4ab',
-      'proj3a',
-      'proj2',
-      'proj',
-      '@ng/core',
-      '@ng/common',
-      'npm-package',
-    ]);
   });
 });

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -405,7 +405,13 @@ export function getFullProjectGraphFromHost(host: Tree): ProjectGraph {
   const workspaceJson = readJsonInTree(host, getWorkspacePath(host));
   const nxJson = readJsonInTree<NxJson>(host, '/nx.json');
 
-  const fileRead = (f: string) => host.read(f).toString();
+  const fileRead = (f: string) => {
+    try {
+      return host.read(f).toString();
+    } catch (e) {
+      throw new Error(`${f} does not exist`);
+    }
+  };
 
   const workspaceFiles: FileData[] = [];
 

--- a/packages/workspace/src/utils/fileutils.ts
+++ b/packages/workspace/src/utils/fileutils.ts
@@ -35,7 +35,11 @@ export function serializeJson(json: any): string {
  * @param path Path of the JSON file on the filesystem
  */
 export function readJsonFile<T = any>(path: string): T {
-  return JSON.parse(stripJsonComments(fs.readFileSync(path, 'utf-8')));
+  return parseJsonWithComments<T>(fs.readFileSync(path, 'utf-8'));
+}
+
+export function parseJsonWithComments<T = any>(content: string): T {
+  return JSON.parse(stripJsonComments(content));
 }
 
 export function writeJsonFile(path: string, json: any) {


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

The `TargetProjectLocator` does a lot of extra work to find projects.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `TargetProjectLocator` is more optimized.

## Results
On a large project, this function used to execute for ~15s, now it executes for ~1.1s.

Overall time to build the project graph used to take ~18s, now it takes ~4.4s. (75% improvement)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
