### PR TITLE
docs(docs): Update React & Angular tutorials to use npx for Nx CLI commands

### DIFF
--- a/docs/angular/tutorial/01-create-application.md
+++ b/docs/angular/tutorial/01-create-application.md
@@ -73,12 +73,18 @@ The generate command added two projects to our workspace:
 Now that the application is set up, run it locally via:
 
 ```bash
-nx serve todos
+npx nx serve todos
 ```
 
 ## Note on `nx serve` and `ng serve`
 
 Internally, the Nx CLI delegates to the Angular CLI when running commands or generating code. The `nx serve` command produces the same result as `ng serve`, and `nx build` produces the same results as `ng build`. However, the Nx CLI supports advanced capabilities that aren't supported by the Angular CLI. For instance, Nx's computation cache only works when using the Nx CLI. In other words, using `nx` instead `ng` will result in the same output, but often will perform a lot better. [Read more about Nx CLI and Angular CLI.](/angular/cli/nx-and-cli)
+
+If you would prefer to run using a global installation of Nx, you can run:
+
+```bash
+nx serve todos
+```
 
 Depending on how your dev env is set up, the command above might result in `Command 'nx' not found`.
 
@@ -94,7 +100,7 @@ or
 yarn global add nx
 ```
 
-Or you can prepend every command with `npm run`:
+Alternatively, you can run the local installation of Nx by prepending every command with `npm run`:
 
 ```bash
 npm run nx -- serve todos

--- a/docs/angular/tutorial/01-create-application.md
+++ b/docs/angular/tutorial/01-create-application.md
@@ -76,9 +76,7 @@ Now that the application is set up, run it locally via:
 npx nx serve todos
 ```
 
-## Note on `nx serve` and `ng serve`
-
-Internally, the Nx CLI delegates to the Angular CLI when running commands or generating code. The `nx serve` command produces the same result as `ng serve`, and `nx build` produces the same results as `ng build`. However, the Nx CLI supports advanced capabilities that aren't supported by the Angular CLI. For instance, Nx's computation cache only works when using the Nx CLI. In other words, using `nx` instead `ng` will result in the same output, but often will perform a lot better. [Read more about Nx CLI and Angular CLI.](/angular/cli/nx-and-cli)
+## Note on the Nx CLI
 
 If you would prefer to run using a global installation of Nx, you can run:
 
@@ -111,6 +109,10 @@ or
 ```bash
 yarn nx serve todos
 ```
+
+## Note on `nx serve` and `ng serve`
+
+Internally, the Nx CLI delegates to the Angular CLI when running commands or generating code. The `nx serve` command produces the same result as `ng serve`, and `nx build` produces the same results as `ng build`. However, the Nx CLI supports advanced capabilities that aren't supported by the Angular CLI. For instance, Nx's computation cache only works when using the Nx CLI. In other words, using `nx` instead `ng` will result in the same output, but often will perform a lot better. [Read more about Nx CLI and Angular CLI.](/angular/cli/nx-and-cli)
 
 !!!!!
 Open http://localhost:4200 in the browser. What do you see?

--- a/docs/angular/tutorial/02-add-e2e-test.md
+++ b/docs/angular/tutorial/02-add-e2e-test.md
@@ -29,7 +29,7 @@ describe('TodoApps', () => {
 
 This is not a great example of an E2E test, but it will suffice for the purposes of this tutorial.
 
-If you have not done so already, stop the `nx serve` command and run `nx e2e todos-e2e --watch`.
+If you have not done so already, stop the `npx nx serve` command and run `npx nx e2e todos-e2e --watch`.
 
 A UI will open. Click the button in the top right corner that says "Run all specs". Keep the E2E tests running.
 

--- a/docs/angular/tutorial/03-display-todos.md
+++ b/docs/angular/tutorial/03-display-todos.md
@@ -79,7 +79,7 @@ export class AppComponent {
 The tests should pass now.
 
 !!!!!
-What will you see if you run: `nx e2e todos-e2e --headless`
+What will you see if you run: `npx nx e2e todos-e2e --headless`
 !!!!!
 Cypress will run in the headless mode, and the test will pass.
 Cypress will run in the headless mode, and the test will fail.

--- a/docs/angular/tutorial/04-connect-to-api.md
+++ b/docs/angular/tutorial/04-connect-to-api.md
@@ -55,7 +55,7 @@ export class AppComponent {
 ```
 
 !!!!!
