### PR TITLE
feat(core): add strict as an option to workspace, nest and node lib schematics

### DIFF
--- a/docs/angular/api-nest/generators/library.md
+++ b/docs/angular/api-nest/generators/library.md
@@ -120,6 +120,14 @@ Type: `boolean`
 
 Do not update tsconfig.base.json for development experience.
 
+### strict
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to enable tsconfig strict mode or not.
+
 ### tags
 
 Alias(es): t

--- a/docs/angular/api-node/generators/library.md
+++ b/docs/angular/api-node/generators/library.md
@@ -130,6 +130,14 @@ Type: `boolean`
 
 Do not update tsconfig.base.json for development experience.
 
+### strict
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to enable tsconfig strict mode or not.
+
 ### tags
 
 Alias(es): t

--- a/docs/angular/api-workspace/generators/library.md
+++ b/docs/angular/api-workspace/generators/library.md
@@ -106,6 +106,14 @@ Type: `boolean`
 
 Do not update tsconfig.json for development experience.
 
+### strict
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to enable tsconfig strict mode or not.
+
 ### tags
 
 Type: `string`

--- a/docs/node/api-nest/generators/library.md
+++ b/docs/node/api-nest/generators/library.md
@@ -120,6 +120,14 @@ Type: `boolean`
 
 Do not update tsconfig.base.json for development experience.
 
+### strict
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to enable tsconfig strict mode or not.
+
 ### tags
 
 Alias(es): t

--- a/docs/node/api-node/generators/library.md
+++ b/docs/node/api-node/generators/library.md
@@ -130,6 +130,14 @@ Type: `boolean`
 
 Do not update tsconfig.base.json for development experience.
 
+### strict
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to enable tsconfig strict mode or not.
+
 ### tags
 
 Alias(es): t

--- a/docs/node/api-workspace/generators/library.md
+++ b/docs/node/api-workspace/generators/library.md
@@ -106,6 +106,14 @@ Type: `boolean`
 
 Do not update tsconfig.json for development experience.
 
+### strict
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to enable tsconfig strict mode or not.
+
 ### tags
 
 Type: `string`

--- a/docs/react/api-nest/generators/library.md
+++ b/docs/react/api-nest/generators/library.md
@@ -120,6 +120,14 @@ Type: `boolean`
 
 Do not update tsconfig.base.json for development experience.
 
+### strict
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to enable tsconfig strict mode or not.
+
 ### tags
 
 Alias(es): t

--- a/docs/react/api-node/generators/library.md
+++ b/docs/react/api-node/generators/library.md
@@ -130,6 +130,14 @@ Type: `boolean`
 
 Do not update tsconfig.base.json for development experience.
 
+### strict
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to enable tsconfig strict mode or not.
+
 ### tags
 
 Alias(es): t

--- a/docs/react/api-workspace/generators/library.md
+++ b/docs/react/api-workspace/generators/library.md
@@ -106,6 +106,14 @@ Type: `boolean`
 
 Do not update tsconfig.json for development experience.
 
+### strict
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to enable tsconfig strict mode or not.
+
 ### tags
 
 Type: `string`

--- a/packages/nest/src/schematics/library/library.spec.ts
+++ b/packages/nest/src/schematics/library/library.spec.ts
@@ -336,6 +336,13 @@ describe('lib', () => {
       );
 
       expect(tsconfigJson.compilerOptions.strict).toBeTruthy();
+      expect(
+        tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
+      ).toBeTruthy();
+      expect(tsconfigJson.compilerOptions.noImplicitReturns).toBeTruthy();
+      expect(
+        tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
+      ).toBeTruthy();
     });
 
     it('should default to strict false', async () => {
@@ -352,6 +359,13 @@ describe('lib', () => {
       );
 
       expect(tsconfigJson.compilerOptions.strict).not.toBeDefined();
+      expect(
+        tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
+      ).not.toBeDefined();
+      expect(tsconfigJson.compilerOptions.noImplicitReturns).not.toBeDefined();
+      expect(
+        tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
+      ).not.toBeDefined();
     });
   });
 

--- a/packages/nest/src/schematics/library/library.spec.ts
+++ b/packages/nest/src/schematics/library/library.spec.ts
@@ -320,6 +320,41 @@ describe('lib', () => {
     });
   });
 
