### PR TITLE
fix(misc): fix removing the last project in the jest config

### DIFF
--- a/packages/workspace/src/schematics/remove/lib/__snapshots__/update-jest-config.spec.ts.snap
+++ b/packages/workspace/src/schematics/remove/lib/__snapshots__/update-jest-config.spec.ts.snap
@@ -17,7 +17,17 @@ exports[`updateRootJestConfig should delete lib project ref from root jest confi
   projects: [
     '<rootDir>/apps/my-app/',
     '<rootDir>/apps/my-other-app',
-     '<rootDir>/libs/my-other-lib/',
+    '<rootDir>/libs/my-other-lib/',
+  ],
+};
+"
+`;
+
+exports[`updateRootJestConfig should delete lib project ref from root jest config 3`] = `
+"module.exports = {
+  projects: [
+    '<rootDir>/apps/my-app/',
+    '<rootDir>/apps/my-other-app',
   ],
 };
 "

--- a/packages/workspace/src/schematics/remove/lib/update-jest-config.spec.ts
+++ b/packages/workspace/src/schematics/remove/lib/update-jest-config.spec.ts
@@ -1,4 +1,4 @@
-import { Tree } from '@nrwl/devkit';
+import { readProjectConfiguration, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
 import { readFileSync } from 'fs';
@@ -24,6 +24,9 @@ describe('updateRootJestConfig', () => {
     await libraryGenerator(tree, {
       name: 'my-lib',
     });
+    await libraryGenerator(tree, {
+      name: 'my-other-lib',
+    });
 
     tree.write(
       'jest.config.js',
@@ -36,10 +39,20 @@ describe('updateRootJestConfig', () => {
 
     expect(jestConfig).toMatchSnapshot();
 
-    updateJestConfig(tree, schema);
+    updateJestConfig(tree, schema, readProjectConfiguration(tree, 'my-lib'));
 
     const updatedJestConfig = tree.read('jest.config.js').toString();
 
     expect(updatedJestConfig).toMatchSnapshot();
+
+    updateJestConfig(
+      tree,
+      { ...schema, projectName: 'my-other-lib' },
+      readProjectConfiguration(tree, 'my-other-lib')
+    );
+
+    const updatedJestConfig2 = tree.read('jest.config.js').toString();
+
+    expect(updatedJestConfig2).toMatchSnapshot();
   });
 });

--- a/packages/workspace/src/schematics/remove/remove.ts
+++ b/packages/workspace/src/schematics/remove/remove.ts
@@ -20,7 +20,7 @@ export async function removeGenerator(tree: Tree, schema: Schema) {
   removeProject(tree, project);
   removeProjectConfig(tree, schema);
   updateTsconfig(tree, schema, project);
-  updateJestConfig(tree, schema);
+  updateJestConfig(tree, schema, project);
   if (!schema.skipFormat) {
     await formatFiles(tree);
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When the last project in `jest.config.js` is removed, a trailing comma is left over and the configuration becomes malformed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When the last project in `jest.config.js` is removed, the configuration should not become malformed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
