### PR TITLE
feat(react): update generator defaults in workspace.json for strict mode

### DIFF
--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -713,5 +713,28 @@ describe('app', () => {
         },
       ]);
     });
+
+    it('should default strict to true in workspace.json', async () => {
+      await applicationGenerator(appTree, {
+        ...schema,
+        strict: true,
+      });
+      const workspaceJson = readWorkspaceConfiguration(appTree);
+
+      expect(workspaceJson.generators['@nrwl/react']).toMatchObject({
+        application: {
+          babel: true,
+          style: schema.style,
+          strict: true,
+        },
+        component: {
+          style: schema.style,
+        },
+        library: {
+          style: schema.style,
+          strict: true,
+        },
+      });
+    });
   });
 });

--- a/packages/react/src/generators/application/lib/set-defaults.ts
+++ b/packages/react/src/generators/application/lib/set-defaults.ts
@@ -29,6 +29,7 @@ export function setDefaults(host: Tree, options: NormalizedSchema) {
       application: {
         style: options.style,
         linter: options.linter,
+        strict: options.strict,
         ...prev.application,
       },
       component: {
@@ -38,6 +39,7 @@ export function setDefaults(host: Tree, options: NormalizedSchema) {
       library: {
         style: options.style,
         linter: options.linter,
+        strict: options.strict,
         ...prev.library,
       },
     },


### PR DESCRIPTION
ISSUES CLOSED: #5250

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Users need to add `--strict` every time even after generating a React application with strict mode.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Strict option for React generators should default to `true` after running `nx generate nrwl/react:application --strict`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes #5250
