### PR TITLE
fix(angular): handle delimited name in NgRx templates

### DIFF
--- a/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.facade.spec.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.facade.spec.ts__tmpl__
@@ -14,7 +14,7 @@ import { <%= className %>Facade } from './<%= fileName %>.facade';
 import * as <%= className %>Selectors from './<%= fileName %>.selectors';
 import * as <%= className %>Actions from './<%= fileName %>.actions';
 import {
-  <%= className.toUpperCase() %>_FEATURE_KEY,
+  <%= constantName %>_FEATURE_KEY,
   State,
   initialState,
   reducer
@@ -41,7 +41,7 @@ describe('<%= className %>Facade', () => {
     beforeEach(() => {
       @NgModule({
         imports: [
-          StoreModule.forFeature(<%= className.toUpperCase() %>_FEATURE_KEY, reducer),
+          StoreModule.forFeature(<%= constantName %>_FEATURE_KEY, reducer),
           EffectsModule.forFeature([<%= className %>Effects])
         ],
         providers: [<%= className %>Facade]

--- a/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.reducer.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.reducer.ts__tmpl__
@@ -4,7 +4,7 @@ import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
 import * as <%= className %>Actions from './<%= fileName %>.actions';
 import { <%= className %>Entity } from './<%= fileName %>.models';
 
-export const <%= className.toUpperCase() %>_FEATURE_KEY = '<%= propertyName %>';
+export const <%= constantName %>_FEATURE_KEY = '<%= propertyName %>';
 
 export interface State extends EntityState<<%= className %>Entity> {
   selectedId ?: string | number;          // which <%= className %> record has been selected
@@ -13,7 +13,7 @@ export interface State extends EntityState<<%= className %>Entity> {
 }
 
 export interface <%= className %>PartialState {
-  readonly [<%= className.toUpperCase() %>_FEATURE_KEY]: State;
+  readonly [<%= constantName %>_FEATURE_KEY]: State;
 }
 
 export const <%= propertyName %>Adapter: EntityAdapter<<%= className %>Entity> = createEntityAdapter<<%= className %>Entity>();

--- a/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.selectors.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.selectors.ts__tmpl__
@@ -1,5 +1,5 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { <%= className.toUpperCase() %>_FEATURE_KEY, State, <%= className %>PartialState, <%= propertyName %>Adapter } from './<%= fileName %>.reducer';
+import { <%= constantName %>_FEATURE_KEY, State, <%= className %>PartialState, <%= propertyName %>Adapter } from './<%= fileName %>.reducer';
 
 // Lookup the '<%= className %>' feature state managed by NgRx
 export const get<%= className %>State = createFeatureSelector<<%= className %>PartialState, State>(<%= propertyName.toUpperCase() %>_FEATURE_KEY);

--- a/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.reducer.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.reducer.ts__tmpl__
@@ -1,6 +1,6 @@
 import { <%= className %>Action, <%= className %>ActionTypes } from './<%= fileName %>.actions';
 
-export const <%= className.toUpperCase() %>_FEATURE_KEY = '<%= propertyName %>';
+export const <%= constantName %>_FEATURE_KEY = '<%= propertyName %>';
 
 /**
  * Interface for the '<%= className %>' data used in
@@ -21,7 +21,7 @@ export interface <%= className %>State {
 };
 
 export interface <%= className %>PartialState {
-  readonly [<%= className.toUpperCase() %>_FEATURE_KEY]: <%= className %>State;
+  readonly [<%= constantName %>_FEATURE_KEY]: <%= className %>State;
 }
 
 export const initialState: <%= className %>State = {

--- a/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.selectors.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.selectors.ts__tmpl__
@@ -1,5 +1,5 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { <%= className.toUpperCase() %>_FEATURE_KEY, <%= className %>State } from './<%= fileName %>.reducer';
+import { <%= constantName %>_FEATURE_KEY, <%= className %>State } from './<%= fileName %>.reducer';
 
 // Lookup the '<%= className %>' feature state managed by NgRx
 const get<%= className %>State = createFeatureSelector<<%= className %>State>(<%= propertyName.toUpperCase() %>_FEATURE_KEY);

--- a/packages/workspace/src/utils/name-utils.ts
+++ b/packages/workspace/src/utils/name-utils.ts
@@ -9,25 +9,27 @@ export function names(
   name: string;
   className: string;
   propertyName: string;
+  constantName: string;
   fileName: string;
 } {
   return {
     name,
     className: toClassName(name),
     propertyName: toPropertyName(name),
+    constantName: toConstantName(name),
     fileName: toFileName(name),
   };
 }
 
 /**
- * hypenated to UpperCamelCase
+ * Hyphenated to UpperCamelCase
  */
 export function toClassName(str: string): string {
   return toCapitalCase(toPropertyName(str));
 }
 
 /**
- * Hypenated to lowerCamelCase
+ * Hyphenated to lowerCamelCase
  */
 export function toPropertyName(s: string): string {
   return s
@@ -38,7 +40,14 @@ export function toPropertyName(s: string): string {
 }
 
 /**
- * Upper camelCase to lowercase, hypenated
+ * Hyphenated to CONSTANT_CASE
+ */
+function toConstantName(s: string): string {
+  return s.replace(/(-|_|\.|\s)/g, '_').toUpperCase();
+}
+
+/**
+ * Upper camelCase to lowercase, hyphenated
  */
 export function toFileName(s: string): string {
   return s
@@ -47,6 +56,9 @@ export function toFileName(s: string): string {
     .replace(/[ _]/g, '-');
 }
 
+/**
+ * Capitalizes the first letter of a string
+ */
 function toCapitalCase(s: string): string {
   return s.charAt(0).toUpperCase() + s.substr(1);
 }


### PR DESCRIPTION
NgRx schematics would not render the feature key properly (which should be CONSTANT_CASE) when given a delimited name like 'my-store'. It would end up as `MYSTATE_FEATURE_KEY`.

This changes it to `MY_STATE_FEATURE_KEY`.
