### PR TITLE
Ability to get the dep-graph port from process.env

### DIFF
--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -316,13 +316,14 @@ function startServer(html: string, host: string) {
     });
   });
 
-  app.listen(4211, host);
+  const port = process.env.PORT || 4211;
+  app.listen(port, host);
 
   output.note({
-    title: `Dep graph started at http://${host}:4211`,
+    title: `Dep graph started at http://${host}:${port}`,
   });
 
-  opn(`http://${host}:4211`, {
+  opn(`http://${host}:${port}`, {
     wait: false,
   });
 }


### PR DESCRIPTION
I need to have the port of dep-graph to be customizable from command line so I propose here the ability to access it from `process.env.PORT`, this way it can be set at runtime like:

`PORT=4210 yarn run nx dep-graph`