### PR TITLE
cleanup(repo): avoid node_modules references on plugin list

### DIFF
--- a/packages/workspace/src/command-line/list.ts
+++ b/packages/workspace/src/command-line/list.ts
@@ -4,7 +4,7 @@ import { output } from '../utils/output';
 import {
   fetchCommunityPlugins,
   fetchCorePlugins,
-  getInstalledPluginsFromNodeModules,
+  getInstalledPluginsFromPackageJson,
   listCommunityPlugins,
   listCorePlugins,
   listInstalledPlugins,
@@ -43,7 +43,7 @@ async function listHandler(args: YargsListArgs) {
   } else {
     const corePlugins = await fetchCorePlugins();
     const communityPlugins = await fetchCommunityPlugins();
-    const installedPlugins = getInstalledPluginsFromNodeModules(
+    const installedPlugins = getInstalledPluginsFromPackageJson(
       appRootPath,
       corePlugins,
       communityPlugins

--- a/packages/workspace/src/utils/plugins/index.ts
+++ b/packages/workspace/src/utils/plugins/index.ts
@@ -4,7 +4,7 @@ export {
 } from './community-plugins';
 export { fetchCorePlugins, listCorePlugins } from './core-plugins';
 export {
-  getInstalledPluginsFromNodeModules,
+  getInstalledPluginsFromPackageJson,
   listInstalledPlugins,
 } from './installed-plugins';
 export {


### PR DESCRIPTION
Towards Yarn 2 support 😃 nx list command doesn't rely on node_modules path.