### PR TITLE
fix(core): hash implicit dependencies considering the context

### DIFF
--- a/e2e/workspace-integrations/src/workspace.test.ts
+++ b/e2e/workspace-integrations/src/workspace.test.ts
@@ -752,11 +752,21 @@ describe('cache', () => {
     expect(outputWithBuildApp2Cached).toContain('read the output from cache');
     expectMatchedOutput(outputWithBuildApp2Cached, [myapp2]);
 
-    // touch package.json
+    // touch not relevant section in package.json
     // --------------------------------------------
     updateFile(`package.json`, (c) => {
       const r = JSON.parse(c);
       r.description = 'different';
+      return JSON.stringify(r);
+    });
+    const outputWithBuildCached = runCLI(`affected:build ${files}`);
+    expect(outputWithBuildCached).toContain('read the output from cache');
+
+    // touch relevant section in package.json
+    // --------------------------------------------
+    updateFile(`package.json`, (c) => {
+      const r = JSON.parse(c);
+      r.dependencies['some-package'] = '99.99.99';
       return JSON.stringify(r);
     });
     const outputWithNoBuildCached = runCLI(`affected:build ${files}`);

--- a/packages/linter/src/executors/eslint/hasher.ts
+++ b/packages/linter/src/executors/eslint/hasher.ts
@@ -18,7 +18,7 @@ export default async function run(
   const tags = hasher.hashArray(
     deps.map((d) => (workspace.projects[d].tags || []).join('|'))
   );
-  const context = await hasher.hashContext();
+  const context = await hasher.hashContext(task);
   return {
     value: hasher.hashArray([
       command,

--- a/packages/workspace/src/core/hasher/implicit-deps-hasher.ts
+++ b/packages/workspace/src/core/hasher/implicit-deps-hasher.ts
@@ -23,13 +23,12 @@ interface FileHashResult {
 }
 
 export class ImplicitDepsHasher {
+  private fileHashResults: { [fileWithPaths: string]: FileHashResult } = {};
   private globalImplicitDepsHashResult: Promise<ImplicitHashResult>;
+  private implicitDependencies: ImplicitDependencies;
   private jsonFilesCache: { [path: string]: any } = {};
   private projectSpecificImplicitDepsHashResults: {
     [project: string]: Promise<ImplicitHashResult>;
-  } = {};
-  private projectSpecificImplicitDepsCacheKeys: {
-    [project: string]: string;
   } = {};
 
   constructor(
@@ -37,7 +36,7 @@ export class ImplicitDepsHasher {
     private readonly nxJson: NxJsonConfiguration,
     private readonly hashing: HashingImpl
   ) {
-    this.parseImplicitDepsSetup();
+    this.implicitDependencies = new ImplicitDependencies(this.nxJson);
   }
 
   async hashImplicitDeps(project: string): Promise<ImplicitHashResult> {
@@ -99,262 +98,21 @@ export class ImplicitDepsHasher {
   }
 
   private getProjectImplicitDepsHashes(project: string): FileHashResult[] {
-    const hashes: FileHashResult[] = [];
-
-    Object.entries(this.nxJson.implicitDependencies ?? {}).forEach(
-      ([filePattern, depConfig]) => {
+    const implicitDepsConfig =
+      this.implicitDependencies.getProjectImplicitDepsConfig(project);
+    const hashes: FileHashResult[] = Object.entries(implicitDepsConfig).flatMap(
+      ([filePattern, paths]) => {
         const files =
           this.resolveWorkspaceFilesMatchingPattern(filePattern).filter(
             existsSync
           );
-        if (typeof depConfig === 'string') {
-          if (depConfig === '*') {
-            files.forEach((f) =>
-              hashes.push({
-                file: f,
-                hash: this.hashing.hashFile(resolvePathFromRoot(f)),
-              })
-            );
-          }
-        } else if (Array.isArray(depConfig)) {
-          if (depConfig.includes(project)) {
-            files.forEach((f) =>
-              hashes.push({
-                file: f,
-                hash: this.hashing.hashFile(resolvePathFromRoot(f)),
-              })
-            );
-          }
-        } else {
-          // these are json configs with specific keys config
-          files.forEach((f) => {
-            const fileJson = this.readJsonFile(
-              resolvePathFromRoot(f),
-              depConfig
-            );
-            const matchingFileContent = this.getObjectMatchingDepConfig(
-              project,
-              depConfig,
-              fileJson
-            );
-
-            if (matchingFileContent) {
-              hashes.push({
-                file: f,
-                hash: this.hashing.hashArray([
-                  JSON.stringify(matchingFileContent),
-                ]),
-              });
-            }
-          });
-        }
+        return files
+          .map((file) => this.getFileHashResult(file, paths))
+          .filter(Boolean);
       }
     );
 
     return hashes;
-  }
-
-  private getObjectMatchingDepConfig(
-    project: string,
-    config: Record<string, any>,
-    object: Record<string, any>
-  ): Record<string, any> | null {
-    const matchingObject: Record<string, any> = {};
-
-    Object.entries(config).forEach(([key, depConfig]) => {
-      const keys = this.resolveObjectKeysMatchingPattern(object, key);
-      if (typeof depConfig === 'string') {
-        if (depConfig === '*') {
-          keys.forEach((k) => {
-            matchingObject[k] = object[k];
-          });
-        }
-      } else if (Array.isArray(depConfig)) {
-        if (depConfig.includes(project)) {
-          keys.forEach((k) => {
-            matchingObject[k] = object[k];
-          });
-        }
-      } else {
-        keys.forEach((k) => {
-          const result = this.getObjectMatchingDepConfig(
-            project,
-            depConfig,
-            object[k]
-          );
-          if (result) {
-            matchingObject[k] = result;
-          }
-        });
-      }
-    });
-
-    return Object.keys(matchingObject).length > 0 ? matchingObject : null;
-  }
-
-  private getCachedProjectImplicitDepsHashResult(
-    project: string
-  ): Promise<ImplicitHashResult> | null {
-    if (
-      this.projectSpecificImplicitDepsHashResults[
-        this.projectSpecificImplicitDepsCacheKeys[project]
-      ]
-    ) {
-      return this.projectSpecificImplicitDepsHashResults[
-        this.projectSpecificImplicitDepsCacheKeys[project]
-      ];
-    }
-
-    if (
-      !this.projectSpecificImplicitDepsCacheKeys[project] &&
-      this.globalImplicitDepsHashResult
-    ) {
-      return this.globalImplicitDepsHashResult;
-    }
-
-    return null;
-  }
-
-  private cacheImplicitDepsHashResult(
-    project: string,
-    hashResult: Promise<ImplicitHashResult>
-  ): void {
-    if (this.projectSpecificImplicitDepsCacheKeys[project]) {
-      this.projectSpecificImplicitDepsHashResults[
-        this.projectSpecificImplicitDepsCacheKeys[project]
-      ] = hashResult;
-    } else {
-      this.globalImplicitDepsHashResult = hashResult;
-    }
-  }
-
-  private parseImplicitDepsSetup(
-    object: {
-      [file: string]: any;
-    } = this.nxJson.implicitDependencies ?? {}
-  ): void {
-    Object.entries(object).forEach(([file, depConfig]) => {
-      if (typeof depConfig === 'string') {
-        return;
-      } else if (Array.isArray(depConfig)) {
-        depConfig.forEach((project) => {
-          this.addPatternToProjectCacheKey(project, file);
-        });
-      } else {
-        this.addPatternWithSpecificConfigToProjectCacheKey(depConfig, file);
-        this.parseDepConfigObjectSetup(depConfig, file);
-      }
-    });
-  }
-
-  private parseDepConfigObjectSetup(
-    object: { [key: string]: any },
-    file: string
-  ) {
-    Object.entries(object).forEach(([key, depConfig]) => {
-      if (typeof depConfig === 'string') {
-        return;
-      } else if (Array.isArray(depConfig)) {
-        depConfig.forEach((project) => {
-          this.addConfigKeyToProjectCacheKey(project, key);
-        });
-      } else {
-        this.parseDepConfigObjectSetup(depConfig, file);
-      }
-    });
-  }
-
-  private addPatternToProjectCacheKey(project: string, pattern: string): void {
-    if (this.projectSpecificImplicitDepsCacheKeys[project]) {
-      this.projectSpecificImplicitDepsCacheKeys[
-        project
-      ] = `${this.projectSpecificImplicitDepsCacheKeys[project]}|${pattern}`;
-    } else {
-      this.projectSpecificImplicitDepsCacheKeys[project] = pattern;
-    }
-  }
-
-  private addPatternWithSpecificConfigToProjectCacheKey(
-    project: string,
-    pattern: string
-  ): void {
-    if (this.projectSpecificImplicitDepsCacheKeys[project]) {
-      this.projectSpecificImplicitDepsCacheKeys[
-        project
-      ] = `${this.projectSpecificImplicitDepsCacheKeys[project]}|${pattern}>`;
-    } else {
-      this.projectSpecificImplicitDepsCacheKeys[project] = `${pattern}>`;
-    }
-  }
-
-  private addConfigKeyToProjectCacheKey(project: string, key: string): void {
-    this.projectSpecificImplicitDepsCacheKeys[project] = `${key},`;
-  }
-
-  private readJsonFile(
-    file: string,
-    implicitDepConfig: Record<string, any>
-  ): any {
-    const relativePath = file.startsWith(appRootPath)
-      ? file.substr(appRootPath.length + 1)
-      : file;
-    if (this.jsonFilesCache[relativePath]) {
-      return this.jsonFilesCache[relativePath];
-    }
-
-    this.jsonFilesCache[relativePath] = this.stripNonDepKeysFromObject(
-      readJsonFile(file),
-      implicitDepConfig
-    );
-
-    return this.jsonFilesCache[relativePath];
-  }
-
-  private stripNonDepKeysFromObject(
-    object: any,
-    config: Record<string, any>
-  ): any {
-    const result: any = {};
-    Object.entries(config).forEach(([key, depConfig]) => {
-      const keys = this.resolveObjectKeysMatchingPattern(object, key);
-      if (typeof depConfig === 'string' || Array.isArray(depConfig)) {
-        keys.forEach((k) => {
-          result[k] = object[k];
-        });
-      } else {
-        keys.forEach((k) => {
-          result[k] = this.stripNonDepKeysFromObject(object[k], config[k]);
-        });
-      }
-    });
-
-    return result;
-  }
-
-  private resolveWorkspaceFilesMatchingPattern(pattern: string): string[] {
-    const elements = (this.projectGraph.allWorkspaceFiles ?? []).map(
-      (f) => f.file
-    );
-
-    return this.resolveElementsMatchingPattern(elements, pattern);
-  }
-
-  private resolveObjectKeysMatchingPattern(
-    object: { [key: string]: any },
-    pattern: string
-  ): string[] {
-    return this.resolveElementsMatchingPattern(Object.keys(object), pattern);
-  }
-
-  private resolveElementsMatchingPattern(
-    elements: string[],
-    pattern: string
-  ): string[] {
-    if (pattern.indexOf('*') === -1) {
-      return [pattern];
-    }
-
-    return elements.filter((key) => minimatch(key, pattern));
   }
 
   private hashNxJson() {
@@ -377,5 +135,264 @@ export class ImplicitDepsHasher {
         file: 'nx.json',
       },
     ];
+  }
+
+  private getFileHashResult(
+    file: string,
+    paths: string[]
+  ): FileHashResult | null {
+    const fileKey = `${file}|${paths.join('|')}`;
+    if (this.fileHashResults[fileKey]) {
+      return this.fileHashResults[fileKey];
+    }
+
+    if (paths.length === 0) {
+      const hash = this.hashing.hashFile(resolvePathFromRoot(file));
+      if (!hash) {
+        return null;
+      }
+
+      this.fileHashResults[fileKey] = { file, hash };
+    } else {
+      const fileJson = this.readJsonFile(resolvePathFromRoot(file));
+      if (!fileJson) {
+        return null;
+      }
+
+      const matchingFileContent = this.parseObjectPaths(fileJson, paths);
+      this.fileHashResults[fileKey] = {
+        file: file,
+        hash: this.hashing.hashArray([JSON.stringify(matchingFileContent)]),
+      };
+    }
+
+    return this.fileHashResults[fileKey];
+  }
+
+  private parseObjectPaths(
+    sourceObject: Record<string, any>,
+    paths: string[]
+  ): Record<string, any> {
+    let result: Record<string, any> = {};
+
+    paths.forEach((path) => {
+      const segments = path.split('|');
+      result = {
+        ...result,
+        ...this.parseObjectSegments(sourceObject, segments, result),
+      };
+    });
+
+    return result;
+  }
+
+  private parseObjectSegments(
+    sourceObject: Record<string, any>,
+    segments: string[],
+    result: Record<string, any>
+  ): Record<string, any> {
+    if (!sourceObject) {
+      return result;
+    }
+    const segment = segments.shift();
+    const keys = this.resolveObjectKeysMatchingPattern(sourceObject, segment);
+
+    if (segments.length === 0) {
+      keys
+        .filter((key) => sourceObject[key] !== undefined)
+        .forEach((key) => {
+          result[key] = sourceObject[key];
+        });
+    } else {
+      keys
+        .filter((key) => sourceObject[key] !== undefined)
+        .forEach((key) => {
+          result[key] = {
+            ...result[key],
+            ...this.parseObjectSegments(
+              sourceObject[key],
+              segments,
+              result[key] ?? {}
+            ),
+          };
+        });
+    }
+
+    return result;
+  }
+
+  private getCachedProjectImplicitDepsHashResult(
+    project: string
+  ): Promise<ImplicitHashResult> | null {
+    if (
+      !this.implicitDependencies.projectHasSpecificConfig(project) &&
+      this.globalImplicitDepsHashResult
+    ) {
+      return this.globalImplicitDepsHashResult;
+    }
+
+    if (this.projectSpecificImplicitDepsHashResults[project]) {
+      return this.projectSpecificImplicitDepsHashResults[project];
+    }
+
+    return null;
+  }
+
+  private cacheImplicitDepsHashResult(
+    project: string,
+    hashResult: Promise<ImplicitHashResult>
+  ): void {
+    if (this.implicitDependencies.projectHasSpecificConfig(project)) {
+      this.projectSpecificImplicitDepsHashResults[project] = hashResult;
+    } else {
+      this.globalImplicitDepsHashResult = hashResult;
+    }
+  }
+
+  private readJsonFile(file: string): any | undefined {
+    const relativePath = file.startsWith(appRootPath)
+      ? file.substr(appRootPath.length + 1)
+      : file;
+    if (this.jsonFilesCache[relativePath]) {
+      return this.jsonFilesCache[relativePath];
+    }
+
+    try {
+      this.jsonFilesCache[relativePath] = readJsonFile(file);
+    } catch {}
+
+    return this.jsonFilesCache[relativePath];
+  }
+
+  private resolveWorkspaceFilesMatchingPattern(pattern: string): string[] {
+    const elements = (this.projectGraph.allWorkspaceFiles ?? []).map(
+      (f) => f.file
+    );
+
+    return this.resolveElementsMatchingPattern(elements, pattern);
+  }
+
+  private resolveObjectKeysMatchingPattern(
+    object: { [key: string]: any },
+    pattern: string
+  ): string[] {
+    return this.resolveElementsMatchingPattern(Object.keys(object), pattern);
+  }
+
+  private resolveElementsMatchingPattern(
+    elements: string[],
+    pattern: string
+  ): string[] {
+    if (pattern.indexOf(this.implicitDependencies.wildcard) === -1) {
+      return [pattern];
+    }
+
+    return elements.filter((key) => minimatch(key, pattern));
+  }
+}
+
+type ProjectImplicitDepConfig = { [file: string]: string[] };
+
+class ImplicitDependencies {
+  readonly wildcard = '*';
+
+  private parsedImplicitDependencies: {
+    [project: string]: ProjectImplicitDepConfig;
+  } = {};
+
+  constructor(nxJson: NxJsonConfiguration) {
+    this.parseImplicitDepsSetup(nxJson.implicitDependencies ?? {});
+  }
+
+  getProjectImplicitDepsConfig(project: string): ProjectImplicitDepConfig {
+    return (
+      this.parsedImplicitDependencies[project] ??
+      this.parsedImplicitDependencies[this.wildcard] ??
+      {}
+    );
+  }
+
+  projectHasSpecificConfig(project: string) {
+    return this.parsedImplicitDependencies[project] !== undefined;
+  }
+
+  private parseImplicitDepsSetup(implicitDeps: { [file: string]: any }): void {
+    Object.entries(implicitDeps).forEach(([file, depConfig]) => {
+      if (typeof depConfig === 'string') {
+        this.addImplicitFileToProject(this.wildcard, file);
+      } else if (Array.isArray(depConfig)) {
+        depConfig.forEach((project) => {
+          this.addImplicitFileToProject(project, file);
+        });
+      } else {
+        this.parseDepConfigObjectSetup(depConfig, file);
+      }
+    });
+
+    if (!this.parsedImplicitDependencies[this.wildcard]) {
+      return;
+    }
+
+    Object.keys(this.parsedImplicitDependencies)
+      .filter((project) => project !== this.wildcard)
+      .forEach((project) => {
+        this.mergeAllProjectsConfigIntoProjectConfig(
+          this.parsedImplicitDependencies[project],
+          this.parsedImplicitDependencies[this.wildcard]
+        );
+      });
+  }
+
+  private parseDepConfigObjectSetup(
+    object: { [key: string]: any },
+    file: string,
+    paths: string[] = []
+  ): void {
+    Object.entries(object).forEach(([key, depConfig]) => {
+      const currentPaths = [...paths, key];
+      if (typeof depConfig === 'string') {
+        this.addImplicitFileToProject(
+          this.wildcard,
+          file,
+          currentPaths.join('|')
+        );
+      } else if (Array.isArray(depConfig)) {
+        depConfig.forEach((project) => {
+          this.addImplicitFileToProject(project, file, currentPaths.join('|'));
+        });
+      } else {
+        this.parseDepConfigObjectSetup(depConfig, file, currentPaths);
+      }
+    });
+  }
+
+  private addImplicitFileToProject(
+    project: string,
+    file: string,
+    path?: string
+  ): void {
+    const projectConfig = this.parsedImplicitDependencies[project];
+    if (projectConfig) {
+      projectConfig[file] = [
+        ...(projectConfig[file] ?? []),
+        ...(path ? [path] : []),
+      ];
+    } else {
+      this.parsedImplicitDependencies[project] = {
+        [file]: path ? [path] : [],
+      };
+    }
+  }
+
+  private mergeAllProjectsConfigIntoProjectConfig(
+    projectConfig: ProjectImplicitDepConfig,
+    allProjectsDepConfig: ProjectImplicitDepConfig
+  ): void {
+    Object.keys(allProjectsDepConfig).forEach((file) => {
+      projectConfig[file] = [
+        ...(projectConfig[file] ?? []),
+        ...allProjectsDepConfig[file],
+      ];
+    });
   }
 }

--- a/packages/workspace/src/core/hasher/implicit-deps-hasher.ts
+++ b/packages/workspace/src/core/hasher/implicit-deps-hasher.ts
@@ -1,0 +1,381 @@
+import {
+  NxJsonConfiguration,
+  parseJson,
+  ProjectGraph,
+  readJsonFile,
+} from '@nrwl/devkit';
+import { appRootPath } from '@nrwl/tao/src/utils/app-root';
+import { existsSync, readFileSync } from 'fs';
+import * as minimatch from 'minimatch';
+import { join } from 'path';
+import { performance } from 'perf_hooks';
+import { resolvePathFromRoot } from '../../utilities/fileutils';
+import { HashingImpl } from './hashing-impl';
+
+export interface ImplicitHashResult {
+  value: string;
+  files: { [fileName: string]: string };
+}
+
+interface FileHashResult {
+  file: string;
+  hash: string;
+}
+
+export class ImplicitDepsHasher {
+  private globalImplicitDepsHashResult: Promise<ImplicitHashResult>;
+  private jsonFilesCache: { [path: string]: any } = {};
+  private projectSpecificImplicitDepsHashResults: {
+    [project: string]: Promise<ImplicitHashResult>;
+  } = {};
+  private projectSpecificImplicitDepsCacheKeys: {
+    [project: string]: string;
+  } = {};
+
+  constructor(
+    private readonly projectGraph: ProjectGraph,
+    private readonly nxJson: NxJsonConfiguration,
+    private readonly hashing: HashingImpl
+  ) {
+    this.parseImplicitDepsSetup();
+  }
+
+  async hashImplicitDeps(project: string): Promise<ImplicitHashResult> {
+    const cached = this.getCachedProjectImplicitDepsHashResult(project);
+    if (cached) {
+      return cached;
+    }
+
+    performance.mark('hasher:implicit deps hash:start');
+
+    const hashResult: Promise<ImplicitHashResult> = new Promise((res) => {
+      const fileNames = [
+        //TODO: vsavkin move the special cases into explicit ts support
+        'package-lock.json',
+        'yarn.lock',
+        'pnpm-lock.yaml',
+
+        // ignore files will change the set of inputs to the hasher
+        '.gitignore',
+        '.nxignore',
+      ];
+
+      const fileHashes: FileHashResult[] = [
+        ...this.getProjectImplicitDepsHashes(project),
+        ...fileNames
+          .map((file) => {
+            const filePath = resolvePathFromRoot(file);
+            if (!existsSync(filePath)) {
+              return null;
+            }
+
+            // we should use default file hasher here
+            const hash = this.hashing.hashFile(filePath);
+            return { file, hash };
+          })
+          .filter(Boolean),
+        ...this.hashNxJson(),
+      ];
+      const combinedHash = this.hashing.hashArray(
+        fileHashes.map((v) => v.hash)
+      );
+
+      performance.mark('hasher:implicit deps hash:end');
+      performance.measure(
+        'hasher:implicit deps hash',
+        'hasher:implicit deps hash:start',
+        'hasher:implicit deps hash:end'
+      );
+
+      res({
+        value: combinedHash,
+        files: fileHashes.reduce((m, c) => ((m[c.file] = c.hash), m), {}),
+      });
+    });
+
+    this.cacheImplicitDepsHashResult(project, hashResult);
+
+    return hashResult;
+  }
+
+  private getProjectImplicitDepsHashes(project: string): FileHashResult[] {
+    const hashes: FileHashResult[] = [];
+
+    Object.entries(this.nxJson.implicitDependencies ?? {}).forEach(
+      ([filePattern, depConfig]) => {
+        const files =
+          this.resolveWorkspaceFilesMatchingPattern(filePattern).filter(
+            existsSync
+          );
+        if (typeof depConfig === 'string') {
+          if (depConfig === '*') {
+            files.forEach((f) =>
+              hashes.push({
+                file: f,
+                hash: this.hashing.hashFile(resolvePathFromRoot(f)),
+              })
+            );
+          }
+        } else if (Array.isArray(depConfig)) {
+          if (depConfig.includes(project)) {
+            files.forEach((f) =>
+              hashes.push({
+                file: f,
+                hash: this.hashing.hashFile(resolvePathFromRoot(f)),
+              })
+            );
+          }
+        } else {
+          // these are json configs with specific keys config
+          files.forEach((f) => {
+            const fileJson = this.readJsonFile(
+              resolvePathFromRoot(f),
+              depConfig
+            );
+            const matchingFileContent = this.getObjectMatchingDepConfig(
+              project,
+              depConfig,
+              fileJson
+            );
+
+            if (matchingFileContent) {
+              hashes.push({
+                file: f,
+                hash: this.hashing.hashArray([
+                  JSON.stringify(matchingFileContent),
+                ]),
+              });
+            }
+          });
+        }
+      }
+    );
+
+    return hashes;
+  }
+
+  private getObjectMatchingDepConfig(
+    project: string,
+    config: Record<string, any>,
+    object: Record<string, any>
+  ): Record<string, any> | null {
+    const matchingObject: Record<string, any> = {};
+
+    Object.entries(config).forEach(([key, depConfig]) => {
+      const keys = this.resolveObjectKeysMatchingPattern(object, key);
+      if (typeof depConfig === 'string') {
+        if (depConfig === '*') {
+          keys.forEach((k) => {
+            matchingObject[k] = object[k];
+          });
+        }
+      } else if (Array.isArray(depConfig)) {
+        if (depConfig.includes(project)) {
+          keys.forEach((k) => {
+            matchingObject[k] = object[k];
+          });
+        }
+      } else {
+        keys.forEach((k) => {
+          const result = this.getObjectMatchingDepConfig(
+            project,
+            depConfig,
+            object[k]
+          );
+          if (result) {
+            matchingObject[k] = result;
+          }
+        });
+      }
+    });
+
+    return Object.keys(matchingObject).length > 0 ? matchingObject : null;
+  }
+
+  private getCachedProjectImplicitDepsHashResult(
+    project: string
+  ): Promise<ImplicitHashResult> | null {
+    if (
+      this.projectSpecificImplicitDepsHashResults[
+        this.projectSpecificImplicitDepsCacheKeys[project]
+      ]
+    ) {
+      return this.projectSpecificImplicitDepsHashResults[
+        this.projectSpecificImplicitDepsCacheKeys[project]
+      ];
+    }
+
+    if (
+      !this.projectSpecificImplicitDepsCacheKeys[project] &&
+      this.globalImplicitDepsHashResult
+    ) {
+      return this.globalImplicitDepsHashResult;
+    }
+
+    return null;
+  }
+
+  private cacheImplicitDepsHashResult(
+    project: string,
+    hashResult: Promise<ImplicitHashResult>
+  ): void {
+    if (this.projectSpecificImplicitDepsCacheKeys[project]) {
+      this.projectSpecificImplicitDepsHashResults[
+        this.projectSpecificImplicitDepsCacheKeys[project]
+      ] = hashResult;
+    } else {
+      this.globalImplicitDepsHashResult = hashResult;
+    }
+  }
+
+  private parseImplicitDepsSetup(
+    object: {
+      [file: string]: any;
+    } = this.nxJson.implicitDependencies ?? {}
+  ): void {
+    Object.entries(object).forEach(([file, depConfig]) => {
+      if (typeof depConfig === 'string') {
+        return;
+      } else if (Array.isArray(depConfig)) {
+        depConfig.forEach((project) => {
+          this.addPatternToProjectCacheKey(project, file);
+        });
+      } else {
+        this.addPatternWithSpecificConfigToProjectCacheKey(depConfig, file);
+        this.parseDepConfigObjectSetup(depConfig, file);
+      }
+    });
+  }
+
+  private parseDepConfigObjectSetup(
+    object: { [key: string]: any },
+    file: string
+  ) {
+    Object.entries(object).forEach(([key, depConfig]) => {
+      if (typeof depConfig === 'string') {
+        return;
+      } else if (Array.isArray(depConfig)) {
+        depConfig.forEach((project) => {
+          this.addConfigKeyToProjectCacheKey(project, key);
+        });
+      } else {
+        this.parseDepConfigObjectSetup(depConfig, file);
+      }
+    });
+  }
+
+  private addPatternToProjectCacheKey(project: string, pattern: string): void {
+    if (this.projectSpecificImplicitDepsCacheKeys[project]) {
+      this.projectSpecificImplicitDepsCacheKeys[
+        project
+      ] = `${this.projectSpecificImplicitDepsCacheKeys[project]}|${pattern}`;
+    } else {
+      this.projectSpecificImplicitDepsCacheKeys[project] = pattern;
+    }
+  }
+
+  private addPatternWithSpecificConfigToProjectCacheKey(
+    project: string,
+    pattern: string
+  ): void {
+    if (this.projectSpecificImplicitDepsCacheKeys[project]) {
+      this.projectSpecificImplicitDepsCacheKeys[
+        project
+      ] = `${this.projectSpecificImplicitDepsCacheKeys[project]}|${pattern}>`;
+    } else {
+      this.projectSpecificImplicitDepsCacheKeys[project] = `${pattern}>`;
+    }
+  }
+
+  private addConfigKeyToProjectCacheKey(project: string, key: string): void {
+    this.projectSpecificImplicitDepsCacheKeys[project] = `${key},`;
+  }
+
+  private readJsonFile(
+    file: string,
+    implicitDepConfig: Record<string, any>
+  ): any {
+    const relativePath = file.startsWith(appRootPath)
+      ? file.substr(appRootPath.length + 1)
+      : file;
+    if (this.jsonFilesCache[relativePath]) {
+      return this.jsonFilesCache[relativePath];
+    }
+
+    this.jsonFilesCache[relativePath] = this.stripNonDepKeysFromObject(
+      readJsonFile(file),
+      implicitDepConfig
+    );
+
+    return this.jsonFilesCache[relativePath];
+  }
+
+  private stripNonDepKeysFromObject(
+    object: any,
+    config: Record<string, any>
+  ): any {
+    const result: any = {};
+    Object.entries(config).forEach(([key, depConfig]) => {
+      const keys = this.resolveObjectKeysMatchingPattern(object, key);
+      if (typeof depConfig === 'string' || Array.isArray(depConfig)) {
+        keys.forEach((k) => {
+          result[k] = object[k];
+        });
+      } else {
+        keys.forEach((k) => {
+          result[k] = this.stripNonDepKeysFromObject(object[k], config[k]);
+        });
+      }
+    });
+
+    return result;
+  }
+
+  private resolveWorkspaceFilesMatchingPattern(pattern: string): string[] {
+    const elements = (this.projectGraph.allWorkspaceFiles ?? []).map(
+      (f) => f.file
+    );
+
+    return this.resolveElementsMatchingPattern(elements, pattern);
+  }
+
+  private resolveObjectKeysMatchingPattern(
+    object: { [key: string]: any },
+    pattern: string
+  ): string[] {
+    return this.resolveElementsMatchingPattern(Object.keys(object), pattern);
+  }
+
+  private resolveElementsMatchingPattern(
+    elements: string[],
+    pattern: string
+  ): string[] {
+    if (pattern.indexOf('*') === -1) {
+      return [pattern];
+    }
+
+    return elements.filter((key) => minimatch(key, pattern));
+  }
+
+  private hashNxJson() {
+    const nxJsonPath = join(appRootPath, 'nx.json');
+    if (!existsSync(nxJsonPath)) {
+      return [];
+    }
+
+    let nxJsonContents = '{}';
+    try {
+      const fileContents = readFileSync(nxJsonPath, 'utf-8');
+      const r = parseJson(fileContents);
+      delete r.projects;
+      nxJsonContents = JSON.stringify(r);
+    } catch {}
+
+    return [
+      {
+        hash: this.hashing.hashArray([nxJsonContents]),
+        file: 'nx.json',
+      },
+    ];
+  }
+}

--- a/packages/workspace/src/utilities/fileutils.ts
+++ b/packages/workspace/src/utilities/fileutils.ts
@@ -8,8 +8,9 @@ import {
   renameSync as fsRenameSync,
 } from 'fs';
 import { ensureDirSync } from 'fs-extra';
-import { basename, dirname, resolve as pathResolve } from 'path';
+import { basename, dirname, join, resolve as pathResolve } from 'path';
 import { readJsonFile, writeJsonFile } from '@nrwl/devkit';
+import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 
 export function writeToFile(filePath: string, str: string) {
   ensureDirSync(dirname(filePath));
@@ -97,3 +98,7 @@ export function isRelativePath(path: string): boolean {
 }
 
 export const resolve = require.resolve;
+
+export function resolvePathFromRoot(path: string): string {
+  return join(appRootPath, path);
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
All keys in the implicit dependencies configuration are being hashed regardless of the projects that are configured to be affected by it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Hashing the implicit dependencies of a task should take into account the task project and only hash the implicit dependencies keys that are set to affect the task project as described in https://nx.dev/configuration/packagejson#files--implicit-dependencies.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6461 #6078 #6273 

Closes https://github.com/nrwl/nx/pull/6235
