### PR TITLE
fix(react): use only `liveReload` option of webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@types/react-redux": "7.1.5",
     "@types/react-router-dom": "5.1.3",
     "@types/webpack": "^4.4.24",
+    "@types/webpack-dev-server": "^3.11.1",
     "@types/yargs": "^15.0.5",
     "@typescript-eslint/eslint-plugin": "^4.3.0",
     "@typescript-eslint/experimental-utils": "^4.3.0",

--- a/packages/web/src/utils/devserver.config.spec.ts
+++ b/packages/web/src/utils/devserver.config.spec.ts
@@ -272,8 +272,8 @@ describe('getDevServerConfig', () => {
     });
 
     describe('liveReload option', () => {
-      it('should push the live reload entry to the main entry', () => {
-        const result = getDevServerConfig(
+      it('should set the correct value', () => {
+        const { devServer: result } = getDevServerConfig(
           root,
           sourceRoot,
           buildInput,
@@ -281,48 +281,19 @@ describe('getDevServerConfig', () => {
           logger
         );
 
-        expect(result.entry['main']).toContain(
-          `${require.resolve('webpack-dev-server/client')}?http://0.0.0.0:0`
-        );
+        expect(result.liveReload).toEqual(true);
       });
 
-      it('should push the correct entry when publicHost option is used', () => {
-        const result = getDevServerConfig(
+      it('should set the correct if false', () => {
+        const { devServer: result } = getDevServerConfig(
           root,
           sourceRoot,
           buildInput,
-          {
-            ...serveInput,
-            publicHost: 'www.example.com',
-          },
+          { ...serveInput, liveReload: false },
           logger
         );
 
-        expect(result.entry['main']).toContain(
-          `${require.resolve(
-            'webpack-dev-server/client'
-          )}?http://www.example.com/`
-        );
-      });
-
-      it('should push the correct entry when publicHost and ssl options are used', () => {
-        const result = getDevServerConfig(
-          root,
-          sourceRoot,
-          buildInput,
-          {
-            ...serveInput,
-            ssl: true,
-            publicHost: 'www.example.com',
-          },
-          logger
-        );
-
-        expect(result.entry['main']).toContain(
-          `${require.resolve(
-            'webpack-dev-server/client'
-          )}?https://www.example.com/`
-        );
+        expect(result.liveReload).toEqual(false);
       });
     });
 

--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -1,10 +1,6 @@
-import {
-  Configuration as WebpackDevServerConfiguration,
-  HistoryApiFallbackConfig,
-} from 'webpack-dev-server';
+import { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 import { readFileSync } from 'fs';
 import * as path from 'path';
-import * as url from 'url';
 import { getWebConfig } from './web.config';
 import { Configuration } from 'webpack';
 import { LoggerApi } from '@angular-devkit/core/src/logger';
@@ -33,30 +29,8 @@ export function getDevServerConfig(
     serveOptions,
     buildOptions
   );
-  if (serveOptions.liveReload) {
-    webpackConfig.entry['main'].unshift(getLiveReloadEntry(serveOptions));
-  }
-  return webpackConfig;
-}
 
-function getLiveReloadEntry(serveOptions: WebDevServerOptions) {
-  let clientAddress = `${serveOptions.ssl ? 'https' : 'http'}://0.0.0.0:0`;
-  if (serveOptions.publicHost) {
-    let publicHost = serveOptions.publicHost;
-    if (!/^\w+:\/\//.test(publicHost)) {
-      publicHost = `${serveOptions.ssl ? 'https' : 'http'}://${publicHost}`;
-    }
-    const clientUrl = url.parse(publicHost);
-    serveOptions.publicHost = clientUrl.host;
-    clientAddress = url.format(clientUrl);
-  }
-  let webpackDevServerPath;
-  try {
-    webpackDevServerPath = require.resolve('webpack-dev-server/client');
-  } catch {
-    throw new Error('The "webpack-dev-server" package could not be found.');
-  }
-  return `${webpackDevServerPath}?${clientAddress}`;
+  return webpackConfig;
 }
 
 function getDevServerPartial(
@@ -79,7 +53,7 @@ function getDevServerPartial(
       index: `${servePath}/${path.basename(buildOptions.index)}`,
       disableDotRule: true,
       htmlAcceptHeaders: ['text/html', 'application/xhtml+xml'],
-    } as HistoryApiFallbackConfig,
+    },
     stats: false,
     compress: scriptsOptimization || stylesOptimization,
     https: options.ssl,
@@ -94,6 +68,7 @@ function getDevServerPartial(
     publicPath: servePath,
     contentBase: false,
     allowedHosts: [],
+    liveReload: options.liveReload,
   };
 
   if (options.ssl && options.sslKey && options.sslCert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,42 +1929,6 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@bazel/bazel-darwin_x64@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@bazel/bazel-darwin_x64/-/bazel-darwin_x64-1.2.0.tgz#e29840c263e0ebb9286bec9fa285907c9161f890"
-  integrity sha512-3th94yNeqNdmzYhUlUeGWx8XEgE9UEh/1TBsG69QOPnYw4I1MYztfAa1iYXREs7qbvQP2R260tRaNhnwg2x6JQ==
-
-"@bazel/bazel-linux_x64@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@bazel/bazel-linux_x64/-/bazel-linux_x64-1.2.0.tgz#da4f4036c38638d8d49c77c16e21f6f6bae1be06"
-  integrity sha512-pEFEu1mkqFcpKBkjlFbMwWj0J+f+e54EmJrOheNCneRi5ArZLBdHtGaxcWr27VMMR99qZM656R8NXXelOmhCqA==
-
-"@bazel/bazel-win32_x64@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@bazel/bazel-win32_x64/-/bazel-win32_x64-1.2.0.tgz#1b0cf50fa4ec77e438d0ccf9550ac71a6c285f09"
-  integrity sha512-fl/eKtWSW1fJIhyGD99p0c0GFv2L4019YFftmv5UBIu2Thb9wYZKQqLVyDBVe8D+Vz2tW6LpefCb+VcmiweJ8A==
-
-"@bazel/bazel@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@bazel/bazel/-/bazel-1.2.0.tgz#3aa126823c7c880fb09afe1fadfdb457f6b99531"
-  integrity sha512-+NDzRxFpYBhdCbTiCMVK9dPXWqIBLMCXH1qq28Edy7xDMoP/J0gWITh8reMBwzDte/qC5ZAq6WjRDX75hWLUog==
-  dependencies:
-    "@bazel/hide-bazel-files" latest
-  optionalDependencies:
-    "@bazel/bazel-darwin_x64" "1.2.0"
-    "@bazel/bazel-linux_x64" "1.2.0"
-    "@bazel/bazel-win32_x64" "1.2.0"
-
-"@bazel/hide-bazel-files@latest":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@bazel/hide-bazel-files/-/hide-bazel-files-1.7.0.tgz#7cb140c23c4269d6464c24be0a2acf0241d2a31d"
-  integrity sha512-pvdyRX/EsU8n+oElFb+OZ9i5M48HNFR+Z4D3vc0qDGiJ8oly9fZcUb2gbw4CzyeovJz0IzjSxjqMS6cp5gKoeg==
-
-"@bazel/ibazel@^0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.10.3.tgz#2e2b8a1d3e885946eac41db2b1aa6801fb319887"
-  integrity sha512-v1nXbMTHVlMM4z4uWp6XiRoHAyUlYggF1SOboLLWRp0+D22kWixqArWqnozLw2mOtnxr97BdLjluWiho6A8Hjg==
-
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
@@ -3644,6 +3608,14 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/connect-history-api-fallback@*":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.3.tgz#4772b79b8b53185f0f4c9deab09236baf76ee3b4"
+  integrity sha512-7SxFCd+FLlxCfwVwbyPxbR4khL9aNikJhrorw8nUIOqeuooc9gifBuDQOJw5kzN7i6i3vLn9G8Wde/4QDihpYw==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/node" "*"
+
 "@types/connect@*":
   version "3.4.33"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
@@ -3902,6 +3874,16 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
+"@types/express@*":
+  version "4.17.8"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.8.tgz#3df4293293317e61c60137d273a2e96cd8d5f27a"
+  integrity sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
 "@types/express@4.17.0":
   version "4.17.0"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.0.tgz#49eaedb209582a86f12ed9b725160f12d04ef287"
@@ -3967,6 +3949,22 @@
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.0.tgz#551a4589b6ee2cc9c1dff08056128aec29b94880"
   integrity sha512-iYCgjm1dGPRuo12+BStjd1HiVQqhlRhWDOQigNxn023HcjnhsiFz9pc6CzJj4HwDCSQca9bxTL4PxJDbkdm3PA==
+
+"@types/http-proxy-middleware@*":
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy-middleware/-/http-proxy-middleware-0.19.3.tgz#b2eb96fbc0f9ac7250b5d9c4c53aade049497d03"
+  integrity sha512-lnBTx6HCOUeIJMLbI/LaL5EmdKLhczJY5oeXZpX/cXE4rRqb3RmV7VcMpiEfYkmTjipv3h7IAyIINe4plEv7cA==
+  dependencies:
+    "@types/connect" "*"
+    "@types/http-proxy" "*"
+    "@types/node" "*"
+
+"@types/http-proxy@*":
+  version "1.17.4"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.4.tgz#e7c92e3dbe3e13aa799440ff42e6d3a17a9d045b"
+  integrity sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==
+  dependencies:
+    "@types/node" "*"
 
 "@types/is-function@^1.0.0":
   version "1.0.0"
@@ -4318,6 +4316,17 @@
   integrity sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==
   dependencies:
     source-map "^0.6.1"
+
+"@types/webpack-dev-server@^3.11.1":
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz#f8f4dac1da226d530bd15a1d5dc34b23ba766ccb"
+  integrity sha512-rIb+LtUkKnh7+oIJm3WiMJONd71Q0lZuqGLcSqhZ5qjN9gV/CNmZe7Bai+brnBPZ/KVYOsr+4bFLiNZwjBicLw==
+  dependencies:
+    "@types/connect-history-api-fallback" "*"
+    "@types/express" "*"
+    "@types/http-proxy-middleware" "*"
+    "@types/serve-static" "*"
+    "@types/webpack" "*"
 
 "@types/webpack-env@^1.15.2":
   version "1.15.2"


### PR DESCRIPTION
## Current Behavior
LiveReload is enabled (by default)  twice through main entry and webpack-dev-server
![image](https://user-images.githubusercontent.com/551595/98392752-0869cc80-2061-11eb-9e74-ff52da656f22.png)
Or enabled once only by webpack-dev-server if `no-liveReload` is used.

## Expected Behavior
LiveReload should be on/off controlled by `liveReload` option.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3910
