### PR TITLE
fix(core): update version of yargs-parser

### DIFF
--- a/packages/create-nx-plugin/package.json
+++ b/packages/create-nx-plugin/package.json
@@ -30,7 +30,7 @@
     "@nrwl/workspace": "*",
     "tmp": "0.0.33",
     "yargs": "15.4.1",
-    "yargs-parser": "17.0.0",
+    "yargs-parser": "20.0.0",
     "inquirer": "^6.3.1",
     "fs-extra": "7.0.1"
   }


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

`yargs-parser` v17 is used in `create-nx-plugin` with a security vulnerability.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`yargs-parser` v20 is used in `create-nx-plugin` without a security vulnerability.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
