### PR TITLE
fix(devkit): nullcheck for engineHost.paths in invokeNxGenerator

### DIFF
--- a/packages/devkit/src/utils/invoke-nx-generator.ts
+++ b/packages/devkit/src/utils/invoke-nx-generator.ts
@@ -44,7 +44,7 @@ function invokeNxGenerator<T = any>(generator: Generator<T>, options: T) {
       engineHost.registerTaskExecutor(createRunCallbackTask());
     }
 
-    const root = context.engine.workflow
+    const root = context.engine.workflow.engineHost.paths
       ? context.engine.workflow.engineHost.paths[1]
       : tree.root.path;
 


### PR DESCRIPTION
check that engineHost.paths is defined before checking paths[1]

## Current Behavior
E.g `nx g move`-schematic is failing with `TypeError: Cannot read property '1' of undefined`

## Expected Behavior
That `invokeNxGenerator` works if `context.engine.workflow.engineHost.paths` are undefined


fixes #4687 