### PR TITLE
fix(angular): override TSLint deprecation message to point to Nx ESLint conversion generator

### DIFF
--- a/docs/angular/api-angular/generators/convert-tslint-to-eslint.md
+++ b/docs/angular/api-angular/generators/convert-tslint-to-eslint.md
@@ -24,10 +24,22 @@ nx g convert-tslint-to-eslint ... --dry-run
 
 ### Examples
 
-Convert the Angular project `myapp` from TSLint to ESLint:
+The following will first configure the project, `myapp`, the same way a _new_ project is configured i.e. It will use Nx's new recommended ESLint config. By default, this also adds the existing TSLint configuration on top of the default ESLint config from Nx to continue checking what it checks today. This is done by migrating TSLint rules to their equivalent ESLint rules to the best of its abilities. Some TSLint rules may not have ESLint equivalents and will be reported during the conversion:
 
 ```bash
 nx g convert-tslint-to-eslint myapp
+```
+
+If your TSLint config isn't extremely important to you, ignoring it makes this process more deterministic. Unlike the prior example, this will discard the existing TSLint configuration, meaning that the project will only have the Nx's latest recommended ESLint configuration which may be good enough for some workspaces:
+
+```bash
+nx g convert-tslint-to-eslint myapp --ignoreExistingTslintConfig=true
+```
+
+By default, this process removes the TSLint related dependencies and configuration once no more projects use TSLint. This can be disabled with the following flag to keep TSLint related dependencies and configuration in the repo:
+
+```bash
+nx g convert-tslint-to-eslint myapp --removeTSLintIfNoMoreTSLintTargets=false
 ```
 
 ## Options

--- a/docs/node/api-angular/generators/convert-tslint-to-eslint.md
+++ b/docs/node/api-angular/generators/convert-tslint-to-eslint.md
@@ -24,10 +24,22 @@ nx g convert-tslint-to-eslint ... --dry-run
 
 ### Examples
 
-Convert the Angular project `myapp` from TSLint to ESLint:
+The following will first configure the project, `myapp`, the same way a _new_ project is configured i.e. It will use Nx's new recommended ESLint config. By default, this also adds the existing TSLint configuration on top of the default ESLint config from Nx to continue checking what it checks today. This is done by migrating TSLint rules to their equivalent ESLint rules to the best of its abilities. Some TSLint rules may not have ESLint equivalents and will be reported during the conversion:
 
 ```bash
 nx g convert-tslint-to-eslint myapp
+```
+
+If your TSLint config isn't extremely important to you, ignoring it makes this process more deterministic. Unlike the prior example, this will discard the existing TSLint configuration, meaning that the project will only have the Nx's latest recommended ESLint configuration which may be good enough for some workspaces:
+
+```bash
+nx g convert-tslint-to-eslint myapp --ignoreExistingTslintConfig=true
+```
+
+By default, this process removes the TSLint related dependencies and configuration once no more projects use TSLint. This can be disabled with the following flag to keep TSLint related dependencies and configuration in the repo:
+
+```bash
+nx g convert-tslint-to-eslint myapp --removeTSLintIfNoMoreTSLintTargets=false
 ```
 
 ## Options

--- a/docs/react/api-angular/generators/convert-tslint-to-eslint.md
+++ b/docs/react/api-angular/generators/convert-tslint-to-eslint.md
@@ -24,10 +24,22 @@ nx g convert-tslint-to-eslint ... --dry-run
 
 ### Examples
 
-Convert the Angular project `myapp` from TSLint to ESLint:
+The following will first configure the project, `myapp`, the same way a _new_ project is configured i.e. It will use Nx's new recommended ESLint config. By default, this also adds the existing TSLint configuration on top of the default ESLint config from Nx to continue checking what it checks today. This is done by migrating TSLint rules to their equivalent ESLint rules to the best of its abilities. Some TSLint rules may not have ESLint equivalents and will be reported during the conversion:
 
 ```bash
 nx g convert-tslint-to-eslint myapp
+```
+
+If your TSLint config isn't extremely important to you, ignoring it makes this process more deterministic. Unlike the prior example, this will discard the existing TSLint configuration, meaning that the project will only have the Nx's latest recommended ESLint configuration which may be good enough for some workspaces:
+
+```bash
+nx g convert-tslint-to-eslint myapp --ignoreExistingTslintConfig=true
+```
+
+By default, this process removes the TSLint related dependencies and configuration once no more projects use TSLint. This can be disabled with the following flag to keep TSLint related dependencies and configuration in the repo:
+
+```bash
+nx g convert-tslint-to-eslint myapp --removeTSLintIfNoMoreTSLintTargets=false
 ```
 
 ## Options

