### PR TITLE
fix(linter): run migration for targets that are not lint

### DIFF
--- a/packages/linter/src/migrations/update-10-3-0/add-json-ext-to-eslintrc.ts
+++ b/packages/linter/src/migrations/update-10-3-0/add-json-ext-to-eslintrc.ts
@@ -1,42 +1,41 @@
 import { basename } from '@angular-devkit/core';
-import { chain, Tree } from '@angular-devkit/schematics';
+import { chain } from '@angular-devkit/schematics';
 import {
   formatFiles,
-  readJsonInTree,
-  serializeJson,
+  updateBuilderConfig,
   updateWorkspace,
   visitNotIgnoredFiles,
 } from '@nrwl/workspace';
 
 function updateESLintConfigReferencesInWorkspace() {
-  return updateWorkspace((workspace) => {
-    workspace.projects.forEach((project) => {
-      const lintTarget = project.targets.get('lint');
+  return updateBuilderConfig(
+    (options, target, project) => {
       if (
-        lintTarget?.builder !== '@nrwl/linter:eslint' &&
-        (lintTarget?.builder !== '@nrwl/linter:lint' ||
-          lintTarget?.options?.linter === 'tslint')
+        target.builder === '@nrwl/linter:lint' &&
+        options?.linter === 'tslint'
       ) {
-        return;
+        return options;
       }
 
-      if (lintTarget.builder === '@nrwl/linter:eslint') {
-        if (!lintTarget.options.eslintConfig) {
-          return;
+      if (target.builder === '@nrwl/linter:eslint') {
+        if (!options.eslintConfig) {
+          return options;
         }
-        lintTarget.options.eslintConfig = `${lintTarget.options.eslintConfig}.json`;
-        return;
+        options.eslintConfig = `${options.eslintConfig}.json`;
+        return options;
       }
 
-      if (lintTarget.builder === '@nrwl/linter:lint') {
-        if (!lintTarget.options.config) {
-          return;
+      if (target.builder === '@nrwl/linter:lint') {
+        if (!options.config) {
+          return options;
         }
-        lintTarget.options.config = `${lintTarget.options.config}.json`;
-        return;
+        options.config = `${options.config}.json`;
+        return options;
       }
-    });
-  });
+    },
+    '@nrwl/linter:eslint',
+    '@nrwl/linter:lint'
+  );
 }
 
 function renameESLintConfigFiles() {

--- a/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.ts
+++ b/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.ts
@@ -1,5 +1,9 @@
 import { chain, Tree } from '@angular-devkit/schematics';
-import { formatFiles, readJsonInTree, updateWorkspace } from '@nrwl/workspace';
+import {
+  formatFiles,
+  readJsonInTree,
+  updateBuilderConfig,
+} from '@nrwl/workspace';
 import { join, normalize } from '@angular-devkit/core';
 
 /**
@@ -9,55 +13,43 @@ import { join, normalize } from '@angular-devkit/core';
  * the migration.
  */
 function updateESLintBuilder(host: Tree) {
-  return updateWorkspace((workspace) => {
-    workspace.projects.forEach((project) => {
-      const lintTarget = project.targets.get('lint');
-      if (
-        lintTarget?.builder !== '@nrwl/linter:lint' ||
-        lintTarget?.options?.linter === 'tslint'
-      ) {
-        return;
-      }
-      lintTarget.builder = '@nrwl/linter:eslint';
+  return updateBuilderConfig((options, target, project) => {
+    if (options.linter === 'tslint') {
+      return options;
+    }
+    target.builder = '@nrwl/linter:eslint';
 
-      const tsconfigs = [];
+    const tsconfigs = [];
 
-      try {
-        tsconfigs.push(readJsonInTree(host, `${project.root}/tsconfig.json`));
-      } catch {}
-      try {
-        tsconfigs.push(
-          readJsonInTree(host, `${project.root}/tsconfig.app.json`)
-        );
-      } catch {}
-      try {
-        tsconfigs.push(
-          readJsonInTree(host, `${project.root}/tsconfig.lib.json`)
-        );
-      } catch {}
-      try {
-        tsconfigs.push(
-          readJsonInTree(host, `${project.root}/tsconfig.spec.json`)
-        );
-      } catch {}
+    try {
+      tsconfigs.push(readJsonInTree(host, `${project.root}/tsconfig.json`));
+    } catch {}
+    try {
+      tsconfigs.push(readJsonInTree(host, `${project.root}/tsconfig.app.json`));
+    } catch {}
+    try {
+      tsconfigs.push(readJsonInTree(host, `${project.root}/tsconfig.lib.json`));
+    } catch {}
+    try {
+      tsconfigs.push(
+        readJsonInTree(host, `${project.root}/tsconfig.spec.json`)
+      );
+    } catch {}
 
-      const defaultLintFilePatterns = [`${project.root}/**/*.ts`];
+    const defaultLintFilePatterns = [`${project.root}/**/*.ts`];
 
-      // Merge any available `includes` and `files` from the tsconfig files
-      const lintFilePatterns = !tsconfigs.length
-        ? defaultLintFilePatterns
-        : tsconfigs
-            .map((tsconfig) => {
-              return [...(tsconfig.include || []), ...(tsconfig.files || [])];
-            })
-            .reduce((flat, val) => flat.concat(val), [])
-            .map((pattern) => join(normalize(project.root), pattern));
+    // Merge any available `includes` and `files` from the tsconfig files
+    const lintFilePatterns = !tsconfigs.length
+      ? defaultLintFilePatterns
+      : tsconfigs
+          .map((tsconfig) => {
+            return [...(tsconfig.include || []), ...(tsconfig.files || [])];
+          })
+          .reduce((flat, val) => flat.concat(val), [])
+          .map((pattern) => join(normalize(project.root), pattern));
 
-      lintTarget.options = {
-        lintFilePatterns,
-      };
-    });
-  });
+    return { lintFilePatterns };
+  }, '@nrwl/linter:lint');
 }
 
 export default function () {

--- a/packages/node/src/schematics/application/application.spec.ts
+++ b/packages/node/src/schematics/application/application.spec.ts
@@ -284,11 +284,13 @@ describe('app', () => {
           displayName: 'my-node-app',
           preset: '../../jest.preset.js',
           transform: {
-            '^.+\\\\\\\\.[tj]s$': [ 'babel-jest',
-            { cwd: __dirname, configFile: './babel-jest.config.json' }]
+            '^.+\\\\\\\\.[tj]s$': [
+              'babel-jest',
+              { cwd: __dirname, configFile: './babel-jest.config.json' },
+            ],
           },
-            moduleFileExtensions: ['ts', 'js', 'html'],
-          coverageDirectory: '../../coverage/apps/my-node-app'
+          moduleFileExtensions: ['ts', 'js', 'html'],
+          coverageDirectory: '../../coverage/apps/my-node-app',
         };
         "
       `);

--- a/packages/node/src/schematics/application/application.ts
+++ b/packages/node/src/schematics/application/application.ts
@@ -18,6 +18,7 @@ import {
   updateWorkspaceInTree,
   generateProjectLint,
   addLintFiles,
+  formatFiles,
 } from '@nrwl/workspace';
 import { toFileName } from '@nrwl/workspace';
 import { getProjectConfig } from '@nrwl/workspace';
@@ -167,6 +168,7 @@ export default function (schema: Schema): Rule {
           })
         : noop(),
       options.frontendProject ? addProxy(options) : noop(),
+      formatFiles(options),
     ])(host, context);
   };
 }

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -62,7 +62,11 @@ export {
   serializeTarget,
 } from './src/utils/cli-config-utils';
 
-export { getWorkspace, updateWorkspace } from './src/utils/workspace';
+export {
+  getWorkspace,
+  updateWorkspace,
+  updateBuilderConfig,
+} from './src/utils/workspace';
 export { addUpdateTask } from './src/utils/update-task';
 export { addLintFiles, generateProjectLint, Linter } from './src/utils/lint';
 

--- a/packages/workspace/src/migrations/update-9-4-0/update-linters-exclude.ts
+++ b/packages/workspace/src/migrations/update-9-4-0/update-linters-exclude.ts
@@ -1,6 +1,6 @@
 import { chain, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { formatFiles } from '../../utils/rules/format-files';
-import { updateBuilderOptions, updateWorkspace } from '../../utils/workspace';
+import { updateBuilderConfig, updateWorkspace } from '../../utils/workspace';
 import { JsonArray } from '@angular-devkit/core';
 
 function updateExcludePattern(host: Tree, context: SchematicContext) {
@@ -8,7 +8,7 @@ function updateExcludePattern(host: Tree, context: SchematicContext) {
     '@nrwl/linter:lint',
     '@angular-devkit/build-angular:tslint',
   ];
-  return updateBuilderOptions((options, project) => {
+  return updateBuilderConfig((options, target, project) => {
     if (!options?.exclude) {
       return options;
     }

--- a/packages/workspace/src/utils/workspace.spec.ts
+++ b/packages/workspace/src/utils/workspace.spec.ts
@@ -1,7 +1,7 @@
 import { Tree } from '@angular-devkit/schematics';
 import { callRule } from '@nrwl/workspace/src/utils/testing';
 import { readWorkspace, updateWorkspace } from '@nrwl/workspace';
-import { updateBuilderOptions } from '@nrwl/workspace/src/utils/workspace';
+import { updateBuilderConfig } from '@nrwl/workspace/src/utils/workspace';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
 
 describe('workspace utils', () => {
@@ -53,7 +53,7 @@ describe('workspace utils', () => {
 
     it('should update options', async () => {
       const result = await callRule(
-        updateBuilderOptions((options) => {
+        updateBuilderConfig((options) => {
           options.i = 99;
           return options;
         }, 'builder1'),
@@ -70,7 +70,7 @@ describe('workspace utils', () => {
 
     it('should not update options of other builders', async () => {
       const result = await callRule(
-        updateBuilderOptions((options) => {
+        updateBuilderConfig((options) => {
           options.i = 99;
           return options;
         }, 'builder1'),

--- a/packages/workspace/src/utils/workspace.ts
+++ b/packages/workspace/src/utils/workspace.ts
@@ -1,6 +1,9 @@
 import { Tree, Rule } from '@angular-devkit/schematics';
 import { JsonArray, JsonObject, workspaces } from '@angular-devkit/core';
-import { ProjectDefinition } from '@angular-devkit/core/src/workspace';
+import {
+  ProjectDefinition,
+  TargetDefinition,
+} from '@angular-devkit/core/src/workspace';
 
 function createHost(tree: Tree): workspaces.WorkspaceHost {
   return {
@@ -65,12 +68,13 @@ export function updateWorkspace(
 /**
  * Updates builder options for options and configurations for given builder names
  */
-export function updateBuilderOptions(
+export function updateBuilderConfig(
   updater: (
     currentValue: Record<
       string,
       string | number | boolean | JsonArray | JsonObject
     >,
+    target?: TargetDefinition,
     project?: ProjectDefinition
   ) => Record<string, string | number | boolean | JsonArray | JsonObject>,
   ...builderNames: string[]
@@ -85,14 +89,18 @@ export function updateBuilderOptions(
           return;
         }
         if (target.options) {
-          target.options = updater(target.options, project);
+          target.options = updater(target.options, target, project);
         }
         if (!target.configurations) {
           return;
         }
         Object.entries(target.configurations).forEach(
           ([configName, options]) => {
-            target.configurations[configName] = updater(options, project);
+            target.configurations[configName] = updater(
+              options,
+              target,
+              project
+            );
           }
         );
       });


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Linter migrations are run for lint targets.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Linter migrations are run for any target with the right builder.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
