### PR TITLE
fix(core): fix resolving projects for imports to '.'

### DIFF
--- a/packages/workspace/src/utils/fileutils.spec.ts
+++ b/packages/workspace/src/utils/fileutils.spec.ts
@@ -1,6 +1,6 @@
 import { fs, vol } from 'memfs';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
-import { createDirectory } from './fileutils';
+import { createDirectory, isRelativePath } from './fileutils';
 
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('./app-root', () => ({ appRootPath: '/root' }));
@@ -33,6 +33,20 @@ describe('fileutils', () => {
       expect(fs.statSync('/root').isDirectory()).toBe(true);
       expect(fs.statSync('/root/b').isDirectory()).toBe(true);
       expect(fs.statSync('/root/b/c').isDirectory()).toBe(true);
+    });
+  });
+
+  describe('isRelativePath()', () => {
+    it('should return true for deeper imports', () => {
+      expect(isRelativePath('.')).toEqual(true);
+      expect(isRelativePath('./file')).toEqual(true);
+    });
+    it('should return true for upper imports', () => {
+      expect(isRelativePath('../file')).toEqual(true);
+    });
+    it('should return false for absolute imports', () => {
+      expect(isRelativePath('file')).toEqual(false);
+      expect(isRelativePath('@nrwl/angular')).toEqual(false);
     });
   });
 });

--- a/packages/workspace/src/utils/fileutils.ts
+++ b/packages/workspace/src/utils/fileutils.ts
@@ -112,5 +112,5 @@ export function renameSync(
 }
 
 export function isRelativePath(path: string): boolean {
-  return path.startsWith('./') || path.startsWith('../');
+  return path === '.' || path.startsWith('./') || path.startsWith('../');
 }


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

`import { action } from '.'` is improperly identified as an absolute path which means it gets cached irrespective of its file path. This causes all imports from `'.'` to create a dependency to the first project that imports from `'.'` which is clearly wrong.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`import { action } from '.'` is properly identified as a relative path which means it gets resolved from its file path.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
