### PR TITLE
feat(web): support multiple `rollupConfig` plugins

### DIFF
--- a/docs/angular/api-web/executors/package.md
+++ b/docs/angular/api-web/executors/package.md
@@ -12,11 +12,13 @@ Type: `array`
 
 List of static assets.
 
-### babelConfig
+### ~~babelConfig~~
 
 Type: `string`
 
-(deprecated) Path to a function which takes a babel config and returns an updated babel config
+**Deprecated:** Use the .babelrc file for project instead
+
+Path to a function which takes a babel config and returns an updated babel config
 
 ### buildableProjectDepsInPackageJsonType
 
@@ -88,7 +90,7 @@ The path to package.json file.
 
 ### rollupConfig
 
-Type: `string`
+Type: `array[] | string `
 
 Path to a function which takes a rollup config and returns an updated rollup config
 

--- a/docs/node/api-web/executors/package.md
+++ b/docs/node/api-web/executors/package.md
@@ -13,11 +13,13 @@ Type: `array`
 
 List of static assets.
 
-### babelConfig
+### ~~babelConfig~~
 
 Type: `string`
 
-(deprecated) Path to a function which takes a babel config and returns an updated babel config
+**Deprecated:** Use the .babelrc file for project instead
+
+Path to a function which takes a babel config and returns an updated babel config
 
 ### buildableProjectDepsInPackageJsonType
 
@@ -89,7 +91,7 @@ The path to package.json file.
 
 ### rollupConfig
 
-Type: `string`
+Type: `array[] | string `
 
 Path to a function which takes a rollup config and returns an updated rollup config
 

--- a/docs/react/api-web/executors/package.md
+++ b/docs/react/api-web/executors/package.md
@@ -13,11 +13,13 @@ Type: `array`
 
 List of static assets.
 
-### babelConfig
+### ~~babelConfig~~
 
 Type: `string`
 
-(deprecated) Path to a function which takes a babel config and returns an updated babel config
+**Deprecated:** Use the .babelrc file for project instead
+
+Path to a function which takes a babel config and returns an updated babel config
 
 ### buildableProjectDepsInPackageJsonType
 
@@ -89,7 +91,7 @@ The path to package.json file.
 
 ### rollupConfig
 
-Type: `string`
+Type: `array[] | string `
 
 Path to a function which takes a rollup config and returns an updated rollup config
 

