### PR TITLE
feat(core): add --buildable support to workspace lib

### DIFF
--- a/docs/angular/api-workspace/executors/tsc.md
+++ b/docs/angular/api-workspace/executors/tsc.md
@@ -1,0 +1,31 @@
+# tsc
+
+Build a project using TypeScript.
+
+Properties can be configured in angular.json when defining the executor, or when invoking it.
+
+## Properties
+
+### assets
+
+Type: `array`
+
+List of static assets.
+
+### main
+
+Type: `string`
+
+The name of the main entry-point file.
+
+### outputPath
+
+Type: `string`
+
+The output path of the generated files.
+
+### tsConfig
+
+Type: `string`
+
+The path to the Typescript configuration file.

--- a/docs/angular/api-workspace/generators/library.md
+++ b/docs/angular/api-workspace/generators/library.md
@@ -44,6 +44,14 @@ Type: `boolean`
 
 Use babel instead ts-jest
 
+### buildable
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a buildable library.
+
 ### directory
 
 Type: `string`

--- a/docs/map.json
+++ b/docs/map.json
@@ -332,6 +332,11 @@
             "name": "run-script executor",
             "id": "run-script",
             "file": "angular/api-workspace/executors/run-script"
+          },
+          {
+            "name": "tsc executor",
+            "id": "tsc",
+            "file": "angular/api-workspace/executors/tsc"
           }
         ]
       },
@@ -1389,6 +1394,11 @@
             "name": "run-script executor",
             "id": "run-script",
             "file": "react/api-workspace/executors/run-script"
+          },
+          {
+            "name": "tsc executor",
+            "id": "tsc",
+            "file": "react/api-workspace/executors/tsc"
           }
         ]
       },
@@ -2405,6 +2415,11 @@
             "name": "run-script executor",
             "id": "run-script",
             "file": "node/api-workspace/executors/run-script"
+          },
+          {
+            "name": "tsc executor",
+            "id": "tsc",
+            "file": "node/api-workspace/executors/tsc"
           }
         ]
       },

--- a/docs/node/api-workspace/executors/tsc.md
+++ b/docs/node/api-workspace/executors/tsc.md
@@ -1,0 +1,32 @@
+# tsc
+
+Build a project using TypeScript.
+
+Properties can be configured in workspace.json when defining the executor, or when invoking it.
+Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+
+## Properties
+
+### assets
+
+Type: `array`
+
+List of static assets.
+
+### main
+
+Type: `string`
+
+The name of the main entry-point file.
+
+### outputPath
+
+Type: `string`
+
+The output path of the generated files.
+
+### tsConfig
+
+Type: `string`
+
+The path to the Typescript configuration file.

--- a/docs/node/api-workspace/generators/library.md
+++ b/docs/node/api-workspace/generators/library.md
@@ -44,6 +44,14 @@ Type: `boolean`
 
 Use babel instead ts-jest
 
+### buildable
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a buildable library.
+
 ### directory
 
 Type: `string`

--- a/docs/react/api-workspace/executors/tsc.md
+++ b/docs/react/api-workspace/executors/tsc.md
@@ -1,0 +1,32 @@
+# tsc
+
+Build a project using TypeScript.
+
+Properties can be configured in workspace.json when defining the executor, or when invoking it.
+Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+
+## Properties
+
+### assets
+
+Type: `array`
+
+List of static assets.
+
+### main
+
+Type: `string`
+
+The name of the main entry-point file.
+
+### outputPath
+
+Type: `string`
+
+The output path of the generated files.
+
+### tsConfig
+
+Type: `string`
+
+The path to the Typescript configuration file.

--- a/docs/react/api-workspace/generators/library.md
+++ b/docs/react/api-workspace/generators/library.md
@@ -44,6 +44,14 @@ Type: `boolean`
 
 Use babel instead ts-jest
 
+### buildable
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a buildable library.
+
 ### directory
 
 Type: `string`

