### PR TITLE
fix(nextjs): fix component generator

### DIFF
--- a/packages/next/src/generators/component/component.spec.ts
+++ b/packages/next/src/generators/component/component.spec.ts
@@ -2,25 +2,35 @@ import { applicationGenerator } from '../application/application';
 import { componentGenerator } from './component';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Tree } from '@nrwl/devkit';
+import { libraryGenerator } from '@nrwl/react';
+import { Linter } from '@nrwl/linter';
 
 describe('component', () => {
   let tree: Tree;
-  let projectName: string;
+  const appName = 'my-app';
+  const libName = 'my-lib';
 
   beforeEach(async () => {
-    projectName = 'my-app';
     tree = createTreeWithEmptyWorkspace();
     await applicationGenerator(tree, {
-      name: projectName,
+      name: appName,
       style: 'css',
       standaloneConfig: false,
     });
+    await libraryGenerator(tree, {
+      name: libName,
+      linter: Linter.EsLint,
+      style: 'css',
+      skipFormat: true,
+      skipTsConfig: false,
+      unitTestRunner: 'jest',
+    });
   });
 
-  it('should generate component in components directory', async () => {
+  it('should generate component in components directory for application', async () => {
     await componentGenerator(tree, {
       name: 'hello',
-      project: projectName,
+      project: appName,
       style: 'css',
     });
 
@@ -33,16 +43,45 @@ describe('component', () => {
     ).toBeTruthy();
   });
 
-  it('should allow directory override', async () => {
+  it('should generate component in default directory for library', async () => {
     await componentGenerator(tree, {
       name: 'hello',
-      project: projectName,
-      directory: 'lib',
+      project: libName,
       style: 'css',
     });
 
-    expect(tree.exists('apps/my-app/lib/hello/hello.tsx')).toBeTruthy();
-    expect(tree.exists('apps/my-app/lib/hello/hello.spec.tsx')).toBeTruthy();
-    expect(tree.exists('apps/my-app/lib/hello/hello.module.css')).toBeTruthy();
+    expect(tree.exists('libs/my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
+    expect(
+      tree.exists('libs/my-lib/src/lib/hello/hello.spec.tsx')
+    ).toBeTruthy();
+    expect(
+      tree.exists('libs/my-lib/src/lib/hello/hello.module.css')
+    ).toBeTruthy();
+  });
+
+  it('should allow directory override', async () => {
+    await componentGenerator(tree, {
+      name: 'hello',
+      project: appName,
+      directory: 'foo',
+      style: 'css',
+    });
+    await componentGenerator(tree, {
+      name: 'world',
+      project: libName,
+      directory: 'bar',
+      style: 'css',
+    });
+
+    expect(tree.exists('apps/my-app/foo/hello/hello.tsx')).toBeTruthy();
+    expect(tree.exists('apps/my-app/foo/hello/hello.spec.tsx')).toBeTruthy();
+    expect(tree.exists('apps/my-app/foo/hello/hello.module.css')).toBeTruthy();
+    expect(tree.exists('libs/my-lib/src/bar/world/world.tsx')).toBeTruthy();
+    expect(
+      tree.exists('libs/my-lib/src/bar/world/world.spec.tsx')
+    ).toBeTruthy();
+    expect(
+      tree.exists('libs/my-lib/src/bar/world/world.module.css')
+    ).toBeTruthy();
   });
 });

--- a/packages/next/src/generators/component/component.ts
+++ b/packages/next/src/generators/component/component.ts
@@ -1,7 +1,7 @@
 import { addStyleDependencies } from '../../utils/styles';
 import type { SupportedStyles } from '@nrwl/react';
 import { componentGenerator as reactComponentGenerator } from '@nrwl/react';
-import { convertNxGenerator, Tree } from '@nrwl/devkit';
+import { convertNxGenerator, getProjects, Tree } from '@nrwl/devkit';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 interface Schema {
@@ -12,6 +12,17 @@ interface Schema {
   flat?: boolean;
 }
 
+function getDirectory(host: Tree, options: Schema) {
+  const workspace = getProjects(host);
+  const projectType = workspace.get(options.project).projectType;
+
+  return options.directory
+    ? options.directory
+    : projectType === 'application'
+    ? 'components'
+    : undefined;
+}
+
 /*
  * This schematic is basically the React one, but for Next we need
  * extra dependencies for css, sass, less, styl style options.
@@ -19,7 +30,7 @@ interface Schema {
 export async function componentGenerator(host: Tree, options: Schema) {
   const componentInstall = await reactComponentGenerator(host, {
     ...options,
-    directory: options.directory || 'components',
+    directory: getDirectory(host, options),
     pascalCaseFiles: false,
     export: false,
     classComponent: false,

--- a/packages/next/src/generators/component/schema.json
+++ b/packages/next/src/generators/component/schema.json
@@ -33,11 +33,6 @@
       },
       "x-prompt": "What name would you like to use for the component?"
     },
-    "directory": {
-      "type": "string",
-      "description": "Create the component under this directory (can be nested).",
-      "alias": "d"
-    },
     "style": {
       "description": "The file extension to be used for style files.",
       "type": "string",


### PR DESCRIPTION
ISSUES CLOSED: #6084

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx generate @nrwl/next:component` generates a component in `/components`  when the target project is a library.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It should be `src/lib` (default) for libraries to keep consistency with `@nrwl/react:component`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6084
