### PR TITLE
fix(core): add @nrwl/storybook & @nrwl/gatsby to pkgs listed by nx report

### DIFF
--- a/packages/workspace/src/command-line/report.ts
+++ b/packages/workspace/src/command-line/report.ts
@@ -24,6 +24,7 @@ export const packagesWeCareAbout = [
   '@nrwl/web',
   '@nrwl/workspace',
   '@nrwl/storybook',
+  '@nrwl/gatsby',
   'typescript',
 ];
 

--- a/packages/workspace/src/command-line/report.ts
+++ b/packages/workspace/src/command-line/report.ts
@@ -23,6 +23,7 @@ export const packagesWeCareAbout = [
   '@nrwl/tao',
   '@nrwl/web',
   '@nrwl/workspace',
+  '@nrwl/storybook',
   'typescript',
 ];
 


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

`nx report` doesn't list storybook and gatsby package


## Related Issue(s)

#4942
