### PR TITLE
feat(node) builder should support multiple entries

### DIFF
--- a/packages/node/src/utils/config.spec.ts
+++ b/packages/node/src/utils/config.spec.ts
@@ -119,6 +119,17 @@ describe('getBaseWebpackPartial', () => {
     });
   });
 
+  describe('the additionalEntries option', () => {
+    it ('should have multiple entries', () => {
+      const result = getBaseWebpackPartial({...input, additionalEntries: {test: 'some/test/path.ts'}});
+      expect(result.entry).toEqual({
+        main: ['main.ts'],
+        test: 'some/test/path.ts'
+      })
+      expect(result.output.filename).toEqual('[name].js')
+    })
+  })
+
   describe('the output option', () => {
     it('should set the correct output options', () => {
       const result = getBaseWebpackPartial(input);

--- a/packages/node/src/utils/config.spec.ts
+++ b/packages/node/src/utils/config.spec.ts
@@ -120,15 +120,24 @@ describe('getBaseWebpackPartial', () => {
   });
 
   describe('the additionalEntries option', () => {
-    it ('should have multiple entries', () => {
-      const result = getBaseWebpackPartial({...input, additionalEntries: {test: 'some/test/path.ts'}});
+    it('should have multiple entries', () => {
+      const result = getBaseWebpackPartial({
+        ...input,
+        additionalEntries: {
+          test: 'some/test/path.ts',
+          testy: 'some/other/path.ts',
+        },
+      });
+
       expect(result.entry).toEqual({
         main: ['main.ts'],
-        test: 'some/test/path.ts'
-      })
-      expect(result.output.filename).toEqual('[name].js')
-    })
-  })
+        test: 'some/test/path.ts',
+        testy: 'some/other/path.ts',
+      });
+
+      expect(result.output.filename).toEqual('[name].js');
+    });
+  });
 
   describe('the output option', () => {
     it('should set the correct output options', () => {

--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -12,6 +12,7 @@ import { readTsConfig } from '@nrwl/workspace';
 import { BuildBuilderOptions } from './types';
 
 export const OUT_FILENAME = 'main.js';
+const OUT_FILENAME_TEMPLATE = '[name].js'
 
 export function getBaseWebpackPartial(
   options: BuildBuilderOptions
@@ -25,12 +26,13 @@ export function getBaseWebpackPartial(
   const webpackConfig: Configuration = {
     entry: {
       main: [options.main],
+      ...options.additionalEntries
     },
     devtool: options.sourceMap ? 'source-map' : false,
     mode: options.optimization ? 'production' : 'development',
     output: {
       path: options.outputPath,
-      filename: OUT_FILENAME,
+      filename: options.additionalEntries ? OUT_FILENAME_TEMPLATE : OUT_FILENAME,
     },
     module: {
       rules: [

--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -12,7 +12,7 @@ import { readTsConfig } from '@nrwl/workspace';
 import { BuildBuilderOptions } from './types';
 
 export const OUT_FILENAME = 'main.js';
-const OUT_FILENAME_TEMPLATE = '[name].js'
+const OUT_FILENAME_TEMPLATE = '[name].js';
 
 export function getBaseWebpackPartial(
   options: BuildBuilderOptions
@@ -26,13 +26,15 @@ export function getBaseWebpackPartial(
   const webpackConfig: Configuration = {
     entry: {
       main: [options.main],
-      ...options.additionalEntries
+      ...options.additionalEntries,
     },
     devtool: options.sourceMap ? 'source-map' : false,
     mode: options.optimization ? 'production' : 'development',
     output: {
       path: options.outputPath,
-      filename: options.additionalEntries ? OUT_FILENAME_TEMPLATE : OUT_FILENAME,
+      filename: options.additionalEntries
+        ? OUT_FILENAME_TEMPLATE
+        : OUT_FILENAME,
     },
     module: {
       rules: [

--- a/packages/node/src/utils/normalize.spec.ts
+++ b/packages/node/src/utils/normalize.spec.ts
@@ -52,6 +52,16 @@ describe('normalizeBuildOptions', () => {
     expect(result.main).toEqual('/root/apps/nodeapp/src/main.ts');
   });
 
+  it('should resolve additional entries from root', () => {
+    const result = normalizeBuildOptions(
+      { ...testOptions, additionalEntries: { test: 'some/path.ts' } },
+      root,
+      sourceRoot,
+      projectRoot
+    );
+    expect(result.additionalEntries.test).toEqual(['/root/some/path.ts']);
+  });
+
   it('should resolve the output path', () => {
     const result = normalizeBuildOptions(
       testOptions,

--- a/packages/node/src/utils/normalize.ts
+++ b/packages/node/src/utils/normalize.ts
@@ -27,7 +27,10 @@ export function normalizeBuildOptions<T extends BuildBuilderOptions>(
     webpackConfig: options.webpackConfig
       ? resolve(root, options.webpackConfig)
       : options.webpackConfig,
-    additionalEntries: normalizeAddtionalEntries(root, options.additionalEntries), 
+    additionalEntries: normalizeAddtionalEntries(
+      root,
+      options.additionalEntries
+    ),
   };
 }
 
@@ -90,11 +93,11 @@ function normalizeFileReplacements(
 
 function normalizeAddtionalEntries(
   root: string,
-  additionalEntries: { [name: string]: string },
+  additionalEntries: { [name: string]: string }
 ) {
-  const normalizedEntries = {}
+  const normalizedEntries = {};
   for (const property in additionalEntries) {
-    normalizedEntries[property] = resolve(root, additionalEntries[property])
+    normalizedEntries[property] = [resolve(root, additionalEntries[property])];
   }
-  return normalizedEntries
+  return normalizedEntries;
 }

--- a/packages/node/src/utils/normalize.ts
+++ b/packages/node/src/utils/normalize.ts
@@ -27,6 +27,7 @@ export function normalizeBuildOptions<T extends BuildBuilderOptions>(
     webpackConfig: options.webpackConfig
       ? resolve(root, options.webpackConfig)
       : options.webpackConfig,
+    additionalEntries: normalizeAddtionalEntries(root, options.additionalEntries), 
   };
 }
 
@@ -85,4 +86,15 @@ function normalizeFileReplacements(
     replace: resolve(root, fileReplacement.replace),
     with: resolve(root, fileReplacement.with),
   }));
+}
+
+function normalizeAddtionalEntries(
+  root: string,
+  additionalEntries: { [name: string]: string },
+) {
+  const normalizedEntries = {}
+  for (const property in additionalEntries) {
+    normalizedEntries[property] = resolve(root, additionalEntries[property])
+  }
+  return normalizedEntries
 }

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -42,6 +42,8 @@ export interface BuildBuilderOptions {
   root?: string;
   sourceRoot?: Path;
   projectRoot?: string;
+
+  additionalEntries?: { [name: string]: string }
 }
 
 export interface BuildNodeBuilderOptions extends BuildBuilderOptions {

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -43,7 +43,7 @@ export interface BuildBuilderOptions {
   sourceRoot?: Path;
   projectRoot?: string;
 
-  additionalEntries?: { [name: string]: string }
+  additionalEntries?: { [name: string]: string };
 }
 
 export interface BuildNodeBuilderOptions extends BuildBuilderOptions {


### PR DESCRIPTION
## Current Behavior
Currently today, when i build a node application using default settings only one entry file is generated `main.js`

## Expected Behavior
I am not changing behavior but updating when a new flag is available. 

## Related Issue(s)
[Allow for multiple artifacts to be created via @nrwl/node:build](https://github.com/nrwl/nx/issues/4448)

Fixes #
In this pr, i allow for a new setting to be added to workspace.json that will allow for a build to generate more than one entry file. As mentioned in the issue my reasoning for this is so that i can thread more easily via node threading api, which requires a reference file in js format to spin up the new thread. 


