### PR TITLE
feat(misc): display skip-nx-cache option in help output

### DIFF
--- a/packages/tao/src/shared/print-help.ts
+++ b/packages/tao/src/shared/print-help.ts
@@ -28,6 +28,7 @@ ${chalk.bold(header + positional + ' [options,...]')}
 
 ${chalk.bold('Options')}:
 ${args}
+${formatOption('skip-nx-cache', 'Skip the use of Nx cache.')}
 ${formatOption('help', 'Show available options for project target.')}
   `)
   );

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -31,6 +31,8 @@ export const commandsObject = yargs
 
     You can also use the infix notation to run a target:
     (e.g., nx serve myapp --configuration=production)
+
+    You can skip the use of Nx cache by using the --skip-nx-cache option.
     `
   )
   .command(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently both `nx --help` and `nx [project][:target][:configuration] --help` do not display that the `--skip-nx-cache` option can be used to disable the use of nx cache for a specific project target execution.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The output of the `nx --help` and `nx [project][:target][:configuration] --help` commands should display that the `--skip-nx-cache` option is available.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3338
