### PR TITLE
feat(core): provide the cache key as env var

### DIFF
--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -105,11 +105,19 @@ export async function affected(
             projectsWithTarget,
             affectedProjects,
             projectGraph,
+            env,
             nxArgs,
             overrides
           );
         } else {
-          printAffected([], affectedProjects, projectGraph, nxArgs, overrides);
+          printAffected(
+            [],
+            affectedProjects,
+            projectGraph,
+            env,
+            nxArgs,
+            overrides
+          );
         }
         break;
 

--- a/packages/workspace/src/tasks-runner/task-orchestrator.ts
+++ b/packages/workspace/src/tasks-runner/task-orchestrator.ts
@@ -291,6 +291,7 @@ export class TaskOrchestrator {
       ...envsFromFiles,
       FORCE_COLOR: forceColor,
       ...process.env,
+      NX_TASK_HASH: task.hash,
       NX_INVOKED_BY_RUNNER: 'true',
       NX_WORKSPACE_ROOT: this.workspaceRoot,
     };


### PR DESCRIPTION
## Current Behavior
The Nx cache is not provided as environment variable and cannot be used by targets.

##  Expected Behavior
Provides the task hash as environment variable. This way, targets declared in `angular.json` or `workspace.json` can use this hash.

Below is an example of building and tagging docker images using the cache key. For information, both of the targets are declared as `cacheableOperations`. 
Thanks to Nx computation cache, the `docker-build` target will not be executed again if source code does not change, while `docker-tag` may be run again if the `tag` argument changes. A common use case is merging a branch into master: all targets will be skipped because of computation cache, except the `docker-tag` one which will receive the `master` tag argument.

```json
"docker-build": {
  "builder": "@nrwl/workspace:run-commands",
  "options": {
    "commands": [
      "docker build -t yannickglt/api:$NX_CACHE_KEY -f ./apps/api/Dockerfile ./dist/apps/api",
      "docker push yannickglt/api:$NX_CACHE_KEY"
    ],
    "parallel": false
  }
},
"docker-tag": {
  "builder": "@nrwl/workspace:run-commands",
  "options": {
    "commands": [
      "docker pull yannickglt/api:$NX_CACHE_KEY",
      "docker tag yannickglt/api:$NX_CACHE_KEY yannickglt/api:{args.tag}",
      "docker push yannickglt/api:{args.tag}"
    ],
    "parallel": false
  }
},
```
