### PR TITLE
feat(nextjs): add nextConfig option for nextjs build builder to provide customization

### DIFF
--- a/docs/angular/api-next/builders/build.md
+++ b/docs/angular/api-next/builders/build.md
@@ -24,6 +24,12 @@ Type: `string`
 
 undefined
 
+### nextConfig
+
+Type: `string`
+
+Path to a function which takes phase, config, and builder options, and returns the resulting config.
+
 ### outputPath
 
 Type: `string`

--- a/docs/node/api-next/builders/build.md
+++ b/docs/node/api-next/builders/build.md
@@ -25,6 +25,12 @@ Type: `string`
 
 undefined
 
+### nextConfig
+
+Type: `string`
+
+Path to a function which takes phase, config, and builder options, and returns the resulting config.
+
 ### outputPath
 
 Type: `string`

--- a/docs/react/api-next/builders/build.md
+++ b/docs/react/api-next/builders/build.md
@@ -25,6 +25,12 @@ Type: `string`
 
 undefined
 
+### nextConfig
+
+Type: `string`
+
+Path to a function which takes phase, config, and builder options, and returns the resulting config.
+
 ### outputPath
 
 Type: `string`

--- a/packages/next/src/builders/build/schema.json
+++ b/packages/next/src/builders/build/schema.json
@@ -29,6 +29,10 @@
         "required": ["replace", "with"]
       },
       "default": []
+    },
+    "nextConfig": {
+      "description": "Path to a function which takes phase, config, and builder options, and returns the resulting config.",
+      "type": "string"
     }
   },
   "required": []

--- a/packages/next/src/utils/config.fixture.ts
+++ b/packages/next/src/utils/config.fixture.ts
@@ -1,0 +1,7 @@
+module.exports = (phase, config, context) => {
+  return {
+    ...config,
+    myPhase: phase,
+    myCustomValue: context.options.customValue,
+  };
+};

--- a/packages/next/src/utils/config.spec.ts
+++ b/packages/next/src/utils/config.spec.ts
@@ -83,5 +83,24 @@ describe('Next.js webpack config builder', () => {
         })
       );
     });
+
+    it('should support nextConfig option to customize the config', () => {
+      const config = prepareConfig(
+        PHASE_PRODUCTION_BUILD,
+        {
+          root: 'apps/wibble',
+          outputPath: 'dist/apps/wibble',
+          fileReplacements: [],
+          nextConfig: require.resolve('./config.fixture'),
+          customValue: 'test',
+        },
+        { workspaceRoot: '/root' } as any
+      );
+
+      expect(config).toMatchObject({
+        myPhase: 'phase-production-build',
+        myCustomValue: 'test',
+      });
+    });
   });
 });

--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -108,15 +108,18 @@ export function prepareConfig(
   context: BuilderContext
 ) {
   const config = loadConfig(phase, options.root, null);
+  const userWebpack = config.webpack;
+  const userNextConfig = options.nextConfig
+    ? require(options.nextConfig)
+    : (_, x) => x;
   // Yes, these do have different capitalisation...
   config.outdir = `${offsetFromRoot(options.root)}${options.outputPath}`;
   config.distDir = join(config.outdir, '.next');
-  const userWebpack = config.webpack;
   config.webpack = (a, b) =>
     createWebpackConfig(
       context.workspaceRoot,
       options.root,
       options.fileReplacements
     )(userWebpack ? userWebpack(a, b) : a, b);
-  return config;
+  return userNextConfig(phase, config, { options });
 }

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -34,6 +34,7 @@ export interface NextBuildBuilderOptions extends JsonObject {
   root: string;
   outputPath: string;
   fileReplacements: FileReplacement[];
+  nextConfig?: string;
 }
 
 export interface NextServeBuilderOptions extends JsonObject {


### PR DESCRIPTION
This PR adds a `nextConfig` option to the nextjs build builder. 

## Usage

With this option, you can create your own builder that can customize the next config based  on your own options.

For example, in your builder implementation:

```ts
import {  BuilderContext,  BuilderOutput,  createBuilder } from '@angular-devkit/architect';
import { Observable } from 'rxjs';
import { run } from '@nrwl/next/src/builders/build/build.impl';
import { NextBuildBuilderOptions } from '@nrwl/next/src/utils/types';

export default createBuilder<NextBuildBuilderOptions>(customRun);

export function customRun(
  options: NextBuildBuilderOptions,
  context: BuilderContext
): Observable<BuilderOutput> {
  // Resolve the local module to pass as a path string
  options.nextConfig = require.resolve('./custom-config');

  return run(options, context);
}
```

Then add the `custom-config.ts`  file:

```ts
import * as withNextBundleAnalyzer from '@next/bundle-analyzer';
import { PHASE_PRODUCTION_BUILD } from 'next/dist/next-server/lib/constants';

module.exports = (phase, config, { options } /* the builder options are passed  in the context */) => {
  if (phase === PHASE_PRODUCTION_BUILD && options.analyze) {
    config = withNextBundleAnalyzer({ enabled: true })(config);
  }
  return config;
};
```

And finally, now you can run your own builder with the analyze:

```bash
# Assuming "build" is pointing to your custom builder
nx build my-app --analyze
```

---

Closes #3692