### PR TITLE
docs(misc): documentation headers should include collectionName for searchability

### DIFF
--- a/docs/angular/api-angular/executors/delegate-build.md
+++ b/docs/angular/api-angular/executors/delegate-build.md
@@ -1,4 +1,4 @@
-# delegate-build
+# @nrwl/angular:delegate-build
 
 Delegates the build to a different target while supporting incremental builds.
 

--- a/docs/angular/api-angular/executors/ng-packagr-lite.md
+++ b/docs/angular/api-angular/executors/ng-packagr-lite.md
@@ -1,4 +1,4 @@
-# ng-packagr-lite
+# @nrwl/angular:ng-packagr-lite
 
 Builds a library with support for incremental builds.
 

--- a/docs/angular/api-angular/executors/package.md
+++ b/docs/angular/api-angular/executors/package.md
@@ -1,4 +1,4 @@
-# package
+# @nrwl/angular:package
 
 Builds and packages an Angular library to be distributed as an NPM package. It supports incremental builds.
 

--- a/docs/angular/api-angular/executors/webpack-browser.md
+++ b/docs/angular/api-angular/executors/webpack-browser.md
@@ -1,4 +1,4 @@
-# webpack-browser
+# @nrwl/angular:webpack-browser
 
 Builds a browser application with support for incremental builds and custom webpack configuration.
 

--- a/docs/angular/api-angular/executors/webpack-server.md
+++ b/docs/angular/api-angular/executors/webpack-server.md
@@ -1,4 +1,4 @@
-# webpack-server
+# @nrwl/angular:webpack-server
 
 Serves a browser application with support for a custom webpack configuration.
 

--- a/docs/angular/api-angular/generators/application.md
+++ b/docs/angular/api-angular/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/angular:application
 
 Creates an Angular application.
 

--- a/docs/angular/api-angular/generators/convert-tslint-to-eslint.md
+++ b/docs/angular/api-angular/generators/convert-tslint-to-eslint.md
@@ -1,4 +1,4 @@
-# convert-tslint-to-eslint
+# @nrwl/angular:convert-tslint-to-eslint
 
 Converts a project from TSLint to ESLint.
 

--- a/docs/angular/api-angular/generators/downgrade-module.md
+++ b/docs/angular/api-angular/generators/downgrade-module.md
@@ -1,4 +1,4 @@
-# downgrade-module
+# @nrwl/angular:downgrade-module
 
 Sets up a Downgrade Module.
 

--- a/docs/angular/api-angular/generators/karma-project.md
+++ b/docs/angular/api-angular/generators/karma-project.md
@@ -1,4 +1,4 @@
-# karma-project
+# @nrwl/angular:karma-project
 
 Adds Karma configuration to a project.
 

--- a/docs/angular/api-angular/generators/karma.md
+++ b/docs/angular/api-angular/generators/karma.md
@@ -1,4 +1,4 @@
-# karma
+# @nrwl/angular:karma
 
 Adds Karma configuration to a workspace.
 

--- a/docs/angular/api-angular/generators/library.md
+++ b/docs/angular/api-angular/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/angular:library
 
 Creates an Angular library.
 

--- a/docs/angular/api-angular/generators/move.md
+++ b/docs/angular/api-angular/generators/move.md
@@ -1,4 +1,4 @@
-# move
+# @nrwl/angular:move
 
 Moves an Angular application or library to another folder within the workspace and updates the project configuration.
 

--- a/docs/angular/api-angular/generators/ngrx.md
+++ b/docs/angular/api-angular/generators/ngrx.md
@@ -1,4 +1,4 @@
-# ngrx
+# @nrwl/angular:ngrx
 
 Adds NgRx support to an application or library.
 

--- a/docs/angular/api-angular/generators/setup-mfe.md
+++ b/docs/angular/api-angular/generators/setup-mfe.md
@@ -1,4 +1,4 @@
-# setup-mfe
+# @nrwl/angular:setup-mfe
 
 Generate a Module Federation configuration for a given Angular application.
 

--- a/docs/angular/api-angular/generators/stories.md
+++ b/docs/angular/api-angular/generators/stories.md
@@ -1,4 +1,4 @@
-# stories
+# @nrwl/angular:stories
 
 Creates stories/specs for all components declared in a project.
 

--- a/docs/angular/api-angular/generators/storybook-configuration.md
+++ b/docs/angular/api-angular/generators/storybook-configuration.md
@@ -1,4 +1,4 @@
-# storybook-configuration
+# @nrwl/angular:storybook-configuration
 
 Adds Storybook configuration to a project.
 

--- a/docs/angular/api-angular/generators/storybook-migrate-defaults-5-to-6.md
+++ b/docs/angular/api-angular/generators/storybook-migrate-defaults-5-to-6.md
@@ -1,4 +1,4 @@
-# storybook-migrate-defaults-5-to-6
+# @nrwl/angular:storybook-migrate-defaults-5-to-6
 
 Generates default Storybook configuration files using Storybook version >=6.x specs, for projects that already have Storybook instances and configurations of versions <6.x.
 

--- a/docs/angular/api-angular/generators/storybook-migrate-stories-to-6-2.md
+++ b/docs/angular/api-angular/generators/storybook-migrate-stories-to-6-2.md
@@ -1,4 +1,4 @@
-# storybook-migrate-stories-to-6-2
+# @nrwl/angular:storybook-migrate-stories-to-6-2
 
 Migrates stories to match the new syntax in v6.2 where the component declaration should be in the default export.
 

--- a/docs/angular/api-angular/generators/upgrade-module.md
+++ b/docs/angular/api-angular/generators/upgrade-module.md
@@ -1,4 +1,4 @@
-# upgrade-module
+# @nrwl/angular:upgrade-module
 
 Sets up an Upgrade Module.
 

--- a/docs/angular/api-angular/generators/web-worker.md
+++ b/docs/angular/api-angular/generators/web-worker.md
@@ -1,4 +1,4 @@
-# web-worker
+# @nrwl/angular:web-worker
 
 Creates a Web Worker.
 

--- a/docs/angular/api-cypress/executors/cypress.md
+++ b/docs/angular/api-cypress/executors/cypress.md
@@ -1,4 +1,4 @@
-# cypress
+# @nrwl/cypress:cypress
 
 Run Cypress e2e tests
 

--- a/docs/angular/api-express/generators/application.md
+++ b/docs/angular/api-express/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/express:application
 
 Create an express application
 

--- a/docs/angular/api-gatsby/executors/build.md
+++ b/docs/angular/api-gatsby/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/gatsby:build
 
 Build a Gatsby app
 

--- a/docs/angular/api-gatsby/executors/server.md
+++ b/docs/angular/api-gatsby/executors/server.md
@@ -1,4 +1,4 @@
-# server
+# @nrwl/gatsby:server
 
 Starts server for app
 

--- a/docs/angular/api-gatsby/generators/application.md
+++ b/docs/angular/api-gatsby/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/gatsby:application
 
 Create an application
 

--- a/docs/angular/api-gatsby/generators/component.md
+++ b/docs/angular/api-gatsby/generators/component.md
@@ -1,4 +1,4 @@
-# component
+# @nrwl/gatsby:component
 
 Create a component
 

--- a/docs/angular/api-gatsby/generators/page.md
+++ b/docs/angular/api-gatsby/generators/page.md
@@ -1,4 +1,4 @@
-# page
+# @nrwl/gatsby:page
 
 Create a page
 

--- a/docs/angular/api-jest/executors/jest.md
+++ b/docs/angular/api-jest/executors/jest.md
@@ -1,4 +1,4 @@
-# jest
+# @nrwl/jest:jest
 
 Run Jest unit tests
 

--- a/docs/angular/api-linter/executors/eslint.md
+++ b/docs/angular/api-linter/executors/eslint.md
@@ -1,4 +1,4 @@
-# eslint
+# @nrwl/linter:eslint
 
 Run ESLint on a project
 

--- a/docs/angular/api-linter/executors/lint.md
+++ b/docs/angular/api-linter/executors/lint.md
@@ -1,4 +1,4 @@
-# lint
+# @nrwl/linter:lint
 
 **[DEPRECATED]**: Please use the eslint builder instead, an automated migration was provided in v10.3.0
 

--- a/docs/angular/api-nest/generators/application.md
+++ b/docs/angular/api-nest/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/nest:application
 
 Create a NestJS application.
 

--- a/docs/angular/api-nest/generators/class.md
+++ b/docs/angular/api-nest/generators/class.md
@@ -1,4 +1,4 @@
-# class
+# @nrwl/nest:class
 
 Run the `class` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/controller.md
+++ b/docs/angular/api-nest/generators/controller.md
@@ -1,4 +1,4 @@
-# controller
+# @nrwl/nest:controller
 
 Run the `controller` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/convert-tslint-to-eslint.md
