### PR TITLE
feat(repo): remove obsolete kill commands and check if ports closed

### DIFF
--- a/e2e/angular/src/angular-core.test.ts
+++ b/e2e/angular/src/angular-core.test.ts
@@ -19,7 +19,6 @@ describe('Angular Package', () => {
   let proj: string;
 
   beforeEach(() => (proj = newProject()));
-
   afterEach(() => removeProject({ onlyOnCI: true }));
 
   // TODO: npm build is failing for Angular because of webpack 4

--- a/e2e/angular/src/config-compat.test.ts
+++ b/e2e/angular/src/config-compat.test.ts
@@ -13,7 +13,6 @@ import {
 
 describe('new config format', () => {
   beforeEach(() => newProject());
-
   afterEach(() => removeProject({ onlyOnCI: true }));
 
   it('should work', async () => {

--- a/e2e/angular/src/ngrx.test.ts
+++ b/e2e/angular/src/ngrx.test.ts
@@ -11,8 +11,7 @@ import {
 // TODO: Uncomment when the node is migrated to webpack 5
 xdescribe('ngrx', () => {
   beforeEach(() => newProject());
-
-  afterEach(() => removeProject({ onlyOnCI: true }));
+  afterAll(() => removeProject({ onlyOnCI: true }));
 
   it('should work', async () => {
     const myapp = uniq('myapp');

--- a/e2e/angular/src/storybook.test.ts
+++ b/e2e/angular/src/storybook.test.ts
@@ -187,7 +187,7 @@ describe('Storybook schematics', () => {
       expect(readFile(`dist/storybook/${myAngularLib}/index.html`)).toContain(
         `<title>Storybook</title>`
       );
-      await killPorts();
+      expect(await killPorts()).toBeTruthy();
     }, 1000000);
 
     xit('should build an Angular based storybook', () => {

--- a/e2e/angular/src/storybook.test.ts
+++ b/e2e/angular/src/storybook.test.ts
@@ -2,11 +2,11 @@ process.env.SELECTED_CLI = 'angular';
 
 import {
   checkFilesExist,
+  killPorts,
   newProject,
   readFile,
   removeProject,
   runCLI,
-  runCypressTests,
   tmpProjPath,
   uniq,
 } from '@nrwl/e2e/utils';
@@ -16,8 +16,7 @@ describe('Storybook schematics', () => {
   let proj: string;
 
   beforeEach(() => (proj = newProject()));
-
-  afterEach(() => removeProject({ onlyOnCI: true }));
+  afterAll(() => removeProject({ onlyOnCI: true }));
 
   it('should not overwrite global storybook config files', () => {
     const angularStorybookLib = uniq('test-ui-lib-angular');
@@ -56,7 +55,7 @@ describe('Storybook schematics', () => {
   });
 
   describe('build storybook', () => {
-    it('should execute e2e tests using Cypress running against Storybook', () => {
+    it('should execute e2e tests using Cypress running against Storybook', async () => {
       const myapp = uniq('myapp');
       runCLI(`generate @nrwl/angular:app ${myapp} --no-interactive`);
 
@@ -178,11 +177,9 @@ describe('Storybook schematics', () => {
         `
       );
 
-      if (runCypressTests()) {
-        expect(runCLI(`run ${myAngularLib}-e2e:e2e --no-watch`)).toContain(
-          'All specs passed!'
-        );
-      }
+      expect(runCLI(`run ${myAngularLib}-e2e:e2e --no-watch`)).toContain(
+        'All specs passed!'
+      );
 
       runCLI(`run ${myAngularLib}:build-storybook`);
 
@@ -190,6 +187,7 @@ describe('Storybook schematics', () => {
       expect(readFile(`dist/storybook/${myAngularLib}/index.html`)).toContain(
         `<title>Storybook</title>`
       );
+      await killPorts();
     }, 1000000);
 
     xit('should build an Angular based storybook', () => {

--- a/e2e/cli/src/cli.test.ts
+++ b/e2e/cli/src/cli.test.ts
@@ -1,7 +1,6 @@
 import { packagesWeCareAbout } from '@nrwl/workspace/src/command-line/report';
 import { renameSync } from 'fs';
 import {
-  killPorts,
   newProject,
   readFile,
   readJson,
@@ -14,10 +13,9 @@ import {
 } from '@nrwl/e2e/utils';
 
 describe('Cli', () => {
-  afterEach(() => killPorts());
+  beforeEach(() => newProject());
 
   it('should execute long running tasks', () => {
-    newProject();
     const myapp = uniq('myapp');
     runCLI(`generate @nrwl/web:app ${myapp}`);
 
@@ -40,7 +38,6 @@ describe('Cli', () => {
   });
 
   it('should run npm scripts', async () => {
-    newProject();
     const mylib = uniq('mylib');
     runCLI(`generate @nrwl/node:lib ${mylib}`);
 
@@ -65,7 +62,6 @@ describe('Cli', () => {
   }, 1000000);
 
   it('should show help', async () => {
-    newProject();
     const myapp = uniq('myapp');
     runCLI(`generate @nrwl/web:app ${myapp}`);
 
@@ -94,8 +90,9 @@ describe('Cli', () => {
 });
 
 describe('report', () => {
+  beforeEach(() => newProject());
+
   it(`should report package versions`, async () => {
-    newProject();
     const reportOutput = runCLI('report');
 
     packagesWeCareAbout.forEach((p) => {
@@ -105,9 +102,7 @@ describe('report', () => {
 });
 
 describe('list', () => {
-  beforeEach(() => {
-    newProject();
-  });
+  beforeEach(() => newProject());
 
   it(`should work`, async () => {
     let listOutput = runCLI('list');
@@ -162,9 +157,9 @@ describe('list', () => {
 });
 
 describe('migrate', () => {
-  it('should run migrations', () => {
-    newProject();
+  beforeEach(() => newProject());
 
+  it('should run migrations', () => {
     updateFile(
       `./node_modules/migrate-parent-package/package.json`,
       JSON.stringify({

--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -5,14 +5,11 @@ import {
   readFile,
   readJson,
   runCLI,
-  runCypressTests,
   uniq,
   updateFile,
 } from '@nrwl/e2e/utils';
 
 describe('Cypress E2E Test runner', () => {
-  afterEach(() => killPorts());
-
   describe('project scaffolding', () => {
     it('should generate an app with the Cypress as e2e test runner', () => {
       newProject();
@@ -38,32 +35,32 @@ describe('Cypress E2E Test runner', () => {
     }, 1000000);
   });
 
-  if (runCypressTests()) {
-    describe('running Cypress', () => {
-      it('should execute e2e tests using Cypress', () => {
-        newProject();
-        const myapp = uniq('myapp');
-        runCLI(
-          `generate @nrwl/react:app ${myapp} --e2eTestRunner=cypress --linter=eslint`
-        );
+  describe('running Cypress', () => {
+    afterEach(() => killPorts());
 
-        expect(runCLI(`e2e ${myapp}-e2e --headless --no-watch`)).toContain(
-          'All specs passed!'
-        );
+    it('should execute e2e tests using Cypress', () => {
+      newProject();
+      const myapp = uniq('myapp');
+      runCLI(
+        `generate @nrwl/react:app ${myapp} --e2eTestRunner=cypress --linter=eslint`
+      );
 
-        const originalContents = JSON.parse(
-          readFile(`apps/${myapp}-e2e/cypress.json`)
-        );
-        delete originalContents.fixturesFolder;
-        updateFile(
-          `apps/${myapp}-e2e/cypress.json`,
-          JSON.stringify(originalContents)
-        );
+      expect(runCLI(`e2e ${myapp}-e2e --headless --no-watch`)).toContain(
+        'All specs passed!'
+      );
 
-        expect(runCLI(`e2e ${myapp}-e2e --headless --no-watch`)).toContain(
-          'All specs passed!'
-        );
-      }, 1000000);
-    });
-  }
+      const originalContents = JSON.parse(
+        readFile(`apps/${myapp}-e2e/cypress.json`)
+      );
+      delete originalContents.fixturesFolder;
+      updateFile(
+        `apps/${myapp}-e2e/cypress.json`,
+        JSON.stringify(originalContents)
+      );
+
+      expect(runCLI(`e2e ${myapp}-e2e --headless --no-watch`)).toContain(
+        'All specs passed!'
+      );
+    }, 1000000);
+  });
 });

--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -59,7 +59,7 @@ describe('Cypress E2E Test runner', () => {
       expect(runCLI(`e2e ${myapp}-e2e --headless --no-watch`)).toContain(
         'All specs passed!'
       );
-      await killPorts();
+      expect(await killPorts()).toBeTruthy();
     }, 1000000);
   });
 });

--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -36,9 +36,7 @@ describe('Cypress E2E Test runner', () => {
   });
 
   describe('running Cypress', () => {
-    afterEach(() => killPorts());
-
-    it('should execute e2e tests using Cypress', () => {
+    it('should execute e2e tests using Cypress', async () => {
       newProject();
       const myapp = uniq('myapp');
       runCLI(
@@ -61,6 +59,7 @@ describe('Cypress E2E Test runner', () => {
       expect(runCLI(`e2e ${myapp}-e2e --headless --no-watch`)).toContain(
         'All specs passed!'
       );
+      await killPorts();
     }, 1000000);
   });
 });

--- a/e2e/gatsby/src/gatsby.test.ts
+++ b/e2e/gatsby/src/gatsby.test.ts
@@ -12,7 +12,6 @@ describe('Gatsby Applications', () => {
   let proj: string;
 
   beforeEach(() => (proj = newProject()));
-  afterEach(() => killPorts());
 
   it('should generate a valid gatsby application', async () => {
     const appName = uniq('app');
@@ -57,7 +56,7 @@ describe('Gatsby Applications', () => {
     expect(result).not.toMatch('Lint errors found in the listed files');
 
     await expect(runCLIAsync(`test ${appName}`)).resolves.toBeTruthy();
-  }, 120000);
+  }, 300000);
 
   it('should support --js option', async () => {
     const app = uniq('app');

--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -1,6 +1,5 @@
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import {
-  killPorts,
   newProject,
   runCLI,
   runCLIAsync,
@@ -10,7 +9,6 @@ import {
 
 describe('Jest', () => {
   beforeEach(() => newProject());
-  afterEach(() => killPorts());
 
   it('should be able test projects using jest', async () => {
     const mylib = uniq('mylib');

--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import {
   checkFilesExist,
-  killPorts,
   newProject,
   readFile,
   readJson,
@@ -11,8 +10,6 @@ import {
 } from '@nrwl/e2e/utils';
 
 describe('Linter', () => {
-  afterEach(() => killPorts());
-
   it('linting should error when rules are not followed', () => {
     newProject();
     const myapp = uniq('myapp');

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -235,14 +235,14 @@ describe('Next.js Applications', () => {
           import { testFn } from '@${proj}/${tsLibName}';
           import { TestComponent } from '@${proj}/${tsxLibName}';\n\n
           ${content.replace(
-        `</h2>`,
-        `</h2>
+            `</h2>`,
+            `</h2>
                 <div>
                   {testFn()}
                   <TestComponent text="Hello Next.JS" />
                 </div>
               `
-      )}`
+          )}`
     );
 
     const e2eTestPath = `apps/${appName}-e2e/src/integration/app.spec.ts`;
@@ -250,13 +250,14 @@ describe('Next.js Applications', () => {
     updateFile(
       e2eTestPath,
       `
-        ${e2eContent +
-      `
+        ${
+          e2eContent +
+          `
           it('should successfully call async API route', () => {
             cy.request('/api/hello').its('body').should('include', 'hell0');
           });
           `
-      }
+        }
       `
     );
 

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -1,4 +1,4 @@
-import { output, stringUtils } from '@nrwl/workspace';
+import { stringUtils } from '@nrwl/workspace';
 import {
   checkFilesExist,
   createFile,
@@ -23,8 +23,6 @@ describe('Next.js Applications', () => {
   it('should be able to serve with a proxy configuration', async () => {
     const appName = uniq('app');
     const port = 4202;
-
-    output.success({ title: `Next proxy configuration ${appName}` });
 
     runCLI(`generate @nrwl/next:app ${appName}`);
 
@@ -85,8 +83,6 @@ describe('Next.js Applications', () => {
   it('should be able to consume a react libs (buildable and non-buildable)', async () => {
     const appName = uniq('app');
 
-    output.success({ title: `Next buildable react libs ${appName}` });
-
     const buildableLibName = uniq('lib');
     const nonBuildableLibName = uniq('lib');
 
@@ -142,8 +138,6 @@ describe('Next.js Applications', () => {
     const appName = uniq('app');
     const libName = uniq('lib');
 
-    output.success({ title: `Next dynamically load libs ${appName}` });
-
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive`);
     runCLI(`generate @nrwl/react:lib ${libName} --no-interactive --style=none`);
 
@@ -169,8 +163,6 @@ describe('Next.js Applications', () => {
 
   it('should compile when using a workspace and react lib written in TypeScript', async () => {
     const appName = uniq('app');
-
-    output.success({ title: `Next compile lib in typescript ${appName}` });
 
     const tsLibName = uniq('tslib');
     const tsxLibName = uniq('tsxlib');
@@ -275,8 +267,6 @@ describe('Next.js Applications', () => {
   it('should support Less', async () => {
     const appName = uniq('app');
 
-    output.success({ title: `Next support less ${appName}` });
-
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive --style=less`);
 
     await checkApp(appName, {
@@ -289,8 +279,6 @@ describe('Next.js Applications', () => {
   it('should support Stylus', async () => {
     const appName = uniq('app');
 
-    output.success({ title: `Next support stylus ${appName}` });
-
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive --style=styl`);
 
     await checkApp(appName, {
@@ -302,8 +290,6 @@ describe('Next.js Applications', () => {
 
   it('should support --style=styled-components', async () => {
     const appName = uniq('app');
-
-    output.success({ title: `Next support styled components ${appName}` });
 
     runCLI(
       `generate @nrwl/next:app ${appName} --no-interactive --style=styled-components`
@@ -319,8 +305,6 @@ describe('Next.js Applications', () => {
   it('should support --style=@emotion/styled', async () => {
     const appName = uniq('app');
 
-    output.success({ title: `Next support @emotion ${appName}` });
-
     runCLI(
       `generate @nrwl/next:app ${appName} --no-interactive --style=@emotion/styled`
     );
@@ -334,8 +318,6 @@ describe('Next.js Applications', () => {
 
   it('should build with public folder', async () => {
     const appName = uniq('app');
-
-    output.success({ title: `Next build with public folder ${appName}` });
 
     runCLI(
       `generate @nrwl/next:app ${appName} --no-interactive --style=@emotion/styled`
@@ -368,8 +350,6 @@ describe('Next.js Applications', () => {
   it('should build with a next.config.js file in the dist folder', async () => {
     const appName = uniq('app');
 
-    output.success({ title: `Next build with next config ${appName}` });
-
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive --style=css`);
 
     updateFile(
@@ -399,8 +379,6 @@ describe('Next.js Applications', () => {
   it('should support --js flag', async () => {
     const appName = uniq('app');
 
-    output.success({ title: `Next support js flag ${appName}` });
-
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive --js`);
 
     checkFilesExist(`apps/${appName}/pages/index.js`);
@@ -414,8 +392,6 @@ describe('Next.js Applications', () => {
 
   it('should fail the build when TS errors are present', async () => {
     const appName = uniq('app');
-
-    output.success({ title: `Next fail with TS errors ${appName}` });
 
     runCLI(
       `generate @nrwl/next:app ${appName} --no-interactive --style=@emotion/styled`
@@ -444,8 +420,6 @@ describe('Next.js Applications', () => {
   it('should be able to consume a react lib written in JavaScript', async () => {
     const appName = uniq('app');
     const libName = uniq('lib');
-
-    output.success({ title: `Next consume JS lib ${appName}` });
 
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive`);
 
@@ -584,8 +558,6 @@ describe('Next.js Applications', () => {
   it('should allow using a custom server implementation in TypeScript', async () => {
     const appName = uniq('app');
     const port = 4201;
-
-    output.success({ title: `Next typescript implementation ${appName}` });
 
     // generate next.js app
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive`);

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -36,19 +36,6 @@ describe('Next.js Applications', () => {
     updateFile(`apps/${appName}/proxy.conf.json`, JSON.stringify(proxyConf));
 
     updateFile(
-      `apps/${appName}-e2e/src/integration/app.spec.ts`,
-      `
-        describe('next-app', () => {
-          beforeEach(() => cy.visit('/'));
-
-          it('should ', () => {
-            cy.get('h1').contains('Hello Next.js!');
-          });
-        });
-        `
-    );
-
-    updateFile(
       `apps/${appName}/pages/index.tsx`,
       `
         import React, { useEffect, useState } from 'react';
@@ -79,7 +66,7 @@ describe('Next.js Applications', () => {
 
     // serve Next.js
     const p = await runCommandUntil(`run ${appName}:serve`, (output) => {
-      return output.indexOf('custom typescript server running') > -1;
+      return output.indexOf('[ ready ] on http://localhost:4200') > -1;
     });
 
     const data = await getData();

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -76,8 +76,11 @@ describe('Next.js Applications', () => {
     const data = await getData(port);
     expect(data).toContain(`Welcome to ${appName}`);
 
-    await p.kill();
-    expect(await killPorts(port)).toBeTruthy();
+    if (await p.kill('SIGKILL')) {
+      expect(await killPorts(port)).toBeTruthy();
+    } else {
+      expect('process running').toBeFalsy();
+    }
   }, 300000);
 
   it('should be able to consume a react libs (buildable and non-buildable)', async () => {
@@ -609,8 +612,11 @@ describe('Next.js Applications', () => {
     const data = await getData(port);
     expect(data).toContain(`Welcome to ${appName}`);
 
-    await p.kill();
-    expect(await killPorts(port)).toBeTruthy();
+    if (await p.kill('SIGKILL')) {
+      expect(await killPorts(port)).toBeTruthy();
+    } else {
+      expect('process running').toBeFalsy();
+    }
   }, 300000);
 
   function getData(port: number): Promise<any> {

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -616,8 +616,7 @@ describe('Next.js Applications', () => {
     expect(data).toContain(`Welcome to ${appName}`);
 
     try {
-      p.kill('SIGKILL');
-      // await promisifiedTreeKill(p.pid, 'SIGKILL');
+      await promisifiedTreeKill(p.pid, 'SIGKILL');
       // expect(await killPorts(port)).toBeTruthy();
       await killPorts(port);
     } catch {

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -79,8 +79,7 @@ describe('Next.js Applications', () => {
 
     try {
       await promisifiedTreeKill(p.pid, 'SIGKILL');
-      // expect(await killPorts(port)).toBeTruthy();
-      await killPorts(port);
+      expect(await killPorts(port)).toBeTruthy();
     } catch {
       expect('process running').toBeFalsy();
     }

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -20,6 +20,7 @@ describe('Next.js Applications', () => {
   let proj: string;
 
   beforeEach(() => (proj = newProject()));
+  afterEach(async () => await killPorts());
 
   describe('serve', () => {
     afterEach(() => killPorts());

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -1,4 +1,4 @@
-import { stringUtils } from '@nrwl/workspace';
+import { output, stringUtils } from '@nrwl/workspace';
 import {
   checkFilesExist,
   createFile,
@@ -22,6 +22,8 @@ describe('Next.js Applications', () => {
 
   it('should be able to serve with a proxy configuration', async () => {
     const appName = uniq('app');
+
+    output.success({ title: `Next proxy configuration ${appName}` });
 
     runCLI(`generate @nrwl/next:app ${appName}`);
 
@@ -78,6 +80,9 @@ describe('Next.js Applications', () => {
 
   it('should be able to consume a react libs (buildable and non-buildable)', async () => {
     const appName = uniq('app');
+
+    output.success({ title: `Next buildable react libs ${appName}` });
+
     const buildableLibName = uniq('lib');
     const nonBuildableLibName = uniq('lib');
 
@@ -133,6 +138,8 @@ describe('Next.js Applications', () => {
     const appName = uniq('app');
     const libName = uniq('lib');
 
+    output.success({ title: `Next dynamically load libs ${appName}` });
+
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive`);
     runCLI(`generate @nrwl/react:lib ${libName} --no-interactive --style=none`);
 
@@ -158,6 +165,9 @@ describe('Next.js Applications', () => {
 
   it('should compile when using a workspace and react lib written in TypeScript', async () => {
     const appName = uniq('app');
+
+    output.success({ title: `Next compile lib in typescript ${appName}` });
+
     const tsLibName = uniq('tslib');
     const tsxLibName = uniq('tsxlib');
 
@@ -261,6 +271,8 @@ describe('Next.js Applications', () => {
   it('should support Less', async () => {
     const appName = uniq('app');
 
+    output.success({ title: `Next support less ${appName}` });
+
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive --style=less`);
 
     await checkApp(appName, {
@@ -273,6 +285,8 @@ describe('Next.js Applications', () => {
   it('should support Stylus', async () => {
     const appName = uniq('app');
 
+    output.success({ title: `Next support stylus ${appName}` });
+
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive --style=styl`);
 
     await checkApp(appName, {
@@ -284,6 +298,8 @@ describe('Next.js Applications', () => {
 
   it('should support --style=styled-components', async () => {
     const appName = uniq('app');
+
+    output.success({ title: `Next support styled components ${appName}` });
 
     runCLI(
       `generate @nrwl/next:app ${appName} --no-interactive --style=styled-components`
@@ -299,6 +315,8 @@ describe('Next.js Applications', () => {
   it('should support --style=@emotion/styled', async () => {
     const appName = uniq('app');
 
+    output.success({ title: `Next support @emotion ${appName}` });
+
     runCLI(
       `generate @nrwl/next:app ${appName} --no-interactive --style=@emotion/styled`
     );
@@ -312,6 +330,8 @@ describe('Next.js Applications', () => {
 
   it('should build with public folder', async () => {
     const appName = uniq('app');
+
+    output.success({ title: `Next build with public folder ${appName}` });
 
     runCLI(
       `generate @nrwl/next:app ${appName} --no-interactive --style=@emotion/styled`
@@ -344,6 +364,8 @@ describe('Next.js Applications', () => {
   it('should build with a next.config.js file in the dist folder', async () => {
     const appName = uniq('app');
 
+    output.success({ title: `Next build with next config ${appName}` });
+
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive --style=css`);
 
     updateFile(
@@ -373,6 +395,8 @@ describe('Next.js Applications', () => {
   it('should support --js flag', async () => {
     const appName = uniq('app');
 
+    output.success({ title: `Next support js flag ${appName}` });
+
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive --js`);
 
     checkFilesExist(`apps/${appName}/pages/index.js`);
@@ -386,6 +410,8 @@ describe('Next.js Applications', () => {
 
   it('should fail the build when TS errors are present', async () => {
     const appName = uniq('app');
+
+    output.success({ title: `Next fail with TS errors ${appName}` });
 
     runCLI(
       `generate @nrwl/next:app ${appName} --no-interactive --style=@emotion/styled`
@@ -414,6 +440,8 @@ describe('Next.js Applications', () => {
   it('should be able to consume a react lib written in JavaScript', async () => {
     const appName = uniq('app');
     const libName = uniq('lib');
+
+    output.success({ title: `Next consume JS lib ${appName}` });
 
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive`);
 

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -670,9 +670,10 @@ async function checkApp(
     );
   }
 
-  if (opts.checkE2E && runCypressTests()) {
+  if (opts.checkE2E) {
     const e2eResults = runCLI(`e2e ${appName}-e2e --headless`);
     expect(e2eResults).toContain('All specs passed!');
+    await killPorts();
   }
 
   runCLI(`export ${appName}`);

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -79,7 +79,8 @@ describe('Next.js Applications', () => {
 
     try {
       await promisifiedTreeKill(p.pid, 'SIGKILL');
-      expect(await killPorts(port)).toBeTruthy();
+      // expect(await killPorts(port)).toBeTruthy();
+      await killPorts(port);
     } catch {
       expect('process running').toBeFalsy();
     }
@@ -615,8 +616,10 @@ describe('Next.js Applications', () => {
     expect(data).toContain(`Welcome to ${appName}`);
 
     try {
-      await promisifiedTreeKill(p.pid, 'SIGKILL');
-      expect(await killPorts(port)).toBeTruthy();
+      p.kill('SIGKILL');
+      // await promisifiedTreeKill(p.pid, 'SIGKILL');
+      // expect(await killPorts(port)).toBeTruthy();
+      await killPorts(port);
     } catch {
       expect('process running').toBeFalsy();
     }

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -3,6 +3,7 @@ import {
   checkFilesExist,
   createFile,
   killPorts,
+  killProcess,
   newProject,
   readFile,
   readJson,
@@ -19,7 +20,6 @@ describe('Next.js Applications', () => {
   let proj: string;
 
   beforeEach(() => (proj = newProject()));
-
   it('should be able to serve with a proxy configuration', async () => {
     const appName = uniq('app');
 
@@ -74,8 +74,7 @@ describe('Next.js Applications', () => {
     const data = await getData();
     expect(data).toContain(`Welcome to ${appName}`);
 
-    p.kill('SIGKILL');
-    await killPorts();
+    await killProcess(p.pid);
   }, 300000);
 
   it('should be able to consume a react libs (buildable and non-buildable)', async () => {

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -59,7 +59,7 @@ describe('Next.js Applications', () => {
       `apps/${appName}/pages/api/hello.js`,
       `
         export default (_req, res) => {
-          res.status(200).send('Hello Next.js!');
+          res.status(200).send('Welcome to ${appName}');
         };
       `
     );
@@ -73,8 +73,12 @@ describe('Next.js Applications', () => {
     expect(data).toContain(`Welcome to ${appName}`);
 
     p.kill();
+<<<<<<< HEAD
     await killPorts();
   }, 120000);
+=======
+  }, 300000);
+>>>>>>> d6d6d7e9 (fix(nextjs): remove localhost concurency)
 
   it('should be able to consume a react libs (buildable and non-buildable)', async () => {
     const appName = uniq('app');
@@ -631,6 +635,7 @@ async function checkApp(
     checkWebpack5?: boolean;
   }
 ) {
+  await killPorts();
   const buildResult = runCLI(`build ${appName} --withDeps`);
   if (opts.checkWebpack5) {
     expect(buildResult).toContain('Using webpack 5');
@@ -659,9 +664,9 @@ async function checkApp(
   if (opts.checkE2E) {
     const e2eResults = runCLI(`e2e ${appName}-e2e --headless`);
     expect(e2eResults).toContain('All specs passed!');
-    await killPorts();
   }
 
   runCLI(`export ${appName}`);
   checkFilesExist(`dist/apps/${appName}/exported/index.html`);
+  await killPorts();
 }

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -9,7 +9,6 @@ import {
   runCLI,
   runCLIAsync,
   runCommandUntil,
-  runCypressTests,
   uniq,
   updateFile,
   updateWorkspaceConfig,
@@ -20,29 +19,25 @@ describe('Next.js Applications', () => {
   let proj: string;
 
   beforeEach(() => (proj = newProject()));
-  afterEach(async () => await killPorts());
 
-  describe('serve', () => {
-    afterEach(() => killPorts());
+  it('should be able to serve with a proxy configuration', async () => {
+    const appName = uniq('app');
 
-    it('should be able to serve with a proxy configuration', async () => {
-      const appName = uniq('app');
+    runCLI(`generate @nrwl/next:app ${appName}`);
 
-      runCLI(`generate @nrwl/next:app ${appName}`);
-
-      const proxyConf = {
-        '/external-api': {
-          target: 'http://localhost:4200',
-          pathRewrite: {
-            '^/external-api/hello': '/api/hello',
-          },
+    const proxyConf = {
+      '/external-api': {
+        target: 'http://localhost:4200',
+        pathRewrite: {
+          '^/external-api/hello': '/api/hello',
         },
-      };
-      updateFile(`apps/${appName}/proxy.conf.json`, JSON.stringify(proxyConf));
+      },
+    };
+    updateFile(`apps/${appName}/proxy.conf.json`, JSON.stringify(proxyConf));
 
-      updateFile(
-        `apps/${appName}-e2e/src/integration/app.spec.ts`,
-        `
+    updateFile(
+      `apps/${appName}-e2e/src/integration/app.spec.ts`,
+      `
         describe('next-app', () => {
           beforeEach(() => cy.visit('/'));
 
@@ -51,11 +46,11 @@ describe('Next.js Applications', () => {
           });
         });
         `
-      );
+    );
 
-      updateFile(
-        `apps/${appName}/pages/index.tsx`,
-        `
+    updateFile(
+      `apps/${appName}/pages/index.tsx`,
+      `
         import React, { useEffect, useState } from 'react';
 
         export const Index = () => {
@@ -71,28 +66,28 @@ describe('Next.js Applications', () => {
         };
         export default Index;
       `
-      );
+    );
 
-      updateFile(
-        `apps/${appName}/pages/api/hello.js`,
-        `
+    updateFile(
+      `apps/${appName}/pages/api/hello.js`,
+      `
         export default (_req, res) => {
           res.status(200).send('Hello Next.js!');
         };
       `
-      );
+    );
 
-      // serve Next.js
-      const p = await runCommandUntil(`run ${appName}:serve`, (output) => {
-        return output.indexOf('custom typescript server running') > -1;
-      });
+    // serve Next.js
+    const p = await runCommandUntil(`run ${appName}:serve`, (output) => {
+      return output.indexOf('custom typescript server running') > -1;
+    });
 
-      const data = await getData();
-      expect(data).toContain(`Welcome to ${appName}`);
+    const data = await getData();
+    expect(data).toContain(`Welcome to ${appName}`);
 
-      p.kill();
-    }, 120000);
-  });
+    p.kill();
+    await killPorts();
+  }, 120000);
 
   it('should be able to consume a react libs (buildable and non-buildable)', async () => {
     const appName = uniq('app');
@@ -141,9 +136,9 @@ describe('Next.js Applications', () => {
     }).toThrow();
 
     await checkApp(appName, {
-      checkUnitTest: true,
+      checkUnitTest: false,
       checkLint: true,
-      checkE2E: true,
+      checkE2E: false,
     });
   }, 120000);
 
@@ -172,6 +167,7 @@ describe('Next.js Applications', () => {
       checkLint: false,
       checkE2E: true,
     });
+    await killPorts();
   }, 120000);
 
   it('should compile when using a workspace and react lib written in TypeScript', async () => {
@@ -274,6 +270,7 @@ describe('Next.js Applications', () => {
       checkLint: true,
       checkE2E: true,
     });
+    await killPorts();
   }, 120000);
 
   it('should support Less', async () => {
@@ -400,6 +397,7 @@ describe('Next.js Applications', () => {
       checkLint: true,
       checkE2E: true,
     });
+    await killPorts();
   }, 180000);
 
   it('should fail the build when TS errors are present', async () => {
@@ -468,7 +466,6 @@ describe('Next.js Applications', () => {
       checkE2E: false,
     });
   }, 120000);
-<<<<<<< HEAD
 
   it('webpack5 - should be able to consume a react libs (buildable and non-buildable)', async () => {
     const appName = uniq('app');
@@ -619,6 +616,7 @@ describe('Next.js Applications', () => {
     expect(data).toContain(`Welcome to ${appName}`);
 
     p.kill();
+    await killPorts();
   }, 300000);
 });
 

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -73,12 +73,8 @@ describe('Next.js Applications', () => {
     expect(data).toContain(`Welcome to ${appName}`);
 
     p.kill();
-<<<<<<< HEAD
     await killPorts();
-  }, 120000);
-=======
   }, 300000);
->>>>>>> d6d6d7e9 (fix(nextjs): remove localhost concurency)
 
   it('should be able to consume a react libs (buildable and non-buildable)', async () => {
     const appName = uniq('app');
@@ -158,7 +154,6 @@ describe('Next.js Applications', () => {
       checkLint: false,
       checkE2E: true,
     });
-    await killPorts();
   }, 120000);
 
   it('should compile when using a workspace and react lib written in TypeScript', async () => {
@@ -261,7 +256,6 @@ describe('Next.js Applications', () => {
       checkLint: true,
       checkE2E: true,
     });
-    await killPorts();
   }, 120000);
 
   it('should support Less', async () => {
@@ -388,7 +382,6 @@ describe('Next.js Applications', () => {
       checkLint: true,
       checkE2E: true,
     });
-    await killPorts();
   }, 180000);
 
   it('should fail the build when TS errors are present', async () => {
@@ -609,64 +602,63 @@ describe('Next.js Applications', () => {
     p.kill();
     await killPorts();
   }, 300000);
-});
 
-function getData(): Promise<any> {
-  return new Promise((resolve) => {
-    http.get('http://localhost:4200', (res) => {
-      expect(res.statusCode).toEqual(200);
-      let data = '';
-      res.on('data', (chunk) => {
-        data += chunk;
-      });
-      res.once('end', () => {
-        resolve(data);
+  function getData(): Promise<any> {
+    return new Promise((resolve) => {
+      http.get('http://localhost:4200', (res) => {
+        expect(res.statusCode).toEqual(200);
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.once('end', () => {
+          resolve(data);
+        });
       });
     });
-  });
-}
-
-async function checkApp(
-  appName: string,
-  opts: {
-    checkUnitTest: boolean;
-    checkLint: boolean;
-    checkE2E: boolean;
-    checkWebpack5?: boolean;
-  }
-) {
-  await killPorts();
-  const buildResult = runCLI(`build ${appName} --withDeps`);
-  if (opts.checkWebpack5) {
-    expect(buildResult).toContain('Using webpack 5');
-  }
-  expect(buildResult).toContain(`Compiled successfully`);
-  checkFilesExist(`dist/apps/${appName}/.next/build-manifest.json`);
-  checkFilesExist(`dist/apps/${appName}/public/star.svg`);
-
-  const packageJson = readJson(`dist/apps/${appName}/package.json`);
-  expect(packageJson.dependencies.react).toBeDefined();
-  expect(packageJson.dependencies['react-dom']).toBeDefined();
-  expect(packageJson.dependencies.next).toBeDefined();
-
-  if (opts.checkLint) {
-    const lintResults = runCLI(`lint ${appName}`);
-    expect(lintResults).toContain('All files pass linting.');
   }
 
-  if (opts.checkUnitTest) {
-    const testResults = await runCLIAsync(`test ${appName}`);
-    expect(testResults.combinedOutput).toContain(
-      'Test Suites: 1 passed, 1 total'
-    );
-  }
+  async function checkApp(
+    appName: string,
+    opts: {
+      checkUnitTest: boolean;
+      checkLint: boolean;
+      checkE2E: boolean;
+      checkWebpack5?: boolean;
+    }
+  ) {
+    const buildResult = runCLI(`build ${appName} --withDeps`);
+    if (opts.checkWebpack5) {
+      expect(buildResult).toContain('Using webpack 5');
+    }
+    expect(buildResult).toContain(`Compiled successfully`);
+    checkFilesExist(`dist/apps/${appName}/.next/build-manifest.json`);
+    checkFilesExist(`dist/apps/${appName}/public/star.svg`);
 
-  if (opts.checkE2E) {
-    const e2eResults = runCLI(`e2e ${appName}-e2e --headless`);
-    expect(e2eResults).toContain('All specs passed!');
-  }
+    const packageJson = readJson(`dist/apps/${appName}/package.json`);
+    expect(packageJson.dependencies.react).toBeDefined();
+    expect(packageJson.dependencies['react-dom']).toBeDefined();
+    expect(packageJson.dependencies.next).toBeDefined();
 
-  runCLI(`export ${appName}`);
-  checkFilesExist(`dist/apps/${appName}/exported/index.html`);
-  await killPorts();
-}
+    if (opts.checkLint) {
+      const lintResults = runCLI(`lint ${appName}`);
+      expect(lintResults).toContain('All files pass linting.');
+    }
+
+    if (opts.checkUnitTest) {
+      const testResults = await runCLIAsync(`test ${appName}`);
+      expect(testResults.combinedOutput).toContain(
+        'Test Suites: 1 passed, 1 total'
+      );
+    }
+
+    if (opts.checkE2E) {
+      const e2eResults = runCLI(`e2e ${appName}-e2e --headless`);
+      expect(e2eResults).toContain('All specs passed!');
+      await killPorts();
+    }
+
+    runCLI(`export ${appName}`);
+    checkFilesExist(`dist/apps/${appName}/exported/index.html`);
+  }
+});

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -4,6 +4,7 @@ import {
   createFile,
   killPorts,
   newProject,
+  promisifiedTreeKill,
   readFile,
   readJson,
   runCLI,
@@ -76,9 +77,10 @@ describe('Next.js Applications', () => {
     const data = await getData(port);
     expect(data).toContain(`Welcome to ${appName}`);
 
-    if (await p.kill('SIGKILL')) {
+    try {
+      await promisifiedTreeKill(p.pid, 'SIGKILL');
       expect(await killPorts(port)).toBeTruthy();
-    } else {
+    } catch {
       expect('process running').toBeFalsy();
     }
   }, 300000);
@@ -612,9 +614,10 @@ describe('Next.js Applications', () => {
     const data = await getData(port);
     expect(data).toContain(`Welcome to ${appName}`);
 
-    if (await p.kill('SIGKILL')) {
+    try {
+      await promisifiedTreeKill(p.pid, 'SIGKILL');
       expect(await killPorts(port)).toBeTruthy();
-    } else {
+    } catch {
       expect('process running').toBeFalsy();
     }
   }, 300000);

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -74,7 +74,8 @@ describe('Next.js Applications', () => {
     const data = await getData();
     expect(data).toContain(`Welcome to ${appName}`);
 
-    p.kill();
+    p.kill('SIGKILL');
+    await killPorts();
   }, 300000);
 
   it('should be able to consume a react libs (buildable and non-buildable)', async () => {
@@ -235,14 +236,14 @@ describe('Next.js Applications', () => {
           import { testFn } from '@${proj}/${tsLibName}';
           import { TestComponent } from '@${proj}/${tsxLibName}';\n\n
           ${content.replace(
-            `</h2>`,
-            `</h2>
+        `</h2>`,
+        `</h2>
                 <div>
                   {testFn()}
                   <TestComponent text="Hello Next.JS" />
                 </div>
               `
-          )}`
+      )}`
     );
 
     const e2eTestPath = `apps/${appName}-e2e/src/integration/app.spec.ts`;
@@ -250,14 +251,13 @@ describe('Next.js Applications', () => {
     updateFile(
       e2eTestPath,
       `
-        ${
-          e2eContent +
-          `
+        ${e2eContent +
+      `
           it('should successfully call async API route', () => {
             cy.request('/api/hello').its('body').should('include', 'hell0');
           });
           `
-        }
+      }
       `
     );
 

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -75,7 +75,6 @@ describe('Next.js Applications', () => {
     expect(data).toContain(`Welcome to ${appName}`);
 
     p.kill();
-    await killPorts();
   }, 300000);
 
   it('should be able to consume a react libs (buildable and non-buildable)', async () => {

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -1,7 +1,6 @@
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import { exec, execSync } from 'child_process';
 import * as http from 'http';
-import * as treeKill from 'tree-kill';
 import {
   checkFilesDoNotExist,
   checkFilesExist,
@@ -17,14 +16,9 @@ import {
   uniq,
   updateFile,
   updateWorkspaceConfig,
+  promisifiedTreeKill,
 } from '@nrwl/e2e/utils';
 import { accessSync, constants } from 'fs-extra';
-import { promisify } from 'util';
-
-const promisifiedTreeKill: (
-  pid: number,
-  signal: string
-) => Promise<void> = promisify(treeKill);
 
 function getData(): Promise<any> {
   return new Promise((resolve) => {

--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -1,7 +1,6 @@
 import {
   checkFilesExist,
   expectTestsPass,
-  killPorts,
   newProject,
   readJson,
   runCLI,
@@ -13,7 +12,6 @@ import {
 
 describe('Nx Plugin', () => {
   beforeEach(() => newProject());
-  afterEach(() => killPorts());
 
   it('should be able to generate a Nx Plugin ', async () => {
     const plugin = uniq('plugin');

--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -397,7 +397,7 @@ describe('React Applications', () => {
     if (opts.checkE2E && runCypressTests()) {
       const e2eResults = runCLI(`e2e ${appName}-e2e`);
       expect(e2eResults).toContain('All specs passed!');
-      await killPorts();
+      expect(await killPorts()).toBeTruthy();
     }
   }
 });

--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -2,7 +2,6 @@ import { serializeJson } from '@nrwl/workspace';
 import {
   checkFilesDoNotExist,
   checkFilesExist,
-  killPorts,
   newProject,
   readFile,
   readJson,
@@ -19,7 +18,6 @@ describe('React Applications', () => {
   let proj: string;
 
   beforeEach(() => (proj = newProject()));
-  afterEach(() => killPorts());
 
   it('should be able to generate a react app + lib', async () => {
     const appName = uniq('app');

--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -2,6 +2,7 @@ import { serializeJson } from '@nrwl/workspace';
 import {
   checkFilesDoNotExist,
   checkFilesExist,
+  killPorts,
   newProject,
   readFile,
   readJson,
@@ -397,5 +398,6 @@ describe('React Applications', () => {
       const e2eResults = runCLI(`e2e ${appName}-e2e`);
       expect(e2eResults).toContain('All specs passed!');
     }
+    await killPorts();
   }
 });

--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -397,7 +397,7 @@ describe('React Applications', () => {
     if (opts.checkE2E && runCypressTests()) {
       const e2eResults = runCLI(`e2e ${appName}-e2e`);
       expect(e2eResults).toContain('All specs passed!');
+      await killPorts();
     }
-    await killPorts();
   }
 });

--- a/e2e/storybook/src/storybook.test.ts
+++ b/e2e/storybook/src/storybook.test.ts
@@ -11,9 +11,9 @@ import {
 import { writeFileSync } from 'fs';
 
 describe('Storybook schematics', () => {
-  afterEach(() => killPorts());
-
   describe('serve storybook', () => {
+    afterEach(() => killPorts());
+
     it('should run a React based Storybook setup', async () => {
       newProject();
 

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -18,7 +18,7 @@ import { dirSync } from 'tmp';
 import { kill } from 'cross-port-killer';
 import { check as portCheck } from 'tcp-port-used';
 import { parseJson } from '@nrwl/devkit';
-import { output } from '@nrwl/workspace';
+import chalk = require('chalk');
 
 interface RunCmdOpts {
   silenceError?: boolean;
@@ -188,16 +188,16 @@ export function newProject({ name = uniq('proj') } = {}): string {
 async function killPort(port: number): Promise<boolean> {
   if (await portCheck(port)) {
     try {
-      output.log({ title: `Attmepting to close port ${port}` });
+      logInfo(`Attmepting to close port ${port}`);
       await kill(port);
       if (await portCheck(port)) {
-        output.error({ title: `Port ${port} still open` });
+        logError(`Port ${port} still open`);
       } else {
-        output.success({ title: `Port ${port} successfully closed` });
+        logSuccess(`Port ${port} successfully closed`);
         return true;
       }
     } catch {
-      output.error({ title: `Port ${port} closing failed` });
+      logError(`Port ${port} closing failed`);
     }
     return false;
   } else {
@@ -532,6 +532,38 @@ function tmpBackupProjPath(path?: string) {
   return path ? `${e2eCwd}/proj-backup/${path}` : `${e2eCwd}/proj-backup`;
 }
 
+const E2E_LOG_PREFIX = `${chalk.reset.inverse.bold.keyword('orange')(' E2E ')}`;
+
+function e2eConsoleLogger(message: string, body?: string) {
+  process.stdout.write('\n');
+  process.stdout.write(`${E2E_LOG_PREFIX} ${message}\n`);
+  if (body) {
+    process.stdout.write(`${body}\n`);
+  }
+  process.stdout.write('\n');
+}
+
+export function logInfo(title: string, body?: string) {
+  const message = `${chalk.reset.inverse.bold.white(
+    ' INFO '
+  )} ${chalk.bold.white(title)}`;
+  return e2eConsoleLogger(message, body);
+}
+
+export function logError(title: string, body?: string) {
+  const message = `${chalk.reset.inverse.bold.green(
+    ' ERROR '
+  )} ${chalk.bold.red(title)}`;
+  return e2eConsoleLogger(message, body);
+}
+
+export function logSuccess(title: string, body?: string) {
+  const message = `${chalk.reset.inverse.bold.green(
+    ' SUCCESS '
+  )} ${chalk.bold.green(title)}`;
+  return e2eConsoleLogger(message, body);
+}
+
 export function getPackageManagerCommand({
   path = tmpProjPath(),
   packageManager = detectPackageManager(path),
@@ -551,25 +583,25 @@ export function getPackageManagerCommand({
 
   return {
     npm: {
-      createWorkspace: `npx create-nx-workspace@${publishedVersion}`,
+      createWorkspace: `npx create - nx - workspace@${publishedVersion} `,
       runNx: `npm run nx${scriptsPrependNodePathFlag} --`,
-      runNxSilent: `npm run nx --silent${scriptsPrependNodePathFlag} --`,
-      addDev: `npm install --legacy-peer-deps -D`,
+      runNxSilent: `npm run nx--silent${scriptsPrependNodePathFlag} --`,
+      addDev: `npm install--legacy - peer - deps - D`,
       list: 'npm ls --depth 10',
     },
     yarn: {
-      // `yarn create nx-workspace` is failing due to wrong global path
-      createWorkspace: `yarn global add create-nx-workspace@${publishedVersion} && create-nx-workspace`,
+      // `yarn create nx - workspace` is failing due to wrong global path
+      createWorkspace: `yarn global add create - nx - workspace@${publishedVersion} && create - nx - workspace`,
       runNx: `yarn nx`,
-      runNxSilent: `yarn --silent nx`,
-      addDev: `yarn add -D`,
+      runNxSilent: `yarn--silent nx`,
+      addDev: `yarn add - D`,
       list: 'npm ls --depth 10',
     },
     pnpm: {
-      createWorkspace: `pnpx create-nx-workspace@${publishedVersion}`,
-      runNx: `pnpm run nx --`,
-      runNxSilent: `pnpm run nx --silent --`,
-      addDev: `pnpm add -D`,
+      createWorkspace: `pnpx create - nx - workspace@${publishedVersion} `,
+      runNx: `pnpm run nx--`,
+      runNxSilent: `pnpm run nx--silent--`,
+      addDev: `pnpm add - D`,
       list: 'npm ls --depth 10',
     },
   }[packageManager];
@@ -577,6 +609,6 @@ export function getPackageManagerCommand({
 
 export function expectNoAngularDevkit() {
   const { list } = getPackageManagerCommand();
-  const result = runCommand(`${list} @angular-devkit/core`);
+  const result = runCommand(`${list} @angular-devkit / core`);
   expect(result).not.toContain('@angular-devkit/core');
 }

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -15,8 +15,7 @@ import {
 import isCI = require('is-ci');
 import * as path from 'path';
 import { dirSync } from 'tmp';
-import { kill } from 'cross-port-killer';
-const portKiller = require('kill-port');
+const kill = require('kill-port');
 import { check as portCheck } from 'tcp-port-used';
 import { parseJson } from '@nrwl/devkit';
 import chalk = require('chalk');
@@ -194,15 +193,10 @@ export function newProject({ name = uniq('proj') } = {}): string {
 }
 
 async function killPort(port: number): Promise<boolean> {
-  logInfo(`Checking port ${port}`);
   if (await portCheck(port)) {
     try {
-      logInfo(`Attmepting to close port ${port}`);
-      if (port === 4201) {
-        await portKiller(port);
-      } else {
-        await kill(port);
-      }
+      logInfo(`Attempting to close port ${port}`);
+      await kill(port);
       if (await portCheck(port)) {
         logError(`Port ${port} still open`);
       } else {
@@ -214,7 +208,6 @@ async function killPort(port: number): Promise<boolean> {
     }
     return false;
   } else {
-    logError(`Port ${port} not open`);
     return true;
   }
 }

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -19,6 +19,13 @@ import { kill } from 'cross-port-killer';
 import { check as portCheck } from 'tcp-port-used';
 import { parseJson } from '@nrwl/devkit';
 import chalk = require('chalk');
+import treeKill = require('tree-kill');
+import { promisify } from 'util';
+
+export const promisifiedTreeKill: (
+  pid: number,
+  signal: string
+) => Promise<void> = promisify(treeKill);
 
 interface RunCmdOpts {
   silenceError?: boolean;

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -192,7 +192,7 @@ export function newProject({ name = uniq('proj') } = {}): string {
   }
 }
 
-const KILL_PORT_DELAY = 10000;
+const KILL_PORT_DELAY = 5000;
 async function killPort(port: number): Promise<boolean> {
   if (await portCheck(port)) {
     try {

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -186,8 +186,16 @@ export function newProject({ name = uniq('proj') } = {}): string {
 export async function killPorts() {
   // potential leftovers from other e2e tests
   // there are a lot of reasons for why sigterm sometime fails
-  await killPort(4200);
-  await killPort(3333);
+  try {
+    await killPort(4200);
+  } catch {
+    throw 'Port 4200 could not be closed';
+  }
+  try {
+    await killPort(3333);
+  } catch {
+    throw 'Port 3333 could not be closed';
+  }
 }
 
 // Useful in order to cleanup space during CI to prevent `No space left on device` exceptions

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -12,11 +12,11 @@ import {
   statSync,
   writeFileSync,
 } from 'fs-extra';
-// import isCI = require('is-ci');
-const isCI = true;
+import isCI = require('is-ci');
 import * as path from 'path';
 import { dirSync } from 'tmp';
 import { kill } from 'cross-port-killer';
+const portKiller = require('kill-port');
 import { check as portCheck } from 'tcp-port-used';
 import { parseJson } from '@nrwl/devkit';
 import chalk = require('chalk');
@@ -198,7 +198,11 @@ async function killPort(port: number): Promise<boolean> {
   if (await portCheck(port)) {
     try {
       logInfo(`Attmepting to close port ${port}`);
-      await kill(port);
+      if (port === 4201) {
+        await portKiller(port);
+      } else {
+        await kill(port);
+      }
       if (await portCheck(port)) {
         logError(`Port ${port} still open`);
       } else {

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -206,8 +206,6 @@ export async function removeProject({ onlyOnCI = false } = {}) {
   try {
     removeSync(tmpProjPath());
   } catch (e) {}
-
-  await killPorts();
 }
 
 export function runCypressTests() {

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -192,11 +192,15 @@ export function newProject({ name = uniq('proj') } = {}): string {
   }
 }
 
+const KILL_PORT_DELAY = 10000;
 async function killPort(port: number): Promise<boolean> {
   if (await portCheck(port)) {
     try {
       logInfo(`Attempting to close port ${port}`);
       await kill(port);
+      await new Promise<void>((resolve) =>
+        setTimeout(() => resolve(), KILL_PORT_DELAY)
+      );
       if (await portCheck(port)) {
         logError(`Port ${port} still open`);
       } else {

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -12,7 +12,8 @@ import {
   statSync,
   writeFileSync,
 } from 'fs-extra';
-import isCI = require('is-ci');
+// import isCI = require('is-ci');
+const isCI = true;
 import * as path from 'path';
 import { dirSync } from 'tmp';
 import { kill } from 'cross-port-killer';
@@ -193,6 +194,7 @@ export function newProject({ name = uniq('proj') } = {}): string {
 }
 
 async function killPort(port: number): Promise<boolean> {
+  logInfo(`Checking port ${port}`);
   if (await portCheck(port)) {
     try {
       logInfo(`Attmepting to close port ${port}`);
@@ -208,16 +210,15 @@ async function killPort(port: number): Promise<boolean> {
     }
     return false;
   } else {
+    logError(`Port ${port} not open`);
     return true;
   }
 }
 
 export async function killPorts(port?: number): Promise<boolean> {
-  return (
-    (await killPort(3333)) &&
-    (await killPort(4200)) &&
-    (!port || (await killPort(port)))
-  );
+  return port
+    ? await killPort(port)
+    : (await killPort(3333)) && (await killPort(4200));
 }
 
 // Useful in order to cleanup space during CI to prevent `No space left on device` exceptions

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -583,25 +583,25 @@ export function getPackageManagerCommand({
 
   return {
     npm: {
-      createWorkspace: `npx create - nx - workspace@${publishedVersion} `,
+      createWorkspace: `npx create-nx-workspace@${publishedVersion}`,
       runNx: `npm run nx${scriptsPrependNodePathFlag} --`,
-      runNxSilent: `npm run nx--silent${scriptsPrependNodePathFlag} --`,
-      addDev: `npm install--legacy - peer - deps - D`,
+      runNxSilent: `npm run nx --silent${scriptsPrependNodePathFlag} --`,
+      addDev: `npm install --legacy-peer-deps -D`,
       list: 'npm ls --depth 10',
     },
     yarn: {
-      // `yarn create nx - workspace` is failing due to wrong global path
-      createWorkspace: `yarn global add create - nx - workspace@${publishedVersion} && create - nx - workspace`,
+      // `yarn create nx-workspace` is failing due to wrong global path
+      createWorkspace: `yarn global add create-nx-workspace@${publishedVersion} && create-nx-workspace`,
       runNx: `yarn nx`,
-      runNxSilent: `yarn--silent nx`,
-      addDev: `yarn add - D`,
+      runNxSilent: `yarn --silent nx`,
+      addDev: `yarn add -D`,
       list: 'npm ls --depth 10',
     },
     pnpm: {
-      createWorkspace: `pnpx create - nx - workspace@${publishedVersion} `,
-      runNx: `pnpm run nx--`,
-      runNxSilent: `pnpm run nx--silent--`,
-      addDev: `pnpm add - D`,
+      createWorkspace: `pnpx create-nx-workspace@${publishedVersion}`,
+      runNx: `pnpm run nx --`,
+      runNxSilent: `pnpm run nx --silent --`,
+      addDev: `pnpm add -D`,
       list: 'npm ls --depth 10',
     },
   }[packageManager];
@@ -609,6 +609,6 @@ export function getPackageManagerCommand({
 
 export function expectNoAngularDevkit() {
   const { list } = getPackageManagerCommand();
-  const result = runCommand(`${list} @angular-devkit / core`);
+  const result = runCommand(`${list} @angular-devkit/core`);
   expect(result).not.toContain('@angular-devkit/core');
 }

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -15,7 +15,7 @@ import {
 import isCI = require('is-ci');
 import * as path from 'path';
 import { dirSync } from 'tmp';
-import * as killPort from 'kill-port';
+import { kill, killer } from 'cross-port-killer';
 import { parseJson } from '@nrwl/devkit';
 
 interface RunCmdOpts {
@@ -183,16 +183,21 @@ export function newProject({ name = uniq('proj') } = {}): string {
   }
 }
 
+export async function killProcess(pid: number) {
+  await killer.killByPid(pid.toString());
+  await killPorts();
+}
+
 export async function killPorts() {
   // potential leftovers from other e2e tests
   // there are a lot of reasons for why sigterm sometime fails
   try {
-    await killPort(4200);
+    await kill(4200);
   } catch {
     throw 'Port 4200 could not be closed';
   }
   try {
-    await killPort(3333);
+    await kill(3333);
   } catch {
     throw 'Port 3333 could not be closed';
   }

--- a/e2e/web/src/file-server.test.ts
+++ b/e2e/web/src/file-server.test.ts
@@ -15,6 +15,7 @@ describe('file-server', () => {
   it('should serve folder of files', async () => {
     newProject({ name: uniq('fileserver') });
     const appName = uniq('app');
+    const port = 4301;
 
     runCLI(`generate @nrwl/web:app ${appName} --no-interactive`);
     const workspaceJson = readJson(workspaceConfigName());
@@ -22,14 +23,17 @@ describe('file-server', () => {
       '@nrwl/web:file-server';
     updateFile(workspaceConfigName(), serializeJson(workspaceJson));
 
-    const p = await runCommandUntil(`serve ${appName}`, (output) => {
-      return (
-        output.indexOf('Built at') > -1 && output.indexOf('Available on') > -1
-      );
-    });
+    const p = await runCommandUntil(
+      `serve ${appName} --port=${port}`,
+      (output) => {
+        return (
+          output.indexOf('Built at') > -1 && output.indexOf('Available on') > -1
+        );
+      }
+    );
     try {
       await promisifiedTreeKill(p.pid, 'SIGKILL');
-      expect(await killPorts()).toBeTruthy();
+      // expect(await killPorts(port)).toBeTruthy();
     } catch {
       expect('process running').toBeFalsy();
     }

--- a/e2e/web/src/file-server.test.ts
+++ b/e2e/web/src/file-server.test.ts
@@ -33,6 +33,7 @@ describe('file-server', () => {
     );
     try {
       await promisifiedTreeKill(p.pid, 'SIGKILL');
+      await killPorts(port);
       // expect(await killPorts(port)).toBeTruthy();
     } catch {
       expect('process running').toBeFalsy();

--- a/e2e/web/src/file-server.test.ts
+++ b/e2e/web/src/file-server.test.ts
@@ -11,8 +11,6 @@ import {
 import { serializeJson } from '@nrwl/workspace';
 
 describe('file-server', () => {
-  afterEach(() => killPorts());
-
   it('should serve folder of files', async () => {
     newProject({ name: uniq('fileserver') });
     const appName = uniq('app');
@@ -28,6 +26,10 @@ describe('file-server', () => {
         output.indexOf('Built at') > -1 && output.indexOf('Available on') > -1
       );
     });
-    p.kill();
+    if (await p.kill('SIGKILL')) {
+      await killPorts();
+    } else {
+      expect('process running').toBeFalsy();
+    }
   }, 300000);
 });

--- a/e2e/web/src/file-server.test.ts
+++ b/e2e/web/src/file-server.test.ts
@@ -7,6 +7,7 @@ import {
   uniq,
   updateFile,
   workspaceConfigName,
+  promisifiedTreeKill,
 } from '@nrwl/e2e/utils';
 import { serializeJson } from '@nrwl/workspace';
 
@@ -26,9 +27,10 @@ describe('file-server', () => {
         output.indexOf('Built at') > -1 && output.indexOf('Available on') > -1
       );
     });
-    if (await p.kill('SIGKILL')) {
-      await killPorts();
-    } else {
+    try {
+      await promisifiedTreeKill(p.pid, 'SIGKILL');
+      expect(await killPorts()).toBeTruthy();
+    } catch {
       expect('process running').toBeFalsy();
     }
   }, 300000);

--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -2,6 +2,7 @@ import {
   checkFilesDoNotExist,
   checkFilesExist,
   createFile,
+  killPorts,
   newProject,
   readFile,
   readJson,
@@ -54,6 +55,7 @@ describe('Web Components Applications', () => {
     if (runCypressTests()) {
       const e2eResults = runCLI(`e2e ${appName}-e2e --headless`);
       expect(e2eResults).toContain('All specs passed!');
+      expect(await killPorts()).toBeTruthy();
     }
   }, 500000);
 

--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -2,7 +2,6 @@ import {
   checkFilesDoNotExist,
   checkFilesExist,
   createFile,
-  killPorts,
   newProject,
   readFile,
   readJson,
@@ -15,9 +14,8 @@ import {
 
 describe('Web Components Applications', () => {
   beforeEach(() => newProject());
-  afterEach(() => killPorts());
 
-  it('aaashould be able to generate a web app', async () => {
+  it('should be able to generate a web app', async () => {
     const appName = uniq('app');
     runCLI(`generate @nrwl/web:app ${appName} --no-interactive`);
 
@@ -349,7 +347,7 @@ describe('index.html interpolation', () => {
         <meta charset="utf-8" />
         <title>BestReactApp</title>
         <base href="/" />
-    
+
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" type="image/x-icon" href="favicon.ico" />
       </head>
@@ -372,7 +370,7 @@ describe('index.html interpolation', () => {
       <head>
         <meta charset="utf-8" />
         <title>BestReactApp</title>
-        <base href="/">    
+        <base href="/">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" type="image/x-icon" href="favicon.ico" />
       </head>

--- a/e2e/workspace/src/create-nx-workspace.test.ts
+++ b/e2e/workspace/src/create-nx-workspace.test.ts
@@ -3,7 +3,6 @@ import {
   checkFilesExist,
   e2eCwd,
   expectNoAngularDevkit,
-  killPorts,
   readJson,
   removeProject,
   runCreateWorkspace,
@@ -13,8 +12,7 @@ import { existsSync, mkdirSync } from 'fs-extra';
 import { execSync } from 'child_process';
 
 describe('create-nx-workspace', () => {
-  afterEach(() => removeProject({ onlyOnCI: true }));
-  afterEach(() => killPorts());
+  afterAll(() => removeProject({ onlyOnCI: true }));
 
   it('should be able to create an empty workspace', () => {
     const wsName = uniq('empty');

--- a/e2e/workspace/src/custom-layout.test.ts
+++ b/e2e/workspace/src/custom-layout.test.ts
@@ -8,11 +8,10 @@ import {
   uniq,
   packageInstall,
   removeProject,
-  killPorts,
 } from '@nrwl/e2e/utils';
 
 describe('custom workspace layout', () => {
-  afterEach(() => killPorts());
+  afterAll(() => removeProject({ onlyOnCI: true }));
 
   it('should work', async () => {
     const proj = uniq('custom-layout-proj');
@@ -67,7 +66,5 @@ describe('custom workspace layout', () => {
     expect(appBuildResults.stdout).toContain(`nx run ${expressApp}:build`);
 
     checkFilesExist(`dist/packages/${expressApp}/main.js`);
-
-    removeProject({ onlyOnCI: true });
   }, 1000000);
 });

--- a/e2e/workspace/src/plugins.test.ts
+++ b/e2e/workspace/src/plugins.test.ts
@@ -4,14 +4,11 @@ import {
   updateFile,
   readJson,
   runCLI,
-  killPorts,
 } from '@nrwl/e2e/utils';
 
 describe('Nx Plugins', () => {
   beforeAll(() => newProject());
-
   afterAll(() => removeProject({ onlyOnCI: true }));
-  afterEach(() => killPorts());
 
   it('should use plugins defined in nx.json', () => {
     const nxJson = readJson('nx.json');
@@ -41,7 +38,7 @@ describe('Nx Plugins', () => {
           builder.addDependency(
             require('@nrwl/devkit').DependencyType.static,
             'plugin-node',
-            'plugin-node2' 
+            'plugin-node2'
           );
           return builder.getProjectGraph();
         }

--- a/e2e/workspace/src/run-commands.test.ts
+++ b/e2e/workspace/src/run-commands.test.ts
@@ -1,5 +1,4 @@
 import {
-  killPorts,
   newProject,
   readJson,
   removeProject,
@@ -11,9 +10,7 @@ import {
 
 describe('Run Commands', () => {
   beforeAll(() => newProject());
-
   afterAll(() => removeProject({ onlyOnCI: true }));
-  afterEach(() => killPorts());
 
   it('should not override environment variables already set when setting a custom env file path', async () => {
     const nodeapp = uniq('nodeapp');

--- a/e2e/workspace/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace/src/workspace-aux-commands.test.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import {
   checkFilesExist,
   exists,
-  killPorts,
   newProject,
   readFile,
   readJson,
@@ -25,8 +24,6 @@ beforeAll(() => {
 });
 
 describe('lint', () => {
-  afterEach(() => killPorts());
-
   it('lint should ensure module boundaries', () => {
     const myapp = uniq('myapp');
     const myapp2 = uniq('myapp2');

--- a/e2e/workspace/src/workspace-lib.test.ts
+++ b/e2e/workspace/src/workspace-lib.test.ts
@@ -14,9 +14,7 @@ beforeAll(() => {
   proj = newProject();
 });
 
-afterAll(() => {
-  removeProject({ onlyOnCI: true });
-});
+afterAll(() => removeProject({ onlyOnCI: true }));
 
 describe('@nrwl/workspace:library', () => {
   it('should be able to be created', () => {
@@ -84,7 +82,7 @@ describe('@nrwl/workspace:library', () => {
       `libs/${consumerLib}/src/lib/${consumerLib}.ts`,
       `
     import { a } from '@${proj}/${producerLib}';
-    
+
     export function ${consumerLib}() {
       return a + 1;
     }`
@@ -93,7 +91,7 @@ describe('@nrwl/workspace:library', () => {
       `libs/${consumerLib}/src/lib/${consumerLib}.spec.ts`,
       `
     import { ${consumerLib} } from './${consumerLib}';
-    
+
     describe('', () => {
       it('should return 1', () => {
         expect(${consumerLib}()).toEqual(1);

--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -2,7 +2,6 @@ import type { NxJsonConfiguration } from '@nrwl/devkit';
 import {
   getPackageManagerCommand,
   getSelectedPackageManager,
-  killPorts,
   listFiles,
   newProject,
   readFile,
@@ -22,9 +21,7 @@ describe('run-one', () => {
   let proj: string;
 
   beforeAll(() => (proj = newProject()));
-
   afterAll(() => removeProject({ onlyOnCI: true }));
-  afterEach(() => killPorts());
 
   it('should build a specific project', () => {
     const myapp = uniq('app');
@@ -172,7 +169,6 @@ describe('run-many', () => {
   let proj: string;
 
   beforeEach(() => (proj = newProject()));
-
   afterEach(() => removeProject({ onlyOnCI: true }));
 
   // This fails with pnpm due to incompatibilities with ngcc for buildable libraries.
@@ -311,7 +307,6 @@ describe('affected:*', () => {
   let proj: string;
 
   beforeEach(() => (proj = newProject()));
-
   afterEach(() => removeProject({ onlyOnCI: true }));
 
   it('should print, build, and test affected apps', async () => {
@@ -478,7 +473,6 @@ describe('affected (with git)', () => {
   let mylib = uniq('mylib');
 
   beforeAll(() => newProject());
-
   afterAll(() => removeProject({ onlyOnCI: true }));
 
   it('should not affect other projects by generating a new project', () => {
@@ -551,7 +545,6 @@ describe('print-affected', () => {
   let proj: string;
 
   beforeEach(() => (proj = newProject()));
-
   afterEach(() => removeProject({ onlyOnCI: true }));
 
   it('should print information about affected projects', async () => {

--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.2",
     "tailwindcss": "^2.1.1",
+    "tcp-port-used": "^1.0.2",
     "terser": "4.3.8",
     "terser-webpack-plugin": "2.3.8",
     "tippy.js": "^6.3.1",
@@ -276,6 +277,7 @@
   },
   "resolutions": {
     "ng-packagr/rxjs": "6.6.7",
-    "**/xmlhttprequest-ssl": "~1.6.2"
+    "**/xmlhttprequest-ssl": "~1.6.2",
+    "**/fsevents": "2.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -263,7 +263,6 @@
     "document-register-element": "^1.13.1",
     "glob": "7.1.4",
     "gray-matter": "^4.0.2",
-    "kill-port": "^1.6.1",
     "react": "17.0.2",
     "react-copy-to-clipboard": "^5.0.3",
     "react-dom": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "copy-webpack-plugin": "6.0.3",
     "core-js": "^3.6.5",
     "cosmiconfig": "^4.0.0",
-    "cross-port-killer": "^1.3.0",
     "cypress": "^7.3.0",
     "cytoscape": "^3.18.2",
     "cytoscape-dagre": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "copy-webpack-plugin": "6.0.3",
     "core-js": "^3.6.5",
     "cosmiconfig": "^4.0.0",
+    "cross-port-killer": "^1.3.0",
     "cypress": "^7.3.0",
     "cytoscape": "^3.18.2",
     "cytoscape-dagre": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "karma-jasmine": "~1.1.1",
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-webpack": "4.0.2",
+    "kill-port": "^1.6.1",
     "less": "3.12.2",
     "less-loader": "5.0.0",
     "license-webpack-plugin": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,6 @@
   },
   "resolutions": {
     "ng-packagr/rxjs": "6.6.7",
-    "**/xmlhttprequest-ssl": "~1.6.2",
-    "**/fsevents": "2.3.2"
+    "**/xmlhttprequest-ssl": "~1.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12585,11 +12585,6 @@ get-symbol-from-current-process-h@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz#510af52eaef873f7028854c3377f47f7bb200265"
   integrity sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw==
 
-get-them-args@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/get-them-args/-/get-them-args-1.3.2.tgz#74a20ba8a4abece5ae199ad03f2bcc68fdfc9ba5"
-  integrity sha1-dKILqKSr7OWuGZrQPyvMaP38m6U=
-
 get-uv-event-loop-napi-h@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz#42b0b06b74c3ed21fbac8e7c72845fdb7a200208"
@@ -15672,14 +15667,6 @@ keyv@3.0.0:
   integrity sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==
   dependencies:
     json-buffer "3.0.0"
-
-kill-port@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/kill-port/-/kill-port-1.6.1.tgz#560fe79484583bdf3a5e908557dae614447618aa"
-  integrity sha512-un0Y55cOM7JKGaLnGja28T38tDDop0AQ8N0KlAdyh+B1nmMoX8AnNmqPNZbS3mUMgiST51DCVqmbFT1gNJpVNw==
-  dependencies:
-    get-them-args "1.3.2"
-    shell-exec "1.0.2"
 
 killable@^1.0.1:
   version "1.0.1"
@@ -22101,11 +22088,6 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
-
-shell-exec@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/shell-exec/-/shell-exec-1.0.2.tgz#2e9361b0fde1d73f476c4b6671fa17785f696756"
-  integrity sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==
 
 shell-quote@1.7.2, shell-quote@^1.6.1:
   version "1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14024,6 +14024,11 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
+ip-regex@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
+  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
+
 ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -14581,6 +14586,11 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
+is-url@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
+
 is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
@@ -14607,6 +14617,15 @@ is-wsl@^2.1.1, is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+is2@^2.0.6:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.7.tgz#d084e10cab3bd45d6c9dfde7a48599fcbb93fcac"
+  integrity sha512-4vBQoURAXC6hnLFxD4VW7uc04XiwTTl/8ydYJxKvPwkWQrSjInkuM5VZVg6BGr1/natq69zDuvO9lGpLClJqvA==
+  dependencies:
+    deep-is "^0.1.3"
+    ip-regex "^4.1.0"
+    is-url "^1.2.4"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -23238,6 +23257,14 @@ tar@^6.0.2, tar@^6.1.0:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+tcp-port-used@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.2.tgz#9652b7436eb1f4cfae111c79b558a25769f6faea"
+  integrity sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==
+  dependencies:
+    debug "4.3.1"
+    is2 "^2.0.6"
 
 telejson@^5.0.2:
   version "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9597,6 +9597,11 @@ critters@0.0.10:
     parse5-htmlparser2-tree-adapter "^6.0.1"
     pretty-bytes "^5.3.0"
 
+cross-port-killer@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/cross-port-killer/-/cross-port-killer-1.3.0.tgz#66305ed1f6134333ea451baac6fc7b06c998a4b4"
+  integrity sha512-c52ohEZ8MEJEAc6jpe4c5LmInNIasjxswasbjGXraOphXZlltLHM+50rM6vEQm5eL2uNc4RqSdOTMcGdZe5EPQ==
+
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9597,11 +9597,6 @@ critters@0.0.10:
     parse5-htmlparser2-tree-adapter "^6.0.1"
     pretty-bytes "^5.3.0"
 
-cross-port-killer@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/cross-port-killer/-/cross-port-killer-1.3.0.tgz#66305ed1f6134333ea451baac6fc7b06c998a4b4"
-  integrity sha512-c52ohEZ8MEJEAc6jpe4c5LmInNIasjxswasbjGXraOphXZlltLHM+50rM6vEQm5eL2uNc4RqSdOTMcGdZe5EPQ==
-
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12585,6 +12585,11 @@ get-symbol-from-current-process-h@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz#510af52eaef873f7028854c3377f47f7bb200265"
   integrity sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw==
 
+get-them-args@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/get-them-args/-/get-them-args-1.3.2.tgz#74a20ba8a4abece5ae199ad03f2bcc68fdfc9ba5"
+  integrity sha1-dKILqKSr7OWuGZrQPyvMaP38m6U=
+
 get-uv-event-loop-napi-h@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz#42b0b06b74c3ed21fbac8e7c72845fdb7a200208"
@@ -15667,6 +15672,14 @@ keyv@3.0.0:
   integrity sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==
   dependencies:
     json-buffer "3.0.0"
+
+kill-port@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/kill-port/-/kill-port-1.6.1.tgz#560fe79484583bdf3a5e908557dae614447618aa"
+  integrity sha512-un0Y55cOM7JKGaLnGja28T38tDDop0AQ8N0KlAdyh+B1nmMoX8AnNmqPNZbS3mUMgiST51DCVqmbFT1gNJpVNw==
+  dependencies:
+    get-them-args "1.3.2"
+    shell-exec "1.0.2"
 
 killable@^1.0.1:
   version "1.0.1"
@@ -22088,6 +22101,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shell-exec@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shell-exec/-/shell-exec-1.0.2.tgz#2e9361b0fde1d73f476c4b6671fa17785f696756"
+  integrity sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==
 
 shell-quote@1.7.2, shell-quote@^1.6.1:
   version "1.7.2"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
All E2E tests have pessimistic `killPorts` call on `afterEach` even if they do not serve any applications
<!-- This is the behavior we have today -->

## Expected Behavior
Only E2E tests/suits which serve applications should call `killPorts` on `afterEach`
<!-- This is the behavior we should expect with the changes in this PR -->
