### PR TITLE
fix(core): fix lint failures for npm packages

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -18,6 +18,7 @@ import { createESLintRule } from '../utils/create-eslint-rule';
 import { normalize } from '@angular-devkit/core';
 import {
   createProjectGraph,
+  isNpmProject,
   ProjectGraph,
   ProjectType,
 } from '@nrwl/workspace/src/core/project-graph';
@@ -169,6 +170,10 @@ export default createESLintRule<Options, MessageIds>({
           return;
         }
 
+        // project => npm package
+        if (isNpmProject(targetProject)) {
+          return;
+        }
         // check constraints between libs and apps
         // check for circular dependency
         const circularPath = checkCircularPath(

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -248,6 +248,15 @@ describe('Enforce Module Boundaries', () => {
             files: [createFile(`libs/untagged/src/index.ts`)],
           },
         },
+        npmPackage: {
+          name: 'npm:npm-package',
+          type: 'npm',
+          data: {
+            packageName: 'npm-package',
+            version: '0.0.0',
+            files: [],
+          },
+        },
       },
       dependencies: {},
     };
@@ -278,6 +287,18 @@ describe('Enforce Module Boundaries', () => {
       expect(failures[0].message).toEqual(
         'A project tagged with "api" can only depend on libs tagged with "api"'
       );
+    });
+
+    it('should allow imports to npm packages', () => {
+      const failures = runRule(
+        depConstraints,
+        `${process.cwd()}/proj/libs/api/src/index.ts`,
+        `
+            import 'npm-package';
+          `,
+        graph
+      );
+      expect(failures.length).toEqual(0);
     });
 
     it('should error when the target library is untagged', () => {

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -244,6 +244,18 @@ describe('Enforce Module Boundaries', () => {
             files: [createFile(`libs/untagged/src/index.ts`)],
           },
         },
+        npmPackage: {
+          name: 'npmPackage',
+          type: 'npm',
+          data: {
+            packageName: 'npm-package',
+            version: '0.0.0',
+            tags: [],
+            implicitDependencies: [],
+            architect: {},
+            files: [],
+          },
+        },
       },
       dependencies: {},
     };
@@ -274,6 +286,19 @@ describe('Enforce Module Boundaries', () => {
       expect(failures[0].getFailure()).toEqual(
         'A project tagged with "api" can only depend on libs tagged with "api"'
       );
+    });
+
+    it('should allow imports to npm projects', () => {
+      const failures = runRule(
+        depConstraints,
+        `${process.cwd()}/proj/libs/api/src/index.ts`,
+        `
+        import 'npm-package';
+      `,
+        graph
+      );
+
+      expect(failures.length).toEqual(0);
     });
 
     it('should error when the target library is untagged', () => {

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -3,6 +3,7 @@ import { IOptions } from 'tslint';
 import * as ts from 'typescript';
 import {
   createProjectGraph,
+  isNpmProject,
   ProjectGraph,
   ProjectType,
 } from '../core/project-graph';
@@ -156,6 +157,12 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
 
     // same project => allow
     if (sourceProject === targetProject) {
+      super.visitImportDeclaration(node);
+      return;
+    }
+
+    // project => npm package
+    if (isNpmProject(targetProject)) {
       super.visitImportDeclaration(node);
       return;
     }


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Circular dependencies check in lint rule fails because npm packages are passed in.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Lint rule does not fail because of imports to npm packages

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
