### PR TITLE
fix(core): throw an error if implicit dependency is a string that is …

### DIFF
--- a/packages/workspace/src/core/assert-workspace-validity.spec.ts
+++ b/packages/workspace/src/core/assert-workspace-validity.spec.ts
@@ -7,6 +7,9 @@ describe('assertWorkspaceValidity', () => {
 
   beforeEach(() => {
     mockNxJson = {
+      implicitDependencies: {
+        'nx.json': '*',
+      },
       projects: {
         app1: {
           tags: [],
@@ -122,6 +125,25 @@ describe('assertWorkspaceValidity', () => {
         `The following implicitDependencies specified in nx.json are invalid:
     app2
         invalidproj`,
+      ],
+    });
+    mockExit.mockRestore();
+  });
+
+  it('should throw for a project-level implicit dependency that is a string', () => {
+    spyOn(output, 'error');
+    mockNxJson.implicitDependencies['nx.json'] = 'invalidproj';
+
+    const mockExit = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {}) as any);
+    assertWorkspaceValidity(mockWorkspaceJson, mockNxJson);
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(output.error).toHaveBeenCalledWith({
+      title: 'Configuration Error',
+      bodyLines: [
+        'nx.json is not configured properly. "nx.json" is improperly configured to implicitly depend on "invalidproj" but should be an array of project names or "*".',
       ],
     });
     mockExit.mockRestore();


### PR DESCRIPTION
…not '*'

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If an `implicitDependency` is set to a `string`, the workspace-validity check exceeds the maximum call stack.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

If an `implicitDependency` is set to a `string`, the workspace-validity check throws an error.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/5173
