### PR TITLE
feat(devkit): adds projectName to the executor TargetContext

### DIFF
--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -133,6 +133,7 @@ export interface TargetContext {
   root: string;
   target: TargetConfiguration;
   workspace: WorkspaceConfiguration;
+  projectName: string;
 }
 
 export async function run(
@@ -165,7 +166,12 @@ export async function run(
     }
 
     if (ws.isNxExecutor(nodeModule, executor)) {
-      return await implementation(combinedOptions, { root, target, workspace });
+      return await implementation(combinedOptions, {
+        root,
+        target,
+        workspace,
+        projectName: opts.project,
+      });
     } else {
       return (await import('./ngcli-adapter')).run(
         root,


### PR DESCRIPTION
The projectName is needed so that executors can look up more information about the specific project they're being run against.

## Current Behavior
There is no way for an executor to get the sourceRoot of the project it is being run against.

## Expected Behavior
The `@angular-devkit/schematics` provides the project name under `context.target.project` but that doesn't make a lot of sense to me since the `project` property doesn't exist on the actual target definition in the `workspace.json`.  I put the project name under `context.projectName`.

With this change, executors can access the sourceRoot like this:

```ts
async function run(options, context) {
  const projectName = context.projectName;
  const projectSourceRoot = context.workspace.projects[projectName].sourceRoot;
}
```