### PR TITLE
feat(angular): use webpack-server executor for mfe apps

### DIFF
--- a/packages/angular/src/generators/setup-mfe/lib/setup-serve-target.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/setup-serve-target.ts
@@ -7,9 +7,14 @@ import {
 } from '@nrwl/devkit';
 
 export function setupServeTarget(host: Tree, options: Schema) {
-  if (options.mfeType === 'remote') {
-    const appConfig = readProjectConfiguration(host, options.appName);
+  const appConfig = readProjectConfiguration(host, options.appName);
 
+  appConfig.targets['serve'] = {
+    ...appConfig.targets['serve'],
+    executor: '@nrwl/angular:webpack-server',
+  };
+
+  if (options.mfeType === 'remote') {
     const port = options.port ?? 4200;
 
     appConfig.targets['mfe-serve'] = {
@@ -19,7 +24,6 @@ export function setupServeTarget(host: Tree, options: Schema) {
         port,
       },
     };
-
-    updateProjectConfiguration(host, options.appName, appConfig);
   }
+  updateProjectConfiguration(host, options.appName, appConfig);
 }

--- a/packages/angular/src/generators/setup-mfe/setup-mfe.spec.ts
+++ b/packages/angular/src/generators/setup-mfe/setup-mfe.spec.ts
@@ -97,7 +97,7 @@ describe('Init MFE', () => {
     ['app1', 'host'],
     ['remote1', 'remote'],
   ])(
-    'should change the build target and set correct path to webpack config',
+    'should change the build and serve target and set correct path to webpack config',
     async (app, type: 'host' | 'remote') => {
       // ACT
       await setupMfe(host, {
@@ -106,8 +106,9 @@ describe('Init MFE', () => {
       });
 
       // ASSERT
-      const { build } = readProjectConfiguration(host, app).targets;
+      const { build, serve } = readProjectConfiguration(host, app).targets;
 
+      expect(serve.executor).toEqual('@nrwl/angular:webpack-server');
       expect(build.executor).toEqual('@nrwl/angular:webpack-browser');
       expect(build.options.customWebpackConfig.path).toEqual(
         `apps/${app}/webpack.config.js`


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Angular Devkit's dev-server overwrites the webpack.config meaning MFE apps do not serve correctly

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use webpack-server for MFE angular apps as it will merge the webpack configs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
