### PR TITLE
feat(angular): export angular generators from @nrwl/angular/generators

### DIFF
--- a/packages/angular/generators.ts
+++ b/packages/angular/generators.ts
@@ -1,0 +1,1 @@
+export * from './src/schematics/generators';

--- a/packages/angular/src/schematics/generators.ts
+++ b/packages/angular/src/schematics/generators.ts
@@ -1,0 +1,5 @@
+export { applicationGenerator } from './application/application';
+export { libraryGenerator } from './library/library';
+export { moveGenerator } from './move/move';
+export { ngrxGenerator } from './ngrx/ngrx';
+export { storybookConfigurationGenerator } from './storybook-configuration/configuration';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`@nrwl/angular` generators are not exported.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@nrwl/angular` generators are exported from `@nrwl/angular/generators`. They cannot be exported from `@nrwl/angular` because it contains utils used at runtime.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/4539
