### PR TITLE
fix(core): prioritize local projects over npm when sharing names

### DIFF
--- a/packages/workspace/src/core/target-project-locator.spec.ts
+++ b/packages/workspace/src/core/target-project-locator.spec.ts
@@ -37,6 +37,7 @@ describe('findTargetProjectWithImport', () => {
           '@proj/proj123': ['libs/proj123/index.ts'],
           '@proj/proj1234': ['libs/proj1234/index.ts'],
           '@proj/proj1234-child': ['libs/proj1234-child/index.ts'],
+          express: ['libs/express/index.ts'],
         },
       },
     };
@@ -54,6 +55,7 @@ describe('findTargetProjectWithImport', () => {
       './libs/proj123/index.ts': 'export const a = 5',
       './libs/proj1234/index.ts': 'export const a = 6',
       './libs/proj1234-child/index.ts': 'export const a = 7',
+      './libs/express/index.ts': 'export const a = 8',
     };
     vol.fromJSON(fsJson, '/root');
 
@@ -202,6 +204,22 @@ describe('findTargetProjectWithImport', () => {
           files: [],
         },
       },
+      express: {
+        name: 'express',
+        type: 'lib',
+        data: {
+          root: 'libs/express',
+          files: [],
+        },
+      },
+      'npm:express': {
+        name: 'npm:express',
+        type: 'npm',
+        data: {
+          files: [],
+          packageName: 'express',
+        },
+      },
     };
 
     targetProjectLocator = new TargetProjectLocator(projects);
@@ -251,7 +269,7 @@ describe('findTargetProjectWithImport', () => {
     expect(proj3a).toEqual('proj3a');
   });
 
-  it('should be able to npm dependencies', () => {
+  it('should be able to resolve npm dependencies', () => {
     const result1 = targetProjectLocator.findProjectWithImport(
       '@ng/core',
       'libs/proj1/index.ts',
@@ -265,6 +283,16 @@ describe('findTargetProjectWithImport', () => {
 
     expect(result1).toEqual('npm:@ng/core');
     expect(result2).toEqual('npm:npm-package');
+  });
+
+  it('should be able to prioritize local projects over dependencies', () => {
+    const result = targetProjectLocator.findProjectWithImport(
+      'express',
+      'libs/proj1/index.ts',
+      ctx.nxJson.npmScope
+    );
+
+    expect(result).toEqual('express');
   });
 
   it('should be able to resolve a module using a normalized path', () => {

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -64,11 +64,6 @@ export class TargetProjectLocator {
       return this.findProjectOfResolvedModule(resolvedModule);
     }
 
-    const npmProject = this.findNpmPackage(importExpr);
-    if (npmProject) {
-      return npmProject;
-    }
-
     if (this.paths && this.paths[normalizedImportExpr]) {
       for (let p of this.paths[normalizedImportExpr]) {
         const maybeResolvedProject = this.findProjectOfResolvedModule(p);
@@ -95,6 +90,11 @@ export class TargetProjectLocator {
       if (resolvedProject) {
         return resolvedProject;
       }
+    }
+
+    const npmProject = this.findNpmPackage(importExpr);
+    if (npmProject) {
+      return npmProject;
     }
 
     const importedProject = this.sortedWorkspaceProjects.find((p) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When a local project shares a name with an npm dependency, imports to the local project are recognized as imports to the npm dependency.

For example, when `@nrwl/workspace` is imported from within this repo, a dependency to the npm dependency is created. This is improper because when we import from `@nrwl/workspace` in this repo, Typescript actually imports from the local project. As a result, we have `implicitDependencies` to `@nrwl/workspace` when they should be inferrable by Nx.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When a local project shares a name with an npm dependency, imports to the local project are recognized as imports to the local project.

For example, when `@nrwl/workspace` is imported from within this repo, a dependency to the local project should be created. We can remove `implicitDependencies` to `@nrwl/workspace` as Nx should infer them.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
