### PR TITLE
fix(nextjs): add ^v10.x to the peerDependencies for next

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@nrwl/workspace": "*",
-    "next": "^9.3.3"
+    "next": "^9.3.3 || ^10.x"
   },
   "dependencies": {
     "@nrwl/react": "*",


### PR DESCRIPTION
The auto install of peerDeps in node 15 was causing an error due to Next.js version 10 being too high
for our @nrwl/next plugin


## Current Behavior
See issue #4196 

## Expected Behavior
You should be able to create an Next.js preset workspace without error

## Related Issue(s)

Fixes #4196 
