### PR TITLE
feat(node): support `webpackConfig` as array

### DIFF
--- a/docs/angular/api-node/executors/build.md
+++ b/docs/angular/api-node/executors/build.md
@@ -156,6 +156,6 @@ Run build when files change.
 
 ### webpackConfig
 
-Type: `string`
+Type: `array[] | string `
 
 Path to a function which takes a webpack config, context and returns the resulting webpack config

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -157,6 +157,6 @@ Run build when files change.
 
 ### webpackConfig
 
-Type: `string`
+Type: `array[] | string `
 
 Path to a function which takes a webpack config, context and returns the resulting webpack config

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -157,6 +157,6 @@ Run build when files change.
 
 ### webpackConfig
 
-Type: `string`
+Type: `array[] | string `
 
 Path to a function which takes a webpack config, context and returns the resulting webpack config

--- a/packages/node/src/executors/build/build.impl.spec.ts
+++ b/packages/node/src/executors/build/build.impl.spec.ts
@@ -1,0 +1,120 @@
+import { ExecutorContext } from '@nrwl/devkit';
+import { of } from 'rxjs';
+import * as projectGraph from '@nrwl/workspace/src/core/project-graph';
+import type { ProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import buildExecutor from './build.impl';
+import { BuildNodeBuilderOptions } from '../../utils/types';
+
+jest.mock('tsconfig-paths-webpack-plugin');
+jest.mock('@nrwl/workspace/src/utilities/run-webpack', () => ({
+  runWebpack: jest.fn(),
+}));
+import { runWebpack } from '@nrwl/workspace/src/utilities/run-webpack';
+
+describe('Node Build Executor', () => {
+  let context: ExecutorContext;
+  let options: BuildNodeBuilderOptions;
+
+  beforeEach(async () => {
+    jest
+      .spyOn(projectGraph, 'createProjectGraph')
+      .mockReturnValue({} as ProjectGraph);
+
+    (<any>runWebpack).mockReturnValue(of([]));
+    context = {
+      root: '/root',
+      cwd: '/root',
+      projectName: 'my-app',
+      targetName: 'build',
+      workspace: {
+        version: 2,
+        projects: {
+          'my-app': <any>{
+            root: 'apps/wibble',
+            sourceRoot: 'apps/wibble',
+          },
+        },
+      },
+      isVerbose: false,
+    };
+    options = {
+      outputPath: 'dist/apps/wibble',
+      externalDependencies: 'all',
+      main: 'apps/wibble/src/main.ts',
+      tsConfig: 'apps/wibble/tsconfig.ts',
+      buildLibsFromSource: true,
+      fileReplacements: [],
+    };
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should call webpack', async () => {
+    await buildExecutor(options, context);
+
+    expect(runWebpack).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: {
+          filename: 'main.js',
+          libraryTarget: 'commonjs',
+          path: '/root/dist/apps/wibble',
+        },
+      })
+    );
+  });
+
+  describe('webpackConfig', () => {
+    it('sholud hanldle custom path', async () => {
+      jest.mock(
+        '/root/config.js',
+        () => (options) => ({ ...options, prop: 'my-val' }),
+        { virtual: true }
+      );
+      await buildExecutor({ ...options, webpackConfig: 'config.js' }, context);
+
+      expect(runWebpack).toHaveBeenCalledWith(
+        expect.objectContaining({
+          output: {
+            filename: 'main.js',
+            libraryTarget: 'commonjs',
+            path: '/root/dist/apps/wibble',
+          },
+          prop: 'my-val',
+        })
+      );
+    });
+
+    it('sholud hanldle multiple custom paths in order', async () => {
+      jest.mock(
+        '/root/config1.js',
+        () => (o) => ({ ...o, prop1: 'my-val-1' }),
+        { virtual: true }
+      );
+      jest.mock(
+        '/root/config2.js',
+        () => (o) => ({
+          ...o,
+          prop1: o.prop1 + '-my-val-2',
+          prop2: 'my-val-2',
+        }),
+        { virtual: true }
+      );
+      await buildExecutor(
+        { ...options, webpackConfig: ['config1.js', 'config2.js'] },
+        context
+      );
+
+      expect(runWebpack).toHaveBeenCalledWith(
+        expect.objectContaining({
+          output: {
+            filename: 'main.js',
+            libraryTarget: 'commonjs',
+            path: '/root/dist/apps/wibble',
+          },
+          prop1: 'my-val-1-my-val-2',
+          prop2: 'my-val-2',
+        })
+      );
+    });
+  });
+});

