### PR TITLE
fix(nextjs): use html component from next/document

### DIFF
--- a/packages/next/src/schematics/application/files/pages/_document.tsx__tmpl__
+++ b/packages/next/src/schematics/application/files/pages/_document.tsx__tmpl__
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 
 export default class CustomDocument extends Document<{ styleTags: ReactElement[] }> {
@@ -17,7 +17,7 @@ export default class CustomDocument extends Document<{ styleTags: ReactElement[]
 
   render() {
     return (
-      <html>
+      <Html>
         <Head>
           {this.props.styleTags}
         </Head>
@@ -25,7 +25,7 @@ export default class CustomDocument extends Document<{ styleTags: ReactElement[]
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Currently the native `<html>` element is used in the custom document, which results in the following warning while running the app:

```
warn  - Your custom Document (pages/_document) did not render all the required subcomponent.
Missing component: <Html />
Read how to fix here: https://err.sh/next.js/missing-document-component
```

## Expected Behavior

The `<Html>` component that `next/document` provides should be used (see https://err.sh/next.js/missing-document-component)