### PR TITLE
fix(repo): clear output before building packages again

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -12,6 +12,7 @@ if [[ $NX_VERSION == "--local" ]]; then
     NX_VERSION="*"
 fi
 
+rm -rf build
 npx nx run-many --target=build --all --parallel || { echo 'Build failed' ; exit 1; }
 
 cd build/packages


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The output of the build is not cleared before packaging sometimes leading to stray packages.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The output of the build is cleared before packaging so that any stray packages aren't there anymore.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
