### PR TITLE
fix(core): Fix error with caret ancestor commits such as HEAD^1 in nx affected

### DIFF
--- a/packages/workspace/src/command-line/shared.ts
+++ b/packages/workspace/src/command-line/shared.ts
@@ -45,19 +45,21 @@ function getUntrackedFiles(): string[] {
 function getFilesUsingBaseAndHead(base: string, head: string): string[] {
   let mergeBase;
   try {
-    mergeBase = execSync(`git merge-base ${base} ${head}`, {
+    mergeBase = execSync(`git merge-base "${base}" "${head}"`, {
       maxBuffer: TEN_MEGABYTES,
     })
       .toString()
       .trim();
   } catch {
-    mergeBase = execSync(`git merge-base --fork-point ${base} ${head}`, {
+    mergeBase = execSync(`git merge-base --fork-point "${base}" "${head}"`, {
       maxBuffer: TEN_MEGABYTES,
     })
       .toString()
       .trim();
   }
-  return parseGitOutput(`git diff --name-only --relative ${mergeBase} ${head}`);
+  return parseGitOutput(
+    `git diff --name-only --relative "${mergeBase}" "${head}"`
+  );
 }
 
 function parseGitOutput(command: string): string[] {


### PR DESCRIPTION
On windows caret symbols are removed from command line args unless wrapped in double quotes, causing an error in this case.

Closes #4828.



## Current Behavior
Nx passes the argument with the caret stripped out, due to windows CMD stripping the caret.

## Expected Behavior
Nx should pass arguments with carets in them to git.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4828 
