### PR TITLE
fix(testing): fixing formatting on root jest.config migration

### DIFF
--- a/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.spec.ts
+++ b/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.spec.ts
@@ -50,4 +50,37 @@ describe('update 12.6.0', () => {
       "
     `);
   });
+
+  test('proper formatting with multiple uncovered jest projects', async () => {
+    mockGetJestProjects.mockImplementation(() => ['<rootDir>/test-2']);
+    tree.write(
+      'jest.config.js',
+      `
+module.exports = {
+  projects: [
+    '<rootDir>/test-1',
+    '<rootDir>/test-2',
+    '<rootDir>/test-3',
+    '<rootDir>/test-4',
+    '<rootDir>/test-5'
+  ]
+}`
+    );
+    await update(tree);
+    const result = tree.read('jest.config.js').toString();
+    expect(result).toMatchInlineSnapshot(`
+"const { getJestProjects } = require('@nrwl/jest');
+
+module.exports = {
+  projects: [
+    ...getJestProjects(),
+    '<rootDir>/test-1',
+    '<rootDir>/test-3',
+    '<rootDir>/test-4',
+    '<rootDir>/test-5',
+  ],
+};
+"
+`);
+  });
 });

--- a/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.ts
+++ b/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.ts
@@ -22,7 +22,6 @@ function determineProjectsValue(uncoveredJestProjects: string[]): string {
   if (!uncoveredJestProjects.length) {
     return `getJestProjects()`;
   }
-  console.log(uncoveredJestProjects);
   return `[...getJestProjects(), ${uncoveredJestProjects
     .map((projectName) => `'${projectName}', `)
     .join('')}]`;

--- a/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.ts
+++ b/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.ts
@@ -22,9 +22,10 @@ function determineProjectsValue(uncoveredJestProjects: string[]): string {
   if (!uncoveredJestProjects.length) {
     return `getJestProjects()`;
   }
-  return `[...getJestProjects(), ${uncoveredJestProjects.map(
-    (projectName) => `'${projectName}', `
-  )}]`;
+  console.log(uncoveredJestProjects);
+  return `[...getJestProjects(), ${uncoveredJestProjects
+    .map((projectName) => `'${projectName}', `)
+    .join('')}]`;
 }
 
 function updateBaseJestConfig(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Formatting bug in the migration results in extra empty lines of commas:

```js
const { getJestProjects } = require('@nrwl/jest');
module.exports = {
  projects: [
    ...getJestProjects(),
    '<rootDir>/1',
    ,
    '<rootDir>/2',
    ,
    '<rootDir>/3',
    ,
    '<rootDir>/4',
    ,
    '<rootDir>/5'
  ],
};
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running the migration should format the file correctly:

```js
const { getJestProjects } = require('@nrwl/jest');
module.exports = {
  projects: [
    ...getJestProjects(),
    '<rootDir>/1',
    '<rootDir>/2',
    '<rootDir>/3',
    '<rootDir>/4',
    '<rootDir>/5'
  ],
};
```


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
