### PR TITLE
docs(misc): fixing broken links in jest executor doc page

### DIFF
--- a/docs/angular/api-jest/executors/jest.md
+++ b/docs/angular/api-jest/executors/jest.md
@@ -12,13 +12,13 @@ Alias(es): b
 
 Type: `number | boolean `
 
-Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/en/cli#bail)
+Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/cli#--bail)
 
 ### ci
 
 Type: `boolean`
 
-Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/en/cli#ci)
+Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/cli#--ci)
 
 ### clearCache
 
@@ -32,7 +32,7 @@ Alias(es): coverage
 
 Type: `boolean`
 
-Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)
+Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/cli#--coverageboolean)
 
 ### color
 
@@ -40,13 +40,13 @@ Alias(es): colors
 
 Type: `boolean`
 
-Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/en/cli#colors)
+Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/cli#--colors)
 
 ### colors
 
 Type: `boolean`
 
-Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)
+Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/cli#--colors)
 
 ### config
 
@@ -70,13 +70,13 @@ A list of reporter names that Jest uses when writing coverage reports. Any istan
 
 Type: `boolean`
 
-Attempt to collect and print open handles preventing Jest from exiting cleanly (https://jestjs.io/docs/en/cli.html#--detectopenhandles)
+Attempt to collect and print open handles preventing Jest from exiting cleanly (https://jestjs.io/docs/cli#--detectopenhandles)
 
 ### findRelatedTests
 
 Type: `string`
 
-Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/en/cli#findrelatedtests-spaceseparatedlistofsourcefiles)
+Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles)
 
 ### jestConfig
 
@@ -88,7 +88,7 @@ The path of the Jest configuration. (https://jestjs.io/docs/en/configuration)
 
 Type: `boolean`
 
-Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/en/cli#json)
+Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/cli#--json)
 
 ### maxWorkers
 
@@ -96,7 +96,7 @@ Alias(es): w
 
 Type: `number | string `
 
-Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/en/cli#maxworkers-num)
+Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/cli#--maxworkersnumstring)
 
 ### onlyChanged
 
@@ -104,25 +104,25 @@ Alias(es): o
 
 Type: `boolean`
 
-Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment. (https://jestjs.io/docs/en/cli#onlychanged)
+Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment. (https://jestjs.io/docs/cli#--onlychanged)
 
 ### outputFile
 
 Type: `string`
 
-Write test results to a file when the --json option is also specified. (https://jestjs.io/docs/en/cli#outputfile-filename)
+Write test results to a file when the --json option is also specified. (https://jestjs.io/docs/cli#--outputfilefilename)
 
 ### passWithNoTests
 
 Type: `boolean`
 
-Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/en/cli#passwithnotests)
+Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/cli#--passwithnotests)
 
 ### reporters
 
 Type: `array`
 
-Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/en/cli#reporters)
+Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/cli#--reporters)
 
 ### runInBand
 
@@ -130,7 +130,7 @@ Alias(es): i
 
 Type: `boolean`
 
-Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/en/cli#runinband)
+Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/cli#--runinband)
 
 ### ~~setupFile~~
 
@@ -148,7 +148,7 @@ Print your Jest config and then exits. (https://jestjs.io/docs/en/cli#--showconf
 
 Type: `boolean`
 
-Prevent tests from printing messages through the console. (https://jestjs.io/docs/en/cli#silent)
+Prevent tests from printing messages through the console. (https://jestjs.io/docs/cli#--silent)
 
 ### testFile
 
@@ -160,7 +160,7 @@ The name of the file to test.
 
 Type: `boolean`
 
-Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/en/cli#testlocationinresults)
+Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/cli#--testlocationinresults)
 
 ### testNamePattern
 
@@ -168,13 +168,13 @@ Alias(es): t
 
 Type: `string`
 
-Run only tests with a name that matches the regex pattern. (https://jestjs.io/docs/en/cli#testnamepattern-regex)
+Run only tests with a name that matches the regex pattern. (https://jestjs.io/docs/cli#--testnamepatternregex)
 
 ### testPathPattern
 
 Type: `array`
 
-An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
+An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/cli#--testpathpatternregex)
 
 ### testResultsProcessor
 
@@ -200,7 +200,7 @@ Alias(es): u
 
 Type: `boolean`
 
-Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern. (https://jestjs.io/docs/en/cli#updatesnapshot)
+Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern. (https://jestjs.io/docs/cli#--updatesnapshot)
 
 ### useStderr
 
@@ -212,16 +212,16 @@ Divert all output to stderr.
 
 Type: `boolean`
 
-Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)
+Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/cli#--verbose)
 
 ### watch
 
 Type: `boolean`
 
-Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option. (https://jestjs.io/docs/en/cli#watch)
+Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option. (https://jestjs.io/docs/cli#--watch)
 
 ### watchAll
 
 Type: `boolean`
 
-Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/en/cli#watchall)
+Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/cli#--watchall)

--- a/docs/node/api-jest/executors/jest.md
+++ b/docs/node/api-jest/executors/jest.md
@@ -13,13 +13,13 @@ Alias(es): b
 
 Type: `number | boolean `
 
-Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/en/cli#bail)
+Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/cli#--bail)
 
 ### ci
 
 Type: `boolean`
 
-Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/en/cli#ci)
+Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/cli#--ci)
 
 ### clearCache
 
@@ -33,7 +33,7 @@ Alias(es): coverage
 
 Type: `boolean`
 
-Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)
+Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/cli#--coverageboolean)
 
 ### color
 
@@ -41,13 +41,13 @@ Alias(es): colors
 
 Type: `boolean`
 
-Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/en/cli#colors)
+Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/cli#--colors)
 
 ### colors
 
 Type: `boolean`
 
-Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)
+Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/cli#--colors)
 
 ### config
 
@@ -71,13 +71,13 @@ A list of reporter names that Jest uses when writing coverage reports. Any istan
 
 Type: `boolean`
 
-Attempt to collect and print open handles preventing Jest from exiting cleanly (https://jestjs.io/docs/en/cli.html#--detectopenhandles)
+Attempt to collect and print open handles preventing Jest from exiting cleanly (https://jestjs.io/docs/cli#--detectopenhandles)
 
 ### findRelatedTests
 
 Type: `string`
 
-Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/en/cli#findrelatedtests-spaceseparatedlistofsourcefiles)
+Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles)
 
 ### jestConfig
 
@@ -89,7 +89,7 @@ The path of the Jest configuration. (https://jestjs.io/docs/en/configuration)
 
 Type: `boolean`
 
-Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/en/cli#json)
+Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/cli#--json)
 
 ### maxWorkers
 
@@ -97,7 +97,7 @@ Alias(es): w
 
 Type: `number | string `
 
-Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/en/cli#maxworkers-num)
+Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/cli#--maxworkersnumstring)
 
 ### onlyChanged
 
@@ -105,25 +105,25 @@ Alias(es): o
 
 Type: `boolean`
 
-Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment. (https://jestjs.io/docs/en/cli#onlychanged)
+Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment. (https://jestjs.io/docs/cli#--onlychanged)
 
 ### outputFile
 
 Type: `string`
 
-Write test results to a file when the --json option is also specified. (https://jestjs.io/docs/en/cli#outputfile-filename)
+Write test results to a file when the --json option is also specified. (https://jestjs.io/docs/cli#--outputfilefilename)
 
 ### passWithNoTests
 
 Type: `boolean`
 
-Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/en/cli#passwithnotests)
+Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/cli#--passwithnotests)
 
 ### reporters
 
 Type: `array`
 
-Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/en/cli#reporters)
+Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/cli#--reporters)
 
 ### runInBand
 
@@ -131,7 +131,7 @@ Alias(es): i
 
 Type: `boolean`
 
-Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/en/cli#runinband)
+Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/cli#--runinband)
 
 ### ~~setupFile~~
 
@@ -149,7 +149,7 @@ Print your Jest config and then exits. (https://jestjs.io/docs/en/cli#--showconf
 
 Type: `boolean`
 
-Prevent tests from printing messages through the console. (https://jestjs.io/docs/en/cli#silent)
+Prevent tests from printing messages through the console. (https://jestjs.io/docs/cli#--silent)
 
 ### testFile
 
@@ -161,7 +161,7 @@ The name of the file to test.
 
 Type: `boolean`
 
-Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/en/cli#testlocationinresults)
+Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/cli#--testlocationinresults)
 
 ### testNamePattern
 
@@ -169,13 +169,13 @@ Alias(es): t
 
 Type: `string`
 
-Run only tests with a name that matches the regex pattern. (https://jestjs.io/docs/en/cli#testnamepattern-regex)
+Run only tests with a name that matches the regex pattern. (https://jestjs.io/docs/cli#--testnamepatternregex)
 
 ### testPathPattern
 
 Type: `array`
 
-An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
+An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/cli#--testpathpatternregex)
 
 ### testResultsProcessor
 
@@ -201,7 +201,7 @@ Alias(es): u
 
 Type: `boolean`
 
-Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern. (https://jestjs.io/docs/en/cli#updatesnapshot)
+Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern. (https://jestjs.io/docs/cli#--updatesnapshot)
 
 ### useStderr
 
@@ -213,16 +213,16 @@ Divert all output to stderr.
 
 Type: `boolean`
 
-Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)
+Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/cli#--verbose)
 
 ### watch
 
 Type: `boolean`
 
-Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option. (https://jestjs.io/docs/en/cli#watch)
+Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option. (https://jestjs.io/docs/cli#--watch)
 
 ### watchAll
 
 Type: `boolean`
 
-Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/en/cli#watchall)
+Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/cli#--watchall)

--- a/docs/react/api-jest/executors/jest.md
+++ b/docs/react/api-jest/executors/jest.md
@@ -13,13 +13,13 @@ Alias(es): b
 
 Type: `number | boolean `
 
-Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/en/cli#bail)
+Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/cli#--bail)
 
 ### ci
 
 Type: `boolean`
 
-Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/en/cli#ci)
+Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/cli#--ci)
 
 ### clearCache
 
@@ -33,7 +33,7 @@ Alias(es): coverage
 
 Type: `boolean`
 
-Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)
+Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/cli#--coverageboolean)
 
 ### color
 
@@ -41,13 +41,13 @@ Alias(es): colors
 
 Type: `boolean`
 
-Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/en/cli#colors)
+Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/cli#--colors)
 
 ### colors
 
 Type: `boolean`
 
-Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)
+Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/cli#--colors)
 
 ### config
 
@@ -71,13 +71,13 @@ A list of reporter names that Jest uses when writing coverage reports. Any istan
 
 Type: `boolean`
 
-Attempt to collect and print open handles preventing Jest from exiting cleanly (https://jestjs.io/docs/en/cli.html#--detectopenhandles)
+Attempt to collect and print open handles preventing Jest from exiting cleanly (https://jestjs.io/docs/cli#--detectopenhandles)
 
 ### findRelatedTests
 
 Type: `string`
 
-Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/en/cli#findrelatedtests-spaceseparatedlistofsourcefiles)
+Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles)
 
 ### jestConfig
 
@@ -89,7 +89,7 @@ The path of the Jest configuration. (https://jestjs.io/docs/en/configuration)
 
 Type: `boolean`
 
-Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/en/cli#json)
+Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/cli#--json)
 
 ### maxWorkers
 
@@ -97,7 +97,7 @@ Alias(es): w
 
 Type: `number | string `
 
-Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/en/cli#maxworkers-num)
+Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/cli#--maxworkersnumstring)
 
 ### onlyChanged
 
@@ -105,25 +105,25 @@ Alias(es): o
 
 Type: `boolean`
 
-Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment. (https://jestjs.io/docs/en/cli#onlychanged)
+Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment. (https://jestjs.io/docs/cli#--onlychanged)
 
 ### outputFile
 
 Type: `string`
 
-Write test results to a file when the --json option is also specified. (https://jestjs.io/docs/en/cli#outputfile-filename)
+Write test results to a file when the --json option is also specified. (https://jestjs.io/docs/cli#--outputfilefilename)
 
 ### passWithNoTests
 
 Type: `boolean`
 
-Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/en/cli#passwithnotests)
+Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/cli#--passwithnotests)
 
 ### reporters
 
 Type: `array`
 
-Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/en/cli#reporters)
+Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters="default" --reporters="jest-junit" (https://jestjs.io/docs/cli#--reporters)
 
 ### runInBand
 
@@ -131,7 +131,7 @@ Alias(es): i
 
 Type: `boolean`
 
-Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/en/cli#runinband)
+Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/cli#--runinband)
 
 ### ~~setupFile~~
 
@@ -149,7 +149,7 @@ Print your Jest config and then exits. (https://jestjs.io/docs/en/cli#--showconf
 
 Type: `boolean`
 
-Prevent tests from printing messages through the console. (https://jestjs.io/docs/en/cli#silent)
+Prevent tests from printing messages through the console. (https://jestjs.io/docs/cli#--silent)
 
 ### testFile
 
@@ -161,7 +161,7 @@ The name of the file to test.
 
 Type: `boolean`
 
-Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/en/cli#testlocationinresults)
+Adds a location field to test results. Used to report location of a test in a reporter. { "column": 4, "line": 5 } (https://jestjs.io/docs/cli#--testlocationinresults)
 
 ### testNamePattern
 
@@ -169,13 +169,13 @@ Alias(es): t
 
 Type: `string`
 
-Run only tests with a name that matches the regex pattern. (https://jestjs.io/docs/en/cli#testnamepattern-regex)
+Run only tests with a name that matches the regex pattern. (https://jestjs.io/docs/cli#--testnamepatternregex)
 
 ### testPathPattern
 
 Type: `array`
 
-An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)
+An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/cli#--testpathpatternregex)
 
 ### testResultsProcessor
 
@@ -201,7 +201,7 @@ Alias(es): u
 
 Type: `boolean`
 
-Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern. (https://jestjs.io/docs/en/cli#updatesnapshot)
+Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern. (https://jestjs.io/docs/cli#--updatesnapshot)
 
 ### useStderr
 
@@ -213,16 +213,16 @@ Divert all output to stderr.
 
 Type: `boolean`
 
-Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)
+Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/cli#--verbose)
 
 ### watch
 
 Type: `boolean`
 
-Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option. (https://jestjs.io/docs/en/cli#watch)
+Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option. (https://jestjs.io/docs/cli#--watch)
 
 ### watchAll
 
 Type: `boolean`
 
-Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/en/cli#watchall)
+Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/cli#--watchall)

--- a/packages/jest/src/executors/jest/schema.json
+++ b/packages/jest/src/executors/jest/schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "codeCoverage": {
-      "description": "Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/en/cli#coverage)",
+      "description": "Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/cli#--coverageboolean)",
       "type": "boolean",
       "aliases": ["coverage"]
     },
@@ -18,7 +18,7 @@
       "type": "boolean"
     },
     "detectOpenHandles": {
-      "description": "Attempt to collect and print open handles preventing Jest from exiting cleanly (https://jestjs.io/docs/en/cli.html#--detectopenhandles)",
+      "description": "Attempt to collect and print open handles preventing Jest from exiting cleanly (https://jestjs.io/docs/cli#--detectopenhandles)",
       "type": "boolean"
     },
     "jestConfig": {
@@ -41,47 +41,47 @@
     },
     "bail": {
       "alias": "b",
-      "description": "Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/en/cli#bail)",
+      "description": "Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/cli#--bail)",
       "oneOf": [{ "type": "number" }, { "type": "boolean" }]
     },
     "ci": {
-      "description": "Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/en/cli#ci)",
+      "description": "Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/cli#--ci)",
       "type": "boolean"
     },
     "color": {
       "alias": "colors",
-      "description": "Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/en/cli#colors)",
+      "description": "Forces test results output color highlighting (even if stdout is not a TTY). Set to false if you would like to have no colors. (https://jestjs.io/docs/cli#--colors)",
       "type": "boolean"
     },
     "findRelatedTests": {
-      "description": "Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/en/cli#findrelatedtests-spaceseparatedlistofsourcefiles)",
+      "description": "Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles)",
       "type": "string"
     },
     "json": {
-      "description": "Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/en/cli#json)",
+      "description": "Prints the test results in JSON. This mode will send all other test output and user messages to stderr. (https://jestjs.io/docs/cli#--json)",
       "type": "boolean"
     },
     "maxWorkers": {
       "alias": "w",
-      "description": "Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/en/cli#maxworkers-num)",
+      "description": "Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/cli#--maxworkersnumstring)",
       "oneOf": [{ "type": "number" }, { "type": "string" }]
     },
     "onlyChanged": {
       "alias": "o",
-      "description": "Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment. (https://jestjs.io/docs/en/cli#onlychanged)",
+      "description": "Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git or hg repository at the moment. (https://jestjs.io/docs/cli#--onlychanged)",
       "type": "boolean"
     },
     "outputFile": {
-      "description": "Write test results to a file when the --json option is also specified. (https://jestjs.io/docs/en/cli#outputfile-filename)",
+      "description": "Write test results to a file when the --json option is also specified. (https://jestjs.io/docs/cli#--outputfilefilename)",
       "type": "string"
     },
     "passWithNoTests": {
-      "description": "Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/en/cli#passwithnotests)",
+      "description": "Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/cli#--passwithnotests)",
       "type": "boolean"
     },
     "runInBand": {
       "alias": "i",
-      "description": "Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/en/cli#runinband)",
+      "description": "Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/cli#--runinband)",
       "type": "boolean"
     },
     "showConfig": {
@@ -89,16 +89,16 @@
       "type": "boolean"
     },
     "silent": {
-      "description": "Prevent tests from printing messages through the console. (https://jestjs.io/docs/en/cli#silent)",
+      "description": "Prevent tests from printing messages through the console. (https://jestjs.io/docs/cli#--silent)",
       "type": "boolean"
     },
     "testNamePattern": {
       "alias": "t",
-      "description": "Run only tests with a name that matches the regex pattern. (https://jestjs.io/docs/en/cli#testnamepattern-regex)",
+      "description": "Run only tests with a name that matches the regex pattern. (https://jestjs.io/docs/cli#--testnamepatternregex)",
       "type": "string"
     },
     "testPathPattern": {
-      "description": "An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/en/cli#testpathpattern-regex)",
+      "description": "An array of regexp pattern strings that is matched against all tests paths before executing the test. (https://jestjs.io/docs/cli#--testpathpatternregex)",
       "type": "array",
       "items": {
         "type": "string"
@@ -106,18 +106,18 @@
       "default": []
     },
     "colors": {
-      "description": "Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/en/cli#colors)",
+      "description": "Forces test results output highlighting even if stdout is not a TTY. (https://jestjs.io/docs/cli#--colors)",
       "type": "boolean"
     },
     "reporters": {
-      "description": "Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters=\"default\" --reporters=\"jest-junit\" (https://jestjs.io/docs/en/cli#reporters)",
+      "description": "Run tests with specified reporters. Reporter options are not available via CLI. Example with multiple reporters: jest --reporters=\"default\" --reporters=\"jest-junit\" (https://jestjs.io/docs/cli#--reporters)",
       "type": "array",
       "items": {
         "type": "string"
       }
     },
     "verbose": {
-      "description": "Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/en/cli#verbose)",
+      "description": "Display individual test results with the test suite hierarchy. (https://jestjs.io/docs/cli#--verbose)",
       "type": "boolean"
     },
     "coverageReporters": {
@@ -137,7 +137,7 @@
     },
     "updateSnapshot": {
       "alias": "u",
-      "description": "Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern. (https://jestjs.io/docs/en/cli#updatesnapshot)",
+      "description": "Use this flag to re-record snapshots. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshot for test matching the pattern. (https://jestjs.io/docs/cli#--updatesnapshot)",
       "type": "boolean"
     },
     "useStderr": {
@@ -145,15 +145,15 @@
       "type": "boolean"
     },
     "watch": {
-      "description": "Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option. (https://jestjs.io/docs/en/cli#watch)",
+      "description": "Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option. (https://jestjs.io/docs/cli#--watch)",
       "type": "boolean"
     },
     "watchAll": {
-      "description": "Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/en/cli#watchall)",
+      "description": "Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option. (https://jestjs.io/docs/cli#--watchall)",
       "type": "boolean"
     },
     "testLocationInResults": {
-      "description": "Adds a location field to test results.  Used to report location of a test in a reporter. { \"column\": 4, \"line\": 5 } (https://jestjs.io/docs/en/cli#testlocationinresults)",
+      "description": "Adds a location field to test results.  Used to report location of a test in a reporter. { \"column\": 4, \"line\": 5 } (https://jestjs.io/docs/cli#--testlocationinresults)",
       "type": "boolean"
     },
     "testTimeout": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

# Note
Need to make sure that these changes are pushed down to the public directory as well (to ensure they're being used in nx-dev)

## Current Behavior
<!-- This is the behavior we have today -->
Some external links (esp. anchors) to jest.io are no longer valid, dropping the user at the top of the options page.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Clicking on an external jest link should take the user to the specific option requested.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
