### PR TITLE
cleanup(core): removed reexport of devkit types in workspace

### DIFF
--- a/dep-graph/dep-graph/src/app/graph.ts
+++ b/dep-graph/dep-graph/src/app/graph.ts
@@ -1,9 +1,9 @@
-import { ProjectGraph, ProjectGraphNode } from '@nrwl/workspace';
+import type { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
 import * as cy from 'cytoscape';
 import cytoscapeDagre from 'cytoscape-dagre';
 import popper from 'cytoscape-popper';
 import { Subject } from 'rxjs';
-import { Instance } from 'tippy.js';
+import type { Instance } from 'tippy.js';
 import { ProjectNodeToolTip } from './project-node-tooltip';
 import { edgeStyles, nodeStyles } from './styles-graph';
 import { GraphTooltipService } from './tooltip-service';
@@ -13,7 +13,7 @@ import {
   ProjectEdge,
   ProjectNode,
 } from './util-cytoscape';
-import { VirtualElement } from '@popperjs/core';
+import type { VirtualElement } from '@popperjs/core';
 
 export interface GraphPerfReport {
   renderTime: number;

--- a/dep-graph/dep-graph/src/app/ui-sidebar/project-list.ts
+++ b/dep-graph/dep-graph/src/app/ui-sidebar/project-list.ts
@@ -1,4 +1,4 @@
-import { ProjectGraphNode } from '@nrwl/workspace';
+import type { ProjectGraphNode } from '@nrwl/devkit';
 import { Subject } from 'rxjs';
 import {
   parseParentDirectoriesFromPilePath,

--- a/dep-graph/dep-graph/src/app/util-cytoscape/edge.ts
+++ b/dep-graph/dep-graph/src/app/util-cytoscape/edge.ts
@@ -1,5 +1,4 @@
-import { ProjectGraphDependency } from '@nrwl/workspace';
-
+import type { ProjectGraphDependency } from '@nrwl/devkit';
 import * as cy from 'cytoscape';
 
 export class ProjectEdge {

--- a/dep-graph/dep-graph/src/app/util-cytoscape/project-node.ts
+++ b/dep-graph/dep-graph/src/app/util-cytoscape/project-node.ts
@@ -1,4 +1,4 @@
-import { ProjectGraphNode } from '@nrwl/workspace';
+import type { ProjectGraphNode } from '@nrwl/devkit';
 import * as cy from 'cytoscape';
 import { parseParentDirectoriesFromPilePath } from '../util';
 

--- a/e2e/workspace/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace/src/workspace-aux-commands.test.ts
@@ -15,7 +15,7 @@ import {
   updateFile,
   workspaceConfigName,
 } from '@nrwl/e2e/utils';
-import { NxJson } from '@nrwl/workspace';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 import { classify } from '@nrwl/workspace/src/utils/strings';
 
 let proj: string;
@@ -758,7 +758,7 @@ describe('Move Project', () => {
      */
 
     runCLI(`generate @nrwl/workspace:lib ${lib3}`);
-    let nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+    let nxJson = JSON.parse(readFile('nx.json')) as NxJsonConfiguration;
     nxJson.projects[lib3].implicitDependencies = [`${lib1}-data-access`];
     updateFile(`nx.json`, JSON.stringify(nxJson));
 
@@ -817,7 +817,7 @@ describe('Move Project', () => {
     checkFilesExist(rootClassPath);
 
     expect(moveOutput).toContain('UPDATE nx.json');
-    nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+    nxJson = JSON.parse(readFile('nx.json')) as NxJsonConfiguration;
     expect(nxJson.projects[`${lib1}-data-access`]).toBeUndefined();
     expect(nxJson.projects[newName]).toEqual({
       tags: [],
@@ -894,7 +894,7 @@ describe('Move Project', () => {
      */
 
     runCLI(`generate @nrwl/workspace:lib ${lib3}`);
-    let nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+    let nxJson = JSON.parse(readFile('nx.json')) as NxJsonConfiguration;
     nxJson.projects[lib3].implicitDependencies = [`${lib1}-data-access`];
     updateFile(`nx.json`, JSON.stringify(nxJson));
 
@@ -953,7 +953,7 @@ describe('Move Project', () => {
     checkFilesExist(rootClassPath);
 
     expect(moveOutput).toContain('UPDATE nx.json');
-    nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+    nxJson = JSON.parse(readFile('nx.json')) as NxJsonConfiguration;
     expect(nxJson.projects[`${lib1}-data-access`]).toBeUndefined();
     expect(nxJson.projects[newName]).toEqual({
       tags: [],
@@ -1033,7 +1033,7 @@ describe('Move Project', () => {
      */
 
     runCLI(`generate @nrwl/workspace:lib ${lib3}`);
-    nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+    nxJson = JSON.parse(readFile('nx.json')) as NxJsonConfiguration;
     nxJson.projects[lib3].implicitDependencies = [`${lib1}-data-access`];
     updateFile(`nx.json`, JSON.stringify(nxJson));
 
@@ -1092,7 +1092,7 @@ describe('Move Project', () => {
     checkFilesExist(rootClassPath);
 
     expect(moveOutput).toContain('UPDATE nx.json');
-    nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+    nxJson = JSON.parse(readFile('nx.json')) as NxJsonConfiguration;
     expect(nxJson.projects[`${lib1}-data-access`]).toBeUndefined();
     expect(nxJson.projects[newName]).toEqual({
       tags: [],
@@ -1153,7 +1153,7 @@ describe('Remove Project', () => {
      */
 
     runCLI(`generate @nrwl/workspace:lib ${lib2}`);
-    let nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+    let nxJson = JSON.parse(readFile('nx.json')) as NxJsonConfiguration;
     nxJson.projects[lib2].implicitDependencies = [lib1];
     updateFile(`nx.json`, JSON.stringify(nxJson));
 
@@ -1185,7 +1185,7 @@ describe('Remove Project', () => {
     expect(exists(tmpProjPath(`libs/${lib1}`))).toBeFalsy();
 
     expect(removeOutputForced).toContain(`UPDATE nx.json`);
-    nxJson = JSON.parse(readFile('nx.json')) as NxJson;
+    nxJson = JSON.parse(readFile('nx.json')) as NxJsonConfiguration;
     expect(nxJson.projects[`${lib1}`]).toBeUndefined();
     expect(nxJson.projects[lib2].implicitDependencies).toEqual([]);
 

--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -1,4 +1,4 @@
-import { NxJson } from '@nrwl/workspace';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 import {
   getPackageManagerCommand,
   getSelectedPackageManager,
@@ -475,7 +475,7 @@ describe('affected (with git)', () => {
   afterAll(() => removeProject({ onlyOnCI: true }));
 
   it('should not affect other projects by generating a new project', () => {
-    const nxJson: NxJson = readJson('nx.json');
+    const nxJson: NxJsonConfiguration = readJson('nx.json');
 
     delete nxJson.implicitDependencies;
 
@@ -503,7 +503,7 @@ describe('affected (with git)', () => {
   }, 1000000);
 
   it('should detect changes to projects based on the nx.json', () => {
-    const nxJson: NxJson = readJson('nx.json');
+    const nxJson: NxJsonConfiguration = readJson('nx.json');
 
     nxJson.projects[myapp].tags = ['tag'];
     updateFile('nx.json', JSON.stringify(nxJson));

--- a/packages/angular/src/schematics/application/application.spec.ts
+++ b/packages/angular/src/schematics/application/application.spec.ts
@@ -1,5 +1,6 @@
 import { Tree } from '@angular-devkit/schematics';
-import { NxJson, readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
+import { readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 import { createEmptyWorkspace, getFileContent } from '@nrwl/workspace/testing';
 import * as stripJsonComments from 'strip-json-comments';
 import { callRule, runSchematic } from '../../utils/testing';
@@ -35,7 +36,7 @@ describe('app', () => {
         { name: 'myApp', tags: 'one,two' },
         appTree
       );
-      const nxJson = readJsonInTree<NxJson>(tree, '/nx.json');
+      const nxJson = readJsonInTree<NxJsonConfiguration>(tree, '/nx.json');
       expect(nxJson.projects).toEqual({
         'my-app': {
           tags: ['one', 'two'],
@@ -184,7 +185,7 @@ describe('app', () => {
         { name: 'myApp', directory: 'myDir', tags: 'one,two' },
         appTree
       );
-      const nxJson = readJsonInTree<NxJson>(tree, '/nx.json');
+      const nxJson = readJsonInTree<NxJsonConfiguration>(tree, '/nx.json');
       expect(nxJson.projects).toEqual({
         'my-dir-my-app': {
           tags: ['one', 'two'],

--- a/packages/angular/src/schematics/library/library.spec.ts
+++ b/packages/angular/src/schematics/library/library.spec.ts
@@ -1,10 +1,11 @@
 import { stripIndent } from '@angular-devkit/core/src/utils/literals';
 import { Tree } from '@angular-devkit/schematics';
 import { UnitTestTree } from '@angular-devkit/schematics/testing';
-import { NxJson, readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
+import { readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
 import { createEmptyWorkspace, getFileContent } from '@nrwl/workspace/testing';
 import * as stripJsonComments from 'strip-json-comments';
 import { createApp, runSchematic, callRule } from '../../utils/testing';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 
 describe('lib', () => {
   let appTree: Tree;
@@ -154,7 +155,7 @@ describe('lib', () => {
         { name: 'myLib', tags: 'one,two' },
         appTree
       );
-      const nxJson = readJsonInTree<NxJson>(tree, '/nx.json');
+      const nxJson = readJsonInTree<NxJsonConfiguration>(tree, '/nx.json');
       expect(nxJson.projects).toEqual({
         'my-lib': {
           tags: ['one', 'two'],
@@ -392,7 +393,7 @@ describe('lib', () => {
         },
         appTree
       );
-      const nxJson = readJsonInTree<NxJson>(tree, '/nx.json');
+      const nxJson = readJsonInTree<NxJsonConfiguration>(tree, '/nx.json');
       expect(nxJson.projects).toEqual({
         'my-dir-my-lib': {
           tags: ['one'],
@@ -410,7 +411,7 @@ describe('lib', () => {
         },
         tree
       );
-      const nxJson2 = readJsonInTree<NxJson>(tree2, '/nx.json');
+      const nxJson2 = readJsonInTree<NxJsonConfiguration>(tree2, '/nx.json');
       expect(nxJson2.projects).toEqual({
         'my-dir-my-lib': {
           tags: ['one'],

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -20,14 +20,15 @@ import {
 } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { normalizePath } from '@nrwl/devkit';
+import type { ProjectGraph } from '@nrwl/devkit';
 import {
   isNpmProject,
   ProjectType,
+  readCurrentProjectGraph,
 } from '@nrwl/workspace/src/core/project-graph';
 import { readNxJson } from '@nrwl/workspace/src/core/file-utils';
 import { TargetProjectLocator } from '@nrwl/workspace/src/core/target-project-locator';
 import { checkCircularPath } from '@nrwl/workspace/src/utils/graph-utils';
-import { readCurrentProjectGraph } from '@nrwl/workspace/src/core/project-graph/project-graph';
 import { isRelativePath } from '@nrwl/workspace/src/utilities/fileutils';
 
 type Options = [

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -1,6 +1,6 @@
+import type { ProjectGraph } from '@nrwl/devkit';
 import {
   DependencyType,
-  ProjectGraph,
   ProjectType,
 } from '@nrwl/workspace/src/core/project-graph';
 import { TSESLint } from '@typescript-eslint/experimental-utils';

--- a/packages/nest/src/schematics/library/library.spec.ts
+++ b/packages/nest/src/schematics/library/library.spec.ts
@@ -1,8 +1,9 @@
 import { Tree } from '@angular-devkit/schematics';
-import { NxJson, readJsonInTree } from '@nrwl/workspace';
+import { readJsonInTree } from '@nrwl/workspace';
 import { createEmptyWorkspace, getFileContent } from '@nrwl/workspace/testing';
 import { runSchematic } from '../../utils/testing';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 
 describe('lib', () => {
   let appTree: Tree;
@@ -144,7 +145,7 @@ describe('lib', () => {
         { name: 'myLib', tags: 'one,two' },
         appTree
       );
-      const nxJson = readJsonInTree<NxJson>(tree, '/nx.json');
+      const nxJson = readJsonInTree<NxJsonConfiguration>(tree, '/nx.json');
       expect(nxJson.projects).toEqual({
         'my-lib': {
           tags: ['one', 'two'],
@@ -259,7 +260,7 @@ describe('lib', () => {
         },
         appTree
       );
-      const nxJson = readJsonInTree<NxJson>(tree, '/nx.json');
+      const nxJson = readJsonInTree<NxJsonConfiguration>(tree, '/nx.json');
       expect(nxJson.projects).toEqual({
         'my-dir-my-lib': {
           tags: ['one'],
@@ -275,7 +276,7 @@ describe('lib', () => {
         },
         tree
       );
-      const nxJson2 = readJsonInTree<NxJson>(tree2, '/nx.json');
+      const nxJson2 = readJsonInTree<NxJsonConfiguration>(tree2, '/nx.json');
       expect(nxJson2.projects).toEqual({
         'my-dir-my-lib': {
           tags: ['one'],

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -1,6 +1,6 @@
-import { readJson, Tree } from '@nrwl/devkit';
+import { readJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { NxJson } from '@nrwl/workspace/src/core/shared-interfaces';
+import type { Tree, NxJsonConfiguration } from '@nrwl/devkit';
 
 import { applicationGenerator } from './application';
 import { Schema } from './schema';
@@ -26,7 +26,7 @@ describe('app', () => {
 
     it('should update nx.json', async () => {
       await applicationGenerator(tree, { name: 'myApp', tags: 'one,two' });
-      const nxJson = readJson<NxJson>(tree, '/nx.json');
+      const nxJson = readJson<NxJsonConfiguration>(tree, '/nx.json');
       expect(nxJson.projects).toEqual({
         'my-app': {
           tags: ['one', 'two'],
@@ -132,7 +132,7 @@ describe('app', () => {
         directory: 'myDir',
         tags: 'one,two',
       });
-      const nxJson = readJson<NxJson>(tree, '/nx.json');
+      const nxJson = readJson<NxJsonConfiguration>(tree, '/nx.json');
       expect(nxJson.projects).toEqual({
         'my-dir-my-app': {
           tags: ['one', 'two'],

--- a/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.spec.ts
+++ b/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.spec.ts
@@ -1,10 +1,7 @@
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { readJson, Tree } from '@nrwl/devkit';
+import { readJson, DependencyType } from '@nrwl/devkit';
 import { createBabelrcForWorkspaceLibs } from './create-babelrc-for-workspace-libs';
-import {
-  DependencyType,
-  ProjectGraph,
-} from '@nrwl/workspace/src/core/project-graph';
+import type { ProjectGraph, Tree } from '@nrwl/devkit';
 
 let projectGraph: ProjectGraph;
 jest.mock('@nrwl/workspace/src/core/project-graph', () => ({

--- a/packages/web/src/migrations/update-11-5-2/utils.spec.ts
+++ b/packages/web/src/migrations/update-11-5-2/utils.spec.ts
@@ -1,9 +1,5 @@
-import { getProjects } from '@nrwl/devkit';
-import { ProjectGraph } from '@nrwl/workspace';
-import {
-  DependencyType,
-  reverse,
-} from '@nrwl/workspace/src/core/project-graph';
+import { getProjects, ProjectGraph, DependencyType } from '@nrwl/devkit';
+import { reverse } from '@nrwl/workspace/src/core/project-graph';
 import { hasDependentAppUsingWebBuild } from '@nrwl/web/src/migrations/update-11-5-2/utils';
 
 describe('hasDependentAppUsingWebBuild', () => {

--- a/packages/web/src/migrations/update-11-5-2/utils.ts
+++ b/packages/web/src/migrations/update-11-5-2/utils.ts
@@ -1,6 +1,4 @@
-import { ProjectGraph } from '@nrwl/workspace';
-import { getProjects } from '@nrwl/devkit';
-import { DependencyType } from '@nrwl/workspace/src/core/project-graph';
+import { getProjects, ProjectGraph, DependencyType } from '@nrwl/devkit';
 
 const cache = new Map<string, boolean>();
 

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -25,12 +25,6 @@ export {
   readNxJson,
   readWorkspaceConfig,
 } from './src/core/file-utils';
-export { NxJson } from './src/core/shared-interfaces';
-export {
-  ProjectGraphNode,
-  ProjectGraphDependency,
-  ProjectGraph,
-} from './src/core/project-graph';
 export { ProjectGraphCache } from './src/core/nx-deps/nx-deps-cache';
 export {
   readJsonInTree,

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -19,8 +19,8 @@ import { connectToNxCloudUsingScan } from './connect-to-nx-cloud';
 import { parseFiles } from './shared';
 import { NxArgs, RawNxArgs, splitArgsIntoNxArgsAndOverrides } from './utils';
 import { performance } from 'perf_hooks';
-import { Environment } from '@nrwl/workspace/src/core/shared-interfaces';
-import { EmptyReporter } from '@nrwl/workspace/src/tasks-runner/empty-reporter';
+import type { Environment } from '../core/shared-interfaces';
+import { EmptyReporter } from '../tasks-runner/empty-reporter';
 
 export async function affected(
   command: 'apps' | 'libs' | 'dep-graph' | 'print-affected' | 'affected',

--- a/packages/workspace/src/command-line/print-affected.ts
+++ b/packages/workspace/src/command-line/print-affected.ts
@@ -1,10 +1,10 @@
-import { ProjectGraph, ProjectGraphNode } from '../core/project-graph';
-import { Environment } from '../core/shared-interfaces';
-import { Task } from '../tasks-runner/tasks-runner';
+import type { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
+import type { Environment } from '../core/shared-interfaces';
+import type { Task } from '../tasks-runner/tasks-runner';
 import { createTask, getRunner } from '../tasks-runner/run-command';
 import { getCommandAsString, getOutputs } from '../tasks-runner/utils';
 import * as yargs from 'yargs';
-import { NxArgs } from './utils';
+import type { NxArgs } from './utils';
 import { Hasher } from '../core/hasher/hasher';
 import { detectPackageManager } from '@nrwl/tao/src/shared/package-manager';
 

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -1,9 +1,8 @@
 import * as yargsParser from 'yargs-parser';
 import * as yargs from 'yargs';
 import * as fileUtils from '../core/file-utils';
-import { NxAffectedConfig } from '../core/shared-interfaces';
 import { output } from '../utilities/output';
-import { names } from '@nrwl/devkit';
+import { names, NxAffectedConfig } from '@nrwl/devkit';
 
 const runOne = [
   'target',

--- a/packages/workspace/src/command-line/workspace-integrity-checks.ts
+++ b/packages/workspace/src/command-line/workspace-integrity-checks.ts
@@ -1,5 +1,5 @@
 import { output, CLIErrorMessageConfig } from '../utilities/output';
-import { ProjectGraph } from '../core/project-graph';
+import type { ProjectGraph } from '@nrwl/devkit';
 import { workspaceFileName } from '../core/file-utils';
 
 export class WorkspaceIntegrityChecks {

--- a/packages/workspace/src/command-line/workspace-results.ts
+++ b/packages/workspace/src/command-line/workspace-results.ts
@@ -5,9 +5,9 @@ import {
 } from '../utilities/fileutils';
 import { existsSync, unlinkSync } from 'fs';
 import { ensureDirSync } from 'fs-extra';
-import { ProjectGraphNode } from '../core/project-graph';
+import type { ProjectGraphNode } from '@nrwl/devkit';
 import { join } from 'path';
-import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
+import { appRootPath } from '../utilities/app-root';
 import {
   cacheDirectory,
   readCacheDirectoryProperty,

--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph-models.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph-models.ts
@@ -1,10 +1,9 @@
-import { NxJson } from '../shared-interfaces';
-import { Change, FileChange } from '../file-utils';
-import { ProjectGraph } from '../project-graph';
+import type { NxJsonConfiguration, ProjectGraph } from '@nrwl/devkit';
+import type { Change, FileChange } from '../file-utils';
 
 export interface AffectedProjectGraphContext {
   workspaceJson: any;
-  nxJson: NxJson<string[]>;
+  nxJson: NxJsonConfiguration<string[]>;
   touchedProjects: string[];
 }
 
@@ -12,7 +11,7 @@ export interface TouchedProjectLocator<T extends Change = Change> {
   (
     fileChanges: FileChange<T>[],
     workspaceJson?: any,
-    nxJson?: NxJson<string[]>,
+    nxJson?: NxJsonConfiguration<string[]>,
     packageJson?: any,
     projectGraph?: ProjectGraph
   ): string[];

--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
@@ -5,7 +5,7 @@ import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import { createProjectGraph } from '../project-graph';
 import { filterAffected } from './affected-project-graph';
 import { FileData, WholeFileChange } from '../file-utils';
-import { NxJson } from '../shared-interfaces';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('../../utilities/app-root', () => ({ appRootPath: '/root' }));
@@ -14,7 +14,7 @@ describe('project graph', () => {
   let packageJson: any;
   let workspaceJson: any;
   let tsConfigJson: any;
-  let nxJson: NxJson;
+  let nxJson: NxJsonConfiguration;
   let filesJson: any;
   let filesAtMasterJson: any;
   let files: FileData[];

--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph.ts
@@ -1,11 +1,11 @@
-import { ProjectGraph, ProjectGraphBuilder, reverse } from '../project-graph';
+import { ProjectGraphBuilder, reverse } from '../project-graph';
 import {
   FileChange,
   readNxJson,
   readPackageJson,
   readWorkspaceJson,
 } from '../file-utils';
-import { NxJson } from '../shared-interfaces';
+import type { NxJsonConfiguration, ProjectGraph } from '@nrwl/devkit';
 import {
   getImplicitlyTouchedProjects,
   getTouchedProjects,
@@ -25,7 +25,7 @@ export function filterAffected(
   graph: ProjectGraph,
   touchedFiles: FileChange[],
   workspaceJson: any = readWorkspaceJson(),
-  nxJson: NxJson = readNxJson(),
+  nxJson: NxJsonConfiguration = readNxJson(),
   packageJson: any = readPackageJson()
 ): ProjectGraph {
   const normalizedNxJson = normalizeNxJson(nxJson);

--- a/packages/workspace/src/core/affected-project-graph/locators/implicit-json-changes.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/implicit-json-changes.spec.ts
@@ -1,5 +1,5 @@
 import { getImplicitlyTouchedProjectsByJsonChanges } from './implicit-json-changes';
-import { NxJson } from '../../shared-interfaces';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 import { WholeFileChange } from '../../file-utils';
 import { DiffType } from '../../../utilities/json-diff';
 
@@ -16,7 +16,7 @@ function getModifiedChange(path: string[]) {
 
 describe('getImplicitlyTouchedProjectsByJsonChanges', () => {
   let workspaceJson;
-  let nxJson: NxJson<string[]>;
+  let nxJson: NxJsonConfiguration<string[]>;
   beforeEach(() => {
     workspaceJson = null;
     nxJson = {

--- a/packages/workspace/src/core/affected-project-graph/locators/implicit-json-changes.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/implicit-json-changes.ts
@@ -7,7 +7,7 @@ import {
   walkJsonTree,
 } from '../../../utilities/json-diff';
 import { TouchedProjectLocator } from '../affected-project-graph-models';
-import { ImplicitDependencyEntry } from '../../shared-interfaces';
+import type { ImplicitDependencyEntry } from '@nrwl/devkit';
 
 export const getImplicitlyTouchedProjectsByJsonChanges: TouchedProjectLocator<
   WholeFileChange | JsonChange

--- a/packages/workspace/src/core/affected-project-graph/locators/npm-packages.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/npm-packages.spec.ts
@@ -1,12 +1,11 @@
 import { getTouchedNpmPackages } from './npm-packages';
-import { NxJson } from '../../shared-interfaces';
+import type { NxJsonConfiguration, ProjectGraph } from '@nrwl/devkit';
 import { WholeFileChange } from '../../file-utils';
 import { DiffType } from '../../../utilities/json-diff';
-import { ProjectGraph } from '../../project-graph';
 
 describe('getTouchedNpmPackages', () => {
   let workspaceJson;
-  let nxJson: NxJson<string[]>;
+  let nxJson: NxJsonConfiguration<string[]>;
   let projectGraph: ProjectGraph;
   beforeEach(() => {
     workspaceJson = {

--- a/packages/workspace/src/core/assert-workspace-validity.ts
+++ b/packages/workspace/src/core/assert-workspace-validity.ts
@@ -1,11 +1,14 @@
 import { workspaceFileName } from './file-utils';
-import {
+import type {
   ImplicitJsonSubsetDependency,
-  NxJson,
-} from '@nrwl/workspace/src/core/shared-interfaces';
+  NxJsonConfiguration,
+} from '@nrwl/devkit';
 import { output } from '../utilities/output';
 
-export function assertWorkspaceValidity(workspaceJson, nxJson: NxJson) {
+export function assertWorkspaceValidity(
+  workspaceJson,
+  nxJson: NxJsonConfiguration
+) {
   const workspaceJsonProjects = Object.keys(workspaceJson.projects);
   const nxJsonProjects = Object.keys(nxJson.projects);
 

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -1,17 +1,20 @@
 import { toOldFormatOrNull, Workspaces } from '@nrwl/tao/src/shared/workspace';
-import { FileData, NxJsonConfiguration } from '@nrwl/devkit';
+import type {
+  FileData,
+  NxJsonConfiguration,
+  ProjectGraphNode,
+} from '@nrwl/devkit';
 import { execSync } from 'child_process';
 import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { extname, join, relative, sep } from 'path';
 import { performance } from 'perf_hooks';
-import { NxArgs } from '../command-line/utils';
+import type { NxArgs } from '../command-line/utils';
 import { WorkspaceResults } from '../command-line/workspace-results';
 import { appRootPath } from '../utilities/app-root';
 import { fileExists, readJsonFile } from '../utilities/fileutils';
 import { jsonDiff } from '../utilities/json-diff';
 import { defaultFileHasher } from './hasher/file-hasher';
-import { ProjectGraphNode } from './project-graph';
-import { Environment } from './shared-interfaces';
+import type { Environment } from './shared-interfaces';
 
 const ignore = require('ignore');
 

--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
@@ -1,9 +1,9 @@
 import { FileData, filesChanged } from '../file-utils';
-import {
+import type {
   ProjectGraph,
   ProjectGraphDependency,
   ProjectGraphNode,
-} from '../project-graph';
+} from '@nrwl/devkit';
 import { join } from 'path';
 import { appRootPath } from '../../utilities/app-root';
 import { existsSync } from 'fs';
@@ -14,7 +14,7 @@ import {
   readJsonFile,
   writeJsonFile,
 } from '../../utilities/fileutils';
-import { ProjectFileMap } from '@nrwl/workspace/src/core/file-graph';
+import type { ProjectFileMap } from '../file-graph';
 import { performance } from 'perf_hooks';
 import {
   cacheDirectory,

--- a/packages/workspace/src/core/project-graph/build-dependencies/explicit-package-json-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/explicit-package-json-dependencies.ts
@@ -5,7 +5,7 @@ import {
   ProjectGraphNodeRecords,
 } from '../project-graph-models';
 import { defaultFileRead } from '../../file-utils';
-import { parseJsonWithComments } from '@nrwl/workspace/src/utilities/fileutils';
+import { parseJsonWithComments } from '../../../utilities/fileutils';
 import { joinPathFragments } from '@nrwl/devkit';
 
 export function buildExplicitPackageJsonDependencies(

--- a/packages/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.ts
@@ -1,6 +1,6 @@
 import type * as ts from 'typescript';
 import * as path from 'path';
-import { DependencyType } from '../project-graph-models';
+import { DependencyType } from '@nrwl/devkit';
 import { stripSourceCode } from '../../../utilities/strip-source-code';
 import { defaultFileRead } from '../../file-utils';
 

--- a/packages/workspace/src/core/project-graph/operators.ts
+++ b/packages/workspace/src/core/project-graph/operators.ts
@@ -1,5 +1,5 @@
 import { ProjectGraphBuilder } from './project-graph-builder';
-import { ProjectGraph, ProjectGraphNode } from './project-graph-models';
+import type { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
 
 const reverseMemo = new Map<ProjectGraph, ProjectGraph>();
 

--- a/packages/workspace/src/core/project-graph/project-graph-models.ts
+++ b/packages/workspace/src/core/project-graph/project-graph-models.ts
@@ -1,4 +1,4 @@
-import { ProjectFileMap } from '../file-graph';
+import type { ProjectFileMap } from '../file-graph';
 import type {
   ProjectGraphNode,
   DependencyType,

--- a/packages/workspace/src/core/project-graph/project-graph.spec.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.spec.ts
@@ -1,17 +1,18 @@
 import { vol, fs } from 'memfs';
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('../../utilities/app-root', () => ({ appRootPath: '/root' }));
-
-import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import { createProjectGraph } from './project-graph';
-import { DependencyType } from './project-graph-models';
-import { NxJson } from '../shared-interfaces';
-import { defaultFileHasher } from '@nrwl/workspace/src/core/hasher/file-hasher';
+import {
+  NxJsonConfiguration,
+  stripIndents,
+  DependencyType,
+} from '@nrwl/devkit';
+import { defaultFileHasher } from '../hasher/file-hasher';
 
 describe('project graph', () => {
   let packageJson: any;
   let workspaceJson: any;
-  let nxJson: NxJson;
+  let nxJson: NxJsonConfiguration;
   let tsConfigJson: any;
   let filesJson: any;
 

--- a/packages/workspace/src/core/project-graph/project-graph.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.ts
@@ -1,11 +1,13 @@
 import type {
   FileData,
+  NxJsonConfiguration,
   NxJsonProjectConfiguration,
   ProjectConfiguration,
   ProjectFileMap,
   WorkspaceJsonConfiguration,
   ProjectGraphProcessorContext,
   NxPlugin,
+  ProjectGraph,
 } from '@nrwl/devkit';
 
 import { ProjectGraphBuilder } from '@nrwl/devkit';
@@ -32,13 +34,11 @@ import {
   buildNpmPackageNodes,
   buildWorkspaceProjectNodes,
 } from './build-nodes';
-import { ProjectGraph } from './project-graph-models';
 import {
   differentFromCache,
   readCache,
   writeCache,
 } from '../nx-deps/nx-deps-cache';
-import { NxJson } from '../shared-interfaces';
 import { performance } from 'perf_hooks';
 
 export function createProjectGraph(
@@ -104,7 +104,7 @@ function addWorkspaceFiles(
 
 function buildProjectGraph(
   ctx: {
-    nxJson: NxJson<string[]>;
+    nxJson: NxJsonConfiguration<string[]>;
     workspaceJson: WorkspaceJsonConfiguration;
     fileMap: ProjectFileMap;
   },

--- a/packages/workspace/src/core/shared-interfaces.ts
+++ b/packages/workspace/src/core/shared-interfaces.ts
@@ -1,22 +1,8 @@
-import { WorkspaceResults } from '@nrwl/workspace/src/command-line/workspace-results';
-import type {
-  ImplicitDependencyEntry,
-  ImplicitJsonSubsetDependency,
-  NxAffectedConfig,
-  NxJsonConfiguration,
-  NxJsonProjectConfiguration,
-} from '@nrwl/devkit';
+import { WorkspaceResults } from '../command-line/workspace-results';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 
 export interface Environment {
   nxJson: NxJsonConfiguration;
   workspaceJson: any;
   workspaceResults: WorkspaceResults;
 }
-
-export {
-  NxJsonProjectConfiguration as NxJsonProjectConfig,
-  NxJsonConfiguration as NxJson,
-  NxAffectedConfig,
-  ImplicitDependencyEntry,
-  ImplicitJsonSubsetDependency,
-};

--- a/packages/workspace/src/core/target-project-locator.spec.ts
+++ b/packages/workspace/src/core/target-project-locator.spec.ts
@@ -1,8 +1,6 @@
-import { fs, vol } from 'memfs';
-import {
-  ProjectGraphContext,
-  ProjectGraphNode,
-} from './project-graph/project-graph-models';
+import { vol } from 'memfs';
+import { ProjectGraphContext } from './project-graph';
+import type { ProjectGraphNode } from '@nrwl/devkit';
 import { TargetProjectLocator } from './target-project-locator';
 
 jest.mock('../utilities/app-root', () => ({

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -1,14 +1,15 @@
 import { resolveModuleByImport } from '../utilities/typescript';
 import { normalizedProjectRoot, readFileIfExisting } from './file-utils';
-import { ProjectGraphNode } from './project-graph/project-graph-models';
+import type { ProjectGraphNode } from '@nrwl/devkit';
 import {
   getSortedProjectNodes,
   isNpmProject,
   isWorkspaceProject,
+  ProjectGraphNodeRecords,
 } from './project-graph';
 import { isRelativePath, parseJsonWithComments } from '../utilities/fileutils';
 import { dirname, join, posix } from 'path';
-import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
+import { appRootPath } from '../utilities/app-root';
 
 export class TargetProjectLocator {
   private sortedProjects = getSortedProjectNodes(this.nodes);

--- a/packages/workspace/src/generators/library/library.spec.ts
+++ b/packages/workspace/src/generators/library/library.spec.ts
@@ -1,7 +1,6 @@
 import { readJson, Tree, updateJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-
-import { NxJson } from '../../core/shared-interfaces';
+import { NxJsonConfiguration } from '@nrwl/devkit';
 
 import { libraryGenerator } from './library';
 import { Schema } from './schema.d';
@@ -42,7 +41,7 @@ describe('lib', () => {
         name: 'myLib',
         tags: 'one,two',
       });
-      const nxJson = readJson<NxJson>(tree, '/nx.json');
+      const nxJson = readJson<NxJsonConfiguration>(tree, '/nx.json');
       expect(nxJson.projects).toEqual({
         'my-lib': {
           tags: ['one', 'two'],
@@ -170,7 +169,7 @@ describe('lib', () => {
         directory: 'myDir',
         tags: 'one',
       });
-      const nxJson = readJson<NxJson>(tree, '/nx.json');
+      const nxJson = readJson<NxJsonConfiguration>(tree, '/nx.json');
       expect(nxJson.projects).toEqual({
         'my-dir-my-lib': {
           tags: ['one'],
@@ -184,7 +183,7 @@ describe('lib', () => {
         tags: 'one,two',
         simpleModuleName: true,
       });
-      const nxJson2 = readJson<NxJson>(tree, '/nx.json');
+      const nxJson2 = readJson<NxJsonConfiguration>(tree, '/nx.json');
       expect(nxJson2.projects).toEqual({
         'my-dir-my-lib': {
           tags: ['one'],

--- a/packages/workspace/src/generators/move/lib/move-project-configuration.spec.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-configuration.spec.ts
@@ -2,13 +2,12 @@ import {
   addProjectConfiguration,
   readJson,
   readProjectConfiguration,
-  Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { NxJson } from '../../../core/shared-interfaces';
-import { Schema } from '../schema';
+import type { Tree, NxJsonConfiguration } from '@nrwl/devkit';
+import type { Schema } from '../schema';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { moveProjectConfiguration } from '@nrwl/workspace/src/generators/move/lib/move-project-configuration';
+import { moveProjectConfiguration } from './move-project-configuration';
 
 describe('moveProjectConfiguration', () => {
   let tree: Tree;
@@ -176,7 +175,7 @@ describe('moveProjectConfiguration', () => {
   });
 
   it('honor custom workspace layouts', async () => {
-    updateJson<NxJson>(tree, 'nx.json', (json) => {
+    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
       json.workspaceLayout = { appsDir: 'e2e', libsDir: 'packages' };
       return json;
     });

--- a/packages/workspace/src/generators/move/lib/update-implicit-dependencies.ts
+++ b/packages/workspace/src/generators/move/lib/update-implicit-dependencies.ts
@@ -1,7 +1,6 @@
-import { Tree, updateJson } from '@nrwl/devkit';
-
-import { NxJson } from '../../../core/shared-interfaces';
-import { Schema } from '../schema';
+import { updateJson } from '@nrwl/devkit';
+import type { Tree, NxJsonConfiguration } from '@nrwl/devkit';
+import type { Schema } from '../schema';
 import { getNewProjectName } from './utils';
 
 /**
@@ -10,7 +9,7 @@ import { getNewProjectName } from './utils';
  * @param schema The options provided to the schematic
  */
 export function updateImplicitDependencies(tree: Tree, schema: Schema) {
-  updateJson<NxJson>(tree, 'nx.json', (json) => {
+  updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
     Object.values(json.projects).forEach((project) => {
       if (project.implicitDependencies) {
         const index = project.implicitDependencies.indexOf(schema.projectName);

--- a/packages/workspace/src/generators/remove/lib/check-dependencies.ts
+++ b/packages/workspace/src/generators/remove/lib/check-dependencies.ts
@@ -1,9 +1,9 @@
 import {
   createProjectGraph,
   onlyWorkspaceProjects,
-  ProjectGraph,
   reverse,
 } from '../../../core/project-graph';
+import type { ProjectGraph } from '@nrwl/devkit';
 import { Schema } from '../schema';
 
 /**

--- a/packages/workspace/src/generators/workspace/workspace.spec.ts
+++ b/packages/workspace/src/generators/workspace/workspace.spec.ts
@@ -1,7 +1,7 @@
-import { readJson, Tree } from '@nrwl/devkit';
+import { readJson } from '@nrwl/devkit';
+import type { Tree, NxJsonConfiguration } from '@nrwl/devkit';
 import { workspaceGenerator } from './workspace';
 import { createTree } from '@nrwl/devkit/testing';
-import { NxJson } from '../../core/shared-interfaces';
 
 describe('@nrwl/workspace:workspace', () => {
   let tree: Tree;
@@ -32,7 +32,7 @@ describe('@nrwl/workspace:workspace', () => {
       layout: 'apps-and-libs',
       defaultBase: 'master',
     });
-    const nxJson = readJson<NxJson>(tree, '/proj/nx.json');
+    const nxJson = readJson<NxJsonConfiguration>(tree, '/proj/nx.json');
     expect(nxJson).toEqual({
       npmScope: 'proj',
       affected: {

--- a/packages/workspace/src/migrations/update-10-0-0/solution-tsconfigs.ts
+++ b/packages/workspace/src/migrations/update-10-0-0/solution-tsconfigs.ts
@@ -1,11 +1,7 @@
 import { basename, dirname, join, normalize, Path } from '@angular-devkit/core';
 import { chain, Rule, Tree } from '@angular-devkit/schematics';
-import {
-  formatFiles,
-  NxJson,
-  readJsonInTree,
-  updateJsonInTree,
-} from '@nrwl/workspace';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
+import { formatFiles, readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
 import { relative } from 'path';
 import { visitNotIgnoredFiles } from '../../utils/rules/visit-not-ignored-files';
 
@@ -73,18 +69,21 @@ function updateExtend(file: Path): Rule {
 
 const originalExtendedTsconfigMap = new Map<string, any>();
 
-const changeImplicitDependency = updateJsonInTree<NxJson>('nx.json', (json) => {
-  if (
-    !json.implicitDependencies ||
-    !json.implicitDependencies['tsconfig.json']
-  ) {
+const changeImplicitDependency = updateJsonInTree<NxJsonConfiguration>(
+  'nx.json',
+  (json) => {
+    if (
+      !json.implicitDependencies ||
+      !json.implicitDependencies['tsconfig.json']
+    ) {
+      return json;
+    }
+    json.implicitDependencies['tsconfig.base.json'] =
+      json.implicitDependencies['tsconfig.json'];
+    delete json.implicitDependencies['tsconfig.json'];
     return json;
   }
-  json.implicitDependencies['tsconfig.base.json'] =
-    json.implicitDependencies['tsconfig.json'];
-  delete json.implicitDependencies['tsconfig.json'];
-  return json;
-});
+);
 
 export default function (schema: any): Rule {
   return chain([

--- a/packages/workspace/src/migrations/update-10-0-0/update-10-0-0.ts
+++ b/packages/workspace/src/migrations/update-10-0-0/update-10-0-0.ts
@@ -1,6 +1,6 @@
 import { chain } from '@angular-devkit/schematics';
 import { updateJsonInTree } from '../../utils/ast-utils';
-import { NxJson } from '../../core/shared-interfaces';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 import { updatePackagesInPackageJson } from '../../utils/update-packages-in-package-json';
 import { join } from 'path';
 
@@ -9,13 +9,16 @@ const updatePackages = updatePackagesInPackageJson(
   '10.0.0'
 );
 
-const addNxJsonAffectedConfig = updateJsonInTree('nx.json', (json: NxJson) => {
-  json.affected = {
-    defaultBase: 'master',
-  };
+const addNxJsonAffectedConfig = updateJsonInTree(
+  'nx.json',
+  (json: NxJsonConfiguration) => {
+    json.affected = {
+      defaultBase: 'master',
+    };
 
-  return json;
-});
+    return json;
+  }
+);
 
 export default function () {
   return chain([updatePackages, addNxJsonAffectedConfig]);

--- a/packages/workspace/src/migrations/update-8-12-0/add-implicit-e2e-deps.spec.ts
+++ b/packages/workspace/src/migrations/update-8-12-0/add-implicit-e2e-deps.spec.ts
@@ -2,7 +2,7 @@ import { Tree } from '@angular-devkit/schematics';
 import { createEmptyWorkspace } from '../../utils/testing-utils';
 import { callRule, runMigration } from '../../utils/testing';
 import { readJsonInTree, updateJsonInTree } from '../../utils/ast-utils';
-import { NxJson } from '../../core/shared-interfaces';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 
 describe('Update 8.12.0', () => {
   let tree: Tree;
@@ -11,7 +11,7 @@ describe('Update 8.12.0', () => {
     tree = Tree.empty();
     tree = createEmptyWorkspace(tree);
     tree = await callRule(
-      updateJsonInTree<NxJson>('nx.json', (json) => {
+      updateJsonInTree<NxJsonConfiguration>('nx.json', (json) => {
         json.projects['my-app'] = {
           tags: [],
         };
@@ -30,7 +30,7 @@ describe('Update 8.12.0', () => {
   it('should add implicit dependencies for e2e projects', async () => {
     const result = await runMigration('add-implicit-e2e-deps', {}, tree);
 
-    const nxJson = readJsonInTree<NxJson>(result, 'nx.json');
+    const nxJson = readJsonInTree<NxJsonConfiguration>(result, 'nx.json');
 
     expect(nxJson.projects['my-app-e2e']).toEqual({
       tags: [],
@@ -44,7 +44,7 @@ describe('Update 8.12.0', () => {
 
   it('should not add duplicate implicit dependencies for e2e projects', async () => {
     tree = await callRule(
-      updateJsonInTree<NxJson>('nx.json', (json) => {
+      updateJsonInTree<NxJsonConfiguration>('nx.json', (json) => {
         json.projects['my-app-e2e'].implicitDependencies = ['my-app'];
         return json;
       }),
@@ -52,7 +52,7 @@ describe('Update 8.12.0', () => {
     );
     const result = await runMigration('add-implicit-e2e-deps', {}, tree);
 
-    const nxJson = readJsonInTree<NxJson>(result, 'nx.json');
+    const nxJson = readJsonInTree<NxJsonConfiguration>(result, 'nx.json');
 
     expect(nxJson.projects['my-app-e2e']).toEqual({
       tags: [],

--- a/packages/workspace/src/migrations/update-8-12-0/add-implicit-e2e-deps.ts
+++ b/packages/workspace/src/migrations/update-8-12-0/add-implicit-e2e-deps.ts
@@ -7,10 +7,10 @@ import {
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 
 import { updateJsonInTree } from '../../utils/ast-utils';
-import { NxJson } from '../../core/shared-interfaces';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 import { formatFiles } from '@nrwl/workspace/src/utils/rules/format-files';
 
-const addE2eImplicitDependencies = updateJsonInTree<NxJson>(
+const addE2eImplicitDependencies = updateJsonInTree<NxJsonConfiguration>(
   'nx.json',
   (json) => {
     Object.keys(json.projects).forEach((proj) => {

--- a/packages/workspace/src/migrations/update-8-12-0/update-enforce-boundary-lint-rule.spec.ts
+++ b/packages/workspace/src/migrations/update-8-12-0/update-enforce-boundary-lint-rule.spec.ts
@@ -5,7 +5,7 @@ import {
   _test_addWorkspaceFile,
   WorkspaceFormat,
 } from '@angular-devkit/core/src/workspace/core';
-import { NxJson } from '../../core/shared-interfaces';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 
 describe('Add update-enforce-boundary-lint rule', () => {
   let tree: Tree;
@@ -31,7 +31,7 @@ describe('Add update-enforce-boundary-lint rule', () => {
     );
     tree.create(
       '/nx.json',
-      JSON.stringify(<NxJson>{ npmScope: 'proj', projects: {} })
+      JSON.stringify(<NxJsonConfiguration>{ npmScope: 'proj', projects: {} })
     );
     tree.create(
       '/tsconfig.json',

--- a/packages/workspace/src/migrations/update-9-2-0/update-9-2-0.spec.ts
+++ b/packages/workspace/src/migrations/update-9-2-0/update-9-2-0.spec.ts
@@ -1,5 +1,6 @@
-import { chain, Tree } from '@angular-devkit/schematics';
-import { NxJson, readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
+import { Tree } from '@angular-devkit/schematics';
+import { readJsonInTree, updateJsonInTree } from '@nrwl/workspace';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
 import { callRule, runMigration } from '../../utils/testing';
 
@@ -14,7 +15,7 @@ describe('Update 9.2.0', () => {
   describe('for projects with no tasks runner options', () => {
     it('should add configuration for cacheable operations', async () => {
       tree = await runMigration('update-9-2-0', {}, tree);
-      const nxJson = readJsonInTree<NxJson>(tree, 'nx.json');
+      const nxJson = readJsonInTree<NxJsonConfiguration>(tree, 'nx.json');
       expect(nxJson.tasksRunnerOptions).toEqual({
         default: {
           runner: '@nrwl/workspace/tasks-runners/default',
@@ -45,7 +46,7 @@ describe('Update 9.2.0', () => {
           tree
         );
         tree = await runMigration('update-9-2-0', {}, tree);
-        const nxJson = readJsonInTree<NxJson>(tree, 'nx.json');
+        const nxJson = readJsonInTree<NxJsonConfiguration>(tree, 'nx.json');
         expect(nxJson.tasksRunnerOptions).toEqual({
           default: {
             runner: '@nrwl/workspace/tasks-runners/default',
@@ -81,7 +82,7 @@ describe('Update 9.2.0', () => {
           tree
         );
         tree = await runMigration('update-9-2-0', {}, tree);
-        const nxJson = readJsonInTree<NxJson>(tree, 'nx.json');
+        const nxJson = readJsonInTree<NxJsonConfiguration>(tree, 'nx.json');
         expect(nxJson.tasksRunnerOptions).toEqual({
           default: {
             runner: '@nrwl/workspace/tasks-runners/default',

--- a/packages/workspace/src/tasks-runner/default-tasks-runner.ts
+++ b/packages/workspace/src/tasks-runner/default-tasks-runner.ts
@@ -1,17 +1,11 @@
 import { Observable } from 'rxjs';
-import {
-  AffectedEventType,
-  Task,
-  TaskCompleteEvent,
-  TasksRunner,
-} from './tasks-runner';
-import { ProjectGraph } from '../core/project-graph';
-import { NxJson } from '../core/shared-interfaces';
+import { Task, TaskCompleteEvent, TasksRunner } from './tasks-runner';
+import type { ProjectGraph, NxJsonConfiguration } from '@nrwl/devkit';
 import { TaskOrchestrator } from './task-orchestrator';
 import { getDefaultDependencyConfigs } from './utils';
 import { performance } from 'perf_hooks';
 import { TaskGraphCreator } from './task-graph-creator';
-import { Hasher } from '@nrwl/workspace/src/core/hasher/hasher';
+import { Hasher } from '../core/hasher/hasher';
 
 export interface RemoteCache {
   retrieve: (hash: string, cacheDirectory: string) => Promise<boolean>;
@@ -55,7 +49,7 @@ export const defaultTasksRunner: TasksRunner<DefaultTasksRunnerOptions> = (
     target: string;
     initiatingProject?: string;
     projectGraph: ProjectGraph;
-    nxJson: NxJson;
+    nxJson: NxJsonConfiguration;
     hideCachedOutput?: boolean;
   }
 ): Observable<TaskCompleteEvent> => {
@@ -97,7 +91,7 @@ async function runAllTasks(
   context: {
     initiatingProject?: string;
     projectGraph: ProjectGraph;
-    nxJson: NxJson;
+    nxJson: NxJsonConfiguration;
     hideCachedOutput?: boolean;
   }
 ): Promise<Array<{ task: Task; type: any; success: boolean }>> {

--- a/packages/workspace/src/tasks-runner/run-command.spec.ts
+++ b/packages/workspace/src/tasks-runner/run-command.spec.ts
@@ -1,8 +1,8 @@
 import { TasksRunner } from './tasks-runner';
 import defaultTaskRunner from './default-tasks-runner';
 import { createTasksForProjectToRun, getRunner } from './run-command';
-import { NxJson } from '../core/shared-interfaces';
-import { DependencyType, ProjectGraph } from '@nrwl/devkit';
+import { DependencyType } from '@nrwl/devkit';
+import type { ProjectGraph, NxJsonConfiguration } from '@nrwl/devkit';
 
 describe('createTasksForProjectToRun', () => {
   let projectGraph: ProjectGraph;
@@ -477,7 +477,7 @@ describe('createTasksForProjectToRun', () => {
 });
 
 describe('getRunner', () => {
-  let nxJson: NxJson;
+  let nxJson: NxJsonConfiguration;
   let mockRunner: TasksRunner;
   let overrides: any;
 

--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -3,12 +3,13 @@ import { join } from 'path';
 import { appRootPath } from '../utilities/app-root';
 import { Reporter, ReporterArgs } from './reporter';
 import * as yargs from 'yargs';
-import {
+import type {
   ProjectGraph,
   ProjectGraphNode,
   TargetDependencyConfig,
+  NxJsonConfiguration,
 } from '@nrwl/devkit';
-import { Environment, NxJson } from '../core/shared-interfaces';
+import { Environment } from '../core/shared-interfaces';
 import { NxArgs } from '@nrwl/workspace/src/command-line/utils';
 import { isRelativePath } from '../utilities/fileutils';
 import {
@@ -340,7 +341,7 @@ function getId({
 
 export function getRunner(
   nxArgs: NxArgs,
-  nxJson: NxJson
+  nxJson: NxJsonConfiguration
 ): {
   tasksRunner: TasksRunner;
   runnerOptions: unknown;

--- a/packages/workspace/src/tasks-runner/task-graph-creator.ts
+++ b/packages/workspace/src/tasks-runner/task-graph-creator.ts
@@ -1,7 +1,6 @@
-import { ProjectGraph } from '../core/project-graph';
+import type { ProjectGraph, TargetDependencyConfig } from '@nrwl/devkit';
 import { Task } from './tasks-runner';
 import { getDependencyConfigs } from './utils';
-import { TargetDependencyConfig } from '@nrwl/tao/src/shared/workspace';
 
 export interface TaskGraph {
   roots: string[];

--- a/packages/workspace/src/tasks-runner/task-orchestrator.ts
+++ b/packages/workspace/src/tasks-runner/task-orchestrator.ts
@@ -2,7 +2,7 @@ import { Workspaces } from '@nrwl/tao/src/shared/workspace';
 import { ChildProcess, fork } from 'child_process';
 import * as dotenv from 'dotenv';
 import { readFileSync, writeFileSync } from 'fs';
-import { ProjectGraph } from '../core/project-graph';
+import type { ProjectGraph } from '@nrwl/devkit';
 import { appRootPath } from '../utilities/app-root';
 import { output, TaskCacheStatus } from '../utilities/output';
 import { Cache, TaskWithCachedResult } from './cache';

--- a/packages/workspace/src/tasks-runner/tasks-runner.ts
+++ b/packages/workspace/src/tasks-runner/tasks-runner.ts
@@ -1,7 +1,5 @@
 import type { Observable } from 'rxjs';
-
-import { ProjectGraph } from '../core/project-graph';
-import { NxJson } from '../core/shared-interfaces';
+import type { NxJsonConfiguration, ProjectGraph } from '@nrwl/devkit';
 
 export interface Task {
   id: string;
@@ -40,7 +38,7 @@ export type TasksRunner<T = unknown> = (
     target?: string;
     initiatingProject?: string | null;
     projectGraph: ProjectGraph;
-    nxJson: NxJson;
+    nxJson: NxJsonConfiguration;
     hideCachedOutput?: boolean;
   }
 ) => Observable<AffectedEvent>;

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -1,7 +1,12 @@
 import * as Lint from 'tslint';
 import { IOptions } from 'tslint';
 import * as ts from 'typescript';
-import { isNpmProject, ProjectGraph, ProjectType } from '../core/project-graph';
+import type { ProjectGraph } from '@nrwl/devkit';
+import {
+  isNpmProject,
+  ProjectType,
+  readCurrentProjectGraph,
+} from '../core/project-graph';
 import { appRootPath } from '../utilities/app-root';
 import {
   DepConstraint,
@@ -19,10 +24,9 @@ import {
   onlyLoadChildren,
 } from '../utils/runtime-lint-utils';
 import { normalize } from 'path';
-import { readNxJson } from '@nrwl/workspace/src/core/file-utils';
+import { readNxJson } from '../core/file-utils';
 import { TargetProjectLocator } from '../core/target-project-locator';
-import { checkCircularPath } from '@nrwl/workspace/src/utils/graph-utils';
-import { readCurrentProjectGraph } from '@nrwl/workspace/src/core/project-graph/project-graph';
+import { checkCircularPath } from '../utils/graph-utils';
 import { isRelativePath } from '../utilities/fileutils';
 
 export class Rule extends Lint.Rules.AbstractRule {

--- a/packages/workspace/src/utilities/buildable-libs-utils.ts
+++ b/packages/workspace/src/utilities/buildable-libs-utils.ts
@@ -1,16 +1,9 @@
-import {
-  ProjectGraph,
-  ProjectGraphNode,
-  ProjectType,
-} from '../core/project-graph';
+import { ProjectType } from '../core/project-graph';
 import { join, resolve, dirname, relative } from 'path';
-import {
-  fileExists,
-  readJsonFile,
-  writeJsonFile,
-} from '@nrwl/workspace/src/utilities/fileutils';
+import { fileExists, readJsonFile, writeJsonFile } from './fileutils';
 import { stripIndents } from '@nrwl/devkit';
-import { getOutputsForTargetAndConfiguration } from '@nrwl/workspace/src/tasks-runner/utils';
+import type { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
+import { getOutputsForTargetAndConfiguration } from '../tasks-runner/utils';
 import * as ts from 'typescript';
 import { unlinkSync } from 'fs';
 import { output } from './output';

--- a/packages/workspace/src/utilities/create-package-json.ts
+++ b/packages/workspace/src/utilities/create-package-json.ts
@@ -1,4 +1,4 @@
-import { ProjectGraph } from '../core/project-graph';
+import type { ProjectGraph } from '@nrwl/devkit';
 import { readJsonFile } from './fileutils';
 
 /**

--- a/packages/workspace/src/utilities/project-graph-utils.ts
+++ b/packages/workspace/src/utilities/project-graph-utils.ts
@@ -1,4 +1,4 @@
-import { ProjectGraphNode } from '../core/project-graph/project-graph-models';
+import type { ProjectGraphNode } from '@nrwl/devkit';
 
 export function projectHasTarget(project: ProjectGraphNode, target: string) {
   return project.data && project.data.targets && project.data.targets[target];

--- a/packages/workspace/src/utilities/run-tasks-in-serial.ts
+++ b/packages/workspace/src/utilities/run-tasks-in-serial.ts
@@ -1,4 +1,4 @@
-import { GeneratorCallback } from '@nrwl/devkit';
+import type { GeneratorCallback } from '@nrwl/devkit';
 
 export function runTasksInSerial(
   ...tasks: GeneratorCallback[]

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -24,11 +24,14 @@ import { getWorkspacePath } from './cli-config-utils';
 import {
   createProjectGraph,
   onlyWorkspaceProjects,
-  ProjectGraph,
 } from '../core/project-graph';
 import { FileData } from '../core/file-utils';
 import { extname, join, normalize, Path } from '@angular-devkit/core';
-import { NxJson, NxJsonProjectConfig } from '../core/shared-interfaces';
+import type {
+  NxJsonConfiguration,
+  NxJsonProjectConfiguration,
+  ProjectGraph,
+} from '@nrwl/devkit';
 import { addInstallTask } from './rules/add-install-task';
 import { findNodes } from '../utilities/typescript/find-nodes';
 import { getSourceNodes } from '../utilities/typescript/get-source-nodes';
@@ -446,21 +449,24 @@ export function updateWorkspaceInTree<T = any, O = T>(
 }
 
 export function readNxJsonInTree(host: Tree) {
-  return readJsonInTree<NxJson>(host, 'nx.json');
+  return readJsonInTree<NxJsonConfiguration>(host, 'nx.json');
 }
 
 export function libsDir(host: Tree) {
-  const json = readJsonInTree<NxJson>(host, 'nx.json');
+  const json = readJsonInTree<NxJsonConfiguration>(host, 'nx.json');
   return json?.workspaceLayout?.libsDir ?? 'libs';
 }
 
 export function appsDir(host: Tree) {
-  const json = readJsonInTree<NxJson>(host, 'nx.json');
+  const json = readJsonInTree<NxJsonConfiguration>(host, 'nx.json');
   return json?.workspaceLayout?.appsDir ?? 'apps';
 }
 
 export function updateNxJsonInTree(
-  callback: (json: NxJson, context: SchematicContext) => NxJson
+  callback: (
+    json: NxJsonConfiguration,
+    context: SchematicContext
+  ) => NxJsonConfiguration
 ): Rule {
   return (host: Tree, context: SchematicContext): Tree => {
     host.overwrite(
@@ -473,7 +479,7 @@ export function updateNxJsonInTree(
 
 export function addProjectToNxJsonInTree(
   projectName: string,
-  options: NxJsonProjectConfig
+  options: NxJsonProjectConfiguration
 ): Rule {
   const defaultOptions = {
     tags: [],

--- a/packages/workspace/src/utils/buildable-libs-utils.ts
+++ b/packages/workspace/src/utils/buildable-libs-utils.ts
@@ -1,17 +1,14 @@
-import {
-  ProjectGraph,
-  ProjectGraphNode,
-  ProjectType,
-} from '../core/project-graph';
+import { ProjectType } from '../core/project-graph';
+import type { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
 import { BuilderContext } from '@angular-devkit/architect';
 import { join, resolve, dirname, relative } from 'path';
 import {
   fileExists,
   readJsonFile,
   writeJsonFile,
-} from '@nrwl/workspace/src/utilities/fileutils';
+} from '../utilities/fileutils';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
-import { getOutputsForTargetAndConfiguration } from '@nrwl/workspace/src/tasks-runner/utils';
+import { getOutputsForTargetAndConfiguration } from '../tasks-runner/utils';
 import * as ts from 'typescript';
 import { unlinkSync } from 'fs';
 

--- a/packages/workspace/src/utils/cli-config-utils.ts
+++ b/packages/workspace/src/utils/cli-config-utils.ts
@@ -1,14 +1,14 @@
 import { Tree } from '@angular-devkit/schematics';
 import { readJsonInTree } from './ast-utils';
-import { NxJson } from '@nrwl/workspace/src/core/shared-interfaces';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 
 export function getWorkspacePath(host: Tree) {
   const possibleFiles = ['/angular.json', '/workspace.json'];
   return possibleFiles.filter((path) => host.exists(path))[0];
 }
 
-export function getNpmScope(host: Tree) {
-  return readJsonInTree<NxJson>(host, 'nx.json').npmScope;
+export function getNpmScope(host: Tree): string {
+  return readJsonInTree<NxJsonConfiguration>(host, 'nx.json').npmScope;
 }
 
 export function parseTarget(targetString: string) {

--- a/packages/workspace/src/utils/graph-utils.spec.ts
+++ b/packages/workspace/src/utils/graph-utils.spec.ts
@@ -1,4 +1,4 @@
-import { ProjectGraph } from '../core/project-graph';
+import type { ProjectGraph } from '@nrwl/devkit';
 import { checkCircularPath } from './graph-utils';
 
 describe('should find the path between nodes', () => {

--- a/packages/workspace/src/utils/graph-utils.ts
+++ b/packages/workspace/src/utils/graph-utils.ts
@@ -1,7 +1,4 @@
-import {
-  ProjectGraph,
-  ProjectGraphNode,
-} from '../core/project-graph/project-graph-models';
+import type { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
 import { isWorkspaceProject } from '../core/project-graph/operators';
 
 interface Reach {

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -1,13 +1,13 @@
 import * as path from 'path';
 import { FileData } from '../core/file-utils';
-import {
-  DependencyType,
+import type {
   ProjectGraph,
   ProjectGraphDependency,
   ProjectGraphNode,
-} from '../core/project-graph';
+  TargetConfiguration,
+} from '@nrwl/devkit';
 import { TargetProjectLocator } from '../core/target-project-locator';
-import { normalizePath, TargetConfiguration } from '@nrwl/devkit';
+import { normalizePath, DependencyType } from '@nrwl/devkit';
 
 export interface MappedProjectGraphNode<T = any> {
   type: string;

--- a/packages/workspace/src/utils/testing-utils.ts
+++ b/packages/workspace/src/utils/testing-utils.ts
@@ -3,7 +3,7 @@ import {
   _test_addWorkspaceFile,
   WorkspaceFormat,
 } from '@angular-devkit/core/src/workspace/core';
-import { NxJson } from '@nrwl/workspace/src/core/shared-interfaces';
+import type { NxJsonConfiguration } from '@nrwl/devkit';
 import { Architect, BuilderContext, Target } from '@angular-devkit/architect';
 import { TestingArchitectHost } from '@angular-devkit/architect/testing';
 import { json, JsonObject } from '@angular-devkit/core';
@@ -37,7 +37,7 @@ export function createEmptyWorkspace(tree: Tree): Tree {
   );
   tree.create(
     '/nx.json',
-    JSON.stringify(<NxJson>{
+    JSON.stringify(<NxJsonConfiguration>{
       npmScope: 'proj',
       projects: {},
       affected: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- the `shared-interfaces.ts` in `@nrwl/workspace` reexports types from `@nrwl/devkit` with another name
- the ProjectGraph types are often imported from `@nrwl/workspace` but should be imported from `@nrwl/devkit`

## Expected Behavior
- types from `@nrwl/devkit` should be used and not duplicated
- the ProjectGraph types should be imported from `@nrwl/devkit`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
