### PR TITLE
chore(repo): add angular and react to e2e-workspace implicit deps

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -115,7 +115,7 @@
       "implicitDependencies": ["web"]
     },
     "e2e-workspace": {
-      "implicitDependencies": ["create-nx-workspace"]
+      "implicitDependencies": ["create-nx-workspace", "angular", "react"]
     },
     "gatsby": {
       "tags": []


### PR DESCRIPTION
Workspace integration tests are generating `react` or `angular` projects to test the core 
functionality. Some of those integration tests are cross-cutting and could be potentially broken by changes in respectively `react` or `angular` project.

## Current Behavior
When react or angular changes, the workspace e2e tests are not triggered by `affected` since they are not listed as dependencies of `e2e-workspace`.

## Expected Behavior
Changes to react or angular should trigger run of `e2e-workspace`.