### PR TITLE
chore(repo): hide cypress e2e tests behind NX_E2E_CI_NIGHTLY flag

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -100,6 +100,7 @@ jobs:
         GIT_COMMITTER_EMAIL: test@test.com
         GIT_COMMITTER_NAME: Test
         NX_E2E_CI_CACHE_KEY: e2e-gha-${{ matrix.os }}-${{ matrix.node_version }}-${{ matrix.package_manager }}
+        NX_E2E_CI_NIGHTLY: ${{ 'true' }}
         NODE_OPTIONS: --max_old_space_size=8192
         SELECTED_PM: ${{ matrix.package_manager }}
         YARN_REGISTRY: http://localhost:4872

--- a/e2e/angular/src/angular-core.test.ts
+++ b/e2e/angular/src/angular-core.test.ts
@@ -4,6 +4,7 @@ import {
   expectTestsPass,
   getSelectedPackageManager,
   getSize,
+  killPorts,
   newProject,
   removeProject,
   runCLI,
@@ -11,6 +12,7 @@ import {
   tmpProjPath,
   uniq,
   updateFile,
+  runCypressTests,
 } from '@nrwl/e2e/utils';
 
 import { names } from '@nrwl/devkit';
@@ -21,10 +23,10 @@ describe('Angular Package', () => {
   beforeEach(() => (proj = newProject()));
   afterEach(() => removeProject({ onlyOnCI: true }));
 
-  // TODO: npm build is failing for Angular because of webpack 4
-  // remove this condition once `node` is migrated to webpack 5
-  if (getSelectedPackageManager() !== 'npm') {
-    it('should work', async () => {
+  it('should work', async () => {
+    // TODO: npm build is failing for Angular because of webpack 4
+    // remove this condition once `node` is migrated to webpack 5
+    if (getSelectedPackageManager() !== 'npm') {
       const myapp = uniq('myapp');
       const mylib = uniq('mylib');
       runCLI(
@@ -72,27 +74,18 @@ describe('Angular Package', () => {
       // running tests for the lib
       expectTestsPass(await runCLIAsync(`test my-dir-${mylib} --no-watch`));
 
-      // if (supportUi()) {
-      //   try {
-      //     const r = runCLI(`e2e my-dir-${myapp}-e2e --headless --no-watch`);
-      //     console.log(r);
-      //     expect(r).toContain('All specs passed!');
-      //   } catch (e) {
-      //     console.log(e);
-      //     if (e.stdout) {
-      //       console.log(e.stdout.toString());
-      //     }
-      //     if (e.stderr) {
-      //       console.log(e.stdout.toString());
-      //     }
-      //     throw e;
-      //   }
-      // }
-    }, 1000000);
-  }
+      if (runCypressTests()) {
+        const e2eResults = runCLI(
+          `e2e my-dir-${myapp}-e2e --headless --no-watch`
+        );
+        expect(e2eResults).toContain('All specs passed!');
+        expect(await killPorts()).toBeTruthy();
+      }
+    }
+  }, 1000000);
 
-  if (getSelectedPackageManager() !== 'npm') {
-    it('should support router config generation (lazy)', async () => {
+  it('should support router config generation (lazy)', async () => {
+    if (getSelectedPackageManager() !== 'npm') {
       const myapp = uniq('myapp');
       const mylib = uniq('mylib');
       runCLI(`generate @nrwl/angular:app ${myapp} --directory=myDir --routing`);
@@ -102,11 +95,13 @@ describe('Angular Package', () => {
 
       runCLI(`build my-dir-${myapp} --aot`);
       expectTestsPass(await runCLIAsync(`test my-dir-${myapp} --no-watch`));
-    }, 1000000);
-  }
+    }
+  }, 1000000);
 
-  if (getSelectedPackageManager() !== 'npm') {
-    it('should support router config generation (eager)', async () => {
+  it('should support router config generation (eager)', async () => {
+    // TODO: npm build is failing for Angular because of webpack 4
+    // remove this condition once `node` is migrated to webpack 5
+    if (getSelectedPackageManager() !== 'npm') {
       const myapp = uniq('myapp');
       runCLI(`generate @nrwl/angular:app ${myapp} --directory=myDir --routing`);
       const mylib = uniq('mylib');
@@ -116,11 +111,13 @@ describe('Angular Package', () => {
 
       runCLI(`build my-dir-${myapp} --aot`);
       expectTestsPass(await runCLIAsync(`test my-dir-${myapp} --no-watch`));
-    }, 1000000);
-  }
+    }
+  }, 1000000);
 
-  if (getSelectedPackageManager() !== 'npm') {
-    it('should support Ivy', async () => {
+  it('should support Ivy', async () => {
+    // TODO: npm build is failing for Angular because of webpack 4
+    // remove this condition once `node` is migrated to webpack 5
+    if (getSelectedPackageManager() !== 'npm') {
       const myapp = uniq('myapp');
       runCLI(
         `generate @nrwl/angular:app ${myapp} --directory=myDir --routing --enable-ivy`
@@ -128,11 +125,13 @@ describe('Angular Package', () => {
 
       runCLI(`build my-dir-${myapp} --aot`);
       expectTestsPass(await runCLIAsync(`test my-dir-${myapp} --no-watch`));
-    }, 1000000);
-  }
+    }
+  }, 1000000);
 
-  if (getSelectedPackageManager() !== 'npm') {
-    it('should support building in parallel', () => {
+  it('should support building in parallel', () => {
+    // TODO: npm build is failing for Angular because of webpack 4
+    // remove this condition once `node` is migrated to webpack 5
+    if (getSelectedPackageManager() !== 'npm') {
       if (getSelectedPackageManager() === 'pnpm') {
         // TODO: This tests fails with pnpm but we should still enable this for other package managers
         return;
@@ -143,8 +142,8 @@ describe('Angular Package', () => {
       runCLI(`generate @nrwl/angular:app ${myapp2}`);
 
       runCLI('run-many --target build --all --parallel');
-    });
-  }
+    }
+  });
 
   it('should support eslint and pass linting on the standard generated code', async () => {
     const myapp = uniq('myapp');

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -11,6 +11,7 @@ import {
   runCLI,
   runCLIAsync,
   runCommandUntil,
+  runCypressTests,
   uniq,
   updateFile,
   updateWorkspaceConfig,
@@ -671,7 +672,7 @@ async function checkApp(
     );
   }
 
-  if (opts.checkE2E) {
+  if (opts.checkE2E && runCypressTests()) {
     const e2eResults = runCLI(`e2e ${appName}-e2e --headless`);
     expect(e2eResults).toContain('All specs passed!');
     expect(await killPorts()).toBeTruthy();

--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -7,6 +7,7 @@ import {
   readJson,
   runCLI,
   runCLIAsync,
+  runCypressTests,
   uniq,
   workspaceConfigName,
 } from '@nrwl/e2e/utils';
@@ -60,7 +61,7 @@ describe('Nx Plugin', () => {
     const plugin = uniq('plugin-name');
     runCLI(`generate @nrwl/nx-plugin:plugin ${plugin} --linter=eslint`);
 
-    if (isNotWindows()) {
+    if (isNotWindows() && runCypressTests()) {
       const e2eResults = runCLI(`e2e ${plugin}-e2e --no-watch --headless`);
       expect(e2eResults).toContain('Running target "e2e" succeeded');
       expect(await killPorts()).toBeTruthy();

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -39,6 +39,10 @@ export function currentCli() {
   return process.env.SELECTED_CLI ?? 'nx';
 }
 
+export function isNightlyRun() {
+  return process.env.NX_E2E_CI_NIGHTLY === 'true';
+}
+
 export const e2eRoot = isCI ? dirSync({ prefix: 'nx-e2e-' }).name : `./tmp`;
 export const e2eCwd = `${e2eRoot}/${currentCli()}`;
 ensureDirSync(e2eCwd);
@@ -235,8 +239,7 @@ export async function removeProject({ onlyOnCI = false } = {}) {
 }
 
 export function runCypressTests() {
-  // temporary enable
-  return true;
+  return isNightlyRun();
 }
 
 export function isNotWindows() {

--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -53,7 +53,7 @@ describe('Web Components Applications', () => {
     const lintE2eResults = runCLI(`lint ${appName}-e2e`);
     expect(lintE2eResults).toContain('All files pass linting.');
 
-    if (isNotWindows()) {
+    if (isNotWindows() && runCypressTests()) {
       const e2eResults = runCLI(`e2e ${appName}-e2e --headless`);
       expect(e2eResults).toContain('All specs passed!');
       expect(await killPorts()).toBeTruthy();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
E2E checks on PRs can take a very long time, partially due to cypress tests runs. There is no way to toggle them off when we want to save time.

## Expected Behavior
Cypress test runs `nx e2e...` should be run only on nightly checks or be toggled on using NX_E2E_CI_NIGHTLY flag.
