### PR TITLE
feat(web): add fallback to file-server builder

### DIFF
--- a/packages/web/src/builders/file-server/file-server.impl.ts
+++ b/packages/web/src/builders/file-server/file-server.impl.ts
@@ -18,7 +18,8 @@ export interface FileServerOptions {
 }
 
 function getHttpServerArgs(opts: FileServerOptions) {
-  const args = [] as any[];
+  const args: string[] = [];
+
   if (opts.port) {
     args.push(`-p ${opts.port}`);
   }
@@ -128,9 +129,10 @@ export default async function* fileServerExecutor(
   const outputPath = getBuildTargetOutputPath(opts, context);
   const args = getHttpServerArgs(opts);
 
-  const serve = exec(`npx http-server ${outputPath} ${args.join(' ')}`, {
-    cwd: context.root,
-  });
+  const serve = exec(
+    `npx spa-http-server ${outputPath} ${args.join(' ')} --push-state`,
+    { cwd: context.root }
+  );
   const processExitListener = () => serve.kill();
   process.on('exit', processExitListener);
   serve.stdout.on('data', (chunk) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
A blank screen is shown when reloading the browser when the application uses `@nrwl/web:file-server` because the builder  does not support fallback for SPA.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`@nrwl/web:file-server` should show the screen of the SPA instead of the blank screen.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

⚠️ The implementation is subject to change
~One of the contributors of `http-server` recommended `spa-http-server` to solve this problem. 
https://github.com/http-party/http-server/issues/601~ 
