### PR TITLE
docs(core): add nrwlio link in place of nrwlio twitter

### DIFF
--- a/nx-dev/ui/common/src/lib/footer.tsx
+++ b/nx-dev/ui/common/src/lib/footer.tsx
@@ -127,7 +127,7 @@ export function Footer({ version, flavor }: FooterProps) {
             </svg>{' '}
             by
             <a
-              href="https://twitter.com/nrwl_io"
+              href="https://nrwl.io"
               className="text-gray-600 ml-1 point-cursor"
               rel="noopener noreferrer"
               target="_blank"


### PR DESCRIPTION
## What it does?
This replace the twitter handle link of nrwlio by a link to nrwl.io