### PR TITLE
fix: make external use correct npm package name

### DIFF
--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -234,7 +234,7 @@ export function createRollupOptions(
       : {};
 
     const externalPackages = dependencies
-      .map((d) => d.name)
+      .map((d) => d.name.split(':')[1])
       .concat(options.external || [])
       .concat(Object.keys(packageJson.dependencies || {}));
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Those lines: https://github.com/nrwl/nx/blob/e6e2dc67aac472aa4fafebf50e98af8a98c94984/packages/web/src/builders/package/package.impl.ts#L236-L237

will produce:

```js
[
  'npm:yup',
  'npm:formik',
  'npm:react',
]
```

## Expected Behavior

```js
[
  'yup',
  'formik',
  'react',
]
```

## Related Issue(s)
https://github.com/nrwl/nx/issues/3629

