### PR TITLE
fix(core): invalidate previous failed projects if they are excluded

### DIFF
--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -47,15 +47,14 @@ export async function affected(
   const projects = parsedArgs.all ? projectGraph.nodes : affectedGraph.nodes;
   const projectsNotExcluded = Object.keys(projects)
     .filter((key) => !parsedArgs.exclude.includes(key))
-    .reduce((_p, key) => {
-      return projects[key];
-    }, {});
+    .reduce((p, key) => {
+      p[key] = projects[key];
+      return p;
+    }, {} as Record<string, ProjectGraphNode>);
   const env = readEnvironment(nxArgs.target, projectsNotExcluded);
-  const affectedProjects = Object.values(projects)
-    .filter((n) => !parsedArgs.exclude.includes(n.name))
-    .filter(
-      (n) => !parsedArgs.onlyFailed || !env.workspaceResults.getResult(n.name)
-    );
+  const affectedProjects = Object.values(projectsNotExcluded).filter(
+    (n) => !parsedArgs.onlyFailed || !env.workspaceResults.getResult(n.name)
+  );
 
   try {
     switch (command) {

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -1,10 +1,6 @@
 import * as yargs from 'yargs';
-import { generateGraph } from './dep-graph';
-import { output } from '../utils/output';
-import { parseFiles } from './shared';
-import { runCommand } from '../tasks-runner/run-command';
-import { NxArgs, splitArgsIntoNxArgsAndOverrides, RawNxArgs } from './utils';
 import { filterAffected } from '../core/affected-project-graph';
+import { calculateFileChanges, readEnvironment } from '../core/file-utils';
 import {
   createProjectGraph,
   onlyWorkspaceProjects,
@@ -12,11 +8,15 @@ import {
   ProjectType,
   withDeps,
 } from '../core/project-graph';
-import { calculateFileChanges, readEnvironment } from '../core/file-utils';
-import { printAffected } from './print-affected';
-import { projectHasTarget } from '../utils/project-graph-utils';
 import { DefaultReporter } from '../tasks-runner/default-reporter';
+import { runCommand } from '../tasks-runner/run-command';
+import { output } from '../utils/output';
+import { projectHasTarget } from '../utils/project-graph-utils';
+import { generateGraph } from './dep-graph';
+import { printAffected } from './print-affected';
 import { promptForNxCloud } from './prompt-for-nx-cloud';
+import { parseFiles } from './shared';
+import { NxArgs, RawNxArgs, splitArgsIntoNxArgsAndOverrides } from './utils';
 
 export async function affected(
   command: 'apps' | 'libs' | 'dep-graph' | 'print-affected' | 'affected',
@@ -45,7 +45,12 @@ export async function affected(
     );
   }
   const projects = parsedArgs.all ? projectGraph.nodes : affectedGraph.nodes;
-  const env = readEnvironment(nxArgs.target, projects);
+  const projectsNotExcluded = Object.keys(projects)
+    .filter((key) => !parsedArgs.exclude.includes(key))
+    .reduce((_p, key) => {
+      return projects[key];
+    }, {});
+  const env = readEnvironment(nxArgs.target, projectsNotExcluded);
   const affectedProjects = Object.values(projects)
     .filter((n) => !parsedArgs.exclude.includes(n.name))
     .filter(


### PR DESCRIPTION
## Current Behavior
Project build that failed once also failed with `--exclude` option

## Expected Behavior
Project build didn't failed with `--exclude` option, they are not build at all

## Related Issue(s)
Fixes #4002 
