### PR TITLE
feat(nextjs): add option to turn off svgr

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -1,6 +1,13 @@
+import { WebpackConfigOptions } from '../src/utils/types';
+
 const { join } = require('path');
 const { appRootPath } = require('@nrwl/workspace/src/utilities/app-root');
 const { workspaceLayout } = require('@nrwl/workspace/src/core/file-utils');
+
+export interface WithNxOptions {
+  nx?: WebpackConfigOptions;
+  [key: string]: any;
+}
 
 function regexEqual(x, y) {
   return (
@@ -13,7 +20,7 @@ function regexEqual(x, y) {
   );
 }
 
-function withNx(nextConfig = {} as any) {
+function withNx(nextConfig = {} as WithNxOptions) {
   /**
    * In collaboration with Vercel themselves, we have been advised to set the "experimental-serverless-trace" target
    * if we detect that the build is running on Vercel to allow for the most ergonomic configuration for Vercel users.

--- a/packages/next/src/generators/application/files/next.config.js__tmpl__
+++ b/packages/next/src/generators/application/files/next.config.js__tmpl__
@@ -4,6 +4,11 @@ const withNx = require('@nrwl/next/plugins/with-nx');
 <% if (style === 'less') { %>
 const withLess = require('@zeit/next-less');
 module.exports = withLess(withNx({
+  nx: {
+    // Set this to false if you do not want to use SVGR 
+    // See: https://github.com/gregberge/svgr
+    svgr: true,
+  },
   // Set this to true if you use CSS modules.
   // See: https://github.com/css-modules/css-modules
   cssModules: false
@@ -11,6 +16,11 @@ module.exports = withLess(withNx({
 <% } else if (style === 'styl') { %>
 const withStylus = require('@zeit/next-stylus');
 module.exports = withStylus(withNx({
+  nx: {
+    // Set this to false if you do not want to use SVGR 
+    // See: https://github.com/gregberge/svgr
+    svgr: true,
+  },
   // Set this to true if you use CSS modules.
   // See: https://github.com/css-modules/css-modules
   cssModules: false
@@ -21,8 +31,20 @@ module.exports = withStylus(withNx({
   || style === 'styled-jsx'
   || style === 'none'
 ) { %>
-module.exports = withNx({});
+module.exports = withNx({
+  nx: {
+    // Set this to false if you do not want to use SVGR 
+    // See: https://github.com/gregberge/svgr
+    svgr: true,
+  },
+});
 <% } else {
 // Defaults to CSS/SASS (which don't need plugin as of Next 9.3) %>
-module.exports = withNx({});
+module.exports = withNx({
+  nx: {
+    // Set this to false if you do not want to use SVGR 
+    // See: https://github.com/gregberge/svgr
+    svgr: true,
+  },
+});
 <% } %>

--- a/packages/next/src/utils/config.spec.ts
+++ b/packages/next/src/utils/config.spec.ts
@@ -64,6 +64,40 @@ describe('Next.js webpack config builder', () => {
       // just check they get added
       expect(config.module.rules.length).toBe(2);
     });
+
+    it('should set svgr rule by default', () => {
+      const webpackConfig = createWebpackConfig('/root', 'apps/wibble', []);
+
+      const config = webpackConfig(
+        { resolve: { alias: {} }, module: { rules: [] }, plugins: [] },
+        { defaultLoaders: {} }
+      );
+
+      const svgrRule = config.module.rules.find(
+        (rule) => rule.test.toString() === String(/\.svg$/)
+      );
+      expect(svgrRule).toBeTruthy();
+    });
+
+    it('should not set svgr rule when its turned off', () => {
+      const webpackConfig = createWebpackConfig(
+        '/root',
+        'apps/wibble',
+        [],
+        undefined,
+        { svgr: false }
+      );
+
+      const config = webpackConfig(
+        { resolve: { alias: {} }, module: { rules: [] }, plugins: [] },
+        { defaultLoaders: {} }
+      );
+
+      const svgrRule = config.module.rules.find(
+        (rule) => rule.test.toString() === String(/\.svg$/)
+      );
+      expect(svgrRule).toBeFalsy();
+    });
   });
 
   describe('prepareConfig', () => {

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -52,3 +52,7 @@ export interface NextExportBuilderOptions {
   silent: boolean;
   threads: number;
 }
+
+export interface WebpackConfigOptions {
+  svgr?: boolean;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->


<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Usage of all webpack rules is baked into executor logic. this PR specifically, addresses the use of webpack rules targeting svg imports from js(x) and ts(x) files. Our choice of using [the svgr tool](https://github.com/gregberge/svgr) isn't configurable. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Some webpack rules should be configurable, and users should be able to turn it off via configuration. this PR specifically, introduces logic to opt out of svgr for importing SVGs via a new configuration option in the `withNx()` config plugin

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5130 
