### PR TITLE
fix(core): clean up tmp directories during migrate

### DIFF
--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -459,6 +459,7 @@ function createFetcher(packageManager: PackageManager) {
           version: resolvedVersion,
         };
       }
+      removeSync(dir);
     }
     return cache[`${packageName}-${packageVersion}`];
   };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx migrate` leaves a lot of tmp directories around. Usually the operating system cleans these up. But they can collect and cause a lot of storage to be used.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx migrate` cleans up tmp directories when things are successful. When things fail though, tmp directories stay around to help debug the issue.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5947 
