### PR TITLE
fix(linter): Respect the "quiet" option

### DIFF
--- a/packages/linter/src/builders/eslint/lint.impl.spec.ts
+++ b/packages/linter/src/builders/eslint/lint.impl.spec.ts
@@ -285,6 +285,124 @@ describe('Linter Builder', () => {
       );
     });
 
+    it('should not log warnings if the quiet flag was passed', async () => {
+      mockReports = [
+        {
+          errorCount: 1,
+          warningCount: 4,
+          results: [],
+          usedDeprecatedRules: [],
+          messages: [
+            {
+              ruleId: 'mock',
+              severity: 2,
+              message: 'Mock error 1.',
+            },
+            {
+              ruleId: 'mock',
+              severity: 1,
+              message: 'Mock warning 1.',
+            },
+            {
+              ruleId: 'mock',
+              severity: 1,
+              message: 'Mock warning 2.',
+            },
+            {
+              ruleId: 'mock',
+              severity: 1,
+              message: 'Mock warning 3.',
+            },
+            {
+              ruleId: 'mock',
+              severity: 1,
+              message: 'Mock warning 4.',
+            },
+          ],
+        },
+        {
+          errorCount: 3,
+          warningCount: 6,
+          results: [],
+          usedDeprecatedRules: [],
+          messages: [
+            {
+              ruleId: 'mock',
+              severity: 2,
+              message: 'Mock error 1.',
+            },
+            {
+              ruleId: 'mock',
+              severity: 2,
+              message: 'Mock error 2.',
+            },
+            {
+              ruleId: 'mock',
+              severity: 2,
+              message: 'Mock error 3.',
+            },
+            {
+              ruleId: 'mock',
+              severity: 1,
+              message: 'Mock warning 1.',
+            },
+            {
+              ruleId: 'mock',
+              severity: 1,
+              message: 'Mock warning 2.',
+            },
+            {
+              ruleId: 'mock',
+              severity: 1,
+              message: 'Mock warning 3.',
+            },
+            {
+              ruleId: 'mock',
+              severity: 1,
+              message: 'Mock warning 4.',
+            },
+            {
+              ruleId: 'mock',
+              severity: 1,
+              message: 'Mock warning 5.',
+            },
+            {
+              ruleId: 'mock',
+              severity: 1,
+              message: 'Mock warning 6.',
+            },
+          ],
+        },
+      ];
+      setupMocks();
+      await runBuilder(
+        createValidRunBuilderOptions({
+          eslintConfig: './.eslintrc.json',
+          lintFilePatterns: ['includedFile1'],
+          format: 'json',
+          silent: false,
+          quiet: true,
+        })
+      );
+      console.log('FPPP', loggerSpy.mock.calls);
+      const flattenedCalls = loggerSpy.mock.calls.reduce((logs, call) => {
+        return [...logs, call[0]];
+      }, []);
+      expect(flattenedCalls).toContainEqual(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'Lint errors found in the listed files.'
+          ),
+        })
+      );
+      expect(flattenedCalls).not.toContainEqual(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'Lint warnings found in the listed files.'
+          ),
+        })
+      );
+    });
     it('should not log if the silent flag was passed', async () => {
       mockReports = [
         {

--- a/packages/linter/src/builders/eslint/lint.impl.spec.ts
+++ b/packages/linter/src/builders/eslint/lint.impl.spec.ts
@@ -384,7 +384,6 @@ describe('Linter Builder', () => {
           quiet: true,
         })
       );
-      console.log('FPPP', loggerSpy.mock.calls);
       const flattenedCalls = loggerSpy.mock.calls.reduce((logs, call) => {
         return [...logs, call[0]];
       }, []);

--- a/packages/linter/src/builders/eslint/lint.impl.ts
+++ b/packages/linter/src/builders/eslint/lint.impl.ts
@@ -46,13 +46,16 @@ async function run(
     ? path.resolve(systemRoot, options.eslintConfig)
     : undefined;
 
-  const lintResults: ESLint.LintResult[] = await lint(
-    eslintConfigPath,
-    options
-  );
+  let lintResults: ESLint.LintResult[] = await lint(eslintConfigPath, options);
 
   if (lintResults.length === 0) {
     throw new Error('Invalid lint configuration. Nothing to lint.');
+  }
+
+  // if quiet, only show errors
+  if (options.quiet) {
+    context.logger.debug('Quiet mode enabled - filtering out warnings\n');
+    lintResults = ESLint.getErrorResults(lintResults);
   }
 
   const formatter = await eslint.loadFormatter(options.format);


### PR DESCRIPTION
## Current Behavior
The eslint plugin doesn't properly respect the "quiet" configuration option, displaying warnings even if "quiet" is `true`.

## Expected Behavior
The eslint plugin should respect the "quiet" configuration option, not displaying errors if it is `true`.

## Related Issue(s)
Fixes #3946
