### PR TITLE
cleanup(nx-plugin): migrate e2e executor to nx devkit

### DIFF
--- a/docs/angular/api-nx-plugin/executors/e2e.md
+++ b/docs/angular/api-nx-plugin/executors/e2e.md
@@ -1,6 +1,6 @@
 # e2e
 
-Creates and runs an e2e for a Nx Plugin
+Creates and runs the e2e tests for an Nx Plugin.
 
 Properties can be configured in angular.json when defining the executor, or when invoking it.
 
@@ -10,16 +10,18 @@ Properties can be configured in angular.json when defining the executor, or when
 
 Type: `string`
 
-Jest config file
+Jest config file.
 
 ### target
 
 Type: `string`
 
-the target Nx Plugin project and build
+The build target for the Nx Plugin project.
 
 ### ~~tsSpecConfig~~
 
 Type: `string`
 
-**Deprecated:** Spec tsconfig file
+**Deprecated:** Use the `tsconfig` property for `ts-jest` in the e2e project `jest.config.js` file. It will be removed in the next major release.
+
+The tsconfig file for specs.

--- a/docs/node/api-nx-plugin/executors/e2e.md
+++ b/docs/node/api-nx-plugin/executors/e2e.md
@@ -1,6 +1,6 @@
 # e2e
 
-Creates and runs an e2e for a Nx Plugin
+Creates and runs the e2e tests for an Nx Plugin.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
 Read more about how to use executors and the CLI here: https://nx.dev/node/getting-started/nx-cli#running-tasks.
@@ -11,16 +11,18 @@ Read more about how to use executors and the CLI here: https://nx.dev/node/getti
 
 Type: `string`
 
-Jest config file
+Jest config file.
 
 ### target
 
 Type: `string`
 
-the target Nx Plugin project and build
+The build target for the Nx Plugin project.
 
 ### ~~tsSpecConfig~~
 
 Type: `string`
 
-**Deprecated:** Spec tsconfig file
+**Deprecated:** Use the `tsconfig` property for `ts-jest` in the e2e project `jest.config.js` file. It will be removed in the next major release.
+
+The tsconfig file for specs.

--- a/docs/react/api-nx-plugin/executors/e2e.md
+++ b/docs/react/api-nx-plugin/executors/e2e.md
@@ -1,6 +1,6 @@
 # e2e
 
-Creates and runs an e2e for a Nx Plugin
+Creates and runs the e2e tests for an Nx Plugin.
 
 Properties can be configured in workspace.json when defining the executor, or when invoking it.
 Read more about how to use executors and the CLI here: https://nx.dev/react/getting-started/nx-cli#running-tasks.
@@ -11,16 +11,18 @@ Read more about how to use executors and the CLI here: https://nx.dev/react/gett
 
 Type: `string`
 
-Jest config file
+Jest config file.
 
 ### target
 
 Type: `string`
 
-the target Nx Plugin project and build
+The build target for the Nx Plugin project.
 
 ### ~~tsSpecConfig~~
 
 Type: `string`
 
-**Deprecated:** Spec tsconfig file
+**Deprecated:** Use the `tsconfig` property for `ts-jest` in the e2e project `jest.config.js` file. It will be removed in the next major release.
+
+The tsconfig file for specs.

--- a/packages/nx-plugin/.eslintrc.json
+++ b/packages/nx-plugin/.eslintrc.json
@@ -14,6 +14,19 @@
     {
       "files": ["*.js", "*.jsx"],
       "rules": {}
+    },
+    {
+      "files": ["**/*.ts"],
+      "excludedFiles": ["./src/migrations/**"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          "@angular-devkit/architect",
+          "@angular-devkit/core",
+          "@angular-devkit/schematics",
+          "@nrwl/workspace"
+        ]
+      }
     }
   ]
 }

