### PR TITLE
fix(web): bump less from version 3.11.1 to 3.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-source-map-support": "1.4.0",
     "karma-webpack": "4.0.2",
-    "less": "3.11.1",
+    "less": "3.12.2",
     "less-loader": "5.0.0",
     "license-webpack-plugin": "2.1.2",
     "loader-utils": "1.2.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -71,7 +71,7 @@
     "identity-obj-proxy": "3.0.0",
     "jest-worker": "25.1.0",
     "karma-source-map-support": "1.4.0",
-    "less": "3.11.1",
+    "less": "3.12.2",
     "less-loader": "5.0.0",
     "license-webpack-plugin": "2.1.2",
     "loader-utils": "1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14919,6 +14919,21 @@ less@3.11.1:
     request "^2.83.0"
     source-map "~0.6.0"
 
+less@3.12.2, less@^3.11.3:
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/less/-/less-3.12.2.tgz#157e6dd32a68869df8859314ad38e70211af3ab4"
+  integrity sha512-+1V2PCMFkL+OIj2/HrtrvZw0BC0sYLMICJfbQjuj/K8CEnlrFX6R5cKKgzzttsZDHyxQNL1jqMREjKN3ja/E3Q==
+  dependencies:
+    tslib "^1.10.0"
+  optionalDependencies:
+    errno "^0.1.1"
+    graceful-fs "^4.1.2"
+    image-size "~0.5.0"
+    make-dir "^2.1.0"
+    mime "^1.4.1"
+    native-request "^1.0.5"
+    source-map "~0.6.0"
+
 less@^3.10.3:
   version "3.11.3"
   resolved "https://registry.yarnpkg.com/less/-/less-3.11.3.tgz#2d853954fcfe0169a8af869620bcaa16563dcc1c"
@@ -14934,21 +14949,6 @@ less@^3.10.3:
     mime "^1.4.1"
     promise "^7.1.1"
     request "^2.83.0"
-    source-map "~0.6.0"
-
-less@^3.11.3:
-  version "3.12.2"
-  resolved "https://registry.yarnpkg.com/less/-/less-3.12.2.tgz#157e6dd32a68869df8859314ad38e70211af3ab4"
-  integrity sha512-+1V2PCMFkL+OIj2/HrtrvZw0BC0sYLMICJfbQjuj/K8CEnlrFX6R5cKKgzzttsZDHyxQNL1jqMREjKN3ja/E3Q==
-  dependencies:
-    tslib "^1.10.0"
-  optionalDependencies:
-    errno "^0.1.1"
-    graceful-fs "^4.1.2"
-    image-size "~0.5.0"
-    make-dir "^2.1.0"
-    mime "^1.4.1"
-    native-request "^1.0.5"
     source-map "~0.6.0"
 
 level-codec@^9.0.0:


### PR DESCRIPTION
Bump less from version 3.11.1 to 3.12.2 because one of the packages in less was using an insecure version of acorn (v6.3.0).

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Version of the `less` package is 3.11.1.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Version of the `less` package is now 3.12.2.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
