### PR TITLE
fix(angular): update karma, jasmine & protractor deps

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -40,6 +40,11 @@
       "version": "10.3.0-beta.1",
       "description": "Add tsconfig.editor.json to angular apps and update jest-angular-preset",
       "factory": "./src/migrations/update-10-3-0/update-10-3-0"
+    },
+    "update-10-4-0": {
+      "version": "10.4.0-beta.3",
+      "description": "Adjust karma and protractor setup",
+      "factory": "./src/migrations/update-10-4-0/update-10-4-0"
     }
   },
   "packageJsonUpdates": {
@@ -134,6 +139,47 @@
         },
         "jest-preset-angular": {
           "version": "8.3.1",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "10.4.0": {
+      "version": "10.4.0-beta.3",
+      "packages": {
+        "protractor": {
+          "version": "~7.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "jasmine-core": {
+          "version": "~3.6.0",
+          "alwaysAddToPackageJson": false
+        },
+        "jasmine-spec-reporter": {
+          "version": "~5.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/jasmine": {
+          "version": "~3.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "karma": {
+          "version": "~5.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "karma-chrome-launcher": {
+          "version": "~3.1.0",
+          "alwaysAddToPackageJson": false
+        },
+        "karma-coverage-istanbul-reporter": {
+          "version": "~3.0.2",
+          "alwaysAddToPackageJson": false
+        },
+        "karma-jasmine": {
+          "version": "~4.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "karma-jasmine-html-reporter": {
+          "version": "^1.5.0",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/angular/src/migrations/update-10-4-0/update-10-4-0.spec.ts
+++ b/packages/angular/src/migrations/update-10-4-0/update-10-4-0.spec.ts
@@ -1,0 +1,111 @@
+import { callRule, runMigration } from '../../utils/testing';
+import { chain, Tree } from '@angular-devkit/schematics';
+import {
+  readJsonInTree,
+  updateJsonInTree,
+  updateWorkspace,
+} from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+
+describe('update-10.4.0', () => {
+  describe('update Protractor e2e tsconfig.json', () => {
+    let tree: Tree;
+    beforeAll(async () => {
+      tree = Tree.empty();
+      tree = createEmptyWorkspace(tree);
+      tree = await callRule(
+        updateWorkspace((workspace) => {
+          workspace.projects.add({
+            name: 'app1',
+            root: 'apps/app1-e2e',
+            projectType: 'application',
+            targets: {
+              e2e: {
+                builder: '@angular-devkit/build-angular:protractor',
+                options: {
+                  protractorConfig: 'apps/app1-e2e/protractor.conf.js',
+                  devServerTarget: 'testapp:serve',
+                },
+                configurations: {
+                  production: {
+                    devServerTarget: 'testapp:serve:production',
+                  },
+                },
+              },
+            },
+          });
+        }),
+        tree
+      );
+      tree = await callRule(
+        chain([
+          updateJsonInTree('apps/app1-e2e/tsconfig.json', () => ({
+            extends: '../../tsconfig.json',
+          })),
+        ]),
+        tree
+      );
+
+      tree = await runMigration('update-10-4-0', {}, tree);
+    });
+
+    it('should update the protractor e2e tsconfig to correctly point to the tsconfig.base.json', async () => {
+      const tsconfig = readJsonInTree(tree, 'apps/app1-e2e/tsconfig.json');
+      expect(tsconfig.extends).toEqual('../../tsconfig.base.json');
+    });
+  });
+
+  describe('update Protractor, Karma and Jasmine dependencies', () => {
+    let tree: Tree;
+    beforeAll(async () => {
+      tree = Tree.empty();
+      tree = createEmptyWorkspace(tree);
+
+      tree = await callRule(
+        chain([
+          // update package.json to have the deps that are being upgraded
+          updateJsonInTree('package.json', (json) => {
+            json.devDependencies = {
+              ...json.devDependencies,
+              protractor: '1.0.0',
+              'jasmine-core': '1.0.0',
+              'jasmine-spec-reporter': '1.0.0',
+              '@types/jasmine': '1.0.0',
+              karma: '1.0.0',
+              'karma-chrome-launcher': '1.0.0',
+              'karma-coverage-istanbul-reporter': '1.0.0',
+              'karma-jasmine': '1.0.0',
+              'karma-jasmine-html-reporter': '1.0.0',
+            };
+            return json;
+          }),
+        ]),
+        tree
+      );
+
+      tree = await runMigration('update-10-4-0', {}, tree);
+    });
+
+    it('should update the karma, jasmine and protractor dependencies', async () => {
+      const packageJson = readJsonInTree(tree, 'package.json');
+
+      expect(packageJson.devDependencies['protractor']).toEqual('~7.0.0');
+      expect(packageJson.devDependencies['jasmine-core']).toEqual('~3.6.0');
+      expect(packageJson.devDependencies['jasmine-spec-reporter']).toEqual(
+        '~5.0.0'
+      );
+      expect(packageJson.devDependencies['@types/jasmine']).toEqual('~3.5.0');
+      expect(packageJson.devDependencies['karma']).toEqual('~5.0.0');
+      expect(packageJson.devDependencies['karma-chrome-launcher']).toEqual(
+        '~3.1.0'
+      );
+      expect(
+        packageJson.devDependencies['karma-coverage-istanbul-reporter']
+      ).toEqual('~3.0.2');
+      expect(packageJson.devDependencies['karma-jasmine']).toEqual('~4.0.0');
+      expect(
+        packageJson.devDependencies['karma-jasmine-html-reporter']
+      ).toEqual('^1.5.0');
+    });
+  });
+});

--- a/packages/angular/src/migrations/update-10-4-0/update-10-4-0.ts
+++ b/packages/angular/src/migrations/update-10-4-0/update-10-4-0.ts
@@ -1,0 +1,47 @@
+import { normalize, Path } from '@angular-devkit/core';
+import { ProjectDefinition } from '@angular-devkit/core/src/workspace';
+import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import {
+  formatFiles,
+  getWorkspace,
+  offsetFromRoot,
+  updateJsonInTree,
+  updatePackagesInPackageJson,
+} from '@nrwl/workspace';
+import { join as pathJoin } from 'path';
+
+function updateBaseConfig(project: ProjectDefinition, baseConfig: Path): Rule {
+  return updateJsonInTree(baseConfig, (json) => {
+    return {
+      ...json,
+      extends: `${offsetFromRoot(project.root)}tsconfig.base.json`,
+    };
+  });
+}
+
+async function udpateProtractorTsConfig(host: Tree) {
+  const workspace = await getWorkspace(host);
+  const rules = [];
+
+  workspace.projects.forEach((project) => {
+    project.targets.forEach((target) => {
+      if (target.builder === '@angular-devkit/build-angular:protractor') {
+        rules.push(
+          updateBaseConfig(project, normalize(`${project.root}/tsconfig.json`))
+        );
+      }
+    });
+  });
+  return chain(rules);
+}
+
+export default function () {
+  return chain([
+    updatePackagesInPackageJson(
+      pathJoin(__dirname, '../../../migrations.json'),
+      '10.4.0'
+    ),
+    udpateProtractorTsConfig,
+    formatFiles(),
+  ]);
+}

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -632,6 +632,14 @@ function updateE2eProject(options: NormalizedSchema): Rule {
           };
         }
       ),
+      updateJsonInTree(`${options.e2eProjectRoot}/tsconfig.json`, (json) => {
+        return {
+          ...json,
+          extends: `${offsetFromRoot(
+            options.e2eProjectRoot
+          )}tsconfig.base.json`,
+        };
+      }),
     ]);
   };
 }

