### PR TITLE
fix(core): update root jest config with move generator

### DIFF
--- a/packages/workspace/src/generators/move/lib/update-jest-config.ts
+++ b/packages/workspace/src/generators/move/lib/update-jest-config.ts
@@ -1,4 +1,4 @@
-import { Tree, ProjectConfiguration, getWorkspaceLayout } from '@nrwl/devkit';
+import { Tree, ProjectConfiguration } from '@nrwl/devkit';
 
 import * as path from 'path';
 
@@ -44,11 +44,7 @@ export function updateJestConfig(
     return;
   }
 
-  const { libsDir, appsDir } = getWorkspaceLayout(tree);
-  const findProject = new RegExp(
-    `<rootDir>\/(${libsDir}|${appsDir})\/${schema.projectName}`,
-    'g'
-  );
+  const findProject = new RegExp(`<rootDir>\/${project.root}`, 'g');
 
   const oldRootJestConfigContent = tree.read(rootJestConfigPath, 'utf-8');
 


### PR DESCRIPTION
ISSUES CLOSED: #6303

```
  const findProject = new RegExp(
    `<rootDir>\/(${libsDir}|${appsDir})\/${schema.projectName}`,
    'g'
  );
```

produces a path like `<rootDir>/libs/shared-test-project` for a path that should be `<rootDir>/libs/shared/test/project`, because it constructs the path from the `schema.projectName`.

Using `project.root` instead, to get the correct path:
```
const findProject = new RegExp(`<rootDir>\/${project.root}`, 'g');
```

Not sure if there are some niche cases where `project.root` would not work @FrozenPandaz 