### PR TITLE
fix(core): update rollup-plugin-typescript2 to fix array spread error

### DIFF
--- a/dep-graph/dep-graph/src/graphs/nx.ts
+++ b/dep-graph/dep-graph/src/graphs/nx.ts
@@ -19437,7 +19437,7 @@ export const nxGraph: ProjectGraphCache = {
       type: 'npm',
       name: 'npm:rollup-plugin-typescript2',
       data: {
-        version: '^0.27.1',
+        version: '^0.30.0',
         packageName: 'rollup-plugin-typescript2',
         files: [],
       },

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "rollup-plugin-local-resolve": "1.0.7",
     "rollup-plugin-peer-deps-external": "2.2.2",
     "rollup-plugin-postcss": "^4.0.0",
-    "rollup-plugin-typescript2": "^0.27.1",
+    "rollup-plugin-typescript2": "^0.30.0",
     "rxjs": "6.6.7",
     "rxjs-for-await": "0.0.2",
     "sass": "1.26.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -85,7 +85,7 @@
     "rollup-plugin-local-resolve": "^1.0.7",
     "rollup-plugin-peer-deps-external": "^2.2.2",
     "rollup-plugin-postcss": "^4.0.0",
-    "rollup-plugin-typescript2": "^0.27.1",
+    "rollup-plugin-typescript2": "^0.30.0",
     "sass": "^1.26.3",
     "sass-loader": "8.0.2",
     "semver": "7.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3473,6 +3473,14 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@rollup/pluginutils@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz#0dcc61c780e39257554feb7f77207dceca13c838"
+  integrity sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==
+  dependencies:
+    estree-walker "^2.0.1"
+    picomatch "^2.2.2"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"
@@ -21485,6 +21493,17 @@ rollup-plugin-typescript2@^0.27.1:
     fs-extra "8.1.0"
     resolve "1.17.0"
     tslib "2.0.1"
+
+rollup-plugin-typescript2@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.30.0.tgz#1cc99ac2309bf4b9d0a3ebdbc2002aecd56083d3"
+  integrity sha512-NUFszIQyhgDdhRS9ya/VEmsnpTe+GERDMmFo0Y+kf8ds51Xy57nPNGglJY+W6x1vcouA7Au7nsTgsLFj2I0PxQ==
+  dependencies:
+    "@rollup/pluginutils" "^4.1.0"
+    find-cache-dir "^3.3.1"
+    fs-extra "8.1.0"
+    resolve "1.20.0"
+    tslib "2.1.0"
 
 rollup-pluginutils@^2.8.2:
   version "2.8.2"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If a library uses the spread operator in an array (e.g `[...someArray]`, an error is thrown on bundle: "__spreadArray" is not exported by tslib.js. This was resolved in the most recent version of the rollup-plugin-typescript2

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This error is no longer displayed when using array spreads in libraries.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes: #5467 
