### PR TITLE
feat(linter): use overrides in root eslint config

### DIFF
--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -19,7 +19,11 @@ forEachCli('nx', () => {
       runCLI(`generate @nrwl/react:app ${myapp}`);
 
       const eslintrc = readJson('.eslintrc.json');
-      eslintrc.rules['no-console'] = 'error';
+      eslintrc.overrides.forEach((override) => {
+        if (override.files.includes('*.ts')) {
+          override.rules['no-console'] = 'error';
+        }
+      });
       updateFile('.eslintrc.json', JSON.stringify(eslintrc, null, 2));
 
       updateFile(`apps/${myapp}/src/main.ts`, `console.log("should fail");`);
@@ -35,7 +39,11 @@ forEachCli('nx', () => {
       runCLI(`generate @nrwl/react:app ${myapp}`);
 
       const eslintrc = readJson('.eslintrc.json');
-      eslintrc.rules['no-console'] = 'error';
+      eslintrc.overrides.forEach((override) => {
+        if (override.files.includes('*.ts')) {
+          override.rules['no-console'] = 'error';
+        }
+      });
       updateFile('.eslintrc.json', JSON.stringify(eslintrc, null, 2));
 
       updateFile(`apps/${myapp}/src/main.ts`, `console.log("should fail");`);
@@ -50,7 +58,11 @@ forEachCli('nx', () => {
       runCLI(`generate @nrwl/react:app ${myapp}`);
 
       const eslintrc = readJson('.eslintrc.json');
-      eslintrc.rules['no-console'] = undefined;
+      eslintrc.overrides.forEach((override) => {
+        if (override.files.includes('*.ts')) {
+          override.rules['no-console'] = undefined;
+        }
+      });
       updateFile('.eslintrc.json', JSON.stringify(eslintrc, null, 2));
 
       updateFile(`apps/${myapp}/src/main.ts`, `console.log("should fail");`);
@@ -82,7 +94,11 @@ forEachCli('nx', () => {
       updateFile('workspace.json', JSON.stringify(workspaceJson, null, 2));
 
       const eslintrc = readJson('.eslintrc.json');
-      eslintrc.rules['no-console'] = undefined;
+      eslintrc.overrides.forEach((override) => {
+        if (override.files.includes('*.ts')) {
+          override.rules['no-console'] = undefined;
+        }
+      });
       updateFile('.eslintrc.json', JSON.stringify(eslintrc, null, 2));
 
       updateFile(`apps/${myapp}/src/main.ts`, `console.log("should fail");`);
@@ -130,7 +146,11 @@ forEachCli('nx', () => {
       runCLI(`generate @nrwl/react:app ${myapp}`);
 
       const eslintrc = readJson('.eslintrc.json');
-      eslintrc.rules['no-console'] = 'error';
+      eslintrc.overrides.forEach((override) => {
+        if (override.files.includes('*.ts')) {
+          override.rules['no-console'] = 'error';
+        }
+      });
       updateFile('.eslintrc.json', JSON.stringify(eslintrc, null, 2));
       updateFile(`apps/${myapp}/src/main.ts`, `console.log("should fail");`);
 

--- a/packages/eslint-plugin-nx/src/configs/javascript.ts
+++ b/packages/eslint-plugin-nx/src/configs/javascript.ts
@@ -1,0 +1,37 @@
+/**
+ * This configuration is intended to be applied to ALL .js and .jsx files
+ * within an Nx workspace.
+ *
+ * It should therefore NOT contain any rules or plugins which are specific
+ * to one ecosystem, such as React, Angular, Node etc.
+ *
+ * We use @typescript-eslint/parser rather than the built in JS parser
+ * because that is what Nx ESLint configs have always done and we don't
+ * want to change too much all at once.
+ *
+ * TODO: Evaluate switching to the built-in JS parser (espree) in Nx v11,
+ * it should yield a performance improvement but could introduce subtle
+ * breaking changes - we should also look to replace all the @typescript-eslint
+ * related plugins and rules below.
+ */
+export default {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+    'prettier/@typescript-eslint',
+  ],
+  rules: {
+    '@typescript-eslint/explicit-member-accessibility': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-parameter-properties': 'off',
+  },
+};

--- a/packages/eslint-plugin-nx/src/index.ts
+++ b/packages/eslint-plugin-nx/src/index.ts
@@ -1,4 +1,5 @@
 import typescript from './configs/typescript';
+import javascript from './configs/javascript';
 import reactTmp from './configs/react-tmp';
 import reactBase from './configs/react-base';
 import reactJsx from './configs/react-jsx';
@@ -11,6 +12,7 @@ import enforceModuleBoundaries, {
 module.exports = {
   configs: {
     typescript,
+    javascript,
     react: reactTmp,
     'react-base': reactBase,
     'react-typescript': reactTypescript,

--- a/packages/linter/migrations.json
+++ b/packages/linter/migrations.json
@@ -29,6 +29,11 @@
       "version": "10.4.0-beta.0",
       "description": "Update ESLint config files to use preset configs which eslint-plugin-nx exports",
       "factory": "./src/migrations/update-10-4-0/update-eslint-configs-to-use-nx-presets"
+    },
+    "update-root-eslint-config-to-use-overrides": {
+      "version": "10.4.0-beta.1",
+      "description": "Update root ESLint config to use overrides",
+      "factory": "./src/migrations/update-10-4-0/update-root-eslint-config-to-use-overrides"
     }
   },
   "packageJsonUpdates": {

--- a/packages/linter/src/migrations/update-10-4-0/update-root-eslint-config-to-use-overrides.spec.ts
+++ b/packages/linter/src/migrations/update-10-4-0/update-root-eslint-config-to-use-overrides.spec.ts
@@ -1,0 +1,209 @@
+import { Tree } from '@angular-devkit/schematics';
+import { readJsonInTree } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { runMigration } from '../../utils/testing';
+
+describe('Update root ESLint config to use overrides', () => {
+  let tree: Tree;
+  beforeEach(async () => {
+    tree = Tree.empty();
+    tree = createEmptyWorkspace(tree);
+  });
+
+  const testCases = [
+    {
+      // Most recent root ESLint config (before this change) with no modifications
+      input: {
+        root: true,
+        ignorePatterns: ['**/*'],
+        plugins: ['@nrwl/nx'],
+        extends: ['plugin:@nrwl/nx/typescript'],
+        rules: {
+          '@nrwl/nx/enforce-module-boundaries': [
+            'error',
+            {
+              enforceBuildableLibDependency: true,
+              allow: [],
+              depConstraints: [
+                { sourceTag: '*', onlyDependOnLibsWithTags: ['*'] },
+              ],
+            },
+          ],
+        },
+      },
+      expected: {
+        root: true,
+        ignorePatterns: ['**/*'],
+        plugins: ['@nrwl/nx'],
+        overrides: [
+          {
+            files: ['*.ts', '*.tsx', '*.js', '*.jsx'],
+            rules: {
+              '@nrwl/nx/enforce-module-boundaries': [
+                'error',
+                {
+                  enforceBuildableLibDependency: true,
+                  allow: [],
+                  depConstraints: [
+                    { sourceTag: '*', onlyDependOnLibsWithTags: ['*'] },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            files: ['*.ts', '*.tsx'],
+            extends: ['plugin:@nrwl/nx/typescript'],
+            parserOptions: { project: './tsconfig.*?.json' },
+            rules: {},
+          },
+          {
+            files: ['*.js', '*.jsx'],
+            extends: ['plugin:@nrwl/nx/javascript'],
+            rules: {},
+          },
+        ],
+      },
+    },
+
+    {
+      // Example using custom overrides already (should be a noop)
+      input: {
+        root: true,
+        ignorePatterns: ['**/*'],
+        plugins: ['@nrwl/nx'],
+        extends: ['plugin:@nrwl/nx/typescript'],
+        overrides: [
+          {
+            files: ['*.ts'],
+            rules: {
+              foo: 'error',
+            },
+          },
+        ],
+      },
+      expected: {
+        root: true,
+        ignorePatterns: ['**/*'],
+        plugins: ['@nrwl/nx'],
+        extends: ['plugin:@nrwl/nx/typescript'],
+        overrides: [
+          {
+            files: ['*.ts'],
+            rules: {
+              foo: 'error',
+            },
+          },
+        ],
+      },
+    },
+
+    {
+      // Example using custom rules and plugins at the top-level
+      input: {
+        root: true,
+        ignorePatterns: ['**/*'],
+        plugins: ['@nrwl/nx', 'plugin-a', 'plugin-b'],
+        extends: ['plugin:@nrwl/nx/typescript'],
+        rules: {
+          bar: 'warn',
+          'plugin-a/qux': ['error', { someConfig: true }],
+          'plugin-b/baz': 'off',
+        },
+      },
+      expected: {
+        root: true,
+        ignorePatterns: ['**/*'],
+        plugins: ['@nrwl/nx'],
+        overrides: [
+          {
+            files: ['*.ts', '*.tsx', '*.js', '*.jsx'],
+            plugins: ['plugin-a', 'plugin-b'],
+            rules: {
+              bar: 'warn',
+              'plugin-a/qux': ['error', { someConfig: true }],
+              'plugin-b/baz': 'off',
+            },
+          },
+          {
+            files: ['*.ts', '*.tsx'],
+            extends: ['plugin:@nrwl/nx/typescript'],
+            parserOptions: { project: './tsconfig.*?.json' },
+            rules: {},
+          },
+          {
+            files: ['*.js', '*.jsx'],
+            extends: ['plugin:@nrwl/nx/javascript'],
+            rules: {},
+          },
+        ],
+      },
+    },
+
+    {
+      // Example using other custom config at the top-level
+      input: {
+        root: true,
+        ignorePatterns: ['**/*'],
+        plugins: ['@nrwl/nx'],
+        settings: {
+          foo: 'bar',
+        },
+        env: {
+          browser: true,
+        },
+        parser: 'some-custom-parser-value',
+        parserOptions: {
+          custom: 'option',
+        },
+        extends: ['plugin:@nrwl/nx/typescript', 'custom-extends-config'],
+      },
+      expected: {
+        root: true,
+        ignorePatterns: ['**/*'],
+        plugins: ['@nrwl/nx'],
+        overrides: [
+          {
+            files: ['*.ts', '*.tsx', '*.js', '*.jsx'],
+            extends: ['custom-extends-config'],
+            env: {
+              browser: true,
+            },
+            settings: {
+              foo: 'bar',
+            },
+            parser: 'some-custom-parser-value',
+            parserOptions: {
+              custom: 'option',
+            },
+            rules: {},
+          },
+          {
+            files: ['*.ts', '*.tsx'],
+            extends: ['plugin:@nrwl/nx/typescript'],
+            parserOptions: { project: './tsconfig.*?.json' },
+            rules: {},
+          },
+          {
+            files: ['*.js', '*.jsx'],
+            extends: ['plugin:@nrwl/nx/javascript'],
+            rules: {},
+          },
+        ],
+      },
+    },
+  ];
+
+  testCases.forEach((tc, i) => {
+    it(`should update the existing root .eslintrc.json file to use overrides, CASE ${i}`, async () => {
+      tree.create('.eslintrc.json', JSON.stringify(tc.input));
+
+      const result = await runMigration(
+        'update-root-eslint-config-to-use-overrides',
+        {},
+        tree
+      );
+      expect(readJsonInTree(result, '.eslintrc.json')).toEqual(tc.expected);
+    });
+  });
+});

--- a/packages/linter/src/migrations/update-10-4-0/update-root-eslint-config-to-use-overrides.ts
+++ b/packages/linter/src/migrations/update-10-4-0/update-root-eslint-config-to-use-overrides.ts
@@ -1,0 +1,117 @@
+import { chain, noop, Tree } from '@angular-devkit/schematics';
+import { formatFiles, updateJsonInTree } from '@nrwl/workspace';
+import type { Linter } from 'eslint';
+
+/**
+ * We want to update the JSON in such a way that we:
+ * - translate the config to use overrides
+ * - don't break existing setups
+ *
+ * In order to achieve the second point we need to assume
+ * that any existing top level rules/plugins etc are intended
+ * to be run on all source files.
+ */
+function updateRootESLintConfig(host: Tree) {
+  return host.exists('.eslintrc.json')
+    ? updateJsonInTree('.eslintrc.json', (json: Linter.Config) => {
+        /**
+         * If the user already has overrides specified it is likely they have "forged their own path"
+         * when it comes to their ESLint setup, so we do nothing.
+         */
+        if (Array.isArray(json.overrides)) {
+          return json;
+        }
+
+        let normalizedExtends: string[] | undefined = undefined;
+        if (json.extends) {
+          if (typeof json.extends === 'string') {
+            normalizedExtends = [json.extends];
+          } else if (Array.isArray(json.extends)) {
+            normalizedExtends = json.extends;
+          }
+        }
+
+        json.overrides = [
+          /**
+           * This configuration is intended to apply to all "source code" (but not
+           * markup like HTML, or other custom file types like GraphQL).
+           *
+           * This is where we will apply any top-level config that the user currently
+           * has to ensure that it behaves the same before and after the migration.
+           */
+          {
+            files: ['*.ts', '*.tsx', '*.js', '*.jsx'],
+            extends: undefinedIfEmptyArr(
+              normalizedExtends
+                ? normalizedExtends.filter(
+                    (e) => e !== 'plugin:@nrwl/nx/typescript'
+                  )
+                : normalizedExtends
+            ),
+            env: json.env,
+            settings: json.settings,
+            parser: json.parser,
+            parserOptions: json.parserOptions,
+            plugins: undefinedIfEmptyArr(
+              json.plugins.filter((p) => p !== '@nrwl/nx') // remains at top-level, used everywhere
+            ),
+            rules: json.rules || {},
+          },
+
+          /**
+           * This configuration is intended to apply to all TypeScript source files.
+           * See the eslint-plugin-nx package for what is in the referenced shareable config.
+           */
+          {
+            files: ['*.ts', '*.tsx'],
+            extends: ['plugin:@nrwl/nx/typescript'],
+            parserOptions: { project: './tsconfig.*?.json' },
+            /**
+             * Having an empty rules object present makes it more obvious to the user where they would
+             * extend things from if they needed to
+             */
+            rules: {},
+          },
+
+          /**
+           * This configuration is intended to apply to all JavaScript source files.
+           * See the eslint-plugin-nx package for what is in the referenced shareable config.
+           */
+          {
+            files: ['*.js', '*.jsx'],
+            extends: ['plugin:@nrwl/nx/javascript'],
+            /**
+             * Having an empty rules object present makes it more obvious to the user where they would
+             * extend things from if they needed to
+             */
+            rules: {},
+          },
+        ];
+
+        /**
+         * Clean up after copying config to main override
+         */
+        json.plugins = ['@nrwl/nx'];
+        delete json.rules;
+        delete json.extends;
+        delete json.env;
+        delete json.settings;
+        delete json.globals;
+        delete json.parser;
+        delete json.parserOptions;
+
+        return json;
+      })
+    : noop();
+}
+
+function undefinedIfEmptyArr<T>(possibleArr: T): T | undefined {
+  if (Array.isArray(possibleArr) && possibleArr.length === 0) {
+    return undefined;
+  }
+  return possibleArr;
+}
+
+export default function () {
+  return chain([updateRootESLintConfig, formatFiles()]);
+}

--- a/packages/storybook/src/schematics/configuration/configuration.ts
+++ b/packages/storybook/src/schematics/configuration/configuration.ts
@@ -236,11 +236,28 @@ function updateLintConfig(schema: StorybookConfigureSchema): Rule {
       return updateJsonInTree(
         `${projectConfig.root}/.eslintrc.json`,
         (json) => {
+          if (typeof json.parserOptions?.project === 'string') {
+            json.parserOptions.project = [json.parserOptions.project];
+          }
+
           if (Array.isArray(json.parserOptions?.project)) {
             json.parserOptions.project.push(
               `${projectConfig.root}/.storybook/tsconfig.json`
             );
           }
+
+          const overrides = json.overrides || [];
+          for (const override of overrides) {
+            if (typeof override.parserOptions?.project === 'string') {
+              override.parserOptions.project = [override.parserOptions.project];
+            }
+            if (Array.isArray(override.parserOptions?.project)) {
+              override.parserOptions.project.push(
+                `${projectConfig.root}/.storybook/tsconfig.json`
+              );
+            }
+          }
+
           return json;
         }
       );

--- a/packages/workspace/src/utils/lint.ts
+++ b/packages/workspace/src/utils/lint.ts
@@ -234,24 +234,69 @@ const globalTsLint = `
 }
 `;
 
-const globalESLint = `
-{
-  "root": true,
-  "ignorePatterns": ["**/*"],
-  "plugins": ["@nrwl/nx"],
-  "extends": ["plugin:@nrwl/nx/typescript"],
-  "parserOptions": { "project": "./tsconfig.*?.json" },
-  "rules": {
-    "@nrwl/nx/enforce-module-boundaries": [
-      "error",
-      {
-        "enforceBuildableLibDependency": true,
-        "allow": [],
-        "depConstraints": [
-          { "sourceTag": "*", "onlyDependOnLibsWithTags": ["*"] }
-        ]
-      }
-    ]
-  }
-}
-`;
+const globalESLint = JSON.stringify({
+  root: true,
+  ignorePatterns: ['**/*'],
+  plugins: ['@nrwl/nx'],
+  /**
+   * We leverage ESLint's "overrides" capability so that we can set up a root config which will support
+   * all permutations of Nx workspaces across all frameworks, libraries and tools.
+   *
+   * The key point is that we need entirely different ESLint config to apply to different types of files,
+   * but we still want to share common config where possible.
+   */
+  overrides: [
+    /**
+     * This configuration is intended to apply to all "source code" (but not
+     * markup like HTML, or other custom file types like GraphQL)
+     */
+    {
+      files: ['*.ts', '*.tsx', '*.js', '*.jsx'],
+      rules: {
+        '@nrwl/nx/enforce-module-boundaries': [
+          'error',
+          {
+            enforceBuildableLibDependency: true,
+            allow: [],
+            depConstraints: [
+              { sourceTag: '*', onlyDependOnLibsWithTags: ['*'] },
+            ],
+          },
+        ],
+      },
+    },
+
+    /**
+     * This configuration is intended to apply to all TypeScript source files.
+     * See the eslint-plugin-nx package for what is in the referenced shareable config.
+     */
+    {
+      files: ['*.ts', '*.tsx'],
+      extends: ['plugin:@nrwl/nx/typescript'],
+      /**
+       * TODO: Remove this usage of project at the root in a follow up PR (and migration),
+       * it should be set in each project's config
+       */
+      parserOptions: { project: './tsconfig.*?.json' },
+      /**
+       * Having an empty rules object present makes it more obvious to the user where they would
+       * extend things from if they needed to
+       */
+      rules: {},
+    },
+
+    /**
+     * This configuration is intended to apply to all JavaScript source files.
+     * See the eslint-plugin-nx package for what is in the referenced shareable config.
+     */
+    {
+      files: ['*.js', '*.jsx'],
+      extends: ['plugin:@nrwl/nx/javascript'],
+      /**
+       * Having an empty rules object present makes it more obvious to the user where they would
+       * extend things from if they needed to
+       */
+      rules: {},
+    },
+  ],
+});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The root level ESLint config in an Nx workspace currently applies all configuration (parser, plugins, rules etc) to all files within the workspace.

This is ok for TypeScript and JavaScript (where the same custom parser can be used for both file types), but for Nx to truly support linting any and all frameworks, libraries and tools, it needs to become more precise in how config is applied.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We leverage ESLint's "overrides" capability so that we can set up a root config which will support all permutations of Nx workspaces across all frameworks, libraries and tools.

The key point is that we need entirely different ESLint config to apply to different types of files, but we still want to share common config where possible.

I did not need to change any other existing project level configs, they all still work as before.

**This is the final step to unlocking proper Angular linting via ESLint in Nx workspaces**, because now HTML files (and inline HTML templates within Components) can be linted alongside other source code.

I have personally verified this locally by using a build of this PR and creating a custom Nx workspace which mixes React and Angular apps together.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
