### PR TITLE
fix(core): list files from the tree in the ngcli-adapter

### DIFF
--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -1,8 +1,10 @@
 /* eslint-disable no-restricted-imports */
 import {
+  fragment,
   logging,
   normalize,
   Path,
+  PathFragment,
   schema,
   tags,
   virtualFs,
@@ -402,6 +404,11 @@ export class NxScopeHostUsedForWrappedSchematics extends NxScopedHost {
         ? of(true)
         : super.isFile(path);
     }
+  }
+
+  list(path: Path): Observable<PathFragment[]> {
+    const fragments = this.host.children(path).map((child) => fragment(child));
+    return of(fragments);
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
In certain scenarios, when a generator runs a schematic from `@schematics/angular` using the `wrapAngularDevkitSchematic` utility, it fails with the error `Unable to determine format for workspace path`. This happens when those schematics read the workspace config because there is a check which only lists files from the recorded changes made during the wrapped schematic execution and from the filesystem. Any changes made by the parent generator or empty tree in tests are not going to be picked as recorded changes, since they were not done in the scope of the wrapped schematic execution.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running a schematic from `@schematics/angular` should run successfully and pick files from the existing Nx DevKit Tree.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
