### PR TITLE
fix(devkit): match angular devkit root path for host tree

### DIFF
--- a/packages/angular/src/migrations/update-12-3-0/update-storybook.spec.ts
+++ b/packages/angular/src/migrations/update-12-3-0/update-storybook.spec.ts
@@ -34,7 +34,7 @@ describe('12.4.0 - Update Storybook', () => {
     });
     tree.write('proj/.storybook/main.js', 'module.exports = {};');
     jest.requireMock('@storybook/core/package.json').version = '6.2.0';
-    jest.mock('/virtual/proj/.storybook/main.js', () => ({}), {
+    jest.mock('/proj/.storybook/main.js', () => ({}), {
       virtual: true,
     });
 
@@ -52,7 +52,7 @@ describe('12.4.0 - Update Storybook', () => {
     ).toEqual('6.2.0');
 
     // Should not do it again if run again
-    jest.requireMock('/virtual/proj/.storybook/main.js').core = {
+    jest.requireMock('/proj/.storybook/main.js').core = {
       builder: 'webpack5',
     };
     await update(tree);
@@ -82,7 +82,7 @@ describe('12.4.0 - Update Storybook', () => {
     });
     tree.write('proj/.storybook/main.js', 'module.exports = {};');
     jest.requireMock('@storybook/core/package.json').version = '5.2.0';
-    jest.mock('/virtual/proj/.storybook/main.js', () => ({}), {
+    jest.mock('/proj/.storybook/main.js', () => ({}), {
       virtual: true,
     });
 
@@ -114,7 +114,7 @@ describe('12.4.0 - Update Storybook', () => {
     });
     tree.write('proj/.storybook/main.js', 'module.exports = {};');
     jest.requireMock('@storybook/core/package.json').version = '6.2.0';
-    jest.mock('/virtual/proj/.storybook/main.js', () => ({}), {
+    jest.mock('/proj/.storybook/main.js', () => ({}), {
       virtual: true,
     });
 

--- a/packages/devkit/src/tests/create-tree-with-empty-workspace.ts
+++ b/packages/devkit/src/tests/create-tree-with-empty-workspace.ts
@@ -5,7 +5,7 @@ import type { Tree } from '@nrwl/tao/src/shared/tree';
  * Creates a host for testing.
  */
 export function createTreeWithEmptyWorkspace(): Tree {
-  const tree = new FsTree('/virtual', false);
+  const tree = new FsTree('/', false);
 
   tree.write('/workspace.json', JSON.stringify({ version: 1, projects: {} }));
   tree.write('./.prettierrc', JSON.stringify({ singleQuote: true }));

--- a/packages/devkit/src/tests/create-tree.ts
+++ b/packages/devkit/src/tests/create-tree.ts
@@ -5,5 +5,5 @@ import type { Tree } from '@nrwl/tao/src/shared/tree';
  * Creates a host for testing.
  */
 export function createTree(): Tree {
-  return new FsTree('/virtual', false);
+  return new FsTree('/', false);
 }


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Angular Devkit's root path for Host is not configurable and always set to `'/'`.
This causes issues when we run Angular Schematics within Nx Devkit Unit Tests that create a Tree with a root path of
`'/virtual'`.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Match the root paths to allow for less discrepancy between the two devkits.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
