### PR TITLE
fix(nxdev): fixing sidbar appearance with anchored links

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/sidebar.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/sidebar.tsx
@@ -123,7 +123,7 @@ function SidebarSectionItems({ item }: { item: MenuItem }) {
   }, [collapsed, setCollapsed, item]);
 
   function withoutAnchors(linkText: string): string {
-    return linkText.includes('#')
+    return linkText?.includes('#')
       ? linkText.substring(0, linkText.indexOf('#'))
       : linkText;
   }

--- a/nx-dev/feature-doc-viewer/src/lib/sidebar.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/sidebar.tsx
@@ -122,6 +122,12 @@ function SidebarSectionItems({ item }: { item: MenuItem }) {
     }
   }, [collapsed, setCollapsed, item]);
 
+  function withoutAnchors(linkText: string): string {
+    return linkText.includes('#')
+      ? linkText.substring(0, linkText.indexOf('#'))
+      : linkText;
+  }
+
   return (
     <>
       <h5
@@ -140,7 +146,7 @@ function SidebarSectionItems({ item }: { item: MenuItem }) {
       </h5>
       <ul className={cx('mb-6', collapsed ? 'hidden' : '')}>
         {item.itemList.map((item) => {
-          const isActiveLink = item.path === router?.asPath;
+          const isActiveLink = item.path === withoutAnchors(router?.asPath);
           return (
             <li key={item.id} data-testid={`section-li:${item.id}`}>
               <Link href={item.path}>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Entering into nx.dev via an anchored link (e.g.: https://nx.dev/latest/react/getting-started/intro#some-anchor) will cause the active link in the side-menu to get garbled.

<img width="341" alt="Screen Shot 2021-07-14 at 9 55 58 AM" src="https://user-images.githubusercontent.com/3788405/125662877-5bce4e4e-d02d-4a0a-a55c-93ee36ec6667.png">

(Server and client are at odds as the server doesn't get the anchor in it's router object, so it ends up trying to combine the text and the active link indicator `<span>`s.)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Sidebar links should look correct when entering nx.dev via an anchored link.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

![](https://files.slack.com/files-pri/T3ACEGMLK-F028S924Z5W/screen_shot_2021-07-14_at_9.55.58_am.png)
