### PR TITLE
docs(docs): old syntax workspace-schematic should using new syntax

### DIFF
--- a/docs/shared/tools-workspace-generators.md
+++ b/docs/shared/tools-workspace-generators.md
@@ -166,7 +166,7 @@ Next, run the schematic:
 > Use the `-d` or `--dry-run` flag to see your changes without applying them.
 
 ```sh
-nx workspace-schematic my-schematic mylib
+nx workspace-generator my-schematic mylib
 ```
 
 The following information will be displayed.


### PR DESCRIPTION
new syntax is good, it already replaced in all place but I think we missing this

