### PR TITLE
fix(core): iteration of targets should not break if targets don't exist

### DIFF
--- a/packages/workspace/src/utilities/executor-options-utils.spec.ts
+++ b/packages/workspace/src/utilities/executor-options-utils.spec.ts
@@ -39,6 +39,12 @@ describe('forEachExecutorOptions', () => {
         },
       },
     });
+
+    // configuration with no targets at all which is not valid
+    // but should not break the iteration over target configs
+    addProjectConfiguration(tree, 'proj3', {
+      root: 'proj3',
+    } as any);
   });
 
   it('should call a function for all options', () => {

--- a/packages/workspace/src/utilities/executor-options-utils.ts
+++ b/packages/workspace/src/utilities/executor-options-utils.ts
@@ -20,7 +20,7 @@ export function forEachExecutorOptions<Options>(
   ) => void
 ) {
   for (const [projectName, project] of getProjects(tree)) {
-    for (const [targetName, target] of Object.entries(project.targets)) {
+    for (const [targetName, target] of Object.entries(project.targets || {})) {
       if (executorName !== target.executor) {
         continue;
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior / Expected behavior
<!-- This is the behavior we have today -->

Having no targets in a project config in `workspace.json` might not make much sense, but still the iteration should not break. Right now, in case of running migrations, it breaks with an odd error message which is hard to understand or for ppl to track down

![image](https://user-images.githubusercontent.com/542458/119617350-0ea77680-be02-11eb-9faa-06deada63691.png)
