### PR TITLE
fix(storybook): fix .eslintrc.json being undefined when adding storyb…

### DIFF
--- a/packages/storybook/src/schematics/configuration/configuration.spec.ts
+++ b/packages/storybook/src/schematics/configuration/configuration.spec.ts
@@ -1,7 +1,11 @@
 import { Tree } from '@angular-devkit/schematics';
-import { readJsonInTree, getProjectConfig } from '@nrwl/workspace';
+import {
+  readJsonInTree,
+  getProjectConfig,
+  updateJsonInTree,
+} from '@nrwl/workspace';
 
-import { createTestUILib, runSchematic } from '../../utils/testing';
+import { callRule, createTestUILib, runSchematic } from '../../utils/testing';
 import { getTsConfigContent, TsConfig } from '../../utils/utils';
 import * as fileUtils from '@nrwl/workspace/src/core/file-utils';
 
@@ -141,6 +145,38 @@ describe('schematic:configuration', () => {
           "path": "./.storybook/tsconfig.json",
         },
       ]
+    `);
+  });
+
+  it("should update the project's .eslintrc.json if config exists", async () => {
+    appTree = await createTestUILib('test-ui-lib2', '@nrwl/angular', {
+      linter: 'eslint',
+    });
+
+    appTree = await callRule(
+      updateJsonInTree('libs/test-ui-lib2/.eslintrc.json', (json) => {
+        json.parserOptions = {
+          project: [],
+        };
+        return json;
+      }),
+      appTree
+    );
+
+    const tree = await runSchematic(
+      'configuration',
+      { name: 'test-ui-lib2' },
+      appTree
+    );
+
+    expect(
+      readJsonInTree(tree, 'libs/test-ui-lib2/.eslintrc.json').parserOptions
+    ).toMatchInlineSnapshot(`
+      Object {
+        "project": Array [
+          "libs/test-ui-lib2/.storybook/tsconfig.json",
+        ],
+      }
     `);
   });
 });

--- a/packages/storybook/src/schematics/configuration/configuration.ts
+++ b/packages/storybook/src/schematics/configuration/configuration.ts
@@ -241,6 +241,7 @@ function updateLintConfig(schema: StorybookConfigureSchema): Rule {
               `${projectConfig.root}/.storybook/tsconfig.json`
             );
           }
+          return json;
         }
       );
     },

--- a/packages/storybook/src/utils/testing.ts
+++ b/packages/storybook/src/utils/testing.ts
@@ -63,13 +63,15 @@ export function runMigration(migrationName: string, options: any, tree: Tree) {
 
 export async function createTestUILib(
   libName: string,
-  collectionName: '@nrwl/angular' | '@nrwl/react'
+  collectionName: '@nrwl/angular' | '@nrwl/react',
+  options: any = {}
 ): Promise<Tree> {
   let appTree = Tree.empty();
   appTree = createEmptyWorkspace(appTree);
   appTree = await callRule(
     externalSchematic(collectionName, 'library', {
       name: libName,
+      ...options,
     }),
     appTree
   );


### PR DESCRIPTION
…ook to project

## Current Behavior
<!-- This is the behavior we have today -->

When generating storybook configuration for an eslint project, the project's `.eslintrc.json` becomes

```
undefined
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `.eslintrc.json` is not `undefined`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
