### PR TITLE
cleanup(core): remove superfluous resolve of `collection.json` on workspace creation

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -499,16 +499,10 @@ function createApp(
   const command = `new ${name} ${args} --preset="${preset}"${appNameArg}${styleArg}${linterArg}${nxCloudArg}${interactiveArg}${defaultBaseArg} --collection=@nrwl/workspace`;
   console.log(command);
 
-  const collectionJsonPath = require.resolve(
-    '@nrwl/workspace/collection.json',
-    { paths: [tmpDir] }
-  );
-
   execSync(
-    `${packageExec} tao ${command.replace(
-      '--collection=@nrwl/workspace',
-      `--collection=${collectionJsonPath}`
-    )} --cli=${cli.command} --nxWorkspaceRoot="${process.cwd()}"`,
+    `${packageExec} tao ${command}/collection.json --cli=${
+      cli.command
+    } --nxWorkspaceRoot="${process.cwd()}"`,
     {
       stdio: [0, 1, 2],
       cwd: tmpDir,


### PR DESCRIPTION
Also, passing the resolved path makes Yarn 2 to fail during installation.

