### PR TITLE
cleanup(linter): use common fileutils and typescript logical assignment operators

### DIFF
--- a/packages/linter/src/executors/eslint/lint.impl.spec.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
-import { Schema } from './schema';
-import { ExecutorContext } from '@nrwl/devkit';
+import type { Schema } from './schema';
+import type { ExecutorContext } from '@nrwl/devkit';
 
 jest.spyOn(fs, 'writeFileSync').mockImplementation();
 let mockCreateDirectory = jest.fn();

--- a/packages/linter/src/executors/eslint/lint.impl.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.ts
@@ -1,10 +1,10 @@
-import { ExecutorContext } from '@nrwl/devkit';
+import type { ExecutorContext } from '@nrwl/devkit';
 import { ESLint } from 'eslint';
 
 import { writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 
-import { Schema } from './schema';
+import type { Schema } from './schema';
 import { lint, loadESLint } from './utility/eslint-utils';
 import { createDirectory } from './utility/create-directory';
 

--- a/packages/linter/src/executors/eslint/utility/create-directory.ts
+++ b/packages/linter/src/executors/eslint/utility/create-directory.ts
@@ -14,7 +14,7 @@ export function createDirectory(directoryPath: string) {
 function directoryExists(name: string) {
   try {
     return statSync(name).isDirectory();
-  } catch (e) {
+  } catch {
     return false;
   }
 }

--- a/packages/linter/src/executors/eslint/utility/eslint-utils.ts
+++ b/packages/linter/src/executors/eslint/utility/eslint-utils.ts
@@ -1,5 +1,5 @@
 import { ESLint } from 'eslint';
-import { Schema } from '../schema';
+import type { Schema } from '../schema';
 
 export async function loadESLint() {
   let eslint;

--- a/packages/linter/src/executors/lint/lint.impl.ts
+++ b/packages/linter/src/executors/lint/lint.impl.ts
@@ -1,11 +1,11 @@
 import { CLIEngine } from 'eslint';
 import { writeFileSync } from 'fs';
 import * as path from 'path';
-import { Schema } from './schema';
+import type { Schema } from './schema';
 import { createProgram } from './utility/ts-utils';
 import { lint, loadESLint } from './utility/eslint-utils';
 import { createDirectory } from '../eslint/utility/create-directory';
-import { ExecutorContext } from '@nrwl/devkit';
+import type { ExecutorContext } from '@nrwl/devkit';
 
 /**
  * Adapted from @angular-eslint/builder source

--- a/packages/linter/src/executors/lint/utility/eslint-utils.ts
+++ b/packages/linter/src/executors/lint/utility/eslint-utils.ts
@@ -1,5 +1,5 @@
 import { getFilesToLint } from './file-utils';
-import { Schema } from '../schema';
+import type { Schema } from '../schema';
 import { CLIEngine } from 'eslint';
 
 /**

--- a/packages/linter/src/generators/init/init.ts
+++ b/packages/linter/src/generators/init/init.ts
@@ -1,10 +1,9 @@
 import {
   addDependenciesToPackageJson,
-  GeneratorCallback,
-  Tree,
   updateJson,
   writeJson,
 } from '@nrwl/devkit';
+import type { GeneratorCallback, Tree } from '@nrwl/devkit';
 import {
   buildAngularVersion,
   eslintConfigPrettierVersion,
@@ -153,7 +152,6 @@ function initTsLint(tree: Tree): GeneratorCallback {
 
   return addDependenciesToPackageJson(
     tree,
-
     {},
     {
       tslint: tslintVersion,
@@ -168,7 +166,7 @@ function initEsLint(tree: Tree): GeneratorCallback {
   }
 
   updateJson(tree, 'package.json', (json) => {
-    json.dependencies = json.dependencies || {};
+    json.dependencies ||= {};
 
     delete json.dependencies['@nrwl/linter'];
 
@@ -179,7 +177,7 @@ function initEsLint(tree: Tree): GeneratorCallback {
 
   if (tree.exists('.vscode/extensions.json')) {
     updateJson(tree, '.vscode/extensions.json', (json) => {
-      json.recommendations = json.recommendations || [];
+      json.recommendations ||= [];
       const extension = 'dbaeumer.vscode-eslint';
       if (!json.recommendations.includes(extension)) {
         json.recommendations.push(extension);
@@ -190,7 +188,6 @@ function initEsLint(tree: Tree): GeneratorCallback {
 
   return addDependenciesToPackageJson(
     tree,
-
     {},
     {
       '@nrwl/linter': nxVersion,

--- a/packages/linter/src/generators/lint-project/lint-project.ts
+++ b/packages/linter/src/generators/lint-project/lint-project.ts
@@ -1,12 +1,11 @@
 import {
-  ProjectConfiguration,
-  Tree,
   writeJson,
   updateProjectConfiguration,
   offsetFromRoot,
   readProjectConfiguration,
   formatFiles,
 } from '@nrwl/devkit';
+import type { ProjectConfiguration, Tree } from '@nrwl/devkit';
 import { join } from 'path';
 import { Linter } from '../utils/linter';
 import { lintInitGenerator } from '../init/init';

--- a/packages/linter/src/migrations/update-10-3-0/add-json-ext-to-eslintrc.ts
+++ b/packages/linter/src/migrations/update-10-3-0/add-json-ext-to-eslintrc.ts
@@ -3,7 +3,6 @@ import { chain } from '@angular-devkit/schematics';
 import {
   formatFiles,
   updateBuilderConfig,
-  updateWorkspace,
   visitNotIgnoredFiles,
 } from '@nrwl/workspace';
 

--- a/packages/linter/src/migrations/update-10-3-0/add-root-eslintrc-json-to-workspace-implicit-deps.spec.ts
+++ b/packages/linter/src/migrations/update-10-3-0/add-root-eslintrc-json-to-workspace-implicit-deps.spec.ts
@@ -2,6 +2,7 @@ import { runMigration } from '../../utils/testing';
 import { UnitTestTree } from '@angular-devkit/schematics/testing';
 import { Tree } from '@angular-devkit/schematics';
 import { readJsonInTree } from '@nrwl/workspace';
+import { serializeJson } from '@nrwl/devkit';
 
 describe('Update implicitDependencies within nx.json to include root .eslintrc.json', () => {
   let tree: UnitTestTree;
@@ -9,7 +10,7 @@ describe('Update implicitDependencies within nx.json to include root .eslintrc.j
     tree = new UnitTestTree(Tree.empty());
     tree.create(
       'nx.json',
-      JSON.stringify({
+      serializeJson({
         npmScope: 'nrwl',
         implicitDependencies: {
           'workspace.json': '*',

--- a/packages/linter/src/migrations/update-10-3-0/add-root-eslintrc-json-to-workspace-implicit-deps.ts
+++ b/packages/linter/src/migrations/update-10-3-0/add-root-eslintrc-json-to-workspace-implicit-deps.ts
@@ -4,7 +4,7 @@ import { formatFiles, updateJsonInTree } from '@nrwl/workspace';
 function addRootESLintrcToImplicitDependencies(host: Tree) {
   return host.exists('nx.json')
     ? updateJsonInTree('nx.json', (json) => {
-        const implicitDependencies = json.implicitDependencies || {};
+        json.implicitDependencies ||= {};
         json.implicitDependencies['.eslintrc.json'] = '*';
         return json;
       })

--- a/packages/linter/src/migrations/update-10-3-0/update-10-3-0.ts
+++ b/packages/linter/src/migrations/update-10-3-0/update-10-3-0.ts
@@ -14,7 +14,7 @@ const updatePackages = updatePackagesInPackageJson(
 const addLintRule = (host: Tree) => {
   return host.exists('.eslintrc')
     ? updateJsonInTree('.eslintrc', (json) => {
-        json.rules = json.rules || {};
+        json.rules ||= {};
         json.rules['@typescript-eslint/explicit-module-boundary-types'] = 'off';
         return json;
       })

--- a/packages/linter/src/migrations/update-10-3-1/revert-node-modules-files-in-eslint-builder-options.ts
+++ b/packages/linter/src/migrations/update-10-3-1/revert-node-modules-files-in-eslint-builder-options.ts
@@ -1,9 +1,5 @@
-import { chain, Tree } from '@angular-devkit/schematics';
-import {
-  formatFiles,
-  readJsonInTree,
-  updateBuilderConfig,
-} from '@nrwl/workspace';
+import { chain } from '@angular-devkit/schematics';
+import { formatFiles, updateBuilderConfig } from '@nrwl/workspace';
 
 /**
  * The migration for v10.3.0 called "update-eslint-builder-and-config" initially had a bug

--- a/packages/linter/src/migrations/update-10-4-0/update-eslint-configs-to-use-nx-presets.spec.ts
+++ b/packages/linter/src/migrations/update-10-4-0/update-eslint-configs-to-use-nx-presets.spec.ts
@@ -1,6 +1,7 @@
 import { Tree } from '@angular-devkit/schematics';
 import { readJsonInTree, updateWorkspace } from '@nrwl/workspace';
 import { callRule, createEmptyWorkspace } from '@nrwl/workspace/testing';
+import { serializeJson } from '@nrwl/devkit';
 import type { Linter } from 'eslint';
 import { runMigration } from '../../utils/testing';
 import {
@@ -54,7 +55,7 @@ describe('Update ESLint config files to use preset configs which eslint-plugin-n
   it('should update the current (v10.3.0) root .eslintrc.json file to the use the eslint-plugin-nx shared config', async () => {
     tree.create(
       '.eslintrc.json',
-      JSON.stringify({
+      serializeJson({
         root: true,
         parser: '@typescript-eslint/parser',
         parserOptions: {
@@ -402,22 +403,22 @@ describe('Update ESLint config files to use preset configs which eslint-plugin-n
 
     tree.create(
       'apps/reactapp/.eslintrc.json',
-      JSON.stringify(reactESLintConfig)
+      serializeJson(reactESLintConfig)
     );
 
     tree.create(
       'apps/notreactapp/.eslintrc.json',
-      JSON.stringify(notReactESLintConfig)
+      serializeJson(notReactESLintConfig)
     );
 
     tree.create(
       'libs/reactlib/.eslintrc.json',
-      JSON.stringify(reactESLintConfig)
+      serializeJson(reactESLintConfig)
     );
 
     tree.create(
       'libs/notreactlib/.eslintrc.json',
-      JSON.stringify(notReactESLintConfig)
+      serializeJson(notReactESLintConfig)
     );
 
     const result = await runMigration(

--- a/packages/linter/src/migrations/update-10-4-0/update-eslint-configs-to-use-nx-presets.ts
+++ b/packages/linter/src/migrations/update-10-4-0/update-eslint-configs-to-use-nx-presets.ts
@@ -444,8 +444,8 @@ export function updatePluginsAndRemoveDuplication(
   deleteIfUltimatelyEmpty: boolean,
   ensurePlugin?: string
 ): void {
-  json.plugins = json.plugins || [];
-  configBeingExtended.plugins = configBeingExtended.plugins || [];
+  json.plugins ||= [];
+  configBeingExtended.plugins ||= [];
   if (ensurePlugin && !json.plugins.includes(ensurePlugin)) {
     json.plugins.unshift(ensurePlugin);
   }
@@ -462,8 +462,8 @@ export function updateParserOptionsAndRemoveDuplication(
   json: Linter.Config,
   configBeingExtended: Linter.Config
 ): void {
-  json.parserOptions = json.parserOptions || {};
-  configBeingExtended.parserOptions = configBeingExtended.parserOptions || {};
+  json.parserOptions ||= {};
+  configBeingExtended.parserOptions ||= {};
   /**
    * If the user is still using the 2018 ecmaVersion that Nx set for them
    * previously we can just remove it and let them inherit the new 2020 value.
@@ -494,8 +494,8 @@ export function updateObjPropAndRemoveDuplication(
   objPropName: string,
   deleteIfUltimatelyEmpty: boolean
 ): void {
-  json[objPropName] = json[objPropName] || {};
-  configBeingExtended[objPropName] = configBeingExtended[objPropName] || {};
+  json[objPropName] ||= {};
+  configBeingExtended[objPropName] ||= {};
 
   for (const [name, val] of Object.entries(json[objPropName])) {
     const valueOfSamePropInExtendedConfig =

--- a/packages/linter/src/migrations/update-10-4-0/update-root-eslint-config-to-use-overrides.spec.ts
+++ b/packages/linter/src/migrations/update-10-4-0/update-root-eslint-config-to-use-overrides.spec.ts
@@ -2,6 +2,7 @@ import { Tree } from '@angular-devkit/schematics';
 import { readJsonInTree } from '@nrwl/workspace';
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
 import { runMigration } from '../../utils/testing';
+import { serializeJson } from '@nrwl/devkit';
 
 describe('Update root ESLint config to use overrides', () => {
   let tree: Tree;
@@ -196,7 +197,7 @@ describe('Update root ESLint config to use overrides', () => {
 
   testCases.forEach((tc, i) => {
     it(`should update the existing root .eslintrc.json file to use overrides, CASE ${i}`, async () => {
-      tree.create('.eslintrc.json', JSON.stringify(tc.input));
+      tree.create('.eslintrc.json', serializeJson(tc.input));
 
       const result = await runMigration(
         'update-root-eslint-config-to-use-overrides',

--- a/packages/linter/src/migrations/update-11-5-0/always-use-project-level-tsconfigs-with-eslint.spec.ts
+++ b/packages/linter/src/migrations/update-11-5-0/always-use-project-level-tsconfigs-with-eslint.spec.ts
@@ -1,4 +1,9 @@
-import { addProjectConfiguration, readJson, Tree } from '@nrwl/devkit';
+import {
+  addProjectConfiguration,
+  Tree,
+  readJson,
+  writeJson,
+} from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import updateTsConfigsWithEslint from './always-use-project-level-tsconfigs-with-eslint';
 
@@ -27,7 +32,7 @@ describe('Always use project level tsconfigs with eslint', () => {
   });
 
   it('should remove the "project" parserOption from the root ESLint config', async () => {
-    const rootEslintConfig = {
+    writeJson(tree, '.eslintrc.json', {
       root: true,
       ignorePatterns: ['**/*'],
       plugins: ['@nrwl/nx'],
@@ -60,9 +65,7 @@ describe('Always use project level tsconfigs with eslint', () => {
           rules: {},
         },
       ],
-    };
-
-    tree.write('.eslintrc.json', JSON.stringify(rootEslintConfig));
+    });
 
     await updateTsConfigsWithEslint(tree);
 
