### PR TITLE
fix(react): fix react publish library copy readme

### DIFF
--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -199,7 +199,7 @@ function addProject(host: Tree, options: NormalizedSchema) {
         rollupConfig: `@nrwl/react/plugins/bundle-rollup`,
         assets: [
           {
-            glob: 'README.md',
+            glob: `${options.projectRoot}/README.md`,
             input: '.',
             output: '.',
           },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When building/publishing a library, the README.md is copied from the root of the workspace instead of the library README.md

## Expected Behavior
The README.md file should copy from the library origin.

## Related Issue(s)


Fixes #4698 
