### PR TITLE
feat(testing): add projects into jest config

### DIFF
--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -355,8 +355,8 @@ forEachCli((currentCLIName) => {
 
       expect(stripIndents`${jestConfigContent}`).toEqual(
         stripIndents`module.exports = {
-                name: '${nestlib}',
-                preset: '../../jest.config.js',
+                displayName: '${nestlib}',
+                preset: '../../jest.preset.js',
                 globals: {
                   'ts-jest': {
                   tsConfig: '<rootDir>/tsconfig.spec.json',

--- a/packages/angular/src/schematics/storybook-configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/angular/src/schematics/storybook-configuration/__snapshots__/configuration.spec.ts.snap
@@ -8,6 +8,7 @@ Array [
   "/tsconfig.base.json",
   "/tslint.json",
   "/jest.config.js",
+  "/jest.preset.js",
   "/libs/test-ui-lib/README.md",
   "/libs/test-ui-lib/tsconfig.lib.json",
   "/libs/test-ui-lib/tslint.json",

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -39,6 +39,11 @@
       "version": "10.2.0",
       "description": "Remove deprecated jest builder options",
       "factory": "./src/migrations/update-10-2-0/update-10-2-0"
+    },
+    "update-projects-property": {
+      "version": "10.3.0-beta.1",
+      "description": "Adds all jest projects into the root jest config",
+      "factory": "./src/migrations/update-10-3-0/update-projects-property"
     }
   },
   "packageJsonUpdates": {

--- a/packages/jest/preset/index.ts
+++ b/packages/jest/preset/index.ts
@@ -1,0 +1,1 @@
+export = require('./jest-preset');

--- a/packages/jest/preset/jest-preset.ts
+++ b/packages/jest/preset/jest-preset.ts
@@ -1,4 +1,4 @@
-module.exports = {
+export = {
   testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
   resolver: '@nrwl/jest/plugins/resolver',
   moduleFileExtensions: ['ts', 'js', 'html'],

--- a/packages/jest/preset/jest-preset.ts
+++ b/packages/jest/preset/jest-preset.ts
@@ -1,0 +1,9 @@
+module.exports = {
+  testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
+  resolver: '@nrwl/jest/plugins/resolver',
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageReporters: ['html'],
+  transform: {
+    '^.+\\.(ts|js|html)$': 'ts-jest',
+  },
+};

--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -63,6 +63,7 @@ describe('Jest Builder', () => {
           _: [],
           testPathPattern: [],
           watch: false,
+          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -103,6 +104,7 @@ describe('Jest Builder', () => {
           coverageReporters: ['test'],
           coverageDirectory: '/test/path',
           watch: false,
+          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -133,6 +135,7 @@ describe('Jest Builder', () => {
           testNamePattern: 'should load',
           testPathPattern: [],
           watch: false,
+          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -201,6 +204,7 @@ describe('Jest Builder', () => {
           watch: false,
           watchAll: false,
           testLocationInResults: true,
+          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -222,6 +226,7 @@ describe('Jest Builder', () => {
           _: [],
           maxWorkers: '50%',
           testPathPattern: [],
+          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -245,6 +250,7 @@ describe('Jest Builder', () => {
           setupFilesAfterEnv: ['/root/test-setup.ts'],
           testPathPattern: [],
           watch: false,
+          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -293,6 +299,7 @@ describe('Jest Builder', () => {
           setupFilesAfterEnv: ['/root/test-setup.ts'],
           testPathPattern: [],
           watch: false,
+          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -330,6 +337,7 @@ describe('Jest Builder', () => {
           _: [],
           testPathPattern: [],
           watch: false,
+          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );

--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -63,7 +63,6 @@ describe('Jest Builder', () => {
           _: [],
           testPathPattern: [],
           watch: false,
-          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -104,7 +103,6 @@ describe('Jest Builder', () => {
           coverageReporters: ['test'],
           coverageDirectory: '/test/path',
           watch: false,
-          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -135,7 +133,6 @@ describe('Jest Builder', () => {
           testNamePattern: 'should load',
           testPathPattern: [],
           watch: false,
-          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -204,7 +201,6 @@ describe('Jest Builder', () => {
           watch: false,
           watchAll: false,
           testLocationInResults: true,
-          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -226,7 +222,6 @@ describe('Jest Builder', () => {
           _: [],
           maxWorkers: '50%',
           testPathPattern: [],
-          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -250,7 +245,6 @@ describe('Jest Builder', () => {
           setupFilesAfterEnv: ['/root/test-setup.ts'],
           testPathPattern: [],
           watch: false,
-          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -299,7 +293,6 @@ describe('Jest Builder', () => {
           setupFilesAfterEnv: ['/root/test-setup.ts'],
           testPathPattern: [],
           watch: false,
-          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );
@@ -337,7 +330,6 @@ describe('Jest Builder', () => {
           _: [],
           testPathPattern: [],
           watch: false,
-          projects: ['/root/jest.config.js'],
         },
         ['/root/jest.config.js']
       );

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -69,7 +69,6 @@ function run(
     useStderr: options.useStderr,
     watch: options.watch,
     watchAll: options.watchAll,
-    projects: [options.jestConfig],
   };
 
   // for backwards compatibility

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { from, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { JestBuilderOptions } from './schema';
+import { Config } from '@jest/types';
 
 try {
   require('dotenv').config();
@@ -15,7 +16,7 @@ try {
   // noop
 }
 
-if (process.env.NODE_ENV == null || process.env.NODE_ENV == undefined) {
+if (process.env.NODE_ENV === null || process.env.NODE_ENV === undefined) {
   (process.env as any).NODE_ENV = 'test';
 }
 
@@ -40,7 +41,8 @@ function run(
     );
   }
 
-  const config: any = {
+  const config: Config.Argv = {
+    $0: undefined,
     _: [],
     config: options.config,
     coverage: options.codeCoverage,
@@ -67,6 +69,7 @@ function run(
     useStderr: options.useStderr,
     watch: options.watch,
     watchAll: options.watchAll,
+    projects: [options.jestConfig],
   };
 
   // for backwards compatibility
@@ -98,14 +101,17 @@ function run(
     config.reporters = options.reporters;
   }
 
-  if (options.coverageReporters && options.coverageReporters.length > 0) {
+  if (
+    Array.isArray(options.coverageReporters) &&
+    options.coverageReporters.length > 0
+  ) {
     config.coverageReporters = options.coverageReporters;
   }
 
   return from(runCLI(config, [options.jestConfig])).pipe(
-    map((results) => {
+    map(({ results }) => {
       return {
-        success: results.results.success,
+        success: results.success,
       };
     })
   );

--- a/packages/jest/src/builders/jest/schema.d.ts
+++ b/packages/jest/src/builders/jest/schema.d.ts
@@ -25,7 +25,7 @@ export interface JestBuilderOptions extends JsonObject {
   colors?: boolean;
   reporters?: string[];
   verbose?: boolean;
-  coverageReporters?: string;
+  coverageReporters?: string[];
   coverageDirectory?: string;
   testResultsProcessor?: string;
   updateSnapshot?: boolean;

--- a/packages/jest/src/migrations/update-10-3-0/update-projects-property.spec.ts
+++ b/packages/jest/src/migrations/update-10-3-0/update-projects-property.spec.ts
@@ -122,13 +122,14 @@ describe('update projects property', () => {
 
     const jestPreset = result.readContent('jest.preset.js');
     expect(tags.stripIndents`${jestPreset}`).toEqual(tags.stripIndents`
+    const nxPreset = require('@nrwl/jest/preset');
     module.exports = {
+        ...nxPreset,
         testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
         transform: {
           '^.+\\\\.(ts|js|html)$': 'ts-jest',
         },
         maxWorkers: 2,
-        preset: '@nrwl/jest/preset',
       };
     `);
 

--- a/packages/jest/src/migrations/update-10-3-0/update-projects-property.spec.ts
+++ b/packages/jest/src/migrations/update-10-3-0/update-projects-property.spec.ts
@@ -1,0 +1,161 @@
+import { tags } from '@angular-devkit/core';
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { serializeJson } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import * as path from 'path';
+
+describe('update projects property', () => {
+  let initialTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(() => {
+    initialTree = createEmptyWorkspace(Tree.empty());
+
+    initialTree.create(
+      'jest.config.js',
+      tags.stripIndents`
+      module.exports = {
+        testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
+        transform: {
+          '^.+\\\\.(ts|js|html)$': 'ts-jest',
+        },
+        maxWorkers: 2,
+      };
+    `
+    );
+
+    initialTree.create(
+      'apps/products/jest.config.js',
+      tags.stripIndents`
+      module.exports = {
+        name: 'products',
+        preset: '../../jest.config.js',
+        coverageDirectory: '../../coverage/apps/products',
+        snapshotSerializers: [
+          'jest-preset-angular/build/AngularSnapshotSerializer.js',
+          'jest-preset-angular/build/HTMLCommentSerializer.js'
+        ],
+        setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+        globals: {
+          'ts-jest': {
+            tsConfig: '<rootDir>/tsconfig.spec.json',
+            stringifyContentPathRegex: '\\.(html|svg)$',
+            astTransformers: [
+              'jest-preset-angular/build/InlineFilesTransformer',
+              'jest-preset-angular/build/StripStylesTransformer'
+            ]
+          }
+        }
+      };
+    `
+    );
+
+    initialTree.overwrite(
+      'workspace.json',
+      serializeJson({
+        version: 1,
+        projects: {
+          products: {
+            root: 'apps/products',
+            sourceRoot: 'apps/products/src',
+            architect: {
+              build: {
+                builder: '@angular-devkit/build-angular:browser',
+              },
+              test: {
+                builder: '@nrwl/jest:jest',
+                options: {
+                  jestConfig: 'apps/products/jest.config.js',
+                  tsConfig: 'apps/products/tsconfig.spec.json',
+                  setupFile: 'apps/products/src/test-setup.ts',
+                  passWithNoTests: true,
+                },
+              },
+            },
+          },
+          cart: {
+            root: 'apps/cart',
+            sourceRoot: 'apps/cart/src',
+            architect: {
+              build: {
+                builder: '@nrwl/web:build',
+              },
+              test: {
+                builder: '@nrwl/jest:jest',
+                options: {
+                  jestConfig: 'apps/cart/jest.config.js',
+                  passWithNoTests: true,
+                },
+              },
+            },
+          },
+          basket: {
+            root: 'apps/basket',
+            sourceRoot: 'apps/basket/src',
+            architect: {
+              build: {
+                builder: '@nrwl/web:build',
+              },
+            },
+          },
+        },
+      })
+    );
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/jest',
+      path.join(__dirname, '../../../migrations.json')
+    );
+  });
+
+  it('should remove setupFile and tsconfig in test architect from workspace.json', async (done) => {
+    const result = await schematicRunner
+      .runSchematicAsync('update-projects-property', {}, initialTree)
+      .toPromise();
+
+    const updatedJestConfig = result.readContent('jest.config.js');
+    expect(tags.stripIndents`${updatedJestConfig}`).toEqual(tags.stripIndents`
+     module.exports = {
+        projects: ['<rootDir>/apps/products', '<rootDir>/apps/cart'],
+      };
+    `);
+
+    const jestPreset = result.readContent('jest.preset.js');
+    expect(tags.stripIndents`${jestPreset}`).toEqual(tags.stripIndents`
+    module.exports = {
+        testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
+        transform: {
+          '^.+\\\\.(ts|js|html)$': 'ts-jest',
+        },
+        maxWorkers: 2,
+        preset: '@nrwl/jest/preset',
+      };
+    `);
+
+    const projectConfig = result.readContent('apps/products/jest.config.js');
+    expect(tags.stripIndents`${projectConfig}`).toEqual(tags.stripIndents`
+     module.exports = {
+       preset: '../../jest.preset.js',
+       coverageDirectory: '../../coverage/apps/products',
+       snapshotSerializers: [
+         'jest-preset-angular/build/AngularSnapshotSerializer.js',
+         'jest-preset-angular/build/HTMLCommentSerializer.js',
+        ],
+        setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+        globals: {
+          'ts-jest': {
+            tsConfig: '<rootDir>/tsconfig.spec.json',
+            stringifyContentPathRegex: '\\.(html|svg)$',
+            astTransformers: [
+              'jest-preset-angular/build/InlineFilesTransformer',
+              'jest-preset-angular/build/StripStylesTransformer',
+            ],
+          },
+        },
+        displayName: 'products',
+      };
+    `);
+
+    done();
+  });
+});

--- a/packages/jest/src/migrations/update-10-3-0/update-projects-property.ts
+++ b/packages/jest/src/migrations/update-10-3-0/update-projects-property.ts
@@ -1,0 +1,98 @@
+import {
+  chain,
+  Rule,
+  SchematicContext,
+  Tree,
+} from '@angular-devkit/schematics';
+import {
+  formatFiles,
+  getWorkspace,
+  offsetFromRoot,
+  serializeJson,
+} from '@nrwl/workspace';
+import {
+  addPropertyToJestConfig,
+  removePropertyFromJestConfig,
+} from '../../utils/config/update-config';
+
+function updateRootJestConfig(): Rule {
+  return async (host: Tree, context: SchematicContext) => {
+    const workspace = await getWorkspace(host);
+
+    const rootDirs = [];
+    for (const [projectName, project] of workspace.projects) {
+      for (const [, target] of project.targets) {
+        if (target.builder !== '@nrwl/jest:jest') {
+          continue;
+        }
+
+        rootDirs.push(`<rootDir>/${project.root}`);
+
+        try {
+          addPropertyToJestConfig(
+            host,
+            target.options.jestConfig as string,
+            'preset',
+            `${offsetFromRoot(project.root)}jest.preset.js`
+          );
+          addPropertyToJestConfig(
+            host,
+            target.options.jestConfig as string,
+            'displayName',
+            projectName
+          );
+          removePropertyFromJestConfig(
+            host,
+            target.options.jestConfig as string,
+            'name'
+          );
+        } catch {
+          context.logger.error(
+            `Unable to update the jest preset for project ${projectName}. Please manually add "@nrwl/jest/preset" as the preset.`
+          );
+        }
+      }
+    }
+
+    if (rootDirs.length == 0) {
+      return;
+    } else {
+      try {
+        context.logger.info(`
+The root jest.config.js file will be updated to include all references to each individual project's jest config. 
+A new jest.preset.js file will be created that would have your existing configuration. All projects will now have this preset.
+        `);
+
+        const existingRootConfig = host
+          .read('jest.config.js')
+          .toString('utf-8');
+
+        host.create('jest.preset.js', existingRootConfig);
+        addPropertyToJestConfig(
+          host,
+          'jest.preset.js',
+          'preset',
+          '@nrwl/jest/preset'
+        );
+
+        host.overwrite(
+          'jest.config.js',
+          `
+        module.exports = {
+          projects: ${serializeJson(rootDirs)}
+        }
+        `
+        );
+      } catch {
+        context.logger.error(`
+Unable to update the root jest.config.js with projects. Please add the "projects" property to the exported jest config with the following:
+${serializeJson(rootDirs)}
+        `);
+      }
+    }
+  };
+}
+
+export default function update(): Rule {
+  return chain([updateRootJestConfig(), formatFiles()]);
+}

--- a/packages/jest/src/schematics/init/init.spec.ts
+++ b/packages/jest/src/schematics/init/init.spec.ts
@@ -1,3 +1,4 @@
+import { tags } from '@angular-devkit/core';
 import { Tree } from '@angular-devkit/schematics';
 import { readJsonInTree } from '@nrwl/workspace';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
@@ -19,13 +20,7 @@ describe('jest', () => {
     expect(resultTree.exists('jest.config.js')).toBeTruthy();
     expect(resultTree.readContent('jest.config.js')).toMatchInlineSnapshot(`
       "module.exports = {
-      testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
-      transform: {
-      '^.+\\\\\\\\.(ts|js|html)$': 'ts-jest'
-      },
-      resolver: '@nrwl/jest/plugins/resolver',
-      moduleFileExtensions: ['ts', 'js', 'html'],
-      coverageReporters: ['html']
+      projects: []
       };"
     `);
   });

--- a/packages/jest/src/schematics/init/init.spec.ts
+++ b/packages/jest/src/schematics/init/init.spec.ts
@@ -1,4 +1,3 @@
-import { tags } from '@angular-devkit/core';
 import { Tree } from '@angular-devkit/schematics';
 import { readJsonInTree } from '@nrwl/workspace';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';

--- a/packages/jest/src/schematics/init/init.ts
+++ b/packages/jest/src/schematics/init/init.ts
@@ -58,7 +58,9 @@ const createJestConfig = (host: Tree) => {
     host.create(
       'jest.preset.js',
       `
-    module.exports = { preset: '@nrwl/jest/preset' }`
+      const nxPreset = require('@nrwl/jest/preset');
+     
+      module.exports = { ...nxPreset }`
     );
   }
 };

