### PR TITLE
feat(core): add hint for --verbose flag in case of task exec error

### DIFF
--- a/packages/workspace/src/tasks-runner/run-one-reporter.ts
+++ b/packages/workspace/src/tasks-runner/run-one-reporter.ts
@@ -3,7 +3,6 @@ import { Reporter, ReporterArgs } from './reporter';
 import { Task } from './tasks-runner';
 
 export class RunOneReporter implements Reporter {
-  private projectNames: string[];
   constructor(private readonly initiatingProject: string) {}
 
   beforeRun(
@@ -15,7 +14,6 @@ export class RunOneReporter implements Reporter {
     if (process.env.NX_INVOKED_BY_RUNNER) {
       return;
     }
-    this.projectNames = projectNames;
     const numberOfDeps = tasks.length - 1;
 
     if (numberOfDeps > 0) {
@@ -80,6 +78,10 @@ export class RunOneReporter implements Reporter {
         output.colors.gray('Failed tasks:'),
         '',
         ...failedTasks.map((task) => `${output.colors.gray('-')} ${task.id}`),
+        '',
+        `${output.colors.gray(
+          'Hint: run the command with'
+        )} --verbose ${output.colors.gray('for more details.')}`,
       ];
       output.error({
         title: `Running target "${this.initiatingProject}:${args.target}" failed`,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When errors are thrown during the task execution it is hard to determine where the error came from. Nx already supports the `--verbose` flag but it is kinda hidden.

![image](https://user-images.githubusercontent.com/542458/122425876-1933d680-cf90-11eb-80f6-fed06137c96a.png)


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR adds a hint to the task execution output in case of an error, s.t. the user is aware of the `--verbose` flag.

![image](https://user-images.githubusercontent.com/542458/122425765-04efd980-cf90-11eb-8fa9-ffb11a7768cc.png)
