### PR TITLE
fix(angular): fix eslint component/directive selector prefix

### DIFF
--- a/packages/angular/src/utils/lint.ts
+++ b/packages/angular/src/utils/lint.ts
@@ -1,4 +1,5 @@
 import type { TargetDefinition } from '@angular-devkit/core/src/workspace';
+import { stringUtils } from '@nrwl/workspace';
 import { angularEslintVersion } from './versions';
 
 export function createAngularProjectESLintLintTarget(
@@ -41,11 +42,19 @@ export const createAngularEslintJson = (
       rules: {
         '@angular-eslint/directive-selector': [
           'error',
-          { type: 'attribute', prefix, style: 'camelCase' },
+          {
+            type: 'attribute',
+            prefix: stringUtils.camelize(prefix),
+            style: 'camelCase',
+          },
         ],
         '@angular-eslint/component-selector': [
           'error',
-          { type: 'element', prefix, style: 'kebab-case' },
+          {
+            type: 'element',
+            prefix: stringUtils.dasherize(prefix),
+            style: 'kebab-case',
+          },
         ],
       },
     },


### PR DESCRIPTION
## Current Behavior
If we generate an Angular app/lib with a prefix either in `camelCase` or `kebab-case` style (e.g. fooBar or foo-bar) the ESLint configuration always use the prefix as is so either the `@angular-eslint/component-selector` (`kebab-case`) or the `@angular-eslint/directive-selector` (`camelCase`) rules would be wrong depending on which style the prefix has.

## Expected Behavior
The `@angular-eslint/component-selector` or the `@angular-eslint/directive-selector` rules are configured using the right style in the generated ESLint configuration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5103 
