### PR TITLE
docs(devkit): clean up devkit docs

### DIFF
--- a/docs/angular/guides/configuration.md
+++ b/docs/angular/guides/configuration.md
@@ -174,7 +174,7 @@ The selected configuration adds/overrides the default options, and the provided 
 
 ### Generators
 
-Generators that are created using `@angular/devkit` are called schematics. You can configure default generator options in `angular.json` as well. For instance, the following will tell Nx to always pass `--style=scss` when creating new libraries.
+Generators that are created using `@angular-devkit` are called schematics. You can configure default generator options in `angular.json` as well. For instance, the following will tell Nx to always pass `--style=scss` when creating new libraries.
 
 ```json
 {

--- a/docs/angular/guides/nx-devkit-angular-devkit.md
+++ b/docs/angular/guides/nx-devkit-angular-devkit.md
@@ -1,6 +1,6 @@
 # Nx Devkit and Angular Devkit
 
-> Note, this document covers the difference between Nx Devkit and Angular Devkit. See [Nx Devkt](/{{framework}}/core-concepts/nx-devkit) guide for more information about Nx Devkit.
+> Note: this document covers the difference between Nx Devkit and Angular Devkit. See the [Nx Devkit](/{{framework}}/core-concepts/nx-devkit) guide for more in-depth details about Nx Devkit.
 
 Nx comes with a devkit to write generators and executors, but you can also use Angular devkit (schematics and builders). An Angular schematic is a second way to implement generators. An Angular builder is a second way to implement an executor.
 
@@ -19,15 +19,15 @@ interface Schema {
   skipFormat: boolean;
 }
 
-export default async function (host: Tree, optoins: Schema) {
+export default async function (tree: Tree, optoins: Schema) {
   generateFiles(
-    host,
+    tree,
     path.join(__dirname, 'files'),
     path.join('tools/generators', schema.name),
     options
   );
   if (!schema.skipFormat) {
-    await formatFiles(host);
+    await formatFiles(tree);
   }
 }
 ```
@@ -71,14 +71,14 @@ export default function (options: Schema): Rule {
 
 **Some notable changes:**
 
-- Nx Devkit generators do not use partial application. An Angular Schematic returns a rule that is then invoked with a host.
-- Nx Devkit generators do not use RxJS observables. Just invoke the helpers directly. This makes them more debuggable. As you step through the generator you can see the host being updated.
-- `chain([mergeWith(apply(url` is replaced with `generateFiles` :)
+- Nx Devkit generators do not use partial application. An Angular Schematic returns a rule that is then invoked with a tree.
+- Nx Devkit generators do not use RxJS observables. Just invoke the helpers directly. This makes them more debuggable. As you step through the generator you can see the tree being updated.
+- `chain([mergeWith(apply(url` is replaced with `generateFiles`)
 - Nx Devkit generators return a function that performs side effects. Angular Schematics have to create a custom task runner and register a task using it.
-- You don't need any special helpers to compose Nx Devkit generators. You do need to go through a special resolution step to compose schematics.
-- No special utilities needed to test Nx Devkit generators. Special utilities are needed to test Angular Schematics.
+- You don't need any special helpers to compose Nx Devkit generators. You do need to go through a special resolution step to compose Angular Schematics.
+- No special utilities are needed to test Nx Devkit generators. Special utilities are needed to test Angular Schematics.
 
-The schema files for both Nx Devkit generators and Angular Schematics are the same. Nx can run both of them in the same way. You can invoke Angular schematics from withing Nx Devkit generator using `wrapAngularDevkitSchematic`.
+The schema files for both Nx Devkit generators and Angular Schematics are the same. Nx can run both of them in the same way. You can invoke Angular schematics from within Nx Devkit generators using `wrapAngularDevkitSchematic`.
 
 ## Executors
 
