### PR TITLE
feat(core): add plugins for project-graph analysis wip

### DIFF
--- a/e2e/workspace/src/plugins.test.ts
+++ b/e2e/workspace/src/plugins.test.ts
@@ -1,0 +1,60 @@
+import {
+  newProject,
+  removeProject,
+  updateFile,
+  readJson,
+  runCLI,
+} from '@nrwl/e2e/utils';
+
+describe('Nx Plugins', () => {
+  beforeAll(() => newProject());
+
+  afterAll(() => removeProject({ onlyOnCI: true }));
+
+  it('should use plugins defined in nx.json', () => {
+    const nxJson = readJson('nx.json');
+    nxJson.plugins = ['./tools/plugin'];
+    updateFile('nx.json', JSON.stringify(nxJson));
+    updateFile(
+      'tools/plugin.js',
+      `
+      module.exports = {
+        processProjectGraph: (graph) => {
+          const Builder = require('@nrwl/devkit').ProjectGraphBuilder;
+          const builder = new Builder(graph);
+          builder.addNode({
+            name: 'plugin-node',
+            type: 'lib',
+            data: {
+              root: 'test'
+            }
+          });
+          builder.addNode({
+            name: 'plugin-node2',
+            type: 'lib',
+            data: {
+              root: 'test2'
+            }
+          });
+          builder.addDependency(
+            require('@nrwl/devkit').DependencyType.static,
+            'plugin-node',
+            'plugin-node2' 
+          );
+          return builder.getProjectGraph();
+        }
+      };
+    `
+    );
+
+    runCLI('dep-graph --file project-graph.json');
+    const projectGraphJson = readJson('project-graph.json');
+    expect(projectGraphJson.graph.nodes['plugin-node']).toBeDefined();
+    expect(projectGraphJson.graph.nodes['plugin-node2']).toBeDefined();
+    expect(projectGraphJson.graph.dependencies['plugin-node']).toContainEqual({
+      type: 'static',
+      source: 'plugin-node',
+      target: 'plugin-node2',
+    });
+  });
+});

--- a/packages/devkit/index.ts
+++ b/packages/devkit/index.ts
@@ -8,10 +8,14 @@ export {
   GeneratorCallback,
   Executor,
   ExecutorContext,
+  Workspace,
 } from '@nrwl/tao/src/shared/workspace';
 export {
+  ImplicitDependencyEntry,
+  ImplicitJsonSubsetDependency,
   NxJsonConfiguration,
   NxJsonProjectConfiguration,
+  NxAffectedConfig,
 } from '@nrwl/tao/src/shared/nx';
 export { logger } from '@nrwl/tao/src/shared/logger';
 export { getPackageManagerCommand } from '@nrwl/tao/src/shared/package-manager';
@@ -35,6 +39,18 @@ export { visitNotIgnoredFiles } from './src/generators/visit-not-ignored-files';
 
 export { parseTargetString } from './src/executors/parse-target-string';
 export { readTargetOptions } from './src/executors/read-target-options';
