### PR TITLE
fix(angular): prevent running ngcc with incremental builds

### DIFF
--- a/docs/angular/guides/setup-incremental-builds.md
+++ b/docs/angular/guides/setup-incremental-builds.md
@@ -2,12 +2,30 @@
 
 In this guide we’ll specifically look into which changes need to be made to enable [incremental builds](/angular/ci/incremental-builds) for Angular applications.
 
+## Requirements
+
+It’s required that you run the Angular compatibility compiler (`ngcc`) after every package installation if you have Ivy enabled. This comes configured by default in every Nx workspace. The incremental build relies on the fact that `ngcc` must have already been run. You can check your `package.json` and make sure you have the following:
+
+```json
+{
+    ...
+    "scripts": {
+        ...
+        "postinstall": "ngcc --properties es2015 browser module main",
+        ...
+    }
+    ...
+}
+```
+
+> Please note that `ngcc` doesn’t support `pnpm` ([#32087](https://github.com/angular/angular/issues/32087#issuecomment-523225437) and [#38023](https://github.com/angular/angular/issues/38023#issuecomment-732423078)), so you need to use either `yarn` or `npm`.
+
 ## Use buildable libraries
 
 To enable incremental builds you need to use buildable libraries.
 You can generate a new buildable lib with
 
-```
+```bash
 nx g @nrwl/angular:lib mylib --buildable
 ```
 
@@ -15,7 +33,7 @@ nx g @nrwl/angular:lib mylib --buildable
 
 Nx comes with faster executors allowing for a faster build. Make sure that your libraries use the @nrwl/angular:ng-packagr-lite builder.
 
-```
+```json
 "mylib": {
     "projectType": "library",
     ...
@@ -34,7 +52,7 @@ Nx comes with faster executors allowing for a faster build. Make sure that your 
 
 Change your Angular app’s executor to @nrwl/angular:webpack-browser and the “serve” executor to @nrwl/web:file-server instead.
 
-```
+```json
 "app0": {
     "projectType": "application",
     ...
@@ -64,19 +82,19 @@ Change your Angular app’s executor to @nrwl/angular:webpack-browser and the �
 
 To build an app incrementally use the following commands.
 
-```
+```bash
 nx build myapp --with-deps --parallel
 ```
 
 To serve an app incrementally use this command:
 
-```
+```bash
 nx serve myapp --with-deps --parallel
 ```
 
 Note: you can specify the `--with-deps` and `--parallel` flags as part of the options property on the file-server executor in your `angular.json` or `workspace.json`. The file-server executor will pass those to the `nx build` command it invokes.
 
-```
+```json
 "app0": {
     "projectType": "application",
     ...

--- a/e2e/angular/src/angular-app.test.ts
+++ b/e2e/angular/src/angular-app.test.ts
@@ -1,4 +1,5 @@
 import {
+  getSelectedPackageManager,
   newProject,
   readFile,
   readJson,
@@ -14,21 +15,25 @@ describe('Angular Nrwl app builder', () => {
   let buildableLib;
   let proj: string;
 
-  beforeEach(() => {
-    app = uniq('app');
-    buildableLib = uniq('buildlib1');
+  // This fails with pnpm due to incompatibilities with ngcc.
+  // Since this suite has a single test, we wrap everything to avoid the hooks to run and
+  // waste time.
+  if (getSelectedPackageManager() !== 'pnpm') {
+    beforeEach(() => {
+      app = uniq('app');
+      buildableLib = uniq('buildlib1');
 
-    proj = newProject();
+      proj = newProject();
 
-    runCLI(`generate @nrwl/angular:app ${app} --style=css --no-interactive`);
-    runCLI(
-      `generate @nrwl/angular:library ${buildableLib} --buildable=true --no-interactive`
-    );
+      runCLI(`generate @nrwl/angular:app ${app} --style=css --no-interactive`);
+      runCLI(
+        `generate @nrwl/angular:library ${buildableLib} --buildable=true --no-interactive`
+      );
 
-    // update the app module to include a ref to the buildable lib
-    updateFile(
-      `apps/${app}/src/app/app.module.ts`,
-      `
+      // update the app module to include a ref to the buildable lib
+      updateFile(
+        `apps/${app}/src/app/app.module.ts`,
+        `
         import { BrowserModule } from '@angular/platform-browser';
         import { NgModule } from '@angular/core';
         import {${
@@ -45,27 +50,30 @@ describe('Angular Nrwl app builder', () => {
         })
         export class AppModule {}
     `
-    );
+      );
 
-    // update the angular.json
-    const workspaceJson = readJson(`angular.json`);
-    workspaceJson.projects[app].architect.build.builder =
-      '@nrwl/angular:webpack-browser';
-    updateFile('angular.json', JSON.stringify(workspaceJson, null, 2));
-  });
+      // update the angular.json
+      const workspaceJson = readJson(`angular.json`);
+      workspaceJson.projects[app].architect.build.builder =
+        '@nrwl/angular:webpack-browser';
+      updateFile('angular.json', JSON.stringify(workspaceJson, null, 2));
+    });
 
