### PR TITLE
fix(node): apps use `commonjs` module

### DIFF
--- a/packages/express/src/schematics/application/application.spec.ts
+++ b/packages/express/src/schematics/application/application.spec.ts
@@ -97,6 +97,7 @@ describe('app', () => {
     expect(tsconfig).toMatchInlineSnapshot(`
       Object {
         "compilerOptions": Object {
+          "module": "commonjs",
           "outDir": "../../dist/out-tsc",
           "types": Array [
             "node",

--- a/packages/node/src/generators/application/files/app/tsconfig.app.json
+++ b/packages/node/src/generators/application/files/app/tsconfig.app.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= offset %>dist/out-tsc",
+    "module": "commonjs",
     "types": ["node"]
   },
   "exclude": ["**/*.spec.ts"],


### PR DESCRIPTION
Not using `commonjs` module in Node apps could cause issues while serving.

Fixes #2975 