### PR TITLE
feat(angular): add mfe options to app generator

### DIFF
--- a/docs/angular/api-angular/generators/application.md
+++ b/docs/angular/api-angular/generators/application.md
@@ -80,11 +80,35 @@ Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 
+### mfe
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a Module Federation configuration for the application
+
+### mfeType
+
+Default: `remote`
+
+Type: `string`
+
+Possible values: `shell`, `remote`
+
+Type of application to generate the Module Federation configuration for.
+
 ### name
 
 Type: `string`
 
 The name of the application.
+
+### port
+
+Type: `number`
+
+The port at which the remote application should be served.
 
 ### prefix
 
@@ -93,6 +117,12 @@ Alias(es): p
 Type: `string`
 
 The prefix to apply to generated selectors.
+
+### remotes
+
+Type: `array`
+
+A list of remote application names that the shell application should consume.
 
 ### routing
 

--- a/docs/angular/api-angular/generators/setup-mfe.md
+++ b/docs/angular/api-angular/generators/setup-mfe.md
@@ -32,7 +32,7 @@ The name of the application to generate the Module Federation configuration for.
 
 ### mfeType
 
-Default: `shell`
+Default: `remote`
 
 Type: `string`
 

--- a/docs/node/api-angular/generators/application.md
+++ b/docs/node/api-angular/generators/application.md
@@ -80,11 +80,35 @@ Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 
+### mfe
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a Module Federation configuration for the application
+
+### mfeType
+
+Default: `remote`
+
+Type: `string`
+
+Possible values: `shell`, `remote`
+
+Type of application to generate the Module Federation configuration for.
+
 ### name
 
 Type: `string`
 
 The name of the application.
+
+### port
+
+Type: `number`
+
+The port at which the remote application should be served.
 
 ### prefix
 
@@ -93,6 +117,12 @@ Alias(es): p
 Type: `string`
 
 The prefix to apply to generated selectors.
+
+### remotes
+
+Type: `array`
+
+A list of remote application names that the shell application should consume.
 
 ### routing
 

--- a/docs/node/api-angular/generators/setup-mfe.md
+++ b/docs/node/api-angular/generators/setup-mfe.md
@@ -32,7 +32,7 @@ The name of the application to generate the Module Federation configuration for.
 
 ### mfeType
 
-Default: `shell`
+Default: `remote`
 
 Type: `string`
 

--- a/docs/react/api-angular/generators/application.md
+++ b/docs/react/api-angular/generators/application.md
@@ -80,11 +80,35 @@ Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 
+### mfe
+
+Default: `false`
+
+Type: `boolean`
+
+Generate a Module Federation configuration for the application
+
+### mfeType
+
+Default: `remote`
+
+Type: `string`
+
+Possible values: `shell`, `remote`
+
+Type of application to generate the Module Federation configuration for.
+
 ### name
 
 Type: `string`
 
 The name of the application.
+
+### port
+
+Type: `number`
+
+The port at which the remote application should be served.
 
 ### prefix
 
@@ -93,6 +117,12 @@ Alias(es): p
 Type: `string`
 
 The prefix to apply to generated selectors.
+
+### remotes
+
+Type: `array`
+
+A list of remote application names that the shell application should consume.
 
 ### routing
 

--- a/docs/react/api-angular/generators/setup-mfe.md
+++ b/docs/react/api-angular/generators/setup-mfe.md
@@ -32,7 +32,7 @@ The name of the application to generate the Module Federation configuration for.
 
 ### mfeType
 
