### PR TITLE
fix(storybook): deactivate file watcher for ci runs

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -118,6 +118,7 @@ describe('@nrwl/storybook:configuration', () => {
       configurations: {
         ci: {
           quiet: true,
+          watch: false,
         },
       },
       options: {

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -302,6 +302,7 @@ function addStorybookTask(
     configurations: {
       ci: {
         quiet: true,
+        watch: false,
       },
     },
   };


### PR DESCRIPTION
ISSUES CLOSED: #6463

## Current Behavior
When creating the Storybook configuration file watchers are activated for CI runs.

## Expected Behavior
File watchers should be deactivated for CI runs.

## Related Issue(s)
Fixes #6463 
