### PR TITLE
docs(core): fix relative images for previews on vercel

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/renderers/transform-image-path.spec.ts
+++ b/nx-dev/feature-doc-viewer/src/lib/renderers/transform-image-path.spec.ts
@@ -3,37 +3,71 @@ import { transformImagePath } from './transform-image-path';
 describe('transformImagePath', () => {
   it('should transform relative paths', () => {
     const opts = {
-      version: '1.0.0',
-      document: { content: '', excerpt: '', filePath: 'a/b/test.md', data: {} },
+      version: 'latest',
+      document: {
+        content: '',
+        excerpt: '',
+        filePath: 'latest/react/test.md',
+        data: {},
+      },
     };
     const transform = transformImagePath(opts);
 
-    expect(transform('./test.png')).toEqual('/documentation/a/b/test.png');
-    expect(transform('../test.png')).toEqual('/documentation/a/test.png');
+    expect(transform('./test.png')).toEqual(
+      '/documentation/latest/react/test.png'
+    );
+    expect(transform('../test.png')).toEqual('/documentation/latest/test.png');
     expect(transform('../../test.png')).toEqual('/documentation/test.png');
+  });
+
+  it('should transform relative paths for previews on vercel', () => {
+    const opts = {
+      version: 'preview',
+      document: {
+        content: '',
+        excerpt: '',
+        filePath: 'react/test.md',
+        data: {},
+      },
+    };
+    const transform = transformImagePath(opts);
+
+    expect(transform('./test.png')).toEqual(
+      '/api/preview-asset?uri=.%2Ftest.png&document=react%2Ftest.md'
+    );
   });
 
   it('should transform absolute paths', () => {
     const opts = {
-      version: '1.0.0',
-      document: { content: '', excerpt: '', filePath: 'a/b/test.md', data: {} },
+      version: 'latest',
+      document: {
+        content: '',
+        excerpt: '',
+        filePath: 'latest/b/test.md',
+        data: {},
+      },
     };
     const transform = transformImagePath(opts);
 
     expect(transform('/shared/test.png')).toEqual(
-      '/documentation/1.0.0/shared/test.png'
+      '/documentation/latest/shared/test.png'
     );
   });
 
   it('should support preview links', () => {
     const opts = {
       version: 'preview',
-      document: { content: '', excerpt: '', filePath: 'a/b/test.md', data: {} },
+      document: {
+        content: '',
+        excerpt: '',
+        filePath: 'react/test.md',
+        data: {},
+      },
     };
     const transform = transformImagePath(opts);
 
     expect(transform('/shared/test.png')).toEqual(
-      '/api/preview-asset?uri=%2Fshared%2Ftest.png&document=a%2Fb%2Ftest.md'
+      '/api/preview-asset?uri=%2Fshared%2Ftest.png&document=react%2Ftest.md'
     );
   });
 });


### PR DESCRIPTION
This MR fixes relative image paths nx.dev docs.

For example on `/preview/react/guides/nextjs`.