### PR TITLE
fix(storybook): fix windows path in storybook configuration

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -306,7 +306,7 @@ function addStorybookTask(
     outputs: ['{options.outputPath}'],
     options: {
       uiFramework,
-      outputPath: join('dist/storybook', projectName),
+      outputPath: joinPathFragments('dist/storybook', projectName),
       config: {
         configFolder: `${projectConfig.root}/.storybook`,
       },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Storybook configuration had windows style paths on windows.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Storybook configuration has unix style paths on windows.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
