### PR TITLE
fix(workspace): adding support for production-only environment variables on build

### DIFF
--- a/packages/workspace/src/tasks-runner/task-orchestrator.ts
+++ b/packages/workspace/src/tasks-runner/task-orchestrator.ts
@@ -280,12 +280,22 @@ export class TaskOrchestrator {
     forwardOutput: boolean,
     forceColor: string
   ) {
-    const envsFromFiles = {
-      ...parseEnv('.env'),
-      ...parseEnv('.local.env'),
-      ...parseEnv(`${task.projectRoot}/.env`),
-      ...parseEnv(`${task.projectRoot}/.local.env`),
-    };
+    let envsFromFiles;
+    
+    // Check if the current task requires a production configuration, and load the appropriate environment variables
+    if(task.target.configuration && task.target.configuration === 'production') {
+      envsFromFiles = {
+        ...parseEnv('.env'),
+        ...parseEnv(`${task.projectRoot}/.env`),
+      };
+    } else {
+      envsFromFiles = {
+        ...parseEnv('.env'),
+        ...parseEnv('.local.env'),
+        ...parseEnv(`${task.projectRoot}/.env`),
+        ...parseEnv(`${task.projectRoot}/.local.env`),
+      };
+    }
 
     const env = {
       ...envsFromFiles,


### PR DESCRIPTION
## Current Behavior
Currently when building a @nrwl/react project, all environment variables are loaded for any type of build: production or otherwise.

When running `nx build XXX --prod` (where XXX is the name of a @nrwl/react project, _I haven't tested other project types but would expect an identical result_), all environment variables are loaded. This isn't really desirable since `.env` files are generally meant to include production-only variables while `.local.env` files are generally meant to include development-only variables.

## Expected Behavior
This commit successfully determines whether or not the user is trying to run a task in a production configuration, and loads only the appropriate environment variables (excluding all `.local.env` files) in the build process.

## Related Issue(s)
https://github.com/nrwl/nx/issues/4420

Fixes #4420
