### PR TITLE
fix(testing): support cypress projects for default serve configuration

### DIFF
--- a/packages/angular/src/schematics/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/schematics/application/__snapshots__/application.spec.ts.snap
@@ -110,7 +110,7 @@ Object {
       },
       "options": Object {
         "cypressConfig": "apps/my-dir/my-app-e2e/cypress.json",
-        "devServerTarget": "my-dir-my-app:serve",
+        "devServerTarget": "my-dir-my-app:serve:development",
         "tsConfig": "apps/my-dir/my-app-e2e/tsconfig.e2e.json",
       },
     },
@@ -239,7 +239,7 @@ Object {
       },
       "options": Object {
         "cypressConfig": "apps/my-app-e2e/cypress.json",
-        "devServerTarget": "my-app:serve",
+        "devServerTarget": "my-app:serve:development",
         "tsConfig": "apps/my-app-e2e/tsconfig.e2e.json",
       },
     },

--- a/packages/cypress/src/generators/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.ts
@@ -1,6 +1,7 @@
 import {
   addDependenciesToPackageJson,
   addProjectConfiguration,
+  readProjectConfiguration,
   convertNxGenerator,
   formatFiles,
   generateFiles,
@@ -40,8 +41,17 @@ function createFiles(host: Tree, options: CypressProjectSchema) {
   }
 }
 
-function addProject(host: Tree, options: CypressProjectSchema) {
-  addProjectConfiguration(host, options.projectName, {
+function addProject(tree: Tree, options: CypressProjectSchema) {
+  let devServerTarget: string = `${options.project}:serve`;
+  if (options.project) {
+    const project = readProjectConfiguration(tree, options.project);
+    devServerTarget =
+      project.targets.serve && project.targets.serve.defaultConfiguration
+        ? `${options.project}:serve:${project.targets.serve.defaultConfiguration}`
+        : devServerTarget;
+  }
+
+  addProjectConfiguration(tree, options.projectName, {
     root: options.projectRoot,
     sourceRoot: joinPathFragments(options.projectRoot, 'src'),
     projectType: 'application',
@@ -51,7 +61,7 @@ function addProject(host: Tree, options: CypressProjectSchema) {
         options: {
           cypressConfig: joinPathFragments(options.projectRoot, 'cypress.json'),
           tsConfig: joinPathFragments(options.projectRoot, 'tsconfig.e2e.json'),
-          devServerTarget: `${options.project}:serve`,
+          devServerTarget,
         },
         configurations: {
           production: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Wrong `devServerTarget` is used for Angular apps

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Proper `devServerTarget` is used for apps with default configurations

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5664 
