### PR TITLE
fix(react): temporarily remove gatsby preset from create-nx-workspace

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -30,10 +30,11 @@ const presetOptions: { value: Preset; name: string }[] = [
     value: Preset.NextJs,
     name: 'next.js           [a workspace with a single Next.js application]',
   },
-  {
-    value: Preset.Gatsby,
-    name: 'gatsby            [a workspace with a single Gatsby application]',
-  },
+  // TODO: Re-enable when gatsby preset is implemented
+  // {
+  //   value: Preset.Gatsby,
+  //   name: 'gatsby            [a workspace with a single Gatsby application]',
+  // },
   {
     value: Preset.Nest,
     name: 'nest              [a workspace with a single Nest application]',
@@ -303,7 +304,15 @@ function determineStyle(preset: Preset, parsedArgs: WorkspaceArgs) {
     },
   ];
 
-  if ([Preset.ReactWithExpress, Preset.React, Preset.NextJs].includes(preset)) {
+  if (
+    [
+      Preset.ReactWithExpress,
+      Preset.React,
+      Preset.NextJs,
+      // TODO: Re-enable when gatsby preset is implemented
+      // Preset.Gatsby,
+    ].includes(preset)
+  ) {
     choices.push(
       {
         value: 'styled-components',
@@ -484,7 +493,8 @@ function pointToTutorialAndCourse(preset: Preset) {
     case Preset.React:
     case Preset.ReactWithExpress:
     case Preset.NextJs:
-    case Preset.Gatsby:
+      // TODO: Re-enable when gatsby preset is implemented
+      // case Preset.Gatsby:
       output.addVerticalSeparator();
       output.note({
         title: title,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `gatsby` preset was not implemented properly and throws an error when chosen.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `gatsby` preset is temporarily disabled until it is properly implemented. This should be re-introduced soon.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
