### PR TITLE
chore(core): run-commands executor schema supports descriptions alongside commands

### DIFF
--- a/packages/workspace/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.ts
@@ -25,6 +25,11 @@ export interface RunCommandsBuilderOptions extends Json {
     | {
         command: string;
         forwardAllArgs?: boolean;
+        /**
+         * description was added to allow users to document their commands inline,
+         * it is not intended to be used as part of the execution of the command.
+         */
+        description?: string;
       }
     | string
   )[];

--- a/packages/workspace/src/executors/run-commands/schema.json
+++ b/packages/workspace/src/executors/run-commands/schema.json
@@ -20,6 +20,10 @@
               "forwardAllArgs": {
                 "type": "boolean",
                 "description": "Whether arguments should be forwarded when interpolation is not present"
+              },
+              "description": {
+                "type": "string",
+                "description": "An optional description useful for inline documentation purposes. It is not used as part of the execution of the command"
               }
             },
             "additionalProperties": false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If you have more complex setups which require composing things with `run-commands` builder, there can often be specific knowledge the resides with the original author of those commands.

Currently there is no way document intent/context etc inline when writing custom commands and so it can make it harder for other team members to understand.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR adds the ability to have an arbitrary description alongside commands and not invalidate the schema

