### PR TITLE
feat(node): add CLI wrapper option for publishable libraries

### DIFF
--- a/docs/angular/api-node/executors/package.md
+++ b/docs/angular/api-node/executors/package.md
@@ -22,6 +22,12 @@ Possible values: `dependencies`, `peerDependencies`
 
 When updateBuildableProjectDepsInPackageJson is true, this adds dependencies to either `peerDependencies` or `dependencies`
 
+### cli
+
+Type: `boolean`
+
+Adds a CLI wrapper to main entry-point file.
+
 ### deleteOutputPath
 
 Default: `true`

--- a/docs/node/api-node/executors/package.md
+++ b/docs/node/api-node/executors/package.md
@@ -23,6 +23,12 @@ Possible values: `dependencies`, `peerDependencies`
 
 When updateBuildableProjectDepsInPackageJson is true, this adds dependencies to either `peerDependencies` or `dependencies`
 
+### cli
+
+Type: `boolean`
+
+Adds a CLI wrapper to main entry-point file.
+
 ### deleteOutputPath
 
 Default: `true`

--- a/docs/react/api-node/executors/package.md
+++ b/docs/react/api-node/executors/package.md
@@ -23,6 +23,12 @@ Possible values: `dependencies`, `peerDependencies`
 
 When updateBuildableProjectDepsInPackageJson is true, this adds dependencies to either `peerDependencies` or `dependencies`
 
+### cli
+
+Type: `boolean`
+
+Adds a CLI wrapper to main entry-point file.
+
 ### deleteOutputPath
 
 Default: `true`

--- a/packages/node/src/executors/package/package.impl.spec.ts
+++ b/packages/node/src/executors/package/package.impl.spec.ts
@@ -135,8 +135,8 @@ describe('NodePackageBuilder', () => {
         `${testOptions.outputPath}/package.json`,
         {
           name: 'nodelib',
-          main: 'src/index.js',
-          typings: 'src/index.d.ts',
+          main: './src/index.js',
+          typings: './src/index.d.ts',
         }
       );
     });

--- a/packages/node/src/executors/package/package.impl.ts
+++ b/packages/node/src/executors/package/package.impl.ts
@@ -10,6 +10,7 @@ import compileTypeScriptFiles from './utils/compile-typescript-files';
 import updatePackageJson from './utils/update-package-json';
 import normalizeOptions from './utils/normalize-options';
 import copyAssetFiles from './utils/copy-asset-files';
+import addCliWrapper from './utils/cli';
 
 export async function packageExecutor(
   options: NodePackageBuilderOptions,
@@ -58,6 +59,10 @@ export async function packageExecutor(
       dependencies,
       normalizedOptions.buildableProjectDepsInPackageJsonType
     );
+  }
+
+  if (options.cli) {
+    addCliWrapper(normalizedOptions, context);
   }
 
   return {

--- a/packages/node/src/executors/package/schema.json
+++ b/packages/node/src/executors/package/schema.json
@@ -57,6 +57,10 @@
       "type": "boolean",
       "description": "Delete the output path before building.",
       "default": true
+    },
+    "cli": {
+      "type": "boolean",
+      "description": "Adds a CLI wrapper to main entry-point file."
     }
   },
   "required": ["tsConfig", "main"],

--- a/packages/node/src/executors/package/utils/cli.ts
+++ b/packages/node/src/executors/package/utils/cli.ts
@@ -1,0 +1,33 @@
+import { ExecutorContext } from '@nrwl/devkit';
+
+import {
+  readJsonFile,
+  writeJsonFile,
+  writeToFile,
+} from '@nrwl/workspace/src/utilities/fileutils';
+import { chmodSync } from 'fs-extra';
+import { NormalizedBuilderOptions } from './models';
+
+export default function addCliWrapper(
+  options: NormalizedBuilderOptions,
+  context: ExecutorContext
+) {
+  const packageJson = readJsonFile(`${options.outputPath}/package.json`);
+
+  const binFile = `${options.outputPath}/index.bin.js`;
+  writeToFile(
+    binFile,
+    `#!/usr/bin/env node
+'use strict';
+
+require('${packageJson.main}');
+`
+  );
+
+  chmodSync(binFile, '755'); // Make the command-line file executable
+
+  packageJson.bin = {
+    [context.projectName]: './index.bin.js',
+  };
+  writeJsonFile(`${options.outputPath}/package.json`, packageJson);
+}

--- a/packages/node/src/executors/package/utils/models.ts
+++ b/packages/node/src/executors/package/utils/models.ts
@@ -10,6 +10,7 @@ export interface NodePackageBuilderOptions {
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
   srcRootForCompilationRoot?: string;
   deleteOutputPath: boolean;
+  cli?: boolean;
 }
 
 export interface NormalizedBuilderOptions extends NodePackageBuilderOptions {

--- a/packages/node/src/executors/package/utils/normalize-options.ts
+++ b/packages/node/src/executors/package/utils/normalize-options.ts
@@ -1,4 +1,4 @@
-import { ExecutorContext } from '@nrwl/devkit';
+import { ExecutorContext, normalizePath } from '@nrwl/devkit';
 
 import * as glob from 'glob';
 import { basename, dirname, join, relative } from 'path';
@@ -50,7 +50,10 @@ export default function normalizeOptions(
   const rootDir = libRoot || '';
   const mainFileDir = dirname(options.main);
 
-  const relativeMainFileOutput = relative(rootDir, mainFileDir);
+  // Always include a preceding dot to match format used for entry points
+  const relativeMainFileOutput = `./${normalizePath(
+    relative(rootDir, mainFileDir)
+  )}`;
 
   if (options.buildableProjectDepsInPackageJsonType == undefined) {
     options.buildableProjectDepsInPackageJsonType = 'dependencies';

--- a/packages/node/src/executors/package/utils/update-package-json.ts
+++ b/packages/node/src/executors/package/utils/update-package-json.ts
@@ -1,4 +1,4 @@
-import { ExecutorContext, normalizePath } from '@nrwl/devkit';
+import { ExecutorContext } from '@nrwl/devkit';
 
 import {
   readJsonFile,
@@ -16,12 +16,7 @@ export default function updatePackageJson(
   const mainJsFile = `${mainFile}.js`;
   const packageJson = readJsonFile(join(context.root, options.packageJson));
 
-  packageJson.main = normalizePath(
-    `${options.relativeMainFileOutput}/${mainJsFile}`
-  );
-  packageJson.typings = normalizePath(
-    `${options.relativeMainFileOutput}/${typingsFile}`
-  );
-
+  packageJson.main = `${options.relativeMainFileOutput}/${mainJsFile}`;
+  packageJson.typings = `${options.relativeMainFileOutput}/${typingsFile}`;
   writeJsonFile(`${options.outputPath}/package.json`, packageJson);
 }


### PR DESCRIPTION
Will create a simple CLI wrapper for a publishable library, configures package.json's "bin" field to point to it and change it to executable. Can be useful for Nx release process also 😄 