### PR TITLE
fix(core): ensure overrides are not parsed as head and base for affected

### DIFF
--- a/packages/workspace/src/command-line/utils.spec.ts
+++ b/packages/workspace/src/command-line/utils.spec.ts
@@ -120,7 +120,7 @@ describe('splitArgs', () => {
     const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides(
       {
         notNxArg: true,
-        _: ['sha1', 'sha2', '--override'],
+        _: ['affected', '--name', 'bob', 'sha1', 'sha2', '--override'],
         $0: '',
       },
       'affected'
@@ -134,6 +134,7 @@ describe('splitArgs', () => {
     expect(overrides).toEqual({
       notNxArg: true,
       override: true,
+      name: 'bob',
     });
   });
 

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -86,6 +86,9 @@ export function splitArgsIntoNxArgsAndOverrides(
       'strip-dashed': true,
     },
   });
+  // This removes the overrides from the nxArgs._
+  args._ = overrides._;
+
   delete overrides._;
 
   Object.entries(args).forEach(([key, value]) => {
@@ -135,10 +138,10 @@ export function splitArgsIntoNxArgsAndOverrides(
       !nxArgs.base &&
       !nxArgs.head &&
       !nxArgs.all &&
-      args._.length >= 2
+      args._.length >= 3
     ) {
-      nxArgs.base = args._[0] as string;
-      nxArgs.head = args._[1] as string;
+      nxArgs.base = args._[1] as string;
+      nxArgs.head = args._[2] as string;
     }
 
     // Allow setting base and head via environment variables (lower priority then direct command arguments)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When running `nx affected --target test -- --maxWorkers 2`, Nx parses the `--head` to be `--maxWorkers` and the `--base` to be `2` which is incorrect.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When running `nx affected --target test -- --maxWorkers 2`, Nx should use the default `--head` and `--base` while keeping `{ maxWorkers: 2 }` as overrides.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
