### PR TITLE
Fix babel for NextJS and Gatsby

### DIFF
--- a/packages/gatsby/src/generators/application/files/.babel.config.js__tmpl__
+++ b/packages/gatsby/src/generators/application/files/.babel.config.js__tmpl__
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "presets": ["@nrwl/gatsby/babel"],
   "plugins": []
 }

--- a/packages/next/src/generators/application/files/babel.config.js__tmpl__
+++ b/packages/next/src/generators/application/files/babel.config.js__tmpl__
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "presets": ["next/babel"],
   "plugins": [<% if (style === 'styled-components') { %>["styled-components", { "pure": true, "ssr": true }]<% } %>]
 }


### PR DESCRIPTION
## Current Behavior
Babel plugins don't work in libs in generated NextJS and Gatsby projects.

## Expected Behavior
Generated NextJS and Gatsby projects should support babel in libs.

## Related Issue(s)
Fixes #4611
