### PR TITLE
fix(linter): safely check if angular-eslint is the right version

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -53,7 +53,7 @@
     "nest": {
       "implicitDependencies": ["node", "linter"]
     },
-    "linter": {},
+    "linter": { "implicitDependencies": ["eslint-plugin-nx"] },
     "express": {
       "implicitDependencies": ["node"]
     },

--- a/packages/eslint-plugin-nx/src/configs/angular.ts
+++ b/packages/eslint-plugin-nx/src/configs/angular.ts
@@ -1,4 +1,9 @@
-import angularEslintPlugin from '@angular-eslint/eslint-plugin';
+import type AngularEslintPlugin from '@angular-eslint/eslint-plugin';
+
+let angularEslintPlugin: typeof AngularEslintPlugin;
+try {
+  angularEslintPlugin = require('@angular-eslint/eslint-plugin');
+} catch {}
 
 /**
  * This configuration is intended to be applied to ALL .ts files in Angular


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If angular-eslint is not installed, the check causes linting to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Linting passes even without angular-eslint installed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
