### PR TITLE
feat(angular): change serve target to use nrwl/web:file-server for mfes

### DIFF
--- a/packages/angular/src/generators/setup-mfe/lib/change-workspace-target.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/change-workspace-target.ts
@@ -6,7 +6,7 @@ import {
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 
-export function changeBuildTarget(host: Tree, options: Schema) {
+export function changeWorkspaceTargets(host: Tree, options: Schema) {
   const appConfig = readProjectConfiguration(host, options.appName);
 
   appConfig.targets.build.executor = '@nrwl/angular:webpack-browser';
@@ -21,6 +21,18 @@ export function changeBuildTarget(host: Tree, options: Schema) {
     ...appConfig.targets.build.configurations.production,
     customWebpackConfig: {
       path: `${appConfig.root}/webpack.prod.config.js`,
+    },
+  };
+
+  appConfig.targets.serve.executor = '@nrwl/web:file-server';
+  appConfig.targets.serve.configurations = {
+    production: {
+      buildTarget:
+        appConfig.targets.serve.configurations.production.browserTarget,
+    },
+    development: {
+      buildTarget:
+        appConfig.targets.serve.configurations.development.browserTarget,
     },
   };
 

--- a/packages/angular/src/generators/setup-mfe/lib/index.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/index.ts
@@ -1,5 +1,5 @@
 export * from './add-implicit-deps';
-export * from './change-build-target';
+export * from './change-workspace-target';
 export * from './fix-bootstrap';
 export * from './generate-config';
 export * from './get-remotes-with-ports';

--- a/packages/angular/src/generators/setup-mfe/setup-mfe.spec.ts
+++ b/packages/angular/src/generators/setup-mfe/setup-mfe.spec.ts
@@ -119,6 +119,31 @@ describe('Init MFE', () => {
     ['app1', 'shell'],
     ['remote1', 'remote'],
   ])(
+    'should change the serve target to nrwl/web:file-server',
+    async (app, type: 'shell' | 'remote') => {
+      // ACT
+      await setupMfe(host, {
+        appName: app,
+        mfeType: type,
+      });
+
+      // ASSERT
+      const { serve } = readProjectConfiguration(host, app).targets;
+
+      expect(serve.executor).toEqual('@nrwl/web:file-server');
+      expect(serve.configurations.development.buildTarget).toEqual(
+        `${app}:build:development`
+      );
+      expect(serve.configurations.production.buildTarget).toEqual(
+        `${app}:build:production`
+      );
+    }
+  );
+
+  test.each([
+    ['app1', 'shell'],
+    ['remote1', 'remote'],
+  ])(
     'should install @angular-architects/module-federation in the monorepo',
     async (app, type: 'shell' | 'remote') => {
       // ACT

--- a/packages/angular/src/generators/setup-mfe/setup-mfe.ts
+++ b/packages/angular/src/generators/setup-mfe/setup-mfe.ts
@@ -9,12 +9,13 @@ import {
 
 import {
   addImplicitDeps,
-  changeBuildTarget,
+  changeWorkspaceTargets,
   fixBootstrap,
   generateWebpackConfig,
   getRemotesWithPorts,
   setupServeTarget,
 } from './lib';
+import { nxVersion } from '../../utils/versions';
 
 export async function setupMfe(host: Tree, options: Schema) {
   const projectConfig = readProjectConfiguration(host, options.appName);
@@ -24,7 +25,7 @@ export async function setupMfe(host: Tree, options: Schema) {
   generateWebpackConfig(host, options, projectConfig.root, remotesWithPorts);
 
   addImplicitDeps(host, options);
-  changeBuildTarget(host, options);
+  changeWorkspaceTargets(host, options);
   setupServeTarget(host, options);
 
   fixBootstrap(host, projectConfig.root);
@@ -32,7 +33,10 @@ export async function setupMfe(host: Tree, options: Schema) {
   // add package to install
   const installPackages = addDependenciesToPackageJson(
     host,
-    { '@angular-architects/module-federation': '^12.2.0' },
+    {
+      '@angular-architects/module-federation': '^12.2.0',
+      '@nrwl/web': nxVersion,
+    },
     {}
   );
 


### PR DESCRIPTION

## Current Behavior
Angular's dev-server builder was being used to serve the MFE apps, but it doesn't merge the custom webpack config correctly

## Expected Behavior
Switch to `@nrwl/web:file:server` which builds the app, taking into account the custom webpack config, and serve the apps correctly, supporting local development of MFEs

