### PR TITLE
fix(angular): fix(angular): fix --skipFormat option on application schematic

### DIFF
--- a/packages/angular/src/schematics/application/application.spec.ts
+++ b/packages/angular/src/schematics/application/application.spec.ts
@@ -1,8 +1,10 @@
 import { Tree } from '@angular-devkit/schematics';
+import { NxJson, readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
 import { createEmptyWorkspace, getFileContent } from '@nrwl/workspace/testing';
 import * as stripJsonComments from 'strip-json-comments';
-import { readJsonInTree, updateJsonInTree, NxJson } from '@nrwl/workspace';
-import { runSchematic, callRule } from '../../utils/testing';
+import { callRule, runSchematic } from '../../utils/testing';
+
+const prettier = require('prettier');
 
 describe('app', () => {
   let appTree: Tree;
@@ -316,6 +318,28 @@ describe('app', () => {
     });
   });
 
+  describe('--skipFormat', () => {
+    it('should format files by default', async () => {
+      const spy = spyOn(prettier, 'getFileInfo').and.callThrough();
+
+      appTree = await runSchematic('app', { name: 'myApp' }, appTree);
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should skip format when set to true', async () => {
+      const spy = spyOn(prettier, 'format').and.callThrough();
+
+      appTree = await runSchematic(
+        'app',
+        { name: 'myApp', skipFormat: true },
+        appTree
+      );
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('--linter', () => {
     describe('eslint', () => {
       it('should add an architect target for lint', async () => {
@@ -405,17 +429,18 @@ describe('app', () => {
           ]
         `);
       });
+    });
 
-      describe('tslint', () => {
-        it('should add an architect target for lint', async () => {
-          const tree = await runSchematic(
-            'app',
-            { name: 'myApp', linter: 'tslint' },
-            appTree
-          );
-          const workspaceJson = readJsonInTree(tree, 'workspace.json');
-          expect(workspaceJson.projects['my-app'].architect.lint)
-            .toMatchInlineSnapshot(`
+    describe('tslint', () => {
+      it('should add an architect target for lint', async () => {
+        const tree = await runSchematic(
+          'app',
+          { name: 'myApp', linter: 'tslint' },
+          appTree
+        );
+        const workspaceJson = readJsonInTree(tree, 'workspace.json');
+        expect(workspaceJson.projects['my-app'].architect.lint)
+          .toMatchInlineSnapshot(`
             Object {
               "builder": "@angular-devkit/build-angular:tslint",
               "options": Object {
@@ -431,17 +456,17 @@ describe('app', () => {
               },
             }
           `);
-        });
+      });
 
-        it('should add valid tslint JSON configuration', async () => {
-          const tree = await runSchematic(
-            'app',
-            { name: 'myApp', linter: 'tslint' },
-            appTree
-          );
+      it('should add valid tslint JSON configuration', async () => {
+        const tree = await runSchematic(
+          'app',
+          { name: 'myApp', linter: 'tslint' },
+          appTree
+        );
 
-          const tslintConfig = readJsonInTree(tree, 'apps/my-app/tslint.json');
-          expect(tslintConfig).toMatchInlineSnapshot(`
+        const tslintConfig = readJsonInTree(tree, 'apps/my-app/tslint.json');
+        expect(tslintConfig).toMatchInlineSnapshot(`
             Object {
               "extends": "../../tslint.json",
               "linterOptions": Object {
@@ -465,7 +490,6 @@ describe('app', () => {
               },
             }
           `);
-        });
       });
     });
   });

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -835,6 +835,7 @@ export default function (schema: Schema): Rule {
             supportTsx: false,
             skipSerializers: false,
             setupFile: 'angular',
+            skipFormat: options.skipFormat,
           })
         : noop(),
       options.unitTestRunner === 'karma'
@@ -848,6 +849,7 @@ export default function (schema: Schema): Rule {
             directory: options.directory,
             project: options.name,
             linter: options.linter,
+            skipFormat: options.skipFormat,
           })
         : noop(),
       addEditorTsConfigReference(options),

--- a/packages/angular/src/schematics/init/init.ts
+++ b/packages/angular/src/schematics/init/init.ts
@@ -167,6 +167,6 @@ export default function (options: Schema): Rule {
     updateDependencies(options),
     addUnitTestRunner(options),
     addE2eTestRunner(options),
-    formatFiles(),
+    formatFiles(options),
   ]);
 }


### PR DESCRIPTION
## Current Behavior
Running the `@nrwl/angular:application` schematic with `--skipFormat=true` still formats files afterward.

## Expected Behavior
Running the `@nrwl/angular:application` schematic with `--skipFormat=true` does not format files afterward.

To verify:

1) Publish local version of this branch.
2) Create new Angular workspace with local version
3) Add `"semi": false` to `.prettierrc` (because it's an easy option to verify)
4) Run `nx g @nrwl/angular:application with-format`
5) Run `nx g @nrwl/angular:application skip-format --skipFormat`
6) Compare the two apps. `app.component.ts` should have semicolons in `with-format` and should not have semicolons in `skip-format`

## Related Issue(s)
Fixes #3914
