### PR TITLE
fix(react): support vendor sourcemap option for web build

### DIFF
--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -47,6 +47,35 @@ forEachCli('nx', () => {
       });
     }, 120000);
 
+    it('should support vendor sourcemaps', () => {
+      ensureProject();
+      const appName = uniq('app');
+
+      runCLI(`generate @nrwl/react:app ${appName} --no-interactive`);
+
+      // By default, vendor sourcemaps are off
+      runCLI(`build ${appName}`);
+
+      let vendorContent = readFile(`dist/apps/${appName}/vendor.js`);
+
+      expect(vendorContent).not.toMatch(/sourceMappingURL/);
+
+      // Turn vendor sourcemaps on
+      updateFile(`workspace.json`, (content) => {
+        const json = JSON.parse(content);
+        json.projects[appName].architect.build.options.sourceMap = {
+          scripts: true,
+          vendor: true,
+        };
+        return JSON.stringify(json, null, 2);
+      });
+
+      runCLI(`build ${appName}`);
+      vendorContent = readFile(`dist/apps/${appName}/vendor.js`);
+
+      expect(vendorContent).toMatch(/sourceMappingURL/);
+    }, 120000);
+
     it('should be able to generate a publishable react lib', async () => {
       ensureProject();
       const libName = uniq('lib');

--- a/packages/web/src/utils/third-party/cli-files/models/webpack-configs/browser.ts
+++ b/packages/web/src/utils/third-party/cli-files/models/webpack-configs/browser.ts
@@ -31,6 +31,7 @@ export function getBrowserConfig(
     styles: stylesSourceMap,
     scripts: scriptsSourceMap,
     hidden: hiddenSourceMap,
+    vendor: vendorSourceMap,
   } = buildOptions.sourceMap;
 
   // See https://webpack.js.org/configuration/devtool/ for sourcemap types.
@@ -70,7 +71,8 @@ export function getBrowserConfig(
       getSourceMapDevTool(
         !!scriptsSourceMap,
         !!stylesSourceMap,
-        hiddenSourceMap
+        hiddenSourceMap,
+        vendorSourceMap
       )
     );
   }

--- a/packages/web/src/utils/third-party/cli-files/models/webpack-configs/utils.ts
+++ b/packages/web/src/utils/third-party/cli-files/models/webpack-configs/utils.ts
@@ -83,7 +83,7 @@ export function getSourceMapDevTool(
   scriptsSourceMap: boolean,
   stylesSourceMap: boolean,
   hiddenSourceMap = false,
-  inlineSourceMap = false
+  vendorSourceMap = false
 ): SourceMapDevToolPlugin {
   const include = [];
   if (scriptsSourceMap) {
@@ -95,13 +95,14 @@ export function getSourceMapDevTool(
   }
 
   return new SourceMapDevToolPlugin({
-    filename: inlineSourceMap ? undefined : '[file].map',
+    filename: '[file].map',
     include,
+    exclude: vendorSourceMap ? [] : ['vendor'],
     // We want to set sourceRoot to  `webpack:///` for non
     // inline sourcemaps as otherwise paths to sourcemaps will be broken in browser
     // `webpack:///` is needed for Visual Studio breakpoints to work properly as currently
     // there is no way to set the 'webRoot'
-    sourceRoot: inlineSourceMap ? '' : 'webpack:///',
+    sourceRoot: 'webpack:///',
     moduleFilenameTemplate: '[resource-path]',
     append: hiddenSourceMap ? false : undefined,
   });


### PR DESCRIPTION

## Current Behavior
Cannot turn off vendor sourcemaps

## Expected Behavior
Can turn  vendor sourcemaps on/off based on builder options. (e.g. `{ sourceMap: { scripts: true, vendor: true } }`).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3848
