### PR TITLE
cleanup(core): avoid referencing `node_modules`

### DIFF
--- a/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import { tmpProjPath } from './paths';
+import { getPackageManagerExecuteCommand } from '@nrwl/workspace/src/utils/detect-package-manager';
 
 /**
  * Run a command asynchronously inside the e2e directory.
@@ -41,7 +42,7 @@ export function runNxCommandAsync(
   }
 ): Promise<{ stdout: string; stderr: string }> {
   return runCommandAsync(
-    `node ./node_modules/@nrwl/cli/bin/nx.js ${command}`,
+    `${getPackageManagerExecuteCommand()} nx ${command}`,
     opts
   );
 }

--- a/packages/nx-plugin/src/utils/testing-utils/commands.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/commands.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process';
 import { tmpProjPath } from './paths';
+import { getPackageManagerExecuteCommand } from '@nrwl/workspace/src/utils/detect-package-manager';
 
 /**
  * Run a nx command inside the e2e directory
@@ -15,7 +16,7 @@ export function runNxCommand(
   }
 ): string {
   try {
-    return execSync(`node ./node_modules/@nrwl/cli/bin/nx.js ${command}`, {
+    return execSync(`${getPackageManagerExecuteCommand()} nx ${command}`, {
       cwd: tmpProjPath(),
     })
       .toString()

--- a/packages/workspace/src/command-line/report.ts
+++ b/packages/workspace/src/command-line/report.ts
@@ -40,15 +40,15 @@ export const report = {
  *
  */
 function reportHandler() {
-  const nodeModulesDir = path.join(appRootPath, 'node_modules');
   const bodyLines = [];
 
   packagesWeCareAbout.forEach((p) => {
     let status = 'Not Found';
     try {
-      const packageJson = JSON.parse(
-        readFileSync(path.join(nodeModulesDir, p, 'package.json')).toString()
-      );
+      const packageJsonPath = require.resolve(`${p}/package.json`, {
+        paths: [appRootPath],
+      });
+      const packageJson = JSON.parse(readFileSync(packageJsonPath).toString());
       status = packageJson.version;
     } catch {}
     bodyLines.push(`${terminal.green(p)} : ${terminal.bold(status)}`);


### PR DESCRIPTION
 Towards Yarn 2 support.