### PR TITLE
chore(repo): remove flaky headless param from e2e test (#6244)

### DIFF
--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -75,9 +75,13 @@ export function DocumentationPage({
     if (flavor.value !== storedFlavor) {
       router.push(`/${version.id}/${storedFlavor}${router.asPath}`);
     } else if (!router.asPath.startsWith(`/${version.id}`)) {
-      router.push(`/${version.id}/${storedFlavor}${router.asPath}`, undefined, {
-        shallow: true,
-      });
+      router.replace(
+        `/${version.id}/${storedFlavor}${router.asPath}`,
+        undefined,
+        {
+          shallow: true,
+        }
+      );
     }
   }, [router, version, flavor, storedFlavor, isFallback]);
 
@@ -278,8 +282,23 @@ function findDocumentAndMenu(
   flavor: { label: string; value: string },
   segments: string[]
 ): { menu?: Menu; document?: DocumentData; isFallback?: boolean } {
-  const isFallback = segments[0] !== version.id;
-  const path = isFallback ? segments : segments.slice(2);
+  const segmentsIncludeVersion = segments[0] === version.id;
+  const segmentsIncludeFlavor = segmentsIncludeVersion
+    ? segments[1] === flavor.value
+    : segments[0] === flavor.value;
+  const isFallback = !segmentsIncludeVersion && !segmentsIncludeFlavor;
+
+  let path: string[];
+
+  if (!isFallback) {
+    path = segments.slice(2);
+  } else if (!segmentsIncludeVersion && !segmentsIncludeFlavor) {
+    path = segments;
+  } else if (segmentsIncludeVersion && !segmentsIncludeFlavor) {
+    path = segments.slice(1);
+  } else {
+    throw new Error('Unsupported URL');
+  }
 
   let menu: Menu;
   let document: DocumentData;

--- a/nx-dev/ui/common/src/lib/footer.tsx
+++ b/nx-dev/ui/common/src/lib/footer.tsx
@@ -2,7 +2,7 @@ import cx from 'classnames';
 import Link from 'next/link';
 
 export interface FooterProps {
-  useDarkBackground: boolean;
+  useDarkBackground?: boolean;
 }
 export function Footer({ useDarkBackground }: FooterProps) {
   return (

--- a/nx-dev/ui/common/src/lib/header.tsx
+++ b/nx-dev/ui/common/src/lib/header.tsx
@@ -4,12 +4,12 @@ import { AlgoliaSearch } from '@nrwl/nx-dev/feature-search';
 
 interface HeaderPropsWithoutFlavorAndVersion {
   showSearch: false;
-  useDarkBackground: boolean;
+  useDarkBackground?: boolean;
 }
 
 interface HeaderPropsWithFlavorAndVersion {
   showSearch: boolean;
-  useDarkBackground: boolean;
+  useDarkBackground?: boolean;
   flavor: { name: string; value: string };
   version: { name: string; value: string };
 }


### PR DESCRIPTION
This PR adds support for doc URLs qualified by flavor only (no version). This change fixes issues where internal doc links do not currently specify the latest/previous version, but only the flavor.

e.g.

- /react/getting-started/intro
- /angular/cli/run
