### PR TITLE
fix(storybook): do not update existing root configuration

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -75,6 +75,31 @@ describe('@nrwl/storybook:configuration', () => {
     ).toBeFalsy();
   });
 
+  it('should not update root files after generating them once', async () => {
+    await configurationGenerator(tree, {
+      name: 'test-ui-lib',
+      uiFramework: '@storybook/angular',
+    });
+
+    const newContents = `module.exports = {
+  stories: [],
+  addons: ['@storybook/addon-knobs/register', 'new-addon'],
+};
+`;
+    // Setup a new lib
+    await libraryGenerator(tree, {
+      name: 'test-ui-lib-2',
+    });
+
+    tree.write('.storybook/main.js', newContents);
+    await configurationGenerator(tree, {
+      name: 'test-ui-lib-2',
+      uiFramework: '@storybook/angular',
+    });
+
+    expect(tree.read('.storybook/main.js').toString()).toEqual(newContents);
+  });
+
   it('should update workspace file', async () => {
     await configurationGenerator(tree, {
       name: 'test-ui-lib',

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -93,6 +93,9 @@ function createRootStorybookDir(
   js: boolean,
   workspaceStorybookVersion: string
 ) {
+  if (tree.exists('.storybook')) {
+    return;
+  }
   const { projectType } = readProjectConfiguration(tree, projectName);
   const projectDirectory = projectType === 'application' ? 'app' : 'lib';
   logger.debug(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The root config is overwritten every time a storybook configuration is generated.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The root config is not overwritten for new storybook configurations

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/5015
