### PR TITLE
fix(core): eslint workspaces should not contain codelyzer

### DIFF
--- a/packages/angular/src/schematics/init/init.spec.ts
+++ b/packages/angular/src/schematics/init/init.spec.ts
@@ -28,7 +28,9 @@ describe('init', () => {
     expect(devDependencies['@angular/compiler-cli']).toBeDefined();
     expect(devDependencies['@angular/language-service']).toBeDefined();
     expect(devDependencies['@angular-devkit/build-angular']).toBeDefined();
-    expect(devDependencies['codelyzer']).toBeDefined();
+
+    // codelyzer should no longer be there by default
+    expect(devDependencies['codelyzer']).toBeUndefined();
   });
 
   it('should add a postinstall script for ngcc', async () => {
@@ -204,6 +206,22 @@ describe('init', () => {
         expect(schematics['@nrwl/angular:application'].e2eTestRunner).toEqual(
           'protractor'
         );
+      });
+    });
+  });
+
+  describe('--linter', () => {
+    describe('tslint', () => {
+      it('should add codelyzer', async () => {
+        const tree = await runSchematic(
+          'init',
+          {
+            linter: 'tslint',
+          },
+          appTree
+        );
+        const { devDependencies } = readJsonInTree(tree, 'package.json');
+        expect(devDependencies['codelyzer']).toBeDefined();
       });
     });
   });

--- a/packages/angular/src/schematics/init/init.ts
+++ b/packages/angular/src/schematics/init/init.ts
@@ -13,6 +13,7 @@ import {
   setDefaultCollection,
   updateJsonInTree,
   updateWorkspace,
+  Linter,
 } from '@nrwl/workspace';
 import {
   angularDevkitVersion,
@@ -22,29 +23,29 @@ import {
 } from '../../utils/versions';
 import { Schema } from './schema';
 import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
-import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 
-const updateDependencies = addDepsToPackageJson(
-  {
-    '@angular/animations': angularVersion,
-    '@angular/common': angularVersion,
-    '@angular/compiler': angularVersion,
-    '@angular/core': angularVersion,
-    '@angular/forms': angularVersion,
-    '@angular/platform-browser': angularVersion,
-    '@angular/platform-browser-dynamic': angularVersion,
-    '@angular/router': angularVersion,
-    rxjs: rxjsVersion,
-    tslib: '^2.0.0',
-    'zone.js': '^0.10.2',
-  },
-  {
-    '@angular/compiler-cli': angularVersion,
-    '@angular/language-service': angularVersion,
-    '@angular-devkit/build-angular': angularDevkitVersion,
-    codelyzer: '^6.0.0',
-  }
-);
+const updateDependencies = (options: Pick<Schema, 'linter'>): Rule =>
+  addDepsToPackageJson(
+    {
+      '@angular/animations': angularVersion,
+      '@angular/common': angularVersion,
+      '@angular/compiler': angularVersion,
+      '@angular/core': angularVersion,
+      '@angular/forms': angularVersion,
+      '@angular/platform-browser': angularVersion,
+      '@angular/platform-browser-dynamic': angularVersion,
+      '@angular/router': angularVersion,
+      rxjs: rxjsVersion,
+      tslib: '^2.0.0',
+      'zone.js': '^0.10.2',
+    },
+    {
+      '@angular/compiler-cli': angularVersion,
+      '@angular/language-service': angularVersion,
+      '@angular-devkit/build-angular': angularDevkitVersion,
+      codelyzer: options.linter === Linter.TsLint ? '^6.0.0' : undefined,
+    }
+  );
 
 export function addUnitTestRunner(
   options: Pick<Schema, 'unitTestRunner'>
@@ -168,7 +169,7 @@ export default function (options: Schema): Rule {
     setDefaults(options),
     // TODO: Remove this when ngcc can be run in parallel
     addPostinstall(),
-    updateDependencies,
+    updateDependencies(options),
     addUnitTestRunner(options),
     addE2eTestRunner(options),
     formatFiles(),

--- a/packages/angular/src/schematics/init/schema.d.ts
+++ b/packages/angular/src/schematics/init/schema.d.ts
@@ -1,8 +1,11 @@
 import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
+import { Linter } from '@nrwl/workspace';
+
 export interface Schema {
   unitTestRunner: UnitTestRunner;
   e2eTestRunner?: E2eTestRunner;
   skipFormat: boolean;
   skipInstall?: boolean;
   style?: string;
+  linter: Linter;
 }

--- a/packages/angular/src/schematics/init/schema.json
+++ b/packages/angular/src/schematics/init/schema.json
@@ -26,6 +26,12 @@
       "description": "Skip formatting files",
       "type": "boolean",
       "default": false
+    },
+    "linter": {
+      "description": "The tool to use for running lint checks.",
+      "type": "string",
+      "enum": ["tslint", "eslint"],
+      "default": "eslint"
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Codelyzer is present in the user's package.json even if they choose eslint when using a preset during workspace creation.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Codelyzer is not present in the user's package.json when choosing eslint when using a preset during workspace creation.

If the user chooses an Angular + TSLint combo for a later project within in the workspace that started life as ESLint-only, the generators will add codelyzer back in, so this change should not preclude that (rare) use-case.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4017
