### PR TITLE
feat(core): exclude projects from affected based on tags

### DIFF
--- a/docs/angular/cli/affected-apps.md
+++ b/docs/angular/cli/affected-apps.md
@@ -50,6 +50,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/angular/cli/affected-apps.md
+++ b/docs/angular/cli/affected-apps.md
@@ -52,8 +52,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/angular/cli/affected-build.md
+++ b/docs/angular/cli/affected-build.md
@@ -80,6 +80,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/angular/cli/affected-build.md
+++ b/docs/angular/cli/affected-build.md
@@ -82,8 +82,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/angular/cli/affected-dep-graph.md
+++ b/docs/angular/cli/affected-dep-graph.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### file

--- a/docs/angular/cli/affected-dep-graph.md
+++ b/docs/angular/cli/affected-dep-graph.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### file
 
 output file (e.g. --file=output.json or --file=dep-graph.html)

--- a/docs/angular/cli/affected-e2e.md
+++ b/docs/angular/cli/affected-e2e.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/angular/cli/affected-e2e.md
+++ b/docs/angular/cli/affected-e2e.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/angular/cli/affected-libs.md
+++ b/docs/angular/cli/affected-libs.md
@@ -50,6 +50,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/angular/cli/affected-libs.md
+++ b/docs/angular/cli/affected-libs.md
@@ -52,8 +52,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/angular/cli/affected-lint.md
+++ b/docs/angular/cli/affected-lint.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/angular/cli/affected-lint.md
+++ b/docs/angular/cli/affected-lint.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/angular/cli/affected-test.md
+++ b/docs/angular/cli/affected-test.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/angular/cli/affected-test.md
+++ b/docs/angular/cli/affected-test.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/angular/cli/affected.md
+++ b/docs/angular/cli/affected.md
@@ -86,6 +86,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/angular/cli/affected.md
+++ b/docs/angular/cli/affected.md
@@ -88,8 +88,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/angular/cli/format-check.md
+++ b/docs/angular/cli/format-check.md
@@ -32,8 +32,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/angular/cli/format-check.md
+++ b/docs/angular/cli/format-check.md
@@ -30,6 +30,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/angular/cli/format-write.md
+++ b/docs/angular/cli/format-write.md
@@ -32,8 +32,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/angular/cli/format-write.md
+++ b/docs/angular/cli/format-write.md
@@ -30,6 +30,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/angular/cli/print-affected.md
+++ b/docs/angular/cli/print-affected.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/angular/cli/print-affected.md
+++ b/docs/angular/cli/print-affected.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/node/cli/affected-apps.md
+++ b/docs/node/cli/affected-apps.md
@@ -50,6 +50,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/node/cli/affected-apps.md
+++ b/docs/node/cli/affected-apps.md
@@ -52,8 +52,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/node/cli/affected-build.md
+++ b/docs/node/cli/affected-build.md
@@ -80,6 +80,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/node/cli/affected-build.md
+++ b/docs/node/cli/affected-build.md
@@ -82,8 +82,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/node/cli/affected-dep-graph.md
+++ b/docs/node/cli/affected-dep-graph.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### file

--- a/docs/node/cli/affected-dep-graph.md
+++ b/docs/node/cli/affected-dep-graph.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### file
 
 output file (e.g. --file=output.json or --file=dep-graph.html)

--- a/docs/node/cli/affected-e2e.md
+++ b/docs/node/cli/affected-e2e.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/node/cli/affected-e2e.md
+++ b/docs/node/cli/affected-e2e.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/node/cli/affected-libs.md
+++ b/docs/node/cli/affected-libs.md
@@ -50,6 +50,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/node/cli/affected-libs.md
+++ b/docs/node/cli/affected-libs.md
@@ -52,8 +52,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/node/cli/affected-lint.md
+++ b/docs/node/cli/affected-lint.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/node/cli/affected-lint.md
+++ b/docs/node/cli/affected-lint.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/node/cli/affected-test.md
+++ b/docs/node/cli/affected-test.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/node/cli/affected-test.md
+++ b/docs/node/cli/affected-test.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/node/cli/affected.md
+++ b/docs/node/cli/affected.md
@@ -86,6 +86,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/node/cli/affected.md
+++ b/docs/node/cli/affected.md
@@ -88,8 +88,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/node/cli/format-check.md
+++ b/docs/node/cli/format-check.md
@@ -32,8 +32,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/node/cli/format-check.md
+++ b/docs/node/cli/format-check.md
@@ -30,6 +30,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/node/cli/format-write.md
+++ b/docs/node/cli/format-write.md
@@ -32,8 +32,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/node/cli/format-write.md
+++ b/docs/node/cli/format-write.md
@@ -30,6 +30,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/node/cli/print-affected.md
+++ b/docs/node/cli/print-affected.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/node/cli/print-affected.md
+++ b/docs/node/cli/print-affected.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/react/cli/affected-apps.md
+++ b/docs/react/cli/affected-apps.md
@@ -50,6 +50,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/react/cli/affected-apps.md
+++ b/docs/react/cli/affected-apps.md
@@ -52,8 +52,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/react/cli/affected-build.md
+++ b/docs/react/cli/affected-build.md
@@ -80,6 +80,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/react/cli/affected-build.md
+++ b/docs/react/cli/affected-build.md
@@ -82,8 +82,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/react/cli/affected-dep-graph.md
+++ b/docs/react/cli/affected-dep-graph.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### file

