### PR TITLE
fix(core): consistently process args with yargs-parser instead of min…

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,6 @@
     "mime": "2.4.4",
     "mini-css-extract-plugin": "0.8.0",
     "minimatch": "3.0.4",
-    "minimist": "^1.2.5",
     "next": "10.1.2",
     "ng-packagr": "~11.2.0",
     "ngrx-store-freeze": "0.2.4",

--- a/packages/cli/lib/parse-run-one-options.ts
+++ b/packages/cli/lib/parse-run-one-options.ts
@@ -1,4 +1,4 @@
-import yargsParser = require('yargs-parser');
+import * as yargsParser from 'yargs-parser';
 
 function calculateDefaultProjectName(cwd: string, root: string, wc: any) {
   let relativeCwd = cwd.replace(/\\/g, '/').split(root.replace(/\\/g, '/'))[1];
@@ -69,6 +69,9 @@ export function parseRunOneOptions(
     string: ['configuration', 'project'],
     alias: {
       c: 'configuration',
+    },
+    configuration: {
+      'strip-dashed': true,
     },
   });
 

--- a/packages/tao/package.json
+++ b/packages/tao/package.json
@@ -32,7 +32,6 @@
     "chalk": "4.1.0",
     "enquirer": "~2.3.6",
     "fs-extra": "^9.1.0",
-    "minimist": "^1.2.5",
     "rxjs": "^6.5.4",
     "rxjs-for-await": "0.0.2",
     "semver": "7.3.4",

--- a/packages/tao/src/commands/generate.ts
+++ b/packages/tao/src/commands/generate.ts
@@ -1,4 +1,4 @@
-import * as minimist from 'minimist';
+import * as yargsParser from 'yargs-parser';
 import {
   combineOptionsForGenerator,
   convertToCamelCase,
@@ -38,7 +38,7 @@ function parseGenerateOpts(
   defaultCollection: string | null
 ): GenerateOptions {
   const generatorOptions = convertToCamelCase(
-    minimist(args, {
+    yargsParser(args, {
       boolean: ['help', 'dryRun', 'debug', 'force', 'interactive', 'defaults'],
       alias: {
         dryRun: 'dry-run',

--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync, removeSync } from 'fs-extra';
-import * as minimist from 'minimist';
+import * as yargsParser from 'yargs-parser';
 import { dirname, join } from 'path';
 import { gt, lte } from 'semver';
 import * as stripJsonComments from 'strip-json-comments';
@@ -367,7 +367,7 @@ export function parseMigrationsOptions(
   args: string[]
 ): GenerateMigrations | RunMigrations {
   const options = convertToCamelCase(
-    minimist(args, {
+    yargsParser(args, {
       string: ['runMigrations', 'from', 'to'],
       alias: {
         runMigrations: 'run-migrations',

--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -1,4 +1,4 @@
-import * as minimist from 'minimist';
+import * as yargsParser from 'yargs-parser';
 import {
   combineOptionsForExecutor,
   convertToCamelCase,
@@ -42,7 +42,7 @@ function parseRunOpts(
   defaultProjectName: string | null
 ): RunOptions {
   const runOptions = convertToCamelCase(
-    minimist(args, {
+    yargsParser(args, {
       boolean: ['help', 'prod'],
       string: ['configuration', 'project'],
       alias: {

--- a/packages/tao/src/shared/params.spec.ts
+++ b/packages/tao/src/shared/params.spec.ts
@@ -1,4 +1,4 @@
-import { ParsedArgs } from 'minimist';
+import * as yargsParser from 'yargs-parser';
 import {
   coerceTypesInOptions,
   convertAliases,
@@ -137,33 +137,39 @@ describe('params', () => {
   describe('convertToCamelCase', () => {
     it('should convert dash case to camel case', () => {
       expect(
-        convertToCamelCase({
-          _: undefined,
-          'one-two': 1,
-        } as ParsedArgs)
+        convertToCamelCase(
+          yargsParser(['--one-two', '1'], {
+            number: ['oneTwo'],
+          })
+        )
       ).toEqual({
+        _: [],
         oneTwo: 1,
       });
     });
 
     it('should not convert camel case', () => {
       expect(
-        convertToCamelCase({
-          _: undefined,
-          oneTwo: 1,
-        })
+        convertToCamelCase(
+          yargsParser(['--oneTwo', '1'], {
+            number: ['oneTwo'],
+          })
+        )
       ).toEqual({
+        _: [],
         oneTwo: 1,
       });
     });
 
     it('should handle mixed case', () => {
       expect(
-        convertToCamelCase({
-          _: undefined,
-          'one-Two': 1,
-        })
+        convertToCamelCase(
+          yargsParser(['--one-Two', '1'], {
+            number: ['oneTwo'],
+          })
+        )
       ).toEqual({
+        _: [],
         oneTwo: 1,
       });
     });

--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -1,4 +1,4 @@
-import { ParsedArgs } from 'minimist';
+import type { Arguments } from 'yargs-parser';
 import { TargetConfiguration, WorkspaceJsonConfiguration } from './workspace';
 import { logger } from './logger';
 
@@ -67,7 +67,7 @@ function camelCase(input: string): string {
   }
 }
 
-export function convertToCamelCase(parsed: ParsedArgs): Options {
+export function convertToCamelCase(parsed: Arguments): Options {
   return Object.keys(parsed).reduce(
     (m, c) => ({ ...m, [camelCase(c)]: parsed[c] }),
     {}

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -15,6 +15,9 @@ const noop = (yargs: yargs.Argv): yargs.Argv => yargs;
  * be executed correctly.
  */
 export const commandsObject = yargs
+  .parserConfiguration({
+    'strip-dashed': true,
+  })
   .usage('Powerful, Extensible Dev Tools')
   .command(
     'run [project][:target][:configuration] [options, ...]',


### PR DESCRIPTION
…imist

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`minimist` is used for `tao` whereas `yargs` is used for most other parts of Nx

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`yargs` is used for `tao` and parsing args is consistent

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/5477
