### PR TITLE
fix(core): fix linter prompt in create-nx-workspace

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -93,7 +93,7 @@ determineWorkspaceName(parsedArgs).then((name) => {
     return determineAppName(preset, parsedArgs).then((appName) => {
       return determineStyle(preset, parsedArgs).then((style) => {
         return determineCli(preset, parsedArgs).then((cli) => {
-          return determineLinter(cli, parsedArgs).then((linter) => {
+          return determineLinter(preset, parsedArgs).then((linter) => {
             return askAboutNxCloud(parsedArgs).then((cloud) => {
               const tmpDir = createSandbox(packageManager);
               createApp(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`create-nx-workspace` with the Angular preset doesn't prompt for the linter, and assumes eslint as default.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It should prompt.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
