### PR TITLE
fix(core): rm resolve dependency

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -77,7 +77,6 @@
     "flat": "^5.0.2",
     "minimatch": "3.0.4",
     "enquirer": "~2.3.6",
-    "resolve": "1.17.0",
     "tslib": "^2.0.0"
   }
 }

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -1,6 +1,5 @@
 import { execSync } from 'child_process';
 import * as path from 'path';
-import * as resolve from 'resolve';
 import { getProjectRoots, parseFiles } from './shared';
 import { fileExists } from '../utilities/fileutils';
 import {
@@ -127,10 +126,10 @@ function check(patterns: string[]) {
 }
 
 function prettierPath() {
-  const basePath = path.dirname(
-    resolve.sync('prettier', { basedir: __dirname })
+  return path.join(
+    require.resolve('prettier/bin-prettier.js'),
+    'bin-prettier.js'
   );
-  return path.join(basePath, 'bin-prettier.js');
 }
 
 function updateWorkspaceJsonToMatchFormatVersion() {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Issue with vulnerability on `path-parser` (stems from `resolve`)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Dependency on `resolve` not needed. Using `require.resolve()` instead.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
