### PR TITLE
docs(core): allow builds when PRs are merged into master

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,7 +1,8 @@
 {
   "implicitDependencies": {
     "package.json": "*",
-    ".eslintrc.json": "*"
+    ".eslintrc.json": "*",
+    "scripts/vercel/*": ["nx-dev"]
   },
   "affected": {
     "defaultBase": "master"

--- a/scripts/vercel/ignore-build.sh
+++ b/scripts/vercel/ignore-build.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-# Ignore all production deployments since this should be a manual promotion
-if [ $VERCEL_GIT_COMMIT_REF == "master" ]; then
-  echo "🛑 - Build cancelled"
-  exit 0
-fi
-
 # This script is used in Vercel to determine whether to continue the build or not for nx-dev.
 # Exits with 0 if the build should be skipped, and exits with 1 to continue.
 


### PR DESCRIPTION
This MR enables production deploys when PRs are merged into master.

Since we need to manually update previous/latest versions in `nx-dev/nx-dev` app, this shouldn't really affect production unless we update the `nx-dev` app itself. Updates to the preview `docs` folder shouldn't be exposed.