+
+export {
+  ProjectFileMap,
+  FileData,
+  ProjectGraph,
+  ProjectGraphDependency,
+  DependencyType,
+  ProjectGraphNode,
+  NxPlugin,
+  ProjectGraphProcessorContext,
+} from './src/project-graph/interfaces';
+export { ProjectGraphBuilder } from './src/project-graph/utils';
 
 export { readJson, writeJson, updateJson } from './src/utils/json';
 export {

--- a/packages/devkit/src/project-graph/interfaces.ts
+++ b/packages/devkit/src/project-graph/interfaces.ts
@@ -1,0 +1,55 @@
+import { TargetConfiguration, Workspace } from '@nrwl/tao/src/shared/workspace';
+
+export interface FileData {
+  file: string;
+  hash: string;
+  ext: string;
+}
+
+export interface ProjectFileMap {
+  [projectName: string]: FileData[];
+}
+
+export interface ProjectGraph {
+  nodes: Record<string, ProjectGraphNode>;
+  dependencies: Record<string, ProjectGraphDependency[]>;
+
+  // this is optional otherwise it might break folks who use project graph creation
+  allWorkspaceFiles?: FileData[];
+}
+
+export enum DependencyType {
+  static = 'static',
+  dynamic = 'dynamic',
+  implicit = 'implicit',
+}
+
+export interface ProjectGraphNode<T = any> {
+  type: string;
+  name: string;
+  data: T & {
+    root?: string;
+    targets?: { [targetName: string]: TargetConfiguration };
+    files: FileData[];
+  };
+}
+
+export interface ProjectGraphDependency {
+  type: DependencyType | string;
+  target: string;
+  source: string;
+}
+
+export interface ProjectGraphProcessorContext {
+  workspace: Workspace;
+  fileMap: ProjectFileMap;
+}
+
+export type ProjectGraphProcessor = (
+  currentGraph: ProjectGraph,
+  context: ProjectGraphProcessorContext
+) => ProjectGraph;
+
+export interface NxPlugin {
+  processProjectGraph: ProjectGraphProcessor;
+}

--- a/packages/devkit/src/project-graph/utils.ts
+++ b/packages/devkit/src/project-graph/utils.ts
@@ -1,0 +1,83 @@
+import {
+  DependencyType,
+  ProjectGraph,
+  ProjectGraphDependency,
+  ProjectGraphNode,
+} from './interfaces';
+
+/**
+ * Builder for adding nodes and dependencies to a {@link ProjectGraph}
+ */
+export class ProjectGraphBuilder {
+  readonly nodes: Record<string, ProjectGraphNode> = {};
+  readonly dependencies: Record<
+    string,
+    Record<string, ProjectGraphDependency>
+  > = {};
+
+  constructor(g?: ProjectGraph) {
+    if (g) {
+      Object.values(g.nodes).forEach((n) => this.addNode(n));
+      Object.values(g.dependencies).forEach((ds) => {
+        ds.forEach((d) => this.addDependency(d.type, d.source, d.target));
+      });
+    }
+  }
+
+  /**
+   * Adds a project node to the project graph
+   */
+  addNode(node: ProjectGraphNode) {
+    // Check if project with the same name already exists
+    if (this.nodes[node.name]) {
+      // Throw if existing project is of a different type
+      if (this.nodes[node.name].type !== node.type) {
+        throw new Error(
+          `Multiple projects are named "${node.name}". One is of type "${
+            node.type
+          }" and the other is of type "${
+            this.nodes[node.name].type
+          }". Please resolve the conflicting project names.`
+        );
+      }
+    }
+    this.nodes[node.name] = node;
+    this.dependencies[node.name] = {};
+  }
+
+  /**
+   * Adds a dependency from source project to target project
+   */
+  addDependency(
+    type: DependencyType | string,
+    sourceProjectName: string,
+    targetProjectName: string
+  ) {
+    if (sourceProjectName === targetProjectName) {
+      return;
+    }
+    if (!this.nodes[sourceProjectName]) {
+      throw new Error(`Source project does not exist: ${sourceProjectName}`);
+    }
+    if (!this.nodes[targetProjectName]) {
+      throw new Error(`Target project does not exist: ${targetProjectName}`);
+    }
+    this.dependencies[sourceProjectName][
+      `${sourceProjectName} -> ${targetProjectName}`
+    ] = {
+      type,
+      source: sourceProjectName,
+      target: targetProjectName,
+    };
+  }
+
+  getProjectGraph(): ProjectGraph {
+    return {
+      nodes: this.nodes as ProjectGraph['nodes'],
+      dependencies: Object.keys(this.dependencies).reduce((acc, k) => {
+        acc[k] = Object.values(this.dependencies[k]);
+        return acc;
+      }, {} as ProjectGraph['dependencies']),
+    };
+  }
+}

--- a/packages/tao/src/shared/nx.ts
+++ b/packages/tao/src/shared/nx.ts
@@ -33,6 +33,7 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
       options?: any;
     };
   };
