### PR TITLE
fix(core): correctly alias `format:write` to `format`

### DIFF
--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -138,12 +138,11 @@ export const commandsObject = yargs
     (args) => format('check', args)
   )
   .command(
-    'format:write',
+    ['format:write', 'format'],
     'Overwrite un-formatted files',
     withFormatOptions,
     (args) => format('write', args)
   )
-  .alias('format:write', 'format')
   .command(
     'workspace-lint [files..]',
     'Lint workspace or list of files.  Note: To exclude files from this lint rule, you can add them to the ".nxignore" file',


### PR DESCRIPTION
## Current Behavior
`nx format` does nothing, neither throws an error.

## Expected Behavior
`nx format` is an alias for `nx format:write` and properly overwrites the files.