### PR TITLE
cleanup(react): remove import react from component generator

### DIFF
--- a/e2e/react/src/react-package.test.ts
+++ b/e2e/react/src/react-package.test.ts
@@ -220,7 +220,6 @@ describe('Build React libraries and apps', () => {
         expect.objectContaining({
           [`@${proj}/${childLib}`]: '0.0.1',
           [`@${proj}/${childLib2}`]: '0.0.1',
-          react: expect.anything(),
         })
       );
     });

--- a/packages/react/src/generators/component/files/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/component/files/__fileName__.tsx__tmpl__
@@ -1,7 +1,5 @@
 <% if (classComponent) { %>
-import React, { Component } from 'react';
-<% } else { %>
-import React from 'react';
+import { Component } from 'react';
 <% } %>
 
 <% if (routing) { %>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The template for React component generator has `import React from 'react'` which is not needed after Nx v12.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`import React from 'react` should be removed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
