### PR TITLE
fix(repo): allowing wildcard {{version}} links to pass

### DIFF
--- a/scripts/documentation/internal-link-checker.ts
+++ b/scripts/documentation/internal-link-checker.ts
@@ -91,6 +91,8 @@ function extractAllInternalLinks(): Record<string, string[]> {
       .filter(isNotNxCommunityLink)
       // `/latest/{{framework}}/...` are valid links too but we need to strip the version
       .map((x) => x.replace(/^\/latest/, ''))
+      // `/{{ version }}/...` are valid links as well
+      .map((x) => x.replace(/^\/{{version}}/, ''))
       .map(removeAnchors);
     if (links.length) {
       acc[path] = expandFrameworks(links);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Internal link checking script would fail if a documentation file contained a link that started with `{{version}}`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This should pass the link checking script.
(@bcabanes will be reworking documentation routing strategy as part of docs site migration to Next.)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
