### PR TITLE
fix(node): set buildLibFromSource to true by default

### DIFF
--- a/docs/angular/api-node/executors/build.md
+++ b/docs/angular/api-node/executors/build.md
@@ -14,7 +14,7 @@ List of static application assets.
 
 ### buildLibsFromSource
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/angular/api-web/executors/build.md
+++ b/docs/angular/api-web/executors/build.md
@@ -28,7 +28,7 @@ Budget thresholds to ensure parts of your application stay within boundaries whi
 
 ### buildLibsFromSource
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -15,7 +15,7 @@ List of static application assets.
 
 ### buildLibsFromSource
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/node/api-web/executors/build.md
+++ b/docs/node/api-web/executors/build.md
@@ -29,7 +29,7 @@ Budget thresholds to ensure parts of your application stay within boundaries whi
 
 ### buildLibsFromSource
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -15,7 +15,7 @@ List of static application assets.
 
 ### buildLibsFromSource
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/react/api-web/executors/build.md
+++ b/docs/react/api-web/executors/build.md
@@ -29,7 +29,7 @@ Budget thresholds to ensure parts of your application stay within boundaries whi
 
 ### buildLibsFromSource
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -507,7 +507,9 @@ describe('with dependencies', () => {
   });
 
   it('should build an app composed out of buildable libs', () => {
-    const buildWithDeps = runCLI(`build ${app} --with-deps`);
+    const buildWithDeps = runCLI(
+      `build ${app} --with-deps --buildLibsFromSource=false`
+    );
     expect(buildWithDeps).toContain(`Running target "build" succeeded`);
     checkFilesDoNotExist(`apps/${app}/tsconfig/tsconfig.nx-tmp`);
 

--- a/e2e/react/src/react-package.test.ts
+++ b/e2e/react/src/react-package.test.ts
@@ -222,7 +222,9 @@ describe('Build React libraries and apps', () => {
     });
 
     it('should build an app composed out of publishable libs', () => {
-      const buildWithDeps = runCLI(`build ${app} --with-deps`);
+      const buildWithDeps = runCLI(
+        `build ${app} --with-deps --buildLibsFromSource=false`
+      );
       expect(buildWithDeps).toContain(`Running target "build" succeeded`);
       checkFilesDoNotExist(`apps/${app}/tsconfig/tsconfig.nx-tmp`);
 

--- a/packages/node/src/builders/build/schema.json
+++ b/packages/node/src/builders/build/schema.json
@@ -116,7 +116,7 @@
     "buildLibsFromSource": {
       "type": "boolean",
       "description": "Read buildable libraries from source instead of building them separately.",
-      "default": false
+      "default": true
     },
     "generatePackageJson": {
       "type": "boolean",

--- a/packages/web/src/builders/build/schema.json
+++ b/packages/web/src/builders/build/schema.json
@@ -238,7 +238,7 @@
     "buildLibsFromSource": {
       "type": "boolean",
       "description": "Read buildable libraries from source instead of building them separately.",
-      "default": false
+      "default": true
     }
   },
   "required": ["tsConfig", "main", "index"],


### PR DESCRIPTION

## Current Behavior
<!-- This is the behavior we have today -->

Currently new workspaces that generate node apps or apps that use the @nrwl/web builder have `buildLibsFromSource` set to `false` by default, meaning the incremental building is enabled by default for all of them.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Right now the benefit for incremental builds is only noticeable for larger repositories, as for small ones the normal building is still faster. This PR aligns the node and web builder to use not use incremental build by default, hence `buildLibsFromSource` will be set to `true` by default.