### PR TITLE
feat(storybook): add @storybook/html for generic non React/Angular pr…

### DIFF
--- a/packages/storybook/src/schematics/init/init.spec.ts
+++ b/packages/storybook/src/schematics/init/init.spec.ts
@@ -53,6 +53,9 @@ describe('init', () => {
       expect(packageJson.devDependencies['@storybook/react']).not.toBeDefined();
       expect(packageJson.devDependencies['@babel/core']).not.toBeDefined();
       expect(packageJson.devDependencies['babel-loader']).not.toBeDefined();
+
+      // generic html specific
+      expect(packageJson.devDependencies['@storybook/html']).not.toBeDefined();
     });
 
     it('should add react related dependencies when using React as uiFramework', async () => {
@@ -94,7 +97,50 @@ describe('init', () => {
         packageJson.devDependencies['@storybook/angular']
       ).not.toBeDefined();
       expect(packageJson.devDependencies['@angular/forms']).not.toBeDefined();
+
+      // generic html specific
+      expect(packageJson.devDependencies['@storybook/html']).not.toBeDefined();
     });
+  });
+
+  it('should add html related dependencies when using html as uiFramework', async () => {
+    const existing = 'existing';
+    const existingVersion = '1.0.0';
+    await callRule(
+      addDepsToPackageJson(
+        { '@nrwl/storybook': storybookVersion, [existing]: existingVersion },
+        { [existing]: existingVersion },
+        false
+      ),
+      appTree
+    );
+    const tree = await runSchematic(
+      'init',
+      {
+        uiFramework: '@storybook/html',
+      },
+      appTree
+    );
+    const packageJson = readJsonInTree(tree, 'package.json');
+
+    // general deps
+    expect(packageJson.devDependencies['@nrwl/storybook']).toBeDefined();
+    expect(packageJson.dependencies['@nrwl/storybook']).toBeUndefined();
+    expect(packageJson.dependencies[existing]).toBeDefined();
+    expect(packageJson.devDependencies[existing]).toBeDefined();
+    expect(packageJson.devDependencies['@storybook/addon-knobs']).toBeDefined();
+
+    // react specific
+    expect(packageJson.devDependencies['@storybook/react']).not.toBeDefined();
+    expect(packageJson.devDependencies['@babel/core']).not.toBeDefined();
+    expect(packageJson.devDependencies['babel-loader']).not.toBeDefined();
+
+    // angular specific
+    expect(packageJson.devDependencies['@storybook/angular']).not.toBeDefined();
+    expect(packageJson.devDependencies['@angular/forms']).not.toBeDefined();
+
+    // generic html specific
+    expect(packageJson.devDependencies['@storybook/html']).toBeDefined();
   });
 
   it('should add build-storybook to cacheable operations', async () => {

--- a/packages/storybook/src/schematics/init/init.ts
+++ b/packages/storybook/src/schematics/init/init.ts
@@ -78,6 +78,10 @@ function checkDependenciesInstalled(schema: Schema): Rule {
       }
     }
 
+    if (isFramework('html', schema)) {
+      devDependencies['@storybook/html'] = storybookVersion;
+    }
+
     return addDepsToPackageJson(dependencies, devDependencies);
   };
 }

--- a/packages/storybook/src/schematics/init/schema.d.ts
+++ b/packages/storybook/src/schematics/init/schema.d.ts
@@ -1,3 +1,3 @@
 export interface Schema {
-  uiFramework: '@storybook/angular' | '@storybook/react';
+  uiFramework: '@storybook/angular' | '@storybook/react' | '@storybook/html';
 }

--- a/packages/storybook/src/schematics/init/schema.json
+++ b/packages/storybook/src/schematics/init/schema.json
@@ -7,7 +7,7 @@
     "uiFramework": {
       "type": "string",
       "description": "Storybook UI Framework to use",
-      "enum": ["@storybook/angular", "@storybook/react"],
+      "enum": ["@storybook/angular", "@storybook/react", "@storybook/html"],
       "x-prompt": "What UI framework plugin should storybook use?"
     }
   }

--- a/packages/storybook/src/utils/utils.ts
+++ b/packages/storybook/src/utils/utils.ts
@@ -42,6 +42,7 @@ export const Constants = {
   uiFrameworks: {
     angular: '@storybook/angular',
     react: '@storybook/react',
+    html: '@storybook/html',
   } as const,
 };
 type Constants = typeof Constants;
@@ -58,6 +59,9 @@ export function isFramework(
     return true;
   }
   if (type === 'react' && schema.uiFramework === '@storybook/react') {
+    return true;
+  }
+  if (type === 'html' && schema.uiFramework === '@storybook/html') {
     return true;
   }
 


### PR DESCRIPTION
## Current Behavior
Storybook supports react and angular modules

## Expected Behavior
additionally it's possible to start without a framework and just a html config, adding @storybook/html

## Related Issue(s)
#4466 

Fixes #
#4466 