### PR TITLE
docs(core): slack links updated

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     about: "Please make sure you have read the submission guidelines before posting an issue"
     url: https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-an-issue
   - name: Have a question?
-    url: https://bit.ly/2ZApcSo
+    url: http://go.nrwl.io/join-slack
     about: "The Community Slack is a great place for questions to be asked and answered. Please use the #support channel if you need help with your workspace!"
   - name: Are you looking for integration with a new tool?
     url: https://nx.dev/nx-community

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Semantic Release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)]()
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![Join the chat at https://gitter.im/nrwl-nx/community](https://badges.gitter.im/nrwl-nx/community.svg)](https://gitter.im/nrwl-nx/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Join us @nrwl/community on slack](https://img.shields.io/badge/slack-%40nrwl%2Fcommunity-brightgreen)](https://bit.ly/nx-slack)
+[![Join us @nrwl/community on slack](https://img.shields.io/badge/slack-%40nrwl%2Fcommunity-brightgreen)](http://go.nrwl.io/join-slack)
 
 </div>
 


### PR DESCRIPTION
Updates the slack links present in the repostory to be the same as https://nx.dev/nx-community.
Resolve #4567.