### PR TITLE
fix(core): update project package.json on move

### DIFF
--- a/packages/workspace/src/generators/move/lib/update-package-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-package-json.spec.ts
@@ -1,0 +1,51 @@
+import {
+  ProjectConfiguration,
+  readProjectConfiguration,
+  Tree,
+  readJson,
+  writeJson,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { Schema } from '../schema';
+import { updatePackageJson } from './update-package-json';
+import { libraryGenerator } from '../../library/library';
+
+describe('updatePackageJson', () => {
+  let tree: Tree;
+  let schema: Schema;
+  let projectConfig: ProjectConfiguration;
+
+  beforeEach(async () => {
+    schema = {
+      projectName: 'my-lib',
+      destination: 'my-destination',
+      importPath: undefined,
+      updateImportPath: true,
+    };
+
+    tree = createTreeWithEmptyWorkspace();
+    await libraryGenerator(tree, { name: 'my-lib' });
+    projectConfig = readProjectConfiguration(tree, 'my-lib');
+  });
+
+  it('should handle package.json not existing', async () => {
+    expect(() => {
+      updatePackageJson(tree, schema, projectConfig);
+    }).not.toThrow();
+  });
+
+  it('should update the name', async () => {
+    const packageJson = {
+      name: '@proj/my-lib',
+    };
+
+    writeJson(tree, '/libs/my-destination/package.json', packageJson);
+
+    updatePackageJson(tree, schema, projectConfig);
+
+    expect(readJson(tree, '/libs/my-destination/package.json')).toEqual({
+      ...packageJson,
+      name: '@proj/my-destination',
+    });
+  });
+});

--- a/packages/workspace/src/generators/move/lib/update-package-json.ts
+++ b/packages/workspace/src/generators/move/lib/update-package-json.ts
@@ -1,0 +1,35 @@
+import { Tree, getWorkspaceLayout } from '@nrwl/devkit';
+import * as path from 'path';
+import { Schema } from '../schema';
+import { getDestination, normalizeSlashes } from './utils';
+import { ProjectConfiguration } from '@nrwl/tao/src/shared/workspace';
+
+interface PartialPackageJson {
+  name: string;
+}
+
+/**
+ * Updates the name in the package.json if it exists.
+ *
+ * @param schema The options provided to the schematic
+ */
+export function updatePackageJson(
+  tree: Tree,
+  schema: Schema,
+  project: ProjectConfiguration
+) {
+  const destination = getDestination(tree, schema, project);
+  const packageJsonPath = path.join(destination, 'package.json');
+
+  if (!tree.exists(packageJsonPath)) {
+    // nothing to do
+    return;
+  }
+
+  const { npmScope } = getWorkspaceLayout(tree);
+  const packageJson = JSON.parse(
+    tree.read(packageJsonPath).toString('utf-8')
+  ) as PartialPackageJson;
+  packageJson.name = normalizeSlashes(`@${npmScope}/${schema.destination}`);
+  tree.write(packageJsonPath, JSON.stringify(packageJson));
+}

--- a/packages/workspace/src/generators/move/move.ts
+++ b/packages/workspace/src/generators/move/move.ts
@@ -19,6 +19,7 @@ import { updateEslintrcJson } from './lib/update-eslintrc-json';
 import { moveProjectConfiguration } from './lib/move-project-configuration';
 import { updateBuildTargets } from './lib/update-build-targets';
 import { updateReadme } from './lib/update-readme';
+import { updatePackageJson } from './lib/update-package-json';
 
 export async function moveGenerator(tree: Tree, schema: Schema) {
   const projectConfig = readProjectConfiguration(tree, schema.projectName);
@@ -31,6 +32,7 @@ export async function moveGenerator(tree: Tree, schema: Schema) {
   updateStorybookConfig(tree, schema, projectConfig);
   updateEslintrcJson(tree, schema, projectConfig);
   updateReadme(tree, schema, projectConfig);
+  updatePackageJson(tree, schema, projectConfig);
   moveProjectConfiguration(tree, schema, projectConfig);
   updateBuildTargets(tree, schema);
   updateDefaultProject(tree, schema);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `move` generator causes semantic error when building a library which depends on other buildable libraries because TS path mapping relis on the `name` property in `package.json`.

```
nx g @nrwl/workspace:move --destination=foo --projectName=my-lib
nx build my-app --with-deps
...
semantic error TS6059: File '.../libs/foo/src/lib/index.ts' is not under 'rootDir' '.../libs/foo/src'.
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Buildable libraries should be built without the semantic error even after they are moved.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#3994
