### PR TITLE
feat(core): allow passing multiple configurations to combine configur…

### DIFF
--- a/packages/cli/lib/parse-run-one-options.ts
+++ b/packages/cli/lib/parse-run-one-options.ts
@@ -66,6 +66,9 @@ export function parseRunOneOptions(
   const parsedArgs = yargsParser(args, {
     boolean: ['prod', 'help'],
     string: ['configuration', 'project'],
+    coerce: {
+      configuration: parseCsv,
+    },
     alias: {
       c: 'configuration',
     },
@@ -81,6 +84,9 @@ export function parseRunOneOptions(
 
   if (parsedArgs._[0] === 'run') {
     [project, target, configuration] = (parsedArgs._[1] as any).split(':');
+    if (configuration) {
+      configuration = configuration.split(',').filter((a) => !!a);
+    }
     parsedArgs._ = parsedArgs._.slice(2);
   } else {
     target = parsedArgs._[0];
@@ -96,7 +102,7 @@ export function parseRunOneOptions(
   if (parsedArgs.configuration) {
     configuration = parsedArgs.configuration;
   } else if (parsedArgs.prod) {
-    configuration = 'production';
+    configuration = ['production'];
   }
   if (parsedArgs.project) {
     project = parsedArgs.project;
@@ -124,4 +130,8 @@ export function parseRunOneOptions(
   delete parsedArgs['project'];
 
   return res;
+}
+
+function parseCsv(csv: string): string[] {
+  return csv.split(',').filter((a) => !!a);
 }

--- a/packages/devkit/src/executors/read-target-options.ts
+++ b/packages/devkit/src/executors/read-target-options.ts
@@ -18,9 +18,11 @@ export function readTargetOptions<T = any>(
     context.workspace
   );
 
+  const configs = configuration ? configuration.split(',') : [];
+
   return combineOptionsForExecutor(
     {},
-    configuration,
+    configs,
     targetConfiguration,
     schema,
     defaultProject,

--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -189,6 +189,8 @@ async function runExecutorInternal<T extends { success: boolean }>(
     executor
   );
 
+  const configArray = configuration ? configuration.split(',') : [];
+
   if (printHelp) {
     printRunHelp({ project, target }, schema);
     process.exit(0);
@@ -196,7 +198,7 @@ async function runExecutorInternal<T extends { success: boolean }>(
 
   const combinedOptions = combineOptionsForExecutor(
     options,
-    configuration,
+    configArray,
     targetConfig,
     schema,
     project,

--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -339,7 +339,7 @@ function resolveDefinition(ref: string, definitions: Properties) {
 
 export function combineOptionsForExecutor(
   commandLineOpts: Options,
-  config: string,
+  config: string[],
   target: TargetConfiguration,
   schema: Schema,
   defaultProjectName: string | null,
@@ -350,8 +350,13 @@ export function combineOptionsForExecutor(
     schema,
     false
   );
-  const configOpts =
-    config && target.configurations ? target.configurations[config] || {} : {};
+  let configOpts = {};
+  for (const configuration of config) {
+    Object.assign(
+      configOpts,
+      target.configurations ? target.configurations[configuration] || {} : {}
+    );
+  }
   const combined = { ...target.options, ...configOpts, ...r };
   convertSmartDefaultsIntoNamedParams(
     combined,

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -292,6 +292,7 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
       describe:
         'This is the configuration to use when performing tasks on projects',
       type: 'string',
+      coerce: (arg) => (Array.isArray(arg) ? arg : parseCSV([arg])),
     })
     .options('only-failed', {
       describe: 'Isolate projects which previously failed',
@@ -339,6 +340,7 @@ function withRunManyOptions(yargs: yargs.Argv): yargs.Argv {
       describe:
         'This is the configuration to use when performing tasks on projects',
       type: 'string',
+      coerce: (arg) => (Array.isArray(arg) ? arg : parseCSV([arg])),
     })
     .options('with-deps', {
       describe:
@@ -393,7 +395,7 @@ function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
 
 function parseCSV(args: string[]) {
   return args
-    .map((arg) => arg.split(','))
+    .map((arg) => arg.split(',').filter((a) => !!a))
     .reduce((acc, value) => {
       return [...acc, ...value];
     }, [] as string[]);

--- a/packages/workspace/src/command-line/print-affected.ts
+++ b/packages/workspace/src/command-line/print-affected.ts
@@ -51,7 +51,7 @@ async function createTasks(
       createTask({
         project: affectedProject,
         target: nxArgs.target,
-        configuration: nxArgs.configuration,
+        configurations: nxArgs.configuration,
         overrides: overrides,
         errorIfCannotFindConfiguration: false,
       })

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -43,7 +43,7 @@ export interface RawNxArgs extends NxArgs {
 
 export interface NxArgs {
   target?: string;
-  configuration?: string;
+  configuration?: string[];
   runner?: string;
   parallel?: boolean;
   maxParallel?: number;
@@ -106,7 +106,7 @@ export function splitArgsIntoNxArgsAndOverrides(
 
   if (nxArgs.prod) {
     delete nxArgs.prod;
-    nxArgs.configuration = 'production';
+    nxArgs.configuration = ['production'];
   }
 
   if (mode === 'affected') {


### PR DESCRIPTION
…ations

# This is a draft

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

It is not possible to specify multiple configurations to combine different configurations. This is useful when minor changes need to be made to a configuration such as when staging should be the same as production except for the `baseUrl`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Users can specify multiple configurations to combine them when running nx commands.

```
nx build app1 # Default build
nx build app1 --configuration production # Build with production options
nx build app1 --configuration production,staging # Build with production and staging options

nx run-many --target build --all --configuration production,staging # Build all projects with production and staging options if applicable

nx affected --target build --configuration production staging # Build all affected projects with production and staging options if applicable
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/2839
