### PR TITLE
fix(angular): replace TestBed.get with TestBed.inject inside spec files

### DIFF
--- a/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.effects.spec.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.effects.spec.ts__tmpl__
@@ -28,7 +28,7 @@ describe('<%= className %>Effects', () => {
       ],
     });
 
-    effects = TestBed.get(<%= className %>Effects);
+    effects = TestBed.inject(<%= className %>Effects);
   });
 
   describe('init$', () => {

--- a/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.facade.spec.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.facade.spec.ts__tmpl__
@@ -59,8 +59,8 @@ describe('<%= className %>Facade', () => {
       class RootModule {}
       TestBed.configureTestingModule({ imports: [RootModule] });
 
-      store = TestBed.get(Store);
-      facade = TestBed.get(<%= className %>Facade);
+      store = TestBed.inject(Store);
+      facade = TestBed.inject(<%= className %>Facade);
     });
 
     /**

--- a/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.effects.spec.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.effects.spec.ts__tmpl__
@@ -30,7 +30,7 @@ describe('<%= className %>Effects', () => {
       ],
     });
 
-    effects = TestBed.get(<%= className %>Effects);
+    effects = TestBed.inject(<%= className %>Effects);
   });
 
   describe('load<%= className %>$', () => {

--- a/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.facade.spec.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.facade.spec.ts__tmpl__
@@ -58,8 +58,8 @@ describe('<%= className %>Facade', () => {
       class RootModule {}
       TestBed.configureTestingModule({ imports: [RootModule] });
 
-      store = TestBed.get(Store);
-      facade = TestBed.get(<%= className %>Facade);
+      store = TestBed.inject(Store);
+      facade = TestBed.inject(<%= className %>Facade);
     });
 
     /**


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Generated NgRx spec files contains old API `TestBed.get`
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generated NgRx spec files should contains new API `TestBed.inject`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->


