### PR TITLE
fix(core): ensure cache pathMappings always exist

### DIFF
--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
@@ -83,7 +83,7 @@ export function readCache(): false | ProjectGraphCache {
 export function writeCache(
   packageJsonDeps: Record<string, string>,
   nxJson: NxJsonConfiguration,
-  tsConfig: { compilerOptions: { paths: { [k: string]: any } } },
+  tsConfig: { compilerOptions: { paths?: { [k: string]: any } } },
   projectGraph: ProjectGraph
 ): void {
   performance.mark('write cache:start');
@@ -94,7 +94,7 @@ export function writeCache(
   const newValue: ProjectGraphCache = {
     version: '3.0',
     deps: packageJsonDeps,
-    pathMappings: tsConfig.compilerOptions.paths,
+    pathMappings: tsConfig.compilerOptions.paths || {},
     nxJsonPlugins,
     nodes: projectGraph.nodes,
     dependencies: projectGraph.dependencies,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Nx cannot execute any targets when `"paths"` does not exist in `"compilerOptions"` within `tsconfig.base.json` (and it is not required to exist). This caused 12.6.0 to break typescript-eslint

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx should be able to execute targets when `"paths"` is not used by the workspace.


---

**NOTE: Even though I also updated the type information to be more correct, TypeScript still cannot help us here as `strictNullChecks` is not enabled. Maybe that should be revisited?**