--- a/e2e/workspace/src/workspace-lib.test.ts
+++ b/e2e/workspace/src/workspace-lib.test.ts
@@ -103,4 +103,21 @@ describe('@nrwl/workspace:library', () => {
 
     runCLI(`test ${consumerLib}`);
   });
+
+  it('should be able to be built when it is buildable', () => {
+    const buildableLib = uniq('buildable');
+
+    runCLI(`generate @nrwl/workspace:lib ${buildableLib} --buildable`);
+
+    const result = runCLI(`build ${buildableLib}`);
+
+    expect(result).toContain(
+      `Compiling TypeScript files for project "${buildableLib}"...`
+    );
+    expect(result).toContain(
+      `Done compiling TypeScript files for project "${buildableLib}".`
+    );
+    expect(result).toContain('Copying asset files...');
+    expect(result).toContain('Done copying asset files.');
+  });
 });

--- a/packages/workspace/builders.json
+++ b/packages/workspace/builders.json
@@ -5,6 +5,11 @@
       "schema": "./src/executors/run-commands/schema.json",
       "description": "Run any custom commands with Nx"
     },
+    "tsc": {
+      "implementation": "./src/executors/tsc/compat",
+      "schema": "./src/executors/tsc/schema.json",
+      "description": "Build a project using TypeScript."
+    },
     "run-script": {
       "implementation": "./src/executors/run-script/compat",
       "schema": "./src/executors/run-script/schema.json",
@@ -17,6 +22,11 @@
       "implementation": "./src/executors/run-commands/run-commands.impl",
       "schema": "./src/executors/run-commands/schema.json",
       "description": "Run any custom commands with Nx"
+    },
+    "tsc": {
+      "implementation": "./src/executors/tsc/tsc.impl",
+      "schema": "./src/executors/tsc/schema.json",
+      "description": "Build a project using TypeScript."
     },
     "counter": {
       "implementation": "./src/executors/counter/counter.impl",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -61,6 +61,7 @@
     "cosmiconfig": "^4.0.0",
     "fs-extra": "^9.1.0",
     "dotenv": "8.2.0",
+    "glob": "7.1.4",
     "ignore": "^5.0.4",
     "npm-run-all": "^4.1.5",
     "open": "^7.4.2",

--- a/packages/workspace/src/executors/tsc/compat.ts
+++ b/packages/workspace/src/executors/tsc/compat.ts
@@ -1,0 +1,5 @@
+import { convertNxExecutor } from '@nrwl/devkit';
+
+import { tscExecutor } from './tsc.impl';
+
+export default convertNxExecutor(tscExecutor);

--- a/packages/workspace/src/executors/tsc/schema.d.ts
+++ b/packages/workspace/src/executors/tsc/schema.d.ts
@@ -1,0 +1,6 @@
+export interface TypeScriptExecutorOptions {
+  assets: Array<AssetGlob | string>;
+  main: string;
+  outputPath: string;
+  tsConfig: string;
+}

--- a/packages/workspace/src/executors/tsc/schema.json
+++ b/packages/workspace/src/executors/tsc/schema.json
@@ -1,0 +1,65 @@
+{
+  "title": "Typescript Build Target",
+  "description": "Builds using TypeScript",
+  "cli": "nx",
+  "type": "object",
+  "properties": {
+    "main": {
+      "type": "string",
+      "description": "The name of the main entry-point file."
+    },
+    "outputPath": {
+      "type": "string",
+      "description": "The output path of the generated files."
+    },
+    "tsConfig": {
+      "type": "string",
+      "description": "The path to the Typescript configuration file."
+    },
+    "assets": {
+      "type": "array",
+      "description": "List of static assets.",
+      "default": [],
+      "items": {
+        "$ref": "#/definitions/assetPattern"
+      }
+    }
+  },
+  "required": ["main", "outputPath", "tsConfig"],
+
+  "definitions": {
+    "assetPattern": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "glob": {
+              "type": "string",
+              "description": "The pattern to match."
+            },
+            "input": {
+              "type": "string",
+              "description": "The input directory path in which to apply 'glob'. Defaults to the project root."
+            },
+            "ignore": {
+              "description": "An array of globs to ignore.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "output": {
+              "type": "string",
+              "description": "Absolute path within the output."
+            }
+          },
+          "additionalProperties": false,
+          "required": ["glob", "input", "output"]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  }
+}

