### PR TITLE
Universal JS flag

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -22,6 +22,7 @@ module.exports = {
     { name: 'nextjs', description: 'anything Next specific' },
     { name: 'nest', description: 'anything Nest specific' },
     { name: 'node', description: 'anything Node specific' },
+    { name: 'express', description: 'anything Express specific' },
     { name: 'nx-plugin', description: 'anything Nx Plugin specific' },
     { name: 'react', description: 'anything React specific' },
     { name: 'web', description: 'anything Web specific' },

--- a/docs/angular/api-express/schematics/application.md
+++ b/docs/angular/api-express/schematics/application.md
@@ -48,6 +48,14 @@ Type: `string`
 
 Frontend project that needs to access this application. This sets up proxy configuration.
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files.
+
 ### linter
 
 Default: `eslint`

--- a/docs/angular/api-node/schematics/application.md
+++ b/docs/angular/api-node/schematics/application.md
@@ -48,6 +48,14 @@ Type: `string`
 
 Frontend project that needs to access this application. This sets up proxy configuration.
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files.
+
 ### linter
 
 Default: `eslint`

--- a/docs/angular/api-node/schematics/library.md
+++ b/docs/angular/api-node/schematics/library.md
@@ -66,6 +66,14 @@ Type: `string`
 
 The library name used to import it, like @myorg/my-awesome-lib. Must be a valid npm name.
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files.
+
 ### linter
 
 Default: `eslint`

--- a/docs/node/api-express/schematics/application.md
+++ b/docs/node/api-express/schematics/application.md
@@ -48,6 +48,14 @@ Type: `string`
 
 Frontend project that needs to access this application. This sets up proxy configuration.
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files.
+
 ### linter
 
 Default: `eslint`

--- a/docs/node/api-node/schematics/application.md
+++ b/docs/node/api-node/schematics/application.md
@@ -48,6 +48,14 @@ Type: `string`
 
 Frontend project that needs to access this application. This sets up proxy configuration.
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files.
+
 ### linter
 
 Default: `eslint`

--- a/docs/node/api-node/schematics/library.md
+++ b/docs/node/api-node/schematics/library.md
@@ -66,6 +66,14 @@ Type: `string`
 
 The library name used to import it, like @myorg/my-awesome-lib. Must be a valid npm name.
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files.
+
 ### linter
 
 Default: `eslint`

--- a/docs/react/api-express/schematics/application.md
+++ b/docs/react/api-express/schematics/application.md
@@ -48,6 +48,14 @@ Type: `string`
 
 Frontend project that needs to access this application. This sets up proxy configuration.
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files.
+
 ### linter
 
 Default: `eslint`

--- a/docs/react/api-node/schematics/application.md
+++ b/docs/react/api-node/schematics/application.md
@@ -48,6 +48,14 @@ Type: `string`
 
 Frontend project that needs to access this application. This sets up proxy configuration.
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files.
+
 ### linter
 
 Default: `eslint`

--- a/docs/react/api-node/schematics/library.md
+++ b/docs/react/api-node/schematics/library.md
@@ -66,6 +66,14 @@ Type: `string`
 
 The library name used to import it, like @myorg/my-awesome-lib. Must be a valid npm name.
 
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files.
+
 ### linter
 
 Default: `eslint`

--- a/packages/cypress/src/schematics/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/schematics/cypress-project/cypress-project.ts
@@ -44,7 +44,6 @@ function generateFiles(options: CypressProjectSchema): Rule {
           offsetFromRoot: offsetFromRoot(options.projectRoot),
         }),
         move(options.projectRoot),
-        options.js ? toJS() : noop(),
       ])
     );
   };
@@ -137,6 +136,7 @@ export default function (options: CypressProjectSchema): Rule {
       generateFiles(options),
       updateWorkspaceJson(options),
       updateNxJson(options),
+      options.js ? toJS() : noop(),
     ])(host, context);
   };
 }

--- a/packages/express/src/schematics/application/application.spec.ts
+++ b/packages/express/src/schematics/application/application.spec.ts
@@ -34,4 +34,31 @@ describe('app', () => {
       path: './tsconfig.spec.json',
     });
   });
