### PR TITLE
feat(workspace): support formatting on `.graphql`, `.gql`, `.yaml` & `.yml` files

### DIFF
--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -35,7 +35,6 @@ const PRETTIER_EXTENSIONS = [
   'gql',
   'yaml',
   'yml',
-  'vue',
 ];
 
 const MATCH_ALL_PATTERN = `**/*.{${PRETTIER_EXTENSIONS.join(',')}}`;

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -31,6 +31,11 @@ const PRETTIER_EXTENSIONS = [
   'json',
   'md',
   'mdx',
+  'graphql',
+  'gql',
+  'yaml',
+  'yml',
+  'vue',
 ];
 
 const MATCH_ALL_PATTERN = `**/*.{${PRETTIER_EXTENSIONS.join(',')}}`;


### PR DESCRIPTION
## Current Behavior
`.graphql`, `.gql`, `.yaml` & `.yml` files aren't formatted

## Expected Behavior
`.graphql`, `.gql`, `.yaml` & `.yml` files are formatted
