### PR TITLE
fix(linter): Add quiet option for eslint

### DIFF
--- a/packages/linter/src/builders/eslint/utility/eslint-utils.ts
+++ b/packages/linter/src/builders/eslint/utility/eslint-utils.ts
@@ -34,5 +34,10 @@ export async function lint(
     errorOnUnmatchedPattern: false,
   });
 
+  if (options.quiet) {
+    return await eslint.lintFiles(options.lintFilePatterns)
+      .then((results) => (projectESLint.ESLint.getErrorResults(results)));
+  }
+
   return await eslint.lintFiles(options.lintFilePatterns);
 }

--- a/packages/linter/src/builders/eslint/utility/eslint-utils.ts
+++ b/packages/linter/src/builders/eslint/utility/eslint-utils.ts
@@ -35,8 +35,9 @@ export async function lint(
   });
 
   if (options.quiet) {
-    return await eslint.lintFiles(options.lintFilePatterns)
-      .then((results) => (projectESLint.ESLint.getErrorResults(results)));
+    return await eslint
+      .lintFiles(options.lintFilePatterns)
+      .then((results) => projectESLint.ESLint.getErrorResults(results));
   }
 
   return await eslint.lintFiles(options.lintFilePatterns);


### PR DESCRIPTION
I current use Angular10.x with Nx.
When i run to "nx lint app -- --quiet", it is not working.
So, i fixed source code. "packages/linter/builder/eslint/utility/eslint-utils.ts"

please review this PR.
I wait for your feed back.
Thank you!

## Current Behavior

## Expected Behavior

## Related Issue(s)

Fixes #
