### PR TITLE
chore(react): fix e2e test that checks for vendor sourcemap

### DIFF
--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -65,9 +65,7 @@ describe('React Applications', () => {
     });
 
     runCLI(`build ${appName}`);
-    vendorContent = readFile(`dist/apps/${appName}/vendor.js`);
-
-    expect(vendorContent).toMatch(/sourceMappingURL/);
+    checkFilesExist(`dist/apps/${appName}/vendor.js.map`);
   }, 120000);
 
   it('should be able to generate a publishable react lib', async () => {


### PR DESCRIPTION
- No longer check "sourceMappingURL" in content, but check existence of 'vendor.js.map' in dist

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
