### PR TITLE
fix(core): adjust logger to avoid errors when the passed object is not a string

### DIFF
--- a/packages/tao/src/shared/logger.ts
+++ b/packages/tao/src/shared/logger.ts
@@ -9,14 +9,14 @@ export const NX_ERROR = chalk.inverse(chalk.bold(chalk.red(' ERROR ')));
 export const logger = {
   warn: (s) => console.warn(chalk.bold(chalk.yellow(s))),
   error: (s) => {
-    if (s.startsWith('NX ')) {
+    if (typeof s === 'string' && s.startsWith('NX ')) {
       console.error(`\n${NX_ERROR} ${chalk.bold(chalk.red(s.substr(3)))}\n`);
     } else {
       console.error(chalk.bold(chalk.red(s)));
     }
   },
   info: (s) => {
-    if (s.startsWith('NX ')) {
+    if (typeof s === 'string' && s.startsWith('NX ')) {
       console.info(`\n${NX_PREFIX} ${chalk.bold(s.substr(3))}\n`);
     } else {
       console.info(chalk.white(s));


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

if right now you just pass the error object to the logger it fails on the `startsWith` function

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

I'd expect it to just log the stacktrace in those cases.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
