### PR TITLE
fix(core): error when an invalid target/configuration is passed

### DIFF
--- a/packages/workspace/src/tasks-runner/run-command.spec.ts
+++ b/packages/workspace/src/tasks-runner/run-command.spec.ts
@@ -330,6 +330,44 @@ describe('createTasksForProjectToRun', () => {
     ]);
   });
 
+  it('should throw an error for an invalid target', () => {
+    spyOn(process, 'exit').and.throwError('');
+    try {
+      createTasksForProjectToRun(
+        [projectGraph.nodes.app1],
+        {
+          target: 'invalid',
+          configuration: undefined,
+          overrides: {},
+        },
+        projectGraph,
+        null
+      );
+      fail();
+    } catch (e) {
+      expect(process.exit).toHaveBeenCalledWith(1);
+    }
+  });
+
+  it('should throw an error for an invalid configuration for the initiating project', () => {
+    spyOn(process, 'exit').and.throwError('');
+    try {
+      createTasksForProjectToRun(
+        [projectGraph.nodes.app1],
+        {
+          target: 'serve',
+          configuration: 'invalid',
+          overrides: {},
+        },
+        projectGraph,
+        'app1'
+      );
+      fail();
+    } catch (e) {
+      expect(process.exit).toHaveBeenCalledWith(1);
+    }
+  });
+
   it('should throw an error for circular dependencies', () => {
     projectGraph.nodes.app1.data.targets.build.dependsOn = [
       {

--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -173,6 +173,14 @@ function addTasksForProjectTarget(
   tasksMap: Map<string, Task>,
   path: string[]
 ) {
+  const task = createTask({
+    project,
+    target,
+    configuration,
+    overrides,
+    errorIfCannotFindConfiguration,
+  });
+
   const dependencyConfigs = getDependencyConfigs(
     { project: project.name, target },
     defaultDependencyConfigs,
@@ -195,13 +203,6 @@ function addTasksForProjectTarget(
       );
     }
   }
-  const task = createTask({
-    project,
-    target,
-    configuration,
-    overrides,
-    errorIfCannotFindConfiguration,
-  });
   tasksMap.set(task.id, task);
 }
 
@@ -229,7 +230,7 @@ export function createTask({
 
   if (errorIfCannotFindConfiguration && configuration && !config) {
     output.error({
-      title: `Cannot find configuration '${configuration}' for project '${project.name}'`,
+      title: `Cannot find configuration '${configuration}' for project '${project.name}:${target}'`,
     });
     process.exit(1);
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running on a non-existent target/configuration will fail for a weird reason.

```
jason@pop-os ~/p/nx (error-invalid) [1]> nx build nx-dev

>  NX   ERROR  Cannot find target 'build-base' for project 'nx-dev'
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running on a non-existent target/configuration will fail for a reason that makes sense.

```
jason@pop-os ~/p/nx (error-invalid) [1]> nx build nx-dev

>  NX   ERROR  Cannot find target 'build' for project 'nx-dev'
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
