### PR TITLE
fix(devkit): do not update unknown properties to workspace configuration

### DIFF
--- a/packages/devkit/src/generators/project-configuration.spec.ts
+++ b/packages/devkit/src/generators/project-configuration.spec.ts
@@ -5,6 +5,9 @@ import {
   updateProjectConfiguration,
   removeProjectConfiguration,
   getProjects,
+  readWorkspaceConfiguration,
+  WorkspaceConfiguration,
+  updateWorkspaceConfiguration,
 } from './project-configuration';
 import { createTreeWithEmptyWorkspace } from '../tests/create-tree-with-empty-workspace';
 import { ProjectConfiguration } from '@nrwl/tao/src/shared/workspace';
@@ -23,115 +26,149 @@ describe('project configuration', () => {
     tree = createTreeWithEmptyWorkspace();
   });
 
-  it('should create project.json file when adding a project if standalone is true', () => {
-    addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
+  describe('addProjectConfiguration', () => {
+    it('should create project.json file when adding a project if standalone is true', () => {
+      addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
 
-    expect(tree.exists('libs/test/project.json')).toBeTruthy();
-  });
+      expect(tree.exists('libs/test/project.json')).toBeTruthy();
+    });
 
-  it('should create project.json file if all other apps in the workspace use project.json', () => {
-    addProjectConfiguration(
-      tree,
-      'project-a',
-      {
+    it('should create project.json file if all other apps in the workspace use project.json', () => {
+      addProjectConfiguration(
+        tree,
+        'project-a',
+        {
+          root: 'apps/project-a',
+          targets: {},
+        },
+        true
+      );
+      addProjectConfiguration(
+        tree,
+        'project-b',
+        {
+          root: 'apps/project-b',
+          targets: {},
+        },
+        true
+      );
+      expect(tree.exists('apps/project-b/project.json')).toBeTruthy();
+    });
+
+    it("should not create project.json file if any other app in the workspace doesn't use project.json", () => {
+      addProjectConfiguration(tree, 'project-a', {
         root: 'apps/project-a',
         targets: {},
-      },
-      true
-    );
-    addProjectConfiguration(
-      tree,
-      'project-b',
-      {
+      });
+      addProjectConfiguration(tree, 'project-b', {
         root: 'apps/project-b',
         targets: {},
-      },
-      true
-    );
-    expect(tree.exists('apps/project-b/project.json')).toBeTruthy();
-  });
-
-  it("should not create project.json file if any other app in the workspace doesn't use project.json", () => {
-    addProjectConfiguration(tree, 'project-a', {
-      root: 'apps/project-a',
-      targets: {},
+      });
+      expect(tree.exists('apps/project-a/project.json')).toBeFalsy();
+      expect(tree.exists('apps/project-b/project.json')).toBeFalsy();
     });
-    addProjectConfiguration(tree, 'project-b', {
-      root: 'apps/project-b',
-      targets: {},
+
+    it('should not create project.json file when adding a project if standalone is false', () => {
+      addProjectConfiguration(tree, 'test', baseTestProjectConfig, false);
+
+      expect(tree.exists('libs/test/project.json')).toBeFalsy();
     });
-    expect(tree.exists('apps/project-a/project.json')).toBeFalsy();
-    expect(tree.exists('apps/project-b/project.json')).toBeFalsy();
-  });
 
-  it('should not create project.json file when adding a project if standalone is false', () => {
-    addProjectConfiguration(tree, 'test', baseTestProjectConfig, false);
-
-    expect(tree.exists('libs/test/project.json')).toBeFalsy();
-  });
-
-  it('should be able to read from standalone projects', () => {
-    tree.write(
-      'libs/test/project.json',
-      JSON.stringify(baseTestProjectConfig, null, 2)
-    );
-    tree.write(
-      'workspace.json',
-      JSON.stringify(
-        {
-          projects: {
-            test: 'libs/test',
+    it('should be able to read from standalone projects', () => {
+      tree.write(
+        'libs/test/project.json',
+        JSON.stringify(baseTestProjectConfig, null, 2)
+      );
+      tree.write(
+        'workspace.json',
+        JSON.stringify(
+          {
+            projects: {
+              test: 'libs/test',
+            },
           },
-        },
-        null,
-        2
-      )
-    );
+          null,
+          2
+        )
+      );
 
-    const projectConfig = readProjectConfiguration(tree, 'test');
+      const projectConfig = readProjectConfiguration(tree, 'test');
 
-    expect(projectConfig).toEqual(baseTestProjectConfig);
+      expect(projectConfig).toEqual(baseTestProjectConfig);
+    });
+
+    it('should update project.json file when updating a project', () => {
+      addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
+      const expectedProjectConfig = {
+        ...baseTestProjectConfig,
+        targets: { build: { executor: '' } },
+      };
+      updateProjectConfiguration(tree, 'test', expectedProjectConfig);
+
+      expect(readJson(tree, 'libs/test/project.json')).toEqual(
+        expectedProjectConfig
+      );
+    });
+
+    it('should update workspace.json file when updating an inline project', () => {
+      addProjectConfiguration(tree, 'test', baseTestProjectConfig, false);
+      const expectedProjectConfig = {
+        ...baseTestProjectConfig,
+        targets: { build: { executor: '' } },
+      };
+      updateProjectConfiguration(tree, 'test', expectedProjectConfig);
+
+      expect(readJson(tree, 'workspace.json').projects.test).toEqual(
+        expectedProjectConfig
+      );
+    });
+
+    it('should remove project.json file when removing project configuration', () => {
+      addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
+      removeProjectConfiguration(tree, 'test');
+
+      expect(readJson(tree, 'workspace.json').projects.test).toBeUndefined();
+      expect(tree.exists('test/project.json')).toBeFalsy();
+    });
+
+    it('should support workspaces with standalone and inline projects', () => {
+      addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
+      addProjectConfiguration(tree, 'test2', baseTestProjectConfig, false);
+      const configurations = getProjects(tree);
+      expect(configurations.get('test')).toEqual(baseTestProjectConfig);
+      expect(configurations.get('test2')).toEqual(baseTestProjectConfig);
+    });
   });
 
-  it('should update project.json file when updating a project', () => {
-    addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
-    const expectedProjectConfig = {
-      ...baseTestProjectConfig,
-      targets: { build: { executor: '' } },
-    };
-    updateProjectConfiguration(tree, 'test', expectedProjectConfig);
+  describe('updateWorkspaceConfiguration', () => {
+    let workspaceConfiguration: WorkspaceConfiguration;
+    beforeEach(() => {
+      workspaceConfiguration = readWorkspaceConfiguration(tree);
+    });
 
-    expect(readJson(tree, 'libs/test/project.json')).toEqual(
-      expectedProjectConfig
-    );
-  });
+    it('should update properties in workspace.json', () => {
+      workspaceConfiguration.version = 3;
 
-  it('should update workspace.json file when updating an inline project', () => {
-    addProjectConfiguration(tree, 'test', baseTestProjectConfig, false);
-    const expectedProjectConfig = {
-      ...baseTestProjectConfig,
-      targets: { build: { executor: '' } },
-    };
-    updateProjectConfiguration(tree, 'test', expectedProjectConfig);
+      updateWorkspaceConfiguration(tree, workspaceConfiguration);
 
-    expect(readJson(tree, 'workspace.json').projects.test).toEqual(
-      expectedProjectConfig
-    );
-  });
+      expect(readJson(tree, 'workspace.json').version).toEqual(3);
+    });
 
-  it('should remove project.json file when removing project configuration', () => {
-    addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
-    removeProjectConfiguration(tree, 'test');
+    it('should update properties in nx.json', () => {
+      workspaceConfiguration.npmScope = 'new-npmScope';
 
-    expect(readJson(tree, 'workspace.json').projects.test).toBeUndefined();
-    expect(tree.exists('test/project.json')).toBeFalsy();
-  });
+      updateWorkspaceConfiguration(tree, workspaceConfiguration);
 
-  it('should support workspaces with standalone and inline projects', () => {
-    addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
-    addProjectConfiguration(tree, 'test2', baseTestProjectConfig, false);
-    const configurations = getProjects(tree);
-    expect(configurations.get('test')).toEqual(baseTestProjectConfig);
-    expect(configurations.get('test2')).toEqual(baseTestProjectConfig);
+      expect(readJson(tree, 'nx.json').npmScope).toEqual('new-npmScope');
+    });
+
+    it('should not update unknown properties', () => {
+      workspaceConfiguration['$schema'] = 'schema';
+
+      updateWorkspaceConfiguration(tree, workspaceConfiguration);
+
+      expect(readJson(tree, 'workspace.json').$schema).not.toBeDefined();
+      expect(readJson(tree, 'nx.json').$schema).not.toBeDefined();
+    });
   });
 });

--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -126,13 +126,36 @@ export function updateWorkspaceConfiguration(
   host: Tree,
   workspaceConfig: WorkspaceConfiguration
 ): void {
-  const { version, cli, defaultProject, generators, ...nxJson } =
-    workspaceConfig;
+  const {
+    // Angular Json Properties
+    version,
+    cli,
+    defaultProject,
+    generators,
+
+    // Nx Json Properties
+    implicitDependencies,
+    plugins,
+    npmScope,
+    targetDependencies,
+    workspaceLayout,
+    tasksRunnerOptions,
+    affected,
+  } = workspaceConfig;
   const workspace: Omit<Required<WorkspaceJsonConfiguration>, 'projects'> = {
     version,
     cli,
     defaultProject,
     generators,
+  };
+  const nxJson: Omit<Required<NxJsonConfiguration>, 'projects'> = {
+    implicitDependencies,
+    plugins,
+    npmScope,
+    targetDependencies,
+    workspaceLayout,
+    tasksRunnerOptions,
+    affected,
   };
 
   updateJson<WorkspaceJsonConfiguration>(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When properties such as `$schema` are in `workspace.json` they get copied over to `nx.json` when updating workspace configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Properties such as `$schema` should not be copied from `workspace.json` to `nx.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
