### PR TITLE
fix(core): end tasks after cache is written

### DIFF
--- a/packages/workspace/src/tasks-runner/task-orchestrator.ts
+++ b/packages/workspace/src/tasks-runner/task-orchestrator.ts
@@ -348,24 +348,6 @@ export class TaskOrchestrator {
       this.storeEndTime(task);
     }
 
-    if ('endTasks' in this.options.lifeCycle) {
-      this.options.lifeCycle.endTasks(
-        results.map((result) => {
-          const code =
-            result.status === 'success' || result.status === 'cache' ? 0 : 1;
-          return {
-            task: result.task,
-            code,
-          };
-        })
-      );
-    } else {
-      for (const { task, status } of results) {
-        const code = status === 'success' || status === 'cache' ? 0 : 1;
-        this.options.lifeCycle.endTask(task, code);
-      }
-    }
-
     // cache the results
     await Promise.all(
       results
@@ -389,6 +371,24 @@ export class TaskOrchestrator {
           }
         })
     );
+
+    if ('endTasks' in this.options.lifeCycle) {
+      this.options.lifeCycle.endTasks(
+        results.map((result) => {
+          const code =
+            result.status === 'success' || result.status === 'cache' ? 0 : 1;
+          return {
+            task: result.task,
+            code,
+          };
+        })
+      );
+    } else {
+      for (const { task, status } of results) {
+        const code = status === 'success' || status === 'cache' ? 0 : 1;
+        this.options.lifeCycle.endTask(task, code);
+      }
+    }
 
     this.complete(
       results.map(({ task, status }) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cache is written after the life cycle ends the task which means Nx cloud cannot read the outputs.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Cache is written before the life cycle ends the task which means Nx cloud properly reads the outputs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
