### PR TITLE
fix(nextjs): allow node modules css import in libs

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -165,6 +165,13 @@ describe('Next.js Applications', () => {
     runCLI(`generate @nrwl/react:lib ${tsxLibName} --no-interactive`);
     runCLI(`generate @nrwl/workspace:lib ${tsLibName} --no-interactive`);
 
+    // create a css file in node_modules so that it can be imported in a lib
+    // to test that it works as expected
+    updateFile(
+      'node_modules/@nrwl/next/test-styles.css',
+      'h1 { background-color: red; }'
+    );
+
     updateFile(
       `libs/${tsLibName}/src/lib/${tsLibName}.ts`,
       `
@@ -182,6 +189,7 @@ describe('Next.js Applications', () => {
     updateFile(
       `libs/${tsxLibName}/src/lib/${tsxLibName}.tsx`,
       `
+          import '@nrwl/next/test-styles.css';
 
           interface TestComponentProps {
             text: string;

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -114,6 +114,22 @@ function withNx(nextConfig = {} as WithNxOptions) {
         nextErrorCssModuleLoader.exclude = includes;
       }
 
+      /**
+       * 4. Modify css loader to allow global css from node_modules to be imported from workspace libs
+       */
+      const nextGlobalCssLoader = nextCssLoaders.oneOf.find((rule) =>
+        rule.include?.and?.find((include) =>
+          regexEqual(include, /node_modules/)
+        )
+      );
+      // Might not be found if Next.js webpack config changes in the future
+      if (nextGlobalCssLoader) {
+        nextGlobalCssLoader.issuer.or = nextGlobalCssLoader.issuer.and
+          ? nextGlobalCssLoader.issuer.and.concat(includes)
+          : includes;
+        delete nextGlobalCssLoader.issuer.and;
+      }
+
       return userWebpack(config, options);
     },
   };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

Next.js allows importing "global" css from node modules anywhere in the app ([docs](https://nextjs.org/docs/basic-features/built-in-css-support#import-styles-from-node_modules)).

The change introduced is pretty much the same as what we're already doing for css and sass modules

## Current Behavior
<!-- This is the behavior we have today -->
Importing css files from node modules inside a lib that is then consumed by a next.js app throws an error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Behaviour should be the same as in next.js - no error should be thrown.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3803 
