### PR TITLE
fix(core): fix resolving imports that cannot be resolved via typescript

### DIFF
--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -90,7 +90,11 @@ export class TargetProjectLocator {
 
     this.typescriptResolutionCache.set(normalizedImportExpr, resolvedModule);
     if (resolvedModule) {
-      return this.findProjectOfResolvedModule(resolvedModule);
+      const resolvedProject = this.findProjectOfResolvedModule(resolvedModule);
+
+      if (resolvedProject) {
+        return resolvedProject;
+      }
     }
 
     const importedProject = this.sortedWorkspaceProjects.find((p) => {


### PR DESCRIPTION
## Current Behavior

Imports that can be resolved to a file but not a project via typescript do not fallback to using the npmScope pattern matching.

## Expected Behavior

These imports work as they did before.

## Related Issues

Fixes #3979 