### PR TITLE
fix(linter): always add eslint dependencies

### DIFF
--- a/packages/workspace/src/utils/lint.ts
+++ b/packages/workspace/src/utils/lint.ts
@@ -105,29 +105,28 @@ export function addLintFiles(
 
     if (linter === 'eslint') {
       if (!host.exists('/.eslintrc.json')) {
-        chainedCommands.push((host: Tree) => {
-          host.create('/.eslintrc.json', globalESLint);
-
-          return addDepsToPackageJson(
-            {
-              ...(options.extraPackageDeps
-                ? options.extraPackageDeps.dependencies
-                : {}),
-            },
-            {
-              '@nrwl/linter': nxVersion,
-              '@nrwl/eslint-plugin-nx': nxVersion,
-              '@typescript-eslint/parser': typescriptESLintVersion,
-              '@typescript-eslint/eslint-plugin': typescriptESLintVersion,
-              eslint: eslintVersion,
-              'eslint-config-prettier': eslintConfigPrettierVersion,
-              ...(options.extraPackageDeps
-                ? options.extraPackageDeps.devDependencies
-                : {}),
-            }
-          );
-        });
+        host.create('/.eslintrc.json', globalESLint);
       }
+      chainedCommands.push(
+        addDepsToPackageJson(
+          {
+            ...(options.extraPackageDeps
+              ? options.extraPackageDeps.dependencies
+              : {}),
+          },
+          {
+            '@nrwl/linter': nxVersion,
+            '@nrwl/eslint-plugin-nx': nxVersion,
+            '@typescript-eslint/parser': typescriptESLintVersion,
+            '@typescript-eslint/eslint-plugin': typescriptESLintVersion,
+            eslint: eslintVersion,
+            'eslint-config-prettier': eslintConfigPrettierVersion,
+            ...(options.extraPackageDeps
+              ? options.extraPackageDeps.devDependencies
+              : {}),
+          }
+        )
+      );
 
       if (!options.onlyGlobal) {
         chainedCommands.push((host: Tree) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When a `.eslintrc.json` exists, eslint dependencies are not added.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

eslint dependencies (and any extra dependencies) are added even if `.eslintrc.json` is already existing

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
