### PR TITLE
cleanup(core): refactored @nrwl/tao to improve code quality

### DIFF
--- a/packages/tao/index.ts
+++ b/packages/tao/index.ts
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 import { dirname, join } from 'path';
-
-const argv = require('yargs-parser')(process.argv.slice(2));
 import { existsSync } from 'fs-extra';
+import * as yargsParser from 'yargs-parser';
+
+const argv = yargsParser(process.argv.slice(2));
 
 export async function invokeCommand(
   command: string,
   root: string,
   commandArgs: string[] = []
 ) {
-  if (command === undefined) {
+  if (!command) {
     command = 'help';
   }
 

--- a/packages/tao/package.json
+++ b/packages/tao/package.json
@@ -31,14 +31,14 @@
   "dependencies": {
     "chalk": "4.1.0",
     "enquirer": "~2.3.6",
+    "fs-extra": "7.0.1",
     "minimist": "^1.2.5",
     "rxjs": "^6.5.4",
-    "strip-json-comments": "^3.1.1",
+    "rxjs-for-await": "0.0.2",
     "semver": "7.3.4",
+    "strip-json-comments": "^3.1.1",
     "tmp": "~0.2.1",
     "tslib": "^2.0.0",
-    "yargs-parser": "20.0.0",
-    "fs-extra": "7.0.1",
-    "rxjs-for-await": "0.0.2"
+    "yargs-parser": "20.0.0"
   }
 }

--- a/packages/tao/src/commands/generate.ts
+++ b/packages/tao/src/commands/generate.ts
@@ -8,13 +8,11 @@ import {
 } from '../shared/params';
 import { printHelp } from '../shared/print-help';
 import { WorkspaceJsonConfiguration, Workspaces } from '../shared/workspace';
-import { statSync, unlinkSync, writeFileSync } from 'fs';
-import { mkdirpSync, rmdirSync } from 'fs-extra';
+import { removeSync, ensureDirSync, writeFileSync } from 'fs-extra';
 import * as path from 'path';
 import { FileChange, FsTree } from '../shared/tree';
 import { logger } from '../shared/logger';
-
-const chalk = require('chalk');
+import * as chalk from 'chalk';
 
 export interface GenerateOptions {
   collectionName: string;
@@ -137,19 +135,12 @@ export function flushChanges(root: string, fileChanges: FileChange[]) {
   fileChanges.forEach((f) => {
     const fpath = path.join(root, f.path);
     if (f.type === 'CREATE') {
-      mkdirpSync(path.dirname(fpath));
+      ensureDirSync(path.dirname(fpath));
       writeFileSync(fpath, f.content);
     } else if (f.type === 'UPDATE') {
       writeFileSync(fpath, f.content);
     } else if (f.type === 'DELETE') {
-      try {
-        const stat = statSync(fpath);
-        if (stat.isDirectory()) {
-          rmdirSync(fpath, { recursive: true });
-        } else {
-          unlinkSync(fpath);
-        }
-      } catch (e) {}
+      removeSync(fpath);
     }
   });
 }

--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -11,8 +11,7 @@ import {
 } from '@angular-devkit/core';
 import * as chalk from 'chalk';
 import { createConsoleLogger, NodeJsSyncHost } from '@angular-devkit/core/node';
-import * as fs from 'fs';
-import { readFileSync } from 'fs';
+import { readFileSync, Stats } from 'fs';
 import { detectPackageManager } from '@nrwl/tao/src/shared/package-manager';
 import { GenerateOptions } from './generate';
 import { Tree } from '../shared/tree';
@@ -21,8 +20,7 @@ import {
   toOldFormatOrNull,
   workspaceConfigName,
 } from '@nrwl/tao/src/shared/workspace';
-import * as path from 'path';
-import { dirname, extname, resolve } from 'path';
+import { dirname, extname, resolve, join } from 'path';
 import * as stripJsonComments from 'strip-json-comments';
 import { FileBuffer } from '@angular-devkit/core/src/virtual-fs/host/interface';
 import { Observable, of } from 'rxjs';
@@ -69,7 +67,7 @@ export async function scheduleTarget(
 }
 
 function createWorkflow(
-  fsHost: virtualFs.Host<fs.Stats>,
+  fsHost: virtualFs.Host<Stats>,
   root: string,
   opts: any
 ) {
@@ -551,13 +549,13 @@ export async function runMigration(
       } else {
         let packageJsonPath;
         try {
-          packageJsonPath = require.resolve(path.join(name, 'package.json'), {
+          packageJsonPath = require.resolve(join(name, 'package.json'), {
             paths: [process.cwd()],
           });
         } catch (e) {
           // workaround for a bug in node 12
           packageJsonPath = require.resolve(
-            path.join(process.cwd(), name, 'package.json')
+            join(process.cwd(), name, 'package.json')
           );
         }
 

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import * as path from 'path';
 import * as stripJsonComments from 'strip-json-comments';
 import { NxJsonConfiguration, NxJsonProjectConfiguration } from './nx';
@@ -155,10 +155,9 @@ export interface TargetConfiguration {
 }
 
 export function workspaceConfigName(root: string) {
-  try {
-    fs.statSync(path.join(root, 'angular.json'));
+  if (existsSync(path.join(root, 'angular.json'))) {
     return 'angular.json';
-  } catch (e) {
+  } else {
     return 'workspace.json';
   }
 }
@@ -259,9 +258,10 @@ export class Workspaces {
   readWorkspaceConfiguration(): WorkspaceJsonConfiguration {
     const w = JSON.parse(
       stripJsonComments(
-        fs
-          .readFileSync(path.join(this.root, workspaceConfigName(this.root)))
-          .toString()
+        readFileSync(
+          path.join(this.root, workspaceConfigName(this.root)),
+          'utf-8'
+        )
       )
     );
     return toNewFormat(w);
@@ -289,7 +289,7 @@ export class Workspaces {
       const executorsDir = path.dirname(executorsFilePath);
       const schemaPath = path.join(executorsDir, executorConfig.schema || '');
       const schema = JSON.parse(
-        stripJsonComments(fs.readFileSync(schemaPath).toString())
+        stripJsonComments(readFileSync(schemaPath, 'utf-8'))
       );
       if (!schema.properties || typeof schema.properties !== 'object') {
         schema.properties = {};
@@ -320,7 +320,7 @@ export class Workspaces {
         generatorsJson.schematics?.[normalizedGeneratorName];
       const schemaPath = path.join(generatorsDir, generatorConfig.schema || '');
       const schema = JSON.parse(
-        stripJsonComments(fs.readFileSync(schemaPath).toString())
+        stripJsonComments(readFileSync(schemaPath, 'utf-8'))
       );
       if (!schema.properties || typeof schema.properties !== 'object') {
         schema.properties = {};
@@ -347,7 +347,7 @@ export class Workspaces {
       paths: this.resolvePaths(),
     });
     const packageJson = JSON.parse(
-      stripJsonComments(fs.readFileSync(packageJsonPath).toString())
+      stripJsonComments(readFileSync(packageJsonPath, 'utf-8'))
     );
     const executorsFile = packageJson.executors ?? packageJson.builders;
 
@@ -361,7 +361,7 @@ export class Workspaces {
       path.join(path.dirname(packageJsonPath), executorsFile)
     );
     const executorsJson = JSON.parse(
-      stripJsonComments(fs.readFileSync(executorsFilePath).toString())
+      stripJsonComments(readFileSync(executorsFilePath, 'utf-8'))
     );
     const executorConfig =
       executorsJson.executors?.[executor] || executorsJson.builders?.[executor];
@@ -387,7 +387,7 @@ export class Workspaces {
         }
       );
       const packageJson = JSON.parse(
-        stripJsonComments(fs.readFileSync(packageJsonPath).toString())
+        stripJsonComments(readFileSync(packageJsonPath, 'utf-8'))
       );
       const generatorsFile = packageJson.generators ?? packageJson.schematics;
 
@@ -402,7 +402,7 @@ export class Workspaces {
       );
     }
     const generatorsJson = JSON.parse(
-      stripJsonComments(fs.readFileSync(generatorsFilePath).toString())
+      stripJsonComments(readFileSync(generatorsFilePath, 'utf-8'))
     );
 
     let normalizedGeneratorName =


### PR DESCRIPTION
- use removeSync from fs-extra instead of rmdirSync with recursive option and unlinkSync
- use imports instead of require
- cleanup code
- rmdirSync recursive Option is deprecated in Node.js v16.0.0!

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
