### PR TITLE
fix(storybook): generate story file in new jsx transform

### DIFF
--- a/packages/react/src/generators/component-story/component-story.spec.ts
+++ b/packages/react/src/generators/component-story/component-story.spec.ts
@@ -301,6 +301,38 @@ describe('react:component-story', () => {
         export default Test
         `,
       },
+      {
+        name: 'direct export of component class new JSX transform',
+        src: `
+        export default class Test extends Component<TestProps> {
+          render() {
+            return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+          }
+        }
+        `,
+      },
+      {
+        name: 'component class & then default export new JSX transform',
+        src: `
+        class Test extends Component<TestProps> {
+          render() {
+            return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+          }
+        }
+        export default Test
+        `,
+      },
+      {
+        name: 'PureComponent class & then default export new JSX transform',
+        src: `
+        class Test extends PureComponent<TestProps> {
+          render() {
+            return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+          }
+        }
+        export default Test
+        `,
+      },
     ].forEach((config) => {
       describe(`React component defined as:${config.name}`, () => {
         beforeEach(async () => {

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -527,9 +527,9 @@ export function getComponentPropsInterface(
     if (heritageClause) {
       const propsTypeExpression = heritageClause.types.find(
         (x) =>
-          (x.expression as ts.PropertyAccessExpression).name.text ===
+          (x.expression as ts.PropertyAccessExpression).escapedText ===
             'Component' ||
-          (x.expression as ts.PropertyAccessExpression).name.text ===
+          (x.expression as ts.PropertyAccessExpression).escapedText ===
             'PureComponent'
       );
 

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -525,13 +525,12 @@ export function getComponentPropsInterface(
     const heritageClause = cmpDeclaration.heritageClauses[0];
 
     if (heritageClause) {
-      const propsTypeExpression = heritageClause.types.find(
-        (x) =>
-          (x.expression as ts.PropertyAccessExpression).escapedText ===
-            'Component' ||
-          (x.expression as ts.PropertyAccessExpression).escapedText ===
-            'PureComponent'
-      );
+      const propsTypeExpression = heritageClause.types.find((x) => {
+        const name =
+          (x.expression as ts.Identifier).escapedText ||
+          (x.expression as ts.PropertyAccessExpression).name.text;
+        return name === 'Component' || name === 'PureComponent';
+      });
 
       if (propsTypeExpression && propsTypeExpression.typeArguments) {
         propsTypeName = (propsTypeExpression


### PR DESCRIPTION
## Current Behavior
Generate a storybook file with a component in the new JSX transform failed.

Example: 
```typescript
import { Component } from 'react';

import styled from 'styled-components';

/* eslint-disable-next-line */
export interface TestProps {
  input: string;
}

const StyledTest = styled.div`
  color: pink;
`;

export class Test extends Component<TestProps> {
  render() {
    return (
      <StyledTest>
        <p>Welcome to Test!</p>
      </StyledTest>
    );
  }
}

export default Test;

```

Error message: `Cannot read property 'text' of undefined`

## Expected Behavior
Generate command work.