### PR TITLE
docs(core): remap internal dependencies for nx.dev projects to point to npm packages

### DIFF
--- a/nx-dev/tools/nx-dev-plugin.js
+++ b/nx-dev/tools/nx-dev-plugin.js
@@ -1,0 +1,24 @@
+/*
+ * This plugin updates the project graph so dependencies to internal packages
+ * are rewritten to their npm counterparts since that is where we actually
+ * import from.
+ */
+exports.processProjectGraph = (graph, { workspace }) => {
+  const nrwlPlugins = Object.keys(workspace.projects).filter((name) => {
+    const p = workspace.projects[name];
+    return !p.tags || !p.tags.includes('scope:nx-dev');
+  });
+  Object.keys(graph.dependencies).forEach((name) => {
+    if (!name.startsWith('nx-dev')) return;
+
+    const deps = graph.dependencies[name];
+
+    deps.forEach((dep) => {
+      if (nrwlPlugins.includes(dep.target)) {
+        dep.target = `npm:@nrwl/${dep.target}`;
+      }
+    });
+  });
+
+  return graph;
+};

--- a/nx.json
+++ b/nx.json
@@ -38,6 +38,7 @@
     "libsDir": "",
     "appsDir": ""
   },
+  "plugins": ["./nx-dev/tools/nx-dev-plugin.js"],
   "projects": {
     "nx": {},
     "tao": {},


### PR DESCRIPTION
This PR removes nx.dev projects' dependencies to internal packages since they aren't being used. Instead, we remap them to their npm counterparts. 

e.g. `workspace -> npm:@nrwl/workspace`

This change removes the need to rebuild `nx-dev` unless the version has actually changed in `package.json`. Since our workspace setup is a special case, this is needed. :)