### PR TITLE
docs(core): add anchor links to headings

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/content.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/content.tsx
@@ -45,7 +45,17 @@ export function Content(props: ContentProps) {
     <div className="min-w-0 flex-auto px-4 sm:px-6 xl:px-8 pt-10 pb-24 lg:pb-16">
       <ReactMarkdown
         remarkPlugins={[gfm]}
-        rehypePlugins={[slug, autolinkHeadings, renderIframes]}
+        rehypePlugins={[
+          slug,
+          [
+            autolinkHeadings,
+            {
+              behavior: 'append',
+              content: createAnchorContent,
+            },
+          ],
+          renderIframes,
+        ]}
         children={props.document.content}
         transformLinkUri={transformLinkPath({
           flavor: props.flavor,
@@ -69,6 +79,42 @@ export function Content(props: ContentProps) {
       />
     </div>
   );
+}
+function createAnchorContent(node) {
+  node.properties.className = ['group'];
+  return {
+    type: 'element',
+    tagName: 'svg',
+    properties: {
+      xmlns: 'http://www.w3.org/2000/svg',
+      className: [
+        'inline',
+        'ml-2',
+        'mb-1',
+        `h-5`,
+        `w-5`,
+        'opacity-0',
+        'group-hover:opacity-100',
+      ],
+      fill: 'none',
+      viewBox: '0 0 24 24',
+      stroke: 'currentColor',
+    },
+    children: [
+      {
+        type: 'element',
+        tagName: 'path',
+        properties: {
+          'stroke-linecap': 'round',
+          'stroke-linejoin': 'round',
+          'stroke-width': '2',
+          d:
+            'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1',
+        },
+        children: [],
+      },
+    ],
+  };
 }
 
 export default Content;


### PR DESCRIPTION
This PR adds anchor links to documentation content headings (e.g. h1, h2, ...).