### PR TITLE
fix(react): dependency resolution for buildable libraries

### DIFF
--- a/e2e/react/src/react-package.test.ts
+++ b/e2e/react/src/react-package.test.ts
@@ -8,6 +8,7 @@ import {
   uniq,
   updateFile,
 } from '@nrwl/e2e/utils';
+import { names } from '@nrwl/devkit';
 
 describe('Build React libraries and apps', () => {
   /**
@@ -25,16 +26,45 @@ describe('Build React libraries and apps', () => {
   let childLib: string;
   let childLib2: string;
 
+  let buildableParentLib: string;
+  let buildableChildLib: string;
+  let buildableChildLib2: string;
+
   beforeEach(() => {
     app = uniq('app');
     parentLib = uniq('parentlib');
     childLib = uniq('childlib');
     childLib2 = uniq('childlib2');
+    buildableParentLib = uniq('buildableparentlib');
+    buildableChildLib = uniq('buildablechildlib');
+    buildableChildLib2 = uniq('buildablechildlib2');
 
     newProject();
 
+    // create dependencies by importing
+    const createDep = (parent, children: string[]) => {
+      updateFile(
+        `libs/${parent}/src/index.ts`,
+        `
+        export * from './lib/${parent}';
+
+              ${children
+                .map(
+                  (entry) =>
+                    `import { ${
+                      names(entry).className
+                    } } from '@proj/${entry}'; console.log(${
+                      names(entry).className
+                    });`
+                )
+                .join('\n')}
+            `
+      );
+    };
+
     runCLI(`generate @nrwl/react:app ${app}`);
 
+    // generate publishable libs
     runCLI(
       `generate @nrwl/react:library ${parentLib} --publishable --importPath=@proj/${parentLib} --no-interactive`
     );
@@ -45,32 +75,15 @@ describe('Build React libraries and apps', () => {
       `generate @nrwl/react:library ${childLib2} --publishable --importPath=@proj/${childLib2} --no-interactive`
     );
 
-    // create dependencies by importing
-    const createDep = (parent, children: string[]) => {
-      updateFile(
-        `libs/${parent}/src/lib/${parent}.tsx`,
-        `
-              ${children.map((entry) => `import '@proj/${entry}';`).join('\n')}
-
-            `
-      );
-    };
-
     createDep(parentLib, [childLib, childLib2]);
 
     updateFile(
       `apps/${app}/src/main.tsx`,
       `
-        import "@proj/${parentLib}";
+        import {${names(parentLib).className}} from "@proj/${parentLib}";
+        console.log(${names(parentLib).className});
         `
     );
-
-    // we are setting paths to {} to make sure built libs are read from dist
-    updateFile('tsconfig.base.json', (c) => {
-      const json = JSON.parse(c);
-      json.compilerOptions.paths = {};
-      return JSON.stringify(json, null, 2);
-    });
 
     // Add assets to child lib
     updateFile('workspace.json', (c) => {
@@ -81,123 +94,155 @@ describe('Build React libraries and apps', () => {
       return JSON.stringify(json, null, 2);
     });
     updateFile(`libs/${childLib}/src/assets/hello.txt`, 'Hello World!');
-  });
 
-  it('should throw an error if the dependent library has not been built before building the parent lib', () => {
-    expect.assertions(2);
-
-    try {
-      runCLI(`build ${parentLib}`);
-    } catch (e) {
-      expect(e.stderr.toString()).toContain(
-        `Some of the project ${parentLib}'s dependencies have not been built yet. Please build these libraries before:`
-      );
-      expect(e.stderr.toString()).toContain(`${childLib}`);
-    }
-  });
-
-  it('should preserve the tsconfig target set by user', () => {
-    // Setup
-    const myLib = uniq('my-lib');
+    // generate buildable libs
     runCLI(
-      `generate @nrwl/react:library ${myLib} --publishable=true --importPath="@mproj/${myLib}" --no-interactive`
+      `generate @nrwl/react:library ${buildableParentLib} --buildable --no-interactive`
+    );
+    runCLI(
+      `generate @nrwl/react:library ${buildableChildLib} --buildable --no-interactive`
+    );
+    runCLI(
+      `generate @nrwl/react:library ${buildableChildLib2} --buildable --no-interactive`
     );
 
-    /**
-     *
-     * Here I update my library file
-     * I am just adding this in the end:
-     *
-     * export const TestFunction = async () => {
-     *     return await Promise.resolve('Done!')
-     * }
-     *
-     * So that I can see the change in the Promise.
-     *
-     */
+    createDep(buildableParentLib, [buildableChildLib, buildableChildLib2]);
 
-    updateFile(`libs/${myLib}/src/lib/${myLib}.tsx`, (content) => {
-      return `
+    // we are setting paths to {} to make sure built libs are read from dist
+    updateFile('tsconfig.base.json', (c) => {
+      const json = JSON.parse(c);
+      json.compilerOptions.paths = {};
+      return JSON.stringify(json, null, 2);
+    });
+  });
+
+  describe('Publishable libraries', () => {
+    it('should throw an error if the dependent library has not been built before building the parent lib', () => {
+      expect.assertions(2);
+
+      try {
+        runCLI(`build ${parentLib}`);
+      } catch (e) {
+        expect(e.stderr.toString()).toContain(
+          `Some of the project ${parentLib}'s dependencies have not been built yet. Please build these libraries before:`
+        );
+        expect(e.stderr.toString()).toContain(`${childLib}`);
+      }
+    });
+
+    it('should preserve the tsconfig target set by user', () => {
+      // Setup
+      const myLib = uniq('my-lib');
+      runCLI(
+        `generate @nrwl/react:library ${myLib} --publishable=true --importPath="@mproj/${myLib}" --no-interactive`
+      );
+
+      /**
+       *
+       * Here I update my library file
+       * I am just adding this in the end:
+       *
+       * export const TestFunction = async () => {
+       *     return await Promise.resolve('Done!')
+       * }
+       *
+       * So that I can see the change in the Promise.
+       *
+       */
+
+      updateFile(`libs/${myLib}/src/lib/${myLib}.tsx`, (content) => {
+        return `
         ${content} \n
           export const TestFunction = async () => {
                return await Promise.resolve('Done!')
           }
         `;
-    });
+      });
 
