### PR TITLE
fix(core): properly set smart defaults on windows

### DIFF
--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -418,7 +418,7 @@ export function convertSmartDefaultsIntoNamedParams(
       v.visible === false &&
       relativeCwd
     ) {
-      opts[k] = relativeCwd;
+      opts[k] = relativeCwd.replace(/\\/g, '/');
     }
   });
   delete opts['_'];

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -193,14 +193,7 @@ export class Workspaces {
   constructor(private root: string) {}
 
   relativeCwd(cwd: string) {
-    let relativeCwd = cwd.replace(/\\/g, '/').split(this.root)[1];
-    if (relativeCwd) {
-      return relativeCwd.startsWith('/')
-        ? relativeCwd.substring(1)
-        : relativeCwd;
-    } else {
-      return null;
-    }
+    return path.relative(this.root, cwd) || null;
   }
 
   calculateDefaultProjectName(cwd: string, wc: WorkspaceConfiguration) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When creating a component (or other schematics) inside a nested directory within a project, the files will be generated at the root.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When creating a component (or other schematics) inside a nested directory within a project, the files will be generated at the current working directory.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/4530#event-4238900968
