### PR TITLE
fix(core): add debug to logger when wrapping angular devkit schematics

### DIFF
--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -615,6 +615,7 @@ export function wrapAngularDevkitSchematic(
       log: (e) => {},
       info: (e) => {},
       warn: (e) => {},
+      debug: () => {},
       error: (e) => {},
       fatal: (e) => {},
     } as any;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The debug method is not defined on the logger when wrapping angular devkit schematics.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The debug method is a noop on the logger when wrapping angular devkit schematics.

We can keep expanding this API as necessary but I don't think most of the "required" parts of `Logger` are used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4693