+++ b/docs/angular/api-nest/generators/convert-tslint-to-eslint.md
@@ -1,4 +1,4 @@
-# convert-tslint-to-eslint
+# @nrwl/nest:convert-tslint-to-eslint
 
 Convert a project from TSLint to ESLint.
 

--- a/docs/angular/api-nest/generators/decorator.md
+++ b/docs/angular/api-nest/generators/decorator.md
@@ -1,4 +1,4 @@
-# decorator
+# @nrwl/nest:decorator
 
 Run the `decorator` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/filter.md
+++ b/docs/angular/api-nest/generators/filter.md
@@ -1,4 +1,4 @@
-# filter
+# @nrwl/nest:filter
 
 Run the `filter` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/gateway.md
+++ b/docs/angular/api-nest/generators/gateway.md
@@ -1,4 +1,4 @@
-# gateway
+# @nrwl/nest:gateway
 
 Run the `gateway` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/guard.md
+++ b/docs/angular/api-nest/generators/guard.md
@@ -1,4 +1,4 @@
-# guard
+# @nrwl/nest:guard
 
 Run the `guard` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/interceptor.md
+++ b/docs/angular/api-nest/generators/interceptor.md
@@ -1,4 +1,4 @@
-# interceptor
+# @nrwl/nest:interceptor
 
 Run the `interceptor` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/interface.md
+++ b/docs/angular/api-nest/generators/interface.md
@@ -1,4 +1,4 @@
-# interface
+# @nrwl/nest:interface
 
 Run the `interface` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/library.md
+++ b/docs/angular/api-nest/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/nest:library
 
 Create a new NestJS library.
 

--- a/docs/angular/api-nest/generators/middleware.md
+++ b/docs/angular/api-nest/generators/middleware.md
@@ -1,4 +1,4 @@
-# middleware
+# @nrwl/nest:middleware
 
 Run the `middleware` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/module.md
+++ b/docs/angular/api-nest/generators/module.md
@@ -1,4 +1,4 @@
-# module
+# @nrwl/nest:module
 
 Run the `module` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/pipe.md
+++ b/docs/angular/api-nest/generators/pipe.md
@@ -1,4 +1,4 @@
-# pipe
+# @nrwl/nest:pipe
 
 Run the `pipe` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/provider.md
+++ b/docs/angular/api-nest/generators/provider.md
@@ -1,4 +1,4 @@
-# provider
+# @nrwl/nest:provider
 
 Run the `provider` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/resolver.md
+++ b/docs/angular/api-nest/generators/resolver.md
@@ -1,4 +1,4 @@
-# resolver
+# @nrwl/nest:resolver
 
 Run the `resolver` NestJS generator with Nx project support.
 

--- a/docs/angular/api-nest/generators/service.md
+++ b/docs/angular/api-nest/generators/service.md
@@ -1,4 +1,4 @@
-# service
+# @nrwl/nest:service
 
 Run the `service` NestJS generator with Nx project support.
 

--- a/docs/angular/api-next/executors/build.md
+++ b/docs/angular/api-next/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/next:build
 
 Build a Next.js app
 

--- a/docs/angular/api-next/executors/export.md
+++ b/docs/angular/api-next/executors/export.md
@@ -1,4 +1,4 @@
-# export
+# @nrwl/next:export
 
 Export a Next.js app. The exported application is located at dist/$outputPath/exported.
 

--- a/docs/angular/api-next/executors/server.md
+++ b/docs/angular/api-next/executors/server.md
@@ -1,4 +1,4 @@
-# server
+# @nrwl/next:server
 
 Serve a Next.js app
 

--- a/docs/angular/api-next/generators/application.md
+++ b/docs/angular/api-next/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/next:application
 
 Create a Next.js application
 

--- a/docs/angular/api-next/generators/component.md
+++ b/docs/angular/api-next/generators/component.md
@@ -1,4 +1,4 @@
-# component
+# @nrwl/next:component
 
 Create a React component
 

--- a/docs/angular/api-next/generators/page.md
+++ b/docs/angular/api-next/generators/page.md
@@ -1,4 +1,4 @@
-# page
+# @nrwl/next:page
 
 Create a Next.js page component
 

--- a/docs/angular/api-node/executors/build.md
+++ b/docs/angular/api-node/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/node:build
 
 Build a Node application
 

--- a/docs/angular/api-node/executors/execute.md
+++ b/docs/angular/api-node/executors/execute.md
@@ -1,4 +1,4 @@
-# execute
+# @nrwl/node:execute
 
 Execute a Node application
 

--- a/docs/angular/api-node/executors/package.md
+++ b/docs/angular/api-node/executors/package.md
@@ -1,4 +1,4 @@
-# package
+# @nrwl/node:package
 
 Package a Node library
 

--- a/docs/angular/api-node/generators/application.md
+++ b/docs/angular/api-node/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/node:application
 
 Create a node application
 

--- a/docs/angular/api-node/generators/library.md
+++ b/docs/angular/api-node/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/node:library
 
 Create a library
 

--- a/docs/angular/api-node/generators/migrate-to-webpack-5.md
+++ b/docs/angular/api-node/generators/migrate-to-webpack-5.md
@@ -1,4 +1,4 @@
-# migrate-to-webpack-5
+# @nrwl/node:migrate-to-webpack-5
 
 Add webpack 5 compatible dependencies to the workspace
 

--- a/docs/angular/api-nx-plugin/executors/e2e.md
+++ b/docs/angular/api-nx-plugin/executors/e2e.md
@@ -1,4 +1,4 @@
-# e2e
+# @nrwl/nx-plugin:e2e
 
 Creates and runs the e2e tests for an Nx Plugin.
 

--- a/docs/angular/api-nx-plugin/generators/executor.md
+++ b/docs/angular/api-nx-plugin/generators/executor.md
@@ -1,4 +1,4 @@
-# executor
+# @nrwl/nx-plugin:executor
 
 Create a executor for an Nx Plugin
 

--- a/docs/angular/api-nx-plugin/generators/generator.md
+++ b/docs/angular/api-nx-plugin/generators/generator.md
@@ -1,4 +1,4 @@
-# generator
+# @nrwl/nx-plugin:generator
 
 Create a generator for an Nx Plugin
 

--- a/docs/angular/api-nx-plugin/generators/migration.md
+++ b/docs/angular/api-nx-plugin/generators/migration.md
@@ -1,4 +1,4 @@
-# migration
+# @nrwl/nx-plugin:migration
 
 Create a migration for an Nx Plugin
 

--- a/docs/angular/api-nx-plugin/generators/plugin.md
+++ b/docs/angular/api-nx-plugin/generators/plugin.md
@@ -1,4 +1,4 @@
-# plugin
+# @nrwl/nx-plugin:plugin
 
 Create a Nx Plugin
 

--- a/docs/angular/api-react/generators/application.md
+++ b/docs/angular/api-react/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/react:application
 
 Create an application
 

--- a/docs/angular/api-react/generators/component-cypress-spec.md
+++ b/docs/angular/api-react/generators/component-cypress-spec.md
@@ -1,4 +1,4 @@
-# component-cypress-spec
+# @nrwl/react:component-cypress-spec
 
 Create a cypress spec for a ui component that has a story
 

--- a/docs/angular/api-react/generators/component-story.md
+++ b/docs/angular/api-react/generators/component-story.md
@@ -1,4 +1,4 @@
-# component-story
+# @nrwl/react:component-story
 
 Generate storybook story for a react component
 

--- a/docs/angular/api-react/generators/component.md
+++ b/docs/angular/api-react/generators/component.md
@@ -1,4 +1,4 @@
-# component
+# @nrwl/react:component
 
 Create a component
 

--- a/docs/angular/api-react/generators/library.md
+++ b/docs/angular/api-react/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/react:library
 
 Create a library
 

--- a/docs/angular/api-react/generators/redux.md
+++ b/docs/angular/api-react/generators/redux.md
@@ -1,4 +1,4 @@
-# redux
+# @nrwl/react:redux
 
 Create a redux slice for a project
 

--- a/docs/angular/api-react/generators/stories.md
+++ b/docs/angular/api-react/generators/stories.md
@@ -1,4 +1,4 @@
-# stories
+# @nrwl/react:stories
 
 Create stories/specs for all components declared in a library
 

--- a/docs/angular/api-react/generators/storybook-configuration.md
+++ b/docs/angular/api-react/generators/storybook-configuration.md
@@ -1,4 +1,4 @@
-# storybook-configuration
+# @nrwl/react:storybook-configuration
 
 Set up storybook for a react library
 

--- a/docs/angular/api-react/generators/storybook-migrate-defaults-5-to-6.md
+++ b/docs/angular/api-react/generators/storybook-migrate-defaults-5-to-6.md
@@ -1,4 +1,4 @@
-# storybook-migrate-defaults-5-to-6
+# @nrwl/react:storybook-migrate-defaults-5-to-6
 
 Generate default Storybook configuration files using Storybook version >=6.x specs, for projects that already have Storybook instances and configurations of versions <6.x.
 

