### PR TITLE
fix(linter): update error message guide URL for nx.dev

### DIFF
--- a/packages/linter/src/executors/eslint/lint.impl.spec.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.spec.ts
@@ -253,7 +253,7 @@ describe('Linter Builder', () => {
         `
 Error: You have attempted to use a lint rule which requires the full TypeScript type-checker to be available, but you do not have \`parserOptions.project\` configured to point at your project tsconfig.json files in the relevant TypeScript file "overrides" block of your project ESLint config \`apps/proj/.eslintrc.json\`
 
-Please see https://nx.dev/latest/guides/eslint for full guidance on how to resolve this issue.
+Please see https://nx.dev/guides/eslint for full guidance on how to resolve this issue.
 `
       );
     });

--- a/packages/linter/src/executors/eslint/lint.impl.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.ts
@@ -67,7 +67,7 @@ Error: You have attempted to use a lint rule which requires the full TypeScript 
         eslintConfigPath || eslintConfigPathForError
       }
 
-Please see https://nx.dev/latest/guides/eslint for full guidance on how to resolve this issue.
+Please see https://nx.dev/guides/eslint for full guidance on how to resolve this issue.
 `);
 
       return {


### PR DESCRIPTION
The previous URL used to work on the previous version of nx.dev and @jaysoo will add backwards-compatibility support for it soon. In the meantime, this new structure is more succinct anyway so updating!