### PR TITLE
feat(core): allow defining target dependencies across all projects

### DIFF
--- a/packages/tao/src/shared/nx.ts
+++ b/packages/tao/src/shared/nx.ts
@@ -1,3 +1,5 @@
+import { TargetDependencyConfig } from './workspace';
+
 export type ImplicitDependencyEntry<T = '*' | string[]> = {
   [key: string]: T | ImplicitJsonSubsetDependency<T>;
 };
@@ -17,9 +19,25 @@ export interface NxAffectedConfig {
  * Nx.json configuration
  */
 export interface NxJsonConfiguration<T = '*' | string[]> {
+  /**
+   * Map of files to projects that implicitly depend on them
+   */
   implicitDependencies?: ImplicitDependencyEntry<T>;
+  /**
+   * Dependencies between different target names across all projects
+   */
+  targetDependencies?: Record<string, TargetDependencyConfig[]>;
+  /**
+   * NPM Scope that the workspace uses
+   */
   npmScope: string;
+  /**
+   * Default options for `nx affected`
+   */
   affected?: NxAffectedConfig;
+  /**
+   * Configuration for projects
+   */
   projects: {
     [projectName: string]: NxJsonProjectConfiguration;
   };
@@ -27,12 +45,24 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
     libsDir: string;
     appsDir: string;
   };
+  /**
+   * Available Task Runners
+   */
   tasksRunnerOptions?: {
     [tasksRunnerName: string]: {
+      /**
+       * Path to resolve the runner
+       */
       runner: string;
+      /**
+       * Default options for the runner
+       */
       options?: any;
     };
   };
+  /**
+   * Plugins for extending the project graph
+   */
   plugins?: string[];
 }
 

