### PR TITLE
feat(core): warn when deprecated options are used in generators and executors

### DIFF
--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -50,7 +50,6 @@ export async function scheduleTarget(
 
   const registry = new schema.CoreSchemaRegistry();
   registry.addPostTransform(schema.transforms.addUndefinedDefaults);
-  registry.useXDeprecatedProvider((msg) => logger.warn(msg));
   const architectHost = new WorkspaceNodeModulesArchitectHost(workspace, root);
   const architect = new Architect(architectHost, registry);
   const run = await architect.scheduleTarget(

--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -18,6 +18,7 @@ type PropertyDescription = {
   'x-prompt'?:
     | string
     | { message: string; type: string; items: any[]; multiselect?: boolean };
+  'x-deprecated'?: boolean | string;
 };
 
 type Properties = {
@@ -360,6 +361,7 @@ export function combineOptionsForExecutor(
     defaultProjectName,
     relativeCwd
   );
+  warnDeprecations(combined, schema);
   setDefaults(combined, schema);
   validateOptsAgainstSchema(combined, schema);
   return combined;
@@ -400,10 +402,27 @@ export async function combineOptionsForGenerator(
     combined = await promptForValues(combined, schema);
   }
 
+  warnDeprecations(combined, schema);
   setDefaults(combined, schema);
 
   validateOptsAgainstSchema(combined, schema);
   return combined;
+}
+
+export function warnDeprecations(
+  opts: { [k: string]: any },
+  schema: Schema
+): void {
+  Object.keys(opts).forEach((option) => {
+    const deprecated = schema.properties[option]?.['x-deprecated'];
+    if (deprecated) {
+      logger.warn(
+        `Option "${option}" is deprecated${
+          typeof deprecated == 'string' ? ': ' + deprecated : '.'
+        }`
+      );
+    }
+  });
 }
 
 export function convertSmartDefaultsIntoNamedParams(

--- a/yarn.lock
+++ b/yarn.lock
@@ -25262,9 +25262,9 @@ xmlchars@^2.1.1, xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmlhttprequest-ssl@1.6.3, xmlhttprequest-ssl@~1.5.4:
+xmlhttprequest-ssl@~1.5.4, xmlhttprequest-ssl@~1.6.2:
   version "1.6.3"
-  resolved "http://localhost:4873/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
   integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
 
 xtend@^4.0.0, xtend@^4.0.2, xtend@~4.0.1:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generators or executors are executed there is no warning to devs regarding the usage of deprecated options. There's only support for Angular Schematics, but the current implementation has [an issue](https://github.com/nrwl/nx/issues/5829#issuecomment-851005850) where the default values are set to the options object before checking for deprecated. This causes false positives since it can warn about options that were not set by the devs.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Execution of generators and executors should warn when deprecated options are specified.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
