### PR TITLE
fix(core): cleanup output of task results

### DIFF
--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -270,7 +270,7 @@ describe('run-many', () => {
     expect(failedTests).toContain(`Running target test for 2 project(s):`);
     expect(failedTests).toContain(`- ${myapp}`);
     expect(failedTests).toContain(`- ${myapp2}`);
-    expect(failedTests).toContain(`Failed projects:`);
+    expect(failedTests).toContain(`Failed tasks:`);
     expect(readJson('node_modules/.cache/nx/results.json')).toEqual({
       command: 'test',
       results: {
@@ -428,7 +428,7 @@ describe('affected:*', () => {
     expect(failedTests).toContain(`- ${mylib}`);
     expect(failedTests).toContain(`- ${myapp}`);
     expect(failedTests).toContain(`- ${mypublishablelib}`);
-    expect(failedTests).toContain(`Failed projects:`);
+    expect(failedTests).toContain(`Failed tasks:`);
     expect(failedTests).toContain(
       'You can isolate the above projects by passing: --only-failed'
     );

--- a/packages/workspace/src/tasks-runner/default-reporter.ts
+++ b/packages/workspace/src/tasks-runner/default-reporter.ts
@@ -54,16 +54,16 @@ export class DefaultReporter implements Reporter {
 
   printResults(
     args: ReporterArgs,
-    failedProjectNames: string[],
     startedWithFailedProjects: boolean,
     tasks: Task[],
     failedTasks: Task[],
+    tasksWithFailedDependencies: Task[],
     cachedTasks: Task[]
   ) {
     output.addNewline();
     output.addVerticalSeparatorWithoutNewLines();
 
-    if (failedProjectNames.length === 0) {
+    if (failedTasks.length === 0) {
       const bodyLines =
         cachedTasks.length > 0
           ? [
@@ -92,10 +92,10 @@ export class DefaultReporter implements Reporter {
       }
     } else {
       const bodyLines = [
-        output.colors.gray('Failed projects:'),
+        output.colors.gray('Tasks not run because earlier stages failed:'),
         '',
-        ...failedProjectNames.map(
-          (project) => `${output.colors.gray('-')} ${project}`
+        ...tasksWithFailedDependencies.map(
+          (task) => `${output.colors.gray('-')} ${task.id}`
         ),
         '',
         output.colors.gray('Failed tasks:'),

--- a/packages/workspace/src/tasks-runner/default-tasks-runner.ts
+++ b/packages/workspace/src/tasks-runner/default-tasks-runner.ts
@@ -129,7 +129,7 @@ async function runAllTasks(
 
     // any task failed, we need to skip further stages
     if (statuses.find((s) => !s.success)) {
-      res.push(...markStagesAsNotSuccessful(stages.splice(i + 1)));
+      res.push(...markStagesWithFailingPrequisite(stages.splice(i + 1)));
       return res;
     }
   }
@@ -137,15 +137,17 @@ async function runAllTasks(
   return res;
 }
 
-function markStagesAsNotSuccessful(stages: Task[][]) {
-  return stages.reduce((m, c) => [...m, ...tasksToStatuses(c, false)], []);
+function markStagesWithFailingPrequisite(stages: Task[][]) {
+  return stages.reduce(
+    (m, c) => [...m, ...createTaskWithFailingprerequisite(c)],
+    []
+  );
 }
 
-function tasksToStatuses(tasks: Task[], success: boolean) {
+function createTaskWithFailingprerequisite(tasks: Task[]) {
   return tasks.map((task) => ({
     task,
-    type: AffectedEventType.TaskComplete,
-    success,
+    type: AffectedEventType.TaskDependencyFailed,
   }));
 }
 

--- a/packages/workspace/src/tasks-runner/empty-reporter.ts
+++ b/packages/workspace/src/tasks-runner/empty-reporter.ts
@@ -11,10 +11,10 @@ export class EmptyReporter implements Reporter {
 
   printResults(
     args: ReporterArgs,
-    failedProjectNames: string[],
     startedWithFailedProjects: boolean,
     tasks: Task[],
     failedTasks: Task[],
+    tasksWithFailedDependencies: Task[],
     cachedTasks: Task[]
   ) {}
 }

--- a/packages/workspace/src/tasks-runner/reporter.ts
+++ b/packages/workspace/src/tasks-runner/reporter.ts
@@ -16,10 +16,10 @@ export abstract class Reporter {
 
   abstract printResults(
     nxArgs: ReporterArgs,
-    failedProjects: string[],
     startedWithFailedProjects: boolean,
     tasks: Task[],
     failedTasks: Task[],
+    tasksWithFailedDependencies: Task[],
     cachedTasks: Task[]
   ): void;
 }

--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -60,6 +60,7 @@ export async function runCommand<T extends RunArgs>(
   }
   const cachedTasks: Task[] = [];
   const failedTasks: Task[] = [];
+  const tasksWithFailedDependencies: Task[] = [];
   tasksRunner(tasks, runnerOptions, {
     initiatingProject,
     target: nxArgs.target,
@@ -84,6 +85,10 @@ export async function runCommand<T extends RunArgs>(
           if (!event.success) {
             failedTasks.push(event.task);
           }
+          break;
+        }
+        case AffectedEventType.TaskDependencyFailed: {
+          tasksWithFailedDependencies.push(event.task);
           break;
         }
         case AffectedEventType.TaskCacheRead: {
@@ -114,10 +119,10 @@ export async function runCommand<T extends RunArgs>(
       workspaceResults.saveResults();
       reporter.printResults(
         nxArgs,
-        workspaceResults.failedProjects,
         workspaceResults.startedWithFailedProjects,
         tasks,
         failedTasks,
+        tasksWithFailedDependencies,
         cachedTasks
       );
 

--- a/packages/workspace/src/tasks-runner/run-one-reporter.ts
+++ b/packages/workspace/src/tasks-runner/run-one-reporter.ts
@@ -35,10 +35,10 @@ export class RunOneReporter implements Reporter {
 
   printResults(
     args: ReporterArgs,
-    failedProjectNames: string[],
     startedWithFailedProjects: boolean,
     tasks: Task[],
     failedTasks: Task[],
+    tasksWithFailedDependencies: Task[],
     cachedTasks: Task[]
   ) {
     // Silent for a single task
@@ -48,7 +48,7 @@ export class RunOneReporter implements Reporter {
     output.addNewline();
     output.addVerticalSeparatorWithoutNewLines();
 
-    if (failedProjectNames.length === 0) {
+    if (failedTasks.length === 0) {
       const bodyLines =
         cachedTasks.length > 0
           ? [
@@ -82,7 +82,7 @@ export class RunOneReporter implements Reporter {
         ...failedTasks.map((task) => `${output.colors.gray('-')} ${task.id}`),
       ];
       output.error({
-        title: `Running target "${args.target}" failed`,
+        title: `Running target "${this.initiatingProject}:${args.target}" failed`,
         bodyLines,
       });
     }

--- a/packages/workspace/src/tasks-runner/tasks-runner.ts
+++ b/packages/workspace/src/tasks-runner/tasks-runner.ts
@@ -20,6 +20,7 @@ export interface Task {
 export enum AffectedEventType {
   TaskComplete = '[Task] Complete',
   TaskCacheRead = '[Task] CacheRead',
+  TaskDependencyFailed = '[Task] DependencyFailed',
 }
 
 export interface AffectedEvent {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

<details>
<summary>Output</summary>
>  NX   ERROR  Running target "build" failed

  Failed projects:
  
  - workspace
  - create-nx-workspace
  - eslint-plugin-nx
  - nx-plugin
  - linter
  - jest
  - cli
  - create-nx-plugin
  - cypress
  - node
  - nx
  - storybook
  - express
  - nest
  - web
  - angular
  - react
  - gatsby
  - next
  - nx-dev
  
  Failed tasks:
  
  - workspace:build-base
  - create-nx-workspace:build-base
  - eslint-plugin-nx:build-base
  - nx-plugin:build-base
  - workspace:build
  - linter:build-base
  - jest:build-base
  - cli:build-base
  - create-nx-workspace:build
  - eslint-plugin-nx:build
  - create-nx-plugin:build-base
  - cypress:build-base
  - nx-plugin:build
  - node:build-base
  - linter:build
  - jest:build
  - cli:build
  - nx:build-base
  - create-nx-plugin:build
  - storybook:build-base
  - cypress:build
  - express:build-base
  - web:build-base
  - node:build
  - nest:build-base
  - nx:build
  - storybook:build
  - express:build
  - angular:build-base
  - react:build-base
  - nest:build
  - web:build
  - angular:build
  - gatsby:build-base
  - react:build
  - next:build-base
  - gatsby:build
  - next:build
  - nx-dev:build
  
  You can isolate the above projects by passing: --only-failed


>  NX   CLOUD  See run details at https://nx.app/runs/WSd4WssSsAF
</details>

Printing out failed projects is redundant information.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Failed tasks is only tasks that _ran and failed_

The tasks that did not read because a previous stage failed are printed separately.

This helps people find the root cause of the failure more easily.

<details>
<summary>Output</summary>
>  NX   ERROR  Running target "build" failed

  Tasks not run because earlier stages failed:
  
  - create-nx-workspace:build-base
  - eslint-plugin-nx:build-base
  - nx-plugin:build-base
  - workspace:build
  - linter:build-base
  - jest:build-base
  - cli:build-base
  - create-nx-workspace:build
  - eslint-plugin-nx:build
  - create-nx-plugin:build-base
  - cypress:build-base
  - nx-plugin:build
  - node:build-base
  - linter:build
  - jest:build
  - cli:build
  - nx:build-base
  - create-nx-plugin:build
  - storybook:build-base
  - cypress:build
  - express:build-base
  - web:build-base
  - node:build
  - nest:build-base
  - nx:build
  - storybook:build
  - express:build
  - angular:build-base
  - react:build-base
  - nest:build
  - web:build
  - angular:build
  - gatsby:build-base
  - react:build
  - next:build-base
  - gatsby:build
  - next:build
  - nx-dev:build
  
  Failed tasks:
  
  - workspace:build-base
  
  You can isolate the above projects by passing: --only-failed


>  NX   CLOUD  See run details at https://nx.app/runs/n0D3SD9MKIK
</details>

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
