### PR TITLE
chore(core): update decription of plugin nx-spring-boot

### DIFF
--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -91,7 +91,7 @@
   },
   {
     "name": "@nxrocks/nx-spring-boot",
-    "description": "Nx Plugin to generate, run, package, build (and more) [Spring Boot](https://spring.io/projects/spring-boot) projects inside your Nx workspace",
+    "description": "Nx plugin to generate, run, package, build (and more) Spring Boot projects inside your Nx workspace",
     "url": "https://github.com/tinesoft/nxrocks/tree/master/packages/nx-spring-boot"
   }
 ]


### PR DESCRIPTION
Removed markdown link in the description, as display not supported on http://nx.dev/nx-community
