### PR TITLE
chore(repo): increase timeout for file server serve test

### DIFF
--- a/e2e/web/src/file-server.test.ts
+++ b/e2e/web/src/file-server.test.ts
@@ -38,5 +38,5 @@ describe('file-server', () => {
     } catch {
       expect('process running').toBeFalsy();
     }
-  }, 150000);
+  }, 300000);
 });


### PR DESCRIPTION
This test fails occasionally on Windows due to timeout being reached. We should increase is to 300000, same as other serving tests.