### PR TITLE
fix(linter): remove tslint/config rule from converted eslint configs

### DIFF
--- a/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -39,11 +39,6 @@ export async function conversionGenerator(
   });
 
   /**
-   * Dynamically install tslint-to-eslint-config to assist with the conversion.
-   */
-  projectConverter.installTSLintToESLintConfigPackage();
-
-  /**
    * Create the standard (which is applicable to the current package) ESLint setup
    * for converting the project.
    */
@@ -115,7 +110,6 @@ export async function conversionGenerator(
   await formatFiles(host);
 
   return async () => {
-    projectConverter.uninstallTSLintToESLintConfigPackage();
     await rootConfigInstallTask();
     await projectConfigInstallTask();
     await cypressInstallTask();

--- a/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -155,8 +155,7 @@ function applyAngularRulesToCorrectOverrides(
          */
         if (
           override.files.includes('*.ts') &&
-          !ruleName.startsWith('@angular-eslint/template') &&
-          !ruleName.startsWith('@typescript-eslint/tslint/config')
+          !ruleName.startsWith('@angular-eslint/template')
         ) {
           // Prioritize the converted rules over any base implementations from the original Nx generator
           override.rules[ruleName] = ruleConfig;

--- a/packages/cypress/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/cypress/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -38,11 +38,6 @@ export async function conversionGenerator(
   });
 
   /**
-   * Dynamically install tslint-to-eslint-config to assist with the conversion.
-   */
-  projectConverter.installTSLintToESLintConfigPackage();
-
-  /**
    * Create the standard (which is applicable to the current package) ESLint setup
    * for converting the project.
    */
@@ -89,7 +84,6 @@ export async function conversionGenerator(
   await formatFiles(host);
 
   return async () => {
-    projectConverter.uninstallTSLintToESLintConfigPackage();
     await rootConfigInstallTask();
     await projectConfigInstallTask();
     await uninstallTSLintTask();

--- a/packages/linter/package.json
+++ b/packages/linter/package.json
@@ -31,6 +31,7 @@
     "@nrwl/devkit": "*",
     "glob": "7.1.4",
     "minimatch": "3.0.4",
+    "tmp": "0.0.33",
     "tslib": "^2.0.0"
   }
 }

--- a/packages/linter/src/utils/convert-tslint-to-eslint/utils.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/utils.ts
@@ -74,16 +74,27 @@ export async function convertTSLintConfig(
     rawTSLintJson,
     ignoreExtendsVals
   );
+  convertedProject.convertedESLintConfig.rules =
+    convertedProject.convertedESLintConfig.rules || {};
 
   /**
    * Apply the custom converter for the nx-module-boundaries rule if applicable
    */
   const convertedNxRule = convertTslintNxRuleToEslintNxRule(rawTSLintJson);
   if (convertedNxRule) {
-    convertedProject.convertedESLintConfig.rules =
-      convertedProject.convertedESLintConfig.rules || {};
     convertedProject.convertedESLintConfig.rules[convertedNxRule.ruleName] =
       convertedNxRule.ruleConfig;
+  }
+
+  // Remove the `@typescript-eslint/tslint/config` rule
+  if (
+    convertedProject.convertedESLintConfig.rules[
+      '@typescript-eslint/tslint/config'
+    ]
+  ) {
+    delete convertedProject.convertedESLintConfig.rules[
+      '@typescript-eslint/tslint/config'
+    ];
   }
 
   warnInCaseOfUnconvertedRules(

--- a/packages/nest/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/nest/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -60,11 +60,6 @@ export async function conversionGenerator(
   });
 
   /**
-   * Dynamically install tslint-to-eslint-config to assist with the conversion.
-   */
-  projectConverter.installTSLintToESLintConfigPackage();
-
-  /**
    * Create the standard (which is applicable to the current package) ESLint setup
    * for converting the project.
    */
@@ -111,7 +106,6 @@ export async function conversionGenerator(
   await formatFiles(host);
 
   return async () => {
-    projectConverter.uninstallTSLintToESLintConfigPackage();
     await rootConfigInstallTask();
     await projectConfigInstallTask();
     await uninstallTSLintTask();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

* `@typescript-eslint/tslint/config` rules are in the converted root `.eslintrc`.
* `convert-tslint-to-eslint` is installed and uninstalled (2 installs + 1 more for the generator)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

* `@typescript-eslint/tslint/config` rules are not in the converted root `.eslintrc` . There is a warning.
* `convert-tslint-to-eslint` is installed into a tmp directory and left for the OS to cleanup (1 install + 1 more for the generator)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
