### PR TITLE
fix(repo): add migration for cli dependency

### DIFF
--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -109,6 +109,11 @@
       "version": "10.1.0-beta.0",
       "description": "Migrate .eslintrc files to use tsconfig with a wildcard",
       "factory": "./src/migrations/update-10-1-0/migrate-eslintrc-tsconfig-wildcard"
+    },
+    "add-cli-dependency": {
+      "version": "10.3.0-beta.0",
+      "description": "Add @nrwl/cli as dependency",
+      "factory": "./src/migrations/update-10-3-0/add-cli-dependency"
     }
   },
   "packageJsonUpdates": {

--- a/packages/workspace/src/migrations/update-10-3-0/add-cli-dependency.spec.ts
+++ b/packages/workspace/src/migrations/update-10-3-0/add-cli-dependency.spec.ts
@@ -1,0 +1,24 @@
+import { Tree } from '@angular-devkit/schematics';
+import { callRule, runMigration } from '../../utils/testing';
+import { readJsonInTree, serializeJson } from '@nrwl/workspace';
+import { nxVersion } from '../../../src/utils/versions';
+
+describe('CLI dependency migration', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = Tree.empty();
+    tree.create(
+      'package.json',
+      serializeJson({
+        devDependencies: {},
+      })
+    );
+  });
+
+  it.only('should add @nrwl/cli to package.json', async () => {
+    const result = await runMigration('add-cli-dependency', {}, tree);
+    const packageJson = readJsonInTree(result, 'package.json');
+    expect(packageJson.devDependencies['@nrwl/cli']).toEqual(nxVersion);
+  });
+});

--- a/packages/workspace/src/migrations/update-10-3-0/add-cli-dependency.ts
+++ b/packages/workspace/src/migrations/update-10-3-0/add-cli-dependency.ts
@@ -1,0 +1,10 @@
+import { chain, Rule } from '@angular-devkit/schematics';
+import { formatFiles, addDepsToPackageJson } from '@nrwl/workspace';
+import { nxVersion } from '../../../src/utils/versions';
+
+export default function update(): Rule {
+  return chain([
+    addDepsToPackageJson({}, { '@nrwl/cli': nxVersion }),
+    formatFiles(),
+  ]);
+}


### PR DESCRIPTION
As @FrozenPandaz noticed we will need a migration for 21bbd1e90ad7f48435a46776edc7e225c6f741d7.
