### PR TITLE
feat(core): replace `lodash.template` with a custom interpolation function

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,6 @@
     "less-loader": "5.0.0",
     "license-webpack-plugin": "2.1.2",
     "loader-utils": "1.2.3",
-    "lodash.template": "~4.5.0",
     "memfs": "^3.0.1",
     "mime": "2.4.4",
     "mini-css-extract-plugin": "0.8.0",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -73,7 +73,6 @@
     "chalk": "4.1.0",
     "axios": "0.21.1",
     "flat": "^5.0.2",
-    "lodash.template": "~4.5.0",
     "minimatch": "3.0.4",
     "enquirer": "~2.3.6",
     "resolve": "1.17.0",

--- a/packages/workspace/src/tasks-runner/utils.spec.ts
+++ b/packages/workspace/src/tasks-runner/utils.spec.ts
@@ -53,6 +53,22 @@ describe('utils', () => {
         ).toEqual(['path/one', 'two']);
       });
 
+      it('should support nested interpolation based on options', () => {
+        expect(
+          getOutputsForTargetAndConfiguration(
+            task,
+            getNode({
+              outputs: ['path/{options.nested.myVar}', 'two'],
+              options: {
+                nested: {
+                  myVar: 'one',
+                },
+              },
+            })
+          )
+        ).toEqual(['path/one', 'two']);
+      });
+
       it('should support interpolation based on configuration-specific options', () => {
         expect(
           getOutputsForTargetAndConfiguration(

--- a/packages/workspace/src/tasks-runner/utils.ts
+++ b/packages/workspace/src/tasks-runner/utils.ts
@@ -6,8 +6,7 @@ import {
 } from '@nrwl/devkit';
 import { Task } from './tasks-runner';
 import * as flatten from 'flat';
-import * as _template from 'lodash.template';
-import { output } from '@nrwl/workspace/src/utilities/output';
+import { output } from '../utilities/output';
 
 const commonCommands = ['build', 'test', 'lint', 'e2e', 'deploy'];
 
@@ -123,8 +122,8 @@ export function getOutputsForTargetAndConfiguration(
   };
 
   if (targets?.outputs) {
-    return targets.outputs.map((output) =>
-      _template(output, { interpolate: /{([\s\S]+?)}/g })({ options })
+    return targets.outputs.map((output: string) =>
+      interpolateOutputs(output, options)
     );
   }
 
@@ -176,4 +175,19 @@ function unparseOption(key: string, value: any, unparsed: string[]) {
   } else if (value != null) {
     unparsed.push(`--${key}=${value}`);
   }
+}
+
+function interpolateOutputs(template: string, data: any): string {
+  return template.replace(/{([\s\S]+?)}/g, (match: string) => {
+    let value = data;
+    let path = match.slice(1, -1).trim().split('.').slice(1);
+    for (let idx = 0; idx < path.length; idx++) {
+      if (!value[path[idx]]) {
+        throw new Error(`Could not interpolate output {${match}}!`);
+      }
+      value = value[path[idx]];
+    }
+
+    return value;
+  });
 }


### PR DESCRIPTION
## Current Behavior
nx uses `lodash.template` package

## Expected Behavior
nx should use `lodash` package as the usage of per method packages is discouraged see https://lodash.com/per-method-packages. lodash is a very widely used package and is already a dependency of many dependencies of nx so the usage of the per-method package only increases the nx package size.

Currently @nrwl/workspace adds this 3 extra dependencies to the node_modules: 

![image](https://user-images.githubusercontent.com/17254592/114309572-e41a8c00-9ae7-11eb-9434-b944ddf1a57a.png)

