### PR TITLE
fix(misc): allow run-commands to accept readyWhen for a single command

### DIFF
--- a/docs/angular/api-workspace/executors/run-commands.md
+++ b/docs/angular/api-workspace/executors/run-commands.md
@@ -222,4 +222,4 @@ Run commands in parallel
 
 Type: `string`
 
-String to appear in `stdout` or `stderr` that indicates that the task is done. This option can only be used when multiple commands are run and `parallel` is set to `true`. If not specified, the task is done when all the child processes complete.
+String to appear in `stdout` or `stderr` that indicates that the task is done. When running multiple commands, this option can only be used when `parallel` is set to `true`. If not specified, the task is done when all the child processes complete.

--- a/docs/node/api-workspace/executors/run-commands.md
+++ b/docs/node/api-workspace/executors/run-commands.md
@@ -223,4 +223,4 @@ Run commands in parallel
 
 Type: `string`
 
-String to appear in `stdout` or `stderr` that indicates that the task is done. This option can only be used when multiple commands are run and `parallel` is set to `true`. If not specified, the task is done when all the child processes complete.
+String to appear in `stdout` or `stderr` that indicates that the task is done. When running multiple commands, this option can only be used when `parallel` is set to `true`. If not specified, the task is done when all the child processes complete.

--- a/docs/react/api-workspace/executors/run-commands.md
+++ b/docs/react/api-workspace/executors/run-commands.md
@@ -223,4 +223,4 @@ Run commands in parallel
 
 Type: `string`
 
-String to appear in `stdout` or `stderr` that indicates that the task is done. This option can only be used when multiple commands are run and `parallel` is set to `true`. If not specified, the task is done when all the child processes complete.
+String to appear in `stdout` or `stderr` that indicates that the task is done. When running multiple commands, this option can only be used when `parallel` is set to `true`. If not specified, the task is done when all the child processes complete.

--- a/packages/workspace/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.spec.ts
@@ -194,36 +194,6 @@ describe('Command Runner Builder', () => {
   });
 
   describe('readyWhen', () => {
-    it('should warn when command is specified instead of commands', async () => {
-      jest.spyOn(process.stderr, 'write');
-      await runCommands(
-        {
-          command: `echo 'Hello World'`,
-          readyWhen: 'READY',
-        },
-        context
-      );
-
-      expect(process.stderr.write).toHaveBeenCalledWith(
-        'Warning: "readyWhen" has no effect when a single command is run. The task will be done when the command process is completed. Ignoring.'
-      );
-    });
-
-    it('should warn when a single command is specified', async () => {
-      jest.spyOn(process.stderr, 'write');
-      await runCommands(
-        {
-          commands: [`echo 'Hello World'`],
-          readyWhen: 'READY',
-        },
-        context
-      );
-
-      expect(process.stderr.write).toHaveBeenCalledWith(
-        'Warning: "readyWhen" has no effect when a single command is run. The task will be done when the command process is completed. Ignoring.'
-      );
-    });
-
     it('should error when parallel = false', async () => {
       try {
         await runCommands(
@@ -237,7 +207,7 @@ describe('Command Runner Builder', () => {
         fail('should throw');
       } catch (e) {
         expect(e.message).toEqual(
-          `ERROR: Bad builder config for @nrwl/run-commands - "readyWhen" can only be used when parallel=true.`
+          `ERROR: Bad executor config for @nrwl/run-commands - "readyWhen" can only be used when "parallel=true".`
         );
       }
     });

--- a/packages/workspace/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.ts
@@ -71,15 +71,9 @@ export default async function (
   const normalized = normalizeOptions(options);
 
   if (options.readyWhen && !options.parallel) {
-    if (options.command || options.commands?.length === 1) {
-      process.stderr.write(
-        'Warning: "readyWhen" has no effect when a single command is run. The task will be done when the command process is completed. Ignoring.'
-      );
-    } else {
-      throw new Error(
-        'ERROR: Bad builder config for @nrwl/run-commands - "readyWhen" can only be used when parallel=true.'
-      );
-    }
+    throw new Error(
+      'ERROR: Bad executor config for @nrwl/run-commands - "readyWhen" can only be used when "parallel=true".'
+    );
   }
 
   try {
@@ -146,14 +140,11 @@ function normalizeOptions(
 
   if (options.command) {
     options.commands = [{ command: options.command }];
-    options.parallel = false;
+    options.parallel = !!options.readyWhen;
   } else {
     options.commands = options.commands.map((c) =>
       typeof c === 'string' ? { command: c } : c
     );
-    if (options.commands.length === 1) {
-      options.parallel = false;
-    }
   }
   (options as NormalizedRunCommandsBuilderOptions).commands.forEach((c) => {
     c.command = transformCommand(

--- a/packages/workspace/src/executors/run-commands/schema.json
+++ b/packages/workspace/src/executors/run-commands/schema.json
@@ -46,7 +46,7 @@
     },
     "readyWhen": {
       "type": "string",
-      "description": "String to appear in `stdout` or `stderr` that indicates that the task is done. This option can only be used when multiple commands are run and `parallel` is set to `true`. If not specified, the task is done when all the child processes complete."
+      "description": "String to appear in `stdout` or `stderr` that indicates that the task is done. When running multiple commands, this option can only be used when `parallel` is set to `true`. If not specified, the task is done when all the child processes complete."
     },
     "args": {
       "type": "string",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/workspace:run-commands` does not allow to use `readyWhen` with a single command. This was something that was kind of working before #6448, because we were able to bypass the restriction by using `commands` with a single command, but if you tried to use it with `command` it would error. This was inconsistent behavior and not in line with the docs. In #6448 the restriction was "corrected" to match the docs, but there's actually no reason to enforce that and limit that option to only multiple commands.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`@nrwl/workspace:run-commands` should allow using `readyWhen` with a single command. When running multiple commands, `readyWhen` can only be set if the `parallel` option is set to `true`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
