### PR TITLE
fix(misc): pass in specific copy of webpack

### DIFF
--- a/packages/node/src/executors/build/build.impl.ts
+++ b/packages/node/src/executors/build/build.impl.ts
@@ -7,6 +7,7 @@ import {
   createTmpTsConfig,
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import { runWebpack } from '@nrwl/workspace/src/utilities/run-webpack';
+import * as webpack from 'webpack';
 
 import { map, tap } from 'rxjs/operators';
 import { eachValueFrom } from 'rxjs-for-await';
@@ -87,7 +88,7 @@ export function buildExecutor(
   }
 
   return eachValueFrom(
-    runWebpack(config).pipe(
+    runWebpack(config, webpack).pipe(
       tap((stats) => {
         console.info(stats.toString(config.stats));
       }),

--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -167,7 +167,7 @@ export function run(options: WebBuildBuilderOptions, context: ExecutorContext) {
       mergeScan(
         (acc, config) => {
           if (!acc.hasErrors()) {
-            return runWebpack(config).pipe(
+            return runWebpack(config, webpack).pipe(
               tap((stats) => {
                 console.info(stats.toString(config.stats));
               })

--- a/packages/web/src/builders/dev-server/dev-server.impl.ts
+++ b/packages/web/src/builders/dev-server/dev-server.impl.ts
@@ -7,6 +7,8 @@ import { Configuration } from 'webpack';
 
 import { eachValueFrom } from 'rxjs-for-await';
 import { map, tap } from 'rxjs/operators';
+import * as webpack from 'webpack';
+import * as WebpackDevServer from 'webpack-dev-server';
 import {
   getEmittedFiles,
   runWebpackDevServer,
@@ -58,7 +60,7 @@ export default function devServerExecutor(
   }
 
   return eachValueFrom(
-    runWebpackDevServer(webpackConfig).pipe(
+    runWebpackDevServer(webpackConfig, webpack, WebpackDevServer).pipe(
       tap(({ stats }) => {
         console.info(stats.toString(webpackConfig.stats));
       }),

--- a/packages/workspace/src/utilities/run-webpack.ts
+++ b/packages/workspace/src/utilities/run-webpack.ts
@@ -1,14 +1,15 @@
-import * as webpack from 'webpack';
-import { Stats, Configuration } from 'webpack';
-import * as WebpackDevServer from 'webpack-dev-server';
-import { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
+import type { Stats, Configuration } from 'webpack';
+import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 
 import { Observable } from 'rxjs';
 
 import { extname } from 'path';
 import * as url from 'url';
 
-export function runWebpack(config: Configuration): Observable<Stats> {
+export function runWebpack(
+  config: Configuration,
+  webpack: typeof import('webpack')
+): Observable<Stats> {
   return new Observable((subscriber) => {
     const webpackCompiler = webpack(config);
 
@@ -36,7 +37,9 @@ export function runWebpack(config: Configuration): Observable<Stats> {
 }
 
 export function runWebpackDevServer(
-  config: Configuration
+  config: Configuration,
+  webpack: typeof import('webpack'),
+  WebpackDevServer: typeof import('webpack-dev-server')
 ): Observable<{ stats: Stats; baseUrl: string }> {
   return new Observable((subscriber) => {
     const webpackCompiler = webpack(config);
@@ -97,7 +100,7 @@ export interface EmittedFile {
   asset?: boolean;
 }
 
-export function getEmittedFiles(stats: webpack.Stats) {
+export function getEmittedFiles(stats: Stats) {
   const { compilation } = stats;
   const files: EmittedFile[] = [];
   // adds all chunks to the list of emitted files such as lazy loaded modules


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`@nrwl/node` and `@nrwl/web` builders are not guaranteed to use their own versions of `webpack` to compile.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@nrwl/node` and `@nrwl/web` pass their own copy of `webpack` and `webpack-dev-server` into `runWebpack`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/5169
