### PR TITLE
fix(nx-plugin): fix package name when generating generators

### DIFF
--- a/packages/nx-plugin/src/schematics/generator/lib/normalize-options.ts
+++ b/packages/nx-plugin/src/schematics/generator/lib/normalize-options.ts
@@ -17,7 +17,7 @@ export function normalizeOptions(
     options.project
   );
 
-  const npmPackageName = `@${npmScope}/${fileName}`;
+  const npmPackageName = `@${npmScope}/${options.project}`;
 
   const fileTemplate = getFileTemplate();
 


### PR DESCRIPTION
## Current Behavior
`nx generate @nrwl/nx-plugin:generator [generatorName] --project=[pluginName]` will scaffold out a new generator using `@npm-scope/[generatorName]` as the package name.

## Expected Behavior
`nx generate @nrwl/nx-plugin:generator [generatorName] --project=[pluginName]` should scaffold out a new generator using `@npm-scope/[pluginName]` as the package name.