### PR TITLE
chore(repo): updated dependency 'strip-json-comments'

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
     "source-map": "0.7.3",
     "source-map-loader": "0.2.4",
     "source-map-support": "0.5.16",
-    "strip-json-comments": "2.0.1",
+    "strip-json-comments": "^3.1.1",
     "style-loader": "1.0.0",
     "styled-components": "5.0.0",
     "stylus": "0.54.5",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -30,7 +30,7 @@
     "ejs": "^3.1.5",
     "ignore": "^5.0.4",
     "semver": "7.3.4",
-    "strip-json-comments": "2.0.1",
+    "strip-json-comments": "^3.1.1",
     "tslib": "^2.0.0"
   }
 }

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -35,7 +35,7 @@
     "@nrwl/devkit": "*",
     "jest-resolve": "^26.6.2",
     "rxjs": "^6.5.4",
-    "strip-json-comments": "2.0.1",
+    "strip-json-comments": "^3.1.1",
     "tslib": "^2.0.0"
   }
 }

--- a/packages/tao/package.json
+++ b/packages/tao/package.json
@@ -33,7 +33,7 @@
     "enquirer": "~2.3.6",
     "minimist": "^1.2.5",
     "rxjs": "^6.5.4",
-    "strip-json-comments": "2.0.1",
+    "strip-json-comments": "^3.1.1",
     "semver": "7.3.4",
     "tmp": "~0.2.1",
     "tslib": "^2.0.0",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -66,7 +66,7 @@
     "open": "^7.4.2",
     "rxjs": "^6.5.4",
     "semver": "7.3.4",
-    "strip-json-comments": "2.0.1",
+    "strip-json-comments": "^3.1.1",
     "tmp": "~0.2.1",
     "yargs": "15.4.1",
     "yargs-parser": "20.0.0",


### PR DESCRIPTION
## Current Behavior
nx uses the 5 year old version 2.0.1 of ['strip-json-comments'](https://www.npmjs.com/package/strip-json-comments) 

## Expected Behavior
nx should use the current version of strip-json-comments

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
