### PR TITLE
fix(nextjs): add @nrwl/next as a prod dependency for new workspaces

### DIFF
--- a/packages/next/src/generators/init/init.spec.ts
+++ b/packages/next/src/generators/init/init.spec.ts
@@ -13,8 +13,8 @@ describe('init', () => {
   it('should add react dependencies', async () => {
     await nextInitGenerator(tree, {});
     const packageJson = readJson(tree, 'package.json');
-    expect(packageJson.dependencies['@nrwl/next']).toBeUndefined();
     expect(packageJson.dependencies['@nrwl/react']).toBeUndefined();
+    expect(packageJson.dependencies['@nrwl/next']).toBeDefined();
     expect(packageJson.dependencies['next']).toBeDefined();
   });
 

--- a/packages/next/src/generators/init/init.ts
+++ b/packages/next/src/generators/init/init.ts
@@ -25,14 +25,13 @@ function updateDependencies(host: Tree) {
   return addDependenciesToPackageJson(
     host,
     {
+      '@nrwl/next': nxVersion,
       next: nextVersion,
       react: reactVersion,
       'react-dom': reactDomVersion,
       tslib: '^2.0.0',
     },
-    {
-      '@nrwl/next': nxVersion,
-    }
+    {}
   );
 }
 

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -262,10 +262,10 @@ const presetDependencies: Omit<
     },
   },
   [Preset.NextJs]: {
-    dependencies: {},
-    dev: {
+    dependencies: {
       '@nrwl/next': nxVersion,
     },
+    dev: {},
   },
   [Preset.Gatsby]: {
     dependencies: {},


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/next` dependency is added as a dev dependency in the `package.json` file generated during the build.

Considering that `next.config.js` is used by next.js in prod, and `next.config.js` that is generated by an Nx workspace requires `@nrwl/next/plugins/with-nx` - it's not a dev dependency

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`@nrwl/next` dependency is added as a dependency in the `package.json` file generated during the build

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5473 
