### PR TITLE
feat(devkit): improve logging of ejs errors

### DIFF
--- a/packages/devkit/src/generators/generate-files.ts
+++ b/packages/devkit/src/generators/generate-files.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Tree } from '@nrwl/tao/src/shared/tree';
 import { join, relative } from 'path';
+import { logger } from '@nrwl/tao/src/shared/logger';
 
 const binaryExts = new Set([
   // // Image types originally from https://github.com/sindresorhus/image-type/blob/5541b6a/index.js
@@ -74,7 +75,12 @@ export function generateFiles(
       newContent = fs.readFileSync(filePath);
     } else {
       const template = fs.readFileSync(filePath).toString();
-      newContent = ejs.render(template, substitutions, {});
+      try {
+        newContent = ejs.render(template, substitutions, {});
+      } catch (e) {
+        logger.error(`Error in ${filePath.replace(`${host.root}/`, '')}:`);
+        throw e;
+      }
     }
 
     host.write(computedPath, newContent);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When the EJS rendering fails, it's kinda hard to tell where, given you might have dozens of files in your generator. This especially for workspace generators that developers write on their own.

![image](https://user-images.githubusercontent.com/542458/115610702-848f5e00-a2e9-11eb-9ce0-6ee2a45e56e1.png)

Now go figure out where it fails 😅 


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

After the change

![image](https://user-images.githubusercontent.com/542458/115612289-632f7180-a2eb-11eb-97af-d6f9ba0655d8.png)



## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
