### PR TITLE
fix(web): pass http-server params without "="

### DIFF
--- a/packages/web/src/builders/file-server/file-server.impl.ts
+++ b/packages/web/src/builders/file-server/file-server.impl.ts
@@ -14,29 +14,29 @@ export interface FileServerOptions extends JsonObject {
   proxyUrl?: string;
   buildTarget: string;
   parallel: boolean;
-  maxParalel: number;
+  maxParallel: number;
   withDeps: boolean;
 }
 
 function getHttpServerArgs(opts: FileServerOptions) {
   const args = [] as any[];
   if (opts.port) {
-    args.push(`-p=${opts.port}`);
+    args.push(`-p ${opts.port}`);
   }
   if (opts.host) {
-    args.push(`-a=${opts.host}`);
+    args.push(`-a ${opts.host}`);
   }
   if (opts.ssl) {
     args.push(`-S`);
   }
   if (opts.sslCert) {
-    args.push(`-C=${opts.sslCert}`);
+    args.push(`-C ${opts.sslCert}`);
   }
   if (opts.sslKey) {
-    args.push(`-K=${opts.sslCert}`);
+    args.push(`-K ${opts.sslCert}`);
   }
   if (opts.proxyUrl) {
-    args.push(`-P=${opts.proxyUrl}`);
+    args.push(`-P ${opts.proxyUrl}`);
   }
   return args;
 }
@@ -49,8 +49,8 @@ function getBuildTargetCommand(opts: FileServerOptions) {
   if (opts.parallel) {
     cmd.push(`--parallel`);
   }
-  if (opts.maxParalel) {
-    cmd.push(`--maxParallel=${opts.maxParalel}`);
+  if (opts.maxParallel) {
+    cmd.push(`--maxParallel=${opts.maxParallel}`);
   }
   return cmd.join(' ');
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Creates a `=4200` file 🤔 for some weird reason

![image](https://user-images.githubusercontent.com/542458/99673242-d0a55080-2a74-11eb-94fc-f998f9b16d0f.png)

Also tries to serve at `http://=localhost:=4200`

![image](https://user-images.githubusercontent.com/542458/99673356-f3376980-2a74-11eb-8b4f-97ded06fde2a.png)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

I think the params passed to http-server should not be separated by an `=` sign (also per their docs). Removing that works. Strange though it didn't cause the issue on a new repo 🤷 .

Also fixes typo in `maxParallel` option, which wouldn't have been picked up otherwise.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
