### PR TITLE
docs(docs): rename schematics to generators

### DIFF
--- a/docs/angular/api-nest/generators/class.md
+++ b/docs/angular/api-nest/generators/class.md
@@ -1,6 +1,6 @@
 # class
 
-Run the 'class' NestJs Schematic with Nx project support
+Run the 'class' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/controller.md
+++ b/docs/angular/api-nest/generators/controller.md
@@ -1,6 +1,6 @@
 # controller
 
-Run the 'controller' NestJs Schematic with Nx project support
+Run the 'controller' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/decorator.md
+++ b/docs/angular/api-nest/generators/decorator.md
@@ -1,6 +1,6 @@
 # decorator
 
-Run the 'decorator' NestJs Schematic with Nx project support
+Run the 'decorator' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/filter.md
+++ b/docs/angular/api-nest/generators/filter.md
@@ -1,6 +1,6 @@
 # filter
 
-Run the 'filter' NestJs Schematic with Nx project support
+Run the 'filter' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/gateway.md
+++ b/docs/angular/api-nest/generators/gateway.md
@@ -1,6 +1,6 @@
 # gateway
 
-Run the 'gateway' NestJs Schematic with Nx project support
+Run the 'gateway' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/guard.md
+++ b/docs/angular/api-nest/generators/guard.md
@@ -1,6 +1,6 @@
 # guard
 
-Run the 'guard' NestJs Schematic with Nx project support
+Run the 'guard' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/interceptor.md
+++ b/docs/angular/api-nest/generators/interceptor.md
@@ -1,6 +1,6 @@
 # interceptor
 
-Run the 'interceptor' NestJs Schematic with Nx project support
+Run the 'interceptor' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/interface.md
+++ b/docs/angular/api-nest/generators/interface.md
@@ -1,6 +1,6 @@
 # interface
 
-Run the 'interface' NestJs Schematic with Nx project support
+Run the 'interface' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/middleware.md
+++ b/docs/angular/api-nest/generators/middleware.md
@@ -1,6 +1,6 @@
 # middleware
 
-Run the 'middleware' NestJs Schematic with Nx project support
+Run the 'middleware' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/module.md
+++ b/docs/angular/api-nest/generators/module.md
@@ -1,6 +1,6 @@
 # module
 
-Run the 'module' NestJs Schematic with Nx project support
+Run the 'module' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/pipe.md
+++ b/docs/angular/api-nest/generators/pipe.md
@@ -1,6 +1,6 @@
 # pipe
 
-Run the 'pipe' NestJs Schematic with Nx project support
+Run the 'pipe' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/provider.md
+++ b/docs/angular/api-nest/generators/provider.md
@@ -1,6 +1,6 @@
 # provider
 
-Run the 'provider' NestJs Schematic with Nx project support
+Run the 'provider' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/resolver.md
+++ b/docs/angular/api-nest/generators/resolver.md
@@ -1,6 +1,6 @@
 # resolver
 
-Run the 'resolver' NestJs Schematic with Nx project support
+Run the 'resolver' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-nest/generators/service.md
+++ b/docs/angular/api-nest/generators/service.md
@@ -1,6 +1,6 @@
 # service
 
-Run the 'service' NestJs Schematic with Nx project support
+Run the 'service' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/angular/api-workspace/generators/workspace-generator.md
+++ b/docs/angular/api-workspace/generators/workspace-generator.md
@@ -9,7 +9,7 @@ nx generate workspace-generator ...
 ```
 
 ```bash
-nx g workspace-generator ... # same
+nx g workspace-schematic ... # same
 ```
 
 By default, Nx will search for `workspace-generator` in the default collection provisioned in `angular.json`.

--- a/docs/angular/api-workspace/generators/workspace-generator.md
+++ b/docs/angular/api-workspace/generators/workspace-generator.md
@@ -9,7 +9,7 @@ nx generate workspace-generator ...
 ```
 
 ```bash
-nx g workspace-schematic ... # same
+nx g workspace-generator ... # same
 ```
 
 By default, Nx will search for `workspace-generator` in the default collection provisioned in `angular.json`.

--- a/docs/angular/guides/configuration.md
+++ b/docs/angular/guides/configuration.md
@@ -174,11 +174,11 @@ The selected configuration adds/overrides the default options, and the provided 
 
 ### Generators
 
