### PR TITLE
fix(linter): remove duplicate migration of disabling explicit-module-…

### DIFF
--- a/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.spec.ts
+++ b/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.spec.ts
@@ -109,16 +109,6 @@ describe('Update eslint builder and config for 10.3.0', () => {
     );
   });
 
-  it('should disable the @typescript-eslint/explicit-module-boundary-types rule in the root ESLint config', async () => {
-    await runMigration('update-eslint-builder-and-config', {}, tree);
-
-    const json = readJsonInTree(tree, '.eslintrc');
-
-    expect(
-      json.rules['@typescript-eslint/explicit-module-boundary-types']
-    ).toEqual('off');
-  });
-
   it('should migrate the lint builder usage to the new eslint builder', async () => {
     await runMigration('update-eslint-builder-and-config', {}, tree);
 


### PR DESCRIPTION
…boundary-types

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The migration to update the versions and disable the `@typescript-eslint/explicit-module-boundary-types` rule happens twice.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The migration to update the versions and disable the `@typescript-eslint/explicit-module-boundary-types` rule happens once.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
