### PR TITLE
fix(core): run-commands `cwd` issue

### DIFF
--- a/packages/workspace/src/generators/run-commands/run-commands.ts
+++ b/packages/workspace/src/generators/run-commands/run-commands.ts
@@ -17,6 +17,7 @@ export async function runCommandsGenerator(host: Tree, schema: Schema) {
       : [],
     options: {
       command: schema.command,
+      // https://stackoverflow.com/questions/38458118/nodejs-error-spawn-c-windows-system32-cmd-exe-enoent
       cwd: schema.cwd,
       envFile: schema.envFile,
     },


### PR DESCRIPTION
setting cwd option for run-commands would result in an error
if the command was run from somewhere that is not a workspace root

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Running a `run-commands` executor command from outside the root with the `cwd` option set is not working.

https://stackoverflow.com/questions/18894433/nodejs-child-process-working-directory
https://github.com/nodejs/node/issues/11520

This is the error:
```
$ nx db-migrate

> nx run app:db-migrate
ERROR: Something went wrong in @nrwl/run-commands - spawnSync C:\Windows\system32\cmd.exe ENOENT
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
I tried to change the cwd to the workspace root if the joined path of `process.cwd()` and the provided `cwd` did not exist.

I'm having issues actually testing whether this works, with line endings on WSL and the local release giving me errors. Just not a nice experience for me. I'd appreciate if someone was able to take over this PR and properly test this.

EDIT: Additionally, just remembering to call all the commands from the workspace root is not a valid fix/workaround, because if I want to nest my commands, where both have the `cwd` option set then the  `options.commands` command which calls the other nx command (`nx run app:other-command`) will crash, because I think the first command goes to (pseudojs) `${root}${firstCommand.cwd}` and the second call attempts to do something like this `${root}${firstCommand.cwd}${secondCommand.cwd}` and there's an error.

So the current workaround is:
1. Remove any nesting in your `workspace.json`.
2. Call commands only from root.
