### PR TITLE
fix(core): only do type casting for string values when parsing comman…

### DIFF
--- a/packages/tao/src/shared/params.spec.ts
+++ b/packages/tao/src/shared/params.spec.ts
@@ -89,6 +89,21 @@ describe('params', () => {
         a: false,
       });
     });
+
+    it('should only coerce string values', () => {
+      const opts = coerceTypesInOptions(
+        { a: true } as any,
+        {
+          properties: {
+            a: { oneOf: [{ type: 'boolean' }, { type: 'number' }] },
+          },
+        } as Schema
+      );
+
+      expect(opts).toEqual({
+        a: true,
+      });
+    });
   });
 
   describe('convertToCamelCase', () => {

--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -88,6 +88,8 @@ export function coerceTypesInOptions(opts: Options, schema: Schema): Options {
 
 function coerceType(prop: PropertyDescription | undefined, value: any) {
   if (!prop) return value;
+  if (typeof value !== 'string' && value !== undefined) return value;
+
   if (prop.oneOf) {
     for (let i = 0; i < prop.oneOf.length; ++i) {
       const coerced = coerceType(prop.oneOf[i], value);
@@ -101,10 +103,7 @@ function coerceType(prop: PropertyDescription | undefined, value: any) {
   } else if (normalizedPrimitiveType(prop.type) == 'number') {
     return Number(value);
   } else if (prop.type == 'array') {
-    return value
-      .toString()
-      .split(',')
-      .map((v) => coerceType(prop.items, v));
+    return value.split(',').map((v) => coerceType(prop.items, v));
   } else {
     return value;
   }


### PR DESCRIPTION
…d line args

Closes #4584

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
