### PR TITLE
fix(web): fix dev-server executor output causing ng cli schema validation to fail

### DIFF
--- a/packages/web/src/builders/dev-server/dev-server.impl.ts
+++ b/packages/web/src/builders/dev-server/dev-server.impl.ts
@@ -7,7 +7,10 @@ import { Configuration } from 'webpack';
 
 import { eachValueFrom } from 'rxjs-for-await';
 import { map, tap } from 'rxjs/operators';
-import { runWebpackDevServer } from '@nrwl/workspace/src/utilities/run-webpack';
+import {
+  getEmittedFiles,
+  runWebpackDevServer,
+} from '@nrwl/workspace/src/utilities/run-webpack';
 
 import { normalizeWebBuildOptions } from '../../utils/normalize';
 import { WebBuildBuilderOptions } from '../build/build.impl';
@@ -61,8 +64,8 @@ export default function devServerExecutor(
       }),
       map(({ baseUrl, stats }) => {
         return {
-          stats,
           baseUrl,
+          emittedFiles: getEmittedFiles(stats),
           success: !stats.hasErrors(),
         };
       })


### PR DESCRIPTION
## Current Behavior
The dev-server executor returns the full `stats` object from Webpack. When this generator is scheduled to run by the Angular CLI (e.g. AngularJS projects using Protractor as the e2e test runner), the outputs of every task are validated against the schema. This is done by recursively checking all properties inside the returned output. Since the `stats` object from Webpack is pretty heavy with a lot of nested properties, this ends up causing the call stack size to be exceeded and throw.
This [repo](https://github.com/leosvelperez/nx-angularjs-migration-example) shows the issue.

## Expected Behavior
The dev-server executor should pass successfully the Angular CLI schema validation.

## Related Issue(s)

Fixes #
