### PR TITLE
chore(angular): update jest-preset-angular to 8.4.0

### DIFF
--- a/packages/angular/src/schematics/application/application.spec.ts
+++ b/packages/angular/src/schematics/application/application.spec.ts
@@ -92,10 +92,13 @@ describe('app', () => {
       const tree = await runSchematic('app', { name: 'myApp' }, appTree);
 
       expect(tree.readContent('apps/my-app/jest.config.js')).toContain(
-        `'jest-preset-angular/build/AngularSnapshotSerializer.js'`
+        `'jest-preset-angular/build/serializers/no-ng-attributes'`
       );
       expect(tree.readContent('apps/my-app/jest.config.js')).toContain(
-        `'jest-preset-angular/build/HTMLCommentSerializer.js'`
+        `'jest-preset-angular/build/serializers/ng-snapshot'`
+      );
+      expect(tree.readContent('apps/my-app/jest.config.js')).toContain(
+        `'jest-preset-angular/build/serializers/html-comment'`
       );
     });
 
@@ -507,13 +510,13 @@ describe('app', () => {
         const tree = await runSchematic('app', { name: 'myApp' }, appTree);
 
         expect(tree.readContent('apps/my-app/jest.config.js')).toContain(
-          `'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js'`
+          `'jest-preset-angular/build/serializers/no-ng-attributes'`
         );
         expect(tree.readContent('apps/my-app/jest.config.js')).toContain(
-          `'jest-preset-angular/build/AngularSnapshotSerializer.js'`
+          `'jest-preset-angular/build/serializers/ng-snapshot'`
         );
         expect(tree.readContent('apps/my-app/jest.config.js')).toContain(
-          `'jest-preset-angular/build/HTMLCommentSerializer.js'`
+          `'jest-preset-angular/build/serializers/html-comment'`
         );
       });
     });

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -4,5 +4,5 @@ export const angularDevkitVersion = '~0.1102.0';
 export const angularJsVersion = '1.7.9';
 export const ngrxVersion = '^11.1.0';
 export const rxjsVersion = '~6.6.3';
-export const jestPresetAngularVersion = '8.3.2';
+export const jestPresetAngularVersion = '8.4.0';
 export const angularEslintVersion = '~2.0.2';

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -125,6 +125,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "12.1.0": {
+      "version": "12.1.0-beta.1",
+      "packages": {
+        "jest-preset-angular": {
+          "version": "8.4.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
+++ b/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
@@ -45,9 +45,9 @@ exports[`jestProject --setup-file should have setupFilesAfterEnv and globals.ts-
   },
   coverageDirectory: '../../coverage/libs/lib1',
   snapshotSerializers: [
-    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
-    'jest-preset-angular/build/AngularSnapshotSerializer.js',
-    'jest-preset-angular/build/HTMLCommentSerializer.js'
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
   ]
 };
 "
@@ -64,9 +64,9 @@ exports[`jestProject should create a jest.config.js 1`] = `
   },
   coverageDirectory: '../../coverage/libs/lib1',
   snapshotSerializers: [
-    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
-    'jest-preset-angular/build/AngularSnapshotSerializer.js',
-    'jest-preset-angular/build/HTMLCommentSerializer.js'
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
   ]
 };
 "

--- a/packages/jest/src/generators/jest-project/files/jest.config.js__tmpl__
+++ b/packages/jest/src/generators/jest-project/files/jest.config.js__tmpl__
@@ -22,8 +22,8 @@ module.exports = {
     moduleFileExtensions: ['ts', 'js', 'html'],<% } %><% } %>
   coverageDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>'<% if(!skipSerializers) { %>,
   snapshotSerializers: [
-    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
-    'jest-preset-angular/build/AngularSnapshotSerializer.js',
-    'jest-preset-angular/build/HTMLCommentSerializer.js'
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
   ]<% } %>
 };

--- a/packages/jest/src/generators/jest-project/files/src/test-setup.ts__tmpl__
+++ b/packages/jest/src/generators/jest-project/files/src/test-setup.ts__tmpl__
@@ -1,2 +1,2 @@
-<% if (setupFile === 'angular') { %>import 'jest-preset-angular';
+<% if (setupFile === 'angular') { %>import 'jest-preset-angular/setup-jest';
 <% } else if (setupFile === 'web-components') { %>import 'document-register-element';<% } %>


### PR DESCRIPTION
Change import path and snapshotSerializers according to jest-preset-angular version 9 deprecations.

## Current Behavior
jest-preset-angular version 8.3.2

## Expected Behavior
jest-preset-angular version 8.4.0

## Related Issue(s)
This is identical PR as #5004, but hopefully it can be merged.

As a next step migration script to update import path and snapshotSerializers should be added.
