### PR TITLE
fix(angular): add --skip-format for convert-tslint-to-eslint

### DIFF
--- a/docs/angular/api-angular/generators/convert-tslint-to-eslint.md
+++ b/docs/angular/api-angular/generators/convert-tslint-to-eslint.md
@@ -65,3 +65,11 @@ Default: `true`
 Type: `boolean`
 
 If this conversion leaves no more TSLint usage in the workspace, it will remove TSLint and related dependencies and configuration.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.

--- a/docs/angular/api-nest/generators/convert-tslint-to-eslint.md
+++ b/docs/angular/api-nest/generators/convert-tslint-to-eslint.md
@@ -53,3 +53,11 @@ Default: `true`
 Type: `boolean`
 
 If this conversion leaves no more TSLint usage in the workspace, it will remove TSLint and related dependencies and configuration.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.

--- a/docs/node/api-angular/generators/convert-tslint-to-eslint.md
+++ b/docs/node/api-angular/generators/convert-tslint-to-eslint.md
@@ -65,3 +65,11 @@ Default: `true`
 Type: `boolean`
 
 If this conversion leaves no more TSLint usage in the workspace, it will remove TSLint and related dependencies and configuration.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.

--- a/docs/node/api-nest/generators/convert-tslint-to-eslint.md
+++ b/docs/node/api-nest/generators/convert-tslint-to-eslint.md
@@ -53,3 +53,11 @@ Default: `true`
 Type: `boolean`
 
 If this conversion leaves no more TSLint usage in the workspace, it will remove TSLint and related dependencies and configuration.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.

--- a/docs/react/api-angular/generators/convert-tslint-to-eslint.md
+++ b/docs/react/api-angular/generators/convert-tslint-to-eslint.md
@@ -65,3 +65,11 @@ Default: `true`
 Type: `boolean`
 
 If this conversion leaves no more TSLint usage in the workspace, it will remove TSLint and related dependencies and configuration.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.

--- a/docs/react/api-nest/generators/convert-tslint-to-eslint.md
+++ b/docs/react/api-nest/generators/convert-tslint-to-eslint.md
@@ -53,3 +53,11 @@ Default: `true`
 Type: `boolean`
 
 If this conversion leaves no more TSLint usage in the workspace, it will remove TSLint and related dependencies and configuration.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.

--- a/packages/angular/src/generators/add-linting/add-linting.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.ts
@@ -14,7 +14,10 @@ export async function addLintingGenerator(
   addAngularEsLintDependencies(tree);
   createEsLintConfiguration(tree, options);
   addProjectLintTarget(tree, options);
-  await formatFiles(tree);
+
+  if (!options.skipFormat) {
+    await formatFiles(tree);
+  }
 
   return installTask;
 }

--- a/packages/angular/src/generators/add-linting/schema.d.ts
+++ b/packages/angular/src/generators/add-linting/schema.d.ts
@@ -3,4 +3,5 @@ export interface AddLintingGeneratorSchema {
   projectRoot: string;
   prefix: string;
   setParserOptionsProject?: boolean;
+  skipFormat?: boolean;
 }

--- a/packages/angular/src/generators/add-linting/schema.json
+++ b/packages/angular/src/generators/add-linting/schema.json
@@ -22,6 +22,11 @@
       "type": "boolean",
       "description": "Whether or not to configure the ESLint `parserOptions.project` option. We do not do this by default for lint performance reasons.",
       "default": false
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "description": "Skip formatting files.",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -39,6 +39,7 @@ export async function conversionGenerator(
          * does and remove the config again if it doesn't, so that it is most efficient.
          */
         setParserOptionsProject: true,
+        skipFormat: options.skipFormat,
       });
     },
   });
