### PR TITLE
feat(testing): feat(testing): do not always pass watch to cypress dev server target

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nrwl/nx-source",
-  "version": "10.3.1",
+  "version": "999.9.9",
   "description": "Extensible Dev Tools for Monorepos",
   "homepage": "https://nx.dev",
   "main": "index.js",

--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -218,10 +218,13 @@ export function startDevServer(
   const overrides = {
     watch: isWatching,
   };
+
+  const target = targetFromTargetString(devServerTarget);
+
   return scheduleTargetAndForget(
     context,
-    targetFromTargetString(devServerTarget),
-    overrides
+    target,
+    ['build', 'serve'].includes(target.target) ? overrides : {} // Do not pass the overrides with --watch flag to targets that do not support it
   ).pipe(
     map((output) => {
       if (!output.success && !isWatching) {


### PR DESCRIPTION
When using a target other than `serve` or `build` do not pass watch.
This allows for universal to be used as the dev server target.

ISSUES CLOSED: #2735 

## Current Behavior
Currently only the `serve` target for an app can be used as the `devServerTarget` for a cypress project

## Expected Behavior
Should be able to use a `serve-ssr` (universal) target as for running cypress tests

## Related Issue(s)
Resolves #2735 
