### PR TITLE
fix(linter): keep plugins other than typescript-eslint/tslint

### DIFF
--- a/packages/angular/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
@@ -154,6 +154,8 @@ Object {
       ],
       "plugins": Array [
         "eslint-plugin-import",
+        "@angular-eslint/eslint-plugin",
+        "@typescript-eslint",
       ],
       "rules": Object {
         "@angular-eslint/component-selector": Array [
@@ -269,6 +271,9 @@ Object {
       "files": Array [
         "*.html",
       ],
+      "plugins": Array [
+        "@angular-eslint/eslint-plugin-template",
+      ],
       "rules": Object {
         "@angular-eslint/template/banana-in-box": "error",
         "@angular-eslint/template/no-negated-async": "error",
@@ -304,6 +309,10 @@ Object {
           "apps/angular-app-1/tsconfig.*?.json",
         ],
       },
+      "plugins": Array [
+        "@angular-eslint/eslint-plugin",
+        "@typescript-eslint",
+      ],
       "rules": Object {
         "@angular-eslint/component-selector": Array [
           "error",
@@ -330,6 +339,9 @@ Object {
       ],
       "files": Array [
         "*.html",
+      ],
+      "plugins": Array [
+        "@angular-eslint/eslint-plugin-template",
       ],
       "rules": Object {
         "@angular-eslint/template/banana-in-box": "error",
@@ -493,6 +505,8 @@ Object {
       ],
       "plugins": Array [
         "eslint-plugin-import",
+        "@angular-eslint/eslint-plugin",
+        "@typescript-eslint",
       ],
       "rules": Object {
         "@angular-eslint/component-selector": Array [
@@ -608,6 +622,9 @@ Object {
       "files": Array [
         "*.html",
       ],
+      "plugins": Array [
+        "@angular-eslint/eslint-plugin-template",
+      ],
       "rules": Object {
         "@angular-eslint/template/banana-in-box": "error",
         "@angular-eslint/template/no-negated-async": "error",
@@ -643,6 +660,10 @@ Object {
           "libs/angular-lib-1/tsconfig.*?.json",
         ],
       },
+      "plugins": Array [
+        "@angular-eslint/eslint-plugin",
+        "@typescript-eslint",
+      ],
       "rules": Object {
         "@angular-eslint/component-selector": Array [
           "error",
@@ -669,6 +690,9 @@ Object {
       ],
       "files": Array [
         "*.html",
+      ],
+      "plugins": Array [
+        "@angular-eslint/eslint-plugin-template",
       ],
       "rules": Object {
         "@angular-eslint/template/banana-in-box": "error",

--- a/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -163,7 +163,19 @@ function applyAngularRulesToCorrectOverrides(
     for (const override of json.overrides) {
       if (override.files.includes('*.ts')) {
         override.plugins = override.plugins || [];
-        override.plugins = [...override.plugins, ...json.plugins];
+        override.plugins = [
+          ...override.plugins,
+          ...json.plugins.filter(
+            (plugin) => plugin !== '@angular-eslint/eslint-plugin-template'
+          ),
+        ];
+      }
+
+      if (
+        override.files.includes('*.html') &&
+        json.plugins.includes('@angular-eslint/eslint-plugin-template')
+      ) {
+        override.plugins = ['@angular-eslint/eslint-plugin-template'];
       }
     }
     delete json.plugins;

--- a/packages/cypress/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
+++ b/packages/cypress/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
@@ -150,6 +150,7 @@ Object {
       ],
       "plugins": Array [
         "eslint-plugin-import",
+        "@typescript-eslint",
       ],
       "rules": Object {
         "@typescript-eslint/consistent-type-definitions": "error",
@@ -274,6 +275,9 @@ Object {
         "no-undef": "off",
       },
     },
+  ],
+  "plugins": Array [
+    "@typescript-eslint",
   ],
   "rules": Object {
     "@typescript-eslint/no-empty-interface": "error",

--- a/packages/cypress/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/cypress/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -102,5 +102,10 @@ function removeCodelyzerRelatedRules(json: Linter.Config): Linter.Config {
       delete json.rules[ruleName];
     }
   }
+  if (json.plugins) {
+    json.plugins = json.plugins.filter(
+      (plugin) => !plugin.startsWith('@angular-eslint')
+    );
+  }
   return json;
 }

--- a/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
@@ -151,8 +151,7 @@ export class ProjectConverter {
     delete convertedRootESLintConfig.parser;
     delete convertedRootESLintConfig.parserOptions;
     convertedRootESLintConfig.plugins = convertedRootESLintConfig.plugins.filter(
-      (p) =>
-        !p.startsWith('@angular-eslint') && !p.startsWith('@typescript-eslint')
+      (p) => p !== '@typescript-eslint/tslint'
     );
 
     /**
@@ -245,8 +244,7 @@ export class ProjectConverter {
     delete convertedProjectESLintConfig.parser;
     delete convertedProjectESLintConfig.parserOptions;
     convertedProjectESLintConfig.plugins = convertedProjectESLintConfig.plugins.filter(
-      (p) =>
-        !p.startsWith('@angular-eslint') && !p.startsWith('@typescript-eslint')
+      (p) => p !== '@typescript-eslint/tslint'
     );
 
     const projectESLintConfigPath = joinPathFragments(
@@ -280,7 +278,7 @@ export class ProjectConverter {
         convertedProjectESLintConfig.plugins.length
       ) {
         json.plugins = [
-          ...json.plugins,
+          ...(json.plugins ?? []),
           ...convertedProjectESLintConfig.plugins,
         ];
       }

--- a/packages/nest/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
+++ b/packages/nest/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
@@ -149,6 +149,7 @@ Object {
       ],
       "plugins": Array [
         "eslint-plugin-import",
+        "@typescript-eslint",
       ],
       "rules": Object {
         "@typescript-eslint/consistent-type-definitions": "error",
@@ -279,6 +280,9 @@ Object {
       ],
       "rules": Object {},
     },
+  ],
+  "plugins": Array [
+    "@typescript-eslint",
   ],
   "rules": Object {
     "@typescript-eslint/no-empty-interface": "error",
@@ -435,6 +439,7 @@ Object {
       ],
       "plugins": Array [
         "eslint-plugin-import",
+        "@typescript-eslint",
       ],
       "rules": Object {
         "@typescript-eslint/consistent-type-definitions": "error",
@@ -565,6 +570,9 @@ Object {
       ],
       "rules": Object {},
     },
+  ],
+  "plugins": Array [
+    "@typescript-eslint",
   ],
   "rules": Object {
     "@typescript-eslint/no-empty-interface": "error",

--- a/packages/nest/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/nest/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -124,5 +124,11 @@ function removeCodelyzerRelatedRules(json: Linter.Config): Linter.Config {
       delete json.rules[ruleName];
     }
   }
+
+  if (json.plugins) {
+    json.plugins = json.plugins.filter(
+      (plugin) => !plugin.startsWith('@angular-eslint')
+    );
+  }
   return json;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Projects that already use eslint break after migrating projects from tslint to eslint because rules get added to the config but the plugins are not added. Projects that got migrated are fine because they bring in the extends in their config.. but other projects are not fine.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Projects that already use eslint continue to function with the new rules. The migrated project should still work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
