### PR TITLE
fix(react): buildable libs TS path resolution

### DIFF
--- a/e2e/react/src/react-package.test.ts
+++ b/e2e/react/src/react-package.test.ts
@@ -10,194 +10,258 @@ import {
 } from '@nrwl/e2e/utils';
 
 describe('Build React libraries and apps', () => {
-  /**
-   * Graph:
-   *
-   *                      childLib
-   *                     /
-   * app => parentLib =>
-   *                    \
-   *                     childLib2
-   *
-   */
-  let app: string;
-  let parentLib: string;
-  let childLib: string;
-  let childLib2: string;
+  describe('Publishable libraries', () => {
+    /**
+     * Graph:
+     *
+     *                      childLib
+     *                     /
+     * app => parentLib =>
+     *                    \
+     *                     childLib2
+     *
+     */
+    let app: string;
+    let parentLib: string;
+    let childLib: string;
+    let childLib2: string;
 
-  beforeEach(() => {
-    app = uniq('app');
-    parentLib = uniq('parentlib');
-    childLib = uniq('childlib');
-    childLib2 = uniq('childlib2');
+    beforeEach(() => {
+      app = uniq('app');
+      parentLib = uniq('parentlib');
+      childLib = uniq('childlib');
+      childLib2 = uniq('childlib2');
 
-    newProject();
+      newProject();
 
-    runCLI(`generate @nrwl/react:app ${app}`);
+      runCLI(`generate @nrwl/react:app ${app}`);
 
-    runCLI(
-      `generate @nrwl/react:library ${parentLib} --publishable --importPath=@proj/${parentLib} --no-interactive`
-    );
-    runCLI(
-      `generate @nrwl/react:library ${childLib} --publishable --importPath=@proj/${childLib} --no-interactive`
-    );
-    runCLI(
-      `generate @nrwl/react:library ${childLib2} --publishable --importPath=@proj/${childLib2} --no-interactive`
-    );
+      runCLI(
+        `generate @nrwl/react:library ${parentLib} --publishable --importPath=@proj/${parentLib} --no-interactive`
+      );
+      runCLI(
+        `generate @nrwl/react:library ${childLib} --publishable --importPath=@proj/${childLib} --no-interactive`
+      );
+      runCLI(
+        `generate @nrwl/react:library ${childLib2} --publishable --importPath=@proj/${childLib2} --no-interactive`
+      );
 
-    // create dependencies by importing
-    const createDep = (parent, children: string[]) => {
-      updateFile(
-        `libs/${parent}/src/lib/${parent}.tsx`,
-        `
+      // create dependencies by importing
+      const createDep = (parent, children: string[]) => {
+        updateFile(
+          `libs/${parent}/src/lib/${parent}.tsx`,
+          `
               ${children.map((entry) => `import '@proj/${entry}';`).join('\n')}
 
             `
-      );
-    };
+        );
+      };
 
-    createDep(parentLib, [childLib, childLib2]);
+      createDep(parentLib, [childLib, childLib2]);
 
-    updateFile(
-      `apps/${app}/src/main.tsx`,
-      `
+      updateFile(
+        `apps/${app}/src/main.tsx`,
+        `
         import "@proj/${parentLib}";
         `
-    );
-
-    // we are setting paths to {} to make sure built libs are read from dist
-    updateFile('tsconfig.base.json', (c) => {
-      const json = JSON.parse(c);
-      json.compilerOptions.paths = {};
-      return JSON.stringify(json, null, 2);
-    });
-
-    // Add assets to child lib
-    updateFile('workspace.json', (c) => {
-      const json = JSON.parse(c);
-      json.projects[childLib].architect.build.options.assets = [
-        `libs/${childLib}/src/assets`,
-      ];
-      return JSON.stringify(json, null, 2);
-    });
-    updateFile(`libs/${childLib}/src/assets/hello.txt`, 'Hello World!');
-  });
-
-  it('should throw an error if the dependent library has not been built before building the parent lib', () => {
-    expect.assertions(2);
-
-    try {
-      runCLI(`build ${parentLib}`);
-    } catch (e) {
-      expect(e.stderr.toString()).toContain(
-        `Some of the project ${parentLib}'s dependencies have not been built yet. Please build these libraries before:`
       );
-      expect(e.stderr.toString()).toContain(`${childLib}`);
-    }
-  });
 
-  it('should preserve the tsconfig target set by user', () => {
-    // Setup
-    const myLib = uniq('my-lib');
-    runCLI(
-      `generate @nrwl/react:library ${myLib} --publishable=true --importPath="@mproj/${myLib}" --no-interactive`
-    );
+      // we are setting paths to {} to make sure built libs are read from dist
+      updateFile('tsconfig.base.json', (c) => {
+        const json = JSON.parse(c);
+        json.compilerOptions.paths = {};
+        return JSON.stringify(json, null, 2);
+      });
 
-    /**
-     *
-     * Here I update my library file
-     * I am just adding this in the end:
-     *
-     * export const TestFunction = async () => {
-     *     return await Promise.resolve('Done!')
-     * }
-     *
-     * So that I can see the change in the Promise.
-     *
-     */
+      // Add assets to child lib
+      updateFile('workspace.json', (c) => {
+        const json = JSON.parse(c);
+        json.projects[childLib].architect.build.options.assets = [
+          `libs/${childLib}/src/assets`,
+        ];
+        return JSON.stringify(json, null, 2);
+      });
+      updateFile(`libs/${childLib}/src/assets/hello.txt`, 'Hello World!');
+    });
 
-    updateFile(`libs/${myLib}/src/lib/${myLib}.tsx`, (content) => {
-      return `
+    it('should throw an error if the dependent library has not been built before building the parent lib', () => {
+      expect.assertions(2);
+
+      try {
+        runCLI(`build ${parentLib}`);
+      } catch (e) {
+        expect(e.stderr.toString()).toContain(
+          `Some of the project ${parentLib}'s dependencies have not been built yet. Please build these libraries before:`
+        );
+        expect(e.stderr.toString()).toContain(`${childLib}`);
+      }
+    });
+
+    it('should preserve the tsconfig target set by user', () => {
+      // Setup
+      const myLib = uniq('my-lib');
+      runCLI(
+        `generate @nrwl/react:library ${myLib} --publishable=true --importPath="@mproj/${myLib}" --no-interactive`
+      );
+
+      /**
+       *
+       * Here I update my library file
+       * I am just adding this in the end:
+       *
+       * export const TestFunction = async () => {
+       *     return await Promise.resolve('Done!')
+       * }
+       *
+       * So that I can see the change in the Promise.
+       *
+       */
+
+      updateFile(`libs/${myLib}/src/lib/${myLib}.tsx`, (content) => {
+        return `
         ${content} \n
           export const TestFunction = async () => {
                return await Promise.resolve('Done!')
           }
         `;
-    });
+      });
 
-    updateFile(`libs/${myLib}/tsconfig.json`, (content) => {
-      const json = JSON.parse(content);
+      updateFile(`libs/${myLib}/tsconfig.json`, (content) => {
+        const json = JSON.parse(content);
+
+        /**
+         * Set target as es3!!
+         */
+
+        json.compilerOptions.target = 'es3';
+        return JSON.stringify(json, null, 2);
+      });
+      // What we're testing
+      runCLI(`build ${myLib}`);
+      // Assertion
+      const content = readFile(`dist/libs/${myLib}/${myLib}.esm.js`);
 
       /**
-       * Set target as es3!!
+       * Then check if the result contains this "promise" polyfill?
        */
 
-      json.compilerOptions.target = 'es3';
-      return JSON.stringify(json, null, 2);
+      expect(content).toContain('function __generator(thisArg, body) {');
     });
-    // What we're testing
-    runCLI(`build ${myLib}`);
-    // Assertion
-    const content = readFile(`dist/libs/${myLib}/${myLib}.esm.js`);
 
+    it('should build the library when it does not have any deps', () => {
+      const output = runCLI(`build ${childLib}`);
+      expect(output).toContain(`${childLib}.esm.js`);
+      expect(output).toContain(`${childLib} bundled successfully`);
+      checkFilesExist(`dist/libs/${childLib}/assets/hello.txt`);
+    });
+
+    it('should copy the README to dist', () => {
+      const output = runCLI(`build ${childLib2}`);
+      expect(output).toContain(`${childLib2} bundled successfully`);
+      checkFilesExist(`dist/libs/${childLib2}/README.md`);
+    });
+
+    it('should properly add references to any dependency into the parent package.json', () => {
+      const childLibOutput = runCLI(`build ${childLib}`);
+      const childLib2Output = runCLI(`build ${childLib2}`);
+      const parentLibOutput = runCLI(`build ${parentLib}`);
+
+      expect(childLibOutput).toContain(`${childLib}.esm.js`);
+      expect(childLibOutput).toContain(`${childLib}.umd.js`);
+      expect(childLibOutput).toContain(`${childLib} bundled successfully.`);
+
+      expect(childLib2Output).toContain(`${childLib2}.esm.js`);
+      expect(childLib2Output).toContain(`${childLib2}.umd.js`);
+      expect(childLib2Output).toContain(`${childLib2} bundled successfully.`);
+
+      expect(parentLibOutput).toContain(`${parentLib}.esm.js`);
+      expect(parentLibOutput).toContain(`${parentLib}.umd.js`);
+      expect(parentLibOutput).toContain(`${parentLib} bundled successfully.`);
+
+      const jsonFile = readJson(`dist/libs/${parentLib}/package.json`);
+      expect(jsonFile.peerDependencies).toEqual(
+        expect.objectContaining({
+          [`@proj/${childLib}`]: '0.0.1',
+          [`@proj/${childLib2}`]: '0.0.1',
+          react: expect.anything(),
+        })
+      );
+    });
+
+    it('should build an app composed out of publishable libs', () => {
+      const buildWithDeps = runCLI(`build ${app} --with-deps`);
+      expect(buildWithDeps).toContain(`Running target "build" succeeded`);
+      checkFilesDoNotExist(`apps/${app}/tsconfig/tsconfig.nx-tmp`);
+
+      // we remove all path mappings from the root tsconfig, so when trying to build
+      // libs from source, the builder will throw
+      const failedBuild = runCLI(
+        `build ${app} --with-deps --buildLibsFromSource`,
+        { silenceError: true }
+      );
+      expect(failedBuild).toContain(`Can't resolve`);
+    }, 1000000);
+  });
+
+  describe('Buildable libraries', () => {
     /**
-     * Then check if the result contains this "promise" polyfill?
+     * Graph:
+     *
+     *                      childLib
+     *                     /
+     *        parentLib =>
+     *                    \
+     *                     childLib2
+     *
      */
+    let parentLib: string;
+    let childLib: string;
+    let childLib2: string;
 
-    expect(content).toContain('function __generator(thisArg, body) {');
+    beforeEach(() => {
+      parentLib = uniq('parentlib');
+      childLib = uniq('childlib');
+      childLib2 = uniq('childlib2');
+
+      newProject();
+
+      runCLI(
+        `generate @nrwl/react:library ${parentLib} --buildable --no-interactive`
+      );
+      runCLI(
+        `generate @nrwl/react:library ${childLib} --buildable--no-interactive`
+      );
+      runCLI(
+        `generate @nrwl/react:library ${childLib2} --buildable --no-interactive`
+      );
+
+      // create dependencies by importing
+      const createDep = (parent, children: string[]) => {
+        updateFile(
+          `libs/${parent}/src/lib/${parent}.tsx`,
+          `
+              ${children.map((entry) => `import '@proj/${entry}';`).join('\n')}
+
+            `
+        );
+      };
+
+      createDep(parentLib, [childLib, childLib2]);
+
+      // we are setting paths to {} to make sure built libs are read from dist
+      updateFile('tsconfig.base.json', (c) => {
+        const json = JSON.parse(c);
+        json.compilerOptions.paths = {};
+        return JSON.stringify(json, null, 2);
+      });
+    });
+
+    it('should build dependent libraries', () => {
+      const parentLibOutput = runCLI(`build ${parentLib} --withDeps`);
+
+      expect(parentLibOutput).toContain(`${parentLib} bundled successfully.`);
+      expect(parentLibOutput).toContain(`${childLib} bundled successfully.`);
+      expect(parentLibOutput).toContain(`${childLib2} bundled successfully.`);
+    });
   });
-
-  it('should build the library when it does not have any deps', () => {
-    const output = runCLI(`build ${childLib}`);
-    expect(output).toContain(`${childLib}.esm.js`);
-    expect(output).toContain(`Bundle complete`);
-    checkFilesExist(`dist/libs/${childLib}/assets/hello.txt`);
-  });
-
-  it('should copy the README to dist', () => {
-    const output = runCLI(`build ${childLib2}`);
-    expect(output).toContain(`Bundle complete`);
-    checkFilesExist(`dist/libs/${childLib2}/README.md`);
-  });
-
-  it('should properly add references to any dependency into the parent package.json', () => {
-    const childLibOutput = runCLI(`build ${childLib}`);
-    const childLib2Output = runCLI(`build ${childLib2}`);
-    const parentLibOutput = runCLI(`build ${parentLib}`);
-
-    expect(childLibOutput).toContain(`${childLib}.esm.js`);
-    expect(childLibOutput).toContain(`${childLib}.umd.js`);
-    expect(childLibOutput).toContain(`Bundle complete`);
-
-    expect(childLib2Output).toContain(`${childLib2}.esm.js`);
-    expect(childLib2Output).toContain(`${childLib2}.umd.js`);
-    expect(childLib2Output).toContain(`Bundle complete`);
-
-    expect(parentLibOutput).toContain(`${parentLib}.esm.js`);
-    expect(parentLibOutput).toContain(`${parentLib}.umd.js`);
-    expect(parentLibOutput).toContain(`Bundle complete`);
-
-    const jsonFile = readJson(`dist/libs/${parentLib}/package.json`);
-    expect(jsonFile.peerDependencies).toEqual(
-      expect.objectContaining({
-        [`@proj/${childLib}`]: '0.0.1',
-        [`@proj/${childLib2}`]: '0.0.1',
-        react: expect.anything(),
-      })
-    );
-  });
-
-  it('should build an app composed out of buildable libs', () => {
-    const buildWithDeps = runCLI(`build ${app} --with-deps`);
-    expect(buildWithDeps).toContain(`Running target "build" succeeded`);
-    checkFilesDoNotExist(`apps/${app}/tsconfig/tsconfig.nx-tmp`);
-
-    // we remove all path mappings from the root tsconfig, so when trying to build
-    // libs from source, the builder will throw
-    const failedBuild = runCLI(
-      `build ${app} --with-deps --buildLibsFromSource`,
-      { silenceError: true }
-    );
-    expect(failedBuild).toContain(`Can't resolve`);
-  }, 1000000);
 });

--- a/packages/node/src/builders/package/package.impl.spec.ts
+++ b/packages/node/src/builders/package/package.impl.spec.ts
@@ -269,7 +269,14 @@ describe('NodePackageBuilder', () => {
               data: {
                 files: [],
                 root: 'libs/nodelib',
-                targets: { build: { executor: 'any builder' } },
+                targets: {
+                  build: {
+                    executor: 'any builder',
+                    options: {
+                      tsConfig: 'libs/nodelib-child/tsconfig.lib.json',
+                    },
+                  },
+                },
               },
             },
             'nodelib-child': {

--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -23,6 +23,7 @@ import {
   calculateProjectDependencies,
   checkDependentProjectsHaveBeenBuilt,
   computeCompilerOptionsPaths,
+  createTmpTsConfig,
   DependentBuildableProjectNode,
   updateBuildableProjectPackageJsonDependencies,
 } from '@nrwl/workspace/src/utils/buildable-libs-utils';
@@ -83,6 +84,13 @@ export function run(
         context.workspaceRoot,
         sourceRoot
       );
+      options.tsConfig = createTmpTsConfig(
+        join(context.workspaceRoot, options.tsConfig),
+        context.workspaceRoot,
+        target.data.root,
+        dependencies
+      );
+
       const packageJson = readJsonFile(options.project);
       const rollupOptions = createRollupOptions(
         options,

--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -105,7 +105,7 @@ export function run(
           const watcher = rollup.watch(rollupOptions);
           watcher.on('event', (data) => {
             if (data.code === 'START') {
-              context.logger.info('Bundling...');
+              context.logger.info(`Bundling ${context.target.project}...`);
             } else if (data.code === 'END') {
               updatePackageJson(
                 options,
@@ -129,7 +129,7 @@ export function run(
           return () => watcher.close();
         });
       } else {
-        context.logger.info(`Bundling...`);
+        context.logger.info(`Bundling ${context.target.project}...`);
 
         // Delete output path before bundling
         deleteOutputDir(context.workspaceRoot, options.outputPath);
@@ -152,7 +152,9 @@ export function run(
                       dependencies,
                       packageJson
                     );
-                    context.logger.info('Bundle complete.');
+                    context.logger.info(
+                      `${context.target.project} bundled successfully.`
+                    );
                   } else {
                     context.logger.error('Bundle failed.');
                   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

We rely on the `package.json` `name` property to match the TSConfig path mapping. So the `name` has to be `@myorg/foo` etc. If for some reason someone changes the name or it gets out of sync with the TS path mapping, incremental building will break.

This holds for all, angular, react, node and web.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We should rather find the correct TS path mapping by searching in reverse, using the dependency's `root` path, the entry file etc and based on that find the path mapping in the `tsconfig.base.json`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3994