@@ -135,10 +138,7 @@ describe('Always use project level tsconfigs with eslint', () => {
         'jsx-a11y/anchor-is-valid': ['off'],
       },
     };
-    tree.write(
-      'apps/react-app/.eslintrc.json',
-      JSON.stringify(projectEslintConfig1)
-    );
+    writeJson(tree, 'apps/react-app/.eslintrc.json', projectEslintConfig1);
 
     // Has overrides array, but no parserOptions.project anywhere - add it for them
     const projectEslintConfig2 = {
@@ -153,10 +153,7 @@ describe('Always use project level tsconfigs with eslint', () => {
         },
       ],
     };
-    tree.write(
-      'libs/workspace-lib/.eslintrc.json',
-      JSON.stringify(projectEslintConfig2)
-    );
+    writeJson(tree, 'libs/workspace-lib/.eslintrc.json', projectEslintConfig2);
 
     // parserOptions.project already set manually by the user at some point, leave it alone
     const projectEslintConfig3 = {
@@ -172,10 +169,7 @@ describe('Always use project level tsconfigs with eslint', () => {
         },
       ],
     };
-    tree.write(
-      'libs/some-lib/.eslintrc.json',
-      JSON.stringify(projectEslintConfig3)
-    );
+    writeJson(tree, 'libs/some-lib/.eslintrc.json', projectEslintConfig3);
 
     await updateTsConfigsWithEslint(tree);
 
