### PR TITLE
fix(core): value coercion for schemas with oneOf string enums

### DIFF
--- a/packages/tao/src/shared/params.spec.ts
+++ b/packages/tao/src/shared/params.spec.ts
@@ -90,6 +90,34 @@ describe('params', () => {
       });
     });
 
+    it('should handle oneOf with enums inside', () => {
+      const opts = coerceTypesInOptions(
+        { inspect: 'inspect' } as any,
+        {
+          properties: {
+            inspect: {
+              oneOf: [
+                {
+                  type: 'string',
+                  enum: ['inspect', 'inspect-brk'],
+                },
+                {
+                  type: 'number',
+                },
+                {
+                  type: 'boolean',
+                },
+              ],
+            },
+          },
+        } as Schema
+      );
+
+      expect(opts).toEqual({
+        inspect: 'inspect',
+      });
+    });
+
     it('should only coerce string values', () => {
       const opts = coerceTypesInOptions(
         { a: true } as any,
@@ -533,6 +561,74 @@ describe('params', () => {
           }
         )
       ).not.toThrow();
+    });
+
+    it('should handle oneOf properties with enums', () => {
+      // matching enum value
+      expect(() =>
+        validateOptsAgainstSchema(
+          { a: 'inspect' },
+          {
+            properties: {
+              a: {
+                oneOf: [
+                  {
+                    type: 'string',
+                    enum: ['inspect', 'inspect-brk'],
+                  },
+                  {
+                    type: 'boolean',
+                  },
+                ],
+              },
+            },
+          }
+        )
+      ).not.toThrow();
+
+      // matching oneOf value
+      expect(() =>
+        validateOptsAgainstSchema(
+          { a: true },
+          {
+            properties: {
+              a: {
+                oneOf: [
+                  {
+                    type: 'string',
+                    enum: ['inspect', 'inspect-brk'],
+                  },
+                  {
+                    type: 'boolean',
+                  },
+                ],
+              },
+            },
+          }
+        )
+      ).not.toThrow();
+
+      // non-matching enum value
+      expect(() =>
+        validateOptsAgainstSchema(
+          { a: 'abc' },
+          {
+            properties: {
+              a: {
+                oneOf: [
+                  {
+                    type: 'string',
+                    enum: ['inspect', 'inspect-brk'],
+                  },
+                  {
+                    type: 'boolean',
+                  },
+                ],
+              },
+            },
+          }
+        )
+      ).toThrow();
     });
 
     it("should throw if the type doesn't match (arrays)", () => {

--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -100,9 +100,15 @@ function coerceType(prop: PropertyDescription | undefined, value: any) {
       }
     }
     return value;
-  } else if (normalizedPrimitiveType(prop.type) == 'boolean') {
+  } else if (
+    normalizedPrimitiveType(prop.type) == 'boolean' &&
+    isConvertibleToBoolean(value)
+  ) {
     return value === true || value == 'true';
-  } else if (normalizedPrimitiveType(prop.type) == 'number') {
+  } else if (
+    normalizedPrimitiveType(prop.type) == 'number' &&
+    isConvertibleToNumber(value)
+  ) {
     return Number(value);
   } else if (prop.type == 'array') {
     return value.split(',').map((v) => coerceType(prop.items, v));
@@ -576,4 +582,33 @@ function levenshtein(a: string, b: string) {
 
 function isTTY(): boolean {
   return !!process.stdout.isTTY && process.env['CI'] !== 'true';
+}
+
+/**
+ * Verifies whether the given value can be converted to a boolean
+ * @param value
+ */
+function isConvertibleToBoolean(value) {
+  if ('boolean' === typeof value) {
+    return true;
+  }
+
+  if ('string' === typeof value && /true|false/.test(value)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Verifies whether the given value can be converted to a number
+ * @param value
+ */
+function isConvertibleToNumber(value) {
+  // exclude booleans explicitly
+  if ('boolean' === typeof value) {
+    return false;
+  }
+
+  return !isNaN(+value);
 }


### PR DESCRIPTION
## Current Behavior

There has been a regression in Nx 11 where the command

```
nx serve some-node-app --inspect inspect
```

..failed to properly resolve the `--inspect inspect` argument and pass it to the underlying Node executor. Rather the value `false` gets passed in, thus disabling debugging abilities for node apps.

The schema definition of the `inspect` property for the node builder looks as follows:

```
"inspect": {
  "oneOf": [
    {
      "type": "string",
      "enum": ["inspect", "inspect-brk"]
    },
    {
      "type": "boolean"
    }
  ],
  "description": "Ensures the app is starting with debugging",
  "default": "inspect"
},
```

When `@nrwl/tao` executes the command, it performs a value coercion, which for `--inspect=inspect` isn't needed. But the coercion function fails to detect that and consequently does a boolean conversion (since one of the oneOf is a boolean type) and hence as a result return `false`.

## Expected Behavior

Values that get passed into the coercion function, need to be verified against whether they can be actually converted to a valid respective primitive type. This PR should fix that.
