### PR TITLE
fix(core): project.json split should be remembered if all projects utilize it

### DIFF
--- a/docs/angular/api-nx-devkit/index.md
+++ b/docs/angular/api-nx-devkit/index.md
@@ -780,11 +780,12 @@ Example:
 
 **Returns:** _object_
 
-| Name       | Type     |
-| :--------- | :------- |
-| `appsDir`  | _string_ |
-| `libsDir`  | _string_ |
-| `npmScope` | _string_ |
+| Name                  | Type      |
+| :-------------------- | :-------- |
+| `appsDir`             | _string_  |
+| `libsDir`             | _string_  |
+| `npmScope`            | _string_  |
+| `standaloneAsDefault` | _boolean_ |
 
 ---
 

--- a/docs/node/api-nx-devkit/index.md
+++ b/docs/node/api-nx-devkit/index.md
@@ -780,11 +780,12 @@ Example:
 
 **Returns:** _object_
 
-| Name       | Type     |
-| :--------- | :------- |
-| `appsDir`  | _string_ |
-| `libsDir`  | _string_ |
-| `npmScope` | _string_ |
+| Name                  | Type      |
+| :-------------------- | :-------- |
+| `appsDir`             | _string_  |
+| `libsDir`             | _string_  |
+| `npmScope`            | _string_  |
+| `standaloneAsDefault` | _boolean_ |
 
 ---
 

--- a/docs/react/api-nx-devkit/index.md
+++ b/docs/react/api-nx-devkit/index.md
@@ -780,11 +780,12 @@ Example:
 
 **Returns:** _object_
 
-| Name       | Type     |
-| :--------- | :------- |
-| `appsDir`  | _string_ |
-| `libsDir`  | _string_ |
-| `npmScope` | _string_ |
+| Name                  | Type      |
+| :-------------------- | :-------- |
+| `appsDir`             | _string_  |
+| `libsDir`             | _string_  |
+| `npmScope`            | _string_  |
+| `standaloneAsDefault` | _boolean_ |
 
 ---
 

