### PR TITLE
fix(storybook): exporting a readWorkspaceConfig function to return config to desired format

### DIFF
--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -20,7 +20,11 @@ export {
 export { output } from './src/utils/output';
 export { commandsObject } from './src/command-line/nx-commands';
 export { supportedNxCommands } from './src/command-line/supported-nx-commands';
-export { readWorkspaceJson, readNxJson } from './src/core/file-utils';
+export {
+  readWorkspaceJson,
+  readNxJson,
+  readWorkspaceConfig,
+} from './src/core/file-utils';
 export { NxJson } from './src/core/shared-interfaces';
 export {
   ProjectGraphNode,

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -12,7 +12,7 @@ import { ProjectGraphNode } from './project-graph';
 import { Environment, NxJson } from './shared-interfaces';
 import { defaultFileHasher } from './hasher/file-hasher';
 import { performance } from 'perf_hooks';
-import { Workspaces } from '@nrwl/tao/src/shared/workspace';
+import { toOldFormatOrNull, Workspaces } from '@nrwl/tao/src/shared/workspace';
 
 const ignore = require('ignore');
 
@@ -166,6 +166,16 @@ function readFileIfExisting(path: string) {
 export function readWorkspaceJson(): any {
   const ws = new Workspaces(appRootPath);
   return ws.readWorkspaceConfiguration();
+}
+
+export function readWorkspaceConfig(opts: { format: 'angularCli' | 'nx' }) {
+  const json = readWorkspaceJson();
+  if (opts.format === 'angularCli') {
+    const formatted = toOldFormatOrNull(json);
+    return formatted ? formatted : json;
+  } else {
+    return json;
+  }
 }
 
 export function workspaceFileName() {


### PR DESCRIPTION
Storybook expects the format of workspace.json to match angular.json. This is not the case.
Storybook now will read the workspace.json file using the new function. This will allow us to manage
the new formats.

ISSUES CLOSED: #4305

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes [#4305](https://github.com/nrwl/nx/issues/4305)

This PR is linked to this [Storybook PR](https://github.com/storybookjs/storybook/pull/13558)
