### PR TITLE
cleanup(angular): generated ngrx spec files should pass linting

### DIFF
--- a/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.effects.spec.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.effects.spec.ts__tmpl__
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { Observable } from 'rxjs';
 
 import { EffectsModule } from '@ngrx/effects';
-import { StoreModule } from '@ngrx/store';
+import { Action, StoreModule } from '@ngrx/store';
 import { provideMockActions } from '@ngrx/effects/testing';
 
 import { NxModule<% if (useDataPersistence) { %>, DataPersistence<% } %> } from '@nrwl/angular';
@@ -13,7 +13,7 @@ import { <%= className %>Effects } from './<%= fileName %>.effects';
 import { Load<%= className %>, <%= className %>Loaded } from './<%= fileName %>.actions';
 
 describe('<%= className %>Effects', () => {
-  let actions: Observable<any>;
+  let actions: Observable<Action>;
   let effects: <%= className %>Effects;
 
   beforeEach(() => {

--- a/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.reducer.spec.ts__tmpl__
+++ b/packages/angular/src/schematics/ngrx/files/__directory__/__fileName__.reducer.spec.ts__tmpl__
@@ -1,3 +1,5 @@
+import { Action } from '@ngrx/store';
+
 import { <%= className %>Loaded } from './<%= fileName %>.actions';
 import { <%= className %>State, Entity, initialState, reducer } from './<%= fileName %>.reducer';
 
@@ -23,7 +25,7 @@ describe('<%= className %> Reducer', () => {
 
   describe('unknown action', () => {
     it('should return the previous state', () => {
-      const action = {} as any;
+      const action = {} as Action;
       const result = reducer(initialState, action);
 
       expect(result).toBe(initialState);


### PR DESCRIPTION
## Current Behavior
Generating ngrx features leaves lint errors in the spec files

## Expected Behavior
Files pass linting after running a generator

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6046
