### PR TITLE
fix(core): properly set tsconfig path mapping on windows

### DIFF
--- a/packages/workspace/src/generators/library/library.ts
+++ b/packages/workspace/src/generators/library/library.ts
@@ -80,7 +80,11 @@ function updateRootTsConfig(host: Tree, options: NormalizedSchema) {
     }
 
     c.paths[options.importPath] = [
-      join(options.projectRoot, './src', 'index.' + (options.js ? 'js' : 'ts')),
+      joinPathFragments(
+        options.projectRoot,
+        './src',
+        'index.' + (options.js ? 'js' : 'ts')
+      ),
     ];
 
     return json;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Paths are written wrong in `tsconfig.base.json` for new `@nrwl/workspace:library`s

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Paths are written properly in `tsconfig.base.json` for new `@nrwl/workspace:library`s

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
