### PR TITLE
fix(react): fix externals for buildable libraries

### DIFF
--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -425,7 +425,7 @@ describe('lib', () => {
         executor: '@nrwl/web:package',
         outputs: ['{options.outputPath}'],
         options: {
-          external: ['react', 'react-dom'],
+          external: ['react/jsx-runtime'],
           entryFile: 'libs/my-lib/src/index.ts',
           outputPath: 'dist/libs/my-lib',
           project: 'libs/my-lib/package.json',
@@ -460,12 +460,16 @@ describe('lib', () => {
       });
 
       const workspaceJson = readJson(appTree, '/workspace.json');
+      const babelrc = readJson(appTree, 'libs/my-lib/.babelrc');
 
       expect(workspaceJson.projects['my-lib'].architect.build).toMatchObject({
         options: {
-          external: ['react', 'react-dom', 'react-is', 'styled-components'],
+          external: ['react/jsx-runtime'],
         },
       });
+      expect(babelrc.plugins).toEqual([
+        ['styled-components', { pure: true, ssr: true }],
+      ]);
     });
 
     it('should support @emotion/styled', async () => {
@@ -477,12 +481,14 @@ describe('lib', () => {
       });
 
       const workspaceJson = readJson(appTree, '/workspace.json');
+      const babelrc = readJson(appTree, 'libs/my-lib/.babelrc');
 
       expect(workspaceJson.projects['my-lib'].architect.build).toMatchObject({
         options: {
-          external: ['react', 'react-dom', '@emotion/styled', '@emotion/react'],
+          external: ['react/jsx-runtime', '@emotion/styled/base'],
         },
       });
+      expect(babelrc.plugins).toEqual(['@emotion/babel-plugin']);
     });
 
     it('should support styled-jsx', async () => {
@@ -498,10 +504,10 @@ describe('lib', () => {
 
       expect(workspaceJson.projects['my-lib'].architect.build).toMatchObject({
         options: {
-          external: ['react', 'react-dom', 'styled-jsx'],
+          external: ['react/jsx-runtime'],
         },
       });
-      expect(babelrc.plugins).toContain('styled-jsx/babel');
+      expect(babelrc.plugins).toEqual(['styled-jsx/babel']);
     });
 
     it('should support style none', async () => {
@@ -516,7 +522,7 @@ describe('lib', () => {
 
       expect(workspaceJson.projects['my-lib'].architect.build).toMatchObject({
         options: {
-          external: ['react', 'react-dom'],
+          external: ['react/jsx-runtime'],
         },
       });
     });

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -172,20 +172,12 @@ function addProject(host: Tree, options: NormalizedSchema) {
 
   if (options.publishable || options.buildable) {
     const { libsDir } = getWorkspaceLayout(host);
+    const external = ['react/jsx-runtime'];
 
-    const external = ['react', 'react-dom'];
-    // Also exclude CSS-in-JS packages from build
-    if (
-      options.style !== 'css' &&
-      options.style !== 'scss' &&
-      options.style !== 'styl' &&
-      options.style !== 'less' &&
-      options.style !== 'none'
-    ) {
-      external.push(
-        ...Object.keys(CSS_IN_JS_DEPENDENCIES[options.style].dependencies)
-      );
+    if (options.style === '@emotion/styled') {
+      external.push('@emotion/styled/base');
     }
+
     targets.build = {
       builder: '@nrwl/web:package',
       outputs: ['{options.outputPath}'],


### PR DESCRIPTION
ISSUES CLOSED: #5508

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
React library generator adds wrong `external` configurations in `workspace.json`.

> The default build output for a buildable React library generated with @nrwl/react:library using --style=@emotion/styled contains unexpected code from React and Emotion resulting in a large bundle (~70KB).

<!--![image](https://user-images.githubusercontent.com/2607019/116908001-59a7f100-ac7d-11eb-8696-cb5ed6a9c11e.png)-->

I found following dependencies are not need to add to `external` because they are already added (in most cases) to `dependencies` in `package.json` which Nx uses by default. 

- `react`
- `react-dom`
- `react-is`
- `styled-components`
- `@emotion/react`
- `styled-jsx`

https://github.com/nrwl/nx/blob/master/packages/web/src/builders/package/package.impl.ts#L255-L258

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

React library generator should add correct and necessary `external` configurations in `workspace.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
#5689
Fixes #5508
