### PR TITLE
feat(repo): mark successful circleci runs with tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,12 @@ jobs:
       - run:
           name: Stop All Running Agents for This CI Run
           command: npx nx-cloud stop-all-agents
+      - run:
+          when: on_success
+          shell: '/bin/bash'
+          name: Save successful tag
+          command: |
+            ./scripts/circleci/tag-successful-build.sh nx_successful_ci_run__${CIRCLE_WORKFLOW_ID}
 workflows:
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,17 +127,23 @@ jobs:
           name: Check Package dependencies
           command: yarn depcheck
       - run:
+          name: Get Last Sucessful Tag
+          shell: '/bin/bash'
+          command: |
+            source ./scripts/get-last-successful-tag.sh $CIRCLE_BRANCH main nx_successful_ci_run__* false
+            echo "export BASE_SHA=\"$BASE_SHA\";" >> $BASH_ENV
+      - run:
           name: Run Builds
-          command: npx nx affected --target=build --parallel --max-parallel=3
+          command: npx nx affected --target=build --base=$BASE_SHA --parallel --max-parallel=3
       - run:
           name: Run Unit Tests
-          command: npx nx affected --target=test --parallel --max-parallel=2
+          command: npx nx affected --target=test --base=$BASE_SHA --parallel --max-parallel=2
       - run:
           name: Run Linting
-          command: npx nx affected --target=lint --parallel --max-parallel=4
+          command: npx nx affected --target=lint --base=$BASE_SHA --parallel --max-parallel=4
       - run:
           name: Run E2E Tests
-          command: npx nx affected --target=e2e
+          command: npx nx affected --target=e2e --base=$BASE_SHA
           no_output_timeout: 45m
       - run:
           name: Stop All Running Agents for This CI Run
@@ -162,17 +168,23 @@ jobs:
       - setup:
           os: << parameters.os >>
       - run:
+          name: Get Last Sucessful Tag
+          shell: '/bin/bash'
+          command: |
+            source ./scripts/get-last-successful-tag.sh $CIRCLE_BRANCH main nx_successful_ci_run__* false
+            echo "export BASE_SHA=\"$BASE_SHA\";" >> $BASH_ENV
+      - run:
           name: Run Builds
-          command: npx nx affected --target=build --base=HEAD~1 --parallel --max-parallel=3
+          command: npx nx affected --target=build --base=$BASE_SHA --parallel --max-parallel=3
       - run:
           name: Run Unit Tests
-          command: npx nx affected --target=test --base=HEAD~1 --parallel --max-parallel=2
+          command: npx nx affected --target=test --base=$BASE_SHA --parallel --max-parallel=2
       - run:
           name: Run Linting
-          command: npx nx affected --target=lint --base=HEAD~1 --parallel --max-parallel=4
+          command: npx nx affected --target=lint --base=$BASE_SHA --parallel --max-parallel=4
       - run:
           name: Run E2E Tests
-          command: npx nx affected --target=e2e --base=HEAD~1
+          command: npx nx affected --target=e2e --base=$BASE_SHA
           no_output_timeout: 45m
       - run:
           name: Stop All Running Agents for This CI Run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
           name: Get Last Sucessful Tag
           shell: '/bin/bash'
           command: |
-            source ./scripts/get-last-successful-tag.sh $CIRCLE_BRANCH main nx_successful_ci_run__* false
+            source ./scripts/get-last-successful-tag.sh $CIRCLE_BRANCH master nx_successful_ci_run__* false
             echo "export BASE_SHA=\"$BASE_SHA\";" >> $BASH_ENV
       - run:
           name: Run Builds
@@ -171,7 +171,7 @@ jobs:
           name: Get Last Sucessful Tag
           shell: '/bin/bash'
           command: |
-            source ./scripts/get-last-successful-tag.sh $CIRCLE_BRANCH main nx_successful_ci_run__* false
+            source ./scripts/get-last-successful-tag.sh $CIRCLE_BRANCH master nx_successful_ci_run__* false
             echo "export BASE_SHA=\"$BASE_SHA\";" >> $BASH_ENV
       - run:
           name: Run Builds

--- a/scripts/circleci/get-last-successful-tag.sh
+++ b/scripts/circleci/get-last-successful-tag.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+BRANCH_NAME=$1
+INPUTS_MAIN_BRANCH_NAME=$2
+INPUTS_TAG_MATCH_PATTERN=$3
+INPUTS_ERROR_ON_NO_MATCHING_TAGS=$4
+
+if [ "$BRANCH_NAME" = $INPUTS_MAIN_BRANCH_NAME ]; then
+    BASE_SHA=$(echo $(git merge-base origin/$INPUTS_MAIN_BRANCH_NAME HEAD))
+else
+    # For the base SHA for main builds we use the latest matching tag as a marker for the last commit which was successfully built.
+    # We use 2> /dev/null to swallow any direct errors from the command itself so we can provide more useful messaging
+    TAG=$(git describe --tags --abbrev=0 --match="$INPUTS_TAG_MATCH_PATTERN" 2> /dev/null)
+
+    if [ -z $TAG ]; then
+        if [ $INPUTS_ERROR_ON_NO_MATCHING_TAGS = "true" ]; then
+            echo ""
+            echo "ERROR: Unable to resolve a latest matching tag on 'origin/$INPUTS_MAIN_BRANCH_NAME' based on the pattern '$INPUTS_TAG_MATCH_PATTERN'"
+            echo ""
+            echo "NOTE: You have set 'error-on-no-matching-tags' on the action so this is a hard error."
+            echo ""
+            echo "Is it possible that you have no relevant tags currently on 'origin/$INPUTS_MAIN_BRANCH_NAME' in your repo?"
+            echo ""
+            echo "- If yes, then you simply need to manually apply a tag which matches the 'tag-match-pattern' of '$INPUTS_TAG_MATCH_PATTERN'."
+            echo "- If no, then you likely have an issue with the pattern above as it is not matching the tag you are expecting it to."
+            echo ""
+
+            exit 1
+        else
+            echo ""
+            echo "WARNING: Unable to resolve a latest matching tag on 'origin/$INPUTS_MAIN_BRANCH_NAME' based on the pattern '$INPUTS_TAG_MATCH_PATTERN'"
+            echo ""
+            echo "We are therefore defaulting to use HEAD~1 on 'origin/$INPUTS_MAIN_BRANCH_NAME'"
+            echo ""
+            echo "NOTE: You can instead make this a hard error by settting 'error-on-no-matching-tags' on the action in your workflow."
+            echo ""
+
+            TAG="HEAD~1"
+        fi
+    else
+        echo ""
+        echo "Successfully found a matching tag on 'origin/$INPUTS_MAIN_BRANCH_NAME' based on the pattern '$INPUTS_TAG_MATCH_PATTERN'"
+        echo ""
+        echo "Matching tag: $TAG"
+        echo ""
+    fi
+
+    BASE_SHA=$(echo $(git rev-parse $TAG~0))
+fi
+
+HEAD_SHA=$(git rev-parse HEAD)

--- a/scripts/circleci/tag-successful-build.sh
+++ b/scripts/circleci/tag-successful-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+command_string_to_echo_as_tag_name=$1
+
+git tag $command_string_to_echo_as_tag_name
+git push origin --tags


### PR DESCRIPTION
Every PR merge to master gets checked on merge against itself.
If master was already broken or an unrelated part of the code, the `affected` checks will skip it and master would go back to success although it may still be broken.

Affected should run against last successful commit. In order to do so, we need to mark successful commits with a tag and likewise fetch last successful commit to use as a base for running `affected`

Note: This code should be replaced by `NX` orbs once they are published