### PR TITLE
docs(angular): improve incremental build docs

### DIFF
--- a/docs/angular/guides/setup-incremental-builds.md
+++ b/docs/angular/guides/setup-incremental-builds.md
@@ -1,7 +1,8 @@
 # Setup incremental builds for Angular applications
 
-In this guide we’ll specifically look into which changes need to be made to enable [incremental builds](/angular/ci/incremental-builds) for Angular applications.  
-Incremental builds require @nrwl/angular:webpack-browser, which requires Nx version 10.4.0 or later.
+In this guide we’ll specifically look into which changes need to be made to enable [incremental builds](/angular/ci/incremental-builds) for Angular applications.
+
+> Incremental builds requires Nx version 10.4.0 or later.
 
 ## Requirements
 
@@ -24,15 +25,14 @@ It’s required that you run the Angular compatibility compiler (`ngcc`) after e
 ## Use buildable libraries
 
 To enable incremental builds you need to use buildable libraries.
-You can generate a new buildable lib with
+
+You can generate a new buildable library with:
 
 ```bash
 nx g @nrwl/angular:lib mylib --buildable
 ```
 
-## Adjust the executors/builders
-
-Nx comes with faster executors allowing for a faster build. Make sure that your libraries use the @nrwl/angular:ng-packagr-lite builder.
+The generated buildable library uses the `@nrwl/angular:ng-packagr-lite` executor which is optimized for the incremental builds scenario:
 
 ```json
 "mylib": {
@@ -41,6 +41,7 @@ Nx comes with faster executors allowing for a faster build. Make sure that your 
     "architect": {
         "build": {
             "builder": "@nrwl/angular:ng-packagr-lite",
+            "outputs": ["dist/libs/mylib"],
             "options": {...},
             "configurations": {...}
         },
@@ -51,7 +52,11 @@ Nx comes with faster executors allowing for a faster build. Make sure that your 
 },
 ```
 
-Change your Angular app’s executor to @nrwl/angular:webpack-browser and the “serve” executor to @nrwl/web:file-server instead.
+> Please note that it is important to keep the `outputs` property in sync with the `dest` property in the file `ng-package.json` located inside the library root. When a library is generated, this is configured correctly, but if the path is later changed in `ng-package.json`, it needs to be updated as well in the project configuration.
+
+## Adjust the app executor
+
+Change your Angular app’s “build” target executor to `@nrwl/angular:webpack-browser` and the “serve” target executor to `@nrwl/web:file-server` as shown below:
 
 ```json
 "app0": {
@@ -60,6 +65,7 @@ Change your Angular app’s executor to @nrwl/angular:webpack-browser and the �
     "architect": {
         "build": {
             "builder": "@nrwl/angular:webpack-browser",
+            "outputs": ["{options.outputPath}"],
             "options": { ... }
             "configurations": { ... }
         },
@@ -81,7 +87,7 @@ Change your Angular app’s executor to @nrwl/angular:webpack-browser and the �
 
 ## Running and serving incremental builds
 
-To build an app incrementally use the following commands.
+To build an app incrementally use the following command:
 
 ```bash
 nx build myapp --with-deps --parallel
