### PR TITLE
chore(repo): internal link checker script

### DIFF
--- a/docs/shared/migration/preserving-git-histories.md
+++ b/docs/shared/migration/preserving-git-histories.md
@@ -36,4 +36,4 @@ Note that for these files, the file-history of the stand-alone project will be n
 
 ## Using `git mv`
 
-Especially if your stand-alone project was not an Nx workspace, it's likely that your migration work will also entail moving around directories to match a typical Nx Workspace structure. You can find more information in the [Overview](/{{framwork}}/migration/overview) page, but when migrating an existing project, you'll want to ensure that you use [`git mv`](https://git-scm.com/docs/git-mv) when moving a file or directory to ensure that file history from the old standalone repo is not lost!
+Especially if your stand-alone project was not an Nx workspace, it's likely that your migration work will also entail moving around directories to match a typical Nx Workspace structure. You can find more information in the [Overview](/{{framework}}/migration/overview) page, but when migrating an existing project, you'll want to ensure that you use [`git mv`](https://git-scm.com/docs/git-mv) when moving a file or directory to ensure that file history from the old standalone repo is not lost!

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "npm-run-all": "^4.1.5",
     "open": "6.4.0",
     "opn": "^5.3.0",
+    "parse-markdown-links": "^1.0.4",
     "parse5": "4.0.0",
     "postcss": "8.2.4",
     "postcss-import": "14.0.0",

--- a/scripts/documentation/internal-link-checker.ts
+++ b/scripts/documentation/internal-link-checker.ts
@@ -1,0 +1,142 @@
+import { green, red } from 'chalk';
+import * as shell from 'shelljs';
+import * as fs from 'fs';
+import * as parseLinks from 'parse-markdown-links';
+
+const BASE_PATH = 'docs';
+const FRAMEWORK_SYMBOL = '{{framework}}';
+
+function readFileContents(path: string): string {
+  const buffer = fs.readFileSync(path, { encoding: 'utf-8' });
+  return buffer.toString();
+}
+
+function isLinkInternal(linkPath: string): boolean {
+  return linkPath.startsWith('/');
+}
+
+function isNotAsset(linkPath: string): boolean {
+  return !linkPath.startsWith('/assets');
+}
+
+function isNotImage(linkPath: string): boolean {
+  return !linkPath.endsWith('.png');
+}
+
+function removeAnchors(linkPath: string): string {
+  return linkPath.split('#')[0];
+}
+
+function expandFrameworks(linkPaths: string[]): string[] {
+  return linkPaths.reduce((acc, link) => {
+    if (link.includes(FRAMEWORK_SYMBOL)) {
+      acc.push(link.replace(FRAMEWORK_SYMBOL, 'angular'));
+      acc.push(link.replace(FRAMEWORK_SYMBOL, 'react'));
+      acc.push(link.replace(FRAMEWORK_SYMBOL, 'node'));
+    } else {
+      acc.push(link);
+    }
+    return acc;
+  }, []);
+}
+
+function extractAllInternalLinks(): Record<string, string[]> {
+  return shell.ls(`${BASE_PATH}/**/*.md`).reduce((acc, path) => {
+    const links = parseLinks(readFileContents(path))
+      .filter(isLinkInternal)
+      .filter(isNotAsset)
+      .filter(isNotImage)
+      .map(removeAnchors);
+    if (links.length) {
+      acc[path] = expandFrameworks(links);
+    }
+    return acc;
+  }, {});
+}
+
+interface DocumentTreeFileNode {
+  name: string;
+  id: string;
+  file?: string;
+}
+
+interface DocumentTreeCategoryNode {
+  name?: string;
+  id: string;
+  itemList: DocumentTree[];
+}
+
+type DocumentTree = DocumentTreeFileNode | DocumentTreeCategoryNode;
+
+function isCategoryNode(
+  documentTree: DocumentTree
+): documentTree is DocumentTreeCategoryNode {
+  return !!(documentTree as DocumentTreeCategoryNode).itemList;
+}
+
+function getDocumentMap(): DocumentTree[] {
+  return JSON.parse(
+    fs.readFileSync(`${BASE_PATH}/map.json`, { encoding: 'utf-8' })
+  ) as DocumentTree[];
+}
+
+function buildMapOfExisitingDocumentPaths(
+  tree: DocumentTree[],
+  map: Record<string, boolean> = {},
+  ids: string[] = []
+): Record<string, boolean> {
+  return tree.reduce((acc, treeNode) => {
+    if (isCategoryNode(treeNode)) {
+      buildMapOfExisitingDocumentPaths(treeNode.itemList, acc, [
+        ...ids,
+        treeNode.id,
+      ]);
+    } else {
+      acc[/*treeNode.file ||*/ `${ids.join('/')}/${treeNode.id}`] = true;
+    }
+    return acc;
+  }, map);
+}
+
+function determineErroneousInternalLinks(
+  internalLinks: Record<string, string[]>,
+  validInternalLinksMap: Record<string, boolean>
+): Record<string, string[]> | undefined {
+  let erroneousInternalLinks: Record<string, string[]> | undefined;
+  for (const [docPath, links] of Object.entries(internalLinks)) {
+    const erroneousLinks = links.filter(
+      (link) => !validInternalLinksMap[`${link.slice(1)}`]
+    );
+    if (erroneousLinks.length) {
+      if (!erroneousInternalLinks) {
+        erroneousInternalLinks = {};
+      }
+      erroneousInternalLinks[docPath] = erroneousLinks;
+    }
+  }
+  return erroneousInternalLinks;
+}
+
+const validInternalLinksMap = buildMapOfExisitingDocumentPaths(
+  getDocumentMap()
+);
+
+const internalLinks = extractAllInternalLinks();
+
+const erroneousInternalLinks = determineErroneousInternalLinks(
+  internalLinks,
+  validInternalLinksMap
+);
+
+if (!erroneousInternalLinks) {
+  console.log(green('All internal links appear to be valid!!'));
+  process.exit(0);
+} else {
+  console.log(
+    red(
+      'The following files appear to contain the following invalid internal links:'
+    )
+  );
+  console.log(red(JSON.stringify(erroneousInternalLinks, null, 2)));
+  process.exit(1);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5731,6 +5731,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@~0.1.15:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-0.1.16.tgz#cfd01e0fbba3d6caed049fbd758d40f65196f57c"
+  integrity sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=
+  dependencies:
+    underscore "~1.7.0"
+    underscore.string "~2.4.0"
+
 aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
@@ -5989,6 +5997,11 @@ atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+autolinker@~0.15.0:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-0.15.3.tgz#342417d8f2f3461b14cf09088d5edf8791dc9832"
+  integrity sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI=
 
 autoprefixer@9.7.4:
   version "9.7.4"
@@ -17580,6 +17593,13 @@ parse-json@^5.0.0:
     json-parse-better-errors "^1.0.1"
     lines-and-columns "^1.1.6"
 
+parse-markdown-links@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/parse-markdown-links/-/parse-markdown-links-1.0.4.tgz#43172c8099824e87f327ab3e8a1dddc60b35817f"
+  integrity sha512-/gAfJ4wi6taa0Ayu2S9JXzbzUd2+OWzxlkEs3J00MC24IH2rMriTxMa5unO8a4Ei45nMM2QuAKGpVgX05Aur4w==
+  dependencies:
+    remarkable "1.7.1"
+
 parse-node-version@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-node-version/-/parse-node-version-1.0.1.tgz#e2b5dbede00e7fa9bc363607f53327e8b073189b"
@@ -19620,6 +19640,14 @@ release-it@^7.4.0:
     uuid "3.3.2"
     window-size "1.1.1"
     yargs-parser "11.0.0"
+
+remarkable@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/remarkable/-/remarkable-1.7.1.tgz#aaca4972100b66a642a63a1021ca4bac1be3bff6"
+  integrity sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=
+  dependencies:
+    argparse "~0.1.15"
+    autolinker "~0.15.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -22430,6 +22458,16 @@ ultron@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
   integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
+
+underscore.string@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
+  integrity sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=
+
+underscore@~1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
+  integrity sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=
 
 unfetch@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
# Internal link checker script

+ Adds a script to point out all invalid internal links.
+ Should be attached to CI - however at the moment there are too many broken links to fix all in one go (see below)
+ To run script: `ts-node scripts/documentation/internal-link-checker.ts`

## Current Output

```
The following files appear to contain the following invalid internal links:
{
  "docs/angular/guides/setup-incremental-builds.md": [
    "/angular/guides/ci/incremental-builds"
  ],
  "docs/angular/migration/migration-angular.md": [
    "/angular/guides/transition-to-nx"
  ],
  "docs/angular/tutorial/01-create-application.md": [
    "/angular/cli/nx-and-cli"
  ],
  "docs/shared/angular-plugin.md": [
    "/react/guides/misc-data-persistence",
    "/node/guides/misc-data-persistence",
    "/react/guides/misc-ngrx",
    "/node/guides/misc-ngrx",
    "/angular/guides/misc-angular",
    "/react/guides/misc-angular",
    "/node/guides/misc-angular"
  ],
  "docs/shared/incremental-builds.md": [
    "/angular/guides/ci/setup-incremental-builds-angular",
    "/react/guides/ci/setup-incremental-builds-angular",
    "/node/guides/ci/setup-incremental-builds-angular"
  ],
  "docs/shared/migration/overview.md": [
    "/nx-community"
  ],
  "docs/shared/monorepo-nx-enterprise.md": [
    "/shared/monorepo-tags",
    "/shared/monorepo-affected"
  ],
  "docs/shared/next-plugin.md": [
    "/angular/next/package",
    "/react/next/package",
    "/node/next/package"
  ],
  "docs/shared/nx-plugin.md": [
    "/nx-community"
  ],
  "docs/shared/plugins-overview.md": [
    "/node/storybook/overview",
    "/nx-community"
  ],
  "docs/shared/react-plugin.md": [
    "/node/storybook/overview"
  ],
  "docs/shared/workspace/buildable-and-publishable-libraries.md": [
    "/node/storybook/overview"
  ],
  "docs/shared/workspace/structure/dependency-graph.md": [
    "/{framework}/getting-started/configuration"
  ]
}
```