### PR TITLE
feat(nextjs): custom builder args in next custom server

### DIFF
--- a/packages/next/src/builders/server/lib/custom-server.ts
+++ b/packages/next/src/builders/server/lib/custom-server.ts
@@ -6,7 +6,7 @@ import { NextServerOptions, ProxyConfig } from '../../../utils/types';
 export function customServer(
   settings: NextServerOptions,
   proxyConfig?: ProxyConfig,
-  buildArgs?: NextServeBuilderOptions
+  builderArgs?: NextServeBuilderOptions
 ) {
   const nextApp = new NextServer(settings);
 
@@ -14,6 +14,6 @@ export function customServer(
     nextApp,
     settings,
     proxyConfig,
-    buildArgs
+    builderArgs
   );
 }

--- a/packages/next/src/builders/server/lib/custom-server.ts
+++ b/packages/next/src/builders/server/lib/custom-server.ts
@@ -1,16 +1,19 @@
+import { NextServeBuilderOptions } from './../../../utils/types';
 import NextServer from 'next/dist/server/next-dev-server';
 import * as path from 'path';
 import { NextServerOptions, ProxyConfig } from '../../../utils/types';
 
 export function customServer(
   settings: NextServerOptions,
-  proxyConfig?: ProxyConfig
+  proxyConfig?: ProxyConfig,
+  buildArgs?: NextServeBuilderOptions
 ) {
   const nextApp = new NextServer(settings);
 
   return require(path.resolve(settings.dir, settings.path))(
     nextApp,
     settings,
-    proxyConfig
+    proxyConfig,
+    buildArgs
   );
 }

--- a/packages/next/src/builders/server/server.impl.ts
+++ b/packages/next/src/builders/server/server.impl.ts
@@ -78,7 +78,7 @@ export function run(
         proxyConfig = require(proxyConfigPath);
       }
 
-      return from(server(settings, proxyConfig)).pipe(
+      return from(server(settings, proxyConfig, options)).pipe(
         catchError((err) => {
           if (options.dev) {
             throw err;

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -3,7 +3,7 @@ import { JsonObject } from '@angular-devkit/core';
 export type NextServer = (
   options: NextServerOptions,
   proxyConfig?: ProxyConfig,
-  buildArgs?: NextServeBuilderOptions
+  builderArgs?: NextServeBuilderOptions
 ) => Promise<void>;
 
 export interface ProxyConfig {
@@ -44,7 +44,6 @@ export interface NextServeBuilderOptions extends JsonObject {
   quiet: boolean;
   buildTarget: string;
   customServerPath?: string;
-  customConfigPath?: string;
   hostname?: string;
   proxyConfig?: string;
 }

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -2,7 +2,8 @@ import { JsonObject } from '@angular-devkit/core';
 
 export type NextServer = (
   options: NextServerOptions,
-  proxyConfig?: ProxyConfig
+  proxyConfig?: ProxyConfig,
+  buildArgs?: NextServeBuilderOptions
 ) => Promise<void>;
 
 export interface ProxyConfig {
@@ -43,6 +44,7 @@ export interface NextServeBuilderOptions extends JsonObject {
   quiet: boolean;
   buildTarget: string;
   customServerPath?: string;
+  customConfigPath?: string;
   hostname?: string;
   proxyConfig?: string;
 }


### PR DESCRIPTION
pass through custom builder args in next custom server

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
There's no way to pass builder args through to a custom next server today.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ability to pass builder args through to custom next server.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3692 
