### PR TITLE
feat(node): implicit dependencies for node builder executor

### DIFF
--- a/docs/angular/api-node/executors/build.md
+++ b/docs/angular/api-node/executors/build.md
@@ -62,6 +62,12 @@ Type: `boolean`
 
 Generates a package.json file with the project's node_module dependencies populated for installing in a container. If a package.json exists in the project's directory, it will be reused with dependencies populated.
 
+### implicitDependencies
+
+Type: `array`
+
+Defines implicit dependencies for the generated package json.
+
 ### main
 
 Type: `string`

--- a/docs/angular/api-node/executors/build.md
+++ b/docs/angular/api-node/executors/build.md
@@ -68,6 +68,16 @@ Type: `array`
 
 Defines implicit dependencies for the generated package json.
 
+### implicitDependenciesBehavior
+
+Default: `keep`
+
+Type: `string`
+
+Possible values: `keep`, `replace`
+
+Defines implicit dependencies behavior for the generated package json.
+
 ### main
 
 Type: `string`

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -69,6 +69,16 @@ Type: `array`
 
 Defines implicit dependencies for the generated package json.
 
+### implicitDependenciesBehavior
+
+Default: `keep`
+
+Type: `string`
+
+Possible values: `keep`, `replace`
+
+Defines implicit dependencies behavior for the generated package json.
+
 ### main
 
 Type: `string`

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -63,6 +63,12 @@ Type: `boolean`
 
 Generates a package.json file with the project's node_module dependencies populated for installing in a container. If a package.json exists in the project's directory, it will be reused with dependencies populated.
 
+### implicitDependencies
+
+Type: `array`
+
+Defines implicit dependencies for the generated package json.
+
 ### main
 
 Type: `string`

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -69,6 +69,16 @@ Type: `array`
 
 Defines implicit dependencies for the generated package json.
 
+### implicitDependenciesBehavior
+
+Default: `keep`
+
+Type: `string`
+
+Possible values: `keep`, `replace`
+
+Defines implicit dependencies behavior for the generated package json.
+
 ### main
 
 Type: `string`

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -63,6 +63,12 @@ Type: `boolean`
 
 Generates a package.json file with the project's node_module dependencies populated for installing in a container. If a package.json exists in the project's directory, it will be reused with dependencies populated.
 
+### implicitDependencies
+
+Type: `array`
+
+Defines implicit dependencies for the generated package json.
+
 ### main
 
 Type: `string`

--- a/packages/node/src/builders/build/schema.json
+++ b/packages/node/src/builders/build/schema.json
@@ -122,6 +122,14 @@
       "type": "boolean",
       "description": "Generates a package.json file with the project's node_module dependencies populated for installing in a container. If a package.json exists in the project's directory, it will be reused with dependencies populated.",
       "default": false
+    },
+    "implicitDependencies": {
+      "description": "Defines implicit dependencies for the generated package json.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
     }
   },
   "required": ["tsConfig", "main"],

--- a/packages/node/src/builders/build/schema.json
+++ b/packages/node/src/builders/build/schema.json
@@ -130,6 +130,12 @@
         "type": "string"
       },
       "default": []
+    },
+    "implicitDependenciesBehavior": {
+      "description": "Defines implicit dependencies behavior for the generated package json.",
+      "type": "string",
+      "enum": ["keep", "replace"],
+      "default": "keep"
     }
   },
   "required": ["tsConfig", "main"],

--- a/packages/node/src/utils/generate-package-json.ts
+++ b/packages/node/src/utils/generate-package-json.ts
@@ -1,7 +1,7 @@
 import { ProjectGraph, readJsonFile } from '@nrwl/workspace';
-import { BuildNodeBuilderOptions } from './types';
 import { writeJsonFile } from '@nrwl/workspace/src/utilities/fileutils';
 import { OUT_FILENAME } from './config';
+import { BuildNodeBuilderOptions } from './types';
 
 /**
  * Creates a package.json in the output directory for support  to install dependencies within containers.
@@ -39,6 +39,16 @@ export function generatePackageJson(
   Object.entries(npmDeps).forEach(([packageName, version]) => {
     // don't include devDeps
     if (rootPackageJson.devDependencies?.[packageName]) {
+      return;
+    }
+
+    packageJson.dependencies[packageName] = version;
+  });
+
+  options.implicitDependencies.forEach((packageName) => {
+    const version = rootPackageJson.dependencies[packageName];
+
+    if (!version) {
       return;
     }
 

--- a/packages/node/src/utils/generate-package-json.ts
+++ b/packages/node/src/utils/generate-package-json.ts
@@ -46,7 +46,14 @@ export function generatePackageJson(
   });
 
   options.implicitDependencies.forEach((packageName) => {
-    const version = rootPackageJson.dependencies[packageName];
+    let version: string | undefined;
+
+    switch (options.implicitDependenciesBehavior) {
+      case 'keep':
+        version = packageJson.dependencies[packageName];
+      case 'replace':
+        version = version ?? rootPackageJson.dependencies[packageName];
+    }
 
     if (!version) {
       return;

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -51,4 +51,5 @@ export interface BuildNodeBuilderOptions extends BuildBuilderOptions {
   buildLibsFromSource?: boolean;
   generatePackageJson?: boolean;
   implicitDependencies?: string[];
+  implicitDependenciesBehavior?: 'keep' | 'replace';
 }

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -50,4 +50,5 @@ export interface BuildNodeBuilderOptions extends BuildBuilderOptions {
   externalDependencies: 'all' | 'none' | string[];
   buildLibsFromSource?: boolean;
   generatePackageJson?: boolean;
+  implicitDependencies?: string[];
 }


### PR DESCRIPTION
This MR introduce a new `implicitDependencies` option to node build executor, to set implicit dependencies which are not detected in the generatePackage process. This option must be used together with generatePackageJson

## Current Behavior
When use the generatePackageJson in node build builder, the json  package is generated without all required dependencies to run the final application

## Expected Behavior
The generated package json should contains all required dependencies

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
