### PR TITLE
feat(node): add generatePackageJson option to build executor

### DIFF
--- a/docs/angular/api-node/executors/build.md
+++ b/docs/angular/api-node/executors/build.md
@@ -54,6 +54,14 @@ Type: `string`
 
 undefined
 
+### generatePackageJson
+
+Default: `false`
+
+Type: `boolean`
+
+Generates a package.json file with the project's node_module dependencies populated for installing in a container. If a package.json exists in the project's directory, it will be reused with dependencies populated.
+
 ### main
 
 Type: `string`

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -55,6 +55,14 @@ Type: `string`
 
 undefined
 
+### generatePackageJson
+
+Default: `false`
+
+Type: `boolean`
+
+Generates a package.json file with the project's node_module dependencies populated for installing in a container. If a package.json exists in the project's directory, it will be reused with dependencies populated.
+
 ### main
 
 Type: `string`

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -55,6 +55,14 @@ Type: `string`
 
 undefined
 
+### generatePackageJson
+
+Default: `false`
+
+Type: `boolean`
+
+Generates a package.json file with the project's node_module dependencies populated for installing in a container. If a package.json exists in the project's directory, it will be reused with dependencies populated.
+
 ### main
 
 Type: `string`

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -188,7 +188,31 @@ describe('Node Applications', () => {
     });
   }, 120000);
 });
