### PR TITLE
fix(nextjs): app generator should succeed with --directory

### DIFF
--- a/packages/next/src/generators/application/lib/add-cypress.ts
+++ b/packages/next/src/generators/application/lib/add-cypress.ts
@@ -13,6 +13,6 @@ export async function addCypress(host: Tree, options: NormalizedSchema) {
     linter: Linter.EsLint,
     name: `${options.name}-e2e`,
     directory: options.directory,
-    project: options.name,
+    project: options.projectName,
   });
 }


### PR DESCRIPTION
Next app generator was trying to attach cypress to project: `options.name` instead of `options.projectName`

ISSUES CLOSED: #6027