### PR TITLE
fix(core): don't allow `pnpm` to install with frozen lockfile on CI

### DIFF
--- a/packages/tao/src/shared/package-manager.ts
+++ b/packages/tao/src/shared/package-manager.ts
@@ -32,7 +32,7 @@ export function getPackageManagerCommand(
 
     case 'pnpm':
       return {
-        install: 'pnpm install',
+        install: 'pnpm install --no-frozen-lockfile', // explicitly disable in case of CI
         add: 'pnpm add',
         addDev: 'pnpm add -D',
         rm: 'pnpm rm',


### PR DESCRIPTION
In our tool, package manager installation is usually called after "manual" update of `package.json`. In such cases, using a frozen lockfile is not desired. This commit disables PNPM's default behavior of using `--frozen-lockfile` flag when running on CI.

Closes #4495