### PR TITLE
feat(angular): add executor which allows to delegate the build to another target

### DIFF
--- a/docs/angular/api-angular/executors/delegate-build.md
+++ b/docs/angular/api-angular/executors/delegate-build.md
@@ -1,0 +1,25 @@
+# delegate-build
+
+Delegates the build to a different target while supporting incremental builds
+
+Properties can be configured in angular.json when defining the executor, or when invoking it.
+
+## Properties
+
+### buildTarget
+
+Type: `string`
+
+Build target used for building the app after its dependencies have been built.
+
+### outputPath
+
+Type: `string`
+
+The full path for the output directory, relative to the workspace root.
+
+### tsConfig
+
+Type: `string`
+
+The full path for the TypeScript configuration file, relative to the workspace root.

--- a/docs/angular/api-angular/executors/webpack-browser.md
+++ b/docs/angular/api-angular/executors/webpack-browser.md
@@ -46,12 +46,6 @@ Type: `boolean`
 
 Enables '@angular-devkit/build-optimizer' optimizations when using the 'aot' option.
 
-### buildTarget
-
-Type: `string`
-
-Build target used for building the app after its dependencies have been built. If no target is configured, @angular-devkit/build-angular:browser is sheduled directly.
-
 ### commonChunk
 
 Default: `true`

--- a/docs/map.json
+++ b/docs/map.json
@@ -461,6 +461,11 @@
             "name": "webpack-browser executor",
             "id": "webpack-browser",
             "file": "angular/api-angular/executors/webpack-browser"
+          },
+          {
+            "name": "delegate-build executor",
+            "id": "delegate-build",
+            "file": "angular/api-angular/executors/delegate-build"
           }
         ]
       },
@@ -1523,6 +1528,11 @@
             "name": "webpack-browser executor",
             "id": "webpack-browser",
             "file": "react/api-angular/executors/webpack-browser"
+          },
+          {
+            "name": "delegate-build executor",
+            "id": "delegate-build",
+            "file": "react/api-angular/executors/delegate-build"
           }
         ]
       },
@@ -2544,6 +2554,11 @@
             "name": "webpack-browser executor",
             "id": "webpack-browser",
             "file": "node/api-angular/executors/webpack-browser"
+          },
+          {
+            "name": "delegate-build executor",
+            "id": "delegate-build",
+            "file": "node/api-angular/executors/delegate-build"
           }
         ]
       },

--- a/docs/node/api-angular/executors/delegate-build.md
+++ b/docs/node/api-angular/executors/delegate-build.md
@@ -1,0 +1,26 @@
+# delegate-build
+
+Delegates the build to a different target while supporting incremental builds
+
+Properties can be configured in workspace.json when defining the executor, or when invoking it.
+Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+
+## Properties
+
+### buildTarget
+
+Type: `string`
+
+Build target used for building the app after its dependencies have been built.
+
+### outputPath
+
+Type: `string`
+
+The full path for the output directory, relative to the workspace root.
+
+### tsConfig
+
+Type: `string`
+
+The full path for the TypeScript configuration file, relative to the workspace root.

--- a/docs/node/api-angular/executors/webpack-browser.md
+++ b/docs/node/api-angular/executors/webpack-browser.md
@@ -47,12 +47,6 @@ Type: `boolean`
 
 Enables '@angular-devkit/build-optimizer' optimizations when using the 'aot' option.
 
-### buildTarget
-
-Type: `string`
-
-Build target used for building the app after its dependencies have been built. If no target is configured, @angular-devkit/build-angular:browser is sheduled directly.
-
 ### commonChunk
 
 Default: `true`

