### PR TITLE
feat(core): allow passing a path into read workspace config

### DIFF
--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -160,13 +160,19 @@ function readFileIfExisting(path: string) {
     : '';
 }
 
-export function readWorkspaceJson(): any {
-  const ws = new Workspaces(appRootPath);
-  return ws.readWorkspaceConfiguration();
+export function readWorkspaceJson() {
+  return readWorkspaceConfig({
+    format: 'nx',
+    path: appRootPath,
+  });
 }
 
-export function readWorkspaceConfig(opts: { format: 'angularCli' | 'nx' }) {
-  const json = readWorkspaceJson();
+export function readWorkspaceConfig(opts: {
+  format: 'angularCli' | 'nx';
+  path?: string;
+}) {
+  const ws = new Workspaces(opts.path);
+  const json = ws.readWorkspaceConfiguration();
   if (opts.format === 'angularCli') {
     const formatted = toOldFormatOrNull(json);
     return formatted ?? json;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `readWorkspaceConfig` always reads from the `appRootPath` of the current workspace which doesn't work right when `@nrwl/workspace` lives in a parent directory of the workspace config file. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `readWorkspaceConfig` function accepts a `path` option which is used instead of the `appRootPath` that is useful for being specific about where the workspace config should be. .e.g. in tests.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
