### PR TITLE
cleanup(repo): avoid referencing `node_modules`

### DIFF
--- a/packages/cli/lib/init-global.ts
+++ b/packages/cli/lib/init-global.ts
@@ -12,32 +12,16 @@ export function initGlobal() {
 
   if (workspace) {
     // Found a workspace root - hand off to the local copy of Nx
-    const localNx = path.join(
-      workspace.dir,
-      'node_modules',
-      '@nrwl',
-      'cli',
-      'bin',
-      'nx.js'
-    );
-    if (fs.existsSync(localNx)) {
+    try {
+      const localNx = require.resolve('@nrwl/cli/bin/nx.js', {
+        paths: [workspace.dir],
+      });
       require(localNx);
-    } else {
-      if (fs.existsSync(path.join(workspace.dir, 'node_modules'))) {
-        output.error({
-          title: `Could not find Nx in this workspace.`,
-          bodyLines: [
-            `To convert an Angular workspace to Nx run: ${chalk.bold.white(
-              `ng add @nrwl/workspace`
-            )}`,
-          ],
-        });
-      } else {
-        output.error({
-          title: `Could not find a node_modules folder in this workspace.`,
-          bodyLines: [`Have you run ${chalk.bold.white(`npm/yarn install`)}?`],
-        });
-      }
+    } catch (e) {
+      output.error({
+        title: `Could not find @nrwl/cli module in this workspace.`,
+        bodyLines: [`Have you run ${chalk.bold.white(`npm/yarn install`)}?`],
+      });
       process.exit(1);
     }
   } else {

--- a/packages/cli/lib/init-local.ts
+++ b/packages/cli/lib/init-local.ts
@@ -18,15 +18,7 @@ export function initLocal(workspace: Workspace) {
   if (supportedNxCommands.includes(process.argv[2])) {
     // required to make sure nrwl/workspace import works
     if (workspace.type === 'nx') {
-      require(path.join(
-        workspace.dir,
-        'node_modules',
-        '@nrwl',
-        'tao',
-        'src',
-        'compat',
-        'compat.js'
-      ));
+      require('@nrwl/tao/src/compat/compat.js');
     }
     require('@nrwl/workspace' + '/src/command-line/nx-commands').commandsObject
       .argv;
@@ -40,25 +32,21 @@ export function initLocal(workspace: Workspace) {
 }
 
 function loadCli(workspace: Workspace) {
+  let cliPath: string;
   if (workspace.type === 'nx') {
-    require(path.join(
-      workspace.dir,
-      'node_modules',
-      '@nrwl',
-      'tao',
-      'index.js'
-    ));
+    cliPath = '@nrwl/tao/index.js';
   } else if (workspace.type === 'angular') {
-    require(path.join(
-      workspace.dir,
-      'node_modules',
-      '@angular',
-      'cli',
-      'lib',
-      'init.js'
-    ));
+    cliPath = '@angular/cli/lib/init.js';
   } else {
     console.error(`Cannot recognize the workspace type.`);
+    process.exit(1);
+  }
+
+  try {
+    const cli = require.resolve(cliPath, { paths: [workspace.dir] });
+    require(cli);
+  } catch (e) {
+    console.error(`Could not find ${cliPath} module in this workspace.`, e);
     process.exit(1);
   }
 }

--- a/packages/cli/lib/run-cli.ts
+++ b/packages/cli/lib/run-cli.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import * as fs from 'fs';
 import { findWorkspaceRoot } from './find-workspace-root';
 
@@ -14,23 +13,21 @@ requireCli();
 
 function requireCli() {
   process.env.NX_CLI_SET = 'true';
+  let cliPath: string;
   if (workspace.type === 'nx') {
-    require(path.join(
-      workspace.dir,
-      'node_modules',
-      '@nrwl',
-      'tao',
-      'index.js'
-    ));
+    cliPath = '@nrwl/tao/index.js';
   } else {
-    require(path.join(
-      workspace.dir,
-      'node_modules',
-      '@angular',
-      'cli',
-      'lib',
-      'init.js'
-    ));
+    cliPath = '@angular/cli/lib/init.js';
+  }
+
+  try {
+    const cli = require.resolve(cliPath, {
+      paths: [workspace.dir],
+    });
+    require(cli);
+  } catch (e) {
+    console.error(`Could not find ${cliPath} module in this workspace.`, e);
+    process.exit(1);
   }
 }
 

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -2,6 +2,7 @@
 
 // we can import from '@nrwl/workspace' because it will require typescript
 import { output } from '@nrwl/workspace/src/utils/output';
+import { getPackageManagerExecuteCommand } from '@nrwl/workspace/src/utils/detect-package-manager';
 import { execSync } from 'child_process';
 import { writeFileSync } from 'fs';
 import * as inquirer from 'inquirer';
@@ -442,6 +443,7 @@ function createApp(
     : ` --interactive=false`;
   const defaultBaseArg = defaultBase ? ` --defaultBase="${defaultBase}"` : ``;
 
+  const packageExec = getPackageManagerExecuteCommand(packageManager);
   console.log(
     `new ${name} ${args} --preset="${preset}"${appNameArg}${styleArg}${nxCloudArg}${interactiveArg}${defaultBaseArg} --collection=@nrwl/workspace`
   );
@@ -462,7 +464,7 @@ function createApp(
 
   if (nxCloud) {
     output.addVerticalSeparator();
-    execSync(`npx nx g @nrwl/nx-cloud:init --no-analytics`, {
+    execSync(`${packageExec} nx g @nrwl/nx-cloud:init --no-analytics`, {
       stdio: [0, 1, 2],
       cwd: path.join(process.cwd(), name),
     });

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from 'child_process';
-import { platform } from 'os';
+import { getPackageManagerExecuteCommand } from '../utils/detect-package-manager';
 import * as yargs from 'yargs';
 import { nxVersion } from '../utils/versions';
 import { generateGraph } from './dep-graph';
@@ -180,10 +180,7 @@ export const commandsObject = yargs
     `,
     (yargs) => yargs,
     () => {
-      const executable =
-        platform() === 'win32'
-          ? `.\\node_modules\\.bin\\tao`
-          : `./node_modules/.bin/tao`;
+      const executable = `${getPackageManagerExecuteCommand()} tao`;
       execSync(`${executable} migrate ${process.argv.slice(3).join(' ')}`, {
         stdio: ['inherit', 'inherit', 'inherit'],
       });

--- a/packages/workspace/src/command-line/workspace-schematic.ts
+++ b/packages/workspace/src/command-line/workspace-schematic.ts
@@ -23,11 +23,13 @@ import * as fs from 'fs';
 import { readFileSync, writeFileSync } from 'fs';
 import { copySync, removeSync } from 'fs-extra';
 import * as inquirer from 'inquirer';
-import { platform } from 'os';
 import * as path from 'path';
 import * as yargsParser from 'yargs-parser';
 import { appRootPath } from '../utils/app-root';
-import { detectPackageManager } from '../utils/detect-package-manager';
+import {
+  detectPackageManager,
+  getPackageManagerExecuteCommand,
+} from '../utils/detect-package-manager';
 import { fileExists, readJsonFile, writeJsonFile } from '../utils/fileutils';
 import { output } from '../utils/output';
 import { CompilerOptions } from 'typescript';
@@ -89,10 +91,8 @@ function compileToolsDir(outDir: string) {
     include: [path.join(schematicsDir(), '**/*.ts')],
   });
 
-  const tsc =
-    platform() === 'win32'
-      ? `.\\node_modules\\.bin\\tsc`
-      : `./node_modules/.bin/tsc`;
+  const packageExec = getPackageManagerExecuteCommand();
+  const tsc = `${packageExec} tsc`;
   try {
     execSync(`${tsc} -p ${tmpTsConfigPath}`, {
       stdio: 'inherit',

--- a/packages/workspace/src/schematics/shared-new/shared-new.ts
+++ b/packages/workspace/src/schematics/shared-new/shared-new.ts
@@ -25,7 +25,7 @@ import { nxVersion } from '../../utils/versions';
 import * as path from 'path';
 import { Observable } from 'rxjs';
 import { spawn } from 'child_process';
-import { platform } from 'os';
+import { getPackageManagerExecuteCommand } from '../../utils/detect-package-manager';
 // @ts-ignore
 import yargsParser = require('yargs-parser');
 
@@ -75,10 +75,7 @@ function createPresetTaskExecutor(cli: string, opts: Schema) {
           shell: true,
           cwd: path.join(process.cwd(), opts.directory),
         };
-        const executable =
-          platform() === 'win32'
-            ? `.\\node_modules\\.bin\\${cliCommand}`
-            : `./node_modules/.bin/${cliCommand}`;
+        const executable = `${getPackageManagerExecuteCommand()} ${cliCommand}`;
         const args = [
           `g`,
           `@nrwl/workspace:preset`,

--- a/packages/workspace/src/tasks-runner/task-orchestrator.ts
+++ b/packages/workspace/src/tasks-runner/task-orchestrator.ts
@@ -317,14 +317,10 @@ export class TaskOrchestrator {
   }
 
   private getCommand() {
-    return path.join(
-      this.workspaceRoot,
-      'node_modules',
-      '@nrwl',
-      'cli',
-      'lib',
-      'run-cli.js'
-    );
+    const cli = require.resolve(`@nrwl/cli/lib/run-cli.js`, {
+      paths: [this.workspaceRoot],
+    });
+    return `${cli}`;
   }
 
   private getCommandArgs(task: Task) {

--- a/packages/workspace/src/utils/detect-package-manager.ts
+++ b/packages/workspace/src/utils/detect-package-manager.ts
@@ -18,3 +18,17 @@ export function detectPackageManager(): string {
       : 'npm';
   }
 }
+
+export function getPackageManagerExecuteCommand(
+  packageManager = detectPackageManager()
+) {
+  if (packageManager === 'yarn') {
+    return `yarn`;
+  }
+
+  if (packageManager === 'pnpm') {
+    return `pnpx`;
+  }
+
+  return `npx`;
+}


### PR DESCRIPTION
Towards Yarn 2 support.