### PR TITLE
fix(core): coerce the property key `properties` for the schema object

### DIFF
--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -185,6 +185,9 @@ export class Workspaces {
       const schema = JSON.parse(
         stripJsonComments(fs.readFileSync(schemaPath).toString())
       );
+      if (!schema.properties || typeof schema.properties !== 'object') {
+        schema.properties = {};
+      }
       const [modulePath, exportName] = executorConfig.implementation.split('#');
       const module = require(path.join(executorsDir, modulePath));
       const implementation = module[exportName || 'default'];
@@ -210,6 +213,9 @@ export class Workspaces {
       const schema = JSON.parse(
         stripJsonComments(fs.readFileSync(schemaPath).toString())
       );
+      if (!schema.properties || typeof schema.properties !== 'object') {
+        schema.properties = {};
+      }
       generatorConfig.implementation =
         generatorConfig.implementation || generatorConfig.factory;
       const [modulePath, exportName] = generatorConfig.implementation.split(


### PR DESCRIPTION
Check if the property key `properties` for the parsed schema object exists and is type of `object`. If the property key does not exists initialize the property with an empty object. Added to the methods `readExecutor` and `readGenerator` of the class `Workspaces`

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
After the schema object is parsed it is not checked if the `properties` property is defined.
This could cause that a TypeError exception is thrown if the `properties` property is not defined or not an object.
For example in:
- [function convertAliases](https://github.com/nrwl/nx/blob/0c0a29da71436aed8d3b1771b64dd6cb1cc4c623/packages/tao/src/shared/params.ts#L126)
- [function convertSmartDefaultsIntoNamedParams](https://github.com/nrwl/nx/blob/0c0a29da71436aed8d3b1771b64dd6cb1cc4c623/packages/tao/src/shared/params.ts#L400)
- [function promptForValues](https://github.com/nrwl/nx/blob/0c0a29da71436aed8d3b1771b64dd6cb1cc4c623/packages/tao/src/shared/params.ts#L472)
- [function coerceTypesInOptions](https://github.com/nrwl/nx/blob/0c0a29da71436aed8d3b1771b64dd6cb1cc4c623/packages/tao/src/shared/params.ts#L84)
- [function lookupUnmatched](https://github.com/nrwl/nx/blob/0c0a29da71436aed8d3b1771b64dd6cb1cc4c623/packages/tao/src/shared/params.ts#L522)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
After the schema object is parsed ([Workspaces.readExecutor](https://github.com/nrwl/nx/blob/0c0a29da71436aed8d3b1771b64dd6cb1cc4c623/packages/tao/src/shared/workspace.ts#L185-L187) and [Workspaces.readGenerator](https://github.com/nrwl/nx/blob/0c0a29da71436aed8d3b1771b64dd6cb1cc4c623/packages/tao/src/shared/workspace.ts#L210-L212)) it should be check if the property `properties` is defined and an object. If the property is not defined or not an object the property should be initialized with an empty object.
