### PR TITLE
fix(core): filter generators that don't have a version for migrations

### DIFF
--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -116,7 +116,8 @@ export class Migrator {
         return Object.keys(generators)
           .filter(
             (r) =>
-              this.gt(generators[r].version, currentVersion) &
+              generators[r].version &&
+              this.gt(generators[r].version, currentVersion) &&
               this.lte(generators[r].version, target.version)
           )
           .map((r) => ({


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Some `migrations.json` such as `@angular/material` might have a private generator which is not a migration. These currently cause an error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generators that do not have a version associated with them should not be added to the list of migrations to be run as they are probably private.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4262 
