### PR TITLE
fix(angular): set default linter when creating the first app

### DIFF
--- a/packages/angular/src/schematics/init/init.spec.ts
+++ b/packages/angular/src/schematics/init/init.spec.ts
@@ -211,7 +211,43 @@ describe('init', () => {
   });
 
   describe('--linter', () => {
+    describe('eslint', () => {
+      it('should set the default to eslint', async () => {
+        const tree = await runSchematic(
+          'init',
+          {
+            linter: 'eslint',
+          },
+          appTree
+        );
+        const workspaceJson = readJsonInTree(tree, 'workspace.json');
+        expect(
+          workspaceJson.schematics['@nrwl/angular:application'].linter
+        ).toEqual('eslint');
+        expect(
+          workspaceJson.schematics['@nrwl/angular:library'].linter
+        ).toEqual('eslint');
+      });
+    });
+
     describe('tslint', () => {
+      it('should set the default to tslint', async () => {
+        const tree = await runSchematic(
+          'init',
+          {
+            linter: 'tslint',
+          },
+          appTree
+        );
+        const workspaceJson = readJsonInTree(tree, 'workspace.json');
+        expect(
+          workspaceJson.schematics['@nrwl/angular:application'].linter
+        ).toEqual('tslint');
+        expect(
+          workspaceJson.schematics['@nrwl/angular:library'].linter
+        ).toEqual('tslint');
+      });
+
       it('should add codelyzer', async () => {
         const tree = await runSchematic(
           'init',

--- a/packages/angular/src/schematics/init/init.ts
+++ b/packages/angular/src/schematics/init/init.ts
@@ -123,27 +123,22 @@ export function addE2eTestRunner(options: Pick<Schema, 'e2eTestRunner'>): Rule {
 export function setDefaults(options: Schema): Rule {
   const updateAngularWorkspace = updateWorkspace((workspace) => {
     workspace.extensions.schematics = workspace.extensions.schematics || {};
-
-    workspace.extensions.schematics['@nrwl/angular:application'] =
-      workspace.extensions.schematics['@nrwl/angular:application'] || {};
-    workspace.extensions.schematics[
-      '@nrwl/angular:application'
-    ].unitTestRunner =
-      workspace.extensions.schematics['@nrwl/angular:application']
-        .unitTestRunner || options.unitTestRunner;
-    workspace.extensions.schematics['@nrwl/angular:application'].e2eTestRunner =
-      workspace.extensions.schematics['@nrwl/angular:application']
-        .e2eTestRunner || options.e2eTestRunner;
-
-    workspace.extensions.schematics['@nrwl/angular:library'] =
-      workspace.extensions.schematics['@nrwl/angular:library'] || {};
-    workspace.extensions.schematics['@nrwl/angular:library'].unitTestRunner =
-      workspace.extensions.schematics['@nrwl/angular:library'].unitTestRunner ||
-      options.unitTestRunner;
-
-    workspace.extensions.schematics['@nrwl/angular:component'] = workspace
-      .extensions.schematics['@nrwl/angular:component'] || {
+    workspace.extensions.schematics['@nrwl/angular:application'] = {
       style: options.style,
+      linter: options.linter,
+      unitTestRunner: options.unitTestRunner,
+      e2eTestRunner: options.e2eTestRunner,
+      ...(workspace.extensions.schematics['@nrwl/angular:application'] || {}),
+    };
+    workspace.extensions.schematics['@nrwl/angular:library'] = {
+      style: options.style,
+      linter: options.linter,
+      unitTestRunner: options.unitTestRunner,
+      ...(workspace.extensions.schematics['@nrwl/angular:library'] || {}),
+    };
+    workspace.extensions.schematics['@nrwl/angular:component'] = {
+      style: options.style,
+      ...(workspace.extensions.schematics['@nrwl/angular:component'] || {}),
     };
   });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When generating an application, the linter is not set as a default so subsequent apps will use eslint if none is specified.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When generating an application, the linter is set as a default so subsequent apps will use whichever linter was used for the first.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
