### PR TITLE
fix(angular): fix(angular): change mfe naming convention to use `host`

### DIFF
--- a/docs/angular/api-angular/generators/application.md
+++ b/docs/angular/api-angular/generators/application.md
@@ -94,7 +94,7 @@ Default: `remote`
 
 Type: `string`
 
-Possible values: `shell`, `remote`
+Possible values: `host`, `remote`
 
 Type of application to generate the Module Federation configuration for.
 
@@ -122,7 +122,7 @@ The prefix to apply to generated selectors.
 
 Type: `array`
 
-A list of remote application names that the shell application should consume.
+A list of remote application names that the host application should consume.
 
 ### routing
 

--- a/docs/angular/api-angular/generators/setup-mfe.md
+++ b/docs/angular/api-angular/generators/setup-mfe.md
@@ -36,7 +36,7 @@ Default: `remote`
 
 Type: `string`
 
-Possible values: `shell`, `remote`
+Possible values: `host`, `remote`
 
 Type of application to generate the Module Federation configuration for.
 
@@ -50,7 +50,7 @@ The port at which the remote application should be served.
 
 Type: `array`
 
-A list of remote application names that the shell application should consume.
+A list of remote application names that the host application should consume.
 
 ### skipFormat
 

--- a/docs/node/api-angular/generators/application.md
+++ b/docs/node/api-angular/generators/application.md
@@ -94,7 +94,7 @@ Default: `remote`
 
 Type: `string`
 
-Possible values: `shell`, `remote`
+Possible values: `host`, `remote`
 
 Type of application to generate the Module Federation configuration for.
 
@@ -122,7 +122,7 @@ The prefix to apply to generated selectors.
 
 Type: `array`
 
-A list of remote application names that the shell application should consume.
+A list of remote application names that the host application should consume.
 
 ### routing
 

--- a/docs/node/api-angular/generators/setup-mfe.md
+++ b/docs/node/api-angular/generators/setup-mfe.md
@@ -36,7 +36,7 @@ Default: `remote`
 
 Type: `string`
 
-Possible values: `shell`, `remote`
+Possible values: `host`, `remote`
 
 Type of application to generate the Module Federation configuration for.
 
@@ -50,7 +50,7 @@ The port at which the remote application should be served.
 
 Type: `array`
 
-A list of remote application names that the shell application should consume.
+A list of remote application names that the host application should consume.
 
 ### skipFormat
 

--- a/docs/react/api-angular/generators/application.md
+++ b/docs/react/api-angular/generators/application.md
@@ -94,7 +94,7 @@ Default: `remote`
 
 Type: `string`
 
-Possible values: `shell`, `remote`
+Possible values: `host`, `remote`
 
 Type of application to generate the Module Federation configuration for.
 
@@ -122,7 +122,7 @@ The prefix to apply to generated selectors.
 
 Type: `array`
 
-A list of remote application names that the shell application should consume.
+A list of remote application names that the host application should consume.
 
 ### routing
 

--- a/docs/react/api-angular/generators/setup-mfe.md
+++ b/docs/react/api-angular/generators/setup-mfe.md
@@ -36,7 +36,7 @@ Default: `remote`
 
 Type: `string`
 
-Possible values: `shell`, `remote`
+Possible values: `host`, `remote`
 
 Type of application to generate the Module Federation configuration for.
 
@@ -50,7 +50,7 @@ The port at which the remote application should be served.
 
 Type: `array`
 
