### PR TITLE
fix(react): fix init generators for react

### DIFF
--- a/packages/gatsby/src/generators/init/init.ts
+++ b/packages/gatsby/src/generators/init/init.ts
@@ -3,6 +3,7 @@ import {
   convertNxGenerator,
   GeneratorCallback,
   Tree,
+  updateJson,
 } from '@nrwl/devkit';
 import { jestInitGenerator } from '@nrwl/jest';
 import { cypressInitGenerator } from '@nrwl/cypress';
@@ -33,6 +34,13 @@ import { InitSchema } from './schema';
 import { parallelizeTasks } from '@nrwl/workspace/src/utilities/parallelize-tasks';
 
 function updateDependencies(host: Tree) {
+  updateJson(host, 'package.json', (json) => {
+    if (json.dependencies && json.dependencies['@nrwl/gatsby']) {
+      delete json.dependencies['@nrwl/gatsby'];
+    }
+    return json;
+  });
+
   const isPnpm = host.exists('pnpm-lock.yaml');
   return addDependenciesToPackageJson(
     host,
@@ -54,7 +62,7 @@ function updateDependencies(host: Tree) {
       ...(isPnpm ? { 'gatsby-plugin-pnpm': gatsbyPluginPnpm } : {}),
     },
     {
-      '@nrwl/react': nxVersion,
+      '@nrwl/gatsby': nxVersion,
       '@testing-library/react': testingLibraryReactVersion,
       'babel-plugin-module-resolver': babelPluginModuleResolverVersion,
       'babel-preset-gatsby': babelPresetGatsbyVersion,

--- a/packages/next/src/generators/init/init.ts
+++ b/packages/next/src/generators/init/init.ts
@@ -3,6 +3,7 @@ import {
   convertNxGenerator,
   GeneratorCallback,
   Tree,
+  updateJson,
 } from '@nrwl/devkit';
 import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-collection';
 import { parallelizeTasks } from '@nrwl/workspace/src/utilities/parallelize-tasks';
@@ -10,10 +11,17 @@ import { jestInitGenerator } from '@nrwl/jest';
 import { cypressInitGenerator } from '@nrwl/cypress';
 import { reactDomVersion, reactInitGenerator, reactVersion } from '@nrwl/react';
 
-import { nextVersion } from '../../utils/versions';
+import { nextVersion, nxVersion } from '../../utils/versions';
 import { InitSchema } from './schema';
 
 function updateDependencies(host: Tree) {
+  updateJson(host, 'package.json', (json) => {
+    if (json.dependencies && json.dependencies['@nrwl/gatsby']) {
+      delete json.dependencies['@nrwl/gatsby'];
+    }
+    return json;
+  });
+
   return addDependenciesToPackageJson(
     host,
     {
@@ -22,7 +30,9 @@ function updateDependencies(host: Tree) {
       'react-dom': reactDomVersion,
       tslib: '^2.0.0',
     },
-    {}
+    {
+      '@nrwl/next': nxVersion,
+    }
   );
 }
 

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -5,6 +5,7 @@ import {
   GeneratorCallback,
   readWorkspaceConfiguration,
   Tree,
+  updateJson,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { jestInitGenerator } from '@nrwl/jest';
@@ -41,6 +42,31 @@ function setDefault(host: Tree) {
   setDefaultCollection(host, '@nrwl/react');
 }
 
+function updateDependencies(host: Tree) {
+  updateJson(host, 'package.json', (json) => {
+    if (json.dependencies && json.dependencies['@nrwl/react']) {
+      delete json.dependencies['@nrwl/react'];
+    }
+    return json;
+  });
+
+  return addDependenciesToPackageJson(
+    host,
+    {
+      'core-js': '^3.6.5',
+      react: reactVersion,
+      'react-dom': reactDomVersion,
+      tslib: '^2.0.0',
+    },
+    {
+      '@nrwl/react': nxVersion,
+      '@types/react': typesReactVersion,
+      '@types/react-dom': typesReactDomVersion,
+      '@testing-library/react': testingLibraryReactVersion,
+    }
+  );
+}
+
 export async function reactInitGenerator(host: Tree, schema: InitSchema) {
   const tasks: GeneratorCallback[] = [];
 
@@ -57,21 +83,7 @@ export async function reactInitGenerator(host: Tree, schema: InitSchema) {
 
   const initTask = await webInitGenerator(host, schema);
   tasks.push(initTask);
-  const installTask = addDependenciesToPackageJson(
-    host,
-    {
-      'core-js': '^3.6.5',
-      react: reactVersion,
-      'react-dom': reactDomVersion,
-      tslib: '^2.0.0',
-    },
-    {
-      '@nrwl/react': nxVersion,
-      '@types/react': typesReactVersion,
-      '@types/react-dom': typesReactDomVersion,
-      '@testing-library/react': testingLibraryReactVersion,
-    }
-  );
+  const installTask = updateDependencies(host);
   tasks.push(installTask);
 
   return parallelizeTasks(...tasks);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Initializing `@nrwl/react`, `@nrwl/gatsby`, and `@nrwl/next` don't remove the dependency from `dependencies` and move it to `devDependencies`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Initializing `@nrwl/react`, `@nrwl/gatsby`, and `@nrwl/next` removes the dependency from `dependencies` and move it to `devDependencies`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
