### PR TITLE
Fix svgr/webpack conf

### DIFF
--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -56,7 +56,14 @@ export function createWebpackConfig(
               test: /\.[jt]sx?$/,
             },
             use: [
-              '@svgr/webpack?-svgo,+titleProp,+ref![path]',
+              {
+                loader: require.resolve('@svgr/webpack'),
+                options: {
+                  svgo: false,
+                  titleProp: true,
+                  ref: true,
+                },
+              },
               {
                 loader: require.resolve('url-loader'),
                 options: {

--- a/packages/react/plugins/webpack.ts
+++ b/packages/react/plugins/webpack.ts
@@ -20,7 +20,14 @@ function getWebpackConfig(config: Configuration) {
             test: /\.[jt]sx?$/,
           },
           use: [
-            '@svgr/webpack?-svgo,+titleProp,+ref![path]',
+            {
+              loader: require.resolve('@svgr/webpack'),
+              options: {
+                svgo: false,
+                titleProp: true,
+                ref: true,
+              },
+            },
             {
               loader: require.resolve('url-loader'),
               options: {

--- a/packages/storybook/src/schematics/configuration/project-files-5/.storybook/webpack.config.js__tmpl__
+++ b/packages/storybook/src/schematics/configuration/project-files-5/.storybook/webpack.config.js__tmpl__
@@ -60,7 +60,14 @@ module.exports = async ({ config, mode }) => {
               test: /\.[jt]sx?$/,
             },
             use: [
-              '@svgr/webpack?-svgo,+titleProp,+ref![path]',
+              {
+                loader: require.resolve('@svgr/webpack'),
+                options: {
+                  svgo: false,
+                  titleProp: true,
+                  ref: true,
+                },
+              },
               {
                 loader: require.resolve('url-loader'),
                 options: {

--- a/packages/storybook/src/schematics/configuration/project-files/.storybook/webpack.config.js__tmpl__
+++ b/packages/storybook/src/schematics/configuration/project-files/.storybook/webpack.config.js__tmpl__
@@ -45,7 +45,14 @@ module.exports = async ({ config, mode }) => {
               test: /\.[jt]sx?$/,
             },
             use: [
-              '@svgr/webpack?-svgo,+titleProp,+ref![path]',
+              {
+                loader: require.resolve('@svgr/webpack'),
+                options: {
+                  svgo: false,
+                  titleProp: true,
+                  ref: true,
+                },
+              },
               {
                 loader: require.resolve('url-loader'),
                 options: {

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -85,7 +85,7 @@ export function splitArgsIntoNxArgsAndOverrides(
     mode === 'run-one' ? runOne : mode === 'run-many' ? runMany : runAffected;
 
   const nxArgs: RawNxArgs = {};
-  const overrides = yargsParser(args._);
+  const overrides = yargsParser(args._ as string[]);
   delete overrides._;
 
   Object.entries(args).forEach(([key, value]) => {
@@ -124,8 +124,8 @@ export function splitArgsIntoNxArgsAndOverrides(
       !nxArgs.all &&
       args._.length >= 2
     ) {
-      nxArgs.base = args._[0];
-      nxArgs.head = args._[1];
+      nxArgs.base = args._[0] as string;
+      nxArgs.head = args._[1] as string;
     } else if (!nxArgs.base) {
       const affectedConfig = getAffectedConfig();
 


### PR DESCRIPTION
## Current Behavior

`@svgr/webpack` won't add a `ref` to React components it creates on-the-fly

## Expected Behavior

`@svgr/webpack` adds a `ref` to React components it creates on-the-fly

## More info

From af90b7c06928b33241ef78fea649741bcf44ed47 :

> The previous "import friendly" syntax was actually disabling refs in SVGs parsed by svgr.
>
> I found 3 possible solutions:
> 1. Removing "![path]"
> 2. Separating "+ref![path]" with another comma: "+ref,![path]"
> 3. Rewriting the loader entry in the style of the other loader entries
>
> I chose the last one for added clarity within the file.
