### PR TITLE
feat(core): support `packageManager` argument

### DIFF
--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -84,11 +84,13 @@ export function runCreateWorkspace(
     appName,
     style,
     base,
+    packageManager,
   }: {
     preset: string;
     appName?: string;
     style?: string;
     base?: string;
+    packageManager?: string;
   }
 ) {
   const linterArg =
@@ -103,6 +105,10 @@ export function runCreateWorkspace(
 
   if (base) {
     command += ` --defaultBase="${base}"`;
+  }
+
+  if (packageManager) {
+    command += ` --package-manager=${packageManager}`;
   }
 
   const create = execSync(command, {

--- a/e2e/workspace/src/create-nx-workspace.test.ts
+++ b/e2e/workspace/src/create-nx-workspace.test.ts
@@ -1,4 +1,12 @@
-import { cli, forEachCli, runCreateWorkspace, uniq } from '@nrwl/e2e/utils';
+import {
+  cli,
+  forEachCli,
+  readJson,
+  runCreateWorkspace,
+  setCurrentProjName,
+  uniq,
+  workspaceConfigName,
+} from '@nrwl/e2e/utils';
 import { existsSync, mkdirSync } from 'fs-extra';
 import { execSync } from 'child_process';
 
@@ -110,6 +118,19 @@ forEachCli(() => {
       });
 
       expect(existsSync(`${tmpDir}/${wsName}/package.json`)).toBeTruthy();
+    });
+
+    it('should store `packageManager` preference', () => {
+      const wsName = uniq('empty');
+      setCurrentProjName(wsName);
+
+      runCreateWorkspace(wsName, {
+        preset: 'empty',
+        packageManager: 'yarn',
+      });
+
+      const workspaceJson = readJson(`${workspaceConfigName()}`);
+      expect(workspaceJson.cli.packageManager).toEqual('yarn');
     });
   });
 });

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -74,7 +74,15 @@ const angularCliVersion = 'ANGULAR_CLI_VERSION';
 const prettierVersion = 'PRETTIER_VERSION';
 
 const parsedArgs = yargsParser(process.argv, {
-  string: ['cli', 'preset', 'appName', 'style', 'linter', 'defaultBase'],
+  string: [
+    'cli',
+    'preset',
+    'appName',
+    'style',
+    'linter',
+    'defaultBase',
+    'packageManager',
+  ],
   alias: {
     appName: 'app-name',
     nxCloud: 'nx-cloud',
@@ -87,7 +95,7 @@ if (parsedArgs.help) {
   showHelp();
   process.exit(0);
 }
-const packageManager = determinePackageManager();
+const packageManager = determinePackageManager(parsedArgs.packageManager);
 determineWorkspaceName(parsedArgs).then((name) => {
   determinePreset(parsedArgs).then((preset) => {
     return determineAppName(preset, parsedArgs).then((appName) => {

--- a/packages/create-nx-workspace/bin/shared.spec.ts
+++ b/packages/create-nx-workspace/bin/shared.spec.ts
@@ -1,0 +1,42 @@
+import { determinePackageManager } from './shared';
+
+let INSTALLED_PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm'];
+
+jest.mock('child_process', () => {
+  return {
+    execSync: (command) => {
+      if (command.endsWith(`--version`)) {
+        const pm = command.split(' ')[0];
+        if (INSTALLED_PACKAGE_MANAGERS.includes(pm)) {
+          return;
+        }
+        throw Error();
+      }
+    },
+  };
+});
+
+describe('determinePackageManager', () => {
+  it('will prefer Yarn if installed and there is no preference', () => {
+    const pm = determinePackageManager();
+    expect(pm).toEqual('yarn');
+  });
+
+  it('will use preferred one if installed', () => {
+    expect(determinePackageManager('pnpm')).toEqual('pnpm');
+    expect(determinePackageManager('yarn')).toEqual('yarn');
+    expect(determinePackageManager('npm')).toEqual('npm');
+  });
+
+  it('will not use preferred one if not installed', () => {
+    INSTALLED_PACKAGE_MANAGERS = ['npm', 'pnpm'];
+    const pm = determinePackageManager('yarn');
+    expect(pm).toEqual('pnpm');
+  });
+
+  it('will fallback to NPM', () => {
+    INSTALLED_PACKAGE_MANAGERS = [];
+    const pm = determinePackageManager();
+    expect(pm).toEqual('npm');
+  });
+});

--- a/packages/create-nx-workspace/bin/shared.ts
+++ b/packages/create-nx-workspace/bin/shared.ts
@@ -22,26 +22,19 @@ export function showNxWarning(workspaceName: string) {
   }
 }
 
-export function determinePackageManager() {
-  let packageManager = getPackageManagerFromAngularCLI();
-  if (packageManager === 'npm' || isPackageManagerInstalled(packageManager)) {
-    return packageManager;
-  }
-
-  if (isPackageManagerInstalled('yarn')) {
-    return 'yarn';
-  }
-
-  if (isPackageManagerInstalled('pnpm')) {
-    return 'pnpm';
-  }
-
-  return 'npm';
+export function determinePackageManager(preferredPackageManager?: string) {
+  return (
+    [
+      preferredPackageManager,
+      getPackageManagerFromAngularCLI(),
+      'yarn',
+      'pnpm',
+    ].find((pm) => pm && isPackageManagerInstalled(pm)) || 'npm'
+  );
 }
 
 function getPackageManagerFromAngularCLI(): string {
   // If you have Angular CLI installed, read Angular CLI config.
-  // If it isn't installed, default to 'yarn'.
   try {
     return execSync('ng config -g cli.packageManager', {
       stdio: ['ignore', 'pipe', 'ignore'],
@@ -50,7 +43,7 @@ function getPackageManagerFromAngularCLI(): string {
       .toString()
       .trim();
   } catch (e) {
-    return 'yarn';
+    return;
   }
 }
 

--- a/packages/workspace/src/schematics/ng-new/schema.json
+++ b/packages/workspace/src/schematics/ng-new/schema.json
@@ -92,6 +92,11 @@
       "type": "string",
       "enum": ["tslint", "eslint"],
       "default": "eslint"
+    },
+    "packageManager": {
+      "description": "The package manager used to install dependencies.",
+      "type": "string",
+      "enum": ["npm", "yarn", "pnpm"]
     }
   }
 }

--- a/packages/workspace/src/schematics/shared-new/shared-new.ts
+++ b/packages/workspace/src/schematics/shared-new/shared-new.ts
@@ -52,6 +52,7 @@ export interface Schema {
   defaultBase?: string;
   nxWorkspaceRoot?: string;
   linter: 'tslint' | 'eslint';
+  packageManager?: string;
 }
 
 class RunPresetTask {
@@ -133,6 +134,7 @@ export function sharedNew(cli: string, options: Schema): Rule {
 
     return chain([
       schematic('workspace', { ...workspaceOpts, cli }),
+      setDefaultPackageManager(options),
       setDefaultLinter(options),
       addPresetDependencies(options),
       addCloudDependencies(options),
@@ -323,6 +325,20 @@ function setTSLintDefault() {
       application: { linter: 'tslint' },
       library: { linter: 'tslint' },
     };
+    return json;
+  });
+}
+
+function setDefaultPackageManager({ packageManager }: Schema) {
+  if (!packageManager) {
+    return noop();
+  }
+
+  return updateWorkspaceInTree((json) => {
+    if (!json.cli) {
+      json.cli = {};
+    }
+    json.cli['packageManager'] = packageManager;
     return json;
   });
 }

--- a/packages/workspace/src/schematics/tao-new/schema.json
+++ b/packages/workspace/src/schematics/tao-new/schema.json
@@ -87,6 +87,11 @@
       "type": "string",
       "enum": ["tslint", "eslint"],
       "default": "eslint"
+    },
+    "packageManager": {
+      "description": "The package manager used to install dependencies.",
+      "type": "string",
+      "enum": ["npm", "yarn", "pnpm"]
     }
   }
 }


### PR DESCRIPTION
## Current Behavior
`crearet-nx-workspace` is favoring package managers based on Nx preference. For example, if Yarn is installed on user's machine, this was used and user has no option to override it if preference was npm or pnpm.

## Expected Behavior
User is able to define preferred package manager during installation.

