### PR TITLE
fix(angular): disable double module update on move

### DIFF
--- a/packages/angular/src/generators/move/lib/update-module-name.spec.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.spec.ts
@@ -10,7 +10,7 @@ const libSchematic = wrapAngularDevkitSchematic('@nrwl/angular', 'lib');
 describe('updateModuleName Rule', () => {
   let tree: Tree;
 
-  describe('fresh move', () => {
+  describe('move to subfolder', () => {
     const updatedModulePath =
       '/libs/shared/my-first/src/lib/shared-my-first.module.ts';
     const updatedModuleSpecPath =
@@ -115,7 +115,7 @@ describe('updateModuleName Rule', () => {
     });
   });
 
-  describe('mid move', () => {
+  describe('rename', () => {
     const schema: Schema = {
       projectName: 'my-source',
       destination: 'my-destination',

--- a/packages/angular/src/generators/move/lib/update-module-name.spec.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.spec.ts
@@ -1,6 +1,7 @@
 import { Tree } from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { moveGenerator } from '@nrwl/workspace';
 import { Schema } from '../schema';
 import { updateModuleName } from './update-module-name';
 
@@ -8,111 +9,223 @@ const libSchematic = wrapAngularDevkitSchematic('@nrwl/angular', 'lib');
 
 describe('updateModuleName Rule', () => {
   let tree: Tree;
-  const schema: Schema = {
-    projectName: 'my-source',
-    destination: 'my-destination',
-    updateImportPath: true,
-  };
 
-  const modulePath = '/libs/my-destination/src/lib/my-destination.module.ts';
-  const moduleSpecPath =
-    '/libs/my-destination/src/lib/my-destination.module.spec.ts';
-  const indexPath = '/libs/my-destination/src/index.ts';
-  const importerPath = '/libs/my-importer/src/lib/my-importing-file.ts';
+  describe('fresh move', () => {
+    const updatedModulePath =
+      '/libs/shared/my-first/src/lib/shared-my-first.module.ts';
+    const updatedModuleSpecPath =
+      '/libs/shared/my-first/src/lib/shared-my-first.module.spec.ts';
+    const indexPath = '/libs/shared/my-first/src/index.ts';
+    const secondModulePath = '/libs/my-second/src/lib/my-second.module.ts';
 
-  beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    const schema: Schema = {
+      projectName: 'my-first',
+      destination: 'shared/my-first',
+      updateImportPath: true,
+    };
 
-    // fake a mid-move tree:
-    await libSchematic(tree, {
-      name: 'my-destination',
+    beforeEach(async () => {
+      tree = createTreeWithEmptyWorkspace();
+
+      await libSchematic(tree, {
+        name: 'my-first',
+      });
+      await libSchematic(tree, {
+        name: 'my-second',
+      });
+      tree.write(
+        '/libs/my-first/src/lib/my-first.module.ts',
+        `import { NgModule } from '@angular/core';
+    import { CommonModule } from '@angular/common';
+
+    @NgModule({
+      imports: [CommonModule]
+    })
+    export class MyFirstModule {}`
+      );
+
+      tree.write(
+        '/libs/my-first/src/lib/my-first.module.spec.ts',
+        `import { async, TestBed } from '@angular/core/testing';
+    import { MyFirstModule } from './my-first.module';
+
+    describe('MyFirstModule', () => {
+      beforeEach(async(() => {
+        TestBed.configureTestingModule({
+          imports: [MyFirstModule]
+        }).compileComponents();
+      }));
+
+      it('should create', () => {
+        expect(MyFirstModule).toBeDefined();
+      });
+    });`
+      );
+      tree.write(
+        secondModulePath,
+        `import { MyFirstModule } from '@proj/my-first';
+
+      export class MySecondModule extends MyFirstModule {}
+      `
+      );
+      await moveGenerator(tree, schema);
     });
 
-    tree.write(
-      '/libs/my-destination/src/lib/my-source.module.ts',
-      `import { NgModule } from '@angular/core';
+    it('should rename the module files and update the module name', async () => {
+      await updateModuleName(tree, schema);
+
+      expect(tree.exists(updatedModulePath)).toBe(true);
+      expect(tree.exists(updatedModuleSpecPath)).toBe(true);
+
+      const moduleFile = tree.read(updatedModulePath).toString('utf-8');
+      expect(moduleFile).toContain(`export class SharedMyFirstModule {}`);
+
+      const moduleSpecFile = tree.read(updatedModuleSpecPath).toString('utf-8');
+      expect(moduleSpecFile).toContain(
+        `import { SharedMyFirstModule } from './shared-my-first.module';`
+      );
+      expect(moduleSpecFile).toContain(
+        `describe('SharedMyFirstModule', () => {`
+      );
+      expect(moduleSpecFile).toContain(`imports: [SharedMyFirstModule]`);
+      expect(moduleSpecFile).toContain(
+        `expect(SharedMyFirstModule).toBeDefined();`
+      );
+    });
+
+    it('should update any references to the module', async () => {
+      await updateModuleName(tree, schema);
+
+      const importerFile = tree.read(secondModulePath).toString('utf-8');
+      expect(importerFile).toContain(
+        `import { SharedMyFirstModule } from '@proj/shared/my-first';`
+      );
+      expect(importerFile).toContain(
+        `export class MySecondModule extends SharedMyFirstModule {}`
+      );
+    });
+
+    it('should update the index.ts file which exports the module', async () => {
+      await updateModuleName(tree, schema);
+
+      const indexFile = tree.read(indexPath).toString('utf-8');
+      expect(indexFile).toContain(
+        `export * from './lib/shared-my-first.module';`
+      );
+    });
+  });
+
+  describe('mid move', () => {
+    const schema: Schema = {
+      projectName: 'my-source',
+      destination: 'my-destination',
+      updateImportPath: true,
+    };
+
+    const modulePath = '/libs/my-destination/src/lib/my-destination.module.ts';
+    const moduleSpecPath =
+      '/libs/my-destination/src/lib/my-destination.module.spec.ts';
+    const indexPath = '/libs/my-destination/src/index.ts';
+    const importerPath = '/libs/my-importer/src/lib/my-importing-file.ts';
+
+    beforeEach(async () => {
+      tree = createTreeWithEmptyWorkspace();
+
+      // fake a mid-move tree:
+      await libSchematic(tree, {
+        name: 'my-destination',
+      });
+
+      tree.write(
+        '/libs/my-destination/src/lib/my-source.module.ts',
+        `import { NgModule } from '@angular/core';
     import { CommonModule } from '@angular/common';
-    
+
     @NgModule({
       imports: [CommonModule]
     })
     export class MySourceModule {}`
-    );
+      );
 
-    tree.write(
-      '/libs/my-destination/src/lib/my-source.module.spec.ts',
-      `import { async, TestBed } from '@angular/core/testing';
+      tree.write(
+        '/libs/my-destination/src/lib/my-source.module.spec.ts',
+        `import { async, TestBed } from '@angular/core/testing';
     import { MySourceModule } from './my-source.module';
-    
+
     describe('MySourceModule', () => {
       beforeEach(async(() => {
         TestBed.configureTestingModule({
           imports: [MySourceModule]
         }).compileComponents();
       }));
-    
+
       it('should create', () => {
         expect(MySourceModule).toBeDefined();
       });
     });`
-    );
+      );
 
-    tree.write(
-      indexPath,
-      `export * from './lib/my-source.module';
+      tree.write(
+        indexPath,
+        `export * from './lib/my-source.module';
     `
-    );
+      );
 
-    tree.delete(modulePath);
-    tree.delete(moduleSpecPath);
+      tree.delete(modulePath);
+      tree.delete(moduleSpecPath);
 
-    await libSchematic(tree, { name: 'my-importer' });
+      await libSchematic(tree, { name: 'my-importer' });
 
-    tree.write(
-      importerPath,
-      `import { MySourceModule } from '@proj/my-destination';
-    
+      tree.write(
+        importerPath,
+        `import { MySourceModule } from '@proj/my-destination';
+
       export class MyExtendedSourceModule extends MySourceModule {}
       `
-    );
-  });
+      );
+    });
 
-  it('should rename the module files and update the module name', async () => {
-    await updateModuleName(tree, schema);
+    it('should rename the module files and update the module name', async () => {
+      await updateModuleName(tree, schema);
 
-    expect(tree.exists(modulePath)).toBe(true);
-    expect(tree.exists(moduleSpecPath)).toBe(true);
+      expect(tree.exists(modulePath)).toBe(true);
+      expect(tree.exists(moduleSpecPath)).toBe(true);
 
-    const moduleFile = tree.read(modulePath).toString('utf-8');
-    expect(moduleFile).toContain(`export class MyDestinationModule {}`);
+      const moduleFile = tree.read(modulePath).toString('utf-8');
+      expect(moduleFile).toContain(`export class MyDestinationModule {}`);
 
-    const moduleSpecFile = tree.read(moduleSpecPath).toString('utf-8');
-    expect(moduleSpecFile).toContain(
-      `import { MyDestinationModule } from './my-destination.module';`
-    );
-    expect(moduleSpecFile).toContain(`describe('MyDestinationModule', () => {`);
-    expect(moduleSpecFile).toContain(`imports: [MyDestinationModule]`);
-    expect(moduleSpecFile).toContain(
-      `expect(MyDestinationModule).toBeDefined();`
-    );
-  });
+      const moduleSpecFile = tree.read(moduleSpecPath).toString('utf-8');
+      expect(moduleSpecFile).toContain(
+        `import { MyDestinationModule } from './my-destination.module';`
+      );
+      expect(moduleSpecFile).toContain(
+        `describe('MyDestinationModule', () => {`
+      );
+      expect(moduleSpecFile).toContain(`imports: [MyDestinationModule]`);
+      expect(moduleSpecFile).toContain(
+        `expect(MyDestinationModule).toBeDefined();`
+      );
+    });
 
-  it('should update any references to the module', async () => {
-    await updateModuleName(tree, schema);
+    it('should update any references to the module', async () => {
+      await updateModuleName(tree, schema);
 
-    const importerFile = tree.read(importerPath).toString('utf-8');
-    expect(importerFile).toContain(
-      `import { MyDestinationModule } from '@proj/my-destination';`
-    );
-    expect(importerFile).toContain(
-      `export class MyExtendedSourceModule extends MyDestinationModule {}`
-    );
-  });
+      const importerFile = tree.read(importerPath).toString('utf-8');
+      expect(importerFile).toContain(
+        `import { MyDestinationModule } from '@proj/my-destination';`
+      );
+      expect(importerFile).toContain(
+        `export class MyExtendedSourceModule extends MyDestinationModule {}`
+      );
+    });
 
-  it('should update the index.ts file which exports the module', async () => {
-    await updateModuleName(tree, schema);
+    it('should update the index.ts file which exports the module', async () => {
+      await updateModuleName(tree, schema);
 
-    const indexFile = tree.read(indexPath).toString('utf-8');
-    expect(indexFile).toContain(`export * from './lib/my-destination.module';`);
+      const indexFile = tree.read(indexPath).toString('utf-8');
+      expect(indexFile).toContain(
+        `export * from './lib/my-destination.module';`
+      );
+    });
   });
 });

--- a/packages/angular/src/generators/move/lib/update-module-name.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.ts
@@ -81,7 +81,7 @@ export async function updateModuleName(
     updateFileContent(tree, replacements, indexFile);
   }
 
-  const skipFiles = filesToRename.map((file) => file.from);
+  const skipFiles = [...filesToRename.map((file) => file.to), indexFile];
 
   // Update any files which import the module
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->
Related to #5780

## Current Behavior
* Move command in angular renames the module files and updates contents of `index.ts` twice causing the contents to be double processed:
```bash
# move command
my-destination -> shared/my-destination
# results in 
shared-shared-my-destination.module.ts
```
<!-- This is the behavior we have today -->

## Expected Behavior
* Move command in angular should rename the module files and update contents of `index.ts` only once
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
