### PR TITLE
cleanup(core): copy from cache only when needed

### DIFF
--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -15,6 +15,7 @@ import {
   updateFile,
   workspaceConfigName,
 } from '@nrwl/e2e/utils';
+import { TaskCacheStatus } from '@nrwl/workspace/src/utilities/output';
 
 describe('run-one', () => {
   let proj: string;
@@ -740,7 +741,7 @@ describe('cache', () => {
     });
     const outputWithBuildApp2Cached = runCLI(`affected:build ${files}`);
     expect(outputWithBuildApp2Cached).toContain('read the output from cache');
-    expectCached(outputWithBuildApp2Cached, [myapp2]);
+    expectMatchedOutput(outputWithBuildApp2Cached, [myapp2]);
 
     // touch package.json
     // --------------------------------------------
@@ -754,13 +755,17 @@ describe('cache', () => {
 
     // build individual project with caching
     const individualBuildWithCache = runCLI(`build ${myapp1}`);
-    expect(individualBuildWithCache).toContain('from cache');
+    expect(individualBuildWithCache).toContain(
+      TaskCacheStatus.MatchedExistingOutput
+    );
 
     // skip caching when building individual projects
     const individualBuildWithSkippedCache = runCLI(
       `build ${myapp1} --skip-nx-cache`
     );
-    expect(individualBuildWithSkippedCache).not.toContain('from cache');
+    expect(individualBuildWithSkippedCache).not.toContain(
+      TaskCacheStatus.MatchedExistingOutput
+    );
 
     // run lint with caching
     // --------------------------------------------
@@ -771,7 +776,7 @@ describe('cache', () => {
     expect(outputWithBothLintTasksCached).toContain(
       'read the output from cache'
     );
-    expectCached(outputWithBothLintTasksCached, [
+    expectMatchedOutput(outputWithBothLintTasksCached, [
       myapp1,
       myapp2,
       `${myapp1}-e2e`,
@@ -874,19 +879,38 @@ describe('cache', () => {
     actualOutput: string,
     expectedCachedProjects: string[]
   ) {
-    const cachedProjects = [];
+    expectProjectMatchTaskCacheStatus(actualOutput, expectedCachedProjects);
+  }
+
+  function expectMatchedOutput(
+    actualOutput: string,
+    expectedMatchedOutputProjects: string[]
+  ) {
+    expectProjectMatchTaskCacheStatus(
+      actualOutput,
+      expectedMatchedOutputProjects,
+      TaskCacheStatus.MatchedExistingOutput
+    );
+  }
+
+  function expectProjectMatchTaskCacheStatus(
+    actualOutput: string,
+    expectedProjects: string[],
+    cacheStatus: TaskCacheStatus = TaskCacheStatus.RetrievedFromCache
+  ) {
+    const matchingProjects = [];
     const lines = actualOutput.split('\n');
-    lines.forEach((s, i) => {
+    lines.forEach((s) => {
       if (s.startsWith(`> nx run`)) {
         const projectName = s.split(`> nx run `)[1].split(':')[0].trim();
-        if (s.indexOf('from cache') > -1) {
-          cachedProjects.push(projectName);
+        if (s.indexOf(cacheStatus) > -1) {
+          matchingProjects.push(projectName);
         }
       }
     });
 
-    cachedProjects.sort((a, b) => a.localeCompare(b));
-    expectedCachedProjects.sort((a, b) => a.localeCompare(b));
-    expect(cachedProjects).toEqual(expectedCachedProjects);
+    matchingProjects.sort((a, b) => a.localeCompare(b));
+    expectedProjects.sort((a, b) => a.localeCompare(b));
+    expect(matchingProjects).toEqual(expectedProjects);
   }
 });

--- a/packages/workspace/src/tasks-runner/task-orchestrator.ts
+++ b/packages/workspace/src/tasks-runner/task-orchestrator.ts
@@ -4,7 +4,7 @@ import * as dotenv from 'dotenv';
 import { readFileSync, writeFileSync } from 'fs';
 import { ProjectGraph } from '../core/project-graph';
 import { appRootPath } from '../utilities/app-root';
-import { output } from '../utilities/output';
+import { output, TaskCacheStatus } from '../utilities/output';
 import { Cache, TaskWithCachedResult } from './cache';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { AffectedEventType, Task } from './tasks-runner';
@@ -115,17 +115,28 @@ export class TaskOrchestrator {
     tasks.forEach((t) => {
       this.options.lifeCycle.startTask(t.task);
 
+      const outputs = getOutputs(this.projectGraph.nodes, t.task);
+      const shouldCopyOutputsFromCache = this.cache.shouldCopyOutputsFromCache(
+        t,
+        outputs
+      );
+      if (shouldCopyOutputsFromCache) {
+        this.cache.copyFilesFromCache(t.task.hash, t.cachedResult, outputs);
+      }
+
       if (
         !this.initiatingProject ||
         this.initiatingProject === t.task.target.project
       ) {
         const args = this.getCommandArgs(t.task);
-        output.logCommand(`nx ${args.join(' ')}`, true);
+        output.logCommand(
+          `nx ${args.join(' ')}`,
+          shouldCopyOutputsFromCache
+            ? TaskCacheStatus.RetrievedFromCache
+            : TaskCacheStatus.MatchedExistingOutput
+        );
         process.stdout.write(t.cachedResult.terminalOutput);
       }
-
-      const outputs = getOutputs(this.projectGraph.nodes, t.task);
-      this.cache.copyFilesFromCache(t.task.hash, t.cachedResult, outputs);
 
       this.options.lifeCycle.endTask(t.task, t.cachedResult.code);
     });
@@ -175,6 +186,7 @@ export class TaskOrchestrator {
         if (forwardOutput) {
           output.logCommand(commandLine);
         }
+        this.cache.removeRecordedOutputsHashes(taskOutputs);
         const p = fork(this.getCommand(), args, {
           stdio: ['inherit', 'pipe', 'pipe', 'ipc'],
           env,
@@ -211,6 +223,7 @@ export class TaskOrchestrator {
               this.cache
                 .put(task, terminalOutput, taskOutputs, code)
                 .then(() => {
+                  this.cache.recordOutputsHash(taskOutputs, task.hash);
                   this.options.lifeCycle.endTask(task, code);
                   res(code);
                 })
@@ -218,10 +231,12 @@ export class TaskOrchestrator {
                   rej(e);
                 });
             } else {
+              this.cache.recordOutputsHash(taskOutputs, task.hash);
               this.options.lifeCycle.endTask(task, code);
               res(code);
             }
           } else {
+            this.cache.recordOutputsHash(taskOutputs, task.hash);
             this.options.lifeCycle.endTask(task, code);
             res(code);
           }
@@ -252,6 +267,7 @@ export class TaskOrchestrator {
         if (forwardOutput) {
           output.logCommand(commandLine);
         }
+        this.cache.removeRecordedOutputsHashes(taskOutputs);
         const p = fork(this.getCommand(), args, {
           stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
           env,
@@ -277,6 +293,7 @@ export class TaskOrchestrator {
             this.cache
               .put(task, this.readTerminalOutput(outputPath), taskOutputs, code)
               .then(() => {
+                this.cache.recordOutputsHash(taskOutputs, task.hash);
                 this.options.lifeCycle.endTask(task, code);
                 res(code);
               })
@@ -284,6 +301,7 @@ export class TaskOrchestrator {
                 rej(e);
               });
           } else {
+            this.cache.recordOutputsHash(taskOutputs, task.hash);
             this.options.lifeCycle.endTask(task, code);
             res(code);
           }

--- a/packages/workspace/src/utilities/output.ts
+++ b/packages/workspace/src/utilities/output.ts
@@ -22,6 +22,12 @@ export interface CLISuccessMessageConfig {
   bodyLines?: string[];
 }
 
+export enum TaskCacheStatus {
+  NoCache = '[no cache]',
+  MatchedExistingOutput = '[existing outputs match the cache, left as is]',
+  RetrievedFromCache = '[retrieved from cache]',
+}
+
 /**
  * Automatically disable styling applied by chalk if CI=true
  */
@@ -177,13 +183,16 @@ class CLIOutput {
     this.addNewline();
   }
 
-  logCommand(message: string, isCached: boolean = false) {
+  logCommand(
+    message: string,
+    cacheStatus: TaskCacheStatus = TaskCacheStatus.NoCache
+  ) {
     this.addNewline();
 
     this.writeToStdOut(chalk.bold(`> ${message} `));
 
-    if (isCached) {
-      this.writeToStdOut(chalk.bold.grey(`[retrieved from cache]`));
+    if (cacheStatus !== TaskCacheStatus.NoCache) {
+      this.writeToStdOut(chalk.bold.grey(cacheStatus));
     }
 
     this.addNewline();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Every time there's a cache hit, we remove the output and copy it over from the cache.

## Expected Behavior
We don't remove the output and copy it from the cache when the current local output is expected to be the same as what the cache has stored.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
