### PR TITLE
fix(angular): rename tsconfig.json during ng add

### DIFF
--- a/packages/workspace/src/schematics/init/__snapshots__/init.spec.ts.snap
+++ b/packages/workspace/src/schematics/init/__snapshots__/init.spec.ts.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`workspace move to nx layout should create nx.json 1`] = `
+Object {
+  "affected": Object {
+    "defaultBase": "master",
+  },
+  "implicitDependencies": Object {
+    ".eslintrc.json": "*",
+    "angular.json": "*",
+    "nx.json": "*",
+    "package.json": "*",
+    "tsconfig.base.json": "*",
+    "tslint.json": "*",
+  },
+  "npmScope": "my-app",
+  "projects": Object {
+    "myApp": Object {
+      "tags": Array [],
+    },
+    "myApp-e2e": Object {
+      "tags": Array [],
+    },
+  },
+}
+`;
+
 exports[`workspace move to nx layout should update tsconfig.base.json if present 1`] = `
 Object {
   "compilerOptions": Object {
@@ -10,7 +35,7 @@ Object {
 }
 `;
 
-exports[`workspace move to nx layout should update tsconfig.json if tsconfig.base.json if present 1`] = `
+exports[`workspace move to nx layout should work if angular-cli workspace had tsconfig.base.json 1`] = `
 Object {
   "compilerOptions": Object {
     "baseUrl": ".",

--- a/packages/workspace/src/schematics/init/init.spec.ts
+++ b/packages/workspace/src/schematics/init/init.spec.ts
@@ -57,7 +57,7 @@ describe('workspace', () => {
         '/tsconfig.spec.json',
         '{"extends": "../tsconfig.json", "compilerOptions": {}}'
       );
-      appTree.create('/tsconfig.base.json', '{"compilerOptions": {}}');
+      appTree.create('/tsconfig.json', '{"compilerOptions": {}}');
       appTree.create('/tslint.json', '{"rules": {}}');
       appTree.create('/e2e/protractor.conf.js', '// content');
       appTree.create('/src/app/app.module.ts', '// content');
@@ -133,18 +133,28 @@ describe('workspace', () => {
       }
     });
 
-    it('should update tsconfig.base.json if present', async () => {
+    it('should set the default collection to @nrwl/angular', async () => {
+      const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
+      expect(readJsonInTree(tree, 'angular.json').cli.defaultCollection).toBe(
+        '@nrwl/angular'
+      );
+    });
+
+    it('should create nx.json', async () => {
+      const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
+      expect(readJsonInTree(tree, 'nx.json')).toMatchSnapshot();
+    });
+
+    it('should work if angular-cli workspace had tsconfig.base.json', async () => {
+      appTree.rename('tsconfig.json', 'tsconfig.base.json');
       const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
       expect(readJsonInTree(tree, 'tsconfig.base.json')).toMatchSnapshot();
     });
 
-    it('should update tsconfig.json if tsconfig.base.json if present', async () => {
-      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+    it('should update tsconfig.base.json if present', async () => {
       const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
-      expect(readJsonInTree(tree, 'tsconfig.json')).toMatchSnapshot();
+      expect(readJsonInTree(tree, 'tsconfig.base.json')).toMatchSnapshot();
     });
-
-    it('should add paths to the tsconfig.base.json if present', () => {});
 
     it('should work without nested tsconfig files', async () => {
       const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
@@ -286,6 +296,14 @@ describe('workspace', () => {
     });
 
     it('should work with existing .prettierignore file', async () => {
+      appTree.create('/.prettierignore', '# existing ignore rules');
+      const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
+
+      const prettierIgnore = tree.read('/.prettierignore').toString();
+      expect(prettierIgnore).toBe('# existing ignore rules');
+    });
+
+    it('should update tsconfigs', async () => {
       appTree.create('/.prettierignore', '# existing ignore rules');
       const tree = await runSchematic('ng-add', { name: 'myApp' }, appTree);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Users cannot generate libs after using `ng add` because `tsconfig.json` is not renamed to `tsconfig.base.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`tsconfig.json` is renamed to `tsconfig.base.json` allowing users to create libs after using `ng add`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/4331
