### PR TITLE
fix(nxdev): fix serving

### DIFF
--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -20,6 +20,8 @@
       ],
       "executor": "@nrwl/workspace:run-commands",
       "options": {
+        "root": "nx-dev/nx-dev",
+        "outputPath": "dist/nx-dev/nx-dev",
         "command": "echo Build complete!"
       }
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

temporary fix to get `nx-dev` serve happen again. in the meantime, i'll work on a proper fix to address the underlying issue.

for more context - the build target specified in the options of `@nrwl/next:serve` executor has to use the `@nrwl/next:build` executor. In addition to that, there are some discrepancies between `@nrwl/next:build` schema, and the implementation. specifically, `root` and `outputPath` are required in the implementation, but are not in the schema.json.

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
