### PR TITLE
fix(web): fix postcss-loader options object structure

### DIFF
--- a/packages/web/src/utils/third-party/cli-files/models/webpack-configs/styles.ts
+++ b/packages/web/src/utils/third-party/cli-files/models/webpack-configs/styles.ts
@@ -215,10 +215,8 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
       {
         loader: require.resolve('postcss-loader'),
         options: {
-          postcssOptions: {
-            implementation: require('postcss'),
-            postcssOptions: postcssOptionsCreator(componentsSourceMap),
-          },
+          implementation: require('postcss'),
+          postcssOptions: postcssOptionsCreator(componentsSourceMap),
         },
       },
       ...(use as webpack.Loader[]),


### PR DESCRIPTION
## Current Behavior
Because of the additional `postcssOptions`, the _actual_ `postcssOptions` as well as the `implementation` option are ignored by the loader. I've noticed this bug because after upgrading to Nx v12 I started getting this warning:

```
You did not set any plugins, parser, or stringifier. Right now, PostCSS does nothing.
Pick plugins for your case on https://www.postcss.parts/ and use them in postcss.config.js.
```

Looking at the build output, I also noticed that autoprefixer was not getting applied.

## Expected Behavior
The default PostCSS options are applied (e.g. autoprefixer) and there is no message about PostCSS not being configured.

## Related Issues

Fixes https://github.com/nrwl/nx/issues/5325
Fixes https://github.com/nrwl/nx/issues/5416
