### PR TITLE
fix(misc): handle moving to a subfolder which results in the same project name and normalize import path

### DIFF
--- a/docs/angular/api-angular/generators/move.md
+++ b/docs/angular/api-angular/generators/move.md
@@ -56,6 +56,16 @@ Type: `string`
 
 The new import path to use in the `tsconfig.base.json`.
 
+### skipFormat
+
+Alias(es): skip-format
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.
+
 ### updateImportPath
 
 Default: `true`

--- a/docs/node/api-angular/generators/move.md
+++ b/docs/node/api-angular/generators/move.md
@@ -56,6 +56,16 @@ Type: `string`
 
 The new import path to use in the `tsconfig.base.json`.
 
+### skipFormat
+
+Alias(es): skip-format
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.
+
 ### updateImportPath
 
 Default: `true`

--- a/docs/react/api-angular/generators/move.md
+++ b/docs/react/api-angular/generators/move.md
@@ -56,6 +56,16 @@ Type: `string`
 
 The new import path to use in the `tsconfig.base.json`.
 
+### skipFormat
+
+Alias(es): skip-format
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.
+
 ### updateImportPath
 
 Default: `true`

--- a/e2e/workspace/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace/src/workspace-aux-commands.test.ts
@@ -715,7 +715,7 @@ describe('Move Angular Project', () => {
     const lib2FilePath = `libs/${lib2}/src/lib/${lib2}.module.ts`;
     const lib2File = readFile(lib2FilePath);
     expect(lib2File).toContain(
-      `import { ${newModule} } from '@${proj}/shared/${lib1}';`
+      `import { ${newModule} } from '@${proj}/shared-${lib1}';`
     );
     expect(lib2File).toContain(`extends ${newModule}`);
   });
@@ -834,7 +834,7 @@ describe('Move Project', () => {
       rootTsConfig.compilerOptions.paths[`@${proj}/${lib1}/data-access`]
     ).toBeUndefined();
     expect(
-      rootTsConfig.compilerOptions.paths[`@${proj}/shared/${lib1}/data-access`]
+      rootTsConfig.compilerOptions.paths[`@${proj}/shared-${lib1}-data-access`]
     ).toEqual([`libs/shared/${lib1}/data-access/src/index.ts`]);
 
     expect(moveOutput).toContain(`UPDATE workspace.json`);
@@ -854,7 +854,7 @@ describe('Move Project', () => {
     const lib2FilePath = `libs/${lib2}/ui/src/lib/${lib2}-ui.ts`;
     const lib2File = readFile(lib2FilePath);
     expect(lib2File).toContain(
-      `import { fromLibOne } from '@${proj}/shared/${lib1}/data-access';`
+      `import { fromLibOne } from '@${proj}/shared-${lib1}-data-access';`
     );
   });
 
@@ -970,7 +970,7 @@ describe('Move Project', () => {
       rootTsConfig.compilerOptions.paths[`@${proj}/${lib1}/data-access`]
     ).toBeUndefined();
     expect(
-      rootTsConfig.compilerOptions.paths[`@${proj}/shared/${lib1}/data-access`]
+      rootTsConfig.compilerOptions.paths[`@${proj}/shared-${lib1}-data-access`]
     ).toEqual([`libs/shared/${lib1}/data-access/src/index.ts`]);
 
     expect(moveOutput).toContain(`UPDATE workspace.json`);
@@ -991,7 +991,7 @@ describe('Move Project', () => {
     const lib2FilePath = `libs/${lib2}/ui/src/lib/${lib2}-ui.ts`;
     const lib2File = readFile(lib2FilePath);
     expect(lib2File).toContain(
-      `import { fromLibOne } from '@${proj}/shared/${lib1}/data-access';`
+      `import { fromLibOne } from '@${proj}/shared-${lib1}-data-access';`
     );
   });
 
@@ -1109,7 +1109,7 @@ describe('Move Project', () => {
       rootTsConfig.compilerOptions.paths[`@${proj}/${lib1}/data-access`]
     ).toBeUndefined();
     expect(
-      rootTsConfig.compilerOptions.paths[`@${proj}/shared/${lib1}/data-access`]
+      rootTsConfig.compilerOptions.paths[`@${proj}/shared-${lib1}-data-access`]
     ).toEqual([`packages/shared/${lib1}/data-access/src/index.ts`]);
 
     expect(moveOutput).toContain(`UPDATE workspace.json`);
@@ -1129,7 +1129,7 @@ describe('Move Project', () => {
     const lib2FilePath = `packages/${lib2}/ui/src/lib/${lib2}-ui.ts`;
     const lib2File = readFile(lib2FilePath);
     expect(lib2File).toContain(
-      `import { fromLibOne } from '@${proj}/shared/${lib1}/data-access';`
+      `import { fromLibOne } from '@${proj}/shared-${lib1}-data-access';`
     );
 
     nxJson = readJson('nx.json');

--- a/packages/angular/src/generators/move/move.spec.ts
+++ b/packages/angular/src/generators/move/move.spec.ts
@@ -1,4 +1,5 @@
 import { Tree } from '@nrwl/devkit';
+import * as devkit from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { angularMoveGenerator } from './move';
 import libraryGenerator from '../library/library';
@@ -21,6 +22,8 @@ describe('@nrwl/angular:move', () => {
       skipFormat: false,
       unitTestRunner: UnitTestRunner.Jest,
     });
+
+    jest.clearAllMocks();
   });
 
   it('should move a project', async () => {
@@ -33,5 +36,30 @@ describe('@nrwl/angular:move', () => {
     expect(tree.exists('libs/mynewlib/src/lib/mynewlib.module.ts')).toEqual(
       true
     );
+  });
+
+  it('should format files', async () => {
+    jest.spyOn(devkit, 'formatFiles');
+
+    await angularMoveGenerator(tree, {
+      projectName: 'mylib',
+      destination: 'mynewlib',
+      updateImportPath: true,
+    });
+
+    expect(devkit.formatFiles).toHaveBeenCalled();
+  });
+
+  it('should not format files when --skipFormat=true', async () => {
+    jest.spyOn(devkit, 'formatFiles');
+
+    await angularMoveGenerator(tree, {
+      projectName: 'mylib',
+      destination: 'mynewlib',
+      updateImportPath: true,
+      skipFormat: true,
+    });
+
+    expect(devkit.formatFiles).not.toHaveBeenCalled();
   });
 });

--- a/packages/angular/src/generators/move/move.ts
+++ b/packages/angular/src/generators/move/move.ts
@@ -1,4 +1,4 @@
-import { convertNxGenerator, Tree } from '@nrwl/devkit';
+import { convertNxGenerator, formatFiles, Tree } from '@nrwl/devkit';
 import { moveGenerator } from '@nrwl/workspace';
 import { updateModuleName } from './lib/update-module-name';
 import { Schema } from './schema';
@@ -10,10 +10,16 @@ import { Schema } from './schema';
  * to the workspace, so it can't use the same tricks as the `@nrwl/workspace` rules
  * to get the before and after names and paths.
  */
+export async function angularMoveGenerator(
+  tree: Tree,
+  schema: Schema
+): Promise<void> {
+  await moveGenerator(tree, { ...schema, skipFormat: true });
+  updateModuleName(tree, schema);
 
-export async function angularMoveGenerator(tree: Tree, schema: Schema) {
-  await moveGenerator(tree, schema);
-  await updateModuleName(tree, schema);
+  if (!schema.skipFormat) {
+    await formatFiles(tree);
+  }
 }
 
 export const angularMoveSchematic = convertNxGenerator(angularMoveGenerator);

--- a/packages/angular/src/generators/move/schema.d.ts
+++ b/packages/angular/src/generators/move/schema.d.ts
@@ -1,6 +1,7 @@
 export interface Schema {
   projectName: string;
   destination: string;
-  importPath?: string;
   updateImportPath: boolean;
+  importPath?: string;
+  skipFormat?: boolean;
 }

--- a/packages/angular/src/generators/move/schema.json
+++ b/packages/angular/src/generators/move/schema.json
@@ -33,6 +33,12 @@
       "type": "boolean",
       "description": "Update the import path to reflect the new location.",
       "default": true
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "aliases": ["skip-format"],
+      "description": "Skip formatting files.",
+      "default": false
     }
   },
   "required": ["projectName", "destination"]

--- a/packages/workspace/src/generators/move/lib/check-destination.spec.ts
+++ b/packages/workspace/src/generators/move/lib/check-destination.spec.ts
@@ -65,17 +65,4 @@ describe('checkDestination', () => {
       checkDestination(tree, schema, projectConfig);
     }).not.toThrow();
   });
