### PR TITLE
feat(nextjs): allow custom server to be written in TypeScript

### DIFF
--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -415,7 +415,7 @@ export function createFile(f: string, content: string = ''): void {
   const path = tmpProjPath(f);
   createFileSync(path);
   if (content) {
-    updateFile(path, content);
+    updateFile(f, content);
   }
 }
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -43,6 +43,8 @@
     "chalk": "4.1.0",
     "copy-webpack-plugin": "6.0.3",
     "fs-extra": "^9.1.0",
-    "url-loader": "^3.0.0"
+    "url-loader": "^3.0.0",
+    "tsconfig-paths": "^3.9.0",
+    "ts-node": "~9.1.1"
   }
 }

--- a/packages/next/src/executors/server/lib/custom-server.ts
+++ b/packages/next/src/executors/server/lib/custom-server.ts
@@ -1,16 +1,23 @@
+import { joinPathFragments } from '@nrwl/devkit';
 import NextServer from 'next/dist/server/next-dev-server';
-import * as path from 'path';
 import { NextServerOptions, ProxyConfig } from '../../../utils/types';
+import { tsNodeRegister } from './tsnode-register';
 
 export function customServer(
   settings: NextServerOptions,
   proxyConfig?: ProxyConfig
-) {
+): Promise<void> {
   const nextApp = new NextServer(settings);
 
-  return require(path.resolve(settings.dir, settings.path))(
-    nextApp,
-    settings,
-    proxyConfig
+  tsNodeRegister(
+    joinPathFragments(settings.dir, settings.path),
+    joinPathFragments(settings.dir, 'tsconfig.json')
   );
+
+  const customServerModule = require(joinPathFragments(
+    settings.dir,
+    settings.path
+  ));
+  const customServer = customServerModule.default || customServerModule;
+  return customServer(nextApp, settings, proxyConfig);
 }

--- a/packages/next/src/executors/server/lib/tsnode-register.ts
+++ b/packages/next/src/executors/server/lib/tsnode-register.ts
@@ -1,0 +1,21 @@
+export function tsNodeRegister(file: string = '', tsConfig?: string) {
+  if (file && file.endsWith('.ts')) {
+    // Register TS compiler lazily
+    require('ts-node').register({
+      project: tsConfig,
+      compilerOptions: {
+        module: 'CommonJS',
+        types: ['node'],
+      },
+    });
+
+    // Register paths in tsConfig
+    const tsconfigPaths = require('tsconfig-paths');
+    const { absoluteBaseUrl: baseUrl, paths } = tsconfigPaths.loadConfig(
+      tsConfig
+    );
+    if (baseUrl && paths) {
+      tsconfigPaths.register({ baseUrl, paths });
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

It is possible to provide a custom Next.js server, but only written in JS

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR allows for both, writing the custom server in JS & TS

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

This has previously been discussed here #2227 
