### PR TITLE
fix(storybook): incorrect environment in dev

### DIFF
--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -50,6 +50,7 @@ export default async function* storybookExecutor(
 }
 
 function runInstance(options: StorybookExecutorOptions) {
+  process.env.NODE_ENV = process.env.NODE_ENV ?? 'development';
   return buildDevStandalone({ ...options, ci: true });
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

### Current Behavior

> When I run nx run [package-name]:storybook I see that process.env.NODE_ENV is set to production

### Expected Behavior

> According to [schematics](https://github.com/nrwl/nx/blob/master/packages/storybook/src/executors/storybook/schema.json#L4) description the mode should be set to development

### Related GitHub issues

Fixes #5070, Fixes #4942

Thanks to @esjs, I could fix the issue!
See: https://github.com/nrwl/nx/issues/5070#issue-836173497