### PR TITLE
Fix `buildableProjectDepsInPackageJsonType` ignored in @nrwl/angular:package builder

### DIFF
--- a/packages/angular/src/builders/package/package.impl.ts
+++ b/packages/angular/src/builders/package/package.impl.ts
@@ -90,7 +90,8 @@ export function createLibraryBuilder(
                 updateBuildableProjectPackageJsonDependencies(
                   context,
                   target,
-                  dependencies
+                  dependencies,
+                  options.buildableProjectDepsInPackageJsonType || 'dependencies'
                 );
               }
             }),


### PR DESCRIPTION
The option is said to be available, but it is not actually used. This commit properly utilizes the option.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `buildableProjectDepsInPackageJsonType` is ignored in the @nrwl/angular:package builder. Setting it to the non-default `peerDependencies` has no effect.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `buildableProjectDepsInPackageJsonType` should be honored in the @nrwl/angular:package builder. Setting it to the non-default `peerDependencies` should add buildable dependencies to the `peerDependencies` of the `package.json` file for the packaged library.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
