### PR TITLE
fix(react): calculate npm project dependencies correctly

### DIFF
--- a/packages/web/src/builders/package/package.impl.spec.ts
+++ b/packages/web/src/builders/package/package.impl.spec.ts
@@ -1,21 +1,11 @@
 const mockCopyPlugin = jest.fn();
 jest.mock('rollup-plugin-copy', () => mockCopyPlugin);
 
-import { of, throwError } from 'rxjs';
-import { join } from 'path';
-
-import { workspaces } from '@angular-devkit/core';
-
-import * as f from '@nrwl/workspace/src/utils/fileutils';
 import { MockBuilderContext } from '@nrwl/workspace/testing';
 
-import * as impl from './package.impl';
-import * as rr from './run-rollup';
+import { createRollupOptions } from './package.impl';
 import { getMockContext } from '../../utils/testing';
 import { PackageBuilderOptions } from '../../utils/types';
-import * as projectGraphUtils from '@nrwl/workspace/src/core/project-graph';
-import { ProjectGraph } from '@nrwl/workspace/src/core/project-graph';
-import { createRollupOptions } from './package.impl';
 import { normalizePackageOptions } from '@nrwl/web/src/utils/normalize';
 
 jest.mock('tsconfig-paths-webpack-plugin');
@@ -23,8 +13,6 @@ jest.mock('tsconfig-paths-webpack-plugin');
 describe('WebPackagebuilder', () => {
   let context: MockBuilderContext;
   let testOptions: PackageBuilderOptions;
-  let runRollup: jasmine.Spy;
-  let writeJsonFile: jasmine.Spy;
 
   beforeEach(async () => {
     context = await getMockContext();

--- a/packages/workspace/src/utils/buildable-libs-utils.ts
+++ b/packages/workspace/src/utils/buildable-libs-utils.ts
@@ -63,7 +63,7 @@ export function calculateProjectDependencies(
         };
       } else if (depNode.type === 'npm') {
         return {
-          name: depNode.name,
+          name: depNode.data.packageName,
           outputs: [],
           node: depNode,
         };

--- a/packages/workspace/src/utils/testing.ts
+++ b/packages/workspace/src/utils/testing.ts
@@ -3,6 +3,10 @@ import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import { Rule, Tree } from '@angular-devkit/schematics';
 import { names } from './name-utils';
 import { updateWorkspace } from './workspace';
+import { TestingArchitectHost } from '@angular-devkit/architect/testing';
+import { schema } from '@angular-devkit/core';
+import { Architect } from '@angular-devkit/architect';
+import { MockBuilderContext } from '@nrwl/workspace/testing';
 
 const testRunner = new SchematicTestRunner(
   '@nrwl/workspace',
@@ -101,4 +105,24 @@ export function createLibWithTests(
     }),
     tree
   );
+}
+
+export async function getTestArchitect() {
+  const architectHost = new TestingArchitectHost('/root', '/root');
+  const registry = new schema.CoreSchemaRegistry();
+  registry.addPostTransform(schema.transforms.addUndefinedDefaults);
+
+  const architect = new Architect(architectHost, registry);
+
+  await architectHost.addBuilderFromPackage(join(__dirname, '../..'));
+
+  return [architect, architectHost] as [Architect, TestingArchitectHost];
+}
+
+export async function getMockContext() {
+  const [architect, architectHost] = await getTestArchitect();
+
+  const context = new MockBuilderContext(architect, architectHost);
+  await context.addBuilderFromPackage(join(__dirname, '../..'));
+  return context;
 }


### PR DESCRIPTION
This PR fixes and issue where nx calculates npm package dependencies with `npm:...` name instead of the actual package name.

## Current Behavior

If you include formik into a buildable library, it'll error on build.

## Expected Behavior

Should be able to build with formik since it should be detected as an external dependency.

## Related Issue(s)

Fixes #3629
