### PR TITLE
fix(core): update project's eslintrc and readme on move

### DIFF
--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
@@ -6,6 +6,7 @@ import { Linter } from '../../../utils/lint';
 import { Schema } from '../schema';
 import { updateEslintrcJson } from './update-eslintrc-json';
 import { libraryGenerator } from '../../library/library';
+import { executionAsyncId } from 'node:async_hooks';
 
 describe('updateEslint', () => {
   let tree: Tree;
@@ -56,6 +57,37 @@ describe('updateEslint', () => {
     ).toEqual(
       expect.objectContaining({
         extends: '../../../.eslintrc.json',
+      })
+    );
+  });
+
+  it('should update .eslintrc.json overrides parser project when project is moved', async () => {
+    await libraryGenerator(tree, {
+      name: 'my-lib',
+      linter: Linter.EsLint,
+    });
+
+    // This step is usually handled elsewhere
+    tree.rename(
+      'libs/my-lib/.eslintrc.json',
+      'libs/shared/my-destination/.eslintrc.json'
+    );
+
+    const projectConfig = readProjectConfiguration(tree, 'my-lib');
+
+    updateEslintrcJson(tree, schema, projectConfig);
+
+    expect(
+      readJson(tree, '/libs/shared/my-destination/.eslintrc.json')
+    ).toEqual(
+      expect.objectContaining({
+        overrides: expect.arrayContaining([
+          expect.objectContaining({
+            parserOptions: expect.objectContaining({
+              project: ['libs/shared/my-destination/tsconfig.*?.json'],
+            }),
+          }),
+        ]),
       })
     );
   });

--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
@@ -2,7 +2,6 @@ import { join } from 'path';
 import {
   offsetFromRoot,
   ProjectConfiguration,
-  readJson,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
@@ -10,8 +9,15 @@ import {
 import { Schema } from '../schema';
 import { getDestination } from './utils';
 
+interface PartialEsLintrcOverride {
+  parserOptions?: {
+    project?: [string];
+  };
+}
+
 interface PartialEsLintRcJson {
   extends: string;
+  overrides?: PartialEsLintrcOverride[];
 }
 
 /**
@@ -36,6 +42,12 @@ export function updateEslintrcJson(
 
   updateJson<PartialEsLintRcJson>(tree, eslintRcPath, (eslintRcJson) => {
     eslintRcJson.extends = `${offset}.eslintrc.json`;
+
+    eslintRcJson.overrides?.forEach((override) => {
+      if (override.parserOptions?.project) {
+        override.parserOptions.project = [`${destination}/tsconfig.*?.json`];
+      }
+    });
 
     return eslintRcJson;
   });

--- a/packages/workspace/src/generators/move/lib/update-readme.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-readme.spec.ts
@@ -1,0 +1,61 @@
+import { readJson, readProjectConfiguration, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+import { updateReadme } from './update-readme';
+import { Schema } from '../schema';
+import { libraryGenerator } from '../../library/library';
+import { getDestination } from './utils';
+import { join } from 'path';
+
+describe('updateReadme', () => {
+  let tree: Tree;
+  let schema: Schema;
+
+  beforeEach(async () => {
+    schema = {
+      projectName: 'my-lib',
+      destination: 'shared/my-destination',
+      importPath: undefined,
+      updateImportPath: true,
+    };
+
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should handle README.md not existing', async () => {
+    await libraryGenerator(tree, {
+      name: 'my-lib',
+    });
+
+    const projectConfig = readProjectConfiguration(tree, 'my-lib');
+    const destination = getDestination(tree, schema, projectConfig);
+    const readmePath = join(destination, 'README.md');
+    tree.delete(readmePath);
+
+    expect(() => {
+      updateReadme(tree, schema, projectConfig);
+    }).not.toThrow();
+  });
+
+  it('should update README.md contents', async () => {
+    await libraryGenerator(tree, {
+      name: 'my-lib',
+    });
+
+    // This step is usually handled elsewhere
+    tree.rename(
+      'libs/my-lib/README.md',
+      'libs/shared/my-destination/README.md'
+    );
+
+    const projectConfig = readProjectConfiguration(tree, 'my-lib');
+
+    updateReadme(tree, schema, projectConfig);
+
+    const content = tree
+      .read('/libs/shared/my-destination/README.md')
+      .toString('utf8');
+    expect(content).toMatch('# shared-my-destination');
+    expect(content).toMatch('nx test shared-my-destination');
+  });
+});

--- a/packages/workspace/src/generators/move/lib/update-readme.ts
+++ b/packages/workspace/src/generators/move/lib/update-readme.ts
@@ -1,0 +1,29 @@
+import { join } from 'path';
+import { ProjectConfiguration, Tree } from '@nrwl/devkit';
+
+import { Schema } from '../schema';
+import { getDestination, getNewProjectName } from './utils';
+
+/**
+ * Update the README.md file of the project if it exists.
+ *
+ * @param schema The options provided to the schematic
+ */
+export function updateReadme(
+  tree: Tree,
+  schema: Schema,
+  project: ProjectConfiguration
+) {
+  const destination = getDestination(tree, schema, project);
+  const readmePath = join(destination, 'README.md');
+
+  if (!tree.exists(readmePath)) {
+    // no README found. nothing to do
+    return;
+  }
+  const newProjectName = getNewProjectName(schema.destination);
+  const findName = new RegExp(`${schema.projectName}`, 'g');
+  const oldContent = tree.read(readmePath, 'utf-8');
+  const newContent = oldContent.replace(findName, newProjectName);
+  tree.write(readmePath, newContent);
+}

--- a/packages/workspace/src/generators/move/move.ts
+++ b/packages/workspace/src/generators/move/move.ts
@@ -18,6 +18,7 @@ import { Schema } from './schema';
 import { updateEslintrcJson } from './lib/update-eslintrc-json';
 import { moveProjectConfiguration } from './lib/move-project-configuration';
 import { updateBuildTargets } from './lib/update-build-targets';
+import { updateReadme } from './lib/update-readme';
 
 export async function moveGenerator(tree: Tree, schema: Schema) {
   const projectConfig = readProjectConfiguration(tree, schema.projectName);
@@ -29,6 +30,7 @@ export async function moveGenerator(tree: Tree, schema: Schema) {
   updateJestConfig(tree, schema, projectConfig);
   updateStorybookConfig(tree, schema, projectConfig);
   updateEslintrcJson(tree, schema, projectConfig);
+  updateReadme(tree, schema, projectConfig);
   moveProjectConfiguration(tree, schema, projectConfig);
   updateBuildTargets(tree, schema);
   updateDefaultProject(tree, schema);


### PR DESCRIPTION
Closes #5493

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
* tsconfig's path in `eslintrc.json` is not updated after `move`
* project's name is `README.md` is not updated after `move`
<!-- This is the behavior we have today -->

## Expected Behavior
* tsconfig's path in `eslintrc.json` should point to the new path
* project's name is `README.md` should match the new name
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5493
