### PR TITLE
fix(react): not breaking jest.config.js when no projects exist

### DIFF
--- a/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
+++ b/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
@@ -1,9 +1,26 @@
 import { JestProjectSchema } from '../schema';
 import { addPropertyToJestConfig } from '../../../utils/config/update-config';
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
+import { parse } from '@babel/parser';
+
+/**
+ * Will parse a single-statement `jest.config.js` file to see if the `projects`
+ * property exists on the exported config object.
+ *
+ * Expects a single assignment statement to an Object literal.
+ */
+function hasProjectsProperty(tree: Tree) {
+  const ast = parse(tree.read('jest.config.js').toString());
+  return !!(ast.program.body[0] as any).expression.right.properties.find(
+    (x) => x.key.name === 'projects'
+  );
+}
 
 export function updateJestConfig(host: Tree, options: JestProjectSchema) {
   const project = readProjectConfiguration(host, options.project);
+  if (!hasProjectsProperty(host)) {
+    return;
+  }
   addPropertyToJestConfig(
     host,
     'jest.config.js',

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -162,6 +162,44 @@ describe('lib', () => {
         }
       `);
     });
+
+    describe('jest.config.js behavior', () => {
+      it('should update jest.config.js if the projects property is an array', async (done) => {
+        const treeWithJestConfig = createTreeWithEmptyWorkspace();
+        treeWithJestConfig.write(
+          'jest.config.js',
+          `module.exports = {
+  projects: [],
+};`
+        );
+        await libraryGenerator(treeWithJestConfig, defaultSchema);
+        expect(treeWithJestConfig.read('jest.config.js').toString())
+          .toBe(`module.exports = {
+  projects: ["<rootDir>/libs/my-lib"],
+};`);
+        done();
+      });
+
+      it('should not update jest.config.js if the projects property does not exist', async (done) => {
+        const contents = `module.exports = {
+  testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
+  transform: {
+    '^.+\\.(ts|js|html)$': 'ts-jest',
+  },
+  resolver: '@nrwl/jest/plugins/resolver',
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageReporters: ['html'],
+  passWithNoTests: true,
+};`;
+        const treeWithJestConfig = createTreeWithEmptyWorkspace();
+        treeWithJestConfig.write('jest.config.js', contents);
+        await libraryGenerator(treeWithJestConfig, defaultSchema);
+        expect(treeWithJestConfig.read('jest.config.js').toString()).toBe(
+          contents
+        );
+        done();
+      });
+    });
   });
 
   describe('nested', () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Legacy workspaces have `jest.config.js` files that can look like this:

```js
module.exports = {
  testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
  transform: {
    '^.+\\.(ts|js|html)$': 'ts-jest',
  },
  resolver: '@nrwl/jest/plugins/resolver',
  moduleFileExtensions: ['ts', 'js', 'html'],
  coverageReporters: ['html'],
  passWithNoTests: true,
};
```

Note no `projects` property on the config object. Currently, when adding a new react lib, this updates the contents of this file to:

```js
module.exports = {
  testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
  transform: {
    '^.+\\.(ts|js|html)$': 'ts-jest',
  },
  resolver: '@nrwl/jest/plugins/resolver',
  moduleFileExtensions: ['ts', 'js', 'html'],
  coverageReporters: ['html'],
  passWithNoTests: true,
  projects: '<rootDir>/libs/my-lib'
};
```

This causes all other project tests to fail. See #3885.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This changes behavior on legacy `jest.config.js` files to not update (and therefore break) them.

I believe we may want to investigate a migration to update these legacy `jest.config.js` files in the future, but I also believe that work is not mutually exclusive with this fix.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3885
