### PR TITLE
fix(web): fix circular dependency in babelrc migration

### DIFF
--- a/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.spec.ts
+++ b/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.spec.ts
@@ -117,4 +117,126 @@ describe('Create missing .babelrc files', () => {
 
     expect(tree.exists('libs/nodelib/.babelrc')).toBeFalsy();
   });
+
+  it('should not error if there are circular dependencies', async () => {
+    tree.write(
+      'workspace.json',
+      JSON.stringify({
+        projects: {
+          webapp: {
+            root: 'apps/webapp',
+            projectType: 'application',
+            targets: {
+              build: { executor: '@nrwl/web:build' },
+            },
+          },
+          nodeapp: {
+            root: 'apps/nodeapp',
+            projectType: 'application',
+            targets: {
+              build: { executor: '@nrwl/node:build' },
+            },
+          },
+          weblib: {
+            root: 'libs/weblib',
+            projectType: 'library',
+          },
+          nodelib: {
+            root: 'libs/nodelib',
+            projectType: 'library',
+          },
+        },
+      })
+    );
+    tree.write(
+      'nx.json',
+      JSON.stringify({
+        npmScope: 'proj',
+        projects: {
+          webapp: {},
+          nodeapp: {},
+          weblib: {},
+          nodelib: {},
+        },
+      })
+    );
+    tree.write('apps/webapp/index.ts', `import '@proj/weblib';`);
+
+    projectGraph = {
+      nodes: {
+        webapp: {
+          name: 'webapp',
+          type: 'app',
+          data: {
+            files: [],
+            root: 'apps/webapp',
+          },
+        },
+        nodeapp: {
+          name: 'nodeapp',
+          type: 'app',
+          data: {
+            files: [],
+            root: 'apps/nodeapp',
+          },
+        },
+        weblib: {
+          name: 'weblib',
+          type: 'lib',
+          data: {
+            files: [],
+            root: 'libs/weblib',
+          },
+        },
+        nodelib: {
+          name: 'nodelib',
+          type: 'lib',
+          data: {
+            files: [],
+            root: 'libs/nodelib',
+          },
+        },
+        nodelib2: {
+          name: 'nodelib2',
+          type: 'lib',
+          data: {
+            files: [],
+            root: 'libs/nodelib2',
+          },
+        },
+      },
+      dependencies: {
+        webapp: [
+          {
+            type: DependencyType.static,
+            source: 'webapp',
+            target: 'weblib',
+          },
+        ],
+        nodelib: [
+          {
+            type: DependencyType.static,
+            source: 'nodelib',
+            target: 'nodelib2',
+          },
+        ],
+        nodelib2: [
+          {
+            type: DependencyType.static,
+            source: 'nodelib2',
+            target: 'nodelib',
+          },
+        ],
+      },
+    };
+
+    await createBabelrcForWorkspaceLibs(tree);
+
+    expect(readJson(tree, 'libs/weblib/.babelrc')).toMatchObject({
+      presets: ['@nrwl/web/babel'],
+    });
+
+    expect(tree.exists('libs/nodelib/.babelrc')).toBeFalsy();
+    expect(tree.exists('libs/nodelib2/.babelrc')).toBeFalsy();
+  });
 });

--- a/packages/web/src/migrations/update-11-5-2/utils.ts
+++ b/packages/web/src/migrations/update-11-5-2/utils.ts
@@ -9,7 +9,13 @@ export function hasDependentAppUsingWebBuild(
   reversedProjectGraph: ProjectGraph,
   projects: ReturnType<typeof getProjects>
 ) {
+  const seen = new Set<string>();
   function walk(currProject: string) {
+    if (seen.has(currProject)) {
+      return false;
+    }
+    seen.add(currProject);
+
     if (cache.has(currProject)) {
       return cache.get(currProject);
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When there is a circular dependency in projects that are not used by a project that uses `@nrwl/web`, the migration has an infinite loop.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When there is a circular dependency in projects that are not used by a project that uses `@nrwl/web`, the migration runs fine.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/5174
