### PR TITLE
fix(angular): fix ngrx schematic effect type when used with data persistence

### DIFF
--- a/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.effects.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.effects.ts__tmpl__
@@ -8,12 +8,12 @@ import * as <%= className %>Actions from './<%= fileName %>.actions';
 @Injectable()
 export class <%= className %>Effects {
 <% if (useDataPersistence) { %> init$ = createEffect(() => this.dataPersistence.fetch(<%= className %>Actions.init, {
-    run: (action: ReturnType<typeof <%= className %>Actions.load<%= className %>>, state: <%= className %>Feature.<%= className %>PartialState) => {
+    run: (action: ReturnType<typeof <%= className %>Actions.init, state: <%= className %>Feature.<%= className %>PartialState) => {
       // Your custom service 'load' logic goes here. For now just return a success action...
       return <%= className %>Actions.load<%= className %>Success({ <%= propertyName %>: [] });
     },
 
-    onError: (action: ReturnType<typeof <%= className %>Actions.load<%= className %>>, error) => {
+    onError: (action: ReturnType<typeof <%= className %>Actions.init>>, error) => {
       console.error('Error', error);
       return <%= className %>Actions.load<%= className %>Failure({ error });
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The Ngrx Schematic generates an effect (when using data persistence) that expects an action named "load{ name }" however this action is now named "init" everywhere else so a type error is present as the action does not exist.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The schematic should run without any type errors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
