### PR TITLE
feat(core): add ability to split target runs across nodes

### DIFF
--- a/.verdaccio/htpasswd
+++ b/.verdaccio/htpasswd
@@ -1,1 +1,2 @@
 test:$6FrCaT/v0dwE:autocreated 2020-03-25T19:10:50.254Z
+yharaskrik:glRlsHLcQIQp2:autocreated 2021-04-21T14:46:20.059Z

--- a/packages/workspace/src/command-line/utils.spec.ts
+++ b/packages/workspace/src/command-line/utils.spec.ts
@@ -23,6 +23,8 @@ describe('splitArgs', () => {
       base: 'sha1',
       head: 'sha2',
       skipNxCache: false,
+      currentNode: 0,
+      nodes: 1,
     });
   });
 
@@ -53,6 +55,8 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'master',
       skipNxCache: false,
+      currentNode: 0,
+      nodes: 1,
     });
   });
 
@@ -76,6 +80,8 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'develop',
       skipNxCache: false,
+      currentNode: 0,
+      nodes: 1,
     });
   });
 
@@ -96,6 +102,8 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'master',
       skipNxCache: false,
+      currentNode: 0,
+      nodes: 1,
     });
   });
 
@@ -130,6 +138,8 @@ describe('splitArgs', () => {
       base: 'sha1',
       head: 'sha2',
       skipNxCache: false,
+      currentNode: 0,
+      nodes: 1,
     });
     expect(overrides).toEqual({
       notNxArg: true,
@@ -149,6 +159,8 @@ describe('splitArgs', () => {
 
     expect(nxArgs).toEqual({
       skipNxCache: false,
+      currentNode: 0,
+      nodes: 1,
     });
     expect(overrides).toEqual({
       notNxArg: true,

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -45,6 +45,8 @@ export interface NxArgs {
   target?: string;
   configuration?: string;
   runner?: string;
+  nodes?: number;
+  currentNode?: number;
   parallel?: boolean;
   maxParallel?: number;
   'max-parallel'?: number;
@@ -133,6 +135,13 @@ export function splitArgsIntoNxArgsAndOverrides(
 
   if (!nxArgs.skipNxCache) {
     nxArgs.skipNxCache = false;
+  }
+
+  if (!nxArgs.nodes || nxArgs < 1) {
+    nxArgs.nodes = 1;
+    nxArgs.currentNode = 0;
+  } else if (!nxArgs.currentNode || nxArgs.currentNode < 0) {
+    nxArgs.currentNode = 0;
   }
 
   return { nxArgs, overrides };

--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -39,11 +39,7 @@ export async function runCommand<T extends RunArgs>(
   );
 
   const tasks = createTasksForProjectToRun(
-    chunkArrayBetweenNodes(
-      projectsToRun,
-      nxArgs.nodes,
-      nxArgs.currentNode
-    ),
+    chunkArrayBetweenNodes(projectsToRun, nxArgs.nodes, nxArgs.currentNode),
     {
       target: nxArgs.target,
       configuration: nxArgs.configuration,

--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -17,6 +17,7 @@ import {
   projectHasTargetAndConfiguration,
 } from '../utilities/project-graph-utils';
 import { output } from '../utilities/output';
+import { chunkArrayBetweenNodes } from '@nrwl/workspace/src/tasks-runner/utils';
 import { getDependencyConfigs } from './utils';
 
 type RunArgs = yargs.Arguments & ReporterArgs;
@@ -38,7 +39,11 @@ export async function runCommand<T extends RunArgs>(
   );
 
   const tasks = createTasksForProjectToRun(
-    projectsToRun,
+    chunkArrayBetweenNodes(
+      projectsToRun,
+      nxArgs.nodes,
+      nxArgs.currentNode
+    ),
     {
       target: nxArgs.target,
       configuration: nxArgs.configuration,

--- a/packages/workspace/src/tasks-runner/utils.spec.ts
+++ b/packages/workspace/src/tasks-runner/utils.spec.ts
@@ -1,4 +1,6 @@
 import {
+  chunkArray,
+  chunkArrayBetweenNodes,
   getOutputsForTargetAndConfiguration,
   unparse,
 } from '@nrwl/workspace/src/tasks-runner/utils';
@@ -254,6 +256,32 @@ describe('utils', () => {
         '--string2="one two"',
         '--string3="one two three"',
       ]);
+    });
+  });
+
+  describe('chunkArray', () => {
+    it('should chunk an array evenly', () => {
+      expect(chunkArray([0, 1, 2, 3, 4, 5, 6, 7, 8], 3)).toEqual([
+        [0, 1, 2],
+        [3, 4, 5],
+        [6, 7, 8],
+      ]);
+    });
+
+    it('should chunk an array unevenly', () => {
+      expect(chunkArray([0, 1, 2, 3, 4, 5, 6, 7, 8], 4)).toEqual([
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8],
+      ]);
+    });
+  });
+
+  describe('chunkArrayBetweenNodes', () => {
+    it('should return the chunk for a node', () => {
+      expect(
+        chunkArrayBetweenNodes([0, 1, 2, 3, 4, 5, 6, 7, 8], 3, 0)
+      ).toEqual([0, 1, 2]);
     });
   });
 });

--- a/packages/workspace/src/tasks-runner/utils.ts
+++ b/packages/workspace/src/tasks-runner/utils.ts
@@ -152,3 +152,24 @@ function unparseOption(key: string, value: any, unparsed: string[]) {
     unparsed.push(`--${key}=${value}`);
   }
 }
+
+export function chunkArray<T>(arr: T[] = [], chunkSize: number = 1): T[][] {
+  if (!arr) {
+    return [];
+  }
+  const tmp = [...arr];
+  const chunked = [];
+  if (chunkSize <= 0) return [arr];
+  while (tmp.length) chunked.push(tmp.splice(0, chunkSize));
+  return chunked;
+}
+
+export function chunkArrayBetweenNodes<T>(
+  projectsToRun: T[],
+  nodes: number,
+  currentNode: number
+): T[] {
+  const size = Math.ceil(projectsToRun.length / nodes);
+
+  return chunkArray(projectsToRun, size)[currentNode];
+}


### PR DESCRIPTION
Adds the ability to pass in number of nodes and current node to affected run commands so that target
runs can be split evenly across nodes

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Can run affected commands in parallel but only on a single machine

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Can run affected commands across more than one machine (node) so that affected commands are parallelized in more than one way

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
