### PR TITLE
fix(angular): support maxParallel, parallel, and withDeps options in webpack-browser schema

### DIFF
--- a/docs/angular/api-angular/executors/webpack-browser.md
+++ b/docs/angular/api-angular/executors/webpack-browser.md
@@ -166,6 +166,12 @@ Type: `string`
 
 The full path for the main entry point to the app, relative to the current workspace.
 
+### maxParallel
+
+Type: `number`
+
+Max number of parallel jobs
+
 ### namedChunks
 
 Default: `true`
@@ -205,6 +211,14 @@ Type: `string`
             The full path for the new output directory, relative to the current workspace.
 
 By default, writes output to a folder named dist/ in the current project.
+
+### parallel
+
+Default: `true`
+
+Type: `boolean`
+
+Build the target in parallel
 
 ### poll
 
@@ -323,3 +337,11 @@ Run build when files change.
 Type: `string`
 
 TypeScript configuration for Web Worker modules.
+
+### withDeps
+
+Default: `true`
+
+Type: `boolean`
+
+Build the target and all its deps

--- a/docs/angular/guides/setup-incremental-builds.md
+++ b/docs/angular/guides/setup-incremental-builds.md
@@ -83,7 +83,11 @@ Note: you can specify the `--with-deps` and `--parallel` flags as part of the op
     "architect": {
         "build": {
             "builder": "@nrwl/angular:webpack-browser",
-            "options": { ... }
+            "options": {
+                "withDeps": true,
+                "parallel": true
+                ...
+            },
             "configurations": { ... }
         },
         "serve": {

--- a/docs/node/api-angular/executors/webpack-browser.md
+++ b/docs/node/api-angular/executors/webpack-browser.md
@@ -167,6 +167,12 @@ Type: `string`
 
 The full path for the main entry point to the app, relative to the current workspace.
 
+### maxParallel
+
+Type: `number`
+
+Max number of parallel jobs
+
 ### namedChunks
 
 Default: `true`
@@ -206,6 +212,14 @@ Type: `string`
             The full path for the new output directory, relative to the current workspace.
 
 By default, writes output to a folder named dist/ in the current project.
+
+### parallel
+
+Default: `true`
+
+Type: `boolean`
+
+Build the target in parallel
 
 ### poll
 
@@ -324,3 +338,11 @@ Run build when files change.
 Type: `string`
 
 TypeScript configuration for Web Worker modules.
+
+### withDeps
+
+Default: `true`
+
+Type: `boolean`
+
+Build the target and all its deps

--- a/docs/react/api-angular/executors/webpack-browser.md
+++ b/docs/react/api-angular/executors/webpack-browser.md
@@ -167,6 +167,12 @@ Type: `string`
 
 The full path for the main entry point to the app, relative to the current workspace.
 
+### maxParallel
+
+Type: `number`
+
+Max number of parallel jobs
+
 ### namedChunks
 
 Default: `true`
@@ -206,6 +212,14 @@ Type: `string`
             The full path for the new output directory, relative to the current workspace.
 
 By default, writes output to a folder named dist/ in the current project.
+
+### parallel
+
+Default: `true`
+
+Type: `boolean`
+
+Build the target in parallel
 
 ### poll
 
@@ -324,3 +338,11 @@ Run build when files change.
 Type: `string`
 
 TypeScript configuration for Web Worker modules.
+
+### withDeps
+
+Default: `true`
+
+Type: `boolean`
+
+Build the target and all its deps

--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -344,6 +344,20 @@
         "type": "string"
       },
       "default": []
+    },
+    "withDeps": {
+      "type": "boolean",
+      "description": "Build the target and all its deps",
+      "default": true
+    },
+    "parallel": {
+      "type": "boolean",
+      "description": "Build the target in parallel",
+      "default": true
+    },
+    "maxParallel": {
+      "type": "number",
+      "description": "Max number of parallel jobs"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `withDeps` option is required for incremental build when using the `@nrwl/angular:webpack-browser` executor as briefly mentioned in [Setup incremental builds for Angular applications > Running and serving incremental builds](https://nx.dev/latest/angular/guides/ci/setup-incremental-builds-angular).

This guide also mentions that we can configure `withDeps` and `parallel` in the options of the incremental `serve` target of our workspace configuration. It doesn't mention this for the `build` target.

However, the `maxParallel`, `parallel`, or `withDeps` options are not declared in the executor schema or its documentation.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Seeing as `withDeps` is required for the incremental `build` target to work, we should add support for the `maxParallel`, `parallel`, and `withDeps` options in the schema of `@nrwl/angular:webpack-browser`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

## Other information
We're building an Nx plugin to convert an application and its library dependencies to use incremental build and this is blocking us from implementing it for the best end-developer experience.

See https://github.com/nx-worker/nxworker/pull/5.