### PR TITLE
fix(storybook): read package version from node_modules

### DIFF
--- a/packages/storybook/src/executors/utils.ts
+++ b/packages/storybook/src/executors/utils.ts
@@ -1,6 +1,6 @@
 import { ExecutorContext } from '@nrwl/devkit';
-import { readPackageJson } from '@nrwl/workspace/src/core/file-utils';
 import { gte } from 'semver';
+import { join } from 'path';
 
 export interface NodePackage {
   name: string;
@@ -21,19 +21,10 @@ export function getStorybookFrameworkPath(uiFramework) {
 }
 
 function isStorybookV62onwards(uiFramework) {
-  const packageJsonContents = readPackageJson();
-  packageJsonContents.dependencies = packageJsonContents.dependencies || {};
-  packageJsonContents.devDependencies =
-    packageJsonContents.devDependencies || {};
+  const storybookPackageVersion = require(join(uiFramework, 'package.json'))
+    .version;
 
-  const storybookPackageVersion =
-    packageJsonContents.dependencies[uiFramework] ||
-    packageJsonContents.devDependencies[uiFramework];
-
-  return gte(
-    (storybookPackageVersion || '').replace('~', '').replace('^', ''),
-    '6.2.0-rc.4'
-  );
+  return gte(storybookPackageVersion, '6.2.0-rc.4');
 }
 
 // see: https://github.com/storybookjs/storybook/pull/12565


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The version of `@storybook` framework is read from `package.json` in the workspace  and strips out `^` which could cause the version to go above `6.2`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The version of `@storybook` framework is read from the `package.json` in the installed `node_module`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/5100
