### PR TITLE
fix(core): move generator should respect non-relative extends parts

### DIFF
--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
@@ -62,7 +62,7 @@ describe('updateEslint', () => {
       readJson(tree, '/libs/shared/my-destination/.eslintrc.json')
     ).toEqual(
       expect.objectContaining({
-        extends: '../../../.eslintrc.json',
+        extends: ['../../../.eslintrc.json'],
       })
     );
   });

--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
@@ -1,4 +1,9 @@
-import { readJson, readProjectConfiguration, Tree } from '@nrwl/devkit';
+import {
+  readJson,
+  readProjectConfiguration,
+  Tree,
+  updateJson,
+} from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
 import { Linter } from '../../../utils/lint';
@@ -6,7 +11,6 @@ import { Linter } from '../../../utils/lint';
 import { Schema } from '../schema';
 import { updateEslintrcJson } from './update-eslintrc-json';
 import { libraryGenerator } from '../../library/library';
-import { executionAsyncId } from 'node:async_hooks';
 
 describe('updateEslint', () => {
   let tree: Tree;
@@ -59,6 +63,44 @@ describe('updateEslint', () => {
     ).toEqual(
       expect.objectContaining({
         extends: '../../../.eslintrc.json',
+      })
+    );
+  });
+
+  it('should preserve .eslintrc.json non-relative extends when project is moved to subdirectory', async () => {
+    await libraryGenerator(tree, {
+      name: 'my-lib',
+      linter: Linter.EsLint,
+      standaloneConfig: false,
+    });
+    updateJson(tree, 'libs/my-lib/.eslintrc.json', (eslintRcJson) => {
+      eslintRcJson.extends = [
+        'plugin:@nrwl/nx/react',
+        '../../.eslintrc.json',
+        './customrc.json',
+      ];
+      return eslintRcJson;
+    });
+
+    // This step is usually handled elsewhere
+    tree.rename(
+      'libs/my-lib/.eslintrc.json',
+      'libs/shared/my-destination/.eslintrc.json'
+    );
+
+    const projectConfig = readProjectConfiguration(tree, 'my-lib');
+
+    updateEslintrcJson(tree, schema, projectConfig);
+
+    expect(
+      readJson(tree, '/libs/shared/my-destination/.eslintrc.json')
+    ).toEqual(
+      expect.objectContaining({
+        extends: [
+          'plugin:@nrwl/nx/react',
+          '../../../.eslintrc.json',
+          './customrc.json',
+        ],
       })
     );
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Move generator expects `.eslintrc.json` `extends` to be equal `../../.eslintrc.json` and ignores:
- extends being an array
- extends pointing to a different relative path
<!-- This is the behavior we have today -->

## Expected Behavior
Move generator expects `.eslintrc.json` should support both `string` and `string[]` as a valid `extends` value and recalculate new path based on the actual extends segments without assuming the content.

## Related Issue(s)
https://github.com/nrwl/nx/issues/6314
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6314