--- a/packages/node/src/executors/build/build.impl.ts
+++ b/packages/node/src/executors/build/build.impl.ts
@@ -78,13 +78,12 @@ export function buildExecutor(
   if (options.generatePackageJson) {
     generatePackageJson(context.projectName, projGraph, options);
   }
-  let config = getNodeWebpackConfig(options);
-  if (options.webpackConfig) {
-    config = require(options.webpackConfig)(config, {
+  const config = options.webpackConfig.reduce((currentConfig, plugin) => {
+    return require(plugin)(currentConfig, {
       options,
       configuration: context.configurationName,
     });
-  }
+  }, getNodeWebpackConfig(options));
 
   return eachValueFrom(
     runWebpack(config).pipe(

--- a/packages/node/src/executors/build/schema.json
+++ b/packages/node/src/executors/build/schema.json
@@ -112,7 +112,17 @@
       "default": []
     },
     "webpackConfig": {
-      "type": "string",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
       "description": "Path to a function which takes a webpack config, context and returns the resulting webpack config"
     },
     "buildLibsFromSource": {

--- a/packages/node/src/utils/normalize.spec.ts
+++ b/packages/node/src/utils/normalize.spec.ts
@@ -1,10 +1,10 @@
 import { normalizeBuildOptions } from './normalize';
-import { BuildBuilderOptions } from './types';
+import { BuildNodeBuilderOptions } from './types';
 
 import * as fs from 'fs';
 
 describe('normalizeBuildOptions', () => {
-  let testOptions: BuildBuilderOptions;
+  let testOptions: BuildNodeBuilderOptions;
   let root: string;
   let sourceRoot: string;
   let projectRoot: string;
@@ -26,6 +26,7 @@ describe('normalizeBuildOptions', () => {
       ],
       assets: [],
       statsJson: false,
+      externalDependencies: 'all',
     };
     root = '/root';
     sourceRoot = 'apps/nodeapp/src';
@@ -76,7 +77,7 @@ describe('normalizeBuildOptions', () => {
       isDirectory: () => true,
     });
     const result = normalizeBuildOptions(
-      <BuildBuilderOptions>{
+      {
         ...testOptions,
         root,
         assets: [

--- a/packages/node/src/utils/normalize.ts
+++ b/packages/node/src/utils/normalize.ts
@@ -1,5 +1,8 @@
 import { resolve, dirname, relative, basename } from 'path';
-import { BuildBuilderOptions } from './types';
+import {
+  BuildNodeBuilderOptions,
+  NormalizedBuildNodeBuilderOptions,
+} from './types';
 import { statSync } from 'fs';
 
 export interface FileReplacement {
@@ -7,12 +10,12 @@ export interface FileReplacement {
   with: string;
 }
 
-export function normalizeBuildOptions<T extends BuildBuilderOptions>(
-  options: T,
+export function normalizeBuildOptions(
+  options: BuildNodeBuilderOptions,
   root: string,
   sourceRoot: string,
   projectRoot: string
-): T {
+): NormalizedBuildNodeBuilderOptions {
   return {
     ...options,
     root,
@@ -24,8 +27,10 @@ export function normalizeBuildOptions<T extends BuildBuilderOptions>(
     fileReplacements: normalizeFileReplacements(root, options.fileReplacements),
     assets: normalizeAssets(options.assets, root, sourceRoot),
     webpackConfig: options.webpackConfig
-      ? resolve(root, options.webpackConfig)
-      : options.webpackConfig,
+      ? []
+          .concat(options.webpackConfig)
+          .map((path) => normalizePluginPath(path, root))
+      : [],
   };
 }
 
@@ -34,6 +39,9 @@ function normalizeAssets(
   root: string,
   sourceRoot: string
 ): any[] {
+  if (!Array.isArray(assets)) {
+    return [];
+  }
   return assets.map((asset) => {
     if (typeof asset === 'string') {
       const resolvedAssetPath = resolve(root, asset);
@@ -82,4 +90,12 @@ function normalizeFileReplacements(
     replace: resolve(root, fileReplacement.replace),
     with: resolve(root, fileReplacement.with),
   }));
+}
+
+function normalizePluginPath(path: string, root: string) {
+  try {
+    return require.resolve(path);
+  } catch {
+    return resolve(root, path);
+  }
 }

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -35,7 +35,7 @@ export interface BuildBuilderOptions {
   extractLicenses?: boolean;
   verbose?: boolean;
 
-  webpackConfig?: string;
+  webpackConfig?: string | string[];
 
   root?: string;
   sourceRoot?: string;
@@ -48,4 +48,9 @@ export interface BuildNodeBuilderOptions extends BuildBuilderOptions {
   externalDependencies: 'all' | 'none' | string[];
   buildLibsFromSource?: boolean;
   generatePackageJson?: boolean;
+}
+
+export interface NormalizedBuildNodeBuilderOptions
+  extends BuildNodeBuilderOptions {
+  webpackConfig: string[];
 }


### PR DESCRIPTION
This way we (or other community authors) can create more targeted/custom plugins and optimizations, that users can choose and plug, in order to match their needs, without to match hassle.

## Current Behavior
Support customization using a single file in user's workspace.

## Expected Behavior
Support single and/or multiple files for customization in user's workspace and/or npm plugins .

