### PR TITLE
chore(react): bump versions for react dependencies and add migration

### DIFF
--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -54,6 +54,11 @@
       "version": "9.5.0-beta.1",
       "description": "Update libraries",
       "factory": "./src/migrations/update-9-5-0/update-9-5-0"
+    },
+    "update-10.4.0": {
+      "version": "10.4.0-beta.1",
+      "description": "Update libraries",
+      "factory": "./src/migrations/update-10-4-0/update-10-4-0"
     }
   },
   "packageJsonUpdates": {
@@ -303,6 +308,75 @@
         },
         "eslint-plugin-react-hooks": {
           "version": "4.0.4",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "10.4.0": {
+      "version": "9.5.0-beta.1",
+      "packages": {
+        "react": {
+          "version": "17.0.1",
+          "alwaysAddToPackageJson": false
+        },
+        "react-dom": {
+          "version": "17.0.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react": {
+          "version": "16.9.56",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react-dom": {
+          "version": "16.9.9",
+          "alwaysAddToPackageJson": false
+        },
+        "styled-components": {
+          "version": "5.2.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/styled-components": {
+          "version": "5.1.4",
+          "alwaysAddToPackageJson": false
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "alwaysAddToPackageJson": false
+        },
+        "styled-jsx": {
+          "version": "3.3.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react-router-dom": {
+          "version": "5.1.6",
+          "alwaysAddToPackageJson": false
+        },
+        "@testing-library/react": {
+          "version": "11.1.2",
+          "alwaysAddToPackageJson": false
+        },
+        "react-redux": {
+          "version": "7.2.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react-redux": {
+          "version": "7.1.11",
+          "alwaysAddToPackageJson": false
+        },
+        "eslint-plugin-import": {
+          "version": "2.22.1",
+          "alwaysAddToPackageJson": false
+        },
+        "eslint-plugin-a11y": {
+          "version": "6.4.1",
+          "alwaysAddToPackageJson": false
+        },
+        "eslint-plugin-react": {
+          "version": "7.21.5",
+          "alwaysAddToPackageJson": false
+        },
+        "eslint-plugin-react-hooks": {
+          "version": "4.2.0",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/react/src/migrations/update-10-4-0/update-10-4-0.spec.ts
+++ b/packages/react/src/migrations/update-10-4-0/update-10-4-0.spec.ts
@@ -1,0 +1,43 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { readJsonInTree } from '@nrwl/workspace';
+import * as path from 'path';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+
+describe('Update 10.4.0', () => {
+  let tree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(async () => {
+    tree = Tree.empty();
+    tree = createEmptyWorkspace(tree);
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/react',
+      path.join(__dirname, '../../../migrations.json')
+    );
+  });
+
+  it(`should update libs`, async () => {
+    tree.overwrite(
+      'package.json',
+      JSON.stringify({
+        dependencies: {},
+        devDependencies: {
+          react: '16.9.1',
+        },
+      })
+    );
+
+    tree = await schematicRunner
+      .runSchematicAsync('update-10.4.0', {}, tree)
+      .toPromise();
+
+    const packageJson = readJsonInTree(tree, '/package.json');
+    expect(packageJson).toMatchObject({
+      dependencies: {},
+      devDependencies: {
+        react: '17.0.1',
+      },
+    });
+  });
+});

--- a/packages/react/src/migrations/update-10-4-0/update-10-4-0.ts
+++ b/packages/react/src/migrations/update-10-4-0/update-10-4-0.ts
@@ -1,0 +1,13 @@
+import { chain, Rule } from '@angular-devkit/schematics';
+import { formatFiles, updatePackagesInPackageJson } from '@nrwl/workspace';
+import * as path from 'path';
+
+export default function update(): Rule {
+  return chain([
+    updatePackagesInPackageJson(
+      path.join(__dirname, '../../../', 'migrations.json'),
+      '10.4.0'
+    ),
+    formatFiles(),
+  ]);
+}

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -1,35 +1,35 @@
 export const nxVersion = '*';
 
-export const reactVersion = '16.13.1';
-export const reactDomVersion = '16.13.1';
-export const typesReactVersion = '16.9.38';
-export const typesReactDomVersion = '16.9.8';
+export const reactVersion = '17.0.1';
+export const reactDomVersion = '17.0.1';
+export const typesReactVersion = '16.9.56';
+export const typesReactDomVersion = '16.9.9';
 
-export const styledComponentsVersion = '5.1.1';
-export const typesStyledComponentsVersion = '5.1.0';
+export const styledComponentsVersion = '5.2.1';
+export const typesStyledComponentsVersion = '5.1.4';
 
-export const reactIsVersion = '16.13.1';
+export const reactIsVersion = '17.0.1';
 export const typesReactIsVersion = '16.7.1';
 
 export const emotionStyledVersion = '10.0.27';
 export const emotionCoreVersion = '10.0.28';
 export const emotionBabelPresetCssPropVersion = '10.0.27';
 
-export const styledJsxVersion = '3.3.0';
+export const styledJsxVersion = '3.3.1';
 export const typesStyledJsxVersion = '2.2.8';
 
 export const reactRouterDomVersion = '5.2.0';
-export const typesReactRouterDomVersion = '5.1.5';
+export const typesReactRouterDomVersion = '5.1.6';
 
-export const testingLibraryReactVersion = '10.4.1';
+export const testingLibraryReactVersion = '11.1.2';
 
 export const reduxjsToolkitVersion = '1.4.0';
-export const reactReduxVersion = '7.2.0';
-export const typesReactReduxVersion = '7.1.9';
+export const reactReduxVersion = '7.2.2';
+export const typesReactReduxVersion = '7.1.11';
 
-export const eslintPluginImportVersion = '2.21.2';
-export const eslintPluginJsxA11yVersion = '6.3.1';
-export const eslintPluginReactVersion = '7.20.0';
-export const eslintPluginReactHooksVersion = '4.0.4';
+export const eslintPluginImportVersion = '2.22.1';
+export const eslintPluginJsxA11yVersion = '6.4.1';
+export const eslintPluginReactVersion = '7.21.5';
+export const eslintPluginReactHooksVersion = '4.2.0';
 
 export const babelPluginStyledComponentsVersion = '1.10.7';


### PR DESCRIPTION
Updates react dependencies (minus emotion because that requires a migration) to their latest versions.