### PR TITLE
fix(storybook): typo in build output

### DIFF
--- a/packages/storybook/src/builders/build-storybook/build-storybook.impl.spec.ts
+++ b/packages/storybook/src/builders/build-storybook/build-storybook.impl.spec.ts
@@ -45,7 +45,7 @@ describe('Build storybook', () => {
 
     expect(storybookSpy).toHaveBeenCalled();
     expect(
-      context.logger.includes(`Storybook files availble in ${outputPath}`)
+      context.logger.includes(`Storybook files available in ${outputPath}`)
     ).toBeTruthy();
     expect(
       context.logger.includes(`ui framework: ${uiFramework}`)

--- a/packages/storybook/src/builders/build-storybook/build-storybook.impl.ts
+++ b/packages/storybook/src/builders/build-storybook/build-storybook.impl.ts
@@ -60,7 +60,7 @@ export function run(
     }),
     map((loaded) => {
       context.logger.info(`Storybook builder finished ...`);
-      context.logger.info(`Storybook files availble in ${options.outputPath}`);
+      context.logger.info(`Storybook files available in ${options.outputPath}`);
       const builder: BuilderOutput = { success: true } as BuilderOutput;
       return builder;
     })


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
```
info => Output directory: /.../apps/storybook/dist/main
Storybook builder finished ...
Storybook files availble in apps/storybook/dist/main
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
```
Storybook files available in apps/storybook/dist/main
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
