### PR TITLE
fix(core): add support for formatting using all extensions prettier supports

### DIFF
--- a/dep-graph/dep-graph/tsconfig.app.json
+++ b/dep-graph/dep-graph/tsconfig.app.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "types": ["node"],
-    "lib": ["DOM"]
+    "lib": ["DOM", "es2019"]
   },
   "exclude": ["**/*.spec.ts"],
   "include": ["**/*.ts"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,7 @@
     "emitDecoratorMetadata": true,
     "skipLibCheck": true,
     "types": ["node", "jest"],
-    "lib": ["es2018"],
+    "lib": ["es2019"],
     "declaration": true,
     "resolveJsonModule": true,
     "baseUrl": ".",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`nx format` currently has a list of whitelisted extensions to use for formatting. There are some extensions Prettier currently supports that are not on the list and therefore those files don't get processed when using `nx format`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Keeping a list of whitelisted extensions in sync with what Prettier supports is not desirable. We should instead use Prettier API to gather which extensions are supported by it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4702
