### PR TITLE
fix(angular): change version of angular migrations so they run during…

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -608,7 +608,7 @@
       }
     },
     "12.6.0": {
-      "version": "12.6.0",
+      "version": "12.6.0-beta.11",
       "packages": {
         "jasmine-marbles": {
           "version": "~0.8.3",


### PR DESCRIPTION
… beta

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

migrations for angular 12.1 do not run on beta versions

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

migrations for angular 12.1 do run on beta versions

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
