### PR TITLE
fix(repo): tests and e2e, enable linting for workspace to set baseline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,9 @@ jobs:
       - run:
           name: Check Commit Message Format
           command: yarn checkcommit
+      - run:
+          name: Run linting
+          command: yarn lint
   e2e-1:
     executor: default
     steps:

--- a/e2e/workspace/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace/src/workspace-aux-commands.test.ts
@@ -752,8 +752,8 @@ forEachCli((cli) => {
       expect(moveOutput).toContain(`CREATE ${jestConfigPath}`);
       checkFilesExist(jestConfigPath);
       const jestConfig = readFile(jestConfigPath);
-      expect(jestConfig).toContain(`name: 'shared-${lib1}-data-access'`);
-      expect(jestConfig).toContain(`preset: '../../../../jest.config.js'`);
+      expect(jestConfig).toContain(`displayName: 'shared-${lib1}-data-access'`);
+      expect(jestConfig).toContain(`preset: '../../../../jest.preset.js'`);
       expect(jestConfig).toContain(
         `coverageDirectory: '../../../../coverage/${newPath}'`
       );
@@ -891,8 +891,8 @@ forEachCli((cli) => {
       expect(moveOutput).toContain(`CREATE ${jestConfigPath}`);
       checkFilesExist(jestConfigPath);
       const jestConfig = readFile(jestConfigPath);
-      expect(jestConfig).toContain(`name: 'shared-${lib1}-data-access'`);
-      expect(jestConfig).toContain(`preset: '../../../../jest.config.js'`);
+      expect(jestConfig).toContain(`displayName: 'shared-${lib1}-data-access'`);
+      expect(jestConfig).toContain(`preset: '../../../../jest.preset.js'`);
       expect(jestConfig).toContain(
         `coverageDirectory: '../../../../coverage/${newPath}'`
       );
@@ -1032,8 +1032,8 @@ forEachCli((cli) => {
       expect(moveOutput).toContain(`CREATE ${jestConfigPath}`);
       checkFilesExist(jestConfigPath);
       const jestConfig = readFile(jestConfigPath);
-      expect(jestConfig).toContain(`name: 'shared-${lib1}-data-access'`);
-      expect(jestConfig).toContain(`preset: '../../../../jest.config.js'`);
+      expect(jestConfig).toContain(`displayName: 'shared-${lib1}-data-access'`);
+      expect(jestConfig).toContain(`preset: '../../../../jest.preset.js'`);
       expect(jestConfig).toContain(
         `coverageDirectory: '../../../../coverage/${newPath}'`
       );

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format": "./scripts/format.sh",
     "nx-release": "./scripts/nx-release.js",
     "test": "nx run-many --target=test --all --parallel",
+    "lint": "nx run-many --target=lint --all --parallel",
     "checkformat": "scripts/check-format.sh",
     "checkimports": "node ./scripts/check-imports.js",
     "checkversions": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/check-versions.ts",

--- a/packages/workspace/src/schematics/library/library.spec.ts
+++ b/packages/workspace/src/schematics/library/library.spec.ts
@@ -114,8 +114,8 @@ describe('lib', () => {
       expect(tree.readContent(`libs/my-lib/jest.config.js`))
         .toMatchInlineSnapshot(`
         "module.exports = {
-          name: 'my-lib',
-          preset: '../../jest.config.js',
+          displayName: 'my-lib',
+          preset: '../../jest.preset.js',
           globals: {
             'ts-jest': {
               tsConfig: '<rootDir>/tsconfig.spec.json',
@@ -376,8 +376,8 @@ describe('lib', () => {
       expect(tree.readContent(`libs/my-lib/jest.config.js`))
         .toMatchInlineSnapshot(`
         "module.exports = {
-          name: 'my-lib',
-          preset: '../../jest.config.js',
+          displayName: 'my-lib',
+          preset: '../../jest.preset.js',
           transform: {
             '^.+\\\\\\\\.[tj]sx?$': [
               'babel-jest',

--- a/workspace.json
+++ b/workspace.json
@@ -54,6 +54,18 @@
             ],
             "parallel": false
           }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/nx/.eslintrc",
+            "tsConfig": [
+              "packages/nx/tsconfig.lib.json",
+              "packages/nx/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
+          }
         }
       }
     },
@@ -200,6 +212,18 @@
             ],
             "parallel": false
           }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/workspace/.eslintrc",
+            "tsConfig": [
+              "packages/workspace/tsconfig.lib.json",
+              "packages/workspace/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
+          }
         }
       }
     },
@@ -268,6 +292,18 @@
             ],
             "parallel": false
           }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/web/.eslintrc",
+            "tsConfig": [
+              "packages/web/tsconfig.lib.json",
+              "packages/web/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
+          }
         }
       }
     },
