### PR TITLE
fix(core): fix formatting of strings with periods

### DIFF
--- a/packages/workspace/src/utils/strings.spec.ts
+++ b/packages/workspace/src/utils/strings.spec.ts
@@ -1,0 +1,63 @@
+import { classify, dasherize } from './strings';
+
+describe('String utils', () => {
+  describe('dasherize', () => {
+    it('should format camel casing', () => {
+      expect(dasherize('twoWords')).toEqual('two-words');
+    });
+
+    it('should camel casing with abbreviations', () => {
+      expect(dasherize('twoWORDS')).toEqual('two-words');
+    });
+
+    it('should format spaces', () => {
+      expect(dasherize('two words')).toEqual('two-words');
+    });
+
+    it('should format underscores', () => {
+      expect(dasherize('two_words')).toEqual('two-words');
+    });
+
+    it('should format periods', () => {
+      expect(dasherize('two.words')).toEqual('two-words');
+    });
+
+    it('should format dashes', () => {
+      expect(dasherize('two-words')).toEqual('two-words');
+    });
+
+    it('should return single words', () => {
+      expect(dasherize('word')).toEqual('word');
+    });
+  });
+
+  describe('classify', () => {
+    it('should format camel casing', () => {
+      expect(classify('twoWords')).toEqual('TwoWords');
+    });
+
+    it('should camel casing with abbreviations', () => {
+      expect(classify('twoWORDS')).toEqual('TwoWORDS');
+    });
+
+    it('should format spaces', () => {
+      expect(classify('two words')).toEqual('TwoWords');
+    });
+
+    it('should format underscores', () => {
+      expect(classify('two_words')).toEqual('TwoWords');
+    });
+
+    it('should format periods', () => {
+      expect(classify('two.words')).toEqual('Two.Words');
+    });
+
+    it('should format dashes', () => {
+      expect(classify('two-words')).toEqual('TwoWords');
+    });
+
+    it('should return single words', () => {
+      expect(classify('word')).toEqual('Word');
+    });
+  });
+});

--- a/packages/workspace/src/utils/strings.ts
+++ b/packages/workspace/src/utils/strings.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-const STRING_DASHERIZE_REGEXP = /[ _]/g;
+const STRING_DASHERIZE_REGEXP = /[ _\.]/g;
 const STRING_DECAMELIZE_REGEXP = /([a-z\d])([A-Z])/g;
 const STRING_CAMELIZE_REGEXP = /(-|_|\.|\s)+(.)?/g;
 const STRING_UNDERSCORE_REGEXP_1 = /([a-z\d])([A-Z]+)/g;
@@ -30,13 +30,14 @@ export function decamelize(str: string): string {
 }
 
 /**
- Replaces underscores, spaces, or camelCase with dashes.
+ Replaces underscores, spaces, periods, or camelCase with dashes.
 
  ```javascript
  dasherize('innerHTML');         // 'inner-html'
  dasherize('action_name');       // 'action-name'
  dasherize('css-class-name');    // 'css-class-name'
  dasherize('my favorite items'); // 'my-favorite-items'
+ dasherize('nrwl.io'); // 'nrwl-io'
  ```
 
  @method dasherize


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Workspace names with `.` such as `nrwl.io` will have `nrwl.io` as the npmScope and such which is an issue.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Workspace names such as `nrwl.io` should have a npmScope of `nrwl-io`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
