### PR TITLE
chore(repo): run e2e outside project directory on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,10 @@ jobs:
           command: yarn e2e << parameters.packages >> affected
           no_output_timeout: 30m
     environment:
+      GIT_AUTHOR_NAME: test@test.com
+      GIT_AUTHOR_EMAIL: Test
+      GIT_COMMITTER_EMAIL: test@test.com
+      GIT_COMMITTER_NAME: Test
       NX_E2E_CI_CACHE_KEY: e2e-circleci-<< parameters.os >>-<< parameters.pm >>
       SELECTED_PM: << parameters.pm >>
       SELECTED_CLI: << parameters.cli >>

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -49,6 +49,10 @@ jobs:
     - name: Run e2e tests
       run: yarn e2e ${{ matrix.packages }} affected
       env:
+        GIT_AUTHOR_NAME: test@test.com
+        GIT_AUTHOR_EMAIL: Test
+        GIT_COMMITTER_EMAIL: test@test.com
+        GIT_COMMITTER_NAME: Test
         NX_E2E_CI_CACHE_KEY: e2e-gha-${{ matrix.node_version }}-${{ matrix.package_manager }}
         NODE_OPTIONS: --max_old_space_size=8192
         SELECTED_PM: ${{ matrix.package_manager }}

--- a/apps/dep-graph-client/src/graphs/small.ts
+++ b/apps/dep-graph-client/src/graphs/small.ts
@@ -10458,7 +10458,7 @@ export const smallGraph: ProjectGraphCache = {
       type: 'npm',
       name: 'npm:regenerator-runtime',
       data: {
-        version: '0.13.3',
+        version: '0.13.7',
         packageName: 'regenerator-runtime',
         files: [],
       },

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -14,6 +14,7 @@ import {
 } from 'fs-extra';
 import * as isCI from 'is-ci';
 import * as path from 'path';
+import { dirSync } from 'tmp';
 
 interface RunCmdOpts {
   silenceError?: boolean;
@@ -25,6 +26,10 @@ interface RunCmdOpts {
 export function currentCli() {
   return process.env.SELECTED_CLI ?? 'nx';
 }
+
+export const e2eRoot = isCI ? dirSync({ prefix: 'nx-e2e-' }).name : `./tmp`;
+export const e2eCwd = `${e2eRoot}/${currentCli()}`;
+ensureDirSync(e2eCwd);
 
 let projName: string;
 
@@ -85,7 +90,7 @@ export function runCreateWorkspace(
   }
 
   const create = execSync(command, {
-    cwd: `./tmp/${currentCli()}`,
+    cwd: e2eCwd,
     stdio: [0, 1, 2],
     env: process.env,
   });
@@ -93,7 +98,7 @@ export function runCreateWorkspace(
 }
 
 export function packageInstall(pkg: string, projName?: string) {
-  const cwd = projName ? `./tmp/${currentCli()}/${projName}` : tmpProjPath();
+  const cwd = projName ? `${e2eCwd}/${projName}` : tmpProjPath();
   const pm = getPackageManagerCommand({ path: cwd });
   const install = execSync(`${pm.addDev} ${pkg}`, {
     cwd,
@@ -106,7 +111,7 @@ export function packageInstall(pkg: string, projName?: string) {
 
 export function runNgNew(): string {
   return execSync(`../../node_modules/.bin/ng new proj --no-interactive`, {
-    cwd: `./tmp/${currentCli()}`,
+    cwd: e2eCwd,
     env: process.env,
   }).toString();
 }
@@ -152,7 +157,7 @@ export function newProject({ name = uniq('proj') } = {}): string {
       packageInstall(packages.join(` `), projScope);
 
       if (useBackupProject) {
-        moveSync(`./tmp/${currentCli()}/proj`, `${tmpBackupProjPath()}`);
+        moveSync(`${e2eCwd}/proj`, `${tmpBackupProjPath()}`);
       }
     }
     projName = name;
@@ -468,15 +473,11 @@ export function getSize(filePath: string): number {
 }
 
 export function tmpProjPath(path?: string) {
-  return path
-    ? `./tmp/${currentCli()}/${projName}/${path}`
-    : `./tmp/${currentCli()}/${projName}`;
+  return path ? `${e2eCwd}/${projName}/${path}` : `${e2eCwd}/${projName}`;
 }
 
 function tmpBackupProjPath(path?: string) {
-  return path
-    ? `./tmp/${currentCli()}/proj-backup/${path}`
-    : `./tmp/${currentCli()}/proj-backup`;
+  return path ? `${e2eCwd}/proj-backup/${path}` : `${e2eCwd}/proj-backup`;
 }
 
 export function getPackageManagerCommand({

--- a/e2e/workspace/src/create-nx-workspace.test.ts
+++ b/e2e/workspace/src/create-nx-workspace.test.ts
@@ -1,6 +1,7 @@
 import {
   checkFilesDoNotExist,
   checkFilesExist,
+  e2eCwd,
   expectNoAngularDevkit,
   readJson,
   removeProject,
@@ -145,7 +146,7 @@ describe('create-nx-workspace', () => {
   it('should handle spaces in workspace path', () => {
     const wsName = uniq('empty');
 
-    const tmpDir = `./tmp/nx/with space`;
+    const tmpDir = `${e2eCwd}/with space`;
 
     mkdirSync(tmpDir);
 

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "react-dom": "16.10.2",
     "react-redux": "7.1.3",
     "react-router-dom": "5.1.2",
-    "regenerator-runtime": "0.13.3",
+    "regenerator-runtime": "0.13.7",
     "release-it": "^7.4.0",
     "rimraf": "^3.0.2",
     "rollup": "1.31.1",

--- a/packages/nest/src/schematics/library/library.ts
+++ b/packages/nest/src/schematics/library/library.ts
@@ -28,6 +28,7 @@ import * as ts from 'typescript';
 import { libsDir, RemoveChange } from '@nrwl/workspace/src/utils/ast-utils';
 import { names, offsetFromRoot } from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
+import { updateDependencies } from '../init/init';
 
 export interface NormalizedSchema extends Schema {
   name: string;
@@ -44,6 +45,7 @@ export default function (schema: NormalizedSchema): Rule {
 
     return chain([
       externalSchematic('@nrwl/node', 'lib', schema),
+      updateDependencies,
       createFiles(options),
       addExportsToBarrelFile(options),
       updateTsConfig(options),

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -56,6 +56,7 @@ function updateDependencies(host: Tree) {
       'core-js': '^3.6.5',
       react: reactVersion,
       'react-dom': reactDomVersion,
+      'regenerator-runtime': '0.13.7',
       tslib: '^2.0.0',
     },
     {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -83,7 +83,7 @@
     "raw-loader": "3.1.0",
     "rxjs": "^6.5.4",
     "rxjs-for-await": "0.0.2",
-    "regenerator-runtime": "0.13.3",
+    "regenerator-runtime": "0.13.7",
     "rimraf": "^3.0.2",
     "rollup": "1.31.1",
     "rollup-plugin-copy": "^3.3.0",

--- a/packages/web/src/generators/init/init.ts
+++ b/packages/web/src/generators/init/init.ts
@@ -28,6 +28,7 @@ function updateDependencies(tree: Tree) {
     {
       'core-js': '^3.6.5',
       'document-register-element': documentRegisterElementVersion,
+      'regenerator-runtime': '0.13.7',
       tslib: '^2.0.0',
     },
     {

--- a/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`new --preset angular should generate necessary npm dependencies 1`] = `
 Object {
   "dependencies": Object {
     "@nrwl/angular": "*",
+    "tslib": "^2.0.0",
   },
   "devDependencies": Object {
     "@nrwl/cli": "*",
@@ -47,7 +48,9 @@ Object {
 
 exports[`new --preset empty should generate necessary npm dependencies 1`] = `
 Object {
-  "dependencies": Object {},
+  "dependencies": Object {
+    "tslib": "^2.0.0",
+  },
   "devDependencies": Object {
     "@nrwl/cli": "*",
     "@nrwl/tao": "*",
@@ -90,7 +93,9 @@ Object {
 
 exports[`new --preset react should generate necessary npm dependencies 1`] = `
 Object {
-  "dependencies": Object {},
+  "dependencies": Object {
+    "tslib": "^2.0.0",
+  },
   "devDependencies": Object {
     "@nrwl/cli": "*",
     "@nrwl/react": "*",

--- a/packages/workspace/src/generators/workspace/files/package.json__tmpl__
+++ b/packages/workspace/src/generators/workspace/files/package.json__tmpl__
@@ -30,7 +30,9 @@
     "help": "nx help"
   },
   "private": true,
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.0.0"
+  },
   "devDependencies": {
      <% if(cli === 'angular') { %>"@angular/cli": "<%= angularCliVersion %>",<% } %>
     "@nrwl/tao": "<%= nxVersion %>",

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process';
 import { readdirSync } from 'fs';
-import { ensureDirSync, removeSync, writeFileSync } from 'fs-extra';
+import { removeSync, writeFileSync } from 'fs-extra';
+import { e2eRoot } from '../e2e/utils';
 const kill = require('tree-kill');
 import { build } from './package';
 
@@ -60,6 +61,10 @@ export function setup() {
     .trim()
     .split('.')[0];
 
+  // Remove previous packages with the same version
+  // before publishing the new ones
+  removeSync('./tmp/local-registry');
+
   getDirectories('./build/packages').map((pkg) => {
     updateVersion(`./build/packages/${pkg}`);
     publishPackage(`./build/packages/${pkg}`, +npmMajorVersion);
@@ -94,9 +99,7 @@ async function runTest() {
   build(process.env.PUBLISHED_VERSION, '~10.0.0', '3.9.3', '2.1.2');
 
   if (process.argv[5] != '--rerun') {
-    removeSync(`tmp`);
-    ensureDirSync(`tmp/angular`);
-    ensureDirSync(`tmp/nx`);
+    removeSync(e2eRoot);
   }
 
   try {


### PR DESCRIPTION
During CI we will run E2E tests outside repo directory, to make sure that no project dependency is resolved in repo's own `node_modules`.

Other notable changes:
* `tslib` is added as dependency when creating workspace as we default to `importHelpers: true` on `tsconfig.base.json`
* `regenerator-runtime` is pinned to latest available version and added as dependency on projects that use it in polyfills.