### PR TITLE
docs(nextjs): suggest installing package as a prod dependency

### DIFF
--- a/docs/react/guides/nextjs.md
+++ b/docs/react/guides/nextjs.md
@@ -21,7 +21,7 @@ npx --ignore-existing create-nx-workspace happynrwl --preset=next
 If you used the Next.js preset, you are all set and can skip this. If you created an empty workspace or have an existing workspace, you can add Next.js capabilities to the workspace:
 
 ```bash
-yarn add --dev @nrwl/next
+yarn add @nrwl/next
 ```
 
 ## Generating a Next.js Application

--- a/docs/shared/next-plugin.md
+++ b/docs/shared/next-plugin.md
@@ -11,11 +11,11 @@ The Nx Plugin for Next.js contains executors and generators for managing Next.js
 Installing the Next plugin to a workspace can be done with the following:
 
 ```shell script
-yarn add -D @nrwl/next
+yarn add @nrwl/next
 ```
 
 ```shell script
-npm install -D @nrwl/next
+npm install @nrwl/next
 ```
 
 ## Applications

--- a/nx-dev/nx-dev/public/documentation/latest/react/guides/nextjs.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/guides/nextjs.md
@@ -21,7 +21,7 @@ npx --ignore-existing create-nx-workspace happynrwl --preset=next
 If you used the Next.js preset, you are all set and can skip this. If you created an empty workspace or have an existing workspace, you can add Next.js capabilities to the workspace:
 
 ```bash
-yarn add --dev @nrwl/next
+yarn add @nrwl/next
 ```
 
 ## Generating a Next.js Application

--- a/nx-dev/nx-dev/public/documentation/latest/shared/next-plugin.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/next-plugin.md
@@ -11,11 +11,11 @@ The Nx Plugin for Next.js contains executors and generators for managing Next.js
 Installing the Next plugin to a workspace can be done with the following:
 
 ```shell script
-yarn add -D @nrwl/next
+yarn add @nrwl/next
 ```
 
 ```shell script
-npm install -D @nrwl/next
+npm install @nrwl/next
 ```
 
 ## Applications

--- a/nx-dev/nx-dev/public/documentation/previous/react/guides/nextjs.md
+++ b/nx-dev/nx-dev/public/documentation/previous/react/guides/nextjs.md
@@ -21,7 +21,7 @@ npx --ignore-existing create-nx-workspace happynrwl --preset=next
 If you used the Next.js preset, you are all set and can skip this. If you created an empty workspace or have an existing workspace, you can add Next.js capabilities to the workspace:
 
 ```bash
-yarn add --dev @nrwl/next
+yarn add @nrwl/next
 ```
 
 ## Generating a Next.js Application

--- a/nx-dev/nx-dev/public/documentation/previous/shared/next-plugin.md
+++ b/nx-dev/nx-dev/public/documentation/previous/shared/next-plugin.md
@@ -11,11 +11,11 @@ The Nx Plugin for Next.js contains builders and schematics for managing Next.js 
 Installing the Next plugin to a workspace can be done with the following:
 
 ```shell script
-yarn add -D @nrwl/next
+yarn add @nrwl/next
 ```
 
 ```shell script
-npm install -D @nrwl/next
+npm install @nrwl/next
 ```
 
 ## Applications


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

We recently merged a change (https://github.com/nrwl/nx/pull/5662) that installs `@nrwl/next` dependency as a prod dependency instead of a dev dependency for new workspaces that use the next.js preset.

Reasons for that are in #5473

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Documentation suggests adding `@nrwl/next` as a dev dependency

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Documentation should suggest adding `@nrwl/next` as a prod dependency

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5473
