### PR TITLE
feat(repo): add checks for lock files

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -2,7 +2,8 @@ name: NPM Audit
 
 on:
   schedule:
-  - cron: "0 0 * * *"
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   audit:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+yarn check-lock-files
 yarn check-commit
 yarn documentation
 yarn pretty-quick --check

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check-commit": "node ./scripts/commit-lint.js",
     "check-format": "nx format:check --all",
     "check-imports": "node ./scripts/check-imports.js",
+    "check-lock-files": "node ./scripts/check-lock-files.js",
     "check-internal-links": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/internal-link-checker.ts",
     "check-versions": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/check-versions.ts",
     "check-documentation-map": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/map-link-checker.ts",

--- a/scripts/check-lock-files.js
+++ b/scripts/check-lock-files.js
@@ -7,6 +7,11 @@ function checkLockFiles() {
       'Invalid occurence of "package-lock.json" file. Please remove it and use only "yarn.lock"'
     );
   }
+  if (fs.existsSync('pnpm-lock.yaml')) {
+    errors.push(
+      'Invalid occurence of "pnpm-lock.yaml" file. Please remove it and use only "yarn.lock"'
+    );
+  }
   try {
     const content = fs.readFileSync('yarn.lock', 'utf-8');
     if (content.match(/localhost:487/)) {

--- a/scripts/check-lock-files.js
+++ b/scripts/check-lock-files.js
@@ -3,12 +3,16 @@ const fs = require('fs');
 function checkLockFiles() {
   const errors = [];
   if (fs.existsSync('package-lock.json')) {
-    errors.push('Invalid occurence of "package-lock.json" file. Please remove it and use only "yarn.lock"');
+    errors.push(
+      'Invalid occurence of "package-lock.json" file. Please remove it and use only "yarn.lock"'
+    );
   }
   try {
     const content = fs.readFileSync('yarn.lock', 'utf-8');
     if (content.match(/localhost:487/)) {
-      errors.push('The "yarn.lock" has reference to local yarn repository ("localhost:4873"). Please use "registry.yarnpkg.com" in "yarn.lock"');
+      errors.push(
+        'The "yarn.lock" has reference to local yarn repository ("localhost:4873"). Please use "registry.yarnpkg.com" in "yarn.lock"'
+      );
     }
   } catch {
     errors.push('The "yarn.lock" does not exist or cannot be read');

--- a/scripts/check-lock-files.js
+++ b/scripts/check-lock-files.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+
+function checkLockFiles() {
+  const errors = [];
+  if (fs.existsSync('package-lock.json')) {
+    errors.push('Invalid occurence of "package-lock.json" file. Please remove it and use only "yarn.lock"');
+  }
+  try {
+    const content = fs.readFileSync('yarn.lock', 'utf-8');
+    if (content.match(/localhost:487/)) {
+      errors.push('The "yarn.lock" has reference to local yarn repository ("localhost:4873"). Please use "registry.yarnpkg.com" in "yarn.lock"');
+    }
+  } catch {
+    errors.push('The "yarn.lock" does not exist or cannot be read');
+  }
+  return errors;
+}
+
+const invalid = checkLockFiles();
+if (invalid.length > 0) {
+  invalid.forEach((e) => console.log(e));
+  process.exit(1);
+} else {
+  process.exit(0);
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

Related to https://github.com/nrwl/nx/commit/bb8b99c31307998af1fba213dfb1dcf8ff8457fa and https://github.com/nrwl/nx/commit/4a03859de41631647e60d8a69e2e1e2523fc922e

## Current Behavior
* It's possible to remove "yarn.lock" file in commit
* It's possible to accidentally replace yarn registry with local registry in the lock file
* It's possible to accidentally push "package-lock.json" file
<!-- This is the behavior we have today -->

## Expected Behavior
* Yarn lock file should always exist
* Package-lock.json should not exist
* Yarn lock should not reference local verdaccio registry
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
