### PR TITLE
fix(core): convert workspace root path with forward slashes

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -418,10 +418,9 @@ function createApp(tmpDir: string, name: string, parsedArgs: WorkspaceArgs) {
   const command = `new ${name} ${args} --collection=@nrwl/workspace`;
   console.log(command);
 
+  const nxWorkspaceRoot = process.cwd().replace(/\\/g, '/');
   execSync(
-    `${
-      pmc.exec
-    } tao ${command}/collection.json --cli=${cli} --nxWorkspaceRoot="${process.cwd()}"`,
+    `${pmc.exec} tao ${command}/collection.json --cli=${cli} --nxWorkspaceRoot="${nxWorkspaceRoot}"`,
     {
       stdio: [0, 1, 2],
       cwd: tmpDir,


### PR DESCRIPTION
Yarn was wrongly interpreting `nxWorkspaceRoot` when current working directory was ending in backslash, for example `E:\` in Windows. This commit makes sure that `nxWorkspaceRoot` parameter uses only forward slashes that work in all cases.

Closes #4363