-  afterEach(() => removeProject({ onlyOnCI: true }));
+    afterEach(() => removeProject({ onlyOnCI: true }));
 
-  it('should build the dependent buildable lib as well as the app', () => {
-    const libOutput = runCLI(`build ${app} --with-deps`);
-    expect(libOutput).toContain(
-      `Building entry point '@${proj}/${buildableLib}'`
-    );
-    expect(libOutput).toContain(`nx run ${app}:build`);
+    it('should build the dependent buildable lib as well as the app', () => {
+      const libOutput = runCLI(`build ${app} --with-deps`);
+      expect(libOutput).toContain(
+        `Building entry point '@${proj}/${buildableLib}'`
+      );
+      expect(libOutput).toContain(`nx run ${app}:build`);
 
-    // to proof it has been built from source the "main.js" should actually contain
-    // the path to dist
-    const mainBundle = readFile(`dist/apps/${app}/main.js`);
-    expect(mainBundle).toContain(`dist/libs/${buildableLib}`);
-  });
+      // to proof it has been built from source the "main.js" should actually contain
+      // the path to dist
+      const mainBundle = readFile(`dist/apps/${app}/main.js`);
+      expect(mainBundle).toContain(`dist/libs/${buildableLib}`);
+    });
+  } else {
+    it('Skip tests with pnpm', () => {});
+  }
 });

