### PR TITLE
fix(core): fix remove generator for custom layout

### DIFF
--- a/packages/workspace/src/generators/remove/lib/update-tsconfig.ts
+++ b/packages/workspace/src/generators/remove/lib/update-tsconfig.ts
@@ -16,13 +16,17 @@ export function updateTsconfig(
   schema: Schema,
   project: ProjectConfiguration
 ) {
-  const { npmScope } = getWorkspaceLayout(tree);
+  const { appsDir, libsDir, npmScope } = getWorkspaceLayout(tree);
 
   const tsConfigPath = 'tsconfig.base.json';
   if (tree.exists(tsConfigPath)) {
     updateJson(tree, tsConfigPath, (json) => {
       delete json.compilerOptions.paths[
-        `@${npmScope}/${project.root.substr(5)}`
+        `@${npmScope}/${project.root.substr(
+          project.projectType === 'application'
+            ? appsDir.length + 1
+            : libsDir.length + 1
+        )}`
       ];
 
       return json;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`nx generate @nrwl/workspace:remove` removes the `paths` from `tsconfig.base.json` only when the workspace uses the default layout (`apps/` and `libs/`).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `remove` generator should support custom layout.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5910
