### PR TITLE
fix(misc): correcting link in incremental-builds.md

### DIFF
--- a/docs/shared/incremental-builds.md
+++ b/docs/shared/incremental-builds.md
@@ -55,6 +55,6 @@ Also, using incremental builds only really makes sense when using the distribute
 
 ## Setup an incremental build
 
-- [Setup an incremental build for an Angular app](/latest/angular/ci/setup-incremental-builds-angular)
+- [Setup an incremental build for an Angular app](/angular/ci/setup-incremental-builds-angular)
 - _Setup an incremental build for a React app (soon)_
 - _Setup an incremental build for a Node app (soon)_


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Fails the internal link checking for a link in `incremental-builds.md`, which includes "/latest" in the file path. While this is not necessarily broken, it will send users to the latest version of the docs - which may not be their intent if they are looking at legacy documentation when they click the link.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Internal links do not specify a version - so as to keep users on the version they are looking at when they click the link.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
