### PR TITLE
fix(testing): remove jest executor error while babel-jest exists with…

### DIFF
--- a/packages/jest/src/executors/jest/jest.impl.spec.ts
+++ b/packages/jest/src/executors/jest/jest.impl.spec.ts
@@ -321,35 +321,5 @@ describe('Jest Executor', () => {
         );
       });
     });
-
-    describe('when the user tries to use babel-jest AND ts-jest', () => {
-      beforeEach(() => {
-        jest.doMock(
-          '/root/jest.config.js',
-          () => ({
-            transform: {
-              '^.+\\.tsx?$': 'ts-jest',
-              '^.+\\.jsx?$': 'babel-jest',
-            },
-          }),
-          { virtual: true }
-        );
-      });
-
-      it('should throw an appropriate error', async () => {
-        const options: JestExecutorOptions = {
-          jestConfig: './jest.config.js',
-          watch: false,
-        };
-
-        try {
-          await jestExecutor(options, mockContext);
-        } catch (e) {
-          expect(e.message).toMatch(
-            /Using babel-jest and ts-jest together is not supported/
-          );
-        }
-      });
-    });
   });
 });

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -27,14 +27,6 @@ export async function jestExecutor(
     // eslint-disable-next-line @typescript-eslint/no-var-requires
   } = require(options.jestConfig);
 
-  const transformers = Object.values<string>(jestConfig.transform || {});
-  if (transformers.includes('babel-jest') && transformers.includes('ts-jest')) {
-    throw new Error(
-      'Using babel-jest and ts-jest together is not supported.\n' +
-        'See ts-jest documentation for babel integration: https://kulshekhar.github.io/ts-jest/user/config/babelConfig'
-    );
-  }
-
   const config: Config.Argv = {
     $0: undefined,
     _: [],


### PR DESCRIPTION
… ts-jest (#4729)

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when jest.config.js contains babel-jest with ts-jest it throw error, but actually it's working when properly configured config
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
No error when babel-jest exists with ts-jest
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
check details #4729
Fixes #4729
