### PR TITLE
chore(repo): free space during angular e2e tests

### DIFF
--- a/e2e/angular/src/angular-app.test.ts
+++ b/e2e/angular/src/angular-app.test.ts
@@ -2,6 +2,7 @@ import {
   newProject,
   readFile,
   readJson,
+  removeProject,
   runCLI,
   uniq,
   updateFile,
@@ -52,6 +53,8 @@ describe('Angular Nrwl app builder', () => {
       '@nrwl/angular:webpack-browser';
     updateFile('angular.json', JSON.stringify(workspaceJson, null, 2));
   });
+
+  afterEach(() => removeProject({ onlyOnCI: true }));
 
   it('should build the dependent buildable lib as well as the app', () => {
     const libOutput = runCLI(`build ${app} --with-deps`);

--- a/e2e/angular/src/angular-core.test.ts
+++ b/e2e/angular/src/angular-core.test.ts
@@ -5,6 +5,7 @@ import {
   getSelectedPackageManager,
   getSize,
   newProject,
+  removeProject,
   runCLI,
   runCLIAsync,
   tmpProjPath,
@@ -16,9 +17,9 @@ import { names } from '@nrwl/devkit';
 describe('Angular Package', () => {
   let proj: string;
 
-  beforeEach(() => {
-    proj = newProject();
-  });
+  beforeEach(() => (proj = newProject()));
+
+  afterEach(() => removeProject({ onlyOnCI: true }));
 
   it('should work', async () => {
     const myapp = uniq('myapp');

--- a/e2e/angular/src/storybook.test.ts
+++ b/e2e/angular/src/storybook.test.ts
@@ -2,6 +2,7 @@ import {
   checkFilesExist,
   newProject,
   readFile,
+  removeProject,
   runCLI,
   supportUi,
   tmpProjPath,
@@ -10,10 +11,14 @@ import {
 import { mkdirSync, writeFileSync } from 'fs';
 
 describe('Storybook schematics', () => {
+  let proj: string;
+
+  beforeEach(() => (proj = newProject()));
+
+  afterEach(() => removeProject({ onlyOnCI: true }));
+
   describe('build storybook', () => {
     it('should execute e2e tests using Cypress running against Storybook', () => {
-      newProject();
-
       const myapp = uniq('myapp');
       runCLI(`generate @nrwl/angular:app ${myapp} --no-interactive`);
 
@@ -145,8 +150,6 @@ describe('Storybook schematics', () => {
     }, 1000000);
 
     it('should build an Angular based storybook', () => {
-      newProject();
-
       const angularStorybookLib = uniq('test-ui-lib');
       createTestUILib(angularStorybookLib);
       runCLI(
@@ -162,8 +165,6 @@ describe('Storybook schematics', () => {
     }, 1000000);
 
     it('should build an Angular based storybook that references another lib', () => {
-      const proj = newProject();
-
       const angularStorybookLib = uniq('test-ui-lib');
       createTestUILib(angularStorybookLib);
       runCLI(


### PR DESCRIPTION
This will prevent E2E fails of Angular on GH Actions due to out of space errors.