### PR TITLE
fix(angular): scope eslint migration to angular projects

### DIFF
--- a/packages/angular/src/migrations/update-10-5-0/add-template-support-and-presets-to-eslint.spec.ts
+++ b/packages/angular/src/migrations/update-10-5-0/add-template-support-and-presets-to-eslint.spec.ts
@@ -1,5 +1,9 @@
 import { Tree } from '@angular-devkit/schematics';
-import { readJsonInTree, updateWorkspace } from '@nrwl/workspace';
+import {
+  readJsonInTree,
+  updateJsonInTree,
+  updateWorkspace,
+} from '@nrwl/workspace';
 import { callRule, createEmptyWorkspace } from '@nrwl/workspace/testing';
 import { runMigration } from '../../utils/testing';
 
@@ -47,6 +51,23 @@ describe('add-template-support-and-presets-to-eslint', () => {
               },
             },
           });
+        }),
+        tree
+      );
+      tree = await callRule(
+        updateJsonInTree('nx.json', (json) => {
+          json.projects['app1'] = {};
+          json.projects['lib1'] = {};
+
+          return json;
+        }),
+        tree
+      );
+      tree = await callRule(
+        updateJsonInTree('package.json', (json) => {
+          json.dependencies['@angular/core'] = '11.0.0';
+
+          return json;
         }),
         tree
       );
@@ -129,6 +150,26 @@ describe('add-template-support-and-presets-to-eslint', () => {
         }),
         tree
       );
+      tree = await callRule(
+        updateJsonInTree('nx.json', (json) => {
+          json.projects['app1'] = {};
+          json.projects['app2'] = {};
+          json.projects['lib1'] = {};
+
+          return json;
+        }),
+        tree
+      );
+      tree = await callRule(
+        updateJsonInTree('package.json', (json) => {
+          json.dependencies['@angular/core'] = '11.0.0';
+
+          return json;
+        }),
+        tree
+      );
+      tree.create('apps/app1/src/main.ts', `import '@angular/core';`);
+      tree.create('libs/lib1/src/index.ts', `import '@angular/core';`);
     });
 
     it('should do nothing if the root eslint config has not been updated to use overrides by the latest migrations', async () => {
@@ -180,7 +221,9 @@ describe('add-template-support-and-presets-to-eslint', () => {
 
       expect(packageJsonBefore).toMatchInlineSnapshot(`
         Object {
-          "dependencies": Object {},
+          "dependencies": Object {
+            "@angular/core": "11.0.0",
+          },
           "devDependencies": Object {},
           "name": "test-name",
         }
@@ -189,7 +232,9 @@ describe('add-template-support-and-presets-to-eslint', () => {
       expect(JSON.parse(result.read('package.json').toString()))
         .toMatchInlineSnapshot(`
         Object {
-          "dependencies": Object {},
+          "dependencies": Object {
+            "@angular/core": "11.0.0",
+          },
           "devDependencies": Object {
             "@angular-eslint/eslint-plugin": "0.8.0-beta.1",
             "@angular-eslint/eslint-plugin-template": "0.8.0-beta.1",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Migrating from 10.4.x will migrate non-Angular projects to use the angular eslint config.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Migrating from 10.4.x should only migrate Angular projects to use the Angular Eslint config.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/4259
