### PR TITLE
docs(misc): Adding index.html interpolation to env variable guide

### DIFF
--- a/docs/react/guides/environment-variables.md
+++ b/docs/react/guides/environment-variables.md
@@ -4,7 +4,10 @@ Environment variables are global system variables accessible by all the processe
 
 ## How to Use
 
-It's important to note that NX will only include in the process default and NX prefixed env vars such as: `NODE_ENV` or `NX_CUSTOM_VAR`.
+It's important to note that NX will only include in the process:
+
+- default env vars such as: `NODE_ENV`
+- any environment variable prefixed with `NX_` such as: `NX_CUSTOM_VAR`
 
 Defining environment variables can vary between OSes. It’s also important to know that this is temporary for the life of the shell session.
 
@@ -66,3 +69,17 @@ If you want to load variables from `env` files other than the ones listed above:
 
 1. Use the [env-cmd](https://www.npmjs.com/package/env-cmd) package: `env-cmd -f .qa.env nx serve`
 2. Use the `envFile` option of the [run-commands](/{{framework}}/workspace/run-commands-executor#envfile) builder and execute your command inside of the builder
+
+## Using Environment Variables in index.html
+
+Nx supports interpolating environment variables into your `index.html` file for React and Web applications.
+
+To interpolate an environment variable named `NX_DOMAIN_NAME` into your `index.html`, surround it with `%` symbols like so:
+
+```html
+<html>
+  <body>
+    <p>The domain name is %NX_DOMAIN_NAME%.</p>
+  </body>
+</html>
+```


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
+ Docs don't mention using environment variables in `index.html`.
+ Docs seem potentially ambiguous on `NX_` prefixed variables.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
+ Docs explain using environment variables in `index.html`.
+ Docs are explicit that any environment prefixed with `NX_` is accepted.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