--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -1,4 +1,4 @@
-import { logger, Tree } from '@nrwl/devkit';
+import { getWorkspaceLayout, Tree } from '@nrwl/devkit';
 import type { Schema } from './schema';
 
 import {
@@ -101,7 +101,10 @@ export async function applicationGenerator(
     setApplicationStrictDefault(host, false);
   }
 
-  if (options.standaloneConfig) {
+  if (
+    options.standaloneConfig ||
+    getWorkspaceLayout(host).standaloneAsDefault
+  ) {
     await convertToNxProjectGenerator(host, {
       project: options.name,
       all: false,

--- a/packages/angular/src/generators/application/lib/add-protractor.ts
+++ b/packages/angular/src/generators/application/lib/add-protractor.ts
@@ -7,13 +7,14 @@ import {
   joinPathFragments,
 } from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
+import { convertToNxProjectGenerator } from '@nrwl/workspace';
 
 export async function addProtractor(
   host: Tree,
   options: NormalizedSchema,
   e2eProjectRoot: string
 ) {
-  const { appsDir } = getWorkspaceLayout(host);
+  const { appsDir, standaloneAsDefault } = getWorkspaceLayout(host);
 
   const protractorSchematic = wrapAngularDevkitSchematic(
     '@schematics/angular',
@@ -24,6 +25,12 @@ export async function addProtractor(
     relatedAppName: options.name,
     rootSelector: `${options.prefix}-root`,
   });
+
+  if (options.standaloneConfig || standaloneAsDefault) {
+    await convertToNxProjectGenerator(host, {
+      project: options.e2eProjectName,
+    });
+  }
 
   moveFilesToNewDirectory(
     host,

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -1,5 +1,6 @@
 import {
   formatFiles,
+  getWorkspaceLayout,
   installPackagesTask,
   moveFilesToNewDirectory,
   Tree,
@@ -23,6 +24,7 @@ import {
 } from './lib/enable-strict-type-checking';
 import { NormalizedSchema } from './lib/normalized-schema';
 import { Schema } from './schema';
+import { convertToNxProjectGenerator } from '@nrwl/workspace';
 
 export async function libraryGenerator(host: Tree, schema: Partial<Schema>) {
   // Do some validation checks
@@ -66,6 +68,16 @@ export async function libraryGenerator(host: Tree, schema: Partial<Schema>) {
   addModule(host, options);
   setStrictMode(host, options);
   await addLinting(host, options);
+
+  if (
+    options.standaloneConfig ||
+    getWorkspaceLayout(host).standaloneAsDefault
+  ) {
+    await convertToNxProjectGenerator(host, {
+      project: options.name,
+      all: false,
+    });
+  }
 
   if (!options.skipFormat) {
     await formatFiles(host);

--- a/packages/devkit/src/generators/project-configuration.spec.ts
+++ b/packages/devkit/src/generators/project-configuration.spec.ts
@@ -29,6 +29,41 @@ describe('project configuration', () => {
     expect(tree.exists('libs/test/project.json')).toBeTruthy();
   });
 
+  it('should create project.json file if all other apps in the workspace use project.json', () => {
+    addProjectConfiguration(
+      tree,
+      'project-a',
+      {
+        root: 'apps/project-a',
+        targets: {},
+      },
+      true
+    );
+    addProjectConfiguration(
+      tree,
+      'project-b',
+      {
+        root: 'apps/project-b',
+        targets: {},
+      },
+      true
+    );
+    expect(tree.exists('apps/project-b/project.json')).toBeTruthy();
+  });
+
+  it("should not create project.json file if any other app in the workspace doesn't use project.json", () => {
+    addProjectConfiguration(tree, 'project-a', {
+      root: 'apps/project-a',
+      targets: {},
+    });
+    addProjectConfiguration(tree, 'project-b', {
+      root: 'apps/project-b',
+      targets: {},
+    });
+    expect(tree.exists('apps/project-a/project.json')).toBeFalsy();
+    expect(tree.exists('apps/project-b/project.json')).toBeFalsy();
+  });
+
   it('should not create project.json file when adding a project if standalone is false', () => {
     addProjectConfiguration(tree, 'test', baseTestProjectConfig, false);
 

--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -39,6 +39,7 @@ export function addProjectConfiguration(
   projectConfiguration: ProjectConfiguration & NxJsonProjectConfiguration,
   standalone: boolean = false
 ): void {
+  standalone = standalone || getWorkspaceLayout(host).standaloneAsDefault;
   setProjectConfiguration(
     host,
     projectName,

--- a/packages/devkit/src/utils/get-workspace-layout.ts
+++ b/packages/devkit/src/utils/get-workspace-layout.ts
@@ -1,6 +1,10 @@
 import type { Tree } from '@nrwl/tao/src/shared/tree';
 import { readJson } from './json';
 import type { NxJsonConfiguration } from '@nrwl/tao/src/shared/nx';
+import {
+  RawWorkspaceJsonConfiguration,
+  workspaceConfigName,
+} from '@nrwl/tao/src/shared/workspace';
 
 /**
  * Returns workspace defaults. It includes defaults folders for apps and libs,
@@ -16,13 +20,26 @@ import type { NxJsonConfiguration } from '@nrwl/tao/src/shared/nx';
 export function getWorkspaceLayout(host: Tree): {
   appsDir: string;
   libsDir: string;
+  standaloneAsDefault: boolean;
   npmScope: string;
 } {
   const nxJson = readJson<NxJsonConfiguration>(host, 'nx.json');
+  const rawWorkspace = readJson<RawWorkspaceJsonConfiguration>(
+    host,
+    getWorkspacePath(host)
+  );
+
   return {
     appsDir: nxJson.workspaceLayout?.appsDir ?? 'apps',
     libsDir: nxJson.workspaceLayout?.libsDir ?? 'libs',
     npmScope: nxJson.npmScope,
+    standaloneAsDefault: Object.values(rawWorkspace.projects).reduce(
+      //default for second, third... projects should be based on all projects being defined as a path
+      (allStandalone, next) => allStandalone && typeof next === 'string',
+
+      // default for first project should be false
+      Object.values(rawWorkspace.projects).length > 0
+    ),
   };
 }
 

--- a/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.ts
+++ b/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.ts
@@ -47,8 +47,8 @@ export async function convertToNxProjectGenerator(host: Tree, schema: Schema) {
   if (workspace.version < 2) {
     logger.error(`
 NX Only workspaces with version 2+ support project.json files.
-To upgrade change the version number at the top of ${workspaceConfigName(
-      host.root
+To upgrade change the version number at the top of ${getWorkspacePath(
+      host
     )} and run 'nx format'.
 `);
     throw new Error('v2+ Required');


### PR DESCRIPTION
## Current Behavior
`--standaloneConfig` must be passed each time you generate an app or library, even if all projects are currently utilizing it

## Expected Behavior
`--standaloneConfig` is the default behavior if all projects utilize `project.json` files.

## Closes
#6211