### PR TITLE
fix(node): node-externals fails in subdirectories

### DIFF
--- a/packages/node/src/utils/node.config.spec.ts
+++ b/packages/node/src/utils/node.config.spec.ts
@@ -1,7 +1,15 @@
-import { getNodeWebpackConfig } from './node.config';
 jest.mock('tsconfig-paths-webpack-plugin');
+
+import { getNodeWebpackConfig } from './node.config';
 import TsConfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
 import { BuildNodeBuilderOptions } from './types';
+import { join } from 'path';
+
+jest.mock('@nrwl/tao/src/utils/app-root', () => ({
+  get appRootPath() {
+    return join(__dirname, '../../../..');
+  },
+}));
 
 describe('getNodePartial', () => {
   let input: BuildNodeBuilderOptions;

--- a/packages/node/src/utils/node.config.ts
+++ b/packages/node/src/utils/node.config.ts
@@ -1,3 +1,4 @@
+import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import { Configuration } from 'webpack';
 import * as mergeWebpack from 'webpack-merge';
 import * as nodeExternals from 'webpack-node-externals';
@@ -22,7 +23,8 @@ function getNodePartial(options: BuildNodeBuilderOptions) {
   }
 
   if (options.externalDependencies === 'all') {
-    webpackConfig.externals = [nodeExternals()];
+    const modulesDir = `${appRootPath}/node_modules`;
+    webpackConfig.externals = [nodeExternals({ modulesDir })];
   } else if (Array.isArray(options.externalDependencies)) {
     webpackConfig.externals = [
       function (context, request, callback: Function) {


### PR DESCRIPTION
## Current Behavior
webpack-node-externals looks for node_modules relative to `process.cwd()`.

## Expected Behavior
webpack-node-externals looks for node_modules relative to the workspace root.

## Related Issue(s)

Fixes #5263 