--- a/docs/angular/api-storybook/executors/build.md
+++ b/docs/angular/api-storybook/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/storybook:build
 
 Build Storybook
 

--- a/docs/angular/api-storybook/executors/storybook.md
+++ b/docs/angular/api-storybook/executors/storybook.md
@@ -1,4 +1,4 @@
-# storybook
+# @nrwl/storybook:storybook
 
 Serve Storybook
 

--- a/docs/angular/api-storybook/generators/configuration.md
+++ b/docs/angular/api-storybook/generators/configuration.md
@@ -1,4 +1,4 @@
-# configuration
+# @nrwl/storybook:configuration
 
 Add storybook configuration to a ui library or an application
 

--- a/docs/angular/api-storybook/generators/cypress-project.md
+++ b/docs/angular/api-storybook/generators/cypress-project.md
@@ -1,4 +1,4 @@
-# cypress-project
+# @nrwl/storybook:cypress-project
 
 Add cypress e2e app to test a ui library that is set up for storybook
 

--- a/docs/angular/api-storybook/generators/migrate-defaults-5-to-6.md
+++ b/docs/angular/api-storybook/generators/migrate-defaults-5-to-6.md
@@ -1,4 +1,4 @@
-# migrate-defaults-5-to-6
+# @nrwl/storybook:migrate-defaults-5-to-6
 
 Generate default Storybook configuration files using Storybook version >=6.x specs, for projects that already have Storybook instances and configurations of versions <6.x.
 

--- a/docs/angular/api-storybook/generators/migrate-stories-to-6-2.md
+++ b/docs/angular/api-storybook/generators/migrate-stories-to-6-2.md
@@ -1,4 +1,4 @@
-# migrate-stories-to-6-2
+# @nrwl/storybook:migrate-stories-to-6-2
 
 Migrate stories syntax to 6.2
 

--- a/docs/angular/api-web/executors/build.md
+++ b/docs/angular/api-web/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/web:build
 
 Build a application
 

--- a/docs/angular/api-web/executors/dev-server.md
+++ b/docs/angular/api-web/executors/dev-server.md
@@ -1,4 +1,4 @@
-# dev-server
+# @nrwl/web:dev-server
 
 Serve a web application
 

--- a/docs/angular/api-web/executors/file-server.md
+++ b/docs/angular/api-web/executors/file-server.md
@@ -1,4 +1,4 @@
-# file-server
+# @nrwl/web:file-server
 
 Serve a web application from a folder
 

--- a/docs/angular/api-web/executors/package.md
+++ b/docs/angular/api-web/executors/package.md
@@ -1,4 +1,4 @@
-# package
+# @nrwl/web:package
 
 Package a library
 

--- a/docs/angular/api-web/generators/application.md
+++ b/docs/angular/api-web/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/web:application
 
 Create an application
 

--- a/docs/angular/api-web/generators/migrate-to-webpack-5.md
+++ b/docs/angular/api-web/generators/migrate-to-webpack-5.md
@@ -1,4 +1,4 @@
-# migrate-to-webpack-5
+# @nrwl/web:migrate-to-webpack-5
 
 Add webpack 5 compatible dependencies to the workspace
 

--- a/docs/angular/api-workspace/executors/run-commands.md
+++ b/docs/angular/api-workspace/executors/run-commands.md
@@ -1,4 +1,4 @@
-# run-commands
+# @nrwl/workspace:run-commands
 
 Run any custom commands with Nx
 

--- a/docs/angular/api-workspace/executors/run-script.md
+++ b/docs/angular/api-workspace/executors/run-script.md
@@ -1,4 +1,4 @@
-# run-script
+# @nrwl/workspace:run-script
 
 Run an npm script using Nx
 

--- a/docs/angular/api-workspace/executors/tsc.md
+++ b/docs/angular/api-workspace/executors/tsc.md
@@ -1,4 +1,4 @@
-# tsc
+# @nrwl/workspace:tsc
 
 Build a project using TypeScript.
 

--- a/docs/angular/api-workspace/generators/convert-to-nx-project.md
+++ b/docs/angular/api-workspace/generators/convert-to-nx-project.md
@@ -1,4 +1,4 @@
-# convert-to-nx-project
+# @nrwl/workspace:convert-to-nx-project
 
 Moves a project's configuration outside of workspace.json
 

--- a/docs/angular/api-workspace/generators/library.md
+++ b/docs/angular/api-workspace/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/workspace:library
 
 Create a library
 

--- a/docs/angular/api-workspace/generators/move.md
+++ b/docs/angular/api-workspace/generators/move.md
@@ -1,4 +1,4 @@
-# move
+# @nrwl/workspace:move
 
 Move an application or library to another folder
 

--- a/docs/angular/api-workspace/generators/remove.md
+++ b/docs/angular/api-workspace/generators/remove.md
@@ -1,4 +1,4 @@
-# remove
+# @nrwl/workspace:remove
 
 Remove an application or library
 

--- a/docs/angular/api-workspace/generators/run-commands.md
+++ b/docs/angular/api-workspace/generators/run-commands.md
@@ -1,4 +1,4 @@
-# run-commands
+# @nrwl/workspace:run-commands
 
 Generates a target to run any command in the terminal
 

--- a/docs/angular/api-workspace/generators/workspace-generator.md
+++ b/docs/angular/api-workspace/generators/workspace-generator.md
@@ -1,4 +1,4 @@
-# workspace-generator
+# @nrwl/workspace:workspace-generator
 
 Generates a workspace generator
 

--- a/docs/node/api-angular/executors/delegate-build.md
+++ b/docs/node/api-angular/executors/delegate-build.md
@@ -1,4 +1,4 @@
-# delegate-build
+# @nrwl/angular:delegate-build
 
 Delegates the build to a different target while supporting incremental builds.
 

--- a/docs/node/api-angular/executors/ng-packagr-lite.md
+++ b/docs/node/api-angular/executors/ng-packagr-lite.md
@@ -1,4 +1,4 @@
-# ng-packagr-lite
+# @nrwl/angular:ng-packagr-lite
 
 Builds a library with support for incremental builds.
 

--- a/docs/node/api-angular/executors/package.md
+++ b/docs/node/api-angular/executors/package.md
@@ -1,4 +1,4 @@
-# package
+# @nrwl/angular:package
 
 Builds and packages an Angular library to be distributed as an NPM package. It supports incremental builds.
 

--- a/docs/node/api-angular/executors/webpack-browser.md
+++ b/docs/node/api-angular/executors/webpack-browser.md
@@ -1,4 +1,4 @@
-# webpack-browser
+# @nrwl/angular:webpack-browser
 
 Builds a browser application with support for incremental builds and custom webpack configuration.
 

--- a/docs/node/api-angular/executors/webpack-server.md
+++ b/docs/node/api-angular/executors/webpack-server.md
@@ -1,4 +1,4 @@
-# webpack-server
+# @nrwl/angular:webpack-server
 
 Serves a browser application with support for a custom webpack configuration.
 

--- a/docs/node/api-angular/generators/application.md
+++ b/docs/node/api-angular/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/angular:application
 
 Creates an Angular application.
 

--- a/docs/node/api-angular/generators/convert-tslint-to-eslint.md
+++ b/docs/node/api-angular/generators/convert-tslint-to-eslint.md
@@ -1,4 +1,4 @@
-# convert-tslint-to-eslint
+# @nrwl/angular:convert-tslint-to-eslint
 
 Converts a project from TSLint to ESLint.
 

--- a/docs/node/api-angular/generators/downgrade-module.md
+++ b/docs/node/api-angular/generators/downgrade-module.md
@@ -1,4 +1,4 @@
-# downgrade-module
+# @nrwl/angular:downgrade-module
 
 Sets up a Downgrade Module.
 

--- a/docs/node/api-angular/generators/karma-project.md
+++ b/docs/node/api-angular/generators/karma-project.md
@@ -1,4 +1,4 @@
-# karma-project
+# @nrwl/angular:karma-project
 
 Adds Karma configuration to a project.
 

--- a/docs/node/api-angular/generators/karma.md
+++ b/docs/node/api-angular/generators/karma.md
@@ -1,4 +1,4 @@
-# karma
+# @nrwl/angular:karma
 
 Adds Karma configuration to a workspace.
 

--- a/docs/node/api-angular/generators/library.md
+++ b/docs/node/api-angular/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/angular:library
 
 Creates an Angular library.
 

--- a/docs/node/api-angular/generators/move.md
+++ b/docs/node/api-angular/generators/move.md
@@ -1,4 +1,4 @@
-# move
+# @nrwl/angular:move
 
 Moves an Angular application or library to another folder within the workspace and updates the project configuration.
 

--- a/docs/node/api-angular/generators/ngrx.md
+++ b/docs/node/api-angular/generators/ngrx.md
@@ -1,4 +1,4 @@
-# ngrx
+# @nrwl/angular:ngrx
 
 Adds NgRx support to an application or library.
 

