### PR TITLE
feat(repo): validating PR titles with github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,9 +89,6 @@ jobs:
           name: Run linting
           command: yarn lint
       - run:
-          name: Check Commit Message Format
-          command: yarn check-commit
-      - run:
           name: Check Package dependencies
           command: yarn depcheck
   e2e:

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,43 @@
+name: "Validate PR Title"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  pr_title_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v3.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: true
+          types: |
+            feat
+            fix
+            docs
+            cleanup
+            chore
+          scopes: |
+            angular
+            core
+            nxdev
+            nextjs
+            gatsby
+            nest
+            node
+            express
+            nx-plugin
+            react
+            web
+            linter
+            storybook
+            testing
+            repo
+            misc
+            devkit
+          requireScope: true
+        # Default: https://github.com/commitizen/conventional-commit-types

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Please follow the following guidelines:
 - Make sure you run `yarn format`
 - Update documentation with `yarn documentation`. For documentation, check for spelling and grammatical errors.
 - Update your commit message to follow the guidelines below (use `yarn commit` to automate compliance)
-  - `yarn check-commit` will check to make sure your commit messages are formatted correctly
+  - Github actions will check your commit/PR title when you submit your PR to make sure that your commit message is formatted correctly once you submit your PR. If you'd like to check your last commit manually, you can do so via the command: `yarn check-commit`.
 
 #### Commit Message Guidelines
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Using husky to validate commit messages on a pre-commit hook.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
+ Use github action to validate PR title.
+ NOTE: I'm not familiar enough with our release workflow to know if this PR removes too much (may still need our `lint-commit.js` script)
+ NOTE: Ideally, we'd enforce only squash and merging to ensure commit titles are always valid (rebase and merge or merge will not have their individual commit messages validated). Can enable via nrwl/nx > Settings > Merge Button > only select Squash and Merge

<img width="1193" alt="Screen Shot 2021-03-30 at 9 36 16 PM" src="https://user-images.githubusercontent.com/3788405/113091084-07684180-91a0-11eb-8d65-fac8e62dc61b.png">

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
