### PR TITLE
feat(react, next): adding material-ui support

### DIFF
--- a/docs/angular/api-next/generators/application.md
+++ b/docs/angular/api-next/generators/application.md
@@ -108,7 +108,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`
 
 The file extension to be used for style files.
 

--- a/docs/angular/api-next/generators/component.md
+++ b/docs/angular/api-next/generators/component.md
@@ -102,6 +102,6 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`
 
 The file extension to be used for style files.

--- a/docs/angular/api-next/generators/page.md
+++ b/docs/angular/api-next/generators/page.md
@@ -94,7 +94,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `none`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/angular/api-react/generators/application.md
+++ b/docs/angular/api-react/generators/application.md
@@ -150,7 +150,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `none`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/angular/api-react/generators/component.md
+++ b/docs/angular/api-react/generators/component.md
@@ -140,6 +140,6 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `none`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`, `none`
 
 The file extension to be used for style files.

--- a/docs/angular/api-react/generators/library.md
+++ b/docs/angular/api-react/generators/library.md
@@ -158,7 +158,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `none`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/node/api-next/generators/application.md
+++ b/docs/node/api-next/generators/application.md
@@ -108,7 +108,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`
 
 The file extension to be used for style files.
 

--- a/docs/node/api-next/generators/component.md
+++ b/docs/node/api-next/generators/component.md
@@ -102,6 +102,6 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`
 
 The file extension to be used for style files.

--- a/docs/node/api-next/generators/page.md
+++ b/docs/node/api-next/generators/page.md
@@ -94,7 +94,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `none`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/node/api-react/generators/application.md
+++ b/docs/node/api-react/generators/application.md
@@ -150,7 +150,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `none`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/node/api-react/generators/component.md
+++ b/docs/node/api-react/generators/component.md
@@ -140,6 +140,6 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `none`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`, `none`
 
 The file extension to be used for style files.

--- a/docs/node/api-react/generators/library.md
+++ b/docs/node/api-react/generators/library.md
@@ -158,7 +158,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `none`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/react/api-next/generators/application.md
+++ b/docs/react/api-next/generators/application.md
@@ -108,7 +108,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`
 
 The file extension to be used for style files.
 

--- a/docs/react/api-next/generators/component.md
+++ b/docs/react/api-next/generators/component.md
@@ -102,6 +102,6 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`
 
 The file extension to be used for style files.

--- a/docs/react/api-next/generators/page.md
+++ b/docs/react/api-next/generators/page.md
@@ -94,7 +94,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `none`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/react/api-react/generators/application.md
+++ b/docs/react/api-react/generators/application.md
@@ -150,7 +150,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `none`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`, `none`
 
 The file extension to be used for style files.
 

--- a/docs/react/api-react/generators/component.md
+++ b/docs/react/api-react/generators/component.md
@@ -140,6 +140,6 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `none`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`, `none`
 
 The file extension to be used for style files.

--- a/docs/react/api-react/generators/library.md
+++ b/docs/react/api-react/generators/library.md
@@ -158,7 +158,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `none`
+Possible values: `css`, `scss`, `styl`, `less`, `styled-components`, `@emotion/styled`, `styled-jsx`, `@material-ui`, `none`
 
 The file extension to be used for style files.
 

--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -225,6 +225,19 @@ describe('React Applications', () => {
       checkE2E: false,
     });
 
