### PR TITLE
Fix plugin schematic e2e

### DIFF
--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -63,7 +63,7 @@ forEachCli((currentCLIName) => {
     // we should change it to point to the right collection using relative path
     it(`should run the plugin's e2e tests`, async (done) => {
       ensureProject();
-      const plugin = uniq('plugin');
+      const plugin = uniq('plugin-name');
       runCLI(
         `generate @nrwl/nx-plugin:plugin ${plugin} --linter=${linter} --importPath=@proj/${plugin}`
       );

--- a/packages/nx-plugin/src/schematics/e2e-project/files/tests/__pluginName__.test.ts__tmpl__
+++ b/packages/nx-plugin/src/schematics/e2e-project/files/tests/__pluginName__.test.ts__tmpl__
@@ -9,7 +9,7 @@ describe('<%= pluginName %> e2e', () => {
     it('should create <%= pluginName %>', async (done) => {
         const plugin = uniq('<%= pluginName %>');
         ensureNxProject('<%= npmPackageName %>', '<%= pluginOutputPath %>');
-        await runNxCommandAsync(`generate <%=npmPackageName%>:<%= pluginPropertyName %> ${plugin}`);
+        await runNxCommandAsync(`generate <%=npmPackageName%>:<%= pluginName %> ${plugin}`);
 
         const result = await runNxCommandAsync(`build ${plugin}`);
         expect(result.stdout).toContain('Builder ran');
@@ -22,7 +22,7 @@ describe('<%= pluginName %> e2e', () => {
         const plugin = uniq('<%= pluginName %>');
         ensureNxProject('<%= npmPackageName %>', '<%= pluginOutputPath %>');
         await runNxCommandAsync(
-          `generate <%=npmPackageName%>:<%= pluginPropertyName %> ${plugin} --directory subdir`
+          `generate <%=npmPackageName%>:<%= pluginName %> ${plugin} --directory subdir`
         );
         expect(() => checkFilesExist(`libs/subdir/${plugin}/src/index.ts`)).not.toThrow();
         done();
@@ -34,7 +34,7 @@ describe('<%= pluginName %> e2e', () => {
          const plugin = uniq('<%= pluginName %>');
         ensureNxProject('<%= npmPackageName %>', '<%= pluginOutputPath %>');
         await runNxCommandAsync(
-          `generate <%=npmPackageName%>:<%= pluginPropertyName %> ${plugin} --tags e2etag,e2ePackage`
+          `generate <%=npmPackageName%>:<%= pluginName %> ${plugin} --tags e2etag,e2ePackage`
         );
         const nxJson = readJson('nx.json');
         expect(nxJson.projects[plugin].tags).toEqual(['e2etag', 'e2ePackage']);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When a nx-plugin containing a dash in its name, 'my-plugin' as an example, is generated, the default e2e tests fail because the generated schematic follows the same name as the plugin ('my-plugin') but the e2e tests try to execute the schematic using the property name version of the plugin.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
e2e test for generated plugins should succeed if no changes has been made after the plugin generation.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3933 
