### PR TITLE
fix(react): align component and e2e test generation

### DIFF
--- a/packages/react/src/generators/component-cypress-spec/component-cypress-spec.spec.ts
+++ b/packages/react/src/generators/component-cypress-spec/component-cypress-spec.spec.ts
@@ -108,9 +108,9 @@ describe('react:component-cypress-spec', () => {
         beforeEach(() => cy.visit('/iframe.html?id=test--primary&args=name;displayAge:false;'));
         
         it('should render the component', () => {
-          cy.get('h1').should('contain', 'Welcome to test-ui-lib!');
+          cy.get('h1').should('contain', 'Welcome to Test!');
         });
-      });
+      })
       `);
           });
         });
@@ -135,7 +135,7 @@ describe('react:component-cypress-spec', () => {
       beforeEach(() => cy.visit('/iframe.html?id=test--primary'));
       
       it('should render the component', () => {
-        cy.get('h1').should('contain', 'Welcome to test-ui-lib!');
+        cy.get('h1').should('contain', 'Welcome to Test!');
       });
     });
     `);

--- a/packages/react/src/generators/component-cypress-spec/files/__componentName__.spec.__fileExt__
+++ b/packages/react/src/generators/component-cypress-spec/files/__componentName__.spec.__fileExt__
@@ -8,6 +8,6 @@ describe('<%=projectName%>: <%= componentSelector %> component', () => {
     }%>'));
     
     it('should render the component', () => {
-      cy.get('h1').should('contain', 'Welcome to <%=projectName%>!');
+      cy.get('h1').should('contain', 'Welcome to <%=componentSelector%>!');
     });
 });

--- a/packages/react/src/generators/component/files/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/component/files/__fileName__.tsx__tmpl__
@@ -33,7 +33,7 @@ export class <%= className %> extends Component<<%= className %>Props> {
     return (
       <<%= wrapper %>>
         <%= styledModule === 'styled-jsx' ? `<style jsx>{\`div { color: pink; }\`}</style>` : `` %>
-        <p>Welcome to <%= name %>!</p>
+        <p>Welcome to <%= className %>!</p>
         <% if (routing) { %>
           <ul>
             <li><Link to="/"><%= name %> root</Link></li>
@@ -49,7 +49,7 @@ export function <%= className %>(props: <%= className %>Props) {
   return (
     <<%= wrapper %>>
       <% if (styledModule === 'styled-jsx') { %><style jsx>{`div { color: pink; }`}</style><% } %>
-      <h1>Welcome to <%= name %>!</h1>
+      <h1>Welcome to <%= className %>!</h1>
       <% if (routing) { %>
         <ul>
           <li><Link to="/"><%= name %> root</Link></li>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Right now if you generate a new React component it generates the welcome message in a "dasherized" name.

![image](https://user-images.githubusercontent.com/542458/127463015-3625dde5-f4f4-47b9-b278-66350f4f14f8.png)

It doesn't make a lot of sense since the actual selector of the React component would be `TopicButton` and not `topic-button`. But apart from that, what happens when generating a Cypress storybook test is that the test right now is generated as follows:

```
describe('shared-ui: TopicButton component', () => {
  beforeEach(() => cy.visit('/iframe.html?id=topicbutton--primary'));
    
    it('should render the component', () => {
      cy.get('h1').should('contain', 'Welcome to shared-ui!');
    });
});

```

Basically it checks whether the name is the project name, rather than component name, thus the pre-generated e2e test fails. Which is bad.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR aligns the React component generator with the e2e test generator s.t. when just using code generation tests pass. Which should always be the case

## To test

- generate a new workspace
- generate a library
- generate a storybook story including Cypress e2e tests
- run the cypress e2e tests => should succeed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
