### PR TITLE
fix(core): do not report on tasks when being run within an Nx command

### DIFF
--- a/packages/workspace/src/tasks-runner/run-one-reporter.ts
+++ b/packages/workspace/src/tasks-runner/run-one-reporter.ts
@@ -13,7 +13,7 @@ export class RunOneReporter implements Reporter {
     taskOverrides: any
   ) {
     // Silent for a single task
-    if (tasks.length === 1) {
+    if (tasks.length === 1 && process.env.NX_INVOKED_BY_RUNNER) {
       return;
     }
     this.projectNames = projectNames;
@@ -43,7 +43,7 @@ export class RunOneReporter implements Reporter {
     cachedTasks: Task[]
   ) {
     // Silent for a single task
-    if (tasks.length === 1) {
+    if (tasks.length === 1 && process.env.NX_INVOKED_BY_RUNNER) {
       return;
     }
     output.addNewline();

--- a/yarn.lock
+++ b/yarn.lock
@@ -17397,7 +17397,7 @@ pretty-error@^2.0.2, pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@26.x, pretty-format@^26.0.0, pretty-format@^26.6.2:
+pretty-format@26.x, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -21027,23 +21027,7 @@ ts-essentials@^2.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
-ts-jest@26.5.5:
-  version "26.5.5"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.5.tgz#e40481b6ee4dd162626ba481a2be05fa57160ea5"
-  integrity sha1-5ASBtu5N0WJia6SBor4F+lcWDqU=
-  dependencies:
-    bs-logger "0.x"
-    buffer-from "1.x"
-    fast-json-stable-stringify "2.x"
-    jest-util "^26.1.0"
-    json5 "2.x"
-    lodash "4.x"
-    make-error "1.x"
-    mkdirp "1.x"
-    semver "7.x"
-    yargs-parser "20.x"
-
-ts-jest@26.x:
+ts-jest@26.5.5, ts-jest@26.x:
   version "26.5.5"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.5.tgz#e40481b6ee4dd162626ba481a2be05fa57160ea5"
   integrity sha512-7tP4m+silwt1NHqzNRAPjW1BswnAhopTdc2K3HEkRZjF0ZG2F/e/ypVH0xiZIMfItFtD3CX0XFbwPzp9fIEUVg==


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When a command is run with the `run-commands` builder, the logs will print out

```
>  NX   SUCCESS  Running target "build-base" succeeded

  Nx read the output from cache instead of running the command for 3 out of 4 tasks.


———————————————————————————————————————————————

>  NX   SUCCESS  Running target "build" succeeded

  Nx read the output from cache instead of running the command for 2 out of 4 tasks.


>  NX   CLOUD  See run details at https://nx.app/runs/gvpYkqFl5td
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Commands run within run-commands will not have log their tasks:

```
>  NX   SUCCESS  Running target "build" succeeded

  Nx read the output from cache instead of running the command for 4 out of 4 tasks.


>  NX   CLOUD  See run details at https://nx.app/runs/uYtuM88DIMo

```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
