### PR TITLE
fix(core): fix preset unit tests issues

### DIFF
--- a/packages/workspace/src/schematics/library/library.ts
+++ b/packages/workspace/src/schematics/library/library.ts
@@ -187,6 +187,6 @@ function getCaseAwareFileName(options: {
 
 function addTestFiles(options: Pick<Schema, 'unitTestRunner'>) {
   return options.unitTestRunner === 'none'
-    ? filter((path) => !(path.endsWith('.ts') || path.endsWith('.tsx')))
+    ? filter((path) => !(path.endsWith('spec.ts') || path.endsWith('spec.tsx')))
     : noop();
 }

--- a/packages/workspace/src/schematics/preset/preset.ts
+++ b/packages/workspace/src/schematics/preset/preset.ts
@@ -85,7 +85,11 @@ function createPreset(options: Schema): Rule {
         name: 'api',
         frontendProject: options.name,
       }),
-      schematic('library', { name: 'api-interfaces' }, { interactive: false }),
+      schematic(
+        'library',
+        { name: 'api-interfaces', unitTestRunner: 'none' },
+        { interactive: false }
+      ),
       setDefaultCollection('@nrwl/angular'),
       connectAngularAndNest(options),
     ]);
@@ -99,7 +103,11 @@ function createPreset(options: Schema): Rule {
         name: 'api',
         frontendProject: options.name,
       }),
-      schematic('library', { name: 'api-interfaces' }, { interactive: false }),
+      schematic(
+        'library',
+        { name: 'api-interfaces', unitTestRunner: 'none' },
+        { interactive: false }
+      ),
       setDefaultCollection('@nrwl/react'),
       connectReactAndExpress(options),
     ]);
@@ -280,7 +288,7 @@ export default App;
 
     host.overwrite(
       `apps/${options.name}/src/app/app.spec.tsx`,
-      `import { cleanup, getByText, render, wait } from '@testing-library/react';
+      `import { cleanup, getByText, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import App from './app';
 
@@ -298,7 +306,7 @@ describe('App', () => {
     });
 
     const { baseElement } = render(<App />);
-    await wait(() => getByText(baseElement, 'my message'));
+    await waitFor(() => getByText(baseElement, 'my message'));
   });
 });
     `


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Generated unit tests for the `angular-nest` and `react-express` presets fail. `react-express` preset also uses deprecated code.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Unit tests are no longer generated for the api interface libraries as they are not needed. Deprecated code is removed in favor of the recommended code.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
