### PR TITLE
fix(repo): fixing broken internal links

### DIFF
--- a/docs/angular/guides/setup-incremental-builds.md
+++ b/docs/angular/guides/setup-incremental-builds.md
@@ -1,6 +1,6 @@
 # Setup incremental builds for Angular applications
 
-In this guide we’ll specifically look into which changes need to be made to enable [incremental builds](/angular/guides/ci/incremental-builds) for Angular applications.
+In this guide we’ll specifically look into which changes need to be made to enable [incremental builds](/angular/ci/incremental-builds) for Angular applications.
 
 ## Use buildable libraries
 

--- a/docs/angular/migration/migration-angular.md
+++ b/docs/angular/migration/migration-angular.md
@@ -97,7 +97,7 @@ Learn more about the advantages of Nx in the following guides:
 
 ## Transitioning Manually
 
-If you are unable to automatically transform your Angular CLI workspace to an Nx workspace using the [ng add](/angular/guides/transition-to-nx#using-ng-add) method, there are some manual steps you can take to move your project(s) into an Nx workspace.
+If you are unable to automatically transform your Angular CLI workspace to an Nx workspace using the [ng add](angular/migration/migration-angular#using-ng-add) method, there are some manual steps you can take to move your project(s) into an Nx workspace.
 
 ### Generating a new workspace
 

--- a/docs/angular/tutorial/01-create-application.md
+++ b/docs/angular/tutorial/01-create-application.md
@@ -120,7 +120,7 @@ yarn nx serve todos
 
 ## Note on `nx serve` and `ng serve`
 
-Internally, the Nx CLI delegates to the Angular CLI when running commands or generating code. The `nx serve` command produces the same result as `ng serve`, and `nx build` produces the same results as `ng build`. However, the Nx CLI supports advanced capabilities that aren't supported by the Angular CLI. For instance, Nx's computation cache only works when using the Nx CLI. In other words, using `nx` instead `ng` will result in the same output, but often will perform a lot better. [Read more about Nx CLI and Angular CLI.](/angular/cli/nx-and-cli)
+Internally, the Nx CLI delegates to the Angular CLI when running commands or generating code. The `nx serve` command produces the same result as `ng serve`, and `nx build` produces the same results as `ng build`. However, the Nx CLI supports advanced capabilities that aren't supported by the Angular CLI. For instance, Nx's computation cache only works when using the Nx CLI. In other words, using `nx` instead `ng` will result in the same output, but often will perform a lot better. [Read more about Nx CLI and Angular CLI.](/angular/getting-started/nx-and-cli)
 
 !!!!!
 Open http://localhost:4200 in the browser. What do you see?

--- a/docs/map.json
+++ b/docs/map.json
@@ -2601,6 +2601,11 @@
         "id": "storybook",
         "itemList": [
           {
+            "name": "Overview",
+            "id": "overview",
+            "file": "node/guides/storybook-plugin"
+          },
+          {
             "name": "configuration generator",
             "id": "configuration",
             "file": "node/api-storybook/generators/configuration"

--- a/docs/node/guides/storybook-plugin.md
+++ b/docs/node/guides/storybook-plugin.md
@@ -1,0 +1,12 @@
+# Storybook
+
+![Storybook logo](/shared/storybook-logo.png)
+
+Storybook is a development environment for UI components. It allows you to browse a component library, view the different states of each component, and interactively develop and test components.
+
+## Links to Further Instructions
+
+Storybook doesn't make much sense in the context of Node, but here are links on further details to using Storybook with your frontend framework of choice:
+
+- [Angular](/angular/storybook/overview)
+- [React](/react/storybook/overview)

--- a/docs/node/guides/storybook-plugin.md
+++ b/docs/node/guides/storybook-plugin.md
@@ -6,7 +6,5 @@ Storybook is a development environment for UI components. It allows you to brows
 
 ## Links to Further Instructions
 
-Storybook doesn't make much sense in the context of Node, but here are links on further details to using Storybook with your frontend framework of choice:
-
 - [Angular](/angular/storybook/overview)
 - [React](/react/storybook/overview)

--- a/docs/shared/angular-plugin.md
+++ b/docs/shared/angular-plugin.md
@@ -81,9 +81,9 @@ myorg/
 
 ## See Also
 
-- [Using DataPersistence](/{{framework}}/guides/misc-data-persistence)
-- [Using NgRx](/{{framework}}/guides/misc-ngrx)
-- [Upgrading an AngularJS application to Angular](/{{framework}}/guides/misc-angular)
+- [Using DataPersistence](/angular/guides/misc-data-persistence)
+- [Using NgRx](/angular/guides/misc-ngrx)
+- [Upgrading an AngularJS application to Angular](/angular/guides/misc-upgrade)
 
 ## Executors / Builders
 

--- a/docs/shared/incremental-builds.md
+++ b/docs/shared/incremental-builds.md
@@ -55,6 +55,6 @@ Also, using incremental builds only really makes sense when using the distribute
 
 ## Setup an incremental build
 
-- [Setup an incremental build for an Angular app](/{{framework}}/ci/setup-incremental-builds-angular)
+- [Setup an incremental build for an Angular app](/angular/ci/setup-incremental-builds-angular)
 - _Setup an incremental build for a React app (soon)_
 - _Setup an incremental build for a Node app (soon)_

--- a/docs/shared/monorepo-nx-enterprise.md
+++ b/docs/shared/monorepo-nx-enterprise.md
@@ -136,7 +136,7 @@ For a large organization it's crucial to establish how projects can depend on ea
 - Libraries with a broader scope (e.g., `shared/ui`) should not depend on the libraries with narrower scope (e.g., `happynrwlapp/search/utils-testing`).
 - Component libraries should only depend on other component libraries and utility libraries, but should not depend feature libraries.
 
-Nx provides a feature called tags that can be used to codify and statically-enforce these rules. Read more about tags [here](/shared/monorepo-tags).
+Nx provides a feature called tags that can be used to codify and statically-enforce these rules. Read more about tags [here](/{{framework}}/structure/monorepo-tags).
 
 ## Code Ownership
 
@@ -186,7 +186,7 @@ Note `all the projects affected by a PR/commit`. This is very important. Monorep
 - The performance of CI checks will degrade over time. The time it takes to run the CI checks should be proportional to the impact of the change, not the size of the repo.
 - We will be affected by the code your change didn’t touch
 
-We should utilize `affected:*` commands to build and test projects. Read more about them [here](/shared/monorepo-affected).
+We should utilize `affected:*` commands to build and test projects. Read more about them [here](/{{framework}}/cli/affected).
 
 ### Trunk-based development
 

--- a/docs/shared/next-plugin.md
+++ b/docs/shared/next-plugin.md
@@ -66,7 +66,7 @@ myorg/
 
 - [build](/{{framework}}/next/build) - Builds a Next.js application
 - [server](/{{framework}}/next/server) - Builds and serves a Next.js application
-- [export](/{{framework}}/next/package) - Export a Next.js app. The exported application is located at `dist/$outputPath/exported`
+- [export](/{{framework}}/next/export) - Export a Next.js app. The exported application is located at `dist/$outputPath/exported`
 
 ## Generators
 

--- a/docs/shared/workspace/structure/dependency-graph.md
+++ b/docs/shared/workspace/structure/dependency-graph.md
@@ -18,7 +18,7 @@ Nx creates a graph of all the dependencies between projects in your workspace us
 
    Then `my-app` depends on `awesome-library`
 
-2. Manually created `implicitDependencies` in the `nx.json` file. [Full `implicitDependencies` documentation](/{framework}/getting-started/configuration#implicit-dependencies)
+2. Manually created `implicitDependencies` in the `nx.json` file. [Full `implicitDependencies` documentation](/{{framework}}/getting-started/configuration#implicit-dependencies)
 
    If your `nx.json` has this content:
 


### PR DESCRIPTION
# Fixes broken internal links

## My notes on the fixes:
```
File containing bad link: "docs/angular/guides/setup-incremental-builds.md"
Bad link: "/angular/guides/ci/incremental-builds"
Fix: corrected to "/angular/ci/incremental-builds"

===

File containing bad link: "docs/angular/migration/migration-angular.md"
Bad link: "/angular/guides/transition-to-nx"
Fix: appeared to be pointing to section above, so made that happen correctly.

===

File containing bad link: "docs/angular/tutorial/01-create-application.md"
Bad link: "/angular/cli/nx-and-cli"
Fix: corrected to "angular/getting-started/nx-and-cli"

===

File containing bad link: "docs/shared/angular-plugin.md"
Bad links: 
    "/react/guides/misc-data-persistence",
    "/node/guides/misc-data-persistence",
    "/react/guides/misc-ngrx",
    "/node/guides/misc-ngrx",
    "/angular/guides/misc-angular",
    "/react/guides/misc-angular",
    "/node/guides/misc-angular"
Fix: corrected from "{{framework}}" to "angular"

===

File containing bad link: "docs/shared/incremental-builds.md"
Bad Link: "/{{framework}}/guides/ci/setup-incremental-builds-angular"
Fix: replaced {{framework}} with "angular" and removed "guides"

===

File containing bad link: "docs/shared/migration/overview.md"
Bad Link: "/nx-community"
Fix: no fix necessary - will update script to omit links to `/nx-community` as that apparently is another valid link that our `map.json` file is unaware of.

===

File containing bad link: "docs/shared/monorepo-nx-enterprise.md"
Bad Links: "/shared/monorepo-tags", "/shared/monorepo-affected"
Fix: updated to: "{{framework}}/structure/monorepo-tags" and "/{{framework}}/cli/affected"

===

File containing bad link: "docs/shared/next-plugin.md"
Bad Link: "/{{framework}}/next/package"
Fix: updated to "/{{fraework}}/next/export

===

File containing bad link: "docs/shared/nx-plugin.md"
Bad Link: "/nx-community"
Fix: no fix necessary - will update script to omit links to `/nx-community` as that apparently is another valid link that our `map.json` file is unaware of.

===

Files containing bad link: "docs/shared/nx-plugin.md", "docs/shared/react-plugin.md", "docs/shared/workspace/buildable-and-publishable-libraries.md"
Bad Link: "/node/storybook/overview"
Fix: added "node/guides/storybook-plugin.md" to file structure and `map.json`

===

File containing bad link: "docs/shared/nx-plugin.md"
Bad Link: "/{framework}/getting-started/configuration"
Fix: added double brackets: "/{{framework}}/getting-started/configuration" [looks like this one actually wasn't broken in prod]
```