-
-  it('should normalize the destination', async () => {
-    const schema: Schema = {
-      projectName: 'my-lib',
-      destination: '/my-other-lib//wibble',
-      importPath: undefined,
-      updateImportPath: true,
-    };
-
-    checkDestination(tree, schema, projectConfig);
-
-    expect(schema.destination).toBe('my-other-lib/wibble');
-  });
 });

--- a/packages/workspace/src/generators/move/lib/check-destination.ts
+++ b/packages/workspace/src/generators/move/lib/check-destination.ts
@@ -1,6 +1,6 @@
 import { ProjectConfiguration, Tree } from '@nrwl/devkit';
 import { Schema } from '../schema';
-import { getDestination, normalizeSlashes } from './utils';
+import { getDestination } from './utils';
 
 /**
  * Checks whether the destination folder is valid
@@ -25,9 +25,5 @@ export function checkDestination(
 
   if (tree.children(destination).length > 0) {
     throw new Error(`${INVALID_DESTINATION} - Path is not empty.`);
-  }
-
-  if (schema.destination.startsWith('/')) {
-    schema.destination = normalizeSlashes(schema.destination.substr(1));
   }
 }

--- a/packages/workspace/src/generators/move/lib/move-project-configuration.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-configuration.ts
@@ -1,24 +1,21 @@
 import {
   addProjectConfiguration,
-  removeProjectConfiguration,
   NxJsonProjectConfiguration,
   ProjectConfiguration,
+  removeProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
-
-import { Schema } from '../schema';
-import { getDestination, getNewProjectName } from './utils';
+import { NormalizedSchema } from '../schema';
 
 export function moveProjectConfiguration(
   tree: Tree,
-  schema: Schema,
+  schema: NormalizedSchema,
   projectConfig: ProjectConfiguration & NxJsonProjectConfiguration
 ) {
-  let destination = getDestination(tree, schema, projectConfig);
   const projectString = JSON.stringify(projectConfig);
   const newProjectString = projectString.replace(
     new RegExp(projectConfig.root, 'g'),
-    destination
+    schema.relativeToRootDestination
   );
 
   // rename
@@ -28,9 +25,5 @@ export function moveProjectConfiguration(
   removeProjectConfiguration(tree, schema.projectName);
 
   // Create a new project with the root replaced
-  addProjectConfiguration(
-    tree,
-    getNewProjectName(schema.destination),
-    newProject
-  );
+  addProjectConfiguration(tree, schema.newProjectName, newProject);
 }

--- a/packages/workspace/src/generators/move/lib/move-project.spec.ts
+++ b/packages/workspace/src/generators/move/lib/move-project.spec.ts
@@ -4,9 +4,9 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Schema } from '../schema';
-import { libraryGenerator } from '../../library/library';
 import { moveProject } from '@nrwl/workspace/src/generators/move/lib/move-project';
+import { libraryGenerator } from '../../library/library';
+import { NormalizedSchema } from '../schema';
 
 describe('moveProject', () => {
   let tree: Tree;
@@ -19,18 +19,19 @@ describe('moveProject', () => {
   });
 
   it('should copy all files and delete the source folder', async () => {
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'my-lib',
       destination: 'my-destination',
-      importPath: undefined,
+      importPath: '@proj/my-destination',
       updateImportPath: true,
+      newProjectName: 'my-destination',
+      relativeToRootDestination: 'libs/my-destination',
     };
 
     moveProject(tree, schema, projectConfig);
 
     const destinationChildren = tree.children('libs/my-destination');
     expect(destinationChildren.length).toBeGreaterThan(0);
-
     expect(tree.exists('libs/my-lib')).toBeFalsy();
     expect(tree.children('libs')).not.toContain('my-lib');
   });

--- a/packages/workspace/src/generators/move/lib/move-project.ts
+++ b/packages/workspace/src/generators/move/lib/move-project.ts
@@ -1,7 +1,6 @@
 import { ProjectConfiguration, Tree, visitNotIgnoredFiles } from '@nrwl/devkit';
-import { Schema } from '../schema';
-import { getDestination } from './utils';
 import { join, relative } from 'path';
+import { NormalizedSchema } from '../schema';
 
 /**
  * Moves a project to the given destination path
@@ -10,15 +9,17 @@ import { join, relative } from 'path';
  */
 export function moveProject(
   tree: Tree,
-  schema: Schema,
+  schema: NormalizedSchema,
   project: ProjectConfiguration
 ) {
-  const destination = getDestination(tree, schema, project);
   visitNotIgnoredFiles(tree, project.root, (file) => {
     // This is a rename but Angular Devkit isn't capable of writing to a file after it's renamed so this is a workaround
     const content = tree.read(file);
     const relativeFromOriginalSource = relative(project.root, file);
-    const newFilePath = join(destination, relativeFromOriginalSource);
+    const newFilePath = join(
+      schema.relativeToRootDestination,
+      relativeFromOriginalSource
+    );
     tree.write(newFilePath, content);
     tree.delete(file);
   });

--- a/packages/workspace/src/generators/move/lib/normalize-schema.spec.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.spec.ts
@@ -1,0 +1,78 @@
+import {
+  addProjectConfiguration,
+  NxJsonConfiguration,
+  ProjectConfiguration,
+  readProjectConfiguration,
+  Tree,
+  updateJson,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { NormalizedSchema, Schema } from '../schema';
+import { normalizeSchema } from './normalize-schema';
+
+describe('normalizeSchema', () => {
+  let tree: Tree;
+  let projectConfiguration: ProjectConfiguration;
+  const schema: Schema = {
+    destination: '/my/library',
+    projectName: 'my-library',
+    updateImportPath: true,
+  };
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    addProjectConfiguration(tree, schema.projectName, {
+      root: 'libs/my-library',
+      projectType: 'library',
+      targets: {},
+    });
+
+    projectConfiguration = readProjectConfiguration(tree, schema.projectName);
+  });
+
+  it('should calculate importPath, projectName and relativeToRootDestination correctly', () => {
+    const expected: NormalizedSchema = {
+      destination: 'my/library',
+      importPath: '@proj/my-library',
+      newProjectName: 'my-library',
+      projectName: 'my-library',
+      relativeToRootDestination: 'libs/my/library',
+      updateImportPath: true,
+    };
+
+    const result = normalizeSchema(tree, schema, projectConfiguration);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should use provided import path', () => {
+    const expected: NormalizedSchema = {
+      destination: 'my/library',
+      importPath: '@proj/my-awesome-library',
+      newProjectName: 'my-library',
+      projectName: 'my-library',
+      relativeToRootDestination: 'libs/my/library',
+      updateImportPath: true,
+    };
+
+    const result = normalizeSchema(
+      tree,
+      { ...schema, importPath: expected.importPath },
+      projectConfiguration
+    );
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should honor custom workspace layouts', async () => {
+    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      json.workspaceLayout = { appsDir: 'apps', libsDir: 'packages' };
+      return json;
+    });
+
+    const result = normalizeSchema(tree, schema, projectConfiguration);
+
+    expect(result.relativeToRootDestination).toEqual('packages/my/library');
+  });
+});

