### PR TITLE
fix(angular): use selected style extension for components

### DIFF
--- a/packages/angular/src/schematics/init/init.spec.ts
+++ b/packages/angular/src/schematics/init/init.spec.ts
@@ -214,5 +214,16 @@ describe('init', () => {
       const workspaceJson = readJsonInTree(result, 'workspace.json');
       expect(workspaceJson.cli.defaultCollection).toEqual('@nrwl/angular');
     });
+
+    it.each(['css', 'scss', 'styl', 'less'])(
+      'should set "%s" as default style extension for components',
+      async (style) => {
+        const result = await runSchematic('init', { style }, appTree);
+        const workspaceJson = readJsonInTree(result, 'workspace.json');
+        expect(
+          workspaceJson.schematics['@nrwl/angular:component']['style']
+        ).toBe(style);
+      }
+    );
   });
 });

--- a/packages/angular/src/schematics/init/init.ts
+++ b/packages/angular/src/schematics/init/init.ts
@@ -139,6 +139,11 @@ export function setDefaults(options: Schema): Rule {
     workspace.extensions.schematics['@nrwl/angular:library'].unitTestRunner =
       workspace.extensions.schematics['@nrwl/angular:library'].unitTestRunner ||
       options.unitTestRunner;
+
+    workspace.extensions.schematics['@nrwl/angular:component'] = workspace
+      .extensions.schematics['@nrwl/angular:component'] || {
+      style: options.style,
+    };
   });
 
   return chain([setDefaultCollection('@nrwl/angular'), updateAngularWorkspace]);

--- a/packages/angular/src/schematics/init/schema.d.ts
+++ b/packages/angular/src/schematics/init/schema.d.ts
@@ -1,7 +1,8 @@
-import { UnitTestRunner } from '../../utils/test-runners';
+import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
 export interface Schema {
   unitTestRunner: UnitTestRunner;
   e2eTestRunner?: E2eTestRunner;
   skipFormat: boolean;
   skipInstall?: boolean;
+  style?: string;
 }


### PR DESCRIPTION
ISSUES CLOSED: #4287 

## Current Behavior
When creating a nx repo and choosing a default style option for components, generated components are still defaulting to css as style extension

## Expected Behavior
When creating new components the correct style extension is used for components

## Related Issue(s)
#4287

Fixes #
#4287