+describe('Build Node apps', () => {
+  it('should generate a package.json with the `--generatePackageJson` flag', async () => {
+    newProject();
+    const nestapp = uniq('nestapp');
+    runCLI(`generate @nrwl/nest:app ${nestapp} --linter=eslint`);
 
+    await runCLIAsync(`build ${nestapp} --generatePackageJson`);
+
+    checkFilesExist(`dist/apps/${nestapp}/package.json`);
+    const packageJson = JSON.parse(
+      readFile(`dist/apps/${nestapp}/package.json`)
+    );
+    expect(packageJson).toEqual(
+      expect.objectContaining({
+        dependencies: {
+          '@nestjs/common': '^7.0.0',
+          '@nestjs/core': '^7.0.0',
+        },
+        main: 'main.js',
+        name: expect.any(String),
+        version: '0.0.1',
+      })
+    );
+  });
+});
 describe('Node Libraries', () => {
   it('should be able to generate a node library', async () => {
     newProject();

--- a/packages/node/src/builders/build/build.impl.ts
+++ b/packages/node/src/builders/build/build.impl.ts
@@ -4,10 +4,10 @@ import { runWebpack, BuildResult } from '@angular-devkit/build-webpack';
 
 import { Observable, from } from 'rxjs';
 import { join, resolve } from 'path';
-import { map, concatMap } from 'rxjs/operators';
+import { concatMap, map, tap } from 'rxjs/operators';
 import { getNodeWebpackConfig } from '../../utils/node.config';
 import { OUT_FILENAME } from '../../utils/config';
-import { BuildBuilderOptions } from '../../utils/types';
+import { BuildNodeBuilderOptions } from '../../utils/types';
 import { normalizeBuildOptions } from '../../utils/normalize';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import { createProjectGraph } from '@nrwl/workspace/src/core/project-graph';
@@ -15,17 +15,11 @@ import {
   calculateProjectDependencies,
   createTmpTsConfig,
 } from '@nrwl/workspace/src/utils/buildable-libs-utils';
+import { generatePackageJson } from '../../utils/generate-package-json';
 
 try {
   require('dotenv').config();
 } catch (e) {}
-
-export interface BuildNodeBuilderOptions extends BuildBuilderOptions {
-  optimization?: boolean;
-  sourceMap?: boolean;
-  externalDependencies: 'all' | 'none' | string[];
-  buildLibsFromSource?: boolean;
-}
 
 export type NodeBuildEvent = BuildResult & {
   outfile: string;
@@ -37,8 +31,8 @@ function run(
   options: JsonObject & BuildNodeBuilderOptions,
   context: BuilderContext
 ): Observable<NodeBuildEvent> {
+  const projGraph = createProjectGraph();
   if (!options.buildLibsFromSource) {
-    const projGraph = createProjectGraph();
     const { target, dependencies } = calculateProjectDependencies(
       projGraph,
       context
@@ -51,10 +45,24 @@ function run(
     );
   }
 
-  return from(getSourceRoot(context)).pipe(
-    map((sourceRoot) =>
-      normalizeBuildOptions(options, context.workspaceRoot, sourceRoot)
+  return from(getRoots(context)).pipe(
+    map(({ sourceRoot, projectRoot }) =>
+      normalizeBuildOptions(
+        options,
+        context.workspaceRoot,
+        sourceRoot,
+        projectRoot
+      )
     ),
+    tap((normalizedOptions) => {
+      if (normalizedOptions.generatePackageJson) {
+        generatePackageJson(
+          context.target.project,
+          projGraph,
+          normalizedOptions
+        );
+      }
+    }),
     map((options) => {
       let config = getNodeWebpackConfig(options);
       if (options.webpackConfig) {
@@ -84,17 +92,20 @@ function run(
   );
 }
 
-async function getSourceRoot(context: BuilderContext) {
+async function getRoots(
+  context: BuilderContext
+): Promise<{ sourceRoot: string; projectRoot: string }> {
   const workspaceHost = workspaces.createWorkspaceHost(new NodeJsSyncHost());
   const { workspace } = await workspaces.readWorkspace(
     context.workspaceRoot,
     workspaceHost
   );
-  if (workspace.projects.get(context.target.project).sourceRoot) {
-    return workspace.projects.get(context.target.project).sourceRoot;
+  const project = workspace.projects.get(context.target.project);
+  if (project.sourceRoot && project.root) {
+    return { sourceRoot: project.sourceRoot, projectRoot: project.root };
   } else {
     context.reportStatus('Error');
-    const message = `${context.target.project} does not have a sourceRoot. Please define one.`;
+    const message = `${context.target.project} does not have a sourceRoot or root. Please define one.`;
     context.logger.error(message);
     throw new Error(message);
   }

--- a/packages/node/src/builders/build/schema.json
+++ b/packages/node/src/builders/build/schema.json
@@ -117,6 +117,11 @@
       "type": "boolean",
       "description": "Read buildable libraries from source instead of building them separately.",
       "default": false
+    },
+    "generatePackageJson": {
+      "type": "boolean",
+      "description": "Generates a package.json file with the project's node_module dependencies populated for installing in a container. If a package.json exists in the project's directory, it will be reused with dependencies populated.",
+      "default": false
     }
   },
   "required": ["tsConfig", "main"],

--- a/packages/node/src/utils/generate-package-json.ts
+++ b/packages/node/src/utils/generate-package-json.ts
@@ -1,0 +1,73 @@
+import { ProjectGraph, readJsonFile } from '@nrwl/workspace';
+import { BuildNodeBuilderOptions } from './types';
+import { writeJsonFile } from '@nrwl/workspace/src/utils/fileutils';
+import { OUT_FILENAME } from './config';
+
+/**
+ * Creates a package.json in the output directory for support  to install dependencies within containers.
+ *
+ * If a package.json exists in the project, it will reuse that.
+ *
+ * @param projectName
+ * @param graph
+ * @param options
+ * @constructor
+ */
+export function generatePackageJson(
+  projectName: string,
+  graph: ProjectGraph,
+  options: BuildNodeBuilderOptions
+) {
+  const npmDeps = findAllNpmDeps(projectName, graph);
+  // default package.json if one does not exist
+  let packageJson = {
+    name: projectName,
+    version: '0.0.1',
+    main: OUT_FILENAME,
+    dependencies: {},
+  };
+
+  try {
+    packageJson = readJsonFile(`${options.projectRoot}/package.json`);
+    if (!packageJson.dependencies) {
+      packageJson.dependencies = {};
+    }
+  } catch (e) {}
+
+  const rootPackageJson = readJsonFile(`${options.root}/package.json`);
+
+  Object.entries(npmDeps).forEach(([packageName, version]) => {
+    // don't include devDeps
+    if (rootPackageJson.devDependencies?.[packageName]) {
+      return;
+    }
+
+    packageJson.dependencies[packageName] = version;
+  });
+
+  writeJsonFile(`${options.outputPath}/package.json`, packageJson);
+}
+
+function findAllNpmDeps(
+  projectName: string,
+  graph: ProjectGraph,
+  list: { [packageName: string]: string } = {},
+  seen = new Set<string>()
+) {
+  if (seen.has(projectName)) {
+    return list;
+  }
+
+  seen.add(projectName);
+
+  const node = graph.nodes[projectName];
+
+  if (node.type === 'npm') {
+    list[node.data.packageName] = node.data.version;
+  }
+  graph.dependencies[projectName]?.forEach((dep) => {
+    findAllNpmDeps(dep.target, graph, list, seen);
+  });
+
+  return list;
+}

--- a/packages/node/src/utils/node.config.spec.ts
+++ b/packages/node/src/utils/node.config.spec.ts
@@ -1,8 +1,7 @@
 import { getNodeWebpackConfig } from './node.config';
-import { BannerPlugin } from 'webpack';
 jest.mock('tsconfig-paths-webpack-plugin');
 import TsConfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
-import { BuildNodeBuilderOptions } from '../builders/build/build.impl';
+import { BuildNodeBuilderOptions } from './types';
 
 describe('getNodePartial', () => {
   let input: BuildNodeBuilderOptions;

--- a/packages/node/src/utils/node.config.ts
+++ b/packages/node/src/utils/node.config.ts
@@ -1,9 +1,9 @@
-import { Configuration, BannerPlugin } from 'webpack';
+import { Configuration } from 'webpack';
 import * as mergeWebpack from 'webpack-merge';
 import * as nodeExternals from 'webpack-node-externals';
 
-import { BuildNodeBuilderOptions } from '../builders/build/build.impl';
 import { getBaseWebpackPartial } from './config';
+import { BuildNodeBuilderOptions } from './types';
 
 function getNodePartial(options: BuildNodeBuilderOptions) {
   const webpackConfig: Configuration = {

--- a/packages/node/src/utils/normalize.spec.ts
+++ b/packages/node/src/utils/normalize.spec.ts
@@ -8,6 +8,7 @@ describe('normalizeBuildOptions', () => {
   let testOptions: BuildBuilderOptions;
   let root: string;
   let sourceRoot: Path;
+  let projectRoot: string;
 
   beforeEach(() => {
     testOptions = {
@@ -29,24 +30,45 @@ describe('normalizeBuildOptions', () => {
     };
     root = '/root';
     sourceRoot = normalize('apps/nodeapp/src');
+    projectRoot = 'apps/nodeapp';
   });
   it('should add the root', () => {
-    const result = normalizeBuildOptions(testOptions, root, sourceRoot);
+    const result = normalizeBuildOptions(
+      testOptions,
+      root,
+      sourceRoot,
+      projectRoot
+    );
     expect(result.root).toEqual('/root');
   });
 
   it('should resolve main from root', () => {
-    const result = normalizeBuildOptions(testOptions, root, sourceRoot);
+    const result = normalizeBuildOptions(
+      testOptions,
+      root,
+      sourceRoot,
+      projectRoot
+    );
     expect(result.main).toEqual('/root/apps/nodeapp/src/main.ts');
   });
 
   it('should resolve the output path', () => {
-    const result = normalizeBuildOptions(testOptions, root, sourceRoot);
+    const result = normalizeBuildOptions(
+      testOptions,
+      root,
+      sourceRoot,
+      projectRoot
+    );
     expect(result.outputPath).toEqual('/root/dist/apps/nodeapp');
   });
 
   it('should resolve the tsConfig path', () => {
-    const result = normalizeBuildOptions(testOptions, root, sourceRoot);
+    const result = normalizeBuildOptions(
+      testOptions,
+      root,
+      sourceRoot,
+      projectRoot
+    );
     expect(result.tsConfig).toEqual('/root/apps/nodeapp/tsconfig.app.json');
   });
 
@@ -69,7 +91,8 @@ describe('normalizeBuildOptions', () => {
         ],
       },
       root,
-      sourceRoot
+      sourceRoot,
+      projectRoot
     );
     expect(result.assets).toEqual([
       {
@@ -87,7 +110,12 @@ describe('normalizeBuildOptions', () => {
   });
 
   it('should resolve the file replacement paths', () => {
-    const result = normalizeBuildOptions(testOptions, root, sourceRoot);
+    const result = normalizeBuildOptions(
+      testOptions,
+      root,
+      sourceRoot,
+      projectRoot
+    );
     expect(result.fileReplacements).toEqual([
       {
         replace: '/root/apps/environment/environment.ts',

--- a/packages/node/src/utils/normalize.ts
+++ b/packages/node/src/utils/normalize.ts
@@ -1,4 +1,4 @@
-import { Path, normalize } from '@angular-devkit/core';
+import { normalize } from '@angular-devkit/core';
 import { resolve, dirname, relative, basename } from 'path';
 import { BuildBuilderOptions } from './types';
 import { statSync } from 'fs';
@@ -11,12 +11,14 @@ export interface FileReplacement {
 export function normalizeBuildOptions<T extends BuildBuilderOptions>(
   options: T,
   root: string,
-  sourceRoot: string
+  sourceRoot: string,
+  projectRoot: string
 ): T {
   return {
     ...options,
-    root: root,
-    sourceRoot: sourceRoot,
+    root,
+    sourceRoot,
+    projectRoot,
     main: resolve(root, options.main),
     outputPath: resolve(root, options.outputPath),
     tsConfig: resolve(root, options.tsConfig),

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -41,4 +41,13 @@ export interface BuildBuilderOptions {
 
   root?: string;
   sourceRoot?: Path;
+  projectRoot?: string;
+}
+
+export interface BuildNodeBuilderOptions extends BuildBuilderOptions {
+  optimization?: boolean;
+  sourceMap?: boolean;
+  externalDependencies: 'all' | 'none' | string[];
+  buildLibsFromSource?: boolean;
+  generatePackageJson?: boolean;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There is no way to know what dependencies are needed for an application when trying to deploy with docker. Webpack wouldn't (and really shouldn't) be able to bundle some node specific libraries

## Expected Behavior
The `generatePackageJson` command will generate a package.json (or use an already existing package.json in the project's root) and populate the dependencies.

Only dependencies used within the application would be found, and populated. This means that peer dependencies of frameworks would not be found (unless specifically used by the project). These dependencies should be installed manually in whatever deployment environment. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1518