--- a/packages/workspace/src/executors/tsc/tsc.impl.spec.ts
+++ b/packages/workspace/src/executors/tsc/tsc.impl.spec.ts
@@ -1,0 +1,171 @@
+import { ExecutorContext } from '@nrwl/devkit';
+import { join } from 'path';
+import { copyAssets } from '../../utilities/assets';
+import { readJsonFile, writeJsonFile } from '../../utilities/fileutils';
+import { compileTypeScript } from '../../utilities/typescript/compilation';
+import { TypeScriptExecutorOptions } from './schema';
+import { tscExecutor } from './tsc.impl';
+
+const defaultPackageJson = { name: 'workspacelib', version: '0.0.1' };
+jest.mock('../../utilities/fileutils', () => ({
+  ...jest.requireActual('../../utilities/fileutils'),
+  writeJsonFile: jest.fn(),
+  readJsonFile: jest.fn(() => ({ ...defaultPackageJson })),
+}));
+const readJsonFileMock = readJsonFile as jest.Mock<any>;
+jest.mock('../../utilities/typescript/compilation');
+const compileTypeScriptMock = compileTypeScript as jest.Mock<
+  Promise<{ success: boolean }>
+>;
+jest.mock('../../utilities/assets');
+
+describe('executor: tsc', () => {
+  const assets = ['some-file.md'];
+  let context: ExecutorContext;
+  let normalizedOptions: TypeScriptExecutorOptions;
+  let options: TypeScriptExecutorOptions;
+
+  beforeEach(() => {
+    context = {
+      cwd: '/root',
+      root: '/root',
+      projectName: 'workspacelib',
+      targetName: 'build',
+      workspace: {
+        version: 2,
+        projects: {
+          workspacelib: {
+            root: 'libs/workspacelib',
+            sourceRoot: 'libs/workspacelib/src',
+            targets: {},
+          },
+        },
+      },
+      isVerbose: false,
+    };
+    options = {
+      assets,
+      main: 'libs/workspacelib/src/index.ts',
+      outputPath: 'dist/libs/workspacelib',
+      tsConfig: 'libs/workspacelib/tsconfig.lib.json',
+    };
+    normalizedOptions = {
+      ...options,
+      outputPath: join(context.root, options.outputPath),
+      tsConfig: join(context.root, options.tsConfig),
+    };
+
+    jest.clearAllMocks();
+  });
+
+  it('should return typescript compilation result', async () => {
+    const expectedResult = { success: true };
+    compileTypeScriptMock.mockReturnValue(Promise.resolve(expectedResult));
+
+    const result = await tscExecutor(options, context);
+
+    expect(result).toBe(expectedResult);
+  });
+
+  describe('copy assets', () => {
+    it('should not copy assets when typescript compilation is not successful', async () => {
+      compileTypeScriptMock.mockReturnValue(
+        Promise.resolve({ success: false })
+      );
+
+      await tscExecutor(options, context);
+
+      expect(copyAssets).not.toHaveBeenCalled();
+    });
+
+    it('should copy assets when typescript compilation is successful', async () => {
+      compileTypeScriptMock.mockReturnValue(Promise.resolve({ success: true }));
+
+      await tscExecutor(options, context);
+
+      expect(copyAssets).toHaveBeenCalledWith(
+        assets,
+        context.root,
+        normalizedOptions.outputPath
+      );
+    });
+  });
+
+  describe('update package.json', () => {
+    it('should not update package.json when typescript compilation is not successful', async () => {
+      compileTypeScriptMock.mockReturnValue(
+        Promise.resolve({ success: false })
+      );
+
+      await tscExecutor(options, context);
+
+      expect(writeJsonFile).not.toHaveBeenCalled();
+    });
+
+    it('should update the package.json when typescript compilation is successful and both main and typings are missing', async () => {
+      compileTypeScriptMock.mockReturnValue(Promise.resolve({ success: true }));
+
+      await tscExecutor(options, context);
+
+      expect(writeJsonFile).toHaveBeenCalledWith(
+        join(context.root, options.outputPath, 'package.json'),
+        {
+          ...defaultPackageJson,
+          main: './src/index.js',
+          typings: './src/index.d.ts',
+        }
+      );
+    });
+
+    it('should update the package.json when typescript compilation is successful and only main is missing', async () => {
+      compileTypeScriptMock.mockReturnValue(Promise.resolve({ success: true }));
+      const packageJson = {
+        ...defaultPackageJson,
+        typings: './src/index.d.ts',
+      };
+      readJsonFileMock.mockReturnValue(packageJson);
+
+      await tscExecutor(options, context);
+
+      expect(writeJsonFile).toHaveBeenCalledWith(
+        join(context.root, options.outputPath, 'package.json'),
+        {
+          ...packageJson,
+          main: './src/index.js',
+        }
+      );
+    });
+
+    it('should update the package.json when typescript compilation is successful and only typings is missing', async () => {
+      compileTypeScriptMock.mockReturnValue(Promise.resolve({ success: true }));
+      const packageJson = {
+        ...defaultPackageJson,
+        main: './src/index.js',
+      };
+      readJsonFileMock.mockReturnValue(packageJson);
+
+      await tscExecutor(options, context);
+
+      expect(writeJsonFile).toHaveBeenCalledWith(
+        join(context.root, options.outputPath, 'package.json'),
+        {
+          ...packageJson,
+          typings: './src/index.d.ts',
+        }
+      );
+    });
+
+    it('should not update the package.json when typescript compilation is successful and both main and typings are specified', async () => {
+      compileTypeScriptMock.mockReturnValue(Promise.resolve({ success: true }));
+      readJsonFileMock.mockReturnValue({
+        ...defaultPackageJson,
+        main: './src/index.js',
+        typings: './src/index.d.ts',
+      });
+
+      await tscExecutor(options, context);
+
+      expect(writeJsonFile).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/workspace/src/executors/tsc/tsc.impl.ts
+++ b/packages/workspace/src/executors/tsc/tsc.impl.ts
@@ -1,0 +1,78 @@
+import { ExecutorContext, normalizePath } from '@nrwl/devkit';
+import { basename, dirname, join, relative } from 'path';
+import { copyAssets } from '../../utilities/assets';
+import { readJsonFile, writeJsonFile } from '../../utilities/fileutils';
+import { compileTypeScript } from '../../utilities/typescript/compilation';
+import { TypeScriptExecutorOptions } from './schema';
+
+export async function tscExecutor(
+  options: TypeScriptExecutorOptions,
+  context: ExecutorContext
+) {
+  const normalizedOptions = normalizeOptions(options, context);
+  const projectRoot = context.workspace.projects[context.projectName].root;
+
+  const result = await compileTypeScript({
+    outputPath: normalizedOptions.outputPath,
+    projectName: context.projectName,
+    projectRoot,
+    tsConfig: normalizedOptions.tsConfig,
+  });
+
+  if (result.success) {
+    await copyAssets(
+      normalizedOptions.assets,
+      context.root,
+      normalizedOptions.outputPath
+    );
+    updatePackageJson(normalizedOptions, projectRoot);
+  }
+
+  return result;
+}
+
+function getMainFileDirRelativeToProjectRoot(
+  main: string,
+  projectRoot: string
+): string {
+  const mainFileDir = dirname(main);
+  const relativeDir = normalizePath(relative(projectRoot, mainFileDir));
+  const relativeMainFile = relativeDir === '' ? `./` : `./${relativeDir}/`;
+  return relativeMainFile;
+}
+
+function normalizeOptions(
+  options: TypeScriptExecutorOptions,
+  context: ExecutorContext
+): TypeScriptExecutorOptions {
+  return {
+    ...options,
+    outputPath: join(context.root, options.outputPath),
+    tsConfig: join(context.root, options.tsConfig),
+  };
+}
+
+function updatePackageJson(
+  options: TypeScriptExecutorOptions,
+  projectRoot: string
+): void {
+  const packageJson = readJsonFile(join(projectRoot, 'package.json'));
+  if (packageJson.main && packageJson.typings) {
+    return;
+  }
+
+  const mainFile = basename(options.main).replace(/\.[tj]s$/, '');
+  const relativeMainFileDir = getMainFileDirRelativeToProjectRoot(
+    options.main,
+    projectRoot
+  );
+  const mainJsFile = `${relativeMainFileDir}${mainFile}.js`;
+  const typingsFile = `${relativeMainFileDir}${mainFile}.d.ts`;
+
+  packageJson.main = packageJson.main ?? mainJsFile;
+  packageJson.typings = packageJson.typings ?? typingsFile;
+  const outputPackageJson = join(options.outputPath, 'package.json');
+  writeJsonFile(outputPackageJson, packageJson);
+}
+
+export default tscExecutor;

--- a/packages/workspace/src/generators/library/files/lib/package.json__tmpl__
+++ b/packages/workspace/src/generators/library/files/lib/package.json__tmpl__
@@ -1,0 +1,4 @@
+{
+  "name": "<%= importPath %>",
+  "version": "0.0.1"
+}

--- a/packages/workspace/src/generators/library/files/lib/tsconfig.lib.json
+++ b/packages/workspace/src/generators/library/files/lib/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
+    "declaration": true,
     "types": []
   },
   "include": ["**/*.ts"<% if (js) { %>, "**/*.js"<% } %>],

--- a/packages/workspace/src/generators/library/library.spec.ts
+++ b/packages/workspace/src/generators/library/library.spec.ts
@@ -132,6 +132,7 @@ describe('lib', () => {
       expect(tree.exists('libs/my-lib/src/lib/my-lib.ts')).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/lib/my-lib.spec.ts')).toBeTruthy();
       expect(tree.exists('libs/my-lib/README.md')).toBeTruthy();
+      expect(tree.exists('libs/my-lib/package.json')).toBeFalsy();
 
       const ReadmeContent = tree.read('libs/my-lib/README.md').toString();
       expect(ReadmeContent).toContain('nx test my-lib');
@@ -210,6 +211,7 @@ describe('lib', () => {
       ).toBeTruthy();
       expect(tree.exists('libs/my-dir/my-lib/src/index.ts')).toBeTruthy();
       expect(tree.exists(`libs/my-dir/my-lib/.eslintrc.json`)).toBeTruthy();
+      expect(tree.exists(`libs/my-dir/my-lib/package.json`)).toBeFalsy();
     });
 
     it('should update workspace.json', async () => {
@@ -771,6 +773,33 @@ describe('lib', () => {
         name: 'myLib',
       });
       expect(tree.exists('libs/my-lib/.babelrc')).toBeTruthy();
+    });
+  });
+
+  describe('--buildable', () => {
+    it('should add build target to workspace.json', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        buildable: true,
+      });
+      const workspaceJson = readJson(tree, '/workspace.json');
+
+      expect(workspaceJson.projects['my-lib'].root).toEqual('libs/my-lib');
+      expect(workspaceJson.projects['my-lib'].architect.build).toBeTruthy();
+      expect(workspaceJson.projects['my-lib'].architect.build.builder).toBe(
+        '@nrwl/workspace:tsc'
+      );
+    });
+
+    it('should generate a package.json file', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        buildable: true,
+      });
+
+      expect(tree.exists('libs/my-lib/package.json')).toBeTruthy();
     });
   });
 });