-    updateFile(`libs/${myLib}/tsconfig.json`, (content) => {
-      const json = JSON.parse(content);
+      updateFile(`libs/${myLib}/tsconfig.json`, (content) => {
+        const json = JSON.parse(content);
+
+        /**
+         * Set target as es3!!
+         */
+
+        json.compilerOptions.target = 'es3';
+        return JSON.stringify(json, null, 2);
+      });
+      // What we're testing
+      runCLI(`build ${myLib}`);
+      // Assertion
+      const content = readFile(`dist/libs/${myLib}/${myLib}.esm.js`);
 
       /**
-       * Set target as es3!!
+       * Then check if the result contains this "promise" polyfill?
        */
 
-      json.compilerOptions.target = 'es3';
-      return JSON.stringify(json, null, 2);
+      expect(content).toContain('function __generator(thisArg, body) {');
     });
-    // What we're testing
-    runCLI(`build ${myLib}`);
-    // Assertion
-    const content = readFile(`dist/libs/${myLib}/${myLib}.esm.js`);
 
-    /**
-     * Then check if the result contains this "promise" polyfill?
-     */
+    it('should build the library when it does not have any deps', () => {
+      const output = runCLI(`build ${childLib}`);
+      expect(output).toContain(`${childLib}.esm.js`);
+      expect(output).toContain(`Bundle complete: ${childLib}`);
+      checkFilesExist(`dist/libs/${childLib}/assets/hello.txt`);
+    });
 
-    expect(content).toContain('function __generator(thisArg, body) {');
+    it('should copy the README to dist', () => {
+      const output = runCLI(`build ${childLib2}`);
+      expect(output).toContain(`Bundle complete: ${childLib2}`);
+      checkFilesExist(`dist/libs/${childLib2}/README.md`);
+    });
+
+    it('should properly add references to any dependency into the parent package.json', () => {
+      const childLibOutput = runCLI(`build ${childLib}`);
+      const childLib2Output = runCLI(`build ${childLib2}`);
+      const parentLibOutput = runCLI(`build ${parentLib}`);
+
+      expect(childLibOutput).toContain(`${childLib}.esm.js`);
+      expect(childLibOutput).toContain(`${childLib}.umd.js`);
+      expect(childLibOutput).toContain(`Bundle complete: ${childLib}`);
+
+      expect(childLib2Output).toContain(`${childLib2}.esm.js`);
+      expect(childLib2Output).toContain(`${childLib2}.umd.js`);
+      expect(childLib2Output).toContain(`Bundle complete: ${childLib2}`);
+
+      expect(parentLibOutput).toContain(`${parentLib}.esm.js`);
+      expect(parentLibOutput).toContain(`${parentLib}.umd.js`);
+      expect(parentLibOutput).toContain(`Bundle complete: ${parentLib}`);
+
+      const jsonFile = readJson(`dist/libs/${parentLib}/package.json`);
+      expect(jsonFile.peerDependencies).toEqual(
+        expect.objectContaining({
+          [`@proj/${childLib}`]: '0.0.1',
+          [`@proj/${childLib2}`]: '0.0.1',
+          react: expect.anything(),
+        })
+      );
+    });
+
+    it('should build an app composed out of publishable libs', () => {
+      const buildWithDeps = runCLI(`build ${app} --with-deps`);
+      expect(buildWithDeps).toContain(`Running target "build" succeeded`);
+      checkFilesDoNotExist(`apps/${app}/tsconfig/tsconfig.nx-tmp`);
+
+      // we remove all path mappings from the root tsconfig, so when trying to build
+      // libs from source, the builder will throw
+      const failedBuild = runCLI(
+        `build ${app} --with-deps --buildLibsFromSource`,
+        { silenceError: true }
+      );
+      expect(failedBuild).toContain(`Can't resolve`);
+    }, 1000000);
   });
 
