### PR TITLE
feat(core): add option to skip serve step for cypress builder

### DIFF
--- a/docs/angular/api-cypress/executors/cypress.md
+++ b/docs/angular/api-cypress/executors/cypress.md
@@ -104,6 +104,14 @@ Type: `string`
 
 The reporter options used. Supported options depend on the reporter.
 
+### skipServe
+
+Default: `false`
+
+Type: `boolean`
+
+Skip dev-server build.
+
 ### spec
 
 Type: `string`

--- a/docs/node/api-cypress/executors/cypress.md
+++ b/docs/node/api-cypress/executors/cypress.md
@@ -105,6 +105,14 @@ Type: `string`
 
 The reporter options used. Supported options depend on the reporter.
 
+### skipServe
+
+Default: `false`
+
+Type: `boolean`
+
+Skip dev-server build.
+
 ### spec
 
 Type: `string`

--- a/docs/react/api-cypress/executors/cypress.md
+++ b/docs/react/api-cypress/executors/cypress.md
@@ -105,6 +105,14 @@ Type: `string`
 
 The reporter options used. Supported options depend on the reporter.
 
+### skipServe
+
+Default: `false`
+
+Type: `boolean`
+
+Skip dev-server build.
+
 ### spec
 
 Type: `string`

--- a/packages/cypress/src/executors/cypress/cypress.impl.spec.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.spec.ts
@@ -22,15 +22,17 @@ describe('Cypress builder', () => {
     record: false,
     baseUrl: undefined,
     watch: false,
+    skipServe: false,
   };
   let mockContext;
   let mockedInstalledCypressVersion: jest.Mock<
     ReturnType<typeof installedCypressVersion>
   > = installedCypressVersion as any;
   mockContext = { root: '/root', workspace: { projects: {} } } as any;
+  let runExecutor: any;
 
   beforeEach(async () => {
-    (devkit as any).runExecutor = jest.fn().mockReturnValue([
+    runExecutor = (devkit as any).runExecutor = jest.fn().mockReturnValue([
       {
         success: true,
         baseUrl: 'http://localhost:4200',
@@ -164,6 +166,7 @@ describe('Cypress builder', () => {
         record: false,
         baseUrl: undefined,
         watch: false,
+        skipServe: false,
       },
       mockContext
     );
@@ -250,6 +253,27 @@ describe('Cypress builder', () => {
     expect(success).toEqual(true);
     expect(cypressRun.calls.mostRecent().args[0].config.baseUrl).toBe(
       'http://localhost:4200'
+    );
+    done();
+  });
+
+  it('should call `Cypress.run` without serving the app', async (done) => {
+    const { success } = await cypressExecutor(
+      {
+        ...cypressOptions,
+        skipServe: true,
+        baseUrl: 'http://my-distant-host.com',
+      },
+      mockContext
+    );
+    expect(success).toEqual(true);
+    expect(runExecutor).not.toHaveBeenCalled();
+    expect(cypressRun).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        config: {
+          baseUrl: 'http://my-distant-host.com',
+        },
+      })
     );
     done();
   });

--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -31,6 +31,7 @@ export interface CypressExecutorOptions extends Json {
   ignoreTestFiles?: string;
   reporter?: string;
   reporterOptions?: string;
+  skipServe: boolean;
 }
 
 try {
@@ -105,7 +106,7 @@ async function* startDevServer(
   context: ExecutorContext
 ) {
   // no dev server, return the provisioned base url
-  if (!opts.devServerTarget) {
+  if (!opts.devServerTarget || opts.skipServe) {
     yield opts.baseUrl;
     return;
   }

--- a/packages/cypress/src/executors/cypress/schema.json
+++ b/packages/cypress/src/executors/cypress/schema.json
@@ -86,6 +86,11 @@
     "reporterOptions": {
       "type": "string",
       "description": "The reporter options used. Supported options depend on the reporter."
+    },
+    "skipServe": {
+      "type": "boolean",
+      "description": "Skip dev-server build.",
+      "default": false
     }
   },
   "additionalProperties": true,


### PR DESCRIPTION
The builder currently supports skipping the serve step by passing an empty value for
devServerTarget. This is not intuitive and makes configuring this via the command line messy. This
flag has the same behavior as passing an empty devServerTarget but is more user-friendly. This
option can be useful for CI purposes where applications are previously built and want to use the
same configuration for e2e testing but the serve step is unnecessary.