@@ -285,10 +279,7 @@ describe('Always use project level tsconfigs with eslint', () => {
         'jsx-a11y/anchor-is-valid': ['off'],
       },
     };
-    tree.write(
-      'apps/next-app/.eslintrc.json',
-      JSON.stringify(projectEslintConfig1)
-    );
+    writeJson(tree, 'apps/next-app/.eslintrc.json', projectEslintConfig1);
 
     await updateTsConfigsWithEslint(tree);
 

--- a/packages/linter/src/migrations/update-11-5-0/always-use-project-level-tsconfigs-with-eslint.ts
+++ b/packages/linter/src/migrations/update-11-5-0/always-use-project-level-tsconfigs-with-eslint.ts
@@ -1,4 +1,5 @@
-import { formatFiles, getProjects, Tree, updateJson } from '@nrwl/devkit';
+import { formatFiles, getProjects, updateJson } from '@nrwl/devkit';
+import type { Tree } from '@nrwl/devkit';
 import type { Linter } from 'eslint';
 import { join } from 'path';
 

--- a/packages/linter/src/migrations/update-12-4-0/remove-eslint-project-config-if-no-type-checking-rules.spec.ts
+++ b/packages/linter/src/migrations/update-12-4-0/remove-eslint-project-config-if-no-type-checking-rules.spec.ts
@@ -1,4 +1,9 @@
-import { addProjectConfiguration, readJson, Tree } from '@nrwl/devkit';
+import {
+  addProjectConfiguration,
+  readJson,
+  Tree,
+  writeJson,
+} from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import remoteESLintProjectConfigIfNoTypeCheckingRules from './remove-eslint-project-config-if-no-type-checking-rules';
 
