### PR TITLE
fix(web): convert scripts and styles to extra entry points

### DIFF
--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -32,6 +32,7 @@ import { CrossOriginValue } from '../../utils/third-party/cli-files/utilities/in
 import { readTsConfig } from '@nrwl/workspace';
 import { BuildBrowserFeatures } from '../../utils/third-party/utils/build-browser-features';
 import { deleteOutputDir } from '../../utils/delete-output-dir';
+import { ExtraEntryPoint } from '../../utils/third-party/browser/schema';
 
 export interface WebBuildBuilderOptions extends BuildBuilderOptions {
   index: string;
@@ -45,8 +46,8 @@ export interface WebBuildBuilderOptions extends BuildBuilderOptions {
   polyfills?: string;
   es2015Polyfills?: string;
 
-  scripts: string[];
-  styles: string[];
+  scripts: ExtraEntryPoint[];
+  styles: ExtraEntryPoint[];
 
   vendorChunk?: boolean;
   commonChunk?: boolean;

--- a/packages/web/src/builders/build/schema.json
+++ b/packages/web/src/builders/build/schema.json
@@ -104,14 +104,14 @@
       "type": "array",
       "description": "External Scripts which will be included before the main application entry",
       "items": {
-        "type": "string"
+        "$ref": "#/definitions/extraEntryPoint"
       }
     },
     "styles": {
       "type": "array",
       "description": "External Styles which will be included with the application",
       "items": {
-        "type": "string"
+        "$ref": "#/definitions/extraEntryPoint"
       }
     },
     "budgets": {
@@ -325,6 +325,34 @@
       },
       "additionalProperties": false,
       "required": ["type"]
+    },
+    "extraEntryPoint": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "string",
+              "description": "The file to include."
+            },
+            "bundleName": {
+              "type": "string",
+              "description": "The bundle name for this extra entry point."
+            },
+            "inject": {
+              "type": "boolean",
+              "description": "If the bundle will be referenced in the HTML file.",
+              "default": true
+            }
+          },
+          "additionalProperties": false,
+          "required": ["input"]
+        },
+        {
+          "type": "string",
+          "description": "The file to include."
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
ISSUES CLOSED: #3730

## Current Behavior
@nrwl/web schema validation fails when an object with `ExtraEntryPoint` type is given as `scripts` or `styles` option.

## Expected Behavior
`generateEntryPoints` in `packages/web/src/utils/third-party/cli-files/utilities/package-chunk-sort.ts` expects `ExtraEntryPoint` for both and successfully generates entry points when `ExtraEntryPoint` type is given, so the validation should not fail. The type and the schema for `scripts` and `styles` appear to be outdated.

## Related Issue(s)
#3730

Fixes #3730
