### PR TITLE
fix(angular): fix workspace init generator to workaround file rename issues in the tree

### DIFF
--- a/packages/workspace/src/generators/init/init.ts
+++ b/packages/workspace/src/generators/init/init.ts
@@ -634,15 +634,7 @@ function renameSyncInTree(
 
 function renameDirSyncInTree(tree: Tree, from: string, to: string) {
   visitNotIgnoredFiles(tree, from, (file) => {
-    try {
-      tree.rename(file, file.replace(from, to));
-    } catch (e) {
-      if (!tree.exists(from)) {
-        console.warn(`Path: ${from} does not exist`);
-      } else if (tree.exists(to)) {
-        console.warn(`Path: ${to} already exists`);
-      }
-    }
+    renameSyncInTree(tree, file, file.replace(from, to), true);
   });
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When converting an Angular CLI workspace to an Nx workspace, if the conversion renames files that are also updated, the generation fails saying the file being updated doesn't exist. This due to an issue in the Angular CLI tree, a workaround is to create the file in the new path and remove the old one instead of renaming it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Converting an Angular CLI workspace to an Nx workspace should work successfully.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5751