-Run `nx serve todos` and open http://localhost:4200. What do you see?
+Run `npx nx serve todos` and open http://localhost:4200. What do you see?
 !!!!!
 "the server responded with a status of 404 (Not Found)" in Console.
 Blank screen.

--- a/docs/angular/tutorial/05-add-node-app.md
+++ b/docs/angular/tutorial/05-add-node-app.md
@@ -36,7 +36,7 @@ Nx is an open platform with plugins for many modern tools and frameworks. **To s
   @dev-thought/nx-deploy-it - Nx plugin to deploy applications on your favorite cloud provider
 ```
 
-**Now run `nx list @nrwl/nest`, and you will see:**
+**Now run `npx nx list @nrwl/nest`, and you will see:**
 
 ```bash
 >  NX   NOTE  @nrwl/nest is not currently installed
@@ -63,7 +63,7 @@ yarn add --dev @nrwl/nest
 **Run the following to generate a new Nest application:**
 
 ```bash
-nx g @nrwl/nest:app api --frontendProject=todos
+npx nx g @nrwl/nest:app api --frontendProject=todos
 ```
 
 Nx will ask you a few questions, and, as with the Angular application, the defaults will work well here.
@@ -107,9 +107,9 @@ The `apps` directory is where Nx places anything you can run: frontend applicati
 
 You can run:
 
-- `nx serve api` to serve the application
-- `nx build api` to build the application
-- `nx test api` to test the application
+- `npx nx serve api` to serve the application
+- `npx nx build api` to build the application
+- `npx nx test api` to test the application
 
 **Open `apps/api/src/app/app.module.ts`.**
 