--- a/docs/node/api-angular/generators/setup-mfe.md
+++ b/docs/node/api-angular/generators/setup-mfe.md
@@ -1,4 +1,4 @@
-# setup-mfe
+# @nrwl/angular:setup-mfe
 
 Generate a Module Federation configuration for a given Angular application.
 

--- a/docs/node/api-angular/generators/stories.md
+++ b/docs/node/api-angular/generators/stories.md
@@ -1,4 +1,4 @@
-# stories
+# @nrwl/angular:stories
 
 Creates stories/specs for all components declared in a project.
 

--- a/docs/node/api-angular/generators/storybook-configuration.md
+++ b/docs/node/api-angular/generators/storybook-configuration.md
@@ -1,4 +1,4 @@
-# storybook-configuration
+# @nrwl/angular:storybook-configuration
 
 Adds Storybook configuration to a project.
 

--- a/docs/node/api-angular/generators/storybook-migrate-defaults-5-to-6.md
+++ b/docs/node/api-angular/generators/storybook-migrate-defaults-5-to-6.md
@@ -1,4 +1,4 @@
-# storybook-migrate-defaults-5-to-6
+# @nrwl/angular:storybook-migrate-defaults-5-to-6
 
 Generates default Storybook configuration files using Storybook version >=6.x specs, for projects that already have Storybook instances and configurations of versions <6.x.
 

--- a/docs/node/api-angular/generators/storybook-migrate-stories-to-6-2.md
+++ b/docs/node/api-angular/generators/storybook-migrate-stories-to-6-2.md
@@ -1,4 +1,4 @@
-# storybook-migrate-stories-to-6-2
+# @nrwl/angular:storybook-migrate-stories-to-6-2
 
 Migrates stories to match the new syntax in v6.2 where the component declaration should be in the default export.
 

--- a/docs/node/api-angular/generators/upgrade-module.md
+++ b/docs/node/api-angular/generators/upgrade-module.md
@@ -1,4 +1,4 @@
-# upgrade-module
+# @nrwl/angular:upgrade-module
 
 Sets up an Upgrade Module.
 

--- a/docs/node/api-angular/generators/web-worker.md
+++ b/docs/node/api-angular/generators/web-worker.md
@@ -1,4 +1,4 @@
-# web-worker
+# @nrwl/angular:web-worker
 
 Creates a Web Worker.
 

--- a/docs/node/api-cypress/executors/cypress.md
+++ b/docs/node/api-cypress/executors/cypress.md
@@ -1,4 +1,4 @@
-# cypress
+# @nrwl/cypress:cypress
 
 Run Cypress e2e tests
 

--- a/docs/node/api-express/generators/application.md
+++ b/docs/node/api-express/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/express:application
 
 Create an express application
 

--- a/docs/node/api-gatsby/executors/build.md
+++ b/docs/node/api-gatsby/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/gatsby:build
 
 Build a Gatsby app
 

--- a/docs/node/api-gatsby/executors/server.md
+++ b/docs/node/api-gatsby/executors/server.md
@@ -1,4 +1,4 @@
-# server
+# @nrwl/gatsby:server
 
 Starts server for app
 

--- a/docs/node/api-gatsby/generators/application.md
+++ b/docs/node/api-gatsby/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/gatsby:application
 
 Create an application
 

--- a/docs/node/api-gatsby/generators/component.md
+++ b/docs/node/api-gatsby/generators/component.md
@@ -1,4 +1,4 @@
-# component
+# @nrwl/gatsby:component
 
 Create a component
 

--- a/docs/node/api-gatsby/generators/page.md
+++ b/docs/node/api-gatsby/generators/page.md
@@ -1,4 +1,4 @@
-# page
+# @nrwl/gatsby:page
 
 Create a page
 

--- a/docs/node/api-jest/executors/jest.md
+++ b/docs/node/api-jest/executors/jest.md
@@ -1,4 +1,4 @@
-# jest
+# @nrwl/jest:jest
 
 Run Jest unit tests
 

--- a/docs/node/api-linter/executors/eslint.md
+++ b/docs/node/api-linter/executors/eslint.md
@@ -1,4 +1,4 @@
-# eslint
+# @nrwl/linter:eslint
 
 Run ESLint on a project
 

--- a/docs/node/api-linter/executors/lint.md
+++ b/docs/node/api-linter/executors/lint.md
@@ -1,4 +1,4 @@
-# lint
+# @nrwl/linter:lint
 
 **[DEPRECATED]**: Please use the eslint builder instead, an automated migration was provided in v10.3.0
 

--- a/docs/node/api-nest/generators/application.md
+++ b/docs/node/api-nest/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/nest:application
 
 Create a NestJS application.
 

--- a/docs/node/api-nest/generators/class.md
+++ b/docs/node/api-nest/generators/class.md
@@ -1,4 +1,4 @@
-# class
+# @nrwl/nest:class
 
 Run the `class` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/controller.md
+++ b/docs/node/api-nest/generators/controller.md
@@ -1,4 +1,4 @@
-# controller
+# @nrwl/nest:controller
 
 Run the `controller` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/convert-tslint-to-eslint.md
+++ b/docs/node/api-nest/generators/convert-tslint-to-eslint.md
@@ -1,4 +1,4 @@
-# convert-tslint-to-eslint
+# @nrwl/nest:convert-tslint-to-eslint
 
 Convert a project from TSLint to ESLint.
 

--- a/docs/node/api-nest/generators/decorator.md
+++ b/docs/node/api-nest/generators/decorator.md
@@ -1,4 +1,4 @@
-# decorator
+# @nrwl/nest:decorator
 
 Run the `decorator` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/filter.md
+++ b/docs/node/api-nest/generators/filter.md
@@ -1,4 +1,4 @@
-# filter
+# @nrwl/nest:filter
 
 Run the `filter` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/gateway.md
+++ b/docs/node/api-nest/generators/gateway.md
@@ -1,4 +1,4 @@
-# gateway
+# @nrwl/nest:gateway
 
 Run the `gateway` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/guard.md
+++ b/docs/node/api-nest/generators/guard.md
@@ -1,4 +1,4 @@
-# guard
+# @nrwl/nest:guard
 
 Run the `guard` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/interceptor.md
+++ b/docs/node/api-nest/generators/interceptor.md
@@ -1,4 +1,4 @@
-# interceptor
+# @nrwl/nest:interceptor
 
 Run the `interceptor` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/interface.md
+++ b/docs/node/api-nest/generators/interface.md
@@ -1,4 +1,4 @@
-# interface
+# @nrwl/nest:interface
 
 Run the `interface` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/library.md
+++ b/docs/node/api-nest/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/nest:library
 
 Create a new NestJS library.
 

--- a/docs/node/api-nest/generators/middleware.md
+++ b/docs/node/api-nest/generators/middleware.md
@@ -1,4 +1,4 @@
-# middleware
+# @nrwl/nest:middleware
 
 Run the `middleware` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/module.md
+++ b/docs/node/api-nest/generators/module.md
@@ -1,4 +1,4 @@
-# module
+# @nrwl/nest:module
 
 Run the `module` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/pipe.md
+++ b/docs/node/api-nest/generators/pipe.md
@@ -1,4 +1,4 @@
-# pipe
+# @nrwl/nest:pipe
 
 Run the `pipe` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/provider.md
+++ b/docs/node/api-nest/generators/provider.md
@@ -1,4 +1,4 @@
-# provider
+# @nrwl/nest:provider
 
 Run the `provider` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/resolver.md
+++ b/docs/node/api-nest/generators/resolver.md
@@ -1,4 +1,4 @@
-# resolver
+# @nrwl/nest:resolver
 
 Run the `resolver` NestJS generator with Nx project support.
 

--- a/docs/node/api-nest/generators/service.md
+++ b/docs/node/api-nest/generators/service.md
@@ -1,4 +1,4 @@
-# service
+# @nrwl/nest:service
 
 Run the `service` NestJS generator with Nx project support.
 

--- a/docs/node/api-next/executors/build.md
+++ b/docs/node/api-next/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/next:build
 
 Build a Next.js app
 

--- a/docs/node/api-next/executors/export.md
+++ b/docs/node/api-next/executors/export.md
@@ -1,4 +1,4 @@
-# export
+# @nrwl/next:export
 
 Export a Next.js app. The exported application is located at dist/$outputPath/exported.
 

--- a/docs/node/api-next/executors/server.md
+++ b/docs/node/api-next/executors/server.md
@@ -1,4 +1,4 @@
-# server
+# @nrwl/next:server
 
 Serve a Next.js app
 

--- a/docs/node/api-next/generators/application.md
+++ b/docs/node/api-next/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/next:application
 
 Create a Next.js application
 

