### PR TITLE
feat(core): expose utilities for retrieving source dirs of dependent projects

### DIFF
--- a/packages/next/index.ts
+++ b/packages/next/index.ts
@@ -1,4 +1,5 @@
 export * from './src/utils/types';
+export { createGlobPatternsOfDependentProjects } from './src/utils/generate-globs';
 
 export { applicationGenerator } from './src/generators/application/application';
 export { componentGenerator } from './src/generators/component/component';

--- a/packages/next/src/utils/generate-globs.ts
+++ b/packages/next/src/utils/generate-globs.ts
@@ -1,0 +1,27 @@
+import { joinPathFragments } from '@nrwl/devkit';
+import { createProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
+import { getSourceDirOfDependentProjects } from '@nrwl/workspace/src/utilities/project-graph-utils';
+import { resolve } from 'path';
+
+/**
+ * Creates an array of of the dependent projects' source directories, appended
+ * with the passed glob pattern.
+ * @param projectName workspace relative filename, you can pass `__filename` if executed in a node process
+ * @param fileGlobPattern the glob pattern to be applied to the various project directories
+ * @returns
+ */
+export function createGlobPatternsOfDependentProjects(
+  projectName: string,
+  fileGlobPattern: string = '/**/!(*.stories|*.spec).tsx'
+): string[] {
+  const projectGraph = createProjectGraph();
+  const projectDirs = getSourceDirOfDependentProjects(
+    projectName,
+    projectGraph
+  );
+
+  return projectDirs.map((sourceDir) =>
+    resolve(appRootPath, joinPathFragments(sourceDir, fileGlobPattern))
+  );
+}

--- a/packages/workspace/src/utilities/project-graph-utils.spec.ts
+++ b/packages/workspace/src/utilities/project-graph-utils.spec.ts
@@ -1,0 +1,68 @@
+import { ProjectGraph } from '@nrwl/devkit';
+import { getSourceDirOfDependentProjects } from './project-graph-utils';
+
+describe('project graph utils', () => {
+  describe('getSourceDirOfDependentProjects', () => {
+    it('should correctly gather the source root dirs of the dependent projects', () => {
+      const projGraph: ProjectGraph = {
+        nodes: {
+          'demo-app': {
+            name: 'demo-app',
+            type: 'app',
+            data: {
+              root: 'apps/demo-app',
+              sourceRoot: 'apps/demo-app/src',
+              projectType: 'application',
+              targets: {},
+            },
+          },
+          ui: {
+            name: 'ui',
+            type: 'lib',
+            data: {
+              root: 'libs/ui',
+              sourceRoot: 'libs/ui/src',
+              projectType: 'library',
+              targets: {},
+            },
+          },
+          core: {
+            name: 'core',
+            type: 'lib',
+            data: {
+              root: 'libs/core',
+              sourceRoot: 'libs/core/src',
+              projectType: 'library',
+              targets: {},
+            },
+          },
+        },
+        dependencies: {
+          'demo-app': [
+            {
+              type: 'static',
+              source: 'demo-app',
+              target: 'ui',
+            },
+            {
+              type: 'static',
+              source: 'demo-app',
+              target: 'npm:chalk',
+            },
+            {
+              type: 'static',
+              source: 'demo-app',
+              target: 'core',
+            },
+          ],
+        },
+      };
+
+      const paths = getSourceDirOfDependentProjects('demo-app', projGraph);
+
+      expect(paths.length).toBe(2);
+      expect(paths).toContain(projGraph.nodes['ui'].data.sourceRoot);
+      expect(paths).toContain(projGraph.nodes['core'].data.sourceRoot);
+    });
+  });
+});

--- a/packages/workspace/src/utilities/project-graph-utils.ts
+++ b/packages/workspace/src/utilities/project-graph-utils.ts
@@ -1,4 +1,5 @@
-import type { ProjectGraphNode } from '@nrwl/devkit';
+import type { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
+import { createProjectGraph } from '../core/project-graph';
 
 export function projectHasTarget(project: ProjectGraphNode, target: string) {
   return project.data && project.data.targets && project.data.targets[target];
@@ -14,4 +15,70 @@ export function projectHasTargetAndConfiguration(
     project.data.targets[target].configurations &&
     project.data.targets[target].configurations[configuration]
   );
+}
+
+export function getSourceDirOfDependentProjects(
+  projectName: string,
+  projectGraph = createProjectGraph()
+): string[] {
+  const dependencyNodeNames = findAllProjectNodeDependencies(
+    projectName,
+    projectGraph
+  );
+
+  return dependencyNodeNames.map(
+    (nodeName) => projectGraph.nodes[nodeName].data.sourceRoot
+  );
+}
+
+/**
+ * Takes a filename and figures out the belonging app and from there
+ * collects all dependent
+ * @param filename name of a file in some workspace app / lib
+ */
+function findAllProjectNodeDependencies(
+  parentNodeName: string,
+  projectGraph = createProjectGraph()
+): string[] {
+  const dependencyNodeNames = new Set<string>();
+
+  collectDependentProjectNodesNames(
+    projectGraph,
+    dependencyNodeNames,
+    parentNodeName
+  );
+
+  return Array.from(dependencyNodeNames);
+}
+
+// Recursively get all the dependencies of the node
+function collectDependentProjectNodesNames(
+  nxDeps: ProjectGraph,
+  dependencyNodeNames: Set<string>,
+  parentNodeName: string
+) {
+  const dependencies = nxDeps.dependencies[parentNodeName];
+  if (!dependencies) {
+    // no dependencies for the given node, so silently return,
+    // as we probably wouldn't want to throw here
+    return;
+  }
+
+  for (const dependency of dependencies) {
+    const dependencyName = dependency.target;
+
+    // we're only intersted in project dependencies, not npm
+    if (dependencyName.startsWith('npm:')) {
+      continue;
+    }
+
+    dependencyNodeNames.add(dependencyName);
+
+    // Get the dependencies of the dependencies
+    collectDependentProjectNodesNames(
+      nxDeps,
+      dependencyNodeNames,
+      dependencyName
+    );
+  }
 }


### PR DESCRIPTION
## New Feature

Utilities that are specifically helpful for tailwind config files to get the paths of dependent projects to make CSS purging work across dependent libs

```js
const { createGlobPatternsOfDependentProjects } = require('@nrwl/next');

module.exports = {
  // mode: 'jit',
  purge: [
    './apps/site/pages/**/*.{js,ts,jsx,tsx}',
    './apps/site/components/**/*.{js,ts,jsx,tsx}',
    ...createGlobPatternsOfDependentProjects('my-project-name'),
  ],
  darkMode: false, // or 'media' or 'class'
  theme: {},
  variants: {
    extend: {},
  },
  plugins: [],
};
```