### PR TITLE
feat(core): allow excluding imports using a special ignore comment ca…

### DIFF
--- a/packages/workspace/src/core/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
@@ -14,7 +14,6 @@ import { buildExplicitTypeScriptDependencies } from './explicit-project-dependen
 import { createFileMap } from '../../file-graph';
 import { readWorkspaceFiles } from '../../file-utils';
 import { appRootPath } from '../../../utilities/app-root';
-import { string } from 'prop-types';
 
 describe('explicit project dependencies', () => {
   let ctx: ProjectGraphContext;
@@ -83,6 +82,32 @@ describe('explicit project dependencies', () => {
         import { a } from '@proj/proj1234-child'
       `,
       './libs/proj1234-child/index.ts': 'export const a = 7',
+      './libs/proj1234/a.b.ts': `// nx-ignore-next-line
+                                 import('@proj/proj2')
+                                 /* nx-ignore-next-line */
+                                 import {a} from '@proj/proj3a
+      `,
+      './libs/proj1234/b.c.ts': `// nx-ignore-next-line
+                                 require('@proj/proj4ab#a')
+                                 // nx-ignore-next-line
+                                 import('@proj/proj2')
+                                 /* nx-ignore-next-line */
+                                 import {a} from '@proj/proj3a
+                                 const a = { 
+                                     // nx-ignore-next-line
+                                    loadChildren: '@proj/3a'
+                                 }
+                                 const b = {
+                                    // nx-ignore-next-line
+                                    loadChildren: '@proj/3a',
+                                    children: [{
+                                      // nx-ignore-next-line
+                                      loadChildren: '@proj/proj2,
+                                      // nx-ignore-next-line
+                                      loadChildren: '@proj/proj3a'
+                                    }]
+                                 }
+      `,
     };
     vol.fromJSON(fsJson, '/root');
 

--- a/packages/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.ts
@@ -55,8 +55,10 @@ export class TypeScriptImportLocator {
       ts.isImportDeclaration(node) ||
       (ts.isExportDeclaration(node) && node.moduleSpecifier)
     ) {
-      const imp = this.getStringLiteralValue(node.moduleSpecifier);
-      visitor(imp, filePath, DependencyType.static);
+      if (!this.ignoreStatement(node)) {
+        const imp = this.getStringLiteralValue(node.moduleSpecifier);
+        visitor(imp, filePath, DependencyType.static);
+      }
       return; // stop traversing downwards
     }
 
@@ -66,8 +68,10 @@ export class TypeScriptImportLocator {
       node.arguments.length === 1 &&
       ts.isStringLiteral(node.arguments[0])
     ) {
-      const imp = this.getStringLiteralValue(node.arguments[0]);
-      visitor(imp, filePath, DependencyType.dynamic);
+      if (!this.ignoreStatement(node)) {
+        const imp = this.getStringLiteralValue(node.arguments[0]);
+        visitor(imp, filePath, DependencyType.dynamic);
+      }
       return;
     }
 
@@ -77,8 +81,10 @@ export class TypeScriptImportLocator {
       node.arguments.length === 1 &&
       ts.isStringLiteral(node.arguments[0])
     ) {
-      const imp = this.getStringLiteralValue(node.arguments[0]);
-      visitor(imp, filePath, DependencyType.static);
+      if (!this.ignoreStatement(node)) {
+        const imp = this.getStringLiteralValue(node.arguments[0]);
+        visitor(imp, filePath, DependencyType.static);
+      }
       return;
     }
 
@@ -88,7 +94,10 @@ export class TypeScriptImportLocator {
       );
       if (name === 'loadChildren') {
         const init = (node as ts.PropertyAssignment).initializer;
-        if (init.kind === ts.SyntaxKind.StringLiteral) {
+        if (
+          init.kind === ts.SyntaxKind.StringLiteral &&
+          !this.ignoreLoadChildrenDependency(node.getFullText())
+        ) {
           const childrenExpr = this.getStringLiteralValue(init);
           visitor(childrenExpr, filePath, DependencyType.dynamic);
           return; // stop traversing downwards
@@ -100,6 +109,35 @@ export class TypeScriptImportLocator {
      * Continue traversing down the AST from the current node
      */
     ts.forEachChild(node, (child) => this.fromNode(filePath, child, visitor));
+  }
+
+  private ignoreStatement(node: ts.Node) {
+    return stripSourceCode(this.scanner, node.getFullText()) === '';
+  }
+
+  private ignoreLoadChildrenDependency(contents: string): boolean {
+    this.scanner.setText(contents);
+    let token = this.scanner.scan();
+    while (token !== ts.SyntaxKind.EndOfFileToken) {
+      if (
+        token === ts.SyntaxKind.SingleLineCommentTrivia ||
+        token === ts.SyntaxKind.MultiLineCommentTrivia
+      ) {
+        const start = this.scanner.getStartPos() + 2;
+        token = this.scanner.scan();
+        const isMultiLineCommentTrivia =
+          token === ts.SyntaxKind.MultiLineCommentTrivia;
+        const end =
+          this.scanner.getStartPos() - (isMultiLineCommentTrivia ? 2 : 0);
+        const comment = contents.substring(start, end).trim();
+        if (comment === 'nx-ignore-next-line') {
+          return true;
+        }
+      } else {
+        token = this.scanner.scan();
+      }
+    }
+    return false;
   }
 
   private getPropertyAssignmentName(nameNode: ts.PropertyName) {

--- a/packages/workspace/src/utilities/strip-source-code.spec.ts
+++ b/packages/workspace/src/utilities/strip-source-code.spec.ts
@@ -1,4 +1,3 @@
-import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import { stripSourceCode } from './strip-source-code';
 import { createScanner, ScriptTarget, Scanner } from 'typescript';
 
@@ -21,8 +20,9 @@ describe('stripSourceCode', () => {
       
       import "./app.scss";
 
-      import('./module.ts')
-
+      function inside() {
+        import('./module.ts')
+      }
       const a = 1;
       export class App {}
     `;
@@ -63,6 +63,22 @@ export { C as D } from './c'`;
     expect(stripSourceCode(scanner, input)).toEqual(expected);
   });
 
+  it('should work on dependencies made with the require keyword', () => {
+    const input = `require('./a');
+      
+      require('./b');
+      const c = require('./c');
+
+      const a = 1;
+      export class App {}
+    `;
+    const expected = `require('./a')
+require('./b')
+require('./c')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
   it('should not strip files containing "loadChildren"', () => {
     const input = `const routes = [
       {
@@ -71,5 +87,159 @@ export { C as D } from './c'`;
       }
     ];`;
     expect(stripSourceCode(scanner, input)).toEqual(input);
+  });
+
+  it('should strip static imports that have nx-ignore-next-line comment above them', () => {
+    const input = `
+      // nx-ignore-next-line
+      import * as React from "react";
+      import { Component } from "react";
+      import {
+        Component
+      } from "react"
+      import {
+        Component
+      } from "react";
+      
+      // nx-ignore-next-line
+      import "./app.scss";
+
+      import('./module.ts')
+
+      const a = 1;
+      export class App {}
+    `;
+    const expected = `import { Component } from "react"
+import {
+        Component
+      } from "react"
+import {
+        Component
+      } from "react"
+import('./module.ts')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should strip dynamic imports that have nx-ignore-next-line comment above them', () => {
+    const input = `
+      import * as React from "react";
+      import { Component } from "react";
+      import {
+        Component
+      } from "react"
+      import {
+        Component
+      } from "react";
+      
+      import "./app.scss";
+      // nx-ignore-next-line
+      import('./module.ts')
+
+      const a = 1;
+      export class App {}
+    `;
+    const expected = `import * as React from "react"
+import { Component } from "react"
+import {
+        Component
+      } from "react"
+import {
+        Component
+      } from "react"
+import "./app.scss"`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should strip exports that have nx-ignore-next-line comment above them', () => {
+    const input = `export * from './module';
+      export {
+        A
+      } from './a';
+
+      // nx-ignore-next-line
+      export { B } from './b';
+
+      export { C as D } from './c';
+
+      const a = 1;
+      export class App {}
+    `;
+    const expected = `export * from './module'
+export {
+        A
+      } from './a'
+export { C as D } from './c'`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should strip dependencies made with the require keyword that have nx-ignore-next-line above them', () => {
+    const input = `require('./a');
+      // nx-ignore-next-line
+      const b = require('./b');
+      const c = require('./c');
+
+      const a = 1;
+      export class App {}
+    `;
+    const expected = `require('./a')
+require('./c')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should not strip an import if the next line of code after an nx-ignore-next-line comment is not an import', () => {
+    const input = `
+      // nx-ignore-next-line
+      const a = 1;
+      import('./module.ts')
+
+      export class App {}
+    `;
+    const expected = `import('./module.ts')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should not strip an export if the next line of code after an nx-ignore-next-line comment is not an export', () => {
+    const input = `export * from './module';
+      export {
+        A
+      } from './a';
+
+      // nx-ignore-next-line
+      const a = 1;
+      export { B } from './b';
+
+      export { C as D } from './c';
+
+      export class App {}
+    `;
+    const expected = `export * from './module'
+export {
+        A
+      } from './a'
+export { B } from './b'
+export { C as D } from './c'`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('should not strip a dependency made with the require keyword if the next line of code after an nx-ignore-next-line comment is not a require keyword', () => {
+    const input = `require('./a');
+      // nx-ignore-next-line
+      const a = 1;
+      require('./b');
+      const c = require('./c');
+
+      export class App {}
+    `;
+    const expected = `require('./a')
+require('./b')
+require('./c')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
   });
 });


### PR DESCRIPTION
…lled nx-import-ignore

Placing a comment called nx-import-ignore above an import will exclude it from being used in the creation of the project dependency graph. This allows bypassing the circular dependency linting rule whenever needed.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
