### PR TITLE
fix(web): pass opt.sslKey parameter to -K option of http-server

### DIFF
--- a/packages/web/src/builders/file-server/file-server.impl.ts
+++ b/packages/web/src/builders/file-server/file-server.impl.ts
@@ -33,7 +33,7 @@ function getHttpServerArgs(opts: FileServerOptions) {
     args.push(`-C ${opts.sslCert}`);
   }
   if (opts.sslKey) {
-    args.push(`-K ${opts.sslCert}`);
+    args.push(`-K ${opts.sslKey}`);
   }
   if (opts.proxyUrl) {
     args.push(`-P ${opts.proxyUrl}`);


### PR DESCRIPTION


## Current Behavior
`nx serve` returns error when using ssl in options and @nrwl/web:file-server as a builder

## Expected Behavior
nx serve should start web server when using ssl

## Related Issue(s)

ISSUES CLOSED: #4701