### PR TITLE
Tsconfig js migration

### DIFF
--- a/packages/gatsby/migrations.json
+++ b/packages/gatsby/migrations.json
@@ -1,0 +1,10 @@
+{
+  "schematics": {
+    "add-js-include-11.6.0": {
+      "cli": "nx",
+      "version": "11.6.0-beta.0",
+      "description": "Add js patterns to tsconfig.app.json",
+      "factory": "./src/migrations/update-11-6-0/add-js-include-11-6-0"
+    }
+  }
+}

--- a/packages/gatsby/src/migrations/update-11-6-0/add-js-include-11-6-0.spec.ts
+++ b/packages/gatsby/src/migrations/update-11-6-0/add-js-include-11-6-0.spec.ts
@@ -1,0 +1,42 @@
+import { readJson, Tree, writeJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import addJsInclude from './add-js-include-11-6-0';
+
+describe('Add js include 11.6.0', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add js patterns to tsconfig "include" and "exclude"', async () => {
+    writeJson(tree, 'workspace.json', {
+      projects: {
+        app1: {
+          root: 'apps/app1',
+          targets: {
+            build: {
+              executor: '@nrwl/gatsby:build',
+            },
+          },
+        },
+      },
+    });
+    writeJson(tree, 'nx.json', {
+      projects: {
+        app1: {},
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.app.json', {
+      include: ['**/*.ts'],
+      exclude: ['**/*.spec.tsx'],
+    });
+
+    await addJsInclude(tree);
+
+    expect(readJson(tree, 'apps/app1/tsconfig.app.json')).toMatchObject({
+      include: ['**/*.ts', '**/*.js', '**/*.jsx'],
+      exclude: ['**/*.spec.tsx', '**/*.spec.js', '**/*.spec.jsx'],
+    });
+  });
+});

--- a/packages/gatsby/src/migrations/update-11-6-0/add-js-include-11-6-0.ts
+++ b/packages/gatsby/src/migrations/update-11-6-0/add-js-include-11-6-0.ts
@@ -1,0 +1,29 @@
+import { getProjects, Tree, updateJson } from '@nrwl/devkit';
+
+export async function addJsInclude(host: Tree) {
+  const projects = getProjects(host);
+
+  projects.forEach((project) => {
+    const tsconfigPath = `${project.root}/tsconfig.app.json`;
+
+    if (project.targets?.build?.executor !== '@nrwl/gatsby:build') return;
+
+    if (!host.exists(tsconfigPath)) return;
+
+    updateJson(host, tsconfigPath, (json) => {
+      if (!json.include) {
+        json.include = [];
+      }
+      if (!json.exclude) {
+        json.exclude = [];
+      }
+      json.include = uniq([...json.include, '**/*.js', '**/*.jsx']);
+      json.exclude = uniq([...json.exclude, '**/*.spec.js', '**/*.spec.jsx']);
+      return json;
+    });
+  });
+}
+
+const uniq = <T extends string[]>(value: T) => [...new Set(value)] as T;
+
+export default addJsInclude;

--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -36,6 +36,12 @@
       "version": "11.5.0-beta.1",
       "description": "Remove tsconfig.app.json",
       "factory": "./src/migrations/update-11-5-0/remove-tsconfig-app-11-5-0"
+    },
+    "add-js-include-11.6.0": {
+      "cli": "nx",
+      "version": "11.6.0-beta.0",
+      "description": "Add js patterns to tsconfig.json",
+      "factory": "./src/migrations/update-11-6-0/add-js-include-11-6-0"
     }
   },
   "packageJsonUpdates": {

--- a/packages/next/src/migrations/update-11-6-0/add-js-include-11-6-0.spec.ts
+++ b/packages/next/src/migrations/update-11-6-0/add-js-include-11-6-0.spec.ts
@@ -1,0 +1,41 @@
+import { readJson, Tree, writeJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import addJsInclude from './add-js-include-11-6-0';
+
+describe('Add js include 11.6.0', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add js patterns to tsconfig "include"', async () => {
+    writeJson(tree, 'workspace.json', {
+      projects: {
+        app1: {
+          root: 'apps/app1',
+          targets: {
+            build: {
+              executor: '@nrwl/next:build',
+            },
+          },
+        },
+      },
+    });
+
+    writeJson(tree, 'nx.json', {
+      projects: {
+        app1: {},
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.json', {
+      include: ['**/*.ts'],
+    });
+
+    await addJsInclude(tree);
+
+    expect(readJson(tree, 'apps/app1/tsconfig.json')).toMatchObject({
+      include: ['**/*.ts', '**/*.js', '**/*.jsx'],
+    });
+  });
+});

--- a/packages/next/src/migrations/update-11-6-0/add-js-include-11-6-0.ts
+++ b/packages/next/src/migrations/update-11-6-0/add-js-include-11-6-0.ts
@@ -1,0 +1,25 @@
+import { getProjects, Tree, updateJson } from '@nrwl/devkit';
+
+export async function addJsInclude(host: Tree) {
+  const projects = getProjects(host);
+
+  projects.forEach((project) => {
+    const tsconfigPath = `${project.root}/tsconfig.json`;
+
+    if (project.targets?.build?.executor !== '@nrwl/next:build') return;
+
+    if (!host.exists(tsconfigPath)) return;
+
+    updateJson(host, tsconfigPath, (json) => {
+      if (!json.include) {
+        json.include = [];
+      }
+      json.include = uniq([...json.include, '**/*.js', '**/*.jsx']);
+      return json;
+    });
+  });
+}
+
+const uniq = <T extends string[]>(value: T) => [...new Set(value)] as T;
+
+export default addJsInclude;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

#4657 introduced `**/*.js` and `**/*.jsx` patterns into `tsconfig`s of gatsby apps and next.js apps. So this PR adds migrations for that.

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Without these migrations, existing next.js and gatsby apps are going to throw linting errors after running all other migrations in the next version of Nx.

More specifically, what actually happens is that there's a [linter migration that points ESLint at `.js` and `.jsx` files](https://github.com/nrwl/nx/blob/master/packages/linter/src/migrations/update-11-5-0/always-use-project-level-tsconfigs-with-eslint.ts#L53). And without `.js` and `.jsx` files included in tsconfig - running the `lint` command will fail with:
```
/apps/next-app/jest.config.js
  0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: apps/next-app/jest.config.js.
The file must be included in at least one of the projects provided

/apps/next-app/next.config.js
  0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: apps/next-app/next.config.js.
The file must be included in at least one of the projects provided
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Linting succeeds after running all migrations

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
