### PR TITLE
docs(core): make install step during migrate more evident

### DIFF
--- a/docs/angular/guides/update.md
+++ b/docs/angular/guides/update.md
@@ -72,9 +72,13 @@ This will fetch the specified version of `@nrwl/workspace`, analyze the dependen
 
 At this point, no packages have been installed, and no other files have been touched.
 
-Now, you can inspect `package.json` to see if the changes make sense. Sometimes the migration can update some package to the version that is either not allowed or conflicts with with another package. After you are satisfied, run `npm install`, `yarn`, or `pnpm install`.
+Now, you can inspect `package.json` to see if the changes make sense. Sometimes the migration can update some package to the version that is either not allowed or conflicts with with another package. Feel free to manually apply the desired adjustments.
 
-### Step 2: Running migrations
+### Step 2: Install the packages
+
+After you are satisfied, make sure to actuall install the packages by running `npm install`, `yarn`, or `pnpm install`.
+
+### Step 3: Running migrations
 
 Next, we need to update the repo to match the updated `package.json` and `node_modules`. Every Nx plugin comes with a set of migrations that describe how to update the workspace to make it work with the new version of the plugin. During Step 1 Nx looked at all of the packages being updated and collected their migrations into `migrations.json`. It's important to note that because Nx knows the from and to versions of every package, the `migrations.json` file only contains the relevant migrations.
 
@@ -93,7 +97,7 @@ For small projects, running all the migrations at once often succeeds without an
 
 Since you can run `nx migrate --run-migrations=migrations.json` as many times as you want, you can achieve all of that by commenting out and reordering items in `migrations.json`. The migrate process can take a long time, sometimes a day, so it can be useful to commit the migrations file with the partially-updated repo.
 
-### Step 3: Cleaning up
+### Step 4: Cleaning up
 
 After you run all the migrations, you can remove `migration.json` and commit the changes.
 

--- a/docs/shared/update.md
+++ b/docs/shared/update.md
@@ -32,9 +32,13 @@ This will fetch the specified version of `@nrwl/workspace`, analyze the dependen
 
 At this point, no packages have been installed, and no other files have been touched.
 
-Now, you can inspect `package.json` to see if the changes make sense. Sometimes the migration can update some package to the version that is either not allowed or conflicts with with another package. After you are satisfied, run `npm install`, `yarn`, or `pnpm install`.
+Now, you can inspect `package.json` to see if the changes make sense. Sometimes the migration can update some package to the version that is either not allowed or conflicts with with another package. Feel free to manually apply the desired adjustments.
 
-### Step 2: Running migrations
+### Step 2: Install the packages
+
+After you are satisfied, make sure to actuall install the packages by running `npm install`, `yarn`, or `pnpm install`.
+
+### Step 3: Running migrations
 
 Next, we need to update the repo to match the updated `package.json` and `node_modules`. Every Nx plugin comes with a set of migrations that describe how to update the workspace to make it work with the new version of the plugin. During Step 1 Nx looked at all of the packages being updated and collected their migrations into `migrations.json`. It's important to note that because Nx knows the from and to versions of every package, the `migrations.json` file only contains the relevant migrations.
 
@@ -53,7 +57,7 @@ For small projects, running all the migrations at once often succeeds without an
 
 Since you can run `nx migrate --run-migrations=migrations.json` as many times as you want, you can achieve all of that by commenting out and reordering items in `migrations.json`. The migrate process can take a long time, sometimes a day, so it can be useful to commit the migrations file with the partially-updated repo.
 
-### Step 3: Cleaning up
+### Step 4: Cleaning up
 
 After you run all the migrations, you can remove `migration.json` and commit the changes.
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

I'm getting a lot of questions due to failed migrations, because people oversee the installation step of actually running `npm install` or `yarn install` during the Nx multistep migration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

That part should be more evident and have its own heading.
