### PR TITLE
fix(core): print error if there is an issue creating the sandbox duri…

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -476,10 +476,23 @@ function createSandbox(packageManager: string) {
     })
   );
 
-  execSync(`${packageManager} install --silent`, {
-    cwd: tmpDir,
-    stdio: [0, 1, 2],
-  });
+  try {
+    execSync(`${packageManager} install --silent`, {
+      cwd: tmpDir,
+      stdio: 'ignore',
+    });
+  } catch (_) {
+    // Install failed so run again without --silent
+    try {
+      execSync(`${packageManager} install`, {
+        cwd: tmpDir,
+        stdio: [0, 1, 2],
+      });
+    } catch (e) {
+      // This will probably fail so we exit with the same status
+      process.exit(e.status);
+    }
+  }
 
   return tmpDir;
 }


### PR DESCRIPTION
…ng create

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

This is the error if we can't create the sandbox. This happens when npm hasn't gotten all of the different packages yet.

```
jason@pop-os /t/tmp-95809-j8Hb8LMC2qiH [1]> npx create-nx-workspace@latest --pm pnpm
✔ Workspace name (e.g., org name)     · aweofjoaiwef
✔ What to create in the new workspace · react
✔ Application name                    · app1
✔ Default stylesheet format           · scss
✔ Use Nx Cloud? (It's free and doesn't require registration.) · No

>  NX  Nx is creating your workspace.

  To make sure the command works reliably in all environments, and that the preset is applied correctly,
  Nx will run "pnpm install" several times. Please wait.


>  NX   ERROR  Something went wrong! v12.0.7

node:child_process:707
    err = new Error(msg);
          ^

Error: Command failed: pnpm install --silent
    at checkExecSyncError (node:child_process:707:11)
    at Object.execSync (node:child_process:744:15)
    at createSandbox (/home/jason/.npm/_npx/505743838affa773/node_modules/create-nx-workspace/bin/create-nx-workspace.js:417:21)
    at /home/jason/.npm/_npx/505743838affa773/node_modules/create-nx-workspace/bin/create-nx-workspace.js:112:24
    at Generator.next (<anonymous>)
    at fulfilled (/home/jason/.npm/_npx/505743838affa773/node_modules/tslib/tslib.js:114:62)
    at processTicksAndRejections (node:internal/process/task_queues:94:5) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 101020,
  stdout: null,
  stderr: null
}
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This is the error if we can't create the sandbox. This happens when npm hasn't gotten all of the different packages yet.

```
jason@pop-os /t/tmp-95809-j8Hb8LMC2qiH [1]> npx create-nx-workspace@latest --pm pnpm
✔ Workspace name (e.g., org name)     · awefhawef
✔ What to create in the new workspace · empty
✔ Use Nx Cloud? (It's free and doesn't require registration.) · No

>  NX  Nx is creating your workspace.

  To make sure the command works reliably in all environments, and that the preset is applied correctly,
  Nx will run "pnpm install" several times. Please wait.

 ERROR  No matching version found for @nrwl/devkit@12.0.7

The latest release of @nrwl/devkit is "12.0.6".

Other releases are:
  * next: 12.1.0-beta.1
  * previous: 11.6.2

If you need the full list of all 119 published versions run "$ pnpm view @nrwl/devkit versions".
Progress: resolved 27, reused 21, downloaded 0, added 0
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
