### PR TITLE
fix(next): Pass `defaultLoaders` through to user webpack config

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -83,7 +83,7 @@ function withNx(nextConfig = {} as any) {
         nextErrorCssModuleLoader.exclude = includes;
       }
 
-      return userWebpack(config);
+      return userWebpack(config, { defaultLoaders });
     },
   };
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
User-defined webpack config is called with only the `config` argument and not the `defaultLoaders`. This can cause issues for user-defined webpack configs that are expecting an object/`defaultLoaders` to exist.

## Expected Behavior
`defaultLoaders` should be passed through to the user-defined webpack config


