### PR TITLE
fix(angular): allow setting appsDir and libsDir to workspace root

### DIFF
--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -451,16 +451,12 @@ export function readNxJsonInTree(host: Tree) {
 
 export function libsDir(host: Tree) {
   const json = readJsonInTree<NxJson>(host, 'nx.json');
-  return json && json.workspaceLayout && json.workspaceLayout.libsDir
-    ? json.workspaceLayout.libsDir
-    : 'libs';
+  return json?.workspaceLayout?.libsDir ?? 'libs';
 }
 
 export function appsDir(host: Tree) {
   const json = readJsonInTree<NxJson>(host, 'nx.json');
-  return json && json.workspaceLayout && json.workspaceLayout.appsDir
-    ? json.workspaceLayout.appsDir
-    : 'apps';
+  return json?.workspaceLayout?.appsDir ?? 'apps';
 }
 
 export function updateNxJsonInTree(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When creating an Angular app with `appsDir` set to the workspace root, the app is created inside the `apps` directory by default. Likewise, when creating an Angular lib with `libsDir` set to the workspace root, the lib is created inside the `libs` directory by default.

## Expected Behavior
The apps and libs are created correctly in the workspace root when `appsDir` and `libsDir` are set to the workspace root.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5415 