### PR TITLE
fix(misc): updates the mv schematic to cope with libs created with --importPath

### DIFF
--- a/docs/angular/api-angular/schematics/move.md
+++ b/docs/angular/api-angular/schematics/move.md
@@ -42,6 +42,12 @@ Type: `string`
 
 The folder to move the Angular project into
 
+### importPath
+
+Type: `string`
+
+The new import path to use in the tsconfig.base.json
+
 ### projectName
 
 Alias(es): project
@@ -49,3 +55,11 @@ Alias(es): project
 Type: `string`
 
 The name of the Angular project to move
+
+### updateImportPath
+
+Default: `true`
+
+Type: `boolean`
+
+Should the schematic update the import path to reflect the new location?

--- a/docs/angular/api-workspace/schematics/move.md
+++ b/docs/angular/api-workspace/schematics/move.md
@@ -42,6 +42,12 @@ Type: `string`
 
 The folder to move the project into
 
+### importPath
+
+Type: `string`
+
+The new import path to use in the tsconfig.base.json
+
 ### projectName
 
 Alias(es): project
@@ -49,3 +55,11 @@ Alias(es): project
 Type: `string`
 
 The name of the project to move
+
+### updateImportPath
+
+Default: `true`
+
+Type: `boolean`
+
+Should the schematic update the import path to reflect the new location?

--- a/docs/node/api-angular/schematics/move.md
+++ b/docs/node/api-angular/schematics/move.md
@@ -42,6 +42,12 @@ Type: `string`
 
 The folder to move the Angular project into
 
+### importPath
+
+Type: `string`
+
+The new import path to use in the tsconfig.base.json
+
 ### projectName
 
 Alias(es): project
@@ -49,3 +55,11 @@ Alias(es): project
 Type: `string`
 
 The name of the Angular project to move
+
+### updateImportPath
+
+Default: `true`
+
+Type: `boolean`
+
+Should the schematic update the import path to reflect the new location?

--- a/docs/node/api-workspace/schematics/move.md
+++ b/docs/node/api-workspace/schematics/move.md
@@ -42,6 +42,12 @@ Type: `string`
 
 The folder to move the project into
 
+### importPath
+
+Type: `string`
+
+The new import path to use in the tsconfig.base.json
+
 ### projectName
 
 Alias(es): project
@@ -49,3 +55,11 @@ Alias(es): project
 Type: `string`
 
 The name of the project to move
+
+### updateImportPath
+
+Default: `true`
+
+Type: `boolean`
+
+Should the schematic update the import path to reflect the new location?

--- a/docs/react/api-angular/schematics/move.md
+++ b/docs/react/api-angular/schematics/move.md
@@ -42,6 +42,12 @@ Type: `string`
 
 The folder to move the Angular project into
 
+### importPath
+
+Type: `string`
+
+The new import path to use in the tsconfig.base.json
+
 ### projectName
 
 Alias(es): project
@@ -49,3 +55,11 @@ Alias(es): project
 Type: `string`
 
 The name of the Angular project to move
+
+### updateImportPath
+
+Default: `true`
+
+Type: `boolean`
+
+Should the schematic update the import path to reflect the new location?

--- a/docs/react/api-workspace/schematics/move.md
+++ b/docs/react/api-workspace/schematics/move.md
@@ -42,6 +42,12 @@ Type: `string`
 
 The folder to move the project into
 
+### importPath
+
+Type: `string`
+
+The new import path to use in the tsconfig.base.json
+
 ### projectName
 
 Alias(es): project
@@ -49,3 +55,11 @@ Alias(es): project
 Type: `string`
 
 The name of the project to move
+
+### updateImportPath
+
+Default: `true`
+
+Type: `boolean`
+
+Should the schematic update the import path to reflect the new location?

