### PR TITLE
fix(devkit): devkitTreeFromAngularDevkitTree exists function should also work on dirs

### DIFF
--- a/e2e/angular/src/storybook.test.ts
+++ b/e2e/angular/src/storybook.test.ts
@@ -17,6 +17,42 @@ describe('Storybook schematics', () => {
 
   afterEach(() => removeProject({ onlyOnCI: true }));
 
+  it('aaashould not overwrite global storybook config files', () => {
+    const angularStorybookLib = uniq('test-ui-lib-angular');
+    runCLI(
+      `generate @nrwl/angular:lib ${angularStorybookLib} --no-interactive`
+    );
+    runCLI(
+      `generate @nrwl/angular:storybook-configuration ${angularStorybookLib} --generateStories --no-interactive`
+    );
+
+    checkFilesExist(`.storybook/main.js`);
+    writeFileSync(
+      tmpProjPath(`.storybook/main.js`),
+      `
+        module.exports = {
+          stories: [],
+          addons: ['@storybook/addon-knobs/register'],
+        };      
+
+        console.log('hi there');
+      `
+    );
+
+    // generate another lib with storybook config
+    const anotherAngularStorybookLib = uniq('test-ui-lib-angular2');
+    runCLI(
+      `generate @nrwl/angular:lib ${anotherAngularStorybookLib} --no-interactive`
+    );
+    runCLI(
+      `generate @nrwl/angular:storybook-configuration ${anotherAngularStorybookLib} --generateStories --no-interactive`
+    );
+
+    expect(readFile(`.storybook/main.js`)).toContain(
+      `console.log('hi there');`
+    );
+  });
+
   describe('build storybook', () => {
     it('should execute e2e tests using Cypress running against Storybook', () => {
       const myapp = uniq('myapp');

--- a/packages/devkit/src/utils/invoke-nx-generator.ts
+++ b/packages/devkit/src/utils/invoke-nx-generator.ts
@@ -86,7 +86,11 @@ class DevkitTreeFromAngularDevkitTree {
   }
 
   exists(filePath: string): boolean {
-    return this.tree.exists(filePath);
+    if (this.isFile(filePath)) {
+      return this.tree.exists(filePath);
+    } else {
+      return this.children(filePath).length > 0;
+    }
   }
 
   isFile(filePath: string): boolean {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The current implementation of the `DevkitTreeFromAngularDevkitTree.exists` function doesn't work on directories, effectively always returning `false`. Thus checks in generators that use `tree.exits('.storybook')` where `.storybook` is a directory don't work.

Note, this is just a problem of the `DevkitTreeFromAngularDevkitTree` version. The Tao `FsTree` already handles this correctly. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The check should also work on directories.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5318
