### PR TITLE
[WIP] feat(core): hash nx.json, tsconfig.base.json and angular/workspace.js…

### DIFF
--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -255,6 +255,12 @@ export function readWorkspaceFiles(): FileData[] {
   }
 }
 
+export function readTsConfig(): any {
+  return JSON.parse(
+    readFileSync(`${appRootPath}/tsconfig.base.json`).toString()
+  );
+}
+
 export function readEnvironment(
   target: string,
   projects: Record<string, ProjectGraphNode>

--- a/packages/workspace/src/core/hasher/hashing-impl.ts
+++ b/packages/workspace/src/core/hasher/hashing-impl.ts
@@ -1,7 +1,21 @@
 import * as crypto from 'crypto';
 import { readFileSync } from 'fs';
+import { sortObject } from '../../utils/object-utils';
 
 export class HashingImp {
+  hashObject(input: any): string {
+    const hasher = crypto.createHash('sha256');
+
+    // Sort the properties before stringifying and hashing so that reordering properties in an object
+    // does not cause a cache miss.
+    const sortedObject = sortObject(input);
+
+    hasher.update(JSON.stringify(sortedObject));
+
+    const hash = hasher.digest().buffer;
+    return Buffer.from(hash).toString('hex');
+  }
+
   hashArray(input: string[]): string {
     const hasher = crypto.createHash('sha256');
     for (const part of input) {

--- a/packages/workspace/src/utils/object-utils.spec.ts
+++ b/packages/workspace/src/utils/object-utils.spec.ts
@@ -1,0 +1,72 @@
+import { sortObject } from './object-utils';
+
+describe('object-utils', () => {
+  describe('sortObject', () => {
+    it('should sort an object with one level of strings', () => {
+      const obj: Record<string, string> = {
+        c: '2',
+        g: '5',
+        a: '',
+        z: '3',
+      };
+      expect(sortObject(obj)).toEqual({
+        a: '',
+        c: '2',
+        g: '5',
+        z: '3',
+      });
+    });
+
+    it('should sort an object with two levels of strings', () => {
+      const obj: Record<string, any> = {
+        c: '2',
+        g: '5',
+        a: '',
+        z: '3',
+        b: {
+          b: '5',
+          a: '4',
+        },
+      };
+      expect(sortObject(obj)).toEqual({
+        a: '',
+        b: {
+          a: '4',
+          b: '5',
+        },
+        c: '2',
+        g: '5',
+        z: '3',
+      });
+    });
+
+    it('should sort an object with two levels of strings and arrays', () => {
+      const obj: Record<string, any> = {
+        c: '2',
+        g: '5',
+        a: '',
+        z: '3',
+        b: {
+          b: '5',
+          a: '4',
+        },
+        d: {
+          b: ['b', 'a'],
+        },
+      };
+      expect(sortObject(obj)).toEqual({
+        a: '',
+        b: {
+          a: '4',
+          b: '5',
+        },
+        c: '2',
+        d: {
+          b: ['a', 'b'],
+        },
+        g: '5',
+        z: '3',
+      });
+    });
+  });
+});

--- a/packages/workspace/src/utils/object-utils.ts
+++ b/packages/workspace/src/utils/object-utils.ts
@@ -1,0 +1,19 @@
+function isObject(v) {
+  return '[object Object]' === Object.prototype.toString.call(v);
+}
+
+export function sortObject(o: any) {
+  if (Array.isArray(o)) {
+    return o.sort().map(sortObject);
+  } else if (isObject(o)) {
+    return Object.keys(o)
+      .sort()
+      .reduce((a, k) => {
+        a[k] = sortObject(o[k]);
+
+        return a;
+      }, {});
+  }
+
+  return o;
+}


### PR DESCRIPTION
Initial Implementation of a more intelligent way to hash workspace files.

New Implementations:

1. tsconfig.base.json
hash everything except compilerOptions#paths
hash only the compilerOptions#paths that relate to the transitive dependencies from the current project being hashed

2. nx.json
hash the implicitDependencies the same as before
hash only the projects records related to the transitive dependencies from the current project being hashed (with properties and tags sorted, since order shouldn't matter)

3. workspace.json
hash only the projects related to the transitive dependencies from the current project being hashed

Hey, @vsavkin here is an initial implementation of what we talked about in the other PR. I have some basic tests in place but figured I would get this up and the idea reviewed before switching up the existing tests and writing some more comprehensive ones.

Original PR https://github.com/nrwl/nx/pull/3942
