### PR TITLE
fix(storybook): tsconfig.json errors with js files

### DIFF
--- a/packages/gatsby/src/generators/application/application.spec.ts
+++ b/packages/gatsby/src/generators/application/application.spec.ts
@@ -319,15 +319,15 @@ describe('app', () => {
             "files": Array [
               "*.ts",
               "*.tsx",
-              "*.js",
-              "*.jsx",
             ],
             "parserOptions": Object {
               "project": Array [
                 "apps/my-app/tsconfig.*?.json",
               ],
             },
-            "rules": Object {},
+            "rules": Object {
+              "@typescript-eslint/camelcase": "off",
+            },
           },
           Object {
             "files": Array [

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -280,8 +280,6 @@ describe('app', () => {
                 "files": Array [
                   "*.ts",
                   "*.tsx",
-                  "*.js",
-                  "*.jsx",
                 ],
                 "parserOptions": Object {
                   "project": Array [

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -366,8 +366,6 @@ describe('app', () => {
             "files": Array [
               "*.ts",
               "*.tsx",
-              "*.js",
-              "*.jsx",
             ],
             "parserOptions": Object {
               "project": Array [

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -134,8 +134,6 @@ describe('lib', () => {
               "files": Array [
                 "*.ts",
                 "*.tsx",
-                "*.js",
-                "*.jsx",
               ],
               "parserOptions": Object {
                 "project": Array [

--- a/packages/react/src/utils/lint.ts
+++ b/packages/react/src/utils/lint.ts
@@ -25,7 +25,7 @@ export const createReactEslintJson = (projectRoot: string): Linter.Config => ({
   ignorePatterns: ['!**/*'],
   overrides: [
     {
-      files: ['*.ts', '*.tsx', '*.js', '*.jsx'],
+      files: ['*.ts', '*.tsx'],
       parserOptions: {
         /**
          * In order to ensure maximum efficiency when typescript-eslint generates TypeScript Programs

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
@@ -4,5 +4,5 @@
     "emitDecoratorMetadata": true
   },
   "exclude": ["../**/*.spec.ts" <% if(uiFramework === '@storybook/react') { %>, "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx"<% } %>],
-  "include": ["../src/**/*", "*.js"]
+  "include": ["../src/**/*"]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

### Current Behavior
<!-- This is the behavior we have today -->

Currently in a storybook configuration, we include `main.js`, `preview.js` and `webpack.config.js` in `tsconfig.json` but that is causing errors (essentially in VSCode).

![image](https://user-images.githubusercontent.com/25207499/114323275-bacc2100-9b24-11eb-9b7a-d480411c3085.png)

#### Steps to reproduce

- `npx create-nx-workspace testnx`
- `npm install --save-dev @nrwl/storybook @nrwl/react`
- `nx generate @nrwl/react:lib ui`
- `nx generate @nrwl/react:storybook-configuration ui`

### Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We should exclude these files, so we can avoid this error in VSCode.

### Solution

To fix this error, we need to 
- exclude theses files by removing `*.js` inside `include` property of `tsconfig.json`, of a `.storybook` folder.
This has been added here: https://github.com/nrwl/nx/pull/5146/files
- To still have linting on these files, we need to remove them inside `.eslintrc.json` when we're using `parserOptions`, if we don't do that we've got this `eslint` error:
```
Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: libs/ui/.storybook/preview.js.
The file must be included in at least one of the projects provided
```
