### PR TITLE
fix(web): change sourceRoot to projectRoot for validation

### DIFF
--- a/packages/web/src/utils/normalize.ts
+++ b/packages/web/src/utils/normalize.ts
@@ -91,9 +91,9 @@ export function normalizeAssets(
       const resolvedAssetPath = resolve(root, assetPath);
       const resolvedSourceRoot = resolve(root, sourceRoot);
 
-      if (!resolvedAssetPath.startsWith(resolvedSourceRoot)) {
+      if (!resolvedAssetPath.startsWith(root)) {
         throw new Error(
-          `The ${resolvedAssetPath} asset path must start with the project source root: ${sourceRoot}`
+          `The ${resolvedAssetPath} asset path must start with the project root: ${root}`
         );
       }
 


### PR DESCRIPTION
Possible changes for #3985 I'd see

Change the @nrwl/web validation for Rollup assets path from sourceRoot to projectRoot to be able to
use the rollup runner for other project templates

ISSUES CLOSED: #3985

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
