### PR TITLE
fix(repo): fixed documentation map-link-checker

### DIFF
--- a/scripts/documentation/map-link-checker.ts
+++ b/scripts/documentation/map-link-checker.ts
@@ -83,16 +83,12 @@ if (!!mapMissList.length) {
   scriptError = true;
 } else {
   console.log(
-    console.log(
-      `${chalk.green(
-        '🗸'
-      )} The 'map.json' file and the documentation files are in sync.`
-    )
+    `${chalk.green(
+      '🗸'
+    )} The 'map.json' file and the documentation files are in sync.`
   );
 }
 
 if (scriptError) {
   process.exit(1);
-} else {
-  process.exit(0);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Documentation map-link-checker script prints undefined

```
$ ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/map-link-checker.ts
i Documentation Map Check
🗸 Markdown files are in sync with docs/maps.json.
🗸 The 'map.json' file and the documentation files are in sync.
undefined
Done in 2.04s.
```

## Expected Behavior

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
