### PR TITLE
chore(testing): fix gatsby e2e CI setup

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -47,7 +47,7 @@ jobs:
         version: 5.18.9
 
     - name: Run e2e tests
-      run: yarn nx e2e ${{ matrix.packages }} affected
+      run: yarn nx e2e ${{ matrix.packages }}
       env:
         GIT_AUTHOR_NAME: test@test.com
         GIT_AUTHOR_EMAIL: Test

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -22,7 +22,7 @@ jobs:
           - e2e-cli,e2e-nx-plugin,dep-graph-dep-graph-e2e
           - e2e-cypress,e2e-jest
           - e2e-react
-          - e2e-next
+          - e2e-next,e2e-gatsby
           - e2e-node
           - e2e-web,e2e-linter,e2e-storybook
           - e2e-angular

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -47,7 +47,7 @@ jobs:
         version: 5.18.9
 
     - name: Run e2e tests
-      run: yarn e2e ${{ matrix.packages }} affected
+      run: yarn nx e2e ${{ matrix.packages }} affected
       env:
         GIT_AUTHOR_NAME: test@test.com
         GIT_AUTHOR_EMAIL: Test

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -47,7 +47,7 @@ jobs:
         version: 5.18.9
 
     - name: Run e2e tests
-      run: yarn nx e2e ${{ matrix.packages }}
+      run: yarn nx run-many --target=e2e --projects=${{ matrix.packages }} --ignore-engines
       env:
         GIT_AUTHOR_NAME: test@test.com
         GIT_AUTHOR_EMAIL: Test

--- a/e2e/gatsby/jest.config.js
+++ b/e2e/gatsby/jest.config.js
@@ -6,5 +6,5 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
   maxWorkers: 1,
   globals: { 'ts-jest': { tsconfig: '<rootDir>/tsconfig.spec.json' } },
-  displayName: 'e2e-next',
+  displayName: 'e2e-gatsby',
 };

--- a/workspace.json
+++ b/workspace.json
@@ -2019,32 +2019,6 @@
       "sourceRoot": "packages/gatsby",
       "projectType": "library",
       "targets": {
-        "e2e": {
-          "executor": "@nrwl/workspace:run-commands",
-          "options": {
-            "commands": [
-              {
-                "command": "yarn e2e-start-local-registry"
-              },
-              {
-                "command": "yarn e2e-build-package-publish"
-              },
-              {
-                "command": "nx run-e2e-tests e2e-gatsby"
-              }
-            ],
-            "parallel": false
-          }
-        },
-        "run-e2e-tests": {
-          "executor": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "e2e/gatsby/jest.config.js",
-            "passWithNoTests": true,
-            "runInBand": true
-          },
-          "outputs": ["coverage/e2e/gatsby"]
-        },
         "test": {
           "executor": "@nrwl/jest:jest",
           "options": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Gatsby E2E tests run twice on CI - as `gatsby` and `e2e-gatsby`
<!-- This is the behavior we have today -->

## Expected Behavior
Only a single run of e2e tests as `e2e-gatsby` should be ran
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