--- a/packages/workspace/src/tasks-runner/__snapshots__/task-orderer.spec.ts.snap
+++ b/packages/workspace/src/tasks-runner/__snapshots__/task-orderer.spec.ts.snap
@@ -14,18 +14,6 @@ Array [
       },
     },
     Object {
-      "id": "common2:build",
-      "overrides": Object {},
-      "projectRoot": "common2-root",
-      "target": Object {
-        "configuration": undefined,
-        "project": "common2",
-        "target": "build",
-      },
-    },
-  ],
-  Array [
-    Object {
       "id": "app1:prebuild",
       "overrides": Object {},
       "projectRoot": "app1-root",
@@ -33,6 +21,16 @@ Array [
         "configuration": undefined,
         "project": "app1",
         "target": "prebuild",
+      },
+    },
+    Object {
+      "id": "common2:build",
+      "overrides": Object {},
+      "projectRoot": "common2-root",
+      "target": Object {
+        "configuration": undefined,
+        "project": "common2",
+        "target": "build",
       },
     },
     Object {

--- a/packages/workspace/src/tasks-runner/default-tasks-runner.ts
+++ b/packages/workspace/src/tasks-runner/default-tasks-runner.ts
@@ -9,6 +9,7 @@ import { ProjectGraph } from '../core/project-graph';
 import { NxJson } from '../core/shared-interfaces';
 import { TaskOrderer } from './task-orderer';
 import { TaskOrchestrator } from './task-orchestrator';
+import { getDefaultDependencyConfigs } from './utils';
 
 export interface RemoteCache {
   retrieve: (hash: string, cacheDirectory: string) => Promise<boolean>;
@@ -75,16 +76,18 @@ async function runAllTasks(
   tasks: Task[],
   options: DefaultTasksRunnerOptions,
   context: {
-    target: string;
     initiatingProject?: string;
     projectGraph: ProjectGraph;
     nxJson: NxJson;
   }
 ): Promise<Array<{ task: Task; type: any; success: boolean }>> {
+  const defaultTargetDependencies = getDefaultDependencyConfigs(
+    context.nxJson,
+    options
+  );
   const stages = new TaskOrderer(
-    options,
-    context.target,
-    context.projectGraph
+    context.projectGraph,
+    defaultTargetDependencies
   ).splitTasksIntoStages(tasks);
 
   const orchestrator = new TaskOrchestrator(

--- a/packages/workspace/src/tasks-runner/task-orderer.ts
+++ b/packages/workspace/src/tasks-runner/task-orderer.ts
@@ -3,6 +3,7 @@ import { Task } from './tasks-runner';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { getDependencyConfigs } from './utils';
 import { performance } from 'perf_hooks';
+import { TargetDependencyConfig } from '@nrwl/tao/src/shared/workspace';
 
 interface TaskGraph {
   tasks: Record<string, Task>;
@@ -11,18 +12,14 @@ interface TaskGraph {
 
 export class TaskOrderer {
   constructor(
-    private readonly options: DefaultTasksRunnerOptions,
-    private readonly target: string,
-    private readonly projectGraph: ProjectGraph
+    private readonly projectGraph: ProjectGraph,
+    private readonly defaultTargetDependencies: Record<
+      string,
+      TargetDependencyConfig[]
+    >
   ) {}
 
   splitTasksIntoStages(tasks: Task[]) {
-    if (
-      (this.options.strictlyOrderedTargets || ['build']).indexOf(
-        this.target
-      ) === -1
-    )
-      return [tasks];
     if (tasks.length === 0) return [];
 
     const stages: Task[][] = [];
@@ -60,14 +57,6 @@ export class TaskOrderer {
       }
       stageIndex++;
     }
-    // this.topologicallySortTasks(tasks).forEach((t) => {
-    //   const earliestStage = this.findEarliestStage(t, stages, taskGraph);
-    //   if (earliestStage) {
-    //     earliestStage.push(t);
-    //   } else {
-    //     stages.push([t]);
-    //   }
-    // });
     performance.mark('ordering tasks:end');
     performance.measure(
       'ordering tasks',
@@ -87,93 +76,42 @@ export class TaskOrderer {
       graph.dependencies[task.id] = [];
       const dependencyConfigs = getDependencyConfigs(
         task.target,
+        this.defaultTargetDependencies,
         this.projectGraph
       );
+
+      if (!dependencyConfigs) {
+        continue;
+      }
+
       const projectDependencies = new Set(
         this.projectGraph.dependencies[task.target.project].map(
           (dependency) => dependency.target
         )
       );
 
-      if (!dependencyConfigs) {
-        for (const t of tasks) {
-          if (projectDependencies.has(t.target.project)) {
-            graph.dependencies[task.id].push(t.id);
-          }
-        }
-      } else {
-        for (const dependencyConfig of dependencyConfigs) {
-          if (dependencyConfig.projects === 'self') {
-            for (const t of tasks) {
-              if (
-                t.target.project === task.target.project &&
-                t.target.target === dependencyConfig.target
-              ) {
-                graph.dependencies[task.id].push(t.id);
-              }
+      for (const dependencyConfig of dependencyConfigs) {
+        if (dependencyConfig.projects === 'self') {
+          for (const t of tasks) {
+            if (
+              t.target.project === task.target.project &&
+              t.target.target === dependencyConfig.target
+            ) {
+              graph.dependencies[task.id].push(t.id);
             }
-          } else if (dependencyConfig.projects === 'dependencies') {
-            for (const t of tasks) {
-              if (
-                projectDependencies.has(t.target.project) &&
-                t.target.target === dependencyConfig.target
-              ) {
-                graph.dependencies[task.id].push(t.id);
-              }
+          }
+        } else if (dependencyConfig.projects === 'dependencies') {
+          for (const t of tasks) {
+            if (
+              projectDependencies.has(t.target.project) &&
+              t.target.target === dependencyConfig.target
+            ) {
+              graph.dependencies[task.id].push(t.id);
             }
           }
         }
       }
     }
     return graph;
-  }
-
-  private findEarliestStage(
-    task: Task,
-    stages: Task[][],
-    taskGraph: TaskGraph
-  ) {
-    const unseenDependencies = new Set(taskGraph.dependencies[task.id]);
-    for (const stage of stages) {
-      // The stage after seeing all the dependencies is the earliest stage
-      if (unseenDependencies.size === 0) {
-        return stage;
-      }
-      for (const taskInStage of stage) {
-        unseenDependencies.delete(taskInStage.id);
-      }
-    }
-
-    // There is no stage after all of the dependencies
-    return null;
-  }
-
-  private topologicallySortTasks(tasks: Task[]) {
-    const visited: { [k: string]: boolean } = {};
-    const sortedProjects: string[] = [];
-
-    const visitNode = (id: string) => {
-      if (visited[id]) return;
-      visited[id] = true;
-      this.projectGraph.dependencies[id].forEach((d) => {
-        visitNode(d.target);
-      });
-      sortedProjects.push(id);
-    };
-    tasks.forEach((t) => visitNode(t.target.project));
-
-    return tasks.sort((a, b) => {
-      if (a.target.project === b.target.project) {
-        return this.projectGraph.nodes[a.target.project].data.targets.dependsOn
-          ?.target === a.target.target
-          ? -1
-          : 1;
-      } else {
-        return (
-          sortedProjects.indexOf(a.target.project) -
-          sortedProjects.indexOf(b.target.project)
-        );
-      }
-    });
   }
 }


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Configuring how targets depend on one another is done in `workspace.json` for each project.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Configuring how targets depend on one another can be done for all targets of a certain name in `nx.json`.

nx.json
```json
{
  ...,
  "targetDependencies": {
    "build": [
      // All builds depend on the builds of their dependencies
      {
        "target": "build",
        "projects": "dependencies"
      }
    ]
  }
}
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