--- a/packages/angular/src/generators/convert-tslint-to-eslint/schema.json
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/schema.json
@@ -1,13 +1,21 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "$id": "angular-convert-tslint-to-eslint",
+  "$id": "NxAngularConvertTSLintToESLintGenerator",
   "cli": "nx",
   "title": "Convert an Angular project from TSLint to ESLint",
   "description": "NOTE: Does not work in --dry-run mode",
   "examples": [
     {
       "command": "g convert-tslint-to-eslint myapp",
-      "description": "Convert the Angular project `myapp` from TSLint to ESLint"
+      "description": "The following will first configure the project, `myapp`, the same way a _new_ project is configured i.e. It will use Nx's new recommended ESLint config. By default, this also adds the existing TSLint configuration on top of the default ESLint config from Nx to continue checking what it checks today. This is done by migrating TSLint rules to their equivalent ESLint rules to the best of its abilities. Some TSLint rules may not have ESLint equivalents and will be reported during the conversion"
+    },
+    {
+      "command": "g convert-tslint-to-eslint myapp --ignoreExistingTslintConfig=true",
+      "description": "If your TSLint config isn't extremely important to you, ignoring it makes this process more deterministic. Unlike the prior example, this will discard the existing TSLint configuration, meaning that the project will only have the Nx's latest recommended ESLint configuration which may be good enough for some workspaces"
+    },
+    {
+      "command": "g convert-tslint-to-eslint myapp --removeTSLintIfNoMoreTSLintTargets=false",
+      "description": "By default, this process removes the TSLint related dependencies and configuration once no more projects use TSLint. This can be disabled with the following flag to keep TSLint related dependencies and configuration in the repo"
     }
   ],
   "type": "object",

--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -36,6 +36,7 @@ export async function scheduleTarget(
     target: string;
     configuration: string;
     runOptions: any;
+    executor: string;
   },
   verbose: boolean
 ): Promise<Observable<import('@angular-devkit/architect').BuilderOutput>> {
@@ -44,7 +45,7 @@ export async function scheduleTarget(
     WorkspaceNodeModulesArchitectHost,
   } = require('@angular-devkit/architect/node');
 
-  const logger = getLogger(verbose);
+  const logger = getTargetLogger(opts.executor, verbose);
   const fsHost = new NxScopedHost(normalize(root));
   const { workspace } = await workspaces.readWorkspace(
     workspaceConfigName(root),
@@ -842,25 +843,66 @@ export async function invokeNew(
 }
 
 let logger: logging.Logger;
-export const getLogger = (isVerbose = false): any => {
+
+const loggerColors: Partial<Record<logging.LogLevel, (s: string) => string>> = {
+  warn: (s) => chalk.bold(chalk.yellow(s)),
+  error: (s) => {
+    if (s.startsWith('NX ')) {
+      return `\n${NX_ERROR} ${chalk.bold(chalk.red(s.substr(3)))}\n`;
+    }
+
+    return chalk.bold(chalk.red(s));
+  },
+  info: (s) => {
+    if (s.startsWith('NX ')) {
+      return `\n${NX_PREFIX} ${chalk.bold(s.substr(3))}\n`;
+    }
+
+    return chalk.white(s);
+  },
+};
+
+export const getLogger = (isVerbose = false): logging.Logger => {
   if (!logger) {
-    logger = createConsoleLogger(isVerbose, process.stdout, process.stderr, {
-      warn: (s) => chalk.bold(chalk.yellow(s)),
-      error: (s) => {
-        if (s.startsWith('NX ')) {
-          return `\n${NX_ERROR} ${chalk.bold(chalk.red(s.substr(3)))}\n`;
-        }
-
-        return chalk.bold(chalk.red(s));
-      },
-      info: (s) => {
-        if (s.startsWith('NX ')) {
-          return `\n${NX_PREFIX} ${chalk.bold(s.substr(3))}\n`;
-        }
-
-        return chalk.white(s);
-      },
-    });
+    logger = createConsoleLogger(
+      isVerbose,
+      process.stdout,
+      process.stderr,
+      loggerColors
+    );
   }
   return logger;
+};
+
+const getTargetLogger = (
+  executor: string,
+  isVerbose = false
+): logging.Logger => {
+  if (executor !== '@angular-devkit/build-angular:tslint') {
+    return getLogger(isVerbose);
+  }
+
+  const tslintExecutorLogger = createConsoleLogger(
+    isVerbose,
+    process.stdout,
+    process.stderr,
+    {
+      ...loggerColors,
+      warn: (s) => {
+        if (
+          s.startsWith(
+            `TSLint's support is discontinued and we're deprecating its support in Angular CLI.`
+          )
+        ) {
+          s =
+            `TSLint's support is discontinued and the @angular-devkit/build-angular:tslint executor is deprecated.\n` +
+            'To start using a modern linter tool, please consider replacing TSLint with ESLint. ' +
+            'You can use the "@nrwl/angular:convert-tslint-to-eslint" generator to automatically convert your projects.\n' +
+            'For more info, visit https://nx.dev/latest/angular/angular/convert-tslint-to-eslint.';
+        }
+        return chalk.bold(chalk.yellow(s));
+      },
+    }
+  );
+  return tslintExecutorLogger;
 };

--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -252,6 +252,7 @@ async function runExecutorInternal<T extends { success: boolean }>(
         target,
         configuration,
         runOptions: combinedOptions,
+        executor: targetConfig.executor,
       },
       isVerbose
     );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running a target using the `@angular-devkit/build-angular:tslint` executor, it prints a warning about TSLint deprecation. The message points to docs on how to migrate from an Angular CLI project with TSLint to ESLint.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The TSLint deprecation message should recommend to convert the project to ESLint using the `@nrwl/angular:convert-tslint-to-eslint` generator.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5749 
