### PR TITLE
fix(linter): add missing check for tslint and schema property

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -64,6 +64,7 @@ export default createESLintRule<Options, MessageIds>({
         type: 'object',
         properties: {
           enforceBuildableLibDependency: { type: 'boolean' },
+          allowCircularSelfDependency: { type: 'boolean' },
           allow: [{ type: 'string' }],
           depConstraints: [
             {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Self circular dependency check only works on `eslint`
<!-- This is the behavior we have today -->

## Expected Behavior
Self circular dependency check should work for both `eslint` and `tslint`
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
Related to #5555 

The previous implementation only implemented check from `eslint`