### PR TITLE
feat(core): allow to collapse the sidebar on dep-graph UI

### DIFF
--- a/dep-graph/dep-graph-e2e/src/integration/app.spec.ts
+++ b/dep-graph/dep-graph-e2e/src/integration/app.spec.ts
@@ -16,6 +16,12 @@ describe('dep-graph-client', () => {
     cy.get('[data-cy=project-select]').select('Ocean');
   });
 
+  it('should toggle the sidebar', () => {
+    cy.get('#sidebar').should('be.visible');
+    cy.get('#sidebar-toggle-button').click();
+    cy.get('#sidebar').should('not.be.visible');
+  });
+
   it('should display message to select projects', () => {
     getSelectProjectsMessage().should('be.visible');
   });

--- a/dep-graph/dep-graph-e2e/src/integration/app.spec.ts
+++ b/dep-graph/dep-graph-e2e/src/integration/app.spec.ts
@@ -1,13 +1,13 @@
 import {
-  getDeselectAllButton,
-  getUnfocusProjectButton,
-  getProjectCheckboxes,
   getCheckedProjectCheckboxes,
+  getDeselectAllButton,
+  getIncludeProjectsInPathButton,
+  getProjectCheckboxes,
   getSelectAllButton,
   getSelectProjectsMessage,
-  getTextFilterInput,
   getTextFilterButton,
-  getIncludeProjectsInPathButton,
+  getTextFilterInput,
+  getUnfocusProjectButton,
 } from '../support/app.po';
 
 describe('dep-graph-client', () => {
@@ -24,6 +24,22 @@ describe('dep-graph-client', () => {
 
   it('should display message to select projects', () => {
     getSelectProjectsMessage().should('be.visible');
+  });
+
+  describe('selecting a different project', () => {
+    it('should change the available projects', () => {
+      getProjectCheckboxes().should('have.length', 133);
+      cy.get('[data-cy=project-select]').select('Nx');
+      getProjectCheckboxes().should('have.length', 42);
+    });
+
+    it("should restore sidebar if it's been hidden", () => {
+      cy.get('#sidebar').should('be.visible');
+      cy.get('#sidebar-toggle-button').click();
+      cy.get('#sidebar').should('not.be.visible');
+      cy.get('[data-cy=project-select]').select('Nx');
+      cy.get('#sidebar').should('be.visible');
+    });
   });
 
   describe('select all button', () => {

--- a/dep-graph/dep-graph/src/app/app.ts
+++ b/dep-graph/dep-graph/src/app/app.ts
@@ -21,6 +21,7 @@ export class AppComponent {
 
   private windowResize$ = fromEvent(window, 'resize').pipe(startWith({}));
   private render$ = new Subject<void>();
+  private destroy$ = new Subject<void>();
 
   constructor(private config: AppConfig = DEFAULT_CONFIG) {
     this.render$.subscribe(() => this.render());
@@ -28,6 +29,9 @@ export class AppComponent {
   }
 
   private onProjectGraphChange(projectGraphId: string) {
+    // reset previous listeners as we're re-rendering
+    this.destroy$.next();
+
     const project = projectGraphs.find((graph) => graph.id === projectGraphId);
     const projectGraph = project?.graph;
     const workspaceLayout = project?.workspaceLayout;
@@ -72,6 +76,7 @@ export class AppComponent {
 
     this.graph.affectedProjects = affectedProjects;
     this.sidebar = new SidebarComponent(
+      this.destroy$,
       affectedProjects,
       this.config.showDebugger
     );

--- a/dep-graph/dep-graph/src/app/ui-sidebar/display-options-panel.ts
+++ b/dep-graph/dep-graph/src/app/ui-sidebar/display-options-panel.ts
@@ -1,4 +1,4 @@
-import { Subject } from 'rxjs';
+import { fromEvent, Subject } from 'rxjs';
 import { removeChildrenFromContainer } from '../util';
 
 export class DisplayOptionsPanel {

--- a/dep-graph/dep-graph/src/app/ui-sidebar/sidebar.ts
+++ b/dep-graph/dep-graph/src/app/ui-sidebar/sidebar.ts
@@ -29,6 +29,8 @@ export class SidebarComponent {
     private affectedProjects: string[],
     showDebugger: boolean
   ) {
+    this.resetSidebarVisibility();
+
     const showAffected = this.affectedProjects.length > 0;
 
     const displayOptionsPanelContainer = document.getElementById(
@@ -76,6 +78,15 @@ export class SidebarComponent {
 
     if (window.exclude.length > 0) {
       window.exclude.forEach((project) => this.excludeProject(project));
+    }
+  }
+
+  private resetSidebarVisibility() {
+    const sidebarElement = document.getElementById('sidebar');
+
+    if (sidebarElement.classList.contains('hidden')) {
+      sidebarElement.classList.remove('hidden');
+      sidebarElement.style.marginLeft = `0px`;
     }
   }
 

--- a/dep-graph/dep-graph/src/index.html
+++ b/dep-graph/dep-graph/src/index.html
@@ -31,8 +31,13 @@
   </svg>
 
   <div id="app">
-    <div class="sidebar">
+    <div class="sidebar" id="sidebar">
       <div class="sidebar-content">
+        <a
+          href="javascript:;"
+          class="sidebar-hide-button"
+          id="sidebar-toggle-button"
+        ></a>
         <div class="sidebar-section" id="focused-project"></div>
 
         <div class="sidebar-section" id="display-options-panel"></div>
@@ -51,7 +56,6 @@
       <div id="graph-container"></div>
     </div>
   </div>
-
   <script>
     window.projects = [];
     window.graph = {};

--- a/dep-graph/dep-graph/src/styles.scss
+++ b/dep-graph/dep-graph/src/styles.scss
@@ -9,6 +9,7 @@ $color-nrwl-black: #231f20 !default;
 $color-nrwl-red: #f85477 !default;
 $font-family: 'Montserrat', 'Helvetica Neue', sans-serif !default;
 $color-primary: $color-nrwl-navy !default;
+$sidebar-width: 260px;
 
 * {
   -webkit-box-sizing: border-box;
@@ -95,12 +96,40 @@ h5 {
 }
 
 .sidebar {
-  min-width: 260px;
+  min-width: $sidebar-width;
   max-width: calc(50% - 10px);
   z-index: 1;
   position: relative;
   height: 100%;
   box-shadow: 2px 0 2px rgba(51, 51, 51, 0.1);
+  transition: margin-left 0.5s;
+
+  &.hidden {
+    .sidebar-hide-button:after {
+      content: '\00BB';
+    }
+  }
+
+  .sidebar-hide-button {
+    content: '<<';
+    background-color: white;
+    border-top: 1px solid;
+    border-right: 1px solid;
+    border-bottom: 1px solid;
+    border-color: rgba(51, 51, 51, 0.3);
+    color: rgba(51, 51, 51, 0.6);
+    position: absolute;
+    // left: 319px;
+    top: 10px;
+    text-decoration: none;
+    padding: 10px;
+    border-radius: 0 5px 5px 0;
+    box-shadow: 2px 0 2px rgba(51, 51, 51, 0.1);
+
+    &:after {
+      content: '\00AB';
+    }
+  }
 }
 
 .sidebar > .sidebar-content {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

On a larger project with long names, the side-bar on the dep-graph visualization is really in the way. Which frustrated me 😉

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Thus, I added a toggle that allows to hide / show the dep-graph

https://user-images.githubusercontent.com/542458/117502358-ae9a7e80-af7f-11eb-9d64-492114c7b59c.mp4

