### PR TITLE
fix(core): set browser + node eslint env in @nrwl/nx/javascript

### DIFF
--- a/packages/eslint-plugin-nx/src/configs/javascript.ts
+++ b/packages/eslint-plugin-nx/src/configs/javascript.ts
@@ -15,6 +15,10 @@
  * related plugins and rules below.
  */
 export default {
+  env: {
+    browser: true,
+    node: true,
+  },
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2020,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

For config files, such as `jest.config.js`, under certain project types such as `express`, users might see issues from ESLint in their IDEs to do with globals being missing.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Users should not see issues with globals in their `jest.config.js` files.

I verified the before and after behaviour locally on a fresh `express` project. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3515
