### PR TITLE
fix(angular): generate the outputs property for build targets

### DIFF
--- a/packages/angular/src/schematics/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/schematics/application/__snapshots__/application.spec.ts.snap
@@ -52,6 +52,9 @@ Object {
         ],
         "tsConfig": "apps/my-dir/my-app/tsconfig.app.json",
       },
+      "outputs": Array [
+        "{options.outputPath}",
+      ],
     },
     "extract-i18n": Object {
       "builder": "@angular-devkit/build-angular:extract-i18n",
@@ -181,6 +184,9 @@ Object {
         ],
         "tsConfig": "apps/my-app/tsconfig.app.json",
       },
+      "outputs": Array [
+        "{options.outputPath}",
+      ],
     },
     "extract-i18n": Object {
       "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/packages/angular/src/schematics/application/application.ts
+++ b/packages/angular/src/schematics/application/application.ts
@@ -444,6 +444,15 @@ function updateProject(options: NormalizedSchema): Rule {
 
         delete fixedProject.architect.test;
 
+        // Ensure the outputs property comes after the builder for
+        // better readability.
+        const { builder, ...rest } = fixedProject.architect.build;
+        fixedProject.architect.build = {
+          builder,
+          outputs: ['{options.outputPath}'],
+          ...rest,
+        };
+
         if (options.unitTestRunner === 'none') {
           host.delete(
             `${options.appProjectRoot}/src/app/app.component.spec.ts`


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating Angular apps and libs, the `outputs` property is not getting generated for the `build` target.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
New Angular apps and libs should have an `outputs` property specified in the `build` target.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
