### PR TITLE
fix(nextjs): copy the next.config.js file to the dist when building

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -239,6 +239,23 @@ describe('Next.js Applications', () => {
 
     checkFilesExist(`dist/apps/${appName}/public/a/b.txt`);
   }, 120000);
+
+  it('should build with a next.config.js file in the dist folder', async () => {
+    const appName = uniq('app');
+
+    runCLI(`generate @nrwl/next:app ${appName} --no-interactive --style=css`);
+
+    updateFile(
+      `apps/${appName}/next.config.js`,
+      `
+    module.exports = {}
+    `
+    );
+
+    runCLI(`build ${appName}`);
+
+    checkFilesExist(`dist/apps/${appName}/next.config.js`);
+  }, 120000);
 });
 
 async function checkApp(

--- a/packages/next/src/builders/build/build.impl.ts
+++ b/packages/next/src/builders/build/build.impl.ts
@@ -6,11 +6,13 @@ import {
 import build from 'next/dist/build';
 import { PHASE_PRODUCTION_BUILD } from 'next/dist/next-server/lib/constants';
 import * as path from 'path';
+import { copyFileSync } from 'fs';
 import { from, Observable } from 'rxjs';
 import { concatMap, map } from 'rxjs/operators';
 import { prepareConfig } from '../../utils/config';
 import { NextBuildBuilderOptions } from '../../utils/types';
 import { createPackageJson } from './lib/create-package-json';
+import { createNextConfigFile } from './lib/create-next-config-file';
 
 try {
   require('dotenv').config();
@@ -26,6 +28,7 @@ export function run(
   const config = prepareConfig(PHASE_PRODUCTION_BUILD, options, context);
   return from(build(root, config as any)).pipe(
     concatMap(() => from(createPackageJson(options, context))),
+    concatMap(() => from(createNextConfigFile(options, context))),
     map(() => ({ success: true }))
   );
 }

--- a/packages/next/src/builders/build/lib/create-next-config-file.ts
+++ b/packages/next/src/builders/build/lib/create-next-config-file.ts
@@ -1,0 +1,17 @@
+import { copyFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { BuilderContext } from '@angular-devkit/architect';
+import { NextBuildBuilderOptions } from '../../../utils/types';
+
+export async function createNextConfigFile(
+  options: NextBuildBuilderOptions,
+  context: BuilderContext
+) {
+  const nextConfigPath = options.nextConfig
+    ? join(context.workspaceRoot, options.nextConfig)
+    : join(context.workspaceRoot, options.root, 'next.config.js');
+
+  if (existsSync(nextConfigPath)) {
+    copyFileSync(nextConfigPath, join(options.outputPath, 'next.config.js'));
+  }
+}

--- a/packages/next/src/builders/build/lib/create-package-json.ts
+++ b/packages/next/src/builders/build/lib/create-package-json.ts
@@ -2,7 +2,35 @@ import { BuilderContext } from '@angular-devkit/architect';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { readJsonFile } from '@nrwl/workspace';
+import { createProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import { calculateProjectDependencies } from '@nrwl/workspace/src/utils/buildable-libs-utils';
 import { NextBuildBuilderOptions } from '../../../utils/types';
+
+function getProjectDeps(context: BuilderContext, rootPackageJson: any) {
+  const projGraph = createProjectGraph();
+  const { dependencies: deps } = calculateProjectDependencies(
+    projGraph,
+    context
+  );
+  const depNames = deps
+    .map((d) => d.node)
+    .filter((node) => node.type === 'npm')
+    .map((node) => node.data.packageName);
+  const dependencies = depNames
+    .filter((packageName) => packageName in rootPackageJson.dependencies)
+    .reduce((deps, pkgName) => {
+      return { ...deps, [pkgName]: rootPackageJson.dependencies[pkgName] };
+    }, {});
+  const devDependencies = depNames
+    .filter((packageName) => packageName in rootPackageJson.devDependencies)
+    .reduce((deps, pkgName) => {
+      return { ...deps, [pkgName]: rootPackageJson.devDependencies[pkgName] };
+    }, {});
+  return {
+    dependencies,
+    devDependencies,
+  };
+}
 
 export async function createPackageJson(
   options: NextBuildBuilderOptions,
@@ -11,6 +39,10 @@ export async function createPackageJson(
   const rootPackageJson = readJsonFile(
     join(context.workspaceRoot, 'package.json')
   );
+  const { dependencies, devDependencies } = getProjectDeps(
+    context,
+    rootPackageJson
+  );
 
   const outPackageJson = {
     name: context.target.project,
@@ -18,7 +50,15 @@ export async function createPackageJson(
     scripts: {
       start: 'next start',
     },
-    dependencies: rootPackageJson.dependencies,
+    dependencies: {
+      ...dependencies,
+      // peer deps of next, so we need to add them here
+      react: rootPackageJson.dependencies['react'],
+      'react-dom': rootPackageJson.dependencies['react-dom'],
+      next: rootPackageJson.dependencies['next'],
+    },
+    // needed for the next.config.js file
+    devDependencies,
   };
 
   writeFileSync(


### PR DESCRIPTION
This is necessary for the next server to respect config options

## Current Behavior
The `next.config.js` file is working in dev, but when building for a prod environment, the file is not copied into the dist directory and doesn't work.

## Expected Behavior
The `dist` directory for the built Next.js app, should have the `next.config.js` file and it's `package.json` should include any dependencies needed for the configuration and application to work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

May resolve #3961 
May resolve #4048 
