### PR TITLE
fix(react): :sparkles: Update react templates

### DIFF
--- a/packages/react/src/schematics/component-story/component-story.spec.ts
+++ b/packages/react/src/schematics/component-story/component-story.spec.ts
@@ -63,7 +63,7 @@ describe('react:component-story', () => {
         expect(stripIndents`${tree.readContent(storyFilePath)}`)
           .toContain(stripIndents`
             import React from 'react';
-            import { TestUiLib, TestUiLibProps } from './test-ui-lib';
+            import { TestUiLib, ITestUiLibProps } from './test-ui-lib';
             
             export default {
               component: TestUiLib,
@@ -72,9 +72,9 @@ describe('react:component-story', () => {
             
             export const primary = () => {
               /* eslint-disable-next-line */
-              const props: TestUiLibProps = {};
+              const props: ITestUiLibProps = {};
             
-              return <TestUiLib />;
+              return <TestUiLib></TestUiLib>;
             };
           `);
       });
@@ -132,7 +132,7 @@ describe('react:component-story', () => {
               /* eslint-disable-next-line */
               const props = {};
             
-              return <Test />;
+              return <Test></Test>;
             };
           `);
       });
@@ -180,7 +180,7 @@ describe('react:component-story', () => {
             };
             
             export const primary = () => {
-              return <Test />;
+              return <Test></Test>;
             };
           `);
       });
