### PR TITLE
chore(repo): run cypress tests on merge to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,7 @@ jobs:
       NX_CLOUD_DISTRIBUTED_EXECUTION: 'true'
       SELECTED_CLI: << parameters.cli >>
       NX_E2E_CI_CACHE_KEY: e2e-circleci-<< parameters.os >>-<< parameters.pm >>
+      NX_E2E_RUN_CYPRESS: 'true'
     steps:
       - setup:
           os: << parameters.os >>
@@ -213,11 +214,11 @@ workflows:
           name: 'agent5'
       - agent:
           name: 'agent6'
-      - trunk-main:
-          filters:
-            branches:
-              only: master
       - pr-main:
           filters:
             branches:
               ignore: master
+      - trunk-main:
+          filters:
+            branches:
+              only: master

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -100,7 +100,7 @@ jobs:
         GIT_COMMITTER_EMAIL: test@test.com
         GIT_COMMITTER_NAME: Test
         NX_E2E_CI_CACHE_KEY: e2e-gha-${{ matrix.os }}-${{ matrix.node_version }}-${{ matrix.package_manager }}
-        NX_E2E_CI_NIGHTLY: ${{ 'true' }}
+        NX_E2E_RUN_CYPRESS: ${{ 'true' }}
         NODE_OPTIONS: --max_old_space_size=8192
         SELECTED_PM: ${{ matrix.package_manager }}
         YARN_REGISTRY: http://localhost:4872

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -1,5 +1,4 @@
 import { detectPackageManager } from '@nrwl/tao/src/shared/package-manager';
-import { inlineProjectConfigurations } from '@nrwl/tao/src/shared/workspace';
 import { ChildProcess, exec, execSync } from 'child_process';
 import {
   copySync,
@@ -39,10 +38,6 @@ interface RunCmdOpts {
 
 export function currentCli() {
   return process.env.SELECTED_CLI || 'nx';
-}
-
-export function isNightlyRun() {
-  return process.env.NX_E2E_CI_NIGHTLY === 'true';
 }
 
 export const e2eRoot = isCI ? dirSync({ prefix: 'nx-e2e-' }).name : `./tmp`;
@@ -241,7 +236,7 @@ export async function removeProject({ onlyOnCI = false } = {}) {
 }
 
 export function runCypressTests() {
-  return isNightlyRun();
+  return process.env.NX_E2E_RUN_CYPRESS === 'true';
 }
 
 export function isNotWindows() {


### PR DESCRIPTION
Currently cypress tests, that are part of our E2E tests, run only in the nightly mode.
This speeds up the PR development tremendously.
The cost to this is however that once the errors occur, we often need to track the exact commit that caused it. 

This process is often tiresome and additionally author of the commit might not be aware of the bug.

This PR sets the flag on E2E, so that merge to master always involves full tests with Cypress run.
This will allow us to catch errors sooner at a cost of a bit longer merging loops.

The PR runs should remain as they are - with Cypress runs switched off.

