### PR TITLE
fix(core): update project in root jest config when running move command

### DIFF
--- a/packages/workspace/src/schematics/move/lib/update-jest-config.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-jest-config.spec.ts
@@ -40,6 +40,8 @@ describe('updateJestConfig Rule', () => {
     };`;
     const jestConfigPath = '/libs/my-destination/jest.config.js';
 
+    const rootJestConfigPath = '/jest.config.js';
+
     tree = await runSchematic('lib', { name: 'my-source' }, tree);
     tree.create(jestConfigPath, jestConfig);
 
@@ -53,9 +55,13 @@ describe('updateJestConfig Rule', () => {
     tree = (await callRule(updateJestConfig(schema), tree)) as UnitTestTree;
 
     const jestConfigAfter = tree.read(jestConfigPath).toString();
+    const rootJestConfigAfter = tree.read(rootJestConfigPath).toString();
     expect(jestConfigAfter).toContain(`name: 'my-destination'`);
     expect(jestConfigAfter).toContain(
       `coverageDirectory: '../../coverage/libs/my-destination'`
     );
+
+    expect(rootJestConfigAfter).not.toContain('<rootDir>/libs/my-source');
+    expect(rootJestConfigAfter).toContain('<rootDir>/libs/my-destination');
   });
 });

--- a/packages/workspace/src/schematics/move/lib/update-jest-config.ts
+++ b/packages/workspace/src/schematics/move/lib/update-jest-config.ts
@@ -39,6 +39,29 @@ export function updateJestConfig(schema: Schema): Rule {
           .replace(findDir, destination);
         tree.overwrite(jestConfigPath, newContent);
 
+        // update root jest.config.js
+        const rootJestConfigPath = '/jest.config.js';
+
+        if (!tree.exists(rootJestConfigPath)) {
+          return tree;
+        }
+
+        const oldRootJestConfigContent = tree
+          .read(rootJestConfigPath)
+          .toString('utf-8');
+
+        const findProject = new RegExp(
+          `'<rootDir>\/(libs|apps)\/${schema.projectName}'`,
+          'g'
+        );
+
+        const newRootJestConfigContent = oldRootJestConfigContent.replace(
+          findProject,
+          `<rootDir>/${destination}`
+        );
+
+        tree.overwrite(rootJestConfigPath, newRootJestConfigContent);
+
         return tree;
       })
     );


### PR DESCRIPTION
ISSUES CLOSED: #4226

## Current Behavior
using the move schematic, the root jest config js is not updated

## Expected Behavior
using the move schematic should update the root jest config properly

## Related Issue(s)
#4192 

Fixes #
#4226