### PR TITLE
nrwl/next, plugin "with-nx": Pass down all webpack options to support all cases of next.config.js

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -22,7 +22,7 @@ function withNx(nextConfig = {} as any) {
      *
      * Note: This would be easier if Next.js exposes css-loader and sass-loader on `defaultLoaders`.
      */
-    webpack: (config, { defaultLoaders }) => {
+    webpack: (config, options) => {
       // Include workspace libs in css/sass loaders
       const includes = [join(appRootPath, workspaceLayout().libsDir)];
 
@@ -83,7 +83,7 @@ function withNx(nextConfig = {} as any) {
         nextErrorCssModuleLoader.exclude = includes;
       }
 
-      return userWebpack(config, { defaultLoaders });
+      return userWebpack(config, options);
     },
   };
 }


### PR DESCRIPTION
## Current Behavior
When you have an existing next.config.js, where you need to fully override "webpack", then this plugin "withNx" is killing the options object by only passing down { defaultLoaders }. This way, we're not able anymore to get other variables of the option object like "isServer" or "dev":

```javascript
webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
  console.log({ buildId, dev, isServer, webpack })
  /**
     * Output:
     * {
     *   buildId: undefined,
     *   dev: undefined,
     *   isServer: undefined,
     *   webpack: undefined
     * }
     */
}
```

## Expected Behavior
By passing down the full `options` object like i did in this PR, everything works again as expected:

```javascript
webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
  console.log({ buildId, dev, isServer, webpack })
  /**
     * Output:
     * {
     *   buildId: '48e2c788-fc99-4047-84df-7d4d4c481d2c',
     *   dev: false,
     *   isServer: true,
     *   webpack: [Function: webpack]
     * }
     */
}
```

Would be nice if this change could be integrated - but for me it is ok now... as i've read through the plugin "with-nx.js", i know now that we don't even need it (we're only working with styled-components, no css-modules) 