--- a/packages/workspace/src/generators/library/library.ts
+++ b/packages/workspace/src/generators/library/library.ts
@@ -11,6 +11,8 @@ import {
   updateJson,
   GeneratorCallback,
   joinPathFragments,
+  ProjectConfiguration,
+  NxJsonProjectConfiguration,
 } from '@nrwl/devkit';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import { join } from 'path';
@@ -31,13 +33,30 @@ export interface NormalizedSchema extends Schema {
 }
 
 function addProject(tree: Tree, options: NormalizedSchema) {
-  addProjectConfiguration(tree, options.name, {
+  const projectConfiguration: ProjectConfiguration &
+    NxJsonProjectConfiguration = {
     root: options.projectRoot,
     sourceRoot: joinPathFragments(options.projectRoot, 'src'),
     projectType: 'library',
     targets: {},
     tags: options.parsedTags,
-  });
+  };
+
+  if (options.buildable) {
+    const { libsDir } = getWorkspaceLayout(tree);
+    projectConfiguration.targets.build = {
+      executor: '@nrwl/workspace:tsc',
+      outputs: ['{options.outputPath}'],
+      options: {
+        outputPath: `dist/${libsDir}/${options.projectDirectory}`,
+        main: `${options.projectRoot}/src/index` + (options.js ? '.js' : '.ts'),
+        tsConfig: `${options.projectRoot}/tsconfig.lib.json`,
+        assets: [`${options.projectRoot}/*.md`],
+      },
+    };
+  }
+
+  addProjectConfiguration(tree, options.name, projectConfiguration);
 }
 
 export function addLint(
@@ -126,6 +145,10 @@ function createFiles(tree: Tree, options: NormalizedSchema) {
 
   if (options.js) {
     toJS(tree);
+  }
+
+  if (!options.buildable) {
+    tree.delete(join(options.projectRoot, 'package.json'));
   }
 
   updateLibTsConfig(tree, options);

--- a/packages/workspace/src/generators/library/schema.d.ts
+++ b/packages/workspace/src/generators/library/schema.d.ts
@@ -17,4 +17,5 @@ export interface Schema {
   pascalCaseFiles?: boolean;
   strict?: boolean;
   skipBabelrc?: boolean;
+  buildable?: boolean;
 }

--- a/packages/workspace/src/generators/library/schema.json
+++ b/packages/workspace/src/generators/library/schema.json
@@ -86,6 +86,11 @@
       "type": "boolean",
       "description": "Do not generate .babelrc file. Useful for Node libraries that are not compiled by Babel",
       "default": false
+    },
+    "buildable": {
+      "type": "boolean",
+      "default": false,
+      "description": "Generate a buildable library."
     }
   },
   "required": ["name"]

