### PR TITLE
fix(react): set defaults properly for unitTestRunner and e2eTestRunner

### DIFF
--- a/packages/react/src/generators/application/lib/normalize-options.ts
+++ b/packages/react/src/generators/application/lib/normalize-options.ts
@@ -30,6 +30,8 @@ export function normalizeOptions(
 
   options.routing = options.routing ?? false;
   options.classComponent = options.classComponent ?? false;
+  options.unitTestRunner = options.unitTestRunner ?? 'jest';
+  options.e2eTestRunner = options.e2eTestRunner ?? 'cypress';
 
   return {
     ...options,


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Defaults arent set for some properties when calling the generator directly.

## Expected Behavior
Defaults are set in the generator when properties are undefiend.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
