### PR TITLE
fix(core): make missing output check more comprehensive

### DIFF
--- a/packages/workspace/src/tasks-runner/cache.ts
+++ b/packages/workspace/src/tasks-runner/cache.ts
@@ -8,7 +8,7 @@ import {
   lstatSync,
   unlinkSync,
 } from 'fs';
-import { removeSync, ensureDirSync, copySync } from 'fs-extra';
+import { removeSync, ensureDirSync, copySync, readdirSync } from 'fs-extra';
 import { join, resolve, sep } from 'path';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { spawn } from 'child_process';
@@ -190,11 +190,21 @@ export class Cache {
     cachedResult: CachedResult,
     outputs: string[]
   ): boolean {
-    return outputs.some(
-      (output) =>
-        existsSync(join(cachedResult.outputsPath, output)) &&
-        !existsSync(join(this.root, output))
-    );
+    return outputs.some((output) => {
+      const cacheOutputPath = join(cachedResult.outputsPath, output);
+      const rootOutputPath = join(this.root, output);
+
+      const haveDifferentAmountOfFiles =
+        existsSync(cacheOutputPath) &&
+        existsSync(rootOutputPath) &&
+        readdirSync(cacheOutputPath).length !==
+          readdirSync(rootOutputPath).length;
+
+      return (
+        (existsSync(cacheOutputPath) && !existsSync(rootOutputPath)) ||
+        haveDifferentAmountOfFiles
+      );
+    });
   }
 
   private getFileNameWithLatestRecordedHashForOutput(output: string): string {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
to determine whether any cached outputs are missing - nx only checks for presence of directories.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
to determine whether any cached outputs are missing - nx should perform a more comprehensive check.

---

this PR adds a small additional check - whether the amount of files in two directories is the same. if not - that means that some output files are missing.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
