### PR TITLE
chore(angular): fix e2e failing tests caused by angular upgrade

### DIFF
--- a/e2e/angular/src/angular-core.test.ts
+++ b/e2e/angular/src/angular-core.test.ts
@@ -66,7 +66,7 @@ describe('Angular Package', () => {
       console.log(
         `The current es2015 bundle size is ${es2015BundleSize / 1000} KB`
       );
-      expect(es2015BundleSize).toBeLessThanOrEqual(125000);
+      expect(es2015BundleSize).toBeLessThanOrEqual(160000);
 
       // running tests for the app
       expectTestsPass(await runCLIAsync(`test my-dir-${myapp} --no-watch`));

--- a/e2e/angular/src/angular-library.test.ts
+++ b/e2e/angular/src/angular-library.test.ts
@@ -158,7 +158,7 @@ import { names } from '@nrwl/devkit';
 
         const jsonFile = readJson(`dist/libs/${parentLib}/package.json`);
 
-        expect(jsonFile.dependencies['tslib']).toEqual('^2.1.0');
+        expect(jsonFile.dependencies['tslib']).toMatch(/\^2\.\d+\.\d+/); // match any ^2.x.x
         expect(jsonFile.peerDependencies[`@${proj}/${childLib}`]).toBeDefined();
         expect(
           jsonFile.peerDependencies[`@${proj}/${childLib2}`]


### PR DESCRIPTION
Currently two E2E tests fail after latest angular upgrade.

- E2E test fails as the bundle size has increased with latest angular update and it's now tipping over with 128KB. There should be enough buffer to not fail this test with updates.
- E2E test fails because it has hardcoded `tslib` version check, and version has been updated. The check should be more flexible