--- a/packages/nx-plugin/builders.json
+++ b/packages/nx-plugin/builders.json
@@ -1,9 +1,0 @@
-{
-  "builders": {
-    "e2e": {
-      "implementation": "./src/executors/e2e/e2e.impl",
-      "schema": "./src/executors/e2e/schema.json",
-      "description": "Creates and runs an e2e for a Nx Plugin"
-    }
-  }
-}

--- a/packages/nx-plugin/executors.json
+++ b/packages/nx-plugin/executors.json
@@ -1,0 +1,16 @@
+{
+  "builders": {
+    "e2e": {
+      "implementation": "./src/executors/e2e/e2e.impl#nxPluginE2EBuilder",
+      "schema": "./src/executors/e2e/schema.json",
+      "description": "Creates and runs the e2e tests for an Nx Plugin."
+    }
+  },
+  "executors": {
+    "e2e": {
+      "implementation": "./src/executors/e2e/e2e.impl",
+      "schema": "./src/executors/e2e/schema.json",
+      "description": "Creates and runs the e2e tests for an Nx Plugin."
+    }
+  }
+}

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -20,15 +20,12 @@
   },
   "homepage": "https://nx.dev",
   "schematics": "./collection.json",
-  "builders": "./builders.json",
+  "builders": "./executors.json",
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "@angular-devkit/architect": "^0.1200.0",
-    "@angular-devkit/core": "^12.0.0",
-    "@angular-devkit/schematics": "^12.0.0",
     "@nrwl/devkit": "*",
     "@nrwl/jest": "*",
     "@nrwl/linter": "*",

--- a/packages/nx-plugin/src/executors/e2e/e2e.impl.ts
+++ b/packages/nx-plugin/src/executors/e2e/e2e.impl.ts
@@ -1,38 +1,67 @@
+import type { ExecutorContext } from '@nrwl/devkit';
 import {
-  BuilderContext,
-  createBuilder,
-  scheduleTargetAndForget,
-  targetFromTargetString,
-} from '@angular-devkit/architect';
-import { from } from 'rxjs';
-import { concatMap, switchMap } from 'rxjs/operators';
-import { Schema } from './schema';
+  convertNxExecutor,
+  logger,
+  parseTargetString,
+  readTargetOptions,
+  runExecutor,
+} from '@nrwl/devkit';
+import { jestExecutor } from '@nrwl/jest/src/executors/jest/jest.impl';
+import type { NxPluginE2EExecutorOptions } from './schema';
 
 try {
   require('dotenv').config();
   // eslint-disable-next-line no-empty
 } catch (e) {}
 