-  it('should build the library when it does not have any deps', () => {
-    const output = runCLI(`build ${childLib}`);
-    expect(output).toContain(`${childLib}.esm.js`);
-    expect(output).toContain(`Bundle complete`);
-    checkFilesExist(`dist/libs/${childLib}/assets/hello.txt`);
+  describe('Buildable libraries', () => {
+    it('should build dependent libraries', () => {
+      const parentLibOutput = runCLI(`build ${parentLib} --with-deps`);
+
+      expect(parentLibOutput).toContain(`Bundle complete: ${parentLib}`);
+      expect(parentLibOutput).toContain(`Bundle complete: ${childLib}`);
+      expect(parentLibOutput).toContain(`Bundle complete: ${childLib2}`);
+    });
   });
-
-  it('should copy the README to dist', () => {
-    const output = runCLI(`build ${childLib2}`);
-    expect(output).toContain(`Bundle complete`);
-    checkFilesExist(`dist/libs/${childLib2}/README.md`);
-  });
-
-  it('should properly add references to any dependency into the parent package.json', () => {
-    const childLibOutput = runCLI(`build ${childLib}`);
-    const childLib2Output = runCLI(`build ${childLib2}`);
-    const parentLibOutput = runCLI(`build ${parentLib}`);
-
-    expect(childLibOutput).toContain(`${childLib}.esm.js`);
-    expect(childLibOutput).toContain(`${childLib}.umd.js`);
-    expect(childLibOutput).toContain(`Bundle complete`);
-
-    expect(childLib2Output).toContain(`${childLib2}.esm.js`);
-    expect(childLib2Output).toContain(`${childLib2}.umd.js`);
-    expect(childLib2Output).toContain(`Bundle complete`);
-
-    expect(parentLibOutput).toContain(`${parentLib}.esm.js`);
-    expect(parentLibOutput).toContain(`${parentLib}.umd.js`);
-    expect(parentLibOutput).toContain(`Bundle complete`);
-
-    const jsonFile = readJson(`dist/libs/${parentLib}/package.json`);
-    expect(jsonFile.peerDependencies).toEqual(
-      expect.objectContaining({
-        [`@proj/${childLib}`]: '0.0.1',
-        [`@proj/${childLib2}`]: '0.0.1',
-        react: expect.anything(),
-      })
-    );
-  });
-
-  it('should build an app composed out of buildable libs', () => {
-    const buildWithDeps = runCLI(`build ${app} --with-deps`);
-    expect(buildWithDeps).toContain(`Running target "build" succeeded`);
-    checkFilesDoNotExist(`apps/${app}/tsconfig/tsconfig.nx-tmp`);
-
-    // we remove all path mappings from the root tsconfig, so when trying to build
-    // libs from source, the builder will throw
-    const failedBuild = runCLI(
-      `build ${app} --with-deps --buildLibsFromSource`,
-      { silenceError: true }
-    );
-    expect(failedBuild).toContain(`Can't resolve`);
-  }, 1000000);
 });

--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -79,7 +79,7 @@ describe('React Applications', () => {
     const libTestResults = await runCLIAsync(
       `build ${libName} --no-extract-css`
     );
-    expect(libTestResults.stdout).toContain('Bundle complete.');
+    expect(libTestResults.stdout).toContain(`Bundle complete: ${libName}`);
 
     checkFilesExist(
       `dist/libs/${libName}/package.json`,

--- a/packages/react/src/schematics/library/library.ts
+++ b/packages/react/src/schematics/library/library.ts
@@ -113,7 +113,9 @@ export default function (schema: Schema): Rule {
             pascalCaseFiles: options.pascalCaseFiles,
           })
         : noop(),
-      options.publishable ? updateLibPackageNpmScope(options) : noop(),
+      options.publishable || options.buildable
+        ? updateLibPackageNpmScope(options)
+        : noop(),
       addDepsToPackageJson(
         {
           react: reactVersion,

--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -97,7 +97,7 @@ export function run(
           const watcher = rollup.watch(rollupOptions);
           watcher.on('event', (data) => {
             if (data.code === 'START') {
-              context.logger.info('Bundling...');
+              context.logger.info(`Bundling ${context.target.project}...`);
             } else if (data.code === 'END') {
               updatePackageJson(
                 options,
@@ -121,7 +121,7 @@ export function run(
           return () => watcher.close();
         });
       } else {
-        context.logger.info(`Bundling...`);
+        context.logger.info(`Bundling ${context.target.project}...`);
 
         // Delete output path before bundling
         deleteOutputDir(context.workspaceRoot, options.outputPath);
@@ -144,9 +144,13 @@ export function run(
                       dependencies,
                       packageJson
                     );
-                    context.logger.info('Bundle complete.');
+                    context.logger.info(
+                      `Bundle complete: ${context.target.project}`
+                    );
                   } else {
-                    context.logger.error('Bundle failed.');
+                    context.logger.error(
+                      `Bundle failed: ${context.target.project}`
+                    );
                   }
                 },
               })


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

- `package.json` `name` prop doesn't have the `@workspace/...` resolution for `--buildable` React libs.
- current react e2e tests don't catch that problem

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Fixes the above..

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3994
