### PR TITLE
feat(core): sort projects in nx.json, workspace.json, and tsconfig.base.json

### DIFF
--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import type * as Prettier from 'prettier';
 import { getWorkspacePath } from '../utils/get-workspace-layout';
 import { readJson, writeJson } from '../utils/json';
+import { objectSort } from '@nrwl/tao/src/utils/object-sort';
 
 /**
  * Formats all the created or updated files using Prettier
@@ -16,6 +17,9 @@ export async function formatFiles(host: Tree): Promise<void> {
   } catch {}
 
   updateWorkspaceJsonToMatchFormatVersion(host);
+  sortWorkspaceJson(host);
+  sortNxJson(host);
+  sortTsConfig(host);
 
   if (!prettier) return;
 
@@ -71,4 +75,26 @@ function updateWorkspaceJsonToMatchFormatVersion(host: Tree) {
     console.error(`Failed to format: ${path}`);
     console.error(e);
   }
+}
+
+function sortWorkspaceJson(host: Tree) {
+  const workspaceJsonPath = getWorkspacePath(host);
+  const workspaceJson = readJson(host, workspaceJsonPath);
+  const sortedProjects = objectSort(workspaceJson.projects);
+  workspaceJson.projects = sortedProjects;
+  writeJson(host, workspaceJsonPath, workspaceJson);
+}
+
+function sortNxJson(host: Tree) {
+  const nxJson = readJson(host, 'nx.json');
+  const sortedProjects = objectSort(nxJson.projects);
+  nxJson.projects = sortedProjects;
+  writeJson(host, 'nx.json', nxJson);
+}
+
+function sortTsConfig(host: Tree) {
+  const tsconfig = readJson(host, 'tsconfig.base.json');
+  const sortedPaths = objectSort(tsconfig.compilerOptions.paths);
+  tsconfig.compilerOptions.paths = sortedPaths;
+  writeJson(host, 'tsconfig.base.json', tsconfig);
 }

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import type * as Prettier from 'prettier';
 import { getWorkspacePath } from '../utils/get-workspace-layout';
 import { readJson, writeJson } from '../utils/json';
-import { objectSort } from '@nrwl/tao/src/utils/object-sort';
+import { objectSortByKeys } from '@nrwl/tao/src/utils/object-sort';
 
 /**
  * Formats all the created or updated files using Prettier
@@ -81,7 +81,7 @@ function sortWorkspaceJson(host: Tree) {
   const workspaceJsonPath = getWorkspacePath(host);
   try {
     const workspaceJson = readJson(host, workspaceJsonPath);
-    const sortedProjects = objectSort(workspaceJson.projects);
+    const sortedProjects = objectSortByKeys(workspaceJson.projects);
     workspaceJson.projects = sortedProjects;
     writeJson(host, workspaceJsonPath, workspaceJson);
   } catch (e) {
@@ -92,7 +92,7 @@ function sortWorkspaceJson(host: Tree) {
 function sortNxJson(host: Tree) {
   try {
     const nxJson = readJson(host, 'nx.json');
-    const sortedProjects = objectSort(nxJson.projects);
+    const sortedProjects = objectSortByKeys(nxJson.projects);
     nxJson.projects = sortedProjects;
     writeJson(host, 'nx.json', nxJson);
   } catch (e) {
@@ -103,7 +103,7 @@ function sortNxJson(host: Tree) {
 function sortTsConfig(host: Tree) {
   try {
     const tsconfig = readJson(host, 'tsconfig.base.json');
-    const sortedPaths = objectSort(tsconfig.compilerOptions.paths);
+    const sortedPaths = objectSortByKeys(tsconfig.compilerOptions.paths);
     tsconfig.compilerOptions.paths = sortedPaths;
     writeJson(host, 'tsconfig.base.json', tsconfig);
   } catch (e) {

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -81,11 +81,13 @@ function sortWorkspaceJson(host: Tree) {
   const workspaceJsonPath = getWorkspacePath(host);
   try {
     const workspaceJson = readJson(host, workspaceJsonPath);
-    const sortedProjects = objectSortByKeys(workspaceJson.projects);
-    workspaceJson.projects = sortedProjects;
-    writeJson(host, workspaceJsonPath, workspaceJson);
+    if (Object.entries(workspaceJson.projects).length !== 0) {
+      const sortedProjects = objectSortByKeys(workspaceJson.projects);
+      workspaceJson.projects = sortedProjects;
+      writeJson(host, workspaceJsonPath, workspaceJson);
+    }
   } catch (e) {
-    console.error(`failed to sort projects in ${workspaceJsonPath}`);
+    console.warn(`failed to sort projects in ${workspaceJsonPath}`);
   }
 }
 
@@ -96,7 +98,7 @@ function sortNxJson(host: Tree) {
     nxJson.projects = sortedProjects;
     writeJson(host, 'nx.json', nxJson);
   } catch (e) {
-    console.error('failed to sort projects in nx.json');
+    console.warn('failed to sort projects in nx.json');
   }
 }
 
@@ -107,6 +109,6 @@ function sortTsConfig(host: Tree) {
     tsconfig.compilerOptions.paths = sortedPaths;
     writeJson(host, 'tsconfig.base.json', tsconfig);
   } catch (e) {
-    console.error('failed to sort paths in tsconfig.base.json');
+    console.warn('failed to sort paths in tsconfig.base.json');
   }
 }

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -79,22 +79,34 @@ function updateWorkspaceJsonToMatchFormatVersion(host: Tree) {
 
 function sortWorkspaceJson(host: Tree) {
   const workspaceJsonPath = getWorkspacePath(host);
-  const workspaceJson = readJson(host, workspaceJsonPath);
-  const sortedProjects = objectSort(workspaceJson.projects);
-  workspaceJson.projects = sortedProjects;
-  writeJson(host, workspaceJsonPath, workspaceJson);
+  try {
+    const workspaceJson = readJson(host, workspaceJsonPath);
+    const sortedProjects = objectSort(workspaceJson.projects);
+    workspaceJson.projects = sortedProjects;
+    writeJson(host, workspaceJsonPath, workspaceJson);
+  } catch (e) {
+    console.error(`failed to sort projects in ${workspaceJsonPath}`);
+  }
 }
 
 function sortNxJson(host: Tree) {
-  const nxJson = readJson(host, 'nx.json');
-  const sortedProjects = objectSort(nxJson.projects);
-  nxJson.projects = sortedProjects;
-  writeJson(host, 'nx.json', nxJson);
+  try {
+    const nxJson = readJson(host, 'nx.json');
+    const sortedProjects = objectSort(nxJson.projects);
+    nxJson.projects = sortedProjects;
+    writeJson(host, 'nx.json', nxJson);
+  } catch (e) {
+    console.error('failed to sort projects in nx.json');
+  }
 }
 
 function sortTsConfig(host: Tree) {
-  const tsconfig = readJson(host, 'tsconfig.base.json');
-  const sortedPaths = objectSort(tsconfig.compilerOptions.paths);
-  tsconfig.compilerOptions.paths = sortedPaths;
-  writeJson(host, 'tsconfig.base.json', tsconfig);
+  try {
+    const tsconfig = readJson(host, 'tsconfig.base.json');
+    const sortedPaths = objectSort(tsconfig.compilerOptions.paths);
+    tsconfig.compilerOptions.paths = sortedPaths;
+    writeJson(host, 'tsconfig.base.json', tsconfig);
+  } catch (e) {
+    console.error('failed to sort paths in tsconfig.base.json');
+  }
 }

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import type * as Prettier from 'prettier';
 import { getWorkspacePath } from '../utils/get-workspace-layout';
 import { readJson, writeJson } from '../utils/json';
-import { objectSortByKeys } from '@nrwl/tao/src/utils/object-sort';
+import { sortObjectByKeys } from '@nrwl/tao/src/utils/object-sort';
 
 /**
  * Formats all the created or updated files using Prettier
@@ -79,12 +79,18 @@ function updateWorkspaceJsonToMatchFormatVersion(host: Tree) {
 
 function sortWorkspaceJson(host: Tree) {
   const workspaceJsonPath = getWorkspacePath(host);
+  if (!path) {
+    return;
+  }
+
   try {
     const workspaceJson = readJson(host, workspaceJsonPath);
     if (Object.entries(workspaceJson.projects).length !== 0) {
-      const sortedProjects = objectSortByKeys(workspaceJson.projects);
-      workspaceJson.projects = sortedProjects;
-      writeJson(host, workspaceJsonPath, workspaceJson);
+      const sortedProjects = sortObjectByKeys(workspaceJson.projects);
+      writeJson(host, workspaceJsonPath, {
+        ...workspaceJson,
+        projects: sortedProjects,
+      });
     }
   } catch (e) {
     console.warn(`failed to sort projects in ${workspaceJsonPath}`);
@@ -94,9 +100,11 @@ function sortWorkspaceJson(host: Tree) {
 function sortNxJson(host: Tree) {
   try {
     const nxJson = readJson(host, 'nx.json');
-    const sortedProjects = objectSortByKeys(nxJson.projects);
-    nxJson.projects = sortedProjects;
-    writeJson(host, 'nx.json', nxJson);
+    const sortedProjects = sortObjectByKeys(nxJson.projects);
+    writeJson(host, 'nx.json', {
+      ...nxJson,
+      projects: sortedProjects,
+    });
   } catch (e) {
     console.warn('failed to sort projects in nx.json');
   }
@@ -105,9 +113,14 @@ function sortNxJson(host: Tree) {
 function sortTsConfig(host: Tree) {
   try {
     const tsconfig = readJson(host, 'tsconfig.base.json');
-    const sortedPaths = objectSortByKeys(tsconfig.compilerOptions.paths);
-    tsconfig.compilerOptions.paths = sortedPaths;
-    writeJson(host, 'tsconfig.base.json', tsconfig);
+    const sortedPaths = sortObjectByKeys(tsconfig.compilerOptions.paths);
+    writeJson(host, 'tsconfig.base.json', {
+      ...tsconfig,
+      compilerOptions: {
+        ...tsconfig.compilerOptions,
+        paths: sortedPaths,
+      },
+    });
   } catch (e) {
     console.warn('failed to sort paths in tsconfig.base.json');
   }

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -93,7 +93,7 @@ function sortWorkspaceJson(host: Tree) {
       });
     }
   } catch (e) {
-    console.warn(`failed to sort projects in ${workspaceJsonPath}`);
+    // catch noop
   }
 }
 
@@ -106,7 +106,7 @@ function sortNxJson(host: Tree) {
       projects: sortedProjects,
     });
   } catch (e) {
-    console.warn('failed to sort projects in nx.json');
+    // catch noop
   }
 }
 
@@ -122,6 +122,6 @@ function sortTsConfig(host: Tree) {
       },
     });
   } catch (e) {
-    console.warn('failed to sort paths in tsconfig.base.json');
+    // catch noop
   }
 }

--- a/packages/tao/src/utils/object-sort.ts
+++ b/packages/tao/src/utils/object-sort.ts
@@ -1,8 +1,10 @@
-export function objectSortByKeys(originalObject: object) {
+export function sortObjectByKeys(originalObject: object) {
   return Object.keys(originalObject)
     .sort()
     .reduce((obj, key) => {
-      obj[key] = originalObject[key];
-      return obj;
+      return {
+        ...obj,
+        [key]: originalObject[key],
+      };
     }, {});
 }

--- a/packages/tao/src/utils/object-sort.ts
+++ b/packages/tao/src/utils/object-sort.ts
@@ -1,4 +1,4 @@
-export function objectSort(originalObject: object) {
+export function objectSortByKeys(originalObject: object) {
   return Object.keys(originalObject)
     .sort()
     .reduce((obj, key) => {

--- a/packages/tao/src/utils/object-sort.ts
+++ b/packages/tao/src/utils/object-sort.ts
@@ -1,0 +1,8 @@
+export function objectSort(originalObject: object) {
+  return Object.keys(originalObject)
+    .sort()
+    .reduce((obj, key) => {
+      obj[key] = originalObject[key];
+      return obj;
+    }, {});
+}

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -152,9 +152,11 @@ function sortWorkspaceJson() {
   const workspaceJsonPath = workspaceConfigName(appRootPath);
   try {
     const workspaceJson = readJsonFile(workspaceJsonPath);
-    const sortedProjects = objectSortByKeys(workspaceJson.projects);
-    workspaceJson.projects = sortedProjects;
-    writeJsonFile(workspaceJsonPath, workspaceJson);
+    if (Object.entries(workspaceJson.projects).length !== 0) {
+      const sortedProjects = objectSortByKeys(workspaceJson.projects);
+      workspaceJson.projects = sortedProjects;
+      writeJsonFile(workspaceJsonPath, workspaceJson);
+    }
   } catch (e) {
     console.error(`failed to sort projects in ${workspaceJsonPath}`);
   }

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -150,24 +150,36 @@ function updateWorkspaceJsonToMatchFormatVersion() {
 
 function sortWorkspaceJson() {
   const workspaceJsonPath = workspaceConfigName(appRootPath);
-  const workspaceJson = readJsonFile(workspaceJsonPath);
-  const sortedProjects = objectSort(workspaceJson.projects);
-  workspaceJson.projects = sortedProjects;
-  writeJsonFile(workspaceJsonPath, workspaceJson);
+  try {
+    const workspaceJson = readJsonFile(workspaceJsonPath);
+    const sortedProjects = objectSort(workspaceJson.projects);
+    workspaceJson.projects = sortedProjects;
+    writeJsonFile(workspaceJsonPath, workspaceJson);
+  } catch (e) {
+    console.error(`failed to sort projects in ${workspaceJsonPath}`);
+  }
 }
 
 function sortNxJson() {
-  const nxJsonPath = path.join(appRootPath, 'nx.json');
-  const nxJson = readJsonFile(nxJsonPath);
-  const sortedProjects = objectSort(nxJson.projects);
-  nxJson.projects = sortedProjects;
-  writeJsonFile(nxJsonPath, nxJson);
+  try {
+    const nxJsonPath = path.join(appRootPath, 'nx.json');
+    const nxJson = readJsonFile(nxJsonPath);
+    const sortedProjects = objectSort(nxJson.projects);
+    nxJson.projects = sortedProjects;
+    writeJsonFile(nxJsonPath, nxJson);
+  } catch (e) {
+    console.error('failed to sort projects in nx.json');
+  }
 }
 
 function sortTsConfig() {
-  const tsconfigPath = path.join(appRootPath, 'tsconfig.base.json');
-  const tsconfig = readJsonFile(tsconfigPath);
-  const sortedPaths = objectSort(tsconfig.compilerOptions.paths);
-  tsconfig.compilerOptions.paths = sortedPaths;
-  writeJsonFile(tsconfigPath, tsconfig);
+  try {
+    const tsconfigPath = path.join(appRootPath, 'tsconfig.base.json');
+    const tsconfig = readJsonFile(tsconfigPath);
+    const sortedPaths = objectSort(tsconfig.compilerOptions.paths);
+    tsconfig.compilerOptions.paths = sortedPaths;
+    writeJsonFile(tsconfigPath, tsconfig);
+  } catch (e) {
+    console.error('failed to sort paths in tsconfig.base.json');
+  }
 }

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -17,7 +17,7 @@ import {
 import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
 import * as prettier from 'prettier';
 import { readJsonFile, writeJsonFile } from '@nrwl/devkit';
-import { objectSort } from '@nrwl/tao/src/utils/object-sort';
+import { objectSortByKeys } from '@nrwl/tao/src/utils/object-sort';
 
 const PRETTIER_PATH = require.resolve('prettier/bin-prettier');
 
@@ -152,7 +152,7 @@ function sortWorkspaceJson() {
   const workspaceJsonPath = workspaceConfigName(appRootPath);
   try {
     const workspaceJson = readJsonFile(workspaceJsonPath);
-    const sortedProjects = objectSort(workspaceJson.projects);
+    const sortedProjects = objectSortByKeys(workspaceJson.projects);
     workspaceJson.projects = sortedProjects;
     writeJsonFile(workspaceJsonPath, workspaceJson);
   } catch (e) {
@@ -164,7 +164,7 @@ function sortNxJson() {
   try {
     const nxJsonPath = path.join(appRootPath, 'nx.json');
     const nxJson = readJsonFile(nxJsonPath);
-    const sortedProjects = objectSort(nxJson.projects);
+    const sortedProjects = objectSortByKeys(nxJson.projects);
     nxJson.projects = sortedProjects;
     writeJsonFile(nxJsonPath, nxJson);
   } catch (e) {
@@ -176,7 +176,7 @@ function sortTsConfig() {
   try {
     const tsconfigPath = path.join(appRootPath, 'tsconfig.base.json');
     const tsconfig = readJsonFile(tsconfigPath);
-    const sortedPaths = objectSort(tsconfig.compilerOptions.paths);
+    const sortedPaths = objectSortByKeys(tsconfig.compilerOptions.paths);
     tsconfig.compilerOptions.paths = sortedPaths;
     writeJsonFile(tsconfigPath, tsconfig);
   } catch (e) {

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -17,7 +17,7 @@ import {
 import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
 import * as prettier from 'prettier';
 import { readJsonFile, writeJsonFile } from '@nrwl/devkit';
-import { objectSortByKeys } from '@nrwl/tao/src/utils/object-sort';
+import { sortObjectByKeys } from '@nrwl/tao/src/utils/object-sort';
 
 const PRETTIER_PATH = require.resolve('prettier/bin-prettier');
 
@@ -153,7 +153,7 @@ function sortWorkspaceJson() {
   try {
     const workspaceJson = readJsonFile(workspaceJsonPath);
     if (Object.entries(workspaceJson.projects).length !== 0) {
-      const sortedProjects = objectSortByKeys(workspaceJson.projects);
+      const sortedProjects = sortObjectByKeys(workspaceJson.projects);
       workspaceJson.projects = sortedProjects;
       writeJsonFile(workspaceJsonPath, workspaceJson);
     }
@@ -166,7 +166,7 @@ function sortNxJson() {
   try {
     const nxJsonPath = path.join(appRootPath, 'nx.json');
     const nxJson = readJsonFile(nxJsonPath);
-    const sortedProjects = objectSortByKeys(nxJson.projects);
+    const sortedProjects = sortObjectByKeys(nxJson.projects);
     nxJson.projects = sortedProjects;
     writeJsonFile(nxJsonPath, nxJson);
   } catch (e) {
@@ -178,7 +178,7 @@ function sortTsConfig() {
   try {
     const tsconfigPath = path.join(appRootPath, 'tsconfig.base.json');
     const tsconfig = readJsonFile(tsconfigPath);
-    const sortedPaths = objectSortByKeys(tsconfig.compilerOptions.paths);
+    const sortedPaths = sortObjectByKeys(tsconfig.compilerOptions.paths);
     tsconfig.compilerOptions.paths = sortedPaths;
     writeJsonFile(tsconfigPath, tsconfig);
   } catch (e) {

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -17,6 +17,7 @@ import {
 import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
 import * as prettier from 'prettier';
 import { readJsonFile, writeJsonFile } from '@nrwl/devkit';
+import { objectSort } from '@nrwl/tao/src/utils/object-sort';
 
 const PRETTIER_PATH = require.resolve('prettier/bin-prettier');
 
@@ -36,6 +37,9 @@ export function format(
   switch (command) {
     case 'write':
       updateWorkspaceJsonToMatchFormatVersion();
+      sortWorkspaceJson();
+      sortNxJson();
+      sortTsConfig();
       chunkList.forEach((chunk) => write(chunk));
       break;
     case 'check':
@@ -142,4 +146,28 @@ function updateWorkspaceJsonToMatchFormatVersion() {
     console.error(`Failed to format: ${path}`);
     console.error(e);
   }
+}
+
+function sortWorkspaceJson() {
+  const workspaceJsonPath = workspaceConfigName(appRootPath);
+  const workspaceJson = readJsonFile(workspaceJsonPath);
+  const sortedProjects = objectSort(workspaceJson.projects);
+  workspaceJson.projects = sortedProjects;
+  writeJsonFile(workspaceJsonPath, workspaceJson);
+}
+
+function sortNxJson() {
+  const nxJsonPath = path.join(appRootPath, 'nx.json');
+  const nxJson = readJsonFile(nxJsonPath);
+  const sortedProjects = objectSort(nxJson.projects);
+  nxJson.projects = sortedProjects;
+  writeJsonFile(nxJsonPath, nxJson);
+}
+
+function sortTsConfig() {
+  const tsconfigPath = path.join(appRootPath, 'tsconfig.base.json');
+  const tsconfig = readJsonFile(tsconfigPath);
+  const sortedPaths = objectSort(tsconfig.compilerOptions.paths);
+  tsconfig.compilerOptions.paths = sortedPaths;
+  writeJsonFile(tsconfigPath, tsconfig);
 }

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -158,7 +158,7 @@ function sortWorkspaceJson() {
       writeJsonFile(workspaceJsonPath, workspaceJson);
     }
   } catch (e) {
-    console.error(`failed to sort projects in ${workspaceJsonPath}`);
+    // catch noop
   }
 }
 
@@ -170,7 +170,7 @@ function sortNxJson() {
     nxJson.projects = sortedProjects;
     writeJsonFile(nxJsonPath, nxJson);
   } catch (e) {
-    console.error('failed to sort projects in nx.json');
+    // catch noop
   }
 }
 
@@ -182,6 +182,6 @@ function sortTsConfig() {
     tsconfig.compilerOptions.paths = sortedPaths;
     writeJsonFile(tsconfigPath, tsconfig);
   } catch (e) {
-    console.error('failed to sort paths in tsconfig.base.json');
+    // catch noop
   }
 }

--- a/packages/workspace/src/utils/rules/format-files.ts
+++ b/packages/workspace/src/utils/rules/format-files.ts
@@ -112,11 +112,13 @@ function sortWorkspaceJson(host: Tree, directory: string) {
   const workspaceJsonPath = getWorkspaceFile(host, directory);
   try {
     const workspaceJson = parseJson(host.read(workspaceJsonPath).toString());
-    const sortedProjects = sortObjectByKeys(workspaceJson.projects);
-    workspaceJson.projects = sortedProjects;
-    host.overwrite(workspaceJsonPath, serializeJson(workspaceJson));
+    if (Object.entries(workspaceJson.projects).length !== 0) {
+      const sortedProjects = sortObjectByKeys(workspaceJson.projects);
+      workspaceJson.projects = sortedProjects;
+      host.overwrite(workspaceJsonPath, serializeJson(workspaceJson));
+    }
   } catch (e) {
-    console.error(`failed to sort projects in ${workspaceJsonPath}`);
+    console.warn(`failed to sort projects in ${workspaceJsonPath}`);
   }
 }
 
@@ -127,7 +129,7 @@ function sortNxJson(host: Tree) {
     nxJson.projects = sortedProjects;
     host.overwrite('nx.json', serializeJson(nxJson));
   } catch (e) {
-    console.error('failed to sort projects in nx.json');
+    console.warn('failed to sort projects in nx.json');
   }
 }
 
@@ -138,6 +140,6 @@ function sortTsConfig(host: Tree) {
     tsconfig.compilerOptions.paths = sortedPaths;
     host.overwrite('tsconfig.base.json', serializeJson(tsconfig));
   } catch (e) {
-    console.error('failed to sort paths in tsconfig.base.json');
+    console.warn('failed to sort paths in tsconfig.base.json');
   }
 }

--- a/packages/workspace/src/utils/rules/format-files.ts
+++ b/packages/workspace/src/utils/rules/format-files.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import { appRootPath } from '../../utilities/app-root';
 import { reformattedWorkspaceJsonOrNull } from '@nrwl/tao/src/shared/workspace';
 import { parseJson, serializeJson } from '@nrwl/devkit';
+import { sortObjectByKeys } from '../ast-utils';
 
 export function formatFiles(
   options: { skipFormat: boolean } = { skipFormat: false },
@@ -107,20 +108,11 @@ function updateWorkspaceJsonToMatchFormatVersion(
   }
 }
 
-function objectSort(originalObject: object) {
-  return Object.keys(originalObject)
-    .sort()
-    .reduce((obj, key) => {
-      obj[key] = originalObject[key];
-      return obj;
-    }, {});
-}
-
 function sortWorkspaceJson(host: Tree, directory: string) {
   const workspaceJsonPath = getWorkspaceFile(host, directory);
   try {
     const workspaceJson = parseJson(host.read(workspaceJsonPath).toString());
-    const sortedProjects = objectSort(workspaceJson.projects);
+    const sortedProjects = sortObjectByKeys(workspaceJson.projects);
     workspaceJson.projects = sortedProjects;
     host.overwrite(workspaceJsonPath, serializeJson(workspaceJson));
   } catch (e) {
@@ -131,7 +123,7 @@ function sortWorkspaceJson(host: Tree, directory: string) {
 function sortNxJson(host: Tree) {
   try {
     const nxJson = parseJson(host.read('nx.json').toString());
-    const sortedProjects = objectSort(nxJson.projects);
+    const sortedProjects = sortObjectByKeys(nxJson.projects);
     nxJson.projects = sortedProjects;
     host.overwrite('nx.json', serializeJson(nxJson));
   } catch (e) {
@@ -142,7 +134,7 @@ function sortNxJson(host: Tree) {
 function sortTsConfig(host: Tree) {
   try {
     const tsconfig = parseJson(host.read('tsconfig.base.json').toString());
-    const sortedPaths = objectSort(tsconfig.compilerOptions.paths);
+    const sortedPaths = sortObjectByKeys(tsconfig.compilerOptions.paths);
     tsconfig.compilerOptions.paths = sortedPaths;
     host.overwrite('tsconfig.base.json', serializeJson(tsconfig));
   } catch (e) {

--- a/packages/workspace/src/utils/rules/format-files.ts
+++ b/packages/workspace/src/utils/rules/format-files.ts
@@ -76,20 +76,15 @@ export function formatFiles(
   };
 }
 
-function getWorkspaceFile(host: Tree, directory: string) {
+function updateWorkspaceJsonToMatchFormatVersion(
+  host: Tree,
+  directory: string
+) {
   const possibleFiles = [
     `${directory}/workspace.json`,
     `${directory}/angular.json`,
   ];
   const path = possibleFiles.filter((path) => host.exists(path))[0];
-  return path;
-}
-
-function updateWorkspaceJsonToMatchFormatVersion(
-  host: Tree,
-  directory: string
-) {
-  const path = getWorkspaceFile(host, directory);
   try {
     if (path) {
       const workspaceJson = parseJson(host.read(path).toString());

--- a/packages/workspace/src/utils/rules/format-files.ts
+++ b/packages/workspace/src/utils/rules/format-files.ts
@@ -12,7 +12,6 @@ import * as path from 'path';
 import { appRootPath } from '../../utilities/app-root';
 import { reformattedWorkspaceJsonOrNull } from '@nrwl/tao/src/shared/workspace';
 import { parseJson, serializeJson } from '@nrwl/devkit';
-import { sortObjectByKeys } from '../ast-utils';
 
 export function formatFiles(
   options: { skipFormat: boolean } = { skipFormat: false },
@@ -29,9 +28,6 @@ export function formatFiles(
 
   return (host: Tree, context: SchematicContext) => {
     updateWorkspaceJsonToMatchFormatVersion(host, directory);
-    sortWorkspaceJson(host, directory);
-    sortNxJson(host);
-    sortTsConfig(host);
 
     if (!prettier) {
       return host;
@@ -105,41 +101,5 @@ function updateWorkspaceJsonToMatchFormatVersion(
   } catch (e) {
     console.error(`Failed to format: ${path}`);
     console.error(e);
-  }
-}
-
-function sortWorkspaceJson(host: Tree, directory: string) {
-  const workspaceJsonPath = getWorkspaceFile(host, directory);
-  try {
-    const workspaceJson = parseJson(host.read(workspaceJsonPath).toString());
-    if (Object.entries(workspaceJson.projects).length !== 0) {
-      const sortedProjects = sortObjectByKeys(workspaceJson.projects);
-      workspaceJson.projects = sortedProjects;
-      host.overwrite(workspaceJsonPath, serializeJson(workspaceJson));
-    }
-  } catch (e) {
-    console.warn(`failed to sort projects in ${workspaceJsonPath}`);
-  }
-}
-
-function sortNxJson(host: Tree) {
-  try {
-    const nxJson = parseJson(host.read('nx.json').toString());
-    const sortedProjects = sortObjectByKeys(nxJson.projects);
-    nxJson.projects = sortedProjects;
-    host.overwrite('nx.json', serializeJson(nxJson));
-  } catch (e) {
-    console.warn('failed to sort projects in nx.json');
-  }
-}
-
-function sortTsConfig(host: Tree) {
-  try {
-    const tsconfig = parseJson(host.read('tsconfig.base.json').toString());
-    const sortedPaths = sortObjectByKeys(tsconfig.compilerOptions.paths);
-    tsconfig.compilerOptions.paths = sortedPaths;
-    host.overwrite('tsconfig.base.json', serializeJson(tsconfig));
-  } catch (e) {
-    console.warn('failed to sort paths in tsconfig.base.json');
   }
 }

--- a/packages/workspace/src/utils/rules/format-files.ts
+++ b/packages/workspace/src/utils/rules/format-files.ts
@@ -118,22 +118,34 @@ function objectSort(originalObject: object) {
 
 function sortWorkspaceJson(host: Tree, directory: string) {
   const workspaceJsonPath = getWorkspaceFile(host, directory);
-  const workspaceJson = parseJson(host.read(workspaceJsonPath).toString());
-  const sortedProjects = objectSort(workspaceJson.projects);
-  workspaceJson.projects = sortedProjects;
-  host.overwrite(workspaceJsonPath, serializeJson(workspaceJson));
+  try {
+    const workspaceJson = parseJson(host.read(workspaceJsonPath).toString());
+    const sortedProjects = objectSort(workspaceJson.projects);
+    workspaceJson.projects = sortedProjects;
+    host.overwrite(workspaceJsonPath, serializeJson(workspaceJson));
+  } catch (e) {
+    console.error(`failed to sort projects in ${workspaceJsonPath}`);
+  }
 }
 
 function sortNxJson(host: Tree) {
-  const nxJson = parseJson(host.read('nx.json').toString());
-  const sortedProjects = objectSort(nxJson.projects);
-  nxJson.projects = sortedProjects;
-  host.overwrite('nx.json', serializeJson(nxJson));
+  try {
+    const nxJson = parseJson(host.read('nx.json').toString());
+    const sortedProjects = objectSort(nxJson.projects);
+    nxJson.projects = sortedProjects;
+    host.overwrite('nx.json', serializeJson(nxJson));
+  } catch (e) {
+    console.error('failed to sort projects in nx.json');
+  }
 }
 
 function sortTsConfig(host: Tree) {
-  const tsconfig = parseJson(host.read('tsconfig.base.json').toString());
-  const sortedPaths = objectSort(tsconfig.compilerOptions.paths);
-  tsconfig.compilerOptions.paths = sortedPaths;
-  host.overwrite('tsconfig.base.json', serializeJson(tsconfig));
+  try {
+    const tsconfig = parseJson(host.read('tsconfig.base.json').toString());
+    const sortedPaths = objectSort(tsconfig.compilerOptions.paths);
+    tsconfig.compilerOptions.paths = sortedPaths;
+    host.overwrite('tsconfig.base.json', serializeJson(tsconfig));
+  } catch (e) {
+    console.error('failed to sort paths in tsconfig.base.json');
+  }
 }


### PR DESCRIPTION
## Current Behavior
When creating new apps or libs, the project is added to the end of the the projects list in nx.json and workspace.json, this includes the paths property for tsconfig.base.json. This causes merge conflicts when multiple users are creating new projects in a new project or a highly active repo.

## Expected Behavior
When creating new apps or libs, the projects object are sorted alphabetically. 

## Related Issue(s)
Fixes #2607
