### PR TITLE
feat(angular): allow custom webpack config support for webpack-browse…

### DIFF
--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -15,6 +15,7 @@
     "@angular-devkit",
     "@angular-eslint/",
     "@schematics",
-    "jasmine-marbles"
+    "jasmine-marbles",
+    "webpack-merge"
   ]
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -39,6 +39,7 @@
     "@nrwl/jest": "*",
     "@nrwl/linter": "*",
     "@schematics/angular": "~12.0.0",
-    "jasmine-marbles": "~0.6.0"
+    "jasmine-marbles": "~0.6.0",
+    "webpack-merge": "4.2.1"
   }
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -40,6 +40,6 @@
     "@nrwl/linter": "*",
     "@schematics/angular": "~12.0.0",
     "jasmine-marbles": "~0.6.0",
-    "webpack-merge": "4.2.1"
+    "webpack-merge": "5.7.3"
   }
 }

--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -363,6 +363,17 @@
         "type": "string"
       },
       "default": []
+    },
+    "customWebpackConfig": {
+      "description": "Options for additional webpack configurations",
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Path to additional webpack configuration. Paths will be resolved to workspace root.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -373,7 +373,7 @@
           "type": "string"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -20,6 +20,7 @@ import { Schema } from '@angular-devkit/build-angular/src/browser/schema';
 import { switchMap } from 'rxjs/operators';
 import { existsSync } from 'fs';
 import { merge } from 'webpack-merge';
+import { SchematicsException } from '@angular-devkit/schematics';
 
 type BrowserBuilderSchema = Schema &
   JsonObject & {
@@ -35,8 +36,7 @@ function buildApp(
 ): Observable<BuilderOutput> {
   const { buildTarget, ...delegateOptions } = options;
 
-  // If we don't have a third-party builder being used
-  // And there is a path to custom webpack config
+  // If there is a path to custom webpack config
   // Invoke our own support for custom webpack config
   if (options.customWebpackConfig && options.customWebpackConfig.path) {
     const pathToWebpackConfig = joinPathFragments(
@@ -51,7 +51,9 @@ function buildApp(
         pathToWebpackConfig
       );
     } else {
-      // TODO: Throw bad config error
+      throw new SchematicsException(
+        `Custom Webpack Config File Not Found!\nTo use a custom webpack config, please ensure the path to the custom webpack file is correct: \n${pathToWebpackConfig}`
+      );
     }
   }
 

--- a/scripts/depcheck/discrepancies.ts
+++ b/scripts/depcheck/discrepancies.ts
@@ -1,12 +1,24 @@
 import * as chalk from 'chalk';
 import { satisfies } from 'semver';
 
+// Ignore packages that are defined here per package
+const IGNORE_MATCHES = {
+  '*': [],
+  angular: ['webpack-merge'],
+};
+
 export default function getDiscrepancies(
+  name: string,
   projectDependencies: JSON,
   devDependencies: JSON
 ) {
   return Object.keys(projectDependencies)
     .filter((p) => !p.startsWith('@nrwl/'))
+    .filter((p) =>
+      !IGNORE_MATCHES['*'].includes(p) && IGNORE_MATCHES[name]
+        ? !IGNORE_MATCHES[name].includes(p)
+        : true
+    )
     .filter(
       (p) =>
         devDependencies[p] &&

--- a/scripts/depcheck/index.ts
+++ b/scripts/depcheck/index.ts
@@ -62,7 +62,7 @@ const argv = require('yargs')
           : [];
 
         const discrepancies = argv.discrepancies
-          ? getDiscrepancies(dependencies, devDependencies)
+          ? getDiscrepancies(project.name, dependencies, devDependencies)
           : [];
 
         return { ...project, missing, discrepancies };


### PR DESCRIPTION
…r builds

Allow building with a custom webpack config when using webpack-browser builds

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We do not natively support custom webpack configs when building Angular apps

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should allow users to provide a path to a custom webpack config that we can merge with the default Angular webpack config

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
