### PR TITLE
fix(core): generate schematics map for workspace-generators

### DIFF
--- a/e2e/workspace/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace/src/workspace-aux-commands.test.ts
@@ -364,6 +364,33 @@ describe('workspace-generator', () => {
     expect(listOutput).toContain(custom);
     expect(listOutput).toContain(failing);
   }, 1000000);
+
+  it('should support angular devkit schematics', () => {
+    const angularDevkitSchematic = uniq('angular-devkit-schematic');
+    runCLI(`g workspace-generator ${angularDevkitSchematic} --no-interactive`);
+
+    const json = readJson(
+      `tools/generators/${angularDevkitSchematic}/schema.json`
+    );
+    json.properties = {};
+    json.required = [];
+    delete json.cli;
+    updateFile(
+      `tools/generators/${angularDevkitSchematic}/schema.json`,
+      JSON.stringify(json)
+    );
+
+    updateFile(
+      `tools/generators/${angularDevkitSchematic}/index.ts`,
+      `
+          export default function() {
+            return (tree) => tree;
+          }
+        `
+    );
+
+    runCLI(`workspace-generator ${angularDevkitSchematic} --no-interactive`);
+  });
 });
 
 describe('dep-graph', () => {

--- a/packages/workspace/src/command-line/workspace-generators.ts
+++ b/packages/workspace/src/command-line/workspace-generators.ts
@@ -125,6 +125,7 @@ function constructCollection() {
     name: 'workspace-generators',
     version: '1.0',
     generators: generators,
+    schematics: generators,
   };
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Workspace generators written with angular devkit fail because the schematics map is not there

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Workspace generators written with angular devkit still work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/4637
