### PR TITLE
fix(core): fix prompts for enums

### DIFF
--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -5,6 +5,7 @@ import { logger } from './logger';
 
 type PropertyDescription = {
   type?: string;
+  enum?: string[];
   properties?: any;
   oneOf?: any;
   items?: any;
@@ -494,7 +495,12 @@ async function promptForValues(opts: Options, schema: Schema) {
 
       if (typeof v['x-prompt'] === 'string') {
         question.message = v['x-prompt'];
-        question.type = v.type === 'boolean' ? 'confirm' : 'string';
+        if (v.type === 'string' && v.enum && Array.isArray(v.enum)) {
+          question.type = 'list';
+          question.choices = v.enum;
+        } else {
+          question.type = v.type === 'boolean' ? 'confirm' : 'string';
+        }
       } else if (v['x-prompt'].type == 'number') {
         question.message = v['x-prompt'].message;
         question.type = 'number';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Prompts for properties that have enum values are string prompts.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Prompts for properties that have enum values are list prompts with the enum values.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
