### PR TITLE
feat(core): add an option to run-many by tags

### DIFF
--- a/docs/angular/cli/run-many.md
+++ b/docs/angular/cli/run-many.md
@@ -36,6 +36,12 @@ Build proj1 and proj2 and all their dependencies.:
 nx run-many --target=test --projects=proj1,proj2 --with-deps
 ```
 
+Test all projects that are tagged with foo or bar.:
+
+```bash
+nx run-many --target=test --tags=foo,bar
+```
+
 ## Options
 
 ### all
@@ -77,6 +83,10 @@ Override the tasks runner in `nx.json`
 Default: `false`
 
 Rerun the tasks even when the results are available in the cache
+
+### tags
+
+Run projects having any of the given tags (comma delimited)
 
 ### target
 

--- a/docs/node/cli/run-many.md
+++ b/docs/node/cli/run-many.md
@@ -36,6 +36,12 @@ Build proj1 and proj2 and all their dependencies.:
 nx run-many --target=test --projects=proj1,proj2 --with-deps
 ```
 
+Test all projects that are tagged with foo or bar.:
+
+```bash
+nx run-many --target=test --tags=foo,bar
+```
+
 ## Options
 
 ### all
@@ -77,6 +83,10 @@ Override the tasks runner in `nx.json`
 Default: `false`
 
 Rerun the tasks even when the results are available in the cache
+
+### tags
+
+Run projects having any of the given tags (comma delimited)
 
 ### target
 

--- a/docs/react/cli/run-many.md
+++ b/docs/react/cli/run-many.md
@@ -36,6 +36,12 @@ Build proj1 and proj2 and all their dependencies.:
 nx run-many --target=test --projects=proj1,proj2 --with-deps
 ```
 
+Test all projects that are tagged with foo or bar.:
+
+```bash
+nx run-many --target=test --tags=foo,bar
+```
+
 ## Options
 
 ### all
@@ -77,6 +83,10 @@ Override the tasks runner in `nx.json`
 Default: `false`
 
 Rerun the tasks even when the results are available in the cache
+
+### tags
+
+Run projects having any of the given tags (comma delimited)
 
 ### target
 

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -320,15 +320,21 @@ function withRunManyOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'Projects to run (comma delimited)',
       type: 'string',
     })
+    .option('tags', {
+      describe: 'Run projects having any of the given tags (comma delimited)',
+      type: 'string',
+    })
     .option('all', {
       describe: 'Run the target on all projects in the workspace',
       type: 'boolean',
       default: undefined,
     })
-    .check(({ all, projects }) => {
-      if ((all && projects) || (!all && !projects))
-        throw new Error('You must provide either --all or --projects');
-      return true;
+    .check(({ all, projects, tags }) => {
+      const suppliedArgs = +!!all + +!!projects + +!!tags;
+      if (suppliedArgs === 1) {
+        return true;
+      }
+      throw new Error('You must provide either --all or --projects or --tags');
     })
     .options('runner', {
       describe: 'Override the tasks runner in `nx.json`',

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -21,7 +21,7 @@ const runOne = [
   'scan',
 ];
 
-const runMany = [...runOne, 'projects', 'quiet', 'all', 'verbose'];
+const runMany = [...runOne, 'projects', 'tags', 'quiet', 'all', 'verbose'];
 
 const runAffected = [
   ...runOne,
@@ -65,6 +65,7 @@ export interface NxArgs {
   withDeps?: boolean;
   'with-deps'?: boolean;
   projects?: string[];
+  tags?: string[];
   select?: string;
   skipNxCache?: boolean;
   'skip-nx-cache'?: boolean;
@@ -99,6 +100,13 @@ export function splitArgsIntoNxArgsAndOverrides(
       nxArgs.projects = [];
     } else {
       nxArgs.projects = (args.projects as string)
+        .split(',')
+        .map((p: string) => p.trim());
+    }
+    if (!nxArgs.tags) {
+      nxArgs.tags = [];
+    } else {
+      nxArgs.tags = (args.tags as string)
         .split(',')
         .map((p: string) => p.trim());
     }

--- a/scripts/documentation/generate-cli-data.ts
+++ b/scripts/documentation/generate-cli-data.ts
@@ -348,6 +348,10 @@ const examples = {
       command: 'run-many --target=test --projects=proj1,proj2 --with-deps',
       description: 'Build proj1 and proj2 and all their dependencies.',
     },
+    {
+      command: 'run-many --target=test --tags=foo,bar',
+      description: 'Test all projects that are tagged with foo or bar.',
+    },
   ],
   migrate: [
     {


### PR DESCRIPTION
`nx run-many --target=deploy --tags=foo` runs the given target for all
projects that have a tag `foo` configured in nx.json.

Closes #2675.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
```
nx run-many --target=build --all
``` 
and
```
nx run-many --target=build --projects=p1,p2
```

are supported with `nx run-many`.

## Expected Behavior
Add a --tags option (mutually exclusive with --all and --projects) that allows to target projects by tags as configured in nx.json. E.g.:

```
nx run-many --target=deploy --tags=tag1,tag2
```

Would run `build` for any project tagged with tag1 or tag2.


