### PR TITLE
fix(linter): disable absolute paths within project

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -34,6 +34,7 @@ type Options = [
     allow: string[];
     depConstraints: DepConstraint[];
     enforceBuildableLibDependency: boolean;
+    allowCircularSelfDependency: boolean;
   }
 ];
 export type MessageIds =
@@ -96,9 +97,20 @@ export default createESLintRule<Options, MessageIds>({
       allow: [],
       depConstraints: [],
       enforceBuildableLibDependency: false,
+      allowCircularSelfDependency: false,
     },
   ],
-  create(context, [{ allow, depConstraints, enforceBuildableLibDependency }]) {
+  create(
+    context,
+    [
+      {
+        allow,
+        depConstraints,
+        enforceBuildableLibDependency,
+        allowCircularSelfDependency,
+      },
+    ]
+  ) {
     /**
      * Globally cached info about workspace
      */
@@ -193,7 +205,7 @@ export default createESLintRule<Options, MessageIds>({
       // same project => allow
       if (sourceProject === targetProject) {
         // we only allow relative paths within the same project
-        if (!isRelativePath(imp)) {
+        if (!allowCircularSelfDependency && !isRelativePath(imp)) {
           context.report({
             node,
             messageId: 'noSelfCircularDependencies',

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -81,7 +81,7 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noRelativeOrAbsoluteImportsAcrossLibraries: `Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope`,
       noCircularDependencies: `Circular dependency between "{{sourceProjectName}}" and "{{targetProjectName}}" detected: {{path}}`,
-      noSelfCircularDependencies: `Only relative imports are allowed within the project. Absolute import found {{imp}}`,
+      noSelfCircularDependencies: `Only relative imports are allowed within the project. Absolute import found: {{imp}}`,
       noImportsOfApps: 'Imports of apps are forbidden',
       noImportsOfE2e: 'Imports of e2e projects are forbidden',
       noImportOfNonBuildableLibraries:

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -856,6 +856,67 @@ describe('Enforce Module Boundaries', () => {
     expect(failures[1].message).toEqual(message);
   });
 
+  it('should ignore detected absolute path within project if allowCircularSelfDependency flag is set', () => {
+    const failures = runRule(
+      {
+        allowCircularSelfDependency: true,
+      },
+      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
+      `
+        import '@mycompany/mylib';
+        import('@mycompany/mylib');
+      `,
+      {
+        nodes: {
+          mylibName: {
+            name: 'mylibName',
+            type: ProjectType.lib,
+            data: {
+              root: 'libs/mylib',
+              tags: [],
+              implicitDependencies: [],
+              architect: {},
+              files: [createFile(`libs/mylib/src/main.ts`)],
+            },
+          },
+          anotherlibName: {
+            name: 'anotherlibName',
+            type: ProjectType.lib,
+            data: {
+              root: 'libs/anotherlib',
+              tags: [],
+              implicitDependencies: [],
+              architect: {},
+              files: [createFile(`libs/anotherlib/src/main.ts`)],
+            },
+          },
+          myappName: {
+            name: 'myappName',
+            type: ProjectType.app,
+            data: {
+              root: 'apps/myapp',
+              tags: [],
+              implicitDependencies: [],
+              architect: {},
+              files: [createFile(`apps/myapp/src/index.ts`)],
+            },
+          },
+        },
+        dependencies: {
+          mylibName: [
+            {
+              source: 'mylibName',
+              target: 'anotherlibName',
+              type: DependencyType.static,
+            },
+          ],
+        },
+      }
+    );
+
+    expect(failures.length).toBe(0);
+  });
+
   it('should error when circular dependency detected', () => {
     const failures = runRule(
       {},

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -6,12 +6,11 @@ import {
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import * as parser from '@typescript-eslint/parser';
 import { vol } from 'memfs';
-import { extname, join } from 'path';
+import { extname } from 'path';
 import enforceModuleBoundaries, {
   RULE_NAME as enforceModuleBoundariesRuleName,
 } from '../../src/rules/enforce-module-boundaries';
 import { TargetProjectLocator } from '@nrwl/workspace/src/core/target-project-locator';
-import { readFileSync } from 'fs';
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('../../../workspace/src/utilities/app-root', () => ({
   appRootPath: '/root',
@@ -789,6 +788,69 @@ describe('Enforce Module Boundaries', () => {
     );
 
     const message = 'Imports of e2e projects are forbidden';
+    expect(failures.length).toEqual(2);
+    expect(failures[0].message).toEqual(message);
+    expect(failures[1].message).toEqual(message);
+  });
+
+  it('should error when absolute path within project detected', () => {
+    const failures = runRule(
+      {},
+      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
+      `
+        import '@mycompany/mylib';
+        import('@mycompany/mylib');
+      `,
+      {
+        nodes: {
+          mylibName: {
+            name: 'mylibName',
+            type: ProjectType.lib,
+            data: {
+              root: 'libs/mylib',
+              tags: [],
+              implicitDependencies: [],
+              architect: {},
+              files: [createFile(`libs/mylib/src/main.ts`)],
+            },
+          },
+          anotherlibName: {
+            name: 'anotherlibName',
+            type: ProjectType.lib,
+            data: {
+              root: 'libs/anotherlib',
+              tags: [],
+              implicitDependencies: [],
+              architect: {},
+              files: [createFile(`libs/anotherlib/src/main.ts`)],
+            },
+          },
+          myappName: {
+            name: 'myappName',
+            type: ProjectType.app,
+            data: {
+              root: 'apps/myapp',
+              tags: [],
+              implicitDependencies: [],
+              architect: {},
+              files: [createFile(`apps/myapp/src/index.ts`)],
+            },
+          },
+        },
+        dependencies: {
+          mylibName: [
+            {
+              source: 'mylibName',
+              target: 'anotherlibName',
+              type: DependencyType.static,
+            },
+          ],
+        },
+      }
+    );
+
+    const message =
+      'Only relative imports are allowed within the project. Absolute import found @mycompany/mylib';
     expect(failures.length).toEqual(2);
     expect(failures[0].message).toEqual(message);
     expect(failures[1].message).toEqual(message);

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -850,7 +850,7 @@ describe('Enforce Module Boundaries', () => {
     );
 
     const message =
-      'Only relative imports are allowed within the project. Absolute import found @mycompany/mylib';
+      'Only relative imports are allowed within the project. Absolute import found: @mycompany/mylib';
     expect(failures.length).toEqual(2);
     expect(failures[0].message).toEqual(message);
     expect(failures[1].message).toEqual(message);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If a project imports from itself using the full package name, the lint rule does not detect a circular dependency.
```ts
// In @happy-org/header library
// This should be a circular dependency
import { MyComponent } from '@happy-org/header';
```

## Expected Behavior
The linter should report an error with information why the error happened.
e.g.
```
Only relative imports are allowed within the project. Absolute import found: @happy-org/header
```

## Related Issue(s)
Fixes #2019