--- a/e2e/workspace/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace/src/workspace-aux-commands.test.ts
@@ -1,5 +1,3 @@
-import { NxJson } from '@nrwl/workspace';
-import { classify } from '@nrwl/workspace/src/utils/strings';
 import {
   checkFilesExist,
   ensureProject,
@@ -16,6 +14,8 @@ import {
   updateFile,
   workspaceConfigName,
 } from '@nrwl/e2e/utils';
+import { NxJson } from '@nrwl/workspace';
+import { classify } from '@nrwl/workspace/src/utils/strings';
 
 forEachCli((cli) => {
   describe('lint', () => {
@@ -718,7 +718,146 @@ forEachCli((cli) => {
         `libs/${lib2}/ui/src/lib/${lib2}-ui.ts`,
         `import { fromLibOne } from '@proj/${lib1}/data-access';
 
-        export const fromLibTwo = () => fromLibOne(); }`
+        export const fromLibTwo = () => fromLibOne();`
+      );
+
+      /**
+       * Create a library which has an implicit dependency on lib1
+       */
+
+      runCLI(`generate @nrwl/workspace:lib ${lib3}`);
+      let nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+      nxJson.projects[lib3].implicitDependencies = [`${lib1}-data-access`];
+      updateFile(`nx.json`, JSON.stringify(nxJson));
+
+      /**
+       * Now try to move lib1
+       */
+
+      const moveOutput = runCLI(
+        `generate @nrwl/workspace:move --project ${lib1}-data-access shared/${lib1}/data-access`
+      );
+
+      expect(moveOutput).toContain(`DELETE libs/${lib1}/data-access`);
+      expect(exists(`libs/${lib1}/data-access`)).toBeFalsy();
+
+      const newPath = `libs/shared/${lib1}/data-access`;
+      const newName = `shared-${lib1}-data-access`;
+
+      const readmePath = `${newPath}/README.md`;
+      expect(moveOutput).toContain(`CREATE ${readmePath}`);
+      checkFilesExist(readmePath);
+
+      const jestConfigPath = `${newPath}/jest.config.js`;
+      expect(moveOutput).toContain(`CREATE ${jestConfigPath}`);
+      checkFilesExist(jestConfigPath);
+      const jestConfig = readFile(jestConfigPath);
+      expect(jestConfig).toContain(`name: 'shared-${lib1}-data-access'`);
+      expect(jestConfig).toContain(`preset: '../../../../jest.config.js'`);
+      expect(jestConfig).toContain(
+        `coverageDirectory: '../../../../coverage/${newPath}'`
+      );
+
+      const tsConfigPath = `${newPath}/tsconfig.json`;
+      expect(moveOutput).toContain(`CREATE ${tsConfigPath}`);
+      checkFilesExist(tsConfigPath);
+
+      const tsConfigLibPath = `${newPath}/tsconfig.lib.json`;
+      expect(moveOutput).toContain(`CREATE ${tsConfigLibPath}`);
+      checkFilesExist(tsConfigLibPath);
+      const tsConfigLib = readJson(tsConfigLibPath);
+      expect(tsConfigLib.compilerOptions.outDir).toEqual(
+        '../../../../dist/out-tsc'
+      );
+
+      const tsConfigSpecPath = `${newPath}/tsconfig.spec.json`;
+      expect(moveOutput).toContain(`CREATE ${tsConfigSpecPath}`);
+      checkFilesExist(tsConfigSpecPath);
+      const tsConfigSpec = readJson(tsConfigSpecPath);
+      expect(tsConfigSpec.compilerOptions.outDir).toEqual(
+        '../../../../dist/out-tsc'
+      );
+
+      const indexPath = `${newPath}/src/index.ts`;
+      expect(moveOutput).toContain(`CREATE ${indexPath}`);
+      checkFilesExist(indexPath);
+
+      const rootClassPath = `${newPath}/src/lib/${lib1}-data-access.ts`;
+      expect(moveOutput).toContain(`CREATE ${rootClassPath}`);
+      checkFilesExist(rootClassPath);
+
+      expect(moveOutput).toContain('UPDATE nx.json');
+      nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+      expect(nxJson.projects[`${lib1}-data-access`]).toBeUndefined();
+      expect(nxJson.projects[newName]).toEqual({
+        tags: [],
+      });
+      expect(nxJson.projects[lib3].implicitDependencies).toEqual([
+        `shared-${lib1}-data-access`,
+      ]);
+
+      expect(moveOutput).toContain('UPDATE tsconfig.base.json');
+      const rootTsConfig = readJson('tsconfig.base.json');
+      expect(
+        rootTsConfig.compilerOptions.paths[`@proj/${lib1}/data-access`]
+      ).toBeUndefined();
+      expect(
+        rootTsConfig.compilerOptions.paths[`@proj/shared/${lib1}/data-access`]
+      ).toEqual([`libs/shared/${lib1}/data-access/src/index.ts`]);
+
+      expect(moveOutput).toContain(`UPDATE ${workspace}.json`);
+      const workspaceJson = readJson(`${workspace}.json`);
+      expect(workspaceJson.projects[`${lib1}-data-access`]).toBeUndefined();
+      const project = workspaceJson.projects[newName];
+      expect(project).toBeTruthy();
+      expect(project.root).toBe(newPath);
+      expect(project.sourceRoot).toBe(`${newPath}/src`);
+      expect(project.architect.lint.options.tsConfig).toEqual([
+        `libs/shared/${lib1}/data-access/tsconfig.lib.json`,
+        `libs/shared/${lib1}/data-access/tsconfig.spec.json`,
+      ]);
+
+      /**
+       * Check that the import in lib2 has been updated
+       */
+      const lib2FilePath = `libs/${lib2}/ui/src/lib/${lib2}-ui.ts`;
+      const lib2File = readFile(lib2FilePath);
+      expect(lib2File).toContain(
+        `import { fromLibOne } from '@proj/shared/${lib1}/data-access';`
+      );
+    });
+
+    it('should work for libs created with --importPath', () => {
+      const importPath = '@wibble/fish';
+      const lib1 = uniq('mylib');
+      const lib2 = uniq('mylib');
+      const lib3 = uniq('mylib');
+      newProject();
+      runCLI(
+        `generate @nrwl/workspace:lib ${lib1}/data-access --importPath=${importPath}`
+      );
+
+      updateFile(
+        `libs/${lib1}/data-access/src/lib/${lib1}-data-access.ts`,
+        `export function fromLibOne() { console.log('This is completely pointless'); }`
+      );
+
+      updateFile(
+        `libs/${lib1}/data-access/src/index.ts`,
+        `export * from './lib/${lib1}-data-access.ts'`
+      );
+
+      /**
+       * Create a library which imports a class from lib1
+       */
+
+      runCLI(`generate @nrwl/workspace:lib ${lib2}/ui`);
+
+      updateFile(
+        `libs/${lib2}/ui/src/lib/${lib2}-ui.ts`,
+        `import { fromLibOne } from '${importPath}';
+
+        export const fromLibTwo = () => fromLibOne();`
       );
 
       /**
@@ -859,7 +998,7 @@ forEachCli((cli) => {
         `packages/${lib2}/ui/src/lib/${lib2}-ui.ts`,
         `import { fromLibOne } from '@proj/${lib1}/data-access';
 
-        export const fromLibTwo = () => fromLibOne(); }`
+        export const fromLibTwo = () => fromLibOne();`
       );
 
       /**

--- a/packages/angular/src/schematics/move/lib/update-module-name.spec.ts
+++ b/packages/angular/src/schematics/move/lib/update-module-name.spec.ts
@@ -10,6 +10,7 @@ describe('updateModuleName Rule', () => {
   const schema: Schema = {
     projectName: 'my-source',
     destination: 'my-destination',
+    updateImportPath: true,
   };
 
   const modulePath = '/libs/my-destination/src/lib/my-destination.module.ts';

--- a/packages/angular/src/schematics/move/schema.d.ts
+++ b/packages/angular/src/schematics/move/schema.d.ts
@@ -1,4 +1,6 @@
 export interface Schema {
   projectName: string;
   destination: string;
+  importPath?: string;
+  updateImportPath: boolean;
 }

--- a/packages/angular/src/schematics/move/schema.json
+++ b/packages/angular/src/schematics/move/schema.json
@@ -23,6 +23,15 @@
         "$source": "argv",
         "index": 0
       }
+    },
+    "importPath": {
+      "type": "string",
+      "description": "The new import path to use in the tsconfig.base.json"
+    },
+    "updateImportPath": {
+      "type": "boolean",
+      "description": "Should the schematic update the import path to reflect the new location?",
+      "default": true
     }
   },
   "required": ["projectName", "destination"]

--- a/packages/workspace/src/schematics/move/lib/check-destination.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/check-destination.spec.ts
@@ -16,6 +16,8 @@ describe('checkDestination Rule', () => {
     const schema: Schema = {
       projectName: 'my-lib',
       destination: '../apps/not-an-app',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     await expect(callRule(checkDestination(schema), tree)).rejects.toThrow(
@@ -29,6 +31,8 @@ describe('checkDestination Rule', () => {
     const schema: Schema = {
       projectName: 'my-lib',
       destination: 'my-other-lib',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     await expect(callRule(checkDestination(schema), tree)).rejects.toThrow(
@@ -40,6 +44,8 @@ describe('checkDestination Rule', () => {
     const schema: Schema = {
       projectName: 'my-lib',
       destination: 'my-other-lib',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     await expect(
@@ -51,6 +57,8 @@ describe('checkDestination Rule', () => {
     const schema: Schema = {
       projectName: 'my-lib',
       destination: '/my-other-lib//wibble',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     await callRule(checkDestination(schema), tree);

--- a/packages/workspace/src/schematics/move/lib/move-project.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/move-project.spec.ts
@@ -15,6 +15,8 @@ describe('moveProject Rule', () => {
     const schema: Schema = {
       projectName: 'my-lib',
       destination: 'my-destination',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     // TODO - Currently this test will fail due to

--- a/packages/workspace/src/schematics/move/lib/update-cypress-json.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-cypress-json.spec.ts
@@ -22,6 +22,8 @@ describe('updateCypressJson Rule', () => {
     const schema: Schema = {
       projectName: 'my-lib',
       destination: 'my-destination',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     await expect(
@@ -53,6 +55,8 @@ describe('updateCypressJson Rule', () => {
     const schema: Schema = {
       projectName: 'my-lib',
       destination: 'my-destination',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     tree = (await callRule(updateCypressJson(schema), tree)) as UnitTestTree;

--- a/packages/workspace/src/schematics/move/lib/update-jest-config.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-jest-config.spec.ts
@@ -19,6 +19,8 @@ describe('updateJestConfig Rule', () => {
     const schema: Schema = {
       projectName: 'my-source',
       destination: 'my-destination',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     await expect(
@@ -44,6 +46,8 @@ describe('updateJestConfig Rule', () => {
     const schema: Schema = {
       projectName: 'my-source',
       destination: 'my-destination',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     tree = (await callRule(updateJestConfig(schema), tree)) as UnitTestTree;

--- a/packages/workspace/src/schematics/move/lib/update-nx-json.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-nx-json.spec.ts
@@ -20,6 +20,8 @@ describe('updateNxJson Rule', () => {
     const schema: Schema = {
       projectName: 'my-source',
       destination: 'my-destination',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     tree = (await callRule(updateNxJson(schema), tree)) as UnitTestTree;

--- a/packages/workspace/src/schematics/move/lib/update-project-root-files.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-project-root-files.spec.ts
@@ -31,6 +31,8 @@ describe('updateProjectRootFiles Rule', () => {
     const schema: Schema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     tree = (await callRule(

--- a/packages/workspace/src/schematics/move/lib/update-workspace.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-workspace.spec.ts
@@ -146,6 +146,8 @@ describe('updateWorkspace Rule', () => {
     const schema: Schema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
@@ -160,6 +162,8 @@ describe('updateWorkspace Rule', () => {
     const schema: Schema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
@@ -173,6 +177,8 @@ describe('updateWorkspace Rule', () => {
     const schema: Schema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
@@ -193,6 +199,8 @@ describe('updateWorkspace Rule', () => {
     const schema: Schema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     tree = (await callRule(updateWorkspace(schema), tree)) as UnitTestTree;
@@ -213,6 +221,8 @@ describe('updateWorkspace Rule', () => {
     const schema: Schema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
+      importPath: undefined,
+      updateImportPath: true,
     };
 
     tree = (await callRule(

--- a/packages/workspace/src/schematics/move/schema.d.ts
+++ b/packages/workspace/src/schematics/move/schema.d.ts
@@ -1,4 +1,6 @@
 export interface Schema {
   projectName: string;
   destination: string;
+  importPath?: string;
+  updateImportPath: boolean;
 }

--- a/packages/workspace/src/schematics/move/schema.json
+++ b/packages/workspace/src/schematics/move/schema.json
@@ -23,6 +23,15 @@
         "$source": "argv",
         "index": 0
       }
+    },
+    "importPath": {
+      "type": "string",
+      "description": "The new import path to use in the tsconfig.base.json"
+    },
+    "updateImportPath": {
+      "type": "boolean",
+      "description": "Should the schematic update the import path to reflect the new location?",
+      "default": true
     }
   },
   "required": ["projectName", "destination"]


### PR DESCRIPTION
ISSUES CLOSED: #3476

This adds two extra params to the move schematic

--importPath : With this you can specify the import path of the library yourself.

--updateImportPath : This allows you to disable automatic updating of the import path.

e.g.

Create a new lib - `nx g @nrwl/workspace:lib my-lib --importPath=@wibble/fish`
Then move it - `nx g @nrwl/workspace:mv --project my-lib shared/my-lib --updateImportPath=false`

This will leave the import path of the library as `@wibble/fish` but will update where that path points to.