### PR TITLE
fix(core): improve run-commands dx for ready-when

### DIFF
--- a/docs/angular/api-workspace/executors/run-commands.md
+++ b/docs/angular/api-workspace/executors/run-commands.md
@@ -106,14 +106,18 @@ that sets the `forwardAllArgs` option to `false` as shown below:
 
 ##### Custom **done** conditions
 
-Normally, `run-commands` considers the commands done when all of them have finished running. If you don't need to wait until they're all done, you can set a special string, that considers the command finished the moment the string appears in `stdout` or `stderr`:
+Normally, `run-commands` considers the commands done when all of them have finished running. If you don't need to wait until they're all done, you can set a special string that considers the commands finished the moment the string appears in `stdout` or `stderr`:
 
 ```json
 "finish-when-ready": {
     "builder": "@nrwl/workspace:run-commands",
     "options": {
-        "command": "echo 'READY' && sleep 5 && echo 'FINISHED'",
-        "readyWhen": "READY"
+        "commands": [
+            "sleep 5 && echo 'FINISHED'",
+            "echo 'READY'"
+        ],
+        "readyWhen": "READY",
+        "parallel": true
     }
 }
 ```
@@ -122,7 +126,7 @@ Normally, `run-commands` considers the commands done when all of them have finis
 nx run frontend:finish-when-ready
 ```
 
-The above command will finish immediately, instead of waiting for 5 seconds.
+The above commands will finish immediately, instead of waiting for 5 seconds.
 
 ##### Nx Affected
 
@@ -218,4 +222,4 @@ Run commands in parallel
 
 Type: `string`
 
-String to appear in stdout or stderr that indicates that the task is done. This option can only be used when parallel is set to true. If not specified, the task is done when all the child processes complete.
+String to appear in `stdout` or `stderr` that indicates that the task is done. This option can only be used when multiple commands are run and `parallel` is set to `true`. If not specified, the task is done when all the child processes complete.

--- a/docs/node/api-workspace/executors/run-commands.md
+++ b/docs/node/api-workspace/executors/run-commands.md
@@ -107,14 +107,18 @@ that sets the `forwardAllArgs` option to `false` as shown below:
 
 ##### Custom **done** conditions
 
-Normally, `run-commands` considers the commands done when all of them have finished running. If you don't need to wait until they're all done, you can set a special string, that considers the command finished the moment the string appears in `stdout` or `stderr`:
+Normally, `run-commands` considers the commands done when all of them have finished running. If you don't need to wait until they're all done, you can set a special string that considers the commands finished the moment the string appears in `stdout` or `stderr`:
 
 ```json
 "finish-when-ready": {
     "builder": "@nrwl/workspace:run-commands",
     "options": {
-        "command": "echo 'READY' && sleep 5 && echo 'FINISHED'",
-        "readyWhen": "READY"
+        "commands": [
+            "sleep 5 && echo 'FINISHED'",
+            "echo 'READY'"
+        ],
+        "readyWhen": "READY",
+        "parallel": true
     }
 }
 ```
@@ -123,7 +127,7 @@ Normally, `run-commands` considers the commands done when all of them have finis
 nx run frontend:finish-when-ready
 ```
 
-The above command will finish immediately, instead of waiting for 5 seconds.
+The above commands will finish immediately, instead of waiting for 5 seconds.
 
 ##### Nx Affected
 
@@ -219,4 +223,4 @@ Run commands in parallel
 
 Type: `string`
 
-String to appear in stdout or stderr that indicates that the task is done. This option can only be used when parallel is set to true. If not specified, the task is done when all the child processes complete.
+String to appear in `stdout` or `stderr` that indicates that the task is done. This option can only be used when multiple commands are run and `parallel` is set to `true`. If not specified, the task is done when all the child processes complete.

--- a/docs/react/api-workspace/executors/run-commands.md
+++ b/docs/react/api-workspace/executors/run-commands.md
@@ -107,14 +107,18 @@ that sets the `forwardAllArgs` option to `false` as shown below:
 
 ##### Custom **done** conditions
 
