### PR TITLE
fix(nextjs): remove isServer flag from web babel preset

### DIFF
--- a/packages/web/babel.ts
+++ b/packages/web/babel.ts
@@ -20,9 +20,6 @@ module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
 
   const isModern = api.caller((caller) => caller?.isModern);
 
-  // `isServer` is passed from `next-babel-loader`, when it compiles for the server
-  const isServer = api.caller((caller) => caller?.isServer);
-
   // This is set by `@nrwl/web:package` executor
   const isNxPackage = api.caller((caller) => caller?.isNxPackage);
 
@@ -38,7 +35,7 @@ module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
         // For Jest tests, NODE_ENV is set as 'test' and we only want to set target as Node.
         // All other options will fail in Jest since Node does not support some ES features
         // such as import syntax.
-        isServer || process.env.NODE_ENV === 'test'
+        process.env.NODE_ENV === 'test'
           ? { targets: { node: 'current' } }
           : {
               // Allow importing core-js in entrypoint and use browserlist to select polyfills.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->
Looks like the recently added `isServer` flag is actually causing problems for transpilation of some more modern language features. The problem that `isServer` was attempting to fix seems to have been fixed by https://github.com/nrwl/nx/pull/5257 

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Using modern language features like nullish coalescing breaks the build of next.js apps (see related issue)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Using modern language features like nullish coalescing should not break the build of next.js apps, as such features should be taken care of by babel, based on browserslist configuration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4990