@@ -103,7 +103,7 @@ export default async function (
 }
 ```
 
-Same executor written as an Angular builder:
+The following is an analogous executor written as an Angular builder:
 
 ```typescript
 interface Schema {
@@ -127,7 +127,7 @@ export default createBuilder<NextBuildBuilderOptions>(run);
 
 Some notable changes:
 
-- Nx Devkit executors return promises (or async iterable). If you want, you can always convert an observable to a promise.
+- Nx Devkit executors return a Promise (or async iterable). If you want, you can always convert an observable to a promise or an async iterable. See [Using Rxjs Observables](/{{framework}}/core-concepts/nx-devkit#using-rxjs-observables)
 - Nx Devkit executors do not have to be wrapped using `createBuilder`.
 
 The schema files for both Nx Devkit executors and Angular Builders are the same. Nx can run both of them in the same way.
@@ -136,4 +136,4 @@ The schema files for both Nx Devkit executors and Angular Builders are the same.
 
 If you are writing an Nx plugin, use Nx Devkit. It's **much** easier to use and debug. It has better docs and more people supporting it.
 
-Do you have to rewrite your Nx Plugin if it is written using Angular Devkit. No. Nx supports both and will always support both. And, most importantly, the end user might not even know what you used to write a generator or an executor.
+Do you have to rewrite your Nx Plugin if it is written using Angular Devkit? No. Nx supports both and will always support both. And, most importantly, the end user might not even know what you used to write a generator or an executor.

--- a/docs/shared/tools-workspace-builders.md
+++ b/docs/shared/tools-workspace-builders.md
@@ -4,9 +4,9 @@ Creating Nx Executors/Angular Devkit Builders for your workspace standardizes sc
 
 This guide will show you how to create, run, and customize executors/builders within your Nx workspace. In the examples, we'll use the trivial use-case of an `echo` command.
 
-## Creating a Builder with @angular/devkit
+## Creating a Builder with @angular-devkit
 
-Note: In this article, we'll refer to executors that use the `@angular/devkit` as Angular Devkit Builders.
+> Note: In this article, we'll refer to executors that use the `@angular-devkit` as Angular Devkit Builders.
 
 Your executor should be created within the `tools` directory of your Nx workspace like so:
 

--- a/docs/shared/tools-workspace-generators.md
+++ b/docs/shared/tools-workspace-generators.md
@@ -35,18 +35,18 @@ The initial generator function creates a library.
 import { Tree, formatFiles, installPackagesTask } from '@nrwl/devkit';
 import { libraryGenerator } from '@nrwl/workspace';
 
-export default async function (host: Tree, schema: any) {
-  await libraryGenerator(host, { name: schema.name });
-  await formatFiles(host);
+export default async function (tree: Tree, schema: any) {
+  await libraryGenerator(tree, { name: schema.name });
+  await formatFiles(tree);
   return () => {
-    installPackagesTask(host);
+    installPackagesTask(tree);
   };
 }
 ```
 
-To invoke other generators, import the entry point function and run it against the host tree. `async/await` can be used to make code with Promises read like procedural code. The generator function may return a callback function that is executed after changes to the file system have been applied.
+To invoke other generators, import the entry point function and run it against the tree tree. `async/await` can be used to make code with Promises read like procedural code. The generator function may return a callback function that is executed after changes to the file system have been applied.
 
-In the schema.json file for your generator, the `name` is provided as a default option. The `cli` property is set to `nx` to signal that this is a generator that uses `@nrwl/devkit` and not `@angular/devkit`.
+In the schema.json file for your generator, the `name` is provided as a default option. The `cli` property is set to `nx` to signal that this is a generator that uses `@nrwl/devkit` and not `@angular-devkit`.
 
 ```json
 {
@@ -77,9 +77,9 @@ To run a generator, invoke the `nx workspace-generator` command with the name of
 nx workspace-generator my-generator mylib
 ```
 
-## Running a workspace schematic created with @angular/devkit
+## Running a workspace schematic created with @angular-devkit
 
-Generators that are created using the `@angular/devkit` are called schematics. Workspace schematics that have been created with the `@angular/devkit` will omit the `"cli": "nx"` property in `schema.json`. Nx will recognize this and correctly run the schematic using the same command as an `@nrwl/devkit` generator.
+Generators that are created using the `@angular-devkit` are called schematics. Workspace schematics that have been created with the `@angular-devkit` will omit the `"cli": "nx"` property in `schema.json`. Nx will recognize this and correctly run the schematic using the same command as an `@nrwl/devkit` generator.
 
 ```sh
 nx workspace-generator my-schematic mylib
@@ -91,7 +91,7 @@ The command is also aliased to the previous `workspace-schematic` command, so th
 nx workspace-schematic my-schematic mylib
 ```
 
-## Creating custom rules with @angular/devkit
+## Creating custom rules with @angular-devkit
 
 Generators provide an API for managing files within your workspace. You can use schematics to do things such as create, update, move, and delete files. Files with static or dynamic content can also be created.
 
@@ -208,11 +208,11 @@ Import the TypeScript schema into your generator file and replace the any in you
 import { Tree, formatFiles, installPackagesTask } from '@nrwl/devkit';
 import { libraryGenerator } from '@nrwl/workspace';
 
-export default async function (host: Tree, schema: SchematicOptions) {
-  await libraryGenerator(host, { name: `${schema.name}-${schema.type || ''}` });
-  await formatFiles(host);
+export default async function (tree: Tree, schema: SchematicOptions) {
+  await libraryGenerator(tree, { name: `${schema.name}-${schema.type || ''}` });
+  await formatFiles(tree);
   return () => {
-    installPackagesTask(host);
+    installPackagesTask(tree);
   };
 }
 ```
@@ -304,6 +304,6 @@ Running the generator without providing a value for the type will prompt the use
 
 ![](/shared/vscode-schematics-debug.png)
 
-## Workspace generator utilities
+## Workspace Generator Utilities
 
-The `@nrwl/workspace` package provides many utility functions that can be used in schematics to help with modifying files, reading and updating configuration files, and working with an Abstract Syntax Tree (AST).
+The `@nrwl/devkit` package provides many utility functions that can be used in schematics to help with modifying files, reading and updating configuration files, and working with an Abstract Syntax Tree (AST).

--- a/docs/shared/using-builders.md
+++ b/docs/shared/using-builders.md
@@ -2,7 +2,7 @@
 
 Executors perform actions on your code. This can include building, linting, testing, serving and many other actions.
 
-Executors can be written using `@nx/devkit` or `@angular/devkit`. Executors written with the `@angular/devkit` are called Builders.
+Executors can be written using `@nrwl/devkit` or `@angular-devkit`. Executors written with the `@angular-devkit` are called Builders.
 
 There are two main differences between an executor and a shell script or an npm script:
 
@@ -47,11 +47,11 @@ The executors that are available for each project are defined and configured in 
 }
 ```
 
-Note: There are a few property keys in `workspace.json` that have interchangeable aliases. You can replace `generators` with `schematics`, `targets` with `architect` or `executor` with `builder`.
+> Note: There are a few property keys in `workspace.json` that have interchangeable aliases. You can replace `generators` with `schematics`, `targets` with `architect` or `executor` with `builder`.
 
 Each project has its executors defined in the `targets` property. In this snippet, `cart` has two executors defined - `build` and `test`.
 
-**Note:** `build` and `test` can be any strings you choose. For the sake of consistency, we make `test` run unit tests for every project and `build` produce compiled code for the projects which can be built.
+> Note: `build` and `test` can be any strings you choose. For the sake of consistency, we make `test` run unit tests for every project and `build` produce compiled code for the projects which can be built.
 
 Each executor definition has an `executor` property and, optionally, an `options` and a `configurations` property.
 

--- a/docs/shared/using-schematics.md
+++ b/docs/shared/using-schematics.md
@@ -4,7 +4,7 @@
 
 Generators provide a way to automate many tasks you regularly perform as part of your development workflow. Whether it is scaffolding out components, features, ensuring libraries are generated and structured in a certain way, or updating your configuration files, generators help you standardize these tasks in a consistent, and predictable manner.
 
-Generators can be written using `@nx/devkit` or `@angular/devkit`. Generators written with the `@angular/devkit` are called schematics. To read more about the concepts of `@angular/devkit` schematics, and building an example schematic, see the [Schematics Authoring Guide](https://angular.io/guide/schematics-authoring).
+Generators can be written using `@nrwl/devkit` or `@angular-devkit`. Generators written with the `@angular-devkit` are called schematics. To read more about the concepts of `@angular-devkit` schematics, and building an example schematic, see the [Schematics Authoring Guide](https://angular.io/guide/schematics-authoring).
 
 The [Workspace Generators](/{{framework}}/generators/workspace-generators) guide shows you how to create, run, and customize workspace generators within your Nx workspace.
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

* Devkit docs refer to the `Tree` as a `host` which is ambiguous.
* There are some mentions of `@nx/devkit` and `@angular/devkit` which are the wrong names

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

* Devkit docs refer to the `Tree` as a `tree` which better describes what it is
* Mentions are corrected to `@nrwl/devkit` and `@angular-devkit`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