--- a/docs/node/api-next/generators/component.md
+++ b/docs/node/api-next/generators/component.md
@@ -1,4 +1,4 @@
-# component
+# @nrwl/next:component
 
 Create a React component
 

--- a/docs/node/api-next/generators/page.md
+++ b/docs/node/api-next/generators/page.md
@@ -1,4 +1,4 @@
-# page
+# @nrwl/next:page
 
 Create a Next.js page component
 

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/node:build
 
 Build a Node application
 

--- a/docs/node/api-node/executors/execute.md
+++ b/docs/node/api-node/executors/execute.md
@@ -1,4 +1,4 @@
-# execute
+# @nrwl/node:execute
 
 Execute a Node application
 

--- a/docs/node/api-node/executors/package.md
+++ b/docs/node/api-node/executors/package.md
@@ -1,4 +1,4 @@
-# package
+# @nrwl/node:package
 
 Package a Node library
 

--- a/docs/node/api-node/generators/application.md
+++ b/docs/node/api-node/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/node:application
 
 Create a node application
 

--- a/docs/node/api-node/generators/library.md
+++ b/docs/node/api-node/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/node:library
 
 Create a library
 

--- a/docs/node/api-node/generators/migrate-to-webpack-5.md
+++ b/docs/node/api-node/generators/migrate-to-webpack-5.md
@@ -1,4 +1,4 @@
-# migrate-to-webpack-5
+# @nrwl/node:migrate-to-webpack-5
 
 Add webpack 5 compatible dependencies to the workspace
 

--- a/docs/node/api-nx-plugin/executors/e2e.md
+++ b/docs/node/api-nx-plugin/executors/e2e.md
@@ -1,4 +1,4 @@
-# e2e
+# @nrwl/nx-plugin:e2e
 
 Creates and runs the e2e tests for an Nx Plugin.
 

--- a/docs/node/api-nx-plugin/generators/executor.md
+++ b/docs/node/api-nx-plugin/generators/executor.md
@@ -1,4 +1,4 @@
-# executor
+# @nrwl/nx-plugin:executor
 
 Create a executor for an Nx Plugin
 

--- a/docs/node/api-nx-plugin/generators/generator.md
+++ b/docs/node/api-nx-plugin/generators/generator.md
@@ -1,4 +1,4 @@
-# generator
+# @nrwl/nx-plugin:generator
 
 Create a generator for an Nx Plugin
 

--- a/docs/node/api-nx-plugin/generators/migration.md
+++ b/docs/node/api-nx-plugin/generators/migration.md
@@ -1,4 +1,4 @@
-# migration
+# @nrwl/nx-plugin:migration
 
 Create a migration for an Nx Plugin
 

--- a/docs/node/api-nx-plugin/generators/plugin.md
+++ b/docs/node/api-nx-plugin/generators/plugin.md
@@ -1,4 +1,4 @@
-# plugin
+# @nrwl/nx-plugin:plugin
 
 Create a Nx Plugin
 

--- a/docs/node/api-react/generators/application.md
+++ b/docs/node/api-react/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/react:application
 
 Create an application
 

--- a/docs/node/api-react/generators/component-cypress-spec.md
+++ b/docs/node/api-react/generators/component-cypress-spec.md
@@ -1,4 +1,4 @@
-# component-cypress-spec
+# @nrwl/react:component-cypress-spec
 
 Create a cypress spec for a ui component that has a story
 

--- a/docs/node/api-react/generators/component-story.md
+++ b/docs/node/api-react/generators/component-story.md
@@ -1,4 +1,4 @@
-# component-story
+# @nrwl/react:component-story
 
 Generate storybook story for a react component
 

--- a/docs/node/api-react/generators/component.md
+++ b/docs/node/api-react/generators/component.md
@@ -1,4 +1,4 @@
-# component
+# @nrwl/react:component
 
 Create a component
 

--- a/docs/node/api-react/generators/library.md
+++ b/docs/node/api-react/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/react:library
 
 Create a library
 

--- a/docs/node/api-react/generators/redux.md
+++ b/docs/node/api-react/generators/redux.md
@@ -1,4 +1,4 @@
-# redux
+# @nrwl/react:redux
 
 Create a redux slice for a project
 

--- a/docs/node/api-react/generators/stories.md
+++ b/docs/node/api-react/generators/stories.md
@@ -1,4 +1,4 @@
-# stories
+# @nrwl/react:stories
 
 Create stories/specs for all components declared in a library
 

--- a/docs/node/api-react/generators/storybook-configuration.md
+++ b/docs/node/api-react/generators/storybook-configuration.md
@@ -1,4 +1,4 @@
-# storybook-configuration
+# @nrwl/react:storybook-configuration
 
 Set up storybook for a react library
 

--- a/docs/node/api-react/generators/storybook-migrate-defaults-5-to-6.md
+++ b/docs/node/api-react/generators/storybook-migrate-defaults-5-to-6.md
@@ -1,4 +1,4 @@
-# storybook-migrate-defaults-5-to-6
+# @nrwl/react:storybook-migrate-defaults-5-to-6
 
 Generate default Storybook configuration files using Storybook version >=6.x specs, for projects that already have Storybook instances and configurations of versions <6.x.
 

--- a/docs/node/api-storybook/executors/build.md
+++ b/docs/node/api-storybook/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/storybook:build
 
 Build Storybook
 

--- a/docs/node/api-storybook/executors/storybook.md
+++ b/docs/node/api-storybook/executors/storybook.md
@@ -1,4 +1,4 @@
-# storybook
+# @nrwl/storybook:storybook
 
 Serve Storybook
 

--- a/docs/node/api-storybook/generators/configuration.md
+++ b/docs/node/api-storybook/generators/configuration.md
@@ -1,4 +1,4 @@
-# configuration
+# @nrwl/storybook:configuration
 
 Add storybook configuration to a ui library or an application
 

--- a/docs/node/api-storybook/generators/cypress-project.md
+++ b/docs/node/api-storybook/generators/cypress-project.md
@@ -1,4 +1,4 @@
-# cypress-project
+# @nrwl/storybook:cypress-project
 
 Add cypress e2e app to test a ui library that is set up for storybook
 

--- a/docs/node/api-storybook/generators/migrate-defaults-5-to-6.md
+++ b/docs/node/api-storybook/generators/migrate-defaults-5-to-6.md
@@ -1,4 +1,4 @@
-# migrate-defaults-5-to-6
+# @nrwl/storybook:migrate-defaults-5-to-6
 
 Generate default Storybook configuration files using Storybook version >=6.x specs, for projects that already have Storybook instances and configurations of versions <6.x.
 

--- a/docs/node/api-storybook/generators/migrate-stories-to-6-2.md
+++ b/docs/node/api-storybook/generators/migrate-stories-to-6-2.md
@@ -1,4 +1,4 @@
-# migrate-stories-to-6-2
+# @nrwl/storybook:migrate-stories-to-6-2
 
 Migrate stories syntax to 6.2
 

--- a/docs/node/api-web/executors/build.md
+++ b/docs/node/api-web/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/web:build
 
 Build a application
 

--- a/docs/node/api-web/executors/dev-server.md
+++ b/docs/node/api-web/executors/dev-server.md
@@ -1,4 +1,4 @@
-# dev-server
+# @nrwl/web:dev-server
 
 Serve a web application
 

--- a/docs/node/api-web/executors/file-server.md
+++ b/docs/node/api-web/executors/file-server.md
@@ -1,4 +1,4 @@
-# file-server
+# @nrwl/web:file-server
 
 Serve a web application from a folder
 

--- a/docs/node/api-web/executors/package.md
+++ b/docs/node/api-web/executors/package.md
@@ -1,4 +1,4 @@
-# package
+# @nrwl/web:package
 
 Package a library
 

--- a/docs/node/api-web/generators/application.md
+++ b/docs/node/api-web/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/web:application
 
 Create an application
 

--- a/docs/node/api-web/generators/migrate-to-webpack-5.md
+++ b/docs/node/api-web/generators/migrate-to-webpack-5.md
@@ -1,4 +1,4 @@
-# migrate-to-webpack-5
+# @nrwl/web:migrate-to-webpack-5
 
 Add webpack 5 compatible dependencies to the workspace
 

--- a/docs/node/api-workspace/executors/run-commands.md
+++ b/docs/node/api-workspace/executors/run-commands.md
@@ -1,4 +1,4 @@
-# run-commands
+# @nrwl/workspace:run-commands
 
 Run any custom commands with Nx
 

--- a/docs/node/api-workspace/executors/run-script.md
+++ b/docs/node/api-workspace/executors/run-script.md
@@ -1,4 +1,4 @@
-# run-script
+# @nrwl/workspace:run-script
 
 Run an npm script using Nx
 

--- a/docs/node/api-workspace/executors/tsc.md
+++ b/docs/node/api-workspace/executors/tsc.md
@@ -1,4 +1,4 @@
-# tsc
+# @nrwl/workspace:tsc
 
 Build a project using TypeScript.
 