+    const materialUiApp = uniq('app');
+
+    runCLI(
+      `generate @nrwl/react:app ${materialUiApp} --style @material-ui --no-interactive`
+    );
+
+    await testGeneratedApp(materialUiApp, {
+      checkStyles: false,
+      checkProdBuild: false,
+      checkLinter: false,
+      checkE2E: false,
+    });
+
     const noStylesApp = uniq('app');
 
     runCLI(

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -307,15 +307,23 @@ function determineStyle(preset: Preset, parsedArgs: WorkspaceArgs) {
     choices.push(
       {
         value: 'styled-components',
-        name: 'styled-components [ https://styled-components.com            ]',
+        name:
+          'styled-components [ https://styled-components.com                   ]',
       },
       {
         value: '@emotion/styled',
-        name: 'emotion           [ https://emotion.sh                       ]',
+        name:
+          'emotion           [ https://emotion.sh                              ]',
       },
       {
         value: 'styled-jsx',
-        name: 'styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]',
+        name:
+          'styled-jsx        [ https://www.npmjs.com/package/styled-jsx        ]',
+      },
+      {
+        value: '@material-ui',
+        name:
+          'material-ui       [ https://www.npmjs.com/package/@material-ui/core ]',
       }
     );
   }

--- a/packages/gatsby/src/generators/application/application.spec.ts
+++ b/packages/gatsby/src/generators/application/application.spec.ts
@@ -143,6 +143,7 @@ describe('app', () => {
   });
 
   // TODO: We should also add styled-jsx support for Gatsby to keep React plugins consistent.
+  // TODO: Should @material-ui support be added as well?
   // This needs to be here before Nx 12 is released.
   xdescribe('--style styled-jsx', () => {
     it('should use <style jsx> in index page', async () => {

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -169,6 +169,27 @@ describe('app', () => {
     });
   });
 
+  describe('--style @material-ui', () => {
+    it('should use <Container> in index page', async () => {
+      await applicationGenerator(tree, {
+        name: 'myApp',
+        style: '@material-ui',
+      });
+
+      expect(
+        tree.exists('apps/my-app/pages/index.module.@material-ui')
+      ).toBeFalsy();
+      expect(tree.exists('apps/my-app/pages/styles.@material-ui')).toBeFalsy();
+      expect(tree.exists('apps/my-app/pages/styles.css')).toBeFalsy();
+
+      const indexContent = tree.read('apps/my-app/pages/index.tsx').toString();
+      expect(indexContent).toContain(
+        `import { Container } from '@material-ui/core'`
+      );
+      expect(indexContent).toContain(`<Container>`);
+    });
+  });
+
   it('should setup jest with tsx support', async () => {
     await applicationGenerator(tree, { name: 'my-app', style: 'css' });
 

--- a/packages/next/src/generators/application/files/pages/__fileName__.tsx__tmpl__
+++ b/packages/next/src/generators/application/files/pages/__fileName__.tsx__tmpl__
@@ -1,22 +1,25 @@
 import React from 'react';
-<% if (styledModule && styledModule !== 'styled-jsx') {
+<% if (styledModule && styledModule === '@material-ui') {
+  var wrapper = 'Container';
+%>import { Container } from '@material-ui/core';
+<% } else if  (styledModule && styledModule !== 'styled-jsx') {
   var wrapper = 'StyledPage';
 %>import styled from '<%= styledModule %>';<% } else {
   var wrapper = 'div';
 %>
-  <%- style !== 'styled-jsx' ? `import styles from './${fileName}.module.${style}';` : '' %>
+  <%- (style !== 'styled-jsx' && style !== '@material-ui') ? `import styles from './${fileName}.module.${style}';` : '' %>
 <% }
 %>
 
-<% if (styledModule && styledModule !== 'styled-jsx') { %>
+<% if (styledModule && styledModule !== 'styled-jsx' && styledModule !== '@material-ui') { %>
 const StyledPage = styled.div`<%- pageStyleContent %>`;
-<% }%>
+<% } %>
 
 export function Index() {
   /*
    * Replace the elements below with your own.
    *
-   * Note: The corresponding styles are in the ./<%= fileName %>.<%= style %> file.
+   <% if ((styledModule && styledModule !== '@material-ui') || !styledModule) { %> * Note: The corresponding styles are in the ./<%= fileName %>.<%= style %> file.<% } %>
    */
   return (
     <<%= wrapper %><% if (!styledModule) {%> className={styles.page}<% } %>>

--- a/packages/next/src/generators/application/lib/create-application-files.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.ts
@@ -49,6 +49,12 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
     host.delete(`${options.appProjectRoot}/pages/_document.tsx`);
   }
 
+  if (options.style === '@material-ui') {
+    host.delete(
+      `${options.appProjectRoot}/pages/styles.${templateVariables.stylesExt}`
+    );
+  }
+
   if (options.js) {
     host.delete(`${options.appProjectRoot}/index.d.ts`);
     toJS(host);

--- a/packages/next/src/generators/application/schema.json
+++ b/packages/next/src/generators/application/schema.json
@@ -59,6 +59,10 @@
           {
             "value": "styled-jsx",
             "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
+          },
+          {
+            "value": "@material-ui",
+            "label": "material-ui       [ https://material-ui.com       ]"
           }
         ]
       }

--- a/packages/next/src/generators/component/schema.json
+++ b/packages/next/src/generators/component/schema.json
@@ -71,6 +71,10 @@
           {
             "value": "styled-jsx",
             "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
+          },
+          {
+            "value": "@material-ui",
+            "label": "material-ui       [ https://material-ui.com       ]"
           }
         ]
       }

--- a/packages/next/src/generators/page/schema.json
+++ b/packages/next/src/generators/page/schema.json
@@ -73,6 +73,10 @@
             "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
           },
           {
+            "value": "@material-ui",
+            "label": "material-ui       [ https://material-ui.com       ]"
+          },
+          {
             "value": "none",
             "label": "None"
           }

--- a/packages/next/src/utils/styles.ts
+++ b/packages/next/src/utils/styles.ts
@@ -51,6 +51,10 @@ export const NEXT_SPECIFIC_STYLE_DEPENDENCIES = {
     },
     devDependencies: {},
   },
+  '@material-ui': {
+    dependencies: CSS_IN_JS_DEPENDENCIES['@material-ui'].dependencies,
+    devDependencies: CSS_IN_JS_DEPENDENCIES['@material-ui'].devDependencies,
+  },
 };
 
 export function addStyleDependencies(

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -535,6 +535,57 @@ describe('app', () => {
     });
   });
 
