### PR TITLE
Revert "feat(angular): add support for a target Builder (#4903)"

### DIFF
--- a/docs/angular/api-angular/executors/webpack-browser.md
+++ b/docs/angular/api-angular/executors/webpack-browser.md
@@ -272,14 +272,6 @@ Type: `boolean`
 
 Enables the use of subresource integrity validation.
 
-### targetBuilder
-
-Default: `@angular-devkit/build-angular:browser`
-
-Type: `string`
-
-Override default Angular browser builder
-
 ### tsConfig
 
 Type: `string`

--- a/docs/node/api-angular/executors/webpack-browser.md
+++ b/docs/node/api-angular/executors/webpack-browser.md
@@ -273,14 +273,6 @@ Type: `boolean`
 
 Enables the use of subresource integrity validation.
 
-### targetBuilder
-
-Default: `@angular-devkit/build-angular:browser`
-
-Type: `string`
-
-Override default Angular browser builder
-
 ### tsConfig
 
 Type: `string`

--- a/docs/react/api-angular/executors/webpack-browser.md
+++ b/docs/react/api-angular/executors/webpack-browser.md
@@ -273,14 +273,6 @@ Type: `boolean`
 
 Enables the use of subresource integrity validation.
 
-### targetBuilder
-
-Default: `@angular-devkit/build-angular:browser`
-
-Type: `string`
-
-Override default Angular browser builder
-
 ### tsConfig
 
 Type: `string`

--- a/e2e/angular/src/storybook.test.ts
+++ b/e2e/angular/src/storybook.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@nrwl/e2e/utils';
 import { writeFileSync } from 'fs';
 
-describe('Storybook schematics', () => {
+xdescribe('Storybook schematics', () => {
   let proj: string;
 
   beforeEach(() => (proj = newProject()));

--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -363,14 +363,9 @@
         "type": "string"
       },
       "default": []
-    },
-    "targetBuilder": {
-      "description": "Override default Angular browser builder",
-      "type": "string",
-      "default": "@angular-devkit/build-angular:browser"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["outputPath", "index", "main", "tsConfig"],
   "definitions": {
     "assetPattern": {

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -28,13 +28,8 @@ function buildApp(
 ): Promise<BuilderRun> {
   const { buildTarget, ...delegateOptions } = options;
 
-  // delete targetBuilder from options before passing into scheduleBuilder
-  const targetBuilder =
-    (delegateOptions.targetBuilder as string) || buildTarget;
-  delete delegateOptions.targetBuilder;
-
   if (buildTarget) {
-    const target = targetFromTargetString(targetBuilder);
+    const target = targetFromTargetString(buildTarget);
     return context.scheduleTarget(target, delegateOptions, {
       target: context.target,
       logger: context.logger as any,


### PR DESCRIPTION
This reverts commit a78fe65d81600e2f1b522722b6ce6374b8c652d3.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Target Builder implementation is incorrect.
It is also currently not working

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should build a new builder that will handle delegating to a different builder or `buildTarget`, whilst maintaining incremental build functionality.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