--- a/docs/node/api-workspace/generators/convert-to-nx-project.md
+++ b/docs/node/api-workspace/generators/convert-to-nx-project.md
@@ -1,4 +1,4 @@
-# convert-to-nx-project
+# @nrwl/workspace:convert-to-nx-project
 
 Moves a project's configuration outside of workspace.json
 

--- a/docs/node/api-workspace/generators/library.md
+++ b/docs/node/api-workspace/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/workspace:library
 
 Create a library
 

--- a/docs/node/api-workspace/generators/move.md
+++ b/docs/node/api-workspace/generators/move.md
@@ -1,4 +1,4 @@
-# move
+# @nrwl/workspace:move
 
 Move an application or library to another folder
 

--- a/docs/node/api-workspace/generators/remove.md
+++ b/docs/node/api-workspace/generators/remove.md
@@ -1,4 +1,4 @@
-# remove
+# @nrwl/workspace:remove
 
 Remove an application or library
 

--- a/docs/node/api-workspace/generators/run-commands.md
+++ b/docs/node/api-workspace/generators/run-commands.md
@@ -1,4 +1,4 @@
-# run-commands
+# @nrwl/workspace:run-commands
 
 Generates a target to run any command in the terminal
 

--- a/docs/node/api-workspace/generators/workspace-generator.md
+++ b/docs/node/api-workspace/generators/workspace-generator.md
@@ -1,4 +1,4 @@
-# workspace-generator
+# @nrwl/workspace:workspace-generator
 
 Generates a workspace generator
 

--- a/docs/react/api-angular/executors/delegate-build.md
+++ b/docs/react/api-angular/executors/delegate-build.md
@@ -1,4 +1,4 @@
-# delegate-build
+# @nrwl/angular:delegate-build
 
 Delegates the build to a different target while supporting incremental builds.
 

--- a/docs/react/api-angular/executors/ng-packagr-lite.md
+++ b/docs/react/api-angular/executors/ng-packagr-lite.md
@@ -1,4 +1,4 @@
-# ng-packagr-lite
+# @nrwl/angular:ng-packagr-lite
 
 Builds a library with support for incremental builds.
 

--- a/docs/react/api-angular/executors/package.md
+++ b/docs/react/api-angular/executors/package.md
@@ -1,4 +1,4 @@
-# package
+# @nrwl/angular:package
 
 Builds and packages an Angular library to be distributed as an NPM package. It supports incremental builds.
 

--- a/docs/react/api-angular/executors/webpack-browser.md
+++ b/docs/react/api-angular/executors/webpack-browser.md
@@ -1,4 +1,4 @@
-# webpack-browser
+# @nrwl/angular:webpack-browser
 
 Builds a browser application with support for incremental builds and custom webpack configuration.
 

--- a/docs/react/api-angular/executors/webpack-server.md
+++ b/docs/react/api-angular/executors/webpack-server.md
@@ -1,4 +1,4 @@
-# webpack-server
+# @nrwl/angular:webpack-server
 
 Serves a browser application with support for a custom webpack configuration.
 

--- a/docs/react/api-angular/generators/application.md
+++ b/docs/react/api-angular/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/angular:application
 
 Creates an Angular application.
 

--- a/docs/react/api-angular/generators/convert-tslint-to-eslint.md
+++ b/docs/react/api-angular/generators/convert-tslint-to-eslint.md
@@ -1,4 +1,4 @@
-# convert-tslint-to-eslint
+# @nrwl/angular:convert-tslint-to-eslint
 
 Converts a project from TSLint to ESLint.
 

--- a/docs/react/api-angular/generators/downgrade-module.md
+++ b/docs/react/api-angular/generators/downgrade-module.md
@@ -1,4 +1,4 @@
-# downgrade-module
+# @nrwl/angular:downgrade-module
 
 Sets up a Downgrade Module.
 

--- a/docs/react/api-angular/generators/karma-project.md
+++ b/docs/react/api-angular/generators/karma-project.md
@@ -1,4 +1,4 @@
-# karma-project
+# @nrwl/angular:karma-project
 
 Adds Karma configuration to a project.
 

--- a/docs/react/api-angular/generators/karma.md
+++ b/docs/react/api-angular/generators/karma.md
@@ -1,4 +1,4 @@
-# karma
+# @nrwl/angular:karma
 
 Adds Karma configuration to a workspace.
 

--- a/docs/react/api-angular/generators/library.md
+++ b/docs/react/api-angular/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/angular:library
 
 Creates an Angular library.
 

--- a/docs/react/api-angular/generators/move.md
+++ b/docs/react/api-angular/generators/move.md
@@ -1,4 +1,4 @@
-# move
+# @nrwl/angular:move
 
 Moves an Angular application or library to another folder within the workspace and updates the project configuration.
 

--- a/docs/react/api-angular/generators/ngrx.md
+++ b/docs/react/api-angular/generators/ngrx.md
@@ -1,4 +1,4 @@
-# ngrx
+# @nrwl/angular:ngrx
 
 Adds NgRx support to an application or library.
 

--- a/docs/react/api-angular/generators/setup-mfe.md
+++ b/docs/react/api-angular/generators/setup-mfe.md
@@ -1,4 +1,4 @@
-# setup-mfe
+# @nrwl/angular:setup-mfe
 
 Generate a Module Federation configuration for a given Angular application.
 

--- a/docs/react/api-angular/generators/stories.md
+++ b/docs/react/api-angular/generators/stories.md
@@ -1,4 +1,4 @@
-# stories
+# @nrwl/angular:stories
 
 Creates stories/specs for all components declared in a project.
 

--- a/docs/react/api-angular/generators/storybook-configuration.md
+++ b/docs/react/api-angular/generators/storybook-configuration.md
@@ -1,4 +1,4 @@
-# storybook-configuration
+# @nrwl/angular:storybook-configuration
 
 Adds Storybook configuration to a project.
 

--- a/docs/react/api-angular/generators/storybook-migrate-defaults-5-to-6.md
+++ b/docs/react/api-angular/generators/storybook-migrate-defaults-5-to-6.md
@@ -1,4 +1,4 @@
-# storybook-migrate-defaults-5-to-6
+# @nrwl/angular:storybook-migrate-defaults-5-to-6
 
 Generates default Storybook configuration files using Storybook version >=6.x specs, for projects that already have Storybook instances and configurations of versions <6.x.
 

--- a/docs/react/api-angular/generators/storybook-migrate-stories-to-6-2.md
+++ b/docs/react/api-angular/generators/storybook-migrate-stories-to-6-2.md
@@ -1,4 +1,4 @@
-# storybook-migrate-stories-to-6-2
+# @nrwl/angular:storybook-migrate-stories-to-6-2
 
 Migrates stories to match the new syntax in v6.2 where the component declaration should be in the default export.
 

--- a/docs/react/api-angular/generators/upgrade-module.md
+++ b/docs/react/api-angular/generators/upgrade-module.md
@@ -1,4 +1,4 @@
-# upgrade-module
+# @nrwl/angular:upgrade-module
 
 Sets up an Upgrade Module.
 

--- a/docs/react/api-angular/generators/web-worker.md
+++ b/docs/react/api-angular/generators/web-worker.md
@@ -1,4 +1,4 @@
-# web-worker
+# @nrwl/angular:web-worker
 
 Creates a Web Worker.
 

--- a/docs/react/api-cypress/executors/cypress.md
+++ b/docs/react/api-cypress/executors/cypress.md
@@ -1,4 +1,4 @@
-# cypress
+# @nrwl/cypress:cypress
 
 Run Cypress e2e tests
 

--- a/docs/react/api-express/generators/application.md
+++ b/docs/react/api-express/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/express:application
 
 Create an express application
 

--- a/docs/react/api-gatsby/executors/build.md
+++ b/docs/react/api-gatsby/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/gatsby:build
 
 Build a Gatsby app
 

--- a/docs/react/api-gatsby/executors/server.md
+++ b/docs/react/api-gatsby/executors/server.md
@@ -1,4 +1,4 @@
-# server
+# @nrwl/gatsby:server
 
 Starts server for app
 

--- a/docs/react/api-gatsby/generators/application.md
+++ b/docs/react/api-gatsby/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/gatsby:application
 
 Create an application
 

--- a/docs/react/api-gatsby/generators/component.md
+++ b/docs/react/api-gatsby/generators/component.md
@@ -1,4 +1,4 @@
-# component
+# @nrwl/gatsby:component
 
 Create a component
 

--- a/docs/react/api-gatsby/generators/page.md
+++ b/docs/react/api-gatsby/generators/page.md
@@ -1,4 +1,4 @@
-# page
+# @nrwl/gatsby:page
 
 Create a page
 

--- a/docs/react/api-jest/executors/jest.md
+++ b/docs/react/api-jest/executors/jest.md
@@ -1,4 +1,4 @@
-# jest
+# @nrwl/jest:jest
 
 Run Jest unit tests
 

