### PR TITLE
feat(core): migrations can add packages as dev dependencies

### DIFF
--- a/e2e/cli/src/cli.test.ts
+++ b/e2e/cli/src/cli.test.ts
@@ -237,7 +237,13 @@ describe('migrate', () => {
                       }
                     },
                     packageJsonUpdates: {
-                      'run-11': {version: '1.1.0', packages: {'migrate-child-package': {version: '9.0.0', alwaysAddToPackageJson: true}}},
+                      'run-11': {version: '1.1.0', packages: {
+                        'migrate-child-package': {version: '9.0.0', alwaysAddToPackageJson: true},
+                        'migrate-child-package-2': {version: '9.0.0', alwaysAddToPackageJson: false},
+                        'migrate-child-package-3': {version: '9.0.0', addToPackageJson: false},
+                        'migrate-child-package-4': {version: '9.0.0', addToPackageJson: 'dependencies'},
+                        'migrate-child-package-5': {version: '9.0.0', addToPackageJson: 'devDependencies'},
+                      }},
                     }
                   });
                 } else {
@@ -265,6 +271,18 @@ describe('migrate', () => {
     // updates package.json
     const packageJson = readJson(`package.json`);
     expect(packageJson.dependencies['migrate-child-package']).toEqual('9.0.0');
+    expect(
+      packageJson.dependencies['migrate-child-package-2']
+    ).not.toBeDefined();
+    expect(
+      packageJson.dependencies['migrate-child-package-3']
+    ).not.toBeDefined();
+    expect(packageJson.dependencies['migrate-child-package-4']).toEqual(
+      '9.0.0'
+    );
+    expect(packageJson.devDependencies['migrate-child-package-5']).toEqual(
+      '9.0.0'
+    );
     // should keep new line on package
     const packageContent = readFile('package.json');
     expect(packageContent.charCodeAt(packageContent.length - 1)).toEqual(10);

--- a/packages/tao/src/commands/migrate.spec.ts
+++ b/packages/tao/src/commands/migrate.spec.ts
@@ -33,7 +33,7 @@ describe('Migration', () => {
       expect(await migrator.updatePackageJson('mypackage', '2.0.0')).toEqual({
         migrations: [],
         packageJson: {
-          mypackage: { version: '2.0.0', alwaysAddToPackageJson: false },
+          mypackage: { version: '2.0.0', addToPackageJson: false },
         },
       });
     });
@@ -53,7 +53,7 @@ describe('Migration', () => {
                     child: { version: '2.0.0' },
                     newChild: {
                       version: '3.0.0',
-                      alwaysAddToPackageJson: true,
+                      addToPackageJson: 'devDependencies',
                     },
                   },
                 },
@@ -75,9 +75,49 @@ describe('Migration', () => {
       expect(await migrator.updatePackageJson('parent', '2.0.0')).toEqual({
         migrations: [],
         packageJson: {
-          parent: { version: '2.0.0', alwaysAddToPackageJson: false },
-          child: { version: '2.0.0', alwaysAddToPackageJson: false },
-          newChild: { version: '2.0.0', alwaysAddToPackageJson: true },
+          parent: { version: '2.0.0', addToPackageJson: false },
+          child: { version: '2.0.0', addToPackageJson: false },
+          newChild: { version: '2.0.0', addToPackageJson: 'devDependencies' },
+        },
+      });
+    });
+
+    it('should support the deprecated "alwaysAddToPackageJson" option', async () => {
+      const migrator = new Migrator({
+        packageJson: {},
+        versions: () => '1.0.0',
+        fetch: (p, _v) => {
+          if (p === 'mypackage') {
+            return Promise.resolve({
+              version: '2.0.0',
+              packageJsonUpdates: {
+                version2: {
+                  version: '2.0.0',
+                  packages: {
+                    child1: { version: '3.0.0', alwaysAddToPackageJson: false },
+                    child2: { version: '3.0.0', alwaysAddToPackageJson: true },
+                  },
+                },
+              },
+            });
+          } else if (p === 'child1') {
+            return Promise.resolve({ version: '3.0.0' });
+          } else if (p === 'child2') {
+            return Promise.resolve({ version: '3.0.0' });
+          } else {
+            return Promise.resolve(null);
+          }
+        },
+        from: {},
+        to: {},
+      });
+
+      expect(await migrator.updatePackageJson('mypackage', '2.0.0')).toEqual({
+        migrations: [],
+        packageJson: {
+          mypackage: { version: '2.0.0', addToPackageJson: false },
+          child1: { version: '3.0.0', addToPackageJson: false },
+          child2: { version: '3.0.0', addToPackageJson: 'dependencies' },
         },
       });
     });
@@ -124,8 +164,8 @@ describe('Migration', () => {
       expect(await migrator.updatePackageJson('parent', '2.0.0')).toEqual({
         migrations: [],
         packageJson: {
-          parent: { version: '2.0.0', alwaysAddToPackageJson: false },
-          child: { version: '2.0.0', alwaysAddToPackageJson: false },
+          parent: { version: '2.0.0', addToPackageJson: false },
+          child: { version: '2.0.0', addToPackageJson: false },
         },
       });
     });
@@ -186,10 +226,10 @@ describe('Migration', () => {
       expect(await migrator.updatePackageJson('parent', '2.0.0')).toEqual({
         migrations: [],
         packageJson: {
-          parent: { version: '2.0.0', alwaysAddToPackageJson: false },
-          child1: { version: '2.0.0', alwaysAddToPackageJson: false },
-          child2: { version: '2.0.0', alwaysAddToPackageJson: false },
-          grandchild: { version: '4.0.0', alwaysAddToPackageJson: false },
+          parent: { version: '2.0.0', addToPackageJson: false },
+          child1: { version: '2.0.0', addToPackageJson: false },
+          child2: { version: '2.0.0', addToPackageJson: false },
+          grandchild: { version: '4.0.0', addToPackageJson: false },
         },
       });
     });
@@ -236,8 +276,8 @@ describe('Migration', () => {
       expect(await migrator.updatePackageJson('parent', '2.0.0')).toEqual({
         migrations: [],
         packageJson: {
-          parent: { version: '2.0.0', alwaysAddToPackageJson: false },
-          child: { version: '2.0.0', alwaysAddToPackageJson: false },
+          parent: { version: '2.0.0', addToPackageJson: false },
+          child: { version: '2.0.0', addToPackageJson: false },
         },
       });
     });
@@ -279,8 +319,8 @@ describe('Migration', () => {
       expect(await migrator.updatePackageJson('parent', '2.0.0')).toEqual({
         migrations: [],
         packageJson: {
-          parent: { version: '2.0.0', alwaysAddToPackageJson: false },
-          child1: { version: '2.0.0', alwaysAddToPackageJson: false },
+          parent: { version: '2.0.0', addToPackageJson: false },
+          child1: { version: '2.0.0', addToPackageJson: false },
         },
       });
     });
@@ -323,46 +363,28 @@ describe('Migration', () => {
       ).toEqual({
         migrations: [],
         packageJson: {
-          '@nrwl/workspace': {
-            version: '2.0.0',
-            alwaysAddToPackageJson: false,
-          },
-          '@nrwl/cli': {
-            version: '2.0.0',
-            alwaysAddToPackageJson: false,
-          },
-          '@nrwl/angular': { version: '2.0.0', alwaysAddToPackageJson: false },
-          '@nrwl/cypress': { version: '2.0.0', alwaysAddToPackageJson: false },
-          '@nrwl/devkit': {
-            alwaysAddToPackageJson: false,
-            version: '2.0.0',
-          },
+          '@nrwl/workspace': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/cli': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/angular': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/cypress': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/devkit': { addToPackageJson: false, version: '2.0.0' },
           '@nrwl/eslint-plugin-nx': {
             version: '2.0.0',
-            alwaysAddToPackageJson: false,
+            addToPackageJson: false,
           },
-          '@nrwl/express': { version: '2.0.0', alwaysAddToPackageJson: false },
-          '@nrwl/gatsby': { version: '2.0.0', alwaysAddToPackageJson: false },
-          '@nrwl/jest': { version: '2.0.0', alwaysAddToPackageJson: false },
-          '@nrwl/linter': { version: '2.0.0', alwaysAddToPackageJson: false },
-          '@nrwl/nest': { version: '2.0.0', alwaysAddToPackageJson: false },
-          '@nrwl/next': { version: '2.0.0', alwaysAddToPackageJson: false },
-          '@nrwl/node': { version: '2.0.0', alwaysAddToPackageJson: false },
-          '@nrwl/nx-cloud': {
-            version: '2.0.0',
-            alwaysAddToPackageJson: false,
-          },
-          '@nrwl/nx-plugin': {
-            version: '2.0.0',
-            alwaysAddToPackageJson: false,
-          },
-          '@nrwl/react': { version: '2.0.0', alwaysAddToPackageJson: false },
-          '@nrwl/storybook': {
-            version: '2.0.0',
-            alwaysAddToPackageJson: false,
-          },
-          '@nrwl/tao': { version: '2.0.0', alwaysAddToPackageJson: false },
-          '@nrwl/web': { version: '2.0.0', alwaysAddToPackageJson: false },
+          '@nrwl/express': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/gatsby': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/jest': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/linter': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/nest': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/next': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/node': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/nx-cloud': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/nx-plugin': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/react': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/storybook': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/tao': { version: '2.0.0', addToPackageJson: false },
+          '@nrwl/web': { version: '2.0.0', addToPackageJson: false },
         },
       });
     });
@@ -476,9 +498,9 @@ describe('Migration', () => {
           },
         ],
         packageJson: {
-          parent: { version: '2.0.0', alwaysAddToPackageJson: false },
-          child: { version: '2.0.0', alwaysAddToPackageJson: false },
-          newChild: { version: '3.0.0', alwaysAddToPackageJson: false },
+          parent: { version: '2.0.0', addToPackageJson: false },
+          child: { version: '2.0.0', addToPackageJson: false },
+          newChild: { version: '3.0.0', addToPackageJson: false },
         },
       });
     });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
under the `packageJsonUpdates` key in `migrations.json` - new packages with `alwaysAddToPackageJson` set to `true` will be added as a production dependency (not a dev dependency)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
this PR adds capability to do mark a package with `addToPackageJson: 'dependencies'`, or `addToPackageJson: 'devDependencies'`, and it will be added to `dependencies` or `devDependencies` respectively.

existing `alwaysAddToPackageJson` functionality remains the same

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
