### PR TITLE
feat(core): enable v8 compile cache for cli

### DIFF
--- a/packages/cli/bin/nx.ts
+++ b/packages/cli/bin/nx.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+import 'v8-compile-cache';
 // polyfill rxjs observable to avoid issues with multiple version fo Observable installed in node_modules
 // https://twitter.com/BenLesh/status/1192478226385428483?s=20
 if (!(Symbol as any).observable)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,7 @@
     "yargs": "15.4.1",
     "yargs-parser": "20.0.0",
     "@nrwl/tao": "*",
-    "chalk": "4.1.0"
+    "chalk": "4.1.0",
+    "v8-compile-cache": "2.3.0"
   }
 }


### PR DESCRIPTION
Including the overhead of loading the cache itself, the time from start until entering the run-one command, goes from~320ms to ~230ms (locally).