### PR TITLE
fix(angular): delete src and e2e folders after transitioning to Nx from Angular

### DIFF
--- a/packages/workspace/src/schematics/init/init.ts
+++ b/packages/workspace/src/schematics/init/init.ts
@@ -458,6 +458,7 @@ function moveExistingFiles(options: Schema) {
         context.logger.info(
           `Renamed ${oldAppSourceRoot} -> ${newAppSourceRoot}`
         );
+        host.delete(oldAppSourceRoot);
       } else {
         context.logger.error(err);
         throw err;
@@ -473,6 +474,7 @@ function moveExistingFiles(options: Schema) {
       renameDirSyncInTree(host, oldE2eRoot, newE2eRoot, (err) => {
         if (!err) {
           context.logger.info(`Renamed ${oldE2eRoot} -> ${newE2eRoot}`);
+          host.delete(oldE2eRoot);
         } else {
           context.logger.error(err);
           throw err;


### PR DESCRIPTION
fix(angular): delete src and e2e folders after transitioning to Nx from Angular

ISSUES CLOSED: #3944

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
#3944