### PR TITLE
docs(node): add configuration to guides menu

### DIFF
--- a/docs/map.json
+++ b/docs/map.json
@@ -3003,6 +3003,11 @@
         "id": "guides",
         "itemList": [
           {
+            "name": "Configuration",
+            "id": "configuration",
+            "file": "node/guides/configuration.md"
+          },
+          {
             "name": "CI",
             "id": "ci",
             "itemList": [


### PR DESCRIPTION
Adds the node configuration guide to the nx.dev menu, under "_Guides_" section.