### PR TITLE
docs(core): adds black background to modal backdrop since firefox does not support blurred backdrop filter

### DIFF
--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -165,7 +165,7 @@ export function DocumentationPage({
         onClose={() => {}}
       >
         <div className="flex items-center justify-center min-h-screen">
-          <Dialog.Overlay className="fixed inset-0 backdrop-filter backdrop-blur" />
+          <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-20 backdrop-filter backdrop-blur" />
           <div className="z-50 bg-white rounded w-11/12 max-w-xl filter drop-shadow-2xl">
             <Dialog.Title
               as="h3"


### PR DESCRIPTION
This PR adds background color to the modal backdrop since FF does not support blur filter.

FF:

<img width="1616" alt="Screen Shot 2021-06-17 at 2 11 27 PM" src="https://user-images.githubusercontent.com/53559/122451602-5a1ef180-cf76-11eb-90c3-a9be9d00592f.png">


Chrome:

<img width="1616" alt="Screen Shot 2021-06-17 at 2 11 29 PM" src="https://user-images.githubusercontent.com/53559/122451644-64d98680-cf76-11eb-9624-c61358a3f63c.png">
