### PR TITLE
fix(core): throw an error if generating a new workspace into a non-em…

### DIFF
--- a/packages/workspace/src/generators/new/new.spec.ts
+++ b/packages/workspace/src/generators/new/new.spec.ts
@@ -106,4 +106,19 @@ describe('new', () => {
     expect(readJson(tree, 'package.json')).toEqual(packageJson);
     expect(readJson(tree, '.eslintrc.json')).toEqual(eslintConfig);
   });
+
+  it('should throw an error when the directory is not empty', async () => {
+    tree.write('my-workspace/file.txt', '');
+
+    try {
+      await newGenerator(tree, {
+        ...defaultOptions,
+        name: 'my-workspace',
+        directory: 'my-workspace',
+        npmScope: 'npmScope',
+        appName: 'app',
+      });
+      fail('Generating into a non-empty directory should error.');
+    } catch (e) {}
+  });
 });

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -171,6 +171,16 @@ export async function newGenerator(host: Tree, options: Schema) {
 
   options = normalizeOptions(options);
 
+  if (
+    host.exists(options.name) &&
+    !host.isFile(options.name) &&
+    host.children(options.name).length > 0
+  ) {
+    throw new Error(
+      `${join(host.root, options.name)} is not an empty directory.`
+    );
+  }
+
   const layout: 'packages' | 'apps-and-libs' =
     options.preset === 'oss' ? 'packages' : 'apps-and-libs';
   const workspaceOpts = {


### PR DESCRIPTION
…pty directory

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Creating a new nx workspace into a directory where a workspace already exists throws a cryptic error:

<details>
jason@pop-os ~/p/t/n/12.0.0> npx create-nx-workspace@12.0.0
✔ Workspace name (e.g., org name)     · fail4
✔ What to create in the new workspace · angular
✔ Application name                    · app1
✔ Default stylesheet format           · css
✔ Default linter                      · eslint
✔ Use Nx Cloud? (It's free and doesn't require registration.) · No

>  NX  Nx is creating your workspace.

  To make sure the command works reliably in all environments, and that the preset is applied correctly,
  Nx will run "npm install" several times. Please wait.

⠋ Creating your workspace
>  NX   ERROR  Something went wrong. Rerunning the command with verbose logging.

Failed to format: fail4/angular.json
TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined
    at new NodeError (node:internal/errors:329:5)
    at Function.from (node:buffer:323:9)
    at FsTree.write (/tmp/tmp-62629rHjo0MjN2YuX/node_modules/@nrwl/tao/src/shared/tree.js:35:20)
    at writeJson (/tmp/tmp-62629rHjo0MjN2YuX/node_modules/@nrwl/devkit/src/utils/json.js:32:10)
    at Object.updateJson (/tmp/tmp-62629rHjo0MjN2YuX/node_modules/@nrwl/devkit/src/utils/json.js:44:5)
    at formatWorkspaceJson (/tmp/tmp-62629rHjo0MjN2YuX/node_modules/@nrwl/workspace/src/generators/workspace/workspace.js:53:18)
    at Object.<anonymous> (/tmp/tmp-62629rHjo0MjN2YuX/node_modules/@nrwl/workspace/src/generators/workspace/workspace.js:78:9)
    at Generator.next (<anonymous>)
    at fulfilled (/tmp/tmp-62629rHjo0MjN2YuX/node_modules/tslib/tslib.js:114:62) {
  code: 'ERR_INVALID_ARG_TYPE'
}
MergeConflictException [Error]: A merge conflicted on path "/apps/app1/tsconfig.editor.json".
    at /home/jason/projects/temp/nx-tests/12.0.0/fail4/node_modules/@angular-devkit/schematics/src/tree/host-tree.js:142:35
    at Array.forEach (<anonymous>)
    at HostTree.merge (/home/jason/projects/temp/nx-tests/12.0.0/fail4/node_modules/@angular-devkit/schematics/src/tree/host-tree.js:131:23)
    at MapSubscriber.project (/home/jason/projects/temp/nx-tests/12.0.0/fail4/node_modules/@angular-devkit/schematics/src/rules/base.js:54:91)
    at MapSubscriber._next (/home/jason/projects/temp/nx-tests/12.0.0/fail4/node_modules/rxjs/internal/operators/map.js:49:35)
    at MapSubscriber.Subscriber.next (/home/jason/projects/temp/nx-tests/12.0.0/fail4/node_modules/rxjs/internal/Subscriber.js:66:18)
    at TapSubscriber._next (/home/jason/projects/temp/nx-tests/12.0.0/fail4/node_modules/rxjs/internal/operators/tap.js:65:26)
    at TapSubscriber.Subscriber.next (/home/jason/projects/temp/nx-tests/12.0.0/fail4/node_modules/rxjs/internal/Subscriber.js:66:18)
    at ThrowIfEmptySubscriber._next (/home/jason/projects/temp/nx-tests/12.0.0/fail4/node_modules/rxjs/internal/operators/throwIfEmpty.js:44:26)
    at ThrowIfEmptySubscriber.Subscriber.next (/home/jason/projects/temp/nx-tests/12.0.0/fail4/node_modules/rxjs/internal/Subscriber.js:66:18)
A merge conflicted on path "/apps/app1/tsconfig.editor.json".
npm ERR! code 1
npm ERR! path /home/jason/projects/temp/nx-tests/12.0.0/fail4
npm ERR! command failed
npm ERR! command sh -c ng "g" "@nrwl/workspace:preset" "--name=app1" "--style=css" "--linter=eslint" "--npmScope=fail4" "--preset=angular" "--cli=ng" "--interactive=false"

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/jason/.npm/_logs/2021-04-09T19_38_48_846Z-debug.log
Workspace creation failed, see above.
npm ERR! code 1
npm ERR! path /tmp/tmp-62629rHjo0MjN2YuX
npm ERR! command failed
npm ERR! command sh -c tao "new" "fail4" "--no-interactive" "--preset=angular" "--appName=app1" "--style=css" "--linter=eslint" "--no-nxCloud" "--collection=@nrwl/workspace/collection.json" "--cli=angular" "--nxWorkspaceRoot=/home/jason/projects/temp/nx-tests/12.0.0"

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/jason/.npm/_logs/2021-04-09T19_38_48_873Z-debug.log

>  NX   ERROR  Something went wrong! v12.0.0

node:child_process:707
    err = new Error(msg);
          ^

Error: Command failed: npx tao new fail4 --no-interactive --preset=angular --appName=app1 --style=css --linter=eslint --no-nxCloud --collection=@nrwl/workspace/collection.json --cli=angular --nxWorkspaceRoot="/home/jason/projects/temp/nx-tests/12.0.0"
    at checkExecSyncError (node:child_process:707:11)
    at Object.execSync (node:child_process:744:15)
    at /home/jason/.npm/_npx/12837211e1e52e16/node_modules/create-nx-workspace/bin/create-nx-workspace.js:449:29
    at Generator.throw (<anonymous>)
    at rejected (/home/jason/.npm/_npx/12837211e1e52e16/node_modules/tslib/tslib.js:115:69)
    at processTicksAndRejections (node:internal/process/task_queues:94:5) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 62726,
  stdout: null,
  stderr: null
}
npm ERR! code 1
npm ERR! path /home/jason/projects/temp/nx-tests/12.0.0
npm ERR! command failed
npm ERR! command sh -c create-nx-workspace

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/jason/.npm/_logs/2021-04-09T19_38_48_896Z-debug.log
</details>

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Creating a workspace in any non-empty directory will fail with an error:

<details>
jason@pop-os ~/p/t/n/12.0.0 [1]> npx create-nx-workspace@12.99.0
Need to install the following packages:
  create-nx-workspace@12.99.0
Ok to proceed? (y) y
✔ Workspace name (e.g., org name)     · fail4
✔ What to create in the new workspace · angular
✔ Application name                    · app1
✔ Default stylesheet format           · scss
✔ Default linter                      · eslint
✔ Use Nx Cloud? (It's free and doesn't require registration.) · No

>  NX  Nx is creating your workspace.

  To make sure the command works reliably in all environments, and that the preset is applied correctly,
  Nx will run "npm install" several times. Please wait.

⠸ Creating your workspace
>  NX   ERROR  Something went wrong. Rerunning the command with verbose logging.

/home/jason/projects/temp/nx-tests/12.0.0/fail4 is not an empty directory.
npm ERR! code 1
npm ERR! path /tmp/tmp-65249VT2ObKFJ4Sbb
npm ERR! command failed
npm ERR! command sh -c tao "new" "fail4" "--no-interactive" "--preset=angular" "--appName=app1" "--style=scss" "--linter=eslint" "--no-nxCloud" "--collection=@nrwl/workspace/collection.json" "--cli=angular" "--nxWorkspaceRoot=/home/jason/projects/temp/nx-tests/12.0.0"

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/jason/.npm/_logs/2021-04-09T19_45_58_598Z-debug.log

>  NX   ERROR  Something went wrong! v12.99.0

node:child_process:707
    err = new Error(msg);
          ^

Error: Command failed: npx tao new fail4 --no-interactive --preset=angular --appName=app1 --style=scss --linter=eslint --no-nxCloud --collection=@nrwl/workspace/collection.json --cli=angular --nxWorkspaceRoot="/home/jason/projects/temp/nx-tests/12.0.0"
    at checkExecSyncError (node:child_process:707:11)
    at Object.execSync (node:child_process:744:15)
    at /home/jason/.npm/_npx/f75958e8f0597570/node_modules/create-nx-workspace/bin/create-nx-workspace.js:449:29
    at Generator.throw (<anonymous>)
    at rejected (/home/jason/.npm/_npx/f75958e8f0597570/node_modules/tslib/tslib.js:115:69)
    at processTicksAndRejections (node:internal/process/task_queues:94:5) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 65302,
  stdout: null,
  stderr: null
}
npm ERR! code 1
npm ERR! path /home/jason/projects/temp/nx-tests/12.0.0
npm ERR! command failed
npm ERR! command sh -c create-nx-workspace

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/jason/.npm/_logs/2021-04-09T19_45_58_623Z-debug.log
</details>

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
