### PR TITLE
feat(testing): update cypress to 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "core-js": "^3.6.5",
     "cosmiconfig": "^4.0.0",
     "css-loader": "3.4.2",
-    "cypress": "^5.5.0",
+    "cypress": "^6.0.1",
     "cytoscape": "^3.15.2",
     "cytoscape-anywhere-panning": "^0.5.5",
     "cytoscape-dagre": "^2.2.2",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@nrwl/workspace": "*",
-    "cypress": ">= 3 < 6"
+    "cypress": ">= 3 < 7"
   },
   "dependencies": {
     "@nrwl/devkit": "*",

--- a/packages/cypress/src/utils/versions.ts
+++ b/packages/cypress/src/utils/versions.ts
@@ -1,3 +1,3 @@
 export const nxVersion = '*';
-export const cypressVersion = '^5.5.0';
+export const cypressVersion = '^6.0.1';
 export const eslintPluginCypressVersion = '^2.10.3';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8280,7 +8280,7 @@ commander@^4.1.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^5.0.0:
+commander@^5.0.0, commander@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
@@ -9411,10 +9411,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-5.5.0.tgz#1da0355794a43247f8a80cb7f505e83e1cf847cb"
-  integrity sha512-UHEiTca8AUTevbT2pWkHQlxoHtXmbq+h6Eiu/Mz8DqpNkF98zjTBLv/HFiKJUU5rQzp9EwSWtms33p5TWCJ8tQ==
+cypress@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.0.1.tgz#86857ca2f527c3723575737deab42fd8f2a209df"
+  integrity sha512-3xtQZ0YM65soLgKQUgn2wg2IbWsM6A2yBg6L4RF31mZHr5LNKdO2/9sgiwxEVMKu2C2m6+IQ75zHP41kZP5rPg==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"
@@ -9428,7 +9428,7 @@ cypress@^5.5.0:
     chalk "^4.1.0"
     check-more-types "^2.24.0"
     cli-table3 "~0.6.0"
-    commander "^4.1.1"
+    commander "^5.1.0"
     common-tags "^1.8.0"
     debug "^4.1.1"
     eventemitter2 "^6.4.2"


### PR DESCRIPTION
## Current Behavior
Cypress is at v5.5

## Expected Behavior
Cypress is at v6.0.1

## Related Issue(s)
Once again there are too many breaking changes for a migration script. [See previous migration](https://github.com/nrwl/nx/pull/3759) 
The migration guide for Cypress v6 can be found [here](https://docs.cypress.io/guides/references/migration-guide.html#Migrating-to-Cypress-6-0)

