### PR TITLE
docs(core): separate prompts on create app tutorial

### DIFF
--- a/docs/angular/tutorial/01-create-application.md
+++ b/docs/angular/tutorial/01-create-application.md
@@ -12,7 +12,11 @@ In this tutorial you will use Nx to build a full-stack application out of common
 
 ```bash
 npx create-nx-workspace@latest
+```
 
+You will then receive the following prompts in your command line:
+
+```
 ? Workspace name (e.g., org name)     myorg
 ? What to create in the new workspace angular
 ? Application name                    todos

--- a/docs/node/tutorial/01-create-application.md
+++ b/docs/node/tutorial/01-create-application.md
@@ -12,7 +12,11 @@ In this tutorial you will use Nx to build a server application out of common lib
 
 ```shell script
 yarn create nx-workspace
+```
 
+You will then receive the following prompts in your command line:
+
+```
 ? Workspace name (e.g., org name)         myorg
 ? What to create in the new workspace     nest
 ? Application name                        todos

--- a/docs/react/tutorial/01-create-application.md
+++ b/docs/react/tutorial/01-create-application.md
@@ -14,7 +14,11 @@ In this tutorial you will use Nx to build a full-stack application out of common
 
 ```bash
 npx create-nx-workspace@latest
+```
 
+You will then receive the following prompts in your command line:
+
+```
 ? Workspace name (e.g., org name)     myorg
 ? What to create in the new workspace react
 ? Application name                    todos


### PR DESCRIPTION
Inside the documentation, the snippet tutorial includes the command as well as the output from the terminal after the command is run. Using the "_copy_" feature copies everything in this box, including the terminal output.

This PR splits snippet so the "_copy_" feature is simpler to use.