### PR TITLE
fix(node): don't clobber packageJson.main if it exists

### DIFF
--- a/packages/node/src/utils/generate-package-json.ts
+++ b/packages/node/src/utils/generate-package-json.ts
@@ -11,7 +11,7 @@ export function generatePackageJson(
   options: BuildNodeBuilderOptions
 ) {
   const packageJson = createPackageJson(projectName, graph, options);
-  packageJson.main = OUT_FILENAME;
+  packageJson.main = packageJson.main ?? OUT_FILENAME;
   delete packageJson.devDependencies;
   writeJsonFile(`${options.outputPath}/package.json`, packageJson);
 }


### PR DESCRIPTION
Only assign packageJson.main to OUT_FILENAME if it is nullish in generatePackageJson

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When using the `generatePackageJson` option with the node build executor, the documentation indicates that it is possible to use a `package.json` in the app root dir to create a template for the output `package.json`. However, the `main` field of the `package.json` is always overwritten with `main.js` even if it is set to something different in the `package.json` (such as `index.js). 

## Expected Behavior
This field should only be overwritten if it doesn't already exist in the package json file. In some cases (firebase functions for example), tooling expects a different output filename, so clobbering the name here causes issues.
