### PR TITLE
feat(gatsby): update Gatsby CLI to v3

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -36,6 +36,6 @@
     "@nrwl/node": "*",
     "@nrwl/react": "*",
     "@nrwl/workspace": "*",
-    "gatsby-cli": "^2.17.1"
+    "gatsby-cli": "^3.1.0"
   }
 }


### PR DESCRIPTION
## Current Behavior
`@nrwl/gatsby` uses `gatsby-cli` v2.17.1 which itself rely on `graphql` v14.7.0 to scaffold and build Gatsby v3 projects that rely on `graphql` v15.5.0

## Expected Behavior
Use the same major version for the CLI as the generated project (v3).

## Context

While updating an existing project to `gatsby` v3 following the merge of https://github.com/nrwl/nx/pull/5170 by @jaysoo I encountered the following error:

```
/path/to/project/node_modules/@nrwl/gatsby/node_modules/graphql-compose/lib/TypeMapper.js:294
        throw new Error(`${typeName}.${fieldName} provided incorrect OutputType: '${(0, _misc.inspect)(composeType)}'`);
        ^

Error: GatsbyPlugin.options provided incorrect OutputType: 'JSONObject'
    at TypeMapper.convertOutputFieldConfig (/path/to/project/node_modules/@nrwl/gatsby/node_modules/graphql-compose/lib/TypeMapper.js:294:15)
    at resolveOutputConfigAsThunk (/path/to/project/node_modules/@nrwl/gatsby/node_modules/graphql-compose/lib/utils/configAsThunk.js:19:41)
    at ObjectTypeComposer.getFieldConfig (/path/to/project/node_modules/@nrwl/gatsby/node_modules/graphql-compose/lib/ObjectTypeComposer.js:300:58)
    at /path/to/project/node_modules/@nrwl/gatsby/node_modules/graphql-compose/lib/utils/toInputObjectType.js:44:19
    at Array.forEach (<anonymous>)
    at toInputObjectType (/path/to/project/node_modules/@nrwl/gatsby/node_modules/graphql-compose/lib/utils/toInputObjectType.js:38:14)
    at ObjectTypeComposer.getInputTypeComposer (/path/to/project/node_modules/@nrwl/gatsby/node_modules/graphql-compose/lib/ObjectTypeComposer.js:600:84)
    at ObjectTypeComposer.getInputType (/path/to/project/node_modules/@nrwl/gatsby/node_modules/graphql-compose/lib/ObjectTypeComposer.js:586:17)
    at /path/to/project/node_modules/@nrwl/gatsby/node_modules/gatsby-recipes/dist/graphql-server/server.js:25378:101
    at Array.map (<anonymous>)
```

This error may occur when there is a graphql versions mismatch as reported here: https://github.com/gatsbyjs/gatsby/issues/26111

Testing locally, the upgrade of `@nrwl#gatsby#gatsby-cli` to v3 and by extension of `@nrwl/gatsby#graphql` to v15.5.0 fixes the issue.