### PR TITLE
chore(repo): fix broken e2e test on workspace

### DIFF
--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -172,27 +172,28 @@ describe('run-many', () => {
   beforeEach(() => (proj = newProject()));
   afterEach(() => removeProject({ onlyOnCI: true }));
 
-  // This fails with pnpm due to incompatibilities with ngcc for buildable libraries.
-  if (getSelectedPackageManager() !== 'pnpm') {
-    // TODO: Uncomment when the node is migrated to webpack 5
-    if (getSelectedPackageManager() !== 'npm') {
-      it('should build specific and all projects', () => {
-        const appA = uniq('appa-rand');
-        const libA = uniq('liba-rand');
-        const libB = uniq('libb-rand');
-        const libC = uniq('libc-rand');
-        const libD = uniq('libd-rand');
+  it('should build specific and all projects', () => {
+    // This fails with pnpm due to incompatibilities with ngcc for buildable libraries.
+    if (getSelectedPackageManager() === 'pnpm') {
+      return;
+    }
 
-        runCLI(`generate @nrwl/angular:app ${appA}`);
-        runCLI(`generate @nrwl/angular:lib ${libA} --buildable --defaults`);
-        runCLI(`generate @nrwl/angular:lib ${libB} --buildable --defaults`);
-        runCLI(`generate @nrwl/angular:lib ${libC} --buildable --defaults`);
-        runCLI(`generate @nrwl/angular:lib ${libD} --defaults`);
+    const appA = uniq('appa-rand');
+    const libA = uniq('liba-rand');
+    const libB = uniq('libb-rand');
+    const libC = uniq('libc-rand');
+    const libD = uniq('libd-rand');
 
-        // libA depends on libC
-        updateFile(
-          `libs/${libA}/src/lib/${libA}.module.spec.ts`,
-          `
+    runCLI(`generate @nrwl/angular:app ${appA}`);
+    runCLI(`generate @nrwl/angular:lib ${libA} --buildable --defaults`);
+    runCLI(`generate @nrwl/angular:lib ${libB} --buildable --defaults`);
+    runCLI(`generate @nrwl/angular:lib ${libC} --buildable --defaults`);
+    runCLI(`generate @nrwl/angular:lib ${libD} --defaults`);
+
+    // libA depends on libC
+    updateFile(
+      `libs/${libA}/src/lib/${libA}.module.spec.ts`,
+      `
                 import '@${proj}/${libC}';
                 describe('sample test', () => {
                   it('should test', () => {
@@ -200,60 +201,54 @@ describe('run-many', () => {
                   });
                 });
               `
-        );
+    );
 
-        // testing run many starting'
-        const buildParallel = runCLI(
-          `run-many --target=build --projects="${libC},${libB}"`
-        );
-        expect(buildParallel).toContain(
-          `Running target build for 2 project(s):`
-        );
-        expect(buildParallel).not.toContain(`- ${libA}`);
-        expect(buildParallel).toContain(`- ${libB}`);
-        expect(buildParallel).toContain(`- ${libC}`);
-        expect(buildParallel).not.toContain(`- ${libD}`);
-        expect(buildParallel).toContain('Running target "build" succeeded');
+    // testing run many starting'
+    const buildParallel = runCLI(
+      `run-many --target=build --projects="${libC},${libB}"`
+    );
+    expect(buildParallel).toContain(`Running target build for 2 project(s):`);
+    expect(buildParallel).not.toContain(`- ${libA}`);
+    expect(buildParallel).toContain(`- ${libB}`);
+    expect(buildParallel).toContain(`- ${libC}`);
+    expect(buildParallel).not.toContain(`- ${libD}`);
+    expect(buildParallel).toContain('Running target "build" succeeded');
 
-        // testing run many --all starting
-        const buildAllParallel = runCLI(`run-many --target=build --all`);
-        expect(buildAllParallel).toContain(
-          `Running target build for 4 project(s):`
-        );
-        expect(buildAllParallel).toContain(`- ${appA}`);
-        expect(buildAllParallel).toContain(`- ${libA}`);
-        expect(buildAllParallel).toContain(`- ${libB}`);
-        expect(buildAllParallel).toContain(`- ${libC}`);
-        expect(buildAllParallel).not.toContain(`- ${libD}`);
-        expect(buildAllParallel).toContain('Running target "build" succeeded');
+    // testing run many --all starting
+    const buildAllParallel = runCLI(`run-many --target=build --all`);
+    expect(buildAllParallel).toContain(
+      `Running target build for 4 project(s):`
+    );
+    expect(buildAllParallel).toContain(`- ${appA}`);
+    expect(buildAllParallel).toContain(`- ${libA}`);
+    expect(buildAllParallel).toContain(`- ${libB}`);
+    expect(buildAllParallel).toContain(`- ${libC}`);
+    expect(buildAllParallel).not.toContain(`- ${libD}`);
+    expect(buildAllParallel).toContain('Running target "build" succeeded');
 
-        // testing run many --with-deps
-        const buildWithDeps = runCLI(
-          `run-many --target=build --projects="${libA}" --with-deps`
-        );
-        expect(buildWithDeps).toContain(
-          `Running target build for 2 project(s):`
-        );
-        expect(buildWithDeps).toContain(`- ${libA}`);
-        expect(buildWithDeps).toContain(`- ${libC}`);
-        expect(buildWithDeps).not.toContain(`- ${libB}`);
-        expect(buildWithDeps).not.toContain(`- ${libD}`);
-        expect(buildWithDeps).toContain('Running target "build" succeeded');
+    // testing run many --with-deps
+    const buildWithDeps = runCLI(
+      `run-many --target=build --projects="${libA}" --with-deps`
+    );
+    expect(buildWithDeps).toContain(`Running target build for 2 project(s):`);
+    expect(buildWithDeps).toContain(`- ${libA}`);
+    expect(buildWithDeps).toContain(`- ${libC}`);
+    expect(buildWithDeps).not.toContain(`- ${libB}`);
+    expect(buildWithDeps).not.toContain(`- ${libD}`);
+    expect(buildWithDeps).toContain('Running target "build" succeeded');
 
-        // testing run many --configuration
-        const buildConfig = runCLI(
-          `run-many --target=build --projects="${appA},${libA}" --prod`
-        );
-        expect(buildConfig).toContain(
-          `Running target build for 2 project(s) and 1 task(s) they depend on:`
-        );
-        expect(buildConfig).toContain(`run ${appA}:build:production`);
-        expect(buildConfig).toContain(`run ${libA}:build:production`);
-        expect(buildConfig).toContain(`run ${libC}:build:production`);
-        expect(buildConfig).toContain('Running target "build" succeeded');
-      }, 1000000);
-    }
-  }
+    // testing run many --configuration
+    const buildConfig = runCLI(
+      `run-many --target=build --projects="${appA},${libA}" --prod`
+    );
+    expect(buildConfig).toContain(
+      `Running target build for 2 project(s) and 1 task(s) they depend on:`
+    );
+    expect(buildConfig).toContain(`run ${appA}:build:production`);
+    expect(buildConfig).toContain(`run ${libA}:build:production`);
+    expect(buildConfig).toContain(`run ${libC}:build:production`);
+    expect(buildConfig).toContain('Running target "build" succeeded');
+  }, 1000000);
 
   it('should run only failed projects', () => {
     const myapp = uniq('myapp');

--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -207,7 +207,7 @@ describe('run-many', () => {
           `run-many --target=build --projects="${libC},${libB}"`
         );
         expect(buildParallel).toContain(
-          `Running target build for 2 project(s)`
+          `Running target build for 2 project(s):`
         );
         expect(buildParallel).not.toContain(`- ${libA}`);
         expect(buildParallel).toContain(`- ${libB}`);
@@ -232,7 +232,7 @@ describe('run-many', () => {
           `run-many --target=build --projects="${libA}" --with-deps`
         );
         expect(buildWithDeps).toContain(
-          `Running target build for 2 project(s)`
+          `Running target build for 2 project(s):`
         );
         expect(buildWithDeps).toContain(`- ${libA}`);
         expect(buildWithDeps).toContain(`- ${libC}`);
@@ -244,9 +244,12 @@ describe('run-many', () => {
         const buildConfig = runCLI(
           `run-many --target=build --projects="${appA},${libA}" --prod`
         );
-        expect(buildConfig).toContain(`Running target build for 2 project(s)`);
+        expect(buildConfig).toContain(
+          `Running target build for 2 project(s) and 1 task(s) they depend on:`
+        );
         expect(buildConfig).toContain(`run ${appA}:build:production`);
         expect(buildConfig).toContain(`run ${libA}:build:production`);
+        expect(buildConfig).toContain(`run ${libC}:build:production`);
         expect(buildConfig).toContain('Running target "build" succeeded');
       }, 1000000);
     }

--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -207,7 +207,7 @@ describe('run-many', () => {
           `run-many --target=build --projects="${libC},${libB}"`
         );
         expect(buildParallel).toContain(
-          `Running target build for 2 project(s):`
+          `Running target build for 2 project(s)`
         );
         expect(buildParallel).not.toContain(`- ${libA}`);
         expect(buildParallel).toContain(`- ${libB}`);
@@ -232,7 +232,7 @@ describe('run-many', () => {
           `run-many --target=build --projects="${libA}" --with-deps`
         );
         expect(buildWithDeps).toContain(
-          `Running target build for 2 project(s):`
+          `Running target build for 2 project(s)`
         );
         expect(buildWithDeps).toContain(`- ${libA}`);
         expect(buildWithDeps).toContain(`- ${libC}`);
@@ -244,7 +244,7 @@ describe('run-many', () => {
         const buildConfig = runCLI(
           `run-many --target=build --projects="${appA},${libA}" --prod`
         );
-        expect(buildConfig).toContain(`Running target build for 2 project(s):`);
+        expect(buildConfig).toContain(`Running target build for 2 project(s)`);
         expect(buildConfig).toContain(`run ${appA}:build:production`);
         expect(buildConfig).toContain(`run ${libA}:build:production`);
         expect(buildConfig).toContain('Running target "build" succeeded');


### PR DESCRIPTION
This test incorrectly assumes only two projects to be built, while libA actually depends on libC causing it to be built as well. 