### PR TITLE
fix(core): target project locator should handle tsconfig paths fully

### DIFF
--- a/packages/workspace/src/core/target-project-locator.spec.ts
+++ b/packages/workspace/src/core/target-project-locator.spec.ts
@@ -36,6 +36,7 @@ describe('findTargetProjectWithImport', () => {
           '@proj/my-second-proj': ['libs/proj2'],
           '@proj/my-second-proj/*': ['libs/proj2/*'],
           '@proj/project-3': ['libs/proj3a'],
+          '@proj/proj4ab': ['libs/proj4ab'],
           '@proj/proj123': ['libs/proj123'],
           '@proj/proj1234': ['libs/proj1234'],
           '@proj/proj1234-child': ['libs/proj1234-child'],
@@ -54,9 +55,10 @@ describe('findTargetProjectWithImport', () => {
       './libs/proj2/deep/index.ts': `export const a = 22;`,
       './libs/proj3a/index.ts': `export const a = 3;`,
       './libs/proj4ab/index.ts': `export const a = 4;`,
-      './libs/proj123/index.ts': 'export const a = 5',
-      './libs/proj1234/index.ts': 'export const a = 6',
-      './libs/proj1234-child/index.ts': 'export const a = 7',
+      './libs/proj5/index.ts': `export const a = 5;`,
+      './libs/proj123/index.ts': 'export const a = 123',
+      './libs/proj1234/index.ts': 'export const a = 1234',
+      './libs/proj1234-child/index.ts': 'export const a = 12345',
     };
     vol.fromJSON(fsJson, '/root');
 
@@ -172,6 +174,14 @@ describe('findTargetProjectWithImport', () => {
           files: [],
         },
       },
+      proj5: {
+        name: 'proj5',
+        type: 'lib',
+        data: {
+          root: 'libs/proj5',
+          files: [],
+        },
+      },
       'npm:@ng/core': {
         name: 'npm:@ng/core',
         type: 'npm',
@@ -269,7 +279,7 @@ describe('findTargetProjectWithImport', () => {
     expect(proj3a).toEqual('proj3a');
   });
 
-  it('should be able to resolve nested files', () => {
+  it('should be able to resolve nested files using tsConfig paths', () => {
     const proj2deep = targetProjectLocator.findProjectWithImport(
       '@proj/my-second-proj/deep',
       'libs/proj1/index.ts',
@@ -297,7 +307,7 @@ describe('findTargetProjectWithImport', () => {
 
   it('should be able to resolve a module using a normalized path', () => {
     const proj4ab = targetProjectLocator.findProjectWithImport(
-      '@proj/proj4ab',
+      '@proj/proj4ab#a',
       'libs/proj1/index.ts',
       ctx.workspace.npmScope
     );
@@ -341,5 +351,16 @@ describe('findTargetProjectWithImport', () => {
       ctx.workspace.npmScope
     );
     expect(similarDeepImportFromNpm).toEqual('npm:@proj/proj123-base');
+  });
+
+  // TODO(meeroslav): This should fail if path is missing in tsconfig,
+  // but passes because of implicit check for project's prefix
+  it('should be able to resolve packages using project prefix', () => {
+    const proj5 = targetProjectLocator.findProjectWithImport(
+      '@proj/proj5',
+      'libs/proj/index.ts',
+      ctx.workspace.npmScope
+    );
+    expect(proj5).toEqual('proj5');
   });
 });

--- a/packages/workspace/src/core/target-project-locator.spec.ts
+++ b/packages/workspace/src/core/target-project-locator.spec.ts
@@ -30,13 +30,15 @@ describe('findTargetProjectWithImport', () => {
     const tsConfig = {
       compilerOptions: {
         baseUrl: '.',
+        resolveJsonModule: true,
         paths: {
-          '@proj/proj': ['libs/proj/index.ts'],
-          '@proj/my-second-proj': ['libs/proj2/index.ts'],
-          '@proj/project-3': ['libs/proj3a/index.ts'],
-          '@proj/proj123': ['libs/proj123/index.ts'],
-          '@proj/proj1234': ['libs/proj1234/index.ts'],
-          '@proj/proj1234-child': ['libs/proj1234-child/index.ts'],
+          '@proj/proj': ['libs/proj'],
+          '@proj/my-second-proj': ['libs/proj2'],
+          '@proj/my-second-proj/*': ['libs/proj2/*'],
+          '@proj/project-3': ['libs/proj3a'],
+          '@proj/proj123': ['libs/proj123'],
+          '@proj/proj1234': ['libs/proj1234'],
+          '@proj/proj1234-child': ['libs/proj1234-child'],
         },
       },
     };
@@ -49,6 +51,7 @@ describe('findTargetProjectWithImport', () => {
                               const a = { loadChildren: '@proj/proj4ab#a' };
       `,
       './libs/proj2/index.ts': `export const a = 2;`,
+      './libs/proj2/deep/index.ts': `export const a = 22;`,
       './libs/proj3a/index.ts': `export const a = 3;`,
       './libs/proj4ab/index.ts': `export const a = 4;`,
       './libs/proj123/index.ts': 'export const a = 5',
@@ -73,6 +76,11 @@ describe('findTargetProjectWithImport', () => {
         proj2: [
           {
             file: 'libs/proj2/index.ts',
+            hash: 'some-hash',
+            ext: '.ts',
+          },
+          {
+            file: 'libs/proj2/deep/index.ts',
             hash: 'some-hash',
             ext: '.ts',
           },
@@ -188,6 +196,14 @@ describe('findTargetProjectWithImport', () => {
           packageName: 'npm-package',
         },
       },
+      'npm:@proj/my-second-proj': {
+        name: 'npm:@proj/my-second-proj',
+        type: 'npm',
+        data: {
+          files: [],
+          packageName: '@proj/my-second-proj',
+        },
+      },
       'npm:@proj/proj123-base': {
         name: 'npm:@proj/proj123-base',
         type: 'npm',
@@ -251,6 +267,16 @@ describe('findTargetProjectWithImport', () => {
 
     expect(proj2).toEqual('proj2');
     expect(proj3a).toEqual('proj3a');
+  });
+
+  it('should be able to resolve nested files', () => {
+    const proj2deep = targetProjectLocator.findProjectWithImport(
+      '@proj/my-second-proj/deep',
+      'libs/proj1/index.ts',
+      ctx.workspace.npmScope
+    );
+
+    expect(proj2deep).toEqual('proj2');
   });
 
   it('should be able to npm dependencies', () => {

--- a/packages/workspace/src/core/target-project-locator.spec.ts
+++ b/packages/workspace/src/core/target-project-locator.spec.ts
@@ -37,6 +37,9 @@ describe('findTargetProjectWithImport', () => {
           '@proj/my-second-proj/*': ['libs/proj2/*'],
           '@proj/project-3': ['libs/proj3a'],
           '@proj/proj4ab': ['libs/proj4ab'],
+          '@proj/proj5': ['./libs/proj5/*'],
+          '@proj/proj6': ['../root/libs/proj6/*'],
+          '@proj/proj7': ['/libs/proj7/*'],
           '@proj/proj123': ['libs/proj123'],
           '@proj/proj1234': ['libs/proj1234'],
           '@proj/proj1234-child': ['libs/proj1234-child'],
@@ -56,6 +59,8 @@ describe('findTargetProjectWithImport', () => {
       './libs/proj3a/index.ts': `export const a = 3;`,
       './libs/proj4ab/index.ts': `export const a = 4;`,
       './libs/proj5/index.ts': `export const a = 5;`,
+      './libs/proj6/index.ts': `export const a = 6;`,
+      './libs/proj7/index.ts': `export const a = 7;`,
       './libs/proj123/index.ts': 'export const a = 123',
       './libs/proj1234/index.ts': 'export const a = 1234',
       './libs/proj1234-child/index.ts': 'export const a = 12345',
@@ -97,6 +102,27 @@ describe('findTargetProjectWithImport', () => {
         proj4ab: [
           {
             file: 'libs/proj4ab/index.ts',
+            hash: 'some-hash',
+            ext: '.ts',
+          },
+        ],
+        proj5: [
+          {
+            file: 'libs/proj5/index.ts',
+            hash: 'some-hash',
+            ext: '.ts',
+          },
+        ],
+        proj6: [
+          {
+            file: 'libs/proj6/index.ts',
+            hash: 'some-hash',
+            ext: '.ts',
+          },
+        ],
+        proj7: [
+          {
+            file: 'libs/proj7/index.ts',
             hash: 'some-hash',
             ext: '.ts',
           },
@@ -182,6 +208,22 @@ describe('findTargetProjectWithImport', () => {
           files: [],
         },
       },
+      proj6: {
+        name: 'proj6',
+        type: 'lib',
+        data: {
+          root: 'libs/proj6',
+          files: [],
+        },
+      },
+      proj7: {
+        name: 'proj7',
+        type: 'lib',
+        data: {
+          root: 'libs/proj7',
+          files: [],
+        },
+      },
       'npm:@ng/core': {
         name: 'npm:@ng/core',
         type: 'npm',
@@ -212,6 +254,30 @@ describe('findTargetProjectWithImport', () => {
         data: {
           files: [],
           packageName: '@proj/my-second-proj',
+        },
+      },
+      'npm:@proj/proj5': {
+        name: 'npm:@proj/proj5',
+        type: 'npm',
+        data: {
+          files: [],
+          packageName: '@proj/proj5',
+        },
+      },
+      'npm:@proj/proj6': {
+        name: 'npm:@proj/proj6',
+        type: 'npm',
+        data: {
+          files: [],
+          packageName: '@proj/proj6',
+        },
+      },
+      'npm:@proj/proj7': {
+        name: 'npm:@proj/proj7',
+        type: 'npm',
+        data: {
+          files: [],
+          packageName: '@proj/proj7',
         },
       },
       'npm:@proj/proj123-base': {
@@ -313,6 +379,27 @@ describe('findTargetProjectWithImport', () => {
     );
 
     expect(proj4ab).toEqual('proj4ab');
+  });
+  it('should be able to resolve a modules when npm packages exist', () => {
+    const proj5 = targetProjectLocator.findProjectWithImport(
+      '@proj/proj5',
+      'libs/proj1/index.ts',
+      ctx.workspace.npmScope
+    );
+    const proj6 = targetProjectLocator.findProjectWithImport(
+      '@proj/proj6',
+      'libs/proj1/index.ts',
+      ctx.workspace.npmScope
+    );
+    const proj7 = targetProjectLocator.findProjectWithImport(
+      '@proj/proj7',
+      'libs/proj1/index.ts',
+      ctx.workspace.npmScope
+    );
+
+    expect(proj5).toEqual('proj5');
+    expect(proj6).toEqual('proj6');
+    expect(proj7).toEqual('proj7');
   });
   it('should be able to resolve paths that have similar names', () => {
     const proj = targetProjectLocator.findProjectWithImport(

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -171,20 +171,25 @@ export class TargetProjectLocator {
   private findProjectOfResolvedModule(
     resolvedModule: string
   ): string | undefined {
+    const normalizedModulePath = this.getAbsolutePath(resolvedModule);
     const importedProject = this.sortedWorkspaceProjects.find((p) => {
-      return resolvedModule.startsWith(p.data.root);
+      return normalizedModulePath.startsWith(this.getAbsolutePath(p.data.root));
     });
 
     return importedProject ? importedProject.name : void 0;
   }
 
+  private getAbsolutePath(path: string) {
+    return join(appRootPath, path);
+  }
+
   private getRootTsConfig() {
     let path = 'tsconfig.base.json';
-    let absolutePath = join(appRootPath, path);
+    let absolutePath = this.getAbsolutePath(path);
     let content = readFileIfExisting(absolutePath);
     if (!content) {
       path = 'tsconfig.json';
-      absolutePath = join(appRootPath, path);
+      absolutePath = this.getAbsolutePath(path);
       content = readFileIfExisting(absolutePath);
     }
     return { path, absolutePath, config: parseJson(content) };

--- a/packages/workspace/src/utilities/typescript.ts
+++ b/packages/workspace/src/utilities/typescript.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'path';
 import type * as ts from 'typescript';
-import { appRootPath } from './app-root';
+import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 
 export type { TypeScriptCompilationOptions } from './typescript/compilation';
 export { compileTypeScript } from './typescript/compilation';

--- a/packages/workspace/src/utilities/typescript.ts
+++ b/packages/workspace/src/utilities/typescript.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'path';
 import type * as ts from 'typescript';
-import { appRootPath } from '@nrwl/tao/src/utils/app-root';
+import { appRootPath } from './app-root';
 
 export type { TypeScriptCompilationOptions } from './typescript/compilation';
 export { compileTypeScript } from './typescript/compilation';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behaviour
The `TargetProjectLocator` does not match deep imports (e.g. `@nrwl/tao/src/utils/app-root`) with `tsconfig` wildcard paths (e.g. `@nrwl/tao/*`). 

As a consequence, if we have the same package (e.g. `tao`) locally and installed as an npm dependency, we need to run `typescript resolver` matching before `npm` matching to make sure we target the local one. (See https://github.com/nrwl/nx/pull/6030)

This is an expensive operation, causing slowdowns on `linter`. (See https://github.com/nrwl/nx/pull/5576)

## Expected Behaviour
The `TargetProjectLocator` should match deep imports with `tsconfig` wildcard paths.

NPM package resolving should run before typescript matching, to avoid unnecessary slowdown.

The typescript resolver should probably be removed altogether.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
