### PR TITLE
fix(core): migrate to latest version of @nrwl/nx-cloud

### DIFF
--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -225,7 +225,10 @@ export class Migrator {
         ].reduce(
           (m, c) => ({
             ...m,
-            [c]: { version: targetVersion, alwaysAddToPackageJson: false },
+            [c]: {
+              version: c === '@nrwl/nx-cloud' ? 'latest' : targetVersion,
+              alwaysAddToPackageJson: false,
+            },
           }),
           {}
         ),

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -49,12 +49,14 @@
     ]
   },
   "peerDependencies": {
+    "@nrwl/cli": "*",
     "prettier": "^2.0.4"
   },
   "dependencies": {
     "@angular-devkit/architect": "~0.1000.0",
     "@angular-devkit/core": "~10.0.0",
     "@angular-devkit/schematics": "~10.0.0",
+    "@nrwl/cli": "*",
     "cosmiconfig": "^4.0.0",
     "fs-extra": "7.0.1",
     "dotenv": "6.2.0",


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Using `nx migrate` will result in an error because it probably cannot find the version of `@nrwl/nx-cloud` that is the version of `@nrwl/workspace` is being migrated to.

Also, `@nrwl/cli` was removed as a `dependency` but removing it at this time will cause this issue to disrupt the user experience even further.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Using `nx migrate` will migrate `@nrwl/nx-cloud` to the `latest` version instead of the version of `@nrwl/workspace` which ensures that it exists.

Also, `@nrwl/cli` is added back as a `dependency` as well as a `peerDependency`. Users will be recommended (via npm) to have `@nrwl/cli` installed as a `peerDependency` but it will still be a `dependency` so that the recommendation in error message of `nx migrate` will succeed.

### Caveat

Unfortunately, users on `@nrwl/cli@10.2.1` are going to get an error that will offer a solution to install `@nrwl/workspace` and then run the migration manually. Doing this will succeed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
