### PR TITLE
fix(react): ensure version of webpack is updated when running migrate…

### DIFF
--- a/packages/web/src/generators/migrate-to-webpack-5/migrate-to-webpack-5.ts
+++ b/packages/web/src/generators/migrate-to-webpack-5/migrate-to-webpack-5.ts
@@ -3,6 +3,7 @@ import {
   addDependenciesToPackageJson,
   convertNxGenerator,
   logger,
+  removeDependenciesFromPackageJson,
 } from '@nrwl/devkit';
 
 const webpack5Packages = {
@@ -19,6 +20,8 @@ const webpack5Packages = {
 
 export async function webMigrateToWebpack5Generator(tree: Tree, schema: {}) {
   logger.info(`NX Adding webpack 5 to workspace.`);
+  // Removing the packages ensures that the versions will be updated when adding them after
+  removeDependenciesFromPackageJson(tree, [], Object.keys(webpack5Packages));
   return addDependenciesToPackageJson(tree, {}, webpack5Packages);
 }
 


### PR DESCRIPTION
…-to-webpack-5

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If `webpack` is already installed in the workspace, running `nx g @nrwl/web:migrate-to-webpack-5` will not actually update the version.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

If `webpack` is already installed in the workspace, running `nx g @nrwl/web:migrate-to-webpack-5` will update the version appropriately.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