+  describe('--style @material-ui', () => {
+    it('should use @material-ui as the styled API library', async () => {
+      await applicationGenerator(appTree, {
+        ...schema,
+        style: '@material-ui',
+      });
+
+      expect(
+        appTree.exists('apps/my-app/src/app/app.@material-ui')
+      ).toBeFalsy();
+      expect(
+        appTree.exists('apps/my-app/src/app/styles.@material-ui')
+      ).toBeFalsy();
+      expect(appTree.exists('apps/my-app/src/app/styles.css')).toBeFalsy();
+
+      expect(appTree.exists('apps/my-app/src/app/app.tsx')).toBeTruthy();
+
+      const content = appTree.read('apps/my-app/src/app/app.tsx').toString();
+      expect(content).toContain(
+        `import { Container } from '@material-ui/core'`
+      );
+      expect(content).toContain('<Container>');
+    });
+
+    it('should add dependencies to package.json', async () => {
+      await applicationGenerator(appTree, {
+        ...schema,
+        style: '@material-ui',
+      });
+
+      const packageJSON = readJson(appTree, 'package.json');
+      expect(packageJSON.dependencies['@material-ui/core']).toBeDefined();
+      expect(packageJSON.dependencies['clsx']).toBeDefined();
+    });
+
+    it('should update babel config', async () => {
+      await applicationGenerator(appTree, {
+        ...schema,
+        style: 'styled-jsx',
+      });
+
+      const babelrc = readJson(appTree, 'apps/my-app/.babelrc');
+      const babelJestConfig = readJson(
+        appTree,
+        'apps/my-app/babel-jest.config.json'
+      );
+      expect(babelrc.plugins).toContain('styled-jsx/babel');
+      expect(babelJestConfig.plugins).toContain('styled-jsx/babel');
+    });
+  });
+
   describe('--routing', () => {
     it('should add routes to the App component', async () => {
       await applicationGenerator(appTree, {

--- a/packages/react/src/generators/application/files/material-ui/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/material-ui/src/app/__fileName__.tsx__tmpl__
@@ -1,0 +1,102 @@
+<% if (classComponent) { %>
+import React, { Component } from 'react';
+<% } else { %>
+import React from 'react';
+<% } %>
+import { Container } from '@material-ui/core';
+
+import { ReactComponent as Logo } from './logo.svg';
+import star from './star.svg';
+
+<% if (classComponent) { %>
+export class App extends Component {
+  render() {
+<% } else { %>
+export function App() {
+<% } %>
+  return (
+     <Container>
+         <header>
+      <Logo width="75" height="75"/>
+      <h1>Welcome to <%= name %>!</h1>
+    </header>
+    <main>
+      <h2>Resources &amp; Tools</h2>
+      <p>
+        Thank you for using and showing some ♥ for Nx.
+      </p>
+      <div>
+        <a href="https://github.com/nrwl/nx" target="_blank" rel="noopener noreferrer"> If you like Nx, please give it a star:
+          <div>
+              <img src={star} alt="" />
+              Star
+          </div>
+        </a>
+      </div>
+      <p>
+        Here are some links to help you get started.
+      </p>
+      <ul>
+        <li>
+          <a
+            href="https://egghead.io/playlists/scale-react-development-with-nx-4038"
+          >
+            Scale React Development with Nx (Course)
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://nx.dev/latest/react/tutorial/01-create-application"
+          >
+            Interactive tutorial
+          </a>
+        </li>
+        <li>
+          <a flex" href="https://nx.app/">
+            <svg width="36" height="36" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M120 15V30C103.44 30 90 43.44 90 60C90 76.56 76.56 90 60 90C43.44 90 30 103.44 30 120H15C6.72 120 0 113.28 0 105V15C0 6.72 6.72 0 15 0H105C113.28 0 120 6.72 120 15Z" fill="#0E2039"/>
+              <path d="M120 30V105C120 113.28 113.28 120 105 120H30C30 103.44 43.44 90 60 90C76.56 90 90 76.56 90 60C90 43.44 103.44 30 120 30Z" fill="white"/>
+            </svg>
+            <span>Nx Cloud</span>
+          </a>
+        </li>
+      </ul>
+      <h2>Next Steps</h2>
+      <p>
+        Here are some things you can do with Nx.
+      </p>
+      <details open>
+        <summary>Add UI library</summary>
+        <pre>{`# Generate UI lib
+nx g @nrwl/react:lib ui
+
+# Add a component
+nx g @nrwl/react:component xyz --project ui`}</pre>
+      </details>
+      <details>
+        <summary>View dependency graph</summary>
+        <pre>{`nx dep-graph`}</pre>
+      </details>
+      <details>
+        <summary>Run affected commands</summary>
+        <pre>{`# see what's been affected by changes
+nx affected:dep-graph
+
+# run tests for current changes
+nx affected:test
+
+# run e2e tests for current changes
+nx affected:e2e
+  `}</pre>
+      </details>
+    </main>
+     </Container>
+  );
+<% if (classComponent) { %>
+  }
+}
+<% } else { %>
+}
+<% } %>
+
+export default App;

--- a/packages/react/src/generators/application/lib/add-project.ts
+++ b/packages/react/src/generators/application/lib/add-project.ts
@@ -55,7 +55,8 @@ function createBuildTarget(options: NormalizedSchema): TargetConfiguration {
         joinPathFragments(options.appProjectRoot, 'src/assets'),
       ],
       styles:
-        options.styledModule || !options.hasStyles
+        (options.styledModule && options.styledModule !== '@material-ui') ||
+        !options.hasStyles
           ? []
           : [
               joinPathFragments(

--- a/packages/react/src/generators/application/lib/create-application-files.ts
+++ b/packages/react/src/generators/application/lib/create-application-files.ts
@@ -4,12 +4,20 @@ import { join } from 'path';
 
 export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
   let styleSolutionSpecificAppFiles: string;
-  if (options.styledModule && options.style !== 'styled-jsx') {
-    styleSolutionSpecificAppFiles = '../files/styled-module';
-  } else if (options.style === 'styled-jsx') {
-    styleSolutionSpecificAppFiles = '../files/styled-jsx';
-  } else if (options.style === 'none') {
-    styleSolutionSpecificAppFiles = '../files/none';
+  if (options.styledModule) {
+    switch (options.style) {
+      case 'styled-jsx':
+        styleSolutionSpecificAppFiles = '../files/styled-jsx';
+        break;
+      case '@material-ui':
+        styleSolutionSpecificAppFiles = '../files/material-ui';
+        break;
+      case 'none':
+        styleSolutionSpecificAppFiles = '../files/none';
+        break;
+      default:
+        styleSolutionSpecificAppFiles = '../files/styled-module';
+    }
   } else if (options.globalCss) {
     styleSolutionSpecificAppFiles = '../files/global-css';
   } else {

--- a/packages/react/src/generators/application/lib/normalize-options.ts
+++ b/packages/react/src/generators/application/lib/normalize-options.ts
@@ -22,7 +22,9 @@ export function normalizeOptions(
 
   const fileName = options.pascalCaseFiles ? 'App' : 'app';
 
-  const styledModule = /^(css|scss|less|styl|none)$/.test(options.style)
+  const styledModule = /^(css|scss|less|styl|material|none)$/.test(
+    options.style
+  )
     ? null
     : options.style;
 

--- a/packages/react/src/generators/application/schema.json
+++ b/packages/react/src/generators/application/schema.json
@@ -69,6 +69,10 @@
             "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
           },
           {
+            "value": "@material-ui",
+            "label": "material-ui       [ https://material-ui.com       ]"
+          },
+          {
             "value": "none",
             "label": "None"
           }

--- a/packages/react/src/generators/component/component.spec.ts
+++ b/packages/react/src/generators/component/component.spec.ts
@@ -283,6 +283,40 @@ describe('component', () => {
     });
   });
 
+  describe('--style @material-ui', () => {
+    it('should use @material-ui as the styled API library', async () => {
+      await componentGenerator(appTree, {
+        name: 'hello',
+        project: projectName,
+        style: '@material-ui',
+      });
+
+      expect(
+        appTree.exists('libs/my-lib/src/lib/hello/hello.@material-ui')
+      ).toBeFalsy();
+      expect(
+        appTree.exists('libs/my-lib/src/lib/hello/hello.tsx')
+      ).toBeTruthy();
+
+      const content = appTree
+        .read('libs/my-lib/src/lib/hello/hello.tsx')
+        .toString();
+      expect(content).toContain('<Box>');
+    });
+
+    it('should add dependencies to package.json', async () => {
+      await componentGenerator(appTree, {
+        name: 'hello',
+        project: projectName,
+        style: '@material-ui',
+      });
+
+      const packageJSON = readJson(appTree, 'package.json');
+      expect(packageJSON.dependencies['@material-ui/core']).toBeDefined();
+      expect(packageJSON.dependencies['clsx']).toBeDefined();
+    });
+  });
+
   describe('--routing', () => {
     it('should add routes to the component', async () => {
       await componentGenerator(appTree, {

--- a/packages/react/src/generators/component/component.ts
+++ b/packages/react/src/generators/component/component.ts
@@ -75,7 +75,8 @@ function createComponentFiles(host: Tree, options: NormalizedSchema) {
     }
 
     if (
-      (options.styledModule || !options.hasStyles) &&
+      ((options.styledModule && options.styledModule !== '@material-ui') ||
+        !options.hasStyles) &&
       c.path.endsWith(`.${options.style}`)
     ) {
       deleteFile = true;
@@ -153,7 +154,9 @@ async function normalizeOptions(
 
   const directory = await getDirectory(host, options);
 
-  const styledModule = /^(css|scss|less|styl|none)$/.test(options.style)
+  const styledModule = /^(css|scss|less|styl|material|none)$/.test(
+    options.style
+  )
     ? null
     : options.style;
 

--- a/packages/react/src/generators/component/files/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/component/files/__fileName__.tsx__tmpl__
@@ -9,7 +9,11 @@ import { Route, Link } from 'react-router-dom';
 <% } %>
 
 <% if (hasStyles) {
-   if (styledModule && styledModule !== 'styled-jsx') {
+     if (styledModule && styledModule === '@material-ui') {
+    var wrapper = 'Box';
+  %>
+  import { Box, createStyles, makeStyles, Theme } from '@material-ui/core';
+  <% } else if (styledModule && styledModule !== 'styled-jsx') {
     var wrapper = 'Styled' + className;
   %>
   import styled from '<%= styledModule %>';
@@ -17,18 +21,22 @@ import { Route, Link } from 'react-router-dom';
     var wrapper = 'div';
   %>
   <%- style !== 'styled-jsx' ? globalCss ? `import './${fileName}.${style}';` : `import './${fileName}.module.${style}';`: '' %>
-  <% }
-} else { var wrapper = 'div'; } %>
+  <% } } else { var wrapper = 'div'; } %>
 
 /* eslint-disable-next-line */
 export interface <%= className %>Props {
 }
 
-<% if (styledModule && styledModule !== 'styled-jsx') { %>
+<% if (styledModule && styledModule === '@material-ui') { %>
+// Customize your theme and other variables here
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({})
+);
+<% } else if (styledModule && styledModule !== 'styled-jsx') { %>
 const Styled<%= className %> = styled.div`
   color: pink;
 `;
-<% }%>
+<% } %>
 <% if (classComponent) { %>
 export class <%= className %> extends Component<<%= className %>Props> {
   render() {

--- a/packages/react/src/generators/component/schema.json
+++ b/packages/react/src/generators/component/schema.json
@@ -68,6 +68,10 @@
             "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
           },
           {
+            "value": "@material-ui",
+            "label": "material-ui       [ https://material-ui.com       ]"
+          },
+          {
             "value": "none",
             "label": "None"
           }

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -458,6 +458,22 @@ describe('lib', () => {
       expect(babelJestConfig.plugins).toContain('styled-jsx/babel');
     });
 
+    it('should support @material-ui', async () => {
+      await libraryGenerator(appTree, {
+        ...defaultSchema,
+        publishable: true,
+        importPath: '@proj/my-lib',
+        style: '@material-ui',
+      });
+
+      const workspaceJson = readJson(appTree, '/workspace.json');
+      expect(workspaceJson.projects['my-lib'].architect.build).toMatchObject({
+        options: {
+          external: ['react', 'react-dom', '@material-ui/core', 'clsx'],
+        },
+      });
+    });
+
     it('should support style none', async () => {
       await libraryGenerator(appTree, {
         ...defaultSchema,

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -61,6 +61,9 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
       `For publishable libs you have to provide a proper "--importPath" which needs to be a valid npm package name (e.g. my-awesome-lib or @myorg/my-lib)`
     );
   }
+
+  // TODO: Would this not break a library that intends to use a style library but simply did not want an initial component?
+  // Default library as well as injecting the correct dependencies comes to mind from below
   if (!options.component) {
     options.style = 'none';
   }

--- a/packages/react/src/generators/library/schema.json
+++ b/packages/react/src/generators/library/schema.json
@@ -65,6 +65,10 @@
             "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
           },
           {
+            "value": "@material-ui",
+            "label": "material-ui       [ https://material-ui.com       ]"
+          },
+          {
             "value": "none",
             "label": "None"
           }

--- a/packages/react/src/utils/assertion.ts
+++ b/packages/react/src/utils/assertion.ts
@@ -6,6 +6,7 @@ const VALID_STYLES = [
   'styled-components',
   '@emotion/styled',
   'styled-jsx',
+  '@material-ui',
   'none',
 ];
 export function assertValidStyle(style: string): void {

--- a/packages/react/src/utils/styled.ts
+++ b/packages/react/src/utils/styled.ts
@@ -9,6 +9,8 @@ import {
   typesReactIsVersion,
   typesStyledComponentsVersion,
   typesStyledJsxVersion,
+  materialUiCoreVersion,
+  clsxVersion,
 } from './versions';
 import { PackageDependencies } from './dependencies';
 
@@ -42,5 +44,12 @@ export const CSS_IN_JS_DEPENDENCIES: {
     devDependencies: {
       '@types/styled-jsx': typesStyledJsxVersion,
     },
+  },
+  '@material-ui': {
+    dependencies: {
+      '@material-ui/core': materialUiCoreVersion,
+      clsx: clsxVersion,
+    },
+    devDependencies: {},
   },
 };

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -33,3 +33,6 @@ export const eslintPluginReactVersion = '7.21.5';
 export const eslintPluginReactHooksVersion = '4.2.0';
 
 export const babelPluginStyledComponentsVersion = '1.10.7';
+
+export const materialUiCoreVersion = '4.11.3';
+export const clsxVersion = '1.1.1';

--- a/packages/react/typings/style.d.ts
+++ b/packages/react/typings/style.d.ts
@@ -6,4 +6,5 @@ export type SupportedStyles =
   | 'styled-components'
   | '@emotion/styled'
   | 'styled-jsx'
+  | '@material-ui'
   | 'none';

--- a/scripts/check-versions.ts
+++ b/scripts/check-versions.ts
@@ -23,6 +23,7 @@ const excluded = ['nxVersion'];
 const scoped = [
   'babel',
   'emotion',
+  'material',
   'reduxjs',
   'testing-library',
   'types',


### PR DESCRIPTION
@material-ui is a widely popular React visual framework. Since it does not use style files the only
option was to select none in generation and then add what was missing. This however left some
desired behaviors missing. This PR addresses that by setting up some basic generation for React and Next that allows basic dependency injection and example app/components default. I am not a CSS master so the App that is generated likely does not look great now being only wrapped in a Container.

https://material-ui.com/
