### PR TITLE
fix(angular): change tsconfig.worker.json to extend the right path

### DIFF
--- a/docs/angular/api-angular/generators/web-worker.md
+++ b/docs/angular/api-angular/generators/web-worker.md
@@ -1,0 +1,59 @@
+# web-worker
+
+Create a Web Worker.
+
+## Usage
+
+```bash
+nx generate web-worker ...
+```
+
+By default, Nx will search for `web-worker` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/angular:web-worker ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g web-worker ... --dry-run
+```
+
+## Options
+
+### name
+
+Type: `string`
+
+The name of the worker.
+
+### path
+
+Type: `string`
+
+The path at which to create the worker file, relative to the current workspace.
+
+### project
+
+Type: `string`
+
+The name of the project.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.
+
+### snippet
+
+Default: `true`
+
+Type: `boolean`
+
+Add a worker creation snippet in a sibling file of the same name.

--- a/docs/map.json
+++ b/docs/map.json
@@ -383,19 +383,24 @@
             "file": "angular/api-angular/generators/application"
           },
           {
+            "name": "convert-tslint-to-eslint",
+            "id": "convert-tslint-to-eslint",
+            "file": "angular/api-angular/generators/convert-tslint-to-eslint"
+          },
+          {
             "name": "downgrade-module generator",
             "id": "downgrade-module",
             "file": "angular/api-angular/generators/downgrade-module"
           },
           {
-            "name": "karma-project generator",
-            "id": "karma-project",
-            "file": "angular/api-angular/generators/karma-project"
-          },
-          {
             "name": "karma generator",
             "id": "karma",
             "file": "angular/api-angular/generators/karma"
+          },
+          {
+            "name": "karma-project generator",
+            "id": "karma-project",
+            "file": "angular/api-angular/generators/karma-project"
           },
           {
             "name": "library generator",
@@ -438,14 +443,14 @@
             "file": "angular/api-angular/generators/upgrade-module"
           },
           {
-            "name": "convert-tslint-to-eslint",
-            "id": "convert-tslint-to-eslint",
-            "file": "angular/api-angular/generators/convert-tslint-to-eslint"
+            "name": "web-worker generator",
+            "id": "web-worker",
+            "file": "angular/api-angular/generators/web-worker"
           },
           {
-            "name": "package executor",
-            "id": "package",
-            "file": "angular/api-angular/executors/package"
+            "name": "delegate-build executor",
+            "id": "delegate-build",
+            "file": "angular/api-angular/executors/delegate-build"
           },
           {
             "name": "ng packagr lite executor",
@@ -453,14 +458,14 @@
             "file": "angular/api-angular/executors/ng-packagr-lite"
           },
           {
+            "name": "package executor",
+            "id": "package",
+            "file": "angular/api-angular/executors/package"
+          },
+          {
             "name": "webpack-browser executor",
             "id": "webpack-browser",
             "file": "angular/api-angular/executors/webpack-browser"
-          },
-          {
-            "name": "delegate-build executor",
-            "id": "delegate-build",
-            "file": "angular/api-angular/executors/delegate-build"
           }
         ]
       },
@@ -1509,19 +1514,24 @@
             "file": "react/api-angular/generators/application"
           },
           {
+            "name": "convert-tslint-to-eslint",
+            "id": "convert-tslint-to-eslint",
+            "file": "react/api-angular/generators/convert-tslint-to-eslint"
+          },
+          {
             "name": "downgrade-module generator",
             "id": "downgrade-module",
             "file": "react/api-angular/generators/downgrade-module"
           },
           {
-            "name": "karma-project generator",
-            "id": "karma-project",
-            "file": "react/api-angular/generators/karma-project"
-          },
-          {
             "name": "karma generator",
             "id": "karma",
             "file": "react/api-angular/generators/karma"
+          },
+          {
+            "name": "karma-project generator",
+            "id": "karma-project",
+            "file": "react/api-angular/generators/karma-project"
           },
           {
             "name": "library generator",
@@ -1537,11 +1547,6 @@
             "name": "ngrx generator",
             "id": "ngrx",
             "file": "react/api-angular/generators/ngrx"
-          },
-          {
-            "name": "convert-tslint-to-eslint",
-            "id": "convert-tslint-to-eslint",
-            "file": "react/api-angular/generators/convert-tslint-to-eslint"
           },
           {
             "name": "stories generator",
@@ -1569,9 +1574,14 @@
             "file": "react/api-angular/generators/upgrade-module"
           },
           {
-            "name": "package executor",
-            "id": "package",
-            "file": "react/api-angular/executors/package"
+            "name": "web-worker generator",
+            "id": "web-worker",
+            "file": "react/api-angular/generators/web-worker"
+          },
+          {
+            "name": "delegate-build executor",
+            "id": "delegate-build",
+            "file": "react/api-angular/executors/delegate-build"
           },
           {
             "name": "ng packagr lite executor",
@@ -1579,14 +1589,14 @@
             "file": "react/api-angular/executors/ng-packagr-lite"
           },
           {
+            "name": "package executor",
+            "id": "package",
+            "file": "react/api-angular/executors/package"
+          },
+          {
             "name": "webpack-browser executor",
             "id": "webpack-browser",
             "file": "react/api-angular/executors/webpack-browser"
-          },
-          {
-            "name": "delegate-build executor",
-            "id": "delegate-build",
-            "file": "react/api-angular/executors/delegate-build"
           }
         ]
       },
@@ -2599,19 +2609,24 @@
             "file": "node/api-angular/generators/application"
           },
           {
+            "name": "convert-tslint-to-eslint",
+            "id": "convert-tslint-to-eslint",
+            "file": "node/api-angular/generators/convert-tslint-to-eslint"
+          },
+          {
             "name": "downgrade-module generator",
             "id": "downgrade-module",
             "file": "node/api-angular/generators/downgrade-module"
           },
           {
-            "name": "karma-project generator",
-            "id": "karma-project",
-            "file": "node/api-angular/generators/karma-project"
-          },
-          {
             "name": "karma generator",
             "id": "karma",
             "file": "node/api-angular/generators/karma"
+          },
+          {
+            "name": "karma-project generator",
+            "id": "karma-project",
+            "file": "node/api-angular/generators/karma-project"
           },
           {
             "name": "library generator",
@@ -2654,14 +2669,14 @@
             "file": "node/api-angular/generators/upgrade-module"
           },
           {
-            "name": "convert-tslint-to-eslint",
-            "id": "convert-tslint-to-eslint",
-            "file": "node/api-angular/generators/convert-tslint-to-eslint"
+            "name": "web-worker generator",
+            "id": "web-worker",
+            "file": "node/api-angular/generators/web-worker"
           },
           {
-            "name": "package executor",
-            "id": "package",
-            "file": "node/api-angular/executors/package"
+            "name": "delegate-build executor",
+            "id": "delegate-build",
+            "file": "node/api-angular/executors/delegate-build"
           },
           {
             "name": "ng packagr lite executor",
@@ -2669,14 +2684,14 @@
             "file": "node/api-angular/executors/ng-packagr-lite"
           },
           {
+            "name": "package executor",
+            "id": "package",
+            "file": "node/api-angular/executors/package"
+          },
+          {
             "name": "webpack-browser executor",
             "id": "webpack-browser",
             "file": "node/api-angular/executors/webpack-browser"
-          },
-          {
-            "name": "delegate-build executor",
-            "id": "delegate-build",
-            "file": "node/api-angular/executors/delegate-build"
           }
         ]
       },

--- a/docs/node/api-angular/generators/web-worker.md
+++ b/docs/node/api-angular/generators/web-worker.md
@@ -1,0 +1,59 @@
+# web-worker
+
+Create a Web Worker.
+
+## Usage
+
+```bash
+nx generate web-worker ...
+```
+
+By default, Nx will search for `web-worker` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/angular:web-worker ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g web-worker ... --dry-run
+```
+
+## Options
+
+### name
+
+Type: `string`
+
+The name of the worker.
+
+### path
+
+Type: `string`
+
+The path at which to create the worker file, relative to the current workspace.
+
+### project
+
+Type: `string`
+
+The name of the project.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.
+
+### snippet
+
+Default: `true`
+
+Type: `boolean`
+
+Add a worker creation snippet in a sibling file of the same name.