--- a/packages/workspace/src/utilities/assets.ts
+++ b/packages/workspace/src/utilities/assets.ts
@@ -1,0 +1,75 @@
+import { logger } from '@nrwl/devkit';
+import { copy } from 'fs-extra';
+import * as glob from 'glob';
+import { basename, join } from 'path';
+
+export type FileInputOutput = {
+  input: string;
+  output: string;
+};
+export type AssetGlob = FileInputOutput & {
+  glob: string;
+  ignore: string[];
+};
+
+export function assetGlobsToFiles(
+  assets: AssetGlob[],
+  rootDir: string,
+  outDir: string
+): FileInputOutput[] {
+  const files: FileInputOutput[] = [];
+
+  const globbedFiles = (pattern: string, input = '', ignore: string[] = []) => {
+    return glob.sync(pattern, {
+      cwd: input,
+      nodir: true,
+      ignore,
+    });
+  };
+
+  assets.forEach((asset) => {
+    if (typeof asset === 'string') {
+      globbedFiles(asset, rootDir).forEach((globbedFile) => {
+        files.push({
+          input: join(rootDir, globbedFile),
+          output: join(outDir, basename(globbedFile)),
+        });
+      });
+    } else {
+      globbedFiles(
+        asset.glob,
+        join(rootDir, asset.input),
+        asset.ignore
+      ).forEach((globbedFile) => {
+        files.push({
+          input: join(rootDir, asset.input, globbedFile),
+          output: join(outDir, asset.output, globbedFile),
+        });
+      });
+    }
+  });
+
+  return files;
+}
+
+export function copyAssets(
+  assets: AssetGlob[],
+  rootDir: string,
+  outDir: string
+): Promise<{ success: boolean; error?: string }> {
+  const files = assetGlobsToFiles(assets, rootDir, outDir);
+  return copyAssetFiles(files);
+}
+
+export async function copyAssetFiles(
+  files: FileInputOutput[]
+): Promise<{ success: boolean; error?: string }> {
+  logger.info('Copying asset files...');
+  try {
+    await Promise.all(files.map((file) => copy(file.input, file.output)));
+    logger.info('Done copying asset files.');
+    return { success: true };
+  } catch (err) {
+    return { error: err.message, success: false };
+  }
+}

