### PR TITLE
docs(misc): fixing broken link in api docs generation

### DIFF
--- a/docs/node/api-angular/executors/delegate-build.md
+++ b/docs/node/api-angular/executors/delegate-build.md
@@ -3,7 +3,7 @@
 Delegates the build to a different target while supporting incremental builds.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-angular/executors/ng-packagr-lite.md
+++ b/docs/node/api-angular/executors/ng-packagr-lite.md
@@ -3,7 +3,7 @@
 Build an Angular library for incremental building.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-angular/executors/package.md
+++ b/docs/node/api-angular/executors/package.md
@@ -3,7 +3,7 @@
 Build and package an Angular library for publishing.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-angular/executors/webpack-browser.md
+++ b/docs/node/api-angular/executors/webpack-browser.md
@@ -3,7 +3,7 @@
 Angular browser builder that supports incremental builds.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-cypress/executors/cypress.md
+++ b/docs/node/api-cypress/executors/cypress.md
@@ -3,7 +3,7 @@
 Run Cypress e2e tests
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-gatsby/executors/build.md
+++ b/docs/node/api-gatsby/executors/build.md
@@ -3,7 +3,7 @@
 Build a Gatsby app
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-gatsby/executors/server.md
+++ b/docs/node/api-gatsby/executors/server.md
@@ -3,7 +3,7 @@
 Starts server for app
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-jest/executors/jest.md
+++ b/docs/node/api-jest/executors/jest.md
@@ -3,7 +3,7 @@
 Run Jest unit tests
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-linter/executors/eslint.md
+++ b/docs/node/api-linter/executors/eslint.md
@@ -3,7 +3,7 @@
 Run ESLint on a project
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-linter/executors/lint.md
+++ b/docs/node/api-linter/executors/lint.md
@@ -3,7 +3,7 @@
 **[DEPRECATED]**: Please use the eslint builder instead, an automated migration was provided in v10.3.0
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-next/executors/build.md
+++ b/docs/node/api-next/executors/build.md
@@ -3,7 +3,7 @@
 Build a Next.js app
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-next/executors/export.md
+++ b/docs/node/api-next/executors/export.md
@@ -3,7 +3,7 @@
 Export a Next.js app. The exported application is located at dist/$outputPath/exported.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-next/executors/server.md
+++ b/docs/node/api-next/executors/server.md
@@ -3,7 +3,7 @@
 Serve a Next.js app
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -3,7 +3,7 @@
 Build a Node application
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-node/executors/execute.md
+++ b/docs/node/api-node/executors/execute.md
@@ -3,7 +3,7 @@
 Execute a Node application
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-node/executors/package.md
+++ b/docs/node/api-node/executors/package.md
@@ -3,7 +3,7 @@
 Package a Node library
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-nx-plugin/executors/e2e.md
+++ b/docs/node/api-nx-plugin/executors/e2e.md
@@ -3,7 +3,7 @@
 Creates and runs an e2e for a Nx Plugin
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-storybook/executors/build.md
+++ b/docs/node/api-storybook/executors/build.md
@@ -3,7 +3,7 @@
 Build Storybook
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-storybook/executors/storybook.md
+++ b/docs/node/api-storybook/executors/storybook.md
@@ -3,7 +3,7 @@
 Serve Storybook
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-web/executors/build.md
+++ b/docs/node/api-web/executors/build.md
@@ -3,7 +3,7 @@
 Build a application
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-web/executors/dev-server.md
+++ b/docs/node/api-web/executors/dev-server.md
@@ -3,7 +3,7 @@
 Serve a web application
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-web/executors/file-server.md
+++ b/docs/node/api-web/executors/file-server.md
@@ -3,7 +3,7 @@
 Serve a web application from a folder
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-web/executors/package.md
+++ b/docs/node/api-web/executors/package.md
@@ -3,7 +3,7 @@
 Package a library
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-workspace/executors/run-commands.md
+++ b/docs/node/api-workspace/executors/run-commands.md
@@ -3,7 +3,7 @@
 Run any custom commands with Nx
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Examples
 

--- a/docs/node/api-workspace/executors/run-script.md
+++ b/docs/node/api-workspace/executors/run-script.md
@@ -3,7 +3,7 @@
 Run an npm script using Nx
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/node/api-workspace/executors/tsc.md
+++ b/docs/node/api-workspace/executors/tsc.md
@@ -3,7 +3,7 @@
 Build a project using TypeScript.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/node/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-angular/executors/delegate-build.md
+++ b/docs/react/api-angular/executors/delegate-build.md
@@ -3,7 +3,7 @@
 Delegates the build to a different target while supporting incremental builds.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-angular/executors/ng-packagr-lite.md
+++ b/docs/react/api-angular/executors/ng-packagr-lite.md
@@ -3,7 +3,7 @@
 Build an Angular library for incremental building.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-angular/executors/package.md
+++ b/docs/react/api-angular/executors/package.md
@@ -3,7 +3,7 @@
 Build and package an Angular library for publishing.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-angular/executors/webpack-browser.md
