### PR TITLE
chore(repo): update resources in node modules

### DIFF
--- a/scripts/readme-fragments/resources.md
+++ b/scripts/readme-fragments/resources.md
@@ -30,63 +30,6 @@
   </tr>
 </table>
 
-### Talks
-
-- [Smarter & Faster Angular Development with Nx (ngconf webinar)](https://youtu.be/LEqJ1xKf_1w), Juri Strumpflohner, Isaac Mann (Oct 16, 2020)
-
-- [React Development At Scale (React Vancouver Virtual Meetup)](https://youtu.be/ZGXuzVipe1U?t=3721), Jack Hsu (May 27, 2020)
-
-- [Scalable React Development (React Summit Remote Edition)](https://www.youtube.com/watch?v=Lr-u2ALSEQg), Jason Jean (April 17, 2020)  
-  Slides: [https://prezi.com/view/fm9sUbR7vbr5fZlO9C8D/](https://prezi.com/view/fm9sUbR7vbr5fZlO9C8D/)
-
-- [Beyond Basics: Scaling Development across Large Teams (Angular Rome Meetup online)](https://docs.google.com/presentation/d/1zEgeppole9avhrvV6Zmpmk-L1W9-6JsHbnjaJwBigtQ/edit?usp=sharing), Juri Strumpflohner (April 2, 2020)
-
-- [Develop like Google, Microsoft, and Facebook with Nx - Dev Nexus](https://prezi.com/view/BVhl92reqg7cnhvv6hhH/), Jason Jean (February 18, 2020)
-
-- [Enhancing the workspace with Custom Builders - AngularToronto](https://www.youtube.com/watch?v=M1Bk_O49n94), Benjamin Cabanes (February 18, 2020)
-
-- [Advanced Nx - Angular Air](https://www.youtube.com/watch?v=pcTSDMid-aE), Isaac Mann (February 5th, 2020)
-
-- [Teach Me Anything - HackFlix](https://www.youtube.com/watch?v=WRmj4JwfoMs) - Isaac Mann (January 9th, 2020)
-
-* [E2E Testing at Half the Cost - NG-BE 2019](https://www.youtube.com/watch?v=C88th0SbepE), Isaac Mann (Dev 10, 2019)
-
-* [Sneak Peek of New Nx Workspace Course - ngHouston](https://www.youtube.com/watch?v=uLbA4f2SINE&feature=youtu.be), Isaac Mann (Nov 27, 2019)
-
-* [Building Large Angular Apps - ngBucharest](https://www.youtube.com/watch?v=bKhyTeTCf7M), Isaac Mann (March 30, 2019)
-
-  - Slides: [https://prezi.com/view/jglXvEfeqnjEr4l2L11h/](https://prezi.com/view/jglXvEfeqnjEr4l2L11h/)
-
-* [Modern Development with Angular CLI & Nrwl Nx](https://www.youtube.com/watch?v=tE8sUAfKI3g), Victor Savkin at ngAtlanta (Feb 5, 2019)
-
-* [Supercharging the Angular CLI](https://www.youtube.com/watch?v=bMkKz8AedHc) - ngVikings, James Henry (March 10, 2018)
-
-* [Hands on Full Stack development with Nx and Bazel](https://www.youtube.com/watch?v=1KDDIhcQORM) - ngConf, Alex Eagle, Torgeir Helgevold (April 19, 2018)
-
-* [Angular at Large Organizations](https://www.youtube.com/watch?v=piQ0EZhtus0) - ngConf, Victor Savkin(April 20, 2018)
-
-* [Building Large Angular Apps Successfully with Nx - AngularNYC Meetup](https://youtu.be/Jwv3wRZ3BTM), Jason Jean (December 19, 2018)
-
-- [Nx: The New Way to Build Enterprise Angular Apps](https://www.youtube.com/watch?v=xo-1SDmvM8Y) - Angular Mix, Jeff Cross & Victor Savkin (October 11, 2017)
-
-### Podcasts and Shows
-
-- [Nx Plugins - ngHouston](https://youtu.be/bydqr-Yxsu8), Wes Grimes and Jon Cammisuli (April 8 2020)
-
-- [Apollo GQL, Angular & Nx - ngHouston](https://youtu.be/bydqr-Yxsu8), Philip Fulcher (Feb 26, 2020)
-
-- [Teach Me Anything - With Isaac Mann from Nrwl](https://youtu.be/WRmj4JwfoMs), Isaac Mann (Jan 9, 2020)
-
-- [Sneak Peek of New Nx Workspace Course - ngHouston](https://www.youtube.com/watch?v=uLbA4f2SINE&feature=youtu.be), Isaac Mann (Nov 27, 2019)
-
-- [React Roundup: Nx and Monorepos](https://player.fm/series/react-round-up/rru-081-nx-and-monorepos-with-jeffrey-cross-and-victor-savkin), Victor Savkin (Oct 1, 2019)
-
-- [Nx and Angular CLI - Adventures in Angular](https://devchat.tv/adv-in-angular/aia-254-nx-and-angular-cli-with-brandon-roberts/), Brandon Roberts (Aug 27th 2019)
-
-- [ngHouston: NX Demo](https://www.youtube.com/watch?v=E_UlU2Yv4G0) (Dec 7, 2017)
-
-- [ngAir 140: Nx for Enterprise Angular Development](https://www.youtube.com/watch?v=qYNiOKDno_I), Victor Savkin (Dec 12, 2017)
-
 ### Nx Demo & Tutorial Videos
 
 - [Nx Dev Tools for Monorepos, In-Depth Explainer (React)](https://www.youtube.com/watch?v=jCf92IyR-GE)
@@ -125,8 +68,13 @@
 
 - [Tiny Angular application projects in Nx workspaces](https://indepth.dev/tiny-angular-application-projects-in-nx-workspaces/#peer-reviewers--30/) (March 2020)
 
-### Misc
+### Additional Resources
 
 - [nx-examples](https://github.com/nrwl/nx-examples) repo has branches for different nx comments to display expected behavior and example app and libraries. Check out the branch (workspace, ngrx...) to see what gets created for you. More info on readme.
 
 - [xplat - Cross-platform tools for Nx workspaces](https://nstudio.io/xplat/)
+
+- [Nrwl Talks, Presentations, and Podcasts playlist on YouTube](https://www.youtube.com/playlist?list=PLakNactNC1dHHWx4JIORwfnEajRv6FG5m)
+
+- [Nx Office Hours playlist on YouTube](https://www.youtube.com/playlist?list=PLakNactNC1dE8KLQ5zd3fQwu_yQHjTmR5)
+

--- a/scripts/readme-fragments/resources.md
+++ b/scripts/readme-fragments/resources.md
@@ -56,15 +56,15 @@
 
 - [High Quality React apps with Nx & Cypress](https://youtu.be/mfJBLhjYMdo)
 
-### Books amd Blogs
+### Books and Blogs
 
 - [Nx blog posts](https://blog.nrwl.io/nx/home)
 
 - [Angular Enterprise Monorepo Patterns Book (free)](https://go.nrwl.io/angular-enterprise-monorepo-patterns-new-book?utm_campaign=Book%3A%20Monorepo%20Patterns%2C%20Jan%202019&utm_source=Github&utm_medium=Banner%20Ad)
 
-* [High Quality React apps with Nx & Cypress](https://cypress.io/blog/2020/04/14/high-quality-react-apps-with-nx-cypress/) (April 2020)
+- [High Quality React apps with Nx & Cypress](https://cypress.io/blog/2020/04/14/high-quality-react-apps-with-nx-cypress/) (April 2020)
 
-* [Shell Library patterns with Nx and Monorepo Architectures](https://indepth.dev/the-shell-library-patterns-with-nx-and-monorepo-architectures/) (March 2020)
+- [Shell Library patterns with Nx and Monorepo Architectures](https://indepth.dev/the-shell-library-patterns-with-nx-and-monorepo-architectures/) (March 2020)
 
 - [Tiny Angular application projects in Nx workspaces](https://indepth.dev/tiny-angular-application-projects-in-nx-workspaces/#peer-reviewers--30/) (March 2020)
 


### PR DESCRIPTION
Part 2/4 of PR #4235 - carrying over the same changes to this file.

Description of changes: I removed the list of individual talks, presentations, and podcasts (maintaining the doc with every new talk is a lot of work, and the list was getting very long). We'll maintain a YouTube playlist with all that info. The playlist and Office Hours playlist are now linked in the "Additional Resources" section (formerly known as "Misc").