### PR TITLE
fix(web): add setParserOptionsProject option to web:application

### DIFF
--- a/docs/angular/api-web/generators/application.md
+++ b/docs/angular/api-web/generators/application.md
@@ -68,6 +68,14 @@ Type: `string`
 
 The name of the application.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/node/api-web/generators/application.md
+++ b/docs/node/api-web/generators/application.md
@@ -68,6 +68,14 @@ Type: `string`
 
 The name of the application.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/react/api-web/generators/application.md
+++ b/docs/react/api-web/generators/application.md
@@ -68,6 +68,14 @@ Type: `string`
 
 The name of the application.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -206,6 +206,7 @@ export async function applicationGenerator(host: Tree, schema: Schema) {
     ],
     eslintFilePatterns: [`${options.appProjectRoot}/**/*.ts`],
     skipFormat: true,
+    setParserOptionsProject: options.setParserOptionsProject,
   });
   tasks.push(lintTask);
 

--- a/packages/web/src/generators/application/schema.d.ts
+++ b/packages/web/src/generators/application/schema.d.ts
@@ -12,4 +12,5 @@ export interface Schema {
   linter?: Linter;
   babelJest?: boolean;
   standaloneConfig?: boolean;
+  setParserOptionsProject?: boolean;
 }

--- a/packages/web/src/generators/application/schema.json
+++ b/packages/web/src/generators/application/schema.json
@@ -75,6 +75,11 @@
       "description": "Use babel instead ts-jest",
       "default": false
     },
+    "setParserOptionsProject": {
+      "type": "boolean",
+      "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
+      "default": false
+    },
     "standaloneConfig": {
       "description": "Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json",
       "type": "boolean",


### PR DESCRIPTION
This option is available in most other generators, but was missing for @nrwl/web:application

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
No option is available to pass through setParserOptionsProject to @nrwl/linter

## Expected Behavior
Option is available to pass through setParserOptionsProject to @nrwl/linter