### PR TITLE
docs(core): Fix the URL to the specification 2

### DIFF
--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -176,7 +176,7 @@ function printArgsWarning(options: NxArgs) {
         '',
         output.colors.gray(
           'Learn more about checking only what is affected: '
-        ) + 'https://nx.dev/guides/monorepo-affected.',
+        ) + 'https://nx.dev/latest/angular/cli/affected#affected.',
       ],
     });
   }

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -176,7 +176,10 @@ function printArgsWarning(options: NxArgs) {
         '',
         output.colors.gray(
           'Learn more about checking only what is affected: '
-        ) + 'https://nx.dev/latest/angular/cli/affected#affected.',
+        ) +
+          'https://nx.dev/latest/angular/cli/affected, ' +
+          'https://nx.dev/latest/react/cli/affected or ' +
+          'https://nx.dev/latest/node/cli/affected.',
       ],
     });
   }


### PR DESCRIPTION
## Current Behavior
I just noticed that `nx affected --target=workspace --all` displays a URL to `angular/cli/affected` for reference now, but `react/cli/affected` and `node/cli/affected` URLs are missing.

## Expected Behavior
Display all possible URLs so user can select one.
