### PR TITLE
docs(core): enable back paragraphs tags

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/code-block.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/code-block.tsx
@@ -26,7 +26,7 @@ export function CodeBlock({
     };
   }, [copied]);
   return (
-    <div className="relative group">
+    <div className="relative group code-block">
       <CopyToClipboard
         text={text}
         onCopy={() => {

--- a/nx-dev/feature-doc-viewer/src/lib/content.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/content.tsx
@@ -24,9 +24,6 @@ interface ComponentsConfig {
 }
 
 const components: any = (config: ComponentsConfig) => ({
-  p({ children }) {
-    return <div className={'mb-5'}>{children}</div>;
-  },
   code({ node, inline, className, children, ...props }) {
     const language = /language-(\w+)/.exec(className || '')?.[1];
     return !inline && language ? (


### PR DESCRIPTION
## What it does?
This PR enables back the `p` tag on nx.dev and add a `code-block` class to code blocks. 