### PR TITLE
fix(misc): be more specific finding targets being used when removing …

### DIFF
--- a/packages/workspace/src/generators/remove/lib/check-targets.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/check-targets.spec.ts
@@ -1,4 +1,8 @@
-import { addProjectConfiguration, Tree } from '@nrwl/devkit';
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  Tree,
+} from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Schema } from '../schema';
 import { checkTargets } from './check-targets';
@@ -25,6 +29,10 @@ describe('checkTargets', () => {
           executor: '@angular-devkit/build-angular:browser',
           options: {},
         },
+        serve: {
+          executor: '@angular-devkit/build-angular:dev-server',
+          options: {},
+        },
       },
     });
 
@@ -47,15 +55,20 @@ describe('checkTargets', () => {
 
   it('should throw an error if another project targets', async () => {
     expect(() => {
-      checkTargets(tree, schema);
-    }).toThrow();
+      checkTargets(tree, schema, readProjectConfiguration(tree, 'ng-app'));
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "ng-app is still targeted by some projects:
+
+      \\"ng-app:serve\\" is used by \\"ng-app-e2e\\"
+      "
+    `);
   });
 
   it('should NOT throw an error if no other project targets', async () => {
     schema.projectName = 'ng-app-e2e';
 
     expect(() => {
-      checkTargets(tree, schema);
+      checkTargets(tree, schema, readProjectConfiguration(tree, 'ng-app'));
     }).not.toThrow();
   });
 
@@ -63,7 +76,7 @@ describe('checkTargets', () => {
     schema.forceRemove = true;
 
     expect(() => {
-      checkTargets(tree, schema);
+      checkTargets(tree, schema, readProjectConfiguration(tree, 'ng-app'));
     }).not.toThrow();
   });
 });

--- a/packages/workspace/src/generators/remove/remove.ts
+++ b/packages/workspace/src/generators/remove/remove.ts
@@ -16,7 +16,7 @@ import { updateJestConfig } from './lib/update-jest-config';
 export async function removeGenerator(tree: Tree, schema: Schema) {
   const project = readProjectConfiguration(tree, schema.projectName);
   checkDependencies(tree, schema);
-  checkTargets(tree, schema);
+  checkTargets(tree, schema, project);
   updateJestConfig(tree, schema, project);
   removeProject(tree, project);
   removeProjectConfig(tree, schema);


### PR DESCRIPTION
…projects

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If a project has the name `web`, then the `remove` generator thinks that projects with the executor `@nrwl/web:dev-server` target the project `web`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Each project target is specifically searched for and a specific error is thrown:

```
ng-app is still targeted by some projects:

"ng-app:serve" is used by "ng-app-e2e"
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/5588
