### PR TITLE
fix(core): add fail over --fork-point arg to git merge

### DIFF
--- a/packages/workspace/src/command-line/shared.ts
+++ b/packages/workspace/src/command-line/shared.ts
@@ -45,11 +45,20 @@ function getUntrackedFiles(): string[] {
 }
 
 function getFilesUsingBaseAndHead(base: string, head: string): string[] {
-  const mergeBase = execSync(`git merge-base ${base} ${head}`, {
-    maxBuffer: TEN_MEGABYTES,
-  })
-    .toString()
-    .trim();
+  let mergeBase;
+  try {
+    mergeBase = execSync(`git merge-base ${base} ${head}`, {
+      maxBuffer: TEN_MEGABYTES,
+    })
+      .toString()
+      .trim();
+  } catch {
+    mergeBase = execSync(`git merge-base --fork-point ${base} ${head}`, {
+      maxBuffer: TEN_MEGABYTES,
+    })
+      .toString()
+      .trim();
+  }
   return parseGitOutput(`git diff --name-only --relative ${mergeBase} ${head}`);
 }
 


### PR DESCRIPTION
this fixes getFilesUsingBaseAndHead output in some forking scenarios.

## Current Behavior
fails in some scenarios on this call stack

D:\Data\client-workspace\node_modules\@nrwl\workspace\node_modules\yargs\yargs.js:1109
      else throw err
           ^


Error: Command failed: git merge-base origin/master HEAD
    at checkExecSyncError (child_process.js:630:11)
    at Object.execSync (child_process.js:666:15)
    at getFilesUsingBaseAndHead (D:\Data\client-workspace\node_modules\@nrwl\workspace\src\command-line\shared.js:47:39)
    at Object.parseFiles (D:\Data\client-workspace\node_modules\@nrwl\workspace\src\command-line\shared.js:32:20)
    at Object.affected (D:\Data\client-workspace\node_modules\@nrwl\workspace\src\command-line\affected.js:20:108)
    at Object.handler (D:\Data\client-workspace\node_modules\@nrwl\workspace\src\command-line\nx-commands.js:47:142)
    at Object.runCommand (D:\Data\client-workspace\node_modules\@nrwl\workspace\node_modules\yargs\lib\command.js:235:44)
    at Object.parseArgs [as _parseArgs] (D:\Data\client-workspace\node_modules\@nrwl\workspace\node_modules\yargs\yargs.js:1022:30)
    at Object.get [as argv] (D:\Data\client-workspace\node_modules\@nrwl\workspace\node_modules\yargs\yargs.js:965:21)
    at Object.initLocal (D:\Data\client-workspace\node_modules\@nrwl\cli\lib\init-local.js:24:13) {
  status: 1,
  signal: null,
  output: [ null, <Buffer >, <Buffer > ],
  pid: 28996,
  stdout: <Buffer >,
  stderr: <Buffer >
}

## Expected Behavior
affected commands should work in all forking scenarios

## Related Issue(s)
see #3274 and [3866](https://github.com/nrwl/nx/pull/3866) which was commited in  [444a393](https://github.com/nrwl/nx/commit/444a3930d8134b9649e16af0ac96fc27e519128e) but revrted in [74195bc](https://github.com/nrwl/nx/commit/74195bcf1a2cc2709d50fb76edac7d0020ea2cb1)
Fixes #3274