### PR TITLE
feat(nx-plugin): add generators for the schematics

### DIFF
--- a/packages/nx-plugin/collection.json
+++ b/packages/nx-plugin/collection.json
@@ -4,28 +4,56 @@
   "extends": ["@nrwl/workspace"],
   "schematics": {
     "plugin": {
-      "factory": "./src/schematics/plugin/plugin",
+      "factory": "./src/schematics/plugin/plugin#pluginSchematic",
       "schema": "./src/schematics/plugin/schema.json",
       "description": "Create a Nx Plugin"
     },
     "e2e-project": {
-      "factory": "./src/schematics/e2e-project/e2e",
+      "factory": "./src/schematics/e2e-project/e2e#e2eSchematic",
       "schema": "./src/schematics/e2e-project/schema.json",
       "description": "Create a e2e application for a Nx Plugin",
       "hidden": true
     },
     "migration": {
-      "factory": "./src/schematics/migration/migration",
+      "factory": "./src/schematics/migration/migration#migrationSchematic",
       "schema": "./src/schematics/migration/schema.json",
       "description": "Create a migration for an Nx Plugin"
     },
     "generator": {
-      "factory": "./src/schematics/generator/generator",
+      "factory": "./src/schematics/generator/generator#generatorSchematic",
       "schema": "./src/schematics/generator/schema.json",
       "description": "Create a generator for an Nx Plugin"
     },
     "executor": {
-      "factory": "./src/schematics/executor/executor",
+      "factory": "./src/schematics/executor/executor#executorSchematic",
+      "schema": "./src/schematics/executor/schema.json",
+      "description": "Create a executor for an Nx Plugin"
+    }
+  },
+  "generators": {
+    "plugin": {
+      "factory": "./src/schematics/plugin/plugin#pluginGenerator",
+      "schema": "./src/schematics/plugin/schema.json",
+      "description": "Create a Nx Plugin"
+    },
+    "e2e-project": {
+      "factory": "./src/schematics/e2e-project/e2e#e2eGenerator",
+      "schema": "./src/schematics/e2e-project/schema.json",
+      "description": "Create a e2e application for a Nx Plugin",
+      "hidden": true
+    },
+    "migration": {
+      "factory": "./src/schematics/migration/migration#migrationGenerator",
+      "schema": "./src/schematics/migration/schema.json",
+      "description": "Create a migration for an Nx Plugin"
+    },
+    "generator": {
+      "factory": "./src/schematics/generator/generator#generatorGenerator",
+      "schema": "./src/schematics/generator/schema.json",
+      "description": "Create a generator for an Nx Plugin"
+    },
+    "executor": {
+      "factory": "./src/schematics/executor/executor#executorGenerator",
       "schema": "./src/schematics/executor/schema.json",
       "description": "Create a executor for an Nx Plugin"
     }

--- a/packages/nx-plugin/src/schematics/e2e-project/e2e.ts
+++ b/packages/nx-plugin/src/schematics/e2e-project/e2e.ts
@@ -1,5 +1,6 @@
 import { chain, Rule, Tree } from '@angular-devkit/schematics';
 import { getWorkspace } from '@nrwl/workspace';
+import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { addFiles } from './lib/add-files';
 import { addJest } from './lib/add-jest';
 import { normalizeOptions } from './lib/normalize-options';
@@ -8,7 +9,7 @@ import { updateWorkspaceJson } from './lib/update-workspace-json';
 import { validatePlugin } from './lib/validate-plugin';
 import { Schema } from './schema';
 
-export default function (options: Schema): Rule {
+export function e2eSchematic(options: Schema): Rule {
   return async (host: Tree) => {
     const workspace = await getWorkspace(host);
     validatePlugin(workspace, options.pluginName);
@@ -21,3 +22,9 @@ export default function (options: Schema): Rule {
     ]);
   };
 }
+
+export default e2eSchematic;
+export const e2eGenerator = wrapAngularDevkitSchematic(
+  '@nrwl/nx-plugin',
+  'e2e-project'
+);

--- a/packages/nx-plugin/src/schematics/executor/executor.ts
+++ b/packages/nx-plugin/src/schematics/executor/executor.ts
@@ -1,13 +1,20 @@
 import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { addFiles } from './lib/add-files';
 import { normalizeOptions } from './lib/normalize-options';
 import { updateExecutorJson } from './lib/update-executor-json';
 import { NormalizedSchema } from './schema';
 
-export default function (schema: NormalizedSchema): Rule {
+export function executorSchematic(schema: NormalizedSchema): Rule {
   return (host: Tree) => {
     const options = normalizeOptions(host, schema);
 
     return chain([addFiles(options), updateExecutorJson(host, options)]);
   };
 }
+
+export default executorSchematic;
+export const executorGenerator = wrapAngularDevkitSchematic(
+  '@nrwl/nx-plugin',
+  'executor'
+);

--- a/packages/nx-plugin/src/schematics/generator/generator.ts
+++ b/packages/nx-plugin/src/schematics/generator/generator.ts
@@ -1,13 +1,20 @@
 import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { addFiles } from './lib/add-files';
 import { normalizeOptions } from './lib/normalize-options';
 import { updateGeneratorJson } from './lib/update-generator-json';
 import { NormalizedSchema } from './schema';
 
-export default function (schema: NormalizedSchema): Rule {
+export function generatorSchematic(schema: NormalizedSchema): Rule {
   return (host: Tree) => {
     const options = normalizeOptions(host, schema);
 
     return chain([addFiles(host, options), updateGeneratorJson(host, options)]);
   };
 }
+
+export default generatorSchematic;
+export const generatorGenerator = wrapAngularDevkitSchematic(
+  '@nrwl/nx-plugin',
+  'generator'
+);

--- a/packages/nx-plugin/src/schematics/migration/migration.ts
+++ b/packages/nx-plugin/src/schematics/migration/migration.ts
@@ -1,4 +1,5 @@
 import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { addFiles } from './lib/add-files';
 import { normalizeOptions } from './lib/normalize-options';
 import { updateMigrationsJson } from './lib/update-migrations-json';
@@ -6,7 +7,7 @@ import { updatePackageJson } from './lib/update-package-json';
 import { updateWorkspaceJson } from './lib/update-workspace-json';
 import { NormalizedSchema } from './schema';
 
-export default function (schema: NormalizedSchema): Rule {
+export function migrationSchematic(schema: NormalizedSchema): Rule {
   return (host: Tree) => {
     const options = normalizeOptions(host, schema);
 
@@ -18,3 +19,9 @@ export default function (schema: NormalizedSchema): Rule {
     ]);
   };
 }
+
+export default migrationSchematic;
+export const migrationGenerator = wrapAngularDevkitSchematic(
+  '@nrwl/nx-plugin',
+  'migration'
+);

--- a/packages/nx-plugin/src/schematics/plugin/plugin.ts
+++ b/packages/nx-plugin/src/schematics/plugin/plugin.ts
@@ -5,6 +5,7 @@ import {
   schematic,
   Tree,
 } from '@angular-devkit/schematics';
+import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { addDepsToPackageJson } from '@nrwl/workspace';
 import { formatFiles } from '@nrwl/workspace';
 import { libsDir } from '@nrwl/workspace/src/utils/ast-utils';
@@ -14,7 +15,7 @@ import { normalizeOptions } from './lib/normalize-options';
 import { updateWorkspaceJson } from './lib/update-workspace-json';
 import { Schema } from './schema';
 
-export default function (schema: Schema): Rule {
+export function pluginSchematic(schema: Schema): Rule {
   return (host: Tree) => {
     const options = normalizeOptions(host, schema);
     const { unitTestRunner } = options;
@@ -45,3 +46,9 @@ export default function (schema: Schema): Rule {
     ]);
   };
 }
+
+export default pluginSchematic;
+export const pluginGenerator = wrapAngularDevkitSchematic(
+  '@nrwl/nx-plugin',
+  'plugin'
+);


### PR DESCRIPTION
I just added the generators for the nx-plugin package, using the `wrapAngularDevkitSchematic`

## Current Behavior
For the nx-plugin package there are schematics but no generators to use

## Expected Behavior
There are generators for the schematics

## Related Issue(s)
ISSUES CLOSED: #5783