### PR TITLE
fix(nextjs): leverage nextjs for loading svgs

### DIFF
--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -83,18 +83,6 @@ export function createWebpackConfig(
               },
             ],
           },
-          // Fallback to plain URL loader.
-          {
-            use: [
-              {
-                loader: require.resolve('url-loader'),
-                options: {
-                  limit: 10000, // 10kB
-                  name: '[name].[hash:7].[ext]',
-                },
-              },
-            ],
-          },
         ],
       }
     );


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Our `.svg` loader logic has diverged with the logic used by next.js. As a result, some behaviour that works using plain next.js doesn't work within Nx + next.js setup. For example - #4182 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Same practices that work for `.svg` file loading in next.js should work when using next.js in an Nx workspace

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4182 

---

So what I've done is I removed the fallback url-loader that we specify. Whatever configuration next.js uses internally is used instead now. More specifically, [this is the loader that's seems to be used in this case](https://github.com/vercel/next.js/blob/master/packages/next/build/webpack/config/blocks/css/index.ts#L291-L305)