### PR TITLE
fix(angular): generate constant case name in NgRx schematics

### DIFF
--- a/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.selectors.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.selectors.ts__tmpl__
@@ -2,7 +2,7 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { <%= constantName %>_FEATURE_KEY, State, <%= className %>PartialState, <%= propertyName %>Adapter } from './<%= fileName %>.reducer';
 
 // Lookup the '<%= className %>' feature state managed by NgRx
-export const get<%= className %>State = createFeatureSelector<<%= className %>PartialState, State>(<%= propertyName.toUpperCase() %>_FEATURE_KEY);
+export const get<%= className %>State = createFeatureSelector<<%= className %>PartialState, State>(<%= constantName %>_FEATURE_KEY);
 
 const { selectAll, selectEntities } = <%= propertyName %>Adapter.getSelectors();
 

--- a/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.selectors.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.selectors.ts__tmpl__
@@ -2,7 +2,7 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { <%= constantName %>_FEATURE_KEY, <%= className %>State } from './<%= fileName %>.reducer';
 
 // Lookup the '<%= className %>' feature state managed by NgRx
-const get<%= className %>State = createFeatureSelector<<%= className %>State>(<%= propertyName.toUpperCase() %>_FEATURE_KEY);
+const get<%= className %>State = createFeatureSelector<<%= className %>State>(<%= constantName %>_FEATURE_KEY);
 
 const getLoaded = createSelector( get<%= className %>State, (state:<%= className %>State) => state.loaded );
 const getError = createSelector( get<%= className %>State, (state:<%= className %>State) => state.error );

--- a/packages/angular/src/schematics/ngrx/rules/add-imports-to-module.ts
+++ b/packages/angular/src/schematics/ngrx/rules/add-imports-to-module.ts
@@ -33,7 +33,7 @@ export function addImportsToModule(context: RequestContext): Rule {
     const effectsPath = `${pathPrefix}.effects`;
     const facadePath = `${pathPrefix}.facade`;
 
-    const featureName = `${names(context.featureName).propertyName}`;
+    const constantName = `${names(context.featureName).constantName}`;
     const effectsName = `${names(context.featureName).className}Effects`;
     const facadeName = `${names(context.featureName).className}Facade`;
     const className = `${names(context.featureName).className}`;
@@ -53,7 +53,7 @@ export function addImportsToModule(context: RequestContext): Rule {
     const nxModule = 'NxModule.forRoot()';
     const effectsForRoot = `EffectsModule.forRoot([${effectsName}])`;
     const effectsForEmptyRoot = `EffectsModule.forRoot([])`;
-    const storeForFeature = `StoreModule.forFeature(from${className}.${featureName.toUpperCase()}_FEATURE_KEY, from${className}.reducer)`;
+    const storeForFeature = `StoreModule.forFeature(from${className}.${constantName}_FEATURE_KEY, from${className}.reducer)`;
     const effectsForFeature = `EffectsModule.forFeature([${effectsName}])`;
     const devTools = `!environment.production ? StoreDevtoolsModule.instrument() : []`;
     const storeRouterModule = 'StoreRouterConnectingModule.forRoot()';


### PR DESCRIPTION
nrwl/nx#3955 did not completely fix an issue where `my-lib` would generate `MYLIB_FEATURE_KEY` instead of `MY_LIB_FEATURE_KEY`. This fixes the spots that were missed in that PR.