### PR TITLE
cleanup(core): copy from cache only when needed

### DIFF
--- a/packages/workspace/src/tasks-runner/cache.ts
+++ b/packages/workspace/src/tasks-runner/cache.ts
@@ -6,12 +6,14 @@ import {
   readFileSync,
   writeFileSync,
   lstatSync,
+  unlinkSync,
 } from 'fs';
 import { join, resolve } from 'path';
 import * as fsExtra from 'fs-extra';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { spawn } from 'child_process';
 import { cacheDirectory } from '../utilities/cache-directory';
+import { writeToFile } from '../utilities/fileutils';
 
 export type CachedResult = {
   terminalOutput: string;
@@ -42,6 +44,7 @@ export class Cache {
   root = appRootPath;
   cachePath = this.createCacheDir();
   terminalOutputsDir = this.createTerminalOutputsDir();
+  latestTasksHashesDir = this.ensureLatestTasksHashesDir();
   cacheConfig = new CacheConfig(this.options);
 
   constructor(private readonly options: DefaultTasksRunnerOptions) {}
@@ -136,12 +139,12 @@ export class Cache {
   }
 
   copyFilesFromCache(
-    hash: string,
-    cachedResult: CachedResult,
+    taskWithCachedResult: TaskWithCachedResult,
     outputs: string[]
   ) {
+    this.removeRecordedTaskHash(taskWithCachedResult.task, outputs);
     outputs.forEach((f) => {
-      const cached = join(cachedResult.outputsPath, f);
+      const cached = join(taskWithCachedResult.cachedResult.outputsPath, f);
       if (existsSync(cached)) {
         const isFile = lstatSync(cached).isFile();
         const src = join(this.root, f);
@@ -154,6 +157,7 @@ export class Cache {
         fsExtra.copySync(cached, src);
       }
     });
+    this.recordTaskHash(taskWithCachedResult.task, outputs);
   }
 
   temporaryOutputPath(task: Task) {
@@ -162,6 +166,72 @@ export class Cache {
     } else {
       return null;
     }
+  }
+
+  removeRecordedTaskHash(task: Task, outputs: string[]): void {
+    if (outputs.length === 0) {
+      return;
+    }
+
+    const hashFile = this.getFileNameWithLatestRecordedHashForTask(task);
+    try {
+      unlinkSync(hashFile);
+    } catch (e) {}
+  }
+
+  recordTaskHash(task: Task, outputs: string[]): void {
+    if (outputs.length === 0) {
+      return;
+    }
+
+    const hashFile = this.getFileNameWithLatestRecordedHashForTask(task);
+    writeToFile(hashFile, task.hash);
+  }
+
+  shouldCopyOutputsFromCache(
+    taskWithCachedResult: TaskWithCachedResult,
+    outputs: string[]
+  ): boolean {
+    if (outputs.length === 0) {
+      return false;
+    }
+
+    if (
+      this.getLatestRecordedHashForTask(taskWithCachedResult.task) !==
+      taskWithCachedResult.task.hash
+    ) {
+      return true;
+    }
+
+    return this.isAnyOutputMissing(taskWithCachedResult.cachedResult, outputs);
+  }
+
+  private getLatestRecordedHashForTask(task: Task): string | null {
+    try {
+      return readFileSync(
+        this.getFileNameWithLatestRecordedHashForTask(task)
+      ).toString();
+    } catch (e) {
+      return null;
+    }
+  }
+
+  private isAnyOutputMissing(
+    cachedResult: CachedResult,
+    outputs: string[]
+  ): boolean {
+    return outputs.some(
+      (output) =>
+        existsSync(join(cachedResult.outputsPath, output)) &&
+        !existsSync(join(this.root, output))
+    );
+  }
+
+  private getFileNameWithLatestRecordedHashForTask(task: Task): string {
+    return join(
+      this.latestTasksHashesDir,
+      `${task.target.project}-${task.target.target}.hash`
+    );
   }
 
   private getFromLocalDir(task: Task) {
@@ -196,6 +266,12 @@ export class Cache {
 
   private createTerminalOutputsDir() {
     const path = join(this.cachePath, 'terminalOutputs');
+    fsExtra.ensureDirSync(path);
+    return path;
+  }
+
+  private ensureLatestTasksHashesDir() {
+    const path = join(this.cachePath, 'latestTasksHashes');
     fsExtra.ensureDirSync(path);
     return path;
   }

--- a/packages/workspace/src/utilities/output.ts
+++ b/packages/workspace/src/utilities/output.ts
@@ -22,6 +22,12 @@ export interface CLISuccessMessageConfig {
   bodyLines?: string[];
 }
 
+export enum TaskCacheStatus {
+  NoCache = '[no cache]',
+  MatchedExistingOutput = '[existing outputs match the cache, left as is]',
+  RetrievedFromCache = '[retrieved from cache]',
+}
+
 /**
  * Automatically disable styling applied by chalk if CI=true
  */
@@ -177,13 +183,16 @@ class CLIOutput {
     this.addNewline();
   }
 
-  logCommand(message: string, isCached: boolean = false) {
+  logCommand(
+    message: string,
+    cacheStatus: TaskCacheStatus = TaskCacheStatus.NoCache
+  ) {
     this.addNewline();
 
     this.writeToStdOut(chalk.bold(`> ${message} `));
 
-    if (isCached) {
-      this.writeToStdOut(chalk.bold.grey(`[retrieved from cache]`));
+    if (cacheStatus !== TaskCacheStatus.NoCache) {
+      this.writeToStdOut(chalk.bold.grey(cacheStatus));
     }
 
     this.addNewline();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Every time there's a cache hit, we remove the output and copy it over from the cache.

## Expected Behavior
We don't remove the output and copy it from the cache when the current local output is expected to be the same as what the cache has stored.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
