### PR TITLE
feat(node): builder should support multiple entry files

### DIFF
--- a/docs/angular/api-node/executors/build.md
+++ b/docs/angular/api-node/executors/build.md
@@ -18,6 +18,22 @@ Type: `string`
 
 The name of the Typescript configuration file.
 
+### additionalEntryPoints
+
+Type: `object[]`
+
+#### entryName
+
+Type: `string`
+
+Name of the additional entry file
+
+#### entryPath
+
+Type: `string`
+
+Path to the additional entry file
+
 ### assets
 
 Type: `array`

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -19,6 +19,22 @@ Type: `string`
 
 The name of the Typescript configuration file.
 
+### additionalEntryPoints
+
+Type: `object[]`
+
+#### entryName
+
+Type: `string`
+
+Name of the additional entry file
+
+#### entryPath
+
+Type: `string`
+
+Path to the additional entry file
+
 ### assets
 
 Type: `array`

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -19,6 +19,22 @@ Type: `string`
 
 The name of the Typescript configuration file.
 
+### additionalEntryPoints
+
+Type: `object[]`
+
+#### entryName
+
+Type: `string`
+
+Name of the additional entry file
+
+#### entryPath
+
+Type: `string`
+
+Path to the additional entry file
+
 ### assets
 
 Type: `array`

--- a/packages/node/src/executors/build/schema.json
+++ b/packages/node/src/executors/build/schema.json
@@ -144,6 +144,22 @@
       "items": {
         "$ref": "#/definitions/tsPluginPattern"
       }
+    },
+    "additionalEntryPoints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "entryName": {
+            "type": "string",
+            "description": "Name of the additional entry file"
+          },
+          "entryPath": {
+            "type": "string",
+            "description": "Path to the additional entry file"
+          }
+        }
+      }
     }
   },
   "required": ["tsConfig", "main"],

--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -9,6 +9,7 @@ import CircularDependencyPlugin = require('circular-dependency-plugin');
 import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 export const OUT_FILENAME = 'main.js';
+export const OUT_FILENAME_TEMPLATE = '[name].js';
 
 // TODO(jack): In Nx 13 go back to proper types.
 type Configuration = any;
@@ -29,15 +30,27 @@ export function getBaseWebpackPartial(
 
   const { compilerPluginHooks, hasPlugin } = loadTsPlugins(options.tsPlugins);
 
+  const additionalEntryPoints =
+    options.additionalEntryPoints?.reduce(
+      (obj, current) => ({
+        ...obj,
+        [current.entryName]: current.entryPath,
+      }),
+      {} as { [entryName: string]: string }
+    ) ?? {};
   const webpackConfig: Configuration = {
     entry: {
       main: [options.main],
+      ...additionalEntryPoints,
     },
     devtool: options.sourceMap ? 'source-map' : false,
     mode: options.optimization ? 'production' : 'development',
     output: {
       path: options.outputPath,
-      filename: OUT_FILENAME,
+      filename:
+        options.additionalEntryPoints?.length > 0
+          ? OUT_FILENAME_TEMPLATE
+          : OUT_FILENAME,
     },
     module: {
       rules: [

--- a/packages/node/src/utils/normalize.spec.ts
+++ b/packages/node/src/utils/normalize.spec.ts
@@ -52,6 +52,23 @@ describe('normalizeBuildOptions', () => {
     expect(result.main).toEqual('/root/apps/nodeapp/src/main.ts');
   });
 
+  it('should resolve additional entries from root', () => {
+    const result = normalizeBuildOptions(
+      {
+        ...testOptions,
+        additionalEntryPoints: [
+          { entryName: 'test', entryPath: 'some/path.ts' },
+        ],
+      },
+      root,
+      sourceRoot,
+      projectRoot
+    );
+    expect(result.additionalEntryPoints[0].entryPath).toEqual(
+      '/root/some/path.ts'
+    );
+  });
+
   it('should resolve the output path', () => {
     const result = normalizeBuildOptions(
       testOptions,

--- a/packages/node/src/utils/normalize.ts
+++ b/packages/node/src/utils/normalize.ts
@@ -1,5 +1,6 @@
 import { resolve, dirname, relative, basename } from 'path';
 import {
+  AdditionalEntryPoint,
   BuildNodeBuilderOptions,
   NormalizedBuildNodeBuilderOptions,
 } from './types';
@@ -31,6 +32,10 @@ export function normalizeBuildOptions(
           .concat(options.webpackConfig)
           .map((path) => normalizePluginPath(path, root))
       : [],
+    additionalEntryPoints: normalizeAdditionalEntries(
+      root,
+      options.additionalEntryPoints ?? []
+    ),
   };
 }
 
@@ -98,4 +103,17 @@ function normalizePluginPath(path: string, root: string) {
   } catch {
     return resolve(root, path);
   }
+}
+
+function normalizeAdditionalEntries(
+  root: string,
+  additionalEntries: AdditionalEntryPoint[]
+) {
+  return additionalEntries.map(
+    ({ entryName, entryPath }) =>
+      ({
+        entryName,
+        entryPath: resolve(root, entryPath),
+      } as AdditionalEntryPoint)
+  );
 }

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -49,6 +49,11 @@ export interface CompilerPluginHooks {
   afterDeclarationsHooks: Array<(program?: Program) => Transformer>;
 }
 
+export interface AdditionalEntryPoint {
+  entryName: string;
+  entryPath: string;
+}
+
 export interface BuildBuilderOptions {
   main: string;
   outputPath: string;
@@ -76,6 +81,8 @@ export interface BuildBuilderOptions {
   projectRoot?: string;
 
   tsPlugins?: TsPluginEntry[];
+
+  additionalEntryPoints?: AdditionalEntryPoint[];
 }
 
 export interface BuildNodeBuilderOptions extends BuildBuilderOptions {


### PR DESCRIPTION
Adds a new option to the node build executor in order to enable multiple entry files.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Currently the node build executor will bundle the entire application into a single `main.js` file. This is sub optimal when working with eg. TypeOrm migrations.

## Expected Behavior

This change adds an option to the node build executor, where it is possible to specify additional entry points eg. when needing to split out the bundle for a `worker.js`.

## Related Issue(s)

https://github.com/nrwl/nx/issues/4448

This is my first PR which is a continuation of this rejected pr: https://github.com/nrwl/nx/pull/4450 by @christianallred
