### PR TITLE
fix(angular): remove spec file when unitTestRunner is none

### DIFF
--- a/packages/angular/src/schematics/application/application.spec.ts
+++ b/packages/angular/src/schematics/application/application.spec.ts
@@ -463,6 +463,9 @@ describe('app', () => {
         expect(tree.exists('apps/my-app/tsconfig.spec.json')).toBeFalsy();
         expect(tree.exists('apps/my-app/jest.config.js')).toBeFalsy();
         expect(tree.exists('apps/my-app/karma.config.js')).toBeFalsy();
+        expect(
+          tree.exists('apps/my-app/src/app/app.component.spec.ts')
+        ).toBeFalsy();
         const workspaceJson = readJsonInTree(tree, 'workspace.json');
         expect(workspaceJson.projects['my-app'].architect.test).toBeUndefined();
         expect(

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -512,6 +512,12 @@ function updateProject(options: NormalizedSchema): Rule {
           host.delete(`${options.appProjectRoot}/tslint.json`);
         }
 
+        if (options.unitTestRunner === 'none') {
+          host.delete(
+            `${options.appProjectRoot}/src/app/app.component.spec.ts`
+          );
+        }
+
         if (options.e2eTestRunner === 'none') {
           delete json.projects[options.e2eProjectName];
         }
@@ -809,7 +815,7 @@ export default function (schema: Schema): Rule {
       updateProject(options),
       updateComponentTemplate(options),
       updateComponentStyles(options),
-      updateComponentSpec(options),
+      options.unitTestRunner !== 'none' ? updateComponentSpec(options) : noop(),
       options.routing ? addRouterRootConfiguration(options) : noop(),
       addLintFiles(options.appProjectRoot, options.linter, {
         onlyGlobal: options.linter === Linter.TsLint, // local lint files are added differently when tslint


### PR DESCRIPTION
## Current Behavior
Selecting `none` as `unitTestRunner` leaves app.component.spec.ts

## Expected Behavior
Selecting `none` as `unitTestRunner` removes app.component.spec.ts

Fixes #
ISSUES CLOSED #4373