### PR TITLE
feat(angular): allow for ivy to be enable for buildable libraries

### DIFF
--- a/docs/angular/api-angular/schematics/library.md
+++ b/docs/angular/api-angular/schematics/library.md
@@ -50,6 +50,14 @@ Type: `string`
 
 A directory where the lib is placed
 
+### enableIvy
+
+Default: `false`
+
+Type: `boolean`
+
+Enable Ivy for library in tsconfig.lib.prod.json. Should not be used with publishable libraries.
+
 ### importPath
 
 Type: `string`

--- a/docs/node/api-angular/schematics/library.md
+++ b/docs/node/api-angular/schematics/library.md
@@ -50,6 +50,14 @@ Type: `string`
 
 A directory where the lib is placed
 
+### enableIvy
+
+Default: `false`
+
+Type: `boolean`
+
+Enable Ivy for library in tsconfig.lib.prod.json. Should not be used with publishable libraries.
+
 ### importPath
 
 Type: `string`

--- a/docs/react/api-angular/schematics/library.md
+++ b/docs/react/api-angular/schematics/library.md
@@ -50,6 +50,14 @@ Type: `string`
 
 A directory where the lib is placed
 
+### enableIvy
+
+Default: `false`
+
+Type: `boolean`
+
+Enable Ivy for library in tsconfig.lib.prod.json. Should not be used with publishable libraries.
+
 ### importPath
 
 Type: `string`

--- a/packages/angular/src/schematics/library/lib/update-tsconfig.ts
+++ b/packages/angular/src/schematics/library/lib/update-tsconfig.ts
@@ -1,4 +1,9 @@
-import { chain, Rule, SchematicsException } from '@angular-devkit/schematics';
+import {
+  chain,
+  noop,
+  Rule,
+  SchematicsException,
+} from '@angular-devkit/schematics';
 import { updateJsonInTree } from '@nrwl/workspace';
 import { NormalizedSchema } from './normalized-schema';
 import { libsDir } from '@nrwl/workspace/src/utils/ast-utils';
@@ -34,6 +39,24 @@ function updateProjectConfig(options: NormalizedSchema) {
   );
 }
 
+function updateProjectProdConfig(options: NormalizedSchema) {
+  if (options.enableIvy) {
+    return updateJsonInTree(
+      `${options.projectRoot}/tsconfig.lib.prod.json`,
+      (json) => {
+        json.angularCompilerOptions['enableIvy'] = true;
+        return json;
+      }
+    );
+  }
+
+  return noop();
+}
+
 export function updateTsConfig(options: NormalizedSchema): Rule {
-  return chain([updateRootConfig(options), updateProjectConfig(options)]);
+  return chain([
+    updateRootConfig(options),
+    updateProjectConfig(options),
+    updateProjectProdConfig(options),
+  ]);
 }

--- a/packages/angular/src/schematics/library/library.spec.ts
+++ b/packages/angular/src/schematics/library/library.spec.ts
@@ -75,6 +75,24 @@ describe('lib', () => {
       expect(packageJson.devDependencies['ng-packagr']).toBeDefined();
     });
 
+    it('should update tsconfig.lib.prod.json when enableIvy', async () => {
+      const tree = await runSchematic(
+        'lib',
+        {
+          name: 'myLib',
+          framework: 'angular',
+          buildable: true,
+          enableIvy: true,
+        },
+        appTree
+      );
+      const tsConfig = readJsonInTree(
+        tree,
+        '/libs/my-lib/tsconfig.lib.prod.json'
+      );
+      expect(tsConfig.angularCompilerOptions['enableIvy']).toBe(true);
+    });
+
     it('should update workspace.json', async () => {
       const tree = await runSchematic(
         'lib',

--- a/packages/angular/src/schematics/library/library.ts
+++ b/packages/angular/src/schematics/library/library.ts
@@ -30,6 +30,10 @@ export default function (schema: Schema): Rule {
       throw new Error(`routing must be set`);
     }
 
+    if (options.enableIvy === true && !options.buildable) {
+      throw new Error('enableIvy must only be used with buildable.');
+    }
+
     if (options.publishable === true && !schema.importPath) {
       throw new SchematicsException(
         `For publishable libs you have to provide a proper "--importPath" which needs to be a valid npm package name (e.g. my-awesome-lib or @myorg/my-lib)`

--- a/packages/angular/src/schematics/library/schema.d.ts
+++ b/packages/angular/src/schematics/library/schema.d.ts
@@ -26,4 +26,6 @@ export interface Schema {
 
   linter: Linter;
   unitTestRunner: UnitTestRunner;
+
+  enableIvy: boolean;
 }

--- a/packages/angular/src/schematics/library/schema.json
+++ b/packages/angular/src/schematics/library/schema.json
@@ -124,6 +124,11 @@
       "type": "string",
       "enum": ["tslint", "eslint"],
       "default": "tslint"
+    },
+    "enableIvy": {
+      "description": "Enable Ivy for library in tsconfig.lib.prod.json. Should not be used with publishable libraries.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": []


### PR DESCRIPTION
## Current Behavior
Currently, libraries are always set to `enableIvy: false` when buildable.

## Expected Behavior
When generating a buildable (but not publishable) library `enableIvy` should be settable via an option. This will allow for greater incrementality with caching since the buildable libraries have their ivy generated instructions cached with their build artifacts and do not need to be compiled down to ivy instructions when the built artifact is used `--with-deps` thus decreasing built time and resources needed