@@ -63,7 +68,7 @@ describe('Remove ESLint parserOptions.project config if no rules requiring type-
         },
       ],
     };
-    tree.write('.eslintrc.json', JSON.stringify(rootEslintConfig));
+    writeJson(tree, '.eslintrc.json', rootEslintConfig);
 
     const projectEslintConfig1 = {
       extends: '../../../.eslintrc.json',
@@ -78,10 +83,7 @@ describe('Remove ESLint parserOptions.project config if no rules requiring type-
         },
       ],
     };
-    tree.write(
-      'apps/react-app/.eslintrc.json',
-      JSON.stringify(projectEslintConfig1)
-    );
+    writeJson(tree, 'apps/react-app/.eslintrc.json', projectEslintConfig1);
 
     const projectEslintConfig2 = {
       extends: '../../../.eslintrc.json',
@@ -96,10 +98,7 @@ describe('Remove ESLint parserOptions.project config if no rules requiring type-
         },
       ],
     };
-    tree.write(
-      'libs/workspace-lib/.eslintrc.json',
-      JSON.stringify(projectEslintConfig2)
-    );
+    writeJson(tree, 'libs/workspace-lib/.eslintrc.json', projectEslintConfig2);
 
     await remoteESLintProjectConfigIfNoTypeCheckingRules(tree);
 
