### PR TITLE
feat(workspace): ignore local env file

### DIFF
--- a/packages/workspace/src/schematics/workspace/files/__dot__gitignore
+++ b/packages/workspace/src/schematics/workspace/files/__dot__gitignore
@@ -37,3 +37,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Environment files
+.local.env


### PR DESCRIPTION
In [environment variables][environment-variables] docs is mentioned that developers can create a `.local.env` file that will override `.env` file
In my opinion this file should be git ignored

[environment-variables]: https://nx.dev/latest/react/guides/environment-variables

Related issue #3261