### PR TITLE
fix(core): wip do not use --legacy-peer-deps for npm installs

### DIFF
--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -524,7 +524,7 @@ export function getPackageManagerCommand({
       createWorkspace: `npx create-nx-workspace@9999.0.2`,
       runNx: `npm run nx${scriptsPrependNodePathFlag} --`,
       runNxSilent: `npm run nx --silent${scriptsPrependNodePathFlag} --`,
-      addDev: `npm install --legacy-peer-deps -D`,
+      addDev: `npm install -D`,
       list: 'npm ls --depth 10',
     },
     yarn: {

--- a/packages/create-nx-workspace/bin/package-manager.ts
+++ b/packages/create-nx-workspace/bin/package-manager.ts
@@ -65,9 +65,9 @@ export function getPackageManagerCommand(
 
     case 'npm':
       return {
-        install: 'npm install --legacy-peer-deps',
-        add: 'npm install --legacy-peer-deps',
-        addDev: 'npm install --legacy-peer-deps -D',
+        install: 'npm install',
+        add: 'npm install',
+        addDev: 'npm install -D',
         rm: 'npm rm',
         exec: 'npx',
         run: (script: string, args: string) => `npm run ${script} -- ${args}`,

--- a/packages/tao/src/shared/package-manager.ts
+++ b/packages/tao/src/shared/package-manager.ts
@@ -60,9 +60,9 @@ export function getPackageManagerCommand(
 
     case 'npm':
       return {
-        install: 'npm install --legacy-peer-deps',
-        add: 'npm install --legacy-peer-deps',
-        addDev: 'npm install --legacy-peer-deps -D',
+        install: 'npm install',
+        add: 'npm install',
+        addDev: 'npm install -D',
         rm: 'npm rm',
         exec: 'npx',
         run: (script: string, args: string) => `npm run ${script} -- ${args}`,


### PR DESCRIPTION
# WIP

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
