### PR TITLE
fix(core): refactor reading schema to return impl factories

### DIFF
--- a/packages/tao/src/commands/generate.ts
+++ b/packages/tao/src/commands/generate.ts
@@ -166,7 +166,7 @@ export async function taoNew(cwd: string, args: string[], isVerbose = false) {
     const {
       normalizedGeneratorName,
       schema,
-      implementation,
+      implementationFactory,
     } = ws.readGenerator(opts.collectionName, opts.generatorName);
 
     const combinedOpts = await combineOptionsForGenerator(
@@ -182,6 +182,7 @@ export async function taoNew(cwd: string, args: string[], isVerbose = false) {
 
     if (ws.isNxGenerator(opts.collectionName, normalizedGeneratorName)) {
       const host = new FsTree(cwd, isVerbose);
+      const implementation = implementationFactory();
       const task = await implementation(host, combinedOpts);
       const changes = host.listChanges();
 
@@ -226,7 +227,7 @@ export async function generate(
     const {
       normalizedGeneratorName,
       schema,
-      implementation,
+      implementationFactory,
     } = ws.readGenerator(opts.collectionName, opts.generatorName);
 
     if (opts.help) {
@@ -246,6 +247,7 @@ export async function generate(
 
     if (ws.isNxGenerator(opts.collectionName, normalizedGeneratorName)) {
       const host = new FsTree(root, isVerbose);
+      const implementation = implementationFactory();
       const task = await implementation(host, combinedOpts);
       const changes = host.listChanges();
 

--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -183,7 +183,10 @@ async function runExecutorInternal<T extends { success: boolean }>(
   const ws = new Workspaces(root);
   const targetConfig = workspace.projects[project].targets[target];
   const [nodeModule, executor] = targetConfig.executor.split(':');
-  const { schema, implementation } = ws.readExecutor(nodeModule, executor);
+  const { schema, implementationFactory } = ws.readExecutor(
+    nodeModule,
+    executor
+  );
 
   if (printHelp) {
     printRunHelp({ project, target }, schema);
@@ -200,6 +203,7 @@ async function runExecutorInternal<T extends { success: boolean }>(
   );
 
   if (ws.isNxExecutor(nodeModule, executor)) {
+    const implementation = implementationFactory();
     const r = implementation(combinedOptions, {
       root: root,
       target: targetConfig,

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -238,7 +238,7 @@ export class Workspaces {
   readExecutor(
     nodeModule: string,
     executor: string
-  ): { schema: any; implementation: Executor } {
+  ): { schema: any; implementationFactory: () => Executor } {
     try {
       const { executorsFilePath, executorConfig } = this.readExecutorsJson(
         nodeModule,
@@ -253,9 +253,11 @@ export class Workspaces {
         schema.properties = {};
       }
       const [modulePath, exportName] = executorConfig.implementation.split('#');
-      const module = require(path.join(executorsDir, modulePath));
-      const implementation = module[exportName || 'default'] as Executor;
-      return { schema, implementation };
+      const implementationFactory = () => {
+        const module = require(path.join(executorsDir, modulePath));
+        return module[exportName || 'default'] as Executor;
+      };
+      return { schema, implementationFactory };
     } catch (e) {
       throw new Error(
         `Unable to resolve ${nodeModule}:${executor}.\n${e.message}`
@@ -285,9 +287,11 @@ export class Workspaces {
       const [modulePath, exportName] = generatorConfig.implementation.split(
         '#'
       );
-      const module = require(path.join(generatorsDir, modulePath));
-      const implementation = module[exportName || 'default'] as Generator;
-      return { normalizedGeneratorName, schema, implementation };
+      const implementationFactory = () => {
+        const module = require(path.join(generatorsDir, modulePath));
+        return module[exportName || 'default'] as Generator;
+      };
+      return { normalizedGeneratorName, schema, implementationFactory };
     } catch (e) {
       throw new Error(
         `Unable to resolve ${collectionName}:${generatorName}.\n${e.message}`


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The implementation for executors and generators are being required when reading the schema earlier than expected. As a result, `.env` files are not processed as expected.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Reading executors and generators will return an implementation factory which won't require in the implementation until necessary. As ar result, `.env` files will be processed as expected.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
