### PR TITLE
feat(core): allow NX_BASE and NX_HEAD environment variables to set affected SHAs

### DIFF
--- a/packages/workspace/src/command-line/utils.spec.ts
+++ b/packages/workspace/src/command-line/utils.spec.ts
@@ -137,6 +137,64 @@ describe('splitArgs', () => {
     });
   });
 
+  it('should set base and head based on environment variables in affected mode, if they are not provided directly on the command', () => {
+    const originalNxBase = process.env.NX_BASE;
+    process.env.NX_BASE = 'envVarSha1';
+    const originalNxHead = process.env.NX_HEAD;
+    process.env.NX_HEAD = 'envVarSha2';
+
+    expect(
+      splitArgsIntoNxArgsAndOverrides(
+        {
+          notNxArg: true,
+          _: ['--override'],
+          $0: '',
+        },
+        'affected'
+      ).nxArgs
+    ).toEqual({
+      base: 'envVarSha1',
+      head: 'envVarSha2',
+      skipNxCache: false,
+    });
+
+    expect(
+      splitArgsIntoNxArgsAndOverrides(
+        {
+          notNxArg: true,
+          _: ['--override'],
+          $0: '',
+          head: 'directlyOnCommandSha1' // higher priority than $NX_HEAD
+        },
+        'affected'
+      ).nxArgs
+    ).toEqual({
+      base: 'envVarSha1',
+      head: 'directlyOnCommandSha1',
+      skipNxCache: false,
+    });
+
+    expect(
+      splitArgsIntoNxArgsAndOverrides(
+        {
+          notNxArg: true,
+          _: ['--override'],
+          $0: '',
+          base: 'directlyOnCommandSha2' // higher priority than $NX_BASE
+        },
+        'affected'
+      ).nxArgs
+    ).toEqual({
+      base: 'directlyOnCommandSha2',
+      head: 'envVarSha2',
+      skipNxCache: false,
+    });
+
+    // Reset process data
+    process.env.NX_BASE = originalNxBase;
+    process.env.NX_HEAD = originalNxHead;
+  });
+
   it('should not set base and head in the run-one mode', () => {
     const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides(
       {

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -116,6 +116,7 @@ export function splitArgsIntoNxArgsAndOverrides(
     if (options.printWarnings) {
       printArgsWarning(nxArgs);
     }
+
     if (
       !nxArgs.files &&
       !nxArgs.uncommitted &&
@@ -127,7 +128,17 @@ export function splitArgsIntoNxArgsAndOverrides(
     ) {
       nxArgs.base = args._[0] as string;
       nxArgs.head = args._[1] as string;
-    } else if (!nxArgs.base) {
+    }
+
+    // Allow setting base and head via environment variables (lower priority then direct command arguments)
+    if (!nxArgs.base && process.env.NX_BASE) {
+      nxArgs.base = process.env.NX_BASE;
+    }
+    if (!nxArgs.head && process.env.NX_HEAD) {
+      nxArgs.head = process.env.NX_HEAD;
+    }
+
+    if (!nxArgs.base) {
       const affectedConfig = getAffectedConfig();
 
       nxArgs.base = affectedConfig.defaultBase;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Victor approved this being added as a feature as I have been sharing with him my iterations on efficient CI configs.

Particularly in CI environments, there is a certain amount of repeated boilerplate required because of the need to set `--base` and `--head` on each affected command.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We can set the base and head once (via environment variables) and have multiple affected commands use them.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
