### PR TITLE
feat(express): add express preset to create-nx-workspace

### DIFF
--- a/e2e/workspace/src/create-nx-workspace.test.ts
+++ b/e2e/workspace/src/create-nx-workspace.test.ts
@@ -104,6 +104,16 @@ describe('create-nx-workspace', () => {
     });
   });
 
+  it('should be able to create an express workspace', () => {
+    const wsName = uniq('express');
+    const appName = uniq('app');
+    runCreateWorkspace(wsName, {
+      preset: 'express',
+      style: 'css',
+      appName,
+    });
+  });
+
   it('should be able to create a workspace with a custom base branch and HEAD', () => {
     const wsName = uniq('branch');
     runCreateWorkspace(wsName, {

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -40,6 +40,10 @@ const presetOptions: { value: Preset; name: string }[] = [
     name: 'nest              [a workspace with a single Nest application]',
   },
   {
+    value: Preset.Express,
+    name: 'express           [a workspace with a single Express application]',
+  },
+  {
     value: Preset.WebComponents,
     name:
       'web components    [a workspace with a single app built using web components]',
@@ -280,7 +284,8 @@ function determineStyle(preset: Preset, parsedArgs: WorkspaceArgs) {
   if (
     preset === Preset.Empty ||
     preset === Preset.OSS ||
-    preset === Preset.Nest
+    preset === Preset.Nest ||
+    preset === Preset.Express
   ) {
     return Promise.resolve(null);
   }

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -30,6 +30,7 @@ export enum Preset {
   NextJs = 'next',
   Gatsby = 'gatsby',
   Nest = 'nest',
+  Express = 'express',
 }
 
 export interface Schema {
@@ -242,6 +243,12 @@ const presetDependencies: Omit<
     dependencies: {},
     dev: {
       '@nrwl/nest': nxVersion,
+    },
+  },
+  [Preset.Express]: {
+    dependencies: {},
+    dev: {
+      '@nrwl/express': nxVersion,
     },
   },
   [Preset.NextJs]: {

--- a/packages/workspace/src/generators/preset/preset.spec.ts
+++ b/packages/workspace/src/generators/preset/preset.spec.ts
@@ -112,7 +112,7 @@ describe('preset', () => {
     );
   });
 
-  it('should create files (preset react-express)', async () => {
+  it('should create files (preset = react-express)', async () => {
     await presetGenerator(tree, {
       name: 'proj',
       preset: 'react-express',
@@ -128,5 +128,17 @@ describe('preset', () => {
     expect(tree.exists('/apps/proj/.eslintrc.json')).toBe(true);
     expect(tree.exists('/apps/api/.eslintrc.json')).toBe(true);
     expect(tree.exists('/libs/api-interfaces/.eslintrc.json')).toBe(true);
+  });
+
+  it('should create files (preset = express)', async () => {
+    await presetGenerator(tree, {
+      name: 'proj',
+      preset: 'express',
+      linter: 'eslint',
+      cli: 'nx',
+    });
+
+    expect(tree.exists('apps/proj/src/main.ts')).toBe(true);
+    expect(tree.exists('apps/proj/.eslintrc.json')).toBe(true);
   });
 });

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -145,6 +145,15 @@ async function createPreset(tree: Tree, options: Schema) {
       linter: options.linter,
     });
     setDefaultCollection(tree, '@nrwl/nest');
+  } else if (options.preset === 'express') {
+    const {
+      applicationGenerator: expressApplicationGenerator,
+    } = require('@nrwl' + '/express');
+    await expressApplicationGenerator(tree, {
+      name: options.name,
+      linter: options.linter,
+    });
+    setDefaultCollection(tree, '@nrwl/express');
   } else {
     throw new Error(`Invalid preset ${options.preset}`);
   }

--- a/packages/workspace/src/generators/preset/schema.d.ts
+++ b/packages/workspace/src/generators/preset/schema.d.ts
@@ -13,5 +13,6 @@ export interface Schema {
     | 'web-components'
     | 'angular-nest'
     | 'react-express'
-    | 'nest';
+    | 'nest'
+    | 'express';
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There is no way to create an express app out of the box with create-nx-workspace

## Expected Behavior
`create-nx-workspace` now supports `--preset=express`


