### PR TITLE
fix(angular): check for root tslint.json before updating to support ESlint

### DIFF
--- a/packages/workspace/src/generators/init/init.spec.ts
+++ b/packages/workspace/src/generators/init/init.spec.ts
@@ -312,6 +312,13 @@ describe('workspace', () => {
       const prettierIgnore = tree.read('/.prettierignore').toString();
       expect(prettierIgnore).toBe('# existing ignore rules');
     });
+
+    it('should work with no root tslint.json', async () => {
+      tree.delete('/tslint.json');
+      await initGenerator(tree, { name: 'myApp' });
+
+      expect(tree.exists('/tslint.json')).toBe(false);
+    });
   });
 
   describe('preserve angular cli layout', () => {

--- a/packages/workspace/src/generators/init/init.ts
+++ b/packages/workspace/src/generators/init/init.ts
@@ -294,27 +294,29 @@ function updateTsConfigsJson(host: Tree, options: Schema) {
 }
 
 function updateTsLint(host: Tree) {
-  updateJson(host, 'tslint.json', (tslintJson) => {
-    [
-      'no-trailing-whitespace',
-      'one-line',
-      'quotemark',
-      'typedef-whitespace',
-      'whitespace',
-    ].forEach((key) => {
-      tslintJson[key] = undefined;
+  if (host.exists(`tslint.json`)) {
+    updateJson(host, 'tslint.json', (tslintJson) => {
+      [
+        'no-trailing-whitespace',
+        'one-line',
+        'quotemark',
+        'typedef-whitespace',
+        'whitespace',
+      ].forEach((key) => {
+        tslintJson[key] = undefined;
+      });
+      tslintJson.rulesDirectory = tslintJson.rulesDirectory || [];
+      tslintJson.rulesDirectory.push('node_modules/@nrwl/workspace/src/tslint');
+      tslintJson.rules['nx-enforce-module-boundaries'] = [
+        true,
+        {
+          allow: [],
+          depConstraints: [{ sourceTag: '*', onlyDependOnLibsWithTags: ['*'] }],
+        },
+      ];
+      return tslintJson;
     });
-    tslintJson.rulesDirectory = tslintJson.rulesDirectory || [];
-    tslintJson.rulesDirectory.push('node_modules/@nrwl/workspace/src/tslint');
-    tslintJson.rules['nx-enforce-module-boundaries'] = [
-      true,
-      {
-        allow: [],
-        depConstraints: [{ sourceTag: '*', onlyDependOnLibsWithTags: ['*'] }],
-      },
-    ];
-    return tslintJson;
-  });
+  }
 }
 
 function updateProjectTsLint(host: Tree, options: Schema) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `ng add @nrwl/workspace` on an Angular CLI workspace with no root `tslint.json` fails. This file would not exist in a workspace using ESlint, such as https://github.com/tomastrajan/angular-ngrx-material-starter

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `ng add @nrwl/workspace` on an Angular CLI workspace with no root `tslint.json` continues to run.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4761 
