### PR TITLE
feat(linter): warn on `react-hooks/exhaustive-deps` rule

### DIFF
--- a/packages/eslint-plugin-nx/src/configs/react-jsx.ts
+++ b/packages/eslint-plugin-nx/src/configs/react-jsx.ts
@@ -63,6 +63,7 @@ export default {
      * React Hooks rule configurations
      * https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks
      */
+    'react-hooks/exhaustive-deps': 'warn',
     'react-hooks/rules-of-hooks': 'error',
   },
 };


### PR DESCRIPTION
It's recommended: https://github.com/facebook/react/blob/fb8c1917e9985f83032f642e5db8b9abf089653e/packages/eslint-plugin-react-hooks/src/index.js#L14-L20