### PR TITLE
fix(core): handle directories with lots of files when reading the workspace files

### DIFF
--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -12,6 +12,7 @@ import { performance } from 'perf_hooks';
 import type { NxArgs } from '../command-line/utils';
 import { WorkspaceResults } from '../command-line/workspace-results';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
+import { appendArray } from '../utilities/array';
 import { fileExists, readJsonFile } from '../utilities/fileutils';
 import { jsonDiff } from '../utilities/json-diff';
 import { defaultFileHasher } from './hasher/file-hasher';
@@ -260,12 +261,12 @@ export function readWorkspaceFiles(): FileData[] {
     r.push(...rootWorkspaceFileData());
 
     // Add known workspace files and directories
-    r.push(...allFilesInDir(appRootPath, false));
-    r.push(...allFilesInDir(`${appRootPath}/tools`));
+    appendArray(r, allFilesInDir(appRootPath, false));
+    appendArray(r, allFilesInDir(`${appRootPath}/tools`));
     const wl = workspaceLayout();
-    r.push(...allFilesInDir(`${appRootPath}/${wl.appsDir}`));
+    appendArray(r, allFilesInDir(`${appRootPath}/${wl.appsDir}`));
     if (wl.appsDir !== wl.libsDir) {
-      r.push(...allFilesInDir(`${appRootPath}/${wl.libsDir}`));
+      appendArray(r, allFilesInDir(`${appRootPath}/${wl.libsDir}`));
     }
     performance.mark('read workspace files:end');
     performance.measure(

--- a/packages/workspace/src/utilities/array.ts
+++ b/packages/workspace/src/utilities/array.ts
@@ -1,0 +1,21 @@
+/**
+ * Appends an array to another array.
+ *
+ * Using `array.push(...otherArray)` can cause the stack to overflow when
+ * the `otherArray` is very large. This happens because the spread operator
+ * allocates every item in the stack before pushing them to the source array.
+ *
+ * The solution is to iterate over each element and append it. It is tedious
+ * to repeat this everywhere, so this is a small utility to help with that.
+ *
+ * Note: this mutates the source array. For an immutable operation, use
+ * `Array.prototype.concat` or `[...source, ...otherArray]`.
+ *
+ * @param source The array to append to.
+ * @param arrayToAppend The array to append to the source array.
+ */
+export function appendArray<T>(source: T[], arrayToAppend: T[]) {
+  for (const item of arrayToAppend) {
+    source.push(item);
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Using `array.push(...otherArray)` can cause a stack overflow error if `otherArray` is too large. This happens because the spread operator will put `otherArray` elements in the stack before pushing them to the source array.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should handle appending large arrays. A small utility is introduced that just iterates over the array and append each element to the source array.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
