### PR TITLE
fix(node): early assets copy to "respect" updates on `package.json`

### DIFF
--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -36,6 +36,13 @@ export function workspaceConfigName() {
   return currentCli() === 'angular' ? 'angular.json' : 'workspace.json';
 }
 
+export function updateWorkspaceConfig(
+  callback: (json: { [key: string]: any }) => Object
+) {
+  const file = workspaceConfigName();
+  updateFile(file, JSON.stringify(callback(readJson(file)), null, 2));
+}
+
 export function runCreateWorkspace(
   name: string,
   {

--- a/packages/node/src/executors/package/package.impl.ts
+++ b/packages/node/src/executors/package/package.impl.ts
@@ -41,6 +41,9 @@ export async function packageExecutor(
     libRoot,
     dependencies
   );
+
+  await copyAssetFiles(normalizedOptions, context);
+
   updatePackageJson(normalizedOptions, context);
   if (
     dependencies.length > 0 &&
@@ -56,8 +59,6 @@ export async function packageExecutor(
       normalizedOptions.buildableProjectDepsInPackageJsonType
     );
   }
-
-  await copyAssetFiles(normalizedOptions, context);
 
   return {
     ...result,


### PR DESCRIPTION
If `package.json` is "accidentally" copied with assets, it overwrites the existing updated `package.json` resulting in loss of entry points and buildable dependencies. This commit makes sure that any update to `package.json` happens after asset copying.
