### PR TITLE
cleanup(testing): jest 27 migration updates

### DIFF
--- a/packages/jest/src/migrations/update-12-4-0/add-test-environment-for-node.ts
+++ b/packages/jest/src/migrations/update-12-4-0/add-test-environment-for-node.ts
@@ -54,6 +54,6 @@ export default async function update(tree: Tree) {
 
 function checkIfNodeProject(config: ProjectConfiguration) {
   return Object.entries(config.targets).some(([targetName, targetConfig]) =>
-    targetConfig.executor.includes('node')
+    targetConfig.executor?.includes?.('node')
   );
 }

--- a/packages/jest/src/migrations/update-12-4-0/update-jest-preset-angular.ts
+++ b/packages/jest/src/migrations/update-12-4-0/update-jest-preset-angular.ts
@@ -139,7 +139,11 @@ export function transformerIsFromJestPresetAngular(
 }
 
 export function usesJestPresetAngular(jestConfig: PartialJestConfig) {
-  return jestConfig.globals?.['ts-jest']?.astTransformers?.before?.some?.((x) =>
-    transformerIsFromJestPresetAngular(x)
-  );
+  const transformers = Array.isArray(
+    jestConfig.globals?.['ts-jest']?.astTransformers
+  )
+    ? jestConfig.globals?.['ts-jest']?.astTransformers || []
+    : jestConfig.globals?.['ts-jest']?.astTransformers?.before || [];
+
+  return transformers.some((x) => transformerIsFromJestPresetAngular(x));
 }


### PR DESCRIPTION
This makes the jest 27 migration a bit more robust as a few people are hitting issues with it.

Fixes #6090, #6110
