### PR TITLE
fix(storybook): include storybook v5 project schematics

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -505,7 +505,7 @@
               },
               {
                 "input": "packages/storybook",
-                "glob": "**/lib-files-5/.storybook/**",
+                "glob": "**/project-files-5/.storybook/**",
                 "output": "/"
               },
               {


### PR DESCRIPTION
In projects using storybook v5, the `.storybook` lib folder was not being created.

ISSUES CLOSED: #3995 
