### PR TITLE
fix(nextjs): don't duplicate styles in styled components

### DIFF
--- a/packages/next/src/schematics/application/application.spec.ts
+++ b/packages/next/src/schematics/application/application.spec.ts
@@ -47,6 +47,7 @@ describe('app', () => {
       expect(tree.exists('apps/my-app/tsconfig.app.json')).toBeTruthy();
       expect(tree.exists('apps/my-app/pages/index.tsx')).toBeTruthy();
       expect(tree.exists('apps/my-app/specs/index.spec.tsx')).toBeTruthy();
+      expect(tree.exists('apps/my-app/pages/index.module.css')).toBeTruthy();
     });
   });
 
@@ -57,9 +58,93 @@ describe('app', () => {
         { name: 'myApp', style: 'scss' },
         appTree
       );
-      expect(result.exists('apps/my-app/pages/index.module.scss')).toEqual(
-        true
+      expect(result.exists('apps/my-app/pages/index.module.scss')).toBeTruthy();
+      expect(result.exists('apps/my-app/pages/styles.css')).toBeTruthy();
+
+      const indexContent = result
+        .read('apps/my-app/pages/index.tsx')
+        .toString();
+      expect(indexContent).toContain(
+        `import styles from './index.module.scss'`
       );
+    });
+  });
+
+  describe('--style less', () => {
+    it('should generate scss styles', async () => {
+      const result = await runSchematic(
+        'app',
+        { name: 'myApp', style: 'less' },
+        appTree
+      );
+      expect(result.exists('apps/my-app/pages/index.module.less')).toBeTruthy();
+      expect(result.exists('apps/my-app/pages/styles.less')).toBeTruthy();
+
+      const indexContent = result
+        .read('apps/my-app/pages/index.tsx')
+        .toString();
+      expect(indexContent).toContain(
+        `import styles from './index.module.less'`
+      );
+    });
+  });
+
+  describe('--style styl', () => {
+    it('should generate scss styles', async () => {
+      const result = await runSchematic(
+        'app',
+        { name: 'myApp', style: 'styl' },
+        appTree
+      );
+      expect(result.exists('apps/my-app/pages/index.module.styl')).toBeTruthy();
+      expect(result.exists('apps/my-app/pages/styles.styl')).toBeTruthy();
+
+      const indexContent = result
+        .read('apps/my-app/pages/index.tsx')
+        .toString();
+      expect(indexContent).toContain(
+        `import styles from './index.module.styl'`
+      );
+    });
+  });
+
+  describe('--style styled-components', () => {
+    it('should generate scss styles', async () => {
+      const result = await runSchematic(
+        'app',
+        { name: 'myApp', style: 'styled-components' },
+        appTree
+      );
+      expect(
+        result.exists('apps/my-app/pages/index.module.styled-components')
+      ).toBeFalsy();
+      expect(result.exists('apps/my-app/pages/styles.css')).toBeTruthy();
+
+      const indexContent = result
+        .read('apps/my-app/pages/index.tsx')
+        .toString();
+      expect(indexContent).not.toContain(`import styles from './index.module`);
+      expect(indexContent).toContain(`import styled from 'styled-components'`);
+    });
+  });
+
+  describe('--style @emotion/styled', () => {
+    it('should generate scss styles', async () => {
+      const result = await runSchematic(
+        'app',
+        { name: 'myApp', style: '@emotion/styled' },
+        appTree
+      );
+      expect(
+        result.exists('apps/my-app/pages/index.module.styled-components')
+      ).toBeFalsy();
+      expect(result.exists('apps/my-app/pages/styles.css')).toBeTruthy();
+
+      const indexContent = result
+        .read('apps/my-app/pages/index.tsx')
+        .toString();
+      expect(indexContent).not.toContain(`import styles from './index.module`);
+      expect(indexContent).toContain(`import styled from '@emotion/styled'`);
     });
   });
 
@@ -71,15 +156,26 @@ describe('app', () => {
         appTree
       );
 
-      const content = result.read('apps/my-app/pages/index.tsx').toString();
+      const indexContent = result
+        .read('apps/my-app/pages/index.tsx')
+        .toString();
 
       const babelJestConfig = readJsonInTree(
         result,
         'apps/my-app/babel-jest.config.json'
       );
 
-      expect(content).toMatch(/<style jsx>/);
+      expect(indexContent).toMatch(/<style jsx>/);
       expect(babelJestConfig.plugins).toContain('styled-jsx/babel');
+      expect(
+        result.exists('apps/my-app/pages/index.module.styled-jsx')
+      ).toBeFalsy();
+      expect(result.exists('apps/my-app/pages/styles.css')).toBeTruthy();
+
+      expect(indexContent).not.toContain(`import styles from './index.module`);
+      expect(indexContent).not.toContain(
+        `import styled from 'styled-components'`
+      );
     });
   });
 

--- a/packages/next/src/schematics/application/files/pages/__fileName__.module.__style__
+++ b/packages/next/src/schematics/application/files/pages/__fileName__.module.__style__
@@ -1,2 +1,1 @@
-.page {
-}
+<%= pageStyleContent %>

--- a/packages/next/src/schematics/application/files/pages/__fileName__.tsx__tmpl__
+++ b/packages/next/src/schematics/application/files/pages/__fileName__.tsx__tmpl__
@@ -9,7 +9,7 @@ import React from 'react';
 %>
 
 <% if (styledModule && styledModule !== 'styled-jsx') { %>
-const StyledPage = styled.div`<%= styleContent %>`;
+const StyledPage = styled.div`<%= pageStyleContent %>`;
 <% }%>
 
 export function Index() {
@@ -19,8 +19,8 @@ export function Index() {
    * Note: The corresponding styles are in the ./<%= fileName %>.<%= style %> file.
    */
   return (
-    <<%= wrapper %><% if (!styledModule || styledModule === 'styled-jsx') {%> className={styles.page}<% } %>>
-      <%= styledModule === 'styled-jsx' ? `<style jsx>{\`${styleContent}\`}</style>` : `` %>
+    <<%= wrapper %><% if (!styledModule) {%> className={styles.page}<% } %>>
+      <%= styledModule === 'styled-jsx' ? `<style jsx>{\`${pageStyleContent}\`}</style>` : `` %>
       <%= appContent %>
     </<%= wrapper %>>
   );

--- a/packages/next/src/schematics/application/lib/create-application-files.ts
+++ b/packages/next/src/schematics/application/lib/create-application-files.ts
@@ -25,6 +25,7 @@ export function createApplicationFiles(options: NormalizedSchema): Rule {
         offsetFromRoot: offsetFromRoot(options.appProjectRoot),
         appContent: createAppJsx(options.name),
         styleContent: createStyleRules(),
+        pageStyleContent: `.page {}`,
         stylesExt:
           options.style === 'less' || options.style === 'styl'
             ? options.style


### PR DESCRIPTION
Previously `styled-jsx` was not able to compile due to `styles` variable usage.
Also, `styleContent` were duplicated inside the styled page.
