### PR TITLE
fix(core): fix resolving npm dependencies

### DIFF
--- a/packages/workspace/src/core/target-project-locator.spec.ts
+++ b/packages/workspace/src/core/target-project-locator.spec.ts
@@ -162,7 +162,7 @@ describe('findTargetProjectWithImport', () => {
           files: [],
         },
       },
-      '@ng/core': {
+      'npm:@ng/core': {
         name: 'npm:@ng/core',
         type: 'npm',
         data: {
@@ -170,7 +170,7 @@ describe('findTargetProjectWithImport', () => {
           packageName: '@ng/core',
         },
       },
-      '@ng/common': {
+      'npm:@ng/common': {
         name: 'npm:@ng/common',
         type: 'npm',
         data: {
@@ -178,12 +178,20 @@ describe('findTargetProjectWithImport', () => {
           packageName: '@ng/common',
         },
       },
-      'npm-package': {
+      'npm:npm-package': {
         name: 'npm:npm-package',
         type: 'npm',
         data: {
           files: [],
           packageName: 'npm-package',
+        },
+      },
+      'npm:@proj/proj123-base': {
+        name: 'npm:@proj/proj123-base',
+        type: 'npm',
+        data: {
+          files: [],
+          packageName: '@proj/proj123-base',
         },
       },
       'proj1234-child': {
@@ -289,5 +297,21 @@ describe('findTargetProjectWithImport', () => {
       ctx.nxJson.npmScope
     );
     expect(parentProj).toEqual('proj1234');
+  });
+
+  it('should be able to resolve npm projects', () => {
+    const similarImportFromNpm = targetProjectLocator.findProjectWithImport(
+      '@proj/proj123-base',
+      'libs/proj/index.ts',
+      ctx.nxJson.npmScope
+    );
+    expect(similarImportFromNpm).toEqual('npm:@proj/proj123-base');
+
+    const similarDeepImportFromNpm = targetProjectLocator.findProjectWithImport(
+      '@proj/proj123-base/deep',
+      'libs/proj/index.ts',
+      ctx.nxJson.npmScope
+    );
+    expect(similarDeepImportFromNpm).toEqual('npm:@proj/proj123-base');
   });
 });

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -105,8 +105,10 @@ export class TargetProjectLocator {
     if (this.npmResolutionCache.has(npmImport)) {
       return this.npmResolutionCache.get(npmImport);
     } else {
-      const pkgName = this.npmProjects.find((pkg) =>
-        npmImport.startsWith(pkg.data.packageName)
+      const pkgName = this.npmProjects.find(
+        (pkg) =>
+          npmImport === pkg.data.packageName ||
+          npmImport.startsWith(pkg.data.packageName + '/')
       )?.name;
       this.npmResolutionCache.set(npmImport, pkgName);
       return pkgName;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Dependencies to projects that start with a npm dependency name such as `express-utils` would be inaccurately identified as dependencies to the npm dependency (e.g. `express`)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Dependencies to projects are properly identified.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/2980
