### PR TITLE
cleanup(storybook): add some stricter types for the storybook executor

### DIFF
--- a/docs/angular/api-storybook/executors/storybook.md
+++ b/docs/angular/api-storybook/executors/storybook.md
@@ -76,6 +76,8 @@ Default: `@storybook/angular`
 
 Type: `string`
 
+Possible values: `@storybook/angular`, `@storybook/react`, `@storybook/html`
+
 Storybook framework npm package
 
 ### watch

--- a/docs/node/api-storybook/executors/storybook.md
+++ b/docs/node/api-storybook/executors/storybook.md
@@ -77,6 +77,8 @@ Default: `@storybook/angular`
 
 Type: `string`
 
+Possible values: `@storybook/angular`, `@storybook/react`, `@storybook/html`
+
 Storybook framework npm package
 
 ### watch

--- a/docs/react/api-storybook/executors/storybook.md
+++ b/docs/react/api-storybook/executors/storybook.md
@@ -77,6 +77,8 @@ Default: `@storybook/angular`
 
 Type: `string`
 
+Possible values: `@storybook/angular`, `@storybook/react`, `@storybook/html`
+
 Storybook framework npm package
 
 ### watch

--- a/packages/storybook/src/executors/storybook/schema.json
+++ b/packages/storybook/src/executors/storybook/schema.json
@@ -7,6 +7,7 @@
     "uiFramework": {
       "type": "string",
       "description": "Storybook framework npm package",
+      "enum": ["@storybook/angular", "@storybook/react", "@storybook/html"],
       "default": "@storybook/angular",
       "hidden": true
     },

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -15,7 +15,7 @@ export interface StorybookConfig {
 }
 
 export interface StorybookExecutorOptions {
-  uiFramework: string;
+  uiFramework: '@storybook/angular' | '@storybook/react' | '@storybook/html';
   projectBuildConfig?: string;
   config: StorybookConfig;
   host?: string;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The executor accepts string for the uiFramework field, which leads to a generic error if you use something not expected

## Expected Behavior
The uiFramework field is changed to type which allowed @storybook/<angular/react/html> with an enum set for the schema.json to do early type checks

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
