### PR TITLE
fix(nextjs): add "@nrwl/workspace" to the generated package.json file…

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@nrwl/workspace": "*",
-    "next": "^9.3.3"
+    "next": "^10.0.3"
   },
   "dependencies": {
     "@nrwl/react": "*",

--- a/packages/next/src/builders/build/lib/create-package-json.ts
+++ b/packages/next/src/builders/build/lib/create-package-json.ts
@@ -15,8 +15,12 @@ function getProjectDeps(context: BuilderContext, rootPackageJson: any) {
   const depNames = deps
     .map((d) => d.node)
     .filter((node) => node.type === 'npm')
-    .map((node) => node.data.packageName);
-  const dependencies = depNames
+    .map((node) => node.data.packageName)
+    // Need to make sure @nrwl/workspace is installed
+    // It is only a peer dependency of @nrwl/next so does not get installed automatically
+    // See: https://github.com/nrwl/nx/issues/4336
+    .concat('@nrwl/workspace');
+  const dependencies: string[] = depNames
     .filter((packageName) => packageName in rootPackageJson.dependencies)
     .reduce((deps, pkgName) => {
       return { ...deps, [pkgName]: rootPackageJson.dependencies[pkgName] };


### PR DESCRIPTION
… for built next apps

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Need to explicitly add `@nrwl/workspace` to package.json before the  built application can run.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Should just work

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4336