+++ b/docs/react/api-angular/executors/webpack-browser.md
@@ -3,7 +3,7 @@
 Angular browser builder that supports incremental builds.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-cypress/executors/cypress.md
+++ b/docs/react/api-cypress/executors/cypress.md
@@ -3,7 +3,7 @@
 Run Cypress e2e tests
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-gatsby/executors/build.md
+++ b/docs/react/api-gatsby/executors/build.md
@@ -3,7 +3,7 @@
 Build a Gatsby app
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-gatsby/executors/server.md
+++ b/docs/react/api-gatsby/executors/server.md
@@ -3,7 +3,7 @@
 Starts server for app
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-jest/executors/jest.md
+++ b/docs/react/api-jest/executors/jest.md
@@ -3,7 +3,7 @@
 Run Jest unit tests
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-linter/executors/eslint.md
+++ b/docs/react/api-linter/executors/eslint.md
@@ -3,7 +3,7 @@
 Run ESLint on a project
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-linter/executors/lint.md
+++ b/docs/react/api-linter/executors/lint.md
@@ -3,7 +3,7 @@
 **[DEPRECATED]**: Please use the eslint builder instead, an automated migration was provided in v10.3.0
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-next/executors/build.md
+++ b/docs/react/api-next/executors/build.md
@@ -3,7 +3,7 @@
 Build a Next.js app
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-next/executors/export.md
+++ b/docs/react/api-next/executors/export.md
@@ -3,7 +3,7 @@
 Export a Next.js app. The exported application is located at dist/$outputPath/exported.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-next/executors/server.md
+++ b/docs/react/api-next/executors/server.md
@@ -3,7 +3,7 @@
 Serve a Next.js app
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -3,7 +3,7 @@
 Build a Node application
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-node/executors/execute.md
+++ b/docs/react/api-node/executors/execute.md
@@ -3,7 +3,7 @@
 Execute a Node application
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-node/executors/package.md
+++ b/docs/react/api-node/executors/package.md
@@ -3,7 +3,7 @@
 Package a Node library
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-nx-plugin/executors/e2e.md
+++ b/docs/react/api-nx-plugin/executors/e2e.md
@@ -3,7 +3,7 @@
 Creates and runs an e2e for a Nx Plugin
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-storybook/executors/build.md
+++ b/docs/react/api-storybook/executors/build.md
@@ -3,7 +3,7 @@
 Build Storybook
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-storybook/executors/storybook.md
+++ b/docs/react/api-storybook/executors/storybook.md
@@ -3,7 +3,7 @@
 Serve Storybook
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-web/executors/build.md
+++ b/docs/react/api-web/executors/build.md
@@ -3,7 +3,7 @@
 Build a application
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-web/executors/dev-server.md
+++ b/docs/react/api-web/executors/dev-server.md
@@ -3,7 +3,7 @@
 Serve a web application
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-web/executors/file-server.md
+++ b/docs/react/api-web/executors/file-server.md
@@ -3,7 +3,7 @@
 Serve a web application from a folder
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-web/executors/package.md
+++ b/docs/react/api-web/executors/package.md
@@ -3,7 +3,7 @@
 Package a library
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-workspace/executors/run-commands.md
+++ b/docs/react/api-workspace/executors/run-commands.md
@@ -3,7 +3,7 @@
 Run any custom commands with Nx
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Examples
 

--- a/docs/react/api-workspace/executors/run-script.md
+++ b/docs/react/api-workspace/executors/run-script.md
@@ -3,7 +3,7 @@
 Run an npm script using Nx
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/docs/react/api-workspace/executors/tsc.md
+++ b/docs/react/api-workspace/executors/tsc.md
@@ -3,7 +3,7 @@
 Build a project using TypeScript.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors.
 
 ## Properties
 

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-angular/executors/delegate-build.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-angular/executors/delegate-build.md
@@ -3,7 +3,7 @@
 Delegates the build to a different target while supporting incremental builds.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
-Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
+Read more about how to use executors and the CLI here: https://nx.dev/latest/react/getting-started/nx-cli#running-tasks.
 
 ## Properties
 

--- a/scripts/documentation/generate-executors-data.ts
+++ b/scripts/documentation/generate-executors-data.ts
@@ -83,7 +83,7 @@ function generateTemplate(
     Properties can be configured in ${filename} when defining the executor, or when invoking it.
     ${
       framework != 'angular'
-        ? `Read more about how to use executors and the CLI here: https://nx.dev/${framework}/getting-started/nx-cli#running-tasks.`
+        ? `Read more about how to use executors and the CLI here: https://nx.dev/latest/${framework}/getting-started/nx-cli#acting-on-code-using-executors.`
         : ``
     }
     \n`;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Broken link exists on API pages:
`Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.`.

This link redirects to `https://nx.dev/latest/react/getting-started/intro#running-tasks`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should have a correct link that sends the user to `https://nx.dev/latest/react/getting-started/nx-cli#acting-on-code-using-executors`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