--- a/docs/react/api-linter/executors/eslint.md
+++ b/docs/react/api-linter/executors/eslint.md
@@ -1,4 +1,4 @@
-# eslint
+# @nrwl/linter:eslint
 
 Run ESLint on a project
 

--- a/docs/react/api-linter/executors/lint.md
+++ b/docs/react/api-linter/executors/lint.md
@@ -1,4 +1,4 @@
-# lint
+# @nrwl/linter:lint
 
 **[DEPRECATED]**: Please use the eslint builder instead, an automated migration was provided in v10.3.0
 

--- a/docs/react/api-nest/generators/application.md
+++ b/docs/react/api-nest/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/nest:application
 
 Create a NestJS application.
 

--- a/docs/react/api-nest/generators/class.md
+++ b/docs/react/api-nest/generators/class.md
@@ -1,4 +1,4 @@
-# class
+# @nrwl/nest:class
 
 Run the `class` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/controller.md
+++ b/docs/react/api-nest/generators/controller.md
@@ -1,4 +1,4 @@
-# controller
+# @nrwl/nest:controller
 
 Run the `controller` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/convert-tslint-to-eslint.md
+++ b/docs/react/api-nest/generators/convert-tslint-to-eslint.md
@@ -1,4 +1,4 @@
-# convert-tslint-to-eslint
+# @nrwl/nest:convert-tslint-to-eslint
 
 Convert a project from TSLint to ESLint.
 

--- a/docs/react/api-nest/generators/decorator.md
+++ b/docs/react/api-nest/generators/decorator.md
@@ -1,4 +1,4 @@
-# decorator
+# @nrwl/nest:decorator
 
 Run the `decorator` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/filter.md
+++ b/docs/react/api-nest/generators/filter.md
@@ -1,4 +1,4 @@
-# filter
+# @nrwl/nest:filter
 
 Run the `filter` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/gateway.md
+++ b/docs/react/api-nest/generators/gateway.md
@@ -1,4 +1,4 @@
-# gateway
+# @nrwl/nest:gateway
 
 Run the `gateway` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/guard.md
+++ b/docs/react/api-nest/generators/guard.md
@@ -1,4 +1,4 @@
-# guard
+# @nrwl/nest:guard
 
 Run the `guard` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/interceptor.md
+++ b/docs/react/api-nest/generators/interceptor.md
@@ -1,4 +1,4 @@
-# interceptor
+# @nrwl/nest:interceptor
 
 Run the `interceptor` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/interface.md
+++ b/docs/react/api-nest/generators/interface.md
@@ -1,4 +1,4 @@
-# interface
+# @nrwl/nest:interface
 
 Run the `interface` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/library.md
+++ b/docs/react/api-nest/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/nest:library
 
 Create a new NestJS library.
 

--- a/docs/react/api-nest/generators/middleware.md
+++ b/docs/react/api-nest/generators/middleware.md
@@ -1,4 +1,4 @@
-# middleware
+# @nrwl/nest:middleware
 
 Run the `middleware` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/module.md
+++ b/docs/react/api-nest/generators/module.md
@@ -1,4 +1,4 @@
-# module
+# @nrwl/nest:module
 
 Run the `module` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/pipe.md
+++ b/docs/react/api-nest/generators/pipe.md
@@ -1,4 +1,4 @@
-# pipe
+# @nrwl/nest:pipe
 
 Run the `pipe` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/provider.md
+++ b/docs/react/api-nest/generators/provider.md
@@ -1,4 +1,4 @@
-# provider
+# @nrwl/nest:provider
 
 Run the `provider` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/resolver.md
+++ b/docs/react/api-nest/generators/resolver.md
@@ -1,4 +1,4 @@
-# resolver
+# @nrwl/nest:resolver
 
 Run the `resolver` NestJS generator with Nx project support.
 

--- a/docs/react/api-nest/generators/service.md
+++ b/docs/react/api-nest/generators/service.md
@@ -1,4 +1,4 @@
-# service
+# @nrwl/nest:service
 
 Run the `service` NestJS generator with Nx project support.
 

--- a/docs/react/api-next/executors/build.md
+++ b/docs/react/api-next/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/next:build
 
 Build a Next.js app
 

--- a/docs/react/api-next/executors/export.md
+++ b/docs/react/api-next/executors/export.md
@@ -1,4 +1,4 @@
-# export
+# @nrwl/next:export
 
 Export a Next.js app. The exported application is located at dist/$outputPath/exported.
 

--- a/docs/react/api-next/executors/server.md
+++ b/docs/react/api-next/executors/server.md
@@ -1,4 +1,4 @@
-# server
+# @nrwl/next:server
 
 Serve a Next.js app
 

--- a/docs/react/api-next/generators/application.md
+++ b/docs/react/api-next/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/next:application
 
 Create a Next.js application
 

--- a/docs/react/api-next/generators/component.md
+++ b/docs/react/api-next/generators/component.md
@@ -1,4 +1,4 @@
-# component
+# @nrwl/next:component
 
 Create a React component
 

--- a/docs/react/api-next/generators/page.md
+++ b/docs/react/api-next/generators/page.md
@@ -1,4 +1,4 @@
-# page
+# @nrwl/next:page
 
 Create a Next.js page component
 

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/node:build
 
 Build a Node application
 

--- a/docs/react/api-node/executors/execute.md
+++ b/docs/react/api-node/executors/execute.md
@@ -1,4 +1,4 @@
-# execute
+# @nrwl/node:execute
 
 Execute a Node application
 

--- a/docs/react/api-node/executors/package.md
+++ b/docs/react/api-node/executors/package.md
@@ -1,4 +1,4 @@
-# package
+# @nrwl/node:package
 
 Package a Node library
 

--- a/docs/react/api-node/generators/application.md
+++ b/docs/react/api-node/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/node:application
 
 Create a node application
 

--- a/docs/react/api-node/generators/library.md
+++ b/docs/react/api-node/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/node:library
 
 Create a library
 

--- a/docs/react/api-node/generators/migrate-to-webpack-5.md
+++ b/docs/react/api-node/generators/migrate-to-webpack-5.md
@@ -1,4 +1,4 @@
-# migrate-to-webpack-5
+# @nrwl/node:migrate-to-webpack-5
 
 Add webpack 5 compatible dependencies to the workspace
 

--- a/docs/react/api-nx-plugin/executors/e2e.md
+++ b/docs/react/api-nx-plugin/executors/e2e.md
@@ -1,4 +1,4 @@
-# e2e
+# @nrwl/nx-plugin:e2e
 
 Creates and runs the e2e tests for an Nx Plugin.
 

--- a/docs/react/api-nx-plugin/generators/executor.md
+++ b/docs/react/api-nx-plugin/generators/executor.md
@@ -1,4 +1,4 @@
-# executor
+# @nrwl/nx-plugin:executor
 
 Create a executor for an Nx Plugin
 

--- a/docs/react/api-nx-plugin/generators/generator.md
+++ b/docs/react/api-nx-plugin/generators/generator.md
@@ -1,4 +1,4 @@
-# generator
+# @nrwl/nx-plugin:generator
 
 Create a generator for an Nx Plugin
 

--- a/docs/react/api-nx-plugin/generators/migration.md
+++ b/docs/react/api-nx-plugin/generators/migration.md
@@ -1,4 +1,4 @@
-# migration
+# @nrwl/nx-plugin:migration
 
 Create a migration for an Nx Plugin
 

--- a/docs/react/api-nx-plugin/generators/plugin.md
+++ b/docs/react/api-nx-plugin/generators/plugin.md
@@ -1,4 +1,4 @@
-# plugin
+# @nrwl/nx-plugin:plugin
 
 Create a Nx Plugin
 

--- a/docs/react/api-react/generators/application.md
+++ b/docs/react/api-react/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/react:application
 
 Create an application
 

--- a/docs/react/api-react/generators/component-cypress-spec.md
+++ b/docs/react/api-react/generators/component-cypress-spec.md
@@ -1,4 +1,4 @@
-# component-cypress-spec
+# @nrwl/react:component-cypress-spec
 
 Create a cypress spec for a ui component that has a story
 

--- a/docs/react/api-react/generators/component-story.md
+++ b/docs/react/api-react/generators/component-story.md
@@ -1,4 +1,4 @@
-# component-story
+# @nrwl/react:component-story
 
 Generate storybook story for a react component
 

--- a/docs/react/api-react/generators/component.md
+++ b/docs/react/api-react/generators/component.md
@@ -1,4 +1,4 @@
-# component
+# @nrwl/react:component
 
 Create a component
 

--- a/docs/react/api-react/generators/library.md
+++ b/docs/react/api-react/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/react:library
 
 Create a library
 

--- a/docs/react/api-react/generators/redux.md
+++ b/docs/react/api-react/generators/redux.md
@@ -1,4 +1,4 @@
-# redux
+# @nrwl/react:redux
 
 Create a redux slice for a project
 

