### PR TITLE
feat(angular): add support for a custom builder

### DIFF
--- a/docs/angular/api-angular/executors/webpack-browser.md
+++ b/docs/angular/api-angular/executors/webpack-browser.md
@@ -304,6 +304,14 @@ Type: `boolean`
 
 Enables the use of subresource integrity validation.
 
+### targetBuilder
+
+Default: `@angular-devkit/build-angular:browser`
+
+Type: `string`
+
+Override default Angular browser builder
+
 ### tsConfig
 
 Type: `string`

--- a/docs/node/api-angular/executors/webpack-browser.md
+++ b/docs/node/api-angular/executors/webpack-browser.md
@@ -305,6 +305,14 @@ Type: `boolean`
 
 Enables the use of subresource integrity validation.
 
+### targetBuilder
+
+Default: `@angular-devkit/build-angular:browser`
+
+Type: `string`
+
+Override default Angular browser builder
+
 ### tsConfig
 
 Type: `string`

--- a/docs/react/api-angular/executors/webpack-browser.md
+++ b/docs/react/api-angular/executors/webpack-browser.md
@@ -305,6 +305,14 @@ Type: `boolean`
 
 Enables the use of subresource integrity validation.
 
+### targetBuilder
+
+Default: `@angular-devkit/build-angular:browser`
+
+Type: `string`
+
+Override default Angular browser builder
+
 ### tsConfig
 
 Type: `string`

--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -369,9 +369,14 @@
         "type": "string"
       },
       "default": []
+    },
+    "targetBuilder": {
+      "description": "Override default Angular browser builder",
+      "type": "string",
+      "default": "@angular-devkit/build-angular:browser"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["outputPath", "index", "main", "tsConfig"],
   "definitions": {
     "assetPattern": {

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -28,8 +28,13 @@ function buildApp(
 ): Promise<BuilderRun> {
   const { buildTarget, ...delegateOptions } = options;
 
+  // delete targetBuilder from options before passing into scheduleBuilder
+  const targetBuilder =
+    (delegateOptions.targetBuilder as string) || buildTarget;
+  delete delegateOptions.targetBuilder;
+
   if (buildTarget) {
-    const target = targetFromTargetString(buildTarget);
+    const target = targetFromTargetString(targetBuilder);
     return context.scheduleTarget(target, delegateOptions, {
       target: context.target,
       logger: context.logger as any,


### PR DESCRIPTION
Ability to support incremental builds when using custom builders

## Current Behavior
Currently `@nrwl/angular:webpack-browser` only supports angular builder `@angular-devkit/build-angular`. However, this prevents people to use incremental builder when using common builder such as `@angular-builders/custom-webpack`

## Expected Behavior
Ability to use `customBuilder` to overwrite the default angular builder while still support incremental builds

## Related decussion
https://github.com/nrwl/nx/discussions/4896