@@ -194,12 +194,12 @@ describe('react:component-story', () => {
   
           import './test.scss';
           
-          export interface TestProps {
+          export interface ITestProps {
             name: string;
             displayAge: boolean;
           }
           
-          export const Test = (props: TestProps) => {
+          export const Test = (props: ITestProps) => {
             return (
               <div>
                 <h1>Welcome to test component, {props.name}</h1>
@@ -226,7 +226,7 @@ describe('react:component-story', () => {
           .toContain(stripIndents`
             import { text, boolean } from '@storybook/addon-knobs';
             import React from 'react';
-            import { Test, TestProps } from './test-ui-lib';
+            import { Test, ITestProps } from './test-ui-lib';
             
             export default {
               component: Test,
@@ -234,12 +234,12 @@ describe('react:component-story', () => {
             };
             
             export const primary = () => {
-              const props: TestProps = {
+              const props: ITestProps = {
                 name: text('name', ''),
                 displayAge: boolean('displayAge', false),
               };
             
-              return <Test name={props.name} displayAge={props.displayAge} />;
+              return <Test name={props.name} displayAge={props.displayAge}></Test>;
             };
           `);
       });
@@ -248,7 +248,7 @@ describe('react:component-story', () => {
     [
       {
         name: 'default export function',
-        src: `export default function Test(props: TestProps) {
+        src: `export default function Test(props: ITestProps) {
         return (
           <div>
             <h1>Welcome to test component, {props.name}</h1>
@@ -260,7 +260,7 @@ describe('react:component-story', () => {
       {
         name: 'function and then export',
         src: `
-      function Test(props: TestProps) {
+      function Test(props: ITestProps) {
         return (
           <div>
             <h1>Welcome to test component, {props.name}</h1>
@@ -273,7 +273,7 @@ describe('react:component-story', () => {
       {
         name: 'arrow function',
         src: `
-      const Test = (props: TestProps) => {
+      const Test = (props: ITestProps) => {
         return (
           <div>
             <h1>Welcome to test component, {props.name}</h1>
@@ -286,14 +286,14 @@ describe('react:component-story', () => {
       {
         name: 'arrow function without {..}',
         src: `
-      const Test = (props: TestProps) => <div><h1>Welcome to test component, {props.name}</h1></div>;
+      const Test = (props: ITestProps) => <div><h1>Welcome to test component, {props.name}</h1></div>;
       export default Test
       `,
       },
       {
         name: 'direct export of component class',
         src: `
-        export default class Test extends React.Component<TestProps> {
+        export default class Test extends React.Component<ITestProps> {
           render() {
             return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
           }
@@ -303,7 +303,7 @@ describe('react:component-story', () => {
       {
         name: 'component class & then default export',
         src: `
-        class Test extends React.Component<TestProps> {
+        class Test extends React.Component<ITestProps> {
           render() {
             return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
           }
@@ -314,7 +314,7 @@ describe('react:component-story', () => {
       {
         name: 'PureComponent class & then default export',
         src: `
-        class Test extends React.PureComponent<TestProps> {
+        class Test extends React.PureComponent<ITestProps> {
           render() {
             return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
           }
@@ -331,7 +331,7 @@ describe('react:component-story', () => {
     
             import './test.scss';
             
-            export interface TestProps {
+            export interface ITestProps {
               name: string;
               displayAge: boolean;
             }
@@ -355,7 +355,7 @@ describe('react:component-story', () => {
             .toContain(stripIndents`
             import { text, boolean } from '@storybook/addon-knobs';
             import React from 'react';
-            import { Test, TestProps } from './test-ui-lib';
+            import { Test, ITestProps } from './test-ui-lib';
             
             export default {
               component: Test,
@@ -363,12 +363,12 @@ describe('react:component-story', () => {
             };
             
             export const primary = () => {
-              const props: TestProps = {
+              const props: ITestProps = {
                 name: text('name', ''),
                 displayAge: boolean('displayAge', false),
               };
             
-              return <Test name={props.name} displayAge={props.displayAge} />;
+              return <Test name={props.name} displayAge={props.displayAge}></Test>;
             };
           `);
         });
@@ -393,7 +393,7 @@ describe('react:component-story', () => {
       expect(stripIndents`${tree.readContent(storyFilePath)}`)
         .toContain(stripIndents`
           import React from 'react';
-          import { TestUiLib, TestUiLibProps } from './test-ui-lib';
+          import { TestUiLib, ITestUiLibProps } from './test-ui-lib';
           
           export default {
             component: TestUiLib,
@@ -402,9 +402,9 @@ describe('react:component-story', () => {
           
           export const primary = () => {
             /* eslint-disable-next-line */
-            const props: TestUiLibProps = {};
+            const props: ITestUiLibProps = {};
           
-            return <TestUiLib />;
+            return <TestUiLib></TestUiLib>;
           };
         `);
     });

--- a/packages/react/src/schematics/component-story/files/__componentFileName__.stories.__fileExt__.template
+++ b/packages/react/src/schematics/component-story/files/__componentFileName__.stories.__fileExt__.template
@@ -15,5 +15,5 @@ export const primary = () => {
   };
   <% } %>
 
-  return <<%= componentName %> <% for (let prop of props) { %><%= prop.name %> = {props.<%= prop.name %>} <% } %> />;
+  return <<%= componentName %> <% for (let prop of props) { %><%= prop.name %> = {props.<%= prop.name %>} <% }%>></<%= componentName %>>;
 };

--- a/packages/react/src/schematics/component/files/__fileName__.tsx__tmpl__
+++ b/packages/react/src/schematics/component/files/__fileName__.tsx__tmpl__
@@ -21,7 +21,7 @@ import { Route, Link } from 'react-router-dom';
 } else { var wrapper = 'div'; } %>
 
 /* eslint-disable-next-line */
-export interface <%= className %>Props {
+export interface I<%= className %>Props {
 }
 
 <% if (styledModule && styledModule !== 'styled-jsx') { %>
@@ -30,7 +30,7 @@ const Styled<%= className %> = styled.div`
 `;
 <% }%>
 <% if (classComponent) { %>
-export class <%= className %> extends Component<<%= className %>Props> {
+export class <%= className %> extends Component<I<%= className %>Props> {
   render() {
     return (
       <<%= wrapper %>>
@@ -47,7 +47,7 @@ export class <%= className %> extends Component<<%= className %>Props> {
   }
 }
 <% } else { %>
-export function <%= className %>(props: <%= className %>Props) {
+export const <%= className %>: React.FC<I<%= className %>Props> = (props) => {
   return (
     <<%= wrapper %>>
       <%= styledModule === 'styled-jsx' ? `<style jsx>{\`div { color: pink; }\`}</style>` : `` %>

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -500,6 +500,10 @@ export function getComponentPropsInterface(
     if (propsParam && propsParam.type) {
       propsTypeName = ((propsParam.type as ts.TypeReferenceNode)
         .typeName as ts.Identifier).text;
+    } else {
+      // If user is using React.FC<INTERFACE> then get the name of it
+      propsTypeName = ((cmpDeclaration as ts.VariableDeclaration)
+        .type as ts.NodeWithTypeArguments)?.typeArguments[0].getText();
     }
   } else if (
     // do we have a class component extending from React.Component


### PR DESCRIPTION
Prefix interfaces with I. Have an arrow function as default. Lookup correct type if user is using React.FC as props.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The React template creates the below: 

```typescript
import React from 'react';

import './header.module.scss';

/* eslint-disable-next-line */
export interface HeaderProps {}

export function Header(props: HeaderProps) {
  return (
    <div>
      <h1>Welcome to header!</h1>
    </div>
  );
}

export default Header;
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
```typescript
import React from 'react';

import './header.module.scss';

/* eslint-disable-next-line */
export interface HeaderProps {}

export const Header: React.FC<HeaderProps> = (props) {
  return (
    <div>
      <h1>Welcome to header!</h1>
    </div>
  );
}

export default Header;
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
[#4677](https://github.com/nrwl/nx/issues/4677)