-Normally, `run-commands` considers the commands done when all of them have finished running. If you don't need to wait until they're all done, you can set a special string, that considers the command finished the moment the string appears in `stdout` or `stderr`:
+Normally, `run-commands` considers the commands done when all of them have finished running. If you don't need to wait until they're all done, you can set a special string that considers the commands finished the moment the string appears in `stdout` or `stderr`:
 
 ```json
 "finish-when-ready": {
     "builder": "@nrwl/workspace:run-commands",
     "options": {
-        "command": "echo 'READY' && sleep 5 && echo 'FINISHED'",
-        "readyWhen": "READY"
+        "commands": [
+            "sleep 5 && echo 'FINISHED'",
+            "echo 'READY'"
+        ],
+        "readyWhen": "READY",
+        "parallel": true
     }
 }
 ```
@@ -123,7 +127,7 @@ Normally, `run-commands` considers the commands done when all of them have finis
 nx run frontend:finish-when-ready
 ```
 
-The above command will finish immediately, instead of waiting for 5 seconds.
+The above commands will finish immediately, instead of waiting for 5 seconds.
 
 ##### Nx Affected
 
@@ -219,4 +223,4 @@ Run commands in parallel
 
 Type: `string`
 
-String to appear in stdout or stderr that indicates that the task is done. This option can only be used when parallel is set to true. If not specified, the task is done when all the child processes complete.
+String to appear in `stdout` or `stderr` that indicates that the task is done. This option can only be used when multiple commands are run and `parallel` is set to `true`. If not specified, the task is done when all the child processes complete.

--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -51,6 +51,8 @@ export async function handleErrors(isVerbose: boolean, fn: Function) {
       logger.error('The generator workflow failed. See above.');
     } else if (err.message) {
       logger.error(err.message);
+    } else {
+      logger.error(err);
     }
     if (isVerbose && err.stack) {
       logger.info(err.stack);

--- a/packages/workspace/docs/run-commands-examples.md
+++ b/packages/workspace/docs/run-commands-examples.md
@@ -98,14 +98,18 @@ that sets the `forwardAllArgs` option to `false` as shown below:
 
 ##### Custom **done** conditions
 
-Normally, `run-commands` considers the commands done when all of them have finished running. If you don't need to wait until they're all done, you can set a special string, that considers the command finished the moment the string appears in `stdout` or `stderr`:
+Normally, `run-commands` considers the commands done when all of them have finished running. If you don't need to wait until they're all done, you can set a special string that considers the commands finished the moment the string appears in `stdout` or `stderr`:
 
 ```json
 "finish-when-ready": {
     "builder": "@nrwl/workspace:run-commands",
     "options": {
-        "command": "echo 'READY' && sleep 5 && echo 'FINISHED'",
-        "readyWhen": "READY"
+        "commands": [
+            "sleep 5 && echo 'FINISHED'",
+            "echo 'READY'"
+        ],
+        "readyWhen": "READY",
+        "parallel": true
     }
 }
 ```
@@ -114,7 +118,7 @@ Normally, `run-commands` considers the commands done when all of them have finis
 <%= cli %> run frontend:finish-when-ready
 ```
 
-The above command will finish immediately, instead of waiting for 5 seconds.
+The above commands will finish immediately, instead of waiting for 5 seconds.
 
 ##### Nx Affected
 