--- a/packages/web/src/builders/package/package.impl.spec.ts
+++ b/packages/web/src/builders/package/package.impl.spec.ts
@@ -35,7 +35,7 @@ describe('packageExecutor', () => {
   });
 
   describe('createRollupOptions', () => {
-    it('should', () => {
+    it('should work', () => {
       const result: any = createRollupOptions(
         normalizePackageOptions(testOptions, '/root', '/root/src'),
         [],
@@ -57,6 +57,65 @@ describe('packageExecutor', () => {
           name: 'Example',
         },
       ]);
+    });
+
+    it('should handle custom config path', async () => {
+      jest.mock(
+        '/root/custom-rollup.config.ts',
+        () => (o) => ({ ...o, prop: 'my-val' }),
+        { virtual: true }
+      );
+      const result: any = createRollupOptions(
+        normalizePackageOptions(
+          { ...testOptions, rollupConfig: 'custom-rollup.config.ts' },
+          '/root',
+          '/root/src'
+        ),
+        [],
+        context,
+        { name: 'example' },
+        '/root/src'
+      );
+      expect(result.map((x) => x.prop)).toEqual(['my-val', 'my-val']);
+    });
+
+    it('should handle multiple custom config paths in order', async () => {
+      jest.mock(
+        '/root/custom-rollup-1.config.ts',
+        () => (o) => ({ ...o, prop1: 'my-val' }),
+        { virtual: true }
+      );
+      jest.mock(
+        '/root/custom-rollup-2.config.ts',
+        () => (o) => ({
+          ...o,
+          prop1: o.prop1 + '-my-val-2',
+          prop2: 'my-val-2',
+        }),
+        { virtual: true }
+      );
+      const result: any = createRollupOptions(
+        normalizePackageOptions(
+          {
+            ...testOptions,
+            rollupConfig: [
+              'custom-rollup-1.config.ts',
+              'custom-rollup-2.config.ts',
+            ],
+          },
+          '/root',
+          '/root/src'
+        ),
+        [],
+        context,
+        { name: 'example' },
+        '/root/src'
+      );
+      expect(result.map((x) => x.prop1)).toEqual([
+        'my-val-my-val-2',
+        'my-val-my-val-2',
+      ]);
+      expect(result.map((x) => x.prop2)).toEqual(['my-val-2', 'my-val-2']);
     });
 
     it(`should always use forward slashes for asset paths`, () => {

--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -83,6 +83,12 @@ export default function run(
     throw new Error();
   }
 
+  if (rawOptions.babelConfig) {
+    logger.warn(
+      `Deprecated option "babelConfig" used, please use the .babelrc file for ${context.projectName} instead.`
+    );
+  }
+
   const options = normalizePackageOptions(rawOptions, context.root, sourceRoot);
   const packageJson = readJsonFile(options.project);
 
@@ -93,12 +99,6 @@ export default function run(
     packageJson,
     sourceRoot
   );
-
-  if (options.babelConfig) {
-    logger.warn(
-      `Deprecated option "babelConfig" used, please use the .babelrc file for ${context.projectName} instead.`
-    );
-  }
 
   if (options.watch) {
     const watcher = rollup.watch(rollupOptions);
@@ -268,9 +268,9 @@ export function createRollupOptions(
       plugins,
     };
 
-    return options.rollupConfig
-      ? require(options.rollupConfig)(rollupConfig, options)
-      : rollupConfig;
+    return options.rollupConfig.reduce((currentConfig, plugin) => {
+      return require(plugin)(currentConfig, options);
+    }, rollupConfig);
   });
 }
 

--- a/packages/web/src/builders/package/schema.json
+++ b/packages/web/src/builders/package/schema.json
@@ -49,12 +49,23 @@
       "default": "peerDependencies"
     },
     "rollupConfig": {
-      "type": "string",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
       "description": "Path to a function which takes a rollup config and returns an updated rollup config"
     },
     "babelConfig": {
       "type": "string",
-      "description": "(deprecated) Path to a function which takes a babel config and returns an updated babel config"
+      "description": "Path to a function which takes a babel config and returns an updated babel config",
+      "x-deprecated": "Use the .babelrc file for project instead"
     },
     "umdName": {
       "type": "string",

--- a/packages/web/src/utils/normalize.spec.ts
+++ b/packages/web/src/utils/normalize.spec.ts
@@ -124,41 +124,34 @@ describe('normalizePackageOptions', () => {
       project: 'apps/nodeapp/package.json',
       entryFile: 'apps/nodeapp/src/main.ts',
       tsConfig: 'apps/nodeapp/tsconfig.app.json',
-      babelConfig: 'apps/nodeapp/babel.config',
       rollupConfig: 'apps/nodeapp/rollup.config',
     };
     root = '/root';
     sourceRoot = 'apps/nodeapp/src';
   });
 
-  it('should resolve both node modules and relative path for babelConfig/rollupConfig', () => {
+  it('should resolve both node modules and relative path for rollupConfig', () => {
     let result = normalizePackageOptions(testOptions, root, sourceRoot);
-    expect(result.babelConfig).toEqual('/root/apps/nodeapp/babel.config');
-    expect(result.rollupConfig).toEqual('/root/apps/nodeapp/rollup.config');
+    expect(result.rollupConfig).toEqual(['/root/apps/nodeapp/rollup.config']);
 
     result = normalizePackageOptions(
       {
         ...testOptions,
         // something that exists in node_modules
         rollupConfig: 'react',
-        babelConfig: 'react',
       },
       root,
       sourceRoot
     );
-    expect(result.babelConfig).toMatch('react');
-    expect(result.babelConfig).not.toMatch(root);
-    expect(result.rollupConfig).toMatch('react');
-    expect(result.rollupConfig).not.toMatch(root);
+    expect(result.rollupConfig).toHaveLength(1);
+    expect(result.rollupConfig[0]).toMatch('react');
+    expect(result.rollupConfig[0]).not.toMatch(root);
   });
 
-  it('should handle babelConfig/rollupConfig being undefined', () => {
-    delete testOptions.babelConfig;
+  it('should handle rollupConfig being undefined', () => {
     delete testOptions.rollupConfig;
 
     const result = normalizePackageOptions(testOptions, root, sourceRoot);
-
-    expect(result.babelConfig).toEqual('');
-    expect(result.rollupConfig).toEqual('');
+    expect(result.rollupConfig).toEqual([]);
   });
 });

--- a/packages/web/src/utils/normalize.ts
+++ b/packages/web/src/utils/normalize.ts
@@ -17,6 +17,7 @@ export interface NormalizedBundleBuilderOptions extends PackageBuilderOptions {
   entryRoot: string;
   projectRoot: string;
   assets: AssetGlobPattern[];
+  rollupConfig: string[];
 }
 
 export function normalizePackageOptions(
@@ -36,8 +37,10 @@ export function normalizePackageOptions(
 
   return {
     ...options,
-    babelConfig: normalizePluginPath(options.babelConfig, root),
-    rollupConfig: normalizePluginPath(options.rollupConfig, root),
+    rollupConfig: []
+      .concat(options.rollupConfig)
+      .filter(Boolean)
+      .map((p) => normalizePluginPath(p, root)),
     assets: options.assets
       ? normalizeAssets(options.assets, root, sourceRoot)
       : undefined,

--- a/packages/web/src/utils/types.ts
+++ b/packages/web/src/utils/types.ts
@@ -52,7 +52,7 @@ export interface PackageBuilderOptions {
   extractCss?: boolean;
   globals?: Globals[];
   external?: string[];
-  rollupConfig?: string;
+  rollupConfig?: string | string[];
   babelConfig?: string;
   watch?: boolean;
   assets?: any[];


### PR DESCRIPTION
Also, `babelConfig` is not actually used, so it's removed from normalized options.