### PR TITLE
fix(storybook): change main-js without executing it in migrator

### DIFF
--- a/packages/storybook/src/migrations/update-12-5-0/install-addon-essentials.spec.ts
+++ b/packages/storybook/src/migrations/update-12-5-0/install-addon-essentials.spec.ts
@@ -35,4 +35,89 @@ describe('Add the @storybook/addon-essentials package to package.json', () => {
       ]
     ).toBeFalsy();
   });
+
+  describe('Add the @storybook/addon-essentials addon in the addons array in root main.js', () => {
+    beforeEach(() => {
+      writeJson(tree, 'package.json', {
+        devDependencies: {},
+      });
+    });
+    it('should add the addon if other addons exist in the addons array', async () => {
+      tree.write(
+        '.storybook/main.js',
+        `
+        module.exports = {
+          stories: [],
+          addons: ['@storybook/addon-something'],
+        };
+        `
+      );
+
+      await installAddonEssentials(tree);
+      expect(tree.read('.storybook/main.js', 'utf-8')).toBe(`
+        module.exports = {
+          stories: [],
+          addons: ['@storybook/addon-essentials', '@storybook/addon-something'],
+        };
+        `);
+    });
+
+    it('should add the addon if addons array is empty', async () => {
+      tree.write(
+        '.storybook/main.js',
+        `
+        module.exports = {
+          stories: [],
+          addons: [],
+        };
+        `
+      );
+
+      await installAddonEssentials(tree);
+      expect(tree.read('.storybook/main.js', 'utf-8')).toBe(`
+        module.exports = {
+          stories: [],
+          addons: ['@storybook/addon-essentials', ],
+        };
+        `);
+    });
+
+    it('should add the addon if addons array does not exist', async () => {
+      tree.write(
+        '.storybook/main.js',
+        `
+        module.exports = {
+          stories: [],
+        };
+        `
+      );
+
+      await installAddonEssentials(tree);
+      expect(tree.read('.storybook/main.js', 'utf-8')).toBe(`
+        module.exports = {
+          addons: ['@storybook/addon-essentials'], stories: [],
+        };
+        `);
+    });
+
+    it('should not edit the file if @storybook/addon-essentials already exists', async () => {
+      tree.write(
+        '.storybook/main.js',
+        `
+        module.exports = {
+          stories: [],
+          addons: ['@storybook/addon-essentials'],
+        };
+        `
+      );
+
+      await installAddonEssentials(tree);
+      expect(tree.read('.storybook/main.js', 'utf-8')).toBe(`
+        module.exports = {
+          stories: [],
+          addons: ['@storybook/addon-essentials'],
+        };
+        `);
+    });
+  });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The 12-5-0 Storybook migrator, if used in conjuction with the 12-3-0 angular/update-storybook migrator, would cause some strange errors. It would execute `main.js` due to the use of require in either of the two migrators, resulting in unwanted results.

## Expected Behavior
The migration works smoothly.
