### PR TITLE
fix(core): fix(core): abide by .nxignore when hashing files

### DIFF
--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -151,15 +151,15 @@ export function allFilesInDir(
   return res;
 }
 
-function getIgnoredGlobs() {
+function readFileIfExisting(path: string) {
+  return fs.existsSync(path) ? fs.readFileSync(path, 'UTF-8').toString() : '';
+}
+
+export function getIgnoredGlobs() {
   const ig = ignore();
   ig.add(readFileIfExisting(`${appRootPath}/.gitignore`));
   ig.add(readFileIfExisting(`${appRootPath}/.nxignore`));
   return ig;
-}
-
-function readFileIfExisting(path: string) {
-  return fs.existsSync(path) ? fs.readFileSync(path, 'UTF-8').toString() : '';
 }
 
 export function readWorkspaceJson(): any {


### PR DESCRIPTION
ISSUES CLOSED: #3897

@vsavkin Not sure if we would rather have implicit deps take precedent over .nxignore

With this PR if workspace files are listed in .nxignore they will be ignored unless they are also listed in implicitDependencies
