### PR TITLE
chore(repo): remove dependency from dep-graph to workspace and run-co…

### DIFF
--- a/dep-graph/dep-graph/project.json
+++ b/dep-graph/dep-graph/project.json
@@ -12,29 +12,43 @@
         "main": "dep-graph/dep-graph/src/main.ts",
         "polyfills": "dep-graph/dep-graph/src/polyfills.ts",
         "tsConfig": "dep-graph/dep-graph/tsconfig.app.json",
-        "assets": [
-          "dep-graph/dep-graph/src/favicon.ico",
-          "dep-graph/dep-graph/src/assets"
-        ],
         "styles": ["dep-graph/dep-graph/src/styles.scss"],
-        "scripts": []
+        "scripts": [],
+        "assets": [],
+        "optimization": true,
+        "outputHashing": "none",
+        "sourceMap": false,
+        "extractCss": true,
+        "namedChunks": false,
+        "extractLicenses": true,
+        "vendorChunk": false,
+        "budgets": [
+          {
+            "type": "initial",
+            "maximumWarning": "2mb",
+            "maximumError": "5mb"
+          }
+        ]
       },
       "configurations": {
-        "release": {
+        "dev": {
           "fileReplacements": [
             {
               "replace": "dep-graph/dep-graph/src/environments/environment.ts",
-              "with": "dep-graph/dep-graph/src/environments/environment.release.ts"
+              "with": "dep-graph/dep-graph/src/environments/environment.dev.ts"
             }
           ],
-          "assets": [],
-          "optimization": true,
+          "assets": [
+            "dep-graph/dep-graph/src/favicon.ico",
+            "dep-graph/dep-graph/src/assets"
+          ],
+          "optimization": false,
           "outputHashing": "none",
-          "sourceMap": false,
+          "sourceMap": true,
           "extractCss": true,
           "namedChunks": false,
-          "extractLicenses": true,
-          "vendorChunk": false,
+          "extractLicenses": false,
+          "vendorChunk": true,
           "budgets": [
             {
               "type": "initial",
@@ -72,12 +86,9 @@
     "serve": {
       "executor": "@nrwl/web:dev-server",
       "options": {
-        "buildTarget": "dep-graph-dep-graph:build-base"
+        "buildTarget": "dep-graph-dep-graph:build-base:dev"
       },
       "configurations": {
-        "release": {
-          "buildTarget": "dep-graph-dep-graph:build-base:release"
-        },
         "watch": {
           "buildTarget": "dep-graph-dep-graph:build-base:watch"
         }

--- a/dep-graph/dep-graph/src/app/app.ts
+++ b/dep-graph/dep-graph/src/app/app.ts
@@ -1,5 +1,6 @@
-import { DepGraphClientResponse } from '@nrwl/workspace';
-import { ProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+// nx-ignore-next-line
+import type { DepGraphClientResponse } from '@nrwl/workspace/src/command-line/dep-graph';
+import { ProjectGraph } from '@nrwl/devkit';
 import { combineLatest, fromEvent, Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
 import { DebuggerPanel } from './debugger-panel';

--- a/dep-graph/dep-graph/src/app/fetch-project-graph-service.ts
+++ b/dep-graph/dep-graph/src/app/fetch-project-graph-service.ts
@@ -1,4 +1,5 @@
-import { DepGraphClientResponse } from '@nrwl/workspace';
+// nx-ignore-next-line
+import { DepGraphClientResponse } from '@nrwl/workspace/src/command-line/dep-graph';
 import { ProjectGraphService } from './models';
 
 export class FetchProjectGraphService implements ProjectGraphService {

--- a/dep-graph/dep-graph/src/app/local-project-graph-service.ts
+++ b/dep-graph/dep-graph/src/app/local-project-graph-service.ts
@@ -1,4 +1,5 @@
-import { DepGraphClientResponse } from '@nrwl/workspace';
+// nx-ignore-next-line
+import { DepGraphClientResponse } from '@nrwl/workspace/src/command-line/dep-graph';
 import { ProjectGraphService } from './models';
 
 export class LocalProjectGraphService implements ProjectGraphService {

--- a/dep-graph/dep-graph/src/app/mock-project-graph-service.ts
+++ b/dep-graph/dep-graph/src/app/mock-project-graph-service.ts
@@ -1,5 +1,6 @@
-import { ProjectGraphDependency } from '@nrwl/devkit';
-import { DepGraphClientProject, DepGraphClientResponse } from '@nrwl/workspace';
+import { ProjectGraphDependency, ProjectGraphNode } from '@nrwl/devkit';
+// nx-ignore-next-line
+import { DepGraphClientResponse } from '@nrwl/workspace/src/command-line/dep-graph';
 import { ProjectGraphService } from '../app/models';
 
 export class MockProjectGraphService implements ProjectGraphService {
@@ -58,7 +59,7 @@ export class MockProjectGraphService implements ProjectGraphService {
     return new Promise((resolve) => resolve(this.response));
   }
 
-  private createNewProject(): DepGraphClientProject {
+  private createNewProject(): ProjectGraphNode {
     const type = Math.random() > 0.25 ? 'lib' : 'app';
     const name = `${type}-${this.response.projects.length + 1}`;
 

--- a/dep-graph/dep-graph/src/app/models.ts
+++ b/dep-graph/dep-graph/src/app/models.ts
@@ -1,4 +1,5 @@
-import { DepGraphClientResponse } from '@nrwl/workspace';
+// nx-ignore-next-line
+import { DepGraphClientResponse } from '@nrwl/workspace/src/command-line/dep-graph';
 
 export interface ProjectGraphList {
   id: string;

--- a/dep-graph/dep-graph/src/environments/environment.dev.ts
+++ b/dep-graph/dep-graph/src/environments/environment.dev.ts
@@ -1,18 +1,13 @@
 import { FetchProjectGraphService } from '../app/fetch-project-graph-service';
 import { Environment } from '../app/models';
+import { projectGraphs } from '../graphs';
 
 export const environment: Environment = {
-  environment: 'release',
+  environment: 'dev',
   appConfig: {
-    showDebugger: false,
-    projectGraphs: [
-      {
-        id: 'local',
-        label: 'local',
-        url: 'projectGraph.json',
-      },
-    ],
-    defaultProjectGraph: 'local',
+    showDebugger: true,
+    projectGraphs,
+    defaultProjectGraph: 'nx',
     projectGraphService: new FetchProjectGraphService(),
   },
 };

--- a/dep-graph/dep-graph/src/environments/environment.ts
+++ b/dep-graph/dep-graph/src/environments/environment.ts
@@ -1,13 +1,18 @@
 import { FetchProjectGraphService } from '../app/fetch-project-graph-service';
 import { Environment } from '../app/models';
-import { projectGraphs } from '../graphs';
 
 export const environment: Environment = {
-  environment: 'dev',
+  environment: 'release',
   appConfig: {
-    showDebugger: true,
-    projectGraphs,
-    defaultProjectGraph: 'nx',
+    showDebugger: false,
+    projectGraphs: [
+      {
+        id: 'local',
+        label: 'local',
+        url: 'projectGraph.json',
+      },
+    ],
+    defaultProjectGraph: 'local',
     projectGraphService: new FetchProjectGraphService(),
   },
 };

--- a/dep-graph/dep-graph/src/globals.d.ts
+++ b/dep-graph/dep-graph/src/globals.d.ts
@@ -1,9 +1,6 @@
-import { WorkspaceConfiguration } from '@nrwl/devkit';
-import {
-  DepGraphClientResponse,
-  ProjectGraph,
-  ProjectGraphNode,
-} from '@nrwl/workspace';
+// nx-ignore-next-line
+import { DepGraphClientResponse } from '@nrwl/workspace/src/command-line/dep-graph';
+import { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
 import { ProjectGraphList } from './graphs';
 
 export declare global {

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -20,10 +20,7 @@ export {
 export { output } from './src/utilities/output';
 export { commandsObject } from './src/command-line/nx-commands';
 export { supportedNxCommands } from './src/command-line/supported-nx-commands';
-export {
-  DepGraphClientProject,
-  DepGraphClientResponse,
-} from './src/command-line/dep-graph';
+
 export {
   readWorkspaceJson,
   readNxJson,

--- a/packages/workspace/project.json
+++ b/packages/workspace/project.json
@@ -2,6 +2,7 @@
   "root": "packages/workspace",
   "sourceRoot": "packages/workspace",
   "projectType": "library",
+  "implicitDependencies": ["dep-graph-dep-graph"],
   "targets": {
     "test": {
       "executor": "@nrwl/jest:jest",
@@ -61,9 +62,6 @@
       "outputs": ["build/packages/workspace"],
       "options": {
         "commands": [
-          {
-            "command": "nx build-base dep-graph-dep-graph --configuration release"
-          },
           {
             "command": "node ./scripts/copy-dep-graph.js"
           },

--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -26,17 +26,9 @@ import {
 import { writeJsonFile } from '../utilities/fileutils';
 import { output } from '../utilities/output';
 
-export interface DepGraphClientProject {
-  name: string;
-  type: string;
-  data: {
-    tags: string[];
-    root: string;
-  };
-}
 export interface DepGraphClientResponse {
   hash: string;
-  projects: DepGraphClientProject[];
+  projects: ProjectGraphNode[];
   dependencies: Record<string, ProjectGraphDependency[]>;
   layout: { appsDir: string; libsDir: string };
   changes: {
@@ -512,13 +504,14 @@ async function createDepGraphClientResponse(): Promise<DepGraphClientResponse> {
   performance.mark('dep graph response generation:start');
 
   const layout = workspaceLayout();
-  const projects: DepGraphClientProject[] = Object.values(graph.nodes).map(
+  const projects: ProjectGraphNode[] = Object.values(graph.nodes).map(
     (project) => ({
       name: project.name,
       type: project.type,
       data: {
         tags: project.data.tags,
         root: project.data.root,
+        files: [],
       },
     })
   );


### PR DESCRIPTION
…mmand

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When releasing, `tao` sometimes ends up without a `README.md`

This happened because `nx build workspace` had a `run-commands` target to run `nx build-base dep-graph-dep-graph`. `dep-graph-dep-graph:build-base` depended on `tao:build-base` so it restored the cached directory without the README.md

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`dep-graph` no longer depends on `workspace`. Instead, `workspace` depends on `dep-graph-dep-graph` meaning the `dep-graph:build-base` happens automatically as a dependency of building `workspace`. This means that `tao` should always have a `README.md` now.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
