### PR TITLE
fix(react): temporarily remove babel migration

### DIFF
--- a/packages/web/migrations.json
+++ b/packages/web/migrations.json
@@ -14,12 +14,6 @@
       "version": "9.2.0-beta.1",
       "description": "Set buildLibsFromSource property to true to not break existing projects.",
       "factory": "./src/migrations/update-9-2-0/set-build-libs-from-source"
-    },
-    "update-babel-config-11.5.0": {
-      "cli": "nx",
-      "version": "11.5.0-beta.1",
-      "description": "Update babel config to support different TS setup",
-      "factory": "./src/migrations/update-11-5-0/update-babel-config"
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The babelrc migration was adding a new `.babelrc` file to all libs even if they don't require it. This was done to prevent `@nrwl/workspace` libs from breaking.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This is too aggressive so the migration is skipped for now while we figure out the right way to migrate workspaces.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