-Default: `shell`
+Default: `remote`
 
 Type: `string`
 

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -1,5 +1,93 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`app --mfe should generate a Module Federation correctly for a each app 1`] = `
+"const ModuleFederationPlugin = require(\\"webpack/lib/container/ModuleFederationPlugin\\");
+const mf = require(\\"@angular-architects/module-federation/webpack\\");
+const path = require(\\"path\\");
+
+const sharedMappings = new mf.SharedMappings();
+sharedMappings.register(path.join(__dirname, \\"../../tsconfig.base.json\\"), [
+  /* mapped paths to share */
+]);
+
+module.exports = {
+  output: {
+    uniqueName: \\"my-app\\",
+    publicPath: \\"auto\\",
+  },
+  optimization: {
+    runtimeChunk: false,
+    minimize: false,
+  },
+  resolve: {
+    alias: {
+      ...sharedMappings.getAliases(),
+    },
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      remotes: {
+      
+      },
+      shared: {
+        \\"@angular/core\\": { singleton: true, strictVersion: true },
+        \\"@angular/common\\": { singleton: true, strictVersion: true },
+        \\"@angular/common/http\\": { singleton: true, strictVersion: true },
+        \\"@angular/router\\": { singleton: true, strictVersion: true },
+        ...sharedMappings.getDescriptors(),
+      },
+    }),
+    sharedMappings.getPlugin(),
+  ],
+};
+"
+`;
+
+exports[`app --mfe should generate a Module Federation correctly for a each app 2`] = `
+"const ModuleFederationPlugin = require(\\"webpack/lib/container/ModuleFederationPlugin\\");
+const mf = require(\\"@angular-architects/module-federation/webpack\\");
+const path = require(\\"path\\");
+
+const sharedMappings = new mf.SharedMappings();
+sharedMappings.register(path.join(__dirname, \\"../../tsconfig.base.json\\"), [
+  /* mapped paths to share */
+]);
+
+module.exports = {
+  output: {
+    uniqueName: \\"my-app\\",
+    publicPath: \\"auto\\",
+  },
+  optimization: {
+    runtimeChunk: false,
+    minimize: false,
+  },
+  resolve: {
+    alias: {
+      ...sharedMappings.getAliases(),
+    },
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: \\"my-app\\",
+      filename: \\"remoteEntry.js\\",
+      exposes: {
+        './Component': 'apps/my-app/src/app/app.component.ts',
+      },
+      shared: {
+        \\"@angular/core\\": { singleton: true, strictVersion: true },
+        \\"@angular/common\\": { singleton: true, strictVersion: true },
+        \\"@angular/common/http\\": { singleton: true, strictVersion: true },
+        \\"@angular/router\\": { singleton: true, strictVersion: true },
+        ...sharedMappings.getDescriptors(),
+      },
+    }),
+    sharedMappings.getPlugin(),
+  ],
+};
+"
+`;
+
 exports[`app nested should update workspace.json 1`] = `
 Object {
   "architect": Object {

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -5,6 +5,7 @@ import {
   readJson,
   updateJson,
   NxJsonConfiguration,
+  readProjectConfiguration,
   parseJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
@@ -648,6 +649,36 @@ describe('app', () => {
         false
       );
     });
+  });
+
+  describe('--mfe', () => {
+    test.each(['shell', 'remote'])(
+      'should generate a Module Federation correctly for a each app',
+      async (type: 'shell' | 'remote') => {
+        await generateApp(appTree, 'my-app', { mfe: true, mfeType: type });
+
+        expect(appTree.exists(`apps/my-app/webpack.config.js`)).toBeTruthy();
+        expect(
+          appTree.exists(`apps/my-app/webpack.prod.config.js`)
+        ).toBeTruthy();
+        expect(
+          appTree.read(`apps/my-app/webpack.config.js`, 'utf-8')
+        ).toMatchSnapshot();
+      }
+    );
+
+    test.each(['shell', 'remote'])(
+      'should update the builder to use webpack-browser',
+      async (type: 'shell' | 'remote') => {
+        await generateApp(appTree, 'my-app', { mfe: true, mfeType: type });
+
+        const projectConfig = readProjectConfiguration(appTree, 'my-app');
+
+        expect(projectConfig.targets.build.executor).toEqual(
+          '@nrwl/angular:webpack-browser'
+        );
+      }
+    );
   });
 });
 

--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -1,4 +1,4 @@
-import type { Tree } from '@nrwl/devkit';
+import { logger, Tree } from '@nrwl/devkit';
 import type { Schema } from './schema';
 
 import {
@@ -28,6 +28,7 @@ import {
   enableStrictTypeChecking,
   setApplicationStrictDefault,
   addLinting,
+  addMfe,
 } from './lib';
 import { addUnitTestRunner } from './lib/add-unit-test-runner';
 
@@ -105,6 +106,10 @@ export async function applicationGenerator(
       project: options.name,
       all: false,
     });
+  }
+
+  if (options.mfe) {
+    await addMfe(host, options);
   }
 
   if (!options.skipFormat) {

--- a/packages/angular/src/generators/application/lib/add-mfe.ts
+++ b/packages/angular/src/generators/application/lib/add-mfe.ts
@@ -1,0 +1,14 @@
+import type { Tree } from '@nrwl/devkit';
+import type { NormalizedSchema } from './normalized-schema';
+
+import { setupMfe } from '../../setup-mfe/setup-mfe';
+
+export async function addMfe(host: Tree, options: NormalizedSchema) {
+  await setupMfe(host, {
+    appName: options.name,
+    mfeType: options.mfeType,
+    port: options.port,
+    remotes: options.remotes,
+    skipFormat: true,
+  });
+}

--- a/packages/angular/src/generators/application/lib/index.ts
+++ b/packages/angular/src/generators/application/lib/index.ts
@@ -1,5 +1,6 @@
 export * from './add-e2e';
 export * from './add-linting';
+export * from './add-mfe';
 export * from './add-protractor';
 export * from './add-proxy-config';
 export * from './create-files';

--- a/packages/angular/src/generators/application/schema.d.ts
+++ b/packages/angular/src/generators/application/schema.d.ts
@@ -20,4 +20,8 @@ export interface Schema {
   backendProject?: string;
   strict?: boolean;
   standaloneConfig?: boolean;
+  mfe?: boolean;
+  mfeType?: 'shell' | 'remote';
+  remotes?: string[];
+  port?: number;
 }

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -122,6 +122,25 @@
       "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
       "type": "boolean",
       "default": false
+    },
+    "mfe": {
+      "description": "Generate a Module Federation configuration for the application",
+      "type": "boolean",
+      "default": false
+    },
+    "mfeType": {
+      "type": "string",
+      "enum": ["shell", "remote"],
+      "description": "Type of application to generate the Module Federation configuration for.",
+      "default": "remote"
+    },
+    "port": {
+      "type": "number",
+      "description": "The port at which the remote application should be served."
+    },
+    "remotes": {
+      "type": "array",
+      "description": "A list of remote application names that the shell application should consume."
     }
   },
   "required": []

--- a/packages/angular/src/generators/setup-mfe/schema.json
+++ b/packages/angular/src/generators/setup-mfe/schema.json
@@ -19,7 +19,7 @@
       "type": "string",
       "enum": ["shell", "remote"],
       "description": "Type of application to generate the Module Federation configuration for.",
-      "default": "shell"
+      "default": "remote"
     },
     "port": {
       "type": "number",


### PR DESCRIPTION
## Current Behavior
We currently do not support adding a Module Federation configuration during the scaffolding of an application.

## Expected Behavior
Add support for generating a Module Federation configuration during the scaffolding of an application:

`nx g @nrwl/angular:app appName --mfe --mfeType={shell|remote} --remotes=comma,separated,list,of,remotes --port=portNumberForRemote`
