### PR TITLE
feat(react): generate library with strict mode by default

### DIFF
--- a/docs/angular/api-react/generators/library.md
+++ b/docs/angular/api-react/generators/library.md
@@ -160,7 +160,7 @@ Do not update tsconfig.json for development experience.
 
 ### strict
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/node/api-react/generators/library.md
+++ b/docs/node/api-react/generators/library.md
@@ -160,7 +160,7 @@ Do not update tsconfig.json for development experience.
 
 ### strict
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/react/api-react/generators/library.md
+++ b/docs/react/api-react/generators/library.md
@@ -160,7 +160,7 @@ Do not update tsconfig.json for development experience.
 
 ### strict
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -16,7 +16,7 @@ describe('lib', () => {
     unitTestRunner: 'jest',
     style: 'css',
     component: true,
-    strict: false,
+    strict: true,
   };
 
   beforeEach(() => {
@@ -92,14 +92,14 @@ describe('lib', () => {
           path: './tsconfig.spec.json',
         },
       ]);
-      expect(tsconfigJson.compilerOptions.strict).not.toBeDefined();
       expect(
         tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
-      ).not.toBeDefined();
-      expect(tsconfigJson.compilerOptions.noImplicitReturns).not.toBeDefined();
-      expect(
-        tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
-      ).not.toBeDefined();
+      ).toEqual(true);
+      expect(tsconfigJson.compilerOptions.strict).toEqual(true);
+      expect(tsconfigJson.compilerOptions.noImplicitReturns).toEqual(true);
+      expect(tsconfigJson.compilerOptions.noFallthroughCasesInSwitch).toEqual(
+        true
+      );
     });
 
     it('should extend the local tsconfig.json with tsconfig.spec.json', async () => {
@@ -582,22 +582,22 @@ describe('lib', () => {
     });
   });
 
-  describe('--strict', () => {
-    it('should update tsconfig.json', async () => {
+  describe('--no-strict', () => {
+    it('should not add options for strict mode', async () => {
       await libraryGenerator(appTree, {
         ...defaultSchema,
-        strict: true,
+        strict: false,
       });
       const tsconfigJson = readJson(appTree, '/libs/my-lib/tsconfig.json');
 
-      expect(tsconfigJson.compilerOptions.strict).toBeTruthy();
       expect(
         tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
-      ).toBeTruthy();
-      expect(tsconfigJson.compilerOptions.noImplicitReturns).toBeTruthy();
+      ).not.toBeDefined();
+      expect(tsconfigJson.compilerOptions.strict).not.toBeDefined();
+      expect(tsconfigJson.compilerOptions.noImplicitReturns).not.toBeDefined();
       expect(
         tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
-      ).toBeTruthy();
+      ).not.toBeDefined();
     });
   });
 

--- a/packages/react/src/generators/library/schema.json
+++ b/packages/react/src/generators/library/schema.json
@@ -144,7 +144,7 @@
     "strict": {
       "type": "boolean",
       "description": "Whether to enable tsconfig strict mode or not.",
-      "default": false
+      "default": true
     },
     "setParserOptionsProject": {
       "type": "boolean",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`nx g @nrwl/react:library` does not use strict mode by default.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nx g @nrwl/react:library` generates a library with strict mode by default.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Nx v12.3.4 generates libraries with strict mode by overriding the workspace defaults.
Therefore, https://github.com/nrwl/nx/pull/5529 could be reverted after this PR is merged.
