### PR TITLE
fix(web): support isServer flag in babel

### DIFF
--- a/packages/web/babel.ts
+++ b/packages/web/babel.ts
@@ -16,6 +16,8 @@ module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
   api.assertVersion(7);
 
   const isModern = api.caller((caller) => caller?.isModern);
+  // `isServer` is passed from `next-babel-loader`, when it compiles for the server
+  const isServer = api.caller((caller) => caller?.isServer);
   const emitDecoratorMetadata = api.caller(
     (caller) => caller?.emitDecoratorMetadata ?? true
   );
@@ -28,7 +30,7 @@ module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
         // For Jest tests, NODE_ENV is set as 'test' and we only want to set target as Node.
         // All other options will fail in Jest since Node does not support some ES features
         // such as import syntax.
-        process.env.NODE_ENV === 'test'
+        isServer || process.env.NODE_ENV === 'test'
           ? { targets: { node: 'current' } }
           : {
               // Allow importing core-js in entrypoint and use browserlist to select polyfills.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Node libs (`@nrwl/node:lib`) are generated with a `@nrwl/web/babel` preset in its `.babelrc` file. But unfortunately that may result in a node lib not being compatible with Next.js. 

More specifically, if a node lib is used in server-side Next.js logic, *and* contains features that require transpilation - the lib is currently transpiled with an incorrect target (non node):

the `isServer` flag is passed from the caller, this is what [Next.js does internally](https://github.com/vercel/next.js/blob/canary/packages/next/build/babel/preset.ts#L66).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Node libs should be compatible and fully working inside Next.js server-side logic

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5063 