--- a/packages/angular/src/schematics/init/init.ts
+++ b/packages/angular/src/schematics/init/init.ts
@@ -91,10 +91,10 @@ export function addE2eTestRunner(options: Pick<Schema, 'e2eTestRunner'>): Rule {
         return addDepsToPackageJson(
           {},
           {
-            protractor: '~5.4.0',
-            'jasmine-core': '~2.99.1',
-            'jasmine-spec-reporter': '~4.2.1',
-            '@types/jasmine': '~2.8.6',
+            protractor: '~7.0.0',
+            'jasmine-core': '~3.6.0',
+            'jasmine-spec-reporter': '~5.0.0',
+            '@types/jasmine': '~3.5.0',
             '@types/jasminewd2': '~2.0.3',
           }
         );

--- a/packages/angular/src/schematics/karma/karma.ts
+++ b/packages/angular/src/schematics/karma/karma.ts
@@ -12,14 +12,14 @@ export default function () {
       addDepsToPackageJson(
         {},
         {
-          karma: '~4.0.0',
-          'karma-chrome-launcher': '~2.2.0',
-          'karma-coverage-istanbul-reporter': '~2.0.1',
-          'karma-jasmine': '~1.1.2',
-          'karma-jasmine-html-reporter': '^0.2.2',
-          'jasmine-core': '~2.99.1',
-          'jasmine-spec-reporter': '~4.2.1',
-          '@types/jasmine': '~2.8.8',
+          karma: '~5.0.0',
+          'karma-chrome-launcher': '~3.1.0',
+          'karma-coverage-istanbul-reporter': '~3.0.2',
+          'karma-jasmine': '~4.0.0',
+          'karma-jasmine-html-reporter': '^1.5.0',
+          'jasmine-core': '~3.6.0',
+          'jasmine-spec-reporter': '~5.0.0',
+          '@types/jasmine': '~3.5.0',
         }
       ),
     ]);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Generating a new Nx workspace with a protractor e2e test doesn't work due to out-of-date dependencies as well as a bug in the `tsconfig.json` reference.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

e2e tests should run just fine and dependencies should be up to date.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4035 
