### PR TITLE
fix(gatsby): change migration version for gatsby 3.10

### DIFF
--- a/packages/gatsby/migrations.json
+++ b/packages/gatsby/migrations.json
@@ -8,7 +8,7 @@
     },
     "replace-node-sass-with-sass-12-6-1": {
       "cli": "nx",
-      "version": "12.6.1-beta.0",
+      "version": "12.6.0-beta.12",
       "description": "Replace node-sass with sass in package.json",
       "factory": "./src/migrations/update-12-6-1/replace-node-sass-with-sass-12-6-1"
     }
@@ -152,8 +152,8 @@
         }
       }
     },
-    "12.6.1": {
-      "version": "12.6.1-beta.0",
+    "12.6.0": {
+      "version": "12.6.0-beta.12",
       "packages": {
         "gatsby": {
           "version": "3.10.0",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Runs the migration to update gatsby to `3.10` in `12.6.1-beta.0`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Runs the migration to update gatsby to `3.10` earlier in `12.6.0-beta.12`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