--- a/docs/react/api-react/generators/stories.md
+++ b/docs/react/api-react/generators/stories.md
@@ -1,4 +1,4 @@
-# stories
+# @nrwl/react:stories
 
 Create stories/specs for all components declared in a library
 

--- a/docs/react/api-react/generators/storybook-configuration.md
+++ b/docs/react/api-react/generators/storybook-configuration.md
@@ -1,4 +1,4 @@
-# storybook-configuration
+# @nrwl/react:storybook-configuration
 
 Set up storybook for a react library
 

--- a/docs/react/api-react/generators/storybook-migrate-defaults-5-to-6.md
+++ b/docs/react/api-react/generators/storybook-migrate-defaults-5-to-6.md
@@ -1,4 +1,4 @@
-# storybook-migrate-defaults-5-to-6
+# @nrwl/react:storybook-migrate-defaults-5-to-6
 
 Generate default Storybook configuration files using Storybook version >=6.x specs, for projects that already have Storybook instances and configurations of versions <6.x.
 

--- a/docs/react/api-storybook/executors/build.md
+++ b/docs/react/api-storybook/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/storybook:build
 
 Build Storybook
 

--- a/docs/react/api-storybook/executors/storybook.md
+++ b/docs/react/api-storybook/executors/storybook.md
@@ -1,4 +1,4 @@
-# storybook
+# @nrwl/storybook:storybook
 
 Serve Storybook
 

--- a/docs/react/api-storybook/generators/configuration.md
+++ b/docs/react/api-storybook/generators/configuration.md
@@ -1,4 +1,4 @@
-# configuration
+# @nrwl/storybook:configuration
 
 Add storybook configuration to a ui library or an application
 

--- a/docs/react/api-storybook/generators/cypress-project.md
+++ b/docs/react/api-storybook/generators/cypress-project.md
@@ -1,4 +1,4 @@
-# cypress-project
+# @nrwl/storybook:cypress-project
 
 Add cypress e2e app to test a ui library that is set up for storybook
 

--- a/docs/react/api-storybook/generators/migrate-defaults-5-to-6.md
+++ b/docs/react/api-storybook/generators/migrate-defaults-5-to-6.md
@@ -1,4 +1,4 @@
-# migrate-defaults-5-to-6
+# @nrwl/storybook:migrate-defaults-5-to-6
 
 Generate default Storybook configuration files using Storybook version >=6.x specs, for projects that already have Storybook instances and configurations of versions <6.x.
 

--- a/docs/react/api-storybook/generators/migrate-stories-to-6-2.md
+++ b/docs/react/api-storybook/generators/migrate-stories-to-6-2.md
@@ -1,4 +1,4 @@
-# migrate-stories-to-6-2
+# @nrwl/storybook:migrate-stories-to-6-2
 
 Migrate stories syntax to 6.2
 

--- a/docs/react/api-web/executors/build.md
+++ b/docs/react/api-web/executors/build.md
@@ -1,4 +1,4 @@
-# build
+# @nrwl/web:build
 
 Build a application
 

--- a/docs/react/api-web/executors/dev-server.md
+++ b/docs/react/api-web/executors/dev-server.md
@@ -1,4 +1,4 @@
-# dev-server
+# @nrwl/web:dev-server
 
 Serve a web application
 

--- a/docs/react/api-web/executors/file-server.md
+++ b/docs/react/api-web/executors/file-server.md
@@ -1,4 +1,4 @@
-# file-server
+# @nrwl/web:file-server
 
 Serve a web application from a folder
 

--- a/docs/react/api-web/executors/package.md
+++ b/docs/react/api-web/executors/package.md
@@ -1,4 +1,4 @@
-# package
+# @nrwl/web:package
 
 Package a library
 

--- a/docs/react/api-web/generators/application.md
+++ b/docs/react/api-web/generators/application.md
@@ -1,4 +1,4 @@
-# application
+# @nrwl/web:application
 
 Create an application
 

--- a/docs/react/api-web/generators/migrate-to-webpack-5.md
+++ b/docs/react/api-web/generators/migrate-to-webpack-5.md
@@ -1,4 +1,4 @@
-# migrate-to-webpack-5
+# @nrwl/web:migrate-to-webpack-5
 
 Add webpack 5 compatible dependencies to the workspace
 

--- a/docs/react/api-workspace/executors/run-commands.md
+++ b/docs/react/api-workspace/executors/run-commands.md
@@ -1,4 +1,4 @@
-# run-commands
+# @nrwl/workspace:run-commands
 
 Run any custom commands with Nx
 

--- a/docs/react/api-workspace/executors/run-script.md
+++ b/docs/react/api-workspace/executors/run-script.md
@@ -1,4 +1,4 @@
-# run-script
+# @nrwl/workspace:run-script
 
 Run an npm script using Nx
 

--- a/docs/react/api-workspace/executors/tsc.md
+++ b/docs/react/api-workspace/executors/tsc.md
@@ -1,4 +1,4 @@
-# tsc
+# @nrwl/workspace:tsc
 
 Build a project using TypeScript.
 

--- a/docs/react/api-workspace/generators/convert-to-nx-project.md
+++ b/docs/react/api-workspace/generators/convert-to-nx-project.md
@@ -1,4 +1,4 @@
-# convert-to-nx-project
+# @nrwl/workspace:convert-to-nx-project
 
 Moves a project's configuration outside of workspace.json
 

--- a/docs/react/api-workspace/generators/library.md
+++ b/docs/react/api-workspace/generators/library.md
@@ -1,4 +1,4 @@
-# library
+# @nrwl/workspace:library
 
 Create a library
 

--- a/docs/react/api-workspace/generators/move.md
+++ b/docs/react/api-workspace/generators/move.md
@@ -1,4 +1,4 @@
-# move
+# @nrwl/workspace:move
 
 Move an application or library to another folder
 

--- a/docs/react/api-workspace/generators/remove.md
+++ b/docs/react/api-workspace/generators/remove.md
@@ -1,4 +1,4 @@
-# remove
+# @nrwl/workspace:remove
 
 Remove an application or library
 

--- a/docs/react/api-workspace/generators/run-commands.md
+++ b/docs/react/api-workspace/generators/run-commands.md
@@ -1,4 +1,4 @@
-# run-commands
+# @nrwl/workspace:run-commands
 
 Generates a target to run any command in the terminal
 

--- a/docs/react/api-workspace/generators/workspace-generator.md
+++ b/docs/react/api-workspace/generators/workspace-generator.md
@@ -1,4 +1,4 @@
-# workspace-generator
+# @nrwl/workspace:workspace-generator
 
 Generates a workspace generator
 

--- a/scripts/documentation/generate-executors-data.ts
+++ b/scripts/documentation/generate-executors-data.ts
@@ -36,12 +36,18 @@ function readExecutorsJson(root: string) {
   return readJsonSync(join(root, 'executors.json')).executors;
 }
 
+function readPackageName(root: string) {
+  return readJsonSync(join(root, 'package.json')).name;
+}
+
 function generateSchematicList(
   config: Configuration,
   flattener: SchemaFlattener
 ): Promise<FileSystemSchematicJsonDescription>[] {
   removeSync(config.builderOutput);
   const builderCollection = readExecutorsJson(config.root);
+  const packageName = readPackageName(config.root);
+
   return Object.keys(builderCollection).map((builderName) => {
     const schemaPath = join(
       config.root,
@@ -49,6 +55,7 @@ function generateSchematicList(
     );
     let builder = {
       name: builderName,
+      collectionName: packageName,
       ...builderCollection[builderName],
       rawSchema: readJsonSync(schemaPath),
     };
@@ -74,7 +81,7 @@ function generateTemplate(
   const cliCommand = 'nx';
 
   let template = dedent`
-    # ${builder.name}
+    # ${builder.collectionName}:${builder.name}
     ${builder.description}
 
     Options can be configured in \`${filename}\` when defining the executor, or when invoking it.

--- a/scripts/documentation/generate-generators-data.ts
+++ b/scripts/documentation/generate-generators-data.ts
@@ -68,7 +68,9 @@ function generateTemplate(
   const cliCommand = 'nx';
   const filename = framework === 'angular' ? 'angular.json' : 'workspace.json';
   let template = dedent`
-    # ${schematic.name} ${schematic.hidden ? '[hidden]' : ''}
+    # ${schematic.collectionName}:${schematic.name} ${
+    schematic.hidden ? '[hidden]' : ''
+  }
     ${schematic.description}
   
     ## Usage


### PR DESCRIPTION
## Current Behavior
- Doc headers for executors/generators does not include the collectionName.
- Searching for `@nrwl/node:package` (as an example) does not find the package executor.

## Expected Behavior
- Searching for `@nrwl/node:package` (as an example) should find the package executor.

Signed-off-by: AgentEnder <craigorycoppola@gmail.com>