### PR TITLE
fix(core): convert Windows backslashes on migrate

### DIFF
--- a/packages/tao/src/commands/migrate.spec.ts
+++ b/packages/tao/src/commands/migrate.spec.ts
@@ -542,5 +542,27 @@ describe('Migration', () => {
         parseMigrationsOptions(['8.12.0', '--to', 'myscope'])
       ).toThrowError(`Incorrect 'to' section. Use --to="package@version"`);
     });
+
+    it('should handle backslashes in package names', () => {
+      const r = parseMigrationsOptions([
+        '@nrwl\\workspace@8.12.0',
+        '--from',
+        '@myscope\\a@12.3,@myscope\\b@1.1.1',
+        '--to',
+        '@myscope\\c@12.3.1',
+      ]);
+      expect(r).toEqual({
+        type: 'generateMigrations',
+        targetPackage: '@nrwl/workspace',
+        targetVersion: '8.12.0',
+        from: {
+          '@myscope/a': '12.3.0',
+          '@myscope/b': '1.1.1',
+        },
+        to: {
+          '@myscope/c': '12.3.1',
+        },
+      });
+    });
   });
 });

--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -69,6 +69,10 @@ export function normalizeVersion(version: string) {
   }
 }
 
+function slash(packageName) {
+  return packageName.replace(/\\/g, '/');
+}
+
 export class Migrator {
   private readonly versions: (p: string) => string;
   private readonly fetch: (p: string, v: string) => Promise<MigrationsJson>;
@@ -304,7 +308,7 @@ function versionOverrides(overrides: string, param: string) {
         `Incorrect '${param}' section. Use --${param}="package@version"`
       );
     }
-    res[selectedPackage] = normalizeVersionWithTagCheck(selectedVersion);
+    res[slash(selectedPackage)] = normalizeVersionWithTagCheck(selectedVersion);
   });
   return res;
 }
@@ -378,7 +382,7 @@ export function parseMigrationsOptions(
     );
     return {
       type: 'generateMigrations',
-      targetPackage,
+      targetPackage: slash(targetPackage),
       targetVersion,
       from,
       to,


### PR DESCRIPTION
There are cases that commands arguments like `nx migrate @nrwl/workspace@latest` in Windows OS, are passed as `@nrwl\\workspace@latest` causing unexpected failures.

Closes #4034
Closes #4116
