### PR TITLE
fix(react): nextjs check causes linting commands to fail

### DIFF
--- a/packages/react/babel.ts
+++ b/packages/react/babel.ts
@@ -14,7 +14,7 @@ module.exports = function (api: any, options: ReactBabelOptions) {
   /**
    * pagesDir is set when being transpiled by Next.js
    */
-  const isNextJs = api.caller((caller) => caller && caller.pagesDir);
+  const isNextJs = api.caller((caller) => caller?.pagesDir);
 
   const presets: any[] = [
     ['@nrwl/web/babel', { useBuiltIns: options.useBuiltIns }],

--- a/packages/react/babel.ts
+++ b/packages/react/babel.ts
@@ -14,7 +14,7 @@ module.exports = function (api: any, options: ReactBabelOptions) {
   /**
    * pagesDir is set when being transpiled by Next.js
    */
-  const isNextJs = api.caller((caller) => caller.pagesDir);
+  const isNextJs = api.caller((caller) => caller && caller.pagesDir);
 
   const presets: any[] = [
     ['@nrwl/web/babel', { useBuiltIns: options.useBuiltIns }],


### PR DESCRIPTION
## Current Behavior
Running `nx affected:lint` or `nx run appname:lint` causes an error (see below). This was introduced in a recent PR #5503.

See https://github.com/nrwl/nx/pull/5503/files#diff-39934993694612676cfbc4ec28fe0e9bcde2a23e2aa0c3064f28fc1b01d7b043R17

```
> nx run data:lint 

Linting "data"...

[eslint-import-resolver-babel-module] TypeError: [BABEL] /Users/vreid/Documents/Workspaces/Node/mega-mentor/libs/data/src/index.ts: Cannot read property 'pagesDir' of undefined (While processing: "/Users/vreid/Documents/Workspaces/Node/mega-mentor/node_modules/@nrwl/react/babel.js")
    at /Users/vreid/Documents/Workspaces/Node/mega-mentor/node_modules/@nrwl/react/babel.js:10:52
```

## Expected Behavior
In `api.caller((caller) => ` caller is undefined so I have added a check for that. Linting commands now run as normal.

## Related Issue(s)
None that I can see yet.