### PR TITLE
fix(linter): check existence of eslintrc.json before running migration

### DIFF
--- a/packages/linter/src/migrations/update-12-4-0/remove-eslint-project-config-if-no-type-checking-rules.spec.ts
+++ b/packages/linter/src/migrations/update-12-4-0/remove-eslint-project-config-if-no-type-checking-rules.spec.ts
@@ -5,7 +5,7 @@ import {
   writeJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import remoteESLintProjectConfigIfNoTypeCheckingRules from './remove-eslint-project-config-if-no-type-checking-rules';
+import removeESLintProjectConfigIfNoTypeCheckingRules from './remove-eslint-project-config-if-no-type-checking-rules';
 
 const KNOWN_RULE_REQUIRING_TYPE_CHECKING = '@typescript-eslint/await-thenable';
 
@@ -100,7 +100,7 @@ describe('Remove ESLint parserOptions.project config if no rules requiring type-
     };
     writeJson(tree, 'libs/workspace-lib/.eslintrc.json', projectEslintConfig2);
 
-    await remoteESLintProjectConfigIfNoTypeCheckingRules(tree);
+    await removeESLintProjectConfigIfNoTypeCheckingRules(tree);
 
     // No change
     expect(readJson(tree, 'apps/react-app/.eslintrc.json')).toEqual(
@@ -157,7 +157,7 @@ describe('Remove ESLint parserOptions.project config if no rules requiring type-
     };
     writeJson(tree, 'libs/workspace-lib/.eslintrc.json', projectEslintConfig2);
 
-    await remoteESLintProjectConfigIfNoTypeCheckingRules(tree);
+    await removeESLintProjectConfigIfNoTypeCheckingRules(tree);
 
     // No change - uses rule requiring type-checking
     expect(readJson(tree, 'apps/react-app/.eslintrc.json')).toEqual(
@@ -183,5 +183,9 @@ describe('Remove ESLint parserOptions.project config if no rules requiring type-
         ],
       }
     `);
+  });
+
+  it('should not error if .eslintrc.json does not exist', async () => {
+    await removeESLintProjectConfigIfNoTypeCheckingRules(tree);
   });
 });

--- a/packages/linter/src/migrations/update-12-4-0/remove-eslint-project-config-if-no-type-checking-rules.ts
+++ b/packages/linter/src/migrations/update-12-4-0/remove-eslint-project-config-if-no-type-checking-rules.ts
@@ -24,6 +24,10 @@ function updateProjectESLintConfigs(host: Tree) {
 export default async function removeESLintProjectConfigIfNoTypeCheckingRules(
   host: Tree
 ) {
+  if (!host.exists('.eslintrc.json')) {
+    return;
+  }
+
   // If the root level config uses at least one rule requiring type-checking, do not migrate any project configs
   const rootESLintConfig = readJson(host, '.eslintrc.json');
   if (hasRulesRequiringTypeChecking(rootESLintConfig)) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When `.eslintrc.json` the `@nrwl/linter/migrations.json:remove-eslint-project-config-if-no-type-checking-rules` migration fails.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When `.eslintrc.json` the `@nrwl/linter/migrations.json:remove-eslint-project-config-if-no-type-checking-rules` migration does nothing.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
