### PR TITLE
feat(linter): optimize lint performance. resolves #5210

### DIFF
--- a/packages/devkit/src/project-graph/interfaces.ts
+++ b/packages/devkit/src/project-graph/interfaces.ts
@@ -19,11 +19,8 @@ export interface ProjectFileMap {
 /**
  * A Graph of projects in the workspace and dependencies between them
  */
-export interface ProjectGraph<
-  T = any,
-  FILES extends FileData[] | Record<string, FileData> = FileData[]
-> {
-  nodes: Record<string, ProjectGraphNode<T, FILES>>;
+export interface ProjectGraph<T = any> {
+  nodes: Record<string, ProjectGraphNode<T>>;
   dependencies: Record<string, ProjectGraphDependency[]>;
 
   // this is optional otherwise it might break folks who use project graph creation
@@ -51,10 +48,7 @@ export enum DependencyType {
 /**
  * A node describing a project in a workspace
  */
-export interface ProjectGraphNode<
-  T = any,
-  FILES extends FileData[] | Record<string, FileData> = FileData[]
-> {
+export interface ProjectGraphNode<T = any> {
   type: string;
   name: string;
   /**
@@ -72,7 +66,7 @@ export interface ProjectGraphNode<
     /**
      * Files associated to the project
      */
-    files: FILES;
+    files: FileData[];
   };
 }
 

--- a/packages/devkit/src/project-graph/interfaces.ts
+++ b/packages/devkit/src/project-graph/interfaces.ts
@@ -19,8 +19,11 @@ export interface ProjectFileMap {
 /**
  * A Graph of projects in the workspace and dependencies between them
  */
-export interface ProjectGraph {
-  nodes: Record<string, ProjectGraphNode>;
+export interface ProjectGraph<
+  T = any,
+  FILES extends FileData[] | Record<string, FileData> = FileData[]
+> {
+  nodes: Record<string, ProjectGraphNode<T, FILES>>;
   dependencies: Record<string, ProjectGraphDependency[]>;
 
   // this is optional otherwise it might break folks who use project graph creation
@@ -48,7 +51,10 @@ export enum DependencyType {
 /**
  * A node describing a project in a workspace
  */
-export interface ProjectGraphNode<T = any> {
+export interface ProjectGraphNode<
+  T = any,
+  FILES extends FileData[] | Record<string, FileData> = FileData[]
+> {
   type: string;
   name: string;
   /**
@@ -66,7 +72,7 @@ export interface ProjectGraphNode<T = any> {
     /**
      * Files associated to the project
      */
-    files: FileData[];
+    files: FILES;
   };
 }
 

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -160,7 +160,7 @@ export default createESLintRule<Options, MessageIds>({
       const imp = node.source.value as string;
 
       const sourceFilePath = getSourceFilePath(
-        normalizePath(context.getFilename()),
+        context.getFilename(),
         projectPath
       );
 

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -122,7 +122,9 @@ export default createESLintRule<Options, MessageIds>({
     if (!(global as any).projectGraph) {
       const nxJson = readNxJson();
       (global as any).npmScope = nxJson.npmScope;
-      (global as any).projectGraph = readCurrentProjectGraph();
+      (global as any).projectGraph = mapProjectGraphFiles(
+        readCurrentProjectGraph()
+      );
     }
 
     if (!(global as any).projectGraph) {
@@ -130,9 +132,10 @@ export default createESLintRule<Options, MessageIds>({
     }
 
     const npmScope = (global as any).npmScope;
-    const projectGraph = mapProjectGraphFiles(
-      (global as any).projectGraph as ProjectGraph
-    );
+    const projectGraph = (global as any).projectGraph as ProjectGraph<
+      any,
+      Record<string, FileData>
+    >;
 
     if (!(global as any).targetProjectLocator) {
       (global as any).targetProjectLocator = new TargetProjectLocator(

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -170,12 +170,14 @@ export default createESLintRule<Options, MessageIds>({
       }
 
       // check for relative and absolute imports
+      const sourceProject = findSourceProject(projectGraph, sourceFilePath);
       if (
         isRelativeImportIntoAnotherProject(
           imp,
           projectPath,
           projectGraph,
-          sourceFilePath
+          sourceFilePath,
+          sourceProject
         ) ||
         isAbsoluteImportIntoAnotherProject(imp)
       ) {
@@ -189,7 +191,6 @@ export default createESLintRule<Options, MessageIds>({
         return;
       }
 
-      const sourceProject = findSourceProject(projectGraph, sourceFilePath);
       const targetProject = findProjectUsingImport(
         projectGraph,
         targetProjectLocator,

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -159,15 +159,15 @@ export default createESLintRule<Options, MessageIds>({
 
       const imp = node.source.value as string;
 
-      const sourceFilePath = getSourceFilePath(
-        context.getFilename(),
-        projectPath
-      );
-
       // whitelisted import
       if (allow.some((a) => matchImportWithWildcard(a, imp))) {
         return;
       }
+
+      const sourceFilePath = getSourceFilePath(
+        context.getFilename(),
+        projectPath
+      );
 
       // check for relative and absolute imports
       const sourceProject = findSourceProject(projectGraph, sourceFilePath);

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -9,6 +9,7 @@ import {
   hasNoneOfTheseTags,
   isAbsoluteImportIntoAnotherProject,
   isRelativeImportIntoAnotherProject,
+  mapProjectGraphFiles,
   matchImportWithWildcard,
   onlyLoadChildren,
 } from '@nrwl/workspace/src/utils/runtime-lint-utils';
@@ -17,7 +18,7 @@ import {
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { normalizePath } from '@nrwl/devkit';
+import { normalizePath, FileData } from '@nrwl/devkit';
 import {
   isNpmProject,
   ProjectGraph,
@@ -129,7 +130,9 @@ export default createESLintRule<Options, MessageIds>({
     }
 
     const npmScope = (global as any).npmScope;
-    const projectGraph = (global as any).projectGraph as ProjectGraph;
+    const projectGraph = mapProjectGraphFiles(
+      (global as any).projectGraph as ProjectGraph
+    );
 
     if (!(global as any).targetProjectLocator) {
       (global as any).targetProjectLocator = new TargetProjectLocator(

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -12,16 +12,16 @@ import {
   mapProjectGraphFiles,
   matchImportWithWildcard,
   onlyLoadChildren,
+  MappedProjectGraph,
 } from '@nrwl/workspace/src/utils/runtime-lint-utils';
 import {
   AST_NODE_TYPES,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { normalizePath, FileData } from '@nrwl/devkit';
+import { normalizePath } from '@nrwl/devkit';
 import {
   isNpmProject,
-  ProjectGraph,
   ProjectType,
 } from '@nrwl/workspace/src/core/project-graph';
 import { readNxJson } from '@nrwl/workspace/src/core/file-utils';
@@ -132,10 +132,7 @@ export default createESLintRule<Options, MessageIds>({
     }
 
     const npmScope = (global as any).npmScope;
-    const projectGraph = (global as any).projectGraph as ProjectGraph<
-      any,
-      Record<string, FileData>
-    >;
+    const projectGraph = (global as any).projectGraph as MappedProjectGraph;
 
     if (!(global as any).targetProjectLocator) {
       (global as any).targetProjectLocator = new TargetProjectLocator(

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -11,6 +11,7 @@ import enforceModuleBoundaries, {
   RULE_NAME as enforceModuleBoundariesRuleName,
 } from '../../src/rules/enforce-module-boundaries';
 import { TargetProjectLocator } from '@nrwl/workspace/src/core/target-project-locator';
+import { mapProjectGraphFiles } from '@nrwl/workspace/src/utils/runtime-lint-utils';
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('../../../workspace/src/utilities/app-root', () => ({
   appRootPath: '/root',
@@ -72,7 +73,7 @@ const fileSys = {
   './tsconfig.base.json': JSON.stringify(tsconfig),
 };
 
-describe('Enforce Module Boundaries', () => {
+describe('Enforce Module Boundaries (eslint)', () => {
   beforeEach(() => {
     vol.fromJSON(fileSys, '/root');
   });
@@ -1536,7 +1537,7 @@ function runRule(
 ): TSESLint.Linter.LintMessage[] {
   (global as any).projectPath = `${process.cwd()}/proj`;
   (global as any).npmScope = 'mycompany';
-  (global as any).projectGraph = projectGraph;
+  (global as any).projectGraph = mapProjectGraphFiles(projectGraph);
   (global as any).targetProjectLocator = new TargetProjectLocator(
     projectGraph.nodes
   );

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -149,7 +149,7 @@ function projectsToRun(nxArgs: NxArgs, projectGraph: ProjectGraph) {
 }
 
 function applyExclude(
-  projects: Record<string, ProjectGraphNode<any>>,
+  projects: Record<string, ProjectGraphNode>,
   nxArgs: NxArgs
 ) {
   return Object.keys(projects)
@@ -161,7 +161,7 @@ function applyExclude(
 }
 
 function applyOnlyFailed(
-  projectsNotExcluded: Record<string, ProjectGraphNode<any>>,
+  projectsNotExcluded: Record<string, ProjectGraphNode>,
   nxArgs: NxArgs,
   env: Environment
 ) {

--- a/packages/workspace/src/command-line/run-many.ts
+++ b/packages/workspace/src/command-line/run-many.ts
@@ -80,7 +80,7 @@ function applyExclude(
 }
 
 function applyOnlyFailed(
-  projectsNotExcluded: Record<string, ProjectGraphNode<any>>,
+  projectsNotExcluded: Record<string, ProjectGraphNode>,
   nxArgs: NxArgs,
   env: Environment
 ) {

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -151,7 +151,7 @@ function getIgnoredGlobs() {
   return ig;
 }
 
-function readFileIfExisting(path: string) {
+export function readFileIfExisting(path: string) {
   return existsSync(path) ? readFileSync(path, 'utf-8') : '';
 }
 
@@ -188,10 +188,6 @@ export type FileRead = (s: string) => string;
 
 export function defaultFileRead(filePath: string): string | null {
   return readFileSync(join(appRootPath, filePath), 'utf-8');
-}
-
-export function defaultFileExists(filePath: string): boolean {
-  return existsSync(join(appRootPath, filePath));
 }
 
 export function readPackageJson(): any {

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -190,6 +190,10 @@ export function defaultFileRead(filePath: string): string | null {
   return readFileSync(join(appRootPath, filePath), 'utf-8');
 }
 
+export function defaultFileExists(filePath: string): boolean {
+  return existsSync(join(appRootPath, filePath));
+}
+
 export function readPackageJson(): any {
   return readJsonFile(`${appRootPath}/package.json`);
 }

--- a/packages/workspace/src/core/project-graph/operators.ts
+++ b/packages/workspace/src/core/project-graph/operators.ts
@@ -45,21 +45,19 @@ export function filterNodes(
   };
 }
 
-export function isWorkspaceProject(project: ProjectGraphNode<any, any>) {
+export function isWorkspaceProject(project: ProjectGraphNode) {
   return (
     project.type === 'app' || project.type === 'lib' || project.type === 'e2e'
   );
 }
 
 export function isNpmProject(
-  project: ProjectGraphNode<any, any>
+  project: ProjectGraphNode
 ): project is ProjectGraphNode<{ packageName: string; version: string }> {
   return project.type === 'npm';
 }
 
-export function getSortedProjectNodes(
-  nodes: Record<string, ProjectGraphNode<any, any>>
-) {
+export function getSortedProjectNodes(nodes: Record<string, ProjectGraphNode>) {
   return Object.values(nodes).sort((nodeA, nodeB) => {
     // If a or b is not a nx project, leave them in the same spot
     if (!isWorkspaceProject(nodeA) && !isWorkspaceProject(nodeB)) {

--- a/packages/workspace/src/core/project-graph/operators.ts
+++ b/packages/workspace/src/core/project-graph/operators.ts
@@ -1,9 +1,5 @@
 import { ProjectGraphBuilder } from './project-graph-builder';
-import {
-  ProjectGraph,
-  ProjectGraphNode,
-  ProjectGraphNodeRecords,
-} from './project-graph-models';
+import { ProjectGraph, ProjectGraphNode } from './project-graph-models';
 
 const reverseMemo = new Map<ProjectGraph, ProjectGraph>();
 
@@ -49,19 +45,21 @@ export function filterNodes(
   };
 }
 
-export function isWorkspaceProject(project: ProjectGraphNode) {
+export function isWorkspaceProject(project: ProjectGraphNode<any, any>) {
   return (
     project.type === 'app' || project.type === 'lib' || project.type === 'e2e'
   );
 }
 
 export function isNpmProject(
-  project: ProjectGraphNode
+  project: ProjectGraphNode<any, any>
 ): project is ProjectGraphNode<{ packageName: string; version: string }> {
   return project.type === 'npm';
 }
 
-export function getSortedProjectNodes(nodes: ProjectGraphNodeRecords) {
+export function getSortedProjectNodes(
+  nodes: Record<string, ProjectGraphNode<any, any>>
+) {
   return Object.values(nodes).sort((nodeA, nodeB) => {
     // If a or b is not a nx project, leave them in the same spot
     if (!isWorkspaceProject(nodeA) && !isWorkspaceProject(nodeB)) {

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -92,6 +92,7 @@ export class TargetProjectLocator {
         return resolvedProject;
       }
     }
+    // TODO: meeroslav this block should be probably removed
     const importedProject = this.sortedWorkspaceProjects.find((p) => {
       const projectImport = `@${npmScope}/${p.data.normalizedRoot}`;
       return (
@@ -99,7 +100,9 @@ export class TargetProjectLocator {
         normalizedImportExpr.startsWith(`${projectImport}/`)
       );
     });
-    if (importedProject) return importedProject.name;
+    if (importedProject) {
+      return importedProject.name;
+    }
 
     const npmProject = this.findNpmPackage(importExpr);
     return npmProject ? npmProject : null;
@@ -109,11 +112,12 @@ export class TargetProjectLocator {
     if (this.npmResolutionCache.has(npmImport)) {
       return this.npmResolutionCache.get(npmImport);
     } else {
-      const pkgName = this.npmProjects.find(
+      const pkg = this.npmProjects.find(
         (pkg) =>
           npmImport === pkg.data.packageName ||
           npmImport.startsWith(`${pkg.data.packageName}/`)
-      )?.name;
+      );
+      const pkgName = pkg ? pkg.name : void 0;
       this.npmResolutionCache.set(npmImport, pkgName);
       return pkgName;
     }

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -31,7 +31,9 @@ export class TargetProjectLocator {
   private typescriptResolutionCache = new Map<string, string | null>();
   private npmResolutionCache = new Map<string, string | null>();
 
-  constructor(private readonly nodes: Record<string, ProjectGraphNode>) {}
+  constructor(
+    private readonly nodes: Record<string, ProjectGraphNode<any, any>>
+  ) {}
 
   /**
    * Find a project based on its import

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -1,9 +1,6 @@
 import { resolveModuleByImport } from '../utilities/typescript';
 import { defaultFileRead, normalizedProjectRoot } from './file-utils';
-import {
-  ProjectGraphNode,
-  ProjectGraphNodeRecords,
-} from './project-graph/project-graph-models';
+import { ProjectGraphNode } from './project-graph/project-graph-models';
 import {
   getSortedProjectNodes,
   isNpmProject,
@@ -36,7 +33,7 @@ export class TargetProjectLocator {
   private typescriptResolutionCache = new Map<string, string | null>();
   private npmResolutionCache = new Map<string, string | null>();
 
-  constructor(private nodes: ProjectGraphNodeRecords) {}
+  constructor(private readonly nodes: Record<string, ProjectGraphNode>) {}
 
   /**
    * Find a project based on its import
@@ -127,7 +124,7 @@ export class TargetProjectLocator {
       return resolvedModule.startsWith(p.data.root);
     });
 
-    return importedProject?.name;
+    return importedProject ? importedProject.name : void 0;
   }
 
   private getRootTsConfigPath() {

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -86,7 +86,7 @@ export class TargetProjectLocator {
     }
 
     // TODO: vsavkin temporary workaround. Remove it once we reworking handling of npm packages.
-    if (resolvedModule && resolvedModule.indexOf('/node_modules/') === -1) {
+    if (resolvedModule && resolvedModule.indexOf('node_modules/') === -1) {
       const resolvedProject = this.findProjectOfResolvedModule(resolvedModule);
       if (resolvedProject) {
         return resolvedProject;

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -1,5 +1,9 @@
 import { resolveModuleByImport } from '../utilities/typescript';
-import { defaultFileRead, normalizedProjectRoot } from './file-utils';
+import {
+  defaultFileExists,
+  defaultFileRead,
+  normalizedProjectRoot,
+} from './file-utils';
 import { ProjectGraphNode } from './project-graph/project-graph-models';
 import {
   getSortedProjectNodes,
@@ -141,8 +145,9 @@ export class TargetProjectLocator {
 
   private getRootTsConfigPath() {
     try {
-      defaultFileRead('tsconfig.base.json');
-      return 'tsconfig.base.json';
+      return defaultFileExists('tsconfig.base.json')
+        ? 'tsconfig.base.json'
+        : 'tsconfig.json';
     } catch (e) {
       return 'tsconfig.json';
     }

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -31,9 +31,7 @@ export class TargetProjectLocator {
   private typescriptResolutionCache = new Map<string, string | null>();
   private npmResolutionCache = new Map<string, string | null>();
 
-  constructor(
-    private readonly nodes: Record<string, ProjectGraphNode<any, any>>
-  ) {}
+  constructor(private readonly nodes: Record<string, ProjectGraphNode>) {}
 
   /**
    * Find a project based on its import

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -1178,12 +1178,14 @@ function runRule(
     true
   );
 
+  const mappedProjectGraph = mapProjectGraphFiles(projectGraph);
+
   const rule = new Rule(
     options,
     `${process.cwd()}/proj`,
     'mycompany',
-    mapProjectGraphFiles(projectGraph),
-    new TargetProjectLocator(projectGraph.nodes)
+    mappedProjectGraph,
+    new TargetProjectLocator(mappedProjectGraph.nodes)
   );
   return rule.apply(sourceFile);
 }

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '../core/project-graph';
 import { Rule } from './nxEnforceModuleBoundariesRule';
 import { TargetProjectLocator } from '../core/target-project-locator';
+import { mapProjectGraphFiles } from '../utils/runtime-lint-utils';
 
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('../utilities/app-root', () => ({ appRootPath: '/root' }));
@@ -1181,7 +1182,7 @@ function runRule(
     options,
     `${process.cwd()}/proj`,
     'mycompany',
-    projectGraph,
+    mapProjectGraphFiles(projectGraph),
     new TargetProjectLocator(projectGraph.nodes)
   );
   return rule.apply(sourceFile);

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -70,7 +70,7 @@ const fileSys = {
   './tsconfig.base.json': JSON.stringify(tsconfig),
 };
 
-describe('Enforce Module Boundaries', () => {
+describe('Enforce Module Boundaries (tslint)', () => {
   beforeEach(() => {
     vol.fromJSON(fileSys, '/root');
   });

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -39,12 +39,15 @@ export class Rule extends Lint.Rules.AbstractRule {
       if (!(global as any).projectGraph) {
         const nxJson = readNxJson();
         (global as any).npmScope = nxJson.npmScope;
-        (global as any).projectGraph = readCurrentProjectGraph();
+        (global as any).projectGraph = mapProjectGraphFiles(
+          readCurrentProjectGraph()
+        );
       }
       this.npmScope = (global as any).npmScope;
-      this.projectGraph = mapProjectGraphFiles(
-        (global as any).projectGraph as ProjectGraph
-      );
+      this.projectGraph = (global as any).projectGraph as ProjectGraph<
+        any,
+        Record<string, FileData>
+      >;
 
       if (!(global as any).targetProjectLocator && this.projectGraph) {
         (global as any).targetProjectLocator = new TargetProjectLocator(

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -13,11 +13,12 @@ import {
   hasNoneOfTheseTags,
   isAbsoluteImportIntoAnotherProject,
   isRelativeImportIntoAnotherProject,
+  mapProjectGraphFiles,
   matchImportWithWildcard,
   onlyLoadChildren,
 } from '../utils/runtime-lint-utils';
 import { normalize } from 'path';
-import { readNxJson } from '@nrwl/workspace/src/core/file-utils';
+import { FileData, readNxJson } from '@nrwl/workspace/src/core/file-utils';
 import { TargetProjectLocator } from '../core/target-project-locator';
 import { checkCircularPath } from '@nrwl/workspace/src/utils/graph-utils';
 import { readCurrentProjectGraph } from '@nrwl/workspace/src/core/project-graph/project-graph';
@@ -28,7 +29,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     options: IOptions,
     private readonly projectPath?: string,
     private readonly npmScope?: string,
-    private readonly projectGraph?: ProjectGraph,
+    private readonly projectGraph?: ProjectGraph<any, Record<string, FileData>>,
     private readonly targetProjectLocator?: TargetProjectLocator
   ) {
     super(options);
@@ -41,7 +42,9 @@ export class Rule extends Lint.Rules.AbstractRule {
         (global as any).projectGraph = readCurrentProjectGraph();
       }
       this.npmScope = (global as any).npmScope;
-      this.projectGraph = (global as any).projectGraph;
+      this.projectGraph = mapProjectGraphFiles(
+        (global as any).projectGraph as ProjectGraph
+      );
 
       if (!(global as any).targetProjectLocator && this.projectGraph) {
         (global as any).targetProjectLocator = new TargetProjectLocator(
@@ -78,7 +81,7 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
     options: IOptions,
     private readonly projectPath: string,
     private readonly npmScope: string,
-    private readonly projectGraph: ProjectGraph,
+    private readonly projectGraph: ProjectGraph<any, Record<string, FileData>>,
     private readonly targetProjectLocator: TargetProjectLocator
   ) {
     super(sourceFile, options);

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -109,16 +109,20 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
       return;
     }
 
+    const filePath = getSourceFilePath(
+      this.getSourceFile().fileName,
+      this.projectPath
+    );
+    const sourceProject = findSourceProject(this.projectGraph, filePath);
+
     // check for relative and absolute imports
     if (
       isRelativeImportIntoAnotherProject(
         imp,
         this.projectPath,
         this.projectGraph,
-        getSourceFilePath(
-          normalize(this.getSourceFile().fileName),
-          this.projectPath
-        )
+        filePath,
+        sourceProject
       ) ||
       isAbsoluteImportIntoAnotherProject(imp)
     ) {
@@ -130,12 +134,6 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
       return;
     }
 
-    const filePath = getSourceFilePath(
-      this.getSourceFile().fileName,
-      this.projectPath
-    );
-
-    const sourceProject = findSourceProject(this.projectGraph, filePath);
     const targetProject = findProjectUsingImport(
       this.projectGraph,
       this.targetProjectLocator,

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -13,12 +13,13 @@ import {
   hasNoneOfTheseTags,
   isAbsoluteImportIntoAnotherProject,
   isRelativeImportIntoAnotherProject,
+  MappedProjectGraph,
   mapProjectGraphFiles,
   matchImportWithWildcard,
   onlyLoadChildren,
 } from '../utils/runtime-lint-utils';
 import { normalize } from 'path';
-import { FileData, readNxJson } from '@nrwl/workspace/src/core/file-utils';
+import { readNxJson } from '@nrwl/workspace/src/core/file-utils';
 import { TargetProjectLocator } from '../core/target-project-locator';
 import { checkCircularPath } from '@nrwl/workspace/src/utils/graph-utils';
 import { readCurrentProjectGraph } from '@nrwl/workspace/src/core/project-graph/project-graph';
@@ -29,7 +30,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     options: IOptions,
     private readonly projectPath?: string,
     private readonly npmScope?: string,
-    private readonly projectGraph?: ProjectGraph<any, Record<string, FileData>>,
+    private readonly projectGraph?: MappedProjectGraph,
     private readonly targetProjectLocator?: TargetProjectLocator
   ) {
     super(options);
@@ -44,10 +45,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         );
       }
       this.npmScope = (global as any).npmScope;
-      this.projectGraph = (global as any).projectGraph as ProjectGraph<
-        any,
-        Record<string, FileData>
-      >;
+      this.projectGraph = (global as any).projectGraph as MappedProjectGraph;
 
       if (!(global as any).targetProjectLocator && this.projectGraph) {
         (global as any).targetProjectLocator = new TargetProjectLocator(
@@ -84,7 +82,7 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
     options: IOptions,
     private readonly projectPath: string,
     private readonly npmScope: string,
-    private readonly projectGraph: ProjectGraph<any, Record<string, FileData>>,
+    private readonly projectGraph: ProjectGraph,
     private readonly targetProjectLocator: TargetProjectLocator
   ) {
     super(sourceFile, options);

--- a/packages/workspace/src/utilities/fileutils.ts
+++ b/packages/workspace/src/utilities/fileutils.ts
@@ -47,7 +47,11 @@ export function readJsonFile<T = any>(path: string): T {
 }
 
 export function parseJsonWithComments<T = any>(content: string): T {
-  return JSON.parse(stripJsonComments(content));
+  try {
+    return JSON.parse(content);
+  } catch {
+    return JSON.parse(stripJsonComments(content));
+  }
 }
 
 export function writeJsonFile(path: string, json: any) {

--- a/packages/workspace/src/utils/graph-utils.ts
+++ b/packages/workspace/src/utils/graph-utils.ts
@@ -5,7 +5,7 @@ import {
 import { isWorkspaceProject } from '../core/project-graph/operators';
 
 interface Reach {
-  graph: ProjectGraph;
+  graph: ProjectGraph<any, any>;
   matrix: Record<string, Array<string>>;
   adjList: Record<string, Array<string>>;
 }
@@ -16,7 +16,7 @@ const reach: Reach = {
   adjList: null,
 };
 
-function buildMatrix(graph: ProjectGraph) {
+function buildMatrix(graph: ProjectGraph<any, any>) {
   const dependencies = graph.dependencies;
   const nodes = Object.keys(graph.nodes).filter((s) =>
     isWorkspaceProject(graph.nodes[s])
@@ -65,10 +65,10 @@ function buildMatrix(graph: ProjectGraph) {
 }
 
 export function getPath(
-  graph: ProjectGraph,
+  graph: ProjectGraph<any, any>,
   sourceProjectName: string,
   targetProjectName: string
-): Array<ProjectGraphNode> {
+): Array<ProjectGraphNode<any, any>> {
   if (sourceProjectName === targetProjectName) return [];
 
   if (reach.graph !== graph) {
@@ -109,10 +109,10 @@ export function getPath(
 }
 
 export function checkCircularPath(
-  graph: ProjectGraph,
-  sourceProject: ProjectGraphNode,
-  targetProject: ProjectGraphNode
-): Array<ProjectGraphNode> {
+  graph: ProjectGraph<any, any>,
+  sourceProject: ProjectGraphNode<any, any>,
+  targetProject: ProjectGraphNode<any, any>
+): Array<ProjectGraphNode<any, any>> {
   if (!graph.nodes[targetProject.name]) return [];
   return getPath(graph, targetProject.name, sourceProject.name);
 }

--- a/packages/workspace/src/utils/graph-utils.ts
+++ b/packages/workspace/src/utils/graph-utils.ts
@@ -5,7 +5,7 @@ import {
 import { isWorkspaceProject } from '../core/project-graph/operators';
 
 interface Reach {
-  graph: ProjectGraph<any, any>;
+  graph: ProjectGraph;
   matrix: Record<string, Array<string>>;
   adjList: Record<string, Array<string>>;
 }
@@ -16,7 +16,7 @@ const reach: Reach = {
   adjList: null,
 };
 
-function buildMatrix(graph: ProjectGraph<any, any>) {
+function buildMatrix(graph: ProjectGraph) {
   const dependencies = graph.dependencies;
   const nodes = Object.keys(graph.nodes).filter((s) =>
     isWorkspaceProject(graph.nodes[s])
@@ -65,10 +65,10 @@ function buildMatrix(graph: ProjectGraph<any, any>) {
 }
 
 export function getPath(
-  graph: ProjectGraph<any, any>,
+  graph: ProjectGraph,
   sourceProjectName: string,
   targetProjectName: string
-): Array<ProjectGraphNode<any, any>> {
+): Array<ProjectGraphNode> {
   if (sourceProjectName === targetProjectName) return [];
 
   if (reach.graph !== graph) {
@@ -109,10 +109,10 @@ export function getPath(
 }
 
 export function checkCircularPath(
-  graph: ProjectGraph<any, any>,
-  sourceProject: ProjectGraphNode<any, any>,
-  targetProject: ProjectGraphNode<any, any>
-): Array<ProjectGraphNode<any, any>> {
+  graph: ProjectGraph,
+  sourceProject: ProjectGraphNode,
+  targetProject: ProjectGraphNode
+): Array<ProjectGraphNode> {
   if (!graph.nodes[targetProject.name]) return [];
   return getPath(graph, targetProject.name, sourceProject.name);
 }

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -68,7 +68,8 @@ export function isRelativeImportIntoAnotherProject(
   imp: string,
   projectPath: string,
   projectGraph: ProjectGraph,
-  sourceFilePath: string
+  sourceFilePath: string,
+  sourceProject: ProjectGraphNode
 ): boolean {
   if (!isRelative(imp)) return false;
 
@@ -76,7 +77,6 @@ export function isRelativeImportIntoAnotherProject(
     path.resolve(path.join(projectPath, path.dirname(sourceFilePath)), imp)
   ).substring(projectPath.length + 1);
 
-  const sourceProject = findSourceProject(projectGraph, sourceFilePath);
   const targetProject = findTargetProject(projectGraph, targetFile);
   return sourceProject && targetProject && sourceProject !== targetProject;
 }

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -78,9 +78,9 @@ export function isRelativeImportIntoAnotherProject(
 }
 
 export function findProjectUsingFile(projectGraph: ProjectGraph, file: string) {
-  return Object.values(projectGraph.nodes).filter((n) =>
+  return Object.values(projectGraph.nodes).find((n) =>
     containsFile(n.data.files, file)
-  )[0];
+  );
 }
 
 export function findSourceProject(

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -184,25 +184,16 @@ export function mapProjectGraphFiles<T>(
   if (!projectGraph) {
     return;
   }
-  const nodes = Object.entries(projectGraph.nodes).reduce(
-    (acc, [name, node]) => ({
-      ...acc,
-      [name]: {
-        ...node,
-        data: {
-          ...node.data,
-          files: node.data.files.reduce(
-            (files, { file, hash, ext }) => ({
-              ...files,
-              [file.slice(0, -ext.length)]: { file, hash, ext },
-            }),
-            {}
-          ),
-        },
-      },
-    }),
-    {}
-  );
+  const nodes = {};
+  Object.entries(projectGraph.nodes).forEach(([name, node]) => {
+    const files = {};
+    node.data.files.forEach(({ file, hash, ext }) => {
+      files[file.slice(0, -ext.length)] = { file, hash, ext };
+    });
+    const data = { ...node.data, files };
+
+    nodes[name] = { ...node, data };
+  });
 
   return {
     ...projectGraph,

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -27,7 +27,11 @@ function containsFile(
   files: FileData[],
   targetFileWithoutExtension: string
 ): boolean {
-  return files.some((f) => removeExt(f.file) === targetFileWithoutExtension);
+  return files.some((f) => trimExt(f) === targetFileWithoutExtension);
+}
+
+function trimExt(file: FileData) {
+  return file.ext ? file.file.slice(0, -file.ext.length) : file.file;
 }
 
 function removeExt(file: string): string {

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -27,9 +27,7 @@ function containsFile(
   files: FileData[],
   targetFileWithoutExtension: string
 ): boolean {
-  return !!files.filter(
-    (f) => removeExt(f.file) === targetFileWithoutExtension
-  )[0];
+  return files.some((f) => removeExt(f.file) === targetFileWithoutExtension);
 }
 
 function removeExt(file: string): string {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running `enforce-module-boundaries` rule in linter is slow. This rule can take up to 90% of the entire linting duration.
Most of this time is spent on finding the parent source project and target project from import.

This is an example of such report:
```
Rule                               | Time (ms) | Relative
:----------------------------------|----------:|--------:
@nrwl/nx/enforce-module-boundaries |    45.131 |    54.0%
@typescript-eslint/no-unused-vars  |     5.472 |     6.5%
react/no-direct-mutation-state     |     4.385 |     5.2%
no-restricted-globals              |     1.941 |     2.3%
react/jsx-no-comment-textnodes     |     1.567 |     1.9%
react/no-typos                     |     1.539 |     1.8%
react-hooks/rules-of-hooks         |     1.532 |     1.8%
react/require-render-return        |     1.416 |     1.7%
no-octal-escape                    |     1.385 |     1.7%
no-global-assign                   |     1.359 |     1.6%
```

## Expected Behavior
The duration of `enforce-module-boundaries` should not be significantly higher than that of other lint rules.
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5210 
