### PR TITLE
fix(react): fix application template for strict mode

### DIFF
--- a/docs/angular/api-react/generators/application.md
+++ b/docs/angular/api-react/generators/application.md
@@ -144,7 +144,7 @@ Skip updating workspace.json with default options based on values provided to th
 
 ### strict
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/node/api-react/generators/application.md
+++ b/docs/node/api-react/generators/application.md
@@ -144,7 +144,7 @@ Skip updating workspace.json with default options based on values provided to th
 
 ### strict
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/react/api-react/generators/application.md
+++ b/docs/react/api-react/generators/application.md
@@ -144,7 +144,7 @@ Skip updating workspace.json with default options based on values provided to th
 
 ### strict
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/packages/react/src/generators/application/files/common/src/main.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/common/src/main.tsx__tmpl__
@@ -1,13 +1,7 @@
-import { StrictMode } from 'react';
+<% if (strict) { %>import { StrictMode } from 'react';<% } %>
 import * as ReactDOM from 'react-dom';
-<% if (routing) { %>
-import { BrowserRouter } from 'react-router-dom';
-<% } %>
+<% if (routing) { %>import { BrowserRouter } from 'react-router-dom';<% } %>
 
-import App from './app/app';
+import App from './app/<%= fileName %>';
 
-<% if (routing) { %>
-ReactDOM.render(<StrictMode><BrowserRouter><App /></BrowserRouter></StrictMode>, document.getElementById('root'));
-<% } else { %>
-ReactDOM.render(<StrictMode><App /></StrictMode>, document.getElementById('root'));
-<% } %>
+ReactDOM.render(<% if (strict) { %><StrictMode><% } %><% if (routing) { %><BrowserRouter><% } %><App /><% if (routing) { %></BrowserRouter><% } %><% if (strict) { %></StrictMode><% } %>, document.getElementById('root'));

--- a/packages/react/src/generators/application/lib/normalize-options.ts
+++ b/packages/react/src/generators/application/lib/normalize-options.ts
@@ -29,6 +29,7 @@ export function normalizeOptions(
   assertValidStyle(options.style);
 
   options.routing = options.routing ?? false;
+  options.strict = options.strict ?? true;
   options.classComponent = options.classComponent ?? false;
   options.unitTestRunner = options.unitTestRunner ?? 'jest';
   options.e2eTestRunner = options.e2eTestRunner ?? 'cypress';

--- a/packages/react/src/generators/application/schema.json
+++ b/packages/react/src/generators/application/schema.json
@@ -139,7 +139,7 @@
     "strict": {
       "type": "boolean",
       "description": "Creates an application with stricter type checking and build optimization options.",
-      "default": false
+      "default": true
     }
   },
   "required": []


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`<StrictMode>` is used whichever strict or not.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`<StrictMode>` is used when `--strict` option is `true`.

#### `nx g @nrwl/react:application`
```tsx
import * as ReactDOM from 'react-dom';

import App from './app/app';

ReactDOM.render(<App />, document.getElementById('root'));
```

#### `nx g @nrwl/react:application --routing`
```tsx
import * as ReactDOM from 'react-dom';
import { BrowserRouter } from 'react-router-dom';

import App from './app/app';

ReactDOM.render(
  <BrowserRouter>
    <App />
  </BrowserRouter>,
  document.getElementById('root')
);
```

#### `nx g @nrwl/react:application --strict`
```tsx
import { StrictMode } from 'react';
import * as ReactDOM from 'react-dom';

import App from './app/app';

ReactDOM.render(
  <StrictMode>
    <App />
  </StrictMode>,
  document.getElementById('root')
);
```

#### `nx g @nrwl/react:application --strict --routing`
```tsx
import { StrictMode } from 'react';
import * as ReactDOM from 'react-dom';
import { BrowserRouter } from 'react-router-dom';

import App from './app/app';

ReactDOM.render(
  <StrictMode>
    <BrowserRouter>
      <App />
    </BrowserRouter>
  </StrictMode>,
  document.getElementById('root')
);
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#5529
