### PR TITLE
fix(angular): add workaround to prevent process from exiting early when building

### DIFF
--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-restricted-imports */
 import {
-  json,
   logging,
   normalize,
   Path,
@@ -49,8 +48,9 @@ export async function scheduleTarget(
     workspaces.createWorkspaceHost(fsHost)
   );
 
-  const registry = new json.schema.CoreSchemaRegistry();
+  const registry = new schema.CoreSchemaRegistry();
   registry.addPostTransform(schema.transforms.addUndefinedDefaults);
+  registry.useXDeprecatedProvider((msg) => logger.warn(msg));
   const architectHost = new WorkspaceNodeModulesArchitectHost(workspace, root);
   const architect = new Architect(architectHost, registry);
   const run = await architect.scheduleTarget(

--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -131,19 +131,30 @@ async function iteratorToProcessStatusCode(
 ): Promise<number> {
   let success: boolean;
 
-  let prev: IteratorResult<{ success: boolean }>;
-  let current: IteratorResult<{ success: boolean }>;
-  do {
-    prev = current;
-    current = await i.next();
-  } while (!current.done);
+  // This is a workaround to fix an issue that only happens with
+  // the @angular-devkit/build-angular:browser builder. Starting
+  // on version 12.0.1, a SASS compilation implementation was
+  // introduced making use of workers and it's unref()-ing the worker
+  // too early, causing the process to exit early in environments
+  // like CI or when running Docker builds.
+  const keepProcessAliveInterval = setInterval(() => {}, 1000);
+  try {
+    let prev: IteratorResult<{ success: boolean }>;
+    let current: IteratorResult<{ success: boolean }>;
+    do {
+      prev = current;
+      current = await i.next();
+    } while (!current.done);
 
-  success =
-    current.value !== undefined || !prev
-      ? current.value.success
-      : prev.value.success;
+    success =
+      current.value !== undefined || !prev
+        ? current.value.success
+        : prev.value.success;
 
-  return success ? 0 : 1;
+    return success ? 0 : 1;
+  } finally {
+    clearInterval(keepProcessAliveInterval);
+  }
 }
 
 function createImplicitTargetConfig(


### PR DESCRIPTION
ISSUES CLOSED: #5729

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When building an Angular app with Nx using the `@angular-devkit/build-angular`, since version `12.0.1` there's a new implementation for the SASS compilation which uses workers to do the job. The implementation unref the worker early and that causes, in some environments (CI, Docker builds, where no TTY is available), to exit the process too early, and therefore, no compilation occurs. The Angular CLI is working because they rely (intentionally or not) on a `setInterval` running for analytics while the compilation is occurring, which keeps the event loop busy and prevents the process from exiting.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Building an Angular app with Nx should work correctly. A workaround is added (an empty interval) to keep the event loop busy, until the Angular CLI fixes the way workers are managed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5729
