### PR TITLE
fix(devkit): affected projects should use graph rather than workspace.json

### DIFF
--- a/packages/devkit/src/project-graph/interfaces.ts
+++ b/packages/devkit/src/project-graph/interfaces.ts
@@ -58,7 +58,7 @@ export interface ProjectGraphNode<T = any> {
     /**
      * The project's root directory
      */
-    root?: string;
+    root: string;
     /**
      * Targets associated to the project
      */

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -24,6 +24,7 @@ export {
   readWorkspaceJson,
   readNxJson,
   readWorkspaceConfig,
+  getFileData,
 } from './src/core/file-utils';
 export { NxJson } from './src/core/shared-interfaces';
 export {

--- a/packages/workspace/src/core/affected-project-graph/locators/workspace-projects.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/workspace-projects.spec.ts
@@ -13,6 +13,25 @@ function getFileChanges(files: string[]) {
   }));
 }
 
+function createGraphFromProjects(projects: {
+  [projectName: string]: { root: string };
+}) {
+  const nodes = {};
+  for (const [name, val] of Object.entries(projects)) {
+    nodes[name] = {
+      name,
+      type: 'lib',
+      data: {
+        root: val.root,
+      },
+    };
+  }
+  return {
+    nodes,
+    dependencies: {},
+  };
+}
+
 describe('getTouchedProjects', () => {
   it('should return a list of projects for the given changes', () => {
     const fileChanges = getFileChanges(['libs/a/index.ts', 'libs/b/index.ts']);
@@ -21,7 +40,15 @@ describe('getTouchedProjects', () => {
       b: { root: 'libs/b' },
       c: { root: 'libs/c' },
     };
-    expect(getTouchedProjects(fileChanges, { projects })).toEqual(['a', 'b']);
+    expect(
+      getTouchedProjects(
+        fileChanges,
+        undefined,
+        undefined,
+        undefined,
+        createGraphFromProjects(projects)
+      )
+    ).toEqual(['a', 'b']);
   });
 
   it('should return projects with the root matching a whole directory name in the file path', () => {
@@ -31,7 +58,15 @@ describe('getTouchedProjects', () => {
       abc: { root: 'libs/a-b-c' },
       ab: { root: 'libs/a-b' },
     };
-    expect(getTouchedProjects(fileChanges, { projects })).toEqual(['ab']);
+    expect(
+      getTouchedProjects(
+        fileChanges,
+        undefined,
+        undefined,
+        undefined,
+        createGraphFromProjects(projects)
+      )
+    ).toEqual(['ab']);
   });
 
   it('should return projects with the root matching a whole directory name in the file path', () => {
@@ -41,7 +76,15 @@ describe('getTouchedProjects', () => {
       abc: { root: 'libs/a-b-c' },
       ab: { root: 'libs/a-b' },
     };
-    expect(getTouchedProjects(fileChanges, { projects })).toEqual(['ab']);
+    expect(
+      getTouchedProjects(
+        fileChanges,
+        undefined,
+        undefined,
+        undefined,
+        createGraphFromProjects(projects)
+      )
+    ).toEqual(['ab']);
   });
 
   it('should return the most qualifying match with the file path', () => {
@@ -50,7 +93,15 @@ describe('getTouchedProjects', () => {
       aaaaa: { root: 'libs/a' },
       ab: { root: 'libs/a/b' },
     };
-    expect(getTouchedProjects(fileChanges, { projects })).toEqual(['ab']);
+    expect(
+      getTouchedProjects(
+        fileChanges,
+        undefined,
+        undefined,
+        undefined,
+        createGraphFromProjects(projects)
+      )
+    ).toEqual(['ab']);
   });
 });
 

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -107,7 +107,7 @@ function defaultReadFileAtRevision(
   }
 }
 
-function getFileData(filePath: string): FileData {
+export function getFileData(filePath: string): FileData {
   const file = path.relative(appRootPath, filePath).split(path.sep).join('/');
   return {
     file,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

For project-graph-plugins:

- No help is given by Nx to hash files when writing a plugin
- Affected does not work at all for nodes which have only been added via a plugin

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

For project-graph-plugins:

- Nx should expose its file hashing utility (I have exposed `getFileData` from `@nrwl/workspace`)
- Affected should work for nodes which have only been added via a plugin

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
