### PR TITLE
docs(core): use createGlobPatternsForDependencies for tailwindcss config

### DIFF
--- a/nx-dev/nx-dev/tailwind.config.js
+++ b/nx-dev/nx-dev/tailwind.config.js
@@ -1,32 +1,11 @@
 const path = require('path');
-// nx-ignore-next-line
-const nxJson = require('@nrwl/workspace').readNxJson();
-// nx-ignore-next-line
-const workspaceJson = require('@nrwl/workspace').readWorkspaceJson();
-
-function getProjectNameWithTag(projectsJson, tag) {
-  return Object.keys(projectsJson.projects)
-    .map((projectName) => ({
-      ...projectsJson.projects[projectName],
-      name: projectName,
-    }))
-    .filter((project) => project.tags && project.tags.includes(tag))
-    .map((project) => project.name);
-}
-
-function getNxDevPurgePathList(nxJson, workspace) {
-  return getProjectNameWithTag(nxJson, 'scope:nx-dev')
-    .filter((projectName) => !['nx-dev', 'nx-dev-e2e'].includes(projectName))
-    .map((projectName) => workspace.projects[projectName])
-    .map((project) => path.join(project.sourceRoot, 'lib'))
-    .map((projectLib) => projectLib.concat('/**/*.{js,ts,jsx,tsx}'));
-}
+const { createGlobPatternsForDependencies } = require('@nrwl/next/tailwind');
 
 module.exports = {
   mode: 'jit',
   purge: [
-    './nx-dev/nx-dev/pages/**/*.{js,ts,jsx,tsx}',
-    ...getNxDevPurgePathList(nxJson, workspaceJson),
+    path.join(__dirname, 'pages/**/*.{js,ts,jsx,tsx}'),
+    ...createGlobPatternsForDependencies(__dirname),
   ],
   darkMode: false, // or 'media' or 'class'
   theme: {


### PR DESCRIPTION
## What it does?
This PR update the way the `tailwindcss.config.js` finds its purge files by using the `createGlobPatternsForDependencies()` helper from Nx.