### PR TITLE
fix(web): fix named exports mapping for react/jsx-runtime

### DIFF
--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -237,7 +237,7 @@ export function createRollupOptions(
         namedExports: {
           // This is needed because `react/jsx-runtime` exports `jsx` on the module export.
           // Without this mapping the transformed import `import {jsx as _jsx} from 'react/jsx-runtime'` will fail.
-          'react/jsx-runtime': ['jsx'],
+          'react/jsx-runtime': ['jsx', 'jsxs', 'Fragment'],
         },
       }),
       filesize(),

--- a/packages/web/src/builders/package/package.impl.ts
+++ b/packages/web/src/builders/package/package.impl.ts
@@ -238,6 +238,7 @@ export function createRollupOptions(
           // This is needed because `react/jsx-runtime` exports `jsx` on the module export.
           // Without this mapping the transformed import `import {jsx as _jsx} from 'react/jsx-runtime'` will fail.
           'react/jsx-runtime': ['jsx', 'jsxs', 'Fragment'],
+          'react/jsx-dev-runtime': ['jsxDEV', 'Fragment'],
         },
       }),
       filesize(),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
It seems the mapping is not enough to build a buildable library using `react/jsx-runtime`.

![image](https://user-images.githubusercontent.com/2607019/114203490-2f6f5600-9993-11eb-9686-0b3c59febda4.png)
![image](https://user-images.githubusercontent.com/2607019/114203601-4746da00-9993-11eb-9767-fd2e1a55fe65.png)


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
No errors during building a library.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5328
