### PR TITLE
fix(nextjs): fix asset prefix

### DIFF
--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -105,7 +105,7 @@ export function createWebpackConfig(
         createCopyPlugin(
           normalizeAssets(assets, workspaceRoot, projectRoot).map((asset) => ({
             ...asset,
-            output: join('../public', asset.output),
+            output: join('../', asset.output),
           }))
         )
       );


### PR DESCRIPTION

## Current Behavior 
assets must in public folder

## Expected Behavior
assets are optionally placed in the 'public' folder. 

## Related Issue(s)