@@ -102,6 +108,7 @@ Note: you can specify the `--with-deps` and `--parallel` flags as part of the op
     "architect": {
         "build": {
             "builder": "@nrwl/angular:webpack-browser",
+            "outputs": ["{options.outputPath}"],
             "options": { ... }
             "configurations": { ... }
         },

--- a/nx-dev/nx-dev/public/documentation/latest/angular/guides/setup-incremental-builds.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/guides/setup-incremental-builds.md
@@ -1,7 +1,8 @@
 # Setup incremental builds for Angular applications
 
-In this guide we’ll specifically look into which changes need to be made to enable [incremental builds](/angular/ci/incremental-builds) for Angular applications.  
-Incremental builds require @nrwl/angular:webpack-browser, which requires Nx version 10.4.0 or later.
+In this guide we’ll specifically look into which changes need to be made to enable [incremental builds](/angular/ci/incremental-builds) for Angular applications.
+
+> Incremental builds requires Nx version 10.4.0 or later.
 
 ## Requirements
 
@@ -24,15 +25,14 @@ It’s required that you run the Angular compatibility compiler (`ngcc`) after e
 ## Use buildable libraries
 
 To enable incremental builds you need to use buildable libraries.
-You can generate a new buildable lib with
+
+You can generate a new buildable library with:
 
 ```bash
 nx g @nrwl/angular:lib mylib --buildable
 ```
 
-## Adjust the executors/builders
-
-Nx comes with faster executors allowing for a faster build. Make sure that your libraries use the @nrwl/angular:ng-packagr-lite builder.
+The generated buildable library uses the `@nrwl/angular:ng-packagr-lite` executor which is optimized for the incremental builds scenario:
 
 ```json
 "mylib": {
@@ -41,6 +41,7 @@ Nx comes with faster executors allowing for a faster build. Make sure that your 
     "architect": {
         "build": {
             "builder": "@nrwl/angular:ng-packagr-lite",
+            "outputs": ["dist/libs/mylib"],
             "options": {...},
             "configurations": {...}
         },
@@ -51,7 +52,11 @@ Nx comes with faster executors allowing for a faster build. Make sure that your 
 },
 ```
 
-Change your Angular app’s executor to @nrwl/angular:webpack-browser and the “serve” executor to @nrwl/web:file-server instead.
+> Please note that it is important to keep the `outputs` property in sync with the `dest` property in the file `ng-package.json` located inside the library root. When a library is generated, this is configured correctly, but if the path is later changed in `ng-package.json`, it needs to be updated as well in the project configuration.
+
+## Adjust the app executor
+
+Change your Angular app’s “build” target executor to `@nrwl/angular:webpack-browser` and the “serve” target executor to `@nrwl/web:file-server` as shown below:
 
 ```json
 "app0": {
@@ -60,6 +65,7 @@ Change your Angular app’s executor to @nrwl/angular:webpack-browser and the �
     "architect": {
         "build": {
             "builder": "@nrwl/angular:webpack-browser",
+            "outputs": ["{options.outputPath}"],
             "options": { ... }
             "configurations": { ... }
         },
@@ -81,7 +87,7 @@ Change your Angular app’s executor to @nrwl/angular:webpack-browser and the �
 
 ## Running and serving incremental builds
 
-To build an app incrementally use the following commands.
+To build an app incrementally use the following command:
 
 ```bash
 nx build myapp --with-deps --parallel
@@ -102,6 +108,7 @@ Note: you can specify the `--with-deps` and `--parallel` flags as part of the op
     "architect": {
         "build": {
             "builder": "@nrwl/angular:webpack-browser",
+            "outputs": ["{options.outputPath}"],
             "options": { ... }
             "configurations": { ... }
         },

--- a/nx-dev/nx-dev/public/documentation/previous/angular/guides/setup-incremental-builds.md
+++ b/nx-dev/nx-dev/public/documentation/previous/angular/guides/setup-incremental-builds.md
@@ -2,6 +2,8 @@
 
 In this guide we’ll specifically look into which changes need to be made to enable [incremental builds](/angular/ci/incremental-builds) for Angular applications.
 
+> Incremental builds requires Nx version 10.4.0 or later.
+
 ## Requirements
 
 It’s required that you run the Angular compatibility compiler (`ngcc`) after every package installation if you have Ivy enabled. This comes configured by default in every Nx workspace. The incremental build relies on the fact that `ngcc` must have already been run. You can check your `package.json` and make sure you have the following:
@@ -23,15 +25,14 @@ It’s required that you run the Angular compatibility compiler (`ngcc`) after e
 ## Use buildable libraries
 
 To enable incremental builds you need to use buildable libraries.
-You can generate a new buildable lib with
+
+You can generate a new buildable library with:
 
 ```bash
 nx g @nrwl/angular:lib mylib --buildable
 ```
 
-## Adjust the executors/builders
-
-Nx comes with faster executors allowing for a faster build. Make sure that your libraries use the @nrwl/angular:ng-packagr-lite builder.
+The generated buildable library uses the `@nrwl/angular:ng-packagr-lite` executor which is optimized for the incremental builds scenario:
 
 ```json
 "mylib": {
@@ -40,6 +41,7 @@ Nx comes with faster executors allowing for a faster build. Make sure that your 
     "architect": {
         "build": {
             "builder": "@nrwl/angular:ng-packagr-lite",
+            "outputs": ["dist/libs/mylib"],
             "options": {...},
             "configurations": {...}
         },
@@ -50,7 +52,11 @@ Nx comes with faster executors allowing for a faster build. Make sure that your 
 },
 ```
 
-Change your Angular app’s executor to @nrwl/angular:webpack-browser and the “serve” executor to @nrwl/web:file-server instead.
+> Please note that it is important to keep the `outputs` property in sync with the `dest` property in the file `ng-package.json` located inside the library root. When a library is generated, this is configured correctly, but if the path is later changed in `ng-package.json`, it needs to be updated as well in the project configuration.
+
+## Adjust the app executor
+
+Change your Angular app’s “build” target executor to `@nrwl/angular:webpack-browser` and the “serve” target executor to `@nrwl/web:file-server` as shown below:
 
 ```json
 "app0": {
@@ -59,6 +65,7 @@ Change your Angular app’s executor to @nrwl/angular:webpack-browser and the �
     "architect": {
         "build": {
             "builder": "@nrwl/angular:webpack-browser",
+            "outputs": ["{options.outputPath}"],
             "options": { ... }
             "configurations": { ... }
         },
@@ -80,7 +87,7 @@ Change your Angular app’s executor to @nrwl/angular:webpack-browser and the �
 
 ## Running and serving incremental builds
 
-To build an app incrementally use the following commands.
+To build an app incrementally use the following command:
 
 ```bash
 nx build myapp --with-deps --parallel
@@ -101,6 +108,7 @@ Note: you can specify the `--with-deps` and `--parallel` flags as part of the op
     "architect": {
         "build": {
             "builder": "@nrwl/angular:webpack-browser",
+            "outputs": ["{options.outputPath}"],
             "options": { ... }
             "configurations": { ... }
         },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
There's no indication in the docs about keeping in sync the `build` target `outputs` property with the `dest` property in the `ng-package.json` of the library.
Reading the docs, it would seem as if after the buildable library is generated, devs need to make sure the right executor is specified for the library.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The docs should have a heads up about keeping in sync the `outputs` in the project configuration and the `dest` in the library `ng-package.json`.
The docs should not imply that additional actions in the library configuration need to be made after a buildable library is generated.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
