### PR TITLE
fix(testing): calculate `coverage-directory` from the root

### DIFF
--- a/packages/jest/src/builders/jest/jest.impl.spec.ts
+++ b/packages/jest/src/builders/jest/jest.impl.spec.ts
@@ -81,7 +81,7 @@ describe('Jest Builder', () => {
         reporters: ['/test/path'],
         verbose: false,
         coverageReporters: ['test'],
-        coverageDirectory: '/test/path',
+        coverageDirectory: '/test/coverage',
         watch: false,
       });
       expect(await run.result).toEqual(
@@ -101,7 +101,7 @@ describe('Jest Builder', () => {
           reporters: ['/test/path'],
           verbose: false,
           coverageReporters: ['test'],
-          coverageDirectory: '/test/path',
+          coverageDirectory: '/root/test/coverage',
           watch: false,
         },
         ['/root/jest.config.js']
@@ -160,7 +160,7 @@ describe('Jest Builder', () => {
         reporters: ['/test/path'],
         verbose: false,
         coverageReporters: ['test'],
-        coverageDirectory: '/test/path',
+        coverageDirectory: '/test/coverage',
         testResultsProcessor: 'results-processor',
         updateSnapshot: true,
         useStderr: true,
@@ -194,7 +194,7 @@ describe('Jest Builder', () => {
           verbose: false,
           reporters: ['/test/path'],
           coverageReporters: ['test'],
-          coverageDirectory: '/test/path',
+          coverageDirectory: '/root/test/coverage',
           testResultsProcessor: 'results-processor',
           updateSnapshot: true,
           useStderr: true,

--- a/packages/jest/src/builders/jest/jest.impl.ts
+++ b/packages/jest/src/builders/jest/jest.impl.ts
@@ -63,7 +63,6 @@ function run(
     testPathPattern: options.testPathPattern,
     colors: options.colors,
     verbose: options.verbose,
-    coverageDirectory: options.coverageDirectory,
     testResultsProcessor: options.testResultsProcessor,
     updateSnapshot: options.updateSnapshot,
     useStderr: options.useStderr,
@@ -90,6 +89,13 @@ function run(
       .map((s) => s.trim());
     config._.push(...parsedTests);
     config.findRelatedTests = true;
+  }
+
+  if (options.coverageDirectory) {
+    config.coverageDirectory = path.join(
+      context.workspaceRoot,
+      options.coverageDirectory
+    );
   }
 
   if (options.clearCache) {


### PR DESCRIPTION
## Current Behavior
`nx run myapp:test --code-coverage --coverage-directory=mydir` will output coverage to results to `apps/myapp/mydir`.

## Expected Behavior
`nx run myapp:test --code-coverage --coverage-directory=mydir` should output coverage to results to `mydir`.

