### PR TITLE
docs(core): fix linting based on tags docs

### DIFF
--- a/docs/shared/monorepo-tags.md
+++ b/docs/shared/monorepo-tags.md
@@ -51,14 +51,20 @@ First, use `nx.json` to annotate your projects with tags. In this example, we wi
 }
 ```
 
-Next open the top-level `.eslintrc.json` or `tslint.json` to add the constraints.
+Next you should update your root lint configuration:
 
-```json
+- If you are using **ESLint** you should look for an existing rule entry in your root `.eslintrc.json` called `"@nrwl/nx/enforce-module-boundaries"` and you should update the `"depConstraints"`:
+
+```jsonc
 {
-  "nx-enforce-module-boundaries": [
-    true,
+  // ... more ESLint config here
+
+  // @nrwl/nx/enforce-module-boundaries should already exist within an "overrides" block using `"files": ["*.ts", "*.tsx", "*.js", "*.jsx",]`
+  "@nrwl/nx/enforce-module-boundaries": [
+    "error",
     {
       "allow": [],
+      // update depConstraints based on your tags
       "depConstraints": [
         {
           "sourceTag": "scope:shared",
@@ -75,6 +81,41 @@ Next open the top-level `.eslintrc.json` or `tslint.json` to add the constraints
       ]
     }
   ]
+
+  // ... more ESLint config here
+}
+```
+
+- If you are using **TSLint** you should look for an existing rule entry in your root `tslint.json` called `"nx-enforce-module-boundaries"` and you should update the `"depConstraints"`:
+
+```jsonc
+{
+  // ... more TSLint config here
+
+  // nx-enforce-module-boundaries should already exist at the top-level of your config
+  "nx-enforce-module-boundaries": [
+    true,
+    {
+      "allow": [],
+      // update depConstraints based on your tags
+      "depConstraints": [
+        {
+          "sourceTag": "scope:shared",
+          "onlyDependOnLibsWithTags": ["scope:shared"]
+        },
+        {
+          "sourceTag": "scope:admin",
+          "onlyDependOnLibsWithTags": ["scope:shared", "scope:admin"]
+        },
+        {
+          "sourceTag": "scope:client",
+          "onlyDependOnLibsWithTags": ["scope:shared", "scope:client"]
+        }
+      ]
+    }
+  ]
+
+  // ... more TSLint config here
 }
 ```
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The linting based on tags docs don't make it clear how to configure ESLint vs TSLint for tag enforcement.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The linting based on tags docs make it clear how to configure ESLint vs TSLint for tag enforcement.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5081
