### PR TITLE
fix(nx-plugin): fix package json key for migration generator

### DIFF
--- a/packages/nx-plugin/src/schematics/migration/lib/update-package-json.ts
+++ b/packages/nx-plugin/src/schematics/migration/lib/update-package-json.ts
@@ -7,11 +7,11 @@ export function updatePackageJson(options: NormalizedSchema): Rule {
   return updateJsonInTree(
     path.join(options.projectRoot, 'package.json'),
     (json) => {
-      if (!json['nx-migrate'] || !json['nx-migrate'].migrations) {
-        if (json['nx-migrate']) {
-          json['nx-migrate'].migrations = './migrations.json';
+      if (!json['nx-migrations'] || !json['nx-migrations'].migrations) {
+        if (json['nx-migrations']) {
+          json['nx-migrations'].migrations = './migrations.json';
         } else {
-          json['nx-migrate'] = {
+          json['nx-migrations'] = {
             migrations: './migrations.json',
           };
         }

--- a/packages/nx-plugin/src/schematics/migration/migration.spec.ts
+++ b/packages/nx-plugin/src/schematics/migration/migration.spec.ts
@@ -68,7 +68,9 @@ describe('NxPlugin migration', () => {
     );
     expect(migrationsJson.packageJsonUpdates).toBeFalsy();
 
-    expect(packageJson['nx-migrate'].migrations).toEqual('./migrations.json');
+    expect(packageJson['nx-migrations'].migrations).toEqual(
+      './migrations.json'
+    );
   });
 
   it('should generate files with default name', async () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The generator currently adds the key `nx-migrate` to the plugin's package.json, which is not the correct value.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The generator will add the key `nx-migrations` to the plugin's package.json, which matches what is expected by the [migrate command](https://github.com/nrwl/nx/blob/c71137f34cd687f6b38b96d60c9b7b17deacdf17/packages/tao/src/commands/migrate.ts#L478).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5730
