### PR TITLE
fix(node): assets should be copied when building with --watch

### DIFF
--- a/packages/node/src/executors/package/package.impl.ts
+++ b/packages/node/src/executors/package/package.impl.ts
@@ -40,12 +40,35 @@ export async function packageExecutor(
     normalizedOptions,
     context,
     libRoot,
-    dependencies
+    dependencies,
+    async () =>
+      await updatePackageAndCopyAssets(
+        normalizedOptions,
+        context,
+        target,
+        dependencies
+      )
   );
 
-  await copyAssetFiles(normalizedOptions.files);
+  if (options.cli) {
+    addCliWrapper(normalizedOptions, context);
+  }
 
-  updatePackageJson(normalizedOptions, context);
+  return {
+    ...(result as { success: boolean }),
+    outputPath: normalizedOptions.outputPath,
+  };
+}
+
+async function updatePackageAndCopyAssets(
+  options,
+  context,
+  target,
+  dependencies
+) {
+  await copyAssetFiles(options.files);
+
+  updatePackageJson(options, context);
   if (
     dependencies.length > 0 &&
     options.updateBuildableProjectDepsInPackageJson
@@ -57,18 +80,9 @@ export async function packageExecutor(
       context.configurationName,
       target,
       dependencies,
-      normalizedOptions.buildableProjectDepsInPackageJsonType
+      options.buildableProjectDepsInPackageJsonType
     );
   }
-
-  if (options.cli) {
-    addCliWrapper(normalizedOptions, context);
-  }
-
-  return {
-    ...result,
-    outputPath: normalizedOptions.outputPath,
-  };
 }
 
 export default packageExecutor;

--- a/packages/workspace/src/executors/tsc/tsc.impl.ts
+++ b/packages/workspace/src/executors/tsc/tsc.impl.ts
@@ -1,8 +1,11 @@
-import { ExecutorContext, normalizePath } from '@nrwl/devkit';
+import { ExecutorContext, logger, normalizePath } from '@nrwl/devkit';
 import { basename, dirname, join, relative } from 'path';
 import { copyAssets } from '../../utilities/assets';
 import { readJsonFile, writeJsonFile } from '../../utilities/fileutils';
-import { compileTypeScript } from '../../utilities/typescript/compilation';
+import {
+  compileTypeScript,
+  TypescriptWatchChangeEvent,
+} from '../../utilities/typescript/compilation';
 import { TypeScriptExecutorOptions } from './schema';
 
 export async function tscExecutor(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Assets are not copied to dist when running `nx build my-node-lib --watch`.

## Expected Behavior
Assets, including package.json, should be present in dist. 

## Caveats
This change does not add the assets to the watcher, since it is using the typescript compiler's watch program. As such, if assets change it does not retrigger the compiler.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5724