### PR TITLE
chore(testing): added null check to jest migration

### DIFF
--- a/packages/jest/src/migrations/update-12-4-0/update-jest-preset-angular.ts
+++ b/packages/jest/src/migrations/update-12-4-0/update-jest-preset-angular.ts
@@ -57,7 +57,7 @@ export function updateASTTransformers(
   jestConfig: PartialJestConfig
 ) {
   const newTransformers = getNewAstTransformers(
-    jestConfig.globals?.['ts-jest'].astTransformers
+    jestConfig.globals?.['ts-jest']?.astTransformers
   );
   if (newTransformers === null) {
     removePropertyFromJestConfig(
@@ -146,7 +146,7 @@ export function transformerIsFromJestPresetAngular(
 }
 
 export function usesJestPresetAngular(jestConfig: PartialJestConfig) {
-  return jestConfig.globals['ts-jest']?.astTransformers?.before?.some?.((x) =>
+  return jestConfig.globals?.['ts-jest']?.astTransformers?.before?.some?.((x) =>
     transformerIsFromJestPresetAngular(x)
   );
 }


### PR DESCRIPTION
Testing out 12.4.0-beta, one of the jest migrations failed due to a missing null check in a real world repository.