--- a/docs/react/api-angular/executors/delegate-build.md
+++ b/docs/react/api-angular/executors/delegate-build.md
@@ -1,0 +1,26 @@
+# delegate-build
+
+Delegates the build to a different target while supporting incremental builds
+
+Properties can be configured in workspace.json when defining the executor, or when invoking it.
+Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+
+## Properties
+
+### buildTarget
+
+Type: `string`
+
+Build target used for building the app after its dependencies have been built.
+
+### outputPath
+
+Type: `string`
+
+The full path for the output directory, relative to the workspace root.
+
+### tsConfig
+
+Type: `string`
+
+The full path for the TypeScript configuration file, relative to the workspace root.

--- a/docs/react/api-angular/executors/webpack-browser.md
+++ b/docs/react/api-angular/executors/webpack-browser.md
@@ -47,12 +47,6 @@ Type: `boolean`
 
 Enables '@angular-devkit/build-optimizer' optimizations when using the 'aot' option.
 
-### buildTarget
-
-Type: `string`
-
-Build target used for building the app after its dependencies have been built. If no target is configured, @angular-devkit/build-angular:browser is sheduled directly.
-
 ### commonChunk
 
 Default: `true`

--- a/packages/angular/builders.json
+++ b/packages/angular/builders.json
@@ -1,6 +1,11 @@
 {
   "$schema": "@angular-devkit/architect/src/builders-schema.json",
   "builders": {
+    "delegate-build": {
+      "implementation": "./src/builders/delegate-build/delegate-build.impl",
+      "schema": "./src/builders/delegate-build/schema.json",
+      "description": "Delegates the build to a different target while supporting incremental builds"
+    },
     "ng-packagr-lite": {
       "implementation": "./src/builders/ng-packagr-lite/ng-packagr-lite.impl",
       "schema": "./src/builders/ng-packagr-lite/schema.json",

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -78,6 +78,12 @@
       "version": "12.3.1",
       "description": "Migrates some rules that have changed in Angular EsLint",
       "factory": "./src/migrations/update-12-3-0/update-angular-eslint-rules"
+    },
+    "convert-webpack-browser-build-target-to-delegate-build": {
+      "cli": "nx",
+      "version": "12.3.5-beta.0",
+      "description": "Convert targets using @nrwl/angular:webpack-browser with the buildTarget option set to use the @nrwl/angular:delegate-build executor instead.",
+      "factory": "./src/migrations/update-12-3-0/convert-webpack-browser-build-target-to-delegate-build"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/builders/delegate-build/delegate-build.impl.ts
+++ b/packages/angular/src/builders/delegate-build/delegate-build.impl.ts
@@ -1,0 +1,66 @@
+import {
+  BuilderContext,
+  BuilderOutput,
+  createBuilder,
+} from '@angular-devkit/architect';
+import { JsonObject } from '@angular-devkit/core';
+import { joinPathFragments, parseTargetString } from '@nrwl/devkit';
+import { createProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  calculateProjectDependencies,
+  checkDependentProjectsHaveBeenBuilt,
+  createTmpTsConfig,
+} from '@nrwl/workspace/src/utils/buildable-libs-utils';
+import { from, Observable, of } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { DelegateBuildExecutorSchema } from './schema';
+
+function run(
+  options: DelegateBuildExecutorSchema,
+  context: BuilderContext
+): Observable<BuilderOutput> {
+  const projGraph = createProjectGraph();
+
+  const { target, dependencies } = calculateProjectDependencies(
+    projGraph,
+    context
+  );
+
+  options.tsConfig = createTmpTsConfig(
+    joinPathFragments(context.workspaceRoot, options.tsConfig),
+    context.workspaceRoot,
+    target.data.root,
+    dependencies
+  );
+
+  return of(checkDependentProjectsHaveBeenBuilt(context, dependencies)).pipe(
+    switchMap((result) => {
+      if (result) {
+        return from(scheduleDelegateTarget(options, context)).pipe(
+          switchMap((x) => x.result)
+        );
+      }
+
+      return of({ success: false });
+    })
+  );
+}
+
+function scheduleDelegateTarget(
+  options: DelegateBuildExecutorSchema,
+  context: BuilderContext
+) {
+  const { buildTarget, ...targetOptions } = options;
+  const delegateTarget = parseTargetString(buildTarget);
+
+  return context.scheduleTarget(
+    delegateTarget,
+    targetOptions as DelegateBuildExecutorSchema & JsonObject,
+    {
+      target: context.target,
+      logger: context.logger as any,
+    }
+  );
+}
+
+export default createBuilder<DelegateBuildExecutorSchema>(run);

--- a/packages/angular/src/builders/delegate-build/schema.d.ts
+++ b/packages/angular/src/builders/delegate-build/schema.d.ts
@@ -1,0 +1,5 @@
+export interface DelegateBuildExecutorSchema {
+  buildTarget: string;
+  outputPath: string;
+  tsConfig: string;
+}

--- a/packages/angular/src/builders/delegate-build/schema.json
+++ b/packages/angular/src/builders/delegate-build/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Schema for an executor which delegates a build.",
+  "description": "Options for delegating a build to a different target.",
+  "type": "object",
+  "properties": {
+    "buildTarget": {
+      "description": "Build target used for building the app after its dependencies have been built.",
+      "type": "string"
+    },
+    "outputPath": {
+      "type": "string",
+      "description": "The full path for the output directory, relative to the workspace root."
+    },
+    "tsConfig": {
+      "type": "string",
+      "description": "The full path for the TypeScript configuration file, relative to the workspace root."
+    }
+  },
+  "additionalProperties": false,
+  "required": ["buildTarget", "outputPath", "tsConfig"]
+}

--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -4,10 +4,6 @@
   "description": "Browser target options",
   "type": "object",
   "properties": {
-    "buildTarget": {
-      "description": "Build target used for building the app after its dependencies have been built. If no target is configured, @angular-devkit/build-angular:browser is sheduled directly.",
-      "type": "string"
-    },
     "assets": {
       "type": "array",
       "description": "List of static application assets.",
@@ -373,7 +369,8 @@
           "type": "string"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false,
+      "required": ["path"]
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/migrations/update-12-3-0/__snapshots__/convert-webpack-browser-build-target-to-delegate-build.spec.ts.snap
+++ b/packages/angular/src/migrations/update-12-3-0/__snapshots__/convert-webpack-browser-build-target-to-delegate-build.spec.ts.snap
@@ -1,0 +1,212 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`convertWebpackBrowserBuildTargetToDelegateBuild should update the configuration correctly 1`] = `
+Object {
+  "projects": Object {
+    "ng-app1": Object {
+      "architect": Object {
+        "build": Object {
+          "builder": "@nrwl/angular:delegate-build",
+          "configurations": Object {
+            "development": Object {
+              "buildTarget": "ng-app1:customBuild:development",
+            },
+            "production": Object {
+              "buildTarget": "ng-app1:customBuild:production",
+            },
+          },
+          "defaultConfiguration": "production",
+          "options": Object {
+            "buildTarget": "ng-app:customBuild",
+            "outputPath": "dist/apps/ng-app1",
+            "tsConfig": "apps/ng-app1/tsconfig.app.json",
+          },
+        },
+        "customBuild": Object {
+          "builder": "@angular-devkit/build-angular:browser",
+          "configurations": Object {
+            "development": Object {
+              "buildOptimizer": false,
+              "extractLicenses": false,
+              "namedChunks": true,
+              "optimization": false,
+              "sourceMap": true,
+              "vendorChunk": true,
+            },
+            "production": Object {
+              "budgets": Array [
+                Object {
+                  "maximumError": "1mb",
+                  "maximumWarning": "500kb",
+                  "type": "initial",
+                },
+                Object {
+                  "maximumError": "4kb",
+                  "maximumWarning": "2kb",
+                  "type": "anyComponentStyle",
+                },
+              ],
+              "fileReplacements": Array [
+                Object {
+                  "replace": "apps/ng-app1/src/environments/environment.ts",
+                  "with": "apps/ng-app1/src/environments/environment.prod.ts",
+                },
+              ],
+              "outputHashing": "all",
+            },
+          },
+          "options": Object {
+            "assets": Array [
+              "apps/ng-app1/src/favicon.ico",
+              "apps/ng-app1/src/assets",
+            ],
+            "index": "apps/ng-app1/src/index.html",
+            "inlineStyleLanguage": "scss",
+            "main": "apps/ng-app1/src/main.ts",
+            "polyfills": "apps/ng-app1/src/polyfills.ts",
+            "scripts": Array [],
+            "styles": Array [
+              "apps/ng-app1/src/styles.scss",
+            ],
+          },
+        },
+      },
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+    },
+    "ng-app2": Object {
+      "architect": Object {
+        "build": Object {
+          "builder": "@nrwl/angular:delegate-build",
+          "configurations": Object {
+            "development": Object {
+              "buildTarget": "ng-app:customBuild:development",
+            },
+            "production": Object {
+              "buildTarget": "ng-app:customBuild:production",
+            },
+          },
+          "defaultConfiguration": "production",
+          "options": Object {
+            "outputPath": "dist/apps/ng-app2",
+            "tsConfig": "apps/ng-app2/tsconfig.app.json",
+          },
+        },
+        "customBuild": Object {
+          "builder": "@angular-devkit/build-angular:browser",
+          "configurations": Object {
+            "development": Object {
+              "buildOptimizer": false,
+              "extractLicenses": false,
+              "namedChunks": true,
+              "optimization": false,
+              "sourceMap": true,
+              "vendorChunk": true,
+            },
+            "production": Object {
+              "additionalProperty": "bar",
+              "budgets": Array [
+                Object {
+                  "maximumError": "1mb",
+                  "maximumWarning": "500kb",
+                  "type": "initial",
+                },
+                Object {
+                  "maximumError": "4kb",
+                  "maximumWarning": "2kb",
+                  "type": "anyComponentStyle",
+                },
+              ],
+              "fileReplacements": Array [
+                Object {
+                  "replace": "apps/ng-app2/src/environments/environment.ts",
+                  "with": "apps/ng-app2/src/environments/environment.prod.ts",
+                },
+              ],
+              "outputHashing": "all",
+            },
+          },
+          "options": Object {
+            "additionalProperty": "foo",
+            "assets": Array [
+              "apps/ng-app2/src/favicon.ico",
+              "apps/ng-app2/src/assets",
+            ],
+            "index": "apps/ng-app2/src/index.html",
+            "inlineStyleLanguage": "scss",
+            "main": "apps/ng-app2/src/main.ts",
+            "polyfills": "apps/ng-app2/src/polyfills.ts",
+            "scripts": Array [],
+            "styles": Array [
+              "apps/ng-app2/src/styles.scss",
+            ],
+          },
+        },
+      },
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+    },
+    "ng-app3": Object {
+      "architect": Object {
+        "build": Object {
+          "builder": "@nrwl/angular:webpack-browser",
+          "configurations": Object {
+            "development": Object {
+              "buildOptimizer": false,
+              "extractLicenses": false,
+              "namedChunks": true,
+              "optimization": false,
+              "sourceMap": true,
+              "vendorChunk": true,
+            },
+            "production": Object {
+              "budgets": Array [
+                Object {
+                  "maximumError": "1mb",
+                  "maximumWarning": "500kb",
+                  "type": "initial",
+                },
+                Object {
+                  "maximumError": "4kb",
+                  "maximumWarning": "2kb",
+                  "type": "anyComponentStyle",
+                },
+              ],
+              "fileReplacements": Array [
+                Object {
+                  "replace": "apps/ng-app3/src/environments/environment.ts",
+                  "with": "apps/ng-app3/src/environments/environment.prod.ts",
+                },
+              ],
+              "outputHashing": "all",
+            },
+          },
+          "defaultConfiguration": "production",
+          "options": Object {
+            "assets": Array [
+              "apps/ng-app3/src/favicon.ico",
+              "apps/ng-app3/src/assets",
+            ],
+            "index": "apps/ng-app3/src/index.html",
+            "inlineStyleLanguage": "scss",
+            "main": "apps/ng-app3/src/main.ts",
+            "outputPath": "dist/apps/ng-app3",
+            "polyfills": "apps/ng-app3/src/polyfills.ts",
+            "scripts": Array [],
+            "styles": Array [
+              "apps/ng-app3/src/styles.scss",
+            ],
+            "tsConfig": "apps/ng-app3/tsconfig.app.json",
+          },
+        },
+      },
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+    },
+  },
+  "version": 1,
+}
+`;

--- a/packages/angular/src/migrations/update-12-3-0/convert-webpack-browser-build-target-to-delegate-build.spec.ts
+++ b/packages/angular/src/migrations/update-12-3-0/convert-webpack-browser-build-target-to-delegate-build.spec.ts
@@ -1,0 +1,213 @@
+import { addProjectConfiguration, readJson, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import convertWebpackBrowserBuildTargetToDelegateBuild from './convert-webpack-browser-build-target-to-delegate-build';
+
+function getWsConfig(tree: Tree) {
+  return readJson(tree, 'workspace.json');
+}
+
+describe('convertWebpackBrowserBuildTargetToDelegateBuild', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+
+    addProjectConfiguration(tree, 'ng-app1', {
+      root: '',
+      sourceRoot: 'src',
+      projectType: 'application',
+      targets: {
+        customBuild: {
+          executor: '@angular-devkit/build-angular:browser',
+        },
+        build: {
+          executor: '@nrwl/angular:webpack-browser',
+          options: {
+            buildTarget: 'ng-app:customBuild',
+            outputPath: 'dist/apps/ng-app1',
+            tsConfig: 'apps/ng-app1/tsconfig.app.json',
+            index: 'apps/ng-app1/src/index.html',
+            main: 'apps/ng-app1/src/main.ts',
+            polyfills: 'apps/ng-app1/src/polyfills.ts',
+            inlineStyleLanguage: 'scss',
+            assets: ['apps/ng-app1/src/favicon.ico', 'apps/ng-app1/src/assets'],
+            styles: ['apps/ng-app1/src/styles.scss'],
+            scripts: [],
+          },
+          configurations: {
+            production: {
+              budgets: [
+                {
+                  type: 'initial',
+                  maximumWarning: '500kb',
+                  maximumError: '1mb',
+                },
+                {
+                  type: 'anyComponentStyle',
+                  maximumWarning: '2kb',
+                  maximumError: '4kb',
+                },
+              ],
+              fileReplacements: [
+                {
+                  replace: 'apps/ng-app1/src/environments/environment.ts',
+                  with: 'apps/ng-app1/src/environments/environment.prod.ts',
+                },
+              ],
+              outputHashing: 'all',
+            },
+            development: {
+              buildOptimizer: false,
+              optimization: false,
+              vendorChunk: true,
+              extractLicenses: false,
+              sourceMap: true,
+              namedChunks: true,
+            },
+          },
+          defaultConfiguration: 'production',
+        },
+      },
+    });
+
+    addProjectConfiguration(tree, 'ng-app2', {
+      root: '',
+      sourceRoot: 'src',
+      projectType: 'application',
+      targets: {
+        customBuild: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            outputPath: 'dist/apps/ng-app2',
+            tsConfig: 'apps/ng-app2/tsconfig.app.json',
+            index: 'apps/ng-app2/src/index.html',
+            main: 'apps/ng-app2/src/different-main.ts',
+            additionalProperty: 'foo',
+          },
+          configurations: {
+            development: {
+              buildOptimizer: true,
+            },
+            production: {
+              additionalProperty: 'bar',
+              fileReplacements: [
+                {
+                  replace: 'apps/ng-app2/src/environments/environment.ts',
+                  with: 'apps/ng-app2/src/environments/environment.other.ts',
+                },
+              ],
+            },
+          },
+        },
+        build: {
+          executor: '@nrwl/angular:webpack-browser',
+          options: {
+            outputPath: 'dist/apps/ng-app2',
+            tsConfig: 'apps/ng-app2/tsconfig.app.json',
+            index: 'apps/ng-app2/src/index.html',
+            main: 'apps/ng-app2/src/main.ts',
+            polyfills: 'apps/ng-app2/src/polyfills.ts',
+            inlineStyleLanguage: 'scss',
+            assets: ['apps/ng-app2/src/favicon.ico', 'apps/ng-app2/src/assets'],
+            styles: ['apps/ng-app2/src/styles.scss'],
+            scripts: [],
+          },
+          configurations: {
+            production: {
+              buildTarget: 'ng-app:customBuild:production',
+              budgets: [
+                {
+                  type: 'initial',
+                  maximumWarning: '500kb',
+                  maximumError: '1mb',
+                },
+                {
+                  type: 'anyComponentStyle',
+                  maximumWarning: '2kb',
+                  maximumError: '4kb',
+                },
+              ],
+              fileReplacements: [
+                {
+                  replace: 'apps/ng-app2/src/environments/environment.ts',
+                  with: 'apps/ng-app2/src/environments/environment.prod.ts',
+                },
+              ],
+              outputHashing: 'all',
+            },
+            development: {
+              buildTarget: 'ng-app:customBuild:development',
+              buildOptimizer: false,
+              optimization: false,
+              vendorChunk: true,
+              extractLicenses: false,
+              sourceMap: true,
+              namedChunks: true,
+            },
+          },
+          defaultConfiguration: 'production',
+        },
+      },
+    });
+
+    addProjectConfiguration(tree, 'ng-app3', {
+      root: '',
+      sourceRoot: 'src',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@nrwl/angular:webpack-browser',
+          options: {
+            outputPath: 'dist/apps/ng-app3',
+            tsConfig: 'apps/ng-app3/tsconfig.app.json',
+            index: 'apps/ng-app3/src/index.html',
+            main: 'apps/ng-app3/src/main.ts',
+            polyfills: 'apps/ng-app3/src/polyfills.ts',
+            inlineStyleLanguage: 'scss',
+            assets: ['apps/ng-app3/src/favicon.ico', 'apps/ng-app3/src/assets'],
+            styles: ['apps/ng-app3/src/styles.scss'],
+            scripts: [],
+          },
+          configurations: {
+            production: {
+              budgets: [
+                {
+                  type: 'initial',
+                  maximumWarning: '500kb',
+                  maximumError: '1mb',
+                },
+                {
+                  type: 'anyComponentStyle',
+                  maximumWarning: '2kb',
+                  maximumError: '4kb',
+                },
+              ],
+              fileReplacements: [
+                {
+                  replace: 'apps/ng-app3/src/environments/environment.ts',
+                  with: 'apps/ng-app3/src/environments/environment.prod.ts',
+                },
+              ],
+              outputHashing: 'all',
+            },
+            development: {
+              buildOptimizer: false,
+              optimization: false,
+              vendorChunk: true,
+              extractLicenses: false,
+              sourceMap: true,
+              namedChunks: true,
+            },
+          },
+          defaultConfiguration: 'production',
+        },
+      },
+    });
+  });
+
+  it('should update the configuration correctly', async () => {
+    await convertWebpackBrowserBuildTargetToDelegateBuild(tree);
+
+    expect(getWsConfig(tree)).toMatchSnapshot();
+  });
+});

