### PR TITLE
chore(repo): e2e on windows use the same Node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,13 @@ commands:
         type: string
     steps:
       - checkout
+      - when:
+          condition:
+            equal: [<< parameters.os >>, windows]
+          steps:
+            - run: nvm install 12.20
+            - run: nvm use 12.20
+            - run: npm install -g yarn@1.19.0
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:


### PR DESCRIPTION
Latest `jest-worker` installed via `next` has dropped support for old Node versions, causing our E2E on Windows to fail, with the following message:
`error jest-worker@27.0.0-next.5: The engine "node" is incompatible with this module. Expected version "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0". Got "12.11.1"`.
This commits uses NVM to align the Node version of Windows machine with the one we use in Linux.
