### PR TITLE
fix(web): fix stylePreprocessorOptions option

### DIFF
--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -12,6 +12,7 @@ import {
   runCypressTests,
   uniq,
   updateFile,
+  updateWorkspaceConfig,
 } from '@nrwl/e2e/utils';
 
 describe('Web Components Applications', () => {
@@ -34,9 +35,11 @@ describe('Web Components Applications', () => {
       `dist/apps/${appName}/main.js`,
       `dist/apps/${appName}/styles.js`
     );
+
     expect(readFile(`dist/apps/${appName}/main.js`)).toContain(
       'class AppElement'
     );
+
     runCLI(`build ${appName} --prod --output-hashing none`);
     checkFilesExist(
       `dist/apps/${appName}/index.html`,
@@ -45,14 +48,19 @@ describe('Web Components Applications', () => {
       `dist/apps/${appName}/main.esm.js`,
       `dist/apps/${appName}/styles.css`
     );
+
     expect(readFile(`dist/apps/${appName}/index.html`)).toContain(
       `<link rel="stylesheet" href="styles.css">`
     );
+
     const testResults = await runCLIAsync(`test ${appName}`);
+
     expect(testResults.combinedOutput).toContain(
       'Test Suites: 1 passed, 1 total'
     );
+
     const lintE2eResults = runCLI(`lint ${appName}-e2e`);
+
     expect(lintE2eResults).toContain('All files pass linting.');
 
     if (isNotWindows() && runCypressTests()) {
@@ -377,24 +385,6 @@ describe('index.html interpolation', () => {
       NX_VARIABLE=foo
       SOME_OTHER_VARIABLE=bar
     }`;
-
-    const expectedBuiltIndex = `<!DOCTYPE html>
-    <html lang="en">
-      <head>
-        <meta charset="utf-8" />
-        <title>BestReactApp</title>
-        <base href="/">
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" type="image/x-icon" href="favicon.ico" />
-      </head>
-      <body>
-        <div id="root"></div>
-        <div>Nx Variable: foo</div>
-        <div>Some other variable: %SOME_OTHER_VARIABLE%</div>
-        <div>Deploy Url: baz</div>
-      <script src="bazruntime.js" defer></script><script src="bazpolyfills.js" defer></script><script src="bazstyles.js" defer></script><script src="bazmain.js" defer></script></body>
-    </html>
-`;
 
     createFile(envFilePath);
 

--- a/packages/web/src/executors/build/build.impl.ts
+++ b/packages/web/src/executors/build/build.impl.ts
@@ -53,7 +53,7 @@ export interface WebBuildBuilderOptions extends BuildBuilderOptions {
 
   namedChunks?: boolean;
 
-  stylePreprocessingOptions?: any;
+  stylePreprocessorOptions?: any;
   subresourceIntegrity?: boolean;
 
   verbose?: boolean;

--- a/packages/web/src/utils/sass.ts
+++ b/packages/web/src/utils/sass.ts
@@ -1,0 +1,13 @@
+import { stripIndents, logger } from '@nrwl/devkit';
+
+export let sassImplementation: {} | undefined;
+
+try {
+  sassImplementation = require('node-sass');
+  logger.warn(stripIndents`
+    'node-sass' has been deprecated and may not be supported in the future.
+    To opt-out of the deprecated behaviour and start using 'sass' uninstall 'node-sass'.
+  `);
+} catch {
+  sassImplementation = require('sass');
+}


### PR DESCRIPTION
This PR fixes the `stylePreprocessorOptions` option for Web/React builds.

For example,  if you have this in `workspace.json`:

```
{
  "projects": {
    "my-app": {
      "targets": {
        "build": {
          "executor": "@nrwl/web:build",
          "outputs": ["{options.outputPath}"],
          "options": {
            ...
            "includePaths": ["libs/shared/lib"]
          },
    }
  }
}
```

Then in `apps/my-app/styles.css` you can use this import

```
@import 'variables.css';
```

And that will match `libs/shared/lib/variables.css` (if it exists).

## Current Behavior

Import fails

## Expected Behavior

Import works

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#5669
