### PR TITLE
fix(devkit): replacing multiple occurrences in file path

### DIFF
--- a/packages/devkit/src/generators/generate-files.ts
+++ b/packages/devkit/src/generators/generate-files.ts
@@ -48,7 +48,7 @@ function replaceSegmentsInPath(
   substitutions: { [k: string]: any }
 ) {
   Object.entries(substitutions).forEach(([t, r]) => {
-    filePath = filePath.replace(`__${t}__`, r);
+    filePath = filePath.replace(new RegExp(`__${t}__`, 'g'), r);
   });
   return filePath;
 }


### PR DESCRIPTION

## Current Behavior
<!-- This is the behavior we have today -->
You might run into a situation where there are multiple occurrences in a file path that need to be replaced. E.g. `files/__fileName__/__fileName__.module.ts.template`.
Right now only the first occurrence of `__fileName__` would be replaced.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

All should be replaced. This PR fixes that.