### PR TITLE
fix(core): validate options for `oneOf` rule with factorized type

### DIFF
--- a/packages/tao/src/shared/params.spec.ts
+++ b/packages/tao/src/shared/params.spec.ts
@@ -473,6 +473,38 @@ describe('params', () => {
       ).not.toThrow();
     });
 
+    it('should handle oneOf with factorized type', () => {
+      expect(() =>
+        validateOptsAgainstSchema(
+          { a: 10 },
+          {
+            properties: {
+              a: {
+                type: 'number',
+                oneOf: [{ multipleOf: 5 }, { multipleOf: 3 }],
+              },
+            },
+          }
+        )
+      ).not.toThrow();
+    });
+
+    it('should handle oneOf properties explicit types', () => {
+      expect(() =>
+        validateOptsAgainstSchema(
+          { a: true },
+          {
+            properties: {
+              a: {
+                type: 'number',
+                oneOf: [{ type: 'string' }, { type: 'boolean' }],
+              },
+            },
+          }
+        )
+      ).not.toThrow();
+    });
+
     it("should throw if the type doesn't match (arrays)", () => {
       expect(() =>
         validateOptsAgainstSchema(

--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -209,7 +209,8 @@ function validateProperty(
     let passes = false;
     schema.oneOf.forEach((r) => {
       try {
-        validateProperty(propName, value, r, definitions);
+        const rule = { type: schema.type, ...r };
+        validateProperty(propName, value, rule, definitions);
         passes = true;
       } catch (e) {}
     });


### PR DESCRIPTION
Fixes #4484