-You can configure default generator options in `angular.json` as well. For instance, the following will tell Nx to always pass `--style=scss` when creating new libraries.
+Generators that are created using `@angular/devkit` are called schematics. You can configure default generator options in `angular.json` as well. For instance, the following will tell Nx to always pass `--style=scss` when creating new libraries.
 
 ```json
 {
-  "generators": {
+  "schematics": {
     "@nrwl/angular:library": {
       "style": "scss"
     }
@@ -197,6 +197,10 @@ The following command will generate a new library: `nx g @nrwl/angular:lib mylib
   }
 }
 ```
+
+### workspace.json
+
+Your `angular.json` file can be renamed to `workspace.json` and Nx will process it in the same way. The `workspace.json` has one additional top level property `version`. Setting `version` to 1 means the `workspace.json` file syntax is identical to `angular.json` When the `version` of `workspace.json` is set to 2, `targets`, `generators` and `executor` properties are used instead of the version 1 properties `architect`, `schematics` and `builder`.
 
 ## nx.json
 

--- a/docs/angular/guides/configuration.md
+++ b/docs/angular/guides/configuration.md
@@ -178,7 +178,7 @@ You can configure default generator options in `angular.json` as well. For insta
 
 ```json
 {
-  "schematics": {
+  "generators": {
     "@nrwl/angular:library": {
       "style": "scss"
     }

--- a/docs/angular/guides/nx-devkit-angular-devkit.md
+++ b/docs/angular/guides/nx-devkit-angular-devkit.md
@@ -12,7 +12,7 @@ The following is a generator written using Nx Devkit:
 import { Tree, formatFiles, generateFiles } from '@nrwl/devkit';
 import * as path from 'path';
 
-interface Shema {
+interface Schema {
   name: string;
   skipFormat: boolean;
 }
@@ -46,7 +46,7 @@ import {
 import { formatFiles } from '@nrwl/workspace';
 import { toFileName } from '@nrwl/workspace';
 
-interface Shema {
+interface Schema {
   name: string;
   skipFormat: boolean;
 }

--- a/docs/angular/guides/storybook-plugin.md
+++ b/docs/angular/guides/storybook-plugin.md
@@ -60,7 +60,7 @@ nx run project-name:storybook
 
 ### Auto-generate Stories
 
-The `@nrwl/angular:storybook-configuration` schematic has the option to automatically generate `*.stories.ts` files for each component declared in the library.
+The `@nrwl/angular:storybook-configuration` generator has the option to automatically generate `*.stories.ts` files for each component declared in the library.
 
 ```treeview
 <some-folder>/
@@ -70,7 +70,7 @@ The `@nrwl/angular:storybook-configuration` schematic has the option to automati
 
 ### Run Cypress Tests Against a Storybook Instance
 
-Both `storybook-configuration` schematic gives the option to set up an e2e Cypress app that is configured to run against the project's Storybook instance.
+Both `storybook-configuration` generator gives the option to set up an e2e Cypress app that is configured to run against the project's Storybook instance.
 
 To launch Storybook and run the Cypress tests against the iframe inside of Storybook:
 
@@ -214,7 +214,7 @@ Quoting from the [official Storybook migration guide](https://github.com/storybo
 
 Please follow the [official Storybook version 5.2.x to 5.3.x migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#from-version-52x-to-53x) to change your files accordingly.
 
-If you are using Storybook using only the generated files after running the `storybook-configuration` schematic, things might be easier for you. Please check the [sample files for a manual upgrade](#sample-files-for-manual-upgrade).
+If you are using Storybook using only the generated files after running the `storybook-configuration` generator, things might be easier for you. Please check the [sample files for a manual upgrade](#sample-files-for-manual-upgrade).
 
 #### Step 2: Going from version 5.3 to 6.0
 
@@ -239,7 +239,7 @@ Check that everything works as expected. If you are still having trouble, you ca
 
 ### Sample files for manual upgrade
 
-If you have not changed the content of the files which the `storybook-configuration` schematic produced, you can use the following samples to migrate to Storybook `6`:
+If you have not changed the content of the files which the `storybook-configuration` generator produced, you can use the following samples to migrate to Storybook `6`:
 
 #### Configuring the root `./storybook` directory
 

--- a/docs/angular/migration/migration-angular.md
+++ b/docs/angular/migration/migration-angular.md
@@ -32,14 +32,14 @@ To transform a Angular CLI workspace to an Nx workspace, use the `ng add` comman
 ng add @nrwl/workspace
 ```
 
-This installs the `@nrwl/workspace` package into your workspace and runs a schematic to transform your workspace. The schematic applies the following changes to your workspace:
+This installs the `@nrwl/workspace` package into your workspace and runs a generator to transform your workspace. The generator applies the following changes to your workspace:
 
 - Installs the packages for the `Nx` plugin `@nrwl/angular` in your package.json.
 - Creates an nx.json file in the root of your workspace.
 - Creates configuration files for Prettier.
 - Creates an `apps` folder for generating applications.
 - Creates a `libs` folder for generating libraries.
-- Creates a `tools` folder that includes files for custom workspace tooling, such as workspace-specific schematics and scripts.
+- Creates a `tools` folder that includes files for custom workspace tooling, such as workspace-specific generators and scripts.
 - Moves your application into the `apps` folder, and updates the relevant file paths in your configuration files.
 - Moves your e2e suite into the `apps/{{app name}}-e2e` folder, and updates the relevant file paths in your configuration files.
 - Updates your `package.json` with scripts to run various `Nx` workspace commands.
@@ -201,7 +201,7 @@ If you are using `Karma` for unit testing:
   "projects": {
     "<app name>": {
       "projectType": "application",
-      "schematics": {},
+      "generators": {},
       "root": "apps/<app name>",
       "sourceRoot": "apps/<app name>/src",
       "prefix": "myapp",
@@ -227,7 +227,7 @@ If you are using `Karma` for unit testing:
   "cli": {
     "defaultCollection": "@nrwl/angular"
   },
-  "schematics": {
+  "generators": {
     "@nrwl/angular:application": {
       "unitTestRunner": "jest",
       "e2eTestRunner": "cypress"
@@ -240,7 +240,7 @@ If you are using `Karma` for unit testing:
 }
 ```
 
-> Jest will be used by default when generating new applications. If you want to continue using `Karma`, set the `unitTestRunner` to `karma` in the `schematics` section of the `angular.json` file.
+> Jest will be used by default when generating new applications. If you want to continue using `Karma`, set the `unitTestRunner` to `karma` in the `generators` section of the `angular.json` file.
 
 - Update `test-setup.ts` to `test.ts` in the `files` array of the `apps/<app name>/tsconfig.spec.json` file.
 
@@ -311,7 +311,7 @@ If you are using `Protractor` for E2E testing:
   "cli": {
     "defaultCollection": "@nrwl/angular"
   },
-  "schematics": {
+  "generators": {
     "@nrwl/angular:application": {
       "unitTestRunner": "jest",
       "e2eTestRunner": "cypress"
@@ -355,7 +355,7 @@ Verify your E2E tests run correctly by running:
 ng e2e <app name>-e2e
 ```
 
-> Cypress will be used by default when generating new applications. If you want to continue using `Protractor`, set the `e2eTestRunner` to `protractor` in the `schematics` section of the `angular.json` file.
+> Cypress will be used by default when generating new applications. If you want to continue using `Protractor`, set the `e2eTestRunner` to `protractor` in the `generators` section of the `angular.json` file.
 
 ### Updating your linting configuration
 

--- a/docs/angular/migration/migration-angular.md
+++ b/docs/angular/migration/migration-angular.md
@@ -32,7 +32,7 @@ To transform a Angular CLI workspace to an Nx workspace, use the `ng add` comman
 ng add @nrwl/workspace
 ```
 
-This installs the `@nrwl/workspace` package into your workspace and runs a generator to transform your workspace. The generator applies the following changes to your workspace:
+This installs the `@nrwl/workspace` package into your workspace and runs a generator (or schematic) to transform your workspace. The generator applies the following changes to your workspace:
 
 - Installs the packages for the `Nx` plugin `@nrwl/angular` in your package.json.
 - Creates an nx.json file in the root of your workspace.
@@ -197,11 +197,10 @@ If you are using `Karma` for unit testing:
 
 ```json
 {
-  "version": 1,
   "projects": {
     "<app name>": {
       "projectType": "application",
-      "generators": {},
+      "schematics": {},
       "root": "apps/<app name>",
       "sourceRoot": "apps/<app name>/src",
       "prefix": "myapp",
@@ -227,7 +226,7 @@ If you are using `Karma` for unit testing:
   "cli": {
     "defaultCollection": "@nrwl/angular"
   },
-  "generators": {
+  "schematics": {
     "@nrwl/angular:application": {
       "unitTestRunner": "jest",
       "e2eTestRunner": "cypress"
@@ -240,7 +239,7 @@ If you are using `Karma` for unit testing:
 }
 ```
 
-> Jest will be used by default when generating new applications. If you want to continue using `Karma`, set the `unitTestRunner` to `karma` in the `generators` section of the `angular.json` file.
+> Jest will be used by default when generating new applications. If you want to continue using `Karma`, set the `unitTestRunner` to `karma` in the `schematics` section of the `angular.json` file.
 
 - Update `test-setup.ts` to `test.ts` in the `files` array of the `apps/<app name>/tsconfig.spec.json` file.
 
@@ -311,7 +310,7 @@ If you are using `Protractor` for E2E testing:
   "cli": {
     "defaultCollection": "@nrwl/angular"
   },
-  "generators": {
+  "schematics": {
     "@nrwl/angular:application": {
       "unitTestRunner": "jest",
       "e2eTestRunner": "cypress"

--- a/docs/angular/migration/migration-angular.md
+++ b/docs/angular/migration/migration-angular.md
@@ -354,7 +354,7 @@ Verify your E2E tests run correctly by running:
 ng e2e <app name>-e2e
 ```
 
-> Cypress will be used by default when generating new applications. If you want to continue using `Protractor`, set the `e2eTestRunner` to `protractor` in the `generators` section of the `angular.json` file.
+> Cypress will be used by default when generating new applications. If you want to continue using `Protractor`, set the `e2eTestRunner` to `protractor` in the `schematics` section of the `angular.json` file.
 
 ### Updating your linting configuration
 

--- a/docs/angular/migration/migration-angularjs.md
+++ b/docs/angular/migration/migration-angularjs.md
@@ -98,7 +98,7 @@ Your `package.json` should now look like this:
     "format:write": "nx format:write",
     "format:check": "nx format:check",
     "update": "ng update @nrwl/workspace",
-    "workspace-schematic": "nx workspace-schematic",
+    "workspace-generator": "nx workspace-generator",
     "dep-graph": "nx dep-graph",
     "help": "nx help",
     "postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points"

--- a/docs/node/api-nest/generators/class.md
+++ b/docs/node/api-nest/generators/class.md
@@ -1,6 +1,6 @@
 # class
 
-Run the 'class' NestJs Schematic with Nx project support
+Run the 'class' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/controller.md
+++ b/docs/node/api-nest/generators/controller.md
@@ -1,6 +1,6 @@
 # controller
 
-Run the 'controller' NestJs Schematic with Nx project support
+Run the 'controller' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/decorator.md
+++ b/docs/node/api-nest/generators/decorator.md
@@ -1,6 +1,6 @@
 # decorator
 
-Run the 'decorator' NestJs Schematic with Nx project support
+Run the 'decorator' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/filter.md
+++ b/docs/node/api-nest/generators/filter.md
@@ -1,6 +1,6 @@
 # filter
 
-Run the 'filter' NestJs Schematic with Nx project support
+Run the 'filter' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/gateway.md
+++ b/docs/node/api-nest/generators/gateway.md
@@ -1,6 +1,6 @@
 # gateway
 
-Run the 'gateway' NestJs Schematic with Nx project support
+Run the 'gateway' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/guard.md
+++ b/docs/node/api-nest/generators/guard.md
@@ -1,6 +1,6 @@
 # guard
 
-Run the 'guard' NestJs Schematic with Nx project support
+Run the 'guard' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/interceptor.md
+++ b/docs/node/api-nest/generators/interceptor.md
@@ -1,6 +1,6 @@
 # interceptor
 
-Run the 'interceptor' NestJs Schematic with Nx project support
+Run the 'interceptor' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/interface.md
+++ b/docs/node/api-nest/generators/interface.md
@@ -1,6 +1,6 @@
 # interface
 
-Run the 'interface' NestJs Schematic with Nx project support
+Run the 'interface' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/middleware.md
+++ b/docs/node/api-nest/generators/middleware.md
@@ -1,6 +1,6 @@
 # middleware
 
-Run the 'middleware' NestJs Schematic with Nx project support
+Run the 'middleware' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/module.md
+++ b/docs/node/api-nest/generators/module.md
@@ -1,6 +1,6 @@
 # module
 
-Run the 'module' NestJs Schematic with Nx project support
+Run the 'module' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/pipe.md
+++ b/docs/node/api-nest/generators/pipe.md
@@ -1,6 +1,6 @@
 # pipe
 
-Run the 'pipe' NestJs Schematic with Nx project support
+Run the 'pipe' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/provider.md
+++ b/docs/node/api-nest/generators/provider.md
@@ -1,6 +1,6 @@
 # provider
 
-Run the 'provider' NestJs Schematic with Nx project support
+Run the 'provider' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/resolver.md
+++ b/docs/node/api-nest/generators/resolver.md
@@ -1,6 +1,6 @@
 # resolver
 
-Run the 'resolver' NestJs Schematic with Nx project support
+Run the 'resolver' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-nest/generators/service.md
+++ b/docs/node/api-nest/generators/service.md
@@ -1,6 +1,6 @@
 # service
 
-Run the 'service' NestJs Schematic with Nx project support
+Run the 'service' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/node/api-workspace/generators/workspace-generator.md
+++ b/docs/node/api-workspace/generators/workspace-generator.md
@@ -9,7 +9,7 @@ nx generate workspace-generator ...
 ```
 
 ```bash
-nx g workspace-generator ... # same
+nx g workspace-schematic ... # same
 ```
 
 By default, Nx will search for `workspace-generator` in the default collection provisioned in `workspace.json`.

--- a/docs/node/api-workspace/generators/workspace-generator.md
+++ b/docs/node/api-workspace/generators/workspace-generator.md
@@ -9,7 +9,7 @@ nx generate workspace-generator ...
 ```
 
 ```bash
-nx g workspace-schematic ... # same
+nx g workspace-generator ... # same
 ```
 
 By default, Nx will search for `workspace-generator` in the default collection provisioned in `workspace.json`.

--- a/docs/node/guides/configuration.md
+++ b/docs/node/guides/configuration.md
@@ -71,7 +71,7 @@ The `workspace.json` configuration file contains information about the targets a
   "cli": {
     "defaultCollection": "@nrwl/node"
   },
-  "schematics": {
+  "generators": {
     "@nrwl/node:library": {
       "js": true
     }
@@ -195,7 +195,7 @@ You can configure default generator options in `workspace.json` as well. For ins
 
 ```json
 {
-  "schematics": {
+  "generators": {
     "@nrwl/node:library": {
       "buildable": true
     }
@@ -211,7 +211,7 @@ You can also do it on the project level:
     "root": "libs/mylib/",
     "sourceRoot": "libs/mylib/src",
     "projectType": "library",
-    "schematics": {
+    "generators": {
       "@nrwl/node:lib": {
         "moreOptions": true
       }

--- a/docs/node/guides/configuration.md
+++ b/docs/node/guides/configuration.md
@@ -8,14 +8,15 @@ The `workspace.json` configuration file contains information about the targets a
 
 ```json
 {
+  "version": 2,
   "projects": {
     "myapp": {
       "root": "apps/myapp/",
       "sourceRoot": "apps/myapp/src",
       "projectType": "application",
-      "architect": {
+      "targets": {
         "build": {
-          "builder": "@nrwl/node:build",
+          "executor": "@nrwl/node:build",
           "outputs": ["dist/apps/myapp"],
           "options": {
             "outputPath": "dist/packages/myapp",
@@ -30,13 +31,13 @@ The `workspace.json` configuration file contains information about the targets a
           }
         },
         "serve": {
-          "builder": "@nrwl/node:execute",
+          "executor": "@nrwl/node:execute",
           "options": {
             "buildTarget": "myapp:build"
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "options": {
             "jestConfig": "apps/myapp/jest.config.js"
           }
@@ -47,16 +48,16 @@ The `workspace.json` configuration file contains information about the targets a
       "root": "libs/mylib/",
       "sourceRoot": "libs/mylib/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "options": {
             "jestConfig": "libs/mylib/jest.config.js",
             "tsConfig": "libs/mylib/tsconfig.spec.json"
           }
         },
         "build": {
-          "builder": "@nrwl/node:package",
+          "executor": "@nrwl/node:package",
           "options": {
             "outputPath": "dist/libs/mylib",
             "tsConfig": "libs/mylib/tsconfig.lib.json",
@@ -91,7 +92,7 @@ For instance, the following configures `mylib`.
     "root": "libs/mylib/",
     "sourceRoot": "libs/mylib/src",
     "projectType": "library",
-    "architect": {}
+    "targets": {}
   }
 }
 ```
@@ -99,18 +100,16 @@ For instance, the following configures `mylib`.
 - `root` tells Nx the location of the library including its sources and configuration files.
 - `sourceRoot` tells Nx the location of the library's source files.
 - `projectType` is either 'application' or 'library'.
-- `architect` configures all the targets which define what tasks you can run against the library.
-
-> Nx uses the architect library built by the Angular team at Google. The naming reflects that. Important to note: it's a general purpose library that **does not** have any dependency on Angular.
+- `targets` configures all the targets which define what tasks you can run against the library.
 
 ### Targets
 
-Let's look at the simple architect target:
+Let's look at the simple target:
 
 ```json
 {
   "test": {
-    "builder": "@nrwl/jest:jest",
+    "executor": "@nrwl/jest:jest",
     "options": {
       "jestConfig": "libs/mylib/jest.config.js"
     }
@@ -122,13 +121,13 @@ Let's look at the simple architect target:
 
 The name of the target `test` means that you can invoke it as follows: `nx test mylib` or `nx run mylib:test`. The name isn't significant in any other way. If you rename it to, for example, `mytest`, you will be able to run as follows: `nx run mylib:mytest`.
 
-**Builder**
+**Executor**
 
-The `builder` property tells Nx what function to invoke when you run the target. `"@nrwl/jest:jest"` tells Nx to find the `@nrwl/jest` package, find the builder named `jest` and invoke it with the options.
+The `executor` property tells Nx what function to invoke when you run the target. `"@nrwl/jest:jest"` tells Nx to find the `@nrwl/jest` package, find the executor named `jest` and invoke it with the options.
 
 **Options**
 
-The `options` provides a map of values that will be passed to the builder. The provided command line args will be merged into this map. I.e., `nx test mylib --jestConfig=libs/mylib/another-jest.config.js` will pass the following to the builder:
+The `options` provides a map of values that will be passed to the executor. The provided command line args will be merged into this map. I.e., `nx test mylib --jestConfig=libs/mylib/another-jest.config.js` will pass the following to the executor:
 
 ```json
 {
@@ -138,12 +137,12 @@ The `options` provides a map of values that will be passed to the builder. The p
 
 **Outputs**
 
-The `outputs` property lists the folders the builder will create files in. The property is optional. If not provided, Nx will assume it is `dist/libs/mylib`.
+The `outputs` property lists the folders the executor will create files in. The property is optional. If not provided, Nx will assume it is `dist/libs/mylib`.
 
 ```json
 {
   "build": {
-    "builder": "@nrwl/node:package",
+    "executor": "@nrwl/node:package",
     "options": {
       "outputPath": "dist/libs/mylib",
       "tsConfig": "libs/mylib/tsconfig.lib.json",
@@ -162,7 +161,7 @@ The `configurations` property provides extra sets of values that will be merged 
 ```json
 {
   "build": {
-    "builder": "@nrwl/node:package",
+    "executor": "@nrwl/node:package",
     "options": {
       "outputPath": "dist/libs/mylib",
       "tsConfig": "libs/mylib/tsconfig.lib.json",
@@ -181,10 +180,10 @@ The `configurations` property provides extra sets of values that will be merged 
 
 You can select a configuration like this: `nx build mylib --configuration=production` or `nx run mylib:build:configuration=production`.
 
-The following show how the builder options get constructed:
+The following show how the executor options get constructed:
 
 ```bash
-require(`@nrwl/jest`).builders['jest']({...options, ...selectedConfiguration, ...commandLineArgs}}) // Pseudocode
+require(`@nrwl/jest`).executors['jest']({...options, ...selectedConfiguration, ...commandLineArgs}}) // Pseudocode
 ```
 
 The selected configuration adds/overrides the default options, and the provided command line args add/override the configuration options.
@@ -216,7 +215,7 @@ You can also do it on the project level:
         "moreOptions": true
       }
     },
-    "architect": {}
+    "targets": {}
   }
 }
 ```
@@ -232,6 +231,10 @@ The following command will generate a new library: `nx g @nrwl/node:lib mylib`. 
   }
 }
 ```
+
+### Version
+
+When the `version` of `workspace.json` is set to 2, `targets`, `generators` and `executor` properties are used instead of the version 1 properties `architect`, `schematics` and `builder`.
 
 ## nx.json
 

--- a/docs/node/tutorial/01-create-application.md
+++ b/docs/node/tutorial/01-create-application.md
@@ -44,7 +44,7 @@ myorg/
 │       ├── tsconfig.json
 │       └── tsconfig.spec.json
 ├── tools/
-│   ├── schematics
+│   ├── generators
 │   └── tsconfig.tools.json
 ├── jest.config.js
 ├── libs

--- a/docs/react/api-nest/generators/class.md
+++ b/docs/react/api-nest/generators/class.md
@@ -1,6 +1,6 @@
 # class
 
-Run the 'class' NestJs Schematic with Nx project support
+Run the 'class' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/controller.md
+++ b/docs/react/api-nest/generators/controller.md
@@ -1,6 +1,6 @@
 # controller
 
-Run the 'controller' NestJs Schematic with Nx project support
+Run the 'controller' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/decorator.md
+++ b/docs/react/api-nest/generators/decorator.md
@@ -1,6 +1,6 @@
 # decorator
 
-Run the 'decorator' NestJs Schematic with Nx project support
+Run the 'decorator' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/filter.md
+++ b/docs/react/api-nest/generators/filter.md
@@ -1,6 +1,6 @@
 # filter
 
-Run the 'filter' NestJs Schematic with Nx project support
+Run the 'filter' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/gateway.md
+++ b/docs/react/api-nest/generators/gateway.md
@@ -1,6 +1,6 @@
 # gateway
 
-Run the 'gateway' NestJs Schematic with Nx project support
+Run the 'gateway' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/guard.md
+++ b/docs/react/api-nest/generators/guard.md
@@ -1,6 +1,6 @@
 # guard
 
-Run the 'guard' NestJs Schematic with Nx project support
+Run the 'guard' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/interceptor.md
+++ b/docs/react/api-nest/generators/interceptor.md
@@ -1,6 +1,6 @@
 # interceptor
 
-Run the 'interceptor' NestJs Schematic with Nx project support
+Run the 'interceptor' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/interface.md
+++ b/docs/react/api-nest/generators/interface.md
@@ -1,6 +1,6 @@
 # interface
 
-Run the 'interface' NestJs Schematic with Nx project support
+Run the 'interface' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/middleware.md
+++ b/docs/react/api-nest/generators/middleware.md
@@ -1,6 +1,6 @@
 # middleware
 
-Run the 'middleware' NestJs Schematic with Nx project support
+Run the 'middleware' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/module.md
+++ b/docs/react/api-nest/generators/module.md
@@ -1,6 +1,6 @@
 # module
 
-Run the 'module' NestJs Schematic with Nx project support
+Run the 'module' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/pipe.md
+++ b/docs/react/api-nest/generators/pipe.md
@@ -1,6 +1,6 @@
 # pipe
 
-Run the 'pipe' NestJs Schematic with Nx project support
+Run the 'pipe' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/provider.md
+++ b/docs/react/api-nest/generators/provider.md
@@ -1,6 +1,6 @@
 # provider
 
-Run the 'provider' NestJs Schematic with Nx project support
+Run the 'provider' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/resolver.md
+++ b/docs/react/api-nest/generators/resolver.md
@@ -1,6 +1,6 @@
 # resolver
 
-Run the 'resolver' NestJs Schematic with Nx project support
+Run the 'resolver' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-nest/generators/service.md
+++ b/docs/react/api-nest/generators/service.md
@@ -1,6 +1,6 @@
 # service
 
-Run the 'service' NestJs Schematic with Nx project support
+Run the 'service' NestJs generator with Nx project support
 
 ## Usage
 

--- a/docs/react/api-workspace/generators/workspace-generator.md
+++ b/docs/react/api-workspace/generators/workspace-generator.md
@@ -9,7 +9,7 @@ nx generate workspace-generator ...
 ```
 
 ```bash
-nx g workspace-generator ... # same
+nx g workspace-schematic ... # same
 ```
 
 By default, Nx will search for `workspace-generator` in the default collection provisioned in `workspace.json`.

--- a/docs/react/api-workspace/generators/workspace-generator.md
+++ b/docs/react/api-workspace/generators/workspace-generator.md
@@ -9,7 +9,7 @@ nx generate workspace-generator ...
 ```
 
 ```bash
-nx g workspace-schematic ... # same
+nx g workspace-generator ... # same
 ```
 
 By default, Nx will search for `workspace-generator` in the default collection provisioned in `workspace.json`.

--- a/docs/react/examples/react-nx.md
+++ b/docs/react/examples/react-nx.md
@@ -4,7 +4,7 @@ Learn to:
 
 - Generate a new React monorepo workspace with one application.
 - Add new feature libraries and route to them from our application.
-- Generate React components with a schematic
+- Create React components with a generator
 - Generate a NestJS app in the same monorepo
 
 **Blog post:** [Powering Up React Development With Nx](https://blog.nrwl.io/powering-up-react-development-with-nx-cf0a9385dbec)

--- a/docs/react/guides/configuration.md
+++ b/docs/react/guides/configuration.md
@@ -8,14 +8,15 @@ The `workspace.json` configuration file contains information about the targets a
 
 ```json
 {
+  "version": 2,
   "projects": {
     "myapp": {
       "root": "apps/myapp/",
       "sourceRoot": "apps/myapp/src",
       "projectType": "application",
-      "architect": {
+      "targets": {
         "build": {
-          "builder": "@nrwl/web:build",
+          "executor": "@nrwl/web:build",
           "outputs": ["dist/apps/myapp"],
           "options": {
             "index": "apps/myapp/src/app.html",
@@ -28,14 +29,14 @@ The `workspace.json` configuration file contains information about the targets a
           }
         },
         "serve": {
-          "builder": "@nrwl/web:dev-server",
+          "executor": "@nrwl/web:dev-server",
           "options": {
             "buildTarget": "myapp:build",
             "proxyConfig": "apps/myapp/proxy.conf.json"
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "options": {
             "jestConfig": "apps/myapp/jest.config.js",
             "tsConfig": "apps/myapp/tsconfig.spec.json"
@@ -47,9 +48,9 @@ The `workspace.json` configuration file contains information about the targets a
       "root": "libs/mylib/",
       "sourceRoot": "libs/mylib/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "options": {
             "jestConfig": "libs/mylib/jest.config.js",
             "tsConfig": "libs/mylib/tsconfig.spec.json"
@@ -81,7 +82,7 @@ For instance, the following configures `mylib`.
     "root": "libs/mylib/",
     "sourceRoot": "libs/mylib/src",
     "projectType": "library",
-    "architect": {}
+    "targets": {}
   }
 }
 ```
@@ -89,18 +90,16 @@ For instance, the following configures `mylib`.
 - `root` tells Nx the location of the library including its sources and configuration files.
 - `sourceRoot` tells Nx the location of the library's source files.
 - `projectType` is either 'application' or 'library'.
-- `architect` configures all the targets which define what tasks you can run against the library.
-
-> Nx uses the architect library built by the Angular team at Google. The naming reflects that. Important to note: it's a general purpose library that **does not** have any dependency on Angular.
+- `targets` configures all the targets which define what tasks you can run against the library.
 
 ### Targets
 
-Let's look at the simple architect target:
+Let's look at the simple target:
 
 ```json
 {
   "test": {
-    "builder": "@nrwl/jest:jest",
+    "executor": "@nrwl/jest:jest",
     "options": {
       "jestConfig": "libs/mylib/jest.config.js",
       "tsConfig": "libs/mylib/tsconfig.spec.json"
@@ -113,13 +112,13 @@ Let's look at the simple architect target:
 
 The name of the target `test` means that you can invoke it as follows: `nx test mylib` or `nx run mylib:test`. The name isn't significant in any other way. If you rename it to, for example, `mytest`, you will be able to run as follows: `nx run mylib:mytest`.
 
-**Builder**
+**Executor**
 
-The `builder` property tells Nx what function to invoke when you run the target. `"@nrwl/jest:jest"` tells Nx to find the `@nrwl/jest` package, find the builder named `jest` and invoke it with the options.
+The `executor` property tells Nx what function to invoke when you run the target. `"@nrwl/jest:jest"` tells Nx to find the `@nrwl/jest` package, find the executor named `jest` and invoke it with the options.
 
 **Options**
 
-The `options` provides a map of values that will be passed to the builder. The provided command line args will be merged into this map. I.e., `nx test mylib --jestConfig=libs/mylib/another-jest.config.js` will pass the following to the builder:
+The `options` provides a map of values that will be passed to the executor. The provided command line args will be merged into this map. I.e., `nx test mylib --jestConfig=libs/mylib/another-jest.config.js` will pass the following to the executor:
 
 ```json
 {
@@ -130,12 +129,12 @@ The `options` provides a map of values that will be passed to the builder. The p
 
 **Outputs**
 
-The `outputs` property lists the folders the builder will create files in. The property is optional. If not provided, Nx will assume it is `dist/libs/mylib`.
+The `outputs` property lists the folders the executor will create files in. The property is optional. If not provided, Nx will assume it is `dist/libs/mylib`.
 
 ```json
 {
   "build": {
-    "builder": "@nrwl/web:build",
+    "executor": "@nrwl/web:build",
     "outputs": ["dist/apps/myapp"],
     "options": {
       "index": "apps/myapp/src/app.html",
@@ -152,7 +151,7 @@ The `configurations` property provides extra sets of values that will be merged 
 ```json
 {
   "build": {
-    "builder": "@nrwl/web:build",
+    "executor": "@nrwl/web:build",
     "outputs": ["dist/apps/myapp"],
     "options": {
       "index": "apps/myapp/src/app.html",
@@ -169,10 +168,10 @@ The `configurations` property provides extra sets of values that will be merged 
 
 You can select a configuration like this: `nx build myapp --configuration=production` or `nx run myapp:build:configuration=production`.
 
-The following show how the builder options get constructed:
+The following show how the executor options get constructed:
 
 ```bash
-require(`@nrwl/jest`).builders['jest']({...options, ...selectedConfiguration, ...commandLineArgs}}) // Pseudocode
+require(`@nrwl/jest`).executors['jest']({...options, ...selectedConfiguration, ...commandLineArgs}}) // Pseudocode
 ```
 
 The selected configuration adds/overrides the default options, and the provided command line args add/override the configuration options.
@@ -204,7 +203,7 @@ You can also do it on the project level:
         "classComponent": true
       }
     },
-    "architect": {}
+    "targets": {}
   }
 }
 ```
@@ -220,6 +219,10 @@ The following command will generate a new library: `nx g @nrwl/react:lib mylib`.
   }
 }
 ```
+
+### Version
+
+When the `version` of `workspace.json` is set to 2, `targets`, `generators` and `executor` properties are used instead of the version 1 properties `architect`, `schematics` and `builder`.
 
 ## nx.json
 

--- a/docs/react/guides/configuration.md
+++ b/docs/react/guides/configuration.md
@@ -61,7 +61,7 @@ The `workspace.json` configuration file contains information about the targets a
   "cli": {
     "defaultCollection": "@nrwl/react"
   },
-  "schematics": {
+  "generators": {
     "@nrwl/react:library": {
       "js": true
     }
@@ -183,7 +183,7 @@ You can configure default generator options in `workspace.json` as well. For ins
 
 ```json
 {
-  "schematics": {
+  "generators": {
     "@nrwl/react:library": {
       "js": true
     }
@@ -199,7 +199,7 @@ You can also do it on the project level:
     "root": "libs/mylib/",
     "sourceRoot": "libs/mylib/src",
     "projectType": "library",
-    "schematics": {
+    "generators": {
       "@nrwl/react:component": {
         "classComponent": true
       }

--- a/docs/react/guides/storybook-plugin.md
+++ b/docs/react/guides/storybook-plugin.md
@@ -61,7 +61,7 @@ nx run project-name:storybook
 
 ### Run Cypress Tests Against a Storybook Instance
 
-Both `storybook-configuration` schematic gives the option to set up an e2e Cypress app that is configured to run against the project's Storybook instance.
+Both `storybook-configuration` generator gives the option to set up an e2e Cypress app that is configured to run against the project's Storybook instance.
 
 To launch Storybook and run the Cypress tests against the iframe inside of Storybook:
 
@@ -219,7 +219,7 @@ Check that everything works as expected. If you are still having trouble, you ca
 
 ### Sample files for manual upgrade
 
-If you have not changed the content of the files which the `storybook-configuration` schematic produced, you can use the following samples to migrate to Storybook `6`:
+If you have not changed the content of the files which the `storybook-configuration` generator produced, you can use the following samples to migrate to Storybook `6`:
 
 #### Configuring the root `./storybook` directory
 

--- a/docs/shared/console.md
+++ b/docs/shared/console.md
@@ -19,7 +19,7 @@ Nx is a command-line tool, which works great when you want to serve an applicati
 
 For instance:
 
-- Exploring custom schematic collections is hard in the terminal, but it's easy using Nx Console.
+- Exploring custom generator collections is hard in the terminal, but it's easy using Nx Console.
 - Using rarely-used flags is challenging. Do you pass absolute or relative paths? You don't have to remember any flags, names, or paths -- Nx Console will help you by providing autocompletion and validating your inputs.
 - Finding the right Nx extension can take a long time. When using Nx Console, you can find and install an extension in minutes.
 
@@ -31,7 +31,7 @@ For VSCode users, you can install the [Nx Console VSCode Plugin](https://marketp
 
 ## True UI for Nx
 
-Nx Console is the UI for Nx. It will work for any schematic or any architect commands. Nx Console does not have a specific UI for, say, generating a component. Instead, Nx Console does what the command-line version of Nx does--it analyzes the same meta information to create the needed UI. This means that anything you can do with Nx, you can do with Nx Console. After all, Nx Console is the UI for Nx.
+Nx Console is the UI for Nx. It will work for any generator or any architect commands. Nx Console does not have a specific UI for, say, generating a component. Instead, Nx Console does what the command-line version of Nx does--it analyzes the same meta information to create the needed UI. This means that anything you can do with Nx, you can do with Nx Console. After all, Nx Console is the UI for Nx.
 
 ## Useful for Both Experts and Beginners
 
@@ -41,7 +41,7 @@ Even though we started building Nx Console as a tool for experts, we also aimed 
 
 ### Generate
 
-The `Generate` action allows you to choose a schematic and then opens a form listing out all the options for that schematic. As you make changes to the form, the schematic is executed in `--dry-run` mode in a terminal so you can preview the results of running the schematic in real time.
+The `Generate` action allows you to choose a generator and then opens a form listing out all the options for that generator. As you make changes to the form, the generator is executed in `--dry-run` mode in a terminal so you can preview the results of running the generator in real time.
 
 <iframe width="560" height="420" src="https://www.youtube.com/embed/-nUr66MWRiE?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
@@ -51,7 +51,7 @@ You can also launch the `Generate` action from the Command Palette (`⇧⌘P`) b
 
 <iframe width="560" height="420" src="https://www.youtube.com/embed/Sk2XjFwF8Zo?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-You can even construct the schematic options while staying entirely within the Command Palette. Use `⇧⌘P` to open the Command Palette, then select `nx: generate`. After choosing a schematic, select any of the listed options to modify the schematic command. When you're satified with the constructed command, choose the `Execute` command at the top of the list.
+You can even construct the generator options while staying entirely within the Command Palette. Use `⇧⌘P` to open the Command Palette, then select `nx: generate`. After choosing a generator, select any of the listed options to modify the generator command. When you're satified with the constructed command, choose the `Execute` command at the top of the list.
 
 <iframe width="560" height="420" src="https://www.youtube.com/embed/q5NTTqRYq9c?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/shared/devkit.md
+++ b/docs/shared/devkit.md
@@ -20,7 +20,7 @@ The generator's schema describe the inputs--what you can pass into it.
 ```json
 {
   "cli": "nx",
-  "id": "SchematicsNxWorkspaceSchematic",
+  "id": "generatorsNxWorkspacegenerator",
   "title": "Create a custom generator",
   "type": "object",
   "properties": {

--- a/docs/shared/devkit.md
+++ b/docs/shared/devkit.md
@@ -20,7 +20,7 @@ The generator's schema describe the inputs--what you can pass into it.
 ```json
 {
   "cli": "nx",
-  "id": "generatorsNxWorkspacegenerator",
+  "id": "SchematicsNxWorkspaceSchematic",
   "title": "Create a custom generator",
   "type": "object",
   "properties": {

--- a/docs/shared/tools-workspace-builders.md
+++ b/docs/shared/tools-workspace-builders.md
@@ -28,7 +28,7 @@ happynrwl/
 
 ### schema.json
 
-This file will describe the options being sent to the builder (very similar to the `schema.json` file of schematics).
+This file will describe the options being sent to the builder (very similar to the `schema.json` file of generators).
 
 ```json
 {

--- a/docs/shared/tools-workspace-generators.md
+++ b/docs/shared/tools-workspace-generators.md
@@ -2,7 +2,7 @@
 
 Workspace generators provide a way to automate many tasks you regularly perform as part of your development workflow. Whether it is scaffolding out components, features, or ensuring libraries are generated and structured in a certain way, generators help you standardize these tasks in a consistent, and predictable manner. Nx provides tooling around creating, and running custom generators from within your workspace. This guide shows you how to create, run, and customize workspace generators within your Nx workspace.
 
-## Creating a workspace generator using @angular/devkit
+## Creating a workspace generator
 
 Use the Nx CLI to generate the initial files needed for your workspace generator.
 
@@ -26,31 +26,32 @@ happynrwl/
 └── tsconfig.json
 ```
 
-The `index.ts` provides an entry point to the schematic. The file contains the factory function for the schematic to return a Rule. A rule is an operation that is performed against your filesystem.
-The `schema.json` provides a description of the schematic, available options, validation information, and default values.
+The `index.ts` provides an entry point to the generator. The file contains a function that is called to perform manipulations on a tree that represents the file system.
+The `schema.json` provides a description of the generator, available options, validation information, and default values.
 
-The initial schematic entry point contains a rule to generate a library.
+The initial generator function creates a library.
 
 ```ts
-import { chain, externalSchematic, Rule } from '@angular-devkit/schematics';
+import { Tree, formatFiles, installPackagesTask } from '@nrwl/devkit';
+import { libraryGenerator } from '@nrwl/workspace';
 
-export default function (schema: any): Rule {
-  return chain([
-    externalSchematic('@nrwl/workspace', 'lib', {
-      name: schema.name,
-    }),
-  ]);
+export default async function (host: Tree, schema: any) {
+  await libraryGenerator(host, { name: schema.name });
+  await formatFiles(host);
+  return () => {
+    installPackagesTask(host);
+  };
 }
 ```
 
-The `chain` function takes a an array of rules and combines them into a single rule. You use this function to perform multiple operations against your workspace in a single schematic. The `externalSchematic` function allows you to call schematics provided from by an installed npm package.
+To invoke other generators, import the entry point function and run it against the host tree. `async/await` can be used to make code with Promises read like procedural code. The generator function may return a callback function that is executed after changes to the file system have been applied.
 
-In the schema.json file for your schematic, the `name` is provided as a default option.
+In the schema.json file for your generator, the `name` is provided as a default option. The `cli` property is set to `nx` to signal that this is a generator that uses `@nrwl/devkit` and not `@angular/devkit`.
 
 ```json
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "my-schematic",
+  "cli": "nx",
+  "id": "test",
   "type": "object",
   "properties": {
     "name": {
@@ -66,17 +67,31 @@ In the schema.json file for your schematic, the `name` is provided as a default 
 }
 ```
 
-The `$default` object is used to read arguments from the command-line that are passed to the schematic. The first argument passed to this schematic is used as the `name` property.
+The `$default` object is used to read arguments from the command-line that are passed to the generator. The first argument passed to this schematic is used as the `name` property.
 
-## Running a workspace schematic
+## Running a workspace generator
 
-To run a schematic, invoke the `nx workspace-schematic` command with the name of the schematic.
+To run a generator, invoke the `nx workspace-generator` command with the name of the generator.
+
+```sh
+nx workspace-generator my-generator mylib
+```
+
+## Running a workspace schematic created with @angular/devkit
+
+Generators that are created using the `@angular/devkit` are called schematics. Workspace schematics that have been created with the `@angular/devkit` will omit the `"cli": "nx"` property in `schema.json`. Nx will recognize this and correctly run the schematic using the same command as an `@nrwl/devkit` generator.
+
+```sh
+nx workspace-generator my-schematic mylib
+```
+
+The command is also aliased to the previous `workspace-schematic` command, so this still works:
 
 ```sh
 nx workspace-schematic my-schematic mylib
 ```
 
-## Creating custom rules
+## Creating custom rules with @angular/devkit
 
 Generators provide an API for managing files within your workspace. You can use schematics to do things such as create, update, move, and delete files. Files with static or dynamic content can also be created.
 
@@ -174,11 +189,11 @@ UPDATE nx.json (438 bytes)
 UPDATE package.json (1959 bytes)
 ```
 
-## Customizing schematic options
+## Customizing generator options
 
 ### Adding a TypeScript schema
 
-To create a TypeScript schema to use in your schematic function, define a TypeScript file next to your schema.json named schema.ts. Inside the schema.ts, define an interface to match the properties in your schema.json file, and whether they are required.
+To create a TypeScript schema to use in your generator function, define a TypeScript file next to your schema.json named schema.ts. Inside the schema.ts, define an interface to match the properties in your schema.json file, and whether they are required.
 
 ```ts
 export interface SchematicOptions {
@@ -187,30 +202,29 @@ export interface SchematicOptions {
 }
 ```
 
-Import the TypeScript schema into your schematic file and replace the any in your schematic function with the interface.
+Import the TypeScript schema into your generator file and replace the any in your generator function with the interface.
 
 ```ts
-import { chain, externalSchematic, Rule } from '@angular-devkit/schematics';
-import { SchematicOptions } from './schema';
+import { Tree, formatFiles, installPackagesTask } from '@nrwl/devkit';
+import { libraryGenerator } from '@nrwl/workspace';
 
-export default function (schema: SchematicOptions): Rule {
-  return chain([
-    externalSchematic('@nrwl/workspace', 'lib', {
-      name: `${schema.name}-${schema.type || ''}`,
-      unitTestRunner: 'none',
-    }),
-  ]);
+export default async function (host: Tree, schema: SchematicOptions) {
+  await libraryGenerator(host, { name: `${schema.name}-${schema.type || ''}` });
+  await formatFiles(host);
+  return () => {
+    installPackagesTask(host);
+  };
 }
 ```
 
 ### Adding static options
 
-Static options for a schematic don't prompt the user for input. To add a static option, define a key in the schema.json file with the option name, and define an object with its type, description, and optional default value.
+Static options for a generator don't prompt the user for input. To add a static option, define a key in the schema.json file with the option name, and define an object with its type, description, and optional default value.
 
 ```json
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "my-schematic",
+  "id": "my-generator",
   "type": "object",
   "properties": {
     "name": {
@@ -230,7 +244,7 @@ Static options for a schematic don't prompt the user for input. To add a static 
 }
 ```
 
-If you run the schematic without providing a value for the type, it is not included in the generated name of the library.
+If you run the generator without providing a value for the type, it is not included in the generated name of the library.
 
 ### Adding dynamic prompts
 
@@ -239,7 +253,7 @@ Dynamic options can prompt the user to select from a list of options. To define 
 ```json
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "my-schematic",
+  "id": "my-generator",
   "type": "object",
   "properties": {
     "name": {
@@ -277,32 +291,19 @@ Dynamic options can prompt the user to select from a list of options. To define 
 }
 ```
 
-Running the schematic without providing a value for the type will prompt the user to make a selection.
+Running the generator without providing a value for the type will prompt the user to make a selection.
 
-## Debugging Workspace schematics
+## Debugging Workspace generators
 
 ### With Visual Studio Code
 
-First of all make sure to enable the `debug.node.autoAttach` option. You can set it either in your workspace settings file inside `.vscode/settings.json` or your global `settings.json`. Simply add:
-
-```json
-{
-  "debug.node.autoAttach": "on"
-}
-```
-
-Alternatively press <kbd>Cmd</kbd>+<kbd>P</kbd> (or <kbd>Ctrl</kbd>+<kbd>P</kbd>) to open VSCode's command palette and type "Debug: Toggle Auto Attach".
-
-Once you've activated the `autoAttach` option, set a breakpoint in VSCode and execute your schematic with the `--inspect-brk` flag:
-
-```sh
-node --inspect-brk ./node_modules/nx/bin/nx.js workspace-schematic my-schematic mylib --dry-run
-```
-
-You may want to use the `--dry-run` flag to not actually apply the changes to the file system.
+1. Open the Command Pallette and choose `Debug: Create JavaScript Debug Terminal`.
+   This will open a terminal with debugging enabled.
+2. Set breakpoints in your code
+3. Run `nx workspace-generator my-generator` in the debug terminal.
 
 ![](/shared/vscode-schematics-debug.png)
 
-## Workspace schematic utilities
+## Workspace generator utilities
 
 The `@nrwl/workspace` package provides many utility functions that can be used in schematics to help with modifying files, reading and updating configuration files, and working with an Abstract Syntax Tree (AST).

--- a/docs/shared/using-schematics.md
+++ b/docs/shared/using-schematics.md
@@ -4,7 +4,7 @@
 
 Generators provide a way to automate many tasks you regularly perform as part of your development workflow. Whether it is scaffolding out components, features, ensuring libraries are generated and structured in a certain way, or updating your configuration files, generators help you standardize these tasks in a consistent, and predictable manner.
 
-Generators can be written using `@nx/devkit` or `@angular/devkit`. Generators written with the `@angular/devkit` are called schematics. To read more about the concepts of `@angular/devkit` schematics, and building an example schematic, see the [Schematics Authoring Guide](https://angular.io/guide/generators-authoring).
+Generators can be written using `@nx/devkit` or `@angular/devkit`. Generators written with the `@angular/devkit` are called schematics. To read more about the concepts of `@angular/devkit` schematics, and building an example schematic, see the [Schematics Authoring Guide](https://angular.io/guide/schematics-authoring).
 
 The [Workspace Generators](/{{framework}}/workspace/generators/workspace-generators) guide shows you how to create, run, and customize workspace generators within your Nx workspace.
 

--- a/packages/nest/collection.json
+++ b/packages/nest/collection.json
@@ -25,72 +25,72 @@
     "class": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#classSchematic",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'class' NestJs Schematic with Nx project support"
+      "description": "Run the 'class' NestJs generator with Nx project support"
     },
     "controller": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#controller",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'controller' NestJs Schematic with Nx project support"
+      "description": "Run the 'controller' NestJs generator with Nx project support"
     },
     "decorator": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#decorator",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'decorator' NestJs Schematic with Nx project support"
+      "description": "Run the 'decorator' NestJs generator with Nx project support"
     },
     "filter": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#filter",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'filter' NestJs Schematic with Nx project support"
+      "description": "Run the 'filter' NestJs generator with Nx project support"
     },
     "gateway": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#gateway",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'gateway' NestJs Schematic with Nx project support"
+      "description": "Run the 'gateway' NestJs generator with Nx project support"
     },
     "guard": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#guard",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'guard' NestJs Schematic with Nx project support"
+      "description": "Run the 'guard' NestJs generator with Nx project support"
     },
     "interceptor": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#interceptor",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'interceptor' NestJs Schematic with Nx project support"
+      "description": "Run the 'interceptor' NestJs generator with Nx project support"
     },
     "interface": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#interfaceSchematic",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'interface' NestJs Schematic with Nx project support"
+      "description": "Run the 'interface' NestJs generator with Nx project support"
     },
     "middleware": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#middleware",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'middleware' NestJs Schematic with Nx project support"
+      "description": "Run the 'middleware' NestJs generator with Nx project support"
     },
     "module": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#module",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'module' NestJs Schematic with Nx project support"
+      "description": "Run the 'module' NestJs generator with Nx project support"
     },
     "pipe": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#pipe",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'pipe' NestJs Schematic with Nx project support"
+      "description": "Run the 'pipe' NestJs generator with Nx project support"
     },
     "provider": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#provider",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'provider' NestJs Schematic with Nx project support"
+      "description": "Run the 'provider' NestJs generator with Nx project support"
     },
     "resolver": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#resolver",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'resolver' NestJs Schematic with Nx project support"
+      "description": "Run the 'resolver' NestJs generator with Nx project support"
     },
     "service": {
       "factory": "./src/schematics/nestjs-schematics/nestjs-schematics#service",
       "schema": "./src/schematics/nestjs-schematics/schema.json",
-      "description": "Run the 'service' NestJs Schematic with Nx project support"
+      "description": "Run the 'service' NestJs generator with Nx project support"
     }
   }
 }


### PR DESCRIPTION
Updates the docs to use the word generator instead of schematic, where applicable