@@ -103,6 +104,7 @@ export async function conversionGenerator(
          * step of this parent generator, if applicable
          */
         removeTSLintIfNoMoreTSLintTargets: false,
+        skipFormat: options.skipFormat,
       });
     } catch {
       logger.warn(
@@ -122,7 +124,9 @@ export async function conversionGenerator(
     uninstallTSLintTask = projectConverter.removeTSLintFromWorkspace();
   }
 
-  await formatFiles(host);
+  if (!options.skipFormat) {
+    await formatFiles(host);
+  }
 
   return async () => {
     await eslintInitInstallTask();

--- a/packages/angular/src/generators/convert-tslint-to-eslint/schema.json
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/schema.json
@@ -40,6 +40,11 @@
       "description": "If this conversion leaves no more TSLint usage in the workspace, it will remove TSLint and related dependencies and configuration.",
       "default": true,
       "x-prompt": "Would you like to remove TSLint and its related config if there are no TSLint projects remaining after this conversion?"
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "description": "Skip formatting files.",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/cypress/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/cypress/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -40,6 +40,7 @@ export async function conversionGenerator(
          * does and remove the config again if it doesn't, so that it is most efficient.
          */
         setParserOptionsProject: true,
+        skipFormat: options.skipFormat,
       } as CypressProjectSchema);
     },
   });
@@ -96,7 +97,9 @@ export async function conversionGenerator(
     uninstallTSLintTask = projectConverter.removeTSLintFromWorkspace();
   }
 
-  await formatFiles(host);
+  if (!options.skipFormat) {
+    await formatFiles(host);
+  }
 
   return async () => {
     await eslintInitInstallTask();

--- a/packages/cypress/src/generators/convert-tslint-to-eslint/schema.json
+++ b/packages/cypress/src/generators/convert-tslint-to-eslint/schema.json
@@ -32,6 +32,11 @@
       "description": "If this conversion leaves no more TSLint usage in the workspace, it will remove TSLint and related dependencies and configuration",
       "default": true,
       "x-prompt": "Would you like to remove TSLint and its related config if there are no TSLint projects remaining after this conversion?"
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "description": "Skip formatting files.",
+      "default": false
     }
   },
   "required": ["project"]

--- a/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.ts
@@ -35,6 +35,7 @@ export interface ConvertTSLintToESLintSchema {
   // If true, we are effectively just "resetting" to ESLint, rather than converting from TSLint
   ignoreExistingTslintConfig: boolean;
   removeTSLintIfNoMoreTSLintTargets: boolean;
+  skipFormat?: boolean;
 }
 
 /**

--- a/packages/nest/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/nest/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -54,6 +54,7 @@ export async function conversionGenerator(
           js,
           setParserOptionsProject,
           parsedTags: [],
+          skipFormat: options.skipFormat,
         } as AddLintForApplicationSchema);
       }
 
@@ -67,6 +68,7 @@ export async function conversionGenerator(
           projectDirectory: '',
           fileName: '',
           parsedTags: [],
+          skipFormat: options.skipFormat,
         } as AddLintForLibrarySchema);
       }
     },
@@ -124,7 +126,9 @@ export async function conversionGenerator(
     uninstallTSLintTask = projectConverter.removeTSLintFromWorkspace();
   }
 
-  await formatFiles(host);
+  if (!options.skipFormat) {
+    await formatFiles(host);
+  }
 
   return async () => {
     await eslintInitInstallTask();

--- a/packages/nest/src/generators/convert-tslint-to-eslint/schema.json
+++ b/packages/nest/src/generators/convert-tslint-to-eslint/schema.json
@@ -32,6 +32,11 @@
       "type": "boolean",
       "default": true,
       "x-prompt": "Would you like to remove TSLint and its related config if there are no TSLint projects remaining after this conversion?"
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "description": "Skip formatting files.",
+      "default": false
     }
   },
   "required": ["project"]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Users cannot skip formatting when calling `convert-tslint-to-eslint` which makes it hard to use in a `workspace-generator` since it will take forever.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Users can skip formatting when calling `convert-tslint-to-eslint` which makes it easy and fast to use in a `workspace-generator`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