+
+  describe('--js flag', () => {
+    it('should generate js files instead of ts files', async () => {
+      const tree = await runSchematic(
+        'app',
+        { name: 'myNodeApp', js: true },
+        appTree
+      );
+
+      expect(tree.exists('apps/my-node-app/src/main.js')).toBeTruthy();
+      expect(tree.readContent('apps/my-node-app/src/main.js')).toContain(
+        `import * as express from 'express';`
+      );
+
+      const tsConfig = readJsonInTree(tree, 'apps/my-node-app/tsconfig.json');
+      expect(tsConfig.compilerOptions).toEqual({
+        allowJs: true,
+      });
+
+      const tsConfigApp = readJsonInTree(
+        tree,
+        'apps/my-node-app/tsconfig.app.json'
+      );
+      expect(tsConfigApp.include.includes('**/*.js')).toBe(true);
+      expect(tsConfigApp.exclude.includes('**/*.spec.js')).toBe(true);
+    });
+  });
 });

--- a/packages/express/src/schematics/application/application.ts
+++ b/packages/express/src/schematics/application/application.ts
@@ -4,13 +4,15 @@ import {
   Rule,
   SchematicContext,
   Tree,
+  noop,
 } from '@angular-devkit/schematics';
 import { join, normalize, Path } from '@angular-devkit/core';
-import { Schema } from './schema';
-import { updateJsonInTree } from '@nrwl/workspace';
-import { toFileName, formatFiles } from '@nrwl/workspace';
-import init from '../init/init';
+import { updateJsonInTree, toFileName, formatFiles } from '@nrwl/workspace';
+import { toJS } from '@nrwl/workspace/src/utils/rules/to-js';
 import { appsDir } from '@nrwl/workspace/src/utils/ast-utils';
