### PR TITLE
chore(core): remove reference to parse json with comments

### DIFF
--- a/packages/workspace/src/core/project-graph/build-dependencies/explicit-package-json-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/explicit-package-json-dependencies.ts
@@ -5,8 +5,7 @@ import {
   ProjectGraphNodeRecords,
 } from '../project-graph-models';
 import { defaultFileRead } from '../../file-utils';
-import { parseJsonWithComments } from '../../../utilities/fileutils';
-import { joinPathFragments } from '@nrwl/devkit';
+import { joinPathFragments, parseJson } from '@nrwl/devkit';
 
 export function buildExplicitPackageJsonDependencies(
   ctx: ProjectGraphContext,
@@ -40,7 +39,7 @@ function processPackageJson(
   addDependency: AddProjectDependency
 ) {
   try {
-    const deps = readDeps(parseJsonWithComments(defaultFileRead(fileName)));
+    const deps = readDeps(parseJson(defaultFileRead(fileName)));
     deps.forEach((d) => {
       // package.json refers to another project in the monorepo
       if (nodes[d]) {

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -1,15 +1,15 @@
 import { resolveModuleByImport } from '../utilities/typescript';
 import { normalizedProjectRoot, readFileIfExisting } from './file-utils';
 import type { ProjectGraphNode } from '@nrwl/devkit';
+import { parseJson } from '@nrwl/devkit';
 import {
   getSortedProjectNodes,
   isNpmProject,
   isWorkspaceProject,
-  ProjectGraphNodeRecords,
 } from './project-graph';
-import { isRelativePath, parseJsonWithComments } from '../utilities/fileutils';
+import { isRelativePath } from '../utilities/fileutils';
 import { dirname, join, posix } from 'path';
-import { appRootPath } from '../utilities/app-root';
+import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 
 export class TargetProjectLocator {
   private sortedProjects = getSortedProjectNodes(this.nodes);
@@ -148,6 +148,6 @@ export class TargetProjectLocator {
       absolutePath = join(appRootPath, path);
       content = readFileIfExisting(absolutePath);
     }
-    return { path, absolutePath, config: parseJsonWithComments(content) };
+    return { path, absolutePath, config: parseJson(content) };
   }
 }

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -9,7 +9,7 @@ import {
 } from './project-graph';
 import { isRelativePath } from '../utilities/fileutils';
 import { dirname, join, posix } from 'path';
-import { appRootPath } from '@nrwl/tao/src/utils/app-root';
+import { appRootPath } from '../utilities/app-root';
 
 export class TargetProjectLocator {
   private sortedProjects = getSortedProjectNodes(this.nodes);

--- a/packages/workspace/src/utilities/fileutils.ts
+++ b/packages/workspace/src/utilities/fileutils.ts
@@ -37,12 +37,6 @@ export function updateJsonFile(path: string, callback: (a: any) => any) {
   writeJsonFile(path, json);
 }
 
-export function parseJsonWithComments<T extends object = any>(
-  content: string
-): T {
-  return parseJson(content);
-}
-
 export function copyFile(file: string, target: string) {
   const f = basename(file);
   const source = createReadStream(file);

--- a/packages/workspace/src/utils/fileutils.ts
+++ b/packages/workspace/src/utils/fileutils.ts
@@ -37,12 +37,6 @@ export function updateJsonFile(path: string, callback: (a: any) => any) {
   writeJsonFile(path, json);
 }
 
-export function parseJsonWithComments<T extends object = any>(
-  content: string
-): T {
-  return parseJson(content);
-}
-
 export function copyFile(file: string, target: string) {
   const f = basename(file);
   const source = createReadStream(file);


### PR DESCRIPTION
The `parseJsonWithComments` has been replaced with our own more performant `parseJson` function.
This PR removes the remaining leftover references to `parseJsonWithComments`.
