### PR TITLE
fix(core): update eslintrc when project is moved

### DIFF
--- a/packages/workspace/src/schematics/move/lib/update-eslintrc-json.spec.ts
+++ b/packages/workspace/src/schematics/move/lib/update-eslintrc-json.spec.ts
@@ -1,0 +1,109 @@
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
+import { Tree } from '@angular-devkit/schematics';
+import {
+  callRule,
+  createEmptyWorkspace,
+  runSchematic,
+} from '@nrwl/workspace/testing';
+import { Schema } from '@nrwl/workspace/src/schematics/move/schema';
+import { Linter, readJsonInTree } from '@nrwl/workspace';
+import { updateEslintrcJson } from '@nrwl/workspace/src/schematics/move/lib/update-eslintrc-json';
+
+describe('updateEslint Rule', () => {
+  let tree: UnitTestTree;
+
+  beforeEach(async () => {
+    tree = new UnitTestTree(Tree.empty());
+    tree = createEmptyWorkspace(tree) as UnitTestTree;
+  });
+
+  it('should handle .eslintrc.json not existing', async () => {
+    tree = await runSchematic(
+      'lib',
+      { name: 'my-lib', linter: Linter.TsLint },
+      tree
+    );
+
+    expect(tree.files).not.toContain('/libs/my-destination/.estlintrc.json');
+
+    const schema: Schema = {
+      projectName: 'my-lib',
+      destination: 'my-destination',
+      importPath: undefined,
+      updateImportPath: true,
+    };
+
+    await expect(
+      callRule(updateEslintrcJson(schema), tree)
+    ).resolves.not.toThrow();
+  });
+
+  it('should update .eslintrc.json extends path when project is moved to subdirectory', async () => {
+    const eslintRc = {
+      extends: '../../.eslintrc.json',
+      rules: {},
+      ignorePatterns: ['!**/*'],
+    };
+
+    tree = await runSchematic(
+      'lib',
+      { name: 'my-lib', linter: Linter.EsLint },
+      tree
+    );
+
+    tree.create('/libs/core/my-lib/.eslintrc.json', JSON.stringify(eslintRc));
+
+    expect(tree.files).toContain('/libs/core/my-lib/.eslintrc.json');
+
+    const schema: Schema = {
+      projectName: 'my-lib',
+      destination: 'core/my-lib',
+      importPath: undefined,
+      updateImportPath: true,
+    };
+
+    tree = (await callRule(updateEslintrcJson(schema), tree)) as UnitTestTree;
+
+    expect(readJsonInTree(tree, '/libs/core/my-lib/.eslintrc.json')).toEqual(
+      jasmine.objectContaining({
+        extends: '../../../.eslintrc.json',
+      })
+    );
+  });
+
+  it('should update .eslintrc.json extends path when is renamed', async () => {
+    const eslintRc = {
+      extends: '../../.eslintrc.json',
+      rules: {},
+      ignorePatterns: ['!**/*'],
+    };
+
+    tree = await runSchematic(
+      'lib',
+      { name: 'my-lib', linter: Linter.EsLint },
+      tree
+    );
+
+    tree.create(
+      '/libs/my-destination/.eslintrc.json',
+      JSON.stringify(eslintRc)
+    );
+
+    expect(tree.files).toContain('/libs/my-destination/.eslintrc.json');
+
+    const schema: Schema = {
+      projectName: 'my-lib',
+      destination: 'my-destination',
+      importPath: undefined,
+      updateImportPath: true,
+    };
+
+    tree = (await callRule(updateEslintrcJson(schema), tree)) as UnitTestTree;
+
+    expect(readJsonInTree(tree, '/libs/my-destination/.eslintrc.json')).toEqual(
+      jasmine.objectContaining({
+        extends: '../../.eslintrc.json',
+      })
+    );
+  });
+});

--- a/packages/workspace/src/schematics/move/lib/update-eslintrc-json.ts
+++ b/packages/workspace/src/schematics/move/lib/update-eslintrc-json.ts
@@ -1,0 +1,45 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { Schema } from '../schema';
+import { from, Observable } from 'rxjs';
+import { getWorkspace } from '@nrwl/workspace';
+import { map } from 'rxjs/operators';
+import { join } from 'path';
+import { offsetFromRoot } from '@nrwl/devkit';
+import { getDestination } from '@nrwl/workspace/src/schematics/move/lib/utils';
+
+interface PartialEsLintRcJson {
+  extends: string;
+}
+
+/**
+ * Update the .eslintrc file of the project if it exists.
+ *
+ * @param schema The options provided to the schematic
+ */
+export function updateEslintrcJson(schema: Schema): Rule {
+  return (tree: Tree, _context: SchematicContext): Observable<Tree> => {
+    return from(getWorkspace(tree)).pipe(
+      map((workspace) => {
+        const destination = getDestination(schema, workspace, tree);
+        const eslintRcPath = join(destination, '.eslintrc.json');
+
+        if (!tree.exists(eslintRcPath)) {
+          // no .eslintrc found. nothing to do
+          return tree;
+        }
+
+        const eslintRcJson = JSON.parse(
+          tree.read(eslintRcPath).toString('utf-8')
+        ) as PartialEsLintRcJson;
+
+        const offset = offsetFromRoot(destination);
+
+        eslintRcJson.extends = offset + '.eslintrc.json';
+
+        tree.overwrite(eslintRcPath, JSON.stringify(eslintRcJson));
+
+        return tree;
+      })
+    );
+  };
+}

--- a/packages/workspace/src/schematics/move/move.ts
+++ b/packages/workspace/src/schematics/move/move.ts
@@ -11,6 +11,7 @@ import { updateProjectRootFiles } from './lib/update-project-root-files';
 import { updateWorkspace } from './lib/update-workspace';
 import { Schema } from './schema';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
+import { updateEslintrcJson } from './lib/update-eslintrc-json';
 
 export default function (schema: Schema): Rule {
   return chain([
@@ -23,6 +24,7 @@ export default function (schema: Schema): Rule {
     updateStorybookConfig(schema),
     updateNxJson(schema),
     updateImports(schema),
+    updateEslintrcJson(schema),
     updateWorkspace(schema), // Have to do this last because all previous rules need the information in here
   ]);
 }


### PR DESCRIPTION
## Current Behavior
eslintrc.json is not updated when using the move schematic

## Expected Behavior
eslintrc.json is updated when using the move schematic

## Related Issue(s)
ISSUES CLOSED: #2951

