### PR TITLE
fix(web): adding missing @rollup/plugin-json dependency

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -48,7 +48,7 @@
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-babel": "5.0.2",
     "@rollup/plugin-image": "2.0.4",
-    "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "7.1.1",
     "ajv": "6.10.2",
     "autoprefixer": "9.7.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -48,6 +48,7 @@
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-babel": "5.0.2",
     "@rollup/plugin-image": "2.0.4",
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "7.1.1",
     "ajv": "6.10.2",
     "autoprefixer": "9.7.4",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The web package is missing the `@rollup/plugin-json` dependency. It currently throws the following error:

```
Cannot find module '@rollup/plugin-json'
```

Likely caused by this commit: https://github.com/nrwl/nx/commit/434cb21366ee1492e06795a1773edbad682b5410

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The web builder should run as expected

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/3781
