### PR TITLE
fix(web): set envName to production when script optimization is enabled

### DIFF
--- a/packages/web/src/utils/config.spec.ts
+++ b/packages/web/src/utils/config.spec.ts
@@ -442,16 +442,18 @@ describe('getBaseWebpackPartial', () => {
       });
     });
 
-    it('should support envName overrides', () => {
+    it('should set envName to production when script optimization is enabled', () => {
+      const esm = true;
+      const isScriptOptimizeOn = true;
+      const emitDecoratorMetadata = true;
       const result = getBaseWebpackPartial(
         {
           ...input,
           progress: true,
         },
-        true,
-        true,
-        true,
-        'production'
+        esm,
+        isScriptOptimizeOn,
+        emitDecoratorMetadata
       );
 
       const rule = result.module.rules.find(
@@ -461,6 +463,32 @@ describe('getBaseWebpackPartial', () => {
         rootMode: 'upward',
         cwd: '/root/root/src',
         envName: 'production',
+        babelrc: true,
+      });
+    });
+
+    it('should override envName when script optimization is disabled', () => {
+      const esm = true;
+      const isScriptOptimizeOn = false;
+      const emitDecoratorMetadata = true;
+      const result = getBaseWebpackPartial(
+        {
+          ...input,
+          progress: true,
+        },
+        esm,
+        isScriptOptimizeOn,
+        emitDecoratorMetadata,
+        'staging'
+      );
+
+      const rule = result.module.rules.find(
+        (r) => typeof r.loader === 'string' && r.loader.match(/babel-loader/)
+      );
+      expect(rule.options).toMatchObject({
+        rootMode: 'upward',
+        cwd: '/root/root/src',
+        envName: 'staging',
         babelrc: true,
       });
     });

--- a/packages/web/src/utils/config.ts
+++ b/packages/web/src/utils/config.ts
@@ -57,7 +57,7 @@ export function getBaseWebpackPartial(
             cwd: join(options.root, options.sourceRoot),
             emitDecoratorMetadata,
             isModern: esm,
-            envName: configuration,
+            envName: isScriptOptimizeOn ? 'production' : configuration,
             babelrc: true,
             cacheDirectory: true,
             cacheCompression: false,


### PR DESCRIPTION
ISSUES CLOSED: #5512

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx uses `react-jsxdev` even if script optimization is enabled.

![image](https://user-images.githubusercontent.com/2607019/116726360-1f8ce400-aa1e-11eb-839f-5047fb661d24.png)

This problem happens when `--configuration` is not `production`, for example `--configuration=staging`, because the executor overrides `envName` (`process.env.BABEL_ENV` / `process.env.NODE_ENV`) to the provided configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx should use `react-jsx` when script optimization is enabled.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://nrwlcommunity.slack.com/archives/CMFKWPU6Q/p1620350688313400
#3385 #3693 
Fixes #5323
Fixes #5512
Fixes #5626