### PR TITLE
feat(web): improve support for decorators

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "babel-plugin-macros": "^2.8.0",
     "babel-plugin-styled-components": "^1.10.7",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
+    "babel-plugin-transform-typescript-metadata": "^0.3.1",
     "browserslist": "^4.14.6",
     "cacache": "12.0.2",
     "caniuse-lite": "^1.0.30001030",

--- a/packages/web/babel.ts
+++ b/packages/web/babel.ts
@@ -48,6 +48,7 @@ module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
         require.resolve('@babel/plugin-proposal-class-properties'),
         options.classProperties ?? { loose: true },
       ],
+      require.resolve('babel-plugin-transform-typescript-metadata'),
     ],
     overrides: [
       // Convert `const enum` to `enum`. The former cannot be supported by babel

--- a/packages/web/babel.ts
+++ b/packages/web/babel.ts
@@ -16,6 +16,9 @@ module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
   api.assertVersion(7);
 
   const isModern = api.caller((caller) => caller?.isModern);
+  const emitDecoratorMetadata = api.caller(
+    (caller) => caller?.emitDecoratorMetadata ?? true
+  );
 
   return {
     presets: [
@@ -39,6 +42,9 @@ module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
     ],
     plugins: [
       require.resolve('babel-plugin-macros'),
+      emitDecoratorMetadata
+        ? require.resolve('babel-plugin-transform-typescript-metadata')
+        : undefined,
       // Must use legacy decorators to remain compatible with TypeScript.
       [
         require.resolve('@babel/plugin-proposal-decorators'),
@@ -48,8 +54,7 @@ module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
         require.resolve('@babel/plugin-proposal-class-properties'),
         options.classProperties ?? { loose: true },
       ],
-      require.resolve('babel-plugin-transform-typescript-metadata'),
-    ],
+    ].filter(Boolean),
     overrides: [
       // Convert `const enum` to `enum`. The former cannot be supported by babel
       // but at least we can get it to not error out.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -50,6 +50,7 @@
     "babel-plugin-const-enum": "^1.0.1",
     "babel-plugin-macros": "^2.8.0",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
+    "babel-plugin-transform-typescript-metadata": "^0.3.1",
     "browserslist": "^4.14.6",
     "cacache": "12.0.2",
     "caniuse-lite": "^1.0.30001030",

--- a/packages/web/src/utils/config.spec.ts
+++ b/packages/web/src/utils/config.spec.ts
@@ -5,9 +5,9 @@ import { LicenseWebpackPlugin } from 'license-webpack-plugin';
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 import { ProgressPlugin } from 'webpack';
 import { BuildBuilderOptions } from './types';
+import * as CopyWebpackPlugin from 'copy-webpack-plugin';
 import CircularDependencyPlugin = require('circular-dependency-plugin');
 import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-import * as CopyWebpackPlugin from 'copy-webpack-plugin';
 
 jest.mock('tsconfig-paths-webpack-plugin');
 
@@ -448,6 +448,7 @@ describe('getBaseWebpackPartial', () => {
           ...input,
           progress: true,
         },
+        true,
         true,
         true,
         'production'

--- a/packages/web/src/utils/config.ts
+++ b/packages/web/src/utils/config.ts
@@ -20,6 +20,7 @@ export function getBaseWebpackPartial(
   options: BuildBuilderOptions,
   esm?: boolean,
   isScriptOptimizeOn?: boolean,
+  emitDecoratorMetadata?: boolean,
   configuration?: string
 ): Configuration {
   const extensions = ['.ts', '.tsx', '.mjs', '.js', '.jsx'];
@@ -54,6 +55,7 @@ export function getBaseWebpackPartial(
           options: {
             rootMode: 'upward',
             cwd: join(options.root, options.sourceRoot),
+            emitDecoratorMetadata,
             isModern: esm,
             envName: configuration,
             babelrc: true,

--- a/packages/web/src/utils/web-babel-loader.ts
+++ b/packages/web/src/utils/web-babel-loader.ts
@@ -1,14 +1,15 @@
 module.exports = require('babel-loader').custom((babel) => {
   return {
-    customOptions({ isModern, ...loader }) {
+    customOptions({ isModern, emitDecoratorMetadata, ...loader }) {
       return {
-        custom: { isModern },
+        custom: { isModern, emitDecoratorMetadata },
         loader,
       };
     },
-    config(cfg, { customOptions: { isModern } }) {
+    config(cfg, { customOptions: { isModern, emitDecoratorMetadata } }) {
       // Add hint to our babel preset so it can handle modern vs legacy bundles.
       cfg.options.caller.isModern = isModern;
+      cfg.options.caller.emitDecoratorMetadata = emitDecoratorMetadata;
       return cfg.options;
     },
   };

--- a/packages/web/src/utils/web.config.ts
+++ b/packages/web/src/utils/web.config.ts
@@ -44,7 +44,13 @@ export function getWebConfig(
     tsConfigPath: options.tsConfig,
   };
   return mergeWebpack([
-    _getBaseWebpackPartial(options, esm, isScriptOptimizeOn, configuration),
+    _getBaseWebpackPartial(
+      options,
+      esm,
+      isScriptOptimizeOn,
+      tsConfig.options.emitDecoratorMetadata,
+      configuration
+    ),
     getPolyfillsPartial(options, esm, isScriptOptimizeOn),
     getStylesPartial(wco, options),
     getCommonPartial(wco),
@@ -89,12 +95,14 @@ function _getBaseWebpackPartial(
   options: WebBuildBuilderOptions,
   esm: boolean,
   isScriptOptimizeOn: boolean,
+  emitDecoratorMetadata: boolean,
   configuration?: string
 ) {
   let partial = getBaseWebpackPartial(
     options,
     esm,
     isScriptOptimizeOn,
+    emitDecoratorMetadata,
     configuration
   );
   delete partial.resolve.mainFields;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6891,6 +6891,13 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-plugin-transform-typescript-metadata@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-typescript-metadata/-/babel-plugin-transform-typescript-metadata-0.3.1.tgz#d86599b7139131ba5e917f5f568d0c824a5cdfc3"
+  integrity sha512-thOuACZReULfLy7vh2o3/joYkkRerMKLBDmXy3ImCnkNUnxBmNw0uVa05JhhX0slluaEkio6OIFa7zPgaJdk6g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 babel-plugin-transform-undefined-to-void@^6.9.4:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz#be241ca81404030678b748717322b89d0c8fe280"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`babel-plugin-transform-typescript-metadata` should be installed manually to support Decorators because Babel does not emit metadata like tsc.



## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Decorators can be used ~out-of-the-box~ without installing the babel plugin manually.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#3260
#4396
