### PR TITLE
fix(misc): fix moving projects with standalone configuration

### DIFF
--- a/docs/angular/api-nx-devkit/index.md
+++ b/docs/angular/api-nx-devkit/index.md
@@ -72,6 +72,7 @@
 - [getWorkspaceLayout](../../angular/nx-devkit/index#getworkspacelayout)
 - [getWorkspacePath](../../angular/nx-devkit/index#getworkspacepath)
 - [installPackagesTask](../../angular/nx-devkit/index#installpackagestask)
+- [isStandaloneProject](../../angular/nx-devkit/index#isstandaloneproject)
 - [joinPathFragments](../../angular/nx-devkit/index#joinpathfragments)
 - [moveFilesToNewDirectory](../../angular/nx-devkit/index#movefilestonewdirectory)
 - [names](../../angular/nx-devkit/index#names)
@@ -883,6 +884,25 @@ Runs `npm install` or `yarn install`. It will skip running the install if
 #### Returns
 
 `void`
+
+---
+
+### isStandaloneProject
+
+▸ **isStandaloneProject**(`host`, `project`): `boolean`
+
+Returns if a project has a standalone configuration (project.json).
+
+#### Parameters
+
+| Name      | Type                                         | Description          |
+| :-------- | :------------------------------------------- | :------------------- |
+| `host`    | [`Tree`](../../angular/nx-devkit/index#tree) | the file system tree |
+| `project` | `string`                                     | the project name     |
+
+#### Returns
+
+`boolean`
 
 ---
 

--- a/docs/node/api-nx-devkit/index.md
+++ b/docs/node/api-nx-devkit/index.md
@@ -72,6 +72,7 @@
 - [getWorkspaceLayout](../../node/nx-devkit/index#getworkspacelayout)
 - [getWorkspacePath](../../node/nx-devkit/index#getworkspacepath)
 - [installPackagesTask](../../node/nx-devkit/index#installpackagestask)
+- [isStandaloneProject](../../node/nx-devkit/index#isstandaloneproject)
 - [joinPathFragments](../../node/nx-devkit/index#joinpathfragments)
 - [moveFilesToNewDirectory](../../node/nx-devkit/index#movefilestonewdirectory)
 - [names](../../node/nx-devkit/index#names)
@@ -883,6 +884,25 @@ Runs `npm install` or `yarn install`. It will skip running the install if
 #### Returns
 
 `void`
+
+---
+
+### isStandaloneProject
+
+▸ **isStandaloneProject**(`host`, `project`): `boolean`
+
+Returns if a project has a standalone configuration (project.json).
+
+#### Parameters
+
+| Name      | Type                                      | Description          |
+| :-------- | :---------------------------------------- | :------------------- |
+| `host`    | [`Tree`](../../node/nx-devkit/index#tree) | the file system tree |
+| `project` | `string`                                  | the project name     |
+
+#### Returns
+
+`boolean`
 
 ---
 

--- a/docs/react/api-nx-devkit/index.md
+++ b/docs/react/api-nx-devkit/index.md
@@ -72,6 +72,7 @@
 - [getWorkspaceLayout](../../react/nx-devkit/index#getworkspacelayout)
 - [getWorkspacePath](../../react/nx-devkit/index#getworkspacepath)
 - [installPackagesTask](../../react/nx-devkit/index#installpackagestask)
+- [isStandaloneProject](../../react/nx-devkit/index#isstandaloneproject)
 - [joinPathFragments](../../react/nx-devkit/index#joinpathfragments)
 - [moveFilesToNewDirectory](../../react/nx-devkit/index#movefilestonewdirectory)
 - [names](../../react/nx-devkit/index#names)
@@ -883,6 +884,25 @@ Runs `npm install` or `yarn install`. It will skip running the install if
 #### Returns
 
 `void`
+
+---
+
+### isStandaloneProject
+
+▸ **isStandaloneProject**(`host`, `project`): `boolean`
+
+Returns if a project has a standalone configuration (project.json).
+
+#### Parameters
+
+| Name      | Type                                       | Description          |
+| :-------- | :----------------------------------------- | :------------------- |
+| `host`    | [`Tree`](../../react/nx-devkit/index#tree) | the file system tree |
+| `project` | `string`                                   | the project name     |
+
+#### Returns
+
+`boolean`
 
 ---
 

--- a/packages/devkit/index.ts
+++ b/packages/devkit/index.ts
@@ -41,6 +41,7 @@ export {
   readWorkspaceConfiguration,
   updateWorkspaceConfiguration,
   getProjects,
+  isStandaloneProject,
 } from './src/generators/project-configuration';
 export { toJS } from './src/generators/to-js';
 export { updateTsConfigsToJs } from './src/generators/update-ts-configs-to-js';

--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -205,6 +205,22 @@ export function readProjectConfiguration(
   return getProjectConfiguration(host, projectName, workspace, nxJson);
 }
 
+/**
+ * Returns if a project has a standalone configuration (project.json).
+ *
+ * @param host - the file system tree
+ * @param project - the project name
+ */
+export function isStandaloneProject(host: Tree, project: string): boolean {
+  const rawWorkspace = readJson<RawWorkspaceJsonConfiguration>(
+    host,
+    getWorkspacePath(host)
+  );
+  const projectConfig = rawWorkspace.projects?.[project];
+
+  return typeof projectConfig === 'string';
+}
+
 function getProjectConfiguration(
   host: Tree,
   projectName: string,

--- a/packages/workspace/src/generators/move/lib/move-project-configuration.spec.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-configuration.spec.ts
@@ -188,4 +188,36 @@ describe('moveProjectConfiguration', () => {
     expect(actualProject.implicitDependencies).toEqual(['my-other-lib']);
     expect(readJson(tree, 'nx.json').projects['my-source']).not.toBeDefined();
   });
+
+  it('should support moving a standalone project', () => {
+    const projectName = 'standalone';
+    const newProjectName = 'parent-standalone';
+    addProjectConfiguration(
+      tree,
+      projectName,
+      {
+        projectType: 'library',
+        root: 'libs/standalone',
+        targets: {},
+      },
+      true
+    );
+    const moveSchema: NormalizedSchema = {
+      projectName: 'standalone',
+      destination: 'parent/standalone',
+      importPath: '@proj/parent-standalone',
+      newProjectName,
+      relativeToRootDestination: 'libs/parent/standalone',
+      updateImportPath: true,
+    };
+
+    moveProjectConfiguration(tree, moveSchema, projectConfig);
+
+    expect(() => {
+      readProjectConfiguration(tree, projectName);
+    }).toThrow();
+    const ws = readJson(tree, 'workspace.json');
+    expect(typeof ws.projects[newProjectName]).toBe('string');
+    expect(readProjectConfiguration(tree, newProjectName)).toBeDefined();
+  });
 });

--- a/packages/workspace/src/generators/move/lib/move-project-configuration.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-configuration.ts
@@ -1,5 +1,6 @@
 import {
   addProjectConfiguration,
+  isStandaloneProject,
   NxJsonProjectConfiguration,
   ProjectConfiguration,
   removeProjectConfiguration,
@@ -12,6 +13,7 @@ export function moveProjectConfiguration(
   schema: NormalizedSchema,
   projectConfig: ProjectConfiguration & NxJsonProjectConfiguration
 ) {
+  const isStandalone = isStandaloneProject(tree, schema.projectName);
   const projectString = JSON.stringify(projectConfig);
   const newProjectString = projectString.replace(
     new RegExp(projectConfig.root, 'g'),
@@ -25,5 +27,10 @@ export function moveProjectConfiguration(
   removeProjectConfiguration(tree, schema.projectName);
 
   // Create a new project with the root replaced
-  addProjectConfiguration(tree, schema.newProjectName, newProject);
+  addProjectConfiguration(
+    tree,
+    schema.newProjectName,
+    newProject,
+    isStandalone
+  );
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Moving a project with a standalone configuration adds the updated configuration to workspace.json instead of updating the corresponding project.json. This happens when not all the projects are using standalone configuration or when the project being moved is the only project in the workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Moving a project with a standalone configuration should update the standalone configuration correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6512 