@@ -122,7 +121,7 @@ describe('Remove ESLint parserOptions.project config if no rules requiring type-
       plugins: ['@nrwl/nx'],
       overrides: [],
     };
-    tree.write('.eslintrc.json', JSON.stringify(rootEslintConfig));
+    writeJson(tree, '.eslintrc.json', rootEslintConfig);
 
     const projectEslintConfig1 = {
       extends: '../../../.eslintrc.json',
@@ -139,10 +138,7 @@ describe('Remove ESLint parserOptions.project config if no rules requiring type-
         },
       ],
     };
-    tree.write(
-      'apps/react-app/.eslintrc.json',
-      JSON.stringify(projectEslintConfig1)
-    );
+    writeJson(tree, 'apps/react-app/.eslintrc.json', projectEslintConfig1);
 
     const projectEslintConfig2 = {
       extends: '../../../.eslintrc.json',
@@ -159,10 +155,7 @@ describe('Remove ESLint parserOptions.project config if no rules requiring type-
         },
       ],
     };
-    tree.write(
-      'libs/workspace-lib/.eslintrc.json',
-      JSON.stringify(projectEslintConfig2)
-    );
+    writeJson(tree, 'libs/workspace-lib/.eslintrc.json', projectEslintConfig2);
 
     await remoteESLintProjectConfigIfNoTypeCheckingRules(tree);
 

