### PR TITLE
fix(nextjs): remove tsconfig.app.json

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -314,6 +314,34 @@ describe('Next.js Applications', () => {
       checkE2E: true,
     });
   }, 180000);
+
+  it('should fail the build when TS errors are present', async () => {
+    const appName = uniq('app');
+
+    runCLI(
+      `generate @nrwl/next:app ${appName} --no-interactive --style=@emotion/styled`
+    );
+
+    updateFile(
+      `apps/${appName}/pages/index.tsx`,
+      `
+        import React from 'react';
+
+        export function Index() {
+          let x = '';
+          // below is an intentional TS error
+          x = 3;
+          return <div />;
+        }
+
+        export default Index;
+        `
+    );
+
+    expect(() => runCLI(`build ${appName}`)).toThrowError(
+      `Type error: Type 'number' is not assignable to type 'string'.`
+    );
+  }, 120000);
 });
 
 async function checkApp(

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -47,7 +47,6 @@ describe('app', () => {
     it('should generate files', async () => {
       await applicationGenerator(tree, { name: 'myApp', style: 'css' });
       expect(tree.exists('apps/my-app/tsconfig.json')).toBeTruthy();
-      expect(tree.exists('apps/my-app/tsconfig.app.json')).toBeTruthy();
       expect(tree.exists('apps/my-app/pages/index.tsx')).toBeTruthy();
       expect(tree.exists('apps/my-app/specs/index.spec.tsx')).toBeTruthy();
       expect(tree.exists('apps/my-app/pages/index.module.css')).toBeTruthy();
@@ -292,7 +291,7 @@ describe('app', () => {
                 ],
                 "parserOptions": Object {
                   "project": Array [
-                    "apps/my-app/tsconfig.*?.json",
+                    "apps/my-app/tsconfig(.*)?.json",
                   ],
                 },
                 "rules": Object {},
@@ -357,9 +356,9 @@ describe('app', () => {
       const tsConfig = readJson(tree, 'apps/my-app/tsconfig.json');
       expect(tsConfig.compilerOptions.allowJs).toEqual(true);
 
-      const tsConfigApp = readJson(tree, 'apps/my-app/tsconfig.app.json');
+      const tsConfigApp = readJson(tree, 'apps/my-app/tsconfig.json');
       expect(tsConfigApp.include).toContain('**/*.js');
-      expect(tsConfigApp.exclude).toContain('**/*.spec.js');
+      expect(tsConfigApp.exclude).not.toContain('**/*.spec.js');
     });
   });
 });

--- a/packages/next/src/generators/application/files/next-env.d.ts__tmpl__
+++ b/packages/next/src/generators/application/files/next-env.d.ts__tmpl__
@@ -1,2 +1,13 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+<% if (style === 'less') { %>
+declare module '*.module.less' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+<% } else if (style === 'styl') { %>
+declare module '*.module.styl' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+<% } %>

--- a/packages/next/src/generators/application/files/tsconfig.app.json__tmpl__
+++ b/packages/next/src/generators/application/files/tsconfig.app.json__tmpl__
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "<%= offsetFromRoot %>dist/out-tsc",
-    "types": ["node", "jest"]
-  },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js", "**/*.spec.jsx"],
-  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "next-env.d.ts"]
-}

--- a/packages/next/src/generators/application/files/tsconfig.json__tmpl__
+++ b/packages/next/src/generators/application/files/tsconfig.json__tmpl__
@@ -5,18 +5,13 @@
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "types": ["node", "jest"],
     "strict": false,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "files": [],
-  "include": [],
-  "references": [
-    {
-      "path": "./tsconfig.app.json"
-    }
-  ],
+  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "next-env.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/next/src/generators/application/lib/add-linting.ts
+++ b/packages/next/src/generators/application/lib/add-linting.ts
@@ -29,7 +29,14 @@ export async function addLinting(
     updateJson(
       host,
       joinPathFragments(options.appProjectRoot, '.eslintrc.json'),
-      () => reactEslintJson
+      () => {
+        if (reactEslintJson.overrides?.[0].parserOptions?.project) {
+          reactEslintJson.overrides[0].parserOptions.project = [
+            `${options.appProjectRoot}/tsconfig(.*)?.json`,
+          ];
+        }
+        return reactEslintJson;
+      }
     );
   }
 

--- a/packages/next/src/generators/application/lib/create-application-files.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.ts
@@ -52,6 +52,5 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
   if (options.js) {
     host.delete(`${options.appProjectRoot}/index.d.ts`);
     toJS(host);
-    updateTsConfigsToJs(host, { projectRoot: options.appProjectRoot });
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Running a build on a Next.js project succeeds even if there are TS errors in that application's code.

[Next.js looks for a tsconfig.json file exclusively, during the build](https://github.com/vercel/next.js/blob/master/packages/next/lib/verifyTypeScriptSetup.ts#L19). However, in our case, `tsconfig.json` at the root of a Next.js application is a solution-style config, so it doesn't have anything in the `"files"` or `"includes"`. This results in Next.js skipping type checking during the build, thus ignoring TS errors in the application source files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running a `build` on a Next.js project with TS errors should fail with the TS errors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4651 