--- a/packages/angular/src/migrations/update-12-3-0/convert-webpack-browser-build-target-to-delegate-build.ts
+++ b/packages/angular/src/migrations/update-12-3-0/convert-webpack-browser-build-target-to-delegate-build.ts
@@ -1,0 +1,176 @@
+import {
+  formatFiles,
+  getProjects,
+  NxJsonProjectConfiguration,
+  parseTargetString,
+  ProjectConfiguration,
+  Target,
+  TargetConfiguration,
+  targetToTargetString,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+
+export default async function convertWebpackBrowserBuildTargetToDelegateBuild(
+  host: Tree
+) {
+  const projects = getProjects(host);
+
+  for (const [projectName, project] of projects) {
+    const webpackBrowserTargets = Object.values(project.targets).filter(
+      (target) => target.executor === '@nrwl/angular:webpack-browser'
+    );
+    for (const target of webpackBrowserTargets) {
+      const configurationOptions = getTargetConfigurationOptions(target);
+      const buildTargetName = getBuildTargetNameFromOptions(
+        target.options,
+        configurationOptions
+      );
+      if (buildTargetName) {
+        target.executor = '@nrwl/angular:delegate-build';
+        updateTargetsOptions(project, target, buildTargetName);
+        updateTargetsConfigurations(
+          project,
+          projectName,
+          target,
+          buildTargetName,
+          configurationOptions
+        );
+      }
+    }
+
+    updateProjectConfiguration(host, projectName, project);
+  }
+
+  await formatFiles(host);
+}
+
+function cleanupBuildTargetProperties(options: {
+  tsConfig: string;
+  outputPath: string;
+}): void {
+  delete options.tsConfig;
+  delete options.outputPath;
+}
+
+function extractConfigurationBuildTarget(
+  project: string,
+  target: string,
+  configuration: string,
+  buildTarget: string
+): Target {
+  if (buildTarget) {
+    const buildTargetObj = parseTargetString(buildTarget);
+    return {
+      ...buildTargetObj,
+      configuration: buildTargetObj.configuration ?? configuration,
+    };
+  }
+
+  return {
+    project: project,
+    target: target,
+    configuration: configuration,
+  };
+}
+
+function getBuildTargetNameFromOptions(
+  baseOptions: any,
+  configurationOptions: Map<string, any>
+): string {
+  if (baseOptions.buildTarget) {
+    return parseTargetString(baseOptions.buildTarget).target;
+  }
+  for (const [, options] of configurationOptions) {
+    if (options.buildTarget) {
+      return parseTargetString(options.buildTarget).target;
+    }
+  }
+}
+
+function getTargetConfigurationOptions(
+  target: TargetConfiguration
+): Map<string, any> {
+  const targets = new Map<string, any>();
+  if (target.configurations) {
+    for (const [name, options] of Object.entries(target.configurations)) {
+      if (options !== undefined) {
+        targets.set(name, options);
+      }
+    }
+  }
+
+  return targets;
+}
+
+function updateTargetsConfigurations(
+  project: ProjectConfiguration & NxJsonProjectConfiguration,
+  projectName: string,
+  target: TargetConfiguration,
+  buildTargetName: string,
+  configurationOptions: any
+) {
+  for (const [configurationName, options] of configurationOptions) {
+    const {
+      buildTarget,
+      tsConfig,
+      outputPath,
+      ...delegateTargetOptions
+    } = options;
+
+    const configurationBuildTarget = extractConfigurationBuildTarget(
+      projectName,
+      buildTargetName,
+      configurationName,
+      buildTarget
+    );
+    if (!project.targets[buildTargetName].configurations) {
+      project.targets[buildTargetName].configurations = {};
+    }
+    // Update build target configuration options by overwriting them
+    const buildTargetConfigurations =
+      project.targets[buildTargetName].configurations;
+    buildTargetConfigurations[configurationBuildTarget.configuration] = {
+      ...buildTargetConfigurations[configurationBuildTarget.configuration],
+      ...delegateTargetOptions,
+    };
+    // Delete options already present in the source target
+    cleanupBuildTargetProperties(
+      buildTargetConfigurations[configurationBuildTarget.configuration]
+    );
+    // Update source target configuration with buildTarget
+    target.configurations[configurationName] = {
+      buildTarget: targetToTargetString(configurationBuildTarget),
+      tsConfig,
+      outputPath,
+    };
+  }
+}
+
+function updateTargetsOptions(
+  project: ProjectConfiguration & NxJsonProjectConfiguration,
+  target: TargetConfiguration,
+  buildTargetName: string
+) {
+  if (target.options) {
+    const {
+      buildTarget,
+      tsConfig,
+      outputPath,
+      ...delegateTargetOptions
+    } = target.options;
+    // Update build target options by overwriting them
+    project.targets[buildTargetName].options = {
+      ...project.targets[buildTargetName].options,
+      ...delegateTargetOptions,
+    };
+    // Delete options already present in the source target
+    cleanupBuildTargetProperties(project.targets[buildTargetName].options);
+    // Update source target options to only contain what it needs
+    target.options = {
+      buildTarget,
+      tsConfig,
+      outputPath,
+    };
+  }
+}

--- a/packages/devkit/index.ts
+++ b/packages/devkit/index.ts
@@ -41,7 +41,10 @@ export { toJS } from './src/generators/to-js';
 export { updateTsConfigsToJs } from './src/generators/update-ts-configs-to-js';
 export { visitNotIgnoredFiles } from './src/generators/visit-not-ignored-files';
 
-export { parseTargetString } from './src/executors/parse-target-string';
+export {
+  parseTargetString,
+  targetToTargetString,
+} from './src/executors/parse-target-string';
 export { readTargetOptions } from './src/executors/read-target-options';
 
 export {

--- a/packages/devkit/src/executors/parse-target-string.ts
+++ b/packages/devkit/src/executors/parse-target-string.ts
@@ -1,3 +1,5 @@
+import { Target } from '@nrwl/tao/src/commands/run';
+
 /**
  * Parses a target string into {project, target, configuration}
  *
@@ -20,4 +22,26 @@ export function parseTargetString(targetString: string) {
     target,
     configuration,
   };
+}
+
+/**
+ * Returns a string in the format "project:target[:configuration]" for the target
+ *
+ * @param target - target object
+ *
+ * Examples:
+ *
+ * ```typescript
+ * targetToTargetString({ project: "proj", target: "test" }) // returns "proj:test"
+ * targetToTargetString({ project: "proj", target: "test", configuration: "production" }) // returns "proj:test:production"
+ * ```
+ */
+export function targetToTargetString({
+  project,
+  target,
+  configuration,
+}: Target): string {
+  return `${project}:${target}${
+    configuration !== undefined ? ':' + configuration : ''
+  }`;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `@nrwl/angular:webpack-browser` executor has a `buildTarget` option which allows delegating the build to a different target where another executor is used. This can lead to some issues, like schema validation failures if the delegated target executor doesn't accept some of the options specified by `@nrwl/angular:webpack-browser` or if it does support the options but with a different name.

## Expected Behavior
The `buildTarget` option is removed from the `@nrwl/angular:webpack-browser` executor. A new executor called `@nrwl/angular:delegate-build` is now provided. This new executor still supports incremental builds while allowing to delegate the build to a different target. It's no longer tied to a webpack build or to the specific schema of the `@nrwl/angular:webpack-browser` which reduces the possibilities of schema validation failures. There are still a couple of options required by the incremental builds (`tsConfig` and `outputPath`) which the delegated target executor would need to support, but most likely every executor to build Angular apps requires those options anyways. If we later identify there's a need to provide a mapping because maybe the names of those properties might be different, we can add support for it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
