### PR TITLE
feat(misc): add debugger panel to dep-graph client

### DIFF
--- a/dep-graph/dep-graph-e2e/src/integration/app.spec.ts
+++ b/dep-graph/dep-graph-e2e/src/integration/app.spec.ts
@@ -11,7 +11,10 @@ import {
 } from '../support/app.po';
 
 describe('dep-graph-client', () => {
-  beforeEach(() => cy.visit('/'));
+  beforeEach(() => {
+    cy.visit('/');
+    cy.get('[data-cy=project-select]').select('Medium');
+  });
 
   it('should display message to select projects', () => {
     getSelectProjectsMessage().should('be.visible');

--- a/dep-graph/dep-graph/src/app/app.ts
+++ b/dep-graph/dep-graph/src/app/app.ts
@@ -1,39 +1,104 @@
-import { combineLatest, fromEvent } from 'rxjs';
-import { startWith } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, fromEvent, Subject } from 'rxjs';
+import { startWith, takeUntil } from 'rxjs/operators';
+import { projectGraphs } from '../graphs';
+import { DebuggerPanel } from './debugger-panel';
 import { GraphComponent } from './graph';
 import { GraphTooltipService } from './tooltip-service';
 import { SidebarComponent } from './ui-sidebar/sidebar';
 
+export interface AppConfig {
+  showDebugger: boolean;
+}
+
+const DEFAULT_CONFIG: AppConfig = {
+  showDebugger: false,
+};
 export class AppComponent {
   private sidebar: SidebarComponent;
   private tooltipService = new GraphTooltipService();
   private graph = new GraphComponent(this.tooltipService);
+  private debuggerPanel: DebuggerPanel;
 
   private windowResize$ = fromEvent(window, 'resize').pipe(startWith({}));
+  private render$ = new Subject<void>();
 
-  constructor() {
+  constructor(private config: AppConfig = DEFAULT_CONFIG) {
+    this.render$.subscribe(() => this.render());
+    this.render$.next();
+  }
+
+  private onProjectGraphChange(projectGraphId: string) {
+    const projectGraph = projectGraphs.find(
+      (graph) => graph.id === projectGraphId
+    )?.graph;
+
+    const nodes = Object.values(projectGraph.nodes).filter(
+      (node) => node.type !== 'npm'
+    );
+
+    window.projects = nodes;
+    window.graph = projectGraph;
+    window.affected = [];
+    window.exclude = [];
+    window.focusedProject = null;
+    window.projectGraphList = projectGraphs;
+    window.selectedProjectGraph = projectGraphId;
+
+    this.render();
+  }
+
+  private render() {
+    const debuggerPanelContainer = document.getElementById('debugger-panel');
+
+    if (this.config.showDebugger) {
+      debuggerPanelContainer.hidden = false;
+      debuggerPanelContainer.style.display = 'flex';
+
+      this.debuggerPanel = new DebuggerPanel(
+        debuggerPanelContainer,
+        window.projectGraphList
+      );
+
+      this.debuggerPanel.selectProject$.subscribe((id) => {
+        this.onProjectGraphChange(id);
+      });
+    }
+
     this.graph.projectGraph = window.graph;
     const affectedProjects = window.affected.filter(
       (affectedProjectName) => !affectedProjectName.startsWith('npm:')
     );
 
     this.graph.affectedProjects = affectedProjects;
-    this.sidebar = new SidebarComponent(affectedProjects);
+    this.sidebar = new SidebarComponent(
+      affectedProjects,
+      this.config.showDebugger
+    );
 
     combineLatest([
       this.sidebar.selectedProjectsChanged$,
       this.sidebar.groupByFolderChanged$,
       this.windowResize$,
-    ]).subscribe(([selectedProjectNames, groupByFolder]) => {
-      const selectedProjects = [];
+    ])
+      .pipe(takeUntil(this.render$))
+      .subscribe(([selectedProjectNames, groupByFolder]) => {
+        const selectedProjects = [];
 
-      selectedProjectNames.forEach((projectName) => {
-        if (window.graph.nodes[projectName]) {
-          selectedProjects.push(window.graph.nodes[projectName]);
-        }
+        selectedProjectNames.forEach((projectName) => {
+          if (window.graph.nodes[projectName]) {
+            selectedProjects.push(window.graph.nodes[projectName]);
+          }
+        });
+
+        this.graph.render(selectedProjects, groupByFolder);
       });
 
-      this.graph.render(selectedProjects, groupByFolder);
-    });
+    if (this.debuggerPanel) {
+      this.graph.renderTimes$
+        .pipe(takeUntil(this.render$))
+        .subscribe(
+          (renderTime) => (this.debuggerPanel.renderTime = renderTime)
+        );
+    }
   }
 }

--- a/dep-graph/dep-graph/src/app/debugger-panel.ts
+++ b/dep-graph/dep-graph/src/app/debugger-panel.ts
@@ -1,0 +1,54 @@
+import { Subject } from 'rxjs';
+import { ProjectGraphList } from '../graphs';
+import { GraphPerfReport } from './graph';
+import { removeChildrenFromContainer } from './util';
+
+export class DebuggerPanel {
+  set renderTime(renderTime: GraphPerfReport) {
+    this.renderReportElement.innerText = `Last render took ${renderTime.renderTime} milliseconds for ${renderTime.numNodes} nodes and ${renderTime.numEdges} edges.`;
+  }
+
+  private selectProjectSubject = new Subject<string>();
+
+  selectProject$ = this.selectProjectSubject.asObservable();
+
+  private renderReportElement: HTMLElement;
+
+  constructor(
+    private container: HTMLElement,
+    private projectGraphs: ProjectGraphList[]
+  ) {
+    this.render();
+  }
+
+  private render() {
+    removeChildrenFromContainer(this.container);
+
+    const header = document.createElement('h4');
+    header.innerText = `Debugger`;
+
+    const select = document.createElement('select');
+
+    this.projectGraphs.forEach((projectGraph) => {
+      const option = document.createElement('option');
+      option.value = projectGraph.id;
+      option.innerText = projectGraph.label;
+
+      select.appendChild(option);
+    });
+
+    select.value = window.selectedProjectGraph;
+    select.dataset['cy'] = 'project-select';
+
+    select.onchange = (event) =>
+      this.selectProjectSubject.next(
+        (event.currentTarget as HTMLSelectElement).value
+      );
+
+    this.renderReportElement = document.createElement('p');
+
+    this.container.appendChild(header);
+    this.container.appendChild(select);
+    this.container.appendChild(this.renderReportElement);
+  }
+}

--- a/dep-graph/dep-graph/src/app/project-node-tooltip.ts
+++ b/dep-graph/dep-graph/src/app/project-node-tooltip.ts
@@ -33,7 +33,9 @@ export class ProjectNodeToolTip {
   private createTags() {
     const wrapper = document.createElement('p');
     const tagLabel = document.createElement('strong');
-    const tags = document.createTextNode(this.node.attr('tags').join(', '));
+    const tags = document.createTextNode(
+      this.node.attr('tags')?.join(', ') ?? ''
+    );
 
     tagLabel.innerText = 'tags';
 

--- a/dep-graph/dep-graph/src/app/ui-sidebar/display-options-panel.ts
+++ b/dep-graph/dep-graph/src/app/ui-sidebar/display-options-panel.ts
@@ -1,4 +1,5 @@
 import { Subject } from 'rxjs';
+import { removeChildrenFromContainer } from '../util';
 
 export class DisplayOptionsPanel {
   private showAffected = false;
@@ -19,6 +20,8 @@ export class DisplayOptionsPanel {
   }
 
   render(container: HTMLElement) {
+    removeChildrenFromContainer(container);
+
     const header = document.createElement('h4');
     header.innerText = 'Display Options';
 

--- a/dep-graph/dep-graph/src/app/ui-sidebar/focused-project-panel.ts
+++ b/dep-graph/dep-graph/src/app/ui-sidebar/focused-project-panel.ts
@@ -1,9 +1,8 @@
 import { Subject } from 'rxjs';
+import { removeChildrenFromContainer } from '../util';
 
 export class FocusedProjectPanel {
   private unfocusSubject = new Subject<void>();
-  private header: HTMLHeadingElement;
-  private unfocusButton: HTMLButtonElement;
 
   set projectName(projectName: string) {
     this.render(projectName);
@@ -16,28 +15,24 @@ export class FocusedProjectPanel {
   }
 
   private render(projectName?: string) {
-    if (!this.header) {
-      this.header = document.createElement('h4');
-      this.container.appendChild(this.header);
-    }
+    removeChildrenFromContainer(this.container);
+
+    const header = document.createElement('h4');
+    this.container.appendChild(header);
 
     if (projectName && projectName !== '') {
-      this.header.innerText = `Focused on ${projectName}`;
+      header.innerText = `Focused on ${projectName}`;
       this.container.hidden = false;
     } else {
       this.container.hidden = true;
     }
 
-    if (!this.unfocusButton) {
-      this.unfocusButton = document.createElement('button');
-      this.unfocusButton.innerText = 'Unfocus';
+    const unfocusButton = document.createElement('button');
+    unfocusButton.innerText = 'Unfocus';
 
-      this.unfocusButton.dataset['cy'] = 'unfocusButton';
+    unfocusButton.dataset['cy'] = 'unfocusButton';
 
-      this.unfocusButton.addEventListener('click', () =>
-        this.unfocusSubject.next()
-      );
-      this.container.appendChild(this.unfocusButton);
-    }
+    unfocusButton.addEventListener('click', () => this.unfocusSubject.next());
+    this.container.appendChild(unfocusButton);
   }
 }

--- a/dep-graph/dep-graph/src/app/ui-sidebar/project-list.ts
+++ b/dep-graph/dep-graph/src/app/ui-sidebar/project-list.ts
@@ -1,5 +1,6 @@
 import { ProjectGraphNode } from '@nrwl/workspace';
 import { Subject } from 'rxjs';
+import { removeChildrenFromContainer } from '../util';
 
 export class ProjectList {
   private focusProjectSubject = new Subject<string>();
@@ -47,6 +48,8 @@ export class ProjectList {
   }
 
   private render() {
+    removeChildrenFromContainer(this.container);
+
     const appProjects = this.getProjectsByType('app');
     const libProjects = this.getProjectsByType('lib');
     const e2eProjects = this.getProjectsByType('e2e');

--- a/dep-graph/dep-graph/src/app/ui-sidebar/sidebar.ts
+++ b/dep-graph/dep-graph/src/app/ui-sidebar/sidebar.ts
@@ -21,7 +21,7 @@ export class SidebarComponent {
   private groupByFolder = window.groupByFolder;
   private selectedProjects: string[] = [];
 
-  constructor(private affectedProjects: string[]) {
+  constructor(private affectedProjects: string[], showDebugger: boolean) {
     const showAffected = this.affectedProjects.length > 0;
 
     const displayOptionsPanelContainer = document.getElementById(

--- a/dep-graph/dep-graph/src/app/ui-sidebar/text-filter-panel.ts
+++ b/dep-graph/dep-graph/src/app/ui-sidebar/text-filter-panel.ts
@@ -1,4 +1,5 @@
 import { Subject } from 'rxjs';
+import { removeChildrenFromContainer } from '../util';
 
 export interface TextFilterChangeEvent {
   text: string;
@@ -24,6 +25,8 @@ export class TextFilterPanel {
   }
 
   private render() {
+    removeChildrenFromContainer(this.container);
+
     const inputContainer = document.createElement('div');
     inputContainer.classList.add('flex');
 

--- a/dep-graph/dep-graph/src/app/util.ts
+++ b/dep-graph/dep-graph/src/app/util.ts
@@ -1,0 +1,5 @@
+export function removeChildrenFromContainer(container: HTMLElement) {
+  Array.from(container.children).forEach((child) =>
+    container.removeChild(child)
+  );
+}

--- a/dep-graph/dep-graph/src/environments/environment.prod.ts
+++ b/dep-graph/dep-graph/src/environments/environment.prod.ts
@@ -1,3 +1,0 @@
-export const environment = {
-  production: true,
-};

--- a/dep-graph/dep-graph/src/environments/environment.release.ts
+++ b/dep-graph/dep-graph/src/environments/environment.release.ts
@@ -1,0 +1,8 @@
+import { AppConfig } from '../app/app';
+
+export const environment: { release: boolean; appConfig: AppConfig } = {
+  release: true,
+  appConfig: {
+    showDebugger: false,
+  },
+};

--- a/dep-graph/dep-graph/src/environments/environment.ts
+++ b/dep-graph/dep-graph/src/environments/environment.ts
@@ -1,6 +1,11 @@
 // This file can be replaced during build by using the `fileReplacements` array.
 // When building for production, this file is replaced with `environment.prod.ts`.
 
-export const environment = {
-  production: false,
+import { AppConfig } from '../app/app';
+
+export const environment: { release: boolean; appConfig: AppConfig } = {
+  release: false,
+  appConfig: {
+    showDebugger: true,
+  },
 };

--- a/dep-graph/dep-graph/src/globals.d.ts
+++ b/dep-graph/dep-graph/src/globals.d.ts
@@ -1,4 +1,5 @@
 import { ProjectGraph, ProjectGraphNode } from '@nrwl/workspace';
+import { ProjectGraphList } from './graphs';
 
 export declare global {
   export interface Window {
@@ -11,6 +12,8 @@ export declare global {
     groupByFolder: boolean;
     focusProject: Function;
     excludeProject: Function;
+    projectGraphList: ProjectGraphList[];
+    selectedProjectGraph: string;
   }
 }
 

--- a/dep-graph/dep-graph/src/graphs/index.ts
+++ b/dep-graph/dep-graph/src/graphs/index.ts
@@ -1,0 +1,28 @@
+import { ProjectGraphCache } from '@nrwl/workspace';
+import { mediumGraph } from './medium';
+import { smallGraph } from './small';
+import { subAppsGraph } from './sub-apps';
+
+export interface ProjectGraphList {
+  id: string;
+  label: string;
+  graph: ProjectGraphCache;
+}
+
+export const projectGraphs: ProjectGraphList[] = [
+  {
+    id: 'small',
+    label: 'Small',
+    graph: smallGraph,
+  },
+  {
+    id: 'medium',
+    label: 'Medium',
+    graph: mediumGraph,
+  },
+  {
+    id: 'sub-apps',
+    label: 'Sub Apps',
+    graph: subAppsGraph,
+  },
+];

--- a/dep-graph/dep-graph/src/graphs/sub-apps.ts
+++ b/dep-graph/dep-graph/src/graphs/sub-apps.ts
@@ -1,6 +1,6 @@
 import { ProjectGraphCache } from '@nrwl/workspace';
 
-export const graph: ProjectGraphCache = {
+export const subAppsGraph: ProjectGraphCache = {
   version: '2.0',
   rootFiles: [
     {

--- a/dep-graph/dep-graph/src/index.html
+++ b/dep-graph/dep-graph/src/index.html
@@ -44,6 +44,7 @@
     </div>
 
     <div id="main-content">
+      <div id="debugger-panel" hidden></div>
       <div id="no-projects-chosen">
         <h4>Please select projects in the sidebar.</h4>
       </div>
@@ -52,12 +53,12 @@
   </div>
 
   <script>
-    window.projects = null;
-    window.graph = null;
-    window.affected = null;
+    window.projects = [];
+    window.graph = {};
+    window.affected = [];
     window.focusedProject = null;
     window.filteredProjects = [];
-    window.groupByFolder = null;
-    window.exclude = null;
+    window.groupByFolder = false;
+    window.exclude = [];
   </script>
 </body>

--- a/dep-graph/dep-graph/src/main.release.ts
+++ b/dep-graph/dep-graph/src/main.release.ts
@@ -1,3 +1,0 @@
-import { AppComponent } from './app/app';
-
-setTimeout(() => new AppComponent());

--- a/dep-graph/dep-graph/src/main.ts
+++ b/dep-graph/dep-graph/src/main.ts
@@ -1,15 +1,20 @@
 import { AppComponent } from './app/app';
-import { mediumGraph } from './graphs/medium';
+import { environment } from './environments/environment';
+import { projectGraphs } from './graphs';
+import { smallGraph } from './graphs/small';
 
-const currentGraph = mediumGraph;
+if (!environment.release) {
+  const currentGraph = smallGraph;
 
-const nodes = Object.values(currentGraph.nodes).filter(
-  (node) => node.type !== 'npm'
-);
+  const nodes = Object.values(currentGraph.nodes).filter(
+    (node) => node.type !== 'npm'
+  );
 
-window.projects = nodes;
-window.graph = currentGraph;
-window.affected = [];
-window.exclude = [];
-
-setTimeout(() => new AppComponent());
+  window.projects = nodes;
+  window.graph = currentGraph;
+  window.affected = [];
+  window.exclude = [];
+  window.projectGraphList = projectGraphs;
+  window.selectedProjectGraph = projectGraphs[0].id;
+}
+setTimeout(() => new AppComponent(environment.appConfig));

--- a/dep-graph/dep-graph/src/styles.scss
+++ b/dep-graph/dep-graph/src/styles.scss
@@ -123,6 +123,22 @@ h5 {
   overflow: hidden;
 }
 
+#debugger-panel {
+  display: none;
+  width: 100%;
+  background-color: var(--color-nrwl-light-blue);
+  padding: 1.5em;
+  align-items: baseline;
+
+  & > * {
+    margin-right: 1em;
+  }
+
+  p {
+    margin: 0;
+  }
+}
+
 #apps,
 #libs,
 #e2e {

--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -46,20 +46,20 @@ function projectsToHtml(
 
   f = f
     .replace(
-      `window.projects = null`,
+      `window.projects = []`,
       `window.projects = ${JSON.stringify(projects)}`
     )
-    .replace(`window.graph = null`, `window.graph = ${JSON.stringify(graph)}`)
+    .replace(`window.graph = {}`, `window.graph = ${JSON.stringify(graph)}`)
     .replace(
-      `window.affected = null`,
+      `window.affected = []`,
       `window.affected = ${JSON.stringify(affected)}`
     )
     .replace(
-      `window.groupByFolder = null`,
+      `window.groupByFolder = false`,
       `window.groupByFolder = ${!!groupByFolder}`
     )
     .replace(
-      `window.exclude = null`,
+      `window.exclude = []`,
       `window.exclude = ${JSON.stringify(exclude)}`
     );
 

--- a/workspace.json
+++ b/workspace.json
@@ -2059,8 +2059,8 @@
             "release": {
               "fileReplacements": [
                 {
-                  "replace": "dep-graph/dep-graph/src/main.ts",
-                  "with": "dep-graph/dep-graph/src/main.release.ts"
+                  "replace": "dep-graph/dep-graph/src/environments/environment.ts",
+                  "with": "dep-graph/dep-graph/src/environments/environment.release.ts"
                 }
               ],
               "optimization": true,


### PR DESCRIPTION
## Current Behavior
There is no built-in, repeatable way to measure performance changes on the dep-graph visualization.
It's difficult to test dep-graph visualizations on multiple graphs.

## Expected Behavior
The debugger panel offers measurements of render times, as well as the option to switch between different graphs in-browser.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