@@ -330,6 +366,18 @@
               }
             ],
             "parallel": false
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/cypress/.eslintrc",
+            "tsConfig": [
+              "packages/cypress/tsconfig.lib.json",
+              "packages/cypress/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
           }
         }
       }
@@ -394,6 +442,18 @@
             ],
             "parallel": false
           }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/jest/.eslintrc",
+            "tsConfig": [
+              "packages/jest/tsconfig.lib.json",
+              "packages/jest/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
+          }
         }
       }
     },
@@ -456,6 +516,18 @@
               }
             ],
             "parallel": false
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/storybook/.eslintrc",
+            "tsConfig": [
+              "packages/storybook/tsconfig.lib.json",
+              "packages/storybook/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
           }
         }
       }
@@ -523,6 +595,18 @@
             ],
             "parallel": false
           }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/react/.eslintrc",
+            "tsConfig": [
+              "packages/react/tsconfig.lib.json",
+              "packages/react/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
+          }
         }
       }
     },
@@ -586,6 +670,18 @@
             ],
             "parallel": false
           }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/nx-plugin/.eslintrc",
+            "tsConfig": [
+              "packages/nx-plugin/tsconfig.lib.json",
+              "packages/nx-plugin/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
+          }
         }
       }
     },
@@ -648,6 +744,18 @@
               }
             ],
             "parallel": false
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/node/.eslintrc",
+            "tsConfig": [
+              "packages/node/tsconfig.lib.json",
+              "packages/node/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
           }
         }
       }
@@ -717,6 +825,18 @@
             ],
             "parallel": false
           }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/next/.eslintrc",
+            "tsConfig": [
+              "packages/next/tsconfig.lib.json",
+              "packages/next/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
+          }
         }
       }
     },
@@ -779,6 +899,18 @@
               }
             ],
             "parallel": false
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/nest/.eslintrc",
+            "tsConfig": [
+              "packages/nest/tsconfig.lib.json",
+              "packages/nest/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
           }
         }
       }
@@ -843,6 +975,18 @@
             ],
             "parallel": false
           }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/linter/.eslintrc",
+            "tsConfig": [
+              "packages/linter/tsconfig.lib.json",
+              "packages/linter/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
+          }
         }
       }
     },
@@ -906,6 +1050,18 @@
             ],
             "parallel": false
           }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/express/.eslintrc",
+            "tsConfig": [
+              "packages/express/tsconfig.lib.json",
+              "packages/express/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
+          }
         }
       }
     },
@@ -968,6 +1124,18 @@
               }
             ],
             "parallel": false
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/eslint-plugin-nx/.eslintrc",
+            "tsConfig": [
+              "packages/eslint-plugin-nx/tsconfig.lib.json",
+              "packages/eslint-plugin-nx/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
           }
         }
       }
@@ -1035,6 +1203,18 @@
             ],
             "parallel": false
           }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/create-nx-workspace/.eslintrc",
+            "tsConfig": [
+              "packages/create-nx-workspace/tsconfig.lib.json",
+              "packages/create-nx-workspace/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
+          }
         }
       }
     },
@@ -1100,6 +1280,18 @@
               }
             ],
             "parallel": false
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/create-nx-plugin/.eslintrc",
+            "tsConfig": [
+              "packages/create-nx-plugin/tsconfig.lib.json",
+              "packages/create-nx-plugin/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
           }
         }
       }
@@ -1167,6 +1359,18 @@
             ],
             "parallel": false
           }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/cli/.eslintrc",
+            "tsConfig": [
+              "packages/cli/tsconfig.lib.json",
+              "packages/cli/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
+          }
         }
       }
     },
@@ -1229,6 +1433,18 @@
               }
             ],
             "parallel": false
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/bazel/.eslintrc",
+            "tsConfig": [
+              "packages/bazel/tsconfig.lib.json",
+              "packages/bazel/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
           }
         }
       }
@@ -1300,6 +1516,18 @@
               }
             ],
             "parallel": false
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "packages/angular/.eslintrc",
+            "tsConfig": [
+              "packages/angular/tsconfig.lib.json",
+              "packages/angular/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**"]
           }
         }
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Master has broken tests and e2e suites introduced by https://github.com/nrwl/nx/pull/3766. (This needs further investigation into how this could have happened)

Additionally, linting is not set up for most projects in the Nx workspace (original purpose of PR)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

All tests and e2e suites should work and linting should be set up for all projects and should run in CI.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

As suggested to @FrozenPandaz, it is important that we set up a baseline of linting today before we merge https://github.com/nrwl/nx/pull/3763 so that we can appropriately get an idea of before and after, and so that we can dogfood the automated migrations.