### PR TITLE
chore(repo): docs generator should only format docs files

### DIFF
--- a/scripts/documentation/documentation.ts
+++ b/scripts/documentation/documentation.ts
@@ -1,5 +1,6 @@
 import * as chalk from 'chalk';
 import { execSync, exec } from 'child_process';
+import { join } from 'path';
 import { Frameworks } from './frameworks';
 
 import { generateCLIDocumentation } from './generate-cli-data';
@@ -17,7 +18,14 @@ async function generate() {
     execSync(
       `rm -rf docs/${framework}/api-nx-devkit/modules.md docs/${framework}/api-nx-devkit/README.md`
     );
-    execSync(`nx format`);
+    execSync(
+      `npx prettier docs/${framework}/api-nx-devkit --write --config ${join(
+        __dirname,
+        '..',
+        '..',
+        '.prettierrc'
+      )}`
+    );
   });
   await generateGeneratorsDocumentation();
   await generateExecutorsDocumentation();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`yarn documentation` formats the entire workspace through `nx format`

## Expected Behavior
`yarn documentation` only runs prettier on applicable files.
