### PR TITLE
fix(testing): fix buffer issue on e2e test

### DIFF
--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -328,6 +328,8 @@ export function runCLI(
     let r = execSync(`${pm.runNx} ${command}`, {
       cwd: opts.cwd || tmpProjPath(),
       env: { ...(opts.env || process.env), NX_INVOKED_BY_RUNNER: undefined },
+      encoding: 'utf8',
+      maxBuffer: 50 * 1024 * 1024,
     }).toString();
     r = r.replace(
       /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Some tests fail due to buffer overflow. `execSync` uses rather small buffer for gathering output. Running some complex tasks can span over the size of this buffer.
<!-- This is the behavior we have today -->

## Expected Behavior
Command outputs of normal size should not overflow buffer
<!-- This is the behavior we should expect with the changes in this PR -->

Fixes:
Nightly build
