### PR TITLE
fix(angular): remove Stylus from new Angular workspaces and apps

### DIFF
--- a/docs/angular/api-angular/generators/application.md
+++ b/docs/angular/api-angular/generators/application.md
@@ -142,7 +142,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`
+Possible values: `css`, `scss`, `less`
 
 The file extension to be used for style files.
 

--- a/docs/node/api-angular/generators/application.md
+++ b/docs/node/api-angular/generators/application.md
@@ -142,7 +142,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`
+Possible values: `css`, `scss`, `less`
 
 The file extension to be used for style files.
 

--- a/docs/react/api-angular/generators/application.md
+++ b/docs/react/api-angular/generators/application.md
@@ -142,7 +142,7 @@ Default: `css`
 
 Type: `string`
 
-Possible values: `css`, `scss`, `styl`, `less`
+Possible values: `css`, `scss`, `less`
 
 The file extension to be used for style files.
 

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -15,8 +15,6 @@ import { applicationGenerator } from './application';
 
 import * as devkit from '@nrwl/devkit';
 
-const prettier = require('prettier');
-
 describe('app', () => {
   let appTree: Tree;
 
@@ -452,7 +450,9 @@ describe('app', () => {
 
     describe('karma', () => {
       it('should generate a karma config', async () => {
-        await generateApp(appTree, 'myApp', { unitTestRunner: 'karma' });
+        await generateApp(appTree, 'myApp', {
+          unitTestRunner: UnitTestRunner.Karma,
+        });
 
         expect(appTree.exists('apps/my-app/tsconfig.spec.json')).toBeTruthy();
         expect(appTree.exists('apps/my-app/karma.conf.js')).toBeTruthy();

--- a/packages/angular/src/generators/application/lib/update-component-styles.ts
+++ b/packages/angular/src/generators/application/lib/update-component-styles.ts
@@ -15,7 +15,6 @@ export function updateComponentStyles(host: Tree, options: NormalizedSchema) {
       css: `${options.appProjectRoot}/src/app/app.component.css`,
       scss: `${options.appProjectRoot}/src/app/app.component.scss`,
       less: `${options.appProjectRoot}/src/app/app.component.less`,
-      styl: `${options.appProjectRoot}/src/app/app.component.styl`,
     };
     host.write(filesMap[options.style], content);
 

--- a/packages/angular/src/generators/application/schema.d.ts
+++ b/packages/angular/src/generators/application/schema.d.ts
@@ -1,6 +1,6 @@
-import { E2eTestRunner } from '../../utils/test-runners';
-import { UnitTestRunner } from '../../utils/UnitTestRunner';
 import { Linter } from '@nrwl/linter';
+import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
+import type { Styles } from '../utils/types';
 
 export interface Schema {
   name: string;
@@ -10,7 +10,7 @@ export interface Schema {
   viewEncapsulation?: 'Emulated' | 'Native' | 'None';
   routing?: boolean;
   prefix?: string;
-  style?: string;
+  style?: Styles;
   skipTests?: boolean;
   directory?: string;
   tags?: string;

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -36,10 +36,6 @@
             "label": "SASS(.scss)  [ http://sass-lang.com   ]"
           },
           {
-            "value": "styl",
-            "label": "Stylus(.styl)[ http://stylus-lang.com ]"
-          },
-          {
             "value": "less",
             "label": "LESS         [ http://lesscss.org     ]"
           }

--- a/packages/angular/src/generators/init/init.spec.ts
+++ b/packages/angular/src/generators/init/init.spec.ts
@@ -4,6 +4,7 @@ import { Linter } from '@nrwl/linter';
 
 import init from './init';
 import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
+import { Styles } from '../utils/types';
 
 describe('init', () => {
   let host: Tree;
@@ -302,9 +303,9 @@ describe('init', () => {
       expect(workspaceJson.cli.defaultCollection).toEqual('@nrwl/angular');
     });
 
-    it.each(['css', 'scss', 'styl', 'less'])(
+    it.each(['css', 'scss', 'less'])(
       'should set "%s" as default style extension for components',
-      async (style) => {
+      async (style: Styles) => {
         // ACT
         await init(host, {
           unitTestRunner: UnitTestRunner.Jest,

--- a/packages/angular/src/generators/init/schema.d.ts
+++ b/packages/angular/src/generators/init/schema.d.ts
@@ -1,11 +1,12 @@
-import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
 import { Linter } from '@nrwl/linter';
+import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
+import type { Styles } from '../utils/types';
 
 export interface Schema {
   unitTestRunner: UnitTestRunner;
   e2eTestRunner?: E2eTestRunner;
   skipFormat: boolean;
   skipInstall?: boolean;
-  style?: string;
+  style?: Styles;
   linter: Exclude<Linter, Linter.TsLint>;
 }

--- a/packages/angular/src/generators/init/schema.json
+++ b/packages/angular/src/generators/init/schema.json
@@ -33,6 +33,29 @@
       "type": "string",
       "enum": ["eslint", "none"],
       "default": "eslint"
+    },
+    "style": {
+      "description": "The file extension to be used for style files.",
+      "type": "string",
+      "default": "css",
+      "x-prompt": {
+        "message": "Which stylesheet format would you like to use?",
+        "type": "list",
+        "items": [
+          {
+            "value": "css",
+            "label": "CSS"
+          },
+          {
+            "value": "scss",
+            "label": "SASS(.scss)  [ http://sass-lang.com   ]"
+          },
+          {
+            "value": "less",
+            "label": "LESS         [ http://lesscss.org     ]"
+          }
+        ]
+      }
     }
   },
   "additionalProperties": false

--- a/packages/angular/src/generators/karma-project/karma-project.spec.ts
+++ b/packages/angular/src/generators/karma-project/karma-project.spec.ts
@@ -26,7 +26,7 @@ describe('karmaProject', () => {
 
     await applicationGenerator(tree, {
       name: 'app1',
-      unitTestRunner: 'none',
+      unitTestRunner: UnitTestRunner.None,
     });
   });
 

--- a/packages/angular/src/generators/utils/types.ts
+++ b/packages/angular/src/generators/utils/types.ts
@@ -1,0 +1,1 @@
+export type Styles = 'css' | 'less' | 'scss';

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -177,8 +177,8 @@ function showHelp() {
 
     cli                       CLI to power the Nx workspace (options: "nx", "angular")
     
-    style                     Default style option to be used when a non-empty preset is selected 
-                              options: ("css", "scss", "styl", "less") for React/Next.js also ("styled-components", "@emotion/styled")    
+    style                     Default style option to be used when a non-empty preset is selected
+                              options: ("css", "scss", "less") plus ("styl") for all non-Angular and ("styled-components", "@emotion/styled", "styled-jsx") for React, Next.js, Gatsby
 
     interactive               Enable interactive mode when using presets (boolean)
 
@@ -344,17 +344,20 @@ function determineStyle(preset: Preset, parsedArgs: any) {
     },
     {
       name: 'scss',
-      message: 'SASS(.scss)  [ http://sass-lang.com   ]',
-    },
-    {
-      name: 'styl',
-      message: 'Stylus(.styl)[ http://stylus-lang.com ]',
+      message: 'SASS(.scss)       [ http://sass-lang.com   ]',
     },
     {
       name: 'less',
-      message: 'LESS         [ http://lesscss.org     ]',
+      message: 'LESS              [ http://lesscss.org     ]',
     },
   ];
+
+  if (![Preset.Angular, Preset.AngularWithNest].includes(preset)) {
+    choices.push({
+      name: 'styl',
+      message: 'Stylus(.styl)     [ http://stylus-lang.com ]',
+    });
+  }
 
   if (
     [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Creating a new Angular workspace or application allows to select Stylus as the stylesheet format and this breaks since it's no longer supported.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Stylus shouldn't be provided as an option when creating Angular workspaces or applications.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
