### PR TITLE
fix(misc): @nrwl/workspace:rm generator should work with standalone configs

### DIFF
--- a/packages/devkit/src/generators/project-configuration.spec.ts
+++ b/packages/devkit/src/generators/project-configuration.spec.ts
@@ -119,10 +119,11 @@ describe('project configuration', () => {
     );
   });
 
-  it('should remove project.json file when removing projct configuration', () => {
+  it('should remove project.json file when removing project configuration', () => {
     addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
     removeProjectConfiguration(tree, 'test');
 
+    expect(readJson(tree, 'workspace.json').projects.test).toBeUndefined();
     expect(tree.exists('test/project.json')).toBeFalsy();
   });
 

--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -265,13 +265,12 @@ function addProjectToWorkspaceJson(
   if (configFile) {
     if (mode === 'delete') {
       host.delete(configFile);
+      delete workspaceJson.projects[projectName];
     } else {
       writeJson(host, configFile, project);
     }
-
     if (mode === 'create') {
       workspaceJson.projects[projectName] = project.root;
-      writeJson(host, path, workspaceJson);
     }
   } else {
     let workspaceConfiguration: ProjectConfiguration;
@@ -279,10 +278,9 @@ function addProjectToWorkspaceJson(
       const { tags, implicitDependencies, ...c } = project;
       workspaceConfiguration = c;
     }
-
     workspaceJson.projects[projectName] = workspaceConfiguration;
-    writeJson(host, path, workspaceJson);
   }
+  writeJson(host, path, workspaceJson);
 }
 
 function addProjectToNxJson(

--- a/packages/workspace/src/generators/remove/remove.ts
+++ b/packages/workspace/src/generators/remove/remove.ts
@@ -18,8 +18,8 @@ export async function removeGenerator(tree: Tree, schema: Schema) {
   checkDependencies(tree, schema);
   checkTargets(tree, schema, project);
   updateJestConfig(tree, schema, project);
-  removeProject(tree, project);
   removeProjectConfig(tree, schema);
+  removeProject(tree, project);
   updateTsconfig(tree, schema, project);
   if (!schema.skipFormat) {
     await formatFiles(tree);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- Running removeProjectConfiguration deletes project.json file, but leaves it in workspace.json
- Running `nx g rm {project}` fails when using project.json files
## Expected Behavior
- Running removeProjectConfiguration deletes project.json file, as well as the entry in workspace.json
- Running `nx g rm {project}` succeeds when using project.json files

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6321
