### PR TITLE
fix(core): affected base and head logs

### DIFF
--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -113,8 +113,19 @@ export function splitArgsIntoNxArgsAndOverrides(
   }
 
   if (mode === 'affected') {
-    if (options.printWarnings) {
-      printArgsWarning(nxArgs);
+    if (options.printWarnings && nxArgs.all) {
+      output.warn({
+        title: `Running affected:* commands with --all can result in very slow builds.`,
+        bodyLines: [
+          `${output.bold(
+            '--all'
+          )} is not meant to be used for any sizable project or to be used in CI.`,
+          '',
+          `${output.colors.gray(
+            'Learn more about checking only what is affected: '
+          )}https://nx.dev/latest/angular/cli/affected#affected.`,
+        ],
+      });
     }
 
     if (
@@ -133,15 +144,44 @@ export function splitArgsIntoNxArgsAndOverrides(
     // Allow setting base and head via environment variables (lower priority then direct command arguments)
     if (!nxArgs.base && process.env.NX_BASE) {
       nxArgs.base = process.env.NX_BASE;
+      if (options.printWarnings) {
+        output.note({
+          title: `No explicit --base argument provided, but found environment variable NX_BASE so using its value as the affected base: ${output.bold(
+            `${nxArgs.base}`
+          )}`,
+        });
+      }
     }
     if (!nxArgs.head && process.env.NX_HEAD) {
       nxArgs.head = process.env.NX_HEAD;
+      if (options.printWarnings) {
+        output.note({
+          title: `No explicit --head argument provided, but found environment variable NX_HEAD so using its value as the affected head: ${output.bold(
+            `${nxArgs.head}`
+          )}`,
+        });
+      }
     }
 
     if (!nxArgs.base) {
       const affectedConfig = getAffectedConfig();
-
       nxArgs.base = affectedConfig.defaultBase;
+
+      // No user-provided arguments to set the affected criteria, so inform the user of the defaults being used
+      if (
+        options.printWarnings &&
+        !nxArgs.head &&
+        !nxArgs.files &&
+        !nxArgs.uncommitted &&
+        !nxArgs.untracked &&
+        !nxArgs.all
+      ) {
+        output.note({
+          title: `Affected criteria defaulted to --base=${output.bold(
+            `${nxArgs.base}`
+          )} --head=${output.bold('HEAD')}`,
+        });
+      }
     }
   }
 
@@ -158,32 +198,4 @@ export function getAffectedConfig(): NxAffectedConfig {
   return {
     defaultBase: config.affected?.defaultBase || 'master',
   };
-}
-
-function printArgsWarning(options: NxArgs) {
-  const { files, uncommitted, untracked, base, head, all } = options;
-  const affectedConfig = getAffectedConfig();
-
-  if (!files && !uncommitted && !untracked && !base && !head && !all) {
-    output.note({
-      title: `Affected criteria defaulted to --base=${output.bold(
-        `${affectedConfig.defaultBase}`
-      )} --head=${output.bold('HEAD')}`,
-    });
-  }
-
-  if (all) {
-    output.warn({
-      title: `Running affected:* commands with --all can result in very slow builds.`,
-      bodyLines: [
-        `${output.bold(
-          '--all'
-        )} is not meant to be used for any sizable project or to be used in CI.`,
-        '',
-        `${output.colors.gray(
-          'Learn more about checking only what is affected: '
-        )}https://nx.dev/latest/angular/cli/affected#affected.`,
-      ],
-    });
-  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

(My fault 😅 ) In 12.5.0, if you leverage the new `NX_BASE` and `NX_HEAD` environment variables you will get an incorrect log stating that the criteria defaulted to the default base and `HEAD`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It is clear what is being used for base and head when environment variables are being used.

---

Having the logging logic separated out into a (non-reused) function made it harder to apply the necessary conditional logic for all cases so I refactored it away and I think this makes things easier to follow. Additionally that function was previously technically repeating some logic of the main function by inferring that the `affectedConfig.defaultBase` would be used when certain options were not set, so this refactor should also make the code easier to manage