-export type NxPluginE2EBuilderOptions = Schema;
+export async function* nxPluginE2EExecutor(
+  options: NxPluginE2EExecutorOptions,
+  context: ExecutorContext
+): AsyncGenerator<{ success: boolean }> {
+  let success: boolean;
+  for await (const _ of runBuildTarget(options.target, context)) {
+    try {
+      success = await runTests(options.jestConfig, context);
+    } catch (e) {
+      logger.error(e.message);
+      success = false;
+    }
+  }
 
-function buildTarget(context: BuilderContext, target: string) {
-  return scheduleTargetAndForget(context, targetFromTargetString(target));
+  return { success };
 }
 
-export function runNxPluginE2EBuilder(
-  options: NxPluginE2EBuilderOptions,
-  context: BuilderContext
-) {
-  return buildTarget(context, options.target).pipe(
-    switchMap(() => {
-      return from(
-        context.scheduleBuilder('@nrwl/jest:jest', {
-          jestConfig: options.jestConfig,
-          watch: false,
-        })
-      ).pipe(concatMap((run) => run.output));
-    })
+async function* runBuildTarget(
+  buildTarget: string,
+  context: ExecutorContext
+): AsyncGenerator<boolean> {
+  const { project, target, configuration } = parseTargetString(buildTarget);
+  const buildTargetOptions = readTargetOptions(
+    { project, target, configuration },
+    context
   );
+  const targetSupportsWatch = Object.keys(buildTargetOptions).includes('watch');
+
+  for await (const output of await runExecutor<{ success: boolean }>(
+    { project, target, configuration },
+    targetSupportsWatch ? { watch: false } : {},
+    context
+  )) {
+    if (!output.success)
+      throw new Error('Could not compile application files.');
+    yield output.success;
+  }
 }
 
-export default createBuilder(runNxPluginE2EBuilder);
+async function runTests(
+  jestConfig: string,
+  context: ExecutorContext
+): Promise<boolean> {
+  const { success } = await jestExecutor({ jestConfig, watch: false }, context);
+
+  return success;
+}
+
+export default nxPluginE2EExecutor;
+
+export const nxPluginE2EBuilder = convertNxExecutor(nxPluginE2EExecutor);

--- a/packages/nx-plugin/src/executors/e2e/schema.d.ts
+++ b/packages/nx-plugin/src/executors/e2e/schema.d.ts
@@ -1,6 +1,4 @@
-import { JsonObject } from '@angular-devkit/core';
-
-export interface Schema extends JsonObject {
+export interface NxPluginE2EExecutorOptions {
   target: string;
   jestConfig: string;
 }

--- a/packages/nx-plugin/src/executors/e2e/schema.json
+++ b/packages/nx-plugin/src/executors/e2e/schema.json
@@ -1,21 +1,23 @@
 {
   "title": "Nx Plugin Playground Target",
   "description": "Creates a playground for a Nx Plugin",
+  "cli": "nx",
   "type": "object",
   "properties": {
     "target": {
-      "type": "string",
-      "description": "the target Nx Plugin project and build"
+      "description": "The build target for the Nx Plugin project.",
+      "type": "string"
     },
     "jestConfig": {
       "type": "string",
-      "description": "Jest config file"
+      "description": "Jest config file."
     },
     "tsSpecConfig": {
       "type": "string",
-      "description": "Spec tsconfig file",
-      "x-deprecated": true
+      "description": "The tsconfig file for specs.",
+      "x-deprecated": "Use the `tsconfig` property for `ts-jest` in the e2e project `jest.config.js` file. It will be removed in the next major release."
     }
   },
+  "additionalProperties": false,
   "required": ["target", "jestConfig"]
 }

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
@@ -99,11 +99,7 @@ describe('NxPlugin e2e-project Generator', () => {
     expect(project.targets.e2e).toBeTruthy();
     expect(project.targets.e2e).toMatchObject({
       executor: '@nrwl/nx-plugin:e2e',
-      options: expect.objectContaining({
-        target: 'my-plugin:build',
-        npmPackageName: '@proj/my-plugin',
-        pluginOutputPath: 'dist/libs/my-plugin',
-      }),
+      options: expect.objectContaining({ target: 'my-plugin:build' }),
     });
   });
 

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.ts
@@ -66,11 +66,7 @@ function updateWorkspaceConfiguration(host: Tree, options: NormalizedSchema) {
       targets: {
         e2e: {
           executor: '@nrwl/nx-plugin:e2e',
-          options: {
-            target: `${options.pluginName}:build`,
-            npmPackageName: options.npmPackageName,
-            pluginOutputPath: options.pluginOutputPath,
-          },
+          options: { target: `${options.pluginName}:build` },
         },
       },
       tags: [],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,6 +30,7 @@
       "@nrwl/express": ["./packages/express"],
       "@nrwl/gatsby": ["./packages/gatsby"],
       "@nrwl/jest": ["./packages/jest"],
+      "@nrwl/jest/*": ["./packages/jest/*"],
       "@nrwl/linter": ["./packages/linter"],
       "@nrwl/nest": ["./packages/nest"],
       "@nrwl/next": ["./packages/next"],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nrwl/nx-plugin:e2e` executor is using Angular DevKit.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `@nrwl/nx-plugin:e2e` executor should use Nx DevKit.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
