### PR TITLE
fix(docs): Misnamed link in sidebar

### DIFF
--- a/docs/map.json
+++ b/docs/map.json
@@ -2225,8 +2225,8 @@
             ]
           },
           {
-            "name": "node",
-            "id": "node",
+            "name": "react",
+            "id": "react",
             "itemList": [
               {
                 "id": "overview",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
![image](https://user-images.githubusercontent.com/3788405/93558119-95ca5380-f931-11ea-9569-2f59088d2e2d.png)

Looks like replace-all mix-up in the map.json for the sidebar tree data.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The the first 'node' link in the picture about should be named 'react' (all links still work properly and send user to react docs)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
