### PR TITLE
cleanup(core): copy from cache only when needed

### DIFF
--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -15,6 +15,7 @@ import {
   updateFile,
   workspaceConfigName,
 } from '@nrwl/e2e/utils';
+import { TaskCacheStatus } from '@nrwl/workspace/src/utilities/output';
 
 describe('run-one', () => {
   let proj: string;
@@ -637,7 +638,7 @@ describe('cache', () => {
     });
     const outputWithBuildApp2Cached = runCLI(`affected:build ${files}`);
     expect(outputWithBuildApp2Cached).toContain('read the output from cache');
-    expectCached(outputWithBuildApp2Cached, [myapp2]);
+    expectMatchedOutput(outputWithBuildApp2Cached, [myapp2]);
 
     // touch package.json
     // --------------------------------------------
@@ -651,13 +652,17 @@ describe('cache', () => {
 
     // build individual project with caching
     const individualBuildWithCache = runCLI(`build ${myapp1}`);
-    expect(individualBuildWithCache).toContain('from cache');
+    expect(individualBuildWithCache).toContain(
+      TaskCacheStatus.MatchedExistingOutput
+    );
 
     // skip caching when building individual projects
     const individualBuildWithSkippedCache = runCLI(
       `build ${myapp1} --skip-nx-cache`
     );
-    expect(individualBuildWithSkippedCache).not.toContain('from cache');
+    expect(individualBuildWithSkippedCache).not.toContain(
+      TaskCacheStatus.MatchedExistingOutput
+    );
 
     // run lint with caching
     // --------------------------------------------
@@ -668,7 +673,7 @@ describe('cache', () => {
     expect(outputWithBothLintTasksCached).toContain(
       'read the output from cache'
     );
-    expectCached(outputWithBothLintTasksCached, [
+    expectMatchedOutput(outputWithBothLintTasksCached, [
       myapp1,
       myapp2,
       `${myapp1}-e2e`,
@@ -747,20 +752,39 @@ describe('cache', () => {
     actualOutput: string,
     expectedCachedProjects: string[]
   ) {
-    const cachedProjects = [];
+    expectProjectMatchTaskCacheStatus(actualOutput, expectedCachedProjects);
+  }
+
+  function expectMatchedOutput(
+    actualOutput: string,
+    expectedMatchedOutputProjects: string[]
+  ) {
+    expectProjectMatchTaskCacheStatus(
+      actualOutput,
+      expectedMatchedOutputProjects,
+      TaskCacheStatus.MatchedExistingOutput
+    );
+  }
+
+  function expectProjectMatchTaskCacheStatus(
+    actualOutput: string,
+    expectedProjects: string[],
+    cacheStatus: TaskCacheStatus = TaskCacheStatus.RetrievedFromCache
+  ) {
+    const matchingProjects = [];
     const lines = actualOutput.split('\n');
-    lines.forEach((s, i) => {
+    lines.forEach((s) => {
       if (s.startsWith(`> nx run`)) {
         const projectName = s.split(`> nx run `)[1].split(':')[0].trim();
-        if (s.indexOf('from cache') > -1) {
-          cachedProjects.push(projectName);
+        if (s.indexOf(cacheStatus) > -1) {
+          matchingProjects.push(projectName);
         }
       }
     });
 
-    cachedProjects.sort((a, b) => a.localeCompare(b));
-    expectedCachedProjects.sort((a, b) => a.localeCompare(b));
-    expect(cachedProjects).toEqual(expectedCachedProjects);
+    matchingProjects.sort((a, b) => a.localeCompare(b));
+    expectedProjects.sort((a, b) => a.localeCompare(b));
+    expect(matchingProjects).toEqual(expectedProjects);
   }
 });
 

--- a/packages/workspace/src/tasks-runner/cache.ts
+++ b/packages/workspace/src/tasks-runner/cache.ts
@@ -12,6 +12,7 @@ import * as fsExtra from 'fs-extra';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { spawn } from 'child_process';
 import { cacheDirectory } from '../utilities/cache-directory';
+import { readJsonFile, writeJsonFile } from '../utilities/fileutils';
 
 export type CachedResult = { terminalOutput: string; outputsPath: string };
 export type TaskWithCachedResult = { task: Task; cachedResult: CachedResult };
@@ -38,6 +39,7 @@ export class Cache {
   root = appRootPath;
   cachePath = this.createCacheDir();
   terminalOutputsDir = this.createTerminalOutputsDir();
+  nxOutputsPath = this.ensureNxOutputsFile();
   cacheConfig = new CacheConfig(this.options);
 
   constructor(private readonly options: DefaultTasksRunnerOptions) {}
@@ -148,6 +150,42 @@ export class Cache {
     }
   }
 
+  removeOutputHashesFromNxOutputs(outputs: string[]): void {
+    if (outputs.length === 0) {
+      return;
+    }
+
+    const nxOutputs = readJsonFile(this.nxOutputsPath);
+    outputs.forEach((output) => {
+      delete nxOutputs[output];
+    });
+    writeJsonFile(this.nxOutputsPath, nxOutputs);
+  }
+
+  writeOutputHashesToNxOutputs(outputs: string[], hash: string): void {
+    if (outputs.length === 0) {
+      return;
+    }
+
+    const nxOutputs = readJsonFile(this.nxOutputsPath);
+    outputs.forEach((output) => {
+      nxOutputs[output] = hash;
+    });
+    writeJsonFile(this.nxOutputsPath, nxOutputs);
+  }
+
+  outputsMatchTask(task: Task, outputs: string[]): boolean {
+    if (outputs.length === 0) {
+      return true;
+    }
+
+    const nxOutputs = readJsonFile(this.nxOutputsPath);
+    return outputs.every(
+      (output) =>
+        existsSync(join(this.root, output)) && task.hash === nxOutputs[output]
+    );
+  }
+
   private getFromLocalDir(task: Task) {
     const tdCommit = join(this.cachePath, `${task.hash}.commit`);
     const td = join(this.cachePath, task.hash);
@@ -173,6 +211,14 @@ export class Cache {
   private createTerminalOutputsDir() {
     const path = join(this.cachePath, 'terminalOutputs');
     fsExtra.ensureDirSync(path);
+    return path;
+  }
+
+  private ensureNxOutputsFile() {
+    const path = join(this.cachePath, 'nx-outputs.json');
+    if (!existsSync(path)) {
+      writeJsonFile(path, {});
+    }
     return path;
   }
 }

--- a/packages/workspace/src/tasks-runner/task-orchestrator.ts
+++ b/packages/workspace/src/tasks-runner/task-orchestrator.ts
@@ -4,7 +4,7 @@ import * as dotenv from 'dotenv';
 import * as fs from 'fs';
 import { ProjectGraph } from '../core/project-graph';
 import { appRootPath } from '../utilities/app-root';
-import { output } from '../utilities/output';
+import { output, TaskCacheStatus } from '../utilities/output';
 import { Cache, TaskWithCachedResult } from './cache';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { AffectedEventType, Task } from './tasks-runner';
@@ -115,17 +115,27 @@ export class TaskOrchestrator {
     tasks.forEach((t) => {
       this.options.lifeCycle.startTask(t.task);
 
+      const outputs = getOutputs(this.projectGraph.nodes, t.task);
+      const outputsMatchCache = this.cache.outputsMatchTask(t.task, outputs);
+      if (!outputsMatchCache) {
+        this.cache.removeOutputHashesFromNxOutputs(outputs);
+        this.cache.copyFilesFromCache(t.cachedResult, outputs);
+        this.cache.writeOutputHashesToNxOutputs(outputs, t.task.hash);
+      }
+
       if (
         !this.initiatingProject ||
         this.initiatingProject === t.task.target.project
       ) {
         const args = this.getCommandArgs(t.task);
-        output.logCommand(`nx ${args.join(' ')}`, true);
+        output.logCommand(
+          `nx ${args.join(' ')}`,
+          outputsMatchCache
+            ? TaskCacheStatus.MatchedExistingOutput
+            : TaskCacheStatus.RetrievedFromCache
+        );
         process.stdout.write(t.cachedResult.terminalOutput);
       }
-
-      const outputs = getOutputs(this.projectGraph.nodes, t.task);
-      this.cache.copyFilesFromCache(t.cachedResult, outputs);
 
       this.options.lifeCycle.endTask(t.task, 0);
     });
@@ -175,6 +185,7 @@ export class TaskOrchestrator {
         if (forwardOutput) {
           output.logCommand(commandLine);
         }
+        this.cache.removeOutputHashesFromNxOutputs(taskOutputs);
         const p = fork(this.getCommand(), args, {
           stdio: ['inherit', 'pipe', 'pipe', 'ipc'],
           env,
@@ -210,6 +221,10 @@ export class TaskOrchestrator {
               this.cache
                 .put(task, outputPath, taskOutputs)
                 .then(() => {
+                  this.cache.writeOutputHashesToNxOutputs(
+                    taskOutputs,
+                    task.hash
+                  );
                   this.options.lifeCycle.endTask(task, code);
                   res(code);
                 })
@@ -217,10 +232,12 @@ export class TaskOrchestrator {
                   rej(e);
                 });
             } else {
+              this.cache.writeOutputHashesToNxOutputs(taskOutputs, task.hash);
               this.options.lifeCycle.endTask(task, code);
               res(code);
             }
           } else {
+            this.cache.writeOutputHashesToNxOutputs(taskOutputs, task.hash);
             this.options.lifeCycle.endTask(task, code);
             res(code);
           }
@@ -251,6 +268,7 @@ export class TaskOrchestrator {
         if (forwardOutput) {
           output.logCommand(commandLine);
         }
+        this.cache.removeOutputHashesFromNxOutputs(taskOutputs);
         const p = fork(this.getCommand(), args, {
           stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
           env,
@@ -275,6 +293,7 @@ export class TaskOrchestrator {
             this.cache
               .put(task, outputPath, taskOutputs)
               .then(() => {
+                this.cache.writeOutputHashesToNxOutputs(taskOutputs, task.hash);
                 this.options.lifeCycle.endTask(task, code);
                 res(code);
               })
@@ -282,6 +301,7 @@ export class TaskOrchestrator {
                 rej(e);
               });
           } else {
+            this.cache.writeOutputHashesToNxOutputs(taskOutputs, task.hash);
             this.options.lifeCycle.endTask(task, code);
             res(code);
           }

--- a/packages/workspace/src/utilities/output.ts
+++ b/packages/workspace/src/utilities/output.ts
@@ -22,6 +22,12 @@ export interface CLISuccessMessageConfig {
   bodyLines?: string[];
 }
 
+export enum TaskCacheStatus {
+  NoCache = '[no cache]',
+  MatchedExistingOutput = '[existing outputs match the cache, left as is]',
+  RetrievedFromCache = '[retrieved from cache]',
+}
+
 /**
  * Automatically disable styling applied by chalk if CI=true
  */
@@ -177,13 +183,16 @@ class CLIOutput {
     this.addNewline();
   }
 
-  logCommand(message: string, isCached: boolean = false) {
+  logCommand(
+    message: string,
+    cacheStatus: TaskCacheStatus = TaskCacheStatus.NoCache
+  ) {
     this.addNewline();
 
     this.writeToStdOut(chalk.bold(`> ${message} `));
 
-    if (isCached) {
-      this.writeToStdOut(chalk.bold.grey(`[retrieved from cache]`));
+    if (cacheStatus !== TaskCacheStatus.NoCache) {
+      this.writeToStdOut(chalk.bold.grey(cacheStatus));
     }
 
     this.addNewline();


### PR DESCRIPTION
## Current Behavior
Every time there's a cache hit, we remove the output and copy it over from the cache.

## Expected Behavior
We don't remove the output and copy it from the cache when the current output is expected to be the same as what the cache has stored.

## Related Issue(s)

Fixes #
