### PR TITLE
fix(react): fix react library generator for strict option

### DIFF
--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -92,6 +92,14 @@ describe('lib', () => {
           path: './tsconfig.spec.json',
         },
       ]);
+      expect(tsconfigJson.compilerOptions.strict).not.toBeDefined();
+      expect(
+        tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
+      ).not.toBeDefined();
+      expect(tsconfigJson.compilerOptions.noImplicitReturns).not.toBeDefined();
+      expect(
+        tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
+      ).not.toBeDefined();
     });
 
     it('should extend the local tsconfig.json with tsconfig.spec.json', async () => {
@@ -580,12 +588,12 @@ describe('lib', () => {
   });
 
   describe('--strict', () => {
-    it('should update the projects tsconfig with strict true', async () => {
+    it('should update tsconfig.json', async () => {
       await libraryGenerator(appTree, {
         ...defaultSchema,
         strict: true,
       });
-      const tsconfigJson = readJson(appTree, '/libs/my-lib/tsconfig.lib.json');
+      const tsconfigJson = readJson(appTree, '/libs/my-lib/tsconfig.json');
 
       expect(tsconfigJson.compilerOptions.strict).toBeTruthy();
       expect(
@@ -595,23 +603,6 @@ describe('lib', () => {
       expect(
         tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
       ).toBeTruthy();
-    });
-
-    it('should default to strict false', async () => {
-      await libraryGenerator(appTree, {
-        ...defaultSchema,
-        name: 'myLib',
-      });
-      const tsconfigJson = readJson(appTree, '/libs/my-lib/tsconfig.lib.json');
-
-      expect(tsconfigJson.compilerOptions.strict).not.toBeDefined();
-      expect(
-        tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
-      ).not.toBeDefined();
-      expect(tsconfigJson.compilerOptions.noImplicitReturns).not.toBeDefined();
-      expect(
-        tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
-      ).not.toBeDefined();
     });
   });
 });

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -18,7 +18,6 @@ import {
   reactVersion,
   typesReactRouterDomVersion,
 } from '../../utils/versions';
-import { join } from 'path';
 import { Schema } from './schema';
 import {
   addDependenciesToPackageJson,
@@ -83,7 +82,7 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
   createFiles(host, options);
 
   if (!options.skipTsConfig) {
-    updateTsConfig(host, options);
+    updateBaseTsConfig(host, options);
   }
 
   if (options.unitTestRunner === 'jest') {
@@ -217,23 +216,27 @@ function addProject(host: Tree, options: NormalizedSchema) {
   });
 }
 
-function updateLibTsConfig(tree: Tree, options: NormalizedSchema) {
-  updateJson(tree, join(options.projectRoot, 'tsconfig.lib.json'), (json) => {
-    if (options.strict) {
-      json.compilerOptions = {
-        ...json.compilerOptions,
-        forceConsistentCasingInFileNames: true,
-        strict: true,
-        noImplicitReturns: true,
-        noFallthroughCasesInSwitch: true,
-      };
-    }
+function updateTsConfig(tree: Tree, options: NormalizedSchema) {
+  updateJson(
+    tree,
+    joinPathFragments(options.projectRoot, 'tsconfig.json'),
+    (json) => {
+      if (options.strict) {
+        json.compilerOptions = {
+          ...json.compilerOptions,
+          forceConsistentCasingInFileNames: true,
+          strict: true,
+          noImplicitReturns: true,
+          noFallthroughCasesInSwitch: true,
+        };
+      }
 
-    return json;
-  });
+      return json;
+    }
+  );
 }
 
-function updateTsConfig(host: Tree, options: NormalizedSchema) {
+function updateBaseTsConfig(host: Tree, options: NormalizedSchema) {
   updateJson(host, 'tsconfig.base.json', (json) => {
     const c = json.compilerOptions;
     c.paths = c.paths || {};
@@ -263,7 +266,6 @@ function createFiles(host: Tree, options: NormalizedSchema) {
     {
       ...options,
       ...names(options.name),
-      strict: undefined,
       tmpl: '',
       offsetFromRoot: offsetFromRoot(options.projectRoot),
     }
@@ -277,7 +279,7 @@ function createFiles(host: Tree, options: NormalizedSchema) {
     toJS(host);
   }
 
-  updateLibTsConfig(host, options);
+  updateTsConfig(host, options);
 }
 
 function updateAppRoutes(host: Tree, options: NormalizedSchema) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
React library generator updates `tsconfig.lib.json` when `--strict=true`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
React library generator should update `tsconfig.json` when `--strict=true` to enable strict mode for `*.spec.ts` too.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#5006
#5250