### PR TITLE
fix(core): add @nrwl/nx-cloud to report package list

### DIFF
--- a/packages/workspace/src/command-line/report.ts
+++ b/packages/workspace/src/command-line/report.ts
@@ -20,6 +20,7 @@ export const packagesWeCareAbout = [
   '@nrwl/nest',
   '@nrwl/next',
   '@nrwl/node',
+  '@nrwl/nx-cloud',
   '@nrwl/react',
   '@nrwl/schematics',
   '@nrwl/tao',


### PR DESCRIPTION
## Current Behavior
The package version for `@nrwl/nx-cloud` is not reported with `nx report`

## Expected Behavior
The package version for `@nrwl/nx-cloud` should be reported with `nx report` so we can more easily diagnose nx cloud issues that may be specific to a given version.
