### PR TITLE
chore(repo): update fs-extra to improve IO performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "file-type": "^16.2.0",
     "flat": "^5.0.2",
     "fork-ts-checker-webpack-plugin": "^3.1.1",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "html-webpack-plugin": "^3.2.0",
     "http-server": "0.12.3",
     "husky": "^6.0.0",

--- a/packages/create-nx-plugin/package.json
+++ b/packages/create-nx-plugin/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@nrwl/workspace": "*",
     "enquirer": "~2.3.6",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "tmp": "~0.2.1",
     "yargs": "15.4.1",
     "yargs-parser": "20.0.0"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -42,7 +42,7 @@
     "@svgr/webpack": "^5.4.0",
     "chalk": "4.1.0",
     "copy-webpack-plugin": "6.0.3",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "url-loader": "^3.0.0",
     "tsconfig-paths": "^3.9.0",
     "ts-node": "~9.1.1"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -36,7 +36,7 @@
     "circular-dependency-plugin": "5.2.0",
     "copy-webpack-plugin": "6.0.3",
     "fork-ts-checker-webpack-plugin": "^3.1.1",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "glob": "7.1.4",
     "license-webpack-plugin": "2.1.2",
     "rxjs": "^6.5.4",

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -33,7 +33,7 @@
     "@nrwl/jest": "*",
     "@nrwl/linter": "*",
     "@nrwl/node": "*",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "rxjs": "^6.5.4",
     "tslib": "^2.0.0",
     "yargs": "15.4.1"

--- a/packages/tao/package.json
+++ b/packages/tao/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "chalk": "4.1.0",
     "enquirer": "~2.3.6",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "rxjs": "^6.5.4",
     "rxjs-for-await": "0.0.2",
     "semver": "7.3.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -63,7 +63,7 @@
     "css-loader": "3.6.0",
     "file-loader": "4.2.0",
     "fork-ts-checker-webpack-plugin": "^3.1.1",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "identity-obj-proxy": "3.0.0",
     "less": "3.12.2",
     "less-loader": "5.0.0",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -61,7 +61,7 @@
     "@nrwl/linter": "*",
     "chokidar": "^3.5.1",
     "cosmiconfig": "^4.0.0",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "dotenv": "8.2.0",
     "glob": "7.1.4",
     "ignore": "^5.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12184,6 +12184,15 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx uses `fs-extra` 9.1.0

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx should use `fs-extra` 10.0.0.

`fs-extra` 10.0.0 brings a performance boost for several methods. For example the `remove*()` method uses the native `fs.rm*()` in environments that support it. 

For the full changelog see: https://github.com/jprichardson/node-fs-extra/blob/master/CHANGELOG.md#1000--2021-05-03

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
#5896 