--- a/docs/react/api-angular/generators/web-worker.md
+++ b/docs/react/api-angular/generators/web-worker.md
@@ -1,0 +1,59 @@
+# web-worker
+
+Create a Web Worker.
+
+## Usage
+
+```bash
+nx generate web-worker ...
+```
+
+By default, Nx will search for `web-worker` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/angular:web-worker ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g web-worker ... --dry-run
+```
+
+## Options
+
+### name
+
+Type: `string`
+
+The name of the worker.
+
+### path
+
+Type: `string`
+
+The path at which to create the worker file, relative to the current workspace.
+
+### project
+
+Type: `string`
+
+The name of the project.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.
+
+### snippet
+
+Default: `true`
+
+Type: `boolean`
+
+Add a worker creation snippet in a sibling file of the same name.

--- a/packages/angular/collection.json
+++ b/packages/angular/collection.json
@@ -111,6 +111,11 @@
       "factory": "./src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint#conversionSchematic",
       "schema": "./src/generators/convert-tslint-to-eslint/schema.json",
       "description": "Convert a project from TSLint to ESLint"
+    },
+    "web-worker": {
+      "factory": "./src/generators/web-worker/compat",
+      "schema": "./src/generators/web-worker/schema.json",
+      "description": "Create a Web Worker."
     }
   },
   "generators": {
@@ -206,6 +211,11 @@
       "factory": "./src/generators/upgrade-module/upgrade-module",
       "schema": "./src/generators/upgrade-module/schema.json",
       "description": "Add an upgrade module."
+    },
+    "web-worker": {
+      "factory": "./src/generators/web-worker/web-worker",
+      "schema": "./src/generators/web-worker/schema.json",
+      "description": "Create a Web Worker."
     }
   }
 }

--- a/packages/angular/src/generators/web-worker/compat.ts
+++ b/packages/angular/src/generators/web-worker/compat.ts
@@ -1,0 +1,4 @@
+import { convertNxGenerator } from '@nrwl/devkit';
+import { webWorkerGenerator } from './web-worker';
+
+export default convertNxGenerator(webWorkerGenerator);

--- a/packages/angular/src/generators/web-worker/lib/index.ts
+++ b/packages/angular/src/generators/web-worker/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './normalize-options';
+export * from './update-tsconfig';

--- a/packages/angular/src/generators/web-worker/lib/normalize-options.ts
+++ b/packages/angular/src/generators/web-worker/lib/normalize-options.ts
@@ -1,0 +1,10 @@
+import type { WebWorkerGeneratorOptions } from '../schema';
+
+export function normalizeOptions(
+  options: WebWorkerGeneratorOptions
+): WebWorkerGeneratorOptions {
+  return {
+    ...options,
+    snippet: options.snippet ?? true,
+  };
+}

--- a/packages/angular/src/generators/web-worker/lib/update-tsconfig.ts
+++ b/packages/angular/src/generators/web-worker/lib/update-tsconfig.ts
@@ -1,0 +1,21 @@
+import type { Tree } from '@nrwl/devkit';
+import {
+  getWorkspaceLayout,
+  joinPathFragments,
+  offsetFromRoot,
+  readProjectConfiguration,
+  updateJson,
+} from '@nrwl/devkit';
+
+export function updateTsConfig(tree: Tree, project: string): void {
+  const workerTsConfigPath = joinPathFragments(
+    getWorkspaceLayout(tree).appsDir,
+    project,
+    'tsconfig.worker.json'
+  );
+  const { root } = readProjectConfiguration(tree, project);
+  updateJson(tree, workerTsConfigPath, (json) => {
+    json.extends = `${offsetFromRoot(root)}tsconfig.base.json`;
+    return json;
+  });
+}

--- a/packages/angular/src/generators/web-worker/schema.d.ts
+++ b/packages/angular/src/generators/web-worker/schema.d.ts
@@ -1,0 +1,7 @@
+export interface WebWorkerGeneratorOptions {
+  name: string;
+  project: string;
+  path?: string;
+  skipFormat?: boolean;
+  snippet?: boolean;
+}

--- a/packages/angular/src/generators/web-worker/schema.json
+++ b/packages/angular/src/generators/web-worker/schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "NxAngularWebWorkerGenerator",
+  "title": "Angular Web Worker Options Schema",
+  "description": "Creates a new, generic web worker definition in the given or default project.",
+  "cli": "nx",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path at which to create the worker file, relative to the current workspace."
+    },
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName"
+      }
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the worker.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the worker?"
+    },
+    "snippet": {
+      "type": "boolean",
+      "default": true,
+      "description": "Add a worker creation snippet in a sibling file of the same name."
+    },
+    "skipFormat": {
+      "description": "Skip formatting files.",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "additionalProperties": false,
+  "required": ["name", "project"]
+}

--- a/packages/angular/src/generators/web-worker/web-worker.spec.ts
+++ b/packages/angular/src/generators/web-worker/web-worker.spec.ts
@@ -1,0 +1,51 @@
+import type { Tree } from '@nrwl/devkit';
+import * as devkit from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { applicationGenerator } from '../application/application';
+import { webWorkerGenerator } from './web-worker';
+
+describe('webWorker generator', () => {
+  let tree: Tree;
+  const appName = 'ng-app1';
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+    await applicationGenerator(tree, { name: appName });
+    jest.clearAllMocks();
+  });
+
+  it('should generate files', async () => {
+    await webWorkerGenerator(tree, { name: 'test-worker', project: appName });
+
+    expect(tree.exists(`apps/${appName}/tsconfig.worker.json`));
+    expect(tree.exists(`apps/${appName}/src/app/test-worker.worker.ts`));
+  });
+
+  it('should extend from tsconfig.base.json', async () => {
+    await webWorkerGenerator(tree, { name: 'test-worker', project: appName });
+
+    expect(
+      tree.read(`apps/${appName}/tsconfig.worker.json`, 'utf-8')
+    ).toContain('"extends": "../../tsconfig.base.json"');
+  });
+
+  it('should format files', async () => {
+    jest.spyOn(devkit, 'formatFiles');
+
+    await webWorkerGenerator(tree, { name: 'test-worker', project: appName });
+
+    expect(devkit.formatFiles).toHaveBeenCalled();
+  });
+
+  it('should not format files when --skipFormat=true', async () => {
+    jest.spyOn(devkit, 'formatFiles');
+
+    await webWorkerGenerator(tree, {
+      name: 'test-worker',
+      project: appName,
+      skipFormat: true,
+    });
+
+    expect(devkit.formatFiles).not.toHaveBeenCalled();
+  });
+});

--- a/packages/angular/src/generators/web-worker/web-worker.ts
+++ b/packages/angular/src/generators/web-worker/web-worker.ts
@@ -1,0 +1,26 @@
+import type { Tree } from '@nrwl/devkit';
+import { formatFiles } from '@nrwl/devkit';
+import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
+import { normalizeOptions, updateTsConfig } from './lib';
+import type { WebWorkerGeneratorOptions } from './schema';
+
+export async function webWorkerGenerator(
+  tree: Tree,
+  rawOptions: WebWorkerGeneratorOptions
+): Promise<void> {
+  const options = normalizeOptions(rawOptions);
+  const { skipFormat, ...schematicOptions } = options;
+  const webWorkerSchematic = wrapAngularDevkitSchematic(
+    '@schematics/angular',
+    'web-worker'
+  );
+  await webWorkerSchematic(tree, schematicOptions);
+
+  updateTsConfig(tree, options.project);
+
+  if (!skipFormat) {
+    await formatFiles(tree);
+  }
+}
+
+export default webWorkerGenerator;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating a Web Worker, the generated `tsconfig.woker.json` is extending a wrong path `../../tsconfig.json`, causing the project build to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `tsconfig.worker.json` should extend the right path `../../tsconfig.base.json` and the app should build successfully. So far, there was no generator for Web Workers in Nx, but it's available in `@nrwl/angular` collection since we extend the `@schematics/angular`. A generator for Web Workers is added to handle the differences.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5835
