### PR TITLE
fix(core): fix wrong create-nx-workspace tutorial link

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -173,17 +173,17 @@ function showHelp() {
 
     preset                    What to create in a new workspace (options: ${options})
 
-    appName                   The name of the application created by some presets  
+    appName                   The name of the application created by some presets
 
     cli                       CLI to power the Nx workspace (options: "nx", "angular")
-    
+
     style                     Default style option to be used when a non-empty preset is selected
                               options: ("css", "scss", "less") plus ("styl") for all non-Angular and ("styled-components", "@emotion/styled", "styled-jsx") for React, Next.js, Gatsby
 
     interactive               Enable interactive mode when using presets (boolean)
 
     packageManager            Package manager to use (npm, yarn, pnpm)
-    
+
     nx-cloud                  Use Nx Cloud (boolean)
 
     [new workspace options]   any 'new workspace' options
@@ -581,7 +581,7 @@ function pointToTutorialAndCourse(preset: Preset) {
       output.note({
         title,
         bodyLines: [
-          `https://nx.dev/react/tutorial/01-create-application`,
+          `https://nx.dev/latest/react/tutorial/01-create-application`,
           ...pointToFreeCourseOnEgghead(),
         ],
       });
@@ -592,7 +592,7 @@ function pointToTutorialAndCourse(preset: Preset) {
       output.note({
         title,
         bodyLines: [
-          `https://nx.dev/angular/tutorial/01-create-application`,
+          `https://nx.dev/latest/angular/tutorial/01-create-application`,
           ...pointToFreeCourseOnYoutube(),
         ],
       });
@@ -602,7 +602,7 @@ function pointToTutorialAndCourse(preset: Preset) {
       output.note({
         title,
         bodyLines: [
-          `https://nx.dev/node/tutorial/01-create-application`,
+          `https://nx.dev/latest/node/tutorial/01-create-application`,
           ...pointToFreeCourseOnYoutube(),
         ],
       });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
After successful `create-nx-workspace` command output suggests checking the tutorial for beginners, but link points to outdated url:
- https://nx.dev/{section}/tutorial/01-create-application
Where `section` is: angular, react or node

## Expected Behavior
The link should point to https://nx.dev/latest/{section}/tutorial/01-create-application

## Related Issue(s)
https://github.com/nrwl/nx/issues/6412

Fixes #6412
