### PR TITLE
feat(nextjs): improve WithNxOptions typing

### DIFF
--- a/docs/react/guides/nextjs-webpack5.md
+++ b/docs/react/guides/nextjs-webpack5.md
@@ -8,9 +8,14 @@ Next.js applications within an Nx workspace are generated with a `next.config.js
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const withNx = require('@nrwl/next/plugins/with-nx');
 
-module.exports = withNx({
+/**
+ * @type {import('@nrwl/next/plugins/with-nx').WithNxOptions}
+ **/
+const nextConfig = {
   future: {
     webpack5: true,
   },
-});
+};
+
+module.exports = withNx(nextConfig);
 ```

--- a/docs/react/guides/nextjs.md
+++ b/docs/react/guides/nextjs.md
@@ -157,7 +157,12 @@ Let's continue to use our `tuskdesk` example from above, and so we need to check
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const withNx = require('@nrwl/next/plugins/with-nx');
 
-module.exports = withNx({});
+/**
+ * @type {import('@nrwl/next/plugins/with-nx').WithNxOptions}
+ **/
+const nextConfig = {};
+
+module.exports = withNx(nextConfig);
 ```
 
 If you have a config which looks like that (leveraging the `withNx()` config plugin) **AND** the version of Nx you are using is `11.1.0` or later, **no further action is needed** in your config.
@@ -180,10 +185,15 @@ E.g.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const withNx = require('@nrwl/next/plugins/with-nx');
 
-module.exports = withNx({
+/**
+ * @type {import('@nrwl/next/plugins/with-nx').WithNxOptions}
+ **/
+const nextConfig = {
   target: 'experimental-serverless-trace',
   // ...You can of course have other Next.js config options specified here too, but the "target" is critical for Vercel deployments...
-});
+};
+
+module.exports = withNx(nextConfig);
 ```
 
 OR

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -1,12 +1,12 @@
+import type { NextConfig } from 'next/dist/next-server/server/config';
 import { WebpackConfigOptions } from '../src/utils/types';
 
 const { join } = require('path');
 const { appRootPath } = require('@nrwl/workspace/src/utilities/app-root');
 const { workspaceLayout } = require('@nrwl/workspace/src/core/file-utils');
 
-export interface WithNxOptions {
+export interface WithNxOptions extends NextConfig {
   nx?: WebpackConfigOptions;
-  [key: string]: any;
 }
 
 function regexEqual(x, y) {

--- a/packages/next/src/generators/application/files/next.config.js__tmpl__
+++ b/packages/next/src/generators/application/files/next.config.js__tmpl__
@@ -3,48 +3,70 @@ const withNx = require('@nrwl/next/plugins/with-nx');
 
 <% if (style === 'less') { %>
 const withLess = require('@zeit/next-less');
-module.exports = withLess(withNx({
+
+/**
+ * @type {import('@nrwl/next/plugins/with-nx').WithNxOptions}
+ **/
+const nextConfig = {
   nx: {
-    // Set this to false if you do not want to use SVGR 
+    // Set this to false if you do not want to use SVGR
     // See: https://github.com/gregberge/svgr
     svgr: true,
   },
   // Set this to true if you use CSS modules.
   // See: https://github.com/css-modules/css-modules
   cssModules: false
-}));
+};
+
+module.exports = withLess(withNx(nextConfig));
 <% } else if (style === 'styl') { %>
 const withStylus = require('@zeit/next-stylus');
-module.exports = withStylus(withNx({
+
+/**
+ * @type {import('@nrwl/next/plugins/with-nx').WithNxOptions}
+ **/
+const nextConfig = {
   nx: {
-    // Set this to false if you do not want to use SVGR 
+    // Set this to false if you do not want to use SVGR
     // See: https://github.com/gregberge/svgr
     svgr: true,
   },
   // Set this to true if you use CSS modules.
   // See: https://github.com/css-modules/css-modules
   cssModules: false
-}));
+};
+
+module.exports = withStylus(withNx(nextConfig));
 <% } else if (
   style === 'styled-components'
   ||style === '@emotion/styled'
   || style === 'styled-jsx'
   || style === 'none'
 ) { %>
-module.exports = withNx({
+/**
+ * @type {import('@nrwl/next/plugins/with-nx').WithNxOptions}
+ **/
+const nextConfig = {
   nx: {
-    // Set this to false if you do not want to use SVGR 
+    // Set this to false if you do not want to use SVGR
     // See: https://github.com/gregberge/svgr
     svgr: true,
   },
-});
+};
+
+module.exports = withNx(nextConfig);
 <% } else {
 // Defaults to CSS/SASS (which don't need plugin as of Next 9.3) %>
-module.exports = withNx({
+/**
+ * @type {import('@nrwl/next/plugins/with-nx').WithNxOptions}
+ **/
+const nextConfig = {
   nx: {
-    // Set this to false if you do not want to use SVGR 
+    // Set this to false if you do not want to use SVGR
     // See: https://github.com/gregberge/svgr
     svgr: true,
   },
-});
+};
+
+module.exports = withNx(nextConfig);
 <% } %>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`WithNxOptions` does not extend `NextConfig`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
```ts
import type { NextConfig } from 'next/dist/next-server/server/config';
import { WebpackConfigOptions } from '../src/utils/types';

export interface WithNxOptions extends NextConfig {
  nx?: WebpackConfigOptions;
}
```

```js
// eslint-disable-next-line @typescript-eslint/no-var-requires
const withNx = require('@nrwl/next/plugins/with-nx');

/**
 * @type {import('@nrwl/next/plugins/with-nx').WithNxOptions}
 **/
const nextConfig = {
  nx: {
    // Set this to false if you do not want to use SVGR
    // See: https://github.com/gregberge/svgr
    svgr: true,
  }
};

module.exports = withNx(nextConfig);
```
![image](https://user-images.githubusercontent.com/2607019/123125512-890bfa80-d483-11eb-8ad3-b43a059f24c0.png)

<!-- ![image](https://user-images.githubusercontent.com/2607019/120891698-d9422a80-c644-11eb-8d59-0d6af12d6f6a.png) -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#5665
