### PR TITLE
fix(angular): remove peer dependencies on angular-eslint

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -33,9 +33,6 @@
     "migrations": "./migrations.json"
   },
   "peerDependencies": {
-    "@angular-eslint/eslint-plugin": "*",
-    "@angular-eslint/eslint-plugin-template": "*",
-    "@angular-eslint/template-parser": "*",
     "@nrwl/workspace": "*"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There is a peerDependency on `angular-eslint@11.0.0` which is unnecessary and also the version does not exist.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There is no peer dependency on angular-eslint.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
