### PR TITLE
fix(linter): tslint to eslint conversion should not override existing root config

### DIFF
--- a/packages/angular/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
@@ -1,5 +1,566 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`convert-tslint-to-eslint should not override .eslint config if migration in progress 1`] = `
+Object {
+  "ignorePatterns": Array [
+    "**/*",
+  ],
+  "overrides": Array [
+    Object {
+      "files": Array [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx",
+      ],
+      "rules": Object {
+        "@nrwl/nx/enforce-module-boundaries": Array [
+          "error",
+          Object {
+            "allow": Array [
+              "@nx-example/shared/product/data/testing",
+            ],
+            "depConstraints": Array [
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:feature",
+                  "type:ui",
+                ],
+                "sourceTag": "type:app",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:ui",
+                  "type:data",
+                  "type:types",
+                  "type:state",
+                ],
+                "sourceTag": "type:feature",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:types",
+                ],
+                "sourceTag": "type:types",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:state",
+                  "type:types",
+                  "type:data",
+                ],
+                "sourceTag": "type:state",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:types",
+                ],
+                "sourceTag": "type:data",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:e2e-utils",
+                ],
+                "sourceTag": "type:e2e",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:types",
+                  "type:ui",
+                ],
+                "sourceTag": "type:ui",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "scope:products",
+                  "scope:shared",
+                ],
+                "sourceTag": "scope:products",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "scope:cart",
+                  "scope:shared",
+                ],
+                "sourceTag": "scope:cart",
+              },
+            ],
+            "enforceBuildableLibDependency": true,
+          },
+        ],
+      },
+    },
+    Object {
+      "extends": Array [
+        "plugin:@nrwl/nx/typescript",
+      ],
+      "files": Array [
+        "*.ts",
+        "*.tsx",
+      ],
+      "rules": Object {},
+    },
+    Object {
+      "extends": Array [
+        "plugin:@nrwl/nx/javascript",
+      ],
+      "files": Array [
+        "*.js",
+        "*.jsx",
+      ],
+      "rules": Object {},
+    },
+    Object {
+      "files": Array [
+        "*.ts",
+      ],
+      "plugins": Array [
+        "eslint-plugin-import",
+        "@angular-eslint/eslint-plugin",
+        "@typescript-eslint",
+      ],
+      "rules": Object {
+        "@angular-eslint/component-selector": Array [
+          "error",
+          Object {
+            "prefix": "app",
+            "style": "kebab-case",
+            "type": "element",
+          },
+        ],
+        "@angular-eslint/directive-selector": Array [
+          "error",
+          Object {
+            "prefix": "app",
+            "style": "camelCase",
+            "type": "attribute",
+          },
+        ],
+        "@angular-eslint/no-conflicting-lifecycle": "error",
+        "@angular-eslint/no-host-metadata-property": "error",
+        "@angular-eslint/no-input-rename": "error",
+        "@angular-eslint/no-inputs-metadata-property": "error",
+        "@angular-eslint/no-output-native": "error",
+        "@angular-eslint/no-output-on-prefix": "error",
+        "@angular-eslint/no-output-rename": "error",
+        "@angular-eslint/no-outputs-metadata-property": "error",
+        "@angular-eslint/use-lifecycle-interface": "error",
+        "@angular-eslint/use-pipe-transform-interface": "error",
+        "@typescript-eslint/consistent-type-definitions": "error",
+        "@typescript-eslint/dot-notation": "off",
+        "@typescript-eslint/explicit-member-accessibility": Array [
+          "off",
+          Object {
+            "accessibility": "explicit",
+          },
+        ],
+        "@typescript-eslint/member-ordering": "error",
+        "@typescript-eslint/naming-convention": "error",
+        "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-empty-interface": "error",
+        "@typescript-eslint/no-inferrable-types": Array [
+          "error",
+          Object {
+            "ignoreParameters": true,
+          },
+        ],
+        "@typescript-eslint/no-misused-new": "error",
+        "@typescript-eslint/no-non-null-assertion": "error",
+        "@typescript-eslint/no-shadow": Array [
+          "error",
+          Object {
+            "hoist": "all",
+          },
+        ],
+        "@typescript-eslint/no-unused-expressions": "error",
+        "@typescript-eslint/prefer-function-type": "error",
+        "@typescript-eslint/unified-signatures": "error",
+        "arrow-body-style": "error",
+        "constructor-super": "error",
+        "eqeqeq": Array [
+          "error",
+          "smart",
+        ],
+        "guard-for-in": "error",
+        "id-blacklist": "off",
+        "id-match": "off",
+        "import/no-deprecated": "warn",
+        "no-bitwise": "error",
+        "no-caller": "error",
+        "no-console": Array [
+          "error",
+          Object {
+            "allow": Array [
+              "log",
+              "warn",
+              "dir",
+              "timeLog",
+              "assert",
+              "clear",
+              "count",
+              "countReset",
+              "group",
+              "groupEnd",
+              "table",
+              "dirxml",
+              "error",
+              "groupCollapsed",
+              "_buffer",
+              "_counters",
+              "_timers",
+              "_groupDepth",
+              "Console",
+            ],
+          },
+        ],
+        "no-debugger": "error",
+        "no-empty": "off",
+        "no-eval": "error",
+        "no-fallthrough": "error",
+        "no-new-wrappers": "error",
+        "no-restricted-imports": Array [
+          "error",
+          "rxjs/Rx",
+        ],
+        "no-throw-literal": "error",
+        "no-undef-init": "error",
+        "no-underscore-dangle": "off",
+        "no-var": "error",
+        "prefer-const": "error",
+        "radix": "error",
+      },
+    },
+    Object {
+      "files": Array [
+        "*.html",
+      ],
+      "plugins": Array [
+        "@angular-eslint/eslint-plugin-template",
+      ],
+      "rules": Object {
+        "@angular-eslint/template/banana-in-box": "error",
+        "@angular-eslint/template/eqeqeq": "error",
+        "@angular-eslint/template/no-negated-async": "error",
+      },
+    },
+  ],
+  "plugins": Array [
+    "@nrwl/nx",
+  ],
+  "root": true,
+}
+`;
+
+exports[`convert-tslint-to-eslint should not override .eslint config if migration in progress 2`] = `
+Object {
+  "extends": Array [
+    "../../.eslintrc.json",
+  ],
+  "ignorePatterns": Array [
+    "!**/*",
+  ],
+  "overrides": Array [
+    Object {
+      "extends": Array [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates",
+      ],
+      "files": Array [
+        "*.ts",
+      ],
+      "plugins": Array [
+        "@angular-eslint/eslint-plugin",
+        "@typescript-eslint",
+      ],
+      "rules": Object {
+        "@angular-eslint/component-selector": Array [
+          "error",
+          Object {
+            "prefix": "angular-app",
+            "style": "kebab-case",
+            "type": "element",
+          },
+        ],
+        "@angular-eslint/directive-selector": Array [
+          "error",
+          Object {
+            "prefix": "angular-app",
+            "style": "camelCase",
+            "type": "attribute",
+          },
+        ],
+        "@typescript-eslint/no-empty-interface": "error",
+      },
+    },
+    Object {
+      "extends": Array [
+        "plugin:@nrwl/nx/angular-template",
+      ],
+      "files": Array [
+        "*.html",
+      ],
+      "plugins": Array [
+        "@angular-eslint/eslint-plugin-template",
+      ],
+      "rules": Object {
+        "@angular-eslint/template/banana-in-box": "error",
+      },
+    },
+  ],
+}
+`;
+
+exports[`convert-tslint-to-eslint should not override .eslint config if migration in progress 3`] = `
+Object {
+  "ignorePatterns": Array [
+    "**/*",
+  ],
+  "overrides": Array [
+    Object {
+      "files": Array [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx",
+      ],
+      "rules": Object {
+        "@nrwl/nx/enforce-module-boundaries": Array [
+          "error",
+          Object {
+            "allow": Array [
+              "@nx-example/shared/product/data/testing",
+            ],
+            "depConstraints": Array [
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:feature",
+                  "type:ui",
+                ],
+                "sourceTag": "type:app",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:ui",
+                  "type:data",
+                  "type:types",
+                  "type:state",
+                ],
+                "sourceTag": "type:feature",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:types",
+                ],
+                "sourceTag": "type:types",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:state",
+                  "type:types",
+                  "type:data",
+                ],
+                "sourceTag": "type:state",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:types",
+                ],
+                "sourceTag": "type:data",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:e2e-utils",
+                ],
+                "sourceTag": "type:e2e",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "type:types",
+                  "type:ui",
+                ],
+                "sourceTag": "type:ui",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "scope:products",
+                  "scope:shared",
+                ],
+                "sourceTag": "scope:products",
+              },
+              Object {
+                "onlyDependOnLibsWithTags": Array [
+                  "scope:cart",
+                  "scope:shared",
+                ],
+                "sourceTag": "scope:cart",
+              },
+            ],
+            "enforceBuildableLibDependency": false,
+          },
+        ],
+      },
+    },
+    Object {
+      "extends": Array [
+        "plugin:@nrwl/nx/typescript",
+      ],
+      "files": Array [
+        "*.ts",
+        "*.tsx",
+      ],
+      "rules": Object {},
+    },
+    Object {
+      "extends": Array [
+        "plugin:@nrwl/nx/javascript",
+      ],
+      "files": Array [
+        "*.js",
+        "*.jsx",
+      ],
+      "rules": Object {},
+    },
+    Object {
+      "files": Array [
+        "*.ts",
+      ],
+      "plugins": Array [
+        "eslint-plugin-import",
+        "@angular-eslint/eslint-plugin",
+        "@typescript-eslint",
+      ],
+      "rules": Object {
+        "@angular-eslint/component-selector": Array [
+          "error",
+          Object {
+            "prefix": "app",
+            "style": "kebab-case",
+            "type": "element",
+          },
+        ],
+        "@angular-eslint/directive-selector": Array [
+          "error",
+          Object {
+            "prefix": "app",
+            "style": "camelCase",
+            "type": "attribute",
+          },
+        ],
+        "@angular-eslint/no-conflicting-lifecycle": "error",
+        "@angular-eslint/no-host-metadata-property": "error",
+        "@angular-eslint/no-input-rename": "error",
+        "@angular-eslint/no-inputs-metadata-property": "error",
+        "@angular-eslint/no-output-native": "error",
+        "@angular-eslint/no-output-on-prefix": "error",
+        "@angular-eslint/no-output-rename": "error",
+        "@angular-eslint/no-outputs-metadata-property": "error",
+        "@angular-eslint/use-lifecycle-interface": "error",
+        "@angular-eslint/use-pipe-transform-interface": "error",
+        "@typescript-eslint/consistent-type-definitions": "error",
+        "@typescript-eslint/dot-notation": "off",
+        "@typescript-eslint/explicit-member-accessibility": Array [
+          "off",
+          Object {
+            "accessibility": "explicit",
+          },
+        ],
+        "@typescript-eslint/member-ordering": "error",
+        "@typescript-eslint/naming-convention": "error",
+        "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-empty-interface": "error",
+        "@typescript-eslint/no-inferrable-types": Array [
+          "error",
+          Object {
+            "ignoreParameters": true,
+          },
+        ],
+        "@typescript-eslint/no-misused-new": "error",
+        "@typescript-eslint/no-non-null-assertion": "error",
+        "@typescript-eslint/no-shadow": Array [
+          "error",
+          Object {
+            "hoist": "all",
+          },
+        ],
+        "@typescript-eslint/no-unused-expressions": "error",
+        "@typescript-eslint/prefer-function-type": "error",
+        "@typescript-eslint/unified-signatures": "error",
+        "arrow-body-style": "error",
+        "constructor-super": "error",
+        "eqeqeq": Array [
+          "error",
+          "smart",
+        ],
+        "guard-for-in": "error",
+        "id-blacklist": "off",
+        "id-match": "off",
+        "import/no-deprecated": "warn",
+        "no-bitwise": "error",
+        "no-caller": "error",
+        "no-console": Array [
+          "error",
+          Object {
+            "allow": Array [
+              "log",
+              "warn",
+              "dir",
+              "timeLog",
+              "assert",
+              "clear",
+              "count",
+              "countReset",
+              "group",
+              "groupEnd",
+              "table",
+              "dirxml",
+              "error",
+              "groupCollapsed",
+              "_buffer",
+              "_counters",
+              "_timers",
+              "_groupDepth",
+              "Console",
+            ],
+          },
+        ],
+        "no-debugger": "error",
+        "no-empty": "off",
+        "no-eval": "error",
+        "no-fallthrough": "error",
+        "no-new-wrappers": "error",
+        "no-restricted-imports": Array [
+          "error",
+          "rxjs/Rx",
+        ],
+        "no-throw-literal": "error",
+        "no-undef-init": "error",
+        "no-underscore-dangle": "off",
+        "no-var": "error",
+        "prefer-const": "error",
+        "radix": "error",
+      },
+    },
+    Object {
+      "files": Array [
+        "*.html",
+      ],
+      "plugins": Array [
+        "@angular-eslint/eslint-plugin-template",
+      ],
+      "rules": Object {
+        "@angular-eslint/template/banana-in-box": "error",
+        "@angular-eslint/template/eqeqeq": "error",
+        "@angular-eslint/template/no-negated-async": "error",
+      },
+    },
+  ],
+  "plugins": Array [
+    "@nrwl/nx",
+  ],
+  "root": true,
+}
+`;
+
 exports[`convert-tslint-to-eslint should work for Angular applications 1`] = `
 Object {
   "dependencies": Object {},

--- a/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -44,6 +44,12 @@ export async function conversionGenerator(
   });
 
   /**
+   * If root eslint configuration already exists it will not be recreated
+   * but we also don't want to re-run the tslint config conversion
+   * as it was likely already done
+   */
+  const rootEslintConfigExists = host.exists('.eslintrc.json');
+  /**
    * Create the standard (which is applicable to the current package) ESLint setup
    * for converting the project.
    */
@@ -52,15 +58,11 @@ export async function conversionGenerator(
   /**
    * Convert the root tslint.json and apply the converted rules to the root .eslintrc.json
    */
-  const rootConfigInstallTask = await projectConverter.convertRootTSLintConfig(
-    (json) => {
-      json.overrides = [
-        { files: ['*.ts'], rules: {} },
-        { files: ['*.html'], rules: {} },
-      ];
-      return applyAngularRulesToCorrectOverrides(json);
-    }
+  const rootConfigInstallTask = await convertRootTSLintConfig(
+    projectConverter,
+    rootEslintConfigExists
   );
+
   /**
    * Convert the project's tslint.json to an equivalent ESLint config.
    */
@@ -126,6 +128,34 @@ export async function conversionGenerator(
 }
 
 export const conversionSchematic = convertNxGenerator(conversionGenerator);
+
+/**
+ * If root eslint already exists, we will not override it with converted tslint
+ * as this might break existing configuration in place. This is the common scenario
+ * when large projects are migrating one project at a time and apply custom
+ * changes to root config in the meantime.
+ *
+ * We warn user of this action in case .eslintrc.json was created accidentally
+ */
+async function convertRootTSLintConfig(
+  projectConverter: ProjectConverter,
+  rootEslintConfigExists?: boolean
+): Promise<GeneratorCallback> {
+  if (rootEslintConfigExists) {
+    logger.warn(
+      `Root '.eslintrc.json' found. Assuming conversion was already run for other projects.`
+    );
+    return Promise.resolve(() => {});
+  } else {
+    return await projectConverter.convertRootTSLintConfig((json) => {
+      json.overrides = [
+        { files: ['*.ts'], rules: {} },
+        { files: ['*.html'], rules: {} },
+      ];
+      return applyAngularRulesToCorrectOverrides(json);
+    });
+  }
+}
 
 /**
  * In the case of Angular lint rules, we need to apply them to correct override depending upon whether

--- a/packages/cypress/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/cypress/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -45,6 +45,13 @@ export async function conversionGenerator(
   });
 
   /**
+   * If root eslint configuration already exists it will not be recreated
+   * but we also don't want to re-run the tslint config conversion
+   * as it was likely already done
+   */
+  const rootEslintConfigExists = host.exists('.eslintrc.json');
+
+  /**
    * Create the standard (which is applicable to the current package) ESLint setup
    * for converting the project.
    */
@@ -54,7 +61,8 @@ export async function conversionGenerator(
    * Convert the root tslint.json and apply the converted rules to the root .eslintrc.json.
    */
   const rootConfigInstallTask = await projectConverter.convertRootTSLintConfig(
-    (json) => removeCodelyzerRelatedRules(json)
+    (json) => removeCodelyzerRelatedRules(json),
+    rootEslintConfigExists
   );
 
   /**

--- a/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
@@ -153,6 +153,9 @@ export class ProjectConverter {
     applyPackageSpecificModifications: (json: Linter.Config) => Linter.Config,
     rootEslintConfigExists?: boolean
   ): Promise<Exclude<GeneratorCallback, void>> {
+    if (this.ignoreExistingTslintConfig) {
+      return Promise.resolve(() => {});
+    }
     /**
      * If root eslint already exists, we will not override it with converted tslint
      * as this might break existing configuration in place. This is the common scenario
@@ -165,9 +168,6 @@ export class ProjectConverter {
       logger.warn(
         `Root '.eslintrc.json' found. Assuming conversion was already run for other projects.`
       );
-      return Promise.resolve(() => {});
-    }
-    if (this.ignoreExistingTslintConfig) {
       return Promise.resolve(() => {});
     }
 

--- a/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
@@ -150,8 +150,23 @@ export class ProjectConverter {
    * focus on the project-level config conversion.
    */
   async convertRootTSLintConfig(
-    applyPackageSpecificModifications: (json: Linter.Config) => Linter.Config
+    applyPackageSpecificModifications: (json: Linter.Config) => Linter.Config,
+    rootEslintConfigExists?: boolean
   ): Promise<Exclude<GeneratorCallback, void>> {
+    /**
+     * If root eslint already exists, we will not override it with converted tslint
+     * as this might break existing configuration in place. This is the common scenario
+     * when large projects are migrating one project at a time and apply custom
+     * changes to root config in the meantime.
+     *
+     * We warn user of this action in case .eslintrc.json was created accidentally
+     */
+    if (rootEslintConfigExists) {
+      logger.warn(
+        `Root '.eslintrc.json' found. Assuming conversion was already run for other projects.`
+      );
+      return Promise.resolve(() => {});
+    }
     if (this.ignoreExistingTslintConfig) {
       return Promise.resolve(() => {});
     }

--- a/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
@@ -26,7 +26,6 @@ import {
   deduplicateOverrides,
   ensureESLintPluginsAreInstalled,
 } from './utils';
-import chalk = require('chalk');
 
 /**
  * Common schema used by all implementations of convert-tslint-to-eslint generators
@@ -156,13 +155,6 @@ export class ProjectConverter {
     if (this.ignoreExistingTslintConfig) {
       return Promise.resolve(() => {});
     }
-
-    // if (this.host.exists('.eslintrc.json')) {
-    //   logger.info(
-    //     `Root ${chalk.bold('.eslintrc.json')} found. Assuming conversion was already run for other projects.`
-    //   );
-    //   return Promise.resolve(() => { });
-    // }
 
     const convertedRoot = await convertTSLintConfig(
       this.rootTSLintJson,

--- a/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
@@ -26,6 +26,7 @@ import {
   deduplicateOverrides,
   ensureESLintPluginsAreInstalled,
 } from './utils';
+import chalk = require('chalk');
 
 /**
  * Common schema used by all implementations of convert-tslint-to-eslint generators
@@ -155,6 +156,13 @@ export class ProjectConverter {
     if (this.ignoreExistingTslintConfig) {
       return Promise.resolve(() => {});
     }
+
+    // if (this.host.exists('.eslintrc.json')) {
+    //   logger.info(
+    //     `Root ${chalk.bold('.eslintrc.json')} found. Assuming conversion was already run for other projects.`
+    //   );
+    //   return Promise.resolve(() => { });
+    // }
 
     const convertedRoot = await convertTSLintConfig(
       this.rootTSLintJson,

--- a/packages/nest/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/nest/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -73,6 +73,13 @@ export async function conversionGenerator(
   });
 
   /**
+   * If root eslint configuration already exists it will not be recreated
+   * but we also don't want to re-run the tslint config conversion
+   * as it was likely already done
+   */
+  const rootEslintConfigExists = host.exists('.eslintrc.json');
+
+  /**
    * Create the standard (which is applicable to the current package) ESLint setup
    * for converting the project.
    */
@@ -82,7 +89,8 @@ export async function conversionGenerator(
    * Convert the root tslint.json and apply the converted rules to the root .eslintrc.json.
    */
   const rootConfigInstallTask = await projectConverter.convertRootTSLintConfig(
-    (json) => removeCodelyzerRelatedRules(json)
+    (json) => removeCodelyzerRelatedRules(json),
+    rootEslintConfigExists
   );
 
   /**


### PR DESCRIPTION
If projects are being converted from `tslint` to `eslint` one at a time and user makes changes to root `.eslintrc.json` in the meantime, those changes should not be overridden by next project's conversion.

## Related Issue(s)
https://github.com/nrwl/nx/issues/5912

Fixes #5912
