### PR TITLE
fix(linter): Respect the "silent" and "outputPath" options to show the formatter results in the console output

### DIFF
--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -175,7 +175,7 @@ describe('Linter', () => {
         silenceError: true,
       }
     );
-    expect(stdout).toContain('Unexpected console statement');
+    expect(stdout).not.toContain('Unexpected console statement');
     expect(() => checkFilesExist(outputFile)).not.toThrow();
     const outputContents = JSON.parse(readFile(outputFile));
     const outputForApp: any = Object.values(

--- a/packages/linter/src/executors/eslint/lint.impl.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.ts
@@ -76,7 +76,7 @@ export default async function run(
     const pathToOutputFile = join(context.root, options.outputFile);
     createDirectory(dirname(pathToOutputFile));
     writeFileSync(pathToOutputFile, formattedResults);
-  } else if (printInfo) {
+  } else {
     console.info(formattedResults);
   }
 

--- a/packages/linter/src/executors/eslint/lint.impl.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.ts
@@ -71,12 +71,13 @@ export default async function run(
   }
 
   const formattedResults = formatter.format(lintResults);
-  console.info(formattedResults);
 
   if (options.outputFile) {
     const pathToOutputFile = join(context.root, options.outputFile);
     createDirectory(dirname(pathToOutputFile));
     writeFileSync(pathToOutputFile, formattedResults);
+  } else if (printInfo) {
+    console.info(formattedResults);
   }
 
   if (totalWarnings > 0 && printInfo) {


### PR DESCRIPTION
## Current Behavior
When running `nx run {project}:lint` with `format` and `outputPath` options in the workspace config for lint behaviour, I am still seeing the formatter result output in the console output.

## Expected Behavior
When adding `outputPath` option, the formatter results should be hidden from the console output.

## Related Issue(s)

Fixes https://github.com/nrwl/nx/issues/4754
