### PR TITLE
cleanup(core): remove unneccessary dependencies and refactored prettoer path resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "@typescript-eslint/experimental-utils": "^4.3.0",
     "@typescript-eslint/parser": "^4.3.0",
     "angular": "1.8.0",
-    "app-root-path": "^2.0.1",
     "autoprefixer": "^10.2.5",
     "babel-jest": "26.2.2",
     "caniuse-lite": "^1.0.30001030",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -76,7 +76,6 @@
     "flat": "^5.0.2",
     "minimatch": "3.0.4",
     "enquirer": "~2.3.6",
-    "resolve": "1.17.0",
     "tslib": "^2.0.0"
   }
 }

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -1,6 +1,5 @@
 import { execSync } from 'child_process';
 import * as path from 'path';
-import * as resolve from 'resolve';
 import { getProjectRoots, parseFiles } from './shared';
 import { fileExists } from '../utilities/fileutils';
 import {
@@ -38,6 +37,8 @@ const PRETTIER_EXTENSIONS = [
 ];
 
 const MATCH_ALL_PATTERN = `**/*.{${PRETTIER_EXTENSIONS.join(',')}}`;
+
+const PRETTIER_PATH = require.resolve('prettier/bin-prettier');
 
 export function format(command: 'check' | 'write', args: yargs.Arguments) {
   const { nxArgs } = splitArgsIntoNxArgsAndOverrides(args, 'affected');
@@ -109,7 +110,7 @@ function chunkify(target: string[], size: number): string[][] {
 
 function write(patterns: string[]) {
   if (patterns.length > 0) {
-    execSync(`node "${prettierPath()}" --write ${patterns.join(' ')}`, {
+    execSync(`node "${PRETTIER_PATH}" --write ${patterns.join(' ')}`, {
       stdio: [0, 1, 2],
     });
   }
@@ -119,7 +120,7 @@ function check(patterns: string[]) {
   if (patterns.length > 0) {
     try {
       execSync(
-        `node "${prettierPath()}" --list-different ${patterns.join(' ')}`,
+        `node "${PRETTIER_PATH}" --list-different ${patterns.join(' ')}`,
         {
           stdio: [0, 1, 2],
         }
@@ -128,13 +129,6 @@ function check(patterns: string[]) {
       process.exit(1);
     }
   }
-}
-
-function prettierPath() {
-  const basePath = path.dirname(
-    resolve.sync('prettier', { basedir: __dirname })
-  );
-  return path.join(basePath, 'bin-prettier.js');
 }
 
 function updateWorkspaceJsonToMatchFormatVersion() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6246,11 +6246,6 @@ app-root-dir@^1.0.2:
   resolved "https://registry.yarnpkg.com/app-root-dir/-/app-root-dir-1.0.2.tgz#38187ec2dea7577fff033ffcb12172692ff6e118"
   integrity sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=
 
-app-root-path@^2.0.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.2.1.tgz#d0df4a682ee408273583d43f6f79e9892624bc9a"
-  integrity sha512-91IFKeKk7FjfmezPKkwtaRvSpnUc4gDwPAjA1YZ9Gn0q0PPeW+vbeUsZuyDwjI7+QTHhcLen2v25fi/AmhvbJA==
-
 append-field@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/append-field/-/append-field-1.0.0.tgz#1e3440e915f0b1203d23748e78edd7b9b5b43e56"
@@ -25262,9 +25257,9 @@ xmlchars@^2.1.1, xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmlhttprequest-ssl@1.6.3, xmlhttprequest-ssl@~1.5.4:
+xmlhttprequest-ssl@~1.5.4, xmlhttprequest-ssl@~1.6.2:
   version "1.6.3"
-  resolved "http://localhost:4873/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
   integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
 
 xtend@^4.0.0, xtend@^4.0.2, xtend@~4.0.1:


### PR DESCRIPTION



<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- depends on `app-root-path` and `resolve`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- removed depenedencies `app-root-path` and `resolve`
- refactored `packages/workspace/src/command-line/format.ts` to use `require.resolve()`
