### PR TITLE
feat(linter): checking jest config in workspace-lint

### DIFF
--- a/packages/workspace/src/command-line/lint.ts
+++ b/packages/workspace/src/command-line/lint.ts
@@ -6,9 +6,15 @@ import { WorkspaceIntegrityChecks } from './workspace-integrity-checks';
 import { readWorkspaceFiles, workspaceLayout } from '../core/file-utils';
 import { output } from '../utilities/output';
 import * as path from 'path';
+import { existsSync, readFileSync } from 'fs';
+import { assertJestConfigValidity } from '../core/assert-jest-configuration';
 
 export function workspaceLint() {
   const graph = onlyWorkspaceProjects(createProjectGraph());
+
+  if (existsSync('jest.config.js')) {
+    assertJestConfigValidity(graph, readFileSync('jest.config.js').toString());
+  }
 
   const cliErrorOutputConfigs = new WorkspaceIntegrityChecks(
     graph,

--- a/packages/workspace/src/core/assert-jest-configuration.spec.ts
+++ b/packages/workspace/src/core/assert-jest-configuration.spec.ts
@@ -1,0 +1,135 @@
+import { assertJestConfigValidity } from './assert-jest-configuration';
+import { output } from '../utilities/output';
+
+interface MockGraph {
+  nodes: Record<
+    string,
+    {
+      data: {
+        targets: {
+          test?: {
+            executor: string;
+          };
+        };
+        root: string;
+      };
+    }
+  >;
+}
+
+describe('assertJestConfiguration()', () => {
+  let mockGraph: MockGraph;
+  let mockRootJestConfig: string;
+
+  describe('Basic Workspace config with e2e app and lib that uses Karma', () => {
+    beforeEach(() => {
+      mockGraph = {
+        nodes: {
+          myApp: {
+            data: {
+              targets: {
+                test: { executor: '@nrwl/jest:jest' },
+              },
+              root: 'test-root',
+            },
+          },
+          'myApp-e2e': {
+            data: { targets: {}, root: 'test-root-e2e' },
+          },
+          libWithOtherTestExecutor: {
+            data: {
+              targets: {
+                test: {
+                  executor: '@nrwl/karma:karma',
+                },
+              },
+              root: 'test-karma',
+            },
+          },
+        },
+      };
+    });
+    describe('correct configuration', () => {
+      beforeEach(() => {
+        mockRootJestConfig = `module.exports = {
+  projects: ['<rootDir>/test-root']
+}
+`;
+      });
+      it('Succeeds with success message', () => {
+        const successSpy = jest.spyOn(output, 'success');
+        assertJestConfigValidity(mockGraph as any, mockRootJestConfig);
+        expect(successSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('typo in jest config', () => {
+      beforeEach(() => {
+        mockRootJestConfig = `module.exports = {
+    projects: ['<rootDir>/test-root1']
+  }
+  `;
+      });
+      it('Fails with helpful message', () => {
+        const errorSpy = jest.spyOn(output, 'error');
+        const mockExit = jest
+          .spyOn(process, 'exit')
+          .mockImplementation(((code?: number) => {}) as any);
+        assertJestConfigValidity(mockGraph as any, mockRootJestConfig);
+        expect(errorSpy).toHaveBeenCalledWith({
+          title: 'Configuration Error',
+          bodyLines: [
+            'The following projects from your `jest.config.js` file do not appear to exist in your workspace:',
+            '  <rootDir>/test-root1',
+          ],
+        });
+        expect(mockExit).toHaveBeenCalledWith(1);
+      });
+    });
+    describe('project missing in jest.config.js', () => {
+      beforeEach(() => {
+        mockRootJestConfig = `module.exports = {
+      projects: []
+    }
+    `;
+      });
+      it('Fails with helpful message', () => {
+        const errorSpy = jest.spyOn(output, 'error');
+        const mockExit = jest
+          .spyOn(process, 'exit')
+          .mockImplementation(((code?: number) => {}) as any);
+        assertJestConfigValidity(mockGraph as any, mockRootJestConfig);
+        expect(errorSpy).toHaveBeenCalledWith({
+          title: 'Configuration Error',
+          bodyLines: [
+            'You appear to be missing the following from the `projects` property of your root `jest.config.js`:',
+            '  <rootDir>/test-root',
+          ],
+        });
+        expect(mockExit).toHaveBeenCalledWith(1);
+      });
+    });
+
+    describe('`projects` property missing in jest.config.js', () => {
+      beforeEach(() => {
+        mockRootJestConfig = `module.exports = {}`;
+      });
+      it('Fails with helpful message', () => {
+        const errorSpy = jest.spyOn(output, 'error');
+        const mockExit = jest
+          .spyOn(process, 'exit')
+          .mockImplementation(((code?: number) => {}) as any);
+        assertJestConfigValidity(mockGraph as any, mockRootJestConfig);
+        expect(errorSpy).toHaveBeenCalledWith({
+          title: 'Configuration Error',
+          bodyLines: [
+            'No `projects` property found in `jest.config.json`.',
+            'The following array was expected from the project property:',
+            `["<rootDir>/test-root"]`,
+          ],
+        });
+        expect(mockExit).toHaveBeenCalledWith(1);
+      });
+    });
+  });
+});

--- a/packages/workspace/src/core/assert-jest-configuration.ts
+++ b/packages/workspace/src/core/assert-jest-configuration.ts
@@ -1,0 +1,149 @@
+import { ProjectGraph } from '@nrwl/devkit';
+import * as stripJsonComments from 'strip-json-comments';
+import * as ts from 'typescript';
+import { output } from '../utilities/output';
+
+// TODO: determine best way through circular depenedencies
+// The following utility functions are copied/pasted from @nrwl/jest package
+// I cannot import them without creating a circular dep between workspace and jest
+
+function getJsonObject(object: string) {
+  const value = stripJsonComments(object);
+  // react babel-jest has __dirname in the config.
+  // Put a temp variable in the anon function so that it doesnt fail.
+  // Migration script has a catch handler to give instructions on how to update the jest config if this fails.
+  return Function(`
+  "use strict";
+  let __dirname = '';
+  return (${value});
+ `)();
+}
+
+function jestConfigObjectAst(fileContent: string): ts.ObjectLiteralExpression {
+  const sourceFile = ts.createSourceFile(
+    'jest.config.js',
+    fileContent,
+    ts.ScriptTarget.Latest,
+    true
+  );
+
+  const moduleExportsStatement = sourceFile.statements.find(
+    (statement) =>
+      ts.isExpressionStatement(statement) &&
+      ts.isBinaryExpression(statement.expression) &&
+      statement.expression.left.getText() === 'module.exports' &&
+      statement.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken
+  );
+
+  const moduleExports = (moduleExportsStatement as ts.ExpressionStatement)
+    .expression as ts.BinaryExpression;
+
+  if (!moduleExports) {
+    throw new Error(
+      `
+       The provided jest config file does not have the expected 'module.exports' expression. 
+       See https://jestjs.io/docs/en/configuration for more details.`
+    );
+  }
+
+  if (!ts.isObjectLiteralExpression(moduleExports.right)) {
+    throw new Error(
+      `The 'module.exports' expression is not an object literal.`
+    );
+  }
+
+  return moduleExports.right as ts.ObjectLiteralExpression;
+}
+
+function minus(a: string[], b: string[]): string[] {
+  const res = [];
+  a.forEach((aa) => {
+    if (!b.find((bb) => bb === aa)) {
+      res.push(aa);
+    }
+  });
+  return res;
+}
+
+// END IMPORT WORKAROUND
+
+export function assertJestConfigValidity(
+  graph: ProjectGraph,
+  jestConfigContents: string
+) {
+  const jestConfig = getJsonObject(
+    jestConfigObjectAst(jestConfigContents).getText()
+  );
+  const projectsPerJestConfig = jestConfig.projects;
+
+  const expectedContentsPerGraph: string[] = Object.values(graph.nodes)
+    .filter(
+      ({ data }) =>
+        data.targets.test && data.targets.test.executor === '@nrwl/jest:jest'
+    )
+    .map(({ data }) => `<rootDir>/${data.root}`);
+
+  if (!projectsPerJestConfig) {
+    output.error({
+      title: 'Configuration Error',
+      bodyLines: [
+        'No `projects` property found in `jest.config.json`.',
+        'The following array was expected from the project property:',
+        JSON.stringify(expectedContentsPerGraph),
+      ],
+    });
+    process.exit(1);
+    return; // return to stop when running tests
+  }
+
+  const projectsThatExistInJestConfigButNotInWorkspace = minus(
+    projectsPerJestConfig,
+    expectedContentsPerGraph
+  );
+  if (projectsThatExistInJestConfigButNotInWorkspace.length) {
+    output.error({
+      title: 'Configuration Error',
+      bodyLines: [
+        'The following projects from your `jest.config.js` file do not appear to exist in your workspace:',
+        ...projectsThatExistInJestConfigButNotInWorkspace.map(
+          (x, i) =>
+            `  ${x}${
+              i === projectsThatExistInJestConfigButNotInWorkspace.length - 1
+                ? ''
+                : ','
+            }`
+        ),
+      ],
+    });
+    process.exit(1);
+    return; // return to stop when running tests
+  }
+
+  const projectsThatExistInWorkspaceButNotJestConfig = minus(
+    expectedContentsPerGraph,
+    projectsPerJestConfig
+  );
+  if (projectsThatExistInWorkspaceButNotJestConfig.length) {
+    output.error({
+      title: 'Configuration Error',
+      bodyLines: [
+        'You appear to be missing the following from the `projects` property of your root `jest.config.js`:',
+        ...projectsThatExistInWorkspaceButNotJestConfig.map(
+          (x, i) =>
+            `  ${x}${
+              i === projectsThatExistInWorkspaceButNotJestConfig.length - 1
+                ? ''
+                : ','
+            }`
+        ),
+      ],
+    });
+    process.exit(1);
+    return; // return to stop when running tests
+  }
+
+  output.success({
+    title: 'Checking Root Jest Config',
+    bodyLines: ['`jest.config.js` appears to be configured correctly.'],
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Implementation Notes
+ Unable to import relevant `@nrwl/jest` helper functions due to circular dependency concerns. @jaysoo can you provide some guidance on the correct way forward?
  + Immediate thought was to hoist `workspace-lint` up to it's own lib, but I imagine typologically we'd like to keep that in `workspace`.
  + Alternative thought would be to push the helpful functions from `jest` down into `devkit`?

## Current Behavior
<!-- This is the behavior we have today -->
`nx workspace-lint` will check for `nx.json` and `angular.json`/`workspace.json` being in sync, but will not test the root `jest.config.js` file to make sure that is in sync with the workspace graph.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nx workspace-lint` will check `jest.config.js` and error if this file is not in sync with the workspace graph.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
