### PR TITLE
fix(storybook): warn if skipping generating files in .storybook folder

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -93,6 +93,9 @@ function createRootStorybookDir(
   workspaceStorybookVersion: string
 ) {
   if (tree.exists('.storybook')) {
+    logger.warn(
+      `.storybook folder already exists at root! Skipping generating files in it.`
+    );
     return;
   }
   logger.debug(
@@ -130,6 +133,9 @@ function createProjectStorybookDir(
   const storybookRoot = join(root, '.storybook');
 
   if (tree.exists(storybookRoot)) {
+    logger.warn(
+      `.storybook folder already exists for ${projectName}! Skipping generating files in it.`
+    );
     return;
   }
 


### PR DESCRIPTION
during storybook-configuration, if .storybook folder already exists, generating files in it is skipped  
we should show warnings in this case, as sometimes those directories can exists but be empty, which can cause issues  
this can happen for example when reverting from previous setup using git reset (or something similar)  
in that case content is deleted, but empty folder remains  

showing warning will make it easier to debug what went wrong

PR Template:

## Current Behavior
if .storybook folder exists, then storybook-configuration command doesn't setup files in it. Even when it's empty

## Expected Behavior
There can be two expected behaviors:  
- show warning to user that not creating files in .storybook folder
- instead of just checking if .storybook exists, should also check if it has some content (or better, check if it has required files if possible)

This PR uses 1st approach