### PR TITLE
feat(angular): add migration for jest-preset-angular 8.4.0

### DIFF
--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -59,6 +59,11 @@
       "version": "10.3.1-beta.1",
       "description": "Fix ts-jest migration",
       "factory": "./src/migrations/update-10-3-0/update-ts-jest"
+    },
+    "update-jest-preset-angular-8-4-0": {
+      "version": "12.1.0-beta.1",
+      "description": "Update jest-preset-angular to version 8.4.0",
+      "factory": "./src/migrations/update-12-1-0/update-jest-preset-angular"
     }
   },
   "packageJsonUpdates": {

--- a/packages/jest/src/migrations/update-12-1-0/update-jest-preset-angular.spec.ts
+++ b/packages/jest/src/migrations/update-12-1-0/update-jest-preset-angular.spec.ts
@@ -1,0 +1,105 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { serializeJson } from '@nrwl/workspace';
+import { createEmptyWorkspace } from '@nrwl/workspace/testing';
+import * as path from 'path';
+import { getJestObject } from '../update-10-0-0/require-jest-config';
+import { jestConfigObject } from '../utils/config/legacy/functions';
+
+jest.mock('../update-10-0-0/require-jest-config');
+const getJestObjectMock = getJestObject as jest.Mock<typeof getJestObject>;
+
+const jestObject = {
+  snapshotSerializers: [
+    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
+    'jest-preset-angular/build/AngularSnapshotSerializer.js',
+    'jest-preset-angular/build/HTMLCommentSerializer.js',
+  ],
+};
+
+describe('update 12.1.0', () => {
+  let initialTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+  const jestConfig = String.raw`
+    module.exports = ${JSON.stringify(jestObject, null, 2)}
+  `;
+
+  beforeEach(() => {
+    getJestObjectMock.mockImplementation((path: string): any => {
+      if (path.includes('apps/products')) {
+        return jestObject;
+      }
+    });
+
+    initialTree = createEmptyWorkspace(Tree.empty());
+
+    initialTree.create('apps/products/jest.config.js', jestConfig);
+    initialTree.create(
+      'apps/products/src/test-setup.ts',
+      `import 'jest-preset-angular';`
+    );
+    initialTree.overwrite(
+      'workspace.json',
+      serializeJson({
+        version: 1,
+        projects: {
+          products: {
+            root: 'apps/products',
+            sourceRoot: 'apps/products/src',
+            architect: {
+              build: {
+                builder: '@angular-devkit/build-angular:browser',
+              },
+              test: {
+                builder: '@nrwl/jest:jest',
+                options: {
+                  jestConfig: 'apps/products/jest.config.js',
+                  passWithNoTests: true,
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    schematicRunner = new SchematicTestRunner(
+      '@nrwl/jest',
+      path.join(__dirname, '../../../migrations.json')
+    );
+  });
+
+  it('should update the jest.config files', async (done) => {
+    await schematicRunner
+      .runSchematicAsync('update-jest-preset-angular-8-4-0', {}, initialTree)
+      .toPromise();
+
+    const jestObject = jestConfigObject(
+      initialTree,
+      'apps/products/jest.config.js'
+    );
+
+    expect(jestObject.snapshotSerializers).toEqual([
+      'jest-preset-angular/build/serializers/no-ng-attributes',
+      'jest-preset-angular/build/serializers/ng-snapshot',
+      'jest-preset-angular/build/serializers/html-comment',
+    ]);
+
+    done();
+  });
+
+  it('should update the test-setup files', async (done) => {
+    await schematicRunner
+      .runSchematicAsync('update-jest-preset-angular-8-4-0', {}, initialTree)
+      .toPromise();
+
+    const testSetup = initialTree
+      .read('apps/products/src/test-setup.ts')
+      .toString('utf-8')
+      .trim();
+
+    expect(testSetup).toEqual(`import 'jest-preset-angular/setup-jest';`);
+
+    done();
+  });
+});

--- a/packages/jest/src/migrations/update-12-1-0/update-jest-preset-angular.ts
+++ b/packages/jest/src/migrations/update-12-1-0/update-jest-preset-angular.ts
@@ -1,0 +1,96 @@
+import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+import {
+  chain,
+  Rule,
+  SchematicContext,
+  Tree,
+} from '@angular-devkit/schematics';
+import { formatFiles, getWorkspace } from '@nrwl/workspace';
+import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
+import { join } from 'path';
+import { getJestObject } from '../update-10-0-0/require-jest-config';
+import {
+  addPropertyToJestConfig,
+  removePropertyFromJestConfig,
+} from '../utils/config/legacy/update-config';
+
+function updateJestConfig(): Rule {
+  return async (host: Tree, context: SchematicContext) => {
+    const workspace = await getWorkspace(host);
+
+    for (const [projectName, project] of workspace.projects) {
+      for (const [, target] of project.targets) {
+        if (target.builder !== '@nrwl/jest:jest') {
+          continue;
+        }
+
+        const config = getJestObject(
+          join(appRootPath, target.options.jestConfig as string)
+        );
+
+        if (
+          !config.snapshotSerializers ||
+          !Array.isArray(config.snapshotSerializers)
+        ) {
+          continue;
+        }
+
+        const snapshotSerializers = config.snapshotSerializers.map(
+          (snapshotSerializer) => {
+            switch (snapshotSerializer) {
+              case 'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js':
+                return 'jest-preset-angular/build/serializers/no-ng-attributes';
+              case 'jest-preset-angular/build/AngularSnapshotSerializer.js':
+                return 'jest-preset-angular/build/serializers/ng-snapshot';
+              case 'jest-preset-angular/build/HTMLCommentSerializer.js':
+                return 'jest-preset-angular/build/serializers/html-comment';
+              default:
+                return snapshotSerializer;
+            }
+          }
+        );
+
+        try {
+          removePropertyFromJestConfig(
+            host,
+            target.options.jestConfig as string,
+            'snapshotSerializers'
+          );
+          addPropertyToJestConfig(
+            host,
+            target.options.jestConfig as string,
+            'snapshotSerializers',
+            snapshotSerializers
+          );
+        } catch {
+          context.logger.error(
+            stripIndents`Unable to update snapshotSerializers for project ${projectName}.
+            More information you can check online documentation https://github.com/thymikee/jest-preset-angular/blob/master/CHANGELOG.md#840-2021-03-04`
+          );
+        }
+
+        try {
+          const setupTestPath = join(project.sourceRoot, 'test-setup.ts');
+          if (host.exists(setupTestPath)) {
+            const contents = host.read(setupTestPath).toString();
+            host.overwrite(
+              setupTestPath,
+              contents.replace(
+                `import 'jest-preset-angular';`,
+                `import 'jest-preset-angular/setup-jest';`
+              )
+            );
+          }
+        } catch {
+          context.logger.error(
+            stripIndents`Unable to update test-setup.ts for project ${projectName}.`
+          );
+        }
+      }
+    }
+  };
+}
+
+export default function update(): Rule {
+  return chain([updateJestConfig(), formatFiles()]);
+}


### PR DESCRIPTION
Updates import of jest-preset-angular and snapshotSerializers array in jest config.
