### PR TITLE
feat(testing): enable Jest to consume buildable libs outputs [WIP]

### DIFF
--- a/packages/jest/plugins/resolver.ts
+++ b/packages/jest/plugins/resolver.ts
@@ -1,5 +1,9 @@
-import { dirname, extname } from 'path';
+import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
+import { getTmpProjectRoot } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { readJsonFile } from '@nrwl/workspace/src/utilities/fileutils';
+import { existsSync, statSync } from 'fs';
 import defaultResolver from 'jest-resolve/build/defaultResolver';
+import { dirname, extname, join, relative } from 'path';
 
 interface ResolveOptions {
   rootDir: string;
@@ -13,29 +17,6 @@ interface ResolveOptions {
 
 let compilerSetup;
 let ts;
-
-function getCompilerSetup(rootDir: string) {
-  const tsConfigPath =
-    ts.findConfigFile(rootDir, ts.sys.fileExists, 'tsconfig.spec.json') ||
-    ts.findConfigFile(rootDir, ts.sys.fileExists, 'tsconfig.test.json') ||
-    ts.findConfigFile(rootDir, ts.sys.fileExists, 'tsconfig.jest.json');
-
-  if (!tsConfigPath) {
-    console.error(
-      `Cannot locate a tsconfig.spec.json. Please create one at ${rootDir}/tsconfig.spec.json`
-    );
-  }
-
-  const readResult = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
-  const config = ts.parseJsonConfigFileContent(
-    readResult.config,
-    ts.sys,
-    dirname(tsConfigPath)
-  );
-  const compilerOptions = config.options;
-  const host = ts.createCompilerHost(compilerOptions, true);
-  return { compilerOptions, host };
-}
 
 module.exports = function (path: string, options: ResolveOptions) {
   const ext = extname(path);
@@ -58,11 +39,106 @@ module.exports = function (path: string, options: ResolveOptions) {
     ) {
       return;
     }
-    // Fallback to using typescript
+
+    // Try to find it in the built deps
     ts = ts || require('typescript');
-    compilerSetup = compilerSetup || getCompilerSetup(options.rootDir);
+    compilerSetup =
+      compilerSetup || getCompilerSetup(options.rootDir, appRootPath);
     const { compilerOptions, host } = compilerSetup;
+    const resolved = tryResolveModuleFromBuiltDeps(
+      path,
+      compilerOptions.paths,
+      appRootPath
+    );
+    if (resolved) {
+      return resolved;
+    }
+
+    // Fallback to using typescript
     return ts.resolveModuleName(path, options.basedir, compilerOptions, host)
       .resolvedModule.resolvedFileName;
   }
 };
+
+function getCompilerSetup(rootDir: string, workspaceRoot: string) {
+  const projectRoot = relative(workspaceRoot, rootDir);
+  const tmpDir = getTmpProjectRoot(workspaceRoot, projectRoot);
+  function findTsConfigFile(dir: string, file: string) {
+    return ts.findConfigFile(dir, ts.sys.fileExists, file);
+  }
+  const tsConfigPath =
+    findTsConfigFile(tmpDir, 'tsconfig.spec.generated.json') ||
+    findTsConfigFile(tmpDir, 'tsconfig.test.generated.json') ||
+    findTsConfigFile(tmpDir, 'tsconfig.jest.generated.json') ||
+    findTsConfigFile(rootDir, 'tsconfig.spec.json') ||
+    findTsConfigFile(rootDir, 'tsconfig.test.json') ||
+    findTsConfigFile(rootDir, 'tsconfig.jest.json');
+
+  if (!tsConfigPath) {
+    console.error(
+      `Cannot locate a tsconfig.spec.json. Please create one at ${rootDir}/tsconfig.spec.json`
+    );
+  }
+
+  const readResult = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
+  const config = ts.parseJsonConfigFileContent(
+    readResult.config,
+    ts.sys,
+    dirname(tsConfigPath)
+  );
+  const compilerOptions = config.options;
+  const host = ts.createCompilerHost(compilerOptions, true);
+  return { compilerOptions, host };
+}
+
+function getPathsForModule(
+  moduleName: string,
+  pathMappings: { [key: string]: string[] }
+): string[] {
+  const matchedPattern = ts.matchPatternOrExact(
+    ts.getOwnKeys(pathMappings),
+    moduleName
+  );
+  if (!matchedPattern) {
+    return [];
+  }
+  const matchedPatternText = ts.isString(matchedPattern)
+    ? matchedPattern
+    : ts.patternText(matchedPattern);
+  const matchedStar = ts.isString(matchedPattern)
+    ? undefined
+    : ts.matchedText(matchedPattern, moduleName);
+
+  if (matchedStar) {
+    return pathMappings[matchedPatternText].map((path) =>
+      path.replace('*', matchedStar)
+    );
+  }
+
+  return pathMappings[matchedPatternText];
+}
+
+function tryResolveModuleFromBuiltDeps(
+  moduleName: string,
+  pathMappings: { [key: string]: string[] },
+  workspaceRoot: string
+): string | undefined {
+  const modulePaths = getPathsForModule(moduleName, pathMappings);
+
+  for (const output of modulePaths) {
+    const fullOutputPath = join(workspaceRoot, output);
+    const stats = statSync(fullOutputPath);
+    if (stats.isFile()) {
+      return fullOutputPath;
+    }
+    const packageJsonPath = join(fullOutputPath, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      const packageJson = readJsonFile(packageJsonPath);
+      if (packageJson.main) {
+        return join(fullOutputPath, packageJson.main);
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/packages/jest/src/executors/jest/jest.impl.spec.ts
+++ b/packages/jest/src/executors/jest/jest.impl.spec.ts
@@ -1,20 +1,38 @@
-import { ExecutorContext } from '@nrwl/tao/src/shared/workspace';
+const runCLI = jest.fn();
+jest.mock('jest', () => ({ runCLI }));
 
-let runCLI = jest.fn();
-jest.mock('jest', () => ({
-  runCLI,
+jest.mock('@nrwl/workspace/src/core/project-graph', () => ({
+  ...jest.requireActual('@nrwl/workspace/src/core/project-graph'),
+  createProjectGraph: jest.fn(),
 }));
 
+const calculateProjectTargetDependencies = jest.fn();
+const createTmpJestConfig = jest.fn();
+const createTmpTsConfig = jest.fn();
+const shouldUpdateDependencyPaths = jest.fn();
+jest.mock('@nrwl/workspace/src/utilities/buildable-libs-utils', () => ({
+  calculateProjectTargetDependencies,
+  createTmpJestConfig,
+  createTmpTsConfig,
+  shouldUpdateDependencyPaths,
+}));
+
+const ts = { findConfigFile: jest.fn() };
+jest.mock('typescript', () => ({ findConfigFile: ts.findConfigFile, sys: {} }));
+
+import { ExecutorContext } from '@nrwl/tao/src/shared/workspace';
+import { ProjectType } from '@nrwl/workspace/src/core/project-graph';
 import { jestExecutor } from './jest.impl';
 import { JestExecutorOptions } from './schema';
 
 describe('Jest Executor', () => {
   let mockContext: ExecutorContext;
-  const defaultOptions: Omit<JestExecutorOptions, 'jestConfig'> = {
+  const defaultOptions: JestExecutorOptions = {
+    jestConfig: './jest.config.js',
     testPathPattern: [],
   };
 
-  beforeEach(async () => {
+  beforeEach(() => {
     runCLI.mockReturnValue(
       Promise.resolve({
         results: {
@@ -51,233 +69,204 @@ describe('Jest Executor', () => {
     jest.resetAllMocks();
   });
 
-  describe('when the jest config file is untouched', () => {
+  describe('project with no dependencies', () => {
     beforeEach(() => {
-      jest.mock(
-        '/root/jest.config.js',
-        () => ({
-          transform: {
-            '^.+\\.[tj]sx?$': 'ts-jest',
-          },
-        }),
-        { virtual: true }
-      );
+      calculateProjectTargetDependencies.mockReturnValue({
+        target: {
+          type: ProjectType.app,
+          name: 'proj',
+        },
+        dependencies: [],
+      });
     });
 
-    it('should send appropriate options to jestCLI', async () => {
-      await jestExecutor(
-        {
-          ...defaultOptions,
-          jestConfig: './jest.config.js',
-          watch: false,
-        },
-        mockContext
-      );
-      expect(runCLI).toHaveBeenCalledWith(
-        expect.objectContaining({
-          _: [],
-          testPathPattern: [],
-          watch: false,
-        }),
-        ['/root/jest.config.js']
-      );
-    });
-
-    it('should send appropriate options to jestCLI when testFile is specified', async () => {
-      await jestExecutor(
-        {
-          testFile: 'lib.spec.ts',
-          jestConfig: './jest.config.js',
-          codeCoverage: false,
-          runInBand: true,
-          testNamePattern: 'should load',
-          testPathPattern: ['/test/path'],
-          colors: false,
-          reporters: ['/test/path'],
-          verbose: false,
-          coverageReporters: ['test'],
-          coverageDirectory: '/test/coverage',
-          watch: false,
-        },
-        mockContext
-      );
-
-      expect(runCLI).toHaveBeenCalledWith(
-        expect.objectContaining({
-          _: ['lib.spec.ts'],
-          coverage: false,
-          runInBand: true,
-          testNamePattern: 'should load',
-          testPathPattern: ['/test/path'],
-          colors: false,
-          reporters: ['/test/path'],
-          verbose: false,
-          coverageReporters: ['test'],
-          coverageDirectory: '/root/test/coverage',
-          watch: false,
-        }),
-        ['/root/jest.config.js']
-      );
-    });
-
-    it('should send appropriate options to jestCLI when findRelatedTests is specified', async () => {
-      await jestExecutor(
-        {
-          ...defaultOptions,
-          findRelatedTests: 'file1.ts,file2.ts',
-          jestConfig: './jest.config.js',
-          codeCoverage: false,
-          runInBand: true,
-          testNamePattern: 'should load',
-          watch: false,
-        },
-        mockContext
-      );
-
-      expect(runCLI).toHaveBeenCalledWith(
-        expect.objectContaining({
-          _: ['file1.ts', 'file2.ts'],
-          coverage: false,
-          findRelatedTests: true,
-          runInBand: true,
-          testNamePattern: 'should load',
-          testPathPattern: [],
-          watch: false,
-        }),
-        ['/root/jest.config.js']
-      );
-    });
-
-    it('should send other options to jestCLI', async () => {
-      await jestExecutor(
-        {
-          jestConfig: './jest.config.js',
-          codeCoverage: true,
-          bail: 1,
-          color: false,
-          ci: true,
-          detectOpenHandles: true,
-          json: true,
-          maxWorkers: 2,
-          onlyChanged: true,
-          outputFile: 'abc.txt',
-          passWithNoTests: true,
-          showConfig: true,
-          silent: true,
-          testNamePattern: 'test',
-          testPathPattern: ['/test/path'],
-          colors: false,
-          reporters: ['/test/path'],
-          verbose: false,
-          coverageReporters: ['test'],
-          coverageDirectory: '/test/coverage',
-          testResultsProcessor: 'results-processor',
-          updateSnapshot: true,
-          useStderr: true,
-          watch: false,
-          watchAll: false,
-          testLocationInResults: true,
-        },
-        mockContext
-      );
-      expect(runCLI).toHaveBeenCalledWith(
-        {
-          _: [],
-          coverage: true,
-          bail: 1,
-          color: false,
-          ci: true,
-          detectOpenHandles: true,
-          json: true,
-          maxWorkers: 2,
-          onlyChanged: true,
-          outputFile: 'abc.txt',
-          passWithNoTests: true,
-          showConfig: true,
-          silent: true,
-          testNamePattern: 'test',
-          testPathPattern: ['/test/path'],
-          colors: false,
-          verbose: false,
-          reporters: ['/test/path'],
-          coverageReporters: ['test'],
-          coverageDirectory: '/root/test/coverage',
-          testResultsProcessor: 'results-processor',
-          updateSnapshot: true,
-          useStderr: true,
-          watch: false,
-          watchAll: false,
-          testLocationInResults: true,
-        },
-        ['/root/jest.config.js']
-      );
-    });
-
-    it('should support passing string type for maxWorkers option to jestCLI', async () => {
-      await jestExecutor(
-        {
-          ...defaultOptions,
-          jestConfig: './jest.config.js',
-          maxWorkers: '50%',
-        },
-        mockContext
-      );
-      expect(runCLI).toHaveBeenCalledWith(
-        {
-          _: [],
-          maxWorkers: '50%',
-          testPathPattern: [],
-        },
-        ['/root/jest.config.js']
-      );
-    });
-
-    it('should send the main to runCLI', async () => {
-      await jestExecutor(
-        {
-          ...defaultOptions,
-          jestConfig: './jest.config.js',
-          setupFile: './test-setup.ts',
-          watch: false,
-        },
-        mockContext
-      );
-      expect(runCLI).toHaveBeenCalledWith(
-        expect.objectContaining({
-          _: [],
-          setupFilesAfterEnv: ['/root/test-setup.ts'],
-          testPathPattern: [],
-          watch: false,
-        }),
-        ['/root/jest.config.js']
-      );
-    });
-
-    describe('when the jest config file has been modified', () => {
-      beforeAll(() => {
-        jest.doMock(
+    describe('when the jest config file is untouched', () => {
+      beforeEach(() => {
+        jest.mock(
           '/root/jest.config.js',
           () => ({
             transform: {
               '^.+\\.[tj]sx?$': 'ts-jest',
             },
-            globals: { hereToStay: true, 'ts-jest': { diagnostics: false } },
           }),
           { virtual: true }
         );
       });
 
-      it('should merge the globals property from jest config', async () => {
+      it('should send appropriate options to jestCLI', async () => {
         await jestExecutor(
           {
             ...defaultOptions,
-            jestConfig: './jest.config.js',
-            setupFile: './test-setup.ts',
+            watch: false,
+          },
+          mockContext
+        );
+        expect(runCLI).toHaveBeenCalledWith(
+          expect.objectContaining({
+            _: [],
+            testPathPattern: [],
+            watch: false,
+          }),
+          ['/root/jest.config.js']
+        );
+      });
+
+      it('should send appropriate options to jestCLI when testFile is specified', async () => {
+        await jestExecutor(
+          {
+            ...defaultOptions,
+            testFile: 'lib.spec.ts',
+            codeCoverage: false,
+            runInBand: true,
+            testNamePattern: 'should load',
+            testPathPattern: ['/test/path'],
+            colors: false,
+            reporters: ['/test/path'],
+            verbose: false,
+            coverageReporters: ['test'],
+            coverageDirectory: '/test/coverage',
             watch: false,
           },
           mockContext
         );
 
+        expect(runCLI).toHaveBeenCalledWith(
+          expect.objectContaining({
+            _: ['lib.spec.ts'],
+            coverage: false,
+            runInBand: true,
+            testNamePattern: 'should load',
+            testPathPattern: ['/test/path'],
+            colors: false,
+            reporters: ['/test/path'],
+            verbose: false,
+            coverageReporters: ['test'],
+            coverageDirectory: '/root/test/coverage',
+            watch: false,
+          }),
+          ['/root/jest.config.js']
+        );
+      });
+
+      it('should send appropriate options to jestCLI when findRelatedTests is specified', async () => {
+        await jestExecutor(
+          {
+            ...defaultOptions,
+            findRelatedTests: 'file1.ts,file2.ts',
+            codeCoverage: false,
+            runInBand: true,
+            testNamePattern: 'should load',
+            watch: false,
+          },
+          mockContext
+        );
+
+        expect(runCLI).toHaveBeenCalledWith(
+          expect.objectContaining({
+            _: ['file1.ts', 'file2.ts'],
+            coverage: false,
+            findRelatedTests: true,
+            runInBand: true,
+            testNamePattern: 'should load',
+            testPathPattern: [],
+            watch: false,
+          }),
+          ['/root/jest.config.js']
+        );
+      });
+
+      it('should send other options to jestCLI', async () => {
+        await jestExecutor(
+          {
+            ...defaultOptions,
+            codeCoverage: true,
+            bail: 1,
+            color: false,
+            ci: true,
+            detectOpenHandles: true,
+            json: true,
+            maxWorkers: 2,
+            onlyChanged: true,
+            outputFile: 'abc.txt',
+            passWithNoTests: true,
+            showConfig: true,
+            silent: true,
+            testNamePattern: 'test',
+            testPathPattern: ['/test/path'],
+            colors: false,
+            reporters: ['/test/path'],
+            verbose: false,
+            coverageReporters: ['test'],
+            coverageDirectory: '/test/coverage',
+            testResultsProcessor: 'results-processor',
+            updateSnapshot: true,
+            useStderr: true,
+            watch: false,
+            watchAll: false,
+            testLocationInResults: true,
+          },
+          mockContext
+        );
+        expect(runCLI).toHaveBeenCalledWith(
+          {
+            _: [],
+            coverage: true,
+            bail: 1,
+            color: false,
+            ci: true,
+            detectOpenHandles: true,
+            json: true,
+            maxWorkers: 2,
+            onlyChanged: true,
+            outputFile: 'abc.txt',
+            passWithNoTests: true,
+            showConfig: true,
+            silent: true,
+            testNamePattern: 'test',
+            testPathPattern: ['/test/path'],
+            colors: false,
+            verbose: false,
+            reporters: ['/test/path'],
+            coverageReporters: ['test'],
+            coverageDirectory: '/root/test/coverage',
+            testResultsProcessor: 'results-processor',
+            updateSnapshot: true,
+            useStderr: true,
+            watch: false,
+            watchAll: false,
+            testLocationInResults: true,
+          },
+          ['/root/jest.config.js']
+        );
+      });
+
+      it('should support passing string type for maxWorkers option to jestCLI', async () => {
+        await jestExecutor(
+          {
+            ...defaultOptions,
+            maxWorkers: '50%',
+          },
+          mockContext
+        );
+        expect(runCLI).toHaveBeenCalledWith(
+          {
+            _: [],
+            maxWorkers: '50%',
+            testPathPattern: [],
+          },
+          ['/root/jest.config.js']
+        );
+      });
+
+      it('should send the main to runCLI', async () => {
+        await jestExecutor(
+          {
+            ...defaultOptions,
+            setupFile: './test-setup.ts',
+            watch: false,
+          },
+          mockContext
+        );
         expect(runCLI).toHaveBeenCalledWith(
           expect.objectContaining({
             _: [],
@@ -288,9 +277,217 @@ describe('Jest Executor', () => {
           ['/root/jest.config.js']
         );
       });
+
+      it('should not update jest config nor tsconfig', async () => {
+        await jestExecutor({ ...defaultOptions }, mockContext);
+
+        expect(runCLI).toHaveBeenCalledWith(expect.any(Object), [
+          '/root/jest.config.js',
+        ]);
+        expect(createTmpJestConfig).not.toHaveBeenCalled();
+        expect(createTmpTsConfig).not.toHaveBeenCalled();
+      });
+
+      describe('when the jest config file has been modified', () => {
+        beforeAll(() => {
+          jest.doMock(
+            '/root/jest.config.js',
+            () => ({
+              transform: {
+                '^.+\\.[tj]sx?$': 'ts-jest',
+              },
+              globals: { hereToStay: true, 'ts-jest': { diagnostics: false } },
+            }),
+            { virtual: true }
+          );
+        });
+
+        it('should merge the globals property from jest config', async () => {
+          await jestExecutor(
+            {
+              ...defaultOptions,
+              setupFile: './test-setup.ts',
+              watch: false,
+            },
+            mockContext
+          );
+
+          expect(runCLI).toHaveBeenCalledWith(
+            expect.objectContaining({
+              _: [],
+              setupFilesAfterEnv: ['/root/test-setup.ts'],
+              testPathPattern: [],
+              watch: false,
+            }),
+            ['/root/jest.config.js']
+          );
+        });
+      });
+
+      describe('when we use babel-jest', () => {
+        beforeEach(() => {
+          jest.doMock(
+            '/root/jest.config.js',
+            () => ({
+              transform: {
+                '^.+\\.[tj]sx?$': 'babel-jest',
+              },
+            }),
+            { virtual: true }
+          );
+        });
+
+        it('should send appropriate options to jestCLI', async () => {
+          const options: JestExecutorOptions = {
+            ...defaultOptions,
+            watch: false,
+          };
+
+          await jestExecutor(options, mockContext);
+          expect(runCLI).toHaveBeenCalledWith(
+            expect.objectContaining({
+              _: [],
+              testPathPattern: [],
+              watch: false,
+            }),
+            ['/root/jest.config.js']
+          );
+        });
+      });
+    });
+  });
+
+  describe('project with dependencies', () => {
+    const projecTargetDependencies = {
+      target: {
+        type: ProjectType.app,
+        name: 'proj',
+        data: { root: '/root/proj' },
+      },
+      dependencies: [{ outputs: ['dist/lib1'] }, { outputs: ['dist/lib2'] }],
+    };
+
+    beforeEach(() => {
+      jest.resetModules();
+      jest.mock(
+        '/root/jest.config.js',
+        () => ({
+          transform: {
+            '^.+\\.[tj]sx?$': 'ts-jest',
+          },
+          globals: {
+            'ts-jest': {
+              tsconfig: '<rootDir>/tsconfig.spec.json',
+            },
+          },
+        }),
+        { virtual: true }
+      );
+
+      calculateProjectTargetDependencies.mockReturnValue(
+        projecTargetDependencies
+      );
+
+      shouldUpdateDependencyPaths.mockReturnValue(true);
+      createTmpJestConfig.mockReturnValue('/tmp/jest.config.generated.json');
+      createTmpTsConfig.mockReturnValue('/tmp/tsconfig.spec.generated.json');
+      ts.findConfigFile.mockReturnValue('/root/tsconfig.spec.json');
     });
 
-    describe('when we use babel-jest', () => {
+    it('should not update jest config nor tsconfig when the deps paths should not be updated', async () => {
+      shouldUpdateDependencyPaths.mockReturnValue(false);
+
+      await jestExecutor({ ...defaultOptions }, mockContext);
+
+      expect(runCLI).toHaveBeenCalledWith(expect.any(Object), [
+        '/root/jest.config.js',
+      ]);
+      expect(createTmpJestConfig).not.toHaveBeenCalled();
+      expect(createTmpTsConfig).not.toHaveBeenCalled();
+    });
+
+    it('should update tsconfig paths and the jest config', async () => {
+      await jestExecutor({ ...defaultOptions }, mockContext);
+
+      expect(runCLI).toHaveBeenCalledWith(expect.any(Object), [
+        '/tmp/jest.config.generated.json',
+      ]);
+      expect(createTmpTsConfig).toHaveBeenCalledWith(
+        '/root/tsconfig.spec.json',
+        '/root',
+        projecTargetDependencies.target.data.root,
+        projecTargetDependencies.dependencies
+      );
+      expect(createTmpJestConfig).toHaveBeenCalledWith(
+        '/root',
+        projecTargetDependencies.target.data.root,
+        expect.objectContaining({
+          globals: {
+            'ts-jest': { tsconfig: '/tmp/tsconfig.spec.generated.json' },
+          },
+          transformIgnorePatterns: expect.arrayContaining([
+            '/dist/lib1/',
+            '/dist/lib2/',
+          ]),
+        })
+      );
+    });
+
+    it('should respect existing rootDir', async () => {
+      jest.doMock(
+        '/root/jest.config.js',
+        () => ({
+          transform: {
+            '^.+\\.[tj]sx?$': 'ts-jest',
+          },
+          globals: {
+            'ts-jest': {
+              tsconfig: '<rootDir>/tsconfig.spec.json',
+            },
+          },
+          rootDir: '/other-root',
+        }),
+        { virtual: true }
+      );
+
+      await jestExecutor({ ...defaultOptions }, mockContext);
+
+      expect(createTmpJestConfig).toHaveBeenCalledWith(
+        '/root',
+        projecTargetDependencies.target.data.root,
+        expect.objectContaining({ rootDir: '/other-root' })
+      );
+    });
+
+    it('should respect existing transformIgnorePatterns', async () => {
+      jest.doMock(
+        '/root/jest.config.js',
+        () => ({
+          transform: {
+            '^.+\\.[tj]sx?$': 'ts-jest',
+          },
+          globals: {
+            'ts-jest': {
+              tsconfig: '<rootDir>/tsconfig.spec.json',
+            },
+          },
+          transformIgnorePatterns: ['/pattern/'],
+        }),
+        { virtual: true }
+      );
+
+      await jestExecutor({ ...defaultOptions }, mockContext);
+
+      expect(createTmpJestConfig).toHaveBeenCalledWith(
+        '/root',
+        projecTargetDependencies.target.data.root,
+        expect.objectContaining({
+          transformIgnorePatterns: ['/pattern/', '/dist/lib1/', '/dist/lib2/'],
+        })
+      );
+    });
+
+    describe('when using babel-jest', () => {
       beforeEach(() => {
         jest.doMock(
           '/root/jest.config.js',
@@ -303,21 +500,21 @@ describe('Jest Executor', () => {
         );
       });
 
-      it('should send appropriate options to jestCLI', async () => {
-        const options: JestExecutorOptions = {
-          ...defaultOptions,
-          jestConfig: './jest.config.js',
-          watch: false,
-        };
+      it('should not update the ts-jest tsconfig property in the jest config', async () => {
+        await jestExecutor({ ...defaultOptions }, mockContext);
 
-        await jestExecutor(options, mockContext);
-        expect(runCLI).toHaveBeenCalledWith(
-          expect.objectContaining({
-            _: [],
-            testPathPattern: [],
-            watch: false,
-          }),
-          ['/root/jest.config.js']
+        expect(runCLI).toHaveBeenCalledWith(expect.any(Object), [
+          '/tmp/jest.config.generated.json',
+        ]);
+        expect(createTmpTsConfig).toHaveBeenCalled();
+        expect(createTmpJestConfig).toHaveBeenCalledWith(
+          '/root',
+          projecTargetDependencies.target.data.root,
+          expect.not.objectContaining({
+            globals: {
+              'ts-jest': { tsconfig: expect.any(String) },
+            },
+          })
         );
       });
     });

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -1,8 +1,16 @@
+import { Config } from '@jest/types';
+import { ExecutorContext } from '@nrwl/devkit';
+import { createProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  calculateProjectTargetDependencies,
+  createTmpJestConfig,
+  createTmpTsConfig,
+  DependentBuildableProjectNode,
+  shouldUpdateDependencyPaths,
+} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import { runCLI } from 'jest';
 import * as path from 'path';
 import { JestExecutorOptions } from './schema';
-import { Config } from '@jest/types';
-import { ExecutorContext } from '@nrwl/devkit';
 
 try {
   require('dotenv').config();
@@ -14,11 +22,42 @@ if (process.env.NODE_ENV === null || process.env.NODE_ENV === undefined) {
   (process.env as any).NODE_ENV = 'test';
 }
 
+let ts;
+
 export async function jestExecutor(
   options: JestExecutorOptions,
   context: ExecutorContext
 ): Promise<{ success: boolean }> {
   const config = jestConfigParser(options, context);
+
+  const projectGraph = createProjectGraph();
+  const { dependencies, target } = calculateProjectTargetDependencies(
+    projectGraph,
+    context.root,
+    context.projectName,
+    context.targetName,
+    context.configurationName
+  );
+  const shouldUpdatePaths = dependencies.some(shouldUpdateDependencyPaths);
+  if (shouldUpdatePaths) {
+    const jestConfig: Config.ProjectConfig = require(options.jestConfig);
+    const rootDir = jestConfig.rootDir ?? path.dirname(options.jestConfig);
+    const tmpTsConfigPath = updateTsConfigPaths(
+      jestConfig,
+      context.root,
+      target.data.root,
+      rootDir,
+      dependencies
+    );
+    options.jestConfig = updateJestConfig(
+      jestConfig,
+      rootDir,
+      context.root,
+      target.data.root,
+      tmpTsConfigPath,
+      dependencies
+    );
+  }
 
   const { results } = await runCLI(config, [options.jestConfig]);
 
@@ -111,6 +150,103 @@ export function jestConfigParser(
   }
 
   return config;
+}
+
+function getTsConfigPath(
+  jestConfig: Config.ProjectConfig,
+  workspaceRoot: string,
+  projectRoot: string,
+  jestRootDir: string
+): string | undefined {
+  let tsConfigPath = getTsJestTsConfigPath(jestConfig, jestRootDir);
+  if (tsConfigPath) {
+    return tsConfigPath;
+  }
+
+  const rootDir = path.join(workspaceRoot, projectRoot);
+  ts = ts || require('typescript');
+  tsConfigPath =
+    ts.findConfigFile(rootDir, ts.sys.fileExists, 'tsconfig.spec.json') ||
+    ts.findConfigFile(rootDir, ts.sys.fileExists, 'tsconfig.test.json') ||
+    ts.findConfigFile(rootDir, ts.sys.fileExists, 'tsconfig.jest.json');
+  return tsConfigPath;
+}
+
+function getTsJestTsConfigPath(
+  jestConfig: Config.ProjectConfig,
+  rootDir: string
+): string | undefined {
+  return (jestConfig.globals?.['ts-jest'] as any)?.tsconfig?.replace(
+    '<rootDir>',
+    rootDir
+  );
+}
+
+function updateJestConfig(
+  jestConfig: Config.ProjectConfig,
+  jestRootDir: string,
+  workspaceRoot: string,
+  projectRoot: string,
+  tsConfigPath: string,
+  dependencies: DependentBuildableProjectNode[]
+): string {
+  if (jestConfig.globals?.['ts-jest']) {
+    (jestConfig.globals['ts-jest'] as any).tsconfig = tsConfigPath;
+  }
+  jestConfig.rootDir = jestRootDir;
+
+  const outputs = dependencies
+    .reduce((acc, current) => {
+      acc.push(...current.outputs);
+      return acc;
+    }, [])
+    .map((output: string) => {
+      if (!output.startsWith('/')) {
+        output = `/${output}`;
+      }
+      if (!output.endsWith('/')) {
+        output = `${output}/`;
+      }
+      return output;
+    });
+  const uniqueOutputs = Array.from(new Set(outputs));
+  jestConfig.transformIgnorePatterns = [
+    ...(jestConfig.transformIgnorePatterns ?? [
+      '/node_modules/',
+      '\\.pnp\\.[^\\/]+$',
+    ]),
+    ...uniqueOutputs,
+  ];
+
+  return createTmpJestConfig(workspaceRoot, projectRoot, jestConfig);
+}
+
+function updateTsConfigPaths(
+  jestConfig: Config.ProjectConfig,
+  workspaceRoot: string,
+  projectRoot: string,
+  jestRootDir: string,
+  dependencies: DependentBuildableProjectNode[]
+): string {
+  const tsConfigPath = getTsConfigPath(
+    jestConfig,
+    workspaceRoot,
+    projectRoot,
+    jestRootDir
+  );
+
+  if (!tsConfigPath) {
+    throw new Error(
+      `Cannot locate a tsconfig.spec.json. Please create one at ${projectRoot}/tsconfig.spec.json.`
+    );
+  }
+
+  return createTmpTsConfig(
+    tsConfigPath,
+    workspaceRoot,
+    projectRoot,
+    dependencies
+  );
 }
 
 export default jestExecutor;

--- a/packages/node/src/executors/package/package.impl.spec.ts
+++ b/packages/node/src/executors/package/package.impl.spec.ts
@@ -319,7 +319,7 @@ describe('NodePackageBuilder', () => {
         '/root',
         'tmp',
         'libs/nodelib',
-        'tsconfig.generated.json'
+        'tsconfig.lib.generated.json'
       );
 
       const tsConfigSpy = jest.spyOn(tsUtils, 'readTsConfig');

--- a/packages/nx-plugin/src/builders/e2e/e2e.impl.ts
+++ b/packages/nx-plugin/src/builders/e2e/e2e.impl.ts
@@ -26,10 +26,14 @@ export function runNxPluginE2EBuilder(
   return buildTarget(context, options.target).pipe(
     switchMap(() => {
       return from(
-        context.scheduleBuilder('@nrwl/jest:jest', {
-          jestConfig: options.jestConfig,
-          watch: false,
-        })
+        context.scheduleBuilder(
+          '@nrwl/jest:jest',
+          {
+            jestConfig: options.jestConfig,
+            watch: false,
+          },
+          { target: context.target }
+        )
       ).pipe(concatMap((run) => run.output));
     })
   );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Jest always builds the deps before running the tests.

## Expected Behavior
Jest takes advantage of the incremental builds and consume the built outputs if they are present to avoid building them every time the tests are run.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
