### PR TITLE
fix(linter): apply enforce-module-boundaries rule to import expressions

### DIFF
--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -86,8 +86,10 @@ describe('Enforce Module Boundaries', () => {
         import '@mycompany/mylib';
         import '@mycompany/mylib/deep';
         import '../blah';
+        import('@mycompany/mylib');
+        import('@mycompany/mylib/deep');
+        import('../blah');
       `,
-
       {
         nodes: {
           myappName: {
@@ -131,8 +133,9 @@ describe('Enforce Module Boundaries', () => {
       {},
       `${process.cwd()}/proj/apps/myapp/src/main.ts`,
       `
-          import '@mycompany/myapp2/mylib';
-        `,
+        import '@mycompany/myapp2/mylib';
+        import('@mycompany/myapp2/mylib');
+      `,
       {
         nodes: {
           myappName: {
@@ -280,13 +283,16 @@ describe('Enforce Module Boundaries', () => {
         `${process.cwd()}/proj/libs/api/src/index.ts`,
         `
           import '@mycompany/impl';
+          import('@mycompany/impl');
         `,
         graph
       );
 
-      expect(failures[0].message).toEqual(
-        'A project tagged with "api" can only depend on libs tagged with "api"'
-      );
+      const message =
+        'A project tagged with "api" can only depend on libs tagged with "api"';
+      expect(failures.length).toEqual(2);
+      expect(failures[0].message).toEqual(message);
+      expect(failures[1].message).toEqual(message);
     });
 
     it('should allow imports to npm packages', () => {
@@ -294,10 +300,12 @@ describe('Enforce Module Boundaries', () => {
         depConstraints,
         `${process.cwd()}/proj/libs/api/src/index.ts`,
         `
-            import 'npm-package';
-          `,
+          import 'npm-package';
+          import('npm-package');
+        `,
         graph
       );
+
       expect(failures.length).toEqual(0);
     });
 
@@ -306,14 +314,17 @@ describe('Enforce Module Boundaries', () => {
         depConstraints,
         `${process.cwd()}/proj/libs/api/src/index.ts`,
         `
-            import '@mycompany/untagged';
-          `,
+          import '@mycompany/untagged';
+          import('@mycompany/untagged');
+        `,
         graph
       );
 
-      expect(failures[0].message).toEqual(
-        'A project tagged with "api" can only depend on libs tagged with "api"'
-      );
+      const message =
+        'A project tagged with "api" can only depend on libs tagged with "api"';
+      expect(failures.length).toEqual(2);
+      expect(failures[0].message).toEqual(message);
+      expect(failures[1].message).toEqual(message);
     });
 
     it('should error when the source library is untagged', () => {
@@ -321,14 +332,16 @@ describe('Enforce Module Boundaries', () => {
         depConstraints,
         `${process.cwd()}/proj/libs/untagged/src/index.ts`,
         `
-            import '@mycompany/api';
-          `,
+          import '@mycompany/api';
+          import('@mycompany/api');
+        `,
         graph
       );
 
-      expect(failures[0].message).toEqual(
-        'A project without tags cannot depend on any libraries'
-      );
+      const message = 'A project without tags cannot depend on any libraries';
+      expect(failures.length).toEqual(2);
+      expect(failures[0].message).toEqual(message);
+      expect(failures[1].message).toEqual(message);
     });
 
     it('should check all tags', () => {
@@ -336,14 +349,17 @@ describe('Enforce Module Boundaries', () => {
         depConstraints,
         `${process.cwd()}/proj/libs/impl/src/index.ts`,
         `
-            import '@mycompany/impl-domain2';
-          `,
+          import '@mycompany/impl-domain2';
+          import('@mycompany/impl-domain2');
+        `,
         graph
       );
 
-      expect(failures[0].message).toEqual(
-        'A project tagged with "domain1" can only depend on libs tagged with "domain1"'
-      );
+      const message =
+        'A project tagged with "domain1" can only depend on libs tagged with "domain1"';
+      expect(failures.length).toEqual(2);
+      expect(failures[0].message).toEqual(message);
+      expect(failures[1].message).toEqual(message);
     });
 
     it('should allow a domain1 project to depend on a project that is tagged with domain1 and domain2', () => {
@@ -351,8 +367,9 @@ describe('Enforce Module Boundaries', () => {
         depConstraints,
         `${process.cwd()}/proj/libs/impl/src/index.ts`,
         `
-            import '@mycompany/impl-both-domains';
-          `,
+          import '@mycompany/impl-both-domains';
+          import('@mycompany/impl-both-domains');
+        `,
         graph
       );
 
@@ -364,8 +381,9 @@ describe('Enforce Module Boundaries', () => {
         depConstraints,
         `${process.cwd()}/proj/libs/impl-both-domain/src/index.ts`,
         `
-            import '@mycompany/impl';
-          `,
+          import '@mycompany/impl';
+          import('@mycompany/impl');
+        `,
         graph
       );
 
@@ -377,8 +395,9 @@ describe('Enforce Module Boundaries', () => {
         depConstraints,
         `${process.cwd()}/proj/libs/impl/src/index.ts`,
         `
-            import '@mycompany/impl2';
-          `,
+          import '@mycompany/impl2';
+          import('@mycompany/impl2');
+        `,
         graph
       );
 
@@ -392,8 +411,9 @@ describe('Enforce Module Boundaries', () => {
         },
         `${process.cwd()}/proj/libs/api/src/index.ts`,
         `
-            import '@mycompany/impl';
-          `,
+          import '@mycompany/impl';
+          import('@mycompany/impl');
+        `,
         graph
       );
 
@@ -406,7 +426,10 @@ describe('Enforce Module Boundaries', () => {
       const failures = runRule(
         {},
         `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-        'import "../other"',
+        `
+          import '../other';
+          import('../other');
+        `,
         {
           nodes: {
             mylibName: {
@@ -434,7 +457,10 @@ describe('Enforce Module Boundaries', () => {
       const failures = runRule(
         {},
         `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-        'import "../other"',
+        `
+          import '../other';
+          import('../other');
+        `,
         {
           nodes: {
             mylibName: {
@@ -462,7 +488,10 @@ describe('Enforce Module Boundaries', () => {
       const failures = runRule(
         {},
         `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-        'import "../../other"',
+        `
+          import '../../other';
+          import('../../other');
+        `,
         {
           nodes: {
             mylibName: {
@@ -491,16 +520,22 @@ describe('Enforce Module Boundaries', () => {
           dependencies: {},
         }
       );
-      expect(failures[0].message).toEqual(
-        'Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope'
-      );
+
+      const message =
+        'Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope';
+      expect(failures.length).toEqual(2);
+      expect(failures[0].message).toEqual(message);
+      expect(failures[1].message).toEqual(message);
     });
 
     it('should error when relatively importing the src directory of another library', () => {
       const failures = runRule(
         {},
         `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-        'import "../../other/src"',
+        `
+          import '../../other/src';
+          import('../../other/src');
+        `,
         {
           nodes: {
             mylibName: {
@@ -529,9 +564,12 @@ describe('Enforce Module Boundaries', () => {
           dependencies: {},
         }
       );
-      expect(failures[0].message).toEqual(
-        'Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope'
-      );
+
+      const message =
+        'Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope';
+      expect(failures.length).toEqual(2);
+      expect(failures[0].message).toEqual(message);
+      expect(failures[1].message).toEqual(message);
     });
   });
 
@@ -539,7 +577,10 @@ describe('Enforce Module Boundaries', () => {
     const failures = runRule(
       {},
       `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      'import "libs/src/other.ts"',
+      `
+        import 'libs/src/other';
+        import('libs/src/other');
+      `,
       {
         nodes: {
           mylibName: {
@@ -561,10 +602,11 @@ describe('Enforce Module Boundaries', () => {
       }
     );
 
-    expect(failures.length).toEqual(1);
-    expect(failures[0].message).toEqual(
-      'Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope'
-    );
+    const message =
+      'Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope';
+    expect(failures.length).toEqual(2);
+    expect(failures[0].message).toEqual(message);
+    expect(failures[1].message).toEqual(message);
   });
 
   it('should respect regexp in allow option', () => {
@@ -572,7 +614,8 @@ describe('Enforce Module Boundaries', () => {
       { allow: ['^.*/utils/.*$'] },
       `${process.cwd()}/proj/libs/mylib/src/main.ts`,
       `
-      import "../../utils/a";
+        import '../../utils/a';
+        import('../../utils/a');
       `,
       {
         nodes: {
@@ -602,6 +645,7 @@ describe('Enforce Module Boundaries', () => {
         dependencies: {},
       }
     );
+
     expect(failures.length).toEqual(0);
   });
 
@@ -668,7 +712,10 @@ describe('Enforce Module Boundaries', () => {
     const failures = runRule(
       {},
       `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      'import "@mycompany/myapp"',
+      `
+        import '@mycompany/myapp';
+        import('@mycompany/myappa');
+      `,
       {
         nodes: {
           mylibName: {
@@ -697,14 +744,21 @@ describe('Enforce Module Boundaries', () => {
         dependencies: {},
       }
     );
-    expect(failures[0].message).toEqual('Imports of apps are forbidden');
+
+    const message = 'Imports of apps are forbidden';
+    expect(failures.length).toEqual(2);
+    expect(failures[0].message).toEqual(message);
+    expect(failures[1].message).toEqual(message);
   });
 
   it('should error on importing an e2e project', () => {
     const failures = runRule(
       {},
       `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      'import "@mycompany/myapp-e2e"',
+      `
+        import '@mycompany/myapp-e2e';
+        import('@mycompany/myapp-e2e');
+      `,
       {
         nodes: {
           mylibName: {
@@ -733,16 +787,21 @@ describe('Enforce Module Boundaries', () => {
         dependencies: {},
       }
     );
-    expect(failures[0].message).toEqual(
-      'Imports of e2e projects are forbidden'
-    );
+
+    const message = 'Imports of e2e projects are forbidden';
+    expect(failures.length).toEqual(2);
+    expect(failures[0].message).toEqual(message);
+    expect(failures[1].message).toEqual(message);
   });
 
   it('should error when circular dependency detected', () => {
     const failures = runRule(
       {},
       `${process.cwd()}/proj/libs/anotherlib/src/main.ts`,
-      'import "@mycompany/mylib"',
+      `
+        import '@mycompany/mylib';
+        import('@mycompany/mylibe');
+      `,
       {
         nodes: {
           mylibName: {
@@ -790,16 +849,22 @@ describe('Enforce Module Boundaries', () => {
         },
       }
     );
-    expect(failures[0].message).toEqual(
-      'Circular dependency between "anotherlibName" and "mylibName" detected: anotherlibName -> mylibName -> anotherlibName'
-    );
+
+    const message =
+      'Circular dependency between "anotherlibName" and "mylibName" detected: anotherlibName -> mylibName -> anotherlibName';
+    expect(failures.length).toEqual(2);
+    expect(failures[0].message).toEqual(message);
+    expect(failures[1].message).toEqual(message);
   });
 
   it('should error when circular dependency detected (indirect)', () => {
     const failures = runRule(
       {},
       `${process.cwd()}/proj/libs/mylib/src/main.ts`,
-      'import "@mycompany/badcirclelib"',
+      `
+        import '@mycompany/badcirclelib';
+        import('@mycompany/badcirclelib');
+      `,
       {
         nodes: {
           mylibName: {
@@ -872,9 +937,12 @@ describe('Enforce Module Boundaries', () => {
         },
       }
     );
-    expect(failures[0].message).toEqual(
-      'Circular dependency between "mylibName" and "badcirclelibName" detected: mylibName -> badcirclelibName -> anotherlibName -> mylibName'
-    );
+
+    const message =
+      'Circular dependency between "mylibName" and "badcirclelibName" detected: mylibName -> badcirclelibName -> anotherlibName -> mylibName';
+    expect(failures.length).toEqual(2);
+    expect(failures[0].message).toEqual(message);
+    expect(failures[1].message).toEqual(message);
   });
 
   describe('buildable library imports', () => {
@@ -884,7 +952,10 @@ describe('Enforce Module Boundaries', () => {
           enforceBuildableLibDependency: false,
         },
         `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
-        'import "@mycompany/nonBuildableLib"',
+        `
+          import '@mycompany/nonBuildableLib';
+          import('@mycompany/nonBuildableLib');
+        `,
         {
           nodes: {
             buildableLib: {
@@ -918,6 +989,7 @@ describe('Enforce Module Boundaries', () => {
           dependencies: {},
         }
       );
+
       expect(failures.length).toBe(0);
     });
 
@@ -927,7 +999,10 @@ describe('Enforce Module Boundaries', () => {
           enforceBuildableLibDependency: true,
         },
         `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
-        'import "@nonBuildableScope/nonBuildableLib"',
+        `
+          import '@nonBuildableScope/nonBuildableLib';
+          import('@nonBuildableScope/nonBuildableLib');
+        `,
         {
           nodes: {
             buildableLib: {
@@ -961,9 +1036,12 @@ describe('Enforce Module Boundaries', () => {
           dependencies: {},
         }
       );
-      expect(failures[0].message).toEqual(
-        'Buildable libraries cannot import non-buildable libraries'
-      );
+
+      const message =
+        'Buildable libraries cannot import non-buildable libraries';
+      expect(failures.length).toEqual(2);
+      expect(failures[0].message).toEqual(message);
+      expect(failures[1].message).toEqual(message);
     });
 
     it('should not error when buildable libraries import another buildable libraries', () => {
@@ -972,7 +1050,10 @@ describe('Enforce Module Boundaries', () => {
           enforceBuildableLibDependency: true,
         },
         `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
-        'import "@mycompany/nonBuildableLib"',
+        `
+          import '@mycompany/nonBuildableLib';
+          import('@mycompany/nonBuildableLib');
+        `,
         {
           nodes: {
             buildableLib: {
@@ -1011,6 +1092,7 @@ describe('Enforce Module Boundaries', () => {
           dependencies: {},
         }
       );
+
       expect(failures.length).toBe(0);
     });
 
@@ -1020,7 +1102,10 @@ describe('Enforce Module Boundaries', () => {
           enforceBuildableLibDependency: true,
         },
         `${process.cwd()}/proj/libs/buildableLib/src/main.ts`,
-        'import "@mycompany/nonBuildableLib"',
+        `
+          import '@mycompany/nonBuildableLib';
+          import('@mycompany/nonBuildableLib');
+        `,
         {
           nodes: {
             buildableLib: {
@@ -1047,6 +1132,7 @@ describe('Enforce Module Boundaries', () => {
           dependencies: {},
         }
       );
+
       expect(failures.length).toBe(0);
     });
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`enforce-module-boundaries` rule is applied only import declarations.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`enforce-module-boundaries` rule is applied both import declarations and expressions.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3857
