### PR TITLE
fix(storybook): fix import for findNodes

### DIFF
--- a/packages/storybook/src/generators/migrate-stories-to-6-2/migrate-stories-to-6-2.ts
+++ b/packages/storybook/src/generators/migrate-stories-to-6-2/migrate-stories-to-6-2.ts
@@ -10,7 +10,7 @@ import {
   visitNotIgnoredFiles,
 } from '@nrwl/devkit';
 import { fileExists } from '@nrwl/workspace/src/utilities/fileutils';
-import { findNodes } from '@nrwl/workspace/src/utils/ast-utils';
+import { findNodes } from '@nrwl/workspace/src/utilities/typescript/find-nodes';
 import { join, normalize } from 'path';
 import { SyntaxKind } from 'typescript';
 import ts = require('typescript');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`findNodes` is imported from `@nrwl/workspace/src/utils/ast-utils` which brings in `@angular-devkit` which is not present in react workspaces.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`findNodes` is imported from `@nrwl/workspace/src/utilities/typescript/find-nodes` which does not bring in `@angular-devkit`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
