### PR TITLE
Feat export logger from @nrwl/devkit

### DIFF
--- a/packages/devkit/index.ts
+++ b/packages/devkit/index.ts
@@ -8,6 +8,7 @@ export {
   NxJsonConfiguration,
   NxJsonProjectConfiguration,
 } from '@nrwl/tao/src/shared/nx';
+export { logger } from '@nrwl/tao/src/shared/logger';
 export { TargetContext } from '@nrwl/tao/src/commands/run';
 export { formatFiles } from './src/generators/format-files';
 export { readJson } from './src/utils/read-json';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

With Nx 11 and the use of nrwl executors and generators, nx plugins are not able to use the angular context.logger. Currently, the alternative tao logger is available at @nrwl/tao/src/shared/logger.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

In order to provide a consistent and easy to use plugin development experience, having the tao logger exported from `@nrwl/devkit` would help to move in this direction.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4397
