### PR TITLE
fix(core): report based on projects and tasks

### DIFF
--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -20,50 +20,150 @@ import { TaskCacheStatus } from '@nrwl/workspace/src/utilities/output';
 describe('run-one', () => {
   let proj: string;
 
-  beforeEach(() => (proj = newProject()));
+  beforeAll(() => (proj = newProject()));
 
-  afterEach(() => removeProject({ onlyOnCI: true }));
+  afterAll(() => removeProject({ onlyOnCI: true }));
 
-  it('should build specific project', () => {
-    const myapp = uniq('myapp');
-    const mylib1 = uniq('mylib1');
-    const mylib2 = uniq('mylib1');
+  it('should build a specific project', () => {
+    const myapp = uniq('app');
     runCLI(`generate @nrwl/react:app ${myapp}`);
-    runCLI(`generate @nrwl/react:lib ${mylib1} --buildable`);
-    runCLI(`generate @nrwl/react:lib ${mylib2} --buildable`);
 
-    updateFile(
-      `apps/${myapp}/src/main.ts`,
-      `
-          import "@${proj}/${mylib1}";
-          import "@${proj}/${mylib2}";
-        `
-    );
+    runCLI(`build ${myapp}`);
+  }, 10000);
 
-    // configuration has to be valid for the initiating project
-    expect(() => runCLI(`build ${myapp} -c=invalid`)).toThrow();
+  it('should build a specific project', () => {
+    const myapp = uniq('app');
+    runCLI(`generate @nrwl/react:app ${myapp}`);
+
+    runCLI(`build ${myapp}`);
+  }, 10000);
+
+  it('should build the project when within the project root', () => {
+    const myapp = uniq('app');
+    runCLI(`generate @nrwl/react:app ${myapp}`);
+
+    // Should work within the project directory
     expect(runCommand(`cd apps/${myapp}-e2e/src && npx nx lint`)).toContain(
       `nx run ${myapp}-e2e:lint`
     );
+  }, 10000);
 
-    // configuration doesn't have to exists for deps (here only the app has production)
-    const buildWithDeps = runCLI(`build ${myapp} --with-deps --prod`);
-    expect(buildWithDeps).toContain(`Running target "build" succeeded`);
-    expect(buildWithDeps).toContain(`nx run ${myapp}:build:production`);
-    expect(buildWithDeps).toContain(`nx run ${mylib1}:build`);
-    expect(buildWithDeps).toContain(`nx run ${mylib2}:build`);
+  it('should error for invalid configurations', () => {
+    const myapp = uniq('app');
+    runCLI(`generate @nrwl/react:app ${myapp}`);
+    // configuration has to be valid for the initiating project
+    expect(() => runCLI(`build ${myapp} -c=invalid`)).toThrow();
+  }, 10000);
 
-    const testsWithDeps = runCLI(`test ${myapp} --with-deps`);
-    expect(testsWithDeps).toContain(
-      `NX  Running target test for project ${myapp} and its 2 deps`
-    );
-    expect(testsWithDeps).toContain(myapp);
-    expect(testsWithDeps).toContain(mylib1);
-    expect(testsWithDeps).toContain(mylib2);
+  describe('--with-deps', () => {
+    let myapp;
+    let mylib1;
+    let mylib2;
+    beforeAll(() => {
+      myapp = uniq('myapp');
+      mylib1 = uniq('mylib1');
+      mylib2 = uniq('mylib1');
+      runCLI(`generate @nrwl/react:app ${myapp}`);
+      runCLI(`generate @nrwl/react:lib ${mylib1} --buildable`);
+      runCLI(`generate @nrwl/react:lib ${mylib2} --buildable`);
 
-    const testsWithoutDeps = runCLI(`test ${myapp}`);
-    expect(testsWithoutDeps).not.toContain(mylib1);
-  }, 1000000);
+      updateFile(
+        `apps/${myapp}/src/main.ts`,
+        `
+          import "@${proj}/${mylib1}";
+          import "@${proj}/${mylib2}";
+        `
+      );
+    });
+
+    it('should include deps', () => {
+      const output = runCLI(`test ${myapp} --with-deps`);
+      expect(output).toContain(
+        `NX  Running target test for project ${myapp} and 2 task(s) that it depends on.`
+      );
+      expect(output).toContain(myapp);
+      expect(output).toContain(mylib1);
+      expect(output).toContain(mylib2);
+    }, 10000);
+
+    it('should include deps without the configuration if it does not exist', () => {
+      const buildWithDeps = runCLI(`build ${myapp} --with-deps --prod`);
+      expect(buildWithDeps).toContain(`Running target "build" succeeded`);
+      expect(buildWithDeps).toContain(`nx run ${myapp}:build:production`);
+      expect(buildWithDeps).toContain(`nx run ${mylib1}:build`);
+      expect(buildWithDeps).toContain(`nx run ${mylib2}:build`);
+      expect(buildWithDeps).not.toContain(`nx run ${mylib1}:build:production`);
+      expect(buildWithDeps).not.toContain(`nx run ${mylib2}:build:production`);
+    }, 10000);
+  });
+
+  describe('target dependencies', () => {
+    let myapp;
+    let mylib1;
+    let mylib2;
+    beforeAll(() => {
+      myapp = uniq('myapp');
+      mylib1 = uniq('mylib1');
+      mylib2 = uniq('mylib1');
+      runCLI(`generate @nrwl/react:app ${myapp}`);
+      runCLI(`generate @nrwl/react:lib ${mylib1} --buildable`);
+      runCLI(`generate @nrwl/react:lib ${mylib2} --buildable`);
+
+      updateFile(
+        `apps/${myapp}/src/main.ts`,
+        `
+          import "@${proj}/${mylib1}";
+          import "@${proj}/${mylib2}";
+        `
+      );
+    });
+
+    it('should be able to include deps using target dependencies', () => {
+      const originalWorkspace = readFile('workspace.json');
+      const workspace = readJson('workspace.json');
+      workspace.projects[myapp].targets.build.dependsOn = [
+        {
+          target: 'build',
+          projects: 'dependencies',
+        },
+      ];
+      updateFile('workspace.json', JSON.stringify(workspace));
+
+      const output = runCLI(`build ${myapp}`);
+      expect(output).toContain(
+        `NX  Running target build for project ${myapp} and 2 task(s) that it depends on.`
+      );
+      expect(output).toContain(myapp);
+      expect(output).toContain(mylib1);
+      expect(output).toContain(mylib2);
+
+      updateFile('workspace.json', originalWorkspace);
+    }, 10000);
+
+    it('should be able to include deps using target dependencies defined at the root', () => {
+      const originalNxJson = readFile('nx.json');
+      const nxJson = readJson('nx.json');
+      nxJson.targetDependencies = {
+        build: [
+          {
+            target: 'build',
+            projects: 'dependencies',
+          },
+        ],
+      };
+      updateFile('nx.json', JSON.stringify(nxJson));
+
+      const output = runCLI(`build ${myapp}`);
+      expect(output).toContain(
+        `NX  Running target build for project ${myapp} and 2 task(s) that it depends on.`
+      );
+      expect(output).toContain(myapp);
+      expect(output).toContain(mylib1);
+      expect(output).toContain(mylib2);
+
+      updateFile('nx.json', originalNxJson);
+    }, 10000);
+  });
 });
 
 describe('run-many', () => {
@@ -105,7 +205,7 @@ describe('run-many', () => {
       const buildParallel = runCLI(
         `run-many --target=build --projects="${libC},${libB}"`
       );
-      expect(buildParallel).toContain(`Running target build for projects:`);
+      expect(buildParallel).toContain(`Running target build for 2 project(s):`);
       expect(buildParallel).not.toContain(`- ${libA}`);
       expect(buildParallel).toContain(`- ${libB}`);
       expect(buildParallel).toContain(`- ${libC}`);
@@ -114,7 +214,10 @@ describe('run-many', () => {
 
       // testing run many --all starting
       const buildAllParallel = runCLI(`run-many --target=build --all`);
-      expect(buildAllParallel).toContain(`Running target build for projects:`);
+      expect(buildAllParallel).toContain(
+        `Running target build for 4 project(s):`
+      );
+      expect(buildAllParallel).toContain(`- ${appA}`);
       expect(buildAllParallel).toContain(`- ${libA}`);
       expect(buildAllParallel).toContain(`- ${libB}`);
       expect(buildAllParallel).toContain(`- ${libC}`);
@@ -125,7 +228,7 @@ describe('run-many', () => {
       const buildWithDeps = runCLI(
         `run-many --target=build --projects="${libA}" --with-deps`
       );
-      expect(buildWithDeps).toContain(`Running target build for projects:`);
+      expect(buildWithDeps).toContain(`Running target build for 2 project(s):`);
       expect(buildWithDeps).toContain(`- ${libA}`);
       expect(buildWithDeps).toContain(`- ${libC}`);
       expect(buildWithDeps).not.toContain(`- ${libB}`);
@@ -136,7 +239,7 @@ describe('run-many', () => {
       const buildConfig = runCLI(
         `run-many --target=build --projects="${appA},${libA}" --prod`
       );
-      expect(buildConfig).toContain(`Running target build for projects:`);
+      expect(buildConfig).toContain(`Running target build for 2 project(s):`);
       expect(buildConfig).toContain(`run ${appA}:build:production`);
       expect(buildConfig).toContain(`run ${libA}:build:production`);
       expect(buildConfig).toContain('Running target "build" succeeded');
@@ -164,7 +267,7 @@ describe('run-many', () => {
     const failedTests = runCLI(`run-many --target=test --all`, {
       silenceError: true,
     });
-    expect(failedTests).toContain(`Running target test for projects:`);
+    expect(failedTests).toContain(`Running target test for 2 project(s):`);
     expect(failedTests).toContain(`- ${myapp}`);
     expect(failedTests).toContain(`- ${myapp2}`);
     expect(failedTests).toContain(`Failed projects:`);
@@ -186,7 +289,7 @@ describe('run-many', () => {
     );
 
     const isolatedTests = runCLI(`run-many --target=test --all --only-failed`);
-    expect(isolatedTests).toContain(`Running target test for projects`);
+    expect(isolatedTests).toContain(`Running target test for 1 project(s)`);
     expect(isolatedTests).toContain(`- ${myapp}`);
     expect(isolatedTests).not.toContain(`- ${myapp2}`);
 
@@ -296,7 +399,7 @@ describe('affected:*', () => {
     const build = runCLI(
       `affected:build --files="libs/${mylib}/src/index.ts" --parallel`
     );
-    expect(build).toContain(`Running target build for projects:`);
+    expect(build).toContain(`Running target build for 2 project(s):`);
     expect(build).toContain(`- ${myapp}`);
     expect(build).toContain(`- ${mypublishablelib}`);
     expect(build).not.toContain('is not registered with the build command');
@@ -305,7 +408,7 @@ describe('affected:*', () => {
     const buildExcluded = runCLI(
       `affected:build --files="libs/${mylib}/src/index.ts" --exclude ${myapp}`
     );
-    expect(buildExcluded).toContain(`Running target build for projects:`);
+    expect(buildExcluded).toContain(`Running target build for 1 project(s):`);
     expect(buildExcluded).toContain(`- ${mypublishablelib}`);
 
     // test
@@ -321,7 +424,7 @@ describe('affected:*', () => {
       `affected:test --files="libs/${mylib}/src/index.ts"`,
       { silenceError: true }
     );
-    expect(failedTests).toContain(`Running target test for projects:`);
+    expect(failedTests).toContain(`Running target test for 3 project(s):`);
     expect(failedTests).toContain(`- ${mylib}`);
     expect(failedTests).toContain(`- ${myapp}`);
     expect(failedTests).toContain(`- ${mypublishablelib}`);
@@ -350,7 +453,7 @@ describe('affected:*', () => {
     const isolatedTests = runCLI(
       `affected:test --files="libs/${mylib}/src/index.ts" --only-failed`
     );
-    expect(isolatedTests).toContain(`Running target test for projects`);
+    expect(isolatedTests).toContain(`Running target test for 1 project(s)`);
     expect(isolatedTests).toContain(`- ${myapp}`);
 
     const interpolatedTests = runCLI(

--- a/packages/workspace/src/command-line/run-one.ts
+++ b/packages/workspace/src/command-line/run-one.ts
@@ -1,7 +1,7 @@
 import { runCommand } from '../tasks-runner/run-command';
 import { createProjectGraph, ProjectGraph } from '../core/project-graph';
 import { readEnvironment } from '../core/file-utils';
-import { EmptyReporter } from '../tasks-runner/empty-reporter';
+import { RunOneReporter } from '../tasks-runner/run-one-reporter';
 import { splitArgsIntoNxArgsAndOverrides } from './utils';
 import { projectHasTarget } from '../utilities/project-graph-utils';
 import { connectToNxCloudUsingScan } from './connect-to-nx-cloud';
@@ -38,11 +38,7 @@ export async function runOne(opts: {
     opts.target
   );
   const env = readEnvironment(opts.target, projectsMap);
-  const reporter = nxArgs.withDeps
-    ? new (require(`../tasks-runner/run-one-reporter`).RunOneReporter)(
-        opts.project
-      )
-    : new EmptyReporter();
+  const reporter = new RunOneReporter(opts.project);
 
   runCommand(
     projects,

--- a/packages/workspace/src/tasks-runner/empty-reporter.ts
+++ b/packages/workspace/src/tasks-runner/empty-reporter.ts
@@ -1,5 +1,0 @@
-export class EmptyReporter {
-  beforeRun() {}
-
-  printResults() {}
-}

--- a/packages/workspace/src/tasks-runner/reporter.ts
+++ b/packages/workspace/src/tasks-runner/reporter.ts
@@ -1,0 +1,25 @@
+import { Task } from './tasks-runner';
+
+export interface ReporterArgs {
+  target?: string;
+  configuration?: string;
+  onlyFailed?: boolean;
+}
+
+export abstract class Reporter {
+  abstract beforeRun(
+    projectNames: string[],
+    tasks: Task[],
+    args: ReporterArgs,
+    taskOverrides: any
+  ): void;
+
+  abstract printResults(
+    nxArgs: ReporterArgs,
+    failedProjects: string[],
+    startedWithFailedProjects: boolean,
+    tasks: Task[],
+    failedTasks: Task[],
+    cachedTasks: Task[]
+  ): void;
+}

--- a/packages/workspace/src/tasks-runner/run-one-reporter.ts
+++ b/packages/workspace/src/tasks-runner/run-one-reporter.ts
@@ -1,18 +1,23 @@
 import { output } from '../utilities/output';
+import { Reporter, ReporterArgs } from './reporter';
+import { Task } from './tasks-runner';
 
-export interface ReporterArgs {
-  target?: string;
-  configuration?: string;
-  onlyFailed?: boolean;
-}
-
-export class RunOneReporter {
+export class RunOneReporter implements Reporter {
   private projectNames: string[];
   constructor(private readonly initiatingProject: string) {}
 
-  beforeRun(projectNames: string[], args: ReporterArgs, taskOverrides: any) {
+  beforeRun(
+    projectNames: string[],
+    tasks: Task[],
+    args: ReporterArgs,
+    taskOverrides: any
+  ) {
+    // Silent for a single task
+    if (tasks.length === 1) {
+      return;
+    }
     this.projectNames = projectNames;
-    const numberOfDeps = projectNames.length - 1;
+    const numberOfDeps = tasks.length - 1;
 
     if (numberOfDeps > 0) {
       output.log({
@@ -20,7 +25,10 @@ export class RunOneReporter {
           args.target
         } ${output.colors.gray('for project')} ${
           this.initiatingProject
-        } ${output.colors.gray(`and its ${numberOfDeps} deps.`)}`,
+        } ${output.colors.gray(
+          `and`
+        )} ${numberOfDeps} task(s) ${output.colors.gray(`that it depends on.`)}
+        `,
       });
       output.addVerticalSeparatorWithoutNewLines();
     }
@@ -30,17 +38,23 @@ export class RunOneReporter {
     args: ReporterArgs,
     failedProjectNames: string[],
     startedWithFailedProjects: boolean,
-    cachedProjectNames: string[]
+    tasks: Task[],
+    failedTasks: Task[],
+    cachedTasks: Task[]
   ) {
+    // Silent for a single task
+    if (tasks.length === 1) {
+      return;
+    }
     output.addNewline();
     output.addVerticalSeparatorWithoutNewLines();
 
     if (failedProjectNames.length === 0) {
       const bodyLines =
-        cachedProjectNames.length > 0
+        cachedTasks.length > 0
           ? [
               output.colors.gray(
-                `Nx read the output from cache instead of running the command for ${cachedProjectNames.length} out of ${this.projectNames.length} projects.`
+                `Nx read the output from cache instead of running the command for ${cachedTasks.length} out of ${tasks.length} tasks.`
               ),
             ]
           : [];
@@ -64,11 +78,9 @@ export class RunOneReporter {
       }
     } else {
       const bodyLines = [
-        output.colors.gray('Failed projects:'),
+        output.colors.gray('Failed tasks:'),
         '',
-        ...failedProjectNames.map(
-          (project) => `${output.colors.gray('-')} ${project}`
-        ),
+        ...failedTasks.map((task) => `${output.colors.gray('-')} ${task.id}`),
       ];
       output.error({
         title: `Running target "${args.target}" failed`,

--- a/packages/workspace/src/tasks-runner/tasks-runner.ts
+++ b/packages/workspace/src/tasks-runner/tasks-runner.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 
 import { ProjectGraph } from '../core/project-graph';
 import { NxJson } from '../core/shared-interfaces';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Reporting of the commands run doesn't make sense with phrases like:
`Nx read the output from cache instead of running the command for 42 out of 21 projects.`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Reporting of running commands includes information about both projects and dependent tasks:

Running multiple projects
![image](https://user-images.githubusercontent.com/8104246/115617398-5a28ab00-a2bf-11eb-8f45-128d93bd878d.png)
![image](https://user-images.githubusercontent.com/8104246/115617543-80e6e180-a2bf-11eb-958b-531bcf625c4a.png)

Running one project with dependencies
![image](https://user-images.githubusercontent.com/8104246/115617485-71679880-a2bf-11eb-9204-786695bf4d31.png)
![image](https://user-images.githubusercontent.com/8104246/115617507-775d7980-a2bf-11eb-9939-8177ce662742.png)

Running one project with no dependencies is silent.
