### PR TITLE
cleanup(node): no output for package executor watch mode

### DIFF
--- a/packages/workspace/src/utilities/typescript/compilation.ts
+++ b/packages/workspace/src/utilities/typescript/compilation.ts
@@ -62,6 +62,7 @@ export function compileTypeScriptWatcher(
     await callback?.(a, b, c, d);
   };
 
+  ts.createWatchProgram(host);
   return new Promise(() => {});
 }
 


### PR DESCRIPTION
Somehow #5863 missed creating the watch program, so nothing was happening when running node build w/ --watch. This adds the watch program back in.