### PR TITLE
fix(core): nx run should not use defaultConfiguration when configuration is passed

### DIFF
--- a/packages/cli/lib/parse-run-one-options.spec.ts
+++ b/packages/cli/lib/parse-run-one-options.spec.ts
@@ -1,7 +1,13 @@
 import { parseRunOneOptions } from './parse-run-one-options';
 
 describe('parseRunOneOptions', () => {
-  const workspaceJson = { projects: { myproj: { architect: { build: {} } } } };
+  const workspaceJson = {
+    projects: {
+      myproj: {
+        architect: { build: { defaultConfiguration: 'someDefaultConfig' } },
+      },
+    },
+  };
   const args = ['build', 'myproj', '--configuration=production', '--flag=true'];
 
   it('should work', () => {
@@ -51,13 +57,13 @@ describe('parseRunOneOptions', () => {
     expect(
       parseRunOneOptions('root', workspaceJson, [
         'run',
-        'myproj:build:production',
+        'myproj:build:staging',
         '--flag=true',
       ])
     ).toEqual({
       project: 'myproj',
       target: 'build',
-      configuration: 'production',
+      configuration: 'staging',
       parsedArgs: { _: [], flag: 'true' },
     });
   });
@@ -72,6 +78,22 @@ describe('parseRunOneOptions', () => {
     ).toEqual({
       project: 'myproj',
       target: 'build',
+      configuration: 'someDefaultConfig',
+      parsedArgs: { _: [], flag: 'true' },
+    });
+  });
+
+  it('should use defaultConfiguration when no provided', () => {
+    expect(
+      parseRunOneOptions('root', workspaceJson, [
+        'run',
+        'myproj:build',
+        '--flag=true',
+      ])
+    ).toEqual({
+      project: 'myproj',
+      target: 'build',
+      configuration: 'someDefaultConfig',
       parsedArgs: { _: [], flag: 'true' },
     });
   });

--- a/packages/cli/lib/parse-run-one-options.ts
+++ b/packages/cli/lib/parse-run-one-options.ts
@@ -120,7 +120,7 @@ export function parseRunOneOptions(
     configuration = parsedArgs.configuration;
   } else if (parsedArgs.prod) {
     configuration = 'production';
-  } else if (targets[target].defaultConfiguration) {
+  } else if (!configuration && targets[target].defaultConfiguration) {
     configuration = targets[target].defaultConfiguration;
   }
 


### PR DESCRIPTION
ISSUES CLOSED: #5793

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When a project target has the `defaultConfiguration` specified and the target is run using `nx run` and specifying a configuration, as in `nx run app:build:configName`, the target will be run using the `defaultConfiguration` instead of the specified configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
If a configuration is specified when running a target with `nx run`, it should be used. The `defaultConfiguration` should only be used when no configuration is specified.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5793
