### PR TITLE
feat(testing): add `testingType` option to cypress executor

### DIFF
--- a/docs/angular/api-cypress/executors/cypress.md
+++ b/docs/angular/api-cypress/executors/cypress.md
@@ -118,6 +118,16 @@ Type: `string`
 
 A comma delimited glob string that is provided to the Cypress runner to specify which spec files to run. i.e. '**examples/**,**actions.spec**
 
+### testingType
+
+Default: `e2e`
+
+Type: `string`
+
+Possible values: `component`, `e2e`
+
+Specify the type of tests to execute
+
 ### tsConfig
 
 Type: `string`

--- a/docs/node/api-cypress/executors/cypress.md
+++ b/docs/node/api-cypress/executors/cypress.md
@@ -119,6 +119,16 @@ Type: `string`
 
 A comma delimited glob string that is provided to the Cypress runner to specify which spec files to run. i.e. '**examples/**,**actions.spec**
 
+### testingType
+
+Default: `e2e`
+
+Type: `string`
+
+Possible values: `component`, `e2e`
+
+Specify the type of tests to execute
+
 ### tsConfig
 
 Type: `string`

--- a/docs/react/api-cypress/executors/cypress.md
+++ b/docs/react/api-cypress/executors/cypress.md
@@ -119,6 +119,16 @@ Type: `string`
 
 A comma delimited glob string that is provided to the Cypress runner to specify which spec files to run. i.e. '**examples/**,**actions.spec**
 
+### testingType
+
+Default: `e2e`
+
+Type: `string`
+
+Possible values: `component`, `e2e`
+
+Specify the type of tests to execute
+
 ### tsConfig
 
 Type: `string`

--- a/packages/cypress/src/executors/cypress/cypress.impl.spec.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.spec.ts
@@ -322,4 +322,20 @@ describe('Cypress builder', () => {
     );
     expect(Object.keys(runExecutor.mock.calls[0][1])).toContain('watch');
   });
+
+  it('should forward testingType', async () => {
+    const { success } = await cypressExecutor(
+      {
+        ...cypressOptions,
+        testingType: 'component',
+      },
+      mockContext
+    );
+    expect(success).toEqual(true);
+    expect(cypressRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        testingType: 'component',
+      })
+    );
+  });
 });

--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -34,6 +34,7 @@ export interface CypressExecutorOptions extends Json {
   reporter?: string;
   reporterOptions?: string;
   skipServe: boolean;
+  testingType?: 'component' | 'e2e';
 }
 
 try {
@@ -183,6 +184,7 @@ async function runCypress(baseUrl: string, opts: CypressExecutorOptions) {
   options.ignoreTestFiles = opts.ignoreTestFiles;
   options.reporter = opts.reporter;
   options.reporterOptions = opts.reporterOptions;
+  options.testingType = opts.testingType;
 
   const result = await (!opts.watch || opts.headless
     ? Cypress.run(options)

--- a/packages/cypress/src/executors/cypress/schema.json
+++ b/packages/cypress/src/executors/cypress/schema.json
@@ -91,6 +91,12 @@
       "type": "boolean",
       "description": "Skip dev-server build.",
       "default": false
+    },
+    "testingType": {
+      "type": "string",
+      "description": "Specify the type of tests to execute",
+      "enum": ["component", "e2e"],
+      "default": "e2e"
     }
   },
   "additionalProperties": true,


### PR DESCRIPTION
Cf. https://docs.cypress.io/guides/guides/module-api#Options

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We can't forward `testingType` option to Cypress in order to run component tests instead of e2e which is the default behavior.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Forward `testingType` to Cypress.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5622
