### PR TITLE
fix(storybook): add cssmodule and image typings for React Storybook setup

### DIFF
--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -60,6 +60,12 @@
       "cli": "nx",
       "description": "Install the @storybook/addon-essentials package",
       "factory": "./src/migrations/update-12-5-0/install-addon-essentials"
+    },
+    "update-12-5-9-beta.1": {
+      "version": "12.5.9-beta.1",
+      "cli": "nx",
+      "description": "Update Storybook React typings in tsconfig files",
+      "factory": "./src/migrations/update-12-5-9/update-storybook-react-typings"
     }
   },
   "packageJsonUpdates": {

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -128,7 +128,9 @@ function createProjectStorybookDir(
   const { root, projectType } = readProjectConfiguration(tree, projectName);
   const projectDirectory = projectType === 'application' ? 'app' : 'lib';
 
-  if (tree.exists(join(root, '.storybook'))) {
+  const storybookRoot = join(root, '.storybook');
+
+  if (tree.exists(storybookRoot)) {
     return;
   }
 

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
@@ -4,6 +4,12 @@
     "emitDecoratorMetadata": true
     <% if(uiFramework === '@storybook/react') { %>, "outDir": "" <% } %>
   },
+  <% if(uiFramework === '@storybook/react') { %>
+  "files": [
+    "<%= offsetFromRoot %>node_modules/@nrwl/react/typings/cssmodule.d.ts",
+    "<%= offsetFromRoot %>node_modules/@nrwl/react/typings/image.d.ts"
+  ],
+  <% } %>
   "exclude": ["../**/*.spec.ts" <% if(uiFramework === '@storybook/react') { %>, "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx"<% } %>],
   "include": ["../src/**/*", "*.js"]
 }

--- a/packages/storybook/src/migrations/update-12-5-9/__snapshots__/update-storybook-react-typings.spec.ts.snap
+++ b/packages/storybook/src/migrations/update-12-5-9/__snapshots__/update-storybook-react-typings.spec.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Adjust Storybook React Typings in Storybook tsconfig should add outDir to the storybook tsconfig to avoid VSCode errors 1`] = `
+Object {
+  "compilerOptions": Object {
+    "emitDecoratorMetadata": true,
+  },
+  "extends": "../tsconfig.json",
+  "files": Array [
+    "../../../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+    "../../../../node_modules/@nrwl/react/typings/image.d.ts",
+  ],
+}
+`;

--- a/packages/storybook/src/migrations/update-12-5-9/update-storybook-react-typings.spec.ts
+++ b/packages/storybook/src/migrations/update-12-5-9/update-storybook-react-typings.spec.ts
@@ -1,0 +1,50 @@
+import { readJson, Tree, writeJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import addReactTypings from './update-storybook-react-typings';
+
+describe('Adjust Storybook React Typings in Storybook tsconfig', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+
+    writeJson(tree, 'workspace.json', {
+      projects: {
+        ['home-ui-react']: {
+          projectType: 'library',
+          root: 'libs/home/ui-react',
+          sourceRoot: 'libs/home/ui-react/src',
+          targets: {
+            storybook: {
+              builder: '@nrwl/storybook:storybook',
+              options: {
+                uiFramework: '@storybook/react',
+                port: 4400,
+                config: {
+                  configFolder: 'libs/home/ui-react/.storybook',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    writeJson(tree, 'libs/home/ui-react/.storybook/tsconfig.json', {
+      extends: '../tsconfig.json',
+      compilerOptions: {
+        emitDecoratorMetadata: true,
+      },
+    });
+  });
+
+  it(`should add outDir to the storybook tsconfig to avoid VSCode errors`, async () => {
+    await addReactTypings(tree);
+
+    const tsConfigContent = readJson(
+      tree,
+      'libs/home/ui-react/.storybook/tsconfig.json'
+    );
+    expect(tsConfigContent).toMatchSnapshot();
+  });
+});

--- a/packages/storybook/src/migrations/update-12-5-9/update-storybook-react-typings.ts
+++ b/packages/storybook/src/migrations/update-12-5-9/update-storybook-react-typings.ts
@@ -1,0 +1,76 @@
+import {
+  formatFiles,
+  getProjects,
+  joinPathFragments,
+  logger,
+  offsetFromRoot,
+  readJson,
+  Tree,
+  writeJson,
+} from '@nrwl/devkit';
+import * as path from 'path';
+import { isFramework, TsConfig } from '../../utils/utilities';
+
+export default async function addReactTypings(tree: Tree) {
+  let changesMade = false;
+  const projects = getProjects(tree);
+
+  projects.forEach((projectConfig, projectName) => {
+    const targets = projectConfig.targets;
+    const storybookRoot = path.join(projectConfig.root, '.storybook');
+
+    const paths = {
+      tsConfigStorybook: joinPathFragments(
+        projectConfig.root,
+        '.storybook/tsconfig.json'
+      ),
+    };
+
+    const storybookExecutor = Object.keys(targets).find(
+      (x) => targets[x].executor === '@nrwl/storybook:storybook'
+    );
+
+    const hasStorybookConfig =
+      storybookExecutor && tree.exists(paths.tsConfigStorybook);
+
+    if (!hasStorybookConfig) {
+      logger.info(
+        `${projectName}: no storybook configured. skipping migration...`
+      );
+      return;
+    }
+
+    const isReactProject = isFramework('react', {
+      uiFramework: targets[storybookExecutor].options
+        ?.uiFramework as Parameters<typeof isFramework>[1]['uiFramework'],
+    });
+
+    if (isReactProject) {
+      const tsConfig = {
+        storybook: readJson<TsConfig>(tree, paths.tsConfigStorybook),
+      };
+
+      tsConfig.storybook.files = tsConfig.storybook.files || [];
+      tsConfig.storybook.files = uniqueArray([
+        ...tsConfig.storybook.files,
+        `${offsetFromRoot(
+          storybookRoot
+        )}node_modules/@nrwl/react/typings/cssmodule.d.ts`,
+        `${offsetFromRoot(
+          storybookRoot
+        )}node_modules/@nrwl/react/typings/image.d.ts`,
+      ]);
+
+      writeJson(tree, paths.tsConfigStorybook, tsConfig.storybook);
+      changesMade = true;
+    }
+  });
+
+  if (changesMade) {
+    await formatFiles(tree);
+  }
+}
+
+function uniqueArray<T extends Array<any>>(value: T) {
+  return [...new Set(value)] as T;
+}

--- a/packages/storybook/src/utils/utilities.ts
+++ b/packages/storybook/src/utils/utilities.ts
@@ -51,6 +51,7 @@ export function safeFileDelete(tree: Tree, path: string): boolean {
 export type TsConfig = {
   extends: string;
   compilerOptions: CompilerOptions;
+  files?: string[];
   include?: string[];
   exclude?: string[];
   references?: Array<{ path: string }>;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Right now there's TypeScript warnings which might even result in errors (depending on the Storybook config) when running Storybook with CSS modules in React

![image](https://user-images.githubusercontent.com/542458/125638584-a6796723-8916-4ceb-8183-ebc2095212dd.png)

## Expected Behavior

This PR adds the necessary typings to the storybook tsconfig
