### PR TITLE
chore(gatsby): update pnpm plugin to next version

### DIFF
--- a/packages/gatsby/src/utils/versions.ts
+++ b/packages/gatsby/src/utils/versions.ts
@@ -22,4 +22,4 @@ export const gatsbyPluginLessVersion = '5.2.0';
 export const gatsbyPluginStylusVersion = '3.2.0';
 export const nodeSassVersion = '5.0.0';
 export const gatsbyPluginSvgrVersion = '3.0.0-beta.0';
-export const gatsbyPluginPnpm = '1.2.5';
+export const gatsbyPluginPnpm = '1.2.6';


### PR DESCRIPTION
Version 1.2.5 only supports `gatsby` v2.x.x
Version 1.2.6 supports also versions v3.x.x

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Building of `gatsby` package reports warning of the wrong gatsby version since our plugin supports only `2.x.x`
<!-- This is the behavior we have today -->

## Expected Behavior
There should be no warning on gatsby version mismatch
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
