### PR TITLE
fix(angular): broken buildable libs importPath calculation

### DIFF
--- a/packages/angular/src/generators/library/lib/add-children.ts
+++ b/packages/angular/src/generators/library/lib/add-children.ts
@@ -12,10 +12,9 @@ export function addChildren(host: Tree, options: NormalizedSchema) {
     throw new Error(`Cannot find '${options.parentModule}'`);
   }
 
-  const { npmScope } = getWorkspaceLayout(host);
   const moduleSource = host.read(options.parentModule, 'utf-8');
   const constName = `${names(options.fileName).propertyName}Routes`;
-  const importPath = `@${npmScope}/${options.projectDirectory}`;
+  const importPath = options.importPath;
   let sourceFile = ts.createSourceFile(
     options.parentModule,
     moduleSource,

--- a/packages/angular/src/generators/library/lib/update-lib-package-npm-scope.ts
+++ b/packages/angular/src/generators/library/lib/update-lib-package-npm-scope.ts
@@ -5,17 +5,8 @@ export function updateLibPackageNpmScope(
   host: Tree,
   options: NormalizedSchema
 ) {
-  let pkgName = options.importPath;
-
-  const scopeParts = options.importPath.split('/');
-  if (scopeParts.length > 2) {
-    const prefix = scopeParts.shift();
-    const name = scopeParts.join('-');
-    pkgName = `${prefix}/${name}`;
-  }
-
   return updateJson(host, `${options.projectRoot}/package.json`, (json) => {
-    json.name = pkgName;
+    json.name = options.importPath;
     return json;
   });
 }

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -11,7 +11,6 @@ import { createApp } from '../../utils/nx-devkit/testing';
 import libraryGenerator from './library';
 import { Schema } from './schema';
 import { UnitTestRunner } from '../../utils/test-runners';
-import { stripIndent } from '@nrwl/tao/src/shared/logger';
 
 describe('lib', () => {
   let appTree: Tree;
@@ -478,18 +477,6 @@ describe('lib', () => {
       expect(
         tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']
       ).toBeUndefined();
-    });
-
-    it('should set a default importPath when not passing importPath when using --publishable', async () => {
-      // ACT
-      await runLibraryGeneratorWithOpts({
-        directory: 'myDir',
-        publishable: true,
-      });
-
-      // ASSERT
-      const pkgJson = readJson(appTree, `libs/my-dir/my-lib/package.json`);
-      expect(pkgJson.name).toEqual('@proj/my-dir-my-lib');
     });
 
     it('should update tsconfig.json (no existing path mappings)', async () => {

--- a/packages/angular/src/generators/setup-mfe/lib/setup-serve-target.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/setup-serve-target.ts
@@ -14,14 +14,11 @@ export function setupServeTarget(host: Tree, options: Schema) {
     executor: '@nrwl/angular:webpack-server',
   };
 
-  if (options.mfeType === 'remote') {
-    const port = options.port ?? 4200;
-
+  if (options.mfeType === 'host') {
     appConfig.targets['mfe-serve'] = {
       executor: '@nrwl/workspace:run-commands',
       options: {
-        command: `nx serve ${options.appName}`,
-        port,
+        commands: [`nx serve ${options.appName}"`],
       },
     };
   }


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Buildable libs with Angular Lib generator were broken due to additional `/` in the `importPath`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Fix importPath calculation to allow buildable libs to behave correctly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
