### PR TITLE
fix(core): run-commands should fail when a command in serial fails

### DIFF
--- a/e2e/workspace/src/run-commands.test.ts
+++ b/e2e/workspace/src/run-commands.test.ts
@@ -58,4 +58,25 @@ describe('Run Commands', () => {
     expect(result).toContain('print: y');
     done();
   }, 120000);
+
+  it('should fail when a process exits non-zero', () => {
+    newProject();
+    const myapp = uniq('myapp1');
+
+    runCLI(`generate @nrwl/web:app ${myapp}`);
+
+    const config = readJson(workspaceConfigName());
+    config.projects[myapp].targets.error = {
+      executor: '@nrwl/workspace:run-commands',
+      options: {
+        command: `exit 1`,
+      },
+    };
+    updateFile(workspaceConfigName(), JSON.stringify(config));
+
+    try {
+      runCLI('error');
+      fail('Should error if process errors');
+    } catch (e) {}
+  });
 });

--- a/packages/workspace/src/builders/run-commands-v2/run-commands.impl.spec.ts
+++ b/packages/workspace/src/builders/run-commands-v2/run-commands.impl.spec.ts
@@ -177,7 +177,7 @@ describe('Command Runner Builder', () => {
     });
   });
 
-  it('should stop execution when a command fails', async () => {
+  it('should stop execution and fail when a command fails', async () => {
     const f = fileSync().name;
 
     try {
@@ -185,6 +185,7 @@ describe('Command Runner Builder', () => {
         commands: [`echo 1 >> ${f} && exit 1`, `echo 2 >> ${f}`],
         parallel: false,
       });
+      fail('should fail when a command fails');
     } catch (e) {}
     expect(readFile(f)).toEqual('1');
   });

--- a/packages/workspace/src/builders/run-commands-v2/run-commands.impl.ts
+++ b/packages/workspace/src/builders/run-commands-v2/run-commands.impl.ts
@@ -152,9 +152,9 @@ function normalizeOptions(
 }
 
 async function runSerially(options: NormalizedRunCommandsBuilderOptions) {
-  options.commands.forEach((c) => {
+  for (const c of options.commands) {
     createSyncProcess(c.command, options.color, options.cwd);
-  });
+  }
   return true;
 }
 

--- a/packages/workspace/src/builders/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/builders/run-commands/run-commands.impl.ts
@@ -158,9 +158,16 @@ function normalizeOptions(
 }
 
 async function runSerially(options: NormalizedRunCommandsBuilderOptions) {
-  options.commands.forEach((c) => {
-    createSyncProcess(c.command, options.color, options.cwd);
-  });
+  for (const c of options.commands) {
+    try {
+      createSyncProcess(c.command, options.color, options.cwd);
+    } catch (e) {
+      process.stderr.write(
+        `Warning: @nrwl/run-commands command "${c.command}" exited with non-zero status code`
+      );
+      return false;
+    }
+  }
   return true;
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running a target that uses `run-commands` to run commands serially will not error if a command errors.

For example, the Nx build succeeds even when one package fails to build which as a result causes it to be cached as a success.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running a target that uses `run-commands` to run commands serially will error if a command errors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
