### PR TITLE
chore(repo): disable windows nightly until further investigation

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -17,17 +17,17 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
+          # - windows-latest
         include:
           - os: ubuntu-latest
             os-name: ubuntu
-          - os: windows-latest
-            os-name: windows
-        exclude:
-          - os: windows-latest
-            package_manager: npm
-          - os: windows-latest
-            package_manager: yarn
+          # - os: windows-latest
+          #  os-name: windows
+        # exclude:
+        #   - os: windows-latest
+        #     package_manager: npm
+        #   - os: windows-latest
+        #     package_manager: yarn
         node_version:
           - '14'
           # - '15'


### PR DESCRIPTION
Currently nightly got halted with over 6h runs for some of the windows tests.
Disabling them until further investigation on why this happened.
