### PR TITLE
fix(react): provide option overriding for babel plugins

### DIFF
--- a/packages/web/babel.spec.ts
+++ b/packages/web/babel.spec.ts
@@ -1,0 +1,60 @@
+const babelPreset = require('./babel');
+
+describe('@nrwl/web/babel preset', () => {
+  it('should provide default plugin options', () => {
+    const apiMock = {
+      assertVersion: jest.fn(),
+      caller: jest.fn(),
+    };
+
+    const options = babelPreset(apiMock);
+
+    expect(
+      findPluginOptions('@babel/plugin-proposal-decorators', options)
+    ).toEqual({
+      legacy: true,
+    });
+
+    expect(
+      findPluginOptions('@babel/plugin-proposal-class-properties', options)
+    ).toEqual({
+      loose: true,
+    });
+  });
+
+  it('should allow overrides of plugin options', () => {
+    const apiMock = {
+      assertVersion: jest.fn(),
+      caller: jest.fn(),
+    };
+
+    const options = babelPreset(apiMock, {
+      decorators: {
+        decoratorsBeforeExport: true,
+        legacy: false,
+      },
+      classProperties: {
+        loose: false,
+      },
+    });
+
+    expect(
+      findPluginOptions('@babel/plugin-proposal-decorators', options)
+    ).toEqual({
+      decoratorsBeforeExport: true,
+      legacy: false,
+    });
+
+    expect(
+      findPluginOptions('@babel/plugin-proposal-class-properties', options)
+    ).toEqual({
+      loose: false,
+    });
+  });
+});
+
+function findPluginOptions(name: string, options: any) {
+  return options.plugins.find(
+    (x) => Array.isArray(x) && x[0].indexOf(name) !== -1
+  )[1];
+}

--- a/packages/web/babel.ts
+++ b/packages/web/babel.ts
@@ -2,7 +2,17 @@
  * Babel preset to provide TypeScript support and module/nomodule for Nx.
  */
 
-module.exports = function (api: any, options: {}) {
+interface NxReactBabelPresetOptions {
+  decorators?: {
+    decoratorsBeforeExport?: boolean;
+    legacy?: boolean;
+  };
+  classProperties?: {
+    loose?: boolean;
+  };
+}
+
+module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
   api.assertVersion(7);
 
   const isModern = api.caller((caller) => caller?.isModern);
@@ -30,10 +40,13 @@ module.exports = function (api: any, options: {}) {
     plugins: [
       require.resolve('babel-plugin-macros'),
       // Must use legacy decorators to remain compatible with TypeScript.
-      [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
+      [
+        require.resolve('@babel/plugin-proposal-decorators'),
+        options.decorators ?? { legacy: true },
+      ],
       [
         require.resolve('@babel/plugin-proposal-class-properties'),
-        { loose: true },
+        options.classProperties ?? { loose: true },
       ],
     ],
     overrides: [


### PR DESCRIPTION
Allow babel plugin options to be overridden.

## Current Behavior
Cannot override options

## Expected Behavior
Can override options

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4419 
