### PR TITLE
cleanup(misc): use more es6 features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We would love for you to contribute to Nx! Read this document to see how to do i
 Watch this 5-minute video:
 
 <a href="https://www.youtube.com/watch?v=o11p0zSm0No&feature=youtu.be" target="_blank">
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/how-to-contribute.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/how-to-contribute.png" width="600"></p>
 </a>
 
 ## Got a Question?

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
-<div align="center">
+<div style="text-align: center;">
 
 [![CircleCI](https://circleci.com/gh/nrwl/nx.svg?style=svg)](https://circleci.com/gh/nrwl/nx)
 [![License](https://img.shields.io/npm/l/@nrwl/workspace.svg?style=flat-square)]()
@@ -103,12 +103,12 @@ You are good to go!
   <tr>
     <td>    
       <a href="https://www.youtube.com/watch?v=mVKMse-gFBI" target="_blank">
-      <p align="center">Angular<br><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-angular-video.png" width="350"></p>
+      <p style="text-align: center;">Angular<br><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-angular-video.png" width="350"></p>
       </a>
     </td>
     <td>    
       <a href="https://www.youtube.com/watch?v=E188J7E_MDU" target="_blank">
-      <p align="center">React<br><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-react-video.png" width="350"></p>
+      <p style="text-align: center;">React<br><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-react-video.png" width="350"></p>
       </a>
     </td>
   </tr>
@@ -125,17 +125,17 @@ You are good to go!
   <tr>
     <td>
       <a href="https://egghead.io/playlists/scale-react-development-with-nx-4038" target="_blank">
-      <p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/EGH_ScalingReactNx.png" height="150px"></p>
+      <p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/EGH_ScalingReactNx.png" height="150px"></p>
       </a>
     </td>
     <td>
       <a href="https://www.youtube.com/watch?v=2mYLe9Kp9VM&list=PLakNactNC1dH38AfqmwabvOszDmKriGco" target="_blank">
-        <p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-workspace-course.png" width="350"></p>
+        <p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-workspace-course.png" width="350"></p>
       </a>
     </td>
     <td>  
       <a href="https://nxplaybook.com/p/advanced-nx-workspaces" target="_blank">
-      <p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/advanced-nx-workspace-course.png" width="350"></p>
+      <p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/advanced-nx-workspace-course.png" width="350"></p>
       </a>
     </td>
   </tr>
@@ -193,7 +193,7 @@ You are good to go!
 If you want to file a bug or submit a PR, read up on our [guidelines for contributing](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md) and watch this video that will help you get started.
 
 <a href="https://www.youtube.com/watch?v=o11p0zSm0No&feature=youtu.be" target="_blank">
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/how-to-contribute.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/how-to-contribute.png" width="600"></p>
 </a>
 
 ## Core Team

--- a/apps/dep-graph-client/src/app/util-cytoscape/edge.ts
+++ b/apps/dep-graph-client/src/app/util-cytoscape/edge.ts
@@ -17,7 +17,7 @@ export class ProjectEdge {
         target: this.dep.target,
       },
     };
-    edge.classes = this.dep.type ? this.dep.type : '';
+    edge.classes = this.dep.type ?? '';
     if (this.affected) {
       edge.classes += ' affected';
     }

--- a/apps/dep-graph-client/src/app/util-cytoscape/project-node.ts
+++ b/apps/dep-graph-client/src/app/util-cytoscape/project-node.ts
@@ -37,7 +37,7 @@ export class ProjectNode {
   }
 
   private getClasses(): string {
-    let classes = this.project.type ? this.project.type : '';
+    let classes = this.project.type ?? '';
 
     if (this.focused) {
       classes += ' focused';

--- a/apps/dep-graph-client/src/styles.scss
+++ b/apps/dep-graph-client/src/styles.scss
@@ -102,12 +102,11 @@ h5 {
 }
 
 .sidebar {
-  min-width: 200px;
+  min-width: 260px;
   max-width: calc(50% - 10px);
   z-index: 1;
   position: relative;
   height: 100%;
-  min-width: 260px;
   box-shadow: 2px 0 2px rgba(51, 51, 51, 0.1);
 }
 
@@ -176,13 +175,12 @@ html {
 }
 
 .tag {
-  padding: 0.4rem;
+  padding: 0.5rem;
   font-size: 0.75em;
   display: inline-block;
   border: 1px solid var(--color-nrwl-light-blue);
   text-transform: uppercase;
   color: var(--color-grey);
-  padding: 0.5rem;
   line-height: 1;
   letter-spacing: 0.5px;
   margin-right: 0.4em;

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -1,19 +1,19 @@
+import { detectPackageManager } from '@nrwl/tao/src/shared/package-manager';
 import { ChildProcess, exec, execSync } from 'child_process';
 import {
+  copySync,
+  createFileSync,
+  ensureDirSync,
+  moveSync,
   readdirSync,
   readFileSync,
+  removeSync,
   renameSync,
   statSync,
   writeFileSync,
-  ensureDirSync,
-  createFileSync,
-  moveSync,
-  copySync,
-  removeSync,
 } from 'fs-extra';
-import * as path from 'path';
-import { detectPackageManager } from '@nrwl/tao/src/shared/package-manager';
 import * as isCI from 'is-ci';
+import * as path from 'path';
 
 interface RunCmdOpts {
   silenceError?: boolean;
@@ -23,7 +23,7 @@ interface RunCmdOpts {
 }
 
 export function currentCli() {
-  return process.env.SELECTED_CLI ? process.env.SELECTED_CLI : 'nx';
+  return process.env.SELECTED_CLI ?? 'nx';
 }
 
 let projName: string;
@@ -359,16 +359,14 @@ function setMaxWorkers() {
     const workspace = readJson(workspaceFile);
 
     Object.keys(workspace.projects).forEach((appName) => {
-      const targets = workspace.projects[appName].targets
-        ? workspace.projects[appName].targets
-        : workspace.projects[appName].architect;
-      const build = targets.build;
+      const project = workspace.projects[appName];
+      const { build } = project.targets ?? project.architect;
 
       if (!build) {
         return;
       }
 
-      const executor = build.builder ? build.builder : build.executor;
+      const executor = build.builder ?? build.executor;
       if (
         executor.startsWith('@nrwl/node') ||
         executor.startsWith('@nrwl/web') ||

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 
@@ -36,7 +36,7 @@ You can always add the Angular plugin to an existing workspace by installing `@n
 ## Quick Start Videos
 
 <a href="https://www.youtube.com/watch?v=mVKMse-gFBI" target="_blank">
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-angular-video.png" width="350"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-angular-video.png" width="350"></p>
 </a>
 
 - [Nx Dev Tools for Monorepos, In-Depth Explainer](https://youtu.be/h5FIGDn5YM0)

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -827,7 +827,7 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   const defaultPrefix = getNpmScope(host);
   return {
     ...options,
-    prefix: options.prefix ? options.prefix : defaultPrefix,
+    prefix: options.prefix ?? defaultPrefix,
     name: appProjectName,
     appProjectRoot,
     e2eProjectRoot,

--- a/packages/angular/src/schematics/application/schema.json
+++ b/packages/angular/src/schematics/application/schema.json
@@ -12,7 +12,7 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for the application?",
-      "pattern": "^[a-zA-Z]{1}.*$"
+      "pattern": "^[a-zA-Z].*$"
     },
     "directory": {
       "description": "The directory of the new application.",

--- a/packages/angular/src/schematics/downgrade-module/downgrade-module.ts
+++ b/packages/angular/src/schematics/downgrade-module/downgrade-module.ts
@@ -88,9 +88,7 @@ function addEntryComponentsToModule(options: Schema): Rule {
 }
 
 export default function (options: Schema): Rule {
-  const angularJsImport = options.angularJsImport
-    ? options.angularJsImport
-    : options.name;
+  const angularJsImport = options.angularJsImport ?? options.name;
 
   return chain([
     updateMain(angularJsImport, options),

--- a/packages/angular/src/schematics/library/lib/normalize-options.ts
+++ b/packages/angular/src/schematics/library/lib/normalize-options.ts
@@ -30,7 +30,7 @@ export function normalizeOptions(
 
   return {
     ...options,
-    prefix: options.prefix ? options.prefix : defaultPrefix,
+    prefix: options.prefix ?? defaultPrefix,
     name: projectName,
     projectRoot,
     entryFile: 'index',

--- a/packages/angular/src/schematics/library/schema.json
+++ b/packages/angular/src/schematics/library/schema.json
@@ -12,7 +12,7 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for the library?",
-      "pattern": "^[a-zA-Z]{1}.*$"
+      "pattern": "^[a-zA-Z].*$"
     },
     "directory": {
       "type": "string",

--- a/packages/angular/src/schematics/upgrade-module/upgrade-module.ts
+++ b/packages/angular/src/schematics/upgrade-module/upgrade-module.ts
@@ -123,9 +123,7 @@ function createFiles(angularJsImport: string, options: Schema): Rule {
 }
 
 export default function (options: Schema): Rule {
-  const angularJsImport = options.angularJsImport
-    ? options.angularJsImport
-    : options.name;
+  const angularJsImport = options.angularJsImport ?? options.name;
 
   return chain([
     createFiles(angularJsImport, options),

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/cli/lib/parse-run-one-options.ts
+++ b/packages/cli/lib/parse-run-one-options.ts
@@ -112,7 +112,7 @@ export function parseRunOneOptions(
     workspaceConfigJson.projects && workspaceConfigJson.projects[project];
   if (!p) return false;
 
-  const targets = p.architect ? p.architect : p.targets;
+  const targets = p.architect ?? p.targets;
   // for backwards compat we require targets to be set when use defaultProjectName
   if ((!targets || !targets[target]) && projectIsNotSetExplicitly) return false;
   if (invalidTargetNames.indexOf(target) > -1) return false;

--- a/packages/create-nx-plugin/README.md
+++ b/packages/create-nx-plugin/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/create-nx-workspace/README.md
+++ b/packages/create-nx-workspace/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/cypress/README.md
+++ b/packages/cypress/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/cypress/src/plugins/preprocessor.spec.ts
+++ b/packages/cypress/src/plugins/preprocessor.spec.ts
@@ -19,7 +19,7 @@ describe('getWebpackConfig', () => {
       },
     });
     expect(config.module.rules).toContainEqual({
-      test: /\.(j|t)sx?$/,
+      test: /\.([jt])sx?$/,
       loader: require.resolve('ts-loader'),
       exclude: [/node_modules/],
       options: {

--- a/packages/cypress/src/plugins/preprocessor.ts
+++ b/packages/cypress/src/plugins/preprocessor.ts
@@ -36,7 +36,7 @@ export function getWebpackConfig(config: any) {
     module: {
       rules: [
         {
-          test: /\.(j|t)sx?$/,
+          test: /\.([jt])sx?$/,
           loader: require.resolve('ts-loader'),
           exclude: [/node_modules/],
           options: {

--- a/packages/devkit/README.md
+++ b/packages/devkit/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/devkit/src/utils/get-workspace-layout.ts
+++ b/packages/devkit/src/utils/get-workspace-layout.ts
@@ -15,9 +15,7 @@ export function getWorkspaceLayout(
   host: Tree
 ): { appsDir: string; libsDir: string; npmScope: string } {
   const nxJson = readJson<NxJsonConfiguration>(host, 'nx.json');
-  const layout = nxJson.workspaceLayout
-    ? nxJson.workspaceLayout
-    : { appsDir: 'apps', libsDir: 'libs' };
+  const layout = nxJson.workspaceLayout ?? { appsDir: 'apps', libsDir: 'libs' };
   const npmScope = nxJson.npmScope;
   return { ...layout, npmScope };
 }

--- a/packages/eslint-plugin-nx/README.md
+++ b/packages/eslint-plugin-nx/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/express/src/schematics/application/schema.json
+++ b/packages/express/src/schematics/application/schema.json
@@ -12,7 +12,7 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for the node application?",
-      "pattern": "^[a-zA-Z]{1}.*$"
+      "pattern": "^[a-zA-Z].*$"
     },
     "directory": {
       "description": "The directory of the new application.",

--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-gatsby.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-gatsby.png" width="600"></p>
 
 {{links}}
 
@@ -32,7 +32,7 @@ You are good to go!
 ## Quick Start Videos
 
 <a href="https://www.youtube.com/watch?v=E188J7E_MDU" target="_blank">
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-react-video.png" width="350"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-react-video.png" width="350"></p>
 </a>
 
 - [Nx Dev Tools for Monorepos, In-Depth Explainer (React)](https://www.youtube.com/watch?v=jCf92IyR-GE)

--- a/packages/gatsby/src/generators/application/files/README.md
+++ b/packages/gatsby/src/generators/application/files/README.md
@@ -1,5 +1,5 @@
 <!-- AUTO-GENERATED-CONTENT:START (STARTER) -->
-<p align="center">
+<p style="text-align: center;">
   <a href="https://www.gatsbyjs.org">
     <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
   </a>

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/linter/README.md
+++ b/packages/linter/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/nest/src/schematics/nestjs-schematics/nestjs-schematics.ts
+++ b/packages/nest/src/schematics/nestjs-schematics/nestjs-schematics.ts
@@ -29,7 +29,7 @@ function normalizeOptions(
     name,
     path: options.path,
     sourceRoot,
-    spec: options.spec ? options.spec : options.unitTestRunner === 'jest',
+    spec: options.spec ?? options.unitTestRunner === 'jest',
   };
 }
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-next.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-next.png" width="600"></p>
 
 {{links}}
 
@@ -32,7 +32,7 @@ You are good to go!
 ## Quick Start Videos
 
 <a href="https://www.youtube.com/watch?v=E188J7E_MDU" target="_blank">
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-react-video.png" width="350"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-react-video.png" width="350"></p>
 </a>
 
 - [Nx Dev Tools for Monorepos, In-Depth Explainer (React)](https://www.youtube.com/watch?v=jCf92IyR-GE)

--- a/packages/next/src/generators/application/schema.json
+++ b/packages/next/src/generators/application/schema.json
@@ -19,7 +19,7 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for the application?",
-      "pattern": "^[a-zA-Z]{1}.*$"
+      "pattern": "^[a-zA-Z].*$"
     },
     "directory": {
       "description": "The directory of the new application.",

--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -53,7 +53,7 @@ export function createWebpackConfig(
 
     config.module.rules.push(
       {
-        test: /\.(j|t)sx?$/,
+        test: /\.([jt])sx?$/,
         exclude: /node_modules/,
         use: [defaultLoaders.babel],
       },

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -35,7 +35,7 @@ export function getBaseWebpackPartial(
     module: {
       rules: [
         {
-          test: /\.(j|t)sx?$/,
+          test: /\.([jt])sx?$/,
           loader: require.resolve(`ts-loader`),
           exclude: /node_modules/,
           options: {
@@ -111,7 +111,7 @@ export function getBaseWebpackPartial(
               '.gitkeep',
               '**/.DS_Store',
               '**/Thumbs.db',
-              ...(asset.ignore ? asset.ignore : []),
+              ...(asset.ignore ?? []),
             ],
             dot: true,
           },

--- a/packages/nx-plugin/README.md
+++ b/packages/nx-plugin/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/nx-plugin/src/schematics/executor/lib/update-executor-json.ts
+++ b/packages/nx-plugin/src/schematics/executor/lib/update-executor-json.ts
@@ -15,7 +15,7 @@ export function updateExecutorJson(
   }
 
   return updateJsonInTree(executorPath, (json) => {
-    let executors = json.executors ? json.executors : json.builders;
+    let executors = json.executors ?? json.builders;
     executors = executors || {};
     executors[options.name] = {
       implementation: `./src/executors/${options.name}/executor`,

--- a/packages/nx-plugin/src/schematics/generator/lib/update-generator-json.ts
+++ b/packages/nx-plugin/src/schematics/generator/lib/update-generator-json.ts
@@ -15,7 +15,7 @@ export function updateGeneratorJson(
   }
 
   return updateJsonInTree(generatorPath, (json) => {
-    let generators = json.generators ? json.generators : json.schematics;
+    let generators = json.generators ?? json.schematics;
     generators = generators || {};
     generators[options.name] = {
       factory: `./src/generators/${options.name}/generator`,

--- a/packages/nx-plugin/src/schematics/migration/lib/update-migrations-json.ts
+++ b/packages/nx-plugin/src/schematics/migration/lib/update-migrations-json.ts
@@ -12,7 +12,7 @@ export function updateMigrationsJson(options: NormalizedSchema): Rule {
         delete json.schematics;
       }
 
-      const generators = json.generators ? json.generators : {};
+      const generators = json.generators ?? {};
       generators[options.name] = {
         version: options.version,
         description: options.description,
@@ -22,9 +22,7 @@ export function updateMigrationsJson(options: NormalizedSchema): Rule {
       json.generators = generators;
 
       if (options.packageJsonUpdates) {
-        const packageJsonUpdatesObj = json.packageJsonUpdates
-          ? json.packageJsonUpdates
-          : {};
+        const packageJsonUpdatesObj = json.packageJsonUpdates ?? {};
         if (!packageJsonUpdatesObj[options.version]) {
           packageJsonUpdatesObj[options.version] = {
             version: options.version,

--- a/packages/nx/README.md
+++ b/packages/nx/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-react.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-react.png" width="600"></p>
 
 {{links}}
 
@@ -32,7 +32,7 @@ You can always add the React plugin to an existing workspace by installing `@nrw
 ## Quick Start Videos
 
 <a href="https://www.youtube.com/watch?v=E188J7E_MDU" target="_blank">
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-react-video.png" width="350"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-react-video.png" width="350"></p>
 </a>
 
 - [Nx Dev Tools for Monorepos, In-Depth Explainer (React)](https://www.youtube.com/watch?v=jCf92IyR-GE)

--- a/packages/react/src/generators/application/schema.json
+++ b/packages/react/src/generators/application/schema.json
@@ -27,7 +27,7 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for the application?",
-      "pattern": "^[a-zA-Z]{1}.*$"
+      "pattern": "^[a-zA-Z].*$"
     },
     "directory": {
       "description": "The directory of the new application.",

--- a/packages/react/src/generators/library/schema.json
+++ b/packages/react/src/generators/library/schema.json
@@ -23,7 +23,7 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for the library?",
-      "pattern": "^[a-zA-Z]{1}.*$"
+      "pattern": "^[a-zA-Z].*$"
     },
     "directory": {
       "type": "string",

--- a/packages/storybook/README.md
+++ b/packages/storybook/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/tao/README.md
+++ b/packages/tao/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -322,9 +322,7 @@ export class Workspaces {
     const packageJson = JSON.parse(
       stripJsonComments(fs.readFileSync(packageJsonPath).toString())
     );
-    const executorsFile = packageJson.executors
-      ? packageJson.executors
-      : packageJson.builders;
+    const executorsFile = packageJson.executors ?? packageJson.builders;
 
     if (!executorsFile) {
       throw new Error(
@@ -364,9 +362,7 @@ export class Workspaces {
       const packageJson = JSON.parse(
         stripJsonComments(fs.readFileSync(packageJsonPath).toString())
       );
-      const generatorsFile = packageJson.generators
-        ? packageJson.generators
-        : packageJson.schematics;
+      const generatorsFile = packageJson.generators ?? packageJson.schematics;
 
       if (!generatorsFile) {
         throw new Error(
@@ -431,7 +427,7 @@ export function reformattedWorkspaceJsonOrNull(w: any) {
 
 export function toNewFormat(w: any): WorkspaceJsonConfiguration {
   const f = toNewFormatOrNull(w);
-  return f ? f : w;
+  return f ?? w;
 }
 
 export function toNewFormatOrNull(w: any) {

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -255,7 +255,7 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
 
   return {
     ...options,
-    prefix: options.prefix ? options.prefix : defaultPrefix,
+    prefix: options.prefix ?? defaultPrefix,
     name: names(options.name).fileName,
     projectName: appProjectName,
     appProjectRoot,

--- a/packages/web/src/generators/application/schema.json
+++ b/packages/web/src/generators/application/schema.json
@@ -13,7 +13,7 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for the application?",
-      "pattern": "^[a-zA-Z]{1}.*$"
+      "pattern": "^[a-zA-Z].*$"
     },
     "directory": {
       "description": "The directory of the new application.",

--- a/packages/web/src/utils/config.ts
+++ b/packages/web/src/utils/config.ts
@@ -242,7 +242,7 @@ export function createCopyPlugin(assets: AssetGlobPattern[]) {
             '.gitkeep',
             '**/.DS_Store',
             '**/Thumbs.db',
-            ...(asset.ignore ? asset.ignore : []),
+            ...(asset.ignore ?? []),
           ],
           dot: true,
         },

--- a/packages/web/src/utils/third-party/cli-files/models/webpack-configs/common.ts
+++ b/packages/web/src/utils/third-party/cli-files/models/webpack-configs/common.ts
@@ -467,7 +467,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       // Always replace the context for the System.import in angular/core to prevent warnings.
       // https://github.com/angular/angular/issues/11580
       // With VE the correct context is added in @ngtools/webpack, but Ivy doesn't need it at all.
-      new ContextReplacementPlugin(/\@angular(\\|\/)core(\\|\/)/),
+      new ContextReplacementPlugin(/@angular([\\/])core([\\/])/),
       ...extraPlugins,
     ],
   };

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx.png" width="600" alt="Nx - Powerful, Extensible Dev Tools"></p>
 
 {{links}}
 

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -174,7 +174,7 @@ export function readWorkspaceConfig(opts: { format: 'angularCli' | 'nx' }) {
   const json = readWorkspaceJson();
   if (opts.format === 'angularCli') {
     const formatted = toOldFormatOrNull(json);
-    return formatted ? formatted : json;
+    return formatted ?? json;
   } else {
     return json;
   }

--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
@@ -69,7 +69,7 @@ export function readCache(): false | ProjectGraphCache {
 
   performance.mark('read cache:end');
   performance.measure('read cache', 'read cache:start', 'read cache:end');
-  return data ? data : false;
+  return data ?? false;
 }
 
 export function writeCache(

--- a/packages/workspace/src/generators/library/schema.json
+++ b/packages/workspace/src/generators/library/schema.json
@@ -19,7 +19,7 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for the library?",
-      "pattern": "^[a-zA-Z]{1}.*$"
+      "pattern": "^[a-zA-Z].*$"
     },
     "directory": {
       "type": "string",

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -174,7 +174,7 @@ function connectAngularAndNest(host: Tree, options: Schema) {
   insertNgModuleImport(host, modulePath, 'HttpClientModule');
 
   const scope = options.npmScope;
-  const style = options.style ? options.style : 'css';
+  const style = options.style ?? 'css';
   host.write(
     `apps/${options.name}/src/app/app.component.ts`,
     `import { Component } from '@angular/core';

--- a/packages/workspace/src/generators/workspace/files/README.md__tmpl__
+++ b/packages/workspace/src/generators/workspace/files/README.md__tmpl__
@@ -4,7 +4,7 @@
 
 This project was generated using [Nx](https://nx.dev).
 
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-logo.png" width="450"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-logo.png" width="450"></p>
 
 🔎 **Nx is a set of Extensible Dev Tools for Monorepos.**
 
@@ -96,7 +96,7 @@ Visit the [Nx Documentation](https://nx.dev/angular) to learn more.
 
 This project was generated using [Nx](https://nx.dev).
 
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-logo.png" width="450"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-logo.png" width="450"></p>
 
 🔎 **Nx is a set of Extensible Dev Tools for Monorepos.**
 
@@ -177,7 +177,7 @@ Visit the [Nx Documentation](https://nx.dev) to learn more.
 
 ### Computation Memoization in the Cloud
 
-<p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-cloud-card.png"></p>
+<p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-cloud-card.png"></p>
 
 Nx Cloud pairs with Nx in order to enable you to build and test code more rapidly, by up to 10 times. Even teams that are new to Nx can connect to Nx Cloud and start saving time instantly.
 

--- a/packages/workspace/src/generators/workspace/workspace.ts
+++ b/packages/workspace/src/generators/workspace/workspace.ts
@@ -51,7 +51,7 @@ function createAppsAndLibsFolders(host: Tree, options: Schema) {
 }
 
 function createFiles(host: Tree, options: Schema) {
-  const npmScope = options.npmScope ? options.npmScope : options.name;
+  const npmScope = options.npmScope ?? options.name;
   const formattedNames = names(options.name);
   generateFiles(host, pathJoin(__dirname, './files'), options.directory, {
     formattedNames,

--- a/packages/workspace/src/utils/lint.ts
+++ b/packages/workspace/src/utils/lint.ts
@@ -121,9 +121,7 @@ export function addLintFiles(
             '@typescript-eslint/eslint-plugin': typescriptESLintVersion,
             eslint: eslintVersion,
             'eslint-config-prettier': eslintConfigPrettierVersion,
-            ...(options.extraPackageDeps
-              ? options.extraPackageDeps.devDependencies
-              : {}),
+            ...(options.extraPackageDeps?.devDependencies ?? {}),
           }
         )
       );

--- a/packages/workspace/src/utils/rules/rename-package-imports.ts
+++ b/packages/workspace/src/utils/rules/rename-package-imports.ts
@@ -55,7 +55,7 @@ export function renamePackageImports(packageNameMapping: PackageNameMapping) {
       .forEach((projectDir) => {
         projectDir.visit((file) => {
           // only look at .(j|t)s(x) files
-          if (!/(j|t)sx?$/.test(file)) {
+          if (!/([jt])sx?$/.test(file)) {
             return;
           }
           // if it doesn't contain at least 1 reference to the packages to be renamed bail out

--- a/packages/workspace/src/utils/strings.ts
+++ b/packages/workspace/src/utils/strings.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-const STRING_DASHERIZE_REGEXP = /[ _\.]/g;
+const STRING_DASHERIZE_REGEXP = /[ _.]/g;
 const STRING_DECAMELIZE_REGEXP = /([a-z\d])([A-Z])/g;
 const STRING_CAMELIZE_REGEXP = /(-|_|\.|\s)+(.)?/g;
 const STRING_UNDERSCORE_REGEXP_1 = /([a-z\d])([A-Z]+)/g;
@@ -37,7 +37,7 @@ export function decamelize(str: string): string {
  dasherize('action_name');       // 'action-name'
  dasherize('css-class-name');    // 'css-class-name'
  dasherize('my favorite items'); // 'my-favorite-items'
- dasherize('nrwl.io'); // 'nrwl-io'
+ dasherize('nrwl.io');           // 'nrwl-io'
  ```
 
  @method dasherize

--- a/scripts/readme-fragments/links.md
+++ b/scripts/readme-fragments/links.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div style="text-align: center;">
 
 [![CircleCI](https://circleci.com/gh/nrwl/nx.svg?style=svg)](https://circleci.com/gh/nrwl/nx)
 [![License](https://img.shields.io/npm/l/@nrwl/workspace.svg?style=flat-square)]()

--- a/scripts/readme-fragments/resources.md
+++ b/scripts/readme-fragments/resources.md
@@ -14,17 +14,17 @@
   <tr>
     <td>
       <a href="https://egghead.io/playlists/scale-react-development-with-nx-4038" target="_blank">
-      <p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/EGH_ScalingReactNx.png" height="150px"></p>
+      <p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/EGH_ScalingReactNx.png" height="150px"></p>
       </a>
     </td>
     <td>
       <a href="https://www.youtube.com/watch?v=2mYLe9Kp9VM&list=PLakNactNC1dH38AfqmwabvOszDmKriGco" target="_blank">
-        <p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-workspace-course.png" width="350"></p>
+        <p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-workspace-course.png" width="350"></p>
       </a>
     </td>
     <td>  
       <a href="https://nxplaybook.com/p/advanced-nx-workspaces" target="_blank">
-      <p align="center"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/advanced-nx-workspace-course.png" width="350"></p>
+      <p style="text-align: center;"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/advanced-nx-workspace-course.png" width="350"></p>
       </a>
     </td>
   </tr>


### PR DESCRIPTION
- Single char alternation (e.g. a|b|c|d) in a RegExp can be simplified to use a character class ([abcd]) instead.
  This usually also provides slightly better matching performance.
- Character escapes that are replaceable with the unescaped character without a change in meaning were changed. 
  Inside the square brackets of a character class, many escapes are unnecessary that would be necessary outside of a character class. For example the regex [\\.] is identical to [.]
- If several qualified expressions occur after the qualifier having been checked for nullable, they can be replaced with optional chaining
- fix duplicate attribute definitions in scss
- add alt text to images on markdown files

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->
