### PR TITLE
fix(core): restore tslint for next, clean up Linter enum usage

### DIFF
--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -262,25 +262,58 @@ describe('app', () => {
     expect(appContent).not.toMatch(/extends Component/);
   });
 
-  describe('--linter=eslint', () => {
-    it('should add .eslintrc.json and dependencies', async () => {
-      await applicationGenerator(tree, {
-        name: 'myApp',
-        style: 'css',
-        linter: Linter.EsLint,
+  describe('--linter', () => {
+    describe('default (eslint)', () => {
+      it('should add .eslintrc.json and dependencies', async () => {
+        await applicationGenerator(tree, {
+          name: 'myApp',
+          style: 'css',
+        });
+
+        const packageJson = readJson(tree, '/package.json');
+        expect(packageJson).toMatchObject({
+          devDependencies: {
+            'eslint-plugin-react': expect.anything(),
+            'eslint-plugin-react-hooks': expect.anything(),
+          },
+        });
+
+        const eslintJson = readJson(tree, '/apps/my-app/.eslintrc.json');
+        expect(eslintJson).toMatchInlineSnapshot(`
+          Object {
+            "extends": Array [
+              "plugin:@nrwl/nx/react",
+              "../../.eslintrc.json",
+            ],
+            "ignorePatterns": Array [
+              "!**/*",
+            ],
+            "rules": Object {},
+          }
+        `);
       });
+    });
 
-      const eslintJson = readJson(tree, '/apps/my-app/.eslintrc.json');
-      const packageJson = readJson(tree, '/package.json');
+    describe('tslint', () => {
+      it('should generate files', async () => {
+        await applicationGenerator(tree, {
+          name: 'myApp',
+          style: 'css',
+          linter: Linter.TsLint,
+        });
 
-      expect(eslintJson.extends).toEqual(
-        expect.arrayContaining(['plugin:@nrwl/nx/react'])
-      );
-      expect(packageJson).toMatchObject({
-        devDependencies: {
-          'eslint-plugin-react': expect.anything(),
-          'eslint-plugin-react-hooks': expect.anything(),
-        },
+        const tslintJson = readJson(tree, 'apps/my-app/tslint.json');
+        expect(tslintJson).toMatchInlineSnapshot(`
+          Object {
+            "extends": "../../tslint.json",
+            "linterOptions": Object {
+              "exclude": Array [
+                "!**/*",
+              ],
+            },
+            "rules": Object {},
+          }
+        `);
       });
     });
   });

--- a/packages/next/src/generators/application/lib/add-linting.ts
+++ b/packages/next/src/generators/application/lib/add-linting.ts
@@ -12,8 +12,10 @@ import { NormalizedSchema } from './normalize-options';
 export async function addLinting(host: Tree, options: NormalizedSchema) {
   let installTask: GeneratorCallback;
 
+  const linter = options.linter || Linter.EsLint;
+
   await lintProjectGenerator(host, {
-    linter: Linter.EsLint,
+    linter,
     project: options.projectName,
     tsConfigPaths: [
       joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),
@@ -22,14 +24,16 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
     skipFormat: true,
   });
 
-  updateJson(
-    host,
-    joinPathFragments(options.appProjectRoot, '.eslintrc.json'),
-    (json) => {
-      json.extends = [...reactEslintJson.extends, ...json.extends];
-      return json;
-    }
-  );
+  if (linter === Linter.EsLint) {
+    updateJson(
+      host,
+      joinPathFragments(options.appProjectRoot, '.eslintrc.json'),
+      (json) => {
+        json.extends = [...reactEslintJson.extends, ...json.extends];
+        return json;
+      }
+    );
+  }
 
   installTask = await addDependenciesToPackageJson(
     host,

--- a/packages/next/src/generators/application/lib/add-linting.ts
+++ b/packages/next/src/generators/application/lib/add-linting.ts
@@ -12,7 +12,13 @@ import { NormalizedSchema } from './normalize-options';
 export async function addLinting(host: Tree, options: NormalizedSchema) {
   let installTask: GeneratorCallback;
 
-  const linter = options.linter || Linter.EsLint;
+  /**
+   * TODO: Remove this use of any once we are consistent across the codebase
+   * in our use of the Linter enum. Currently we have one coming from linter
+   * and one from workspace and they do not match because one is a const enum
+   * and one is not.
+   */
+  const linter: any = options.linter || Linter.EsLint;
 
   await lintProjectGenerator(host, {
     linter,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

This commit https://github.com/nrwl/nx/commit/e71cef0ba9db87823cfa94fbe74550a1e20761d0 caused TSLint to no longer be supported for Next, despite it still being an option in its schema.json.

IMO we should only remove support in a major release of Nx (and naturally we should make sure that the schema.json is appropriately updated).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Next should still work with TSLint.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
