### PR TITLE
fix(gatsby): update our gatsby-cli to v3

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -36,6 +36,6 @@
     "@nrwl/node": "*",
     "@nrwl/react": "*",
     "@nrwl/workspace": "*",
-    "gatsby-cli": "^2.17.1"
+    "gatsby-cli": "^3.2.0"
   }
 }


### PR DESCRIPTION
This PR updates our `@nrwl/gatsby` dependency on `gatsby-cli` to v3 so it is in sync with the generated apps.