### PR TITLE
fix(angular): honor `buildableProjectDepsInPackageJsonType` in angula…

### DIFF
--- a/docs/angular/api-angular/executors/ng-packagr-lite.md
+++ b/docs/angular/api-angular/executors/ng-packagr-lite.md
@@ -6,6 +6,16 @@ Properties can be configured in angular.json when defining the executor, or when
 
 ## Properties
 
+### buildableProjectDepsInPackageJsonType
+
+Default: `peerDependencies`
+
+Type: `string`
+
+Possible values: `dependencies`, `peerDependencies`
+
+When updateBuildableProjectDepsInPackageJson is true, this adds dependencies to either `peerDependencies` or `dependencies`
+
 ### project
 
 Type: `string`

--- a/docs/node/api-angular/executors/ng-packagr-lite.md
+++ b/docs/node/api-angular/executors/ng-packagr-lite.md
@@ -7,6 +7,16 @@ Read more about how to use executors and the CLI here: https://nx.dev/node/guide
 
 ## Properties
 
+### buildableProjectDepsInPackageJsonType
+
+Default: `peerDependencies`
+
+Type: `string`
+
+Possible values: `dependencies`, `peerDependencies`
+
+When updateBuildableProjectDepsInPackageJson is true, this adds dependencies to either `peerDependencies` or `dependencies`
+
 ### project
 
 Type: `string`

--- a/docs/react/api-angular/executors/ng-packagr-lite.md
+++ b/docs/react/api-angular/executors/ng-packagr-lite.md
@@ -7,6 +7,16 @@ Read more about how to use executors and the CLI here: https://nx.dev/react/guid
 
 ## Properties
 
+### buildableProjectDepsInPackageJsonType
+
+Default: `peerDependencies`
+
+Type: `string`
+
+Possible values: `dependencies`, `peerDependencies`
+
+When updateBuildableProjectDepsInPackageJson is true, this adds dependencies to either `peerDependencies` or `dependencies`
+
 ### project
 
 Type: `string`

--- a/e2e/angular/src/angular-library.test.ts
+++ b/e2e/angular/src/angular-library.test.ts
@@ -148,7 +148,7 @@ import { names } from '@nrwl/devkit';
       checkFilesExist(`dist/libs/${childLib}/package.json`);
     });
 
-    it('should properly add references to any dependency into the parent package.json', () => {
+    it('aaashould properly add references to any dependency into the parent package.json', () => {
       runCLI(`build ${childLib}`);
       runCLI(`build ${childLib2}`);
       runCLI(`build ${parentLib}`);
@@ -160,11 +160,10 @@ import { names } from '@nrwl/devkit';
       );
 
       const jsonFile = readJson(`dist/libs/${parentLib}/package.json`);
-      // expect(jsonFile.dependencies).toEqual({ tslib: '^2.0.0' });
 
       expect(jsonFile.dependencies['tslib']).toEqual('^2.0.0');
-      expect(jsonFile.dependencies[`@${proj}/${childLib}`]).toBeDefined();
-      expect(jsonFile.dependencies[`@${proj}/${childLib2}`]).toBeDefined();
+      expect(jsonFile.peerDependencies[`@${proj}/${childLib}`]).toBeDefined();
+      expect(jsonFile.peerDependencies[`@${proj}/${childLib2}`]).toBeDefined();
       expect(jsonFile.peerDependencies['@angular/common']).toBeDefined();
       expect(jsonFile.peerDependencies['@angular/core']).toBeDefined();
     });

--- a/packages/angular/src/builders/ng-packagr-lite/schema.json
+++ b/packages/angular/src/builders/ng-packagr-lite/schema.json
@@ -21,6 +21,12 @@
       "type": "boolean",
       "description": "Update buildable project dependencies in package.json",
       "default": true
+    },
+    "buildableProjectDepsInPackageJsonType": {
+      "type": "string",
+      "description": "When updateBuildableProjectDepsInPackageJson is true, this adds dependencies to either `peerDependencies` or `dependencies`",
+      "enum": ["dependencies", "peerDependencies"],
+      "default": "peerDependencies"
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/builders/package/package.impl.ts
+++ b/packages/angular/src/builders/package/package.impl.ts
@@ -90,7 +90,8 @@ export function createLibraryBuilder(
                 updateBuildableProjectPackageJsonDependencies(
                   context,
                   target,
-                  dependencies
+                  dependencies,
+                  options.buildableProjectDepsInPackageJsonType
                 );
               }
             }),


### PR DESCRIPTION
The option is said to be available, but it is not actually used. This commit properly utilizes the option.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `buildableProjectDepsInPackageJsonType` is ignored in the @nrwl/angular:package builder. Setting it to the non-default `peerDependencies` has no effect.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `buildableProjectDepsInPackageJsonType` should be honored in the @nrwl/angular:package builder. Setting it to the non-default `peerDependencies` should add buildable dependencies to the `peerDependencies` of the `package.json` file for the packaged library.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

None found
