### PR TITLE
docs(core): fix internal package dependencies so nx.dev is not affected by their changes

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+nx-dev/**/jest.config.js

--- a/nx-dev/data-access-documents/jest.config.js
+++ b/nx-dev/data-access-documents/jest.config.js
@@ -1,6 +1,7 @@
 const nxPreset = require('@nrwl/jest/preset');
 module.exports = {
   ...nxPreset,
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   displayName: 'nx-dev-data-access-documents',
   globals: {
     'ts-jest': {

--- a/nx-dev/data-access-documents/src/lib/documents.api.spec.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.spec.ts
@@ -1,15 +1,21 @@
 import { DocumentsApi } from './documents.api';
 import type { DocumentMetadata } from './documents.models';
 import { join } from 'path';
-import { readJsonFile } from '@nrwl/workspace';
-import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
+import fs from 'fs';
 
-const archiveRootPath = join(appRootPath, 'nx-dev/nx-dev/public/documentation');
+const archiveRootPath = join(
+  process.env.WORKSPACE_ROOT,
+  'nx-dev/nx-dev/public/documentation'
+);
 const documentsCache = new Map<string, DocumentMetadata[]>([
   ['latest', readJsonFile(join(archiveRootPath, 'latest', 'map.json'))],
   ['previous', readJsonFile(join(archiveRootPath, 'previous', 'map.json'))],
 ]);
 const versionsData = readJsonFile(join(archiveRootPath, 'versions.json'));
+
+function readJsonFile(f) {
+  return JSON.parse(fs.readFileSync(f).toString());
+}
 
 describe('DocumentsApi', () => {
   const api = new DocumentsApi(versionsData, documentsCache);

--- a/nx-dev/data-access-documents/src/lib/documents.utils.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.utils.ts
@@ -1,11 +1,10 @@
 import { join } from 'path';
-import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
 
 export const archiveRootPath = join(
-  appRootPath,
+  process.env.WORKSPACE_ROOT,
   'nx-dev/nx-dev/public/documentation'
 );
-export const previewRootPath = join(appRootPath, 'docs');
+export const previewRootPath = join(process.env.WORKSPACE_ROOT, 'docs');
 
 export function extractTitle(markdownContent: string): string | null {
   return (

--- a/nx-dev/data-access-documents/src/lib/menu.api.spec.ts
+++ b/nx-dev/data-access-documents/src/lib/menu.api.spec.ts
@@ -4,15 +4,21 @@ import {
   DocumentsApi,
 } from '@nrwl/nx-dev/data-access-documents';
 import { join } from 'path';
-import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
-import { readJsonFile } from '@nrwl/workspace';
+import * as fs from 'fs';
 
-const archiveRootPath = join(appRootPath, 'nx-dev/nx-dev/public/documentation');
+const archiveRootPath = join(
+  process.env.WORKSPACE_ROOT,
+  'nx-dev/nx-dev/public/documentation'
+);
 const documentsCache = new Map<string, DocumentMetadata[]>([
   ['latest', readJsonFile(join(archiveRootPath, 'latest', 'map.json'))],
   ['previous', readJsonFile(join(archiveRootPath, 'previous', 'map.json'))],
 ]);
 const versionsData = readJsonFile(join(archiveRootPath, 'versions.json'));
+
+function readJsonFile(f) {
+  return JSON.parse(fs.readFileSync(f).toString());
+}
 
 describe('MenuApi', () => {
   const docsApi = new DocumentsApi(versionsData, documentsCache);

--- a/nx-dev/data-access-documents/src/test-setup.ts
+++ b/nx-dev/data-access-documents/src/test-setup.ts
@@ -1,0 +1,1 @@
+process.env.WORKSPACE_ROOT = process.cwd();

--- a/nx-dev/data-access-documents/tsconfig.lib.json
+++ b/nx-dev/data-access-documents/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "outDir": "../../dist/out-tsc",
-    "types": []
+    "types": ["node"]
   },
   "include": ["**/*.ts"],
   "exclude": ["**/*.spec.ts"]

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -1,4 +1,9 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { join } = require('path');
+// nx-ignore-next-line
 const withNx = require('@nrwl/next/plugins/with-nx');
 
-module.exports = withNx({});
+module.exports = withNx({
+  env: {
+    WORKSPACE_ROOT: join(__dirname, '../..'),
+  },
+});

--- a/nx-dev/nx-dev/pages/api/preview-asset.ts
+++ b/nx-dev/nx-dev/pages/api/preview-asset.ts
@@ -1,11 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { join } from 'path';
-import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
 
 import * as send from 'send';
 
 // Repeated here since `data-access-documents` isn't available at runtime.
-const previewRootPath = join(appRootPath, 'docs');
+const previewRootPath = join(process.env.WORKSPACE_ROOT, 'docs');
 
 export default function (req: NextApiRequest, res: NextApiResponse) {
   return new Promise<void>((resolve) => {

--- a/nx-dev/nx-dev/tailwind.config.js
+++ b/nx-dev/nx-dev/tailwind.config.js
@@ -1,5 +1,7 @@
 const path = require('path');
+// nx-ignore-next-line
 const nxJson = require('@nrwl/workspace').readNxJson();
+// nx-ignore-next-line
 const workspaceJson = require('@nrwl/workspace').readWorkspaceJson();
 
 function getProjectNameWithTag(projectsJson, tag) {

--- a/nx.json
+++ b/nx.json
@@ -119,7 +119,8 @@
       "tags": ["core"]
     },
     "nx-dev": {
-      "tags": ["scope:nx-dev", "type:app"]
+      "tags": ["scope:nx-dev", "type:app"],
+      "implicitDependencies": ["docs"]
     },
     "nx-dev-e2e": {
       "tags": ["scope:nx-dev", "type:e2e"],
@@ -134,7 +135,8 @@
     "nx-dev-data-access-documents": {
       "tags": ["scope:nx-dev", "type:data-access"]
     },
-    "nx-dev-feature-search": { "tags": ["scope:nx-dev", "type:feature"] }
+    "nx-dev-feature-search": { "tags": ["scope:nx-dev", "type:feature"] },
+    "docs": { "tags": ["scope:nx-dev"] }
   },
   "affected": { "defaultBase": "master" }
 }

--- a/workspace.json
+++ b/workspace.json
@@ -2369,6 +2369,11 @@
           }
         }
       }
+    },
+    "docs": {
+      "root": "docs",
+      "sourceRoot": "docs",
+      "projectType": "library"
     }
   },
   "cli": {


### PR DESCRIPTION
This PR cleans up the dependencies of nx.dev projects so they are not affected by changes to internal packages.

<img width="1497" alt="Screen Shot 2021-06-03 at 1 41 37 PM" src="https://user-images.githubusercontent.com/53559/120688966-9845ec80-c471-11eb-9c52-65b5d0b54fb1.png">
