### PR TITLE
chore(repo): added @babel/core to get rid of peer dependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@angular/router": "^12.0.0",
     "@angular/service-worker": "^12.0.0",
     "@angular/upgrade": "^12.0.0",
+    "@babel/core": "7.12.13",
     "@cypress/webpack-preprocessor": "~4.1.2",
     "@nestjs/common": "^7.0.0",
     "@nestjs/core": "^7.0.0",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When running `yarn install` in the Nx repo I get several warnings because of the missing `@babel/core` package. 

```
warning "@nrwl/next > @babel/plugin-proposal-decorators@7.12.13" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "@nrwl/next > @babel/plugin-proposal-decorators > @babel/helper-create-class-features-plugin@7.13.11" has unmet peer dependency "@babel/core@^7.0.0".
warning "@nrwl/next > @babel/plugin-proposal-decorators > @babel/plugin-syntax-decorators@7.12.13" has unmet peer dependency "@babel/core@^7.0.0-0".
warning " > @rollup/plugin-babel@5.0.2" has unmet peer dependency "@babel/core@^7.0.0".
warning " > @storybook/angular@6.2.9" has unmet peer dependency "@babel/core@*".
warning "@storybook/react > @babel/preset-react@7.13.13" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "@storybook/react > @babel/preset-flow@7.12.13" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "@storybook/react > babel-plugin-named-asset-import@0.3.7" has unmet peer dependency "@babel/core@^7.1.0".
warning "@storybook/react > @babel/preset-flow > @babel/plugin-transform-flow-strip-types@7.13.0" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "@storybook/react > @babel/preset-flow > @babel/plugin-transform-flow-strip-types > @babel/plugin-syntax-flow@7.12.13" has unmet peer dependency "@babel/core@^7.0.0-0".
warning " > babel-jest@26.2.2" has unmet peer dependency "@babel/core@^7.0.0".
warning "babel-jest > babel-preset-jest@26.6.2" has unmet peer dependency "@babel/core@^7.0.0".
warning "babel-jest > babel-preset-jest > babel-preset-current-node-syntax@1.0.1" has unmet peer dependency "@babel/core@^7.0.0".
warning "babel-jest > babel-preset-jest > babel-preset-current-node-syntax > @babel/plugin-syntax-bigint@7.8.3" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "babel-jest > babel-preset-jest > babel-preset-current-node-syntax > @babel/plugin-syntax-import-meta@7.10.4" has unmet peer dependency "@babel/core@^7.0.0-0".
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should not get this warnings. So i added `@babel/core` as dependency and we are only left with some other peer dependency warnings. I will try to get rid of these too in extra PRs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
