### PR TITLE
docs(core): add docsearch custom meta tags

### DIFF
--- a/nx-dev/feature-search/src/lib/algolia-search.tsx
+++ b/nx-dev/feature-search/src/lib/algolia-search.tsx
@@ -68,6 +68,8 @@ export function AlgoliaSearch({ flavorId, versionId }: AlgoliaSearchProps) {
   return (
     <>
       <Head>
+        <meta name="docsearch:version" content={versionId} />
+        <meta name="docsearch:framework" content={flavorId} />
         <link
           rel="preconnect"
           href="https://BH4D9OD16A-dsn.algolia.net"


### PR DESCRIPTION
## What it does?
This PR adds the custom `docsearch:version` and `docsearch:framework` tags to help better indexation from Algolia.