+  describe('--strict', () => {
+    it('should update the projects tsconfig with strict true', async () => {
+      const tree = await runSchematic(
+        'lib',
+        {
+          name: 'myLib',
+          strict: true,
+        },
+        appTree
+      );
+      const tsconfigJson = readJsonInTree(
+        tree,
+        '/libs/my-lib/tsconfig.lib.json'
+      );
+
+      expect(tsconfigJson.compilerOptions.strict).toBeTruthy();
+    });
+
+    it('should default to strict false', async () => {
+      const tree = await runSchematic(
+        'lib',
+        {
+          name: 'myLib',
+        },
+        appTree
+      );
+      const tsconfigJson = readJsonInTree(
+        tree,
+        '/libs/my-lib/tsconfig.lib.json'
+      );
+
+      expect(tsconfigJson.compilerOptions.strict).not.toBeDefined();
+    });
+  });
+
   describe('--unit-test-runner none', () => {
     it('should not generate test configuration', async () => {
       const resultTree = await runSchematic(

--- a/packages/nest/src/schematics/library/library.ts
+++ b/packages/nest/src/schematics/library/library.ts
@@ -168,7 +168,13 @@ function updateTsConfig(options: NormalizedSchema): Rule {
       (json) => {
         json.compilerOptions.target = options.target;
         if (options.strict) {
-          json.compilerOptions.strict = options.strict;
+          json.compilerOptions = {
+            ...json.compilerOptions,
+            forceConsistentCasingInFileNames: true,
+            strict: true,
+            noImplicitReturns: true,
+            noFallthroughCasesInSwitch: true,
+          };
         }
         return json;
       }

--- a/packages/nest/src/schematics/library/library.ts
+++ b/packages/nest/src/schematics/library/library.ts
@@ -167,6 +167,9 @@ function updateTsConfig(options: NormalizedSchema): Rule {
       `${projectConfig.root}/tsconfig.lib.json`,
       (json) => {
         json.compilerOptions.target = options.target;
+        if (options.strict) {
+          json.compilerOptions.strict = options.strict;
+        }
         return json;
       }
     );

--- a/packages/nest/src/schematics/library/schema.d.ts
+++ b/packages/nest/src/schematics/library/schema.d.ts
@@ -24,4 +24,5 @@ export interface Schema {
     | 'es2019'
     | 'es2020';
   testEnvironment: 'jsdom' | 'node';
+  strict: boolean;
 }

--- a/packages/nest/src/schematics/library/schema.json
+++ b/packages/nest/src/schematics/library/schema.json
@@ -100,6 +100,11 @@
         "es2019",
         "es2020"
       ]
+    },
+    "strict": {
+      "type": "boolean",
+      "description": "Whether to enable tsconfig strict mode or not.",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/node/src/schematics/library/schema.d.ts
+++ b/packages/node/src/schematics/library/schema.d.ts
@@ -16,4 +16,5 @@ export interface Schema {
   babelJest?: boolean;
   js: boolean;
   pascalCaseFiles: boolean;
+  strict: boolean;
 }

--- a/packages/node/src/schematics/library/schema.json
+++ b/packages/node/src/schematics/library/schema.json
@@ -90,6 +90,11 @@
       "type": "boolean",
       "description": "Generate JavaScript files rather than TypeScript files.",
       "default": false
+    },
+    "strict": {
+      "type": "boolean",
+      "description": "Whether to enable tsconfig strict mode or not.",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/workspace/src/schematics/library/library.spec.ts
+++ b/packages/workspace/src/schematics/library/library.spec.ts
@@ -311,6 +311,13 @@ describe('lib', () => {
       );
 
       expect(tsconfigJson.compilerOptions.strict).toBeTruthy();
+      expect(
+        tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
+      ).toBeTruthy();
+      expect(tsconfigJson.compilerOptions.noImplicitReturns).toBeTruthy();
+      expect(
+        tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
+      ).toBeTruthy();
     });
 
     it('should default to strict false', async () => {
@@ -327,6 +334,13 @@ describe('lib', () => {
       );
 
       expect(tsconfigJson.compilerOptions.strict).not.toBeDefined();
+      expect(
+        tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
+      ).not.toBeDefined();
+      expect(tsconfigJson.compilerOptions.noImplicitReturns).not.toBeDefined();
+      expect(
+        tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
+      ).not.toBeDefined();
     });
   });
 

--- a/packages/workspace/src/schematics/library/library.spec.ts
+++ b/packages/workspace/src/schematics/library/library.spec.ts
@@ -295,6 +295,41 @@ describe('lib', () => {
     });
   });
 
+  describe('--strict', () => {
+    it('should update the projects tsconfig with strict true', async () => {
+      const tree = await runSchematic(
+        'lib',
+        {
+          name: 'myLib',
+          strict: true,
+        },
+        appTree
+      );
+      const tsconfigJson = readJsonInTree(
+        tree,
+        '/libs/my-lib/tsconfig.lib.json'
+      );
+
+      expect(tsconfigJson.compilerOptions.strict).toBeTruthy();
+    });
+
+    it('should default to strict false', async () => {
+      const tree = await runSchematic(
+        'lib',
+        {
+          name: 'myLib',
+        },
+        appTree
+      );
+      const tsconfigJson = readJsonInTree(
+        tree,
+        '/libs/my-lib/tsconfig.lib.json'
+      );
+
+      expect(tsconfigJson.compilerOptions.strict).not.toBeDefined();
+    });
+  });
+
   describe('--importPath', () => {
     it('should update the tsconfig with the given import path', async () => {
       const tree = await runSchematic(

--- a/packages/workspace/src/schematics/library/library.ts
+++ b/packages/workspace/src/schematics/library/library.ts
@@ -59,7 +59,21 @@ function addProject(options: NormalizedSchema): Rule {
   });
 }
 
-function updateTsConfig(options: NormalizedSchema): Rule {
+function updateLibTsConfig(options: NormalizedSchema): Rule {
+  return (host: Tree) =>
+    updateJsonInTree(
+      `${libsDir(host)}/${options.projectDirectory}/tsconfig.lib.json`,
+      (json) => {
+        if (options.strict) {
+          json.compilerOptions.strict = true;
+        }
+
+        return json;
+      }
+    );
+}
+
+function updateRootTsConfig(options: NormalizedSchema): Rule {
   return (host: Tree) =>
     updateJsonInTree('tsconfig.base.json', (json) => {
       const c = json.compilerOptions;
@@ -130,10 +144,11 @@ export default function (schema: Schema): Rule {
       addLintFiles(options.projectRoot, options.linter),
       createFiles(options),
       options.js ? updateTsConfigsToJs(options) : noop(),
-      !options.skipTsConfig ? updateTsConfig(options) : noop(),
+      !options.skipTsConfig ? updateRootTsConfig(options) : noop(),
       addProject(options),
       updateNxJson(options),
       addJest(options),
+      updateLibTsConfig(options),
       formatFiles(options),
     ])(host, context);
   };

--- a/packages/workspace/src/schematics/library/library.ts
+++ b/packages/workspace/src/schematics/library/library.ts
@@ -65,7 +65,13 @@ function updateLibTsConfig(options: NormalizedSchema): Rule {
       `${libsDir(host)}/${options.projectDirectory}/tsconfig.lib.json`,
       (json) => {
         if (options.strict) {
-          json.compilerOptions.strict = true;
+          json.compilerOptions = {
+            ...json.compilerOptions,
+            forceConsistentCasingInFileNames: true,
+            strict: true,
+            noImplicitReturns: true,
+            noFallthroughCasesInSwitch: true,
+          };
         }
 
         return json;

--- a/packages/workspace/src/schematics/library/schema.d.ts
+++ b/packages/workspace/src/schematics/library/schema.d.ts
@@ -14,4 +14,5 @@ export interface Schema {
   js: boolean;
   babelJest?: boolean;
   pascalCaseFiles: boolean;
+  strict: boolean;
 }

--- a/packages/workspace/src/schematics/library/schema.json
+++ b/packages/workspace/src/schematics/library/schema.json
@@ -75,6 +75,11 @@
       "type": "boolean",
       "description": "Generate JavaScript files rather than TypeScript files",
       "default": false
+    },
+    "strict": {
+      "type": "boolean",
+      "description": "Whether to enable tsconfig strict mode or not.",
+      "default": false
     }
   },
   "required": ["name"]


### PR DESCRIPTION
## Current Behavior
There is no way to pass `strict` to the generation of a node or nest lib like you can with angular to enable ts strict mode

## Expected Behavior
Want to be able to generate new libraries with strict mode enabled
