### PR TITLE
chore(nx): upgrade eslint-plugin-react-hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.18.3",
-    "eslint-plugin-react-hooks": "^2.4.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "express": "4.17.1",
     "file-loader": "4.2.0",
     "find-cache-dir": "3.0.0",


### PR DESCRIPTION
## Current Behavior
Getting warning when running npm install and using eslint@7.12.1:
 WARN eslint-plugin-react-hooks@2.5.1 requires a peer of eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 but none is installed. You must install peer dependencies yourself.

## Expected Behavior
No warning

## Related Issue(s)
Fixes #4105