### PR TITLE
cleanup(core): cleanup of the hasher

### DIFF
--- a/packages/workspace/src/core/hasher/file-hasher.ts
+++ b/packages/workspace/src/core/hasher/file-hasher.ts
@@ -1,39 +1,25 @@
 import { getFileHashes } from './git-hasher';
 import { readFileSync } from 'fs';
-import { defaultHashing, HashingImp } from './hashing-impl';
+import { defaultHashing, HashingImpl } from './hashing-impl';
 import { appRootPath } from '../../utilities/app-root';
 import { performance } from 'perf_hooks';
 
-type PathAndTransformer = {
-  path: string;
-  transformer: (x: string) => string | null;
-};
-
-export function extractNameAndVersion(content: string): string {
-  try {
-    const c = JSON.parse(content);
-    return `${c.name}${c.version}`;
-  } catch (e) {
-    return '';
-  }
-}
-
 export class FileHasher {
   fileHashes: { [path: string]: string } = {};
-  workspaceFiles = [];
+  workspaceFiles: string[] = [];
   usesGitForHashing = false;
 
-  constructor(private readonly hashing: HashingImp) {
+  constructor(private readonly hashing: HashingImpl) {
     this.init();
   }
 
-  clear() {
+  clear(): void {
     this.fileHashes = {};
     this.workspaceFiles = [];
     this.usesGitForHashing = false;
   }
 
-  init() {
+  init(): void {
     performance.mark('init hashing:start');
     this.clear();
     this.getHashesFromGit();
@@ -46,17 +32,17 @@ export class FileHasher {
     );
   }
 
-  hashFile(path: string, transformer: (x: string) => string | null = null) {
+  hashFile(path: string, transformer?: (content: string) => string): string {
     const relativePath = path.startsWith(appRootPath)
       ? path.substr(appRootPath.length + 1)
       : path;
     if (!this.fileHashes[relativePath]) {
-      this.fileHashes[relativePath] = this.processPath({ path, transformer });
+      this.fileHashes[relativePath] = this.processPath(path, transformer);
     }
     return this.fileHashes[relativePath];
   }
 
-  private getHashesFromGit() {
+  private getHashesFromGit(): void {
     const sliceIndex = appRootPath.length + 1;
     getFileHashes(appRootPath).forEach((hash, filename) => {
       this.fileHashes[filename.substr(sliceIndex)] = hash;
@@ -68,17 +54,18 @@ export class FileHasher {
     });
   }
 
-  private processPath(pathAndTransformer: PathAndTransformer): string {
+  private processPath(
+    path: string,
+    transformer?: (content: string) => string
+  ): string {
     try {
-      if (pathAndTransformer.transformer) {
-        const transformedFile = pathAndTransformer.transformer(
-          readFileSync(pathAndTransformer.path).toString()
-        );
+      if (transformer) {
+        const transformedFile = transformer(readFileSync(path, 'utf-8'));
         return this.hashing.hashArray([transformedFile]);
       } else {
-        return this.hashing.hashFile(pathAndTransformer.path);
+        return this.hashing.hashFile(path);
       }
-    } catch (e) {
+    } catch {
       return '';
     }
   }

--- a/packages/workspace/src/core/hasher/git-hasher.spec.ts
+++ b/packages/workspace/src/core/hasher/git-hasher.spec.ts
@@ -4,7 +4,7 @@ import { execSync } from 'child_process';
 import { getFileHashes } from './git-hasher';
 
 describe('git-hasher', () => {
-  let dir;
+  let dir: string;
   const warnSpy = jest.spyOn(console, 'warn');
 
   beforeEach(() => {

--- a/packages/workspace/src/core/hasher/git-hasher.ts
+++ b/packages/workspace/src/core/hasher/git-hasher.ts
@@ -79,7 +79,7 @@ function getGitHashForFiles(
         `Passed ${filesToHash.length} file paths to Git to hash, but received ${hashes.length} hashes.`
       );
     }
-    for (let i: number = 0; i < hashes.length; i++) {
+    for (let i = 0; i < hashes.length; i++) {
       const hash: string = hashes[i];
       const filePath: string = filesToHash[i];
       changes.set(filePath, hash);
@@ -130,7 +130,7 @@ function checkForDeletedFiles(
     try {
       statSync(join(path, f)).isFile();
       filesToHash.push(f);
-    } catch (err) {
+    } catch {
       console.warn(
         `Warning: Fell back to using 'fs' to identify ${f} as deleted. Please open an issue at https://github.com/nrwl/nx so we can investigate.`
       );

--- a/packages/workspace/src/core/hasher/hasher.spec.ts
+++ b/packages/workspace/src/core/hasher/hasher.spec.ts
@@ -1,7 +1,6 @@
 import { Hasher } from './hasher';
-import { extractNameAndVersion } from '@nrwl/workspace/src/core/hasher/file-hasher';
+import fs = require('fs');
 
-const fs = require('fs');
 jest.mock('fs');
 
 describe('Hasher', () => {
@@ -312,18 +311,5 @@ describe('Hasher', () => {
 
     expect(tasksHash.value).toContain('global1.hash');
     expect(tasksHash.value).toContain('global2.hash');
-  });
-
-  describe('extractNameAndVersion', () => {
-    it('should work', () => {
-      const nameAndVersion = extractNameAndVersion(`
-      {
-        "name": "myname",
-        "somethingElse": "123",
-        "version": "1.1.1"
-      }
-    `);
-      expect(nameAndVersion).toEqual(`myname1.1.1`);
-    });
   });
 });

--- a/packages/workspace/src/core/hasher/hashing-impl.ts
+++ b/packages/workspace/src/core/hasher/hashing-impl.ts
@@ -1,23 +1,21 @@
-import * as crypto from 'crypto';
+import { createHash } from 'crypto';
 import { readFileSync } from 'fs';
 
-export class HashingImp {
+export class HashingImpl {
   hashArray(input: string[]): string {
-    const hasher = crypto.createHash('sha256');
+    const hasher = createHash('sha256');
     for (const part of input) {
       hasher.update(part);
     }
-    const hash = hasher.digest().buffer;
-    return Buffer.from(hash).toString('hex');
+    return hasher.digest('hex');
   }
 
   hashFile(path: string): string {
-    const hasher = crypto.createHash('sha256');
+    const hasher = createHash('sha256');
     const file = readFileSync(path);
     hasher.update(file);
-    const hash = hasher.digest().buffer;
-    return Buffer.from(hash).toString('hex');
+    return hasher.digest('hex');
   }
 }
 
-export const defaultHashing = new HashingImp();
+export const defaultHashing = new HashingImpl();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- `hasher-impl.ts` contains some weird logic to get the hex string of the hash
- I think there was a Typo because the `HasherImp` misses the `l` whereas the filename `hasher-impl.ts` contains it
- Some Types & Imports can be cleaned up

## What has been done?
- cleaned up the weird hex string logic in `hasher-impl.ts` see https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding
- fixed the typo in `hasher-impl.ts`
- Removed unused `extractNameAndVersion` Method from `file-hasher.ts` and its testcase
- Cleaned Up Types & Imports 