--- a/packages/angular/src/builders/ng-packagr-lite/ng-packagr-adjustments/compile-ngc.ts
+++ b/packages/angular/src/builders/ng-packagr-lite/ng-packagr-adjustments/compile-ngc.ts
@@ -1,0 +1,80 @@
+/**
+ * Adapted from the original ngPackagr source.
+ *
+ * Excludes the ngcc compilation which is not needed
+ * since these libraries will be compiled by the ngtsc.
+ */
+
+import {
+  Transform,
+  transformFromPromise,
+} from 'ng-packagr/lib/graph/transform';
+import {
+  provideTransform,
+  TransformProvider,
+} from 'ng-packagr/lib/graph/transform.di';
+import { COMPILE_NGC_TOKEN } from 'ng-packagr/lib/ng-package/entry-point/compile-ngc.di';
+import {
+  EntryPointNode,
+  isEntryPoint,
+  isEntryPointInProgress,
+} from 'ng-packagr/lib/ng-package/nodes';
+import { compileSourceFiles } from 'ng-packagr/lib/ngc/compile-source-files';
+import { StylesheetProcessor as StylesheetProcessorClass } from 'ng-packagr/lib/styles/stylesheet-processor';
+import { STYLESHEET_PROCESSOR_TOKEN } from 'ng-packagr/lib/styles/stylesheet-processor.di';
+import { setDependenciesTsConfigPaths } from 'ng-packagr/lib/ts/tsconfig';
+import * as path from 'path';
+import * as ts from 'typescript';
+
+export const compileNgcTransformFactory = (
+  StylesheetProcessor: typeof StylesheetProcessorClass
+): Transform => {
+  return transformFromPromise(async (graph) => {
+    try {
+      const entryPoint: EntryPointNode = graph.find(isEntryPointInProgress());
+      const entryPoints: EntryPointNode[] = graph.filter(isEntryPoint);
+      // Add paths mappings for dependencies
+      const tsConfig = setDependenciesTsConfigPaths(
+        entryPoint.data.tsConfig,
+        entryPoints
+      );
+
+      // Compile TypeScript sources
+      const { esm2015, declarations } = entryPoint.data.destinationFiles;
+      const { moduleResolutionCache } = entryPoint.cache;
+      const {
+        basePath,
+        cssUrl,
+        styleIncludePaths,
+      } = entryPoint.data.entryPoint;
+      const stylesheetProcessor = new StylesheetProcessor(
+        basePath,
+        cssUrl,
+        styleIncludePaths
+      );
+
+      await compileSourceFiles(
+        graph,
+        tsConfig,
+        moduleResolutionCache,
+        stylesheetProcessor,
+        {
+          outDir: path.dirname(esm2015),
+          declarationDir: path.dirname(declarations),
+          declaration: true,
+          target: ts.ScriptTarget.ES2015,
+        }
+      );
+    } catch (error) {
+      throw error;
+    }
+
+    return graph;
+  });
+};
+
+export const NX_COMPILE_NGC_TRANSFORM: TransformProvider = provideTransform({
+  provide: COMPILE_NGC_TOKEN,
+  useFactory: compileNgcTransformFactory,
+  deps: [STYLESHEET_PROCESSOR_TOKEN],
+});

--- a/packages/angular/src/builders/ng-packagr-lite/ng-packagr-adjustments/entry-point.di.ts
+++ b/packages/angular/src/builders/ng-packagr-lite/ng-packagr-adjustments/entry-point.di.ts
@@ -4,10 +4,7 @@
  * where Nx takes over with Nx specific functions
  */
 
-import {
-  COMPILE_NGC_TOKEN,
-  COMPILE_NGC_TRANSFORM,
-} from 'ng-packagr/lib/ng-package/entry-point/compile-ngc.di';
+import { COMPILE_NGC_TOKEN } from 'ng-packagr/lib/ng-package/entry-point/compile-ngc.di';
 import {
   NX_WRITE_BUNDLES_TRANSFORM,
   NX_WRITE_BUNDLES_TRANSFORM_TOKEN,
@@ -23,6 +20,7 @@ import {
   TransformProvider,
 } from 'ng-packagr/lib/graph/transform.di';
 import { entryPointTransformFactory } from 'ng-packagr/lib/ng-package/entry-point/entry-point.transform';
+import { NX_COMPILE_NGC_TRANSFORM } from './compile-ngc';
 
 export const NX_ENTRY_POINT_TRANSFORM_TOKEN = new InjectionToken<Transform>(
   `nx.v1.entryPointTransform`
@@ -40,7 +38,7 @@ export const NX_ENTRY_POINT_TRANSFORM: TransformProvider = provideTransform({
 
 export const NX_ENTRY_POINT_PROVIDERS: Provider[] = [
   NX_ENTRY_POINT_TRANSFORM,
-  COMPILE_NGC_TRANSFORM,
+  NX_COMPILE_NGC_TRANSFORM,
   NX_WRITE_BUNDLES_TRANSFORM,
   WRITE_PACKAGE_TRANSFORM,
 ];


### PR DESCRIPTION
## Current Behavior
When Ivy is enabled, ng-packagr runs ngcc and it does so with a locking mechanism when it's run asynchronously and with several workers, This impacts the incremental build perf, creates noise in the terminal output and it can even fail the process depending on the config for ngcc.

## Expected Behavior
The incremental build works without any warning or locks caused by ngcc. For the incremental builds, ngcc is not needed to be run, the packages are not meant to be distributed and Ivy will be enabled by default causing ngtsc to run.

## Related Issue(s)

Fixes #4937
