### PR TITLE
Revert "feat(react): update generator defaults in workspace.json for …

### DIFF
--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -702,28 +702,5 @@ describe('app', () => {
         },
       ]);
     });
-
-    it('should default strict to true in workspace.json', async () => {
-      await applicationGenerator(appTree, {
-        ...schema,
-        strict: true,
-      });
-      const workspaceJson = readWorkspaceConfiguration(appTree);
-
-      expect(workspaceJson.generators['@nrwl/react']).toMatchObject({
-        application: {
-          babel: true,
-          style: schema.style,
-          strict: true,
-        },
-        component: {
-          style: schema.style,
-        },
-        library: {
-          style: schema.style,
-          strict: true,
-        },
-      });
-    });
   });
 });

--- a/packages/react/src/generators/application/lib/set-defaults.ts
+++ b/packages/react/src/generators/application/lib/set-defaults.ts
@@ -29,7 +29,6 @@ export function setDefaults(host: Tree, options: NormalizedSchema) {
       application: {
         style: options.style,
         linter: options.linter,
-        strict: options.strict,
         ...prev.application,
       },
       component: {
@@ -39,7 +38,6 @@ export function setDefaults(host: Tree, options: NormalizedSchema) {
       library: {
         style: options.style,
         linter: options.linter,
-        strict: options.strict,
         ...prev.library,
       },
     },


### PR DESCRIPTION
…strict mode (#5529)"

This reverts commit bcdbb02aaf7596f92e5351d29496f87f3c6a17fd.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
As of v12.3.6, `@nrwl/react` generates applications and libraries `strict: true` by default.
This means we don't need to override the workspace defaults.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

No overrides.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

*Strict Mode by default* was introduced in #5552 for applications and in #5720 for libraries.

