### PR TITLE
fix(devkit): add font file extensions to binaryExts in generate-files.ts

### DIFF
--- a/packages/devkit/src/generators/generate-files.ts
+++ b/packages/devkit/src/generators/generate-files.ts
@@ -27,6 +27,13 @@ const binaryExts = new Set([
   // Java files
   '.jar',
   '.keystore',
+
+  // Font files
+  '.ttf',
+  '.otf',
+  '.woff',
+  '.woff2',
+  '.eot',
 ]);
 
 /**


### PR DESCRIPTION
Add font file extensions to the list of extensions that should not be rendered with ejs

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When using generateFiles, font files (.woff2, .ttf, etc.) are treated as template files and are rendered by ejs. However, they are binary files and they sometimes contain characters that interfere with ejs's templating engine, resulting in errors like this:

```
Error: Could not find matching close tag for "<%".
```

Custom generators can conceivably contain font files in order to generate a web app so it's safer to make sure ejs does not try to render them.

## Expected Behavior
Font files should be in the binaryExts list in order to be excluded from ejs rendering, just like image files.

## Related Issue(s)
Fixes #5213
