### PR TITLE
fix(core): wrap cache read to try/catch

### DIFF
--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
@@ -55,7 +55,17 @@ export function readCache(): false | ProjectGraphCache {
     }
   }
 
-  const data = fileExists(nxDepsPath) ? readJsonFile(nxDepsPath) : null;
+  let data = null;
+  try {
+    if (fileExists(nxDepsPath)) {
+      data = readJsonFile(nxDepsPath);
+    }
+  } catch (error) {
+    console.log(
+      `Error reading cache file: ${nxDepsPath}. Process will continue as if cache would not exists.`
+    );
+    console.log(error);
+  }
 
   performance.mark('read cache:end');
   performance.measure('read cache', 'read cache:start', 'read cache:end');


### PR DESCRIPTION
## Current Behavior
Failure to read cache corrupts whole run. This happens often in CI with mounted cache volumes as discussed in #4470.

## Expected Behavior
Instead of failure in cache read return `false` allowing the process to proceed as if cache was not found.

## Related Issue(s)

Part of #4470
