### PR TITLE
cleanup(core): removed dependency axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "angular": "1.8.0",
     "app-root-path": "^2.0.1",
     "autoprefixer": "^10.2.5",
-    "axios": "0.21.1",
     "babel-jest": "26.2.2",
     "caniuse-lite": "^1.0.30001030",
     "chalk": "4.1.0",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -73,7 +73,6 @@
     "yargs": "15.4.1",
     "yargs-parser": "20.0.0",
     "chalk": "4.1.0",
-    "axios": "0.21.1",
     "flat": "^5.0.2",
     "minimatch": "3.0.4",
     "enquirer": "~2.3.6",

--- a/packages/workspace/src/command-line/list.ts
+++ b/packages/workspace/src/command-line/list.ts
@@ -41,8 +41,16 @@ async function listHandler(args: YargsListArgs) {
   if (args.plugin) {
     listPluginCapabilities(args.plugin);
   } else {
-    const corePlugins = await fetchCorePlugins();
-    const communityPlugins = await fetchCommunityPlugins();
+    const corePlugins = fetchCorePlugins();
+    const communityPlugins = await fetchCommunityPlugins().catch(() => {
+      output.warn({
+        title: `Community plugins:`,
+        bodyLines: [`Error fetching plugins.`],
+      });
+
+      return [];
+    });
+
     const installedPlugins = getInstalledPluginsFromPackageJson(
       appRootPath,
       corePlugins,

--- a/packages/workspace/src/utilities/plugins/community-plugins.ts
+++ b/packages/workspace/src/utilities/plugins/community-plugins.ts
@@ -1,42 +1,54 @@
+import { get } from 'https';
 import * as chalk from 'chalk';
-import axios from 'axios';
 import { output } from '../output';
-import { CommunityPlugin, PluginCapabilities } from './models';
+import type { CommunityPlugin, PluginCapabilities } from './models';
 
 const COMMUNITY_PLUGINS_JSON_URL =
   'https://raw.githubusercontent.com/nrwl/nx/master/community/approved-plugins.json';
 
 export async function fetchCommunityPlugins(): Promise<CommunityPlugin[]> {
-  const response = await axios.get<CommunityPlugin[]>(
-    COMMUNITY_PLUGINS_JSON_URL
-  );
+  return new Promise((resolve, reject) => {
+    const req = get(COMMUNITY_PLUGINS_JSON_URL, (res) => {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        reject(new Error(`Request failed with status code ${res.statusCode}`));
+      }
 
-  return response.data;
+      const data = [];
+      res.on('data', (chunk) => {
+        data.push(chunk);
+      });
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(Buffer.concat(data).toString('utf-8')));
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.end();
+  });
 }
 
 export function listCommunityPlugins(
   installedPlugins: PluginCapabilities[],
-  communityPlugins: CommunityPlugin[]
-) {
-  try {
-    const installedPluginsMap: Set<string> = new Set<string>(
-      installedPlugins.map((p) => p.name)
-    );
+  communityPlugins?: CommunityPlugin[]
+): void {
+  if (!communityPlugins) return;
 
-    const availableCommunityPlugins = communityPlugins.filter(
-      (p) => !installedPluginsMap.has(p.name)
-    );
+  const installedPluginsMap: Set<string> = new Set<string>(
+    installedPlugins.map((p) => p.name)
+  );
 
-    output.log({
-      title: `Community plugins:`,
-      bodyLines: availableCommunityPlugins.map((p) => {
-        return `${chalk.bold(p.name)} - ${p.description}`;
-      }),
-    });
-  } catch (error) {
-    output.warn({
-      title: `Community plugins:`,
-      bodyLines: [`Error fetching plugins.`, error],
-    });
-  }
+  const availableCommunityPlugins = communityPlugins.filter(
+    (p) => !installedPluginsMap.has(p.name)
+  );
+
+  output.log({
+    title: `Community plugins:`,
+    bodyLines: availableCommunityPlugins.map((p) => {
+      return `${chalk.bold(p.name)} - ${p.description}`;
+    }),
+  });
 }

--- a/packages/workspace/src/utilities/plugins/core-plugins.ts
+++ b/packages/workspace/src/utilities/plugins/core-plugins.ts
@@ -1,6 +1,6 @@
 import * as chalk from 'chalk';
 import { output } from '../output';
-import { CorePlugin, PluginCapabilities } from './models';
+import type { CorePlugin, PluginCapabilities } from './models';
 
 export function fetchCorePlugins() {
   const corePlugins: CorePlugin[] = [
@@ -63,7 +63,7 @@ export function fetchCorePlugins() {
 export function listCorePlugins(
   installedPlugins: PluginCapabilities[],
   corePlugins: CorePlugin[]
-) {
+): void {
   const installedPluginsMap: Set<string> = new Set<string>(
     installedPlugins.map((p) => p.name)
   );

--- a/packages/workspace/src/utilities/plugins/installed-plugins.ts
+++ b/packages/workspace/src/utilities/plugins/installed-plugins.ts
@@ -1,14 +1,14 @@
 import * as chalk from 'chalk';
 import { readJsonFile } from '../fileutils';
 import { output } from '../output';
-import { CommunityPlugin, CorePlugin, PluginCapabilities } from './models';
+import type { CommunityPlugin, CorePlugin, PluginCapabilities } from './models';
 import { getPluginCapabilities } from './plugin-capabilities';
 import { hasElements } from './shared';
 
 export function getInstalledPluginsFromPackageJson(
   workspaceRoot: string,
   corePlugins: CorePlugin[],
-  communityPlugins: CommunityPlugin[]
+  communityPlugins: CommunityPlugin[] = []
 ): Array<PluginCapabilities> {
   const packageJson = readJsonFile(`${workspaceRoot}/package.json`);
 
@@ -19,7 +19,7 @@ export function getInstalledPluginsFromPackageJson(
     ...Object.keys(packageJson.devDependencies || {}),
   ]);
 
-  return Array.from(plugins.values())
+  return Array.from(plugins)
     .filter((name) => {
       try {
         // Check for `package.json` existence instead of requiring the module itself

--- a/packages/workspace/src/utilities/plugins/plugin-capabilities.ts
+++ b/packages/workspace/src/utilities/plugins/plugin-capabilities.ts
@@ -3,7 +3,7 @@ import { getPackageManagerCommand } from '@nrwl/tao/src/shared/package-manager';
 import { appRootPath } from '../app-root';
 import { readJsonFile } from '../fileutils';
 import { output } from '../output';
-import { PluginCapabilities } from './models';
+import type { PluginCapabilities } from './models';
 import { hasElements } from './shared';
 
 function tryGetCollection<T>(
@@ -11,7 +11,7 @@ function tryGetCollection<T>(
   pluginName: string,
   jsonFile: string,
   propName: string
-): T {
+): T | null {
   if (!jsonFile) {
     return null;
   }
@@ -29,7 +29,7 @@ function tryGetCollection<T>(
 export function getPluginCapabilities(
   workspaceRoot: string,
   pluginName: string
-): PluginCapabilities {
+): PluginCapabilities | null {
   try {
     const packageJsonPath = require.resolve(`${pluginName}/package.json`, {
       paths: [workspaceRoot],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- `@nrwl/workspace` depends on `axios` but uses it only to get the community plugins for the `nx list` command
- the nx list command does not handle errors related to an unsuccessful request for the community plugins
 
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- should not depend on `axios `
- should use Node.js `https` module to get comunity plugins from GitHub
- should handle errors related to the request 
