### PR TITLE
chore(repo): pin PNPM version for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,14 +61,14 @@ commands:
           steps:
             - run:
                 name: Install PNPM
-                command: npm install --prefix=$HOME/.local -g pnpm
+                command: npm install --prefix=$HOME/.local -g pnpm@5.18.9
       - when:
           condition:
             equal: [<< parameters.os >>, windows]
           steps:
             - run:
                 name: Install PNPM
-                command: npm install -g pnpm
+                command: npm install -g pnpm@5.18.9
 
 jobs:
   checks-and-unit-tests:

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -44,7 +44,7 @@ jobs:
       if: ${{ matrix.package_manager == 'pnpm' }}
       uses: pnpm/action-setup@v1.2.1
       with:
-        version: latest
+        version: 5.18.9
 
     - name: Run e2e tests
       run: yarn e2e ${{ matrix.packages }} affected


### PR DESCRIPTION
PNPM@6.0.0 has been released with a few breaking changes, making our e2e tests to fail. Unitl we properly upgrade, we should use PNPM@5.