### PR TITLE
feat(testing): adding getJestProjects() utility for root jest.config.js file

### DIFF
--- a/packages/jest/index.ts
+++ b/packages/jest/index.ts
@@ -5,3 +5,4 @@ export {
 export { jestConfigObjectAst } from './src/utils/config/functions';
 export { jestProjectGenerator } from './src/generators/jest-project/jest-project';
 export { jestInitGenerator } from './src/generators/init/init';
+export { getJestProjects } from './src/utils/config/get-jest-projects';

--- a/packages/jest/src/utils/config/get-jest-projects.spec.ts
+++ b/packages/jest/src/utils/config/get-jest-projects.spec.ts
@@ -1,0 +1,152 @@
+import { getJestProjects } from './get-jest-projects';
+import * as Workspace from '@nrwl/workspace/src/core/file-utils';
+import type { WorkspaceJsonConfiguration } from '@nrwl/devkit';
+
+describe('getJestProjects', () => {
+  test('single project', () => {
+    const mockedWorkspaceConfig: WorkspaceJsonConfiguration = {
+      projects: {
+        'test-1': {
+          root: 'blah',
+          targets: {
+            test: {
+              executor: '@nrwl/jest:jest',
+              options: {
+                jestConfig: 'test/jest/config/location/jest.config.js',
+              },
+            },
+          },
+        },
+      },
+      version: 1,
+    };
+    jest
+      .spyOn(Workspace, 'readWorkspaceConfig')
+      .mockImplementation(() => mockedWorkspaceConfig);
+    const expectedResults = ['<rootDir>/test/jest/config/location'];
+    expect(getJestProjects()).toEqual(expectedResults);
+  });
+
+  test('custom target name', () => {
+    const mockedWorkspaceConfig: WorkspaceJsonConfiguration = {
+      projects: {
+        'test-1': {
+          root: 'blah',
+          targets: {
+            'test-with-jest': {
+              executor: '@nrwl/jest:jest',
+              options: {
+                jestConfig: 'test/jest/config/location/jest.config.js',
+              },
+            },
+          },
+        },
+      },
+      version: 1,
+    };
+    jest
+      .spyOn(Workspace, 'readWorkspaceConfig')
+      .mockImplementation(() => mockedWorkspaceConfig);
+    const expectedResults = ['<rootDir>/test/jest/config/location'];
+    expect(getJestProjects()).toEqual(expectedResults);
+  });
+
+  test('configuration set with unique jestConfig', () => {
+    const mockedWorkspaceConfig: WorkspaceJsonConfiguration = {
+      projects: {
+        test: {
+          root: 'blah',
+          targets: {
+            'test-with-jest': {
+              executor: '@nrwl/jest:jest',
+              options: {
+                jestConfig: 'test/jest/config/location/jest.config.js',
+              },
+              configurations: {
+                prod: {
+                  jestConfig: 'configuration-specific/jest.config.js',
+                },
+              },
+            },
+          },
+        },
+      },
+      version: 1,
+    };
+    jest
+      .spyOn(Workspace, 'readWorkspaceConfig')
+      .mockImplementation(() => mockedWorkspaceConfig);
+    const expectedResults = [
+      '<rootDir>/test/jest/config/location',
+      '<rootDir>/configuration-specific',
+    ];
+    expect(getJestProjects()).toEqual(expectedResults);
+  });
+
+  test('configuration, set with same jestConfig on configuration', () => {
+    const mockedWorkspaceConfig: WorkspaceJsonConfiguration = {
+      projects: {
+        test: {
+          root: 'blah',
+          targets: {
+            'test-with-jest': {
+              executor: '@nrwl/jest:jest',
+              options: {
+                jestConfig: 'test/jest/config/location/jest.config.js',
+              },
+              configurations: {
+                prod: {
+                  jestConfig: 'test/jest/config/location/jest.config.js',
+                },
+              },
+            },
+          },
+        },
+      },
+      version: 1,
+    };
+    jest
+      .spyOn(Workspace, 'readWorkspaceConfig')
+      .mockImplementation(() => mockedWorkspaceConfig);
+    const expectedResults = ['<rootDir>/test/jest/config/location'];
+    expect(getJestProjects()).toEqual(expectedResults);
+  });
+
+  test('other projects and targets that do not use the nrwl jest test runner', () => {
+    const mockedWorkspaceConfig: WorkspaceJsonConfiguration = {
+      projects: {
+        otherTarget: {
+          root: 'test',
+          targets: {
+            test: {
+              executor: 'something else',
+              options: {},
+            },
+          },
+        },
+        test: {
+          root: 'blah',
+          targets: {
+            'test-with-jest': {
+              executor: 'something else',
+              options: {
+                jestConfig: 'something random',
+              },
+              configurations: {
+                prod: {
+                  jestConfig: 'configuration-specific/jest.config.js',
+                },
+              },
+            },
+          },
+        },
+      },
+      version: 1,
+    };
+    jest
+      .spyOn(Workspace, 'readWorkspaceConfig')
+      .mockImplementation(() => mockedWorkspaceConfig);
+    const expectedResults = [];
+    expect(getJestProjects()).toEqual(expectedResults);
+  });
+});

--- a/packages/jest/src/utils/config/get-jest-projects.ts
+++ b/packages/jest/src/utils/config/get-jest-projects.ts
@@ -1,0 +1,43 @@
+import { readWorkspaceConfig } from '@nrwl/workspace/src/core/file-utils';
+import { dirname, join } from 'path';
+import type { WorkspaceJsonConfiguration } from '@nrwl/devkit';
+
+const JEST_RUNNER_TOKEN = '@nrwl/jest:jest';
+
+function getJestConfigProjectPath(projectJestConfigPath: string): string {
+  return join('<rootDir>', dirname(projectJestConfigPath));
+}
+
+export function getJestProjects() {
+  const ws = readWorkspaceConfig({
+    format: 'nx',
+  }) as WorkspaceJsonConfiguration;
+  const jestConfigurationSet = new Set();
+  for (const projectConfig of Object.values(ws.projects)) {
+    if (!projectConfig.targets) {
+      continue;
+    }
+    for (const targetConfiguration of Object.values(projectConfig.targets)) {
+      if (targetConfiguration.executor !== JEST_RUNNER_TOKEN) {
+        continue;
+      }
+      if (targetConfiguration.options?.jestConfig) {
+        jestConfigurationSet.add(
+          getJestConfigProjectPath(targetConfiguration.options.jestConfig)
+        );
+      }
+      if (targetConfiguration.configurations) {
+        for (const configurationObject of Object.values(
+          targetConfiguration.configurations
+        )) {
+          if (configurationObject.jestConfig) {
+            jestConfigurationSet.add(
+              getJestConfigProjectPath(configurationObject.jestConfig)
+            );
+          }
+        }
+      }
+    }
+  }
+  return Array.from(jestConfigurationSet);
+}

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -171,7 +171,7 @@ export function readWorkspaceConfig(opts: {
   format: 'angularCli' | 'nx';
   path?: string;
 }) {
-  const ws = new Workspaces(opts.path);
+  const ws = new Workspaces(opts.path || process.cwd());
   const json = ws.readWorkspaceConfiguration();
   if (opts.format === 'angularCli') {
     const formatted = toOldFormatOrNull(json);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Remaining Considerations
+ !!! Investigating some testing where the IDE tools appear to work fine even without the root `jest.config.js` set up "properly" !!!
+ Updating app/lib generators to not touch root `jest.config.js` if already using this utility
+ Add migration script to update the root `jest.config.js` to use this utility
(@FrozenPandaz - let me know if it'd be better to address the above in their own PR vs. all in this one PR)

## Current Behavior
<!-- This is the behavior we have today -->
Generating libs/apps in a workspace requires adding the new project to the `projects` array in the jest

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Export utility to be able to use in root `jest.config.js` to generate a `projects` array at runtime from the `angular.json`/`workspace.json` config files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
