### PR TITLE
fix(core): use proper command for removing a dependency via yarn

### DIFF
--- a/packages/tao/src/shared/package-manager.ts
+++ b/packages/tao/src/shared/package-manager.ts
@@ -39,7 +39,7 @@ export function getPackageManagerCommand(
         install: 'yarn',
         add: 'yarn add',
         addDev: 'yarn add -D',
-        rm: 'yarn rm',
+        rm: 'yarn remove',
         exec: 'yarn',
         run: (script: string, args: string) => `yarn ${script} ${args}`,
         list: 'yarn list',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Removing a dependency uses `yarn rm` which is an invalid command.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Removing a dependency uses `yarn remove`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
