### PR TITLE
fix(angular): adjust ngcc postinstall command

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -55,6 +55,11 @@
       "version": "11.0.0-beta.13",
       "description": "Update builder configurations and dependencies",
       "factory": "./src/migrations/update-11-0-0/update-builders-config"
+    },
+    "update-ngcc-postinstall": {
+      "version": "12.0.0-beta.0",
+      "description": "adjusts the ngcc postinstall command to just leave 'ngcc' in there. This fixes Ivy in Jest tests and Storybooks",
+      "factory": "./src/migrations/update-12-0-0/update-ngcc-postinstall"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/migrations/update-12-0-0/update-ngcc-postinstall.spec.ts
+++ b/packages/angular/src/migrations/update-12-0-0/update-ngcc-postinstall.spec.ts
@@ -1,0 +1,57 @@
+import { Tree } from '@angular-devkit/schematics';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { runMigration } from '../../utils/testing';
+
+function createAngularCLIPoweredWorkspace() {
+  const tree = createEmptyWorkspace(Tree.empty());
+  tree.delete('workspace.json');
+  tree.create('angular.json', '{}');
+  return tree;
+}
+
+describe('Remove ngcc flags from postinstall script', () => {
+  [
+    {
+      test:
+        'node ./decorate-angular-cli.js && ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points',
+      expected:
+        'node ./decorate-angular-cli.js && ngcc --properties es2015 browser module main',
+    },
+    {
+      test:
+        'node ./decorate-angular-cli.js && ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points && echo "hi"',
+      expected:
+        'node ./decorate-angular-cli.js && ngcc --properties es2015 browser module main && echo "hi"',
+    },
+    {
+      test:
+        'ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points && node ./decorate-angular-cli.js && echo "hi"',
+      expected:
+        'ngcc --properties es2015 browser module main && node ./decorate-angular-cli.js && echo "hi"',
+    },
+    {
+      test:
+        'ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points && node ./decorate-angular-cli.js',
+      expected:
+        'ngcc --properties es2015 browser module main && node ./decorate-angular-cli.js',
+    },
+  ].forEach((testEntry) => {
+    it(`should adjust ngcc for: "${testEntry.test}"`, async () => {
+      const tree = createAngularCLIPoweredWorkspace();
+
+      tree.overwrite(
+        '/package.json',
+        JSON.stringify({
+          scripts: {
+            postinstall: testEntry.test,
+          },
+        })
+      );
+
+      const result = await runMigration('update-ngcc-postinstall', {}, tree);
+
+      const packageJson = JSON.parse(result.read('/package.json').toString());
+      expect(packageJson.scripts.postinstall).toEqual(testEntry.expected);
+    });
+  });
+});

--- a/packages/angular/src/migrations/update-12-0-0/update-ngcc-postinstall.ts
+++ b/packages/angular/src/migrations/update-12-0-0/update-ngcc-postinstall.ts
@@ -1,0 +1,24 @@
+import { chain, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { updateJsonInTree } from '@nrwl/workspace';
+import { formatFiles } from '@nrwl/workspace';
+
+const udpateNgccPostinstallScript = (host: Tree, context: SchematicContext) => {
+  updateJsonInTree('package.json', (json) => {
+    if (
+      json.scripts &&
+      json.scripts.postinstall &&
+      json.scripts.postinstall.includes('ngcc')
+    ) {
+      // if exists, add execution of this script
+      json.scripts.postinstall = json.scripts.postinstall.replace(
+        /(.*)(ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points)(.*)/,
+        '$1ngcc --properties es2015 browser module main$3'
+      );
+    }
+    return json;
+  })(host, context);
+};
+
+export default function () {
+  return chain([udpateNgccPostinstallScript, formatFiles()]);
+}

--- a/packages/angular/src/schematics/init/init.spec.ts
+++ b/packages/angular/src/schematics/init/init.spec.ts
@@ -45,7 +45,7 @@ describe('init', () => {
     const packageJson = readJsonInTree(tree, 'package.json');
 
     expect(packageJson.scripts.postinstall).toEqual(
-      'ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points'
+      'ngcc --properties es2015 browser module main'
     );
   });
 

--- a/packages/angular/src/schematics/init/init.ts
+++ b/packages/angular/src/schematics/init/init.ts
@@ -148,8 +148,7 @@ export function setDefaults(options: Schema): Rule {
 function addPostinstall(): Rule {
   return updateJsonInTree('package.json', (json, context) => {
     json.scripts = json.scripts || {};
-    const command =
-      'ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points';
+    const command = 'ngcc --properties es2015 browser module main';
     if (!json.scripts.postinstall) {
       json.scripts.postinstall = command;
     } else if (!json.scripts.postinstall.includes('ngcc')) {


### PR DESCRIPTION

## Current Behavior
<!-- This is the behavior we have today -->

Nx adds the following `postinstall` command:

```
ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points
```

This causes some libraries such as Jest and Storybook to not run with Ivy but rather use ViewEngine.

For instance, omitting `--create-ivy-entry-points` fixes the Storybook issue of not running in Ivy mode. Jests still apparently uses ViewEngine though.

When also omitting `--first-only`, then also Jest uses Ivy.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Storybook as well as Jest should use Ivy just as the application itself does to prevent a different behavior when running a component inside a test case / storybook setup.

## Details

The command line args are processed being [taken here](https://github.com/angular/angular-cli/blob/eb313f7dc25bf99813452ce0ed8c9e5120d16a62/packages/ngtools/webpack/src/ngcc_processor.ts#L130-L144) and forwarded to the ngcc which lives in the Angular repo.

Some attempt to explain the params:

- `--create-ivy-entry-points`  
Creates dedicated Ivy compiled entry points that can be used to execute the library in "Ivy mode". Omitting this compiles the existing files to Ivy and replaces them. That might cause issues if you want to use ViewEngine with the given package as the ViewEngine code would no more be there.

Using the `--create-ivy-entry-points` is explicitly discouraged by the [Angular docs](https://angular.io/guide/ivy#ivy-and-universalapp-shell) when using SSR or App Shell.

- `--first-only` - transforms only the first format (main, module,...)

## Migration

While we could totally migrate the postinstall arguments I prefer not to as it might break people's codebase. Tests that passed easily with ViewEngine might no more pass with Ivy as it is stricter in some scenarios. It would definitely unveil inappropriate HTML bindings etc, but still potentially break a lot of Jest tests.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #2601 #2752 #2667
