### PR TITLE
fix(nx-plugin): plugins should not include spec files

### DIFF
--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -92,7 +92,6 @@ describe('Nx Plugin', () => {
     expect(buildResults).toContain('Done compiling TypeScript files');
     checkFilesExist(
       `dist/libs/${plugin}/src/migrations/update-${version}/update-${version}.js`,
-      `dist/libs/${plugin}/src/migrations/update-${version}/update-${version}.ts`,
       `libs/${plugin}/src/migrations/update-${version}/update-${version}.ts`
     );
     const migrationsJson = readJson(`libs/${plugin}/migrations.json`);
@@ -133,8 +132,7 @@ describe('Nx Plugin', () => {
       `libs/${plugin}/src/generators/${generator}/generator.spec.ts`,
       `dist/libs/${plugin}/src/generators/${generator}/schema.d.ts`,
       `dist/libs/${plugin}/src/generators/${generator}/schema.json`,
-      `dist/libs/${plugin}/src/generators/${generator}/generator.js`,
-      `dist/libs/${plugin}/src/generators/${generator}/generator.spec.ts`
+      `dist/libs/${plugin}/src/generators/${generator}/generator.js`
     );
     const generatorJson = readJson(`libs/${plugin}/generators.json`);
     expect(generatorJson).toMatchObject({
@@ -171,8 +169,7 @@ describe('Nx Plugin', () => {
       `libs/${plugin}/src/executors/${executor}/executor.spec.ts`,
       `dist/libs/${plugin}/src/executors/${executor}/schema.d.ts`,
       `dist/libs/${plugin}/src/executors/${executor}/schema.json`,
-      `dist/libs/${plugin}/src/executors/${executor}/executor.js`,
-      `dist/libs/${plugin}/src/executors/${executor}/executor.spec.ts`
+      `dist/libs/${plugin}/src/executors/${executor}/executor.js`
     );
     const executorsJson = readJson(`libs/${plugin}/executors.json`);
     expect(executorsJson).toMatchObject({

--- a/packages/nx-plugin/src/schematics/plugin/lib/update-workspace-json.ts
+++ b/packages/nx-plugin/src/schematics/plugin/lib/update-workspace-json.ts
@@ -12,7 +12,12 @@ export function updateWorkspaceJson(options: NormalizedSchema): Rule {
         ...[
           {
             input: `./${options.projectRoot}/src`,
-            glob: '**/*.!(ts)',
+            glob: '**/!(*.ts)',
+            output: './src',
+          },
+          {
+            input: `./${options.projectRoot}/src`,
+            glob: '**/*.d.ts',
             output: './src',
           },
           {

--- a/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.spec.ts
@@ -26,7 +26,12 @@ describe('NxPlugin plugin', () => {
           'libs/my-plugin/*.md',
           {
             input: './libs/my-plugin/src',
-            glob: '**/*.!(ts)',
+            glob: '**/!(*.ts)',
+            output: './src',
+          },
+          {
+            input: './libs/my-plugin/src',
+            glob: '**/*.d.ts',
             output: './src',
           },
           {


### PR DESCRIPTION
## Current Behavior
*.spec.ts files are included when publishing a plugin

## Expected Behavior
*.spec.ts files should not be included in built dist folder.

## Related Issue(s)

Fixes #5563 