### PR TITLE
Add possibility to specify port when running dep graph

### DIFF
--- a/docs/angular/cli/affected-dep-graph.md
+++ b/docs/angular/cli/affected-dep-graph.md
@@ -102,6 +102,10 @@ Default: `false`
 
 Isolate projects which previously failed
 
+### port
+
+Bind the dep graph server to a specific port.
+
 ### runner
 
 This is the name of the tasks runner configured in nx.json

--- a/docs/angular/cli/dep-graph.md
+++ b/docs/angular/cli/dep-graph.md
@@ -80,6 +80,10 @@ Show help
 
 Bind the dep graph server to a specific ip address.
 
+### port
+
+Bind the dep graph server to a specific port.
+
 ### version
 
 Show version number

--- a/docs/node/cli/affected-dep-graph.md
+++ b/docs/node/cli/affected-dep-graph.md
@@ -102,6 +102,10 @@ Default: `false`
 
 Isolate projects which previously failed
 
+### port
+
+Bind the dep graph server to a specific port.
+
 ### runner
 
 This is the name of the tasks runner configured in nx.json

--- a/docs/node/cli/dep-graph.md
+++ b/docs/node/cli/dep-graph.md
@@ -80,6 +80,10 @@ Show help
 
 Bind the dep graph server to a specific ip address.
 
+### port
+
+Bind the dep graph server to a specific port.
+
 ### version
 
 Show version number

--- a/docs/react/cli/affected-dep-graph.md
+++ b/docs/react/cli/affected-dep-graph.md
@@ -102,6 +102,10 @@ Default: `false`
 
 Isolate projects which previously failed
 
+### port
+
+Bind the dep graph server to a specific port.
+
 ### runner
 
 This is the name of the tasks runner configured in nx.json

--- a/docs/react/cli/dep-graph.md
+++ b/docs/react/cli/dep-graph.md
@@ -80,6 +80,10 @@ Show help
 
 Bind the dep graph server to a specific ip address.
 
+### port
+
+Bind the dep graph server to a specific port.
+
 ### version
 
 Show version number

--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -143,6 +143,7 @@ export function generateGraph(
   args: {
     file?: string;
     host?: string;
+    port?: number;
     focus?: string;
     exclude?: string[];
     groupByFolder?: boolean;
@@ -265,11 +266,11 @@ export function generateGraph(
       process.exit(1);
     }
   } else {
-    startServer(html, args.host || '127.0.0.1');
+    startServer(html, args.host || '127.0.0.1', args.port || 4211);
   }
 }
 
-function startServer(html: string, host: string) {
+function startServer(html: string, host: string, port = 4211) {
   const app = http.createServer((req, res) => {
     // parse URL
     const parsedUrl = url.parse(req.url);
@@ -316,13 +317,13 @@ function startServer(html: string, host: string) {
     });
   });
 
-  app.listen(4211, host);
+  app.listen(port, host);
 
   output.note({
-    title: `Dep graph started at http://${host}:4211`,
+    title: `Dep graph started at http://${host}:${port}`,
   });
 
-  opn(`http://${host}:4211`, {
+  opn(`http://${host}:${port}`, {
     wait: false,
   });
 }

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -361,6 +361,10 @@ function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
     .option('host', {
       describe: 'Bind the dep graph server to a specific ip address.',
       type: 'string',
+    })
+    .option('port', {
+      describe: 'Bind the dep graph server to a specific port.',
+      type: 'number',
     });
 }
 


### PR DESCRIPTION
## Current Behavior
it is not possible to specify on which port the dependency graph should be exposed

## Expected Behavior
the cli accepts an additional argument to set the port
