### PR TITLE
fix(core): make sure schematic folder migration can be run multiple times

### DIFF
--- a/packages/workspace/src/migrations/update-11-0-0/rename-workspace-schematics.ts
+++ b/packages/workspace/src/migrations/update-11-0-0/rename-workspace-schematics.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs-extra';
 
 export default function update(): Rule {
   return () => {
-    fs.moveSync('tools/schematics', 'tools/generators');
+    if (fs.existsSync('tools/schematics')) {
+      fs.moveSync('tools/schematics', 'tools/generators');
+    }
   };
 }


### PR DESCRIPTION

## Current Behavior

When re-running the Nx migration it fails because the `tools/schematics` folder is no more there. 

## Expected Behavior

Re-running might make sense though, especially for those in a monorepo that have open PRs that haven't been migrated yet and thus want to re-run the migrations.