@@ -180,7 +180,7 @@ export class AppController {
 ```
 
 !!!!!
-Run "nx serve api" and open http://localhost:3333/api/todos. What do you see?
+Run "npx nx serve api" and open http://localhost:3333/api/todos. What do you see?
 !!!!!
 `[{"title":"Todo 1"},{"title":"Todo 2"}]`
 Blank screen

--- a/docs/angular/tutorial/06-proxy.md
+++ b/docs/angular/tutorial/06-proxy.md
@@ -39,7 +39,7 @@ It created a proxy configuration that allows the Angular application to talk to 
 This configuration tells `nx serve` to forward all requests starting with `/api` to the process listening on port 3333.
 
 !!!!!
-Now run both "nx serve todos" and "nx serve api" in separate terminals, open http://localhost:4200. What do you see
+Now run both "npx nx serve todos" and "npx nx serve api" in separate terminals, open http://localhost:4200. What do you see
 !!!!!
 Todos application is working!
 404 in the console

--- a/docs/angular/tutorial/07-share-code.md
+++ b/docs/angular/tutorial/07-share-code.md
@@ -5,7 +5,7 @@ Awesome! The application is working end to end! However, there is a problem. Bot
 **Run the following generator to create a library:**
 
 ```bash
-nx g @nrwl/workspace:lib data
+npx nx g @nrwl/workspace:lib data
 ```
 
 The result should look like this:
@@ -104,7 +104,7 @@ export class AppComponent {
 }
 ```
 
-Every time you add a new library, you have to restart `nx serve`. **So restart both `nx serve api` and `nx serve todos` and you should see the application running.**
+Every time you add a new library, you have to restart `npx nx serve`. **So restart both `npx nx serve api` and `npx nx serve todos` and you should see the application running.**
 
 !!!!!
 Nx allows you to share code...

--- a/docs/angular/tutorial/08-create-libs.md
+++ b/docs/angular/tutorial/08-create-libs.md
@@ -10,7 +10,7 @@ Every library has an `index.ts` file, which defines its public API. Other applic
 
 To illustrate how useful libraries can be, create a library of Angular components.
 
-**Run `nx g @nrwl/angular:lib ui`.**
+**Run `npx nx g @nrwl/angular:lib ui`.**
 
 You should see the following:
 
@@ -57,7 +57,7 @@ export class UiModule {}
 **Add a component to the newly created ui library by running:**
 
 ```bash
-nx g component todos --project=ui --export
+npx nx g component todos --project=ui --export
 ```
 
 ```treeview
@@ -150,7 +150,7 @@ export class AppModule {}
 <button (click)="addTodo()">Add Todo</button>
 ```
 
-**Restart both `nx serve api` and `nx serve todos` and you should see the application running.**
+**Restart both `npx nx serve api` and `npx nx serve todos` and you should see the application running.**
 
 !!!!!
 Libraries' public API is defined in...

--- a/docs/angular/tutorial/10-computation-caching.md
+++ b/docs/angular/tutorial/10-computation-caching.md
@@ -2,10 +2,10 @@
 
 Nx has built-in computation caching, which helps drastically improve the performance of the commands.
 
-**To see it in action, run `nx build todos`:**
+**To see it in action, run `npx nx build todos`:**
 
 ```bash
-> nx run todos:build
+> npx nx run todos:build
 Generating ES5 bundles for differential loading...
 ES5 bundle generation complete.
 
@@ -21,10 +21,10 @@ chunk {vendor} vendor-es2015.js, vendor-es2015.js.map (vendor) 2.35 MB [initial]
 chunk {vendor} vendor-es5.js, vendor-es5.js.map (vendor) 2.75 MB [initial] [rendered]
 ```
 
-**Now, run `nx build todos` again, and you will see the results appearing instantly:**
+**Now, run `npx nx build todos` again, and you will see the results appearing instantly:**
 
 ```bash
-> nx run todos:build
+> npx nx run todos:build
 
 >  NX   NOTE  Cached Output:
 
@@ -49,7 +49,7 @@ Based on the state of the source code and the environment, Nx was able to figure
 
 ## Building Multiple Projects
 
-**Now, run `nx run-many --target=build --projects=todos,api` to rebuild the two applications:**
+**Now, run `npx nx run-many --target=build --projects=todos,api` to rebuild the two applications:**
 
 ```bash
 Nx read the output from cache instead of running the command for 1 out of 2 projects.
@@ -61,28 +61,28 @@ Nx built `api` and retrieved `todos` from its computation cache. Read more about
 
 As we saw already, Nx is smart, so it knows how applications and libraries in the workspace depend on each other.
 
-**Run `nx lint todos --with-deps`, and you see that Nx lints both the `todos` app and the libraries it depends on.**
+**Run `npx nx lint todos --with-deps`, and you see that Nx lints both the `todos` app and the libraries it depends on.**
 
 ```bash
 >  NX  Running target lint for project todos and its 2 deps.
 
 ———————————————————————————————————————————————
 
-> nx run todos:lint
+> npx nx run todos:lint
 
 Linting "todos"...
 
 All files pass linting.
 
 
-> nx run ui:lint
+> npx nx run ui:lint
 
 Linting "ui"...
 
 All files pass linting.
 
 
-> nx run data:lint
+> npx nx run data:lint
 
 Linting "data"...
 
@@ -97,7 +97,7 @@ All files pass linting.
 > Add --parallel to any command, and Nx will do most of the work in parallel.
 
 !!!!!
-Run `nx lint api --with-deps`. What do you see?
+Run `npx nx lint api --with-deps`. What do you see?
 !!!!!
 Nx read the output from cache instead of running the command for 1 out of 2 projects.
 Everything was retrieved from the cache

--- a/docs/angular/tutorial/11-test-affected-projects.md
+++ b/docs/angular/tutorial/11-test-affected-projects.md
@@ -26,7 +26,7 @@ git checkout -b testbranch
 
 Printing the affected projects can be handy, but usually you want to do something with them. For instance, you may want to test everything that has been affected.
 
-**Run `nx affected:test` to retest only the projects affected by the change.**
+**Run `npx nx affected:test` to retest only the projects affected by the change.**
 
 You will see the following:
 
@@ -54,12 +54,12 @@ You can run any target against the affected projects in the graph like this:
 
 ```bash
 # The following are equivalent
-nx affected --target=build
-nx affected:build
+npx nx affected --target=build
+npx nx affected:build
 ```
 
 !!!!!
-Run "nx affected --target=invalid --base=master". What do you see?
+Run "npx nx affected --target=invalid --base=master". What do you see?
 !!!!!
 No projects to run test
 The `todos` project failed as before

--- a/docs/react/tutorial/01-create-application.md
+++ b/docs/react/tutorial/01-create-application.md
@@ -71,10 +71,16 @@ The generate command added two projects to our workspace:
 Now that the application is set up, run it locally via:
 
 ```bash
-nx serve todos
+npx nx serve todos
 ```
 
 ## Note on the Nx CLI
+
+If you would prefer to run using a global installation of Nx, you can run:
+
+```bash
+nx serve todos
+```
 
 Depending on how your dev env is set up, the command above might result in `Command 'nx' not found`.
 
@@ -90,7 +96,7 @@ or
 yarn global add nx
 ```
 
-Or you can prepend every command with `npm run`:
+Alternatively, you can run the local installation of Nx by prepending every command with `npm run`:
 
 ```bash
 npm run nx -- serve todos

--- a/docs/react/tutorial/02-add-e2e-test.md
+++ b/docs/react/tutorial/02-add-e2e-test.md
@@ -29,7 +29,7 @@ describe('TodoApps', () => {
 
 This is not a great example of an E2E test, but it will suffice for the purposes of this tutorial.
 
-If you have not done so already, stop the `nx serve` command and run `nx e2e todos-e2e --watch`.
+If you have not done so already, stop the `npx nx serve` command and run `npx nx e2e todos-e2e --watch`.
 
 A UI will open. Click the button in the top right corner that says "Run all specs". Keep the E2E tests running.
 

--- a/docs/react/tutorial/03-display-todos.md
+++ b/docs/react/tutorial/03-display-todos.md
@@ -87,7 +87,7 @@ export default App;
 The tests should pass now.
 
 !!!!!
-What will you see if you run: `nx e2e todos-e2e --headless`
+What will you see if you run: `npx nx e2e todos-e2e --headless`
 !!!!!
 Cypress will run in the headless mode, and the test will pass.
 Cypress will run in the headless mode, and the test will fail.

--- a/docs/react/tutorial/04-connect-to-api.md
+++ b/docs/react/tutorial/04-connect-to-api.md
@@ -50,7 +50,7 @@ export default App;
 ```
 
 !!!!!
-Run `nx serve todos` and open http://localhost:4200. What do you see?
+Run `npx nx serve todos` and open http://localhost:4200. What do you see?
 !!!!!
 "the server responded with a status of 404 (Not Found)" in Console.
 Blank screen.

--- a/docs/react/tutorial/05-add-node-app.md
+++ b/docs/react/tutorial/05-add-node-app.md
@@ -4,7 +4,7 @@ The requests fail because the API has not been created yet. Using Nx you can dev
 
 ## Add Express Plugin to Your Workspace
 
-Nx is an open platform with plugins for many modern tools and frameworks. **To see some plugins, run `nx list`:**
+Nx is an open platform with plugins for many modern tools and frameworks. **To see some plugins, run `npx nx list`:**
 
 ```bash
 >  NX  Installed plugins:
@@ -36,7 +36,7 @@ Nx is an open platform with plugins for many modern tools and frameworks. **To s
   ...
 ```
 
-**Now run `nx list @nrwl/express`, and you will see:**
+**Now run `npx nx list @nrwl/express`, and you will see:**
 
 ```bash
 >  NX   NOTE  @nrwl/express is not currently installed
@@ -56,14 +56,14 @@ or
 yarn add --dev @nrwl/express
 ```
 
-> `@nrwl/express` also added `@nrwl/node`. Run `nx list @nrwl/express` and `nx list @nrwl/node` to see what those plugins provide.
+> `@nrwl/express` also added `@nrwl/node`. Run `npx nx list @nrwl/express` and `npx nx list @nrwl/node` to see what those plugins provide.
 
 ## Generate an Express Application
 
 **Run the following to generate a new Express application:**
 
 ```bash
-nx g @nrwl/express:app api --frontendProject=todos
+npx nx g @nrwl/express:app api --frontendProject=todos
 ```
 
 After this is done, you should see something like this:
@@ -98,9 +98,9 @@ The `apps` directory is where Nx places anything you can run: frontend applicati
 
 You can run:
 
-- `nx serve api` to serve the application
-- `nx build api` to build the application
-- `nx test api` to test the application
+- `npx nx serve api` to serve the application
+- `npx nx build api` to build the application
+- `npx nx test api` to test the application
 
 **Add a file `apps/api/src/app/todos.ts`.**
 
@@ -148,7 +148,7 @@ server.on('error', console.error);
 ```
 
 !!!!!
-Run "nx serve api" and open http://localhost:3333/api/todos. What do you see?
+Run "npx nx serve api" and open http://localhost:3333/api/todos. What do you see?
 !!!!!
 `[{"title":"Todo 1"},{"title":"Todo 2"}]`
 Blank screen

--- a/docs/react/tutorial/06-proxy.md
+++ b/docs/react/tutorial/06-proxy.md
@@ -36,20 +36,20 @@ It created a proxy configuration that allows the React application to talk to th
 }
 ```
 
-This configuration tells `nx serve` to forward all requests starting with `/api` to the process listening on port 3333.
+This configuration tells `npx nx serve` to forward all requests starting with `/api` to the process listening on port 3333.
 
 ## Workspace.json, Targets, Builders
 
-You configure your workspaces in `workspace.json`. This file contains the workspace projects with their architect targets. For instance, `todos` has the `build`, `serve`, `lint`, and `test` targets. This means that you can run `nx build todos`, `nx serve todos`, etc..
+You configure your workspaces in `workspace.json`. This file contains the workspace projects with their architect targets. For instance, `todos` has the `build`, `serve`, `lint`, and `test` targets. This means that you can run `npx nx build todos`, `npx nx serve todos`, etc..
 
 Every target uses a builder which actually runs this target. So targets are analogous to typed npm scripts, and builders are analogous to typed shell scripts.
 
 **Why not use shell scripts and npm scripts directly?**
 
-There are a lot of advantages to providing additional metadata to the build tool. For instance, you can introspect targets. `nx serve todos --help` results in:
+There are a lot of advantages to providing additional metadata to the build tool. For instance, you can introspect targets. `npx nx serve todos --help` results in:
 
 ```bash
-nx run todos:serve [options,...]
+npx nx run todos:serve [options,...]
 
 Options:
   --buildTarget           Target which builds the application`
@@ -73,7 +73,7 @@ It helps with good editor integration (see [VSCode Support](https://nx.dev/react
 But, most importantly, it provides a holistic dev experience regardless of the tools used, and enables advanced build features like distributed computation caching and distributed builds).
 
 !!!!!
-Now run both "nx serve todos" and "nx serve api" in separate terminals, open http://localhost:4200. What do you see?
+Now run both "npx nx serve todos" and "npx nx serve api" in separate terminals, open http://localhost:4200. What do you see?
 !!!!!
 Todos application is working!
 404 in the console

--- a/docs/react/tutorial/07-share-code.md
+++ b/docs/react/tutorial/07-share-code.md
@@ -5,7 +5,7 @@ Awesome! The application is working end to end! However, there is a problem. Bot
 **Run the following generator to create a library:**
 
 ```bash
-nx g @nrwl/workspace:lib data
+npx nx g @nrwl/workspace:lib data
 ```
 
 The result should look like this:
@@ -81,7 +81,7 @@ export const App = () => {
 export default App;
 ```
 
-Every time you add a new library, you have to restart `nx serve`. **So restart both `nx serve api` and `nx serve todos` and you should see the application running.**
+Every time you add a new library, you have to restart `npx nx serve`. **So restart both `npx nx serve api` and `npx nx serve todos` and you should see the application running.**
 
 !!!!!
 Nx allows you to share code...

--- a/docs/react/tutorial/08-create-libs.md
+++ b/docs/react/tutorial/08-create-libs.md
@@ -13,7 +13,7 @@ To illustrate how useful libraries can be, create a library of React components.
 Run
 
 ```bash
-nx g @nrwl/react:lib ui
+npx nx g @nrwl/react:lib ui
 ```
 
 You should see the following:
@@ -71,7 +71,7 @@ Here, you can either change the UI component or generate a new one.
 **Add a component to the newly created ui library by running:**
 
 ```bash
-nx g @nrwl/react:component todos --project=ui --export
+npx nx g @nrwl/react:component todos --project=ui --export
 ```
 
 ```treeview
@@ -167,9 +167,9 @@ const App = () => {
 export default App;
 ```
 
-**Restart both `nx serve api` and `nx serve todos` and you should see the application running.**
+**Restart both `npx nx serve api` and `npx nx serve todos` and you should see the application running.**
 
-> Nx helps you explore code generation options. Run `nx g @nrwl/react:component --help` to see all options available. Pass `--dry-run` to the command to see what would be generated without actually changing anything, like this: `nx g @nrwl/react:component mycmp --project=ui --dry-run`.
+> Nx helps you explore code generation options. Run `npx nx g @nrwl/react:component --help` to see all options available. Pass `--dry-run` to the command to see what would be generated without actually changing anything, like this: `npx nx g @nrwl/react:component mycmp --project=ui --dry-run`.
 
 !!!!!
 Libraries' public API is defined in...

--- a/docs/react/tutorial/09-dep-graph.md
+++ b/docs/react/tutorial/09-dep-graph.md
@@ -7,7 +7,7 @@ Previously, some senior architect would create an ad-hoc dependency diagram and 
 With Nx, you can do better than that.
 
 !!!!!
-Run "nx dep-graph". What do you see?
+Run "npx nx dep-graph". What do you see?
 !!!!!
 A dependency diagram in the browser
 A dep-graph.html file created at the root of the workspace

--- a/docs/react/tutorial/10-computation-caching.md
+++ b/docs/react/tutorial/10-computation-caching.md
@@ -2,10 +2,10 @@
 
 Nx has built-in computation caching, which helps drastically improve the performance of the commands.
 
-**To see it in action, run `nx build todos`:**
+**To see it in action, run `npx nx build todos`:**
 
 ```bash
-> nx run todos:build
+> npx nx run todos:build
 
 Starting type checking service...
 Using 14 workers with 2048MB memory limit
@@ -20,10 +20,10 @@ chunk    {2} polyfills.55535a35b1529d884ca3.esm.js (polyfills) 239 KiB ={0}= [in
 chunk    {3} styles.3ff695c00d717f2d2a11.css (styles) 147 bytes ={0}= [initial] [rendered]
 ```
 
-**Now, run `nx build todos` again, and you will see the results appearing instantly:**
+**Now, run `npx nx build todos` again, and you will see the results appearing instantly:**
 
 ```bash
-> nx run todos:build
+> npx nx run todos:build
 
 >  NX   NOTE  Cached Output:
 
@@ -44,7 +44,7 @@ Based on the state of the source code and the environment, Nx was able to figure
 
 ## Building Multiple Projects
 
-**Now, run `nx run-many --target=build --projects=todos,api` to rebuild the two applications:**
+**Now, run `npx nx run-many --target=build --projects=todos,api` to rebuild the two applications:**
 
 ```bash
 Nx read the output from cache instead of running the command for 1 out of 2 projects.
@@ -56,28 +56,28 @@ Nx built `api` and retrieved `todos` from its computation cache. Read more about
 
 As we saw already, Nx is smart, so it knows how applications and libraries in the workspace depend on each other.
 
-**Run `nx lint todos --with-deps`, and you see that Nx lints both the `todos` app and the libraries it depends on.**
+**Run `npx nx lint todos --with-deps`, and you see that Nx lints both the `todos` app and the libraries it depends on.**
 
 ```bash
 >  NX  Running target lint for project todos and its 2 deps.
 
 ———————————————————————————————————————————————
 
-> nx run todos:lint
+> npx nx run todos:lint
 
 Linting "todos"...
 
 All files pass linting.
 
 
-> nx run ui:lint
+> npx nx run ui:lint
 
 Linting "ui"...
 
 All files pass linting.
 
 
-> nx run data:lint
+> npx nx run data:lint
 
 Linting "data"...
 
@@ -92,7 +92,7 @@ All files pass linting.
 > Add --parallel to any command, and Nx will do most of the work in parallel.
 
 !!!!!
-Run `nx lint api --with-deps`. What do you see?
+Run `npx nx lint api --with-deps`. What do you see?
 !!!!!
 Nx read the output from cache instead of running the command for 1 out of 2 projects.
 Everything was retrieved from the cache

--- a/docs/react/tutorial/11-test-affected-projects.md
+++ b/docs/react/tutorial/11-test-affected-projects.md
@@ -29,15 +29,15 @@ export const Todos = (props: { todos: Todo[] }) => {
 export default Todos;
 ```
 
-**Run `nx affected:apps`**, and you should see `todos` printed out. The `affected:apps` looks at what you have changed and uses the dependency graph to figure out which apps can be affected by this change.
+**Run `npx nx affected:apps`**, and you should see `todos` printed out. The `affected:apps` looks at what you have changed and uses the dependency graph to figure out which apps can be affected by this change.
 
-**Run `nx affected:libs`**, and you should see `ui` printed out. This command works similarly, but instead of printing the affected apps, it prints the affected libs.
+**Run `npx nx affected:libs`**, and you should see `ui` printed out. This command works similarly, but instead of printing the affected apps, it prints the affected libs.
 
 ## Test Affected Projects
 
 Printing the affected projects can be handy, but usually you want to do something with them. For instance, you may want to test everything that has been affected.
 
-**Run `nx affected:test` to retest only the projects affected by the change.**
+**Run `npx nx affected:test` to retest only the projects affected by the change.**
 
 As you can see, since we updated the code, without updating the tests, the unit tests failed.
 
@@ -63,12 +63,12 @@ You can run any target against the affected projects in the graph like this:
 
 ```bash
 # The following are equivalent
-nx affected --target=build
-nx affected:build
+npx nx affected --target=build
+npx nx affected:build
 ```
 
 !!!!!
-Run "nx affected --target=invalid --base=master". What do you see?
+Run "npx nx affected --target=invalid --base=master". What do you see?
 !!!!!
 No projects with "invalid" were run
 An error message saying that the "invalid" target is invalid


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

This PR updates the React & Angular tutorials to use `npx` for command execution using your workspace's local installation of the Nx CLI, instead of assuming a globally installed installation of Nx. ✨ 

I found the getting started tutorial a bit annoying to work through because all of the commands assume you have Nx installed globally and can run `nx serve` (etc), when global installations of npm packages are an anti-pattern. I also found it weird that the primary alternative the docs encouraged was prepending every command with `npm run` (e.g. `npm run nx -- serve`), when it can be pretty verbose and error-prone in practice, and when it's been superseded by `npx` for exactly this kind of use case. `npx` will run your project's local installation of Nx, or otherwise install it for you and then run it. 

`npx` is already used elsewhere in the Nx docs, so hopefully this won't be too controversial. 