### PR TITLE
fix(docs): correction in node: getting started

### DIFF
--- a/docs/node/getting-started/getting-started.md
+++ b/docs/node/getting-started/getting-started.md
@@ -4,10 +4,10 @@ Nx is a suite of powerful, extensible dev tools that help you develop, test, bui
 
 ## Create Nx Workspace
 
-Creating an Nx workspace is easy. Run the following command to set up an Nx workspace with an Angular app in it.
+Creating an Nx workspace is easy. Run the following command to set up an Nx workspace with a Node app in it.
 
 ```bash
-npx create-nx-workspace --preset=express
+npx create-nx-workspace --preset=nest
 ```
 
 ## Learn Nx Fundamentals


### PR DESCRIPTION
## Current

Node: Getting started
- mentions Angular app instead of Node app
- uses `npx create-nx-workspace` with invalid preset `express`.

## Expected

Node: Getting started
- should mention Node app instead of Angular app
- should use `npx create-nx-workspace` with a valid preset, like `nest`.

