### PR TITLE
fix(devkit): add env variable to disable project graph cache

### DIFF
--- a/docs/shared/workspace/project-graph-plugins.md
+++ b/docs/shared/workspace/project-graph-plugins.md
@@ -2,7 +2,7 @@
 
 > This API is experimental and might change.
 
-Nx views the workspace as a graph of projects that depend on one another. It's able to infer most projects and dependencies automatically. Currently, this works best within the Javascript ecosystem but it can be extended to other languages and technologies as well.
+Nx views the workspace as a graph of projects that depend on one another. It's able to infer most projects and dependencies automatically. Currently, this works best within the JavaScript ecosystem, but it can be extended to other languages and technologies as well. This is where project graph plugins come in.
 
 ## Defining Plugins to be used in a workspace
 
@@ -21,14 +21,16 @@ These plugins are used when running targets, linting, and sometimes when generat
 
 ## Implementing a Project Graph Processor
 
-Project Graph Plugins are chained together to produce the final project graph. Each plugin may have a Project Graph Processor which iterates upon the project graph. Plugins should export a function named `processProjectGraph` that handles updating the project graph with new nodes and edges. This function receives two things:
+Project Graph Plugins are chained together to produce the final project graph. Each plugin may have a Project Graph Processor which iterates upon the project graph. Let's first take a look at the API of Project Graph Plugins. In later sections, we will go over some common use cases. Plugins should export a function named `processProjectGraph` that handles updating the project graph with new nodes and edges. This function receives two things:
 
 - A `ProjectGraph`
   - Nodes in the project graph are the different projects currently in the graph.
   - Edges in the project graph are dependencies between different projects in the graph.
 - Some context is also passed into the function to use when processing the project graph. The context contains:
-  - The `workspace` which contains both configuration as well as the different projects.
+  - The `workspace` which contains both configuration and the different projects.
   - A `fileMap` which has a map of files by projects
+
+> Note: The notion of a workspace is separate from the notion of the project graph. The workspace is first party code that is checked into git, targets are run on, etc. The project graph may include third party packages as well that is not checked into git, not run at all, etc.
 
 The `processProjectGraph` function should return an updated `ProjectGraph`. This is most easily done using the `ProjectGraphBuilder` to iteratively add edges and nodes to the graph:
 
@@ -45,27 +47,47 @@ export function processProjectGraph(
   context: ProjectGraphProcessorContext
 ): ProjectGraph {
   const builder = new ProjectGraphBuilder(graph);
-
-  // Add a new node
-  builder.addNode({
-    name: 'new-project',
-    type: 'lib',
-    data: {
-      files: [],
-    },
-  });
-
-  // Add a new edge
-  builder.addDependency(
-    DependencyType.static,
-    'existing-project',
-    'new-project'
-  );
-
+  // We will see how this is used below.
   return builder.getProjectGraph();
 }
 ```
 
+## Adding New Dependencies to the Project Graph
+
+Project Graph Plugins can add smarter dependency resolution to projects already in the workspace. Projects in the workspace are first party code whose dependencies change as the code in the workspace changes and matter to Nx the most. Such projects should be defined in `workspace.json` and `nx.json` and will be automatically included as nodes in the project graph. However, when some projects are written in other languages, the relationships between these projects will not be clear to Nx out of the box. A Project Graph Plugin can add these relationships.
+
+```typescript
+import { DependencyType } from '@nrwl/devkit';
+
+// Add a new edge
+builder.addDependency(DependencyType.static, 'existing-project', 'new-project');
+```
+
+> Note: Even though the plugin is written in JavaScript, resolving dependencies of different languages will probably be more easily written in their native language. Therefore, a common approach is to spawn a new process and communicate via IPC or `stdout`.
+
+Dependencies can be one of the following types:
+
+- `DependencyType.static` dependencies indicate that a dependency is imported directly into the code and would be present even without running the code.
+- `DependencyType.dynamic` dependencies indicate that a dependency _might be_ imported at runtime such as lazy loaded dependencies.
+- `DependencyType.implicit` dependencies indicate that one project affects another project's behavior or outcome even though there is no dependency in the code. For example, e2e tests or communication over HTTP.
+
+## Adding New Nodes to the Project Graph
+
+Sometimes it can be valuable to have third party packages as part of the project graph. A Project Graph Plugin can add these packages to the project graph. After these packages are added as nodes to the project graph, dependencies can then be drawn from the workspace projects to the third party packages as well as between the third party packages.
+
+```typescript
+// Add a new node
+builder.addNode({
+  name: 'new-project',
+  type: 'npm',
+  data: {
+    files: [],
+  },
+});
+```
+
+> Note: You can designate any type for the node. This differentiates third party projects from projects in the workspace. Also, like before, retrieving these projects might be easiest within their native language. Therefore, spawning a new process may also be a common approach here.
+
 ## Visualizing the Project Graph
 
-You can then visualize the project graph as described [here](dependency-graph).
+You can then visualize the project graph as described [here](/{{framework}}/structure/dependency-graph). However, there is a cache that Nx uses to avoid recalculating the project graph as much as possible. As you develop your project graph plugin, it might be a good idea to set the following environment variable to disable the project graph cache: `NX_CACHE_PROJECT_GRAPH=false`.

--- a/packages/angular/src/migrations/update-10-5-0/add-template-support-and-presets-to-eslint.ts
+++ b/packages/angular/src/migrations/update-10-5-0/add-template-support-and-presets-to-eslint.ts
@@ -40,7 +40,7 @@ function addHTMLPatternToBuilderConfig(
 }
 
 function updateProjectESLintConfigsAndBuilders(host: Tree): Rule {
-  const graph = createProjectGraph(undefined, undefined, undefined, false);
+  const graph = createProjectGraph(undefined, undefined, undefined);
 
   /**
    * Make sure user is already using ESLint and is up to date with

--- a/packages/react/src/migrations/update-9-4-0/babelrc-9-4-0.ts
+++ b/packages/react/src/migrations/update-9-4-0/babelrc-9-4-0.ts
@@ -25,12 +25,7 @@ export default function update(): Rule {
   return (host: Tree, context: SchematicContext) => {
     const updates = [];
     const conflicts: Array<[string, string]> = [];
-    const projectGraph = createProjectGraph(
-      undefined,
-      undefined,
-      undefined,
-      false
-    );
+    const projectGraph = createProjectGraph(undefined, undefined, undefined);
     if (host.exists('/babel.config.json')) {
       context.logger.info(
         `

