### PR TITLE
fix(core): allow building of workspaces when hosted at /

### DIFF
--- a/packages/cli/lib/find-workspace-root.ts
+++ b/packages/cli/lib/find-workspace-root.ts
@@ -8,17 +8,17 @@ import { Workspace } from './workspace';
  *
  * @param dir Directory to start searching with
  */
-export function findWorkspaceRoot(dir: string): Workspace {
-  if (path.dirname(dir) === dir) {
-    return null;
-  }
-
+export function findWorkspaceRoot(dir: string): Workspace | null {
   if (existsSync(path.join(dir, 'angular.json'))) {
     return { type: 'angular', dir };
   }
 
   if (existsSync(path.join(dir, 'workspace.json'))) {
     return { type: 'nx', dir };
+  }
+
+  if (path.dirname(dir) === dir) {
+    return null;
   }
 
   return findWorkspaceRoot(path.dirname(dir));


### PR DESCRIPTION
Building a project in the node:14-alpine docker image requires the workspace to be copied in to directory other than /.

The proposed change allows workspaces to be hosted at / and not force the developer to create a directory inside a docker image just to build the project.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
With an `angular.json` file existing at `/angular.json`, I am presented with the error when running `nx build <project>`
```sh
>  NX  The current directory isn't part of an Nx workspace.
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx attempts to build the project

---
An example `Dockerfile` to reproduce

```Dockerfile
FROM node:14-alpine as build

COPY . .

RUN npm install

RUN npm run build <project>

FROM nginx:1.19.9-alpine

COPY --from=build /build/apps/<project>/ /usr/share/nginx/html/
```