### PR TITLE
fix(linter): improve error message for circular reference

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -84,7 +84,7 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noRelativeOrAbsoluteImportsAcrossLibraries: `Libraries cannot be imported by a relative or absolute path, and must begin with a npm scope`,
       noCircularDependencies: `Circular dependency between "{{sourceProjectName}}" and "{{targetProjectName}}" detected: {{path}}`,
-      noSelfCircularDependencies: `Only relative imports are allowed within the project. Absolute import found: {{imp}}`,
+      noSelfCircularDependencies: `Projects should use relative imports to import from other files within the same project. Use "./path/to/file" instead of import from "{{imp}}"`,
       noImportsOfApps: 'Imports of apps are forbidden',
       noImportsOfE2e: 'Imports of e2e projects are forbidden',
       noImportOfNonBuildableLibraries:

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -851,7 +851,7 @@ describe('Enforce Module Boundaries (eslint)', () => {
     );
 
     const message =
-      'Only relative imports are allowed within the project. Absolute import found: @mycompany/mylib';
+      'Projects should use relative imports to import from other files within the same project. Use "./path/to/file" instead of import from "@mycompany/mylib"';
     expect(failures.length).toEqual(2);
     expect(failures[0].message).toEqual(message);
     expect(failures[1].message).toEqual(message);

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -779,7 +779,7 @@ describe('Enforce Module Boundaries (tslint)', () => {
       }
     );
     const message =
-      'Only relative imports are allowed within the project. Absolute import found: @mycompany/mylib';
+      'Projects should use relative imports to import from other files within the same project. Use "./path/to/file" instead of import from "@mycompany/mylib"';
     expect(failures.length).toEqual(1);
     expect(failures[0].getFailure()).toEqual(message);
   });

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -155,7 +155,7 @@ class EnforceModuleBoundariesWalker extends Lint.RuleWalker {
     // same project => allow
     if (sourceProject === targetProject) {
       if (!this.allowCircularSelfDependency && !isRelativePath(imp)) {
-        const error = `Only relative imports are allowed within the project. Absolute import found: ${imp}`;
+        const error = `Projects should use relative imports to import from other files within the same project. Use "./path/to/file" instead of import from "${imp}"`;
         this.addFailureAt(node.getStart(), node.getWidth(), error);
       } else {
         super.visitImportDeclaration(node);


### PR DESCRIPTION
Improves original error message by providing a hint

Closes #5625

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The existing error message on self-circular dependency does not provide enough information to the user
<!-- This is the behavior we have today -->

## Expected Behavior
The error message should provide a hint of what should user do to fix the error
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5625
