### PR TITLE
feat(angular): support font inling optimization for builds

### DIFF
--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -73,6 +73,26 @@
               "type": "boolean",
               "description": "Enables optimization of the styles output.",
               "default": true
+            },
+            "fonts": {
+              "description": "Enables optimization for fonts. This option requires internet access. `HTTPS_PROXY` environment variable can be used to specify a proxy server.",
+              "default": true,
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "inline": {
+                      "type": "boolean",
+                      "description": "Reduce render blocking requests by inlining external Google fonts and icons CSS definitions in the application's HTML index file. This option requires internet access. `HTTPS_PROXY` environment variable can be used to specify a proxy server.",
+                      "default": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Currently, the @nrwl/angular:webpack-browser does not support the font option in optimization.

## Expected Behavior
There should be an option to disable font inlining under optimization

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
