### PR TITLE
fix(angular): make path optional for customWebpackConfig in webpack browser executor

### DIFF
--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -369,8 +369,7 @@
           "type": "string"
         }
       },
-      "additionalProperties": false,
-      "required": ["path"]
+      "additionalProperties": false
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -34,7 +34,7 @@ function buildApp(
   const { customWebpackConfig, ...delegateOptions } = options;
   // If there is a path to custom webpack config
   // Invoke our own support for custom webpack config
-  if (customWebpackConfig) {
+  if (customWebpackConfig && customWebpackConfig.path) {
     const pathToWebpackConfig = joinPathFragments(
       context.workspaceRoot,
       customWebpackConfig.path


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
In the `@nrwl/angular:webpack-browser`, the `path` option of the `customWebpackConfig` option is required. This causes issues with the way the Angular DevKit sets the defaults for options that are not set. Since `customWebpackConfig` is optional when it's not set, the Angular DevKit will initialize it as an empty object and after that, it will set the `path` as `undefined` which breaks the validation and prevents building apps without a custom webpack config.

## Expected Behavior
Apps build successfully when they don't use a custom webpack configuration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
