### PR TITLE
fix(core): take into account name argument in create-nx-workspace generator

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -89,6 +89,7 @@ const prettierVersion = 'PRETTIER_VERSION';
 
 const parsedArgs: any = yargsParser(process.argv.slice(2), {
   string: [
+    'name',
     'cli',
     'preset',
     'appName',
@@ -179,7 +180,9 @@ function showHelp() {
 }
 
 function determineWorkspaceName(parsedArgs: any): Promise<string> {
-  const workspaceName: string = parsedArgs._[0];
+  const workspaceName: string = parsedArgs._[0]
+    ? parsedArgs._[0]
+    : parsedArgs.name;
 
   if (workspaceName) {
     return Promise.resolve(workspaceName);


### PR DESCRIPTION
## Current Behavior
When running `npx create-nx-workspace --name=test` the `--name=test` argument is not taken into account. It still prompts user to enter a workspace name.

## Expected Behavior
Take `--name` argument into account when generating new Nx workspace.
