### PR TITLE
feat(nextjs): add improved createGlobPatternsForDependencies and deprecate createGlobPatternsOfDependentProjects

### DIFF
--- a/packages/angular/tailwind.ts
+++ b/packages/angular/tailwind.ts
@@ -1,0 +1,13 @@
+import { createGlobPatternsForDependencies as workspaceGenerateGlobs } from '@nrwl/workspace/src/utilities/generate-globs';
+
+/**
+ * generates a set of glob patterns based off the source root of the app and it's dependencies
+ * @param dirPath workspace relative directory path that will be used to infer the parent project and dependencies
+ * @param fileGlobPattern pass a custom glob pattern to be used
+ */
+export function createGlobPatternsForDependencies(
+  dirPath: string,
+  fileGlobPattern: string = '/**/!(*.stories|*.spec).{ts,html}'
+) {
+  return workspaceGenerateGlobs(dirPath, fileGlobPattern);
+}

--- a/packages/next/src/utils/generate-globs.ts
+++ b/packages/next/src/utils/generate-globs.ts
@@ -1,27 +1,29 @@
-import { joinPathFragments } from '@nrwl/devkit';
-import { createProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import { joinPathFragments, logger } from '@nrwl/devkit';
 import { appRootPath } from '@nrwl/workspace/src/utilities/app-root';
 import { getSourceDirOfDependentProjects } from '@nrwl/workspace/src/utilities/project-graph-utils';
 import { resolve } from 'path';
 
 /**
- * Creates an array of of the dependent projects' source directories, appended
- * with the passed glob pattern.
- * @param projectName workspace relative filename, you can pass `__filename` if executed in a node process
- * @param fileGlobPattern the glob pattern to be applied to the various project directories
- * @returns
+ * Use createGlobPatterns instead
+ * @deprecated Use createGlobPatterns instead
  */
 export function createGlobPatternsOfDependentProjects(
   projectName: string,
   fileGlobPattern: string = '/**/!(*.stories|*.spec).tsx'
 ): string[] {
-  const projectGraph = createProjectGraph();
-  const projectDirs = getSourceDirOfDependentProjects(
-    projectName,
-    projectGraph
+  logger.warn(
+    `createGlobPatternsOfDependentProjects is deprecated. Use "createGlobPatterns(__filename)" instead`
   );
 
-  return projectDirs.map((sourceDir) =>
-    resolve(appRootPath, joinPathFragments(sourceDir, fileGlobPattern))
-  );
+  try {
+    const projectDirs = getSourceDirOfDependentProjects(projectName);
+
+    return projectDirs.map((sourceDir) =>
+      resolve(appRootPath, joinPathFragments(sourceDir, fileGlobPattern))
+    );
+  } catch (e) {
+    throw new Error(
+      `createGlobPatternsOfDependentProjects: Error when generating globs: ${e?.message}`
+    );
+  }
 }

--- a/packages/next/tailwind.ts
+++ b/packages/next/tailwind.ts
@@ -1,0 +1,13 @@
+import { createGlobPatternsForDependencies as workspaceGenerateGlobs } from '@nrwl/workspace/src/utilities/generate-globs';
+
+/**
+ * generates a set of glob patterns based off the source root of the app and it's dependencies
+ * @param dirPath workspace relative directory path that will be used to infer the parent project and dependencies
+ * @param fileGlobPattern pass a custom glob pattern to be used
+ */
+export function createGlobPatternsForDependencies(
+  dirPath: string,
+  fileGlobPattern: string = '/**/!(*.stories|*.spec).{tsx,jsx,js}'
+) {
+  return workspaceGenerateGlobs(dirPath, fileGlobPattern);
+}

--- a/packages/react/tailwind.ts
+++ b/packages/react/tailwind.ts
@@ -1,0 +1,13 @@
+import { createGlobPatternsForDependencies as workspaceGenerateGlobs } from '@nrwl/workspace/src/utilities/generate-globs';
+
+/**
+ * generates a set of glob patterns based off the source root of the app and it's dependencies
+ * @param dirPath workspace relative directory path that will be used to infer the parent project and dependencies
+ * @param fileGlobPattern pass a custom glob pattern to be used
+ */
+export function createGlobPatternsForDependencies(
+  dirPath: string,
+  fileGlobPattern: string = '/**/!(*.stories|*.spec).{tsx,jsx,js}'
+) {
+  return workspaceGenerateGlobs(dirPath, fileGlobPattern);
+}

--- a/packages/workspace/src/utilities/generate-globs.ts
+++ b/packages/workspace/src/utilities/generate-globs.ts
@@ -1,0 +1,50 @@
+import { joinPathFragments } from '@nrwl/devkit';
+import { relative, resolve } from 'path';
+import { createProjectGraph } from '../core/project-graph';
+import { appRootPath } from './app-root';
+import {
+  getProjectNameFromDirPath,
+  getSourceDirOfDependentProjects,
+} from './project-graph-utils';
+
+/**
+ * generates a set of glob patterns based off the source root of the app and it's dependencies
+ * @param dirPath workspace relative directory path that will be used to infer the parent project and dependencies
+ * @param fileGlobPattern pass a custom glob pattern to be used
+ */
+export function createGlobPatternsForDependencies(
+  dirPath: string,
+  fileGlobPattern: string
+) {
+  const filenameRelativeToWorkspaceRoot = relative(appRootPath, dirPath);
+  const projectGraph = createProjectGraph();
+
+  // find the project
+  let projectName;
+  try {
+    projectName = getProjectNameFromDirPath(
+      filenameRelativeToWorkspaceRoot,
+      projectGraph
+    );
+  } catch (e) {
+    throw new Error(
+      `createGlobPatternsForDependencies: Error when trying to determine main project.\n${e?.message}`
+    );
+  }
+
+  // generate the glob
+  try {
+    const projectDirs = getSourceDirOfDependentProjects(
+      projectName,
+      projectGraph
+    );
+
+    return projectDirs.map((sourceDir) =>
+      resolve(appRootPath, joinPathFragments(sourceDir, fileGlobPattern))
+    );
+  } catch (e) {
+    throw new Error(
+      `createGlobPatternsForDependencies: Error when generating globs.\n${e?.message}`
+    );
+  }
+}

--- a/packages/workspace/src/utilities/project-graph-utils.spec.ts
+++ b/packages/workspace/src/utilities/project-graph-utils.spec.ts
@@ -1,5 +1,8 @@
 import { ProjectGraph } from '@nrwl/devkit';
-import { getSourceDirOfDependentProjects } from './project-graph-utils';
+import {
+  getProjectNameFromDirPath,
+  getSourceDirOfDependentProjects,
+} from './project-graph-utils';
 
 describe('project graph utils', () => {
   describe('getSourceDirOfDependentProjects', () => {
@@ -10,9 +13,6 @@ describe('project graph utils', () => {
           type: 'app',
           data: {
             root: 'apps/demo-app',
-            sourceRoot: 'apps/demo-app/src',
-            projectType: 'application',
-            targets: {},
           },
         },
         ui: {
@@ -68,6 +68,26 @@ describe('project graph utils', () => {
       expect(() =>
         getSourceDirOfDependentProjects('non-existent-app', projGraph)
       ).toThrowError();
+    });
+
+    it('should find the project given a file within its src root', () => {
+      expect(getProjectNameFromDirPath('apps/demo-app', projGraph)).toEqual(
+        'demo-app'
+      );
+
+      expect(getProjectNameFromDirPath('apps/demo-app/src', projGraph)).toEqual(
+        'demo-app'
+      );
+
+      expect(
+        getProjectNameFromDirPath('apps/demo-app/src/subdir/bla', projGraph)
+      ).toEqual('demo-app');
+    });
+
+    it('should throw an error if the project name has not been found', () => {
+      expect(() => {
+        getProjectNameFromDirPath('apps/demo-app-unknown');
+      }).toThrowError();
     });
   });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Deprecates `createGlobPatternsOfDependentProjects` exported from `@nrwl/next`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Exports the `createGlobPatternsForDependencies` utility from

- `@nrwl/angular/tailwind`
- `@nrwl/react/tailwind`
- `@nrwl/next/tailwind`

which is useful to automatically calculate glob patterns used in `tailwind.config.js` to perform CSS purging.

Example for Next.js:

```
const { createGlobPatternsForDependencies } = require('@nrwl/next/tailwind');

module.exports = {
  purge: [
    './apps/site/pages/**/*.{js,ts,jsx,tsx}',
    './apps/site/components/**/*.{js,ts,jsx,tsx}',
    ...createGlobPatternsForDependencies(__dirname),
  ],
  ...
};

```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
