### PR TITLE
docs(devkit): fix incorrect reference

### DIFF
--- a/docs/shared/devkit.md
+++ b/docs/shared/devkit.md
@@ -314,7 +314,7 @@ An executor consists of the following:
 
 ### Schema
 
-A generator's schema describes the inputs--what you can pass into it. The schema is used to validate inputs, to parse args (e.g., covert strings into numbers), to set defaults, and to power the VSCode plugin. It is written with [JSON Schema](https://json-schema.org/).
+An executor's schema describes the inputs--what you can pass into it. The schema is used to validate inputs, to parse args (e.g., covert strings into numbers), to set defaults, and to power the VSCode plugin. It is written with [JSON Schema](https://json-schema.org/).
 
 ```json
 {


### PR DESCRIPTION
The section is about executors but was referring to generators
