### PR TITLE
fix(testing): fix getting jest config from tree when require is used

### DIFF
--- a/packages/jest/src/utils/config/functions.spec.ts
+++ b/packages/jest/src/utils/config/functions.spec.ts
@@ -1,0 +1,85 @@
+import { createTree } from '@nrwl/devkit/testing';
+import { jestConfigObject } from './functions';
+describe('jestConfigObject', () => {
+  it('should work for basic cases', () => {
+    const tree = createTree();
+    tree.write(
+      'jest.config.js',
+      `
+      module.exports = {
+        foo: 'bar'
+      };
+    `
+    );
+
+    expect(jestConfigObject(tree, 'jest.config.js')).toEqual({
+      foo: 'bar',
+    });
+  });
+
+  xit('should work with async functions', async () => {
+    const tree = createTree();
+    jest.mock('@nrwl/jest', () => ({
+      getJestProjects: () => ['<rootDir>/project-a', '<rootDir>/project-b'],
+    }));
+    tree.write(
+      'jest.config.js',
+      `
+      const { getJestProjects } = require('@nrwl/jest');
+      module.exports = async () => ({
+        foo: 'bar'
+      });
+    `
+    );
+
+    expect(await jestConfigObject(tree, 'jest.config.js')).toEqual({
+      foo: 'bar',
+    });
+  });
+
+  it('should work with `getJestConfig`', () => {
+    const tree = createTree();
+    jest.mock('@nrwl/jest', () => ({
+      getJestProjects: () => ['<rootDir>/project-a', '<rootDir>/project-b'],
+    }));
+    tree.write(
+      'jest.config.js',
+      `
+      const { getJestProjects } = require('@nrwl/jest');
+      module.exports = {
+        projects: getJestProjects()
+      };
+    `
+    );
+
+    expect(jestConfigObject(tree, 'jest.config.js')).toEqual({
+      projects: ['<rootDir>/project-a', '<rootDir>/project-b'],
+    });
+  });
+
+  it('should work with node globals (require, __dirname, process, __filename, console, and other globals)', () => {
+    const tree = createTree();
+    jest.mock('@nrwl/jest', () => ({
+      getJestProjects: () => ['<rootDir>/project-a', '<rootDir>/project-b'],
+    }));
+    tree.write(
+      'jest.config.js',
+      `
+      const { getJestProjects } = require('@nrwl/jest');
+      module.exports = {
+        projects: getJestProjects(),
+        filename: __filename,
+        env: process.env,
+        dirname: __dirname
+      };
+    `
+    );
+
+    expect(jestConfigObject(tree, 'jest.config.js')).toEqual({
+      dirname: '/virtual',
+      filename: '/virtual/jest.config.js',
+      env: process.env,
+      projects: ['<rootDir>/project-a', '<rootDir>/project-b'],
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`jestConfigObject` errors if `getJestProjects` is used in `jest.config.js` files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`jestConfigObject` works properly if `getJestProjects` is used in `jest.config.js` files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
