### PR TITLE
fix(linter): allow type imports from lazy-loaded libraries

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -235,6 +235,7 @@ export default createESLintRule<Options, MessageIds>({
 
         // if we import a library using loadChildren, we should not import it using es6imports
         if (
+          node.importKind !== 'type' &&
           onlyLoadChildren(
             projectGraph,
             sourceProject.name,

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -605,51 +605,64 @@ describe('Enforce Module Boundaries', () => {
     expect(failures.length).toEqual(0);
   });
 
-  it('should error on importing a lazy-loaded library', () => {
-    const failures = runRule(
-      {},
-      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      'import "@mycompany/other";',
-      {
-        nodes: {
-          mylibName: {
-            name: 'mylibName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/mylib',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/mylib/src/main.ts`)],
+  it.each`
+    importKind | shouldError | importStatement
+    ${'value'} | ${true}     | ${'import { someValue } from "@mycompany/other";'}
+    ${'type'}  | ${false}    | ${'import type { someType } from "@mycompany/other";'}
+  `(
+    `when importing a lazy-loaded library:
+    \t importKind: $importKind
+    \t shouldError: $shouldError`,
+    ({ importKind, importStatement }) => {
+      const failures = runRule(
+        {},
+        `${process.cwd()}/proj/libs/mylib/src/main.ts`,
+        importStatement,
+        {
+          nodes: {
+            mylibName: {
+              name: 'mylibName',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/mylib',
+                tags: [],
+                implicitDependencies: [],
+                architect: {},
+                files: [createFile(`libs/mylib/src/main.ts`)],
+              },
+            },
+            otherName: {
+              name: 'otherName',
+              type: ProjectType.lib,
+              data: {
+                root: 'libs/other',
+                tags: [],
+                implicitDependencies: [],
+                architect: {},
+                files: [createFile(`libs/other/index.ts`)],
+              },
             },
           },
-          otherName: {
-            name: 'otherName',
-            type: ProjectType.lib,
-            data: {
-              root: 'libs/other',
-              tags: [],
-              implicitDependencies: [],
-              architect: {},
-              files: [createFile(`libs/other/index.ts`)],
-            },
+          dependencies: {
+            mylibName: [
+              {
+                source: 'mylibName',
+                target: 'otherName',
+                type: DependencyType.dynamic,
+              },
+            ],
           },
-        },
-        dependencies: {
-          mylibName: [
-            {
-              source: 'mylibName',
-              target: 'otherName',
-              type: DependencyType.dynamic,
-            },
-          ],
-        },
+        }
+      );
+      if (importKind === 'type') {
+        expect(failures.length).toEqual(0);
+      } else {
+        expect(failures[0].message).toEqual(
+          'Imports of lazy-loaded libraries are forbidden'
+        );
       }
-    );
-    expect(failures[0].message).toEqual(
-      'Imports of lazy-loaded libraries are forbidden'
-    );
-  });
+    }
+  );
 
   it('should error on importing an app', () => {
     const failures = runRule(


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
The `noImportsOfLazyLoadedLibraries` eslint rule does not allow type imports from lazy-loaded libraries, which creates a conflict when using TS with Next.js

**Example:**
```ts
import dynamic from "next/dynamic";
import type { ComponentProps } from "@mycompany/lib"; // error 🥲

const LazyComponent = dynamic<ComponentProps>(() =>
  import("@mycompany/lib")
);
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Type imports should be allowed from lazy-loaded libraries.
