### PR TITLE
fix(nextjs): set NODE_ENV for the serve command

### DIFF
--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -41,6 +41,11 @@ export default async function* serveExecutor(
   options: NextServeBuilderOptions,
   context: ExecutorContext
 ) {
+  process.env.NODE_ENV = process.env.NODE_ENV
+    ? process.env.NODE_ENV
+    : options.dev
+    ? 'development'
+    : 'production';
   let dependencies: DependentBuildableProjectNode[] = [];
   const buildTarget = parseTargetString(options.buildTarget);
   const baseUrl = `http://${options.hostname || 'localhost'}:${options.port}`;


### PR DESCRIPTION
ISSUES CLOSED: #5627

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`NODE_ENV` is `undefined` when serving

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`NODE_ENV` is set `development` or `production`, depending on the `options.dev` flag.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5627
