### PR TITLE
chore(core): Add Webpack and webpack-dev-server to workspace dependencies

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -77,6 +77,8 @@
     "minimatch": "3.0.4",
     "inquirer": "^6.3.1",
     "resolve": "1.17.0",
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.0",
+    "webpack": "4.42.0",
+    "webpack-dev-server": "3.11.0"
   }
 }


### PR DESCRIPTION
This PR adds `webpack` and `webpack-dev-server` to `workspace` as dependencies, since they are used in the `run-webpack` utility.


Fixes #5169 