-A list of remote application names that the shell application should consume.
+A list of remote application names that the host application should consume.
 
 ### skipFormat
 

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -652,9 +652,9 @@ describe('app', () => {
   });
 
   describe('--mfe', () => {
-    test.each(['shell', 'remote'])(
+    test.each(['host', 'remote'])(
       'should generate a Module Federation correctly for a each app',
-      async (type: 'shell' | 'remote') => {
+      async (type: 'host' | 'remote') => {
         await generateApp(appTree, 'my-app', { mfe: true, mfeType: type });
 
         expect(appTree.exists(`apps/my-app/webpack.config.js`)).toBeTruthy();
@@ -667,9 +667,9 @@ describe('app', () => {
       }
     );
 
-    test.each(['shell', 'remote'])(
+    test.each(['host', 'remote'])(
       'should update the builder to use webpack-browser',
-      async (type: 'shell' | 'remote') => {
+      async (type: 'host' | 'remote') => {
         await generateApp(appTree, 'my-app', { mfe: true, mfeType: type });
 
         const projectConfig = readProjectConfiguration(appTree, 'my-app');

--- a/packages/angular/src/generators/application/schema.d.ts
+++ b/packages/angular/src/generators/application/schema.d.ts
@@ -21,7 +21,7 @@ export interface Schema {
   strict?: boolean;
   standaloneConfig?: boolean;
   mfe?: boolean;
-  mfeType?: 'shell' | 'remote';
+  mfeType?: 'host' | 'remote';
   remotes?: string[];
   port?: number;
 }

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -130,7 +130,7 @@
     },
     "mfeType": {
       "type": "string",
-      "enum": ["shell", "remote"],
+      "enum": ["host", "remote"],
       "description": "Type of application to generate the Module Federation configuration for.",
       "default": "remote"
     },
@@ -140,7 +140,7 @@
     },
     "remotes": {
       "type": "array",
-      "description": "A list of remote application names that the shell application should consume."
+      "description": "A list of remote application names that the host application should consume."
     }
   },
   "required": []

--- a/packages/angular/src/generators/setup-mfe/files/webpack.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-mfe/files/webpack.config.js__tmpl__
@@ -27,7 +27,7 @@ module.exports = {
       filename: "remoteEntry.js",
       exposes: {
         './Component': '<%= sourceRoot %>/src/app/app.component.ts',
-      },<% } %><% if(type === 'shell') { %>
+      },<% } %><% if(type === 'host') { %>
       remotes: {
       <% remotes.forEach(function(remote) { %>"<%= remote.remoteName %>": "<%= remote.remoteName %>@http://localhost:<%= remote.port %>/remoteEntry.js",<% }); %>
       },<% } %>

--- a/packages/angular/src/generators/setup-mfe/lib/add-implicit-deps.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/add-implicit-deps.ts
@@ -8,7 +8,7 @@ import {
 
 export function addImplicitDeps(host: Tree, options: Schema) {
   if (
-    options.mfeType === 'shell' &&
+    options.mfeType === 'host' &&
     Array.isArray(options.remotes) &&
     options.remotes.length > 0
   ) {

--- a/packages/angular/src/generators/setup-mfe/lib/fix-bootstrap.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/fix-bootstrap.ts
@@ -1,5 +1,4 @@
 import type { Tree } from '@nrwl/devkit';
-import type { Schema } from '../schema';
 
 import { joinPathFragments } from '@nrwl/devkit';
 

--- a/packages/angular/src/generators/setup-mfe/lib/get-remotes-with-ports.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/get-remotes-with-ports.ts
@@ -4,10 +4,10 @@ import type { Schema } from '../schema';
 import { readProjectConfiguration } from '@nrwl/devkit';
 
 export function getRemotesWithPorts(host: Tree, options: Schema) {
-  // If type is shell and remotes supplied, check remotes exist
+  // If type is host and remotes supplied, check remotes exist
   const remotesWithPort: { remoteName: string; port: number }[] = [];
   if (
-    options.mfeType === 'shell' &&
+    options.mfeType === 'host' &&
     Array.isArray(options.remotes) &&
     options.remotes.length > 0
   ) {

--- a/packages/angular/src/generators/setup-mfe/schema.d.ts
+++ b/packages/angular/src/generators/setup-mfe/schema.d.ts
@@ -1,6 +1,6 @@
 export interface Schema {
   appName: string;
-  mfeType: 'shell' | 'remote';
+  mfeType: 'host' | 'remote';
   port?: number;
   remotes?: string[];
   skipFormat?: boolean;

--- a/packages/angular/src/generators/setup-mfe/schema.json
+++ b/packages/angular/src/generators/setup-mfe/schema.json
@@ -17,7 +17,7 @@
     },
     "mfeType": {
       "type": "string",
-      "enum": ["shell", "remote"],
+      "enum": ["host", "remote"],
       "description": "Type of application to generate the Module Federation configuration for.",
       "default": "remote"
     },
@@ -27,7 +27,7 @@
     },
     "remotes": {
       "type": "array",
-      "description": "A list of remote application names that the shell application should consume."
+      "description": "A list of remote application names that the host application should consume."
     },
     "skipFormat": {
       "type": "boolean",

--- a/packages/angular/src/generators/setup-mfe/setup-mfe.spec.ts
+++ b/packages/angular/src/generators/setup-mfe/setup-mfe.spec.ts
@@ -18,11 +18,11 @@ describe('Init MFE', () => {
   });
 
   test.each([
-    ['app1', 'shell'],
+    ['app1', 'host'],
     ['remote1', 'remote'],
   ])(
     'should create webpack configs correctly',
-    async (app, type: 'shell' | 'remote') => {
+    async (app, type: 'host' | 'remote') => {
       // ACT
       await setupMfe(host, {
         appName: app,
@@ -42,11 +42,11 @@ describe('Init MFE', () => {
   );
 
   test.each([
-    ['app1', 'shell'],
+    ['app1', 'host'],
     ['remote1', 'remote'],
   ])(
     'create bootstrap file with the contents of main.ts',
-    async (app, type: 'shell' | 'remote') => {
+    async (app, type: 'host' | 'remote') => {
       // ARRANGE
       const mainContents = host.read(`apps/${app}/src/main.ts`, 'utf-8');
 
@@ -69,11 +69,11 @@ describe('Init MFE', () => {
   );
 
   test.each([
-    ['app1', 'shell'],
+    ['app1', 'host'],
     ['remote1', 'remote'],
   ])(
     'should alter main.ts to import the bootstrap file dynamically',
-    async (app, type: 'shell' | 'remote') => {
+    async (app, type: 'host' | 'remote') => {
       // ARRANGE
       const mainContents = host.read(`apps/${app}/src/main.ts`, 'utf-8');
 
@@ -94,11 +94,11 @@ describe('Init MFE', () => {
   );
 
   test.each([
-    ['app1', 'shell'],
+    ['app1', 'host'],
     ['remote1', 'remote'],
   ])(
     'should change the build target and set correct path to webpack config',
-    async (app, type: 'shell' | 'remote') => {
+    async (app, type: 'host' | 'remote') => {
       // ACT
       await setupMfe(host, {
         appName: app,
@@ -116,11 +116,11 @@ describe('Init MFE', () => {
   );
 
   test.each([
-    ['app1', 'shell'],
+    ['app1', 'host'],
     ['remote1', 'remote'],
   ])(
     'should install @angular-architects/module-federation in the monorepo',
-    async (app, type: 'shell' | 'remote') => {
+    async (app, type: 'host' | 'remote') => {
       // ACT
       await setupMfe(host, {
         appName: app,
@@ -136,11 +136,11 @@ describe('Init MFE', () => {
     }
   );
 
-  it('should add the remote config to the shell when --remotes flag supplied', async () => {
+  it('should add the remote config to the host when --remotes flag supplied', async () => {
     // ACT
     await setupMfe(host, {
       appName: 'app1',
-      mfeType: 'shell',
+      mfeType: 'host',
       remotes: ['remote1'],
     });
 
@@ -151,11 +151,11 @@ describe('Init MFE', () => {
       '"remote1": "remote1@http://localhost:4200/remoteEntry.js"'
     );
   });
-  it('should update the implicit dependencies of the shell when --remotes flag supplied', async () => {
+  it('should update the implicit dependencies of the host when --remotes flag supplied', async () => {
     // ACT
     await setupMfe(host, {
       appName: 'app1',
-      mfeType: 'shell',
+      mfeType: 'host',
       remotes: ['remote1'],
     });
 


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Previously, naming convention of consuming applications for MFEs was `shell`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Change it to match Webpack Module Federation's naming convention of calling it `host`.


## BREAKING CHANGE:
The `mfeType` options have changed from `shell | remote` to `host | remote`.
