### PR TITLE
fix(storybook): VSCode TypeScript error

### DIFF
--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -30,6 +30,12 @@
       "version": "11.5.3-beta.1",
       "description": "Update react storybook lint config",
       "factory": "./src/migrations/update-11-5-3/update-lint-ignores"
+    },
+    "update-12-1-0": {
+      "version": "12.1.0-beta.7",
+      "cli": "nx",
+      "description": "Update react storybook tsconfig to avoid VSCode errors",
+      "factory": "./src/migrations/update-12-1-0/fix-storybook-tsconfig"
     }
   },
   "packageJsonUpdates": {

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "emitDecoratorMetadata": true
+    <% if(uiFramework === '@storybook/react') { %>, "outDir": "" <% } %>
   },
   "exclude": ["../**/*.spec.ts" <% if(uiFramework === '@storybook/react') { %>, "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx"<% } %>],
   "include": ["../src/**/*", "*.js"]

--- a/packages/storybook/src/migrations/update-12-1-0/fix-storybook-tsconfig.spec.ts
+++ b/packages/storybook/src/migrations/update-12-1-0/fix-storybook-tsconfig.spec.ts
@@ -1,0 +1,54 @@
+import { readJson, Tree, writeJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import updateStorybookTsconfig from './fix-storybook-tsconfig';
+
+describe('Fix Storybook TSConfig to avoid VSCode error', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+
+    writeJson(tree, 'workspace.json', {
+      projects: {
+        ['home-ui-react']: {
+          projectType: 'library',
+          root: 'libs/home/ui-react',
+          sourceRoot: 'libs/home/ui-react/src',
+          targets: {
+            storybook: {
+              builder: '@nrwl/storybook:storybook',
+              options: {
+                uiFramework: '@storybook/react',
+                port: 4400,
+                config: {
+                  configFolder: 'libs/home/ui-react/.storybook',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    writeJson(tree, 'libs/home/ui-react/.storybook/tsconfig.json', {
+      extends: '../tsconfig.json',
+      compilerOptions: {
+        emitDecoratorMetadata: true,
+      },
+    });
+  });
+
+  it(`should add outDir to the storybook tsconfig to avoid VSCode errors`, async () => {
+    await updateStorybookTsconfig(tree);
+
+    expect(
+      readJson(tree, 'libs/home/ui-react/.storybook/tsconfig.json')
+    ).toMatchObject({
+      extends: '../tsconfig.json',
+      compilerOptions: {
+        emitDecoratorMetadata: true,
+        outDir: '',
+      },
+    });
+  });
+});

--- a/packages/storybook/src/migrations/update-12-1-0/fix-storybook-tsconfig.ts
+++ b/packages/storybook/src/migrations/update-12-1-0/fix-storybook-tsconfig.ts
@@ -1,0 +1,63 @@
+import {
+  getProjects,
+  joinPathFragments,
+  logger,
+  readJson,
+  Tree,
+  writeJson,
+  formatFiles,
+} from '@nrwl/devkit';
+import { isFramework, TsConfig } from '../../utils/utilities';
+
+export default async function updateStorybookTsconfig(tree: Tree) {
+  let changesMade = false;
+  const projects = getProjects(tree);
+
+  projects.forEach((projectConfig, projectName) => {
+    const targets = projectConfig.targets;
+
+    const paths = {
+      tsConfigStorybook: joinPathFragments(
+        projectConfig.root,
+        '.storybook/tsconfig.json'
+      ),
+    };
+
+    const storybookExecutor = Object.keys(targets).find(
+      (x) => targets[x].executor === '@nrwl/storybook:storybook'
+    );
+
+    const hasStorybookConfig =
+      storybookExecutor && tree.exists(paths.tsConfigStorybook);
+
+    if (!hasStorybookConfig) {
+      logger.info(
+        `${projectName}: no storybook configured. skipping migration...`
+      );
+      return;
+    }
+
+    const isReactProject = isFramework('react', {
+      uiFramework: targets[storybookExecutor].options
+        ?.uiFramework as Parameters<typeof isFramework>[1]['uiFramework'],
+    });
+
+    if (isReactProject) {
+      const tsConfig = {
+        storybook: readJson<TsConfig>(tree, paths.tsConfigStorybook),
+      };
+
+      tsConfig.storybook.compilerOptions = {
+        ...tsConfig.storybook.compilerOptions,
+        outDir: '',
+      };
+
+      writeJson(tree, paths.tsConfigStorybook, tsConfig.storybook);
+      changesMade = true;
+    }
+  });
+
+  if (changesMade) {
+    await formatFiles(tree);
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Adding js files to the Storybook tsconfig in #5146 to fix the eslint issues introduced a weird error with VSCode and behind the scenes TS compilation.

![image](https://user-images.githubusercontent.com/542458/115887244-08fcf080-a452-11eb-897f-2b29d69696dc.png)

See #5311 for more info.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR fixes it by introducing an empty `outDir` prop to the storybook tsconfig which solves the overwriting issue and doesn't seem to have undesirable side effects.

