### PR TITLE
fix(core): support target without watch option (#2735)

### DIFF
--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -4,6 +4,7 @@ import {
   ExecutorContext,
   logger,
   parseTargetString,
+  readTargetOptions,
   runExecutor,
   stripIndents,
 } from '@nrwl/devkit';
@@ -115,14 +116,23 @@ async function* startDevServer(
   const { project, target, configuration } = parseTargetString(
     opts.devServerTarget
   );
+  const devServerTargetOpts = readTargetOptions(
+    { project, target, configuration },
+    context
+  );
+  const targetSupportsWatchOpt = Object.keys(devServerTargetOpts).includes(
+    'watch'
+  );
+
   for await (const output of await runExecutor<{
     success: boolean;
     baseUrl?: string;
   }>(
     { project, target, configuration },
-    {
-      watch: opts.watch,
-    },
+    // @NOTE: Do not forward watch option if not supported by the target dev server,
+    // this is relevant for running Cypress against dev server target that does not support this option,
+    // for instance @nguniversal/builders:ssr-dev-server.
+    targetSupportsWatchOpt ? { watch: opts.watch } : {},
     context
   )) {
     if (!output.success && !opts.watch)


### PR DESCRIPTION
This commit checks if the target dev server supports the watch option before forwarding it to, this is relevant for running Cypress against dev server target that does not support this option, for instance "@nguniversal/builders:ssr-dev-server".

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Cannot run Cypress against a `devServerTarget` that does not support watch option. 

## Expected Behavior
Check if the `devServerTarget` supports the watch option before passing it to.

## Related Issue(s)

resolves #2735