### PR TITLE
fix(core): resolve npm packages after typescript

### DIFF
--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -69,12 +69,6 @@ export class TargetProjectLocator {
       }
     }
 
-    // try to find npm package before using expensive typescript resolution
-    const npmProject = this.findNpmPackage(importExpr);
-    if (npmProject || this.npmResolutionCache.has(importExpr)) {
-      return npmProject;
-    }
-
     let resolvedModule: string;
     if (this.typescriptResolutionCache.has(normalizedImportExpr)) {
       resolvedModule = this.typescriptResolutionCache.get(normalizedImportExpr);
@@ -97,6 +91,13 @@ export class TargetProjectLocator {
         return resolvedProject;
       }
     }
+
+    // try to find npm package before using expensive typescript resolution
+    const npmProject = this.findNpmPackage(importExpr);
+    if (npmProject || this.npmResolutionCache.has(importExpr)) {
+      return npmProject;
+    }
+
     // TODO: meeroslav this block should be probably removed
     const importedProject = this.sortedWorkspaceProjects.find((p) => {
       const projectImport = `@${npmScope}/${p.data.normalizedRoot}`;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

npm dependencies overrule the dependencies that typescript has which for the Nx repos and maybe others, `tao` is disconnected from the project graph.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

typescript dependencies overrule the npm dependencies and `tao` is connected to the project graph.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
