### PR TITLE
feat(testing): support for Jest 27

### DIFF
--- a/e2e/workspace/src/create-nx-workspace.test.ts
+++ b/e2e/workspace/src/create-nx-workspace.test.ts
@@ -164,9 +164,9 @@ describe('create-nx-workspace', () => {
   it('should handle spaces in workspace path', () => {
     const wsName = uniq('empty');
 
-    const tmpDir = `${e2eCwd}/with space`;
+    const tmpDir = `${e2eCwd}/${uniq('with space')}`;
 
-    mkdirSync(tmpDir);
+    mkdirSync(tmpDir, { recursive: true });
 
     const command = `npx create-nx-workspace@${'9999.0.2'} ${wsName} --cli=nx --preset=empty --no-nxCloud --no-interactive`;
     execSync(command, {

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -104,8 +104,6 @@ function addUnitTestRunner(
     case UnitTestRunner.Karma:
       karmaGenerator(host);
     case UnitTestRunner.Jest:
-      // TODO: remove this when we use `jest-preset-angular@9.0.0`
-      process.env.npm_config_legacy_peer_deps = 'true';
       addDependenciesToPackageJson(
         host,
         {},

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -3,5 +3,5 @@ export const angularVersion = '^12.0.0';
 export const angularJsVersion = '1.7.9';
 export const ngrxVersion = '^12.0.0';
 export const rxjsVersion = '~6.6.0';
-export const jestPresetAngularVersion = '9.0.2';
+export const jestPresetAngularVersion = '9.0.3';
 export const angularEslintVersion = '~12.0.0';

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -3,5 +3,5 @@ export const angularVersion = '^12.0.0';
 export const angularJsVersion = '1.7.9';
 export const ngrxVersion = '^12.0.0';
 export const rxjsVersion = '~6.6.0';
-export const jestPresetAngularVersion = '8.4.0';
+export const jestPresetAngularVersion = '9.0.1';
 export const angularEslintVersion = '~12.0.0';

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -3,5 +3,5 @@ export const angularVersion = '^12.0.0';
 export const angularJsVersion = '1.7.9';
 export const ngrxVersion = '^12.0.0';
 export const rxjsVersion = '~6.6.0';
-export const jestPresetAngularVersion = '9.0.1';
+export const jestPresetAngularVersion = '9.0.2';
 export const angularEslintVersion = '~12.0.0';

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -71,6 +71,18 @@
       "cli": "nx",
       "description": "Replace tsConfig with tsconfig for ts-jest in jest.config.js",
       "factory": "./src/migrations/update-12-1-2/update-ts-jest"
+    },
+    "support-jest-27": {
+      "version": "12.4.0-beta.1",
+      "cli": "nx",
+      "description": "Add testEnvironment: 'jsdom' in web apps + libraries",
+      "factory": "./src/migrations/update-12-4-0/add-test-environment-for-node"
+    },
+    "update-ts-jest-and-jest-preset-angular": {
+      "version": "12.4.0-beta.1",
+      "cli": "nx",
+      "description": "Support for Jest 27 via updating ts-jest + jest-preset-angular",
+      "factory": "./src/migrations/update-12-4-0/update-jest-preset-angular"
     }
   },
   "packageJsonUpdates": {
@@ -147,6 +159,23 @@
         },
         "ts-jest": {
           "version": "26.5.5",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "12.4.0": {
+      "version": "12.4.0-beta.1",
+      "packages": {
+        "jest": {
+          "version": "27.0.3",
+          "alwaysAddToPackageJson": false
+        },
+        "ts-jest": {
+          "version": "27.0.2",
+          "alwaysAddToPackageJson": false
+        },
+        "jest-preset-angular": {
+          "version": "9.0.1",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -175,7 +175,7 @@
           "alwaysAddToPackageJson": false
         },
         "jest-preset-angular": {
-          "version": "9.0.2",
+          "version": "9.0.3",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -171,11 +171,11 @@
           "alwaysAddToPackageJson": false
         },
         "ts-jest": {
-          "version": "27.0.2",
+          "version": "27.0.3",
           "alwaysAddToPackageJson": false
         },
         "jest-preset-angular": {
-          "version": "9.0.1",
+          "version": "9.0.2",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/jest/preset/jest-preset.ts
+++ b/packages/jest/preset/jest-preset.ts
@@ -6,4 +6,5 @@ export = {
   transform: {
     '^.+\\.(ts|js|html)$': 'ts-jest',
   },
+  testEnvironment: 'jsdom',
 };

--- a/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
+++ b/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
@@ -35,15 +35,12 @@ exports[`jestProject --setup-file should have setupFilesAfterEnv and globals.ts-
     'ts-jest': {
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\\\\\\\.(html|svg)$',
-      astTransformers: {
-        before: [
-          'jest-preset-angular/build/InlineFilesTransformer',
-          'jest-preset-angular/build/StripStylesTransformer'
-        ]
-      },
     }
   },
   coverageDirectory: '../../coverage/libs/lib1',
+  transform: {
+    '^.+\\\\\\\\.(ts|js|html)$': 'jest-preset-angular'
+  },
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',
@@ -62,12 +59,7 @@ exports[`jestProject should create a jest.config.js 1`] = `
       tsconfig: '<rootDir>/tsconfig.spec.json',
     }
   },
-  coverageDirectory: '../../coverage/libs/lib1',
-  snapshotSerializers: [
-    'jest-preset-angular/build/serializers/no-ng-attributes',
-    'jest-preset-angular/build/serializers/ng-snapshot',
-    'jest-preset-angular/build/serializers/html-comment',
-  ]
+  coverageDirectory: '../../coverage/libs/lib1'
 };
 "
 `;

--- a/packages/jest/src/generators/jest-project/files-angular/jest.config.js__tmpl__
+++ b/packages/jest/src/generators/jest-project/files-angular/jest.config.js__tmpl__
@@ -1,0 +1,26 @@
+module.exports = {
+  displayName: '<%= project %>',
+  preset: '<%= offsetFromRoot %>jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+    }
+  },<% if(testEnvironment) { %>
+  testEnvironment: '<%= testEnvironment %>',<% } %><% if(skipSerializers){ %>
+  transform: {
+    <% if (supportTsx){ %>'^.+\\.[tj]sx?$'<% } else { %>'^.+\\.[tj]s$'<% } %>: <% if (transformer == 'babel-jest') { %>'babel-jest'<% } else { %> 'ts-jest' <% } %>
+  },<% if (supportTsx) { %>
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],<% } else { %>
+    moduleFileExtensions: ['ts', 'js', 'html'],<% } %><% } %>
+  coverageDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>',
+  transform: {
+    '^.+\\.(ts|js|html)$': 'jest-preset-angular'
+  }<% if(!skipSerializers) { %>,
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ]<% } %>
+};

--- a/packages/jest/src/generators/jest-project/files-angular/src/test-setup.ts__tmpl__
+++ b/packages/jest/src/generators/jest-project/files-angular/src/test-setup.ts__tmpl__
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/packages/jest/src/generators/jest-project/files-angular/tsconfig.spec.json__tmpl__
+++ b/packages/jest/src/generators/jest-project/files-angular/tsconfig.spec.json__tmpl__
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "<%= offsetFromRoot %>dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },<% if(setupFile !== 'none') { %>
+  "files": ["src/test-setup.ts"],<% } %>
+  "include": [
+    "**/*.spec.ts",<% if (supportTsx) { %>
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",<% } %>
+    "**/*.d.ts"
+  ]
+}

--- a/packages/jest/src/generators/jest-project/files/jest.config.js__tmpl__
+++ b/packages/jest/src/generators/jest-project/files/jest.config.js__tmpl__
@@ -4,14 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],<% } %><% if (transformer === 'ts-jest') { %>
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',<%if (setupFile === 'angular') { %>
-      stringifyContentPathRegex: '\\.(html|svg)$',
-      astTransformers: {
-        before: [
-          'jest-preset-angular/build/InlineFilesTransformer',
-          'jest-preset-angular/build/StripStylesTransformer'
-        ]
-      },<% } %>
+      tsconfig: '<rootDir>/tsconfig.spec.json',
     }
   },<% } %><% if(testEnvironment) { %>
   testEnvironment: '<%= testEnvironment %>',<% } %><% if(skipSerializers){ %>
@@ -20,10 +13,5 @@ module.exports = {
   },<% if (supportTsx) { %>
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],<% } else { %>
     moduleFileExtensions: ['ts', 'js', 'html'],<% } %><% } %>
-  coverageDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>'<% if(!skipSerializers) { %>,
-  snapshotSerializers: [
-    'jest-preset-angular/build/serializers/no-ng-attributes',
-    'jest-preset-angular/build/serializers/ng-snapshot',
-    'jest-preset-angular/build/serializers/html-comment',
-  ]<% } %>
+  coverageDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>'
 };

--- a/packages/jest/src/generators/jest-project/files/src/test-setup.ts__tmpl__
+++ b/packages/jest/src/generators/jest-project/files/src/test-setup.ts__tmpl__
@@ -1,2 +1,1 @@
-<% if (setupFile === 'angular') { %>import 'jest-preset-angular/setup-jest';
-<% } else if (setupFile === 'web-components') { %>import 'document-register-element';<% } %>
+<% if (setupFile === 'web-components') { %>import 'document-register-element';<% } %>

--- a/packages/jest/src/generators/jest-project/lib/create-files.ts
+++ b/packages/jest/src/generators/jest-project/lib/create-files.ts
@@ -10,7 +10,10 @@ import { join } from 'path';
 export function createFiles(tree: Tree, options: JestProjectSchema) {
   const projectConfig = readProjectConfiguration(tree, options.project);
 
-  generateFiles(tree, join(__dirname, '../files'), projectConfig.root, {
+  const filesFolder =
+    options.setupFile === 'angular' ? '../files-angular' : '../files';
+
+  generateFiles(tree, join(__dirname, filesFolder), projectConfig.root, {
     tmpl: '',
     ...options,
     transformer: options.babelJest ? 'babel-jest' : 'ts-jest',

--- a/packages/jest/src/migrations/update-12-4-0/add-test-environment-for-node.spec.ts
+++ b/packages/jest/src/migrations/update-12-4-0/add-test-environment-for-node.spec.ts
@@ -1,0 +1,78 @@
+import { addProjectConfiguration, Tree } from '@nrwl/devkit';
+import { getJestObject } from '../update-10-0-0/require-jest-config';
+import { jestConfigObject } from '../../utils/config/functions';
+import update from './add-test-environment-for-node';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+jest.mock('../update-10-0-0/require-jest-config');
+const getJestObjectMock = getJestObject as jest.Mock<typeof getJestObject>;
+
+const jestObject = {};
+
+describe('update 12.4.0', () => {
+  let tree: Tree;
+  const jestConfig = String.raw`
+    module.exports = ${JSON.stringify(jestObject, null, 2)}
+  `;
+
+  beforeEach(() => {
+    getJestObjectMock.mockImplementation((path: string): any => {
+      return jestObject;
+    });
+
+    tree = createTreeWithEmptyWorkspace();
+
+    tree.write('apps/products/jest.config.js', jestConfig);
+    tree.write('apps/products-2/jest.config.js', jestConfig);
+
+    addProjectConfiguration(tree, 'products', {
+      root: 'apps/products',
+      sourceRoot: 'apps/products/src',
+      targets: {
+        build: {
+          executor: '@nrwl/node:package',
+        },
+        test: {
+          executor: '@nrwl/jest:jest',
+          options: {
+            jestConfig: 'apps/products/jest.config.js',
+            passWithNoTests: true,
+          },
+        },
+      },
+    });
+
+    addProjectConfiguration(tree, 'products-2', {
+      root: 'apps/products-2',
+      sourceRoot: 'apps/products-2/src',
+      targets: {
+        build: {
+          executor: '@nrwl/angular:build',
+        },
+        test: {
+          executor: '@nrwl/jest:jest',
+          options: {
+            jestConfig: 'apps/products-2/jest.config.js',
+            passWithNoTests: true,
+          },
+        },
+      },
+    });
+  });
+
+  it('should update the jest.config files by adding testEnvironment for node projects', async () => {
+    await update(tree);
+
+    const jestObject = jestConfigObject(tree, 'apps/products/jest.config.js');
+
+    expect(jestObject.testEnvironment).toEqual('node');
+  });
+
+  it('should not change the testEnvironment for angular apps', async () => {
+    await update(tree);
+
+    const jestObject = jestConfigObject(tree, 'apps/products-2/jest.config.js');
+
+    expect(jestObject.testEnvironment).toBeUndefined();
+  });
+});

--- a/packages/jest/src/migrations/update-12-4-0/add-test-environment-for-node.ts
+++ b/packages/jest/src/migrations/update-12-4-0/add-test-environment-for-node.ts
@@ -1,0 +1,59 @@
+import {
+  formatFiles,
+  logger,
+  ProjectConfiguration,
+  readProjectConfiguration,
+  stripIndents,
+  Tree,
+} from '@nrwl/devkit';
+import { join } from 'path';
+
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+import { JestExecutorOptions } from '../../executors/jest/schema';
+import { getJestObject } from '../update-10-0-0/require-jest-config';
+import { addPropertyToJestConfig } from '../../utils/config/update-config';
+
+function updateJestConfig(tree: Tree) {
+  forEachExecutorOptions<JestExecutorOptions>(
+    tree,
+    '@nrwl/jest:jest',
+    (options, project) => {
+      if (!options.jestConfig) {
+        return;
+      }
+
+      const jestConfigPath = options.jestConfig;
+      const jestConfig = getJestObject(join(tree.root, jestConfigPath));
+      const projectConfig = readProjectConfiguration(tree, project);
+      const testEnvironment = jestConfig.testEnvironment;
+
+      if (testEnvironment || !checkIfNodeProject(projectConfig)) {
+        return;
+      }
+
+      try {
+        addPropertyToJestConfig(
+          tree,
+          jestConfigPath,
+          'testEnvironment',
+          'node'
+        );
+      } catch {
+        logger.error(
+          stripIndents`Unable to update jest.config.js for project ${project}.`
+        );
+      }
+    }
+  );
+}
+
+export default async function update(tree: Tree) {
+  updateJestConfig(tree);
+  await formatFiles(tree);
+}
+
+function checkIfNodeProject(config: ProjectConfiguration) {
+  return Object.entries(config.targets).some(([targetName, targetConfig]) =>
+    targetConfig.executor.includes('node')
+  );
+}

--- a/packages/jest/src/migrations/update-12-4-0/update-jest-preset-angular.spec.ts
+++ b/packages/jest/src/migrations/update-12-4-0/update-jest-preset-angular.spec.ts
@@ -1,0 +1,107 @@
+import { addProjectConfiguration, Tree } from '@nrwl/devkit';
+import { getJestObject } from '../update-10-0-0/require-jest-config';
+import { jestConfigObject } from '../../utils/config/functions';
+import update from './update-jest-preset-angular';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+jest.mock('../update-10-0-0/require-jest-config');
+const getJestObjectMock = getJestObject as jest.Mock<typeof getJestObject>;
+
+const jestObject = {
+  globals: {
+    'ts-jest': {
+      astTransformers: {
+        before: [
+          'jest-preset-angular/build/InlineFilesTransformer',
+          'jest-preset-angular/build/StripStylesTransformer',
+        ],
+      },
+    },
+  },
+};
+
+describe('update 12.4.0', () => {
+  let tree: Tree;
+  const jestConfig = String.raw`
+    module.exports = ${JSON.stringify(jestObject, null, 2)}
+  `;
+
+  beforeEach(() => {
+    getJestObjectMock.mockImplementation((path: string): any => {
+      return jestObject;
+    });
+
+    tree = createTreeWithEmptyWorkspace();
+
+    tree.write('apps/products/jest.config.js', jestConfig);
+    tree.write('apps/products-2/jest.config.js', jestConfig);
+
+    addProjectConfiguration(tree, 'products', {
+      root: 'apps/products',
+      sourceRoot: 'apps/products/src',
+      targets: {
+        build: {
+          executor: '@nrwl/node:package',
+        },
+        test: {
+          executor: '@nrwl/jest:jest',
+          options: {
+            jestConfig: 'apps/products/jest.config.js',
+            passWithNoTests: true,
+          },
+        },
+      },
+    });
+
+    addProjectConfiguration(tree, 'products-2', {
+      root: 'apps/products-2',
+      sourceRoot: 'apps/products-2/src',
+      targets: {
+        build: {
+          executor: '@nrwl/angular:build',
+        },
+        test: {
+          executor: '@nrwl/jest:jest',
+          options: {
+            jestConfig: 'apps/products-2/jest.config.js',
+            passWithNoTests: true,
+          },
+        },
+      },
+    });
+  });
+
+  it('should update the jest.config files by removing astTransformers if using only jest-preset-angular', async () => {
+    await update(tree);
+
+    const jestObject = jestConfigObject(tree, 'apps/products/jest.config.js');
+
+    expect(
+      (jestObject.globals['ts-jest'] as { astTransformers: unknown })
+        .astTransformers
+    ).toBeUndefined();
+  });
+
+  it('should add transform if angular app', async () => {
+    await update(tree);
+
+    const jestObject = jestConfigObject(tree, 'apps/products-2/jest.config.js');
+
+    expect(jestObject.transform).toEqual({
+      '^.+\\.(ts|js|html)$': 'jest-preset-angular',
+    });
+  });
+
+  it('should not add transform if non-angular app', async () => {
+    getJestObjectMock.mockImplementation((path: string): any => {
+      if (path.includes('apps/products')) {
+        // return empty jest config without tsconfig
+        return { globals: { 'ts-jest': {} } };
+      }
+    });
+
+    const jestObject = jestConfigObject(tree, 'apps/products/jest.config.js');
+
+    expect(jestObject.transform).toBeUndefined();
+  });
+});

--- a/packages/jest/src/migrations/update-12-4-0/update-jest-preset-angular.ts
+++ b/packages/jest/src/migrations/update-12-4-0/update-jest-preset-angular.ts
@@ -1,0 +1,152 @@
+import {
+  formatFiles,
+  logger,
+  ProjectConfiguration,
+  readProjectConfiguration,
+  stripIndents,
+  Tree,
+} from '@nrwl/devkit';
+import { join } from 'path';
+
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+import { JestExecutorOptions } from '../../executors/jest/schema';
+import { getJestObject } from '../update-10-0-0/require-jest-config';
+import {
+  addPropertyToJestConfig,
+  removePropertyFromJestConfig,
+} from '../../utils/config/update-config';
+
+function updateJestConfig(tree: Tree) {
+  forEachExecutorOptions<JestExecutorOptions>(
+    tree,
+    '@nrwl/jest:jest',
+    (options, project) => {
+      if (!options.jestConfig) {
+        return;
+      }
+
+      const jestConfigPath = options.jestConfig;
+      const jestConfig = getJestObject(
+        join(tree.root, jestConfigPath)
+      ) as PartialJestConfig;
+
+      if (!usesJestPresetAngular(jestConfig)) {
+        return;
+      }
+
+      try {
+        updateASTTransformers(tree, jestConfigPath, jestConfig);
+        updateTransform(tree, jestConfigPath, jestConfig);
+      } catch {
+        logger.error(
+          stripIndents`Unable to update jest.config.js for project ${project}.`
+        );
+      }
+    }
+  );
+}
+
+export default async function update(tree: Tree) {
+  updateJestConfig(tree);
+  await formatFiles(tree);
+}
+
+export function updateASTTransformers(
+  tree: Tree,
+  jestConfigPath: string,
+  jestConfig: PartialJestConfig
+) {
+  const newTransformers = getNewAstTransformers(
+    jestConfig.globals?.['ts-jest'].astTransformers
+  );
+  if (newTransformers === null) {
+    removePropertyFromJestConfig(
+      tree,
+      jestConfigPath,
+      'globals.ts-jest.astTransformers'
+    );
+  } else {
+    addPropertyToJestConfig(
+      tree,
+      jestConfigPath,
+      'globals.ts-jest.astTransformers',
+      newTransformers
+    );
+  }
+}
+
+export function updateTransform(
+  tree: Tree,
+  jestConfigPath: string,
+  jestConfig: PartialJestConfig
+) {
+  addPropertyToJestConfig(tree, jestConfigPath, 'transform', {
+    ...jestConfig.transform,
+    '^.+\\.(ts|js|html)$': 'jest-preset-angular',
+  });
+}
+
+interface PartialJestConfig {
+  globals: {
+    'ts-jest': {
+      astTransformers: ASTTransformers;
+    };
+  };
+  transform?: Record<string, string>;
+}
+
+interface ASTTransformer {
+  path: string;
+  options: unknown;
+}
+
+interface ASTTransformers {
+  before: (ASTTransformer | string)[];
+  after: (ASTTransformer | string)[];
+  afterDeclarations: (ASTTransformer | string)[];
+}
+
+export function getNewAstTransformers(
+  astTransformers: ASTTransformers
+): ASTTransformers | null {
+  let result = {
+    before: astTransformers?.before?.filter?.(
+      (x) => !transformerIsFromJestPresetAngular(x)
+    ),
+    after: astTransformers?.after?.filter?.(
+      (x) => !transformerIsFromJestPresetAngular(x)
+    ),
+    afterDeclarations: astTransformers?.afterDeclarations?.filter?.(
+      (x) => !transformerIsFromJestPresetAngular(x)
+    ),
+  };
+
+  result = {
+    before: result.before?.length > 0 ? result.before : undefined,
+    after: result.after?.length > 0 ? result.after : undefined,
+    afterDeclarations:
+      result.afterDeclarations?.length > 0
+        ? result.afterDeclarations
+        : undefined,
+  };
+
+  if (!result.before && !result.after && !result.afterDeclarations) {
+    return null;
+  } else {
+    return result;
+  }
+}
+
+export function transformerIsFromJestPresetAngular(
+  transformer: ASTTransformer | string
+) {
+  return typeof transformer === 'string'
+    ? transformer.startsWith('jest-preset-angular')
+    : transformer.path.startsWith('jest-preset-angular');
+}
+
+export function usesJestPresetAngular(jestConfig: PartialJestConfig) {
+  return jestConfig.globals['ts-jest']?.astTransformers?.before?.some?.((x) =>
+    transformerIsFromJestPresetAngular(x)
+  );
+}

--- a/packages/jest/src/utils/versions.ts
+++ b/packages/jest/src/utils/versions.ts
@@ -1,7 +1,7 @@
 export const nxVersion = '*';
 export const jestVersion = '27.0.3';
 export const jestTypesVersion = '26.0.8';
-export const tsJestVersion = '27.0.1';
+export const tsJestVersion = '27.0.3';
 
 export const babelCoreVersion = '7.12.13';
 export const babelPresetEnvVersion = '7.12.13';

--- a/packages/jest/src/utils/versions.ts
+++ b/packages/jest/src/utils/versions.ts
@@ -1,7 +1,7 @@
 export const nxVersion = '*';
-export const jestVersion = '26.2.2';
+export const jestVersion = '27.0.3';
 export const jestTypesVersion = '26.0.8';
-export const tsJestVersion = '26.5.5';
+export const tsJestVersion = '27.0.1';
 
 export const babelCoreVersion = '7.12.13';
 export const babelPresetEnvVersion = '7.12.13';

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -330,6 +330,7 @@ describe('app', () => {
         "module.exports = {
           displayName: 'my-node-app',
           preset: '../../jest.preset.js',
+          testEnvironment: 'node',
           transform: {
             '^.+\\\\\\\\.[tj]s$': 'babel-jest'
           },

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -205,6 +205,7 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
       skipSerializers: true,
       supportTsx: options.js,
       babelJest: options.babelJest,
+      testEnvironment: 'node',
     });
     tasks.push(jestTask);
   }

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -387,6 +387,7 @@ describe('lib', () => {
         "module.exports = {
           displayName: 'my-lib',
           preset: '../../jest.preset.js',
+          testEnvironment: 'node',
           transform: {
             '^.+\\\\\\\\.[tj]sx?$': 'babel-jest'
           },

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -38,6 +38,7 @@ export async function libraryGenerator(tree: Tree, schema: Schema) {
   const libraryInstall = await workspaceLibraryGenerator(tree, {
     ...schema,
     importPath: options.importPath,
+    testEnvironment: 'node',
   });
   createFiles(tree, options);
 

--- a/packages/nx-plugin/src/generators/e2e-project/files/tests/__pluginName__.spec.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/e2e-project/files/tests/__pluginName__.spec.ts__tmpl__
@@ -6,31 +6,28 @@ import {
   uniq,
 } from '@nrwl/nx-plugin/testing';
 describe('<%= pluginName %> e2e', () => {
-    it('should create <%= pluginName %>', async (done) => {
+    it('should create <%= pluginName %>', async () => {
         const plugin = uniq('<%= pluginName %>');
         ensureNxProject('<%= npmPackageName %>', '<%= pluginOutputPath %>');
         await runNxCommandAsync(`generate <%=npmPackageName%>:<%= pluginName %> ${plugin}`);
 
         const result = await runNxCommandAsync(`build ${plugin}`);
         expect(result.stdout).toContain('Executor ran');
-
-        done();
-    })
+    }, 10000)
 
     describe('--directory', () => {
-      it('should create src in the specified directory', async (done) => {
+      it('should create src in the specified directory', async () => {
         const plugin = uniq('<%= pluginName %>');
         ensureNxProject('<%= npmPackageName %>', '<%= pluginOutputPath %>');
         await runNxCommandAsync(
           `generate <%=npmPackageName%>:<%= pluginName %> ${plugin} --directory subdir`
         );
         expect(() => checkFilesExist(`libs/subdir/${plugin}/src/index.ts`)).not.toThrow();
-        done();
-      });
+      }, 10000);
     });
 
     describe('--tags', () => {
-      it('should add tags to nx.json', async (done) => {
+      it('should add tags to nx.json', async () => {
          const plugin = uniq('<%= pluginName %>');
         ensureNxProject('<%= npmPackageName %>', '<%= pluginOutputPath %>');
         await runNxCommandAsync(
@@ -38,7 +35,6 @@ describe('<%= pluginName %> e2e', () => {
         );
         const nxJson = readJson('nx.json');
         expect(nxJson.projects[plugin].tags).toEqual(['e2etag', 'e2ePackage']);
-        done();
-      });
+      }, 10000);
     });
 })

--- a/workspace.json
+++ b/workspace.json
@@ -492,7 +492,7 @@
             "assets": [
               {
                 "input": "packages/jest",
-                "glob": "**/files/**",
+                "glob": "**/@(files|files-angular)/**",
                 "output": "/"
               },
               {


### PR DESCRIPTION
- Sets default testEnvironment to web
- Updates node generators to specify testEnvironment: node
- Provides migrations to update existing jest.config.js files
- Bump angular-preset-jest to latest

Fixes #5771
