### PR TITLE
cleanup(nextjs): change manual dependency migration to use packageJsonUpdates

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -132,6 +132,10 @@
         "next": {
           "version": "11.0.1",
           "alwaysAddToPackageJson": false
+        },
+        "eslint-config-next": {
+          "version": "11.0.1",
+          "addToPackageJson": "devDependencies"
         }
       }
     }

--- a/packages/next/src/migrations/update-12-6-0/add-next-eslint.spec.ts
+++ b/packages/next/src/migrations/update-12-6-0/add-next-eslint.spec.ts
@@ -203,12 +203,4 @@ describe('Add next eslint 12.6.0', () => {
       'plugin:@nrwl/nx/react'
     );
   });
-
-  it('should add eslint-config-next to dev dependencies', async () => {
-    await addNextEslint(tree);
-
-    expect(
-      readJson(tree, 'package.json').devDependencies['eslint-config-next']
-    ).toBeTruthy();
-  });
 });

--- a/packages/next/src/migrations/update-12-6-0/add-next-eslint.ts
+++ b/packages/next/src/migrations/update-12-6-0/add-next-eslint.ts
@@ -1,5 +1,4 @@
 import { formatFiles, getProjects, Tree, updateJson } from '@nrwl/devkit';
-import { eslintConfigNextVersion } from '../../utils/versions';
 
 export async function addNextEslint(host: Tree) {
   const projects = getProjects(host);
@@ -30,15 +29,6 @@ export async function addNextEslint(host: Tree) {
       eslintConfig.env.jest = true;
       return eslintConfig;
     });
-  });
-
-  updateJson(host, 'package.json', (packageJsonContents) => {
-    if (!packageJsonContents.devDependencies) {
-      packageJsonContents.devDependencies = {};
-    }
-    packageJsonContents.devDependencies['eslint-config-next'] =
-      eslintConfigNextVersion;
-    return packageJsonContents;
   });
 
   await formatFiles(host);


### PR DESCRIPTION
Now that `addToPackageJson` is supported by `packageJsonUpdates`, i've updated the next.js migration to use that instead of doing it "manually" in a migration.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
