### PR TITLE
fix(nextjs): disable the default-server x-powered-by option on the express server

### DIFF
--- a/packages/next/src/builders/server/lib/default-server.ts
+++ b/packages/next/src/builders/server/lib/default-server.ts
@@ -16,6 +16,7 @@ export async function defaultServer(
   await app.prepare();
 
   const server: express.Express = express();
+  server.disable('x-powered-by');
 
   // Set up the proxy.
   if (proxyConfig) {


### PR DESCRIPTION
This way, when disabling the same option in the next.config.js it doesn't just revert to express

Resolves: #3961

## Current Behavior
In dev mode, a custom express dev server, even when the `poweredByHeader: false` is added to the `<app>/next.config.js`, 'X-Powered-By' response header changes its value from 'Nest.js' to 'Express' instead of being deleted.

## Expected Behavior
The 'X-Powered-By' header should not be sent at all when `poweredByHeader: false`

## Related Issue(s)
This along with https://github.com/nrwl/nx/pull/4179 should Resolve #3961 