--- a/packages/jest/src/schematics/init/init.ts
+++ b/packages/jest/src/schematics/init/init.ts
@@ -44,23 +44,23 @@ const removeNrwlJestFromDeps = (host: Tree) => {
 };
 
 const createJestConfig = (host: Tree) => {
-  if (host.exists('jest.config.js')) {
-    return;
+  if (!host.exists('jest.config.js')) {
+    host.create(
+      'jest.config.js',
+      stripIndents`
+  module.exports = {
+    projects: []
+  };`
+    );
   }
 
-  host.create(
-    'jest.config.js',
-    stripIndents`
-  module.exports = {
-    testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
-    transform: {
-      '^.+\\.(ts|js|html)$': 'ts-jest'
-    },
-    resolver: '@nrwl/jest/plugins/resolver',
-    moduleFileExtensions: ['ts', 'js', 'html'],
-    coverageReporters: ['html']
-  };`
-  );
+  if (!host.exists('jest.preset.js')) {
+    host.create(
+      'jest.preset.js',
+      `
+    module.exports = { preset: '@nrwl/jest/preset' }`
+    );
+  }
 };
 
 function updateDependencies(options: NormalizedSchema): Rule {

--- a/packages/jest/src/schematics/jest-project/files/jest.config.js__tmpl__
+++ b/packages/jest/src/schematics/jest-project/files/jest.config.js__tmpl__
@@ -1,6 +1,6 @@
 module.exports = {
-  name: '<%= project %>',
-  preset: '<%= offsetFromRoot %>jest.config.js',<% if(setupFile !== 'none') { %>
+  displayName: '<%= project %>',
+  preset: '<%= offsetFromRoot %>jest.preset.js',<% if(setupFile !== 'none') { %>
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],<% } %><% if (transformer === 'ts-jest') { %>
   globals: {
     'ts-jest': {

--- a/packages/jest/src/schematics/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/schematics/jest-project/jest-project.spec.ts
@@ -89,7 +89,7 @@ describe('jestProject', () => {
       tags.stripIndents`${resultTree.readContent('libs/lib1/jest.config.js')}`
     ).toBe(tags.stripIndents`module.exports = {
   displayName: 'lib1',
-  preset: '@nrwl/jest/preset',
+  preset: '../../jest.preset.js',
   globals: {
     'ts-jest': {
       tsConfig: '<rootDir>/tsconfig.spec.json',

--- a/packages/jest/src/schematics/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/schematics/jest-project/jest-project.spec.ts
@@ -4,6 +4,7 @@ import { createEmptyWorkspace } from '@nrwl/workspace/testing';
 import { callRule, runSchematic } from '../../utils/testing';
 import { tags } from '@angular-devkit/core';
 import { JestProjectSchema } from './schema.d';
+import { jestConfigObject } from '../../utils/config/functions';
 
 describe('jestProject', () => {
   let appTree: Tree;
@@ -29,7 +30,7 @@ describe('jestProject', () => {
       appTree
     );
     appTree = await callRule(
-      updateJsonInTree('libs/lib1/tsconfig.json', (json) => {
+      updateJsonInTree('libs/lib1/tsconfig.json', () => {
         return {
           files: [],
           include: [],
@@ -87,8 +88,8 @@ describe('jestProject', () => {
     expect(
       tags.stripIndents`${resultTree.readContent('libs/lib1/jest.config.js')}`
     ).toBe(tags.stripIndents`module.exports = {
-  name: 'lib1',
-  preset: '../../jest.config.js',
+  displayName: 'lib1',
+  preset: '@nrwl/jest/preset',
   globals: {
     'ts-jest': {
       tsConfig: '<rootDir>/tsconfig.spec.json',
@@ -102,6 +103,19 @@ describe('jestProject', () => {
   ]
 };
 `);
+  });
+
+  it('should add a project reference in the root jest.config.js', async () => {
+    const resultTree = await runSchematic(
+      'jest-project',
+      {
+        project: 'lib1',
+      },
+      appTree
+    );
+    const jestConfig = jestConfigObject(resultTree, 'jest.config.js');
+
+    expect(jestConfig.projects).toEqual(['<rootDir>/libs/lib1']);
   });
 
   it('should add a reference to solution tsconfig.json', async () => {

--- a/packages/jest/src/schematics/jest-project/jest-project.ts
+++ b/packages/jest/src/schematics/jest-project/jest-project.ts
@@ -4,6 +4,7 @@ import { checkForTestTarget } from './lib/check-for-test-target';
 import { generateFiles } from './lib/generate-files';
 import { updateTsConfig } from './lib/update-tsconfig';
 import { updateWorkspace } from './lib/update-workspace';
+import { updateJestConfig } from './lib/update-jestconfig';
 import { JestProjectSchema } from './schema';
 
 const schemaDefaults = {
@@ -45,5 +46,6 @@ export default function (schema: JestProjectSchema): Rule {
     generateFiles(options),
     updateTsConfig(options),
     updateWorkspace(options),
+    updateJestConfig(options),
   ]);
 }

--- a/packages/jest/src/schematics/jest-project/lib/update-jestconfig.ts
+++ b/packages/jest/src/schematics/jest-project/lib/update-jestconfig.ts
@@ -1,0 +1,18 @@
+import { Rule, Tree } from '@angular-devkit/schematics';
+import { getWorkspace } from '@nrwl/workspace';
+
+import { JestProjectSchema } from '../schema';
+import { addPropertyToJestConfig } from '../../../utils/config/update-config';
+
+export function updateJestConfig(options: JestProjectSchema): Rule {
+  return async (host: Tree) => {
+    const workspace = await getWorkspace(host);
+    const project = workspace.projects.get(options.project);
+    addPropertyToJestConfig(
+      host,
+      'jest.config.js',
+      'projects',
+      `<rootDir>/${project.root}`
+    );
+  };
+}

--- a/packages/jest/src/utils/config/functions.ts
+++ b/packages/jest/src/utils/config/functions.ts
@@ -89,14 +89,20 @@ export function addOrUpdateProperty(
         return [];
       }
 
-      return [
-        createInsertChange(
-          path,
-          value,
-          arrayLiteral.elements.end,
-          arrayLiteral.elements.hasTrailingComma
-        ),
-      ];
+      if (arrayLiteral.elements.length === 0) {
+        return [
+          new InsertChange(path, arrayLiteral.elements.end, value as string),
+        ];
+      } else {
+        return [
+          createInsertChange(
+            path,
+            value,
+            arrayLiteral.elements.end,
+            arrayLiteral.elements.hasTrailingComma
+          ),
+        ];
+      }
     } else if (
       propertyAssignment.initializer.kind ===
       ts.SyntaxKind.ObjectLiteralExpression

--- a/packages/jest/src/utils/config/update-config.spec.ts
+++ b/packages/jest/src/utils/config/update-config.spec.ts
@@ -29,7 +29,7 @@ describe('Update jest.config.js', () => {
             childArray: ['value1', 'value2']
           }
         },
-        numeric: 0
+        numeric: 0,
       }
     `
     );

--- a/packages/nest/src/schematics/library/library.spec.ts
+++ b/packages/nest/src/schematics/library/library.spec.ts
@@ -416,7 +416,7 @@ describe('lib', () => {
       expect(stripIndents`${jestConfig}`)
         .toEqual(stripIndents`module.exports = {
       displayName: 'my-lib',
-      preset: '../../jest.config.js',
+      preset: '../../jest.preset.js',
       globals: {
         'ts-jest': {
           tsConfig: '<rootDir>/tsconfig.spec.json',

--- a/packages/nest/src/schematics/library/library.spec.ts
+++ b/packages/nest/src/schematics/library/library.spec.ts
@@ -415,7 +415,7 @@ describe('lib', () => {
       const jestConfig = getFileContent(tree, 'libs/my-lib/jest.config.js');
       expect(stripIndents`${jestConfig}`)
         .toEqual(stripIndents`module.exports = {
-      name: 'my-lib',
+      displayName: 'my-lib',
       preset: '../../jest.config.js',
       globals: {
         'ts-jest': {

--- a/packages/node/src/schematics/application/application.spec.ts
+++ b/packages/node/src/schematics/application/application.spec.ts
@@ -281,8 +281,8 @@ describe('app', () => {
       expect(tree.readContent(`apps/my-node-app/jest.config.js`))
         .toMatchInlineSnapshot(`
         "module.exports = {
-          name: 'my-node-app',
-          preset: '../../jest.config.js',
+          displayName: 'my-node-app',
+          preset: '../../jest.preset.js',
           transform: {
             '^.+\\\\\\\\.[tj]s$': [ 'babel-jest',
             { cwd: __dirname, configFile: './babel-jest.config.json' }]

--- a/packages/node/src/schematics/library/library.spec.ts
+++ b/packages/node/src/schematics/library/library.spec.ts
@@ -382,8 +382,8 @@ describe('lib', () => {
       expect(tree.readContent(`libs/my-lib/jest.config.js`))
         .toMatchInlineSnapshot(`
         "module.exports = {
-          name: 'my-lib',
-          preset: '../../jest.config.js',
+          displayName: 'my-lib',
+          preset: '../../jest.preset.js',
           transform: {
             '^.+\\\\\\\\.[tj]sx?$': [
               'babel-jest',

--- a/packages/web/src/schematics/application/application.spec.ts
+++ b/packages/web/src/schematics/application/application.spec.ts
@@ -347,8 +347,8 @@ describe('app', () => {
       expect(tree.readContent(`apps/my-app/jest.config.js`))
         .toMatchInlineSnapshot(`
         "module.exports = {
-          name: 'my-app',
-          preset: '../../jest.config.js',
+          displayName: 'my-app',
+          preset: '../../jest.preset.js',
           setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
           transform: {
             '^.+\\\\\\\\.[tj]s$': [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Jest configs are independant, and cannot be run from the root of the workspace with just `jest`. This causes some issues with VsCode extensions. 

## Expected Behavior
The root jest.config.js file now contains references to all jest projects in the workspace. A new jest.preset.js file is created as well where each project config has this as a preset. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes #747
Closes #1506 
Closes #2377
Closes #2344
Closes #2635
Closes #3507