### PR TITLE
fix(core): allow-tsconfig.json for project graph

### DIFF
--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import { readFileSync } from 'fs';
 import * as path from 'path';
-import { extname } from 'path';
+import { extname, join } from 'path';
 import { NxArgs } from '../command-line/utils';
 import { WorkspaceResults } from '../command-line/workspace-results';
 import { appRootPath } from '../utils/app-root';
@@ -178,8 +178,10 @@ export function workspaceFileName() {
   }
 }
 
-export function defaultFileRead(filePath: string) {
-  return readFileSync(`${appRootPath}/${filePath}`, 'UTF-8');
+export type FileRead = (s: string) => string;
+
+export function defaultFileRead(filePath: string): string | null {
+  return readFileSync(join(appRootPath, filePath), 'UTF-8');
 }
 
 export function readPackageJson(): any {

--- a/packages/workspace/src/core/project-graph/build-dependencies/build-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/build-dependencies.ts
@@ -3,12 +3,13 @@ import {
   ProjectGraphContext,
   ProjectGraphNodeRecords,
 } from '../project-graph-models';
+import { FileRead } from '../../file-utils';
 
 export interface BuildDependencies {
   (
     ctx: ProjectGraphContext,
     nodes: ProjectGraphNodeRecords,
     addDependency: AddProjectDependency,
-    fileRead: (s: string) => string
+    fileRead: FileRead
   ): void;
 }

--- a/packages/workspace/src/core/project-graph/build-dependencies/explicit-npm-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/explicit-npm-dependencies.ts
@@ -6,12 +6,13 @@ import {
   ProjectGraphNodeRecords,
 } from '../project-graph-models';
 import { TypeScriptImportLocator } from './typescript-import-locator';
+import { FileRead } from '../../file-utils';
 
 export function buildExplicitNpmDependencies(
   ctx: ProjectGraphContext,
   nodes: ProjectGraphNodeRecords,
   addDependency: AddProjectDependency,
-  fileRead: (s: string) => string
+  fileRead: FileRead
 ) {
   const importLocator = new TypeScriptImportLocator(fileRead);
 

--- a/packages/workspace/src/core/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -6,12 +6,13 @@ import {
 } from '../project-graph-models';
 import { TypeScriptImportLocator } from './typescript-import-locator';
 import { TargetProjectLocator } from '../../target-project-locator';
+import { FileRead } from '../../file-utils';
 
 export function buildExplicitTypeScriptDependencies(
   ctx: ProjectGraphContext,
   nodes: ProjectGraphNodeRecords,
   addDependency: AddProjectDependency,
-  fileRead: (s: string) => string
+  fileRead: FileRead
 ) {
   const importLocator = new TypeScriptImportLocator(fileRead);
   const targetProjectLocator = new TargetProjectLocator(nodes, fileRead);

--- a/packages/workspace/src/core/project-graph/build-dependencies/implicit-project-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/implicit-project-dependencies.ts
@@ -8,8 +8,7 @@ import {
 export function buildImplicitProjectDependencies(
   ctx: ProjectGraphContext,
   nodes: ProjectGraphNodeRecords,
-  addDependency: AddProjectDependency,
-  fileRead: (s: string) => string
+  addDependency: AddProjectDependency
 ) {
   Object.keys(ctx.nxJson.projects).forEach((source) => {
     const p = ctx.nxJson.projects[source];

--- a/packages/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.ts
@@ -2,6 +2,7 @@ import * as ts from 'typescript';
 import * as path from 'path';
 import { DependencyType } from '../project-graph-models';
 import { stripSourceCode } from '../../../utils/strip-source-code';
+import { FileRead } from '../../file-utils';
 
 export class TypeScriptImportLocator {
   private readonly scanner: ts.Scanner = ts.createScanner(
@@ -9,7 +10,7 @@ export class TypeScriptImportLocator {
     false
   );
 
-  constructor(private readonly fileRead: (s: string) => string) {}
+  constructor(private readonly fileRead: FileRead) {}
 
   fromFile(
     filePath: string,

--- a/packages/workspace/src/core/project-graph/build-nodes/build-nodes.ts
+++ b/packages/workspace/src/core/project-graph/build-nodes/build-nodes.ts
@@ -1,9 +1,6 @@
 import { AddProjectNode, ProjectGraphContext } from '../project-graph-models';
+import { FileRead } from '../../file-utils';
 
 export interface BuildNodes {
-  (
-    ctx: ProjectGraphContext,
-    addNode: AddProjectNode,
-    fileRead: (s: string) => string
-  ): void;
+  (ctx: ProjectGraphContext, addNode: AddProjectNode, fileRead: FileRead): void;
 }

--- a/packages/workspace/src/core/project-graph/build-nodes/npm-packages.ts
+++ b/packages/workspace/src/core/project-graph/build-nodes/npm-packages.ts
@@ -1,10 +1,11 @@
 import * as stripJsonComments from 'strip-json-comments';
 import { ProjectGraphContext, AddProjectNode } from '../project-graph-models';
+import { FileRead } from '../../file-utils';
 
 export function buildNpmPackageNodes(
   ctx: ProjectGraphContext,
   addNode: AddProjectNode,
-  fileRead: (s: string) => string
+  fileRead: FileRead
 ) {
   const packageJson = JSON.parse(stripJsonComments(fileRead('package.json')));
   const deps = {

--- a/packages/workspace/src/core/project-graph/build-nodes/workspace-projects.ts
+++ b/packages/workspace/src/core/project-graph/build-nodes/workspace-projects.ts
@@ -2,8 +2,7 @@ import { AddProjectNode, ProjectGraphContext } from '../project-graph-models';
 
 export function buildWorkspaceProjectNodes(
   ctx: ProjectGraphContext,
-  addNode: AddProjectNode,
-  fileRead: (s: string) => string
+  addNode: AddProjectNode
 ) {
   const toAdd = [];
 

--- a/packages/workspace/src/core/project-graph/project-graph.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.ts
@@ -2,6 +2,7 @@ import { assertWorkspaceValidity } from '../assert-workspace-validity';
 import { createFileMap, FileMap } from '../file-graph';
 import {
   defaultFileRead,
+  FileRead,
   filesChanged,
   readNxJson,
   readWorkspaceFiles,
@@ -35,7 +36,7 @@ export function createProjectGraph(
   workspaceJson = readWorkspaceJson(),
   nxJson = readNxJson(),
   workspaceFiles = readWorkspaceFiles(),
-  fileRead: (s: string) => string = defaultFileRead,
+  fileRead: FileRead = defaultFileRead,
   cache: false | ProjectGraphCache = readCache(),
   shouldCache: boolean = true
 ): ProjectGraph {
@@ -81,7 +82,7 @@ export function createProjectGraph(
 
 function buildProjectGraph(
   ctx: { nxJson: NxJson<string[]>; workspaceJson: any; fileMap: FileMap },
-  fileRead: (s: string) => string,
+  fileRead: FileRead,
   projectGraph: ProjectGraph
 ) {
   performance.mark('build project graph:start');

--- a/packages/workspace/src/schematics/remove/lib/check-dependencies.ts
+++ b/packages/workspace/src/schematics/remove/lib/check-dependencies.ts
@@ -53,7 +53,13 @@ export function checkDependencies(schema: Schema): Rule {
       readWorkspace(tree),
       readNxJsonInTree(tree),
       files,
-      (file) => tree.read(file).toString('utf-8'),
+      (file) => {
+        try {
+          return tree.read(file).toString('utf-8');
+        } catch (e) {
+          throw new Error(`Could not read ${file}`);
+        }
+      },
       false,
       false
     );

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -26,7 +26,7 @@ import {
   onlyWorkspaceProjects,
   ProjectGraph,
 } from '../core/project-graph';
-import { FileData } from '../core/file-utils';
+import { FileData, FileRead } from '../core/file-utils';
 import { extname, join, normalize, Path } from '@angular-devkit/core';
 import { NxJson, NxJsonProjectConfig } from '../core/shared-interfaces';
 import { addInstallTask } from './rules/add-install-task';
@@ -405,7 +405,7 @@ export function getFullProjectGraphFromHost(host: Tree): ProjectGraph {
   const workspaceJson = readJsonInTree(host, getWorkspacePath(host));
   const nxJson = readJsonInTree<NxJson>(host, '/nx.json');
 
-  const fileRead = (f: string) => {
+  const fileRead: FileRead = (f: string) => {
     try {
       return host.read(f).toString();
     } catch (e) {

--- a/packages/workspace/src/utils/typescript.ts
+++ b/packages/workspace/src/utils/typescript.ts
@@ -1,6 +1,8 @@
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import * as ts from 'typescript';
 import { appRootPath } from './app-root';
+import { existsSync } from 'fs';
+import { FileRead } from '@nrwl/workspace/src/core/file-utils';
 
 const normalizedAppRoot = appRootPath.replace(/\\/g, '/');
 
@@ -24,9 +26,14 @@ let compilerHost: {
  *
  * @param importExpr Import used to resolve to a module
  * @param filePath
+ * @param tsConfigPath
  */
-export function resolveModuleByImport(importExpr: string, filePath: string) {
-  compilerHost = compilerHost || getCompilerHost();
+export function resolveModuleByImport(
+  importExpr: string,
+  filePath: string,
+  tsConfigPath: string
+) {
+  compilerHost = compilerHost || getCompilerHost(tsConfigPath);
   const { options, host, moduleResolutionCache } = compilerHost;
 
   const { resolvedModule } = ts.resolveModuleName(
@@ -44,8 +51,8 @@ export function resolveModuleByImport(importExpr: string, filePath: string) {
   }
 }
 
-function getCompilerHost() {
-  const { options } = readTsConfig(`${appRootPath}/tsconfig.base.json`);
+function getCompilerHost(tsConfigPath: string) {
+  const { options } = readTsConfig(tsConfigPath);
   const host = ts.createCompilerHost(options, true);
   const moduleResolutionCache = ts.createModuleResolutionCache(
     appRootPath,


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Project Graph creation fails if `tsconfig.base.json` is not there .e.g. when `tsconfig.json` is at the root.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Project Graph creation falls back to using `tsconfig.json` if `tsconfig.base.json` is not there.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
