### PR TITLE
fix(angular): resolve @angular/cli version mismatch causing data persistence typing to be broken

### DIFF
--- a/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.effects.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/creator-files/__directory__/__fileName__.effects.ts__tmpl__
@@ -13,7 +13,7 @@ export class <%= className %>Effects {
       return <%= className %>Actions.load<%= className %>Success({ <%= propertyName %>: [] });
     },
 
-    onError: (action: ReturnType<typeof <%= className %>Actions.init>>, error) => {
+    onError: (action: ReturnType<typeof <%= className %>Actions.init>, error) => {
       console.error('Error', error);
       return <%= className %>Actions.load<%= className %>Failure({ error });
     }

--- a/packages/workspace/src/utils/versions.ts
+++ b/packages/workspace/src/utils/versions.ts
@@ -1,6 +1,6 @@
 export const nxVersion = '*';
 
-export const angularCliVersion = '~11.0.0';
+export const angularCliVersion = '~11.2.0';
 export const buildAngularVersion = '~0.1102.0';
 export const typescriptVersion = '~4.1.4';
 export const prettierVersion = '2.2.1';


### PR DESCRIPTION
## Current Behavior
When creating a new workspace configured to use the Angular cli instead of Nx (e.g. `preset=angular` or `preset=angular-nest` or `cli=angular`), if any Angular app in the workspace uses the DataPersistence helpers provided by the `@nrwl/angular` package, a typing error occurs due to a version mismatch which causes the `@nrwl/angular` to have in its resolved node_modules a different `rxjs` version than the one existing in the workspace. Everything in Nx with Angular deps has been migrated to 11.2.x, but the `@angular/cli` dep in the workspace is still set to `11.0.x` which ends up causing this issue.

There's this issue #5059 which mention this problem, but it refers to be happening when migrating to version 11 and it doesn't contain much details, I couldn't reproduce the issue when migrating because we do have a migration in 11.3.0 where we update all Angular related packages, including the `@angular/cli` to the right version.

## Expected Behavior
The DataPersistence helpers work correctly with no typing issues.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
