### PR TITLE
fix(core): resolve generators and executors with #

### DIFF
--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -196,11 +196,9 @@ export class Workspaces {
       const executorsDir = path.dirname(executorsFilePath);
       const schemaPath = path.join(executorsDir, executorConfig.schema || '');
       const schema = JSON.parse(fs.readFileSync(schemaPath).toString());
-      const module = require(path.join(
-        executorsDir,
-        executorConfig.implementation
-      ));
-      const implementation = module.default;
+      const [modulePath, exportName] = executorConfig.implementation.split('#');
+      const module = require(path.join(executorsDir, modulePath));
+      const implementation = module[exportName || 'default'];
       return { schema, implementation };
     } catch (e) {
       throw new Error(
@@ -221,13 +219,13 @@ export class Workspaces {
         generatorsJson.schematics)[normalizedGeneratorName];
       const schemaPath = path.join(generatorsDir, generatorConfig.schema || '');
       const schema = JSON.parse(fs.readFileSync(schemaPath).toString());
-      const module = require(path.join(
-        generatorsDir,
-        generatorConfig.implementation
-          ? generatorConfig.implementation
-          : generatorConfig.factory
-      ));
-      const implementation = module.default;
+      generatorConfig.implementation =
+        generatorConfig.implementation || generatorConfig.factory;
+      const [modulePath, exportName] = generatorConfig.implementation.split(
+        '#'
+      );
+      const module = require(path.join(generatorsDir, modulePath));
+      const implementation = module[exportName || 'default'];
       return { schema, implementation };
     } catch (e) {
       throw new Error(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Generators such as `@nrwl/nest:service` do not work because their implementation uses a `#` to dictate the export name. We currently only consider `default` as the export name.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

If an implementation of a generator or an executor contains a `#`, the part after the `#` will be the export name. `@nrwl/nest:service` should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4288 
