### PR TITLE
fix(core): format after sorting nx.json, workspace.json and tsconfig.…

### DIFF
--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -26,7 +26,7 @@ export function format(
   args: yargs.Arguments
 ): void {
   const { nxArgs } = splitArgsIntoNxArgsAndOverrides(args, 'affected');
-
+  const workspaceJsonPath = workspaceConfigName(appRootPath);
   const patterns = getPatterns({ ...args, ...nxArgs } as any).map(
     (p) => `"${p}"`
   );
@@ -40,6 +40,7 @@ export function format(
       sortWorkspaceJson();
       sortNxJson();
       sortTsConfig();
+      chunkList.push([workspaceJsonPath, 'nx.json', 'tsconfig.base.json']);
       chunkList.forEach((chunk) => write(chunk));
       break;
     case 'check':


### PR DESCRIPTION
…base.json

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The output of `nx format:write` is a little different from that of prettier.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx should run `prettier --write` again after it sorted the files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/nrwl/nx/pull/5945
Closes #6118 