### PR TITLE
feat(angular): add buildTarget to webpack-browser builder

### DIFF
--- a/docs/angular/api-angular/executors/webpack-browser.md
+++ b/docs/angular/api-angular/executors/webpack-browser.md
@@ -46,6 +46,12 @@ Type: `boolean`
 
 Enables '@angular-devkit/build-optimizer' optimizations when using the 'aot' option.
 
+### buildTarget
+
+Type: `string`
+
+Build target used for building the app after its dependencies have been built. If no target is configured, @angular-devkit/build-angular:browser is sheduled directly.
+
 ### commonChunk
 
 Default: `true`

--- a/docs/node/api-angular/executors/webpack-browser.md
+++ b/docs/node/api-angular/executors/webpack-browser.md
@@ -47,6 +47,12 @@ Type: `boolean`
 
 Enables '@angular-devkit/build-optimizer' optimizations when using the 'aot' option.
 
+### buildTarget
+
+Type: `string`
+
+Build target used for building the app after its dependencies have been built. If no target is configured, @angular-devkit/build-angular:browser is sheduled directly.
+
 ### commonChunk
 
 Default: `true`

--- a/docs/react/api-angular/executors/webpack-browser.md
+++ b/docs/react/api-angular/executors/webpack-browser.md
@@ -47,6 +47,12 @@ Type: `boolean`
 
 Enables '@angular-devkit/build-optimizer' optimizations when using the 'aot' option.
 
+### buildTarget
+
+Type: `string`
+
+Build target used for building the app after its dependencies have been built. If no target is configured, @angular-devkit/build-angular:browser is sheduled directly.
+
 ### commonChunk
 
 Default: `true`

--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -4,6 +4,10 @@
   "description": "Browser target options",
   "type": "object",
   "properties": {
+    "buildTarget": {
+      "description": "Build target used for building the app after its dependencies have been built. If no target is configured, @angular-devkit/build-angular:browser is sheduled directly.",
+      "type": "string"
+    },
     "assets": {
       "type": "array",
       "description": "List of static application assets.",

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -1,7 +1,9 @@
 import {
   BuilderContext,
   BuilderOutput,
+  BuilderRun,
   createBuilder,
+  targetFromTargetString,
 } from '@angular-devkit/architect';
 import { JsonObject } from '@angular-devkit/core';
 import { from, Observable, of } from 'rxjs';
@@ -12,11 +14,40 @@ import {
 } from '@nrwl/workspace/src/utils/buildable-libs-utils';
 import { join } from 'path';
 import { createProjectGraph } from '@nrwl/workspace/src/core/project-graph';
-import { Schema as BrowserBuilderSchema } from '@angular-devkit/build-angular/src/browser/schema';
+import { Schema } from '@angular-devkit/build-angular/src/browser/schema';
 import { switchMap } from 'rxjs/operators';
 
+type BrowserBuilderSchema = Schema &
+  JsonObject & {
+    buildTarget: string;
+  };
+
+function buildApp(
+  options: BrowserBuilderSchema,
+  context: BuilderContext
+): Promise<BuilderRun> {
+  const { buildTarget, ...delegateOptions } = options;
+
+  if (buildTarget) {
+    const target = targetFromTargetString(buildTarget);
+    return context.scheduleTarget(target, delegateOptions, {
+      target: context.target,
+      logger: context.logger as any,
+    });
+  } else {
+    return context.scheduleBuilder(
+      '@angular-devkit/build-angular:browser',
+      delegateOptions,
+      {
+        target: context.target,
+        logger: context.logger as any,
+      }
+    );
+  }
+}
+
 function run(
-  options: BrowserBuilderSchema & JsonObject,
+  options: BrowserBuilderSchema,
   context: BuilderContext
 ): Observable<BuilderOutput> {
   const projGraph = createProjectGraph();
@@ -36,16 +67,9 @@ function run(
   return of(checkDependentProjectsHaveBeenBuilt(context, dependencies)).pipe(
     switchMap((result) => {
       if (result) {
-        return from(
-          context.scheduleBuilder(
-            '@angular-devkit/build-angular:browser',
-            options,
-            {
-              target: context.target,
-              logger: context.logger as any,
-            }
-          )
-        ).pipe(switchMap((x) => x.result));
+        return from(buildApp(options, context)).pipe(
+          switchMap((x) => x.result)
+        );
       } else {
         // just pass on the result
         return of({ success: false });


### PR DESCRIPTION
Before, the webpack-browser builder always directly scheduled
@angular-devkit/build-angular:browser. Now, one can configure an
optional buildTarget that is scheduled instead. If this option
is not used, the former behavior -- directly scheduling
@angular-devkit/build-angular:browser -- takes place.
