### PR TITLE
fix(angular): check whether project has architect node during migration of eslint

### DIFF
--- a/packages/angular/src/migrations/update-10-5-0/add-template-support-and-presets-to-eslint.ts
+++ b/packages/angular/src/migrations/update-10-5-0/add-template-support-and-presets-to-eslint.ts
@@ -70,7 +70,7 @@ function updateProjectESLintConfigsAndBuilders(host: Tree): Rule {
     ) {
       return;
     }
-    Object.keys(project.architect).forEach((targetName) => {
+    Object.keys(project.architect || {}).forEach((targetName) => {
       const target = project.architect[targetName];
       if (target.builder !== '@nrwl/linter:eslint') {
         return;


### PR DESCRIPTION

## Current Behavior

There might be projects which don't have an architect node and where the migration therefore fails.

## Expected Behavior

Should check for the presence of the `architect` node.