### PR TITLE
fix(storybook): freeze the Storybook version to just patches

### DIFF
--- a/packages/angular/src/schematics/storybook-configuration/configuration.spec.ts
+++ b/packages/angular/src/schematics/storybook-configuration/configuration.spec.ts
@@ -3,6 +3,7 @@ import { runSchematic } from '../../utils/testing';
 import { StorybookConfigureSchema } from './schema';
 import { createTestUILib } from '../stories/stories-lib.spec';
 import * as fileUtils from '@nrwl/workspace/src/core/file-utils';
+import { storybookVersion } from '@nrwl/storybook';
 
 describe('schematic:configuration', () => {
   let appTree: Tree;
@@ -11,8 +12,8 @@ describe('schematic:configuration', () => {
     appTree = await createTestUILib('test-ui-lib');
     jest.spyOn(fileUtils, 'readPackageJson').mockReturnValue({
       devDependencies: {
-        '@storybook/addon-essentials': '^6.0.21',
-        '@storybook/react': '^6.0.21',
+        '@storybook/addon-essentials': storybookVersion,
+        '@storybook/angular': storybookVersion,
       },
     });
   });

--- a/packages/react/src/generators/storybook-configuration/configuration.spec.ts
+++ b/packages/react/src/generators/storybook-configuration/configuration.spec.ts
@@ -6,6 +6,7 @@ import { Linter } from '@nrwl/linter';
 import applicationGenerator from '../application/application';
 import componentGenerator from '../component/component';
 import storybookConfigurationGenerator from './configuration';
+import { storybookVersion } from '@nrwl/storybook';
 
 describe('react:storybook-configuration', () => {
   let appTree;
@@ -13,8 +14,8 @@ describe('react:storybook-configuration', () => {
   beforeEach(async () => {
     jest.spyOn(fileUtils, 'readPackageJson').mockReturnValue({
       devDependencies: {
-        '@storybook/addon-essentials': '^6.0.21',
-        '@storybook/react': '^6.0.21',
+        '@storybook/addon-essentials': storybookVersion,
+        '@storybook/react': storybookVersion,
       },
     });
   });

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -345,10 +345,7 @@ function readCurrentWorkspaceStorybookVersion(tree: Tree): string {
         packageJsonContents['dependencies']['@storybook/core'];
     }
   }
-  if (
-    workspaceStorybookVersion.startsWith('6') ||
-    workspaceStorybookVersion.startsWith('^6')
-  ) {
+  if (/[\^|\~]*6/.test(workspaceStorybookVersion)) {
     workspaceStorybookVersion = '6';
   }
   return workspaceStorybookVersion;

--- a/packages/storybook/src/utils/versions.ts
+++ b/packages/storybook/src/utils/versions.ts
@@ -1,5 +1,5 @@
 export const nxVersion = '*';
-export const storybookVersion = '^6.1.11';
+export const storybookVersion = '~6.1.11';
 export const babelCoreVersion = '7.9.6';
 export const babelLoaderVersion = '8.1.0';
 export const babelPresetTypescriptVersion = '7.9.0';


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

We use deep imports to the server standalone mode which might break in upcoming minor releases (e.g. see #4747)

## Expected Behavior

Nx upgrades should also upgrade the Storybook versions when needed, to guarantee they are both compatible.
As a future improvement it might also be an option to reach out to the Storybook team to discuss exposing some of those references via the public API.