### PR TITLE
docs(core): Fix the URL to the specification

### DIFF
--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -176,7 +176,7 @@ function printArgsWarning(options: NxArgs) {
         '',
         output.colors.gray(
           'Learn more about checking only what is affected: '
-        ) + 'https://nx.dev/guides/monorepo-affected.',
+        ) + 'https://nx.dev/latest/angular/cli/affected#affected.',
       ],
     });
   }


### PR DESCRIPTION
This is just a fix to display a working URL in case you use: `nx affected:apps --all`.

## Current Behavior
When you use `nx affected:apps --all` you will get a link to https://nx.dev/guides/monorepo-affected that will lead to the start page.

## Expected Behavior
Display a link that is working and shows valid information, like: https://nx.dev/latest/angular/cli/affected#affected
