### PR TITLE
feat(web): add generateIndexHtml option to web build executor

### DIFF
--- a/docs/angular/api-web/executors/build.md
+++ b/docs/angular/api-web/executors/build.md
@@ -102,6 +102,14 @@ Type: `string`
 
 undefined
 
+### generateIndexHtml
+
+Default: `true`
+
+Type: `boolean`
+
+Write an `index.html` file based on the `index` option. False may be useful when using a separate plugin to generate HTML such as html-webpack-plugin
+
 ### index
 
 Type: `string`

--- a/docs/node/api-web/executors/build.md
+++ b/docs/node/api-web/executors/build.md
@@ -103,6 +103,14 @@ Type: `string`
 
 undefined
 
+### generateIndexHtml
+
+Default: `true`
+
+Type: `boolean`
+
+Write an `index.html` file based on the `index` option. False may be useful when using a separate plugin to generate HTML such as html-webpack-plugin
+
 ### index
 
 Type: `string`

--- a/docs/react/api-web/executors/build.md
+++ b/docs/react/api-web/executors/build.md
@@ -103,6 +103,14 @@ Type: `string`
 
 undefined
 
+### generateIndexHtml
+
+Default: `true`
+
+Type: `boolean`
+
+Write an `index.html` file based on the `index` option. False may be useful when using a separate plugin to generate HTML such as html-webpack-plugin
+
 ### index
 
 Type: `string`

--- a/packages/web/src/builders/build/build.impl.ts
+++ b/packages/web/src/builders/build/build.impl.ts
@@ -58,6 +58,8 @@ export interface WebBuildBuilderOptions extends BuildBuilderOptions {
   buildLibsFromSource?: boolean;
 
   deleteOutputPath?: boolean;
+
+  generateIndexHtml?: boolean;
 }
 
 function getWebpackConfigs(
@@ -186,7 +188,7 @@ export function run(options: WebBuildBuilderOptions, context: ExecutorContext) {
           result1 && !result1.hasErrors() && (!result2 || !result2.hasErrors());
         const emittedFiles1 = getEmittedFiles(result1);
         const emittedFiles2 = result2 ? getEmittedFiles(result2) : [];
-        if (options.optimization) {
+        if (options.generateIndexHtml) {
           await writeIndexHtml({
             crossOrigin: options.crossOrigin,
             outputPath: join(options.outputPath, basename(options.index)),

--- a/packages/web/src/builders/build/schema.json
+++ b/packages/web/src/builders/build/schema.json
@@ -251,6 +251,11 @@
       "type": "boolean",
       "description": "Read buildable libraries from source instead of building them separately.",
       "default": true
+    },
+    "generateIndexHtml": {
+      "type": "boolean",
+      "description": "Write an `index.html` file based on the `index` option. False may be useful when using a separate plugin to generate HTML such as html-webpack-plugin",
+      "default": true
     }
   },
   "required": ["tsConfig", "main", "index"],


### PR DESCRIPTION
Add new option to web build schema which explicitly controls when an index.html file is generated
for webpack builds.

ISSUES CLOSED: #5407

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

As described in #5407, index.html file is always generated for Web webpack builds and does not allow for use with other HTML plugins such as html-webpack-plugin

## Expected Behavior

This should add a new option to explicitly control when and if webpack build generate an index.html file. The options defaults to `true`.

**Please note: I could not figure out how to write a test for this because of all the webpack mocks that were required. I'm happy to write a test but would appreciate guidance from Nx maintainers, if a test is desired**

Also: I ran `yarn e2e web` but after 30 minutes my terminal output had not changed and I assumed it was frozen. I don't know how to troubleshoot or resolve so I'd appreciate any guidance if desired

This was the terminal output 
```
> yarn e2e web
yarn run v1.19.0
$ run-p -r e2e-registry "e2e-tests {@}" -- web
$ yarn verdaccio --config ./scripts/local-registry/config.yml --listen 4872
$ ts-node -P ./scripts/tsconfig.e2e.json ./scripts/e2e.ts web
$ /Users/eric/dev/nx-ericyd/node_modules/.bin/verdaccio --config ./scripts/local-registry/config.yml --listen 4872
 warn --- config file  - /Users/eric/dev/nx-ericyd/scripts/local-registry/config.yml
 warn --- Verdaccio started
 warn --- http address - http://localhost:4872/ - verdaccio/4.12.0
```

## Related Issue(s)


Fixes #5407 
