### PR TITLE
fix(nextjs): pin `css-loader` version for pnpm

### DIFF
--- a/packages/next/src/schematics/application/application.ts
+++ b/packages/next/src/schematics/application/application.ts
@@ -40,7 +40,7 @@ export default function (schema: Schema): Rule {
       addCypress(options),
       addJest(options),
       updateJestConfig(options),
-      addStyleDependencies(options.style),
+      ...addStyleDependencies(options.style),
       setDefaults(options),
       formatFiles(options),
     ]);

--- a/packages/next/src/schematics/component/component.ts
+++ b/packages/next/src/schematics/component/component.ts
@@ -24,7 +24,7 @@ export default function (options: Schema): Rule {
       classComponent: false,
       routing: false,
     }),
-    addStyleDependencies(options.style),
+    ...addStyleDependencies(options.style),
   ]);
 }
 export const componentGenerator = wrapAngularDevkitSchematic(

--- a/packages/next/src/schematics/page/page.ts
+++ b/packages/next/src/schematics/page/page.ts
@@ -20,7 +20,7 @@ export default function (options: Schema): Rule {
       skipTests: !options.withTests,
       flat: true,
     }),
-    addStyleDependencies(options.style),
+    ...addStyleDependencies(options.style),
   ]);
 }
 export const pageGenerator = wrapAngularDevkitSchematic('@nrwl/next', 'page');

--- a/packages/next/src/utils/styles.ts
+++ b/packages/next/src/utils/styles.ts
@@ -1,5 +1,6 @@
 import { noop, Rule } from '@angular-devkit/schematics';
-import { addDepsToPackageJson } from '@nrwl/workspace';
+import { addDepsToPackageJson, updateJsonInTree } from '@nrwl/workspace';
+import { detectPackageManager } from '@nrwl/tao/src/shared/package-manager';
 import { CSS_IN_JS_DEPENDENCIES } from '@nrwl/react';
 import {
   babelPluginStyledComponentsVersion,
@@ -48,12 +49,23 @@ export const NEXT_SPECIFIC_STYLE_DEPENDENCIES = {
   },
 };
 
-export function addStyleDependencies(style: string): Rule {
+export function addStyleDependencies(style: string): Rule[] {
   const extraDependencies = NEXT_SPECIFIC_STYLE_DEPENDENCIES[style];
   return extraDependencies
-    ? addDepsToPackageJson(
-        extraDependencies.dependencies,
-        extraDependencies.devDependencies
-      )
-    : noop();
+    ? [
+        addDepsToPackageJson(
+          extraDependencies.dependencies,
+          extraDependencies.devDependencies
+        ),
+        // @zeit/next-less & @zeit/next-stylus internal configuration is working only
+        // for specific CSS loader version, causing PNPM resolution to fail.
+        detectPackageManager() === 'pnpm' &&
+        (style === 'less' || style === 'styl')
+          ? updateJsonInTree(`/package.json`, (json) => {
+              json.resolutions = { ...json.resolutions, 'css-loader': '1.0.1' };
+              return json;
+            })
+          : noop(),
+      ]
+    : [noop()];
 }


### PR DESCRIPTION
 `@zeit/next-less` & `@zeit/next-stylus` internal configuration is working only for specific CSS loader version, causing PNPM resolution to fail. This commits adds a `resolution` property to make it explicit
