### PR TITLE
fix(linter): add import source type check for literals

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -123,7 +123,12 @@ export default createESLintRule<Options, MessageIds>({
       .targetProjectLocator as TargetProjectLocator;
 
     function run(node: TSESTree.ImportDeclaration | TSESTree.ImportExpression) {
-      const imp = (node.source as TSESTree.Literal).value as string;
+      // accept only literals because template literals have no value
+      if (node.source.type !== AST_NODE_TYPES.Literal) {
+        return;
+      }
+
+      const imp = node.source.value as string;
 
       const sourceFilePath = getSourceFilePath(
         normalizePath(context.getFilename()),


### PR DESCRIPTION
ISSUES CLOSED: #5224

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`enforce-module-boundaries` shows errors when template literals are used for import expressions.

```ts
const todo = 'todo';
import(`@workspace/${todo}/shell-web-todo`);
```
```
> nx run client-web:lint 

Linting "client-web"...
Cannot read property 'startsWith' of undefined
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Linter should show no errors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5224
