### PR TITLE
fix(linter): allow turning off enforce-module-boundaries rule for files that match a file pattern

### DIFF
--- a/packages/workspace/src/core/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
@@ -14,7 +14,6 @@ import { buildExplicitTypeScriptDependencies } from './explicit-project-dependen
 import { createFileMap } from '../../file-graph';
 import { readWorkspaceFiles } from '../../file-utils';
 import { appRootPath } from '../../../utilities/app-root';
-import { string } from 'prop-types';
 
 describe('explicit project dependencies', () => {
   let ctx: ProjectGraphContext;
@@ -83,6 +82,32 @@ describe('explicit project dependencies', () => {
         import { a } from '@proj/proj1234-child'
       `,
       './libs/proj1234-child/index.ts': 'export const a = 7',
+      './libs/proj1234/a.b.ts': `// nx-ignore-next-line
+                                 import('@proj/proj2')
+                                 /* nx-ignore-next-line */
+                                 import {a} from '@proj/proj3a
+      `,
+      './libs/proj1234/b.c.ts': `// nx-ignore-next-line
+                                 require('@proj/proj4ab#a')
+                                 // nx-ignore-next-line
+                                 import('@proj/proj2')
+                                 /* nx-ignore-next-line */
+                                 import {a} from '@proj/proj3a
+                                 const a = { 
+                                     // nx-ignore-next-line
+                                    loadChildren: '@proj/3a'
+                                 }
+                                 const b = {
+                                    // nx-ignore-next-line
+                                    loadChildren: '@proj/3a',
+                                    children: [{
+                                      // nx-ignore-next-line
+                                      loadChildren: '@proj/proj2,
+                                      // nx-ignore-next-line
+                                      loadChildren: '@proj/proj3a'
+                                    }]
+                                 }
+      `,
     };
     vol.fromJSON(fsJson, '/root');
 

--- a/packages/workspace/src/utilities/strip-source-code.spec.ts
+++ b/packages/workspace/src/utilities/strip-source-code.spec.ts
@@ -1,4 +1,3 @@
-import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import { stripSourceCode } from './strip-source-code';
 import { createScanner, ScriptTarget, Scanner } from 'typescript';
 
@@ -63,6 +62,22 @@ export { C as D } from './c'`;
     expect(stripSourceCode(scanner, input)).toEqual(expected);
   });
 
+  it('should work on dependencies made with the require keyword', () => {
+    const input = `require('./a');
+      
+      require('./b');
+      const c = require('./c');
+
+      const a = 1;
+      export class App {}
+    `;
+    const expected = `require('./a')
+require('./b')
+require('./c')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
   it('should not strip files containing "loadChildren"', () => {
     const input = `const routes = [
       {
@@ -71,5 +86,159 @@ export { C as D } from './c'`;
       }
     ];`;
     expect(stripSourceCode(scanner, input)).toEqual(input);
+  });
+
+  it('should strip static imports that have nx-ignore-next-line comment above them', () => {
+    const input = `
+      // nx-ignore-next-line
+      import * as React from "react";
+      import { Component } from "react";
+      import {
+        Component
+      } from "react"
+      import {
+        Component
+      } from "react";
+      
+      // nx-ignore-next-line
+      import "./app.scss";
+
+      import('./module.ts')
+
+      const a = 1;
+      export class App {}
+    `;
+    const expected = `import { Component } from "react"
+import {
+        Component
+      } from "react"
+import {
+        Component
+      } from "react"
+import('./module.ts')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should strip dynamic imports that have nx-ignore-next-line comment above them', () => {
+    const input = `
+      import * as React from "react";
+      import { Component } from "react";
+      import {
+        Component
+      } from "react"
+      import {
+        Component
+      } from "react";
+      
+      import "./app.scss";
+      // nx-ignore-next-line
+      import('./module.ts')
+
+      const a = 1;
+      export class App {}
+    `;
+    const expected = `import * as React from "react"
+import { Component } from "react"
+import {
+        Component
+      } from "react"
+import {
+        Component
+      } from "react"
+import "./app.scss"`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should strip exports that have nx-ignore-next-line comment above them', () => {
+    const input = `export * from './module';
+      export {
+        A
+      } from './a';
+
+      // nx-ignore-next-line
+      export { B } from './b';
+
+      export { C as D } from './c';
+
+      const a = 1;
+      export class App {}
+    `;
+    const expected = `export * from './module'
+export {
+        A
+      } from './a'
+export { C as D } from './c'`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should strip dependencies made with the require keyword that have nx-ignore-next-line above them', () => {
+    const input = `require('./a');
+      // nx-ignore-next-line
+      require('./b');
+      const c = require('./c');
+
+      const a = 1;
+      export class App {}
+    `;
+    const expected = `require('./a')
+require('./c')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should not strip an import if the next line of code after an nx-ignore-next-line comment is not an import', () => {
+    const input = `
+      // nx-ignore-next-line
+      const a = 1;
+      import('./module.ts')
+
+      export class App {}
+    `;
+    const expected = `import('./module.ts')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should not strip an export if the next line of code after an nx-ignore-next-line comment is not an export', () => {
+    const input = `export * from './module';
+      export {
+        A
+      } from './a';
+
+      // nx-ignore-next-line
+      const a = 1;
+      export { B } from './b';
+
+      export { C as D } from './c';
+
+      export class App {}
+    `;
+    const expected = `export * from './module'
+export {
+        A
+      } from './a'
+export { B } from './b'
+export { C as D } from './c'`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should not strip a dependency made with the require keyword if the next line of code after an nx-ignore-next-line comment is not a require keyword', () => {
+    const input = `require('./a');
+      // nx-ignore-next-line
+      const a = 1;
+      require('./b');
+      const c = require('./c');
+
+      export class App {}
+    `;
+    const expected = `require('./a')
+require('./b')
+require('./c')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
   });
 });

--- a/packages/workspace/src/utilities/strip-source-code.ts
+++ b/packages/workspace/src/utilities/strip-source-code.ts
@@ -4,17 +4,16 @@ export function stripSourceCode(scanner: Scanner, contents: string): string {
   if (contents.indexOf('loadChildren') > -1) {
     return contents;
   }
-  if (contents.indexOf('require') > -1) {
-    return contents;
-  }
 
   scanner.setText(contents);
   let token = scanner.scan();
   const statements = [];
   let start = null;
+  let ignoreNextLine = false;
   while (token !== SyntaxKind.EndOfFileToken) {
     const potentialStart = scanner.getStartPos();
     switch (token) {
+      case SyntaxKind.RequireKeyword:
       case SyntaxKind.ImportKeyword: {
         token = scanner.scan();
         while (
@@ -23,7 +22,38 @@ export function stripSourceCode(scanner: Scanner, contents: string): string {
         ) {
           token = scanner.scan();
         }
-        start = potentialStart;
+        if (!ignoreNextLine) {
+          start = potentialStart;
+        } else {
+          ignoreNextLine = false;
+        }
+        break;
+      }
+
+      case SyntaxKind.MultiLineCommentTrivia:
+      case SyntaxKind.SingleLineCommentTrivia: {
+        const isMultiLineCommentTrivia =
+          token === SyntaxKind.MultiLineCommentTrivia;
+        const start = potentialStart + 2;
+        token = scanner.scan();
+        const end = scanner.getStartPos() - (isMultiLineCommentTrivia ? 2 : 0);
+        const comment = contents.substring(start, end).trim();
+        if (comment === 'nx-ignore-next-line') {
+          ignoreNextLine = true;
+        }
+        while (
+          token === SyntaxKind.WhitespaceTrivia ||
+          token === SyntaxKind.NewLineTrivia
+        ) {
+          token = scanner.scan();
+        }
+        if (
+          token !== SyntaxKind.ImportKeyword &&
+          token !== SyntaxKind.RequireKeyword &&
+          token !== SyntaxKind.ExportKeyword
+        ) {
+          ignoreNextLine = false;
+        }
         break;
       }
 
@@ -39,7 +69,11 @@ export function stripSourceCode(scanner: Scanner, contents: string): string {
           token === SyntaxKind.OpenBraceToken ||
           token === SyntaxKind.AsteriskToken
         ) {
-          start = potentialStart;
+          if (!ignoreNextLine) {
+            start = potentialStart;
+          } else {
+            ignoreNextLine = false;
+          }
         }
         break;
       }


### PR DESCRIPTION
Allow turning off enforce-module-boundaries rule for files that match a file pattern

When creating overrides in an eslintrc file to turn off enforce-module-boundaries rule for a set of files that match a file pattern, the circular dependency rule fails because when the rule determines dependency between projects, it does not exclude the dependencies of files that we do not want to be linted. An option called 'AllowFilePatterns' is added to the linting rule that allows for one to omit a set of files from being linted by the rule. The reason for adding this option is because eslint does not provide a way for a linting rule to know what files the rule should not be applied to.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Creating overrides in your eslintrc file to turn off enforce-module-boundaries for files that match a set of file patterns does not work as expected. 

Suppose library A has a `.special.ts` file and this file imports a file from library B. However, library A is not allowed to import from library B according to the dependency constraints defined in the .eslintrc.json file. However, we want `.special.ts` files to import anything from library B. So we can create an override in the our `eslintrc.json` file that turns off linting of the enforce-module-boundaries rule for `.special.ts` files.
```
{
  "files": ["*.special.ts"],
  "rules": {
    "@nrwl/nx/enforce-module-boundaries": "off"
  }
}
```
However, the problem is that other files in library A and B will end up having a circular dependency error when we lint the project `ng lint libraryA`. This is because when determining if a circular dependency exists, a dependency graph is built and used to determine if the 2 projects have a circular dependency. This dependency graph does does not omit the dependencies of `.special.ts` files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The expected behavior is to turn off enforce-module-boundaries rule for a set of files that match a file pattern.


Fixes #
Added an option called 'allowFilePatterns' that is is used to when determining the explicit dependencies of a project. This extra option was needed because I don't believe it's possible for a linting rule to know what files it's not allowed to lint. Your eslint file ends up looking like this:
```
{
  "root": true,
  "ignorePatterns": ["**/*"],
  "plugins": ["@nrwl/nx"],
  "overrides": [
        {
            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
            "rules": {
                "@nrwl/nx/enforce-module-boundaries": [
                    "error",
                    {
                        "enforceBuildableLibDependency": true,
                        "allow": ["@my-app/shared/testing"],
                        "allowFilePatterns": ["*.special.ts"], // new option
                        "depConstraints": [
                            {
                                "sourceTag": "scope:scope-ba",
                                "onlyDependOnLibsWithTags": [
                                "scope:scopa-a",
                                ]
                            },
                            {
                                "sourceTag": "scope:scope-b",
                                "onlyDependOnLibsWithTags": [
                                "scope:scope-b"
                                ]
                            }
                        ]
                    }
                ]
            }
        },
        {
            "files": ["*.special.ts"],
            "rules": {
                "@nrwl/nx/enforce-module-boundaries": "off"
            }
        }
    ]
}
```

Let me know your thoughts on this. It would be awesome to have this ability to turn off the enforce-module-boundaries rule.