--- a/packages/workspace/src/utilities/typescript/compilation.ts
+++ b/packages/workspace/src/utilities/typescript/compilation.ts
@@ -1,0 +1,85 @@
+import { logger } from '@nrwl/devkit';
+import { removeSync } from 'fs-extra';
+import * as ts from 'typescript';
+import { readTsConfig } from '../typescript';
+
+export interface TypeScriptCompilationOptions {
+  outputPath: string;
+  projectName: string;
+  projectRoot: string;
+  tsConfig: string;
+  deleteOutputPath?: boolean;
+  rootDir?: string;
+  watch?: boolean;
+}
+
+export async function compileTypeScript(
+  options: TypeScriptCompilationOptions
+): Promise<{ success: boolean }> {
+  const normalizedOptions = normalizeOptions(options);
+
+  if (normalizedOptions.deleteOutputPath) {
+    removeSync(normalizedOptions.outputPath);
+  }
+  const tsConfig = readTsConfig(normalizedOptions.tsConfig);
+  tsConfig.options.outDir = normalizedOptions.outputPath;
+  tsConfig.options.noEmitOnError = true;
+  tsConfig.options.rootDir = normalizedOptions.rootDir;
+
+  if (normalizedOptions.watch) {
+    return createWatchProgram(tsConfig);
+  } else {
+    return createProgram(tsConfig, normalizedOptions.projectName);
+  }
+}
+
+async function createProgram(
+  tsconfig: ts.ParsedCommandLine,
+  projectName: string
+) {
+  const host = ts.createCompilerHost(tsconfig.options);
+  const program = ts.createProgram({
+    rootNames: tsconfig.fileNames,
+    options: tsconfig.options,
+    host,
+  });
+  logger.info(`Compiling TypeScript files for project "${projectName}"...`);
+  const results = program.emit();
+  if (results.emitSkipped) {
+    const diagnostics = ts.formatDiagnosticsWithColorAndContext(
+      results.diagnostics,
+      {
+        getCurrentDirectory: () => ts.sys.getCurrentDirectory(),
+        getNewLine: () => ts.sys.newLine,
+        getCanonicalFileName: (name) => name,
+      }
+    );
+    logger.error(diagnostics);
+    throw new Error(diagnostics);
+  } else {
+    logger.info(
+      `Done compiling TypeScript files for project "${projectName}".`
+    );
+    return { success: true };
+  }
+}
+
+function createWatchProgram(tsconfig: ts.ParsedCommandLine) {
+  const host = ts.createWatchCompilerHost(
+    tsconfig.fileNames,
+    tsconfig.options,
+    ts.sys
+  );
+  ts.createWatchProgram(host);
+  return { success: true };
+}
+
+function normalizeOptions(
+  options: TypeScriptCompilationOptions
+): TypeScriptCompilationOptions {
+  return {
+    ...options,
+    deleteOutputPath: options.deleteOutputPath ?? true,
+    rootDir: options.rootDir ?? options.projectRoot,
+  };
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `@nrwl/workspace:library` doesn't have support for the `--buildable` flag.

## Expected Behavior
The `@nrwl/workspace:library` allows to pass the `--buildable` flag. It uses the new `@nrwl/workspace:tsc` executor to build the library.

Note:
The `@nrwl/node:package` executor also does TypeScript compilation. As part of this PR, I'm extracting the TypeScript compilation and the assets handling to a couple of utilities. In another PR, I'll refactor the `@nrwl/node:package` executor to use these utilities and remove the duplicated code.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