--- a/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.ts
+++ b/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.ts
@@ -7,9 +7,7 @@ import { hasDependentAppUsingWebBuild } from './utils';
 
 export async function createBabelrcForWorkspaceLibs(host: Tree) {
   const projects = getProjects(host);
-  const graph = reverse(
-    createProjectGraph(undefined, undefined, undefined, false)
-  );
+  const graph = reverse(createProjectGraph(undefined, undefined, undefined));
 
   for (const [name, p] of projects.entries()) {
     if (!hasDependentAppUsingWebBuild(name, graph, projects)) {

--- a/packages/workspace/src/core/project-graph/project-graph.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.ts
@@ -35,7 +35,6 @@ import {
 import { ProjectGraph } from './project-graph-models';
 import {
   differentFromCache,
-  ProjectGraphCache,
   readCache,
   writeCache,
 } from '../nx-deps/nx-deps-cache';
@@ -45,10 +44,10 @@ import { performance } from 'perf_hooks';
 export function createProjectGraph(
   workspaceJson = readWorkspaceJson(),
   nxJson = readNxJson(),
-  workspaceFiles = readWorkspaceFiles(),
-  cache: false | ProjectGraphCache = readCache(),
-  shouldCache: boolean = true
+  workspaceFiles = readWorkspaceFiles()
 ): ProjectGraph {
+  const cacheEnabled = process.env.NX_CACHE_PROJECT_GRAPH !== 'false';
+  let cache = cacheEnabled ? readCache() : false;
   assertWorkspaceValidity(workspaceJson, nxJson);
   const normalizedNxJson = normalizeNxJson(nxJson);
 
@@ -73,7 +72,7 @@ export function createProjectGraph(
       ctx,
       diff.partiallyConstructedProjectGraph
     );
-    if (shouldCache) {
+    if (cacheEnabled) {
       writeCache(rootFiles, projectGraph);
     }
     return addWorkspaceFiles(projectGraph, workspaceFiles);
@@ -84,7 +83,7 @@ export function createProjectGraph(
       fileMap: projectFileMap,
     };
     const projectGraph = buildProjectGraph(ctx, null);
-    if (shouldCache) {
+    if (cacheEnabled) {
       writeCache(rootFiles, projectGraph);
     }
     return addWorkspaceFiles(projectGraph, workspaceFiles);

--- a/packages/workspace/src/generators/remove/lib/check-dependencies.ts
+++ b/packages/workspace/src/generators/remove/lib/check-dependencies.ts
@@ -19,8 +19,7 @@ export function checkDependencies(_, schema: Schema) {
   const graph: ProjectGraph = createProjectGraph(
     undefined,
     undefined,
-    undefined,
-    false
+    undefined
   );
 
   const reverseGraph = onlyWorkspaceProjects(reverse(graph));

--- a/packages/workspace/src/utilities/create-project-graph-from-tree.ts
+++ b/packages/workspace/src/utilities/create-project-graph-from-tree.ts
@@ -6,5 +6,5 @@ import { createProjectGraph } from '../core/project-graph/project-graph';
  * @deprecated This method is deprecated and is synonymous to {@link createProjectGraph}()
  */
 export function createProjectGraphFromTree(tree: Tree) {
-  return createProjectGraph(undefined, undefined, undefined, false);
+  return createProjectGraph(undefined, undefined, undefined);
 }

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -371,7 +371,7 @@ export function getProjectGraphFromHost(host: Tree): ProjectGraph {
  * @deprecated This method is deprecated and is synonymous to {@link createProjectGraph}()
  */
 export function getFullProjectGraphFromHost(host: Tree): ProjectGraph {
-  return createProjectGraph(undefined, undefined, undefined, false);
+  return createProjectGraph(undefined, undefined, undefined);
 }
 
 // TODO(v13): remove this deprecated method


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When developing project graph plugins, if the workspace files are not touched, Nx will utilize the project graph cache and make testing project graph plugins difficult. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `NX_CACHE_PROJECT_GRAPH=false` environment variable will disable the project graph cache. This is useful when testing project graph plugins. Added specific sections about some different types of project graph plugins to the docs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
