### PR TITLE
fix(core): normalize run-commands and run-script cwd handling

### DIFF
--- a/docs/angular/api-workspace/executors/run-commands.md
+++ b/docs/angular/api-workspace/executors/run-commands.md
@@ -190,7 +190,7 @@ Type: `array`
 
 Type: `string`
 
-Current working directory of the commands.
+Current working directory of the commands. If it's not specified the commands will run in the workspace root, if a relative path is specified the commands will run in that path relative to the workspace root and if it's an absolute path the commands will run in that path.
 
 ### envFile
 

--- a/docs/node/api-workspace/executors/run-commands.md
+++ b/docs/node/api-workspace/executors/run-commands.md
@@ -191,7 +191,7 @@ Type: `array`
 
 Type: `string`
 
-Current working directory of the commands.
+Current working directory of the commands. If it's not specified the commands will run in the workspace root, if a relative path is specified the commands will run in that path relative to the workspace root and if it's an absolute path the commands will run in that path.
 
 ### envFile
 

--- a/docs/react/api-workspace/executors/run-commands.md
+++ b/docs/react/api-workspace/executors/run-commands.md
@@ -191,7 +191,7 @@ Type: `array`
 
 Type: `string`
 
-Current working directory of the commands.
+Current working directory of the commands. If it's not specified the commands will run in the workspace root, if a relative path is specified the commands will run in that path relative to the workspace root and if it's an absolute path the commands will run in that path.
 
 ### envFile
 

