### PR TITLE
fix(misc): fixed a typo in nx not globally installed warning

### DIFF
--- a/packages/create-nx-plugin/bin/shared.ts
+++ b/packages/create-nx-plugin/bin/shared.ts
@@ -15,7 +15,7 @@ export function showNxWarning(workspaceName: string) {
     output.note({
       title: `Nx CLI is not installed globally.`,
       bodyLines: [
-        `This means that you might have to use "yarn nx" or "npm nx" to execute commands in the workspace.`,
+        `This means that you might have to use "yarn nx" or "npx nx" to execute commands in the workspace.`,
         `Run "yarn global add nx" or "npm install -g nx" to be able to execute command directly.`,
       ],
     });

--- a/packages/create-nx-workspace/bin/shared.ts
+++ b/packages/create-nx-workspace/bin/shared.ts
@@ -20,7 +20,7 @@ export function showNxWarning(workspaceName: string) {
     output.note({
       title: `Nx CLI is not installed globally.`,
       bodyLines: [
-        `This means that you might have to use "yarn nx" or "npm nx" to execute commands in the workspace.`,
+        `This means that you might have to use "yarn nx" or "npx nx" to execute commands in the workspace.`,
         `Run "yarn global add nx" or "npm install -g nx" to be able to execute command directly.`,
       ],
     });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
create-nx-workspace and create-nx-plugin suggest running `npm nx` which is a command that does not exist

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
it should suggest running `npx nx` or `npm run nx`, but i decided that `npx nx` is shorter and works even when there is no `nx` script in package.json

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->