### PR TITLE
feat(storybook): story generator takes into account actions

### DIFF
--- a/packages/react/src/generators/component-story/component-story.spec.ts
+++ b/packages/react/src/generators/component-story/component-story.spec.ts
@@ -217,6 +217,67 @@ describe('react:component-story', () => {
       });
     });
 
+    describe('component with props and actions', () => {
+      beforeEach(async () => {
+        appTree.write(
+          cmpPath,
+          `import React from 'react';
+  
+          import './test.scss';
+
+          export type ButtonStyle = 'default' | 'primary' | 'warning';
+          
+          export interface TestProps {
+            name: string;
+            displayAge: boolean;
+            someAction: (e: unknown) => void;
+            style: ButtonStyle;
+          }
+          
+          export const Test = (props: TestProps) => {
+            return (
+              <div>
+                <h1>Welcome to test component, {props.name}</h1>
+                <button onClick={props.someAction}>Click me!</button>
+              </div>
+            );
+          };
+          
+          export default Test;        
+          `
+        );
+
+        await componentStoryGenerator(appTree, {
+          componentPath: 'lib/test-ui-lib.tsx',
+          project: 'test-ui-lib',
+        });
+      });
+
+      it('should setup controls based on the component props', () => {
+        expect(formatFile`${appTree.read(storyFilePath, 'utf-8')}`)
+          .toContain(formatFile`
+            import { Story, Meta } from '@storybook/react';
+            import { Test, TestProps } from './test-ui-lib';
+
+            export default {
+              component: Test,
+              title: 'Test',
+              argTypes: {
+                someAction: { action: 'someAction executed!' },
+              },
+            } as Meta;
+
+            const Template: Story<TestProps> = (args) => <Test {...args} />;
+
+            export const Primary = Template.bind({});
+            Primary.args = {
+              name: '',
+              displayAge: false,
+            };
+          `);
+      });
+    });
+
     [
       {
         name: 'default export function',

--- a/packages/react/src/generators/component-story/files/__componentFileName__.stories.__fileExt__
+++ b/packages/react/src/generators/component-story/files/__componentFileName__.stories.__fileExt__
@@ -3,7 +3,11 @@ import<% if ( !isPlainJs ) { %> { <% } %> <%= componentName %><% if ( propsTypeN
 
 export default {
   component: <%= componentName %>,
-  title: '<%= componentName %>'
+  title: '<%= componentName %>',<% if ( argTypes && argTypes.length > 0 ) { %> 
+  argTypes: {<% for (let argType of argTypes) { %>
+    <%= argType.name %>: { <%- argType.type %> : "<%- argType.actionText %>" },<% } %>
+}
+   <% } %> 
 }<% if ( !isPlainJs ) { %> as Meta <% } %>;
 
 const Template<% if ( !isPlainJs ) { %>: Story<<%= propsTypeName %>><% } %> = (args) => <<%= componentName %> {...args} />;


### PR DESCRIPTION
Storybook stories generator now produces [`argTypes`](https://storybook.js.org/docs/react/essentials/actions) to include actions added in React component props.

```
export interface SomeButtonProps {
  onClick: (e: unknown) => void;
}
```

becomes in the story:

```
export default {
  component: SomeButton,
  title: 'SomeButton',
  argTypes: {
    onClick: { action: 'onClick executed!' },
  },
} as Meta;
```

https://user-images.githubusercontent.com/6603745/124943485-33078d00-e015-11eb-97b1-b6798a1b3afa.mov

