### PR TITLE
fix(repo): remove stale tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
           when: on_success
           name: Save successful tag
           command: |
-            ./scripts/circleci/tag-successful-build.sh nx_successful_ci_run__${CIRCLE_WORKFLOW_ID}
+            ./scripts/circleci/tag-successful-build.sh nx_successful_ci_run__${CIRCLE_WORKFLOW_ID} nx_successful_ci_run__*
 workflows:
   build:
     jobs:

--- a/scripts/circleci/tag-successful-build.sh
+++ b/scripts/circleci/tag-successful-build.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 command_string_to_echo_as_tag_name=$1
+INPUTS_TAG_MATCH_PATTERN=$2
 
+# remove all tags first
+git push -d origin $(git tag -l "$INPUTS_TAG_MATCH_PATTERN")
+# set single tag
 git tag $command_string_to_echo_as_tag_name
-git push origin --tags
+git push origin $command_string_to_echo_as_tag_name


### PR DESCRIPTION
The successful build tagging should not overflow releases with tags.
Before creating new tag, we should cleanup the previous stale ones matching the pattern.

## Related Issue(s)
https://github.com/nrwl/nx/issues/6224

Fixes #6224