### PR TITLE
fix(storybook): emit a value from storybook executor so that e2e test…

### DIFF
--- a/packages/storybook/src/executors/storybook/storybook.impl.spec.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.spec.ts
@@ -44,11 +44,10 @@ describe('@nrwl/storybook:storybook', () => {
     };
   });
 
-  it('should provide options to storybook', (done) => {
-    storybookExecutor(options, context);
-    setTimeout(() => {
-      expect(buildDevStandalone).toHaveBeenCalled();
-      done();
-    }, 0);
+  it('should provide options to storybook', async () => {
+    const iterator = storybookExecutor(options, context);
+    const { value } = await iterator.next();
+    expect(value).toEqual({ success: true });
+    expect(buildDevStandalone).toHaveBeenCalled();
   });
 });

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -33,7 +33,7 @@ try {
   require('dotenv').config();
 } catch (e) {}
 
-export default async function storybookExecutor(
+export default async function* storybookExecutor(
   options: StorybookExecutorOptions,
   context: ExecutorContext
 ) {
@@ -43,8 +43,10 @@ export default async function storybookExecutor(
   const option = storybookOptionMapper(options, frameworkOptions, context);
   await runInstance(option);
 
+  yield { success: true };
+
   // This Promise intentionally never resolves, leaving the process running
-  return new Promise<{ success: boolean }>(() => {});
+  await new Promise<{ success: boolean }>(() => {});
 }
 
 function runInstance(options: StorybookExecutorOptions) {


### PR DESCRIPTION
…s work

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Storybook doesn't emit any output so cypress builder doesn't know to continue.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Storybook builder emits an event so the cypress builder knows the continue.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
