### PR TITLE
fix(core): safely handle when tasksRunnerOptions are not defined

### DIFF
--- a/packages/workspace/src/migrations/update-12-5-0/add-target-dependencies.ts
+++ b/packages/workspace/src/migrations/update-12-5-0/add-target-dependencies.ts
@@ -8,9 +8,10 @@ import { output } from '../../utilities/output';
 
 export async function setTargetDependencies(host: Tree) {
   const config = readWorkspaceConfiguration(host);
-  const strictlyOrderedTargets = config.tasksRunnerOptions['default'].options
-    .strictlyOrderedTargets || ['build'];
-  delete config.tasksRunnerOptions['default'].options.strictlyOrderedTargets;
+  const strictlyOrderedTargets = config.tasksRunnerOptions?.['default']?.options
+    ?.strictlyOrderedTargets || ['build'];
+  delete config.tasksRunnerOptions?.['default']?.options
+    ?.strictlyOrderedTargets;
   config.targetDependencies = config.targetDependencies ?? {};
 
   const updatedStrictlyOrderedTargets = [];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

tasksRunnerOptions might not be defined and this causes the migration to add target dependencies to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The migration works properly when tasksRunnerOptions is not defined.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
