### PR TITLE
fix(linter): use the tsConfig option to find tsconfigs for eslint mig…

### DIFF
--- a/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.spec.ts
+++ b/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.spec.ts
@@ -121,12 +121,12 @@ describe('Update eslint builder and config for 10.3.0', () => {
             "builder": "@nrwl/linter:eslint",
             "options": Object {
               "lintFilePatterns": Array [
-                "apps/testProject/something-ad-hoc/**/*.ts",
                 "apps/testProject/**/*.js",
                 "apps/testProject/**/*.jsx",
                 "apps/testProject/**/*.ts",
                 "apps/testProject/**/*.tsx",
                 "apps/testProject/some-random-relative-file.ts",
+                "apps/testProject/something-ad-hoc/**/*.ts",
                 "apps/testProject/**/*.spec.ts",
                 "apps/testProject/**/*.spec.tsx",
                 "apps/testProject/**/*.spec.js",

--- a/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.ts
+++ b/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.ts
@@ -21,25 +21,48 @@ function updateESLintBuilder(host: Tree) {
 
     const tsconfigs = [];
 
-    try {
-      tsconfigs.push(readJsonInTree(host, `${project.root}/tsconfig.json`));
-    } catch {}
-    try {
-      tsconfigs.push(readJsonInTree(host, `${project.root}/tsconfig.app.json`));
-    } catch {}
-    try {
-      tsconfigs.push(readJsonInTree(host, `${project.root}/tsconfig.lib.json`));
-    } catch {}
-    try {
-      tsconfigs.push(
-        readJsonInTree(host, `${project.root}/tsconfig.spec.json`)
-      );
-    } catch {}
+    if (options.tsConfig) {
+      const normalizedTsConfigOption = Array.isArray(options.tsConfig)
+        ? options.tsConfig
+        : [options.tsConfig];
+      normalizedTsConfigOption.forEach((tsConfigPath) => {
+        try {
+          tsconfigs.push(readJsonInTree(host, tsConfigPath as string));
+        } catch {}
+        try {
+          tsconfigs.push(readJsonInTree(host, `${project.root}/tsconfig.json`));
+        } catch {}
+      });
+    } else {
+      try {
+        tsconfigs.push(readJsonInTree(host, `${project.root}/tsconfig.json`));
+      } catch {}
+      try {
+        tsconfigs.push(
+          readJsonInTree(host, `${project.root}/tsconfig.app.json`)
+        );
+      } catch {}
+      try {
+        tsconfigs.push(
+          readJsonInTree(host, `${project.root}/tsconfig.lib.json`)
+        );
+      } catch {}
+      try {
+        tsconfigs.push(
+          readJsonInTree(host, `${project.root}/tsconfig.spec.json`)
+        );
+      } catch {}
+      try {
+        tsconfigs.push(
+          readJsonInTree(host, `${project.root}/tsconfig.e2e.json`)
+        );
+      } catch {}
+    }
 
     const defaultLintFilePatterns = [`${project.root}/**/*.ts`];
 
     // Merge any available `includes` and `files` from the tsconfig files
-    const lintFilePatterns = !tsconfigs.length
+    let lintFilePatterns = !tsconfigs.length
       ? defaultLintFilePatterns
       : tsconfigs
           .map((tsconfig) => {
@@ -47,6 +70,8 @@ function updateESLintBuilder(host: Tree) {
           })
           .reduce((flat, val) => flat.concat(val), [])
           .map((pattern) => join(normalize(project.root), pattern));
+
+    lintFilePatterns = [...new Set(lintFilePatterns)];
 
     return { lintFilePatterns };
   }, '@nrwl/linter:lint');


### PR DESCRIPTION
…ration

## Current Behavior
<!-- This is the behavior we have today -->

The `tsConfig`s defined by the user are not used for migration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `tsConfig`s defined by the user is used for migration as well as the `tsconfig.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
