### PR TITLE
fix(linter): migration should not include patterns from node_modules

### DIFF
--- a/packages/linter/migrations.json
+++ b/packages/linter/migrations.json
@@ -21,7 +21,7 @@
       "factory": "./src/migrations/update-10-3-0/add-root-eslintrc-json-to-workspace-implicit-deps"
     },
     "revert-node-modules-files-in-eslint-builder-options": {
-      "version": "10.3.1",
+      "version": "10.3.1-beta.1",
       "description": "Revert any node_modules lintFilesPatterns that were accidentally included by update-eslint-builder-and-config",
       "factory": "./src/migrations/update-10-3-1/revert-node-modules-files-in-eslint-builder-options"
     }

--- a/packages/linter/migrations.json
+++ b/packages/linter/migrations.json
@@ -19,6 +19,11 @@
       "version": "10.3.0-beta.3",
       "description": "Update implicitDependencies within nx.json to include root .eslintrc.json",
       "factory": "./src/migrations/update-10-3-0/add-root-eslintrc-json-to-workspace-implicit-deps"
+    },
+    "revert-node-modules-files-in-eslint-builder-options": {
+      "version": "10.3.1",
+      "description": "Revert any node_modules lintFilesPatterns that were accidentally included by update-eslint-builder-and-config",
+      "factory": "./src/migrations/update-10-3-1/revert-node-modules-files-in-eslint-builder-options"
     }
   },
   "packageJsonUpdates": {

--- a/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.spec.ts
+++ b/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.spec.ts
@@ -85,7 +85,13 @@ describe('Update eslint builder and config for 10.3.0', () => {
     tree = await callRule(
       updateJsonInTree('apps/testProject/tsconfig.app.json', () => ({
         include: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'],
-        files: ['./some-random-relative-file.ts'],
+        files: [
+          // We want to include this custom file
+          './some-random-relative-file.ts',
+          // We don't want to include these files from node_modules
+          '../../node_modules/@nrwl/react/typings/cssmodule.d.ts',
+          '../../node_modules/@nrwl/react/typings/image.d.ts',
+        ],
       })),
       tree
     );

--- a/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.ts
+++ b/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.ts
@@ -76,7 +76,7 @@ function updateESLintBuilder(host: Tree) {
            * 3rd party files anyway, and if they are relevant to the TypeScript Program
            * for the linting run they will still be included in that.
            */
-          .filter((pattern) => !pattern.startsWith('node_modules'));
+          .filter((pattern) => !pattern.includes('node_modules'));
 
     lintFilePatterns = [...new Set(lintFilePatterns)];
 

--- a/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.ts
+++ b/packages/linter/src/migrations/update-10-3-0/update-eslint-builder-and-config.ts
@@ -69,7 +69,14 @@ function updateESLintBuilder(host: Tree) {
             return [...(tsconfig.include || []), ...(tsconfig.files || [])];
           })
           .reduce((flat, val) => flat.concat(val), [])
-          .map((pattern) => join(normalize(project.root), pattern));
+          .map((pattern) => join(normalize(project.root), pattern))
+          /**
+           * Exclude any files coming from node_modules, they will be ignored by ESLint
+           * and it will print a warning about it. We shouldn't be spending time linting
+           * 3rd party files anyway, and if they are relevant to the TypeScript Program
+           * for the linting run they will still be included in that.
+           */
+          .filter((pattern) => !pattern.startsWith('node_modules'));
 
     lintFilePatterns = [...new Set(lintFilePatterns)];
 

--- a/packages/linter/src/migrations/update-10-3-1/revert-node-modules-files-in-eslint-builder-options.spec.ts
+++ b/packages/linter/src/migrations/update-10-3-1/revert-node-modules-files-in-eslint-builder-options.spec.ts
@@ -1,0 +1,79 @@
+import { Tree } from '@angular-devkit/schematics';
+import { readWorkspace, updateWorkspace } from '@nrwl/workspace';
+import { callRule, createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { runMigration } from '../../utils/testing';
+
+describe('Revert any node_modules lintFilesPatterns that were accidentally included by update-eslint-builder-and-config', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = Tree.empty();
+    tree = createEmptyWorkspace(tree);
+    tree = await callRule(
+      updateWorkspace((workspace) => {
+        workspace.projects.add({
+          name: 'testProject',
+          root: 'apps/testProject',
+          sourceRoot: 'apps/testProject/src',
+          projectType: 'application',
+          targets: {
+            lint: {
+              builder: '@nrwl/linter:eslint',
+              options: {
+                lintFilePatterns: [
+                  'apps/testProject/**/*.js',
+                  'apps/testProject/**/*.jsx',
+                  'apps/testProject/**/*.ts',
+                  'apps/testProject/**/*.tsx',
+                  'apps/testProject/some-random-relative-file.ts',
+                  'apps/testProject/something-ad-hoc/**/*.ts',
+                  'apps/testProject/**/*.spec.ts',
+                  'apps/testProject/**/*.spec.tsx',
+                  'apps/testProject/**/*.spec.js',
+                  'apps/testProject/**/*.spec.jsx',
+                  'apps/testProject/**/*.d.ts',
+                  // These two should be removed by the migration
+                  'node_modules/@nrwl/react/typings/cssmodule.d.ts',
+                  'node_modules/@nrwl/react/typings/image.d.ts',
+                ],
+              },
+            },
+          },
+        });
+      }),
+      tree
+    );
+  });
+
+  it('should remove any patterns starting with node_modules from the lintFilePatterns array', async () => {
+    await runMigration(
+      'revert-node-modules-files-in-eslint-builder-options',
+      {},
+      tree
+    );
+
+    const workspace = readWorkspace(tree);
+
+    expect(workspace.projects['testProject'].architect.lint)
+      .toMatchInlineSnapshot(`
+      Object {
+        "builder": "@nrwl/linter:eslint",
+        "options": Object {
+          "lintFilePatterns": Array [
+            "apps/testProject/**/*.js",
+            "apps/testProject/**/*.jsx",
+            "apps/testProject/**/*.ts",
+            "apps/testProject/**/*.tsx",
+            "apps/testProject/some-random-relative-file.ts",
+            "apps/testProject/something-ad-hoc/**/*.ts",
+            "apps/testProject/**/*.spec.ts",
+            "apps/testProject/**/*.spec.tsx",
+            "apps/testProject/**/*.spec.js",
+            "apps/testProject/**/*.spec.jsx",
+            "apps/testProject/**/*.d.ts",
+          ],
+        },
+      }
+    `);
+  });
+});

--- a/packages/linter/src/migrations/update-10-3-1/revert-node-modules-files-in-eslint-builder-options.ts
+++ b/packages/linter/src/migrations/update-10-3-1/revert-node-modules-files-in-eslint-builder-options.ts
@@ -1,0 +1,33 @@
+import { chain, Tree } from '@angular-devkit/schematics';
+import {
+  formatFiles,
+  readJsonInTree,
+  updateBuilderConfig,
+} from '@nrwl/workspace';
+import { join, normalize } from '@angular-devkit/core';
+
+/**
+ * The migration for v10.3.0 called "update-eslint-builder-and-config" initially had a bug
+ * where it included files from node_modules in the `lintFilePatterns` option if they were
+ * explicitly included in any of the relevant tsconfig files.
+ *
+ * This has now been fixed in the original migration, but this extra migration will handle
+ * fixing up any setups which migrated in the interim and are currently experiencing lint
+ * warnings as a result.
+ */
+function updateESLintBuilder() {
+  return updateBuilderConfig((options) => {
+    const lintFilePatterns: string[] =
+      (options.lintFilePatterns as string[]) || [];
+    return {
+      ...options,
+      lintFilePatterns: lintFilePatterns.filter(
+        (pattern) => !pattern.startsWith('node_modules')
+      ),
+    };
+  }, '@nrwl/linter:eslint');
+}
+
+export default function () {
+  return chain([updateESLintBuilder, formatFiles()]);
+}

--- a/packages/linter/src/migrations/update-10-3-1/revert-node-modules-files-in-eslint-builder-options.ts
+++ b/packages/linter/src/migrations/update-10-3-1/revert-node-modules-files-in-eslint-builder-options.ts
@@ -22,7 +22,7 @@ function updateESLintBuilder() {
     return {
       ...options,
       lintFilePatterns: lintFilePatterns.filter(
-        (pattern) => !pattern.startsWith('node_modules')
+        (pattern) => !pattern.includes('node_modules')
       ),
     };
   }, '@nrwl/linter:eslint');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

I spent some time trying out 10.3 in different existing workspaces that I have access to. For storybook projects, we configure the tsconfig to bring in some files from `node_modules` and currently the migration will therefore set them up in the `lintFilePatterns` array on the `@nrwl/linter:eslint` builder `options`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Exclude any files coming from node_modules, they will be ignored by ESLint and it will print a warning about it. We shouldn't be spending time linting 3rd party files anyway, and if they are relevant to the TypeScript Program for the linting run they will still be included in that.

I have also added an additional migration which removes the `node_modules` patterns for any people that migrated while the issue was present in the original migration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
