### PR TITLE
fix(node): change default debug port to 9229 to allow for easy debugging

### DIFF
--- a/docs/angular/api-node/executors/execute.md
+++ b/docs/angular/api-node/executors/execute.md
@@ -36,7 +36,7 @@ Ensures the app is starting with debugging
 
 ### port
 
-Default: `0`
+Default: `9229`
 
 Type: `number`
 

--- a/docs/node/api-node/executors/execute.md
+++ b/docs/node/api-node/executors/execute.md
@@ -37,7 +37,7 @@ Ensures the app is starting with debugging
 
 ### port
 
-Default: `0`
+Default: `9229`
 
 Type: `number`
 

--- a/docs/react/api-node/executors/execute.md
+++ b/docs/react/api-node/executors/execute.md
@@ -37,7 +37,7 @@ Ensures the app is starting with debugging
 
 ### port
 
-Default: `0`
+Default: `9229`
 
 Type: `number`
 

--- a/packages/node/src/executors/execute/schema.json
+++ b/packages/node/src/executors/execute/schema.json
@@ -23,7 +23,7 @@
     },
     "port": {
       "type": "number",
-      "default": 0,
+      "default": 9229,
       "description": "The port to inspect the process on. Setting port to 0 will assign random free ports to all forked processes."
     },
     "watch": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Right now debugging a Nest.js app right from VSCode doesn't work out of the box. One has to make sure to set or pass the `--inspect=inspect --port=9229` to the serve target to get it working.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Sets the default debug port to 9229

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #3948
