### PR TITLE
fix(core): convert-to-nx-project should not prompt for project when --all is pased

### DIFF
--- a/packages/workspace/src/generators/convert-to-nx-project/schema.json
+++ b/packages/workspace/src/generators/convert-to-nx-project/schema.json
@@ -17,8 +17,7 @@
   "properties": {
     "project": {
       "description": "Project name",
-      "type": "string",
-      "x-prompt": "Which project should be converted?"
+      "type": "string"
     },
     "all": {
       "description": "Should every project be converted?",


### PR DESCRIPTION
## Current Behavior
User is still prompted for a project when running `nx g @nrwl/workspace:convert-to-nx-project --all`

## Expected Behavior
User is not prompted for a project when running `nx g @nrwl/workspace:convert-to-nx-project --all`