--- a/packages/workspace/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.spec.ts
@@ -1,5 +1,6 @@
-import { fileSync } from 'tmp';
 import { readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { relative } from 'path';
+import { dirSync, fileSync } from 'tmp';
 import runCommands, { LARGE_BUFFER } from './run-commands.impl';
 
 function readFile(f: string) {
@@ -7,31 +8,34 @@ function readFile(f: string) {
 }
 
 describe('Command Runner Builder', () => {
+  const context = {} as any;
+
   it('should run one command', async () => {
     const f = fileSync().name;
-    const result = await runCommands({
-      command: `echo 1 >> ${f}`,
-    });
+    const result = await runCommands({ command: `echo 1 >> ${f}` }, context);
     expect(result).toEqual(jasmine.objectContaining({ success: true }));
     expect(readFile(f)).toEqual('1');
   });
 
   it('should interpolate provided --args', async () => {
     const f = fileSync().name;
-    const result = await runCommands({
-      command: `echo {args.key} >> ${f}`,
-      args: '--key=123',
-    });
+    const result = await runCommands(
+      { command: `echo {args.key} >> ${f}`, args: '--key=123' },
+      context
+    );
     expect(result).toEqual(jasmine.objectContaining({ success: true }));
     expect(readFile(f)).toEqual('123');
   });
 
   it('should interpolate all unknown args as if they were --args', async () => {
     const f = fileSync().name;
-    const result = await runCommands({
-      command: `echo {args.key} >> ${f}`,
-      key: 123,
-    });
+    const result = await runCommands(
+      {
+        command: `echo {args.key} >> ${f}`,
+        key: 123,
+      },
+      context
+    );
     expect(result).toEqual(jasmine.objectContaining({ success: true }));
     expect(readFile(f)).toEqual('123');
   });
@@ -39,11 +43,14 @@ describe('Command Runner Builder', () => {
   it('should add all args to the command if no interpolation in the command', async () => {
     const exec = spyOn(require('child_process'), 'execSync').and.callThrough();
 
-    await runCommands({
-      command: `echo`,
-      a: 123,
-      b: 456,
-    });
+    await runCommands(
+      {
+        command: `echo`,
+        a: 123,
+        b: 456,
+      },
+      context
+    );
     expect(exec).toHaveBeenCalledWith(`echo --a=123 --b=456`, {
       stdio: [0, 1, 2],
       cwd: undefined,
@@ -55,12 +62,15 @@ describe('Command Runner Builder', () => {
   it('ssss should forward args by default when using commands (plural)', async () => {
     const exec = spyOn(require('child_process'), 'exec').and.callThrough();
 
-    await runCommands({
-      commands: [{ command: 'echo' }],
-      parallel: true,
-      a: 123,
-      b: 456,
-    });
+    await runCommands(
+      {
+        commands: [{ command: 'echo' }],
+        parallel: true,
+        a: 123,
+        b: 456,
+      },
+      context
+    );
 
     expect(exec).toHaveBeenCalledWith('echo --a=123 --b=456', {
       maxBuffer: LARGE_BUFFER,
@@ -71,12 +81,15 @@ describe('Command Runner Builder', () => {
   it('should forward args when forwardAllArgs is set to true', async () => {
     const exec = spyOn(require('child_process'), 'exec').and.callThrough();
 
-    await runCommands({
-      commands: [{ command: 'echo', forwardAllArgs: true }],
-      parallel: true,
-      a: 123,
-      b: 456,
-    });
+    await runCommands(
+      {
+        commands: [{ command: 'echo', forwardAllArgs: true }],
+        parallel: true,
+        a: 123,
+        b: 456,
+      },
+      context
+    );
 
     expect(exec).toHaveBeenCalledWith('echo --a=123 --b=456', {
       maxBuffer: LARGE_BUFFER,
@@ -87,12 +100,15 @@ describe('Command Runner Builder', () => {
   it('should not forward args when forwardAllArgs is set to false', async () => {
     const exec = spyOn(require('child_process'), 'exec').and.callThrough();
 
-    await runCommands({
-      commands: [{ command: 'echo', forwardAllArgs: false }],
-      parallel: true,
-      a: 123,
-      b: 456,
-    });
+    await runCommands(
+      {
+        commands: [{ command: 'echo', forwardAllArgs: false }],
+        parallel: true,
+        a: 123,
+        b: 456,
+      },
+      context
+    );
 
     expect(exec).toHaveBeenCalledWith('echo', {
       maxBuffer: LARGE_BUFFER,
@@ -102,10 +118,13 @@ describe('Command Runner Builder', () => {
 
   it('should throw when invalid args', async () => {
     try {
-      await runCommands({
-        command: `echo {args.key}`,
-        args: 'key=value',
-      });
+      await runCommands(
+        {
+          command: `echo {args.key}`,
+          args: 'key=value',
+        },
+        context
+      );
     } catch (e) {
       expect(e.message).toEqual('Invalid args: key=value');
     }
@@ -113,27 +132,33 @@ describe('Command Runner Builder', () => {
 
   it('should run commands serially', async () => {
     const f = fileSync().name;
-    const result = await runCommands({
-      commands: [`sleep 0.2 && echo 1 >> ${f}`, `echo 2 >> ${f}`],
-      parallel: false,
-    });
+    const result = await runCommands(
+      {
+        commands: [`sleep 0.2 && echo 1 >> ${f}`, `echo 2 >> ${f}`],
+        parallel: false,
+      },
+      context
+    );
     expect(result).toEqual(jasmine.objectContaining({ success: true }));
     expect(readFile(f)).toEqual('12');
   });
 
   it('should run commands in parallel', async () => {
     const f = fileSync().name;
-    const result = await runCommands({
-      commands: [
-        {
-          command: `echo 1 >> ${f}`,
-        },
-        {
-          command: `echo 2 >> ${f}`,
-        },
-      ],
-      parallel: true,
-    });
+    const result = await runCommands(
+      {
+        commands: [
+          {
+            command: `echo 1 >> ${f}`,
+          },
+          {
+            command: `echo 2 >> ${f}`,
+          },
+        ],
+        parallel: true,
+      },
+      context
+    );
     expect(result).toEqual(jasmine.objectContaining({ success: true }));
     const contents = readFile(f);
     expect(contents).toContain(1);
@@ -143,11 +168,14 @@ describe('Command Runner Builder', () => {
   describe('readyWhen', () => {
     it('should error when parallel = false', async () => {
       try {
-        await runCommands({
-          commands: [{ command: 'some command' }],
-          parallel: false,
-          readyWhen: 'READY',
-        });
+        await runCommands(
+          {
+            commands: [{ command: 'some command' }],
+            parallel: false,
+            readyWhen: 'READY',
+          },
+          context
+        );
         fail('should throw');
       } catch (e) {
         expect(e.message).toEqual(
@@ -158,15 +186,18 @@ describe('Command Runner Builder', () => {
 
     it('should return success true when the string specified is ready condition is found', async (done) => {
       const f = fileSync().name;
-      const result = await runCommands({
-        commands: [
-          {
-            command: `echo READY && sleep 0.1 && echo 1 >> ${f}`,
-          },
-        ],
-        parallel: true,
-        readyWhen: 'READY',
-      });
+      const result = await runCommands(
+        {
+          commands: [
+            {
+              command: `echo READY && sleep 0.1 && echo 1 >> ${f}`,
+            },
+          ],
+          parallel: true,
+          readyWhen: 'READY',
+        },
+        context
+      );
       expect(result).toEqual(jasmine.objectContaining({ success: true }));
       expect(readFile(f)).toEqual('');
 
@@ -181,10 +212,13 @@ describe('Command Runner Builder', () => {
     const f = fileSync().name;
 
     try {
-      await runCommands({
-        commands: [`echo 1 >> ${f} && exit 1`, `echo 2 >> ${f}`],
-        parallel: false,
-      });
+      await runCommands(
+        {
+          commands: [`echo 1 >> ${f} && exit 1`, `echo 2 >> ${f}`],
+          parallel: false,
+        },
+        context
+      );
       fail('should fail when a command fails');
     } catch (e) {}
     expect(readFile(f)).toEqual('1');
@@ -193,14 +227,17 @@ describe('Command Runner Builder', () => {
   describe('--color', () => {
     it('should not set FORCE_COLOR=true', async () => {
       const exec = spyOn(require('child_process'), 'exec').and.callThrough();
-      await runCommands({
-        commands: [
-          {
-            command: `echo 'Hello World'`,
-          },
-        ],
-        parallel: true,
-      });
+      await runCommands(
+        {
+          commands: [
+            {
+              command: `echo 'Hello World'`,
+            },
+          ],
+          parallel: true,
+        },
+        context
+      );
 
       expect(exec).toHaveBeenCalledWith(`echo 'Hello World'`, {
         maxBuffer: LARGE_BUFFER,
@@ -210,15 +247,18 @@ describe('Command Runner Builder', () => {
 
     it('should set FORCE_COLOR=true when running with --color', async () => {
       const exec = spyOn(require('child_process'), 'exec').and.callThrough();
-      await runCommands({
-        commands: [
-          {
-            command: `echo 'Hello World'`,
-          },
-        ],
-        parallel: true,
-        color: true,
-      });
+      await runCommands(
+        {
+          commands: [
+            {
+              command: `echo 'Hello World'`,
+            },
+          ],
+          parallel: true,
+          color: true,
+        },
+        context
+      );
 
       expect(exec).toHaveBeenCalledWith(`echo 'Hello World'`, {
         maxBuffer: LARGE_BUFFER,
@@ -227,32 +267,71 @@ describe('Command Runner Builder', () => {
     });
   });
 
-  it('should run the task in the specified working directory', async () => {
-    const f = fileSync().name;
-    const result = await runCommands({
-      commands: [
+  describe('cwd', () => {
+    it('should run the task in the workspace root when no cwd is specified', async () => {
+      const root = dirSync().name;
+      const f = fileSync().name;
+
+      const result = await runCommands(
         {
-          command: `pwd >> ${f}`,
+          commands: [
+            {
+              command: `pwd >> ${f}`,
+            },
+          ],
+          parallel: true,
         },
-      ],
-      parallel: true,
+        { root } as any
+      );
+
+      expect(result).toEqual(jasmine.objectContaining({ success: true }));
+      expect(readFile(f)).toBe(root);
     });
 
-    expect(result).toEqual(jasmine.objectContaining({ success: true }));
-    expect(readFile(f)).not.toContain('/packages');
+    it('should run the task in the specified cwd relative to the workspace root when cwd is not an absolute path', async () => {
+      const root = dirSync().name;
+      const childFolder = dirSync({ dir: root }).name;
+      const cwd = relative(root, childFolder);
+      const f = fileSync().name;
 
-    const result2 = await runCommands({
-      commands: [
+      const result = await runCommands(
         {
-          command: `pwd >> ${f}`,
+          commands: [
+            {
+              command: `pwd >> ${f}`,
+            },
+          ],
+          cwd,
+          parallel: true,
         },
-      ],
-      parallel: true,
-      cwd: 'packages',
+        { root } as any
+      );
+
+      expect(result).toEqual(jasmine.objectContaining({ success: true }));
+      expect(readFile(f)).toBe(childFolder);
     });
 
-    expect(result2).toEqual(jasmine.objectContaining({ success: true }));
-    expect(readFile(f)).toContain('/packages');
+    it('should run the task in the specified absolute cwd', async () => {
+      const root = dirSync().name;
+      const childFolder = dirSync({ dir: root }).name;
+      const f = fileSync().name;
+
+      const result = await runCommands(
+        {
+          commands: [
+            {
+              command: `pwd >> ${f}`,
+            },
+          ],
+          cwd: childFolder,
+          parallel: true,
+        },
+        { root } as any
+      );
+
+      expect(result).toEqual(jasmine.objectContaining({ success: true }));
+      expect(readFile(f)).toBe(childFolder);
+    });
   });
 
   describe('dotenv', () => {
@@ -271,13 +350,16 @@ describe('Command Runner Builder', () => {
 
     it('should load the root .env file by default if there is one', async () => {
       let f = fileSync().name;
-      const result = await runCommands({
-        commands: [
-          {
-            command: `echo $NRWL_SITE >> ${f}`,
-          },
-        ],
-      });
+      const result = await runCommands(
+        {
+          commands: [
+            {
+              command: `echo $NRWL_SITE >> ${f}`,
+            },
+          ],
+        },
+        context
+      );
 
       expect(result).toEqual(jasmine.objectContaining({ success: true }));
       expect(readFile(f)).toEqual('https://nrwl.io/');
@@ -287,14 +369,17 @@ describe('Command Runner Builder', () => {
       const devEnv = fileSync().name;
       writeFileSync(devEnv, 'NX_SITE=https://nx.dev/');
       let f = fileSync().name;
-      const result = await runCommands({
-        commands: [
-          {
-            command: `echo $NX_SITE >> ${f} && echo $NRWL_SITE >> ${f}`,
-          },
-        ],
-        envFile: devEnv,
-      });
+      const result = await runCommands(
+        {
+          commands: [
+            {
+              command: `echo $NX_SITE >> ${f} && echo $NRWL_SITE >> ${f}`,
+            },
+          ],
+          envFile: devEnv,
+        },
+        context
+      );
 
       expect(result).toEqual(jasmine.objectContaining({ success: true }));
       expect(readFile(f)).toEqual('https://nx.dev/');
@@ -303,14 +388,17 @@ describe('Command Runner Builder', () => {
     it('should error if the specified .env file does not exist', async () => {
       let f = fileSync().name;
       try {
-        await runCommands({
-          commands: [
-            {
-              command: `echo $NX_SITE >> ${f} && echo $NRWL_SITE >> ${f}`,
-            },
-          ],
-          envFile: '/somePath/.fakeEnv',
-        });
+        await runCommands(
+          {
+            commands: [
+              {
+                command: `echo $NX_SITE >> ${f} && echo $NRWL_SITE >> ${f}`,
+              },
+            ],
+            envFile: '/somePath/.fakeEnv',
+          },
+          context
+        );
         fail('should not reach');
       } catch (e) {
         expect(e.message).toContain(

--- a/packages/workspace/src/executors/run-commands/schema.json
+++ b/packages/workspace/src/executors/run-commands/schema.json
@@ -72,7 +72,7 @@
     },
     "cwd": {
       "type": "string",
-      "description": "Current working directory of the commands."
+      "description": "Current working directory of the commands. If it's not specified the commands will run in the workspace root, if a relative path is specified the commands will run in that path relative to the workspace root and if it's an absolute path the commands will run in that path."
     }
   },
   "additionalProperties": true,

--- a/packages/workspace/src/executors/run-script/run-script.impl.ts
+++ b/packages/workspace/src/executors/run-script/run-script.impl.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process';
 import { getPackageManagerCommand } from '@nrwl/tao/src/shared/package-manager';
 import { ExecutorContext } from '@nrwl/devkit';
+import * as path from 'path';
 
 export interface RunScriptOptions {
   script: string;
@@ -22,7 +23,10 @@ export default async function (
   try {
     execSync(pm.run(script, args.join(' ')), {
       stdio: ['inherit', 'inherit', 'inherit'],
-      cwd: context.workspace.projects[context.projectName].root,
+      cwd: path.join(
+        context.root,
+        context.workspace.projects[context.projectName].root
+      ),
     });
     return { success: true };
   } catch (e) {


### PR DESCRIPTION
## Current Behavior
When the `cwd` option is passed to `run-commands` and `run-script` executors, it's not guaranteed the `cwd` will be resolved to the same path. If the command or script is run a standalone, it will resolve relative to the workspace root, but if they are run from another command or script which also sets the `cwd`, then it will be resolved relative to that `cwd` instead of the workspace root. This inconsistency creates issues and it's harder to maintain to being non-deterministic.

## Expected Behavior
`run-commands`:
The resolution of the `cwd` shouldn't be affected by the commands being nested or not. It follows the following rules:
1. If `cwd` isn't set, then `cwd` is set to the workspace root.
2. If `cwd` is set and it is an absolute path, then `cwd` is set to the provided `cwd`.
3. If `cwd` is set and it is not an absolute path, then `cwd` is set to the provided `cwd` relative to the workspace root.

`run-script`:
The resolution of the `cwd` shouldn't be affected by the script being nested or not. It should always be relative to the workspace root.

## Related Issue(s)

Fixes #