### PR TITLE
fix(devkit): fix reading partial workspace layout

### DIFF
--- a/packages/devkit/src/utils/get-workspace-layout.ts
+++ b/packages/devkit/src/utils/get-workspace-layout.ts
@@ -15,9 +15,11 @@ export function getWorkspaceLayout(
   host: Tree
 ): { appsDir: string; libsDir: string; npmScope: string } {
   const nxJson = readJson<NxJsonConfiguration>(host, 'nx.json');
-  const layout = nxJson.workspaceLayout ?? { appsDir: 'apps', libsDir: 'libs' };
-  const npmScope = nxJson.npmScope;
-  return { ...layout, npmScope };
+  return {
+    appsDir: nxJson.workspaceLayout?.appsDir ?? 'apps',
+    libsDir: nxJson.workspaceLayout?.libsDir ?? 'libs',
+    npmScope: nxJson.npmScope,
+  };
 }
 
 export function getWorkspacePath(host: Tree) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When a user defines only one of `appsDir` or `libsDir` the other one becomes `undefined` which is an issue for joining paths and such.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When a user defines only one of `appsDir` or `libsDir` the other one remains the default.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
