### PR TITLE
fix(core): read tsconfig.json instead of tsconfig.base.json

### DIFF
--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -7,7 +7,7 @@ import { dirname, join } from 'path';
 
 export class TargetProjectLocator {
   private sortedWorkspaceProjects = [];
-  private paths = parseJsonWithComments(this.fileRead(`./tsconfig.base.json`))
+  private paths = parseJsonWithComments(this.fileRead(`./tsconfig.json`))
     ?.compilerOptions?.paths;
   private cache = new Map<string, string>();
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Logic attempts to read from `tsconfig.base.json` which is not introduced until Nx 10

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Logic attempts to read from `tsconfig.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
