### PR TITLE
fix(angular): check for angular.json when converting config event path

### DIFF
--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -732,9 +732,9 @@ function convertEventTypeToHandleMultipleConfigNames(
   eventPath: string,
   content: Buffer | never
 ) {
-  const actualConfigName = host.exists('/workspace.json')
-    ? 'workspace.json'
-    : 'angular.json';
+  const actualConfigName = host.exists('/angular.json')
+    ? 'angular.json'
+    : 'workspace.json';
   const isWorkspaceConfig =
     eventPath === 'angular.json' || eventPath === 'workspace.json';
   if (isWorkspaceConfig) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
In certain scenarios in Angular workspaces (involves several levels of wrapped schematics), when running a generator, the changes to the workspace configuration are made to the `workspace.json` even though it should use `angular.json`. This creates issues with anything reading the workspace configuration after that and causes the generation to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generation should work successfully. We should check for the existence of `angular.json` when converting the schematic event path for the config to the right path the same way is done in the rest of the code.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6065 