--- a/packages/workspace/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.spec.ts
@@ -13,6 +13,10 @@ function readFile(f: string) {
 describe('Command Runner Builder', () => {
   const context = {} as any;
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should run one command', async () => {
     const f = fileSync().name;
     const result = await runCommands({ command: `echo 1 >> ${f}` }, context);
@@ -67,7 +71,7 @@ describe('Command Runner Builder', () => {
 
     await runCommands(
       {
-        commands: [{ command: 'echo' }],
+        commands: [{ command: 'echo' }, { command: 'echo foo' }],
         parallel: true,
         a: 123,
         b: 456,
@@ -75,7 +79,12 @@ describe('Command Runner Builder', () => {
       context
     );
 
-    expect(exec).toHaveBeenCalledWith('echo --a=123 --b=456', {
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(exec).toHaveBeenNthCalledWith(1, 'echo --a=123 --b=456', {
+      maxBuffer: LARGE_BUFFER,
+      env: { ...process.env },
+    });
+    expect(exec).toHaveBeenNthCalledWith(2, 'echo foo --a=123 --b=456', {
       maxBuffer: LARGE_BUFFER,
       env: { ...process.env },
     });
@@ -86,7 +95,10 @@ describe('Command Runner Builder', () => {
 
     await runCommands(
       {
-        commands: [{ command: 'echo', forwardAllArgs: true }],
+        commands: [
+          { command: 'echo', forwardAllArgs: true },
+          { command: 'echo foo', forwardAllArgs: true },
+        ],
         parallel: true,
         a: 123,
         b: 456,
@@ -94,7 +106,12 @@ describe('Command Runner Builder', () => {
       context
     );
 
-    expect(exec).toHaveBeenCalledWith('echo --a=123 --b=456', {
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(exec).toHaveBeenNthCalledWith(1, 'echo --a=123 --b=456', {
+      maxBuffer: LARGE_BUFFER,
+      env: { ...process.env },
+    });
+    expect(exec).toHaveBeenNthCalledWith(2, 'echo foo --a=123 --b=456', {
       maxBuffer: LARGE_BUFFER,
       env: { ...process.env },
     });
@@ -105,7 +122,10 @@ describe('Command Runner Builder', () => {
 
     await runCommands(
       {
-        commands: [{ command: 'echo', forwardAllArgs: false }],
+        commands: [
+          { command: 'echo', forwardAllArgs: false },
+          { command: 'echo foo', forwardAllArgs: false },
+        ],
         parallel: true,
         a: 123,
         b: 456,
@@ -113,7 +133,12 @@ describe('Command Runner Builder', () => {
       context
     );
 
-    expect(exec).toHaveBeenCalledWith('echo', {
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(exec).toHaveBeenNthCalledWith(1, 'echo', {
+      maxBuffer: LARGE_BUFFER,
+      env: { ...process.env },
+    });
+    expect(exec).toHaveBeenNthCalledWith(2, 'echo foo', {
       maxBuffer: LARGE_BUFFER,
       env: { ...process.env },
     });
@@ -169,11 +194,41 @@ describe('Command Runner Builder', () => {
   });
 
   describe('readyWhen', () => {
+    it('should warn when command is specified instead of commands', async () => {
+      jest.spyOn(process.stderr, 'write');
+      await runCommands(
+        {
+          command: `echo 'Hello World'`,
+          readyWhen: 'READY',
+        },
+        context
+      );
+
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        'Warning: "readyWhen" has no effect when a single command is run. The task will be done when the command process is completed. Ignoring.'
+      );
+    });
+
+    it('should warn when a single command is specified', async () => {
+      jest.spyOn(process.stderr, 'write');
+      await runCommands(
+        {
+          commands: [`echo 'Hello World'`],
+          readyWhen: 'READY',
+        },
+        context
+      );
+
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        'Warning: "readyWhen" has no effect when a single command is run. The task will be done when the command process is completed. Ignoring.'
+      );
+    });
+
     it('should error when parallel = false', async () => {
       try {
         await runCommands(
           {
-            commands: [{ command: 'some command' }],
+            commands: [{ command: 'echo foo' }, { command: 'echo bar' }],
             parallel: false,
             readyWhen: 'READY',
           },
@@ -182,20 +237,16 @@ describe('Command Runner Builder', () => {
         fail('should throw');
       } catch (e) {
         expect(e.message).toEqual(
-          `ERROR: Bad builder config for @nrwl/run-commands - "readyWhen" can only be used when parallel=true`
+          `ERROR: Bad builder config for @nrwl/run-commands - "readyWhen" can only be used when parallel=true.`
         );
       }
     });
 
-    it('should return success true when the string specified is ready condition is found', async () => {
+    it('should return success true when the string specified as ready condition is found', async () => {
       const f = fileSync().name;
       const result = await runCommands(
         {
-          commands: [
-            {
-              command: `echo READY && sleep 0.1 && echo 1 >> ${f}`,
-            },
-          ],
+          commands: [`echo READY && sleep 0.1 && echo 1 >> ${f}`, `echo foo`],
           parallel: true,
           readyWhen: 'READY',
         },
@@ -231,17 +282,18 @@ describe('Command Runner Builder', () => {
       const exec = jest.spyOn(require('child_process'), 'exec');
       await runCommands(
         {
-          commands: [
-            {
-              command: `echo 'Hello World'`,
-            },
-          ],
+          commands: [`echo 'Hello World'`, `echo 'Hello Universe'`],
           parallel: true,
         },
         context
       );
 
-      expect(exec).toHaveBeenCalledWith(`echo 'Hello World'`, {
+      expect(exec).toHaveBeenCalledTimes(2);
+      expect(exec).toHaveBeenNthCalledWith(1, `echo 'Hello World'`, {
+        maxBuffer: LARGE_BUFFER,
+        env: { ...process.env },
+      });
+      expect(exec).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, {
         maxBuffer: LARGE_BUFFER,
         env: { ...process.env },
       });
@@ -251,18 +303,19 @@ describe('Command Runner Builder', () => {
       const exec = jest.spyOn(require('child_process'), 'exec');
       await runCommands(
         {
-          commands: [
-            {
-              command: `echo 'Hello World'`,
-            },
-          ],
+          commands: [`echo 'Hello World'`, `echo 'Hello Universe'`],
           parallel: true,
           color: true,
         },
         context
       );
 
-      expect(exec).toHaveBeenCalledWith(`echo 'Hello World'`, {
+      expect(exec).toHaveBeenCalledTimes(2);
+      expect(exec).toHaveBeenNthCalledWith(1, `echo 'Hello World'`, {
+        maxBuffer: LARGE_BUFFER,
+        env: { ...process.env, FORCE_COLOR: `true` },
+      });
+      expect(exec).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, {
         maxBuffer: LARGE_BUFFER,
         env: { ...process.env, FORCE_COLOR: `true` },
       });

--- a/packages/workspace/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.ts
@@ -66,9 +66,15 @@ export default async function (
   const normalized = normalizeOptions(options);
 
   if (options.readyWhen && !options.parallel) {
-    throw new Error(
-      'ERROR: Bad builder config for @nrwl/run-commands - "readyWhen" can only be used when parallel=true'
-    );
+    if (options.command || options.commands?.length === 1) {
+      process.stderr.write(
+        'Warning: "readyWhen" has no effect when a single command is run. The task will be done when the command process is completed. Ignoring.'
+      );
+    } else {
+      throw new Error(
+        'ERROR: Bad builder config for @nrwl/run-commands - "readyWhen" can only be used when parallel=true.'
+      );
+    }
   }
 
   try {
@@ -140,6 +146,9 @@ function normalizeOptions(
     options.commands = options.commands.map((c) =>
       typeof c === 'string' ? { command: c } : c
     );
+    if (options.commands.length === 1) {
+      options.parallel = false;
+    }
   }
   (options as NormalizedRunCommandsBuilderOptions).commands.forEach((c) => {
     c.command = transformCommand(

--- a/packages/workspace/src/executors/run-commands/schema.json
+++ b/packages/workspace/src/executors/run-commands/schema.json
@@ -42,7 +42,7 @@
     },
     "readyWhen": {
       "type": "string",
-      "description": "String to appear in stdout or stderr that indicates that the task is done. This option can only be used when parallel is set to true. If not specified, the task is done when all the child processes complete."
+      "description": "String to appear in `stdout` or `stderr` that indicates that the task is done. This option can only be used when multiple commands are run and `parallel` is set to `true`. If not specified, the task is done when all the child processes complete."
     },
     "args": {
       "type": "string",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When using `run-commands` if the `command` (single command) option is specified with `readyWhen`, it results in an error. However, if the `commands` option is specified with a single command and with `readyWhen`, it doesn't throw an error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`run-commands` should not throw an error when using `readyWhen` with a single command (regardless of using `command` or `commands`). It should instead, ignore the `readyWhen` option and log a warning. Documentation is improved to reflect more clearly that `readyWhen` is meant to be used to short-circuit multiple commands runs and that it has no effect on a single command run.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5526 
