### PR TITLE
cleanup(repo): free space during e2e & enable Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,3 +134,24 @@ workflows:
               os: ['linux']
               packages: *ng_cli
           cli: 'angular'
+
+  build-windows:
+    triggers:
+      - schedule:
+          cron: '0 0 * * *'
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - e2e:
+          matrix:
+            parameters:
+              os: ['windows']
+              packages: *nx_cli
+      - e2e:
+          matrix:
+            parameters:
+              os: ['windows']
+              packages: *ng_cli
+          cli: 'angular'

--- a/e2e/workspace/src/custom-layout.test.ts
+++ b/e2e/workspace/src/custom-layout.test.ts
@@ -7,6 +7,7 @@ import {
   runCreateWorkspace,
   uniq,
   packageInstall,
+  removeProject,
 } from '@nrwl/e2e/utils';
 
 describe('custom workspace layout', () => {
@@ -63,5 +64,7 @@ describe('custom workspace layout', () => {
     expect(appBuildResults.stdout).toContain(`nx run ${expressApp}:build`);
 
     checkFilesExist(`dist/packages/${expressApp}/main.js`);
+
+    removeProject({ onlyOnCI: true });
   }, 1000000);
 });

--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -5,6 +5,7 @@ import {
   newProject,
   readFile,
   readJson,
+  removeProject,
   rmDist,
   runCLI,
   runCLIAsync,
@@ -15,8 +16,13 @@ import {
 } from '@nrwl/e2e/utils';
 
 describe('run-one', () => {
+  let proj: string;
+
+  beforeEach(() => (proj = newProject()));
+
+  afterEach(() => removeProject({ onlyOnCI: true }));
+
   it('should build specific project', () => {
-    const proj = newProject();
     const myapp = uniq('myapp');
     const mylib1 = uniq('mylib1');
     const mylib2 = uniq('mylib1');
@@ -59,8 +65,13 @@ describe('run-one', () => {
 });
 
 describe('run-many', () => {
+  let proj: string;
+
+  beforeEach(() => (proj = newProject()));
+
+  afterEach(() => removeProject({ onlyOnCI: true }));
+
   it('should build specific and all projects', () => {
-    const proj = newProject();
     const appA = uniq('appa-rand');
     const libA = uniq('liba-rand');
     const libB = uniq('libb-rand');
@@ -128,7 +139,6 @@ describe('run-many', () => {
   }, 1000000);
 
   it('should run only failed projects', () => {
-    newProject();
     const myapp = uniq('myapp');
     const myapp2 = uniq('myapp2');
     runCLI(`generate @nrwl/angular:app ${myapp}`);
@@ -181,8 +191,13 @@ describe('run-many', () => {
 });
 
 describe('affected:*', () => {
+  let proj: string;
+
+  beforeEach(() => (proj = newProject()));
+
+  afterEach(() => removeProject({ onlyOnCI: true }));
+
   it('should print, build, and test affected apps', async () => {
-    const proj = newProject();
     const myapp = uniq('myapp');
     const myapp2 = uniq('myapp2');
     const mylib = uniq('mylib');
@@ -344,9 +359,12 @@ describe('affected (with git)', () => {
   let myapp = uniq('myapp');
   let myapp2 = uniq('myapp');
   let mylib = uniq('mylib');
-  it('should not affect other projects by generating a new project', () => {
-    newProject();
 
+  beforeAll(() => newProject());
+
+  afterAll(() => removeProject({ onlyOnCI: true }));
+
+  it('should not affect other projects by generating a new project', () => {
     const nxJson: NxJson = readJson('nx.json');
 
     delete nxJson.implicitDependencies;
@@ -413,8 +431,13 @@ describe('affected (with git)', () => {
 });
 
 describe('print-affected', () => {
+  let proj: string;
+
+  beforeEach(() => (proj = newProject()));
+
+  afterEach(() => removeProject({ onlyOnCI: true }));
+
   it('should print information about affected projects', async () => {
-    const proj = newProject();
     const myapp = uniq('myapp-a');
     const myapp2 = uniq('myapp-b');
     const mylib = uniq('mylib');
@@ -564,9 +587,11 @@ describe('print-affected', () => {
 });
 
 describe('cache', () => {
-  it('should cache command execution', async () => {
-    newProject();
+  beforeEach(() => newProject());
 
+  afterEach(() => removeProject({ onlyOnCI: true }));
+
+  it('should cache command execution', async () => {
     const myapp1 = uniq('myapp1');
     const myapp2 = uniq('myapp2');
     runCLI(`generate @nrwl/web:app ${myapp1}`);
@@ -676,8 +701,6 @@ describe('cache', () => {
   }, 120000);
 
   it('should only cache specific files if build outputs is configured with specific files', async () => {
-    newProject();
-
     const mylib1 = uniq('mylib1');
     runCLI(`generate @nrwl/react:lib ${mylib1} --buildable`);
 
@@ -738,8 +761,11 @@ describe('cache', () => {
 });
 
 describe('workspace structure', () => {
+  beforeEach(() => newProject());
+
+  afterEach(() => removeProject({ onlyOnCI: true }));
+
   it('should have a vscode/extensions.json file created', () => {
-    newProject();
     const extensions = readJson('.vscode/extensions.json');
     expect(extensions).toEqual({
       recommendations: [

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "tslint": "6.1.3",
     "typescript": "4.0.5",
     "url-loader": "^3.0.0",
-    "verdaccio": "^4.10.0",
+    "verdaccio": "^4.11.1",
     "webpack": "4.42.0",
     "webpack-dev-middleware": "3.7.0",
     "webpack-dev-server": "3.11.0",

--- a/scripts/local-registry/config.yml
+++ b/scripts/local-registry/config.yml
@@ -9,10 +9,6 @@ uplinks:
     maxage: 30m
     fail_timeout: 10m
     timeout: 600s
-    agent_options:
-      keepAlive: true
-      maxSockets: 40
-      maxFreeSockets: 10
     cache: false
 
 packages:

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -8,7 +8,7 @@ export function build(
   prettierVersion
 ) {
   try {
-    execSync('npx nx run-many --target=build --all --parallel', {
+    execSync('npx nx run-many --target=build --all', {
       stdio: [0, 1, 2],
     });
   } catch {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5022,10 +5022,10 @@
   resolved "https://registry.yarnpkg.com/@verdaccio/streams/-/streams-9.7.2.tgz#cd5448470d725e221629adb84c74af7dfd8c9678"
   integrity sha512-SoCG1btVFPxOcrs8w9wLJCfe8nfE6EaEXCXyRwGbh+Sr3NLEG0R8JOugGJbuSE+zIRuUs5JaUKjzSec+JKLvZw==
 
-"@verdaccio/ui-theme@1.14.0":
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/@verdaccio/ui-theme/-/ui-theme-1.14.0.tgz#22b397f399bf1dfcc8e471d1895c3f74bd340691"
-  integrity sha512-vTzZYnC+HpeeW6pGFBa51rwbqwjqYkgJE1DEF5fSK5V2QbHi+XPIPucm6hrnaZjMlSYbe+4DaMN1XOKLqOJlzg==
+"@verdaccio/ui-theme@1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@verdaccio/ui-theme/-/ui-theme-1.15.1.tgz#463f12ce3b4950bba1f3f23d5c592b7b235b2652"
+  integrity sha512-CSd/NnVuqWQo7RnmL7ehZeAEYUbvGM33VmWGzoO91Ujny2tbhlg7kdpbfiEIoKl8Yc2wd9bVMd1HJATDF2uHGw==
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -7548,10 +7548,10 @@ bump-file@1.0.0:
     detect-indent "5.0.0"
     semver "5.4.1"
 
-bunyan@1.8.14:
-  version "1.8.14"
-  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.14.tgz#3d8c1afea7de158a5238c7cb8a66ab6b38dd45b4"
-  integrity sha512-LlahJUxXzZLuw/hetUQJmRgZ1LF6+cr5TPpRj6jf327AsiIq2jhYEH4oqUUkVKTor+9w2BT3oxVwhzE5lw9tcg==
+bunyan@1.8.15:
+  version "1.8.15"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.15.tgz#8ce34ca908a17d0776576ca1b2f6cbd916e93b46"
+  integrity sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==
   optionalDependencies:
     dtrace-provider "~0.8"
     moment "^2.19.3"
@@ -9748,10 +9748,10 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-dayjs@1.9.6:
-  version "1.9.6"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.9.6.tgz#6f0c77d76ac1ff63720dd1197e5cb87b67943d70"
-  integrity sha512-HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw==
+dayjs@1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.3.tgz#cf3357c8e7f508432826371672ebf376cb7d619b"
+  integrity sha512-/2fdLN987N8Ki7Id8BUN2nhuiRyxTLumQnSQf9CNncFCyqFsSKb9TNhzRYcC8K8eJSJOKvbvkImo/MKKhNi4iw==
 
 de-indent@^1.0.2:
   version "1.0.2"
@@ -14633,7 +14633,15 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.14.0, js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.9.0:
+js-yaml@3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.9.0:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
@@ -15811,10 +15819,10 @@ marked@1.1.1:
   resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
   integrity sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
 
-marked@1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.5.tgz#a44b31f2a0b8b5bfd610f00d55d1952d1ac1dfdb"
-  integrity sha512-2AlqgYnVPOc9WDyWu7S5DJaEZsfk6dNh/neatQ3IHUW4QLutM/VPSH9lG7bif+XjFWc9K9XR3QvR+fXuECmfdA==
+marked@1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.7.tgz#6e14b595581d2319cdcf033a24caaf41455a01fb"
+  integrity sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA==
 
 material-colors@^1.2.1:
   version "1.2.6"
@@ -16068,6 +16076,11 @@ mime@2.4.6, mime@^2.3.1, mime@^2.4.2, mime@^2.4.4:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
+
+mime@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.0.tgz#2b4af934401779806ee98026bb42e8c1ae1876b1"
+  integrity sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -23020,42 +23033,42 @@ verdaccio-htpasswd@9.7.2:
     http-errors "1.8.0"
     unix-crypt-td-js "1.1.4"
 
-verdaccio@^4.10.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/verdaccio/-/verdaccio-4.10.0.tgz#ca48c4b7a5bb967f0e2b5d38bab599a39cd0aaf1"
-  integrity sha512-9nCIHM9rvgwasBJvo82MiEDzS2HGWolopID8/THU0vZfa1d6MDAiuakjwQ9Z2xDonpoOoDji6xpg2i6il+gEWQ==
+verdaccio@^4.11.1:
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/verdaccio/-/verdaccio-4.11.1.tgz#da644c46bf053839fc423a072acbc26831920292"
+  integrity sha512-xlu61MWAWztdEsGM2vUbv5fUv+E4GWTZ9rTYU/uc1+X3EURMLEHDdFBZR7qe0abfB3Kj59GATNEtQNQ2KvqNDA==
   dependencies:
     "@verdaccio/commons-api" "9.7.1"
     "@verdaccio/local-storage" "9.7.4"
     "@verdaccio/readme" "9.7.3"
     "@verdaccio/streams" "9.7.2"
-    "@verdaccio/ui-theme" "1.14.0"
+    "@verdaccio/ui-theme" "1.15.1"
     JSONStream "1.3.5"
     async "3.2.0"
     body-parser "1.19.0"
-    bunyan "1.8.14"
+    bunyan "1.8.15"
     commander "3.0.2"
     compression "1.7.4"
     cookies "0.8.0"
     cors "2.8.5"
-    dayjs "1.9.6"
+    dayjs "1.10.3"
     envinfo "7.7.3"
     express "4.17.1"
     handlebars "4.7.6"
     http-errors "1.8.0"
-    js-yaml "3.14.0"
+    js-yaml "3.14.1"
     jsonwebtoken "8.5.1"
     kleur "4.1.3"
     lodash "4.17.20"
     lunr-mutable-indexes "2.3.2"
-    marked "1.2.5"
-    mime "2.4.6"
+    marked "1.2.7"
+    mime "2.5.0"
     minimatch "3.0.4"
     mkdirp "0.5.5"
     mv "2.1.1"
     pkginfo "0.4.1"
     request "2.88.0"
-    semver "6.3.0"
+    semver "7.3.4"
     verdaccio-audit "9.7.3"
     verdaccio-htpasswd "9.7.2"
 


### PR DESCRIPTION
E2E changes:
* Free space during CI to avoid failures on GH Actions
* Remove `--parallel` build causing random failures on Windows
* Re-enable daily Windows run
* Upgrade Verdaccio