### PR TITLE
fix(devkit): support partially defining generators in schematics and …

### DIFF
--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -288,8 +288,9 @@ export class Workspaces {
         normalizedGeneratorName,
       } = this.readGeneratorsJson(collectionName, generatorName);
       const generatorsDir = path.dirname(generatorsFilePath);
-      const generatorConfig = (generatorsJson.generators ||
-        generatorsJson.schematics)[normalizedGeneratorName];
+      const generatorConfig =
+        generatorsJson.generators?.[normalizedGeneratorName] ||
+        generatorsJson.schematics?.[normalizedGeneratorName];
       const schemaPath = path.join(generatorsDir, generatorConfig.schema || '');
       const schema = JSON.parse(
         stripJsonComments(fs.readFileSync(schemaPath).toString())
@@ -337,10 +338,8 @@ export class Workspaces {
     const executorsJson = JSON.parse(
       stripJsonComments(fs.readFileSync(executorsFilePath).toString())
     );
-    const mapOfExecutors = executorsJson.executors
-      ? executorsJson.executors
-      : executorsJson.builders;
-    const executorConfig = mapOfExecutors[executor];
+    const executorConfig =
+      executorsJson.executors?.[executor] || executorsJson.builders?.[executor];
     if (!executorConfig) {
       throw new Error(
         `Cannot find executor '${executor}' in ${executorsFilePath}.`
@@ -383,18 +382,9 @@ export class Workspaces {
       stripJsonComments(fs.readFileSync(generatorsFilePath).toString())
     );
 
-    let normalizedGeneratorName;
-    const gens = generatorsJson.generators || generatorsJson.schematics;
-    for (let k of Object.keys(gens)) {
-      if (k === generator) {
-        normalizedGeneratorName = k;
-        break;
-      }
-      if (gens[k].aliases && gens[k].aliases.indexOf(generator) > -1) {
-        normalizedGeneratorName = k;
-        break;
-      }
-    }
+    let normalizedGeneratorName =
+      findFullGeneratorName(generator, generatorsJson.generators) ||
+      findFullGeneratorName(generator, generatorsJson.schematics);
 
     if (!normalizedGeneratorName) {
       for (let parent of generatorsJson.extends || []) {
@@ -412,6 +402,26 @@ export class Workspaces {
 
   private resolvePaths() {
     return this.root ? [this.root, __dirname] : [__dirname];
+  }
+}
+
+function findFullGeneratorName(
+  name: string,
+  generators: {
+    [name: string]: { aliases?: string[] };
+  }
+) {
+  if (generators) {
+    for (let [key, data] of Object.entries<{ aliases?: string[] }>(
+      generators
+    )) {
+      if (
+        key === name ||
+        (data.aliases && (data.aliases as string[]).includes(name))
+      ) {
+        return key;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
…generators

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If `generators` is defined in the `collections.json` then all generators must be defined there. Ones from `schematics` will not be resolved.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Developers can define some of their generators under `generators` and ones defined in `schematics` that are not in `generators` will still be resolved.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
