### PR TITLE
feat(core): add a check when creating tasks to ensure overrides exist

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  testTimeout: 30000,
   projects: [
     '<rootDir>/packages/tao',
     '<rootDir>/packages/workspace',

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -1,10 +1,6 @@
 import * as yargs from 'yargs';
-import { generateGraph } from './dep-graph';
-import { output } from '../utils/output';
-import { parseFiles } from './shared';
-import { runCommand } from '../tasks-runner/run-command';
-import { NxArgs, splitArgsIntoNxArgsAndOverrides, RawNxArgs } from './utils';
 import { filterAffected } from '../core/affected-project-graph';
+import { calculateFileChanges, readEnvironment } from '../core/file-utils';
 import {
   createProjectGraph,
   onlyWorkspaceProjects,
@@ -12,11 +8,15 @@ import {
   ProjectType,
   withDeps,
 } from '../core/project-graph';
-import { calculateFileChanges, readEnvironment } from '../core/file-utils';
-import { printAffected } from './print-affected';
-import { projectHasTarget } from '../utils/project-graph-utils';
 import { DefaultReporter } from '../tasks-runner/default-reporter';
+import { runCommand } from '../tasks-runner/run-command';
+import { output } from '../utils/output';
+import { projectHasTarget } from '../utils/project-graph-utils';
+import { generateGraph } from './dep-graph';
+import { printAffected } from './print-affected';
 import { promptForNxCloud } from './prompt-for-nx-cloud';
+import { parseFiles } from './shared';
+import { NxArgs, RawNxArgs, splitArgsIntoNxArgsAndOverrides } from './utils';
 
 export async function affected(
   command: 'apps' | 'libs' | 'dep-graph' | 'print-affected' | 'affected',
@@ -97,7 +97,7 @@ export async function affected(
             affectedProjects,
             nxArgs
           );
-          printAffected(
+          await printAffected(
             projectsWithTarget,
             affectedProjects,
             projectGraph,
@@ -105,7 +105,13 @@ export async function affected(
             overrides
           );
         } else {
-          printAffected([], affectedProjects, projectGraph, nxArgs, overrides);
+          await printAffected(
+            [],
+            affectedProjects,
+            projectGraph,
+            nxArgs,
+            overrides
+          );
         }
         break;
 


### PR DESCRIPTION
## Current Behavior

e.g. for a command like this:

`nx run-many --target=test --all --parallel --maxParallel=3 --runInBand`

If there are any projects where the test target uses a builder other than Jest, those builders will fail when passed the `--runInBand` override.

## Expected Behavior

Nx uses the builder schema for each task to verify the overrides and won't add unrecognised overrides to tasks, so all the builders will run correctly. 🎉
