### PR TITLE
fix(angular): keep package postinstall script in @nrwl/angular package

### DIFF
--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -19,5 +19,6 @@
     "jasmine-marbles",
     "rxjs-for-await",
     "webpack-merge"
-  ]
+  ],
+  "keepLifecycleScripts": true
 }

--- a/packages/angular/scripts/nx-cli-warning.js
+++ b/packages/angular/scripts/nx-cli-warning.js
@@ -6,14 +6,13 @@ try {
   if (path.basename(root) === 'workspace.json') {
     const workspaceJson = JSON.parse(fs.readFileSync(root));
     if (Object.keys(workspaceJson.projects).length === 0) {
-      const output = require('@nrwl/workspace/src/command-line/output').output;
+      const output = require('@nrwl/workspace/src/utilities/output').output;
       output.warn({
         title: '@nrwl/angular added to a Nx workspace powered by the Nx CLI.',
         bodyLines: [
           "You won't be able to use 'ng' to generate artifacts and run tasks.",
           "If you want to use 'ng', you need to create a new workspace powered by the Angular CLI.",
-          'You can do it by selecting Angular CLI when creating a new workspace.',
-          "Or by providing --cli as follows: 'create-nx-workspace --cli=angular'.",
+          "You can do it by providing --cli when creating a new workspace as follows: 'create-nx-workspace --cli=angular'.",
           "You can invoke the Angular schematics with 'nx generate @nrwl/angular' to generate artifacts.",
         ],
       });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When installing `@nrwl/angular` in an Nx workspace, no warning is shown to let devs know they won't be able to generate artifacts or run tasks with the Angular CLI. This happens because `ng-packagr` removes the `pacakge.json` scripts when building the `@nrwl/angular` package.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
A warning should be shown when installing `@nrwl/angular` in an Nx workspace.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5897