### PR TITLE
fix(core): catch errors when cleaning up tmp dir during migrate

### DIFF
--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -459,7 +459,12 @@ function createFetcher(packageManager: PackageManager) {
           version: resolvedVersion,
         };
       }
-      removeSync(dir);
+
+      try {
+        removeSync(dir);
+      } catch {
+        // It's okay if this fails, the OS will clean it up eventually
+      }
     }
     return cache[`${packageName}-${packageVersion}`];
   };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Errors cleaning up tmp dir cause migrate to fail

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Errors cleaning up tmp dir are alright because the OS will clean it up eventually.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/6077
