### PR TITLE
fix(core): improve performance of analyzing npm dependencies

### DIFF
--- a/packages/workspace/src/core/project-graph/build-dependencies/explicit-npm-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/explicit-npm-dependencies.ts
@@ -7,6 +7,7 @@ import {
 } from '../project-graph-models';
 import { TypeScriptImportLocator } from './typescript-import-locator';
 import { FileRead } from '../../file-utils';
+import { isRelativePath } from '../../../utils/fileutils';
 
 export function buildExplicitNpmDependencies(
   ctx: ProjectGraphContext,
@@ -19,17 +20,28 @@ export function buildExplicitNpmDependencies(
   const npmProjects = Object.values(nodes).filter(
     (node) => node.type === 'npm'
   ) as ProjectGraphNode<{ packageName: string; version: string }>[];
+  const cache = new Map<string, string>();
 
   Object.keys(ctx.fileMap).forEach((source) => {
     Object.values(ctx.fileMap[source]).forEach((f) => {
       importLocator.fromFile(
         f.file,
         (importExpr: string, filePath: string, type: DependencyType) => {
-          const pkg = npmProjects.find((pkg) =>
-            isNpmPackageImport(pkg.data.packageName, importExpr)
-          );
-          if (pkg) {
-            const target = nodes[pkg.name];
+          if (isRelativePath(importExpr)) {
+            return;
+          }
+
+          let pkgName: string;
+          if (cache.has(importExpr)) {
+            pkgName = cache.get(importExpr);
+          } else {
+            pkgName = npmProjects.find((pkg) =>
+              importExpr.startsWith(pkg.data.packageName)
+            )?.name;
+            cache.set(importExpr, pkgName);
+          }
+          if (pkgName) {
+            const target = nodes[pkgName];
             if (source && target) {
               addDependency(type, source, target.name);
             }
@@ -38,12 +50,4 @@ export function buildExplicitNpmDependencies(
       );
     });
   });
-}
-
-function isNpmPackageImport(p: string, e: string) {
-  const toMatch = e
-    .split(/[\/]/)
-    .slice(0, p.startsWith('@') ? 2 : 1)
-    .join('/');
-  return toMatch === p;
 }


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Finding npm dependencies from imports in a large workspace takes ~4.2s
Overall Project Graph creation time took 18s

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Finding npm dependencies from imports in a large workspace takes ~.325s
Overall Project Graph creation time took 15s

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
