### PR TITLE
fix(nextjs): NODE_ENV defaults to production for builds

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -354,14 +354,22 @@ describe('Next.js Applications', () => {
         future: {
           // Nx doesn't support webpack 5 yet
           webpack5: false,
+        },
+        webpack: (c) => {
+          console.log('NODE_ENV is', process.env.NODE_ENV);
+          return c;
         }
       }
       `
     );
-
-    runCLI(`build ${appName}`);
+    // deleting `NODE_ENV` value, so that it's `undefined`, and not `"test"`
+    // by the time it reaches the build executor.
+    // this simulates existing behaviour of running a next.js build executor via Nx
+    delete process.env.NODE_ENV;
+    const result = runCLI(`build ${appName}`);
 
     checkFilesExist(`dist/apps/${appName}/next.config.js`);
+    expect(result).toContain('NODE_ENV is production');
   }, 120000);
 
   it('should support --js flag', async () => {

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -23,6 +23,8 @@ export default async function buildExecutor(
   options: NextBuildBuilderOptions,
   context: ExecutorContext
 ) {
+  process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+
   const root = resolve(context.root, options.root);
 
   const projGraph = createProjectGraph();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

The idea is to bring us closer to how Next.js behaves, and thus how we suspect users expect us to behave - building a Next.js app builds it for production.
- ✅ Next.js apps already aren't being generated with any production configuration in `workspace.json` 
- we're currently not setting `NODE_ENV` to anything ourselves, whereas Next.js does ([code](https://github.com/vercel/next.js/blob/canary/packages/next/bin/next.ts#L93)).  that's what this PR addresses. we've already seen a few issues because of this difference, actually - #5445 , #5312 

I appreciate that this is a pretty brute-force of setting the `NODE_ENV` value. If someone has better ideas as to where this could be put - i'm all ears!

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`NODE_ENV` is `undefined` during the build of a Next.js app

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`NODE_ENV` should be set to `production`, to mirror default Next.js behaviour

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5445, #5312
