### PR TITLE
chore(misc): updated verdaccio config files and local registry scripts

### DIFF
--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -36,4 +36,6 @@ packages:
 
 # log settings
 logs:
-  - { type: stdout, format: pretty, level: http }
+  type: stdout
+  format: pretty
+  level: http

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check-internal-links": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/internal-link-checker.ts",
     "check-versions": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/check-versions.ts",
     "check-documentation-map": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/map-link-checker.ts",
-    "e2e-start-local-registry": "ts-node -P ./scripts/tsconfig.e2e.json scripts/e2e-start-local-registry.ts",
+    "e2e-start-local-registry": "node ./scripts/e2e-start-local-registry.js",
     "e2e-build-package-publish": "ts-node -P ./scripts/tsconfig.e2e.json scripts/e2e-build-package-publish.ts",
     "format": "nx format",
     "nx-release": "./scripts/nx-release.js",

--- a/scripts/e2e-build-package-publish.ts
+++ b/scripts/e2e-build-package-publish.ts
@@ -1,6 +1,10 @@
 import { execSync } from 'child_process';
-import { readFileSync, removeSync, writeFileSync } from 'fs-extra';
-import { readdirSync } from 'fs';
+import { removeSync } from 'fs-extra';
+import { readFileSync, writeFileSync, readdirSync } from 'fs';
+import {
+  prettierVersion,
+  typescriptVersion,
+} from '../packages/workspace/src/utils/versions';
 
 process.env.PUBLISHED_VERSION = `9999.0.2`;
 process.env.npm_config_registry = `http://localhost:4872`;
@@ -12,7 +16,7 @@ export function buildPackagePublishAndCleanPorts() {
   removeSync('./tmp/angular/proj-backup');
   removeSync('./tmp/local-registry');
 
-  build(process.env.PUBLISHED_VERSION, '3.9.3', '2.1.2');
+  build(process.env.PUBLISHED_VERSION);
   try {
     updateVersionsAndPublishPackages();
   } catch (e) {
@@ -21,7 +25,7 @@ export function buildPackagePublishAndCleanPorts() {
   }
 }
 
-export const getDirectories = (source) =>
+export const getDirectories = (source: string) =>
   readdirSync(source, { withFileTypes: true })
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => dirent.name);
@@ -38,13 +42,13 @@ function updateVersionsAndPublishPackages() {
   });
 }
 
-function updateVersion(packagePath) {
+function updateVersion(packagePath: string) {
   return execSync(`npm version ${process.env.PUBLISHED_VERSION}`, {
     cwd: packagePath,
   });
 }
 
-function publishPackage(packagePath, npmMajorVersion: number) {
+function publishPackage(packagePath: string, npmMajorVersion: number) {
   if (process.env.npm_config_registry.indexOf('http://localhost') === -1) {
     throw Error(`
       ------------------
@@ -79,7 +83,7 @@ function publishPackage(packagePath, npmMajorVersion: number) {
   }
 }
 
-function build(nxVersion, typescriptVersion, prettierVersion) {
+function build(nxVersion: string) {
   try {
     execSync('npx nx run-many --target=build --all', {
       stdio: ['ignore', 'ignore', 'ignore'],
@@ -133,8 +137,7 @@ function build(nxVersion, typescriptVersion, prettierVersion) {
   ].map((f) => `${BUILD_DIR}/${f}`);
 
   files.forEach((f) => {
-    let content = readFileSync(f).toString();
-    content = content
+    const content = readFileSync(f, 'utf-8')
       .replace(
         /exports.nxVersion = '\*'/g,
         `exports.nxVersion = '${nxVersion}'`

--- a/scripts/e2e-start-local-registry.js
+++ b/scripts/e2e-start-local-registry.js
@@ -1,7 +1,7 @@
-import { exec } from 'child_process';
+const { exec } = require('child_process');
 
 const verdacio = exec(
-  `yarn verdaccio --config ./scripts/local-registry/config.yml --listen 4872`
+  'yarn verdaccio --config ./scripts/local-registry/config.yml'
 );
 verdacio.unref();
 
@@ -16,10 +16,6 @@ function outputHandling(data) {
 
 verdacio.stdout.on('data', outputHandling);
 verdacio.stderr.on('data', outputHandling);
-verdacio.on('exit', (code) => {
-  process.exit(code);
-});
+verdacio.on('exit', (code) => process.exit(code));
 
-setTimeout(() => {
-  process.exit(0);
-}, 2000);
+setTimeout(() => process.exit(0), 2000);

--- a/scripts/local-registry.sh
+++ b/scripts/local-registry.sh
@@ -12,8 +12,8 @@ fi
 if [[ $COMMAND == "disable" ]]; then
 	npm config delete registry
 	yarn config delete registry
-	CURRENT_NPM_REGISTRY=`npm config get registry`
-	CURRENT_YARN_REGISTRY=`yarn config get registry`
+	CURRENT_NPM_REGISTRY=$(npm config get registry)
+	CURRENT_YARN_REGISTRY=$(yarn config get registry)
 
 	echo "Reverting registries"
 	echo "  > NPM:  $CURRENT_NPM_REGISTRY"
@@ -21,12 +21,12 @@ if [[ $COMMAND == "disable" ]]; then
 fi
 
 if [[ $COMMAND == "clear" ]]; then
-  echo "Clearing Local Registry"
-  rm -rf ./build/local-registry/storage
+	echo "Clearing Local Registry"
+	rm -rf ./build/local-registry/storage
 fi
 
 if [[ $COMMAND == "start" ]]; then
-  echo "Starting Local Registry"
-  VERDACCIO_HANDLE_KILL_SIGNALS=true
-	npx verdaccio --config ./.verdaccio/config.yml
+	echo "Starting Local Registry"
+	VERDACCIO_HANDLE_KILL_SIGNALS=true
+	yarn verdaccio --config ./.verdaccio/config.yml
 fi

--- a/scripts/local-registry/config.yml
+++ b/scripts/local-registry/config.yml
@@ -1,6 +1,8 @@
 # path to a directory with all packages
 storage: ../../tmp/local-registry/storage
 
+listen: localhost:4872
+
 # a list of other known repositories we can talk to
 uplinks:
   npmjs:
@@ -24,4 +26,6 @@ packages:
 
 # log settings
 logs:
-  - { type: stdout, format: pretty, level: warn }
+  type: stdout
+  format: pretty
+  level: warn


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- `verdaccio` was updated to 5.0.4 in #5700 but the config files were not updated
- verdaccio throws deprecation warning because of the old logger config
![image](https://user-images.githubusercontent.com/17254592/118664532-d72d3e80-b7f1-11eb-848d-de3a5ce09406.png)
- `e2e-start-local-registry` is a typescript file but does not use any typescript features. It just takes extra seconds to compile it with ts-node 

- `e2e-build-package-publish.ts` had constant version for `typescript` and `prettier` configured

## Expected Behavior
- verdaccio should not throw any migration warnings
- `e2e-start-local-registry` should be a JS file

- `e2e-build-package-publish.ts` uses the specified `typescript` and `prettier`  version from `@nrwl/workspace/src/utils/versions.ts`


@meeroslav Can you look over it?