--- a/docs/react/cli/affected-dep-graph.md
+++ b/docs/react/cli/affected-dep-graph.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### file
 
 output file (e.g. --file=output.json or --file=dep-graph.html)

--- a/docs/react/cli/affected-e2e.md
+++ b/docs/react/cli/affected-e2e.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/react/cli/affected-e2e.md
+++ b/docs/react/cli/affected-e2e.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/react/cli/affected-libs.md
+++ b/docs/react/cli/affected-libs.md
@@ -50,6 +50,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/react/cli/affected-libs.md
+++ b/docs/react/cli/affected-libs.md
@@ -52,8 +52,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/react/cli/affected-lint.md
+++ b/docs/react/cli/affected-lint.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/react/cli/affected-lint.md
+++ b/docs/react/cli/affected-lint.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/react/cli/affected-test.md
+++ b/docs/react/cli/affected-test.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/react/cli/affected-test.md
+++ b/docs/react/cli/affected-test.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/react/cli/affected.md
+++ b/docs/react/cli/affected.md
@@ -86,6 +86,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/react/cli/affected.md
+++ b/docs/react/cli/affected.md
@@ -88,8 +88,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/react/cli/format-check.md
+++ b/docs/react/cli/format-check.md
@@ -32,8 +32,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/react/cli/format-check.md
+++ b/docs/react/cli/format-check.md
@@ -30,6 +30,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/react/cli/format-write.md
+++ b/docs/react/cli/format-write.md
@@ -32,8 +32,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/react/cli/format-write.md
+++ b/docs/react/cli/format-write.md
@@ -30,6 +30,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/docs/react/cli/print-affected.md
+++ b/docs/react/cli/print-affected.md
@@ -70,8 +70,6 @@ Exclude certain projects from being processed
 
 ### excludeTags
 
-Default: ``
-
 Exclude projects with tags matching one or more of the provided tags
 
 ### files

--- a/docs/react/cli/print-affected.md
+++ b/docs/react/cli/print-affected.md
@@ -68,6 +68,12 @@ Default: ``
 
 Exclude certain projects from being processed
 
+### excludeTags
+
+Default: ``
+
+Exclude projects with tags matching one or more of the provided tags
+
 ### files
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nrwl/nx-source",
-  "version": "10.2.1",
+  "version": "999.9.8",
   "description": "Extensible Dev Tools for Monorepos",
   "homepage": "https://nx.dev",
   "main": "index.js",

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -51,6 +51,7 @@ export async function affected(
       (n) =>
         !parsedArgs.exclude.includes(n.name) &&
         env.nxJson.projects[n.name] &&
+        Array.isArray(parsedArgs.excludeTags) &&
         env.nxJson.projects[n.name].tags.filter((tag) =>
           parsedArgs.excludeTags.includes(tag)
         ).length === 0

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -47,7 +47,14 @@ export async function affected(
   const projects = parsedArgs.all ? projectGraph.nodes : affectedGraph.nodes;
   const env = readEnvironment(nxArgs.target, projects);
   const affectedProjects = Object.values(projects)
-    .filter((n) => !parsedArgs.exclude.includes(n.name))
+    .filter(
+      (n) =>
+        !parsedArgs.exclude.includes(n.name) &&
+        env.nxJson.projects[n.name] &&
+        env.nxJson.projects[n.name].tags.filter((tag) =>
+          parsedArgs.excludeTags.includes(tag)
+        ).length === 0
+    )
     .filter(
       (n) => !parsedArgs.onlyFailed || !env.workspaceResults.getResult(n.name)
     );

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -285,7 +285,6 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
       type: 'array',
       requiresArg: false,
       coerce: parseCSV,
-      default: [],
     })
     .conflicts({
       files: ['uncommitted', 'untracked', 'base', 'head', 'all'],

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -279,6 +279,14 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
     .option('verbose', {
       describe: 'Print additional error stack trace on failure',
     })
+    .option('excludeTags', {
+      describe:
+        'Exclude projects with tags matching one or more of the provided tags',
+      type: 'array',
+      requiresArg: false,
+      coerce: parseCSV,
+      default: [],
+    })
     .conflicts({
       files: ['uncommitted', 'untracked', 'base', 'head', 'all'],
       untracked: ['uncommitted', 'files', 'base', 'head', 'all'],

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -72,6 +72,7 @@ export interface NxArgs {
   skipNxCache?: boolean;
   'skip-nx-cache'?: boolean;
   scan?: boolean;
+  excludeTags?: string[];
 }
 
 const ignoreArgs = ['$0', '_'];

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -138,10 +138,6 @@ export function splitArgsIntoNxArgsAndOverrides(
     nxArgs.skipNxCache = false;
   }
 
-  if (!nxArgs.excludeTags) {
-    nxArgs.excludeTags = [];
-  }
-
   return { nxArgs, overrides };
 }
 

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -138,6 +138,10 @@ export function splitArgsIntoNxArgsAndOverrides(
     nxArgs.skipNxCache = false;
   }
 
+  if (!nxArgs.excludeTags) {
+    nxArgs.excludeTags = [];
+  }
+
   return { nxArgs, overrides };
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There is no current way to exclude projects from `affected:*` commands based on tags (only explicitly with project name).

## Expected Behavior
Should be able to pass in a csv list of tags to exclude from affected commands

`yarn nx affected:libs --excludeTags="scope:noop"`

Any libraries with `scope:noop` in their tags array in `nx.json` should not be considered affected
