### PR TITLE
fix(nx-plugin): fix executors typo in plugin template file

### DIFF
--- a/packages/nx-plugin/src/schematics/plugin/files/plugin/executors.json__tmpl__
+++ b/packages/nx-plugin/src/schematics/plugin/files/plugin/executors.json__tmpl__
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "generators": {}
+  "executors": {}
 }


### PR DESCRIPTION
## Current Behavior

When an Nx plugin is generated, the resulting `executors.json` contains an empty `generators` object that should be `executors`.

## Expected Behavior

The generated `executors.json` contains an empty `executors` object.
