### PR TITLE
fix(core): support local builders and generators

### DIFF
--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -2,7 +2,7 @@ import { Tree } from '@nrwl/tao/src/shared/tree';
 import * as path from 'path';
 import type * as Prettier from 'prettier';
 import { getWorkspacePath } from '../utils/get-workspace-layout';
-import { Workspaces } from '@nrwl/tao/src/shared/workspace';
+import { reformattedWorkspaceJsonOrNull } from '@nrwl/tao/src/shared/workspace';
 
 let prettier: typeof Prettier;
 try {
@@ -52,11 +52,10 @@ export async function formatFiles(host: Tree) {
 }
 
 function updateWorkspaceJsonToMatchFormatVersion(host: Tree) {
-  const ws = new Workspaces();
   const path = getWorkspacePath(host);
   try {
     const workspaceJson = JSON.parse(host.read(path).toString());
-    const reformatted = ws.reformattedWorkspaceJsonOrNull(workspaceJson);
+    const reformatted = reformattedWorkspaceJsonOrNull(workspaceJson);
     if (reformatted) {
       host.write(path, JSON.stringify(reformatted, null, 2));
     }

--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -1,8 +1,8 @@
 import { Tree } from '@nrwl/tao/src/shared/tree';
 import {
   ProjectConfiguration,
+  toNewFormat,
   WorkspaceConfiguration,
-  Workspaces,
 } from '@nrwl/tao/src/shared/workspace';
 import { readJson } from '../utils/read-json';
 import {
@@ -67,10 +67,9 @@ export function readProjectConfiguration(
 }
 
 function readWorkspaceSection(host: Tree, projectName: string) {
-  const ws = new Workspaces();
   const path = getWorkspacePath(host);
   const workspaceJson = readJson<WorkspaceConfiguration>(host, path);
-  const newFormat = ws.toNewFormat(workspaceJson);
+  const newFormat = toNewFormat(workspaceJson);
 
   if (!newFormat.projects[projectName]) {
     throw new Error(`Cannot find Project '${projectName}'`);

--- a/packages/tao/src/commands/generate.ts
+++ b/packages/tao/src/commands/generate.ts
@@ -158,7 +158,7 @@ function printChanges(fileChanges: FileChange[]) {
 }
 
 export async function taoNew(root: string, args: string[], isVerbose = false) {
-  const ws = new Workspaces();
+  const ws = new Workspaces(root);
   return handleErrors(isVerbose, async () => {
     const opts = parseGenerateOpts(args, 'new', null);
 
@@ -191,10 +191,10 @@ export async function generate(
   args: string[],
   isVerbose = false
 ) {
-  const ws = new Workspaces();
+  const ws = new Workspaces(root);
 
   return handleErrors(isVerbose, async () => {
-    const workspaceDefinition = ws.readWorkspaceConfiguration(root);
+    const workspaceDefinition = ws.readWorkspaceConfiguration();
     const opts = parseGenerateOpts(
       args,
       'generate',

--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -32,8 +32,9 @@ import { detectPackageManager } from '@nrwl/tao/src/shared/package-manager';
 import { GenerateOptions } from './generate';
 import * as taoTree from '../shared/tree';
 import {
+  toNewFormatOrNull,
+  toOldFormatOrNull,
   workspaceConfigName,
-  Workspaces,
 } from '@nrwl/tao/src/shared/workspace';
 import { BaseWorkflow } from '@angular-devkit/schematics/src/workflow';
 import { NodePackageName } from '@angular-devkit/schematics/tasks/package-manager/options';
@@ -269,7 +270,7 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
               map((r) => {
                 try {
                   const w = JSON.parse(Buffer.from(r).toString());
-                  const formatted = new Workspaces().toOldFormatOrNull(w);
+                  const formatted = toOldFormatOrNull(w);
                   return formatted
                     ? Buffer.from(JSON.stringify(formatted, null, 2))
                     : r;
@@ -295,7 +296,7 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
           if (newFormat) {
             try {
               const w = JSON.parse(Buffer.from(content).toString());
-              const formatted = new Workspaces().toNewFormatOrNull(w);
+              const formatted = toNewFormatOrNull(w);
               if (formatted) {
                 return super.write(
                   path,

--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -135,10 +135,10 @@ export interface TargetContext {
 }
 
 export async function run(root: string, args: string[], isVerbose: boolean) {
-  const ws = new Workspaces();
+  const ws = new Workspaces(root);
 
   return handleErrors(isVerbose, async () => {
-    const workspace = ws.readWorkspaceConfiguration(root);
+    const workspace = ws.readWorkspaceConfiguration();
     const opts = parseRunOpts(args, workspace.defaultProject);
     validateTargetAndConfiguration(workspace, opts);
 

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -8,12 +8,12 @@ import {
   onlyWorkspaceProjects,
 } from '../core/project-graph';
 import { filterAffected } from '../core/affected-project-graph';
-import { calculateFileChanges, readWorkspaceJson } from '../core/file-utils';
+import { calculateFileChanges } from '../core/file-utils';
 import * as yargs from 'yargs';
 import { NxArgs, splitArgsIntoNxArgsAndOverrides } from './utils';
 import {
+  reformattedWorkspaceJsonOrNull,
   workspaceConfigName,
-  Workspaces,
 } from '@nrwl/tao/src/shared/workspace';
 import { appRootPath } from '@nrwl/workspace/src/utils/app-root';
 import { readFileSync, writeFileSync } from 'fs-extra';
@@ -133,12 +133,11 @@ function prettierPath() {
 }
 
 function updateWorkspaceJsonToMatchFormatVersion() {
-  const ws = new Workspaces();
   try {
     const workspaceJson = JSON.parse(
       readFileSync(workspaceConfigName(appRootPath)).toString()
     );
-    const reformatted = ws.reformattedWorkspaceJsonOrNull(workspaceJson);
+    const reformatted = reformattedWorkspaceJsonOrNull(workspaceJson);
     if (reformatted) {
       writeFileSync(
         workspaceConfigName(appRootPath),

--- a/packages/workspace/src/command-line/workspace-generators.ts
+++ b/packages/workspace/src/command-line/workspace-generators.ts
@@ -59,7 +59,7 @@ export async function workspaceGenerators(args: string[]) {
     return listGenerators(collectionFile, logger);
   }
   const generatorName = args[0];
-  const ws = new Workspaces();
+  const ws = new Workspaces(rootDirectory);
   if (ws.isNxGenerator(collectionFile, generatorName)) {
     try {
       execSync(

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -164,8 +164,8 @@ function readFileIfExisting(path: string) {
 }
 
 export function readWorkspaceJson(): any {
-  const ws = new Workspaces();
-  return ws.readWorkspaceConfiguration(appRootPath);
+  const ws = new Workspaces(appRootPath);
+  return ws.readWorkspaceConfiguration();
 }
 
 export function workspaceFileName() {

--- a/packages/workspace/src/tasks-runner/task-orchestrator.ts
+++ b/packages/workspace/src/tasks-runner/task-orchestrator.ts
@@ -131,7 +131,7 @@ export class TaskOrchestrator {
       const b = p.data.targets[task.target.target].executor;
       const [nodeModule, executor] = b.split(':');
 
-      const w = new Workspaces();
+      const w = new Workspaces(this.workspaceRoot);
       const x = w.readExecutor(nodeModule, executor);
       return x.schema.outputCapture === 'pipe';
     } catch (e) {

--- a/packages/workspace/src/utils/rules/format-files.ts
+++ b/packages/workspace/src/utils/rules/format-files.ts
@@ -10,7 +10,7 @@ import { from } from 'rxjs';
 import { filter, map, mergeMap } from 'rxjs/operators';
 import * as path from 'path';
 import { appRootPath } from '../app-root';
-import { Workspaces } from '@nrwl/tao/src/shared/workspace';
+import { reformattedWorkspaceJsonOrNull } from '@nrwl/tao/src/shared/workspace';
 
 let prettier;
 try {
@@ -79,7 +79,6 @@ function updateWorkspaceJsonToMatchFormatVersion(
   host: Tree,
   directory: string
 ) {
-  const ws = new Workspaces();
   const possibleFiles = [
     `${directory}/workspace.json`,
     `${directory}/angular.json`,
@@ -88,7 +87,7 @@ function updateWorkspaceJsonToMatchFormatVersion(
   try {
     if (path) {
       const workspaceJson = JSON.parse(host.read(path).toString());
-      const reformatted = ws.reformattedWorkspaceJsonOrNull(workspaceJson);
+      const reformatted = reformattedWorkspaceJsonOrNull(workspaceJson);
       if (reformatted) {
         host.overwrite(path, JSON.stringify(reformatted, null, 2));
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There is a regression where executors/builders expressed as relative paths to locally written builders cannot be resolved.

For example,

```json
"build": {
  "executor": "./tools/executors/build",
  "options": {}
}
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

executors/builders expressed as relative paths can be resolved.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/4285
