### PR TITLE
fix(core): throw an error when running default projects with improper…

### DIFF
--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -179,10 +179,15 @@ async function runExecutorInternal<T extends { success: boolean }>(
 
   const ws = new Workspaces(root);
   const proj = workspace.projects[project];
-  const targetConfig =
-    proj.targets && proj.targets[target]
-      ? proj.targets[target]
-      : createImplicitTargetConfig(proj, target);
+  const targetConfig = proj.targets
+    ? proj.targets[target]
+    : createImplicitTargetConfig(proj, target);
+
+  if (!targetConfig) {
+    throw new Error(
+      "NX Cannot find target '${target}' for project '${project.name}'"
+    );
+  }
   const [nodeModule, executor] = targetConfig.executor.split(':');
   const { schema, implementationFactory } = ws.readExecutor(
     nodeModule,


### PR DESCRIPTION
… targets

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `yarn e2e` in a workspace will try and run `app1:e2e` which doesn't exist... but it then falls back to running an npm script... which is `yarn e2e` creating an infinite loop.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Because the project has targets, it should not look at the npm script. It should throw an error.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
