### PR TITLE
cleanup(devkit): rename all variable names of host to tree

### DIFF
--- a/docs/angular/api-nx-devkit/index.md
+++ b/docs/angular/api-nx-devkit/index.md
@@ -505,14 +505,14 @@ Implementation of a target of a project that handles multiple projects to be bat
 
 ### addDependenciesToPackageJson
 
-▸ **addDependenciesToPackageJson**(`host`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../angular/nx-devkit/index#generatorcallback)
+▸ **addDependenciesToPackageJson**(`tree`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../angular/nx-devkit/index#generatorcallback)
 
 Add Dependencies and Dev Dependencies to package.json
 
 For example:
 
 ```typescript
-addDependenciesToPackageJson(host, { react: 'latest' }, { jest: 'latest' });
+addDependenciesToPackageJson(tree, { react: 'latest' }, { jest: 'latest' });
 ```
 
 This will **add** `react` and `jest` to the dependencies and devDependencies sections of package.json respectively.
@@ -521,7 +521,7 @@ This will **add** `react` and `jest` to the dependencies and devDependencies sec
 
 | Name              | Type                                         | Default value    | Description                                                             |
 | :---------------- | :------------------------------------------- | :--------------- | :---------------------------------------------------------------------- |
-| `host`            | [`Tree`](../../angular/nx-devkit/index#tree) | `undefined`      | Tree representing file system to modify                                 |
+| `tree`            | [`Tree`](../../angular/nx-devkit/index#tree) | `undefined`      | Tree representing file system to modify                                 |
 | `dependencies`    | `Record`<`string`, `string`\>                | `undefined`      | Dependencies to be added to the dependencies section of package.json    |
 | `devDependencies` | `Record`<`string`, `string`\>                | `undefined`      | Dependencies to be added to the devDependencies section of package.json |
 | `packageJsonPath` | `string`                                     | `'package.json'` | Path to package.json                                                    |
@@ -536,7 +536,7 @@ Callback to install dependencies only if necessary. undefined is returned if cha
 
 ### addProjectConfiguration
 
-▸ **addProjectConfiguration**(`host`, `projectName`, `projectConfiguration`, `standalone?`): `void`
+▸ **addProjectConfiguration**(`tree`, `projectName`, `projectConfiguration`, `standalone?`): `void`
 
 Adds project configuration to the Nx workspace.
 
@@ -547,7 +547,7 @@ both files.
 
 | Name                   | Type                                                                                                                                                                    | Default value | Description                                                                                |
 | :--------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ | :----------------------------------------------------------------------------------------- |
-| `host`                 | [`Tree`](../../angular/nx-devkit/index#tree)                                                                                                                            | `undefined`   | the file system tree                                                                       |
+| `tree`                 | [`Tree`](../../angular/nx-devkit/index#tree)                                                                                                                            | `undefined`   | the file system tree                                                                       |
 | `projectName`          | `string`                                                                                                                                                                | `undefined`   | unique name. Often directories are part of the name (e.g., mydir-mylib)                    |
 | `projectConfiguration` | [`ProjectConfiguration`](../../angular/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../angular/nx-devkit/index#nxjsonprojectconfiguration) | `undefined`   | project configuration                                                                      |
 | `standalone`           | `boolean`                                                                                                                                                               | `false`       | should the project use package.json? If false, the project config is inside workspace.json |
@@ -694,7 +694,7 @@ Detects which package manager is used in the workspace based on the lock file.
 
 ### formatFiles
 
-▸ **formatFiles**(`host`): `Promise`<`void`\>
+▸ **formatFiles**(`tree`): `Promise`<`void`\>
 
 Formats all the created or updated files using Prettier
 
@@ -702,7 +702,7 @@ Formats all the created or updated files using Prettier
 
 | Name   | Type                                         | Description          |
 | :----- | :------------------------------------------- | :------------------- |
-| `host` | [`Tree`](../../angular/nx-devkit/index#tree) | the file system tree |
+| `tree` | [`Tree`](../../angular/nx-devkit/index#tree) | the file system tree |
 
 #### Returns
 
@@ -712,7 +712,7 @@ Formats all the created or updated files using Prettier
 
 ### generateFiles
 
-▸ **generateFiles**(`host`, `srcFolder`, `target`, `substitutions`): `void`
+▸ **generateFiles**(`tree`, `srcFolder`, `target`, `substitutions`): `void`
 
 Generates a folder of files based on provided templates.
 
@@ -724,7 +724,7 @@ While doing so it performs two substitutions:
 Examples:
 
 ```typescript
-generateFiles(host, path.join(__dirname, 'files'), './tools/scripts', {
+generateFiles(tree, path.join(__dirname, 'files'), './tools/scripts', {
   tmpl: '',
   name: 'myscript',
 });
@@ -740,9 +740,9 @@ doesn't get confused about incorrect TypeScript files.
 
 | Name            | Type                                         | Description                                   |
 | :-------------- | :------------------------------------------- | :-------------------------------------------- |
-| `host`          | [`Tree`](../../angular/nx-devkit/index#tree) | the file system tree                          |
+| `tree`          | [`Tree`](../../angular/nx-devkit/index#tree) | the file system tree                          |
 | `srcFolder`     | `string`                                     | the source folder of files (absolute path)    |
-| `target`        | `string`                                     | the target folder (relative to the host root) |
+| `target`        | `string`                                     | the target folder (relative to the tree root) |
 | `substitutions` | `Object`                                     | an object of key-value pairs                  |
 
 #### Returns
@@ -799,7 +799,7 @@ but it can also be passed in explicitly.
 
 ### getProjects
 
-▸ **getProjects**(`host`): `Map`<`string`, [`ProjectConfiguration`](../../angular/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../angular/nx-devkit/index#nxjsonprojectconfiguration)\>
+▸ **getProjects**(`tree`): `Map`<`string`, [`ProjectConfiguration`](../../angular/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../angular/nx-devkit/index#nxjsonprojectconfiguration)\>
 
 Get a map of all projects in a workspace.
 
@@ -809,7 +809,7 @@ Use [readProjectConfiguration](../../angular/nx-devkit/index#readprojectconfigur
 
 | Name   | Type                                         |
 | :----- | :------------------------------------------- |
-| `host` | [`Tree`](../../angular/nx-devkit/index#tree) |
+| `tree` | [`Tree`](../../angular/nx-devkit/index#tree) |
 
 #### Returns
 
@@ -819,7 +819,7 @@ Use [readProjectConfiguration](../../angular/nx-devkit/index#readprojectconfigur
 
 ### getWorkspaceLayout
 
-▸ **getWorkspaceLayout**(`host`): `Object`
+▸ **getWorkspaceLayout**(`tree`): `Object`
 
 Returns workspace defaults. It includes defaults folders for apps and libs,
 and the default scope.
@@ -834,7 +834,7 @@ Example:
 
 | Name   | Type                                         | Description      |
 | :----- | :------------------------------------------- | :--------------- |
-| `host` | [`Tree`](../../angular/nx-devkit/index#tree) | file system tree |
+| `tree` | [`Tree`](../../angular/nx-devkit/index#tree) | file system tree |
 
 #### Returns
 
@@ -851,13 +851,13 @@ Example:
 
 ### getWorkspacePath
 
-▸ **getWorkspacePath**(`host`): `string`
+▸ **getWorkspacePath**(`tree`): `string`
 
 #### Parameters
 
 | Name   | Type                                         |
 | :----- | :------------------------------------------- |
-| `host` | [`Tree`](../../angular/nx-devkit/index#tree) |
+| `tree` | [`Tree`](../../angular/nx-devkit/index#tree) |
 
 #### Returns
 
@@ -867,7 +867,7 @@ Example:
 
 ### installPackagesTask
 
-▸ **installPackagesTask**(`host`, `alwaysRun?`, `cwd?`, `packageManager?`): `void`
+▸ **installPackagesTask**(`tree`, `alwaysRun?`, `cwd?`, `packageManager?`): `void`
 
 Runs `npm install` or `yarn install`. It will skip running the install if
 `package.json` hasn't changed at all or it hasn't changed since the last invocation.
@@ -876,7 +876,7 @@ Runs `npm install` or `yarn install`. It will skip running the install if
 
 | Name             | Type                                                             | Default value | Description                                                   |
 | :--------------- | :--------------------------------------------------------------- | :------------ | :------------------------------------------------------------ |
-| `host`           | [`Tree`](../../angular/nx-devkit/index#tree)                     | `undefined`   | the file system tree                                          |
+| `tree`           | [`Tree`](../../angular/nx-devkit/index#tree)                     | `undefined`   | the file system tree                                          |
 | `alwaysRun`      | `boolean`                                                        | `false`       | always run the command even if `package.json` hasn't changed. |
 | `cwd`            | `string`                                                         | `''`          | -                                                             |
 | `packageManager` | [`PackageManager`](../../angular/nx-devkit/index#packagemanager) | `undefined`   | -                                                             |
@@ -889,7 +889,7 @@ Runs `npm install` or `yarn install`. It will skip running the install if
 
 ### isStandaloneProject
 
-▸ **isStandaloneProject**(`host`, `project`): `boolean`
+▸ **isStandaloneProject**(`tree`, `project`): `boolean`
 
 Returns if a project has a standalone configuration (project.json).
 
@@ -897,7 +897,7 @@ Returns if a project has a standalone configuration (project.json).
 
 | Name      | Type                                         | Description          |
 | :-------- | :------------------------------------------- | :------------------- |
-| `host`    | [`Tree`](../../angular/nx-devkit/index#tree) | the file system tree |
+| `tree`    | [`Tree`](../../angular/nx-devkit/index#tree) | the file system tree |
 | `project` | `string`                                     | the project name     |
 
 #### Returns
@@ -926,13 +926,13 @@ Normalized path fragments and joins them
 
 ### moveFilesToNewDirectory
 
-▸ **moveFilesToNewDirectory**(`host`, `oldDir`, `newDir`): `void`
+▸ **moveFilesToNewDirectory**(`tree`, `oldDir`, `newDir`): `void`
 
 #### Parameters
 
 | Name     | Type                                         |
 | :------- | :------------------------------------------- |
-| `host`   | [`Tree`](../../angular/nx-devkit/index#tree) |
+| `tree`   | [`Tree`](../../angular/nx-devkit/index#tree) |
 | `oldDir` | `string`                                     |
 | `newDir` | `string`                                     |
 
@@ -1073,9 +1073,9 @@ parseTargetString('proj:test:production'); // returns { project: "proj", target:
 
 ### readJson
 
-▸ **readJson**<`T`\>(`host`, `path`, `options?`): `T`
+▸ **readJson**<`T`\>(`tree`, `path`, `options?`): `T`
 
-Reads a document for host, removes all comments and parses JSON.
+Reads a json file, removes all comments and parses JSON.
 
 #### Type parameters
 
@@ -1087,7 +1087,7 @@ Reads a document for host, removes all comments and parses JSON.
 
 | Name       | Type                                                                 | Description                 |
 | :--------- | :------------------------------------------------------------------- | :-------------------------- |
-| `host`     | [`Tree`](../../angular/nx-devkit/index#tree)                         | file system tree            |
+| `tree`     | [`Tree`](../../angular/nx-devkit/index#tree)                         | file system tree            |
 | `path`     | `string`                                                             | file path                   |
 | `options?` | [`JsonParseOptions`](../../angular/nx-devkit/index#jsonparseoptions) | Optional JSON Parse Options |
 
@@ -1126,7 +1126,7 @@ Object the JSON content of the file represents
 
 ### readProjectConfiguration
 
-▸ **readProjectConfiguration**(`host`, `projectName`): [`ProjectConfiguration`](../../angular/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../angular/nx-devkit/index#nxjsonprojectconfiguration)
+▸ **readProjectConfiguration**(`tree`, `projectName`): [`ProjectConfiguration`](../../angular/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../angular/nx-devkit/index#nxjsonprojectconfiguration)
 
 Reads a project configuration.
 
@@ -1139,7 +1139,7 @@ both files.
 
 | Name          | Type                                         | Description                                                             |
 | :------------ | :------------------------------------------- | :---------------------------------------------------------------------- |
-| `host`        | [`Tree`](../../angular/nx-devkit/index#tree) | the file system tree                                                    |
+| `tree`        | [`Tree`](../../angular/nx-devkit/index#tree) | the file system tree                                                    |
 | `projectName` | `string`                                     | unique name. Often directories are part of the name (e.g., mydir-mylib) |
 
 #### Returns
@@ -1177,7 +1177,7 @@ Works as if you invoked the target yourself without passing any command lint ove
 
 ### readWorkspaceConfiguration
 
-▸ **readWorkspaceConfiguration**(`host`): [`WorkspaceConfiguration`](../../angular/nx-devkit/index#workspaceconfiguration)
+▸ **readWorkspaceConfiguration**(`tree`): [`WorkspaceConfiguration`](../../angular/nx-devkit/index#workspaceconfiguration)
 
 Read general workspace configuration such as the default project or cli settings
 
@@ -1187,7 +1187,7 @@ This does _not_ provide projects configuration, use [readProjectConfiguration](.
 
 | Name   | Type                                         |
 | :----- | :------------------------------------------- |
-| `host` | [`Tree`](../../angular/nx-devkit/index#tree) |
+| `tree` | [`Tree`](../../angular/nx-devkit/index#tree) |
 
 #### Returns
 
@@ -1197,14 +1197,14 @@ This does _not_ provide projects configuration, use [readProjectConfiguration](.
 
 ### removeDependenciesFromPackageJson
 
-▸ **removeDependenciesFromPackageJson**(`host`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../angular/nx-devkit/index#generatorcallback)
+▸ **removeDependenciesFromPackageJson**(`tree`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../angular/nx-devkit/index#generatorcallback)
 
 Remove Dependencies and Dev Dependencies from package.json
 
 For example:
 
 ```typescript
-removeDependenciesFromPackageJson(host, ['react'], ['jest']);
+removeDependenciesFromPackageJson(tree, ['react'], ['jest']);
 ```
 
 This will **remove** `react` and `jest` from the dependencies and devDependencies sections of package.json respectively.
@@ -1213,7 +1213,7 @@ This will **remove** `react` and `jest` from the dependencies and devDependencie
 
 | Name              | Type                                         | Default value    | Description                                                                 |
 | :---------------- | :------------------------------------------- | :--------------- | :-------------------------------------------------------------------------- |
-| `host`            | [`Tree`](../../angular/nx-devkit/index#tree) | `undefined`      | -                                                                           |
+| `tree`            | [`Tree`](../../angular/nx-devkit/index#tree) | `undefined`      | -                                                                           |
 | `dependencies`    | `string`[]                                   | `undefined`      | Dependencies to be removed from the dependencies section of package.json    |
 | `devDependencies` | `string`[]                                   | `undefined`      | Dependencies to be removed from the devDependencies section of package.json |
 | `packageJsonPath` | `string`                                     | `'package.json'` | -                                                                           |
@@ -1228,7 +1228,7 @@ Callback to uninstall dependencies only if necessary. undefined is returned if c
 
 ### removeProjectConfiguration
 
-▸ **removeProjectConfiguration**(`host`, `projectName`): `void`
+▸ **removeProjectConfiguration**(`tree`, `projectName`): `void`
 
 Removes the configuration of an existing project.
 
@@ -1239,7 +1239,7 @@ The utility will update both files.
 
 | Name          | Type                                         |
 | :------------ | :------------------------------------------- |
-| `host`        | [`Tree`](../../angular/nx-devkit/index#tree) |
+| `tree`        | [`Tree`](../../angular/nx-devkit/index#tree) |
 | `projectName` | `string`                                     |
 
 #### Returns
@@ -1419,7 +1419,7 @@ Rename and transpile any new typescript files created to javascript files
 
 ### updateJson
 
-▸ **updateJson**<`T`, `U`\>(`host`, `path`, `updater`, `options?`): `void`
+▸ **updateJson**<`T`, `U`\>(`tree`, `path`, `updater`, `options?`): `void`
 
 Updates a JSON value to the file system tree
 
@@ -1434,7 +1434,7 @@ Updates a JSON value to the file system tree
 
 | Name       | Type                                                                                                                                                | Description                                                                                          |
 | :--------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
-| `host`     | [`Tree`](../../angular/nx-devkit/index#tree)                                                                                                        | File system tree                                                                                     |
+| `tree`     | [`Tree`](../../angular/nx-devkit/index#tree)                                                                                                        | File system tree                                                                                     |
 | `path`     | `string`                                                                                                                                            | Path of JSON file in the Tree                                                                        |
 | `updater`  | (`value`: `T`) => `U`                                                                                                                               | Function that maps the current value of a JSON document to a new value to be written to the document |
 | `options?` | [`JsonParseOptions`](../../angular/nx-devkit/index#jsonparseoptions) & [`JsonSerializeOptions`](../../angular/nx-devkit/index#jsonserializeoptions) | Optional JSON Parse and Serialize Options                                                            |
@@ -1447,7 +1447,7 @@ Updates a JSON value to the file system tree
 
 ### updateProjectConfiguration
 
-▸ **updateProjectConfiguration**(`host`, `projectName`, `projectConfiguration`): `void`
+▸ **updateProjectConfiguration**(`tree`, `projectName`, `projectConfiguration`): `void`
 
 Updates the configuration of an existing project.
 
@@ -1458,7 +1458,7 @@ both files.
 
 | Name                   | Type                                                                                                                                                                    | Description                                                             |
 | :--------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- |
-| `host`                 | [`Tree`](../../angular/nx-devkit/index#tree)                                                                                                                            | the file system tree                                                    |
+| `tree`                 | [`Tree`](../../angular/nx-devkit/index#tree)                                                                                                                            | the file system tree                                                    |
 | `projectName`          | `string`                                                                                                                                                                | unique name. Often directories are part of the name (e.g., mydir-mylib) |
 | `projectConfiguration` | [`ProjectConfiguration`](../../angular/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../angular/nx-devkit/index#nxjsonprojectconfiguration) | project configuration                                                   |
 
@@ -1470,13 +1470,13 @@ both files.
 
 ### updateTsConfigsToJs
 
-▸ **updateTsConfigsToJs**(`host`, `options`): `void`
+▸ **updateTsConfigsToJs**(`tree`, `options`): `void`
 
 #### Parameters
 
 | Name                  | Type                                         |
 | :-------------------- | :------------------------------------------- |
-| `host`                | [`Tree`](../../angular/nx-devkit/index#tree) |
+| `tree`                | [`Tree`](../../angular/nx-devkit/index#tree) |
 | `options`             | `Object`                                     |
 | `options.projectRoot` | `string`                                     |
 
@@ -1488,7 +1488,7 @@ both files.
 
 ### updateWorkspaceConfiguration
 
-▸ **updateWorkspaceConfiguration**(`host`, `workspaceConfig`): `void`
+▸ **updateWorkspaceConfiguration**(`tree`, `workspaceConfig`): `void`
 
 Update general workspace configuration such as the default project or cli settings.
 
@@ -1498,7 +1498,7 @@ This does _not_ update projects configuration, use [updateProjectConfiguration](
 
 | Name              | Type                                                                             |
 | :---------------- | :------------------------------------------------------------------------------- |
-| `host`            | [`Tree`](../../angular/nx-devkit/index#tree)                                     |
+| `tree`            | [`Tree`](../../angular/nx-devkit/index#tree)                                     |
 | `workspaceConfig` | [`WorkspaceConfiguration`](../../angular/nx-devkit/index#workspaceconfiguration) |
 
 #### Returns
@@ -1529,7 +1529,7 @@ Utility to act on all files in a tree that are not ignored by git.
 
 ### writeJson
 
-▸ **writeJson**<`T`\>(`host`, `path`, `value`, `options?`): `void`
+▸ **writeJson**<`T`\>(`tree`, `path`, `value`, `options?`): `void`
 
 Writes a JSON value to the file system tree
 
@@ -1543,7 +1543,7 @@ Writes a JSON value to the file system tree
 
 | Name       | Type                                                                         | Description                     |
 | :--------- | :--------------------------------------------------------------------------- | :------------------------------ |
-| `host`     | [`Tree`](../../angular/nx-devkit/index#tree)                                 | File system tree                |
+| `tree`     | [`Tree`](../../angular/nx-devkit/index#tree)                                 | File system tree                |
 | `path`     | `string`                                                                     | Path of JSON file in the Tree   |
 | `value`    | `T`                                                                          | Serializable value to write     |
 | `options?` | [`JsonSerializeOptions`](../../angular/nx-devkit/index#jsonserializeoptions) | Optional JSON Serialize Options |

--- a/docs/node/api-nx-devkit/index.md
+++ b/docs/node/api-nx-devkit/index.md
@@ -505,14 +505,14 @@ Implementation of a target of a project that handles multiple projects to be bat
 
 ### addDependenciesToPackageJson
 
-▸ **addDependenciesToPackageJson**(`host`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../node/nx-devkit/index#generatorcallback)
+▸ **addDependenciesToPackageJson**(`tree`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../node/nx-devkit/index#generatorcallback)
 
 Add Dependencies and Dev Dependencies to package.json
 
 For example:
 
 ```typescript
-addDependenciesToPackageJson(host, { react: 'latest' }, { jest: 'latest' });
+addDependenciesToPackageJson(tree, { react: 'latest' }, { jest: 'latest' });
 ```
 
 This will **add** `react` and `jest` to the dependencies and devDependencies sections of package.json respectively.
@@ -521,7 +521,7 @@ This will **add** `react` and `jest` to the dependencies and devDependencies sec
 
 | Name              | Type                                      | Default value    | Description                                                             |
 | :---------------- | :---------------------------------------- | :--------------- | :---------------------------------------------------------------------- |
-| `host`            | [`Tree`](../../node/nx-devkit/index#tree) | `undefined`      | Tree representing file system to modify                                 |
+| `tree`            | [`Tree`](../../node/nx-devkit/index#tree) | `undefined`      | Tree representing file system to modify                                 |
 | `dependencies`    | `Record`<`string`, `string`\>             | `undefined`      | Dependencies to be added to the dependencies section of package.json    |
 | `devDependencies` | `Record`<`string`, `string`\>             | `undefined`      | Dependencies to be added to the devDependencies section of package.json |
 | `packageJsonPath` | `string`                                  | `'package.json'` | Path to package.json                                                    |
@@ -536,7 +536,7 @@ Callback to install dependencies only if necessary. undefined is returned if cha
 
 ### addProjectConfiguration
 
-▸ **addProjectConfiguration**(`host`, `projectName`, `projectConfiguration`, `standalone?`): `void`
+▸ **addProjectConfiguration**(`tree`, `projectName`, `projectConfiguration`, `standalone?`): `void`
 
 Adds project configuration to the Nx workspace.
 
@@ -547,7 +547,7 @@ both files.
 
 | Name                   | Type                                                                                                                                                              | Default value | Description                                                                                |
 | :--------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ | :----------------------------------------------------------------------------------------- |
-| `host`                 | [`Tree`](../../node/nx-devkit/index#tree)                                                                                                                         | `undefined`   | the file system tree                                                                       |
+| `tree`                 | [`Tree`](../../node/nx-devkit/index#tree)                                                                                                                         | `undefined`   | the file system tree                                                                       |
 | `projectName`          | `string`                                                                                                                                                          | `undefined`   | unique name. Often directories are part of the name (e.g., mydir-mylib)                    |
 | `projectConfiguration` | [`ProjectConfiguration`](../../node/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../node/nx-devkit/index#nxjsonprojectconfiguration) | `undefined`   | project configuration                                                                      |
 | `standalone`           | `boolean`                                                                                                                                                         | `false`       | should the project use package.json? If false, the project config is inside workspace.json |
@@ -694,7 +694,7 @@ Detects which package manager is used in the workspace based on the lock file.
 
 ### formatFiles
 
-▸ **formatFiles**(`host`): `Promise`<`void`\>
+▸ **formatFiles**(`tree`): `Promise`<`void`\>
 
 Formats all the created or updated files using Prettier
 
@@ -702,7 +702,7 @@ Formats all the created or updated files using Prettier
 
 | Name   | Type                                      | Description          |
 | :----- | :---------------------------------------- | :------------------- |
-| `host` | [`Tree`](../../node/nx-devkit/index#tree) | the file system tree |
+| `tree` | [`Tree`](../../node/nx-devkit/index#tree) | the file system tree |
 
 #### Returns
 
@@ -712,7 +712,7 @@ Formats all the created or updated files using Prettier
 
 ### generateFiles
 
-▸ **generateFiles**(`host`, `srcFolder`, `target`, `substitutions`): `void`
+▸ **generateFiles**(`tree`, `srcFolder`, `target`, `substitutions`): `void`
 
 Generates a folder of files based on provided templates.
 
@@ -724,7 +724,7 @@ While doing so it performs two substitutions:
 Examples:
 
 ```typescript
-generateFiles(host, path.join(__dirname, 'files'), './tools/scripts', {
+generateFiles(tree, path.join(__dirname, 'files'), './tools/scripts', {
   tmpl: '',
   name: 'myscript',
 });
@@ -740,9 +740,9 @@ doesn't get confused about incorrect TypeScript files.
 
 | Name            | Type                                      | Description                                   |
 | :-------------- | :---------------------------------------- | :-------------------------------------------- |
-| `host`          | [`Tree`](../../node/nx-devkit/index#tree) | the file system tree                          |
+| `tree`          | [`Tree`](../../node/nx-devkit/index#tree) | the file system tree                          |
 | `srcFolder`     | `string`                                  | the source folder of files (absolute path)    |
-| `target`        | `string`                                  | the target folder (relative to the host root) |
+| `target`        | `string`                                  | the target folder (relative to the tree root) |
 | `substitutions` | `Object`                                  | an object of key-value pairs                  |
 
 #### Returns
@@ -799,7 +799,7 @@ but it can also be passed in explicitly.
 
 ### getProjects
 
-▸ **getProjects**(`host`): `Map`<`string`, [`ProjectConfiguration`](../../node/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../node/nx-devkit/index#nxjsonprojectconfiguration)\>
+▸ **getProjects**(`tree`): `Map`<`string`, [`ProjectConfiguration`](../../node/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../node/nx-devkit/index#nxjsonprojectconfiguration)\>
 
 Get a map of all projects in a workspace.
 
@@ -809,7 +809,7 @@ Use [readProjectConfiguration](../../node/nx-devkit/index#readprojectconfigurati
 
 | Name   | Type                                      |
 | :----- | :---------------------------------------- |
-| `host` | [`Tree`](../../node/nx-devkit/index#tree) |
+| `tree` | [`Tree`](../../node/nx-devkit/index#tree) |
 
 #### Returns
 
@@ -819,7 +819,7 @@ Use [readProjectConfiguration](../../node/nx-devkit/index#readprojectconfigurati
 
 ### getWorkspaceLayout
 
-▸ **getWorkspaceLayout**(`host`): `Object`
+▸ **getWorkspaceLayout**(`tree`): `Object`
 
 Returns workspace defaults. It includes defaults folders for apps and libs,
 and the default scope.
@@ -834,7 +834,7 @@ Example:
 
 | Name   | Type                                      | Description      |
 | :----- | :---------------------------------------- | :--------------- |
-| `host` | [`Tree`](../../node/nx-devkit/index#tree) | file system tree |
+| `tree` | [`Tree`](../../node/nx-devkit/index#tree) | file system tree |
 
 #### Returns
 
@@ -851,13 +851,13 @@ Example:
 
 ### getWorkspacePath
 
-▸ **getWorkspacePath**(`host`): `string`
+▸ **getWorkspacePath**(`tree`): `string`
 
 #### Parameters
 
 | Name   | Type                                      |
 | :----- | :---------------------------------------- |
-| `host` | [`Tree`](../../node/nx-devkit/index#tree) |
+| `tree` | [`Tree`](../../node/nx-devkit/index#tree) |
 
 #### Returns
 
@@ -867,7 +867,7 @@ Example:
 
 ### installPackagesTask
 
-▸ **installPackagesTask**(`host`, `alwaysRun?`, `cwd?`, `packageManager?`): `void`
+▸ **installPackagesTask**(`tree`, `alwaysRun?`, `cwd?`, `packageManager?`): `void`
 
 Runs `npm install` or `yarn install`. It will skip running the install if
 `package.json` hasn't changed at all or it hasn't changed since the last invocation.
@@ -876,7 +876,7 @@ Runs `npm install` or `yarn install`. It will skip running the install if
 
 | Name             | Type                                                          | Default value | Description                                                   |
 | :--------------- | :------------------------------------------------------------ | :------------ | :------------------------------------------------------------ |
-| `host`           | [`Tree`](../../node/nx-devkit/index#tree)                     | `undefined`   | the file system tree                                          |
+| `tree`           | [`Tree`](../../node/nx-devkit/index#tree)                     | `undefined`   | the file system tree                                          |
 | `alwaysRun`      | `boolean`                                                     | `false`       | always run the command even if `package.json` hasn't changed. |
 | `cwd`            | `string`                                                      | `''`          | -                                                             |
 | `packageManager` | [`PackageManager`](../../node/nx-devkit/index#packagemanager) | `undefined`   | -                                                             |
@@ -889,7 +889,7 @@ Runs `npm install` or `yarn install`. It will skip running the install if
 
 ### isStandaloneProject
 
-▸ **isStandaloneProject**(`host`, `project`): `boolean`
+▸ **isStandaloneProject**(`tree`, `project`): `boolean`
 
 Returns if a project has a standalone configuration (project.json).
 
@@ -897,7 +897,7 @@ Returns if a project has a standalone configuration (project.json).
 
 | Name      | Type                                      | Description          |
 | :-------- | :---------------------------------------- | :------------------- |
-| `host`    | [`Tree`](../../node/nx-devkit/index#tree) | the file system tree |
+| `tree`    | [`Tree`](../../node/nx-devkit/index#tree) | the file system tree |
 | `project` | `string`                                  | the project name     |
 
 #### Returns
@@ -926,13 +926,13 @@ Normalized path fragments and joins them
 
 ### moveFilesToNewDirectory
 
-▸ **moveFilesToNewDirectory**(`host`, `oldDir`, `newDir`): `void`
+▸ **moveFilesToNewDirectory**(`tree`, `oldDir`, `newDir`): `void`
 
 #### Parameters
 
 | Name     | Type                                      |
 | :------- | :---------------------------------------- |
-| `host`   | [`Tree`](../../node/nx-devkit/index#tree) |
+| `tree`   | [`Tree`](../../node/nx-devkit/index#tree) |
 | `oldDir` | `string`                                  |
 | `newDir` | `string`                                  |
 
@@ -1073,9 +1073,9 @@ parseTargetString('proj:test:production'); // returns { project: "proj", target:
 
 ### readJson
 
-▸ **readJson**<`T`\>(`host`, `path`, `options?`): `T`
+▸ **readJson**<`T`\>(`tree`, `path`, `options?`): `T`
 
-Reads a document for host, removes all comments and parses JSON.
+Reads a json file, removes all comments and parses JSON.
 
 #### Type parameters
 
@@ -1087,7 +1087,7 @@ Reads a document for host, removes all comments and parses JSON.
 
 | Name       | Type                                                              | Description                 |
 | :--------- | :---------------------------------------------------------------- | :-------------------------- |
-| `host`     | [`Tree`](../../node/nx-devkit/index#tree)                         | file system tree            |
+| `tree`     | [`Tree`](../../node/nx-devkit/index#tree)                         | file system tree            |
 | `path`     | `string`                                                          | file path                   |
 | `options?` | [`JsonParseOptions`](../../node/nx-devkit/index#jsonparseoptions) | Optional JSON Parse Options |
 
@@ -1126,7 +1126,7 @@ Object the JSON content of the file represents
 
 ### readProjectConfiguration
 
-▸ **readProjectConfiguration**(`host`, `projectName`): [`ProjectConfiguration`](../../node/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../node/nx-devkit/index#nxjsonprojectconfiguration)
+▸ **readProjectConfiguration**(`tree`, `projectName`): [`ProjectConfiguration`](../../node/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../node/nx-devkit/index#nxjsonprojectconfiguration)
 
 Reads a project configuration.
 
@@ -1139,7 +1139,7 @@ both files.
 
 | Name          | Type                                      | Description                                                             |
 | :------------ | :---------------------------------------- | :---------------------------------------------------------------------- |
-| `host`        | [`Tree`](../../node/nx-devkit/index#tree) | the file system tree                                                    |
+| `tree`        | [`Tree`](../../node/nx-devkit/index#tree) | the file system tree                                                    |
 | `projectName` | `string`                                  | unique name. Often directories are part of the name (e.g., mydir-mylib) |
 
 #### Returns
@@ -1177,7 +1177,7 @@ Works as if you invoked the target yourself without passing any command lint ove
 
 ### readWorkspaceConfiguration
 
-▸ **readWorkspaceConfiguration**(`host`): [`WorkspaceConfiguration`](../../node/nx-devkit/index#workspaceconfiguration)
+▸ **readWorkspaceConfiguration**(`tree`): [`WorkspaceConfiguration`](../../node/nx-devkit/index#workspaceconfiguration)
 
 Read general workspace configuration such as the default project or cli settings
 
@@ -1187,7 +1187,7 @@ This does _not_ provide projects configuration, use [readProjectConfiguration](.
 
 | Name   | Type                                      |
 | :----- | :---------------------------------------- |
-| `host` | [`Tree`](../../node/nx-devkit/index#tree) |
+| `tree` | [`Tree`](../../node/nx-devkit/index#tree) |
 
 #### Returns
 
@@ -1197,14 +1197,14 @@ This does _not_ provide projects configuration, use [readProjectConfiguration](.
 
 ### removeDependenciesFromPackageJson
 
-▸ **removeDependenciesFromPackageJson**(`host`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../node/nx-devkit/index#generatorcallback)
+▸ **removeDependenciesFromPackageJson**(`tree`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../node/nx-devkit/index#generatorcallback)
 
 Remove Dependencies and Dev Dependencies from package.json
 
 For example:
 
 ```typescript
-removeDependenciesFromPackageJson(host, ['react'], ['jest']);
+removeDependenciesFromPackageJson(tree, ['react'], ['jest']);
 ```
 
 This will **remove** `react` and `jest` from the dependencies and devDependencies sections of package.json respectively.
@@ -1213,7 +1213,7 @@ This will **remove** `react` and `jest` from the dependencies and devDependencie
 
 | Name              | Type                                      | Default value    | Description                                                                 |
 | :---------------- | :---------------------------------------- | :--------------- | :-------------------------------------------------------------------------- |
-| `host`            | [`Tree`](../../node/nx-devkit/index#tree) | `undefined`      | -                                                                           |
+| `tree`            | [`Tree`](../../node/nx-devkit/index#tree) | `undefined`      | -                                                                           |
 | `dependencies`    | `string`[]                                | `undefined`      | Dependencies to be removed from the dependencies section of package.json    |
 | `devDependencies` | `string`[]                                | `undefined`      | Dependencies to be removed from the devDependencies section of package.json |
 | `packageJsonPath` | `string`                                  | `'package.json'` | -                                                                           |
@@ -1228,7 +1228,7 @@ Callback to uninstall dependencies only if necessary. undefined is returned if c
 
 ### removeProjectConfiguration
 
-▸ **removeProjectConfiguration**(`host`, `projectName`): `void`
+▸ **removeProjectConfiguration**(`tree`, `projectName`): `void`
 
 Removes the configuration of an existing project.
 
@@ -1239,7 +1239,7 @@ The utility will update both files.
 
 | Name          | Type                                      |
 | :------------ | :---------------------------------------- |
-| `host`        | [`Tree`](../../node/nx-devkit/index#tree) |
+| `tree`        | [`Tree`](../../node/nx-devkit/index#tree) |
 | `projectName` | `string`                                  |
 
 #### Returns
@@ -1419,7 +1419,7 @@ Rename and transpile any new typescript files created to javascript files
 
 ### updateJson
 
-▸ **updateJson**<`T`, `U`\>(`host`, `path`, `updater`, `options?`): `void`
+▸ **updateJson**<`T`, `U`\>(`tree`, `path`, `updater`, `options?`): `void`
 
 Updates a JSON value to the file system tree
 
@@ -1434,7 +1434,7 @@ Updates a JSON value to the file system tree
 
 | Name       | Type                                                                                                                                          | Description                                                                                          |
 | :--------- | :-------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
-| `host`     | [`Tree`](../../node/nx-devkit/index#tree)                                                                                                     | File system tree                                                                                     |
+| `tree`     | [`Tree`](../../node/nx-devkit/index#tree)                                                                                                     | File system tree                                                                                     |
 | `path`     | `string`                                                                                                                                      | Path of JSON file in the Tree                                                                        |
 | `updater`  | (`value`: `T`) => `U`                                                                                                                         | Function that maps the current value of a JSON document to a new value to be written to the document |
 | `options?` | [`JsonParseOptions`](../../node/nx-devkit/index#jsonparseoptions) & [`JsonSerializeOptions`](../../node/nx-devkit/index#jsonserializeoptions) | Optional JSON Parse and Serialize Options                                                            |
@@ -1447,7 +1447,7 @@ Updates a JSON value to the file system tree
 
 ### updateProjectConfiguration
 
-▸ **updateProjectConfiguration**(`host`, `projectName`, `projectConfiguration`): `void`
+▸ **updateProjectConfiguration**(`tree`, `projectName`, `projectConfiguration`): `void`
 
 Updates the configuration of an existing project.
 
@@ -1458,7 +1458,7 @@ both files.
 
 | Name                   | Type                                                                                                                                                              | Description                                                             |
 | :--------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- |
-| `host`                 | [`Tree`](../../node/nx-devkit/index#tree)                                                                                                                         | the file system tree                                                    |
+| `tree`                 | [`Tree`](../../node/nx-devkit/index#tree)                                                                                                                         | the file system tree                                                    |
 | `projectName`          | `string`                                                                                                                                                          | unique name. Often directories are part of the name (e.g., mydir-mylib) |
 | `projectConfiguration` | [`ProjectConfiguration`](../../node/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../node/nx-devkit/index#nxjsonprojectconfiguration) | project configuration                                                   |
 
@@ -1470,13 +1470,13 @@ both files.
 
 ### updateTsConfigsToJs
 
-▸ **updateTsConfigsToJs**(`host`, `options`): `void`
+▸ **updateTsConfigsToJs**(`tree`, `options`): `void`
 
 #### Parameters
 
 | Name                  | Type                                      |
 | :-------------------- | :---------------------------------------- |
-| `host`                | [`Tree`](../../node/nx-devkit/index#tree) |
+| `tree`                | [`Tree`](../../node/nx-devkit/index#tree) |
 | `options`             | `Object`                                  |
 | `options.projectRoot` | `string`                                  |
 
@@ -1488,7 +1488,7 @@ both files.
 
 ### updateWorkspaceConfiguration
 
-▸ **updateWorkspaceConfiguration**(`host`, `workspaceConfig`): `void`
+▸ **updateWorkspaceConfiguration**(`tree`, `workspaceConfig`): `void`
 
 Update general workspace configuration such as the default project or cli settings.
 
@@ -1498,7 +1498,7 @@ This does _not_ update projects configuration, use [updateProjectConfiguration](
 
 | Name              | Type                                                                          |
 | :---------------- | :---------------------------------------------------------------------------- |
-| `host`            | [`Tree`](../../node/nx-devkit/index#tree)                                     |
+| `tree`            | [`Tree`](../../node/nx-devkit/index#tree)                                     |
 | `workspaceConfig` | [`WorkspaceConfiguration`](../../node/nx-devkit/index#workspaceconfiguration) |
 
 #### Returns
@@ -1529,7 +1529,7 @@ Utility to act on all files in a tree that are not ignored by git.
 
 ### writeJson
 
-▸ **writeJson**<`T`\>(`host`, `path`, `value`, `options?`): `void`
+▸ **writeJson**<`T`\>(`tree`, `path`, `value`, `options?`): `void`
 
 Writes a JSON value to the file system tree
 
@@ -1543,7 +1543,7 @@ Writes a JSON value to the file system tree
 
 | Name       | Type                                                                      | Description                     |
 | :--------- | :------------------------------------------------------------------------ | :------------------------------ |
-| `host`     | [`Tree`](../../node/nx-devkit/index#tree)                                 | File system tree                |
+| `tree`     | [`Tree`](../../node/nx-devkit/index#tree)                                 | File system tree                |
 | `path`     | `string`                                                                  | Path of JSON file in the Tree   |
 | `value`    | `T`                                                                       | Serializable value to write     |
 | `options?` | [`JsonSerializeOptions`](../../node/nx-devkit/index#jsonserializeoptions) | Optional JSON Serialize Options |

--- a/docs/react/api-nx-devkit/index.md
+++ b/docs/react/api-nx-devkit/index.md
@@ -505,14 +505,14 @@ Implementation of a target of a project that handles multiple projects to be bat
 
 ### addDependenciesToPackageJson
 
-▸ **addDependenciesToPackageJson**(`host`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../react/nx-devkit/index#generatorcallback)
+▸ **addDependenciesToPackageJson**(`tree`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../react/nx-devkit/index#generatorcallback)
 
 Add Dependencies and Dev Dependencies to package.json
 
 For example:
 
 ```typescript
-addDependenciesToPackageJson(host, { react: 'latest' }, { jest: 'latest' });
+addDependenciesToPackageJson(tree, { react: 'latest' }, { jest: 'latest' });
 ```
 
 This will **add** `react` and `jest` to the dependencies and devDependencies sections of package.json respectively.
@@ -521,7 +521,7 @@ This will **add** `react` and `jest` to the dependencies and devDependencies sec
 
 | Name              | Type                                       | Default value    | Description                                                             |
 | :---------------- | :----------------------------------------- | :--------------- | :---------------------------------------------------------------------- |
-| `host`            | [`Tree`](../../react/nx-devkit/index#tree) | `undefined`      | Tree representing file system to modify                                 |
+| `tree`            | [`Tree`](../../react/nx-devkit/index#tree) | `undefined`      | Tree representing file system to modify                                 |
 | `dependencies`    | `Record`<`string`, `string`\>              | `undefined`      | Dependencies to be added to the dependencies section of package.json    |
 | `devDependencies` | `Record`<`string`, `string`\>              | `undefined`      | Dependencies to be added to the devDependencies section of package.json |
 | `packageJsonPath` | `string`                                   | `'package.json'` | Path to package.json                                                    |
@@ -536,7 +536,7 @@ Callback to install dependencies only if necessary. undefined is returned if cha
 
 ### addProjectConfiguration
 
-▸ **addProjectConfiguration**(`host`, `projectName`, `projectConfiguration`, `standalone?`): `void`
+▸ **addProjectConfiguration**(`tree`, `projectName`, `projectConfiguration`, `standalone?`): `void`
 
 Adds project configuration to the Nx workspace.
 
@@ -547,7 +547,7 @@ both files.
 
 | Name                   | Type                                                                                                                                                                | Default value | Description                                                                                |
 | :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------ | :----------------------------------------------------------------------------------------- |
-| `host`                 | [`Tree`](../../react/nx-devkit/index#tree)                                                                                                                          | `undefined`   | the file system tree                                                                       |
+| `tree`                 | [`Tree`](../../react/nx-devkit/index#tree)                                                                                                                          | `undefined`   | the file system tree                                                                       |
 | `projectName`          | `string`                                                                                                                                                            | `undefined`   | unique name. Often directories are part of the name (e.g., mydir-mylib)                    |
 | `projectConfiguration` | [`ProjectConfiguration`](../../react/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../react/nx-devkit/index#nxjsonprojectconfiguration) | `undefined`   | project configuration                                                                      |
 | `standalone`           | `boolean`                                                                                                                                                           | `false`       | should the project use package.json? If false, the project config is inside workspace.json |
@@ -694,7 +694,7 @@ Detects which package manager is used in the workspace based on the lock file.
 
 ### formatFiles
 
-▸ **formatFiles**(`host`): `Promise`<`void`\>
+▸ **formatFiles**(`tree`): `Promise`<`void`\>
 
 Formats all the created or updated files using Prettier
 
@@ -702,7 +702,7 @@ Formats all the created or updated files using Prettier
 
 | Name   | Type                                       | Description          |
 | :----- | :----------------------------------------- | :------------------- |
-| `host` | [`Tree`](../../react/nx-devkit/index#tree) | the file system tree |
+| `tree` | [`Tree`](../../react/nx-devkit/index#tree) | the file system tree |
 
 #### Returns
 
@@ -712,7 +712,7 @@ Formats all the created or updated files using Prettier
 
 ### generateFiles
 
-▸ **generateFiles**(`host`, `srcFolder`, `target`, `substitutions`): `void`
+▸ **generateFiles**(`tree`, `srcFolder`, `target`, `substitutions`): `void`
 
 Generates a folder of files based on provided templates.
 
@@ -724,7 +724,7 @@ While doing so it performs two substitutions:
 Examples:
 
 ```typescript
-generateFiles(host, path.join(__dirname, 'files'), './tools/scripts', {
+generateFiles(tree, path.join(__dirname, 'files'), './tools/scripts', {
   tmpl: '',
   name: 'myscript',
 });
@@ -740,9 +740,9 @@ doesn't get confused about incorrect TypeScript files.
 
 | Name            | Type                                       | Description                                   |
 | :-------------- | :----------------------------------------- | :-------------------------------------------- |
-| `host`          | [`Tree`](../../react/nx-devkit/index#tree) | the file system tree                          |
+| `tree`          | [`Tree`](../../react/nx-devkit/index#tree) | the file system tree                          |
 | `srcFolder`     | `string`                                   | the source folder of files (absolute path)    |
-| `target`        | `string`                                   | the target folder (relative to the host root) |
+| `target`        | `string`                                   | the target folder (relative to the tree root) |
 | `substitutions` | `Object`                                   | an object of key-value pairs                  |
 
 #### Returns
@@ -799,7 +799,7 @@ but it can also be passed in explicitly.
 
 ### getProjects
 
-▸ **getProjects**(`host`): `Map`<`string`, [`ProjectConfiguration`](../../react/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../react/nx-devkit/index#nxjsonprojectconfiguration)\>
+▸ **getProjects**(`tree`): `Map`<`string`, [`ProjectConfiguration`](../../react/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../react/nx-devkit/index#nxjsonprojectconfiguration)\>
 
 Get a map of all projects in a workspace.
 
@@ -809,7 +809,7 @@ Use [readProjectConfiguration](../../react/nx-devkit/index#readprojectconfigurat
 
 | Name   | Type                                       |
 | :----- | :----------------------------------------- |
-| `host` | [`Tree`](../../react/nx-devkit/index#tree) |
+| `tree` | [`Tree`](../../react/nx-devkit/index#tree) |
 
 #### Returns
 
@@ -819,7 +819,7 @@ Use [readProjectConfiguration](../../react/nx-devkit/index#readprojectconfigurat
 
 ### getWorkspaceLayout
 
-▸ **getWorkspaceLayout**(`host`): `Object`
+▸ **getWorkspaceLayout**(`tree`): `Object`
 
 Returns workspace defaults. It includes defaults folders for apps and libs,
 and the default scope.
@@ -834,7 +834,7 @@ Example:
 
 | Name   | Type                                       | Description      |
 | :----- | :----------------------------------------- | :--------------- |
-| `host` | [`Tree`](../../react/nx-devkit/index#tree) | file system tree |
+| `tree` | [`Tree`](../../react/nx-devkit/index#tree) | file system tree |
 
 #### Returns
 
@@ -851,13 +851,13 @@ Example:
 
 ### getWorkspacePath
 
-▸ **getWorkspacePath**(`host`): `string`
+▸ **getWorkspacePath**(`tree`): `string`
 
 #### Parameters
 
 | Name   | Type                                       |
 | :----- | :----------------------------------------- |
-| `host` | [`Tree`](../../react/nx-devkit/index#tree) |
+| `tree` | [`Tree`](../../react/nx-devkit/index#tree) |
 
 #### Returns
 
@@ -867,7 +867,7 @@ Example:
 
 ### installPackagesTask
 
-▸ **installPackagesTask**(`host`, `alwaysRun?`, `cwd?`, `packageManager?`): `void`
+▸ **installPackagesTask**(`tree`, `alwaysRun?`, `cwd?`, `packageManager?`): `void`
 
 Runs `npm install` or `yarn install`. It will skip running the install if
 `package.json` hasn't changed at all or it hasn't changed since the last invocation.
@@ -876,7 +876,7 @@ Runs `npm install` or `yarn install`. It will skip running the install if
 
 | Name             | Type                                                           | Default value | Description                                                   |
 | :--------------- | :------------------------------------------------------------- | :------------ | :------------------------------------------------------------ |
-| `host`           | [`Tree`](../../react/nx-devkit/index#tree)                     | `undefined`   | the file system tree                                          |
+| `tree`           | [`Tree`](../../react/nx-devkit/index#tree)                     | `undefined`   | the file system tree                                          |
 | `alwaysRun`      | `boolean`                                                      | `false`       | always run the command even if `package.json` hasn't changed. |
 | `cwd`            | `string`                                                       | `''`          | -                                                             |
 | `packageManager` | [`PackageManager`](../../react/nx-devkit/index#packagemanager) | `undefined`   | -                                                             |
@@ -889,7 +889,7 @@ Runs `npm install` or `yarn install`. It will skip running the install if
 
 ### isStandaloneProject
 
-▸ **isStandaloneProject**(`host`, `project`): `boolean`
+▸ **isStandaloneProject**(`tree`, `project`): `boolean`
 
 Returns if a project has a standalone configuration (project.json).
 
@@ -897,7 +897,7 @@ Returns if a project has a standalone configuration (project.json).
 
 | Name      | Type                                       | Description          |
 | :-------- | :----------------------------------------- | :------------------- |
-| `host`    | [`Tree`](../../react/nx-devkit/index#tree) | the file system tree |
+| `tree`    | [`Tree`](../../react/nx-devkit/index#tree) | the file system tree |
 | `project` | `string`                                   | the project name     |
 
 #### Returns
@@ -926,13 +926,13 @@ Normalized path fragments and joins them
 
 ### moveFilesToNewDirectory
 
-▸ **moveFilesToNewDirectory**(`host`, `oldDir`, `newDir`): `void`
+▸ **moveFilesToNewDirectory**(`tree`, `oldDir`, `newDir`): `void`
 
 #### Parameters
 
 | Name     | Type                                       |
 | :------- | :----------------------------------------- |
-| `host`   | [`Tree`](../../react/nx-devkit/index#tree) |
+| `tree`   | [`Tree`](../../react/nx-devkit/index#tree) |
 | `oldDir` | `string`                                   |
 | `newDir` | `string`                                   |
 
@@ -1073,9 +1073,9 @@ parseTargetString('proj:test:production'); // returns { project: "proj", target:
 
 ### readJson
 
-▸ **readJson**<`T`\>(`host`, `path`, `options?`): `T`
+▸ **readJson**<`T`\>(`tree`, `path`, `options?`): `T`
 
-Reads a document for host, removes all comments and parses JSON.
+Reads a json file, removes all comments and parses JSON.
 
 #### Type parameters
 
@@ -1087,7 +1087,7 @@ Reads a document for host, removes all comments and parses JSON.
 
 | Name       | Type                                                               | Description                 |
 | :--------- | :----------------------------------------------------------------- | :-------------------------- |
-| `host`     | [`Tree`](../../react/nx-devkit/index#tree)                         | file system tree            |
+| `tree`     | [`Tree`](../../react/nx-devkit/index#tree)                         | file system tree            |
 | `path`     | `string`                                                           | file path                   |
 | `options?` | [`JsonParseOptions`](../../react/nx-devkit/index#jsonparseoptions) | Optional JSON Parse Options |
 
@@ -1126,7 +1126,7 @@ Object the JSON content of the file represents
 
 ### readProjectConfiguration
 
-▸ **readProjectConfiguration**(`host`, `projectName`): [`ProjectConfiguration`](../../react/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../react/nx-devkit/index#nxjsonprojectconfiguration)
+▸ **readProjectConfiguration**(`tree`, `projectName`): [`ProjectConfiguration`](../../react/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../react/nx-devkit/index#nxjsonprojectconfiguration)
 
 Reads a project configuration.
 
@@ -1139,7 +1139,7 @@ both files.
 
 | Name          | Type                                       | Description                                                             |
 | :------------ | :----------------------------------------- | :---------------------------------------------------------------------- |
-| `host`        | [`Tree`](../../react/nx-devkit/index#tree) | the file system tree                                                    |
+| `tree`        | [`Tree`](../../react/nx-devkit/index#tree) | the file system tree                                                    |
 | `projectName` | `string`                                   | unique name. Often directories are part of the name (e.g., mydir-mylib) |
 
 #### Returns
@@ -1177,7 +1177,7 @@ Works as if you invoked the target yourself without passing any command lint ove
 
 ### readWorkspaceConfiguration
 
-▸ **readWorkspaceConfiguration**(`host`): [`WorkspaceConfiguration`](../../react/nx-devkit/index#workspaceconfiguration)
+▸ **readWorkspaceConfiguration**(`tree`): [`WorkspaceConfiguration`](../../react/nx-devkit/index#workspaceconfiguration)
 
 Read general workspace configuration such as the default project or cli settings
 
@@ -1187,7 +1187,7 @@ This does _not_ provide projects configuration, use [readProjectConfiguration](.
 
 | Name   | Type                                       |
 | :----- | :----------------------------------------- |
-| `host` | [`Tree`](../../react/nx-devkit/index#tree) |
+| `tree` | [`Tree`](../../react/nx-devkit/index#tree) |
 
 #### Returns
 
@@ -1197,14 +1197,14 @@ This does _not_ provide projects configuration, use [readProjectConfiguration](.
 
 ### removeDependenciesFromPackageJson
 
-▸ **removeDependenciesFromPackageJson**(`host`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../react/nx-devkit/index#generatorcallback)
+▸ **removeDependenciesFromPackageJson**(`tree`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../react/nx-devkit/index#generatorcallback)
 
 Remove Dependencies and Dev Dependencies from package.json
 
 For example:
 
 ```typescript
-removeDependenciesFromPackageJson(host, ['react'], ['jest']);
+removeDependenciesFromPackageJson(tree, ['react'], ['jest']);
 ```
 
 This will **remove** `react` and `jest` from the dependencies and devDependencies sections of package.json respectively.
@@ -1213,7 +1213,7 @@ This will **remove** `react` and `jest` from the dependencies and devDependencie
 
 | Name              | Type                                       | Default value    | Description                                                                 |
 | :---------------- | :----------------------------------------- | :--------------- | :-------------------------------------------------------------------------- |
-| `host`            | [`Tree`](../../react/nx-devkit/index#tree) | `undefined`      | -                                                                           |
+| `tree`            | [`Tree`](../../react/nx-devkit/index#tree) | `undefined`      | -                                                                           |
 | `dependencies`    | `string`[]                                 | `undefined`      | Dependencies to be removed from the dependencies section of package.json    |
 | `devDependencies` | `string`[]                                 | `undefined`      | Dependencies to be removed from the devDependencies section of package.json |
 | `packageJsonPath` | `string`                                   | `'package.json'` | -                                                                           |
@@ -1228,7 +1228,7 @@ Callback to uninstall dependencies only if necessary. undefined is returned if c
 
 ### removeProjectConfiguration
 
-▸ **removeProjectConfiguration**(`host`, `projectName`): `void`
+▸ **removeProjectConfiguration**(`tree`, `projectName`): `void`
 
 Removes the configuration of an existing project.
 
@@ -1239,7 +1239,7 @@ The utility will update both files.
 
 | Name          | Type                                       |
 | :------------ | :----------------------------------------- |
-| `host`        | [`Tree`](../../react/nx-devkit/index#tree) |
+| `tree`        | [`Tree`](../../react/nx-devkit/index#tree) |
 | `projectName` | `string`                                   |
 
 #### Returns
@@ -1419,7 +1419,7 @@ Rename and transpile any new typescript files created to javascript files
 
 ### updateJson
 
-▸ **updateJson**<`T`, `U`\>(`host`, `path`, `updater`, `options?`): `void`
+▸ **updateJson**<`T`, `U`\>(`tree`, `path`, `updater`, `options?`): `void`
 
 Updates a JSON value to the file system tree
 
@@ -1434,7 +1434,7 @@ Updates a JSON value to the file system tree
 
 | Name       | Type                                                                                                                                            | Description                                                                                          |
 | :--------- | :---------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
-| `host`     | [`Tree`](../../react/nx-devkit/index#tree)                                                                                                      | File system tree                                                                                     |
+| `tree`     | [`Tree`](../../react/nx-devkit/index#tree)                                                                                                      | File system tree                                                                                     |
 | `path`     | `string`                                                                                                                                        | Path of JSON file in the Tree                                                                        |
 | `updater`  | (`value`: `T`) => `U`                                                                                                                           | Function that maps the current value of a JSON document to a new value to be written to the document |
 | `options?` | [`JsonParseOptions`](../../react/nx-devkit/index#jsonparseoptions) & [`JsonSerializeOptions`](../../react/nx-devkit/index#jsonserializeoptions) | Optional JSON Parse and Serialize Options                                                            |
@@ -1447,7 +1447,7 @@ Updates a JSON value to the file system tree
 
 ### updateProjectConfiguration
 
-▸ **updateProjectConfiguration**(`host`, `projectName`, `projectConfiguration`): `void`
+▸ **updateProjectConfiguration**(`tree`, `projectName`, `projectConfiguration`): `void`
 
 Updates the configuration of an existing project.
 
@@ -1458,7 +1458,7 @@ both files.
 
 | Name                   | Type                                                                                                                                                                | Description                                                             |
 | :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :---------------------------------------------------------------------- |
-| `host`                 | [`Tree`](../../react/nx-devkit/index#tree)                                                                                                                          | the file system tree                                                    |
+| `tree`                 | [`Tree`](../../react/nx-devkit/index#tree)                                                                                                                          | the file system tree                                                    |
 | `projectName`          | `string`                                                                                                                                                            | unique name. Often directories are part of the name (e.g., mydir-mylib) |
 | `projectConfiguration` | [`ProjectConfiguration`](../../react/nx-devkit/index#projectconfiguration) & [`NxJsonProjectConfiguration`](../../react/nx-devkit/index#nxjsonprojectconfiguration) | project configuration                                                   |
 
@@ -1470,13 +1470,13 @@ both files.
 
 ### updateTsConfigsToJs
 
-▸ **updateTsConfigsToJs**(`host`, `options`): `void`
+▸ **updateTsConfigsToJs**(`tree`, `options`): `void`
 
 #### Parameters
 
 | Name                  | Type                                       |
 | :-------------------- | :----------------------------------------- |
-| `host`                | [`Tree`](../../react/nx-devkit/index#tree) |
+| `tree`                | [`Tree`](../../react/nx-devkit/index#tree) |
 | `options`             | `Object`                                   |
 | `options.projectRoot` | `string`                                   |
 
@@ -1488,7 +1488,7 @@ both files.
 
 ### updateWorkspaceConfiguration
 
-▸ **updateWorkspaceConfiguration**(`host`, `workspaceConfig`): `void`
+▸ **updateWorkspaceConfiguration**(`tree`, `workspaceConfig`): `void`
 
 Update general workspace configuration such as the default project or cli settings.
 
@@ -1498,7 +1498,7 @@ This does _not_ update projects configuration, use [updateProjectConfiguration](
 
 | Name              | Type                                                                           |
 | :---------------- | :----------------------------------------------------------------------------- |
-| `host`            | [`Tree`](../../react/nx-devkit/index#tree)                                     |
+| `tree`            | [`Tree`](../../react/nx-devkit/index#tree)                                     |
 | `workspaceConfig` | [`WorkspaceConfiguration`](../../react/nx-devkit/index#workspaceconfiguration) |
 
 #### Returns
@@ -1529,7 +1529,7 @@ Utility to act on all files in a tree that are not ignored by git.
 
 ### writeJson
 
-▸ **writeJson**<`T`\>(`host`, `path`, `value`, `options?`): `void`
+▸ **writeJson**<`T`\>(`tree`, `path`, `value`, `options?`): `void`
 
 Writes a JSON value to the file system tree
 
@@ -1543,7 +1543,7 @@ Writes a JSON value to the file system tree
 
 | Name       | Type                                                                       | Description                     |
 | :--------- | :------------------------------------------------------------------------- | :------------------------------ |
-| `host`     | [`Tree`](../../react/nx-devkit/index#tree)                                 | File system tree                |
+| `tree`     | [`Tree`](../../react/nx-devkit/index#tree)                                 | File system tree                |
 | `path`     | `string`                                                                   | Path of JSON file in the Tree   |
 | `value`    | `T`                                                                        | Serializable value to write     |
 | `options?` | [`JsonSerializeOptions`](../../react/nx-devkit/index#jsonserializeoptions) | Optional JSON Serialize Options |

--- a/packages/devkit/src/generators/generate-files.ts
+++ b/packages/devkit/src/generators/generate-files.ts
@@ -38,7 +38,7 @@ const binaryExts = new Set([
  *
  * Examples:
  * ```typescript
- * generateFiles(host, path.join(__dirname , 'files'), './tools/scripts', {tmpl: '', name: 'myscript'})
+ * generateFiles(tree, path.join(__dirname , 'files'), './tools/scripts', {tmpl: '', name: 'myscript'})
  * ```
  * This command will take all the files from the `files` directory next to the place where the command is invoked from.
  * It will replace all `__tmpl__` with '' and all `__name__` with 'myscript' in the file names, and will replace all
@@ -46,13 +46,13 @@ const binaryExts = new Set([
  * `tmpl: ''` is a common pattern. With it you can name files like this: `index.ts__tmpl__`, so your editor
  * doesn't get confused about incorrect TypeScript files.
  *
- * @param host - the file system tree
+ * @param tree - the file system tree
  * @param srcFolder - the source folder of files (absolute path)
- * @param target - the target folder (relative to the host root)
+ * @param target - the target folder (relative to the tree root)
  * @param substitutions - an object of key-value pairs
  */
 export function generateFiles(
-  host: Tree,
+  tree: Tree,
   srcFolder: string,
   target: string,
   substitutions: { [k: string]: any }
@@ -74,12 +74,12 @@ export function generateFiles(
       try {
         newContent = ejs.render(template, substitutions, {});
       } catch (e) {
-        logger.error(`Error in ${filePath.replace(`${host.root}/`, '')}:`);
+        logger.error(`Error in ${filePath.replace(`${tree.root}/`, '')}:`);
         throw e;
       }
     }
 
-    host.write(computedPath, newContent);
+    tree.write(computedPath, newContent);
   });
 }
 

--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -28,20 +28,20 @@ export type WorkspaceConfiguration = Omit<
  * The project configuration is stored in workspace.json and nx.json. The utility will update
  * both files.
  *
- * @param host - the file system tree
+ * @param tree - the file system tree
  * @param projectName - unique name. Often directories are part of the name (e.g., mydir-mylib)
  * @param projectConfiguration - project configuration
  * @param standalone - should the project use package.json? If false, the project config is inside workspace.json
  */
 export function addProjectConfiguration(
-  host: Tree,
+  tree: Tree,
   projectName: string,
   projectConfiguration: ProjectConfiguration & NxJsonProjectConfiguration,
   standalone: boolean = false
 ): void {
-  standalone = standalone || getWorkspaceLayout(host).standaloneAsDefault;
+  standalone = standalone || getWorkspaceLayout(tree).standaloneAsDefault;
   setProjectConfiguration(
-    host,
+    tree,
     projectName,
     projectConfiguration,
     'create',
@@ -55,16 +55,16 @@ export function addProjectConfiguration(
  * The project configuration is stored in workspace.json and nx.json. The utility will update
  * both files.
  *
- * @param host - the file system tree
+ * @param tree - the file system tree
  * @param projectName - unique name. Often directories are part of the name (e.g., mydir-mylib)
  * @param projectConfiguration - project configuration
  */
 export function updateProjectConfiguration(
-  host: Tree,
+  tree: Tree,
   projectName: string,
   projectConfiguration: ProjectConfiguration & NxJsonProjectConfiguration
 ): void {
-  setProjectConfiguration(host, projectName, projectConfiguration, 'update');
+  setProjectConfiguration(tree, projectName, projectConfiguration, 'update');
 }
 
 /**
@@ -74,10 +74,10 @@ export function updateProjectConfiguration(
  * The utility will update both files.
  */
 export function removeProjectConfiguration(
-  host: Tree,
+  tree: Tree,
   projectName: string
 ): void {
-  setProjectConfiguration(host, projectName, undefined, 'delete');
+  setProjectConfiguration(tree, projectName, undefined, 'delete');
 }
 
 /**
@@ -86,16 +86,16 @@ export function removeProjectConfiguration(
  * Use {@link readProjectConfiguration} if only one project is needed.
  */
 export function getProjects(
-  host: Tree
+  tree: Tree
 ): Map<string, ProjectConfiguration & NxJsonProjectConfiguration> {
-  const workspace = readWorkspace(host);
-  const nxJson = readJson<NxJsonConfiguration>(host, 'nx.json');
+  const workspace = readWorkspace(tree);
+  const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
 
   return new Map(
     Object.keys(workspace.projects || {}).map((projectName) => {
       return [
         projectName,
-        getProjectConfiguration(host, projectName, workspace, nxJson),
+        getProjectConfiguration(tree, projectName, workspace, nxJson),
       ];
     })
   );
@@ -106,10 +106,10 @@ export function getProjects(
  *
  * This does _not_ provide projects configuration, use {@link readProjectConfiguration} instead.
  */
-export function readWorkspaceConfiguration(host: Tree): WorkspaceConfiguration {
-  const workspace = readWorkspace(host);
+export function readWorkspaceConfiguration(tree: Tree): WorkspaceConfiguration {
+  const workspace = readWorkspace(tree);
   delete workspace.projects;
-  const nxJson = readJson<NxJsonConfiguration>(host, 'nx.json');
+  const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
   delete nxJson.projects;
   return {
     ...workspace,
@@ -123,7 +123,7 @@ export function readWorkspaceConfiguration(host: Tree): WorkspaceConfiguration {
  * This does _not_ update projects configuration, use {@link updateProjectConfiguration} or {@link addProjectConfiguration} instead.
  */
 export function updateWorkspaceConfiguration(
-  host: Tree,
+  tree: Tree,
   workspaceConfig: WorkspaceConfiguration
 ): void {
   const {
@@ -159,13 +159,13 @@ export function updateWorkspaceConfiguration(
   };
 
   updateJson<WorkspaceJsonConfiguration>(
-    host,
-    getWorkspacePath(host),
+    tree,
+    getWorkspacePath(tree),
     (json) => {
       return { ...json, ...workspace };
     }
   );
-  updateJson<NxJsonConfiguration>(host, 'nx.json', (json) => {
+  updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
     return { ...json, ...nxJson };
   });
 }
@@ -176,24 +176,24 @@ export function updateWorkspaceConfiguration(
  * The project configuration is stored in workspace.json and nx.json. The utility will read
  * both files.
  *
- * @param host - the file system tree
+ * @param tree - the file system tree
  * @param projectName - unique name. Often directories are part of the name (e.g., mydir-mylib)
  * @throws If supplied projectName cannot be found
  */
 export function readProjectConfiguration(
-  host: Tree,
+  tree: Tree,
   projectName: string
 ): ProjectConfiguration & NxJsonProjectConfiguration {
-  const workspace = readWorkspace(host);
+  const workspace = readWorkspace(tree);
   if (!workspace.projects[projectName]) {
     throw new Error(
       `Cannot find configuration for '${projectName}' in ${getWorkspacePath(
-        host
+        tree
       )}.`
     );
   }
 
-  const nxJson = readJson<NxJsonConfiguration>(host, 'nx.json');
+  const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
 
   // TODO: Remove after confirming that nx.json should be optional.
   // if (!nxJson.projects[projectName]) {
@@ -202,19 +202,19 @@ export function readProjectConfiguration(
   //   );
   // }
 
-  return getProjectConfiguration(host, projectName, workspace, nxJson);
+  return getProjectConfiguration(tree, projectName, workspace, nxJson);
 }
 
 /**
  * Returns if a project has a standalone configuration (project.json).
  *
- * @param host - the file system tree
+ * @param tree - the file system tree
  * @param project - the project name
  */
-export function isStandaloneProject(host: Tree, project: string): boolean {
+export function isStandaloneProject(tree: Tree, project: string): boolean {
   const rawWorkspace = readJson<RawWorkspaceJsonConfiguration>(
-    host,
-    getWorkspacePath(host)
+    tree,
+    getWorkspacePath(tree)
   );
   const projectConfig = rawWorkspace.projects?.[project];
 
@@ -222,19 +222,19 @@ export function isStandaloneProject(host: Tree, project: string): boolean {
 }
 
 function getProjectConfiguration(
-  host: Tree,
+  tree: Tree,
   projectName: string,
   workspace: WorkspaceJsonConfiguration,
   nxJson: NxJsonConfiguration
 ): ProjectConfiguration & NxJsonProjectConfiguration {
   return {
-    ...readWorkspaceSection(host, workspace, projectName),
+    ...readWorkspaceSection(tree, workspace, projectName),
     ...readNxJsonSection(nxJson, projectName),
   };
 }
 
 function readWorkspaceSection(
-  host: Tree,
+  tree: Tree,
   workspace: WorkspaceJsonConfiguration,
   projectName: string
 ) {
@@ -247,15 +247,15 @@ function readNxJsonSection(nxJson: NxJsonConfiguration, projectName: string) {
 }
 
 function setProjectConfiguration(
-  host: Tree,
+  tree: Tree,
   projectName: string,
   projectConfiguration: ProjectConfiguration & NxJsonProjectConfiguration,
   mode: 'create' | 'update' | 'delete',
   standalone: boolean = false
 ) {
   if (mode === 'delete') {
-    addProjectToNxJson(host, projectName, undefined, mode);
-    addProjectToWorkspaceJson(host, projectName, undefined, mode);
+    addProjectToNxJson(tree, projectName, undefined, mode);
+    addProjectToWorkspaceJson(tree, projectName, undefined, mode);
     return;
   }
 
@@ -267,14 +267,14 @@ function setProjectConfiguration(
 
   const { tags, implicitDependencies } = projectConfiguration;
   addProjectToWorkspaceJson(
-    host,
+    tree,
     projectName,
     projectConfiguration,
     mode,
     standalone
   );
   addProjectToNxJson(
-    host,
+    tree,
     projectName,
     {
       tags,
@@ -285,28 +285,28 @@ function setProjectConfiguration(
 }
 
 function addProjectToWorkspaceJson(
-  host: Tree,
+  tree: Tree,
   projectName: string,
   project: ProjectConfiguration & NxJsonProjectConfiguration,
   mode: 'create' | 'update' | 'delete',
   standalone: boolean = false
 ) {
-  const path = getWorkspacePath(host);
-  const workspaceJson = readJson<RawWorkspaceJsonConfiguration>(host, path);
+  const path = getWorkspacePath(tree);
+  const workspaceJson = readJson<RawWorkspaceJsonConfiguration>(tree, path);
 
   validateWorkspaceJsonOperations(mode, workspaceJson, projectName);
 
   const configFile =
     mode === 'create' && standalone
       ? joinPathFragments(project.root, 'project.json')
-      : getProjectFileLocation(host, projectName);
+      : getProjectFileLocation(tree, projectName);
 
   if (configFile) {
     if (mode === 'delete') {
-      host.delete(configFile);
+      tree.delete(configFile);
       delete workspaceJson.projects[projectName];
     } else {
-      writeJson(host, configFile, project);
+      writeJson(tree, configFile, project);
     }
     if (mode === 'create') {
       workspaceJson.projects[projectName] = project.root;
@@ -319,19 +319,19 @@ function addProjectToWorkspaceJson(
     }
     workspaceJson.projects[projectName] = workspaceConfiguration;
   }
-  writeJson(host, path, workspaceJson);
+  writeJson(tree, path, workspaceJson);
 }
 
 function addProjectToNxJson(
-  host: Tree,
+  tree: Tree,
   projectName: string,
   config: NxJsonProjectConfiguration,
   mode: 'create' | 'update' | 'delete'
 ) {
   // distributed project files do not use nx.json,
   // so only proceed if the project does not use them.
-  if (!getProjectFileLocation(host, projectName)) {
-    const nxJson = readJson<NxJsonConfiguration>(host, 'nx.json');
+  if (!getProjectFileLocation(tree, projectName)) {
+    const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
     if (mode === 'delete') {
       delete nxJson.projects[projectName];
     } else {
@@ -342,12 +342,12 @@ function addProjectToNxJson(
         ...(config || {}),
       };
     }
-    writeJson(host, 'nx.json', nxJson);
+    writeJson(tree, 'nx.json', nxJson);
   }
 }
 
-function readWorkspace(host: Tree): WorkspaceJsonConfiguration {
-  const workspaceJson = inlineProjectConfigurationsWithTree(host);
+function readWorkspace(tree: Tree): WorkspaceJsonConfiguration {
+  const workspaceJson = inlineProjectConfigurationsWithTree(tree);
   const originalVersion = workspaceJson.version;
   return {
     ...toNewFormat(workspaceJson),
@@ -362,16 +362,16 @@ function readWorkspace(host: Tree): WorkspaceJsonConfiguration {
  * @returns
  */
 function inlineProjectConfigurationsWithTree(
-  host: Tree
+  tree: Tree
 ): WorkspaceJsonConfiguration {
-  const path = getWorkspacePath(host);
-  const workspaceJson = readJson<RawWorkspaceJsonConfiguration>(host, path);
+  const path = getWorkspacePath(tree);
+  const workspaceJson = readJson<RawWorkspaceJsonConfiguration>(tree, path);
   Object.entries(workspaceJson.projects || {}).forEach(([project, config]) => {
     if (typeof config === 'string') {
       const configFileLocation = joinPathFragments(config, 'project.json');
       workspaceJson.projects[project] = readJson<
         ProjectConfiguration & NxJsonProjectConfiguration
-      >(host, configFileLocation);
+      >(tree, configFileLocation);
     }
   });
   return workspaceJson as WorkspaceJsonConfiguration;
@@ -381,10 +381,10 @@ function inlineProjectConfigurationsWithTree(
  * @description Determine where a project's configuration is located.
  * @returns file path if separate from root config, null otherwise.
  */
-function getProjectFileLocation(host: Tree, project: string): string | null {
+function getProjectFileLocation(tree: Tree, project: string): string | null {
   const rawWorkspace = readJson<RawWorkspaceJsonConfiguration>(
-    host,
-    getWorkspacePath(host)
+    tree,
+    getWorkspacePath(tree)
   );
   const projectConfig = rawWorkspace.projects?.[project];
   return typeof projectConfig === 'string'

--- a/packages/devkit/src/generators/update-ts-configs-to-js.ts
+++ b/packages/devkit/src/generators/update-ts-configs-to-js.ts
@@ -2,7 +2,7 @@ import type { Tree } from '@nrwl/tao/src/shared/tree';
 import { updateJson } from '../utils/json';
 
 export function updateTsConfigsToJs(
-  host: Tree,
+  tree: Tree,
   options: { projectRoot: string }
 ): void {
   let updateConfigPath: string;
@@ -26,7 +26,7 @@ export function updateTsConfigsToJs(
     );
   };
 
-  updateJson(host, paths.tsConfig, (json) => {
+  updateJson(tree, paths.tsConfig, (json) => {
     if (json.compilerOptions) {
       json.compilerOptions.allowJs = true;
     } else {
@@ -35,7 +35,7 @@ export function updateTsConfigsToJs(
     return json;
   });
 
-  const projectType = getProjectType(host);
+  const projectType = getProjectType(tree);
 
   if (projectType === 'library') {
     updateConfigPath = paths.tsConfigLib;
@@ -44,7 +44,7 @@ export function updateTsConfigsToJs(
     updateConfigPath = paths.tsConfigApp;
   }
 
-  updateJson(host, updateConfigPath, (json) => {
+  updateJson(tree, updateConfigPath, (json) => {
     json.include = uniq([...json.include, '**/*.js']);
     json.exclude = uniq([...json.exclude, '**/*.spec.js']);
 

--- a/packages/devkit/src/tasks/install-packages-task.ts
+++ b/packages/devkit/src/tasks/install-packages-task.ts
@@ -14,21 +14,21 @@ let storedPackageJsonValue: string;
  * Runs `npm install` or `yarn install`. It will skip running the install if
  * `package.json` hasn't changed at all or it hasn't changed since the last invocation.
  *
- * @param host - the file system tree
+ * @param tree - the file system tree
  * @param alwaysRun - always run the command even if `package.json` hasn't changed.
  */
 export function installPackagesTask(
-  host: Tree,
+  tree: Tree,
   alwaysRun: boolean = false,
   cwd: string = '',
   packageManager: PackageManager = detectPackageManager(cwd)
 ): void {
-  const packageJsonValue = host.read(
+  const packageJsonValue = tree.read(
     joinPathFragments(cwd, 'package.json'),
     'utf-8'
   );
   if (
-    host
+    tree
       .listChanges()
       .find((f) => f.path === joinPathFragments(cwd, 'package.json')) ||
     alwaysRun
@@ -38,7 +38,7 @@ export function installPackagesTask(
       storedPackageJsonValue = packageJsonValue;
       const pmc = getPackageManagerCommand(packageManager);
       execSync(pmc.install, {
-        cwd: join(host.root, cwd),
+        cwd: join(tree.root, cwd),
         stdio: [0, 1, 2],
       });
     }

--- a/packages/devkit/src/utils/get-workspace-layout.ts
+++ b/packages/devkit/src/utils/get-workspace-layout.ts
@@ -15,18 +15,18 @@ import {
  * ```typescript
  * { appsDir: 'apps', libsDir: 'libs', npmScope: 'myorg' }
  * ```
- * @param host - file system tree
+ * @param tree - file system tree
  */
-export function getWorkspaceLayout(host: Tree): {
+export function getWorkspaceLayout(tree: Tree): {
   appsDir: string;
   libsDir: string;
   standaloneAsDefault: boolean;
   npmScope: string;
 } {
-  const nxJson = readJson<NxJsonConfiguration>(host, 'nx.json');
+  const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
   const rawWorkspace = readJson<RawWorkspaceJsonConfiguration>(
-    host,
-    getWorkspacePath(host)
+    tree,
+    getWorkspacePath(tree)
   );
 
   return {
@@ -45,7 +45,7 @@ export function getWorkspaceLayout(host: Tree): {
   };
 }
 
-export function getWorkspacePath(host: Tree): string {
+export function getWorkspacePath(tree: Tree): string {
   const possibleFiles = ['/angular.json', '/workspace.json'];
-  return possibleFiles.filter((path) => host.exists(path))[0];
+  return possibleFiles.filter((path) => tree.exists(path))[0];
 }

--- a/packages/devkit/src/utils/json.ts
+++ b/packages/devkit/src/utils/json.ts
@@ -6,22 +6,22 @@ import type {
 } from '@nrwl/tao/src/utils/json';
 
 /**
- * Reads a document for host, removes all comments and parses JSON.
+ * Reads a json file, removes all comments and parses JSON.
  *
- * @param host - file system tree
+ * @param tree - file system tree
  * @param path - file path
  * @param options - Optional JSON Parse Options
  */
 export function readJson<T extends object = any>(
-  host: Tree,
+  tree: Tree,
   path: string,
   options?: JsonParseOptions
 ): T {
-  if (!host.exists(path)) {
+  if (!tree.exists(path)) {
     throw new Error(`Cannot find ${path}`);
   }
   try {
-    return parseJson(host.read(path, 'utf-8'), options);
+    return parseJson(tree.read(path, 'utf-8'), options);
   } catch (e) {
     throw new Error(`Cannot parse ${path}: ${e.message}`);
   }
@@ -30,34 +30,34 @@ export function readJson<T extends object = any>(
 /**
  * Writes a JSON value to the file system tree
 
- * @param host File system tree
+ * @param tree File system tree
  * @param path Path of JSON file in the Tree
  * @param value Serializable value to write
  * @param options Optional JSON Serialize Options
  */
 export function writeJson<T extends object = object>(
-  host: Tree,
+  tree: Tree,
   path: string,
   value: T,
   options?: JsonSerializeOptions
 ): void {
-  host.write(path, serializeJson(value, options));
+  tree.write(path, serializeJson(value, options));
 }
 
 /**
  * Updates a JSON value to the file system tree
  *
- * @param host File system tree
+ * @param tree File system tree
  * @param path Path of JSON file in the Tree
  * @param updater Function that maps the current value of a JSON document to a new value to be written to the document
  * @param options Optional JSON Parse and Serialize Options
  */
 export function updateJson<T extends object = any, U extends object = T>(
-  host: Tree,
+  tree: Tree,
   path: string,
   updater: (value: T) => U,
   options?: JsonParseOptions & JsonSerializeOptions
 ): void {
-  const updatedValue = updater(readJson(host, path, options));
-  writeJson(host, path, updatedValue, options);
+  const updatedValue = updater(readJson(tree, path, options));
+  writeJson(tree, path, updatedValue, options);
 }

--- a/packages/devkit/src/utils/move-dir.ts
+++ b/packages/devkit/src/utils/move-dir.ts
@@ -2,17 +2,17 @@ import { Tree } from '@nrwl/tao/src/shared/tree';
 import { visitNotIgnoredFiles } from '../generators/visit-not-ignored-files';
 
 export function moveFilesToNewDirectory(
-  host: Tree,
+  tree: Tree,
   oldDir: string,
   newDir: string
 ): void {
-  visitNotIgnoredFiles(host, oldDir, (file) => {
+  visitNotIgnoredFiles(tree, oldDir, (file) => {
     try {
-      host.rename(file, file.replace(oldDir, newDir));
+      tree.rename(file, file.replace(oldDir, newDir));
     } catch (e) {
-      if (!host.exists(oldDir)) {
+      if (!tree.exists(oldDir)) {
         console.warn(`Path ${oldDir} does not exist`);
-      } else if (!host.exists(newDir)) {
+      } else if (!tree.exists(newDir)) {
         console.warn(`Path ${newDir} does not exist`);
       }
     }

--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -8,28 +8,28 @@ import type { GeneratorCallback } from '@nrwl/tao/src/shared/workspace';
  *
  * For example:
  * ```typescript
- * addDependenciesToPackageJson(host, { react: 'latest' }, { jest: 'latest' })
+ * addDependenciesToPackageJson(tree, { react: 'latest' }, { jest: 'latest' })
  * ```
  * This will **add** `react` and `jest` to the dependencies and devDependencies sections of package.json respectively.
  *
- * @param host Tree representing file system to modify
+ * @param tree Tree representing file system to modify
  * @param dependencies Dependencies to be added to the dependencies section of package.json
  * @param devDependencies Dependencies to be added to the devDependencies section of package.json
  * @param packageJsonPath Path to package.json
  * @returns Callback to install dependencies only if necessary. undefined is returned if changes are not necessary.
  */
 export function addDependenciesToPackageJson(
-  host: Tree,
+  tree: Tree,
   dependencies: Record<string, string>,
   devDependencies: Record<string, string>,
   packageJsonPath: string = 'package.json'
 ): GeneratorCallback {
-  const currentPackageJson = readJson(host, packageJsonPath);
+  const currentPackageJson = readJson(tree, packageJsonPath);
 
   if (
     requiresAddingOfPackages(currentPackageJson, dependencies, devDependencies)
   ) {
-    updateJson(host, packageJsonPath, (json) => {
+    updateJson(tree, packageJsonPath, (json) => {
       json.dependencies = {
         ...(json.dependencies || {}),
         ...dependencies,
@@ -47,7 +47,7 @@ export function addDependenciesToPackageJson(
     });
   }
   return (): void => {
-    installPackagesTask(host);
+    installPackagesTask(tree);
   };
 }
 
@@ -56,7 +56,7 @@ export function addDependenciesToPackageJson(
  *
  * For example:
  * ```typescript
- * removeDependenciesFromPackageJson(host, ['react'], ['jest'])
+ * removeDependenciesFromPackageJson(tree, ['react'], ['jest'])
  * ```
  * This will **remove** `react` and `jest` from the dependencies and devDependencies sections of package.json respectively.
  *
@@ -65,12 +65,12 @@ export function addDependenciesToPackageJson(
  * @returns Callback to uninstall dependencies only if necessary. undefined is returned if changes are not necessary.
  */
 export function removeDependenciesFromPackageJson(
-  host: Tree,
+  tree: Tree,
   dependencies: string[],
   devDependencies: string[],
   packageJsonPath: string = 'package.json'
 ): GeneratorCallback {
-  const currentPackageJson = readJson(host, packageJsonPath);
+  const currentPackageJson = readJson(tree, packageJsonPath);
 
   if (
     requiresRemovingOfPackages(
@@ -79,7 +79,7 @@ export function removeDependenciesFromPackageJson(
       devDependencies
     )
   ) {
-    updateJson(host, packageJsonPath, (json) => {
+    updateJson(tree, packageJsonPath, (json) => {
       for (const dep of dependencies) {
         delete json.dependencies[dep];
       }
@@ -93,7 +93,7 @@ export function removeDependenciesFromPackageJson(
     });
   }
   return (): void => {
-    installPackagesTask(host);
+    installPackagesTask(tree);
   };
 }
 

--- a/packages/nx-plugin/src/generators/generator/files/generator/__fileName__/generator.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/generator/files/generator/__fileName__/generator.ts__tmpl__
@@ -17,13 +17,13 @@ interface NormalizedSchema extends <%= className %>GeneratorSchema {
   parsedTags: string[]
 }
 
-function normalizeOptions(host: Tree, options: <%= className %>GeneratorSchema): NormalizedSchema {
+function normalizeOptions(tree: Tree, options: <%= className %>GeneratorSchema): NormalizedSchema {
   const name = names(options.name).fileName;
   const projectDirectory = options.directory
     ? `${names(options.directory).fileName}/${name}`
     : name;
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
-  const projectRoot = `${getWorkspaceLayout(host).libsDir}/${projectDirectory}`;
+  const projectRoot = `${getWorkspaceLayout(tree).libsDir}/${projectDirectory}`;
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())
     : [];
@@ -37,20 +37,20 @@ function normalizeOptions(host: Tree, options: <%= className %>GeneratorSchema):
   };
 }
 
-function addFiles(host: Tree, options: NormalizedSchema) {
+function addFiles(tree: Tree, options: NormalizedSchema) {
     const templateOptions = {
       ...options,
       ...names(options.name),
       offsetFromRoot: offsetFromRoot(options.projectRoot),
       template: ''
     };
-    generateFiles(host, path.join(__dirname, 'files'), options.projectRoot, templateOptions);
+    generateFiles(tree, path.join(__dirname, 'files'), options.projectRoot, templateOptions);
 }
 
-export default async function (host: Tree, options: <%= className %>GeneratorSchema) {
-  const normalizedOptions = normalizeOptions(host, options);
+export default async function (tree: Tree, options: <%= className %>GeneratorSchema) {
+  const normalizedOptions = normalizeOptions(tree, options);
   addProjectConfiguration(
-    host,
+    tree,
     normalizedOptions.projectName,
     {
       root: normalizedOptions.projectRoot,
@@ -64,6 +64,6 @@ export default async function (host: Tree, options: <%= className %>GeneratorSch
       tags: normalizedOptions.parsedTags,
     }
   );
-  addFiles(host, normalizedOptions);
-  await formatFiles(host);
+  addFiles(tree, normalizedOptions);
+  await formatFiles(tree);
 }

--- a/packages/workspace/src/generators/workspace-generator/files/index.ts__tmpl__
+++ b/packages/workspace/src/generators/workspace-generator/files/index.ts__tmpl__
@@ -1,10 +1,10 @@
 import { Tree, formatFiles, installPackagesTask } from '@nrwl/devkit';
 import { libraryGenerator } from '@nrwl/workspace/generators';
 
-export default async function(host: Tree, schema: any) {
-  await libraryGenerator(host, {name: schema.name});
-  await formatFiles(host);
+export default async function(tree: Tree, schema: any) {
+  await libraryGenerator(tree, {name: schema.name});
+  await formatFiles(tree);
   return () => {
-    installPackagesTask(host)
+    installPackagesTask(tree)
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A lot of functions have a parameter name of `host: Tree` which is kind of ambiguous since there are so many types of Hosts

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Functions in devkit now have a parameter name of `tree: Tree` which while not the most descriptive... is more indicative that this is a representation of the file tree

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
