### PR TITLE
fix(core): override isDirectory in wrapped angular schematics host

### DIFF
--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -25,7 +25,7 @@ import { dirname, extname, resolve, join } from 'path';
 import * as stripJsonComments from 'strip-json-comments';
 import { FileBuffer } from '@angular-devkit/core/src/virtual-fs/host/interface';
 import { Observable, of } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { catchError, map, switchMap } from 'rxjs/operators';
 import { NX_ERROR, NX_PREFIX } from '../shared/logger';
 
 export async function scheduleTarget(
@@ -391,6 +391,17 @@ export class NxScopeHostUsedForWrappedSchematics extends NxScopedHost {
         ? of(true)
         : super.exists(path);
     }
+  }
+
+  isDirectory(path: Path): Observable<boolean> {
+    return super.isDirectory(path).pipe(
+      catchError(() => of(false)),
+      switchMap((isDirectory) =>
+        isDirectory
+          ? of(true)
+          : of(this.host.exists(path) && !this.host.isFile(path))
+      )
+    );
   }
 
   isFile(path: Path): Observable<boolean> {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When a wrapped schematic is being executed, if `isDirectory` is invoked in the host, the recorded changes in the outer host are not checked to see if the given path is a directory. This leaves out any previous changes that might have been done in the host invoking the wrapped schematic.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When running a wrapped schematic, it should be able to check if a path in the outer host is a directory.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
