### PR TITLE
fix(storybook): move 10.0.12 migration to 10.3.1 because it was relea…

### DIFF
--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -10,15 +10,15 @@
       "description": "Add build-storybook to cacheable operations",
       "factory": "./src/migrations/update-9-2-0/update-9-2-0"
     },
-    "update-10.0.12": {
-      "version": "10.0.12",
-      "description": "Add missing storybook config to lint target",
-      "factory": "./src/migrations/update-10-0-12/update-10-0-12"
-    },
     "update-10.2.1": {
       "version": "10.2.1-beta.1",
       "description": "Adjusts the tsconfig mapping",
       "factory": "./src/migrations/update-10-2-1/update-10-2-1"
+    },
+    "update-10.3.1": {
+      "version": "10.3.1-beta.1",
+      "description": "Add missing storybook config to lint target",
+      "factory": "./src/migrations/update-10-3-0/update-10-3-0"
     }
   },
   "packageJsonUpdates": {

--- a/packages/storybook/src/migrations/update-10-3-0/update-10-3-0.spec.ts
+++ b/packages/storybook/src/migrations/update-10-3-0/update-10-3-0.spec.ts
@@ -1,12 +1,10 @@
-import * as path from 'path';
-
 import { Tree } from '@angular-devkit/schematics';
 import { readWorkspace } from '@nrwl/workspace';
 import { getFileContent } from '@nrwl/workspace/testing';
 
 import { runMigration } from '../../utils/testing';
 
-describe('Update 10-0-12', () => {
+describe('Update 10-3-0', () => {
   let tree: Tree;
 
   beforeEach(async () => {
@@ -146,7 +144,7 @@ describe('Update 10-0-12', () => {
   });
 
   it(`should add storybook tsconfig to lint target and update tsconfigs in project for Angular project`, async () => {
-    tree = await runMigration('update-10.0.12', {}, tree);
+    tree = await runMigration('update-10.3.1', {}, tree);
 
     const config = readWorkspace(tree);
 
@@ -198,7 +196,7 @@ describe('Update 10-0-12', () => {
   });
 
   it(`should add storybook tsconfig to lint target and update tsconfigs in project for React project`, async () => {
-    tree = await runMigration('update-10.0.12', {}, tree);
+    tree = await runMigration('update-10.3.1', {}, tree);
 
     const config = readWorkspace(tree);
 

--- a/packages/storybook/src/migrations/update-10-3-0/update-10-3-0.ts
+++ b/packages/storybook/src/migrations/update-10-3-0/update-10-3-0.ts
@@ -96,7 +96,12 @@ function updateLintTarget(
     tree.overwrite(paths.tsConfigLib, serializeJson(tsConfig.lib));
   }
 
-  if (Array.isArray(tsConfig.main.references)) {
+  if (
+    Array.isArray(tsConfig.main.references) &&
+    tsConfig.main.references.every(
+      (ref) => ref.path !== './.storybook/tsconfig.json'
+    )
+  ) {
     tsConfig.main.references.push({ path: './.storybook/tsconfig.json' });
     tree.overwrite(paths.tsConfig, serializeJson(tsConfig.main));
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Storybook migration that adds `.storybook/tsconfig.json` to the `references` was not run because it was merged after `10.0.12` so it didn't run for people that went to `10.1.0`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The storybook migration that adds `.storybook/tsconfig.json` to the `references` array is now run for `10.3.1`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
