### PR TITLE
feat(nextjs): allow custom distDir

### DIFF
--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -4,12 +4,13 @@ import build from 'next/dist/build';
 import { PHASE_PRODUCTION_BUILD } from 'next/dist/next-server/lib/constants';
 
 import { join, resolve } from 'path';
-import { copySync } from 'fs-extra';
+import { copySync, mkdir } from 'fs-extra';
 
 import { prepareConfig } from '../../utils/config';
 import { NextBuildBuilderOptions } from '../../utils/types';
 import { createPackageJson } from './lib/create-package-json';
 import { createNextConfigFile } from './lib/create-next-config-file';
+import { directoryExists } from '@nrwl/workspace/src/utilities/fileutils';
 
 try {
   require('dotenv').config();
@@ -21,7 +22,13 @@ export default async function buildExecutor(
 ) {
   const root = resolve(context.root, options.root);
   const config = prepareConfig(PHASE_PRODUCTION_BUILD, options, context);
+
   await build(root, config as any);
+
+  if (!directoryExists(options.outputPath)) {
+    mkdir(options.outputPath);
+  }
+
   createPackageJson(options, context);
   createNextConfigFile(options, context);
 

--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -130,7 +130,10 @@ export function prepareConfig(
     : (_, x) => x;
   // Yes, these do have different capitalisation...
   config.outdir = `${offsetFromRoot(options.root)}${options.outputPath}`;
-  config.distDir = join(config.outdir, '.next');
+  config.distDir =
+    config.distDir && config.distDir !== '.next'
+      ? config.distDir
+      : join(config.outdir, '.next');
   config.webpack = (a, b) =>
     createWebpackConfig(
       context.root,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Nextjs builder does not take into accound custom `distDir` that users set in their `next.config.js` file

## Expected Behavior
Nextjs builder takes into accound custom `distDir` that users set in their `next.config.js` file

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
