### PR TITLE
fix(core): implicit dependencies filtering

### DIFF
--- a/packages/workspace/src/core/hasher/hasher.spec.ts
+++ b/packages/workspace/src/core/hasher/hasher.spec.ts
@@ -275,6 +275,9 @@ describe('Hasher', () => {
         ],
       },
       {
+        projects: {
+          proja: {},
+        },
         implicitDependencies: {
           'global*': '*',
         },

--- a/packages/workspace/src/core/hasher/hasher.ts
+++ b/packages/workspace/src/core/hasher/hasher.ts
@@ -42,7 +42,6 @@ interface RuntimeHashResult {
 
 export class Hasher {
   static version = '2.0';
-  private implicitDependencies: Promise<ImplicitHashResult>;
   private runtimeInputs: Promise<RuntimeHashResult>;
   private fileHasher: FileHasher;
   private projectHashes: ProjectHasher;
@@ -193,11 +192,9 @@ export class Hasher {
     project?: string,
     nxJsonImplicitDependencies?: ImplicitDependencyEntry<string[] | '*'>
   ): Promise<ImplicitHashResult> {
-    if (this.implicitDependencies) return this.implicitDependencies;
-
     performance.mark('hasher:implicit deps hash:start');
 
-    this.implicitDependencies = new Promise((res) => {
+    return new Promise((res) => {
       if (project && nxJsonImplicitDependencies) {
         function filterDeps(deps) {
           return Object.entries(deps).reduce((acc, [key, val]) => {
@@ -273,8 +270,6 @@ export class Hasher {
         files: fileHashes.reduce((m, c) => ((m[c.file] = c.hash), m), {}),
       });
     });
-
-    return this.implicitDependencies;
   }
 
   private hashGlobalConfig() {


### PR DESCRIPTION
## Current Behavior
The list of projects in the `nx.json` implicitDependencies is falsely ignored.

```json
{
  "implicitDependencies": {
    "someConfigFile.json": ["admin", "client"],
  }
}
```

This is in conflict with [specification](https://github.com/nrwl/nx/blob/master/docs/shared/affected.md#when-nx-cant-understand-your-repository):

> The implicitDependencies map is used to define what projects are affected by global files.
> (...)
> You can replace * with an explicit list of projects.

## Expected Behavior
The Hasher should exclude an implicit dependency if the project is not in the list for that dependency.

A test was added in commit 9c2b1ec27be7a23e618df094f9134e12f9da86f0 that demonstrates the issue.

## Related Issue(s)
https://github.com/nrwl/nx/issues/5292 depends on this fix