--- a/packages/workspace/src/generators/move/lib/normalize-schema.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.ts
@@ -1,0 +1,29 @@
+import type { ProjectConfiguration, Tree } from '@nrwl/devkit';
+import { getWorkspaceLayout } from '@nrwl/devkit';
+import type { NormalizedSchema, Schema } from '../schema';
+import { getDestination, getNewProjectName, normalizeSlashes } from './utils';
+
+export function normalizeSchema(
+  tree: Tree,
+  schema: Schema,
+  projectConfiguration: ProjectConfiguration
+): NormalizedSchema {
+  const destination = schema.destination.startsWith('/')
+    ? normalizeSlashes(schema.destination.substr(1))
+    : schema.destination;
+  const newProjectName = getNewProjectName(destination);
+  const { npmScope } = getWorkspaceLayout(tree);
+
+  return {
+    ...schema,
+    destination,
+    importPath:
+      schema.importPath ?? normalizeSlashes(`@${npmScope}/${newProjectName}`),
+    newProjectName,
+    relativeToRootDestination: getDestination(
+      tree,
+      schema,
+      projectConfiguration
+    ),
+  };
+}

--- a/packages/workspace/src/generators/move/lib/update-build-targets.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-build-targets.spec.ts
@@ -1,23 +1,24 @@
-import { Schema } from '../schema';
 import {
   addProjectConfiguration,
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-
+import { NormalizedSchema } from '../schema';
 import { updateBuildTargets } from './update-build-targets';
 
 describe('updateBuildTargets', () => {
   let tree: Tree;
-  let schema: Schema;
+  let schema: NormalizedSchema;
 
   beforeEach(async () => {
     schema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
-      importPath: undefined,
+      importPath: '@proj/subfolder-my-destination',
       updateImportPath: true,
+      newProjectName: 'subfolder-my-destination',
+      relativeToRootDestination: 'libs/subfolder/my-destination',
     };
     tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'my-source', {

--- a/packages/workspace/src/generators/move/lib/update-build-targets.ts
+++ b/packages/workspace/src/generators/move/lib/update-build-targets.ts
@@ -1,19 +1,16 @@
 import { getWorkspacePath, Tree, updateJson } from '@nrwl/devkit';
-import { Schema } from '../schema';
-import { getNewProjectName } from './utils';
+import { NormalizedSchema } from '../schema';
 
 /**
  * Update other references to the source project's targets
  */
-export function updateBuildTargets(tree: Tree, schema: Schema) {
-  const newProjectName = getNewProjectName(schema.destination);
-
+export function updateBuildTargets(tree: Tree, schema: NormalizedSchema) {
   updateJson(tree, getWorkspacePath(tree), (json) => {
     const strWorkspace = JSON.stringify(json);
     json = JSON.parse(
       strWorkspace.replace(
         new RegExp(`${schema.projectName}:`, 'g'),
-        `${newProjectName}:`
+        `${schema.newProjectName}:`
       )
     );
     return json;

--- a/packages/workspace/src/generators/move/lib/update-cypress-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-cypress-json.spec.ts
@@ -1,26 +1,28 @@
 import {
   ProjectConfiguration,
+  readJson,
   readProjectConfiguration,
   Tree,
-  readJson,
   writeJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Schema } from '../schema';
-import { updateCypressJson } from './update-cypress-json';
 import { libraryGenerator } from '../../library/library';
+import { NormalizedSchema } from '../schema';
+import { updateCypressJson } from './update-cypress-json';
 
 describe('updateCypressJson', () => {
   let tree: Tree;
-  let schema: Schema;
+  let schema: NormalizedSchema;
   let projectConfig: ProjectConfiguration;
 
   beforeEach(async () => {
     schema = {
       projectName: 'my-lib',
       destination: 'my-destination',
-      importPath: undefined,
+      importPath: '@proj/my-destination',
       updateImportPath: true,
+      newProjectName: 'my-destination',
+      relativeToRootDestination: 'libs/my-destination',
     };
 
     tree = createTreeWithEmptyWorkspace();
@@ -46,7 +48,6 @@ describe('updateCypressJson', () => {
       screenshotsFolder: '../../dist/cypress/libs/my-lib/screenshots',
       chromeWebSecurity: false,
     };
-
     writeJson(tree, '/libs/my-destination/cypress.json', cypressJson);
 
     updateCypressJson(tree, schema, projectConfig);

--- a/packages/workspace/src/generators/move/lib/update-cypress-json.ts
+++ b/packages/workspace/src/generators/move/lib/update-cypress-json.ts
@@ -1,8 +1,7 @@
 import { Tree } from '@nrwl/devkit';
-import * as path from 'path';
-import { Schema } from '../schema';
-import { getDestination } from './utils';
 import { ProjectConfiguration } from '@nrwl/tao/src/shared/workspace';
+import * as path from 'path';
+import { NormalizedSchema } from '../schema';
 
 interface PartialCypressJson {
   videosFolder: string;
@@ -18,12 +17,13 @@ interface PartialCypressJson {
  */
 export function updateCypressJson(
   tree: Tree,
-  schema: Schema,
+  schema: NormalizedSchema,
   project: ProjectConfiguration
 ) {
-  const destination = getDestination(tree, schema, project);
-
-  const cypressJsonPath = path.join(destination, 'cypress.json');
+  const cypressJsonPath = path.join(
+    schema.relativeToRootDestination,
+    'cypress.json'
+  );
 
   if (!tree.exists(cypressJsonPath)) {
     // nothing to do
@@ -35,11 +35,11 @@ export function updateCypressJson(
   ) as PartialCypressJson;
   cypressJson.videosFolder = cypressJson.videosFolder.replace(
     project.root,
-    destination
+    schema.relativeToRootDestination
   );
   cypressJson.screenshotsFolder = cypressJson.screenshotsFolder.replace(
     project.root,
-    destination
+    schema.relativeToRootDestination
   );
 
   tree.write(cypressJsonPath, JSON.stringify(cypressJson));

--- a/packages/workspace/src/generators/move/lib/update-default-project.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-default-project.spec.ts
@@ -1,4 +1,3 @@
-import { Schema } from '@nrwl/workspace/src/generators/move/schema';
 import {
   addProjectConfiguration,
   readWorkspaceConfiguration,
@@ -6,7 +5,8 @@ import {
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { updateDefaultProject } from '@nrwl/workspace/src/generators/move/lib/update-default-project';
+import { NormalizedSchema } from '../schema';
+import { updateDefaultProject } from './update-default-project';
 
 describe('updateDefaultProject', () => {
   let tree: Tree;
@@ -27,17 +27,18 @@ describe('updateDefaultProject', () => {
   });
 
   it('should update the default project', async () => {
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
-      importPath: undefined,
+      importPath: '@proj/subfolder-my-destination',
       updateImportPath: true,
+      newProjectName: 'subfolder-my-destination',
+      relativeToRootDestination: 'libs/subfolder/my-destination',
     };
 
     updateDefaultProject(tree, schema);
 
     const { defaultProject } = readWorkspaceConfiguration(tree);
-
     expect(defaultProject).toBe('subfolder-my-destination');
   });
 });

--- a/packages/workspace/src/generators/move/lib/update-default-project.ts
+++ b/packages/workspace/src/generators/move/lib/update-default-project.ts
@@ -3,8 +3,7 @@ import {
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { Schema } from '../schema';
-import { getNewProjectName } from './utils';
+import { NormalizedSchema } from '../schema';
 
 /**
  * Updates the project in the workspace file
@@ -13,7 +12,7 @@ import { getNewProjectName } from './utils';
  * - change the project name
  * - change target references
  */
-export function updateDefaultProject(tree: Tree, schema: Schema) {
+export function updateDefaultProject(tree: Tree, schema: NormalizedSchema) {
   const workspaceConfiguration = readWorkspaceConfiguration(tree);
 
   // update default project (if necessary)
@@ -21,9 +20,7 @@ export function updateDefaultProject(tree: Tree, schema: Schema) {
     workspaceConfiguration.defaultProject &&
     workspaceConfiguration.defaultProject === schema.projectName
   ) {
-    workspaceConfiguration.defaultProject = getNewProjectName(
-      schema.destination
-    );
+    workspaceConfiguration.defaultProject = schema.newProjectName;
     updateWorkspaceConfiguration(tree, workspaceConfiguration);
   }
 }

--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
@@ -5,23 +5,23 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-
 import { Linter } from '../../../utils/lint';
-
-import { Schema } from '../schema';
-import { updateEslintrcJson } from './update-eslintrc-json';
 import { libraryGenerator } from '../../library/library';
+import { NormalizedSchema } from '../schema';
+import { updateEslintrcJson } from './update-eslintrc-json';
 
 describe('updateEslint', () => {
   let tree: Tree;
-  let schema: Schema;
+  let schema: NormalizedSchema;
 
   beforeEach(async () => {
     schema = {
       projectName: 'my-lib',
       destination: 'shared/my-destination',
-      importPath: undefined,
+      importPath: '@proj/shared-my-destination',
       updateImportPath: true,
+      newProjectName: 'shared-my-destination',
+      relativeToRootDestination: 'libs/shared/my-destination',
     };
 
     tree = createTreeWithEmptyWorkspace();
@@ -47,13 +47,11 @@ describe('updateEslint', () => {
       linter: Linter.EsLint,
       standaloneConfig: false,
     });
-
     // This step is usually handled elsewhere
     tree.rename(
       'libs/my-lib/.eslintrc.json',
       'libs/shared/my-destination/.eslintrc.json'
     );
-
     const projectConfig = readProjectConfiguration(tree, 'my-lib');
 
     updateEslintrcJson(tree, schema, projectConfig);
@@ -81,13 +79,11 @@ describe('updateEslint', () => {
       ];
       return eslintRcJson;
     });
-
     // This step is usually handled elsewhere
     tree.rename(
       'libs/my-lib/.eslintrc.json',
       'libs/shared/my-destination/.eslintrc.json'
     );
-
     const projectConfig = readProjectConfiguration(tree, 'my-lib');
 
     updateEslintrcJson(tree, schema, projectConfig);
@@ -112,13 +108,11 @@ describe('updateEslint', () => {
       setParserOptionsProject: true,
       standaloneConfig: false,
     });
-
     // This step is usually handled elsewhere
     tree.rename(
       'libs/my-lib/.eslintrc.json',
       'libs/shared/my-destination/.eslintrc.json'
     );
-
     const projectConfig = readProjectConfiguration(tree, 'my-lib');
 
     updateEslintrcJson(tree, schema, projectConfig);

--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
@@ -1,13 +1,11 @@
-import { join, relative } from 'path';
 import {
   offsetFromRoot,
   ProjectConfiguration,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-
-import { Schema } from '../schema';
-import { getDestination } from './utils';
+import { join } from 'path';
+import { NormalizedSchema } from '../schema';
 
 interface PartialEsLintrcOverride {
   parserOptions?: {
@@ -40,18 +38,17 @@ function offsetFilePath(
  */
 export function updateEslintrcJson(
   tree: Tree,
-  schema: Schema,
+  schema: NormalizedSchema,
   project: ProjectConfiguration
 ) {
-  const destination = getDestination(tree, schema, project);
-  const eslintRcPath = join(destination, '.eslintrc.json');
+  const eslintRcPath = join(schema.relativeToRootDestination, '.eslintrc.json');
 
   if (!tree.exists(eslintRcPath)) {
     // no .eslintrc found. nothing to do
     return;
   }
 
-  const offset = offsetFromRoot(destination);
+  const offset = offsetFromRoot(schema.relativeToRootDestination);
 
   updateJson<PartialEsLintRcJson>(tree, eslintRcPath, (eslintRcJson) => {
     if (typeof eslintRcJson.extends === 'string') {
@@ -68,7 +65,9 @@ export function updateEslintrcJson(
 
     eslintRcJson.overrides?.forEach((o) => {
       if (o.parserOptions?.project) {
-        o.parserOptions.project = [`${destination}/tsconfig.*?.json`];
+        o.parserOptions.project = [
+          `${schema.relativeToRootDestination}/tsconfig.*?.json`,
+        ];
       }
     });
 

--- a/packages/workspace/src/generators/move/lib/update-implicit-dependencies.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-implicit-dependencies.spec.ts
@@ -4,20 +4,21 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-
-import { Schema } from '../schema';
+import { NormalizedSchema } from '../schema';
 import { updateImplicitDependencies } from './update-implicit-dependencies';
 
 describe('updateImplicitDepenencies', () => {
   let tree: Tree;
-  let schema: Schema;
+  let schema: NormalizedSchema;
 
   beforeEach(async () => {
     schema = {
       projectName: 'my-lib',
       destination: 'my-destination',
-      importPath: undefined,
+      importPath: '@proj/my-destination',
       updateImportPath: true,
+      newProjectName: 'my-destination',
+      relativeToRootDestination: 'libs/my-destination',
     };
 
     tree = createTreeWithEmptyWorkspace();

--- a/packages/workspace/src/generators/move/lib/update-implicit-dependencies.ts
+++ b/packages/workspace/src/generators/move/lib/update-implicit-dependencies.ts
@@ -1,22 +1,22 @@
+import type { NxJsonConfiguration, Tree } from '@nrwl/devkit';
 import { updateJson } from '@nrwl/devkit';
-import type { Tree, NxJsonConfiguration } from '@nrwl/devkit';
-import type { Schema } from '../schema';
-import { getNewProjectName } from './utils';
+import type { NormalizedSchema } from '../schema';
 
 /**
  * Updates the nx.json file by renaming the project
  *
  * @param schema The options provided to the schematic
  */
-export function updateImplicitDependencies(tree: Tree, schema: Schema) {
+export function updateImplicitDependencies(
+  tree: Tree,
+  schema: NormalizedSchema
+) {
   updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
     Object.values(json.projects).forEach((project) => {
       if (project.implicitDependencies) {
         const index = project.implicitDependencies.indexOf(schema.projectName);
         if (index !== -1) {
-          project.implicitDependencies[index] = getNewProjectName(
-            schema.destination
-          );
+          project.implicitDependencies[index] = schema.newProjectName;
         }
       }
     });

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -9,9 +9,9 @@ import {
   visitNotIgnoredFiles,
   writeJson,
 } from '@nrwl/devkit';
-import { findNodes } from '../../../utilities/typescript/find-nodes';
 import * as ts from 'typescript';
-import { Schema } from '../schema';
+import { findNodes } from '../../../utilities/typescript/find-nodes';
+import { NormalizedSchema } from '../schema';
 import { normalizeSlashes } from './utils';
 
 /**
@@ -21,7 +21,7 @@ import { normalizeSlashes } from './utils';
  */
 export function updateImports(
   tree: Tree,
-  schema: Schema,
+  schema: NormalizedSchema,
   project: ProjectConfiguration
 ) {
   if (project.projectType === 'application') {
@@ -52,9 +52,7 @@ export function updateImports(
       normalizeSlashes(
         `@${npmScope}/${project.root.substr(libsDir.length + 1)}`
       ),
-    to:
-      schema.importPath ||
-      normalizeSlashes(`@${npmScope}/${schema.destination}`),
+    to: schema.importPath,
   };
 
   if (schema.updateImportPath) {

--- a/packages/workspace/src/generators/move/lib/update-jest-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-jest-config.spec.ts
@@ -1,9 +1,8 @@
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-
-import { Schema } from '../schema';
-import { updateJestConfig } from './update-jest-config';
 import { libraryGenerator } from '../../library/library';
+import { NormalizedSchema } from '../schema';
+import { updateJestConfig } from './update-jest-config';
 
 describe('updateJestConfig', () => {
   let tree: Tree;
@@ -18,15 +17,16 @@ describe('updateJestConfig', () => {
       standaloneConfig: false,
     });
     const projectConfig = readProjectConfiguration(tree, 'my-source');
-
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'my-source',
       destination: 'my-destination',
-      importPath: undefined,
+      importPath: '@proj/my-destination',
       updateImportPath: true,
+      newProjectName: 'my-destination',
+      relativeToRootDestination: 'libs/my-destination',
     };
 
-    updateJestConfig(tree, schema, projectConfig);
+    expect(() => updateJestConfig(tree, schema, projectConfig)).not.toThrow();
   });
 
   it('should update the name and coverage directory', async () => {
@@ -40,21 +40,20 @@ describe('updateJestConfig', () => {
       ]
     };`;
     const jestConfigPath = '/libs/my-destination/jest.config.js';
-
     const rootJestConfigPath = '/jest.config.js';
-
     await libraryGenerator(tree, {
       name: 'my-source',
       standaloneConfig: false,
     });
     const projectConfig = readProjectConfiguration(tree, 'my-source');
     tree.write(jestConfigPath, jestConfig);
-
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'my-source',
       destination: 'my-destination',
-      importPath: undefined,
+      importPath: '@proj/my-destination',
       updateImportPath: true,
+      newProjectName: 'my-destination',
+      relativeToRootDestination: 'libs/my-destination',
     };
 
     updateJestConfig(tree, schema, projectConfig);
@@ -65,7 +64,6 @@ describe('updateJestConfig', () => {
     expect(jestConfigAfter).toContain(
       `coverageDirectory: '../../coverage/libs/my-destination'`
     );
-
     expect(rootJestConfigAfter).toContain('getJestProjects()');
   });
 
@@ -80,9 +78,7 @@ describe('updateJestConfig', () => {
       ]
     };`;
     const jestConfigPath = '/libs/other/test/dir/my-destination/jest.config.js';
-
     const rootJestConfigPath = '/jest.config.js';
-
     await libraryGenerator(tree, {
       name: 'some/test/dir/my-source',
       standaloneConfig: false,
@@ -92,29 +88,27 @@ describe('updateJestConfig', () => {
       'some-test-dir-my-source'
     );
     tree.write(jestConfigPath, jestConfig);
-
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'some-test-dir-my-source',
       destination: 'other/test/dir/my-destination',
-      importPath: undefined,
+      importPath: '@proj/other-test-dir-my-destination',
       updateImportPath: true,
+      newProjectName: 'other-test-dir-my-destination',
+      relativeToRootDestination: 'libs/other/test/dir/my-destination',
     };
 
     updateJestConfig(tree, schema, projectConfig);
-
     const jestConfigAfter = tree.read(jestConfigPath, 'utf-8');
     const rootJestConfigAfter = tree.read(rootJestConfigPath, 'utf-8');
     expect(jestConfigAfter).toContain(`name: 'other-test-dir-my-destination'`);
     expect(jestConfigAfter).toContain(
       `coverageDirectory: '../../coverage/libs/other/test/dir/my-destination'`
     );
-
     expect(rootJestConfigAfter).toContain('getJestProjects()');
   });
 
   it('updates the root config if not using `getJestProjects()`', async () => {
     const rootJestConfigPath = '/jest.config.js';
-
     await libraryGenerator(tree, {
       name: 'some/test/dir/my-source',
       standaloneConfig: false,
@@ -130,11 +124,13 @@ describe('updateJestConfig', () => {
       tree,
       'some-test-dir-my-source'
     );
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'some-test-dir-my-source',
       destination: 'other/test/dir/my-destination',
-      importPath: undefined,
+      importPath: '@proj/other-test-dir-my-destination',
       updateImportPath: true,
+      newProjectName: 'other-test-dir-my-destination',
+      relativeToRootDestination: 'libs/other/test/dir/my-destination',
     };
 
     updateJestConfig(tree, schema, projectConfig);
@@ -150,7 +146,6 @@ describe('updateJestConfig', () => {
 
   it('updates the root config if `getJestProjects()` is used but old path exists', async () => {
     const rootJestConfigPath = '/jest.config.js';
-
     await libraryGenerator(tree, {
       name: 'some/test/dir/my-source',
       standaloneConfig: false,
@@ -168,11 +163,13 @@ module.exports = {
       tree,
       'some-test-dir-my-source'
     );
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'some-test-dir-my-source',
       destination: 'other/test/dir/my-destination',
-      importPath: undefined,
+      importPath: '@proj/other-test-dir-my-destination',
       updateImportPath: true,
+      newProjectName: 'other-test-dir-my-destination',
+      relativeToRootDestination: 'libs/other/test/dir/my-destination',
     };
 
     updateJestConfig(tree, schema, projectConfig);
@@ -189,7 +186,6 @@ module.exports = {
 
   it('updates the root config if `getJestProjects()` is used with other projects in the array', async () => {
     const rootJestConfigPath = '/jest.config.js';
-
     await libraryGenerator(tree, {
       name: 'some/test/dir/my-source',
       standaloneConfig: false,
@@ -207,11 +203,13 @@ module.exports = {
       tree,
       'some-test-dir-my-source'
     );
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'some-test-dir-my-source',
       destination: 'other/test/dir/my-destination',
-      importPath: undefined,
+      importPath: '@proj/other-test-dir-my-destination',
       updateImportPath: true,
+      newProjectName: 'other-test-dir-my-destination',
+      relativeToRootDestination: 'libs/other/test/dir/my-destination',
     };
 
     updateJestConfig(tree, schema, projectConfig);

--- a/packages/workspace/src/generators/move/lib/update-jest-config.ts
+++ b/packages/workspace/src/generators/move/lib/update-jest-config.ts
@@ -1,9 +1,6 @@
-import { Tree, ProjectConfiguration } from '@nrwl/devkit';
-
+import { ProjectConfiguration, Tree } from '@nrwl/devkit';
 import * as path from 'path';
-
-import { Schema } from '../schema';
-import { getDestination, getNewProjectName } from './utils';
+import { NormalizedSchema } from '../schema';
 
 /**
  * Updates the project name and coverage folder in the jest.config.js if it exists
@@ -14,13 +11,13 @@ import { getDestination, getNewProjectName } from './utils';
  */
 export function updateJestConfig(
   tree: Tree,
-  schema: Schema,
+  schema: NormalizedSchema,
   project: ProjectConfiguration
 ) {
-  const destination = getDestination(tree, schema, project);
-  const newProjectName = getNewProjectName(schema.destination);
-
-  const jestConfigPath = path.join(destination, 'jest.config.js');
+  const jestConfigPath = path.join(
+    schema.relativeToRootDestination,
+    'jest.config.js'
+  );
 
   if (tree.exists(jestConfigPath)) {
     const oldContent = tree.read(jestConfigPath, 'utf-8');
@@ -29,8 +26,8 @@ export function updateJestConfig(
     const findDir = new RegExp(project.root, 'g');
 
     const newContent = oldContent
-      .replace(findName, `'${newProjectName}'`)
-      .replace(findDir, destination);
+      .replace(findName, `'${schema.newProjectName}'`)
+      .replace(findDir, schema.relativeToRootDestination);
     tree.write(jestConfigPath, newContent);
   }
 
@@ -49,7 +46,7 @@ export function updateJestConfig(
 
   const newRootJestConfigContent = oldRootJestConfigContent.replace(
     findProject,
-    usingJestProjects ? `` : `'<rootDir>/${destination}'`
+    usingJestProjects ? `` : `'<rootDir>/${schema.relativeToRootDestination}'`
   );
 
   tree.write(rootJestConfigPath, newRootJestConfigContent);

--- a/packages/workspace/src/generators/move/lib/update-package-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-package-json.spec.ts
@@ -1,36 +1,30 @@
-import {
-  ProjectConfiguration,
-  readProjectConfiguration,
-  Tree,
-  readJson,
-  writeJson,
-} from '@nrwl/devkit';
+import { readJson, Tree, writeJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Schema } from '../schema';
-import { updatePackageJson } from './update-package-json';
 import { libraryGenerator } from '../../library/library';
+import { NormalizedSchema } from '../schema';
+import { updatePackageJson } from './update-package-json';
 
 describe('updatePackageJson', () => {
   let tree: Tree;
-  let schema: Schema;
-  let projectConfig: ProjectConfiguration;
+  let schema: NormalizedSchema;
 
   beforeEach(async () => {
     schema = {
       projectName: 'my-lib',
       destination: 'my-destination',
-      importPath: undefined,
+      importPath: '@proj/my-destination',
       updateImportPath: true,
+      newProjectName: 'my-destination',
+      relativeToRootDestination: 'libs/my-destination',
     };
 
     tree = createTreeWithEmptyWorkspace();
     await libraryGenerator(tree, { name: 'my-lib', standaloneConfig: false });
-    projectConfig = readProjectConfiguration(tree, 'my-lib');
   });
 
   it('should handle package.json not existing', async () => {
     expect(() => {
-      updatePackageJson(tree, schema, projectConfig);
+      updatePackageJson(tree, schema);
     }).not.toThrow();
   });
 
@@ -38,10 +32,9 @@ describe('updatePackageJson', () => {
     const packageJson = {
       name: '@proj/my-lib',
     };
-
     writeJson(tree, '/libs/my-destination/package.json', packageJson);
 
-    updatePackageJson(tree, schema, projectConfig);
+    updatePackageJson(tree, schema);
 
     expect(readJson(tree, '/libs/my-destination/package.json')).toEqual({
       ...packageJson,

--- a/packages/workspace/src/generators/move/lib/update-package-json.ts
+++ b/packages/workspace/src/generators/move/lib/update-package-json.ts
@@ -1,8 +1,6 @@
-import { Tree, getWorkspaceLayout } from '@nrwl/devkit';
+import { readJson, Tree } from '@nrwl/devkit';
 import * as path from 'path';
-import { Schema } from '../schema';
-import { getDestination, normalizeSlashes } from './utils';
-import { ProjectConfiguration } from '@nrwl/tao/src/shared/workspace';
+import { NormalizedSchema } from '../schema';
 
 interface PartialPackageJson {
   name: string;
@@ -13,23 +11,18 @@ interface PartialPackageJson {
  *
  * @param schema The options provided to the schematic
  */
-export function updatePackageJson(
-  tree: Tree,
-  schema: Schema,
-  project: ProjectConfiguration
-) {
-  const destination = getDestination(tree, schema, project);
-  const packageJsonPath = path.join(destination, 'package.json');
+export function updatePackageJson(tree: Tree, schema: NormalizedSchema) {
+  const packageJsonPath = path.join(
+    schema.relativeToRootDestination,
+    'package.json'
+  );
 
   if (!tree.exists(packageJsonPath)) {
     // nothing to do
     return;
   }
 
-  const { npmScope } = getWorkspaceLayout(tree);
-  const packageJson = JSON.parse(
-    tree.read(packageJsonPath).toString('utf-8')
-  ) as PartialPackageJson;
-  packageJson.name = normalizeSlashes(`@${npmScope}/${schema.destination}`);
+  const packageJson = readJson(tree, packageJsonPath) as PartialPackageJson;
+  packageJson.name = schema.importPath;
   tree.write(packageJsonPath, JSON.stringify(packageJson));
 }

--- a/packages/workspace/src/generators/move/lib/update-project-root-files.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-project-root-files.spec.ts
@@ -1,8 +1,8 @@
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Schema } from '../schema';
-import { updateProjectRootFiles } from './update-project-root-files';
 import { libraryGenerator } from '../../library/library';
+import { NormalizedSchema } from '../schema';
+import { updateProjectRootFiles } from './update-project-root-files';
 
 describe('updateProjectRootFiles', () => {
   let tree: Tree;
@@ -22,19 +22,19 @@ describe('updateProjectRootFiles', () => {
       ]
     };`;
     const testFilePath = '/libs/subfolder/my-destination/jest.config.js';
-
     await libraryGenerator(tree, {
       name: 'my-source',
       standaloneConfig: false,
     });
     const projectConfig = readProjectConfiguration(tree, 'my-source');
     tree.write(testFilePath, testFile);
-
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
-      importPath: undefined,
+      importPath: '@proj/subfolder-my-destination',
       updateImportPath: true,
+      newProjectName: 'subfolder-my-destination',
+      relativeToRootDestination: 'libs/subfolder/my-destination',
     };
 
     updateProjectRootFiles(tree, schema, projectConfig);

--- a/packages/workspace/src/generators/move/lib/update-project-root-files.ts
+++ b/packages/workspace/src/generators/move/lib/update-project-root-files.ts
@@ -1,11 +1,8 @@
-import * as path from 'path';
-
 import { ProjectConfiguration, Tree } from '@nrwl/devkit';
-
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
-import { Schema } from '../schema';
-import { getDestination } from './utils';
+import * as path from 'path';
 import { extname, join } from 'path';
+import { NormalizedSchema } from '../schema';
 
 /**
  * Updates the files in the root of the project
@@ -16,13 +13,14 @@ import { extname, join } from 'path';
  */
 export function updateProjectRootFiles(
   tree: Tree,
-  schema: Schema,
+  schema: NormalizedSchema,
   project: ProjectConfiguration
 ) {
-  const destination = getDestination(tree, schema, project);
-
   const newRelativeRoot = path
-    .relative(path.join(appRootPath, destination), appRootPath)
+    .relative(
+      path.join(appRootPath, schema.relativeToRootDestination),
+      appRootPath
+    )
     .split(path.sep)
     .join('/');
   const oldRelativeRoot = path
@@ -38,13 +36,16 @@ export function updateProjectRootFiles(
   const dots = /\./g;
   const regex = new RegExp(oldRelativeRoot.replace(dots, '\\.'), 'g');
 
-  for (const file of tree.children(destination)) {
+  for (const file of tree.children(schema.relativeToRootDestination)) {
     if (!extname(file).startsWith('.js')) {
       continue;
     }
 
-    const oldContent = tree.read(join(destination, file), 'utf-8');
+    const oldContent = tree.read(
+      join(schema.relativeToRootDestination, file),
+      'utf-8'
+    );
     const newContent = oldContent.replace(regex, newRelativeRoot);
-    tree.write(join(destination, file), newContent);
+    tree.write(join(schema.relativeToRootDestination, file), newContent);
   }
 }

--- a/packages/workspace/src/generators/move/lib/update-readme.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-readme.spec.ts
@@ -1,22 +1,22 @@
-import { readJson, readProjectConfiguration, Tree } from '@nrwl/devkit';
+import { Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-
-import { updateReadme } from './update-readme';
-import { Schema } from '../schema';
-import { libraryGenerator } from '../../library/library';
-import { getDestination } from './utils';
 import { join } from 'path';
+import { libraryGenerator } from '../../library/library';
+import { NormalizedSchema } from '../schema';
+import { updateReadme } from './update-readme';
 
 describe('updateReadme', () => {
   let tree: Tree;
-  let schema: Schema;
+  let schema: NormalizedSchema;
 
   beforeEach(async () => {
     schema = {
       projectName: 'my-lib',
       destination: 'shared/my-destination',
-      importPath: undefined,
+      importPath: '@proj/shared-my-destination',
       updateImportPath: true,
+      newProjectName: 'shared-my-destination',
+      relativeToRootDestination: 'libs/shared/my-destination',
     };
 
     tree = createTreeWithEmptyWorkspace();
@@ -27,14 +27,11 @@ describe('updateReadme', () => {
       name: 'my-lib',
       standaloneConfig: false,
     });
-
-    const projectConfig = readProjectConfiguration(tree, 'my-lib');
-    const destination = getDestination(tree, schema, projectConfig);
-    const readmePath = join(destination, 'README.md');
+    const readmePath = join(schema.relativeToRootDestination, 'README.md');
     tree.delete(readmePath);
 
     expect(() => {
-      updateReadme(tree, schema, projectConfig);
+      updateReadme(tree, schema);
     }).not.toThrow();
   });
 
@@ -43,16 +40,13 @@ describe('updateReadme', () => {
       name: 'my-lib',
       standaloneConfig: false,
     });
-
     // This step is usually handled elsewhere
     tree.rename(
       'libs/my-lib/README.md',
       'libs/shared/my-destination/README.md'
     );
 
-    const projectConfig = readProjectConfiguration(tree, 'my-lib');
-
-    updateReadme(tree, schema, projectConfig);
+    updateReadme(tree, schema);
 
     const content = tree
       .read('/libs/shared/my-destination/README.md')

--- a/packages/workspace/src/generators/move/lib/update-readme.ts
+++ b/packages/workspace/src/generators/move/lib/update-readme.ts
@@ -1,29 +1,21 @@
+import { Tree } from '@nrwl/devkit';
 import { join } from 'path';
-import { ProjectConfiguration, Tree } from '@nrwl/devkit';
-
-import { Schema } from '../schema';
-import { getDestination, getNewProjectName } from './utils';
+import { NormalizedSchema } from '../schema';
 
 /**
  * Update the README.md file of the project if it exists.
  *
  * @param schema The options provided to the schematic
  */
-export function updateReadme(
-  tree: Tree,
-  schema: Schema,
-  project: ProjectConfiguration
-) {
-  const destination = getDestination(tree, schema, project);
-  const readmePath = join(destination, 'README.md');
+export function updateReadme(tree: Tree, schema: NormalizedSchema) {
+  const readmePath = join(schema.relativeToRootDestination, 'README.md');
 
   if (!tree.exists(readmePath)) {
     // no README found. nothing to do
     return;
   }
-  const newProjectName = getNewProjectName(schema.destination);
   const findName = new RegExp(`${schema.projectName}`, 'g');
   const oldContent = tree.read(readmePath, 'utf-8');
-  const newContent = oldContent.replace(findName, newProjectName);
+  const newContent = oldContent.replace(findName, schema.newProjectName);
   tree.write(readmePath, newContent);
 }

--- a/packages/workspace/src/generators/move/lib/update-storybook-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-storybook-config.spec.ts
@@ -1,8 +1,8 @@
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { Schema } from '../schema';
-import { updateStorybookConfig } from './update-storybook-config';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { libraryGenerator } from '../../library/library';
+import { NormalizedSchema } from '../schema';
+import { updateStorybookConfig } from './update-storybook-config';
 
 describe('updateStorybookConfig', () => {
   let tree: Tree;
@@ -17,15 +17,18 @@ describe('updateStorybookConfig', () => {
       standaloneConfig: false,
     });
     const projectConfig = readProjectConfiguration(tree, 'my-source');
-
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'my-source',
       destination: 'my-destination',
-      importPath: undefined,
+      importPath: '@proj/my-destination',
       updateImportPath: true,
+      newProjectName: 'my-destination',
+      relativeToRootDestination: 'libs/my-destination',
     };
 
-    updateStorybookConfig(tree, schema, projectConfig);
+    expect(() =>
+      updateStorybookConfig(tree, schema, projectConfig)
+    ).not.toThrow();
   });
 
   it('should update the import path for main.js', async () => {
@@ -33,22 +36,21 @@ describe('updateStorybookConfig', () => {
       const rootMain = require('../../../.storybook/main');
       module.exports = rootMain;
     `;
-
     const storybookMainPath =
       '/libs/namespace/my-destination/.storybook/main.js';
-
     await libraryGenerator(tree, {
       name: 'my-source',
       standaloneConfig: false,
     });
     const projectConfig = readProjectConfiguration(tree, 'my-source');
     tree.write(storybookMainPath, storybookMain);
-
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'my-source',
       destination: 'namespace/my-destination',
-      importPath: undefined,
+      importPath: '@proj/namespace-my-destination',
       updateImportPath: true,
+      newProjectName: 'namespace-my-destination',
+      relativeToRootDestination: 'libs/namespace/my-destination',
     };
 
     updateStorybookConfig(tree, schema, projectConfig);
@@ -63,22 +65,21 @@ describe('updateStorybookConfig', () => {
     const storybookWebpackConfig = `
       const rootWebpackConfig = require('../../../.storybook/webpack.config');
     `;
-
     const storybookWebpackConfigPath =
       '/libs/namespace/my-destination/.storybook/webpack.config.js';
-
     await libraryGenerator(tree, {
       name: 'my-source',
       standaloneConfig: false,
     });
     const projectConfig = readProjectConfiguration(tree, 'my-source');
     tree.write(storybookWebpackConfigPath, storybookWebpackConfig);
-
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'my-source',
       destination: 'namespace/my-destination',
-      importPath: undefined,
+      importPath: '@proj/namespace-my-destination',
       updateImportPath: true,
+      newProjectName: 'namespace-my-destination',
+      relativeToRootDestination: 'libs/namespace/my-destination',
     };
 
     updateStorybookConfig(tree, schema, projectConfig);

--- a/packages/workspace/src/generators/move/lib/update-storybook-config.ts
+++ b/packages/workspace/src/generators/move/lib/update-storybook-config.ts
@@ -1,11 +1,8 @@
 import { ProjectConfiguration, Tree } from '@nrwl/devkit';
-
-import * as path from 'path';
-
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
-import { Schema } from '../schema';
-import { getDestination } from './utils';
+import * as path from 'path';
 import { join } from 'path';
+import { NormalizedSchema } from '../schema';
 
 /**
  * Updates relative path to root storybook config for `main.js` & `webpack.config.js`
@@ -14,21 +11,25 @@ import { join } from 'path';
  */
 export function updateStorybookConfig(
   tree: Tree,
-  schema: Schema,
+  schema: NormalizedSchema,
   project: ProjectConfiguration
 ) {
-  const destination = getDestination(tree, schema, project);
-
   const oldRelativeRoot = path
     .relative(path.join(appRootPath, `${project.root}/.storybook`), appRootPath)
     .split(path.sep)
     .join('/');
   const newRelativeRoot = path
-    .relative(path.join(appRootPath, `${destination}/.storybook`), appRootPath)
+    .relative(
+      path.join(appRootPath, `${schema.relativeToRootDestination}/.storybook`),
+      appRootPath
+    )
     .split(path.sep)
     .join('/');
 
-  const storybookDir = path.join(destination, '.storybook');
+  const storybookDir = path.join(
+    schema.relativeToRootDestination,
+    '.storybook'
+  );
 
   if (!storybookDir) {
     return;

--- a/packages/workspace/src/generators/move/move.ts
+++ b/packages/workspace/src/generators/move/move.ts
@@ -20,10 +20,13 @@ import { moveProjectConfiguration } from './lib/move-project-configuration';
 import { updateBuildTargets } from './lib/update-build-targets';
 import { updateReadme } from './lib/update-readme';
 import { updatePackageJson } from './lib/update-package-json';
+import { normalizeSchema } from './lib/normalize-schema';
 
-export async function moveGenerator(tree: Tree, schema: Schema) {
-  const projectConfig = readProjectConfiguration(tree, schema.projectName);
-  checkDestination(tree, schema, projectConfig);
+export async function moveGenerator(tree: Tree, rawSchema: Schema) {
+  const projectConfig = readProjectConfiguration(tree, rawSchema.projectName);
+  checkDestination(tree, rawSchema, projectConfig);
+  const schema = normalizeSchema(tree, rawSchema, projectConfig);
+
   moveProjectConfiguration(tree, schema, projectConfig);
   moveProject(tree, schema, projectConfig); // we MUST move the project first, if we don't we get a "This should never happen" error 🤦‍♀️
   updateImports(tree, schema, projectConfig);
@@ -32,8 +35,8 @@ export async function moveGenerator(tree: Tree, schema: Schema) {
   updateJestConfig(tree, schema, projectConfig);
   updateStorybookConfig(tree, schema, projectConfig);
   updateEslintrcJson(tree, schema, projectConfig);
-  updateReadme(tree, schema, projectConfig);
-  updatePackageJson(tree, schema, projectConfig);
+  updateReadme(tree, schema);
+  updatePackageJson(tree, schema);
   updateBuildTargets(tree, schema);
   updateDefaultProject(tree, schema);
   updateImplicitDependencies(tree, schema);

--- a/packages/workspace/src/generators/move/schema.d.ts
+++ b/packages/workspace/src/generators/move/schema.d.ts
@@ -5,3 +5,9 @@ export interface Schema {
   updateImportPath: boolean;
   skipFormat?: boolean;
 }
+
+export interface NormalizedSchema extends Schema {
+  importPath: string;
+  newProjectName: string;
+  relativeToRootDestination: string;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When moving an Angular project to a subfolder which results in the same project name to be generated (e.g. from `my-project` to `my/project`), the module gets incorrectly deleted and the path alias in the `tsconfig.base.json` gets changed even though the project name is the same. The latter issue is caused because when moving any project to a nested structure with no `importPath` provided, the auto-generated `importPath` uses the directory name (with `/`) instead of the project name.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Moving an Angular project should not delete the module file. Moving any project should correctly auto-generate the `importPath`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6487 
