### PR TITLE
chore(repo): run all cypress e2e tests headless and w/o watch

### DIFF
--- a/e2e/angular/src/storybook.test.ts
+++ b/e2e/angular/src/storybook.test.ts
@@ -8,6 +8,7 @@ import {
   readFile,
   removeProject,
   runCLI,
+  runCypressTests,
   tmpProjPath,
   uniq,
 } from '@nrwl/e2e/utils';
@@ -179,11 +180,13 @@ describe('Storybook schematics', () => {
         `
         );
 
-        const e2eResults = runCLI(
-          `e2e ${myAngularLib}-e2e --headless --no-watch`
-        );
-        expect(e2eResults).toContain('All specs passed!');
-        expect(await killPorts()).toBeTruthy();
+        if (runCypressTests()) {
+          const e2eResults = runCLI(
+            `e2e ${myAngularLib}-e2e --headless --no-watch`
+          );
+          expect(e2eResults).toContain('All specs passed!');
+          expect(await killPorts()).toBeTruthy();
+        }
 
         runCLI(`run ${myAngularLib}:build-storybook`);
 

--- a/e2e/angular/src/storybook.test.ts
+++ b/e2e/angular/src/storybook.test.ts
@@ -179,9 +179,11 @@ describe('Storybook schematics', () => {
         `
         );
 
-        expect(runCLI(`run ${myAngularLib}-e2e:e2e --no-watch`)).toContain(
-          'All specs passed!'
+        const e2eResults = runCLI(
+          `e2e ${myAngularLib}-e2e --headless --no-watch`
         );
+        expect(e2eResults).toContain('All specs passed!');
+        expect(await killPorts()).toBeTruthy();
 
         runCLI(`run ${myAngularLib}:build-storybook`);
 
@@ -189,7 +191,6 @@ describe('Storybook schematics', () => {
         expect(readFile(`dist/storybook/${myAngularLib}/index.html`)).toContain(
           `<title>Storybook</title>`
         );
-        expect(await killPorts()).toBeTruthy();
       }
     }, 1000000);
 

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -673,7 +673,7 @@ async function checkApp(
   }
 
   if (opts.checkE2E && runCypressTests()) {
-    const e2eResults = runCLI(`e2e ${appName}-e2e --headless`);
+    const e2eResults = runCLI(`e2e ${appName}-e2e --headless --no-watch`);
     expect(e2eResults).toContain('All specs passed!');
     expect(await killPorts()).toBeTruthy();
   }

--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -62,7 +62,7 @@ describe('Nx Plugin', () => {
     runCLI(`generate @nrwl/nx-plugin:plugin ${plugin} --linter=eslint`);
 
     if (isNotWindows() && runCypressTests()) {
-      const e2eResults = runCLI(`e2e ${plugin}-e2e --no-watch --headless`);
+      const e2eResults = runCLI(`e2e ${plugin}-e2e --headless --no-watch`);
       expect(e2eResults).toContain('Running target "e2e" succeeded');
       expect(await killPorts()).toBeTruthy();
     }

--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -395,7 +395,7 @@ describe('React Applications', () => {
     );
 
     if (opts.checkE2E && runCypressTests()) {
-      const e2eResults = runCLI(`e2e ${appName}-e2e`);
+      const e2eResults = runCLI(`e2e ${appName}-e2e --headless --no-watch`);
       expect(e2eResults).toContain('All specs passed!');
       expect(await killPorts()).toBeTruthy();
     }

--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -56,7 +56,7 @@ describe('Web Components Applications', () => {
     expect(lintE2eResults).toContain('All files pass linting.');
 
     if (isNotWindows() && runCypressTests()) {
-      const e2eResults = runCLI(`e2e ${appName}-e2e --headless`);
+      const e2eResults = runCLI(`e2e ${appName}-e2e --headless --no-watch`);
       expect(e2eResults).toContain('All specs passed!');
       expect(await killPorts()).toBeTruthy();
     }


### PR DESCRIPTION
E2E tests running cypress tests should run them in `headless` and `single run` mode.
