### PR TITLE
feat(core): export jestConfigParser from jest.impl

### DIFF
--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -18,6 +18,17 @@ export async function jestExecutor(
   options: JestExecutorOptions,
   context: ExecutorContext
 ): Promise<{ success: boolean }> {
+  const config = jestConfigParser(options, context);
+
+  const { results } = await runCLI(config, [options.jestConfig]);
+
+  return { success: results.success };
+}
+
+export function jestConfigParser(
+  options: JestExecutorOptions,
+  context: ExecutorContext
+): Config.Argv {
   options.jestConfig = path.resolve(context.root, options.jestConfig);
 
   const jestConfig: {
@@ -107,9 +118,7 @@ export async function jestExecutor(
     config.coverageReporters = options.coverageReporters;
   }
 
-  const { results } = await runCLI(config, [options.jestConfig]);
-
-  return { success: results.success };
+  return config;
 }
 
 export default jestExecutor;


### PR DESCRIPTION
It should allow to easily extend jest config for other purposes.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There is no way to extend jest implementation in any way.

## Expected Behavior
I should be able to use all the good stuff done in jest.impl and be able to extend and modify it the way I please.
The use case I have in mind is ability to pass `testEnvironmentOptions` to configure [jest-playwright](https://github.com/playwright-community/jest-playwright).

## Related Issue(s)
#3390

