### PR TITLE
feat(linter): noEslintrc option for eslint executor

### DIFF
--- a/docs/angular/api-linter/executors/eslint.md
+++ b/docs/angular/api-linter/executors/eslint.md
@@ -70,6 +70,12 @@ Type: `number`
 
 Number of warnings to trigger nonzero exit code - default: -1
 
+### noEslintrc
+
+Type: `string`
+
+The equivalent of the --no-eslintrc flag on the ESLint CLI, it is false by default
+
 ### outputFile
 
 Type: `string`

--- a/docs/angular/api-linter/executors/eslint.md
+++ b/docs/angular/api-linter/executors/eslint.md
@@ -72,7 +72,9 @@ Number of warnings to trigger nonzero exit code - default: -1
 
 ### noEslintrc
 
-Type: `string`
+Default: `false`
+
+Type: `boolean`
 
 The equivalent of the --no-eslintrc flag on the ESLint CLI, it is false by default
 

--- a/docs/node/api-linter/executors/eslint.md
+++ b/docs/node/api-linter/executors/eslint.md
@@ -71,6 +71,12 @@ Type: `number`
 
 Number of warnings to trigger nonzero exit code - default: -1
 
+### noEslintrc
+
+Type: `string`
+
+The equivalent of the --no-eslintrc flag on the ESLint CLI, it is false by default
+
 ### outputFile
 
 Type: `string`

--- a/docs/node/api-linter/executors/eslint.md
+++ b/docs/node/api-linter/executors/eslint.md
@@ -73,7 +73,9 @@ Number of warnings to trigger nonzero exit code - default: -1
 
 ### noEslintrc
 
-Type: `string`
+Default: `false`
+
+Type: `boolean`
 
 The equivalent of the --no-eslintrc flag on the ESLint CLI, it is false by default
 

--- a/docs/react/api-linter/executors/eslint.md
+++ b/docs/react/api-linter/executors/eslint.md
@@ -71,6 +71,12 @@ Type: `number`
 
 Number of warnings to trigger nonzero exit code - default: -1
 
+### noEslintrc
+
+Type: `string`
+
+The equivalent of the --no-eslintrc flag on the ESLint CLI, it is false by default
+
 ### outputFile
 
 Type: `string`

--- a/docs/react/api-linter/executors/eslint.md
+++ b/docs/react/api-linter/executors/eslint.md
@@ -73,7 +73,9 @@ Number of warnings to trigger nonzero exit code - default: -1
 
 ### noEslintrc
 
-Type: `string`
+Default: `false`
+
+Type: `boolean`
 
 The equivalent of the --no-eslintrc flag on the ESLint CLI, it is false by default
 

--- a/packages/linter/src/executors/eslint/lint.impl.spec.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.spec.ts
@@ -52,6 +52,7 @@ function createValidRunBuilderOptions(
     ignorePath: null,
     outputFile: null,
     maxWarnings: -1,
+    noEslintrc: false,
     quiet: false,
     ...additionalOptions,
   };
@@ -134,6 +135,7 @@ describe('Linter Builder', () => {
       maxWarnings: null,
       outputFile: null,
       quiet: false,
+      noEslintrc: false,
     });
   });
 

--- a/packages/linter/src/executors/eslint/schema.d.ts
+++ b/packages/linter/src/executors/eslint/schema.d.ts
@@ -8,6 +8,7 @@ export interface Schema extends JsonObject {
   silent: boolean;
   fix: boolean;
   cache: boolean;
+  noEslintrc: boolean;
   outputFile: string | null;
   cacheLocation: string | null;
   maxWarnings: number;

--- a/packages/linter/src/executors/eslint/schema.json
+++ b/packages/linter/src/executors/eslint/schema.json
@@ -85,7 +85,7 @@
       "description": "The path of the .eslintignore file."
     },
     "noEslintrc": {
-      "type": "string",
+      "type": "boolean",
       "description": "The equivalent of the --no-eslintrc flag on the ESLint CLI, it is false by default",
       "default": false
     }

--- a/packages/linter/src/executors/eslint/schema.json
+++ b/packages/linter/src/executors/eslint/schema.json
@@ -83,6 +83,11 @@
     "ignorePath": {
       "type": "string",
       "description": "The path of the .eslintignore file."
+    },
+    "noEslintrc": {
+      "type": "string",
+      "description": "The equivalent of the --no-eslintrc flag on the ESLint CLI, it is false by default",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/linter/src/executors/eslint/utility/eslint-utils.spec.ts
+++ b/packages/linter/src/executors/eslint/utility/eslint-utils.spec.ts
@@ -52,4 +52,25 @@ describe('eslint-utils', () => {
       errorOnUnmatchedPattern: false,
     });
   });
+
+  describe('noEslintrc', () => {
+    it('should create the ESLint instance with "useEslintrc" set to false', async () => {
+      await lint(undefined, <any>{
+        fix: true,
+        cache: true,
+        cacheLocation: '/root/cache',
+        noEslintrc: true,
+      }).catch(() => {});
+
+      expect(ESLint).toHaveBeenCalledWith({
+        overrideConfigFile: undefined,
+        fix: true,
+        cache: true,
+        cacheLocation: '/root/cache',
+        ignorePath: undefined,
+        useEslintrc: false,
+        errorOnUnmatchedPattern: false,
+      });
+    });
+  });
 });

--- a/packages/linter/src/executors/eslint/utility/eslint-utils.ts
+++ b/packages/linter/src/executors/eslint/utility/eslint-utils.ts
@@ -18,7 +18,11 @@ export async function lint(
   const projectESLint: { ESLint: typeof ESLint } = await loadESLint();
 
   const eslint = new projectESLint.ESLint({
-    useEslintrc: true,
+    /**
+     * If "noEslintrc" is set to `true` (and therefore here "useEslintrc" will be `false`), then ESLint will not
+     * merge the provided config with others it finds automatically.
+     */
+    useEslintrc: !options.noEslintrc,
     overrideConfigFile: eslintConfigPath,
     ignorePath: options.ignorePath || undefined,
     fix: !!options.fix,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The eslint executor does not support the equivalent of the `--no-eslintrc` flag on the ESLint CLI.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The eslint executor supports the equivalent of the `--no-eslintrc` flag on the ESLint CLI.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3220
