### PR TITLE
fix(core): throw an error if user tries generating/executing from a p…

### DIFF
--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -324,6 +324,13 @@ export class Workspaces {
     const executorsFile = packageJson.executors
       ? packageJson.executors
       : packageJson.builders;
+
+    if (!executorsFile) {
+      throw new Error(
+        `The "${nodeModule}" package does not support Nx executors.`
+      );
+    }
+
     const executorsFilePath = require.resolve(
       path.join(path.dirname(packageJsonPath), executorsFile)
     );
@@ -361,6 +368,13 @@ export class Workspaces {
       const generatorsFile = packageJson.generators
         ? packageJson.generators
         : packageJson.schematics;
+
+      if (!generatorsFile) {
+        throw new Error(
+          `The "${collectionName}" package does not support Nx generators.`
+        );
+      }
+
       generatorsFilePath = require.resolve(
         path.join(path.dirname(packageJsonPath), generatorsFile)
       );


### PR DESCRIPTION
…ackage which does not support it

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When a user tries to generate from a package that does not support Nx generators/executors such as `typescript`, Nx throws an obscure error which does not indicate that the package does not support Nx generators/executors:

```sh
nx g typescript:component
Unable to resolve typescript:component.
The "path" argument must be of type string. Received undefined
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When a user tries to generate from a package that does not support Nx generators/executors such as `typescript`, Nx throws an error indicating that the package does not support Nx generators/executors:

```sh
Unable to resolve typescript:component.
The "typescript" package does not support Nx generators.
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/4688
