### PR TITLE
fix(angular): not install @ngrx/component-store if it's not installed…

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -387,7 +387,7 @@
         },
         "@ngrx/component-store": {
           "version": "11.0.0",
-          "alwaysAddToPackageJson": true
+          "alwaysAddToPackageJson": false
         },
         "ng-packagr": {
           "version": "^11.2.0",


### PR DESCRIPTION
… already

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->
Prompted by a discussion - https://github.com/nrwl/nx/discussions/5083

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@ngrx/component-store` is installed for all angular apps when migrating to Nx 11.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`@ngrx/component-store` should only be updated if it's already installed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

