### PR TITLE
Fix error in storybook docs

### DIFF
--- a/docs/angular/api-storybook/executors/storybook.md
+++ b/docs/angular/api-storybook/executors/storybook.md
@@ -22,6 +22,14 @@ Type: `string`
 
 Host to listen on.
 
+### https
+
+Default: `false`
+
+Type: `boolean`
+
+Serve using HTTPS.
+
 ### port
 
 Default: `9009`
@@ -43,14 +51,6 @@ Default: `true`
 Type: `boolean`
 
 Suppress verbose build output.
-
-### ssl
-
-Default: `false`
-
-Type: `boolean`
-
-Serve using HTTPS.
 
 ### sslCert
 

--- a/docs/node/api-storybook/executors/storybook.md
+++ b/docs/node/api-storybook/executors/storybook.md
@@ -23,6 +23,14 @@ Type: `string`
 
 Host to listen on.
 
+### https
+
+Default: `false`
+
+Type: `boolean`
+
+Serve using HTTPS.
+
 ### port
 
 Default: `9009`
@@ -44,14 +52,6 @@ Default: `true`
 Type: `boolean`
 
 Suppress verbose build output.
-
-### ssl
-
-Default: `false`
-
-Type: `boolean`
-
-Serve using HTTPS.
 
 ### sslCert
 

--- a/docs/react/api-storybook/executors/storybook.md
+++ b/docs/react/api-storybook/executors/storybook.md
@@ -23,6 +23,14 @@ Type: `string`
 
 Host to listen on.
 
+### https
+
+Default: `false`
+
+Type: `boolean`
+
+Serve using HTTPS.
+
 ### port
 
 Default: `9009`
@@ -44,14 +52,6 @@ Default: `true`
 Type: `boolean`
 
 Suppress verbose build output.
-
-### ssl
-
-Default: `false`
-
-Type: `boolean`
-
-Serve using HTTPS.
 
 ### sslCert
 

--- a/packages/storybook/src/executors/storybook/schema.json
+++ b/packages/storybook/src/executors/storybook/schema.json
@@ -20,7 +20,7 @@
       "description": "Host to listen on.",
       "default": "localhost"
     },
-    "ssl": {
+    "https": {
       "type": "boolean",
       "description": "Serve using HTTPS.",
       "default": false

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -21,7 +21,7 @@ export interface StorybookExecutorOptions {
   host?: string;
   port?: number;
   quiet?: boolean;
-  ssl?: boolean;
+  https?: boolean;
   sslCert?: string;
   sslKey?: string;
   staticDir?: string[];


### PR DESCRIPTION
replace `ssl` param to `https`.

`ssl` don't work, because `https` is expected by storybook's dev-server

https://github.com/storybookjs/storybook/blob/next/lib/core-server/src/dev-server.ts#L40

Alternatively, you can translate `ssl` to `https` before passing params to dev-server of storybook
