### PR TITLE
cleanup(repo): enable missing dependencies check

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "nx-release": "./scripts/nx-release.js",
     "test": "nx run-many --target=test --all --parallel",
     "lint": "nx run-many --target=lint --all --parallel",
-    "depcheck": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/depcheck.ts",
+    "depcheck": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/depcheck",
     "local-registry": "./scripts/local-registry.sh",
     "documentation": "./scripts/documentation/documentation.sh && ./scripts/documentation/check-documentation.sh && npm run check-documentation-map",
     "submit-plugin": "node ./scripts/submit-plugin.js"
@@ -142,7 +142,7 @@
     "d3": "^6.1.1",
     "d3-zoom": "^2.0.0",
     "dagre-d3": "^0.6.4",
-    "depcheck": "^1.2.0",
+    "depcheck": "^1.3.1",
     "document-register-element": "^1.13.1",
     "dotenv": "6.2.0",
     "eslint": "7.10.0",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@angular-devkit/schematics": "~11.0.1",
     "@nrwl/cypress": "*",
+    "@nrwl/devkit": "*",
     "@nrwl/jest": "*",
     "@nrwl/linter": "*",
     "@schematics/angular": "~11.0.1",

--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -62,17 +62,11 @@ function createWorkspace(
   const command = `new ${args} --preset=empty --collection=@nrwl/workspace`;
   console.log(command);
 
-  const collectionJsonPath = require.resolve(
-    '@nrwl/workspace/collection.json',
-    { paths: [tmpDir] }
-  );
-
   const pmc = getPackageManagerCommand(packageManager);
   execSync(
-    `${pmc.exec} tao ${command.replace(
-      '--collection=@nrwl/workspace',
-      `--collection=${collectionJsonPath}`
-    )} --nxWorkspaceRoot="${process.cwd()}"`,
+    `${
+      pmc.exec
+    } tao ${command}/collection.json --nxWorkspaceRoot="${process.cwd()}"`,
     {
       stdio: [0, 1, 2],
       cwd: tmpDir,

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -36,6 +36,7 @@
     "cypress": ">= 3 < 6"
   },
   "dependencies": {
+    "@nrwl/devkit": "*",
     "@angular-devkit/architect": "~0.1100.1",
     "@angular-devkit/core": "~11.0.1",
     "@angular-devkit/schematics": "~11.0.1",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -27,6 +27,8 @@
   "homepage": "https://nx.dev",
   "dependencies": {
     "@nrwl/tao": "*",
-    "ejs": "^3.1.5"
+    "ejs": "^3.1.5",
+    "strip-json-comments": "2.0.1",
+    "tslib": "^2.0.0"
   }
 }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -32,8 +32,10 @@
     "@nrwl/workspace": "*"
   },
   "dependencies": {
+    "@nrwl/devkit": "*",
     "@nrwl/node": "*",
     "@nrwl/jest": "*",
+    "@angular-devkit/core": "~11.0.1",
     "@angular-devkit/schematics": "~11.0.1"
   }
 }

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -35,9 +35,13 @@
     "@nrwl/workspace": "*"
   },
   "dependencies": {
+    "@nrwl/devkit": "*",
     "@angular-devkit/architect": "~0.1100.1",
     "@angular-devkit/core": "~11.0.1",
     "@angular-devkit/schematics": "~11.0.1",
-    "rxjs": "^6.5.4"
+    "jest-resolve": "^26.6.2",
+    "rxjs": "^6.5.4",
+    "strip-json-comments": "2.0.1",
+    "tslib": "^2.0.0"
   }
 }

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -32,8 +32,10 @@
     "@nrwl/workspace": "*"
   },
   "dependencies": {
+    "@nrwl/devkit": "*",
     "@nrwl/node": "*",
     "@nrwl/jest": "*",
+    "@angular-devkit/core": "~11.0.1",
     "@angular-devkit/schematics": "~11.0.1",
     "@nestjs/schematics": "^7.0.0"
   }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -35,8 +35,10 @@
   "dependencies": {
     "@nrwl/react": "*",
     "@nrwl/web": "*",
+    "@angular-devkit/core": "~11.0.1",
     "@angular-devkit/schematics": "~11.0.1",
     "@svgr/webpack": "^5.4.0",
+    "chalk": "4.1.0",
     "url-loader": "^3.0.0"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -32,6 +32,7 @@
     "@nrwl/workspace": "*"
   },
   "dependencies": {
+    "@nrwl/devkit": "*",
     "@nrwl/jest": "*",
     "@nrwl/linter": "*",
     "@angular-devkit/architect": "~0.1100.1",
@@ -41,7 +42,10 @@
     "circular-dependency-plugin": "5.2.0",
     "copy-webpack-plugin": "6.0.3",
     "fork-ts-checker-webpack-plugin": "^3.1.1",
+    "fs-extra": "7.0.1",
+    "glob": "7.1.4",
     "license-webpack-plugin": "2.1.2",
+    "rxjs": "^6.5.4",
     "source-map-support": "0.5.16",
     "tree-kill": "1.2.2",
     "ts-loader": "5.4.5",

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -29,14 +29,17 @@
     "@nrwl/workspace": "*"
   },
   "dependencies": {
+    "@nrwl/devkit": "*",
     "@nrwl/node": "*",
     "@nrwl/linter": "*",
     "@angular-devkit/architect": "~0.1100.1",
     "@angular-devkit/core": "~11.0.1",
     "@angular-devkit/schematics": "~11.0.1",
     "fs-extra": "7.0.1",
+    "rxjs": "^6.5.4",
     "tmp": "0.0.33",
     "yargs": "15.4.1",
-    "inquirer": "^6.3.1"
+    "inquirer": "^6.3.1",
+    "tslib": "^2.0.0"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,6 +35,7 @@
     "@babel/core": "7.9.6",
     "@babel/preset-react": "7.9.4",
     "@nrwl/cypress": "*",
+    "@nrwl/devkit": "*",
     "@nrwl/jest": "*",
     "@nrwl/web": "*",
     "@angular-devkit/schematics": "~11.0.1",

--- a/packages/react/src/schematics/application/lib/add-routing.ts
+++ b/packages/react/src/schematics/application/lib/add-routing.ts
@@ -13,7 +13,7 @@ import { NormalizedSchema } from '../schema';
 import {
   reactRouterDomVersion,
   typesReactRouterDomVersion,
-} from '@nrwl/react/src/utils/versions';
+} from '../../../../src/utils/versions';
 
 export function addRouting(
   options: NormalizedSchema,

--- a/packages/react/src/schematics/init/init.ts
+++ b/packages/react/src/schematics/init/init.ts
@@ -54,6 +54,7 @@ export default function (schema: Schema) {
     addPackageWithInit('@nrwl/web', schema),
     addDepsToPackageJson(
       {
+        'core-js': '^3.6.5',
         react: reactVersion,
         'react-dom': reactDomVersion,
         tslib: '^2.0.0',

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -14,7 +14,7 @@ import {
   Tree,
   url,
 } from '@angular-devkit/schematics';
-import { CSS_IN_JS_DEPENDENCIES } from '@nrwl/react';
+import { CSS_IN_JS_DEPENDENCIES } from '../../utils/styled';
 import {
   addDepsToPackageJson,
   addLintFiles,

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@nrwl/cypress": "*",
+    "@nrwl/devkit": "*",
     "core-js": "^3.6.5",
     "tree-kill": "1.2.2",
     "ts-loader": "5.4.5",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@nrwl/cypress": "*",
+    "@nrwl/devkit": "*",
     "@nrwl/jest": "*",
     "@nrwl/linter": "*",
     "@angular-devkit/architect": "~0.1100.1",
@@ -59,6 +60,7 @@
     "browserslist": "^4.14.6",
     "cacache": "12.0.2",
     "caniuse-lite": "^1.0.30001030",
+    "chalk": "4.1.0",
     "circular-dependency-plugin": "5.2.0",
     "clean-css": "4.2.1",
     "copy-webpack-plugin": "6.0.3",
@@ -67,6 +69,7 @@
     "file-loader": "4.2.0",
     "find-cache-dir": "3.0.0",
     "fork-ts-checker-webpack-plugin": "^3.1.1",
+    "fs-extra": "7.0.1",
     "glob": "7.1.4",
     "identity-obj-proxy": "3.0.0",
     "jest-worker": "25.1.0",

--- a/packages/workspace/src/schematics/workspace/files/tsconfig.base.json
+++ b/packages/workspace/src/schematics/workspace/files/tsconfig.base.json
@@ -10,7 +10,6 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
-    "typeRoots": ["node_modules/@types"],
     "lib": ["es2017", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,

--- a/scripts/depcheck/discrepancies.ts
+++ b/scripts/depcheck/discrepancies.ts
@@ -1,0 +1,19 @@
+import * as chalk from 'chalk';
+import { satisfies } from 'semver';
+
+export default function getDiscrepancies(
+  projectDependencies: JSON,
+  devDependencies: JSON
+) {
+  return Object.keys(projectDependencies)
+    .filter((p) => !p.startsWith('@nrwl/'))
+    .filter(
+      (p) =>
+        devDependencies[p] &&
+        projectDependencies[p] !== devDependencies[p] &&
+        !satisfies(devDependencies[p], projectDependencies[p])
+    )
+    .map(
+      (p) => `${p}@${devDependencies[p]} ${chalk.dim(projectDependencies[p])}`
+    );
+}

--- a/scripts/depcheck/index.ts
+++ b/scripts/depcheck/index.ts
@@ -1,8 +1,8 @@
-import * as depcheck from 'depcheck';
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import * as chalk from 'chalk';
-import { satisfies } from 'semver';
+import getDiscrepancies from './discrepancies';
+import getMissingDependencies from './missing';
 
 const argv = require('yargs')
   .usage('Check projects for dependency discrepancies.')
@@ -14,7 +14,7 @@ const argv = require('yargs')
   .option('missing', {
     alias: 'm',
     type: 'boolean',
-    default: false,
+    default: true,
     description: 'Check for missing dependencies',
   })
   .option('discrepancies', {
@@ -34,7 +34,7 @@ const argv = require('yargs')
     readFileSync(`./package.json`).toString()
   );
 
-  const packagesDirectory = join(__dirname, '..', 'packages');
+  const packagesDirectory = join(__dirname, '../..', 'packages');
 
   const projects =
     argv.projects ||
@@ -56,7 +56,8 @@ const argv = require('yargs')
           ? await getMissingDependencies(
               project.name,
               projectPath,
-              dependencies
+              dependencies,
+              argv.verbose
             )
           : [];
 
@@ -105,38 +106,3 @@ const argv = require('yargs')
 
   process.exit(0);
 })().catch((err) => console.log(err));
-
-async function getMissingDependencies(
-  name: string,
-  path: string,
-  dependencies: JSON
-) {
-  const options: any = {
-    skipMissing: false, // skip calculation of missing dependencies
-    ignorePatterns: ['*.spec*'],
-  };
-  const { missing } = await depcheck(path, {
-    ...options,
-    package: { dependencies },
-  });
-
-  if (argv.verbose) {
-    console.log(name, missing);
-  }
-
-  return Object.keys(missing).filter((p) => !p.startsWith('@nrwl/'));
-}
-
-function getDiscrepancies(projectDependencies: JSON, devDependencies: JSON) {
-  return Object.keys(projectDependencies)
-    .filter((p) => !p.startsWith('@nrwl/'))
-    .filter(
-      (p) =>
-        devDependencies[p] &&
-        projectDependencies[p] !== devDependencies[p] &&
-        !satisfies(devDependencies[p], projectDependencies[p])
-    )
-    .map(
-      (p) => `${p}@${devDependencies[p]} ${chalk.dim(projectDependencies[p])}`
-    );
-}

--- a/scripts/depcheck/missing.ts
+++ b/scripts/depcheck/missing.ts
@@ -1,0 +1,88 @@
+import * as depcheck from 'depcheck';
+
+// Ignore packages that are defined here per package
+const IGNORE_MATCHES = {
+  '*': ['@nrwl/tao', '@nrwl/workspace', 'prettier', 'typescript', 'dotenv'],
+  angular: [
+    '@angular-devkit/architect',
+    '@angular-devkit/build-angular',
+    '@angular-devkit/core',
+    '@angular/compiler-cli',
+    '@angular/core',
+    '@angular/router',
+    '@ngrx/effects',
+    '@ngrx/router-store',
+    '@ngrx/store',
+    'injection-js',
+    'ng-packagr',
+    'rxjs',
+  ],
+  cli: ['@nrwl/cli'],
+  cypress: ['cypress'],
+  jest: ['jest', '@jest/types', 'identity-obj-proxy'],
+  linter: ['eslint', '@angular-devkit/schematics'],
+  next: [
+    '@angular-devkit/architect',
+    '@nrwl/devkit',
+    'express',
+    'http-proxy-middleware',
+    'next',
+    'rxjs',
+    'tsconfig-paths-webpack-plugin',
+    'webpack',
+  ],
+  react: [
+    'babel-plugin-emotion',
+    'babel-plugin-styled-components',
+    'rollup',
+    'webpack',
+  ],
+  storybook: [
+    '@angular-devkit/architect',
+    '@angular-devkit/core',
+    '@angular-devkit/schematics',
+    '@storybook/addon-knobs',
+    '@storybook/core',
+    'rxjs',
+  ],
+  tao: ['@angular-devkit/build-angular'],
+  web: ['fibers', 'node-sass'],
+  workspace: ['tslint'],
+};
+
+export default async function getMissingDependencies(
+  name: string,
+  path: string,
+  dependencies: JSON,
+  verbose: boolean
+) {
+  const options: any = {
+    skipMissing: false, // skip calculation of missing dependencies
+    ignorePatterns: [
+      '*.d.ts',
+      '.eslintrc.json',
+      '*.spec*',
+      'src/schematics/**/files/**',
+      'src/migrations/**',
+    ],
+  };
+  let { missing } = await depcheck(path, {
+    ...options,
+    package: { dependencies },
+  });
+
+  const packagesMissing = Object.keys(missing).filter(
+    (m) =>
+      !IGNORE_MATCHES['*'].includes(m) &&
+      !(IGNORE_MATCHES[name] || []).includes(m)
+  );
+
+  if (verbose) {
+    console.log(`> ${name}`);
+    packagesMissing.map((p) => {
+      console.log(p, missing[p]);
+    });
+  }
+
+  return packagesMissing;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,6 @@
     "module": "esnext",
     "moduleResolution": "node",
     "outDir": "build",
-    "typeRoots": ["node_modules/@types"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7898,7 +7898,7 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.0.0.tgz#5259f7c30e35e278f1bdc2a4d91230b37cad981e"
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
-camelcase@^6.1.0:
+camelcase@^6.1.0, camelcase@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
@@ -8288,6 +8288,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-deep@^0.2.4:
   version "0.2.4"
@@ -10296,6 +10305,13 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.2.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -10485,31 +10501,34 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-depcheck@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/depcheck/-/depcheck-1.2.0.tgz#4e47caafcad3fc2d4bdefdb7d6e463f4db10721b"
-  integrity sha512-857OvTMgWm35B+B0feJXbkaQo+sm/xMp2Jw4+dGXVsIdEmy9xyDV+q1T1bMp38bN5FbYTgdeqEn5AS7qxC0ubQ==
+depcheck@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/depcheck/-/depcheck-1.3.1.tgz#b4765503da3e6ba1f3810dad0c34c0a649e7e91d"
+  integrity sha512-lLMfqX2J+ZF3xUEqHpgCNk+dA8erAfW6XURGNAIyUS4KL2i3lezXGYDevYk3G0rWCwy/3CpxE8ek10NrURFOtQ==
   dependencies:
-    "@babel/parser" "^7.10.4"
-    "@babel/traverse" "^7.10.4"
+    "@babel/parser" "^7.12.5"
+    "@babel/traverse" "^7.12.5"
     builtin-modules "^3.1.0"
-    camelcase "^6.0.0"
-    cosmiconfig "^6.0.0"
-    debug "^4.1.1"
+    camelcase "^6.2.0"
+    cosmiconfig "^7.0.0"
+    debug "^4.2.0"
     deps-regex "^0.1.4"
     ignore "^5.1.8"
     js-yaml "^3.14.0"
     json5 "^2.1.3"
-    lodash "^4.17.19"
+    lodash "^4.17.20"
     minimatch "^3.0.4"
-    multimatch "^4.0.0"
+    multimatch "^5.0.0"
     please-upgrade-node "^3.2.0"
-    readdirp "^3.4.0"
+    query-ast "^1.0.3"
+    readdirp "^3.5.0"
     require-package-name "^2.0.1"
-    resolve "^1.17.0"
-    sass "^1.26.10"
-    vue-template-compiler "^2.6.11"
-    yargs "^15.4.0"
+    resolve "^1.18.1"
+    sass "^1.29.0"
+    scss-parser "^1.0.4"
+    semver "^7.3.2"
+    vue-template-compiler "^2.6.12"
+    yargs "^16.1.0"
 
 depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
@@ -12546,7 +12565,7 @@ gensync@^1.0.0-beta.1:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
   integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -13948,7 +13967,14 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  integrity sha1-nh9WrArNtr8wMwbzOL47IErmA2A=
+  dependencies:
+    loose-envify "^1.0.0"
+
+invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -14076,6 +14102,13 @@ is-core-module@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.1.0.tgz#a4cc031d9b1aca63eecbd18a650e13cb4eeab946"
   integrity sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
+  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
   dependencies:
     has "^1.0.3"
 
@@ -16086,6 +16119,11 @@ lodash@^4.0.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.1
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
@@ -16967,6 +17005,17 @@ multimatch@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-4.0.0.tgz#8c3c0f6e3e8449ada0af3dd29efb491a375191b3"
   integrity sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==
+  dependencies:
+    "@types/minimatch" "^3.0.3"
+    array-differ "^3.0.0"
+    array-union "^2.1.0"
+    arrify "^2.0.1"
+    minimatch "^3.0.4"
+
+multimatch@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-5.0.0.tgz#932b800963cea7a31a033328fa1e0c3a1874dbe6"
+  integrity sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==
   dependencies:
     "@types/minimatch" "^3.0.3"
     array-differ "^3.0.0"
@@ -19450,6 +19499,14 @@ qs@~6.5.1, qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-ast@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/query-ast/-/query-ast-1.0.3.tgz#4a18374950fa80cbf9b03d7b945bbac8bb4250bf"
+  integrity sha512-k7z4jilpZCujhiJ+QeKSwYXHc9HxqiVKlVE7/em0zBfPpcqnXKUP8F7ld7XaAkO6oXeAD7yonqcNJWqOF2pSGA==
+  dependencies:
+    invariant "2.2.2"
+    lodash "^4.17.15"
+
 query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
@@ -20011,7 +20068,14 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-readdirp@^3.4.0, readdirp@~3.4.0:
+readdirp@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
+
+readdirp@~3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
   integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
@@ -20568,6 +20632,14 @@ resolve@1.18.1:
     is-core-module "^2.0.0"
     path-parse "^1.0.6"
 
+resolve@^1.18.1:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
+  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  dependencies:
+    is-core-module "^2.1.0"
+    path-parse "^1.0.6"
+
 responselike@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
@@ -20958,10 +21030,17 @@ sass@1.27.0, sass@^1.26.3:
   dependencies:
     chokidar ">=2.0.0 <4.0.0"
 
-sass@^1.23.0, sass@^1.26.10:
+sass@^1.23.0:
   version "1.26.10"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.26.10.tgz#851d126021cdc93decbf201d1eca2a20ee434760"
   integrity sha512-bzN0uvmzfsTvjz0qwccN1sPm2HxxpNI/Xa+7PlUEMS+nQvbyuEK7Y0qFqxlPHhiNHb1Ze8WQJtU31olMObkAMw==
+  dependencies:
+    chokidar ">=2.0.0 <4.0.0"
+
+sass@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.29.0.tgz#ec4e1842c146d8ea9258c28c141b8c2b7c6ab7f1"
+  integrity sha512-ZpwAUFgnvAUCdkjwPREny+17BpUj8nh5Yr6zKPGtLNTLrmtoRYIjm7njP24COhjJldjwW1dcv52Lpf4tNZVVRA==
   dependencies:
     chokidar ">=2.0.0 <4.0.0"
 
@@ -21046,6 +21125,14 @@ schema-utils@^3.0.0:
     "@types/json-schema" "^7.0.6"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
+
+scss-parser@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/scss-parser/-/scss-parser-1.0.4.tgz#61cdeb28701ffcb497954b9b05729c6d38eb8b9f"
+  integrity sha512-oDZwDfY2JhnDrHNZPcdcPNVTpAXsJBY2/uhFfN0IzMy1xExAfJDcI1Yl/VXhfRsdQL3wLeg6/Oxt3cafBOuMzQ==
+  dependencies:
+    invariant "2.2.4"
+    lodash "^4.17.4"
 
 secure-compare@3.0.1:
   version "3.0.1"
@@ -23596,7 +23683,7 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
-vue-template-compiler@^2.6.11:
+vue-template-compiler@^2.6.12:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz#947ed7196744c8a5285ebe1233fe960437fcc57e"
   integrity sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==
@@ -24159,6 +24246,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -24268,6 +24364,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+y18n@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -24322,6 +24423,11 @@ yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^20.2.2:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
+
 yargs@15.3.0:
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.0.tgz#403af6edc75b3ae04bf66c94202228ba119f0976"
@@ -24339,7 +24445,7 @@ yargs@15.3.0:
     y18n "^4.0.0"
     yargs-parser "^18.1.0"
 
-yargs@15.4.1, yargs@^15.4.0:
+yargs@15.4.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
@@ -24388,6 +24494,19 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.1.0:
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.1.1.tgz#5a4a095bd1ca806b0a50d0c03611d38034d219a1"
+  integrity sha512-hAD1RcFP/wfgfxgMVswPE+z3tlPFtxG8/yWUrG2i17sTWGCGqWnxKcLTF4cUKDUK8fzokwsmO9H0TDkRbMHy8w==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
* Enable missing dependencies check on CI
* Add an (optional) ignore list for each package. (trim in the future)
* Add packages that Yarn 2 complains are missing.
* Remove `node_modules` from `typeRoots`
* Correctly resolve collection on `create-nx-plugin` for Yarn 2
* Add `core-js` as direct dependency for react (PNPM/Yarn 2)
