### PR TITLE
fix(doc):  corrected doc for adding angular app step with both react and angular are together

### DIFF
--- a/docs/angular/examples/react-and-angular.md
+++ b/docs/angular/examples/react-and-angular.md
@@ -18,8 +18,14 @@ npx --ignore-existing create-nx-workspace happynrwl --preset=empty
 
 An empty workspace does not have any capabilities to create applications. Add capabilities for Angular development via:
 
+First add @angular/cli using
 ```bash
-ng add @nrwl/angular
+npm i -D @angular/cli
+```
+
+Then run
+```bash
+nx add @nrwl/angular
 ```
 
 ## Creating an Angular Application
@@ -27,7 +33,7 @@ ng add @nrwl/angular
 An empty workspace has no application or libraries: nothing to run and nothing to test. Let's add an Angular application into it via:
 
 ```bash
-ng g @nrwl/angular:app angularapp
+nx g @nrwl/angular:app angularapp
 ```
 
 The result should look like this:

--- a/docs/angular/examples/react-and-angular.md
+++ b/docs/angular/examples/react-and-angular.md
@@ -19,11 +19,13 @@ npx --ignore-existing create-nx-workspace happynrwl --preset=empty
 An empty workspace does not have any capabilities to create applications. Add capabilities for Angular development via:
 
 First add @angular/cli using
+
 ```bash
 npm i -D @angular/cli
 ```
 
 Then run
+
 ```bash
 nx add @nrwl/angular
 ```

--- a/nx-dev/nx-dev/public/documentation/latest/angular/examples/react-and-angular.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/examples/react-and-angular.md
@@ -18,8 +18,16 @@ npx --ignore-existing create-nx-workspace happynrwl --preset=empty
 
 An empty workspace does not have any capabilities to create applications. Add capabilities for Angular development via:
 
+First add @angular/cli using
+
 ```bash
-ng add @nrwl/angular
+npm i -D @angular/cli
+```
+
+Then run
+
+```bash
+nx add @nrwl/angular
 ```
 
 ## Creating an Angular Application


### PR DESCRIPTION
If someone has angular cli installed and nx cli installed globally. Running `ng add @nrwl/angular` will pickup angular cli and throws error - 'The add command requires to be run in an Angular project, but a project definition could not be found'

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
Documentation correction