### PR TITLE
chore(repo): fix e2e for npm@7

### DIFF
--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -507,7 +507,7 @@ export function getPackageManagerCommand({
       createWorkspace: `npx create-nx-workspace@${process.env.PUBLISHED_VERSION}`,
       runNx: `npm run nx${scriptsPrependNodePathFlag} --`,
       runNxSilent: `npm run nx --silent${scriptsPrependNodePathFlag} --`,
-      addDev: `npm install -D`,
+      addDev: `npm install --legacy-peer-deps -D`,
       list: 'npm ls --depth 10',
     },
     yarn: {


### PR DESCRIPTION
This fixes the fails of our E2E on npm@7. As @FrozenPandaz suggested, we now use the `--legacy-peer-deps` flags.