--- a/packages/linter/src/migrations/update-12-4-0/remove-eslint-project-config-if-no-type-checking-rules.ts
+++ b/packages/linter/src/migrations/update-12-4-0/remove-eslint-project-config-if-no-type-checking-rules.ts
@@ -1,10 +1,5 @@
-import {
-  formatFiles,
-  getProjects,
-  readJson,
-  Tree,
-  updateJson,
-} from '@nrwl/devkit';
+import { formatFiles, getProjects, readJson, updateJson } from '@nrwl/devkit';
+import type { Tree } from '@nrwl/devkit';
 import { join } from 'path';
 import {
   hasRulesRequiringTypeChecking,

--- a/packages/linter/src/utils/convert-tslint-to-eslint/convert-to-eslint-config.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/convert-to-eslint-config.ts
@@ -1,13 +1,12 @@
 import {
   readProjectConfiguration,
-  Tree,
   visitNotIgnoredFiles,
+  writeJsonFile,
+  getPackageManagerCommand,
 } from '@nrwl/devkit';
-import { getPackageManagerCommand } from '@nrwl/tao/src/shared/package-manager';
+import type { Tree } from '@nrwl/devkit';
 import { execSync } from 'child_process';
 import type { Linter as ESLintLinter } from 'eslint';
-import { mkdirSync, writeFileSync } from 'fs';
-import { dirname } from 'path';
 import { dirSync } from 'tmp';
 import type {
   createESLintConfiguration as CreateESLintConfiguration,
@@ -24,7 +23,7 @@ function getConvertToEslintConfig() {
   try {
     // This is usually not possible during runtime but makes it easy to mock in tests
     return require('tslint-to-eslint-config');
-  } catch (e) {}
+  } catch {}
 
   /**
    * In order to avoid all users of Nx needing to have tslint-to-eslint-config (and therefore tslint)
@@ -102,8 +101,7 @@ export async function convertToESLintConfig(
      * point (1) above - we need to strip the relevant extends and commit that
      * change to disk before the tslint CLI reads the config file.
      */
-    mkdirSync(dirname(pathToTslintJson), { recursive: true });
-    writeFileSync(pathToTslintJson, JSON.stringify(updatedTSLintJson));
+    writeJsonFile(pathToTslintJson, updatedTSLintJson);
   }
   const reportedConfiguration = await findReportedConfiguration(
     'npx tslint --print-config',

--- a/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
@@ -1,20 +1,22 @@
 import {
-  GeneratorCallback,
   getProjects,
   installPackagesTask,
   joinPathFragments,
   logger,
-  NxJsonProjectConfiguration,
   offsetFromRoot,
-  ProjectConfiguration,
   readJson,
   readProjectConfiguration,
   readWorkspaceConfiguration,
   removeDependenciesFromPackageJson,
-  Tree,
   updateJson,
   updateProjectConfiguration,
   updateWorkspaceConfiguration,
+} from '@nrwl/devkit';
+import type {
+  Tree,
+  GeneratorCallback,
+  NxJsonProjectConfiguration,
+  ProjectConfiguration,
 } from '@nrwl/devkit';
 import type { Linter } from 'eslint';
 import { removeParserOptionsProjectIfNotRequired } from '../rules-requiring-type-checking';
@@ -211,7 +213,7 @@ export class ProjectConverter {
       convertedRootESLintConfig
     );
     updateJson(this.host, '.eslintrc.json', (json) => {
-      json.overrides = json.overrides || [];
+      json.overrides ||= [];
       if (
         finalConvertedRootESLintConfig.overrides &&
         finalConvertedRootESLintConfig.overrides.length
@@ -318,7 +320,7 @@ export class ProjectConverter {
        * by using eslint-plugin-tslint. We instead explicitly warn the user about this missing converter,
        * and therefore at this point we strip out any rules which start with @typescript-eslint/tslint/config
        */
-      json.rules = json.rules || {};
+      json.rules ||= {};
       if (
         convertedProjectESLintConfig.rules &&
         Object.keys(convertedProjectESLintConfig.rules).length
@@ -520,9 +522,8 @@ export class ProjectConverter {
   ) {
     const workspace = readWorkspaceConfiguration(this.host);
 
-    workspace.generators = workspace.generators || {};
-    workspace.generators[collectionName] =
-      workspace.generators[collectionName] || {};
+    workspace.generators ||= {};
+    workspace.generators[collectionName] ||= {};
     const prev = workspace.generators[collectionName];
 
     workspace.generators = {

--- a/packages/linter/src/utils/convert-tslint-to-eslint/utils.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/utils.ts
@@ -1,9 +1,5 @@
-import {
-  addDependenciesToPackageJson,
-  GeneratorCallback,
-  logger,
-  Tree,
-} from '@nrwl/devkit';
+import { addDependenciesToPackageJson, logger } from '@nrwl/devkit';
+import type { Tree, GeneratorCallback } from '@nrwl/devkit';
 import type { Linter } from 'eslint';
 import type { TSLintRuleOptions } from 'tslint-to-eslint-config';
 import { convertTslintNxRuleToEslintNxRule } from './convert-nx-enforce-module-boundaries-rule';
@@ -74,8 +70,7 @@ export async function convertTSLintConfig(
     rawTSLintJson,
     ignoreExtendsVals
   );
-  convertedProject.convertedESLintConfig.rules =
-    convertedProject.convertedESLintConfig.rules || {};
+  convertedProject.convertedESLintConfig.rules ||= {};
 
   /**
    * Apply the custom converter for the nx-module-boundaries rule if applicable


### PR DESCRIPTION
## Current Behavior
`@nrwl/linter` does not use the newly introduced json utils

## Expected Behavior
should use the json utils
should use typescripts logical assignment operators for more readable code

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
#5859

Fixes #
