### PR TITLE
cleanup(core): remove `minimist` dependency

### DIFF
--- a/packages/cli/lib/parse-run-one-options.ts
+++ b/packages/cli/lib/parse-run-one-options.ts
@@ -17,6 +17,9 @@ export function parseRunOneOptions(
   const parsedArgs = yargsParser(args, {
     boolean: ['prod', 'help'],
     string: ['configuration', 'project'],
+    configuration: {
+      'strip-dashed': true,
+    },
   });
 
   if (parsedArgs['help']) {

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -83,12 +83,11 @@ const parsedArgs = yargsParser(process.argv, {
     'defaultBase',
     'packageManager',
   ],
-  alias: {
-    appName: 'app-name',
-    nxCloud: 'nx-cloud',
-    defaultBase: 'default-base',
-  },
   boolean: ['help', 'interactive', 'nxCloud'],
+  configuration: {
+    'strip-aliased': true,
+    'strip-dashed': true,
+  },
 });
 
 if (parsedArgs.help) {

--- a/packages/tao/package.json
+++ b/packages/tao/package.json
@@ -33,7 +33,6 @@
     "@angular-devkit/core": "~10.1.3",
     "@angular-devkit/architect": "~0.1001.3",
     "inquirer": "^6.3.1",
-    "minimist": "^1.2.0",
     "strip-json-comments": "2.0.1",
     "semver": "6.3.0",
     "tmp": "0.0.33",

--- a/packages/tao/src/commands/generate.ts
+++ b/packages/tao/src/commands/generate.ts
@@ -1,8 +1,7 @@
-import * as minimist from 'minimist';
+import * as yargsParser from 'yargs-parser';
 import { getLogger } from '../shared/logger';
 import {
   combineOptionsForGenerator,
-  convertToCamelCase,
   handleErrors,
   Options,
   Schema,
@@ -39,20 +38,21 @@ function parseGenerateOpts(
   mode: 'generate' | 'new',
   defaultCollection: string | null
 ): GenerateOptions {
-  const generatorOptions = convertToCamelCase(
-    minimist(args, {
-      boolean: ['help', 'dryRun', 'debug', 'force', 'interactive'],
-      alias: {
-        dryRun: 'dry-run',
-        d: 'dryRun',
-      },
-      default: {
-        debug: false,
-        dryRun: false,
-        interactive: true,
-      },
-    })
-  );
+  const generatorOptions = yargsParser(args, {
+    boolean: ['help', 'dryRun', 'debug', 'force', 'interactive'],
+    alias: {
+      dryRun: 'd',
+    },
+    default: {
+      debug: false,
+      dryRun: false,
+      interactive: true,
+    },
+    configuration: {
+      'strip-aliased': true,
+      'strip-dashed': true,
+    },
+  });
 
   let collectionName: string | null = null;
   let generatorName: string | null = null;

--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -7,13 +7,13 @@ import { NodePackageName } from '@angular-devkit/schematics/tasks/package-manage
 import { NodeModulesEngineHost } from '@angular-devkit/schematics/tools';
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
-import * as minimist from 'minimist';
+import * as yargsParser from 'yargs-parser';
 import { dirname, extname, join, resolve } from 'path';
 import { gt, lte } from 'semver';
 import * as stripJsonComments from 'strip-json-comments';
 import { dirSync } from 'tmp';
 import { getLogger } from '../shared/logger';
-import { convertToCamelCase, handleErrors } from '../shared/params';
+import { handleErrors } from '../shared/params';
 import {
   detectPackageManager,
   getPackageManagerInstallCommand,
@@ -360,14 +360,13 @@ type RunMigrations = { type: 'runMigrations'; runMigrations: string };
 export function parseMigrationsOptions(
   args: string[]
 ): GenerateMigrations | RunMigrations {
-  const options = convertToCamelCase(
-    minimist(args, {
-      string: ['runMigrations', 'from', 'to'],
-      alias: {
-        runMigrations: 'run-migrations',
-      },
-    })
-  );
+  const options = yargsParser(args, {
+    string: ['runMigrations', 'from', 'to'],
+    configuration: {
+      'strip-dashed': true,
+    },
+  });
+
   if (!options.runMigrations) {
     const from = options.from
       ? versionOverrides(options.from as string, 'from')

--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -1,8 +1,7 @@
-import * as minimist from 'minimist';
+import * as yargsParser from 'yargs-parser';
 import { getLogger } from '../shared/logger';
 import {
   combineOptionsForExecutor,
-  convertToCamelCase,
   handleErrors,
   Options,
   Schema,
@@ -35,22 +34,20 @@ function parseRunOpts(
   defaultProjectName: string | null,
   logger: Console
 ): RunOptions {
-  const runOptions = convertToCamelCase(
-    minimist(args, {
-      boolean: ['help', 'prod'],
-      string: ['configuration', 'project'],
-    })
-  );
+  const runOptions = yargsParser(args, {
+    boolean: ['help', 'prod'],
+    string: ['configuration', 'project'],
+    configuration: {
+      'strip-dashed': true,
+    },
+  });
   const help = runOptions.help as boolean;
   if (!runOptions._ || !runOptions._[0]) {
     throwInvalidInvocation();
   }
+
   // eslint-disable-next-line prefer-const
-  let [project, target, configuration]: [
-    string,
-    string,
-    string
-  ] = runOptions._[0].split(':');
+  let [project, target, configuration] = runOptions._[0].split(':');
   if (!project && defaultProjectName) {
     logger.debug(
       `No project name specified. Using default project : ${chalk.default.bold(

--- a/packages/tao/src/shared/params.spec.ts
+++ b/packages/tao/src/shared/params.spec.ts
@@ -1,9 +1,7 @@
-import { ParsedArgs } from 'minimist';
 import {
   coerceTypesInOptions,
   convertAliases,
   convertPositionParamsIntoNamedParams,
-  convertToCamelCase,
   lookupUnmatched,
   Schema,
   setDefaults,
@@ -60,41 +58,6 @@ describe('params', () => {
       expect(opts).toEqual({
         a: ['one', 'two'],
         b: 'three,four',
-      });
-    });
-  });
-
-  describe('convertToCamelCase', () => {
-    it('should convert dash case to camel case', () => {
-      expect(
-        convertToCamelCase({
-          _: undefined,
-          'one-two': 1,
-        } as ParsedArgs)
-      ).toEqual({
-        oneTwo: 1,
-      });
-    });
-
-    it('should not convert camel case', () => {
-      expect(
-        convertToCamelCase({
-          _: undefined,
-          oneTwo: 1,
-        })
-      ).toEqual({
-        oneTwo: 1,
-      });
-    });
-
-    it('should handle mixed case', () => {
-      expect(
-        convertToCamelCase({
-          _: undefined,
-          'one-Two': 1,
-        })
-      ).toEqual({
-        oneTwo: 1,
       });
     });
   });

--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -1,5 +1,4 @@
 import { strings } from '@angular-devkit/core';
-import { ParsedArgs } from 'minimist';
 import { TargetDefinition, WorkspaceDefinition } from './workspace';
 import * as inquirer from 'inquirer';
 
@@ -60,13 +59,6 @@ function camelCase(input: string): string {
   } else {
     return input;
   }
-}
-
-export function convertToCamelCase(parsed: ParsedArgs): Options {
-  return Object.keys(parsed).reduce(
-    (m, c) => ({ ...m, [camelCase(c)]: parsed[c] }),
-    {}
-  );
 }
 
 /**


### PR DESCRIPTION
We already use extensively `yargs-parser` which offers the same functionality.
