### PR TITLE
fix(testing): fix ts-jest transformer migration

### DIFF
--- a/packages/jest/src/migrations/update-12-4-0/update-jest-preset-angular.ts
+++ b/packages/jest/src/migrations/update-12-4-0/update-jest-preset-angular.ts
@@ -1,11 +1,4 @@
-import {
-  formatFiles,
-  logger,
-  ProjectConfiguration,
-  readProjectConfiguration,
-  stripIndents,
-  Tree,
-} from '@nrwl/devkit';
+import { formatFiles, logger, stripIndents, Tree } from '@nrwl/devkit';
 import { join } from 'path';
 
 import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
@@ -146,7 +139,7 @@ export function transformerIsFromJestPresetAngular(
 }
 
 export function usesJestPresetAngular(jestConfig: PartialJestConfig) {
-  return jestConfig.globals['ts-jest']?.astTransformers?.before?.some?.((x) =>
+  return jestConfig.globals?.['ts-jest']?.astTransformers?.before?.some?.((x) =>
     transformerIsFromJestPresetAngular(x)
   );
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Jest configs with no `globals` object cause the migration to error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Jest configs with no `globals` object are skipped by the migrations.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
