### PR TITLE
feat(react): add strict option to react library generator

### DIFF
--- a/docs/angular/api-react/generators/library.md
+++ b/docs/angular/api-react/generators/library.md
@@ -150,6 +150,14 @@ Type: `boolean`
 
 Do not update tsconfig.json for development experience.
 
+### strict
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to enable tsconfig strict mode or not.
+
 ### style
 
 Alias(es): s

--- a/docs/node/api-react/generators/library.md
+++ b/docs/node/api-react/generators/library.md
@@ -150,6 +150,14 @@ Type: `boolean`
 
 Do not update tsconfig.json for development experience.
 
+### strict
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to enable tsconfig strict mode or not.
+
 ### style
 
 Alias(es): s

--- a/docs/react/api-react/generators/library.md
+++ b/docs/react/api-react/generators/library.md
@@ -150,6 +150,14 @@ Type: `boolean`
 
 Do not update tsconfig.json for development experience.
 
+### strict
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to enable tsconfig strict mode or not.
+
 ### style
 
 Alias(es): s

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -16,6 +16,7 @@ describe('lib', () => {
     unitTestRunner: 'jest',
     style: 'css',
     component: true,
+    strict: false,
   };
 
   beforeEach(() => {
@@ -576,6 +577,42 @@ describe('lib', () => {
       }
 
       expect.assertions(1);
+    });
+  });
+
+  describe('--strict', () => {
+    it('should update the projects tsconfig with strict true', async () => {
+      await libraryGenerator(appTree, {
+        ...defaultSchema,
+        strict: true,
+      });
+      const tsconfigJson = readJson(appTree, '/libs/my-lib/tsconfig.lib.json');
+
+      expect(tsconfigJson.compilerOptions.strict).toBeTruthy();
+      expect(
+        tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
+      ).toBeTruthy();
+      expect(tsconfigJson.compilerOptions.noImplicitReturns).toBeTruthy();
+      expect(
+        tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
+      ).toBeTruthy();
+    });
+
+    it('should default to strict false', async () => {
+      await libraryGenerator(appTree, {
+        ...defaultSchema,
+        name: 'myLib',
+      });
+      const tsconfigJson = readJson(appTree, '/libs/my-lib/tsconfig.lib.json');
+
+      expect(tsconfigJson.compilerOptions.strict).not.toBeDefined();
+      expect(
+        tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
+      ).not.toBeDefined();
+      expect(tsconfigJson.compilerOptions.noImplicitReturns).not.toBeDefined();
+      expect(
+        tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
+      ).not.toBeDefined();
     });
   });
 });

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -18,6 +18,7 @@ import {
   reactVersion,
   typesReactRouterDomVersion,
 } from '../../utils/versions';
+import { join } from 'path';
 import { Schema } from './schema';
 import {
   addDependenciesToPackageJson,
@@ -217,6 +218,22 @@ function addProject(host: Tree, options: NormalizedSchema) {
   });
 }
 
+function updateLibTsConfig(tree: Tree, options: NormalizedSchema) {
+  updateJson(tree, join(options.projectRoot, 'tsconfig.lib.json'), (json) => {
+    if (options.strict) {
+      json.compilerOptions = {
+        ...json.compilerOptions,
+        forceConsistentCasingInFileNames: true,
+        strict: true,
+        noImplicitReturns: true,
+        noFallthroughCasesInSwitch: true,
+      };
+    }
+
+    return json;
+  });
+}
+
 function updateTsConfig(host: Tree, options: NormalizedSchema) {
   updateJson(host, 'tsconfig.base.json', (json) => {
     const c = json.compilerOptions;
@@ -247,6 +264,7 @@ function createFiles(host: Tree, options: NormalizedSchema) {
     {
       ...options,
       ...names(options.name),
+      strict: undefined,
       tmpl: '',
       offsetFromRoot: offsetFromRoot(options.projectRoot),
     }
@@ -259,6 +277,8 @@ function createFiles(host: Tree, options: NormalizedSchema) {
   if (options.js) {
     toJS(host);
   }
+
+  updateLibTsConfig(host, options);
 }
 
 function updateAppRoutes(host: Tree, options: NormalizedSchema) {

--- a/packages/react/src/generators/library/schema.d.ts
+++ b/packages/react/src/generators/library/schema.d.ts
@@ -19,4 +19,5 @@ export interface Schema {
   importPath?: string;
   js?: boolean;
   globalCss?: boolean;
+  strict?: boolean;
 }

--- a/packages/react/src/generators/library/schema.json
+++ b/packages/react/src/generators/library/schema.json
@@ -140,6 +140,11 @@
       "type": "boolean",
       "description": "When true, the stylesheet is generated using global CSS instead of CSS modules (e.g. file is '*.css' rather than '*.module.css').",
       "default": false
+    },
+    "strict": {
+      "type": "boolean",
+      "description": "Whether to enable tsconfig strict mode or not.",
+      "default": false
     }
   },
   "required": ["name"]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
React library generator does not have `--strict` option.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
```
nx g @nrwl/react:lib my-lib --strict
```
```js
{
  "extends": "./tsconfig.json",
  "compilerOptions": {
    "outDir": "../../../dist/out-tsc",
    "types": ["node"],
    "forceConsistentCasingInFileNames": true,  // <- added
    "strict": true,                            // <- added
    "noImplicitReturns": true,                 // <- added
    "noFallthroughCasesInSwitch": true,        // <- added
  },
  :
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

The implementation is based on #4057
