### PR TITLE
feat(linter): updated eslint config using overrides

### DIFF
--- a/docs/shared/guides/eslint-configs.md
+++ b/docs/shared/guides/eslint-configs.md
@@ -1,0 +1,5 @@
+# ESLint Configs
+
+ESLint is a powerful tool for static analysis, not just because of what it can do out of the box, but also because of the ways in which it is designed to be extended.
+
+...WIP...

--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -19,7 +19,11 @@ forEachCli('nx', () => {
       runCLI(`generate @nrwl/react:app ${myapp}`);
 
       const eslintrc = readJson('.eslintrc.json');
-      eslintrc.rules['no-console'] = 'error';
+      eslintrc.overrides.forEach((override) => {
+        if (override.files.includes('*.ts')) {
+          override.rules['no-console'] = 'error';
+        }
+      });
       updateFile('.eslintrc.json', JSON.stringify(eslintrc, null, 2));
 
       updateFile(`apps/${myapp}/src/main.ts`, `console.log("should fail");`);
@@ -35,7 +39,11 @@ forEachCli('nx', () => {
       runCLI(`generate @nrwl/react:app ${myapp}`);
 
       const eslintrc = readJson('.eslintrc.json');
-      eslintrc.rules['no-console'] = 'error';
+      eslintrc.overrides.forEach((override) => {
+        if (override.files.includes('*.ts')) {
+          override.rules['no-console'] = 'error';
+        }
+      });
       updateFile('.eslintrc.json', JSON.stringify(eslintrc, null, 2));
 
       updateFile(`apps/${myapp}/src/main.ts`, `console.log("should fail");`);
@@ -50,7 +58,11 @@ forEachCli('nx', () => {
       runCLI(`generate @nrwl/react:app ${myapp}`);
 
       const eslintrc = readJson('.eslintrc.json');
-      eslintrc.rules['no-console'] = undefined;
+      eslintrc.overrides.forEach((override) => {
+        if (override.files.includes('*.ts')) {
+          override.rules['no-console'] = undefined;
+        }
+      });
       updateFile('.eslintrc.json', JSON.stringify(eslintrc, null, 2));
 
       updateFile(`apps/${myapp}/src/main.ts`, `console.log("should fail");`);
@@ -82,7 +94,11 @@ forEachCli('nx', () => {
       updateFile('workspace.json', JSON.stringify(workspaceJson, null, 2));
 
       const eslintrc = readJson('.eslintrc.json');
-      eslintrc.rules['no-console'] = undefined;
+      eslintrc.overrides.forEach((override) => {
+        if (override.files.includes('*.ts')) {
+          override.rules['no-console'] = undefined;
+        }
+      });
       updateFile('.eslintrc.json', JSON.stringify(eslintrc, null, 2));
 
       updateFile(`apps/${myapp}/src/main.ts`, `console.log("should fail");`);
@@ -130,7 +146,11 @@ forEachCli('nx', () => {
       runCLI(`generate @nrwl/react:app ${myapp}`);
 
       const eslintrc = readJson('.eslintrc.json');
-      eslintrc.rules['no-console'] = 'error';
+      eslintrc.overrides.forEach((override) => {
+        if (override.files.includes('*.ts')) {
+          override.rules['no-console'] = 'error';
+        }
+      });
       updateFile('.eslintrc.json', JSON.stringify(eslintrc, null, 2));
       updateFile(`apps/${myapp}/src/main.ts`, `console.log("should fail");`);
 

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -43,6 +43,7 @@ import {
   updateWorkspaceInTree,
   appsDir,
 } from '@nrwl/workspace/src/utils/ast-utils';
+import { createAngularLintConfig } from '../../utils/lint';
 
 interface NormalizedSchema extends Schema {
   appProjectRoot: string;
@@ -808,6 +809,15 @@ export default function (schema: Schema): Rule {
       options.routing ? addRouterRootConfiguration(options) : noop(),
       addLintFiles(options.appProjectRoot, options.linter, {
         onlyGlobal: options.linter === Linter.TsLint, // local lint files are added differently when tslint
+        localConfig:
+          options.linter === Linter.EsLint
+            ? createAngularLintConfig({
+                parserOptionsProject: [
+                  // Will match tsconfig.app.json and tsconfig.spec.json
+                  `${options.appProjectRoot}/tsconfig.*?.json`,
+                ],
+              })
+            : undefined,
       }),
       options.linter === 'tslint' ? updateTsLintConfig(options) : noop(),
       options.unitTestRunner === 'jest'

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -22,6 +22,7 @@ import { updateProject } from './lib/update-project';
 import { updateTsConfig } from './lib/update-tsconfig';
 import { Schema } from './schema';
 import { enableStrictTypeChecking } from './lib/enable-strict-type-checking';
+import { createAngularLintConfig } from '../../utils/lint';
 
 export default function (schema: Schema): Rule {
   return (host: Tree): Rule => {
@@ -39,6 +40,15 @@ export default function (schema: Schema): Rule {
     return chain([
       addLintFiles(options.projectRoot, options.linter, {
         onlyGlobal: options.linter === Linter.TsLint,
+        localConfig:
+          options.linter === Linter.EsLint
+            ? createAngularLintConfig({
+                parserOptionsProject: [
+                  // Will match tsconfig.lib.json and tsconfig.spec.json
+                  `${options.projectRoot}/tsconfig.*?.json`,
+                ],
+              })
+            : undefined,
       }),
       addUnitTestRunner(options),
       // TODO: Remove this after Angular 10.1.0

--- a/packages/angular/src/utils/lint.ts
+++ b/packages/angular/src/utils/lint.ts
@@ -1,0 +1,25 @@
+export function createAngularLintConfig(options: {
+  parserOptionsProject: string[];
+}) {
+  return {
+    overrides: [
+      {
+        /**
+         * -----------------------------------------------------
+         * TYPESCRIPT FILES
+         * -----------------------------------------------------
+         *
+         * Configuration within this section is common to all .ts
+         * files in the project.
+         *
+         * In a future PR we will also add in a section for Component HTML linting
+         */
+        files: ['*.ts'],
+        parserOptions: {
+          project: options.parserOptionsProject,
+        },
+        rules: {},
+      },
+    ],
+  };
+}

--- a/packages/next/src/schematics/application/application.spec.ts
+++ b/packages/next/src/schematics/application/application.spec.ts
@@ -207,7 +207,7 @@ describe('app', () => {
       const eslintJson = readJsonInTree(tree, '/apps/my-app/.eslintrc.json');
       const packageJson = readJsonInTree(tree, '/package.json');
 
-      expect(eslintJson.plugins).toEqual(
+      expect(eslintJson.overrides[1].plugins).toEqual(
         expect.arrayContaining(['react', 'react-hooks'])
       );
       expect(packageJson).toMatchObject({

--- a/packages/next/src/schematics/application/application.ts
+++ b/packages/next/src/schematics/application/application.ts
@@ -4,7 +4,7 @@ import {
   SchematicContext,
   Tree,
 } from '@angular-devkit/schematics';
-import { extraEslintDependencies, reactEslintJson } from '@nrwl/react';
+import { createReactEslintJson, extraEslintDependencies } from '@nrwl/react';
 import { addLintFiles, formatFiles } from '@nrwl/workspace';
 import init from '../init/init';
 import { addCypress } from './lib/add-cypress';
@@ -29,7 +29,11 @@ export default function (schema: Schema): Rule {
         skipFormat: true,
       }),
       addLintFiles(options.appProjectRoot, options.linter, {
-        localConfig: reactEslintJson,
+        localConfig: createReactEslintJson({
+          js: false,
+          // For next, only the tsconfig.json is required
+          parserOptionsProject: [`${options.appProjectRoot}/tsconfig.json`],
+        }),
         extraPackageDeps: extraEslintDependencies,
       }),
       createApplicationFiles(options),

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -1,3 +1,6 @@
-export { extraEslintDependencies, reactEslintJson } from './src/utils/lint';
+export {
+  extraEslintDependencies,
+  createReactEslintJson,
+} from './src/utils/lint';
 export { CSS_IN_JS_DEPENDENCIES } from './src/utils/styled';
 export { assertValidStyle } from './src/utils/assertion';

--- a/packages/react/src/schematics/application/application.spec.ts
+++ b/packages/react/src/schematics/application/application.spec.ts
@@ -368,7 +368,7 @@ describe('app', () => {
     const eslintJson = readJsonInTree(tree, '/apps/my-app/.eslintrc.json');
     const packageJson = readJsonInTree(tree, '/package.json');
 
-    expect(eslintJson.plugins).toEqual(
+    expect(eslintJson.overrides[1].plugins).toEqual(
       expect.arrayContaining(['react', 'react-hooks'])
     );
     expect(packageJson).toMatchObject({

--- a/packages/react/src/schematics/application/application.ts
+++ b/packages/react/src/schematics/application/application.ts
@@ -5,7 +5,10 @@ import {
   Tree,
 } from '@angular-devkit/schematics';
 import { addLintFiles, formatFiles } from '@nrwl/workspace';
-import { extraEslintDependencies, reactEslintJson } from '../../utils/lint';
+import {
+  createReactEslintJson,
+  extraEslintDependencies,
+} from '../../utils/lint';
 import init from '../init/init';
 import { Schema } from './schema';
 import { createApplicationFiles } from './lib/create-application-files';
@@ -28,7 +31,11 @@ export default function (schema: Schema): Rule {
         skipFormat: true,
       }),
       addLintFiles(options.appProjectRoot, options.linter, {
-        localConfig: reactEslintJson,
+        localConfig: createReactEslintJson({
+          js: options.js,
+          // Will match tsconfig.app.json and tsconfig.spec.json
+          parserOptionsProject: [`${options.appProjectRoot}/tsconfig.*?.json`],
+        }),
         extraPackageDeps: extraEslintDependencies,
       }),
       createApplicationFiles(options),

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -41,7 +41,10 @@ import {
   addRoute,
   findComponentImportPath,
 } from '../../utils/ast-utils';
-import { extraEslintDependencies, reactEslintJson } from '../../utils/lint';
+import {
+  createReactEslintJson,
+  extraEslintDependencies,
+} from '../../utils/lint';
 import {
   reactDomVersion,
   reactRouterDomVersion,
@@ -79,7 +82,11 @@ export default function (schema: Schema): Rule {
     }
     return chain([
       addLintFiles(options.projectRoot, options.linter, {
-        localConfig: reactEslintJson,
+        localConfig: createReactEslintJson({
+          js: options.js,
+          // Will match tsconfig.lib.json and tsconfig.spec.json
+          parserOptionsProject: [`${options.projectRoot}/tsconfig.*?.json`],
+        }),
         extraPackageDeps: extraEslintDependencies,
       }),
       createFiles(options),

--- a/packages/react/src/utils/lint.ts
+++ b/packages/react/src/utils/lint.ts
@@ -17,249 +17,306 @@ export const extraEslintDependencies = {
 };
 
 /**
- * ADAPTED FROM https://github.com/facebook/create-react-app/blob/567f36c9235f1e1fd4a76dc6d1ae00be754ca047/packages/eslint-config-react-app/index.js
+ * Rule set used by this utility originally adapted from:
+ * https://github.com/facebook/create-react-app/blob/567f36c9235f1e1fd4a76dc6d1ae00be754ca047/packages/eslint-config-react-app/index.js
  */
-export const reactEslintJson = {
-  env: {
-    browser: true,
-    commonjs: true,
-    es6: true,
-    jest: true,
-    node: true,
-  },
-  settings: {
-    react: {
-      version: 'detect',
-    },
-  },
-  plugins: ['import', 'jsx-a11y', 'react', 'react-hooks'],
+export const createReactEslintJson = (options: {
+  js: boolean;
+  parserOptionsProject: string[];
+}) => {
+  const generalCodeConfig = createGeneralCodeConfig();
+  const jsxSpecificConfig = createJSXSpecificConfig();
+
+  const {
+    plugins: generalCodePlugins,
+    env: generalCodeEnv,
+    rules: generalCodeRules,
+  } = generalCodeConfig;
+  const {
+    plugins: jsxSpecificPlugins,
+    settings: jsxSpecificSettings,
+    rules: jsxSpecificRules,
+  } = jsxSpecificConfig;
 
   /**
-   * Inspired by configuration originally found in create-react-app
-   * https://github.com/facebook/create-react-app
+   * For the standard TypeScript use-case, we have general config that applies to all
+   * TypeScript files within the project, and some separate config which is specific to JSX/React.
+   *
+   * In other relevant configs, such as the tsconfig files, Nx has decided to support including
+   * any ts, tsx, js and jsx files, to allow for easier migration of existing projects, so we also
+   * include all of those file types in the linting config to match that.
    */
-  rules: {
-    /**
-     * Standard ESLint rule configurations
-     * https://eslint.org/docs/rules
-     */
-    'array-callback-return': 'warn',
-    'dot-location': ['warn', 'property'],
-    eqeqeq: ['warn', 'smart'],
-    'new-parens': 'warn',
-    'no-caller': 'warn',
-    'no-cond-assign': ['warn', 'except-parens'],
-    'no-const-assign': 'warn',
-    'no-control-regex': 'warn',
-    'no-delete-var': 'warn',
-    'no-dupe-args': 'warn',
-    'no-dupe-keys': 'warn',
-    'no-duplicate-case': 'warn',
-    'no-empty-character-class': 'warn',
-    'no-empty-pattern': 'warn',
-    'no-eval': 'warn',
-    'no-ex-assign': 'warn',
-    'no-extend-native': 'warn',
-    'no-extra-bind': 'warn',
-    'no-extra-label': 'warn',
-    'no-fallthrough': 'warn',
-    'no-func-assign': 'warn',
-    'no-implied-eval': 'warn',
-    'no-invalid-regexp': 'warn',
-    'no-iterator': 'warn',
-    'no-label-var': 'warn',
-    'no-labels': ['warn', { allowLoop: true, allowSwitch: false }],
-    'no-lone-blocks': 'warn',
-    'no-loop-func': 'warn',
-    'no-mixed-operators': [
-      'warn',
+  return {
+    env: generalCodeEnv,
+    plugins: [...generalCodePlugins],
+    rules: {
+      ...generalCodeRules,
+    },
+    overrides: [
       {
-        groups: [
-          ['&', '|', '^', '~', '<<', '>>', '>>>'],
-          ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
-          ['&&', '||'],
-          ['in', 'instanceof'],
-        ],
-        allowSamePrecedence: false,
+        files: ['*.js', '*.jsx'],
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+        settings: jsxSpecificSettings,
+        plugins: [...jsxSpecificPlugins],
+        rules: {
+          ...jsxSpecificRules,
+        },
+      },
+      {
+        files: ['*.ts', '*.tsx'],
+        parserOptions: {
+          project: options.parserOptionsProject,
+        },
+        rules: {
+          ...typescriptSpecificRules,
+        },
+      },
+      {
+        files: ['*.tsx', '*.jsx'],
+        ...jsxSpecificConfig,
       },
     ],
-    'no-multi-str': 'warn',
-    'no-native-reassign': 'warn',
-    'no-negated-in-lhs': 'warn',
-    'no-new-func': 'warn',
-    'no-new-object': 'warn',
-    'no-new-symbol': 'warn',
-    'no-new-wrappers': 'warn',
-    'no-obj-calls': 'warn',
-    'no-octal': 'warn',
-    'no-octal-escape': 'warn',
-    'no-redeclare': 'warn',
-    'no-regex-spaces': 'warn',
-    'no-restricted-syntax': ['warn', 'WithStatement'],
-    'no-script-url': 'warn',
-    'no-self-assign': 'warn',
-    'no-self-compare': 'warn',
-    'no-sequences': 'warn',
-    'no-shadow-restricted-names': 'warn',
-    'no-sparse-arrays': 'warn',
-    'no-template-curly-in-string': 'warn',
-    'no-this-before-super': 'warn',
-    'no-throw-literal': 'warn',
-    'no-restricted-globals': ['error'].concat(restrictedGlobals),
-    'no-unexpected-multiline': 'warn',
-    'no-unreachable': 'warn',
-    'no-unused-expressions': 'off',
-    'no-unused-labels': 'warn',
-    'no-useless-computed-key': 'warn',
-    'no-useless-concat': 'warn',
-    'no-useless-escape': 'warn',
-    'no-useless-rename': [
-      'warn',
-      {
-        ignoreDestructuring: false,
-        ignoreImport: false,
-        ignoreExport: false,
-      },
-    ],
-    'no-with': 'warn',
-    'no-whitespace-before-property': 'warn',
-    'react-hooks/exhaustive-deps': 'warn',
-    'require-yield': 'warn',
-    'rest-spread-spacing': ['warn', 'never'],
-    strict: ['warn', 'never'],
-    'unicode-bom': ['warn', 'never'],
-    'use-isnan': 'warn',
-    'valid-typeof': 'warn',
-    'no-restricted-properties': [
-      'error',
-      {
-        object: 'require',
-        property: 'ensure',
-        message:
-          'Please use import() instead. More info: https://facebook.github.io/create-react-app/docs/code-splitting',
-      },
-      {
-        object: 'System',
-        property: 'import',
-        message:
-          'Please use import() instead. More info: https://facebook.github.io/create-react-app/docs/code-splitting',
-      },
-    ],
-    'getter-return': 'warn',
+  };
+};
 
-    /**
-     * Import rule configurations
-     * https://github.com/benmosher/eslint-plugin-import
-     */
-    'import/first': 'error',
-    'import/no-amd': 'error',
-    'import/no-webpack-loader-syntax': 'error',
+function createJSXSpecificConfig() {
+  return {
+    settings: { react: { version: 'detect' } },
+    plugins: ['jsx-a11y', 'react', 'react-hooks'],
+    rules: {
+      /**
+       * React-specific rule configurations
+       * https://github.com/yannickcr/eslint-plugin-react
+       */
+      'react/forbid-foreign-prop-types': ['warn', { allowInPropTypes: true }],
+      'react/jsx-no-comment-textnodes': 'warn',
+      'react/jsx-no-duplicate-props': 'warn',
+      'react/jsx-no-target-blank': 'warn',
+      'react/jsx-no-undef': 'error',
+      'react/jsx-pascal-case': ['warn', { allowAllCaps: true, ignore: [] }],
+      'react/jsx-uses-react': 'warn',
+      'react/jsx-uses-vars': 'warn',
+      'react/no-danger-with-children': 'warn',
+      'react/no-direct-mutation-state': 'warn',
+      'react/no-is-mounted': 'warn',
+      'react/no-typos': 'error',
+      'react/react-in-jsx-scope': 'error',
+      'react/require-render-return': 'error',
+      'react/style-prop-object': 'warn',
+      'react/jsx-no-useless-fragment': 'warn',
 
-    /**
-     * React-specific rule configurations
-     * https://github.com/yannickcr/eslint-plugin-react
-     */
-    'react/forbid-foreign-prop-types': ['warn', { allowInPropTypes: true }],
-    'react/jsx-no-comment-textnodes': 'warn',
-    'react/jsx-no-duplicate-props': 'warn',
-    'react/jsx-no-target-blank': 'warn',
-    'react/jsx-no-undef': 'error',
-    'react/jsx-pascal-case': [
-      'warn',
-      {
-        allowAllCaps: true,
-        ignore: [],
-      },
-    ],
-    'react/jsx-uses-react': 'warn',
-    'react/jsx-uses-vars': 'warn',
-    'react/no-danger-with-children': 'warn',
-    'react/no-direct-mutation-state': 'warn',
-    'react/no-is-mounted': 'warn',
-    'react/no-typos': 'error',
-    'react/react-in-jsx-scope': 'error',
-    'react/require-render-return': 'error',
-    'react/style-prop-object': 'warn',
-    'react/jsx-no-useless-fragment': 'warn',
+      /**
+       * JSX Accessibility rule configurations
+       * https://github.com/evcohen/eslint-plugin-jsx-a11y
+       */
+      'jsx-a11y/accessible-emoji': 'warn',
+      'jsx-a11y/alt-text': 'warn',
+      'jsx-a11y/anchor-has-content': 'warn',
+      'jsx-a11y/anchor-is-valid': [
+        'warn',
+        { aspects: ['noHref', 'invalidHref'] },
+      ],
+      'jsx-a11y/aria-activedescendant-has-tabindex': 'warn',
+      'jsx-a11y/aria-props': 'warn',
+      'jsx-a11y/aria-proptypes': 'warn',
+      'jsx-a11y/aria-role': 'warn',
+      'jsx-a11y/aria-unsupported-elements': 'warn',
+      'jsx-a11y/heading-has-content': 'warn',
+      'jsx-a11y/iframe-has-title': 'warn',
+      'jsx-a11y/img-redundant-alt': 'warn',
+      'jsx-a11y/no-access-key': 'warn',
+      'jsx-a11y/no-distracting-elements': 'warn',
+      'jsx-a11y/no-redundant-roles': 'warn',
+      'jsx-a11y/role-has-required-aria-props': 'warn',
+      'jsx-a11y/role-supports-aria-props': 'warn',
+      'jsx-a11y/scope': 'warn',
 
-    /**
-     * JSX Accessibility rule configurations
-     * https://github.com/evcohen/eslint-plugin-jsx-a11y
-     */
-    'jsx-a11y/accessible-emoji': 'warn',
-    'jsx-a11y/alt-text': 'warn',
-    'jsx-a11y/anchor-has-content': 'warn',
-    'jsx-a11y/anchor-is-valid': [
-      'warn',
-      {
-        aspects: ['noHref', 'invalidHref'],
-      },
-    ],
-    'jsx-a11y/aria-activedescendant-has-tabindex': 'warn',
-    'jsx-a11y/aria-props': 'warn',
-    'jsx-a11y/aria-proptypes': 'warn',
-    'jsx-a11y/aria-role': 'warn',
-    'jsx-a11y/aria-unsupported-elements': 'warn',
-    'jsx-a11y/heading-has-content': 'warn',
-    'jsx-a11y/iframe-has-title': 'warn',
-    'jsx-a11y/img-redundant-alt': 'warn',
-    'jsx-a11y/no-access-key': 'warn',
-    'jsx-a11y/no-distracting-elements': 'warn',
-    'jsx-a11y/no-redundant-roles': 'warn',
-    'jsx-a11y/role-has-required-aria-props': 'warn',
-    'jsx-a11y/role-supports-aria-props': 'warn',
-    'jsx-a11y/scope': 'warn',
+      /**
+       * React Hooks rule configurations
+       * https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks
+       */
+      'react-hooks/rules-of-hooks': 'error',
+    },
+  };
+}
 
-    /**
-     * React Hooks rule configurations
-     * https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks
-     */
-    'react-hooks/rules-of-hooks': 'error',
+function createGeneralCodeConfig() {
+  return {
+    plugins: ['import'],
+    env: {
+      browser: true,
+      commonjs: true,
+      es6: true,
+      jest: true,
+      node: true,
+    },
+    rules: {
+      /**
+       * Standard ESLint rule configurations
+       * https://eslint.org/docs/rules
+       */
+      'array-callback-return': 'warn',
+      'dot-location': ['warn', 'property'],
+      eqeqeq: ['warn', 'smart'],
+      'new-parens': 'warn',
+      'no-caller': 'warn',
+      'no-cond-assign': ['warn', 'except-parens'],
+      'no-const-assign': 'warn',
+      'no-control-regex': 'warn',
+      'no-delete-var': 'warn',
+      'no-dupe-args': 'warn',
+      'no-dupe-keys': 'warn',
+      'no-duplicate-case': 'warn',
+      'no-empty-character-class': 'warn',
+      'no-empty-pattern': 'warn',
+      'no-eval': 'warn',
+      'no-ex-assign': 'warn',
+      'no-extend-native': 'warn',
+      'no-extra-bind': 'warn',
+      'no-extra-label': 'warn',
+      'no-fallthrough': 'warn',
+      'no-func-assign': 'warn',
+      'no-implied-eval': 'warn',
+      'no-invalid-regexp': 'warn',
+      'no-iterator': 'warn',
+      'no-label-var': 'warn',
+      'no-labels': ['warn', { allowLoop: true, allowSwitch: false }],
+      'no-lone-blocks': 'warn',
+      'no-loop-func': 'warn',
+      'no-mixed-operators': [
+        'warn',
+        {
+          groups: [
+            ['&', '|', '^', '~', '<<', '>>', '>>>'],
+            ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
+            ['&&', '||'],
+            ['in', 'instanceof'],
+          ],
+          allowSamePrecedence: false,
+        },
+      ],
+      'no-multi-str': 'warn',
+      'no-native-reassign': 'warn',
+      'no-negated-in-lhs': 'warn',
+      'no-new-func': 'warn',
+      'no-new-object': 'warn',
+      'no-new-symbol': 'warn',
+      'no-new-wrappers': 'warn',
+      'no-obj-calls': 'warn',
+      'no-octal': 'warn',
+      'no-octal-escape': 'warn',
+      'no-redeclare': 'warn',
+      'no-regex-spaces': 'warn',
+      'no-restricted-syntax': ['warn', 'WithStatement'],
+      'no-script-url': 'warn',
+      'no-self-assign': 'warn',
+      'no-self-compare': 'warn',
+      'no-sequences': 'warn',
+      'no-shadow-restricted-names': 'warn',
+      'no-sparse-arrays': 'warn',
+      'no-template-curly-in-string': 'warn',
+      'no-this-before-super': 'warn',
+      'no-throw-literal': 'warn',
+      'no-restricted-globals': ['error'].concat(restrictedGlobals),
+      'no-unexpected-multiline': 'warn',
+      'no-unreachable': 'warn',
+      'no-unused-expressions': 'off',
+      'no-unused-labels': 'warn',
+      'no-useless-computed-key': 'warn',
+      'no-useless-concat': 'warn',
+      'no-useless-escape': 'warn',
+      'no-useless-rename': [
+        'warn',
+        {
+          ignoreDestructuring: false,
+          ignoreImport: false,
+          ignoreExport: false,
+        },
+      ],
+      'no-with': 'warn',
+      'no-whitespace-before-property': 'warn',
+      'react-hooks/exhaustive-deps': 'warn',
+      'require-yield': 'warn',
+      'rest-spread-spacing': ['warn', 'never'],
+      strict: ['warn', 'never'],
+      'unicode-bom': ['warn', 'never'],
+      'use-isnan': 'warn',
+      'valid-typeof': 'warn',
+      'no-restricted-properties': [
+        'error',
+        {
+          object: 'require',
+          property: 'ensure',
+          message:
+            'Please use import() instead. More info: https://facebook.github.io/create-react-app/docs/code-splitting',
+        },
+        {
+          object: 'System',
+          property: 'import',
+          message:
+            'Please use import() instead. More info: https://facebook.github.io/create-react-app/docs/code-splitting',
+        },
+      ],
+      'getter-return': 'warn',
 
-    /**
-     * TypeScript-specific rule configurations (in addition to @typescript-eslint:recommended)
-     * https://github.com/typescript-eslint/typescript-eslint
-     */
+      /**
+       * Import rule configurations
+       * https://github.com/benmosher/eslint-plugin-import
+       */
+      'import/first': 'error',
+      'import/no-amd': 'error',
+      'import/no-webpack-loader-syntax': 'error',
+    },
+  };
+}
 
-    // TypeScript"s `noFallthroughCasesInSwitch` option is more robust (#6906)
-    'default-case': 'off',
-    // "tsc" already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/291)
-    'no-dupe-class-members': 'off',
-    // "tsc" already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/477)
-    'no-undef': 'off',
+/**
+ * TypeScript-specific rule configurations (in addition to @typescript-eslint:recommended)
+ * https://github.com/typescript-eslint/typescript-eslint
+ */
+const typescriptSpecificRules = {
+  // TypeScript"s `noFallthroughCasesInSwitch` option is more robust (#6906)
+  'default-case': 'off',
+  // "tsc" already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/291)
+  'no-dupe-class-members': 'off',
+  // "tsc" already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/477)
+  'no-undef': 'off',
 
-    // Add TypeScript specific rules (and turn off ESLint equivalents)
-    '@typescript-eslint/consistent-type-assertions': 'warn',
-    'no-array-constructor': 'off',
-    '@typescript-eslint/no-array-constructor': 'warn',
-    '@typescript-eslint/no-namespace': 'error',
-    'no-use-before-define': 'off',
-    '@typescript-eslint/no-use-before-define': [
-      'warn',
-      {
-        functions: false,
-        classes: false,
-        variables: false,
-        typedefs: false,
-      },
-    ],
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': [
-      'warn',
-      {
-        args: 'none',
-        ignoreRestSiblings: true,
-      },
-    ],
-    'no-useless-constructor': 'off',
-    '@typescript-eslint/no-useless-constructor': 'warn',
-    '@typescript-eslint/no-unused-expressions': [
-      'error',
-      {
-        allowShortCircuit: true,
-        allowTernary: true,
-        allowTaggedTemplates: true,
-      },
-    ],
-  },
+  // Add TypeScript specific rules (and turn off ESLint equivalents)
+  '@typescript-eslint/consistent-type-assertions': 'warn',
+  'no-array-constructor': 'off',
+  '@typescript-eslint/no-array-constructor': 'warn',
+  '@typescript-eslint/no-namespace': 'error',
+  'no-use-before-define': 'off',
+  '@typescript-eslint/no-use-before-define': [
+    'warn',
+    {
+      functions: false,
+      classes: false,
+      variables: false,
+      typedefs: false,
+    },
+  ],
+  'no-unused-vars': 'off',
+  '@typescript-eslint/no-unused-vars': [
+    'warn',
+    {
+      args: 'none',
+      ignoreRestSiblings: true,
+    },
+  ],
+  'no-useless-constructor': 'off',
+  '@typescript-eslint/no-useless-constructor': 'warn',
+  '@typescript-eslint/no-unused-expressions': [
+    'error',
+    {
+      allowShortCircuit: true,
+      allowTernary: true,
+      allowTaggedTemplates: true,
+    },
+  ],
 };

--- a/packages/storybook/src/schematics/configuration/configuration.ts
+++ b/packages/storybook/src/schematics/configuration/configuration.ts
@@ -236,11 +236,27 @@ function updateLintConfig(schema: StorybookConfigureSchema): Rule {
       return updateJsonInTree(
         `${projectConfig.root}/.eslintrc.json`,
         (json) => {
+          if (typeof json.parserOptions?.project === 'string') {
+            json.parserOptions.project = [json.parserOptions.project];
+          }
           if (Array.isArray(json.parserOptions?.project)) {
             json.parserOptions.project.push(
               `${projectConfig.root}/.storybook/tsconfig.json`
             );
           }
+
+          const overrides = json.overrides || [];
+          for (const override of overrides) {
+            if (typeof override.parserOptions?.project === 'string') {
+              override.parserOptions.project = [override.parserOptions.project];
+            }
+            if (Array.isArray(override.parserOptions?.project)) {
+              override.parserOptions.project.push(
+                `${projectConfig.root}/.storybook/tsconfig.json`
+              );
+            }
+          }
+
           return json;
         }
       );

--- a/packages/workspace/src/schematics/library/library.ts
+++ b/packages/workspace/src/schematics/library/library.ts
@@ -107,7 +107,10 @@ export default function (schema: Schema): Rule {
     const options = normalizeOptions(host, schema);
 
     return chain([
-      addLintFiles(options.projectRoot, options.linter),
+      addLintFiles(options.projectRoot, options.linter, {
+        // TODO: Update this to be conditional once JS support for node libraries lands
+        defaultOverridesFiles: ['*.ts'],
+      }),
       createFiles(options),
       !options.skipTsConfig ? updateTsConfig(options) : noop(),
       addProject(options),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Nx's out of the box ESLint configuration works well for JavaScript and TypeScript, but not when additional non-JS files are thrown into the mix (e.g. `.html` for Angular, Vue files, `.graphql` etc)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We should lean on `overrides` more extensively so that it is easy to support non-JS linting using ESLint (over and above TypeScript).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

## TODO

- [ ] Figure out migration story for existing configs - will be tricky 😅 
- [ ] Complete the guide for nx.dev which explains all about ESLint config overrides
- [ ] Maybe use this opportunity to create Nx ESLint configs within the existing `eslint-plugin-nx` that the different packages extend from rather than (particularly in the case of React, having lots of rules inline in every config?)
