### PR TITLE
fix(testing): fixing migration and interop with move generator

### DIFF
--- a/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.ts
+++ b/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.ts
@@ -31,6 +31,9 @@ function updateBaseJestConfig(
   tree: Tree,
   baseJestConfigPath = 'jest.config.js'
 ) {
+  if (tree.read('/jest.config.js', 'utf-8').includes('getJestProjects()')) {
+    return;
+  }
   const currentConfig = jestConfigObject(tree, baseJestConfigPath);
   const uncoveredJestProjects = determineUncoveredJestProjects(
     currentConfig.projects as string[]

--- a/packages/workspace/src/generators/move/lib/update-jest-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-jest-config.spec.ts
@@ -109,11 +109,125 @@ describe('updateJestConfig', () => {
       `coverageDirectory: '../../coverage/libs/other/test/dir/my-destination'`
     );
 
+    expect(rootJestConfigAfter).toContain('getJestProjects()');
+  });
+
+  it('updates the root config if not using `getJestProjects()`', async () => {
+    const rootJestConfigPath = '/jest.config.js';
+
+    await libraryGenerator(tree, {
+      name: 'some/test/dir/my-source',
+      standaloneConfig: false,
+    });
+    tree.write(
+      rootJestConfigPath,
+      `module.exports = {
+  projects: ['<rootDir>/libs/some/test/dir/my-source']
+};
+`
+    );
+    const projectConfig = readProjectConfiguration(
+      tree,
+      'some-test-dir-my-source'
+    );
+    const schema: Schema = {
+      projectName: 'some-test-dir-my-source',
+      destination: 'other/test/dir/my-destination',
+      importPath: undefined,
+      updateImportPath: true,
+    };
+
+    console.log(tree.read(rootJestConfigPath, 'utf-8'));
+
+    updateJestConfig(tree, schema, projectConfig);
+
+    console.log('after', tree.read(rootJestConfigPath, 'utf-8'));
+
+    const rootJestConfigAfter = tree.read(rootJestConfigPath, 'utf-8');
     expect(rootJestConfigAfter).not.toContain(
       '<rootDir>/libs/some/test/dir/my-source'
     );
     expect(rootJestConfigAfter).toContain(
       '<rootDir>/libs/other/test/dir/my-destination'
     );
+  });
+
+  it('updates the root config if `getJestProjects()` is used but old path exists', async () => {
+    const rootJestConfigPath = '/jest.config.js';
+
+    await libraryGenerator(tree, {
+      name: 'some/test/dir/my-source',
+      standaloneConfig: false,
+    });
+    tree.write(
+      rootJestConfigPath,
+      `const { getJestProjects } = require('@nrwl/jest');
+      
+module.exports = {
+  projects: [...getJestProjects(), '<rootDir>/libs/some/test/dir/my-source']
+};
+`
+    );
+    const projectConfig = readProjectConfiguration(
+      tree,
+      'some-test-dir-my-source'
+    );
+    const schema: Schema = {
+      projectName: 'some-test-dir-my-source',
+      destination: 'other/test/dir/my-destination',
+      importPath: undefined,
+      updateImportPath: true,
+    };
+
+    updateJestConfig(tree, schema, projectConfig);
+
+    const rootJestConfigAfter = tree.read(rootJestConfigPath, 'utf-8');
+    expect(rootJestConfigAfter).not.toContain(
+      '<rootDir>/libs/some/test/dir/my-source'
+    );
+    expect(rootJestConfigAfter).not.toContain(
+      '<rootDir>/libs/other/test/dir/my-destination'
+    );
+    expect(rootJestConfigAfter).toContain('getJestProjects()');
+  });
+
+  it('updates the root config if `getJestProjects()` is used with other projects in the array', async () => {
+    const rootJestConfigPath = '/jest.config.js';
+
+    await libraryGenerator(tree, {
+      name: 'some/test/dir/my-source',
+      standaloneConfig: false,
+    });
+    tree.write(
+      rootJestConfigPath,
+      `const { getJestProjects } = require('@nrwl/jest');
+      
+module.exports = {
+  projects: [...getJestProjects(), '<rootDir>/libs/some/test/dir/my-source', '<rootDir>/libs/foo']
+};
+`
+    );
+    const projectConfig = readProjectConfiguration(
+      tree,
+      'some-test-dir-my-source'
+    );
+    const schema: Schema = {
+      projectName: 'some-test-dir-my-source',
+      destination: 'other/test/dir/my-destination',
+      importPath: undefined,
+      updateImportPath: true,
+    };
+
+    updateJestConfig(tree, schema, projectConfig);
+
+    const rootJestConfigAfter = tree.read(rootJestConfigPath, 'utf-8');
+    expect(rootJestConfigAfter).not.toContain(
+      '<rootDir>/libs/some/test/dir/my-source'
+    );
+    expect(rootJestConfigAfter).not.toContain(
+      '<rootDir>/libs/other/test/dir/my-destination'
+    );
+    expect(rootJestConfigAfter).toContain('<rootDir>/libs/foo');
+    expect(rootJestConfigAfter).toContain('getJestProjects()');
   });
 });

--- a/packages/workspace/src/generators/move/lib/update-jest-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-jest-config.spec.ts
@@ -137,11 +137,7 @@ describe('updateJestConfig', () => {
       updateImportPath: true,
     };
 
-    console.log(tree.read(rootJestConfigPath, 'utf-8'));
-
     updateJestConfig(tree, schema, projectConfig);
-
-    console.log('after', tree.read(rootJestConfigPath, 'utf-8'));
 
     const rootJestConfigAfter = tree.read(rootJestConfigPath, 'utf-8');
     expect(rootJestConfigAfter).not.toContain(

--- a/packages/workspace/src/generators/move/lib/update-jest-config.ts
+++ b/packages/workspace/src/generators/move/lib/update-jest-config.ts
@@ -1,4 +1,4 @@
-import { Tree, ProjectConfiguration, formatFiles } from '@nrwl/devkit';
+import { Tree, ProjectConfiguration } from '@nrwl/devkit';
 
 import * as path from 'path';
 

--- a/packages/workspace/src/generators/move/lib/update-jest-config.ts
+++ b/packages/workspace/src/generators/move/lib/update-jest-config.ts
@@ -23,9 +23,7 @@ export function updateJestConfig(
   const jestConfigPath = path.join(destination, 'jest.config.js');
 
   if (tree.exists(jestConfigPath)) {
-    console.log('config exists');
     const oldContent = tree.read(jestConfigPath, 'utf-8');
-    console.log('oldContent', oldContent);
 
     const findName = new RegExp(`'${schema.projectName}'`, 'g');
     const findDir = new RegExp(project.root, 'g');
@@ -43,13 +41,11 @@ export function updateJestConfig(
     return;
   }
 
-  console.log(project.root);
   const findProject = `'<rootDir>/${project.root}'`;
 
   const oldRootJestConfigContent = tree.read(rootJestConfigPath, 'utf-8');
   const usingJestProjects =
     oldRootJestConfigContent.includes('getJestProjects()');
-  console.log(usingJestProjects);
 
   const newRootJestConfigContent = oldRootJestConfigContent.replace(
     findProject,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
+ Migrations fail if using `getJestProjects()` already
+ Move doesn't work as expected

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
