### PR TITLE
fix(core): add description to commands schema help

### DIFF
--- a/docs/angular/api-workspace/executors/run-commands.md
+++ b/docs/angular/api-workspace/executors/run-commands.md
@@ -186,6 +186,8 @@ Command to run in child process
 
 Type: `array`
 
+Commands to run in child process
+
 ### cwd
 
 Type: `string`

--- a/docs/node/api-workspace/executors/run-commands.md
+++ b/docs/node/api-workspace/executors/run-commands.md
@@ -187,6 +187,8 @@ Command to run in child process
 
 Type: `array`
 
+Commands to run in child process
+
 ### cwd
 
 Type: `string`

--- a/docs/react/api-workspace/executors/run-commands.md
+++ b/docs/react/api-workspace/executors/run-commands.md
@@ -187,6 +187,8 @@ Command to run in child process
 
 Type: `array`
 
+Commands to run in child process
+
 ### cwd
 
 Type: `string`

--- a/packages/workspace/src/executors/run-commands/schema.json
+++ b/packages/workspace/src/executors/run-commands/schema.json
@@ -7,6 +7,7 @@
   "properties": {
     "commands": {
       "type": "array",
+      "description": "Commands to run in child process",
       "items": {
         "oneOf": [
           {

--- a/packages/workspace/src/executors/run-commands/schema.json
+++ b/packages/workspace/src/executors/run-commands/schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "commands": {
       "type": "array",
-      "description": "Commands to run in child process",
+      "description": "Commands to run in child process ",
       "items": {
         "oneOf": [
           {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running help command e.g. `nx e2e e2e-angular --help` shows `undefined` next to `commands`, since the description is missing.

```
nx run e2e-angular:e2e [options,...]

Options:
  --commands              undefined
  --command               Command to run in child process
  --parallel              Run commands in parallel (default: true)
  --readyWhen             String to appear in stdout or stderr that indicates that the task is done. This option can only be used when parallel is set to true. If not specified, the task is done when all the child processes complete.
  --args                  Extra arguments. You can pass them as follows: nx run project:target --args='--wait=100'. You can then use {args.wait} syntax to interpolate them in the workspace config file. See example [above](#chaining-commands-interpolating-args-and-setting-the-cwd)
  --envFile               You may specify a custom .env file path
  --color                 Use colors when showing output of command
  --outputPath            Allows you to specify where the build artifacts are stored. This allows Nx Cloud to pick them up correctly, in the case that the build artifacts are placed somewhere other than the top level dist folder.
  --cwd                   Current working directory of the commands. If it's not specified the commands will run in the workspace root, if a relative path is specified the commands will run in that path relative to the workspace root and if it's an absolute path the commands will run in that path.
  --skip-nx-cache         Skip the use of Nx cache.
  --help                  Show available options for project target.
```

<!-- This is the behavior we have today -->

## Expected Behavior
Commands section should have an appropriate description
```
nx run e2e-angular:e2e [options,...]

Options:
  --commands              Commands to run in child process
  --command               Command to run in child process
  --parallel              Run commands in parallel (default: true)
  --readyWhen             String to appear in stdout or stderr that indicates that the task is done. This option can only be used when parallel is set to true. If not specified, the task is done when all the child processes complete.
  --args                  Extra arguments. You can pass them as follows: nx run project:target --args='--wait=100'. You can then use {args.wait} syntax to interpolate them in the workspace config file. See example [above](#chaining-commands-interpolating-args-and-setting-the-cwd)
  --envFile               You may specify a custom .env file path
  --color                 Use colors when showing output of command
  --outputPath            Allows you to specify where the build artifacts are stored. This allows Nx Cloud to pick them up correctly, in the case that the build artifacts are placed somewhere other than the top level dist folder.
  --cwd                   Current working directory of the commands. If it's not specified the commands will run in the workspace root, if a relative path is specified the commands will run in that path relative to the workspace root and if it's an absolute path the commands will run in that path.
  --skip-nx-cache         Skip the use of Nx cache.
  --help                  Show available options for project target.
```
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
