### PR TITLE
cleanup(misc): replace `lodash` with `lodash.template`

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -73,7 +73,7 @@
     "chalk": "4.1.0",
     "axios": "0.21.1",
     "flat": "^5.0.2",
-    "lodash": "^4.17.20",
+    "lodash.template": "~4.5.0",
     "minimatch": "3.0.4",
     "inquirer": "^6.3.1",
     "resolve": "1.17.0",

--- a/packages/workspace/src/tasks-runner/utils.ts
+++ b/packages/workspace/src/tasks-runner/utils.ts
@@ -1,7 +1,7 @@
 import { Task } from './tasks-runner';
 import { ProjectGraphNode } from '../core/project-graph';
 import * as flatten from 'flat';
-import * as _ from 'lodash';
+import * as _template from 'lodash.template';
 
 const commonCommands = ['build', 'test', 'lint', 'e2e', 'deploy'];
 
@@ -66,7 +66,7 @@ export function getOutputsForTargetAndConfiguration(
 
   if (targets?.outputs) {
     return targets.outputs.map((output) =>
-      _.template(output, { interpolate: /{([\s\S]+?)}/g })({ options })
+      _template(output, { interpolate: /{([\s\S]+?)}/g })({ options })
     );
   }
 


### PR DESCRIPTION
No need to import whole `lodash` in our `@nrwl/workspace` bundle, although we use only the `template` function.