+  plugins?: string[];
 }
 
 export interface NxJsonProjectConfiguration {

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -1,6 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as stripJsonComments from 'strip-json-comments';
+import { NxJsonConfiguration, NxJsonProjectConfiguration } from './nx';
+
+export interface Workspace
+  extends WorkspaceJsonConfiguration,
+    NxJsonConfiguration {
+  projects: Record<string, ProjectConfiguration & NxJsonProjectConfiguration>;
+}
 
 /**
  * Workspace configuration

--- a/packages/workspace/src/core/file-graph/project-file-map.ts
+++ b/packages/workspace/src/core/file-graph/project-file-map.ts
@@ -1,8 +1,4 @@
-import { FileData } from '../file-utils';
-
-export interface ProjectFileMap {
-  [projectName: string]: FileData[];
-}
+import { FileData, ProjectFileMap } from '@nrwl/devkit';
 
 export function createProjectFileMap(
   workspaceJson: any,
@@ -36,3 +32,5 @@ export function createProjectFileMap(
     });
   return fileMap;
 }
+
+export { ProjectFileMap } from '@nrwl/devkit';

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -1,4 +1,5 @@
 import { toOldFormatOrNull, Workspaces } from '@nrwl/tao/src/shared/workspace';
+import { FileData, NxJsonConfiguration } from '@nrwl/devkit';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 import { readFileSync } from 'fs';
@@ -12,15 +13,9 @@ import { fileExists, readJsonFile } from '../utilities/fileutils';
 import { jsonDiff } from '../utilities/json-diff';
 import { defaultFileHasher } from './hasher/file-hasher';
 import { ProjectGraphNode } from './project-graph';
-import { Environment, NxJson } from './shared-interfaces';
+import { Environment } from './shared-interfaces';
 
 const ignore = require('ignore');
-
-export interface FileData {
-  file: string;
-  hash: string;
-  ext: string;
-}
 
 export interface Change {
   type: string;
@@ -198,8 +193,8 @@ export function readPackageJson(): any {
   return readJsonFile(`${appRootPath}/package.json`);
 }
 
-export function readNxJson(): NxJson {
-  const config = readJsonFile<NxJson>(`${appRootPath}/nx.json`);
+export function readNxJson(): NxJsonConfiguration {
+  const config = readJsonFile<NxJsonConfiguration>(`${appRootPath}/nx.json`);
   if (!config.npmScope) {
     throw new Error(`nx.json must define the npmScope property.`);
   }
@@ -298,3 +293,6 @@ export function filesChanged(a: FileData[], b: FileData[]) {
   }
   return false;
 }
+
+// Original Exports
+export { FileData };

--- a/packages/workspace/src/core/normalize-nx-json.ts
+++ b/packages/workspace/src/core/normalize-nx-json.ts
@@ -1,6 +1,8 @@
-import { NxJson } from './shared-interfaces';
+import { NxJsonConfiguration } from '@nrwl/devkit';
 
-export function normalizeNxJson(nxJson: NxJson): NxJson<string[]> {
+export function normalizeNxJson(
+  nxJson: NxJsonConfiguration
+): NxJsonConfiguration<string[]> {
   return nxJson.implicitDependencies
     ? {
         ...nxJson,
@@ -24,5 +26,5 @@ export function normalizeNxJson(nxJson: NxJson): NxJson<string[]> {
           }
         }, {}),
       }
-    : (nxJson as NxJson<string[]>);
+    : (nxJson as NxJsonConfiguration<string[]>);
 }

--- a/packages/workspace/src/core/project-graph/project-graph-builder.ts
+++ b/packages/workspace/src/core/project-graph/project-graph-builder.ts
@@ -1,74 +1,7 @@
-import {
-  DependencyType,
-  ProjectGraph,
-  ProjectGraphDependency,
-  ProjectGraphNode,
-} from './project-graph-models';
+import { ProjectGraphBuilder as DevkitProjectGraphBuilder } from '@nrwl/devkit';
 
-export class ProjectGraphBuilder {
-  readonly nodes: Record<string, ProjectGraphNode> = {};
-  readonly dependencies: Record<
-    string,
-    Record<string, ProjectGraphDependency>
-  > = {};
-
-  constructor(g?: ProjectGraph) {
-    if (g) {
-      Object.values(g.nodes).forEach((n) => this.addNode(n));
-      Object.values(g.dependencies).forEach((ds) => {
-        ds.forEach((d) => this.addDependency(d.type, d.source, d.target));
-      });
-    }
-  }
-
-  addNode(node: ProjectGraphNode) {
-    // Check if project with the same name already exists
-    if (this.nodes[node.name]) {
-      // Throw if existing project is of a different type
-      if (this.nodes[node.name].type !== node.type) {
-        throw new Error(
-          `Multiple projects are named "${node.name}". One is of type "${
-            node.type
-          }" and the other is of type "${
-            this.nodes[node.name].type
-          }". Please resolve the conflicting project names.`
-        );
-      }
-    }
-    this.nodes[node.name] = node;
-    this.dependencies[node.name] = {};
-  }
-
-  addDependency(
-    type: DependencyType | string,
-    sourceProjectName: string,
-    targetProjectName: string
-  ) {
-    if (sourceProjectName === targetProjectName) {
-      return;
-    }
-    if (!this.nodes[sourceProjectName]) {
-      throw new Error(`Source project does not exist: ${sourceProjectName}`);
-    }
-    if (!this.nodes[targetProjectName]) {
-      throw new Error(`Target project does not exist: ${targetProjectName}`);
-    }
-    this.dependencies[sourceProjectName][
-      `${sourceProjectName} -> ${targetProjectName}`
-    ] = {
-      type,
-      source: sourceProjectName,
-      target: targetProjectName,
-    };
-  }
-
-  build(): ProjectGraph {
-    return {
-      nodes: this.nodes as ProjectGraph['nodes'],
-      dependencies: Object.keys(this.dependencies).reduce((acc, k) => {
-        acc[k] = Object.values(this.dependencies[k]);
-        return acc;
-      }, {} as ProjectGraph['dependencies']),
-    };
+export class ProjectGraphBuilder extends DevkitProjectGraphBuilder {
+  build() {
+    return super.getProjectGraph();
   }
 }

--- a/packages/workspace/src/core/project-graph/project-graph-models.ts
+++ b/packages/workspace/src/core/project-graph/project-graph-models.ts
@@ -1,52 +1,41 @@
 import { ProjectFileMap } from '../file-graph';
-import { FileData } from '../file-utils';
-import { NxJson } from '../shared-interfaces';
-import { TargetConfiguration } from '@nrwl/tao/src/shared/workspace';
+import type {
+  ProjectGraphNode,
+  DependencyType,
+  NxJsonConfiguration,
+} from '@nrwl/devkit';
+export {
+  ProjectGraph,
+  ProjectGraphDependency,
+  ProjectGraphNode,
+  DependencyType,
+} from '@nrwl/devkit';
 
-export interface ProjectGraph {
-  nodes: Record<string, ProjectGraphNode>;
-  dependencies: Record<string, ProjectGraphDependency[]>;
-
-  // this is optional otherwise it might break folks who use project graph creation
-  allWorkspaceFiles?: FileData[];
-}
-
-export enum DependencyType {
-  static = 'static',
-  dynamic = 'dynamic',
-  implicit = 'implicit',
-}
-
-export interface ProjectGraphNode<T extends {} = {}> {
-  type: string;
-  name: string;
-  data: T & {
-    root?: string;
-    targets?: { [targetName: string]: TargetConfiguration };
-    files: FileData[];
-    [k: string]: any;
-  };
-}
-
+/**
+ * @deprecated
+ */
 export type ProjectGraphNodeRecords = Record<string, ProjectGraphNode>;
 
+/**
+ * @deprecated
+ */
 export type AddProjectNode = (node: ProjectGraphNode) => void;
 
-export interface ProjectGraphDependency {
-  type: DependencyType | string;
-  target: string;
-  source: string;
-}
-
+/**
+ * @deprecated
+ */
 export type AddProjectDependency = (
   type: DependencyType | string,
   source: string,
   target: string
 ) => void;
 
+/**
+ * @deprecated
+ */
 export interface ProjectGraphContext {
   workspaceJson: any;
-  nxJson: NxJson;
+  nxJson: NxJsonConfiguration;
   fileMap: ProjectFileMap;
 }
 

--- a/packages/workspace/src/core/shared-interfaces.ts
+++ b/packages/workspace/src/core/shared-interfaces.ts
@@ -1,43 +1,22 @@
 import { WorkspaceResults } from '@nrwl/workspace/src/command-line/workspace-results';
-
-export type ImplicitDependencyEntry<T = '*' | string[]> = {
-  [key: string]: T | ImplicitJsonSubsetDependency<T>;
-};
-
-export interface ImplicitJsonSubsetDependency<T = '*' | string[]> {
-  [key: string]: T | ImplicitJsonSubsetDependency<T>;
-}
-
-export interface NxAffectedConfig {
-  defaultBase?: string;
-}
-
-export interface NxJson<T = '*' | string[]> {
-  implicitDependencies?: ImplicitDependencyEntry<T>;
-  npmScope: string;
-  affected?: NxAffectedConfig;
-  projects: {
-    [projectName: string]: NxJsonProjectConfig;
-  };
-  workspaceLayout?: {
-    libsDir?: string;
-    appsDir?: string;
-  };
-  tasksRunnerOptions?: {
-    [tasksRunnerName: string]: {
-      runner: string;
-      options?: object;
-    };
-  };
-}
-
-export interface NxJsonProjectConfig {
-  implicitDependencies?: string[];
-  tags?: string[];
-}
+import type {
+  ImplicitDependencyEntry,
+  ImplicitJsonSubsetDependency,
+  NxAffectedConfig,
+  NxJsonConfiguration,
+  NxJsonProjectConfiguration,
+} from '@nrwl/devkit';
 
 export interface Environment {
-  nxJson: NxJson;
+  nxJson: NxJsonConfiguration;
   workspaceJson: any;
   workspaceResults: WorkspaceResults;
 }
+
+export {
+  NxJsonProjectConfiguration as NxJsonProjectConfig,
+  NxJsonConfiguration as NxJson,
+  NxAffectedConfig,
+  ImplicitDependencyEntry,
+  ImplicitJsonSubsetDependency,
+};


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There is no way to extend the project graph creation of Nx.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This is experimental so there may be changes here soon as we explore what's needed. More docs will be coming soon.

Users can define plugins to the project graph creation of Nx in `nx.json` as follows:

`nx.json`:
```json
{
  ...
  "plugins": [
    "awesome-plugin"
  ]
}
```

Plugins should export a function named `processProjectGraph` with the following signature:

```ts
import { ProjectGraph, ProjectGraphProcessorContext, ProjectGraphBuilder } from '@nrwl/devkit';

export function processProjectGraph(graph: ProjectGraph, context: ProjectGraphProcessorContext): ProjectGraph {
  // This is a Builder which makes updating the graph easier.
  const builder = new ProjectGraphBuilder(graph);
  
  builder.addNode({
    name: 'new-node',
    type: 'lib',
    data: {
      files: []
    }
  });
  
  builder.addDependency('static', 'new-node', 'shared-ui');

  return builder.getProjectGraph();
}
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