+import init from '../init/init';
+import { Schema } from './schema';
+import { mainModule } from 'process';
 
 interface NormalizedSchema extends Schema {
   appProjectRoot: Path;
@@ -27,7 +29,7 @@ function addTypes(options: NormalizedSchema): Rule {
 function addMainFile(options: NormalizedSchema): Rule {
   return (host: Tree) => {
     host.overwrite(
-      join(options.appProjectRoot, 'src/main.ts'),
+      join(options.appProjectRoot, options.js ? 'src/main.js' : 'src/main.ts'),
       `/**
  * This is not a production server yet!
  * This is only a minimal backend to get started.
@@ -59,6 +61,7 @@ export default function (schema: Schema): Rule {
       externalSchematic('@nrwl/node', 'application', schema),
       addMainFile(options),
       addTypes(options),
+      options.js ? toJS() : noop(),
       formatFiles(options),
     ])(host, context);
   };

--- a/packages/express/src/schematics/application/schema.d.ts
+++ b/packages/express/src/schematics/application/schema.d.ts
@@ -11,4 +11,5 @@ export interface Schema {
   linter: Linter;
   frontendProject?: string;
   babelJest?: boolean;
+  js?: boolean;
 }

--- a/packages/express/src/schematics/application/schema.json
+++ b/packages/express/src/schematics/application/schema.json
@@ -52,6 +52,11 @@
       "type": "boolean",
       "description": "Use babel instead ts-jest",
       "default": false
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files.",
+      "default": false
     }
   },
   "required": []

--- a/packages/node/src/builders/package/utils/update-package-json.ts
+++ b/packages/node/src/builders/package/utils/update-package-json.ts
@@ -8,7 +8,7 @@ export default function updatePackageJson(
   options: NormalizedBuilderOptions,
   context: BuilderContext
 ) {
-  const mainFile = basename(options.main, '.ts');
+  const mainFile = basename(options.main).replace(/\.[tj]s$/, '');
   const typingsFile = `${mainFile}.d.ts`;
   const mainJsFile = `${mainFile}.js`;
   const packageJson = readJsonFile(

--- a/packages/node/src/schematics/application/application.ts
+++ b/packages/node/src/schematics/application/application.ts
@@ -12,18 +12,19 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import { join, normalize, Path } from '@angular-devkit/core';
-import { Schema } from './schema';
 import {
   updateJsonInTree,
   updateWorkspaceInTree,
   generateProjectLint,
   addLintFiles,
+  getProjectConfig,
+  offsetFromRoot,
+  toFileName,
 } from '@nrwl/workspace';
-import { toFileName } from '@nrwl/workspace';
-import { getProjectConfig } from '@nrwl/workspace';
-import { offsetFromRoot } from '@nrwl/workspace';
-import init from '../init/init';
+import { toJS } from '@nrwl/workspace/src/utils/rules/to-js';
 import { appsDir } from '@nrwl/workspace/src/utils/ast-utils';
+import init from '../init/init';
+import { Schema } from './schema';
 
 interface NormalizedSchema extends Schema {
   appProjectRoot: Path;
@@ -166,6 +167,7 @@ export default function (schema: Schema): Rule {
           })
         : noop(),
       options.frontendProject ? addProxy(options) : noop(),
+      options.js ? toJS() : noop(),
     ])(host, context);
   };
 }

--- a/packages/node/src/schematics/application/schema.d.ts
+++ b/packages/node/src/schematics/application/schema.d.ts
@@ -10,4 +10,5 @@ export interface Schema {
   tags?: string;
   frontendProject?: string;
   babelJest?: boolean;
+  js?: boolean;
 }

--- a/packages/node/src/schematics/application/schema.json
+++ b/packages/node/src/schematics/application/schema.json
@@ -51,6 +51,11 @@
       "type": "boolean",
       "description": "Use babel instead ts-jest",
       "default": false
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files.",
+      "default": false
     }
   },
   "required": []

--- a/packages/node/src/schematics/library/library.ts
+++ b/packages/node/src/schematics/library/library.ts
@@ -23,8 +23,9 @@ import {
   toFileName,
   updateWorkspaceInTree,
 } from '@nrwl/workspace';
-import { Schema } from './schema';
 import { libsDir } from '@nrwl/workspace/src/utils/ast-utils';
+import { toJS } from '@nrwl/workspace/src/utils/rules/to-js';
+import { Schema } from './schema';
 
 export interface NormalizedSchema extends Schema {
   name: string;
@@ -53,6 +54,7 @@ export default function (schema: NormalizedSchema): Rule {
       createFiles(options),
       addProject(options),
       formatFiles(options),
+      options.js ? toJS() : noop(),
     ]);
   };
 }

--- a/packages/node/src/schematics/library/schema.d.ts
+++ b/packages/node/src/schematics/library/schema.d.ts
@@ -14,4 +14,5 @@ export interface Schema {
   testEnvironment: 'jsdom' | 'node';
   rootDir?: string;
   babelJest?: boolean;
+  js?: boolean;
 }

--- a/packages/node/src/schematics/library/schema.json
+++ b/packages/node/src/schematics/library/schema.json
@@ -79,6 +79,11 @@
       "type": "boolean",
       "description": "Use babel instead ts-jest",
       "default": false
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files.",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/react/src/schematics/application/application.ts
+++ b/packages/react/src/schematics/application/application.ts
@@ -3,6 +3,7 @@ import {
   Rule,
   SchematicContext,
   Tree,
+  noop,
 } from '@angular-devkit/schematics';
 import { addLintFiles, formatFiles } from '@nrwl/workspace';
 import { extraEslintDependencies, reactEslintJson } from '../../utils/lint';
@@ -18,6 +19,7 @@ import { addRouting } from './lib/add-routing';
 import { setDefaults } from './lib/set-defaults';
 import { updateNxJson } from './lib/update-nx-json';
 import { addStyledModuleDependencies } from '../../rules/add-styled-dependencies';
+import { toJS } from '@nrwl/workspace/src/utils/rules/to-js';
 
 export default function (schema: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
@@ -40,6 +42,7 @@ export default function (schema: Schema): Rule {
       addStyledModuleDependencies(options.styledModule),
       addRouting(options, context),
       setDefaults(options),
+      options.js ? toJS() : noop(),
       formatFiles(options),
     ]);
   };

--- a/packages/react/src/schematics/application/lib/add-project.ts
+++ b/packages/react/src/schematics/application/lib/add-project.ts
@@ -12,11 +12,8 @@ export function addProject(options: NormalizedSchema): Rule {
       options: {
         outputPath: join(normalize('dist'), options.appProjectRoot),
         index: join(options.appProjectRoot, 'src/index.html'),
-        main: join(options.appProjectRoot, maybeJs(options, `src/main.tsx`)),
-        polyfills: join(
-          options.appProjectRoot,
-          maybeJs(options, 'src/polyfills.ts')
-        ),
+        main: join(options.appProjectRoot, `src/main.tsx`),
+        polyfills: join(options.appProjectRoot, 'src/polyfills.ts'),
         tsConfig: join(options.appProjectRoot, 'tsconfig.app.json'),
         assets: [
           join(options.appProjectRoot, 'src/favicon.ico'),
@@ -35,11 +32,12 @@ export function addProject(options: NormalizedSchema): Rule {
             {
               replace: join(
                 options.appProjectRoot,
-                maybeJs(options, `src/environments/environment.ts`)
+                `src/environments/environment.ts`
               ),
+
               with: join(
                 options.appProjectRoot,
-                maybeJs(options, `src/environments/environment.prod.ts`)
+                `src/environments/environment.prod.ts`
               ),
             },
           ],
@@ -91,10 +89,4 @@ export function addProject(options: NormalizedSchema): Rule {
 
     return json;
   });
-}
-
-function maybeJs(options: NormalizedSchema, path: string): string {
-  return options.js && (path.endsWith('.ts') || path.endsWith('.tsx'))
-    ? path.replace(/\.tsx?$/, '.js')
-    : path;
 }

--- a/packages/react/src/schematics/application/lib/add-routing.ts
+++ b/packages/react/src/schematics/application/lib/add-routing.ts
@@ -24,7 +24,7 @@ export function addRouting(
         function addRouterToComponent(host: Tree) {
           const appPath = join(
             options.appProjectRoot,
-            maybeJs(options, `src/app/${options.fileName}.tsx`)
+            `src/app/${options.fileName}.tsx`
           );
           const appFileContent = host.read(appPath).toString('utf-8');
           const appSource = ts.createSourceFile(
@@ -42,10 +42,4 @@ export function addRouting(
         ),
       ])
     : noop();
-}
-
-function maybeJs(options: NormalizedSchema, path: string): string {
-  return options.js && (path.endsWith('.ts') || path.endsWith('.tsx'))
-    ? path.replace(/\.tsx?$/, '.js')
-    : path;
 }

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -126,6 +126,7 @@ export default function (schema: Schema): Rule {
       ),
       updateAppRoutes(options, context),
       initRootBabelConfig(),
+      options.js ? toJS() : noop(),
       formatFiles(options),
     ])(host, context);
   };
@@ -161,7 +162,7 @@ function addProject(options: NormalizedSchema): Rule {
           outputPath: `dist/${libsDir(host)}/${options.projectDirectory}`,
           tsConfig: `${options.projectRoot}/tsconfig.lib.json`,
           project: `${options.projectRoot}/package.json`,
-          entryFile: maybeJs(options, `${options.projectRoot}/src/index.ts`),
+          entryFile: `${options.projectRoot}/src/index.ts`,
           external,
           babelConfig: `@nrwl/react/plugins/bundle-babel`,
           rollupConfig: `@nrwl/react/plugins/bundle-rollup`,
@@ -203,10 +204,7 @@ function updateTsConfig(options: NormalizedSchema): Rule {
         }
 
         c.paths[options.importPath] = [
-          maybeJs(
-            options,
-            `${libsDir(host)}/${options.projectDirectory}/src/index.ts`
-          ),
+          `${libsDir(host)}/${options.projectDirectory}/src/index.ts`,
         ];
 
         return json;
@@ -228,7 +226,6 @@ function createFiles(options: NormalizedSchema): Rule {
       options.publishable || options.buildable
         ? noop()
         : filter((file) => !file.endsWith('package.json')),
-      options.js ? toJS() : noop(),
     ])
   );
 }
@@ -259,7 +256,7 @@ function updateAppRoutes(
 
     const appComponentPath = join(
       options.appSourceRoot,
-      maybeJs(options, `${componentImportPath}.tsx`)
+      `${componentImportPath}.tsx`
     );
     return chain([
       addDepsToPackageJson(
@@ -391,10 +388,4 @@ function updateLibPackageNpmScope(options: NormalizedSchema): Rule {
     json.name = options.importPath;
     return json;
   });
-}
-
-function maybeJs(options: NormalizedSchema, path: string): string {
-  return options.js && (path.endsWith('.ts') || path.endsWith('.tsx'))
-    ? path.replace(/\.tsx?$/, '.js')
-    : path;
 }

--- a/packages/workspace/src/schematics/library/library.ts
+++ b/packages/workspace/src/schematics/library/library.ts
@@ -70,10 +70,7 @@ function updateTsConfig(options: NormalizedSchema): Rule {
       }
 
       c.paths[options.importPath] = [
-        maybeJs(
-          options,
-          `${libsDir(host)}/${options.projectDirectory}/src/index.ts`
-        ),
+        `${libsDir(host)}/${options.projectDirectory}/src/index.ts`,
       ];
 
       return json;
@@ -92,7 +89,6 @@ function createFiles(options: NormalizedSchema): Rule {
         hasUnitTestRunner: options.unitTestRunner !== 'none',
       }),
       move(options.projectRoot),
-      options.js ? toJS() : noop(),
     ])
   );
 }
@@ -121,6 +117,7 @@ export default function (schema: Schema): Rule {
             testEnvironment: options.testEnvironment,
           })
         : noop(),
+      options.js ? toJS() : noop(),
       formatFiles(options),
     ])(host, context);
   };
@@ -154,10 +151,4 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
     parsedTags,
     importPath,
   };
-}
-
-function maybeJs(options: NormalizedSchema, path: string): string {
-  return options.js && (path.endsWith('.ts') || path.endsWith('.tsx'))
-    ? path.replace(/\.tsx?$/, '.js')
-    : path;
 }

--- a/packages/workspace/src/utils/rules/to-js.spec.ts
+++ b/packages/workspace/src/utils/rules/to-js.spec.ts
@@ -1,0 +1,97 @@
+import { Tree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { runSchematic, callRule } from '../../utils/testing';
+import { toJS } from './to-js';
+
+describe('--js flag util function', () => {
+  let appTree: Tree;
+
+  beforeEach(() => {
+    appTree = createEmptyWorkspace(Tree.empty());
+  });
+
+  test('replace files with .ts extensions with .js extension', async () => {
+    const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+    const indexFileBefore = tree.read('/libs/my-lib/src/index.ts');
+    expect(indexFileBefore).not.toBeNull();
+
+    const resultTree = await callRule(toJS, tree);
+
+    const indexTSFileAfter = resultTree.read('/libs/my-lib/src/index.ts');
+    const indexJSFileAfter = resultTree.read('/libs/my-lib/src/index.js');
+    expect(indexTSFileAfter).toBeNull();
+    expect(indexJSFileAfter).not.toBeNull();
+  });
+
+  test('replace files with .tsx extensions with .js extension', async () => {
+    const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+    tree.create(
+      '/libs/my-lib/src/component.tsx',
+      `export const = () => <h1>Hello World!</h1>`
+    );
+    const indexFileBefore = tree.read('/libs/my-lib/src/component.tsx');
+    expect(indexFileBefore).not.toBeNull();
+
+    const resultTree = await callRule(toJS, tree);
+
+    const indexTSFileAfter = resultTree.read('/libs/my-lib/src/component.tsx');
+    const indexJSFileAfter = resultTree.read('/libs/my-lib/src/component.js');
+    expect(indexTSFileAfter).toBeNull();
+    expect(indexJSFileAfter).not.toBeNull();
+  });
+
+  test('replace files with .ts content with .js content', async () => {
+    appTree.create(
+      '/libs/my-lib/src/index.ts',
+      `const coll: number[] = [1, 2, 3];\n`
+    );
+    const resultTree = await callRule(toJS, appTree);
+    const jsResult = resultTree
+      .read('/libs/my-lib/src/index.js')
+      .toString('utf-8');
+
+    expect(jsResult).toBe(`const coll = [1, 2, 3];\n`);
+  });
+
+  test('replace files with .tsx content with .js content', async () => {
+    appTree.create(
+      '/libs/my-lib/src/component.tsx',
+      `export const HelloWorld = (name: string) => <h1>Hello {name}!</h1>;\n`
+    );
+    const resultTree = await callRule(toJS, appTree);
+    const jsxResult = resultTree
+      .read('/libs/my-lib/src/component.js')
+      .toString('utf-8');
+
+    expect(jsxResult).toBe(
+      `export const HelloWorld = (name) => <h1>Hello {name}!</h1>;\n`
+    );
+  });
+
+  test('replace config strings that end in .ts or .tsx with .js', async () => {
+    const tree = await runSchematic('lib', { name: 'myLib' }, appTree);
+
+    const before = tree.read('/tsconfig.base.json').toString('utf-8');
+    expect(before).toContain(`"@proj/my-lib": ["libs/my-lib/src/index.ts"]`);
+
+    const resultTree = await callRule(toJS, tree);
+
+    const after = resultTree.read('/tsconfig.base.json').toString('utf-8');
+
+    expect(after).not.toContain(`"@proj/my-lib": ["libs/my-lib/src/index.ts"]`);
+    expect(after).toContain(`"@proj/my-lib": ["libs/my-lib/src/index.js"]`);
+  });
+
+  test('do not replace other instances of .ts or .tsx with .js', async () => {
+    appTree.create(
+      '/libs/my-lib/src/README.md',
+      `I like an index.ts way more than a index.js`
+    );
+    const resultTree = await callRule(toJS, appTree);
+    const mdResult = resultTree
+      .read('/libs/my-lib/src/README.md')
+      .toString('utf-8');
+
+    expect(mdResult).toBe(`I like an index.ts way more than a index.js`);
+  });
+});

--- a/packages/workspace/src/utils/rules/to-js.ts
+++ b/packages/workspace/src/utils/rules/to-js.ts
@@ -1,12 +1,25 @@
 import { transpile, JsxEmit, ScriptTarget } from 'typescript';
-import { forEach, Rule, when } from '@angular-devkit/schematics';
+import {
+  forEach,
+  when,
+  chain,
+  CreateFileAction,
+  Rule,
+} from '@angular-devkit/schematics';
 import { normalize } from '@angular-devkit/core';
+import { updateJsonInTree } from '../ast-utils';
 
-export function toJS(): Rule {
+const uniq = <T extends string[]>(value: T) => [...new Set(value)] as T;
+
+const changeFileExtensions: Rule = (tree, context) => {
   return forEach(
     when(
       (path) => path.endsWith('.ts') || path.endsWith('.tsx'),
       (entry) => {
+        const path = normalize(entry.path.replace(/\.tsx?$/, '.js'));
+        if (tree.exists(path)) {
+          return null;
+        }
         const original = entry.content.toString('utf-8');
         const result = transpile(original, {
           allowJs: true,
@@ -15,9 +28,79 @@ export function toJS(): Rule {
         });
         return {
           content: Buffer.from(result, 'utf-8'),
-          path: normalize(entry.path.replace(/\.tsx?$/, '.js')),
+          path,
         };
       }
     )
+  )(tree, context);
+};
+
+const changeExtensionsInConfigFiles: Rule = (tree, context) => {
+  const files = new Set(
+    tree.actions
+      .filter((action) => action.kind === 'c')
+      .map((action: CreateFileAction) => ({
+        path: action.path,
+        content: action.content.toString(),
+      }))
   );
+  if (files.size === 0) {
+    return tree;
+  }
+
+  [...files].forEach((file) => {
+    try {
+      // replace strings in single or double quotes that end with .ts or .tsx with .js
+      tree.overwrite(
+        file.path,
+        file.content.replace(/(?<!\.d)\.tsx?(?=['"])/gi, '.js')
+      );
+    } catch (e) {
+      context.logger.warn(
+        `Error converting ${file.path} with --js flag: ${e.message}`
+      );
+    }
+  });
+
+  return tree;
+};
+
+const updateTsConfigsToJs = forEach(
+  when(
+    (path) =>
+      path.endsWith('/tsconfig.json') ||
+      path.endsWith('/tsconfig.lib.json') ||
+      path.endsWith('/tsconfig.app.json'),
+    ({ path, content }) => {
+      const json = JSON.parse(content.toString('utf-8'));
+      if (path.endsWith('/tsconfig.json')) {
+        if (json.compilerOptions) {
+          json.compilerOptions.allowJs = true;
+        } else {
+          json.compilerOptions = { allowJs: true };
+        }
+      }
+
+      if (
+        path.endsWith('/tsconfig.lib.json') ||
+        path.endsWith('/tsconfig.app.json')
+      ) {
+        json.include = uniq([...json.include, '**/*.js']);
+        json.exclude = uniq([...json.exclude, '**/*.spec.js']);
+      }
+
+      return {
+        content: Buffer.from(JSON.stringify(json), 'utf-8'),
+        path,
+      };
+    }
+  )
+);
+
+export function toJS(): Rule {
+  return chain([
+    changeFileExtensions,
+    changeExtensionsInConfigFiles,
+    updateTsConfigsToJs,
+  ]);
 }


### PR DESCRIPTION
## Current Behavior
Many core schematics either do not accept the `--js` flag or do not produce js files when passed

## Expected Behavior
As per https://nx.dev/react/guides/js-and-ts add ing the `--js` flag to any `g` command should produce JS files instead of typescript files/
