### PR TITLE
fix(core): declare `cli` as direct dependency

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -68,7 +68,6 @@
     "yargs": "15.4.1",
     "yargs-parser": "20.0.0",
     "chalk": "2.4.2",
-    "@nrwl/cli": "*",
     "axios": "0.19.2",
     "flat": "^5.0.2",
     "minimatch": "3.0.4",

--- a/packages/workspace/src/schematics/workspace/files/package.json__tmpl__
+++ b/packages/workspace/src/schematics/workspace/files/package.json__tmpl__
@@ -41,6 +41,7 @@
   "dependencies": {},
   "devDependencies": {
      <% if(cli === 'angular') { %>"@angular/cli": "<%= angularCliVersion %>",<% } %>
+    "@nrwl/cli": "<%= nxVersion %>",
     "@nrwl/workspace": "<%= nxVersion %>",
     "@types/node": "~8.9.4",
     "dotenv": "6.2.0",


### PR DESCRIPTION
Having `cli` as dependency of `workspace` was working because of the flattened module structure that NPM/Yarn use. On stricter package managers like PNPM and Yarn 2 this is not the case, and any `pnpm nx` or `yarn nx` command was failing because `@nrwl/cli` couldn't be located.

ISSUES CLOSED: #2944
