### PR TITLE
feat(devkit): refactoring for stricter types and better performance

### DIFF
--- a/packages/devkit/.eslintrc.json
+++ b/packages/devkit/.eslintrc.json
@@ -20,7 +20,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
-      "rules": {}
+      "rules": {
+        "@typescript-eslint/explicit-module-boundary-types": ["error"]
+      }
     },
     {
       "files": ["*.js", "*.jsx"],

--- a/packages/devkit/index.ts
+++ b/packages/devkit/index.ts
@@ -1,5 +1,5 @@
-export { Tree, FileChange } from '@nrwl/tao/src/shared/tree';
-export {
+export type { Tree, FileChange } from '@nrwl/tao/src/shared/tree';
+export type {
   WorkspaceJsonConfiguration,
   TargetDependencyConfig,
   TargetConfiguration,
@@ -11,7 +11,7 @@ export {
   ExecutorContext,
   Workspace,
 } from '@nrwl/tao/src/shared/workspace';
-export {
+export type {
   ImplicitDependencyEntry,
   ImplicitJsonSubsetDependency,
   NxJsonConfiguration,
@@ -19,16 +19,15 @@ export {
   NxAffectedConfig,
 } from '@nrwl/tao/src/shared/nx';
 export { logger } from '@nrwl/tao/src/shared/logger';
-export {
-  getPackageManagerCommand,
-  PackageManager,
-} from '@nrwl/tao/src/shared/package-manager';
-export { runExecutor, Target } from '@nrwl/tao/src/commands/run';
+export type { PackageManager } from '@nrwl/tao/src/shared/package-manager';
+export { getPackageManagerCommand } from '@nrwl/tao/src/shared/package-manager';
+export type { Target } from '@nrwl/tao/src/commands/run';
+export { runExecutor } from '@nrwl/tao/src/commands/run';
 
 export { formatFiles } from './src/generators/format-files';
 export { generateFiles } from './src/generators/generate-files';
+export type { WorkspaceConfiguration } from './src/generators/project-configuration';
 export {
-  WorkspaceConfiguration,
   addProjectConfiguration,
   readProjectConfiguration,
   removeProjectConfiguration,
@@ -47,16 +46,16 @@ export {
 } from './src/executors/parse-target-string';
 export { readTargetOptions } from './src/executors/read-target-options';
 
-export {
+export type {
   ProjectFileMap,
   FileData,
   ProjectGraph,
   ProjectGraphDependency,
-  DependencyType,
   ProjectGraphNode,
   NxPlugin,
   ProjectGraphProcessorContext,
 } from './src/project-graph/interfaces';
+export { DependencyType } from './src/project-graph/interfaces';
 export { ProjectGraphBuilder } from './src/project-graph/utils';
 
 export { readJson, writeJson, updateJson } from './src/utils/json';
@@ -70,13 +69,12 @@ export {
   getWorkspaceLayout,
   getWorkspacePath,
 } from './src/utils/get-workspace-layout';
-export {
-  applyChangesToString,
-  ChangeType,
+export type {
   StringChange,
   StringDeletion,
   StringInsertion,
 } from './src/utils/string-change';
+export { applyChangesToString, ChangeType } from './src/utils/string-change';
 export { offsetFromRoot } from './src/utils/offset-from-root';
 export { convertNxGenerator } from './src/utils/invoke-nx-generator';
 export { convertNxExecutor } from './src/utils/convert-nx-executor';

--- a/packages/devkit/src/executors/parse-target-string.ts
+++ b/packages/devkit/src/executors/parse-target-string.ts
@@ -1,4 +1,4 @@
-import { Target } from '@nrwl/tao/src/commands/run';
+import type { Target } from '@nrwl/tao/src/commands/run';
 
 /**
  * Parses a target string into {project, target, configuration}
@@ -12,7 +12,7 @@ import { Target } from '@nrwl/tao/src/commands/run';
  * parseTargetString("proj:test:production") // returns { project: "proj", target: "test", configuration: "production" }
  * ```
  */
-export function parseTargetString(targetString: string) {
+export function parseTargetString(targetString: string): Target {
   const [project, target, configuration] = targetString.split(':');
   if (!project || !target) {
     throw new Error(`Invalid Target String: ${targetString}`);

--- a/packages/devkit/src/executors/read-target-options.ts
+++ b/packages/devkit/src/executors/read-target-options.ts
@@ -1,5 +1,6 @@
-import { Target } from '@nrwl/tao/src/commands/run';
-import { ExecutorContext, Workspaces } from '@nrwl/tao/src/shared/workspace';
+import type { Target } from '@nrwl/tao/src/commands/run';
+import type { ExecutorContext } from '@nrwl/tao/src/shared/workspace';
+import { Workspaces } from '@nrwl/tao/src/shared/workspace';
 import { combineOptionsForExecutor } from '@nrwl/tao/src/shared/params';
 
 /**
@@ -25,7 +26,7 @@ export function readTargetOptions<T = any>(
 
   return combineOptionsForExecutor(
     {},
-    configuration,
+    configuration ?? '',
     targetConfiguration,
     schema,
     defaultProject,

--- a/packages/devkit/src/generators/generate-files.spec.ts
+++ b/packages/devkit/src/generators/generate-files.spec.ts
@@ -1,4 +1,4 @@
-import { Tree } from '@nrwl/tao/src/shared/tree';
+import type { Tree } from '@nrwl/tao/src/shared/tree';
 import { createTree } from '../tests/create-tree';
 import { generateFiles } from './generate-files';
 import { join } from 'path';

--- a/packages/devkit/src/generators/generate-files.ts
+++ b/packages/devkit/src/generators/generate-files.ts
@@ -1,7 +1,6 @@
 import { readFileSync, readdirSync, statSync } from 'fs';
 import * as path from 'path';
-import { Tree } from '@nrwl/tao/src/shared/tree';
-import { join, relative } from 'path';
+import type { Tree } from '@nrwl/tao/src/shared/tree';
 import { logger } from '@nrwl/tao/src/shared/logger';
 
 const binaryExts = new Set([
@@ -60,7 +59,7 @@ export function generateFiles(
   srcFolder: string,
   target: string,
   substitutions: { [k: string]: any }
-) {
+): void {
   const ejs = require('ejs');
   allFilesInDir(srcFolder).forEach((filePath) => {
     let newContent: Buffer | string;
@@ -92,9 +91,9 @@ function computePath(
   target: string,
   filePath: string,
   substitutions: { [k: string]: any }
-) {
-  const relativeFromSrcFolder = relative(srcFolder, filePath);
-  let computedPath = join(target, relativeFromSrcFolder);
+): string {
+  const relativeFromSrcFolder = path.relative(srcFolder, filePath);
+  let computedPath = path.join(target, relativeFromSrcFolder);
   if (computedPath.endsWith('.template')) {
     computedPath = computedPath.substring(0, computedPath.length - 9);
   }
@@ -104,11 +103,11 @@ function computePath(
   return computedPath;
 }
 
-function allFilesInDir(parent: string) {
-  let res = [];
+function allFilesInDir(parent: string): string[] {
+  let res: string[] = [];
   try {
     readdirSync(parent).forEach((c) => {
-      const child = join(parent, c);
+      const child = path.join(parent, c);
       try {
         const s = statSync(child);
         if (!s.isDirectory()) {
@@ -116,8 +115,8 @@ function allFilesInDir(parent: string) {
         } else if (s.isDirectory()) {
           res = [...res, ...allFilesInDir(child)];
         }
-      } catch (e) {}
+      } catch {}
     });
-  } catch (e) {}
+  } catch {}
   return res;
 }

--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -1,11 +1,11 @@
-import { Tree } from '@nrwl/tao/src/shared/tree';
-import {
+import type { Tree } from '@nrwl/tao/src/shared/tree';
+import type {
   ProjectConfiguration,
-  toNewFormat,
   WorkspaceJsonConfiguration,
 } from '@nrwl/tao/src/shared/workspace';
-import { readJson, updateJson } from '../utils/json';
-import {
+import { toNewFormat } from '@nrwl/tao/src/shared/workspace';
+import { readJson, updateJson, writeJson } from '../utils/json';
+import type {
   NxJsonConfiguration,
   NxJsonProjectConfiguration,
 } from '@nrwl/tao/src/shared/nx';
@@ -31,7 +31,7 @@ export function addProjectConfiguration(
   host: Tree,
   projectName: string,
   projectConfiguration: ProjectConfiguration & NxJsonProjectConfiguration
-) {
+): void {
   setProjectConfiguration(host, projectName, projectConfiguration, 'create');
 }
 
@@ -49,7 +49,7 @@ export function updateProjectConfiguration(
   host: Tree,
   projectName: string,
   projectConfiguration: ProjectConfiguration & NxJsonProjectConfiguration
-) {
+): void {
   setProjectConfiguration(host, projectName, projectConfiguration, 'update');
 }
 
@@ -59,7 +59,10 @@ export function updateProjectConfiguration(
  * The project configuration is stored in workspace.json and nx.json.
  * The utility will update both files.
  */
-export function removeProjectConfiguration(host: Tree, projectName: string) {
+export function removeProjectConfiguration(
+  host: Tree,
+  projectName: string
+): void {
   setProjectConfiguration(host, projectName, undefined, 'delete');
 }
 
@@ -68,7 +71,9 @@ export function removeProjectConfiguration(host: Tree, projectName: string) {
  *
  * Use {@link readProjectConfiguration} if only one project is needed.
  */
-export function getProjects(host: Tree) {
+export function getProjects(
+  host: Tree
+): Map<string, ProjectConfiguration & NxJsonProjectConfiguration> {
   const workspace = readWorkspace(host);
   const nxJson = readJson<NxJsonConfiguration>(host, 'nx.json');
 
@@ -116,7 +121,7 @@ export function updateWorkspaceConfiguration(
     tasksRunnerOptions,
     workspaceLayout,
   }: WorkspaceConfiguration
-) {
+): void {
   const workspace: Omit<WorkspaceJsonConfiguration, 'projects'> = {
     version,
     cli,
@@ -152,7 +157,10 @@ export function updateWorkspaceConfiguration(
  * @param host - the file system tree
  * @param projectName - unique name. Often directories are part of the name (e.g., mydir-mylib)
  */
-export function readProjectConfiguration(host: Tree, projectName: string) {
+export function readProjectConfiguration(
+  host: Tree,
+  projectName: string
+): ProjectConfiguration & NxJsonProjectConfiguration {
   const workspace = readWorkspace(host);
   if (!workspace.projects[projectName]) {
     throw new Error(
@@ -187,7 +195,7 @@ function readWorkspaceSection(
   workspace: WorkspaceJsonConfiguration,
   projectName: string
 ) {
-  return workspace.projects[projectName] as ProjectConfiguration;
+  return workspace.projects[projectName];
 }
 
 function readNxJsonSection(nxJson: NxJsonConfiguration, projectName: string) {
@@ -253,7 +261,7 @@ function addProjectToWorkspaceJson(
     );
   }
   workspaceJson.projects[projectName] = project;
-  host.write(path, JSON.stringify(workspaceJson, null, 2));
+  writeJson(host, path, workspaceJson);
 }
 
 function addProjectToNxJson(
@@ -273,7 +281,7 @@ function addProjectToNxJson(
       ...(config || {}),
     };
   }
-  host.write('nx.json', JSON.stringify(nxJson, null, 2));
+  writeJson(host, 'nx.json', nxJson);
 }
 
 function readWorkspace(host: Tree): WorkspaceJsonConfiguration {

--- a/packages/devkit/src/generators/to-js.ts
+++ b/packages/devkit/src/generators/to-js.ts
@@ -1,9 +1,9 @@
-import { Tree } from '@nrwl/tao/src/shared/tree';
+import type { Tree } from '@nrwl/tao/src/shared/tree';
 
 /**
  * Rename and transpile any new typescript files created to javascript files
  */
-export function toJS(tree: Tree) {
+export function toJS(tree: Tree): void {
   const { JsxEmit, ScriptTarget, transpile } = require('typescript');
 
   for (const c of tree.listChanges()) {

--- a/packages/devkit/src/generators/typescript/insert-import.ts
+++ b/packages/devkit/src/generators/typescript/insert-import.ts
@@ -1,1 +1,1 @@
-export function insertImport() {}
+export function insertImport(): void {}

--- a/packages/devkit/src/generators/typescript/insert-statement.ts
+++ b/packages/devkit/src/generators/typescript/insert-statement.ts
@@ -1,1 +1,1 @@
-export function insertImport() {}
+export function insertImport(): void {}

--- a/packages/devkit/src/generators/update-ts-configs-to-js.ts
+++ b/packages/devkit/src/generators/update-ts-configs-to-js.ts
@@ -1,10 +1,10 @@
-import { Tree } from '@nrwl/tao/src/shared/tree';
+import type { Tree } from '@nrwl/tao/src/shared/tree';
 import { updateJson } from '../utils/json';
 
 export function updateTsConfigsToJs(
   host: Tree,
   options: { projectRoot: string }
-) {
+): void {
   let updateConfigPath: string;
 
   const paths = {

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -1,5 +1,6 @@
-import { createTree } from '@nrwl/devkit/testing';
-import { Tree, visitNotIgnoredFiles } from '@nrwl/devkit';
+import { createTree } from '../tests/create-tree';
+import type { Tree } from '@nrwl/tao/src/shared/tree';
+import { visitNotIgnoredFiles } from './visit-not-ignored-files';
 
 describe('visitNotIgnoredFiles', () => {
   let tree: Tree;

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -1,7 +1,5 @@
-import { Tree } from '@nrwl/tao/src/shared/tree';
-
+import type { Tree } from '@nrwl/tao/src/shared/tree';
 import { join } from 'path';
-
 import ignore, { Ignore } from 'ignore';
 
 /**
@@ -11,7 +9,7 @@ export function visitNotIgnoredFiles(
   tree: Tree,
   dirPath: string = tree.root,
   visitor: (path: string) => void
-) {
+): void {
   let ig: Ignore;
   if (tree.exists('.gitignore')) {
     ig = ignore();

--- a/packages/devkit/src/project-graph/interfaces.ts
+++ b/packages/devkit/src/project-graph/interfaces.ts
@@ -1,4 +1,7 @@
-import { TargetConfiguration, Workspace } from '@nrwl/tao/src/shared/workspace';
+import type {
+  TargetConfiguration,
+  Workspace,
+} from '@nrwl/tao/src/shared/workspace';
 
 /**
  * Some metadata about a file

--- a/packages/devkit/src/project-graph/utils.ts
+++ b/packages/devkit/src/project-graph/utils.ts
@@ -1,8 +1,8 @@
-import {
-  DependencyType,
+import type {
   ProjectGraph,
   ProjectGraphDependency,
   ProjectGraphNode,
+  DependencyType,
 } from './interfaces';
 
 /**
@@ -27,7 +27,7 @@ export class ProjectGraphBuilder {
   /**
    * Adds a project node to the project graph
    */
-  addNode(node: ProjectGraphNode) {
+  addNode(node: ProjectGraphNode): void {
     // Check if project with the same name already exists
     if (this.nodes[node.name]) {
       // Throw if existing project is of a different type
@@ -52,7 +52,7 @@ export class ProjectGraphBuilder {
     type: DependencyType | string,
     sourceProjectName: string,
     targetProjectName: string
-  ) {
+  ): void {
     if (sourceProjectName === targetProjectName) {
       return;
     }

--- a/packages/devkit/src/tasks/install-packages-task.ts
+++ b/packages/devkit/src/tasks/install-packages-task.ts
@@ -1,15 +1,14 @@
-import { Tree } from '@nrwl/tao/src/shared/tree';
+import type { Tree } from '@nrwl/tao/src/shared/tree';
 import { execSync } from 'child_process';
 import { join } from 'path';
 import {
   detectPackageManager,
   getPackageManagerCommand,
-  PackageManager,
 } from '@nrwl/tao/src/shared/package-manager';
-
+import type { PackageManager } from '@nrwl/tao/src/shared/package-manager';
 import { joinPathFragments } from '../utils/path';
 
-let storedPackageJsonValue;
+let storedPackageJsonValue: string;
 
 /**
  * Runs `npm install` or `yarn install`. It will skip running the install if
@@ -22,8 +21,8 @@ export function installPackagesTask(
   host: Tree,
   alwaysRun: boolean = false,
   cwd: string = '',
-  packageManager?: PackageManager
-) {
+  packageManager: PackageManager = detectPackageManager(cwd)
+): void {
   const packageJsonValue = host.read(
     joinPathFragments(cwd, 'package.json'),
     'utf-8'
@@ -36,12 +35,8 @@ export function installPackagesTask(
   ) {
     // Don't install again if install was already executed with package.json
     if (storedPackageJsonValue != packageJsonValue || alwaysRun) {
-      storedPackageJsonValue = host.read(
-        joinPathFragments(cwd, 'package.json'),
-        'utf-8'
-      );
-      const pm = packageManager || detectPackageManager(cwd);
-      const pmc = getPackageManagerCommand(pm);
+      storedPackageJsonValue = packageJsonValue;
+      const pmc = getPackageManagerCommand(packageManager);
       execSync(pmc.install, {
         cwd: join(host.root, cwd),
         stdio: [0, 1, 2],

--- a/packages/devkit/src/tests/create-tree-with-empty-workspace.ts
+++ b/packages/devkit/src/tests/create-tree-with-empty-workspace.ts
@@ -1,13 +1,14 @@
 import { FsTree } from '@nrwl/tao/src/shared/tree';
+import type { Tree } from '@nrwl/tao/src/shared/tree';
 
 /**
  * Creates a host for testing.
  */
-export function createTreeWithEmptyWorkspace() {
+export function createTreeWithEmptyWorkspace(): Tree {
   const tree = new FsTree('/virtual', false);
 
   tree.write('/workspace.json', JSON.stringify({ version: 1, projects: {} }));
-  tree.write('./.prettierrc', '{"singleQuote": true}');
+  tree.write('./.prettierrc', JSON.stringify({ singleQuote: true }));
   tree.write(
     '/package.json',
     JSON.stringify({

--- a/packages/devkit/src/tests/create-tree.ts
+++ b/packages/devkit/src/tests/create-tree.ts
@@ -1,8 +1,9 @@
 import { FsTree } from '@nrwl/tao/src/shared/tree';
+import type { Tree } from '@nrwl/tao/src/shared/tree';
 
 /**
  * Creates a host for testing.
  */
-export function createTree() {
+export function createTree(): Tree {
   return new FsTree('/virtual', false);
 }

--- a/packages/devkit/src/utils/convert-nx-executor.ts
+++ b/packages/devkit/src/utils/convert-nx-executor.ts
@@ -1,16 +1,13 @@
 import { from, Observable } from 'rxjs';
-
-import {
-  Executor,
-  ExecutorContext,
-  Workspaces,
-} from '@nrwl/tao/src/shared/workspace';
+import type { Executor, ExecutorContext } from '@nrwl/tao/src/shared/workspace';
+import { Workspaces } from '@nrwl/tao/src/shared/workspace';
 
 /**
  * Convert an Nx Executor into an Angular Devkit Builder
  *
  * Use this to expose a compatible Angular Builder
  */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function convertNxExecutor(executor: Executor) {
   const builderFunction = (options, builderContext) => {
     const workspaceConfig = new Workspaces(

--- a/packages/devkit/src/utils/get-workspace-layout.ts
+++ b/packages/devkit/src/utils/get-workspace-layout.ts
@@ -1,6 +1,6 @@
-import { Tree } from '@nrwl/tao/src/shared/tree';
+import type { Tree } from '@nrwl/tao/src/shared/tree';
 import { readJson } from './json';
-import { NxJsonConfiguration } from '@nrwl/tao/src/shared/nx';
+import type { NxJsonConfiguration } from '@nrwl/tao/src/shared/nx';
 
 /**
  * Returns workspace defaults. It includes defaults folders for apps and libs,
@@ -22,7 +22,7 @@ export function getWorkspaceLayout(
   };
 }
 
-export function getWorkspacePath(host: Tree) {
+export function getWorkspacePath(host: Tree): string {
   const possibleFiles = ['/angular.json', '/workspace.json'];
   return possibleFiles.filter((path) => host.exists(path))[0];
 }

--- a/packages/devkit/src/utils/invoke-nx-generator.ts
+++ b/packages/devkit/src/utils/invoke-nx-generator.ts
@@ -34,6 +34,7 @@ function createRunCallbackTask() {
  * Convert an Nx Generator into an Angular Devkit Schematic
  */
 export function convertNxGenerator<T = any>(generator: Generator<T>) {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   return (options: T) => invokeNxGenerator(generator, options);
 }
 
@@ -131,7 +132,7 @@ class DevkitTreeFromAngularDevkitTree implements Tree {
     return fileChanges;
   }
 
-  private normalize(path) {
+  private normalize(path: string): string {
     return relative(this.root, join(this.root, path));
   }
 
@@ -142,10 +143,6 @@ class DevkitTreeFromAngularDevkitTree implements Tree {
       ? this.tree.read(filePath).toString(encoding)
       : this.tree.read(filePath);
   }
-
-  /* read(filePath: string): Buffer | null {
-    return this.tree.read(filePath);
-  }*/
 
   rename(from: string, to: string): void {
     this.tree.rename(from, to);

--- a/packages/devkit/src/utils/json.ts
+++ b/packages/devkit/src/utils/json.ts
@@ -1,4 +1,4 @@
-import { Tree } from '@nrwl/tao/src/shared/tree';
+import type { Tree } from '@nrwl/tao/src/shared/tree';
 import * as stripJsonComments from 'strip-json-comments';
 
 /**
@@ -7,7 +7,7 @@ import * as stripJsonComments from 'strip-json-comments';
  * @param host - file system tree
  * @param path - file path
  */
-export function readJson<T = any>(host: Tree, path: string) {
+export function readJson<T = any>(host: Tree, path: string): T {
   if (!host.exists(path)) {
     throw new Error(`Cannot find ${path}`);
   }
@@ -26,7 +26,7 @@ export function readJson<T = any>(host: Tree, path: string) {
  * @param path Path of JSON file in the Tree
  * @param value Serializable value to write
  */
-export function writeJson<T = any>(host: Tree, path: string, value: T) {
+export function writeJson<T = any>(host: Tree, path: string, value: T): void {
   host.write(path, JSON.stringify(value, null, 2));
 }
 
@@ -41,7 +41,7 @@ export function updateJson<T = any, U = T>(
   host: Tree,
   path: string,
   updater: (value: T) => U
-) {
+): void {
   const updatedValue = updater(readJson(host, path));
   writeJson(host, path, updatedValue);
 }

--- a/packages/devkit/src/utils/package-json.spec.ts
+++ b/packages/devkit/src/utils/package-json.spec.ts
@@ -1,10 +1,7 @@
-import {
-  addDependenciesToPackageJson,
-  readJson,
-  writeJson,
-  Tree,
-} from '@nrwl/devkit';
-import { createTree } from '@nrwl/devkit/testing';
+import type { Tree } from '@nrwl/tao/src/shared/tree';
+import { readJson, writeJson } from './json';
+import { addDependenciesToPackageJson } from './package-json';
+import { createTree } from '../tests/create-tree';
 
 describe('addDependenciesToPackageJson', () => {
   let tree: Tree;

--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -1,8 +1,7 @@
 import { readJson, updateJson } from './json';
 import { installPackagesTask } from '../tasks/install-packages-task';
-
-import { Tree } from '@nrwl/tao/src/shared/tree';
-import { GeneratorCallback } from '@nrwl/tao/src/shared/workspace';
+import type { Tree } from '@nrwl/tao/src/shared/tree';
+import type { GeneratorCallback } from '@nrwl/tao/src/shared/workspace';
 
 /**
  * Add Dependencies and Dev Dependencies to package.json
@@ -44,7 +43,7 @@ export function addDependenciesToPackageJson(
       return json;
     });
   }
-  return () => {
+  return (): void => {
     installPackagesTask(host);
   };
 }
@@ -87,12 +86,12 @@ export function removeDependenciesFromPackageJson(
       return json;
     });
   }
-  return () => {
+  return (): void => {
     installPackagesTask(host);
   };
 }
 
-function sortObjectByKeys(obj: unknown) {
+function sortObjectByKeys(obj: unknown): unknown {
   return Object.keys(obj)
     .sort()
     .reduce((result, key) => {

--- a/packages/devkit/src/utils/string-change.ts
+++ b/packages/devkit/src/utils/string-change.ts
@@ -75,7 +75,7 @@ export function applyChangesToString(
         return 0;
       } else {
         // When at the same place, Insert before Delete
-        return a.type === ChangeType.Insert ? -1 : 1;
+        return isStringInsertion(a) ? -1 : 1;
       }
     }
     return diff;
@@ -83,64 +83,56 @@ export function applyChangesToString(
   let offset = 0;
   for (const change of sortedChanges) {
     const index = getChangeIndex(change) + offset;
-    switch (change.type) {
-      case ChangeType.Insert: {
-        text = text.substr(0, index) + change.text + text.substr(index);
-        offset += change.text.length;
-        break;
-      }
-      case ChangeType.Delete: {
-        text = text.substr(0, index) + text.substr(index + change.length);
-        offset -= change.length;
-        break;
-      }
+    if (isStringInsertion(change)) {
+      text = text.substr(0, index) + change.text + text.substr(index);
+      offset += change.text.length;
+    } else {
+      text = text.substr(0, index) + text.substr(index + change.length);
+      offset -= change.length;
     }
   }
   return text;
 }
 
-function assertChangesValid(changes: Array<StringInsertion | StringDeletion>) {
+function assertChangesValid(
+  changes: Array<StringInsertion | StringDeletion>
+): void {
   for (const change of changes) {
-    switch (change.type) {
-      case ChangeType.Delete: {
-        if (!Number.isInteger(change.start)) {
-          throw new TypeError(`${change.start} must be an integer.`);
-        }
-        if (change.start < 0) {
-          throw new Error(`${change.start} must be a positive integer.`);
-        }
-        if (!Number.isInteger(change.length)) {
-          throw new TypeError(`${change.length} must be an integer.`);
-        }
-        if (change.length < 0) {
-          throw new Error(`${change.length} must be a positive integer.`);
-        }
-        break;
+    if (isStringInsertion(change)) {
+      if (!Number.isInteger(change.index)) {
+        throw new TypeError(`${change.index} must be an integer.`);
       }
-      case ChangeType.Insert:
-        {
-          if (!Number.isInteger(change.index)) {
-            throw new TypeError(`${change.index} must be an integer.`);
-          }
-          if (change.index < 0) {
-            throw new Error(`${change.index} must be a positive integer.`);
-          }
-          if (typeof change.text !== 'string') {
-            throw new Error(`${change.text} must be a string.`);
-          }
-        }
-        break;
+      if (change.index < 0) {
+        throw new Error(`${change.index} must be a positive integer.`);
+      }
+      if (typeof change.text !== 'string') {
+        throw new Error(`${change.text} must be a string.`);
+      }
+    } else {
+      if (!Number.isInteger(change.start)) {
+        throw new TypeError(`${change.start} must be an integer.`);
+      }
+      if (change.start < 0) {
+        throw new Error(`${change.start} must be a positive integer.`);
+      }
+      if (!Number.isInteger(change.length)) {
+        throw new TypeError(`${change.length} must be an integer.`);
+      }
+      if (change.length < 0) {
+        throw new Error(`${change.length} must be a positive integer.`);
+      }
     }
   }
 }
 
-function getChangeIndex(change: StringInsertion | StringDeletion) {
-  switch (change.type) {
-    case ChangeType.Insert: {
-      return change.index;
-    }
-    case ChangeType.Delete: {
-      return change.start;
-    }
+function getChangeIndex(change: StringChange): number {
+  if (isStringInsertion(change)) {
+    return change.index;
+  } else {
+    return change.start;
   }
+}
+
+function isStringInsertion(change: StringChange): change is StringInsertion {
+  return change.type === ChangeType.Insert;
 }

--- a/packages/devkit/src/utils/strip-indents.ts
+++ b/packages/devkit/src/utils/strip-indents.ts
@@ -11,7 +11,10 @@
  * `
  * ```
  */
-export function stripIndents(strings, ...values) {
+export function stripIndents(
+  strings: TemplateStringsArray,
+  ...values: any[]
+): string {
   return String.raw(strings, ...values)
     .split('\n')
     .map((line) => line.trim())


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- string change utils use `switch ... case`
## Expected Behavior
- `@nrwl/devkit` should use `import type` and `export type` feature which exists since TypeScript 3.8 see: [Type-Only Imports and Exports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export)
- `@nrwl/devkit` should define types in a strict way to ensure that developers don`t make any breaking changes by accident
- string change utils should use typescript type guard and `if...else` 
- `@nrwl/devkit` should enforce strict module boundary types with eslint see: [explicit-module-boundary-types](https://github.com/typescript-eslint/typescript-eslint/blob/ddfab95841814351db0bf3d89281a964ee9daa43/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md)
- `@nrwl/devkit` should use `readJson()` and `writeJson()` from `utils/json.ts`
- `createTree()` and `createTreeWithEmptyWorkspace()` from `@nrwl/devkit/testing` should not expose `FsTree` from `@nrwl/tao`

