### PR TITLE
fix(nextjs): generate nextjs library with "next/babel" preset rather than the default "@nrwl/react/babel" preset

### DIFF
--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -1,0 +1,56 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import libraryGenerator from './library';
+import { Linter } from '@nrwl/linter';
+import { readJson } from '@nrwl/devkit';
+import { Schema } from './schema';
+
+describe('next library', () => {
+  it('should use "next/babel" preset in babelrc', async () => {
+    const baseOptions: Schema = {
+      name: '',
+      linter: Linter.EsLint,
+      skipFormat: false,
+      skipTsConfig: false,
+      unitTestRunner: 'jest',
+      style: 'css',
+      component: true,
+    };
+
+    const appTree = createTreeWithEmptyWorkspace();
+
+    await libraryGenerator(appTree, {
+      ...baseOptions,
+      name: 'myLib',
+    });
+    await libraryGenerator(appTree, {
+      ...baseOptions,
+      name: 'myLib2',
+      style: '@emotion/styled',
+    });
+    await libraryGenerator(appTree, {
+      ...baseOptions,
+      name: 'myLib3',
+      directory: 'myDir',
+    });
+
+    expect(readJson(appTree, 'libs/my-lib/.babelrc')).toEqual({
+      presets: ['next/babel'],
+      plugins: [],
+    });
+    expect(readJson(appTree, 'libs/my-lib2/.babelrc')).toEqual({
+      presets: [
+        'next/babel',
+        {
+          'preset-react': {
+            importSource: '@emotion/react',
+          },
+        },
+      ],
+      plugins: ['@emotion/babel-plugin'],
+    });
+    expect(readJson(appTree, 'libs/my-dir/my-lib3/.babelrc')).toEqual({
+      presets: ['next/babel'],
+      plugins: [],
+    });
+  });
+});

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -1,0 +1,43 @@
+import { libraryGenerator as reactLibraryGenerator } from '@nrwl/react';
+import {
+  convertNxGenerator,
+  getWorkspaceLayout,
+  joinPathFragments,
+  names,
+  Tree,
+  updateJson,
+} from '@nrwl/devkit';
+import { Schema } from './schema';
+
+export async function libraryGenerator(host: Tree, options: Schema) {
+  const name = names(options.name).fileName;
+  const projectDirectory = options.directory
+    ? `${names(options.directory).fileName}/${name}`
+    : name;
+
+  const { libsDir } = getWorkspaceLayout(host);
+  const projectRoot = joinPathFragments(`${libsDir}/${projectDirectory}`);
+
+  const task = await reactLibraryGenerator(host, options);
+
+  updateJson(host, joinPathFragments(projectRoot, '.babelrc'), (json) => {
+    if (options.style === '@emotion/styled') {
+      json.presets = [
+        'next/babel',
+        {
+          'preset-react': {
+            importSource: '@emotion/react',
+          },
+        },
+      ];
+    } else {
+      json.presets = ['next/babel'];
+    }
+    return json;
+  });
+
+  return task;
+}
+
+export default libraryGenerator;
+export const librarySchematic = convertNxGenerator(libraryGenerator);

--- a/packages/next/src/generators/library/schema.d.ts
+++ b/packages/next/src/generators/library/schema.d.ts
@@ -1,0 +1,25 @@
+import { SupportedStyles } from '../../../typings/style';
+import { Linter } from '@nrwl/linter';
+
+export interface Schema {
+  name: string;
+  directory?: string;
+  style: SupportedStyles;
+  skipTsConfig: boolean;
+  skipFormat: boolean;
+  tags?: string;
+  pascalCaseFiles?: boolean;
+  routing?: boolean;
+  appProject?: string;
+  unitTestRunner: 'jest' | 'none';
+  linter: Linter;
+  component?: boolean;
+  publishable?: boolean;
+  buildable?: boolean;
+  importPath?: string;
+  js?: boolean;
+  globalCss?: boolean;
+  strict?: boolean;
+  setParserOptionsProject?: boolean;
+  standaloneConfig?: boolean;
+}

--- a/packages/next/src/generators/library/schema.json
+++ b/packages/next/src/generators/library/schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "NxReactLibrary",
+  "title": "Create a React Library for Nx",
+  "type": "object",
+  "examples": [
+    {
+      "command": "g lib mylib --directory=myapp",
+      "description": "Generate libs/myapp/mylib"
+    },
+    {
+      "command": "g lib mylib --appProject=myapp",
+      "description": "Generate a library with routes and add them to myapp"
+    }
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Library name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the library?",
+      "pattern": "^[a-zA-Z].*$"
+    },
+    "directory": {
+      "type": "string",
+      "description": "A directory where the lib is placed.",
+      "alias": "d"
+    },
+    "style": {
+      "description": "The file extension to be used for style files.",
+      "type": "string",
+      "default": "css",
+      "alias": "s",
+      "x-prompt": {
+        "message": "Which stylesheet format would you like to use?",
+        "type": "list",
+        "items": [
+          { "value": "css", "label": "CSS" },
+          {
+            "value": "scss",
+            "label": "SASS(.scss)       [ http://sass-lang.com          ]"
+          },
+          {
+            "value": "styl",
+            "label": "Stylus(.styl)     [ http://stylus-lang.com        ]"
+          },
+          {
+            "value": "less",
+            "label": "LESS              [ http://lesscss.org            ]"
+          },
+          {
+            "value": "styled-components",
+            "label": "styled-components [ https://styled-components.com ]"
+          },
+          {
+            "value": "@emotion/styled",
+            "label": "emotion           [ https://emotion.sh            ]"
+          },
+          {
+            "value": "styled-jsx",
+            "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
+          },
+          {
+            "value": "none",
+            "label": "None"
+          }
+        ]
+      }
+    },
+    "linter": {
+      "description": "The tool to use for running lint checks.",
+      "type": "string",
+      "enum": ["eslint", "tslint"],
+      "default": "eslint"
+    },
+    "unitTestRunner": {
+      "type": "string",
+      "enum": ["jest", "none"],
+      "description": "Test runner to use for unit tests.",
+      "default": "jest"
+    },
+    "tags": {
+      "type": "string",
+      "description": "Add tags to the library (used for linting).",
+      "alias": "t"
+    },
+    "skipFormat": {
+      "description": "Skip formatting files.",
+      "type": "boolean",
+      "default": false
+    },
+    "skipTsConfig": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not update tsconfig.json for development experience."
+    },
+    "pascalCaseFiles": {
+      "type": "boolean",
+      "description": "Use pascal case component file name (e.g. App.tsx).",
+      "alias": "P",
+      "default": false
+    },
+    "routing": {
+      "type": "boolean",
+      "description": "Generate library with routes."
+    },
+    "appProject": {
+      "type": "string",
+      "description": "The application project to add the library route to.",
+      "alias": "a"
+    },
+    "publishable": {
+      "type": "boolean",
+      "description": "Create a publishable library."
+    },
+    "buildable": {
+      "type": "boolean",
+      "default": false,
+      "description": "Generate a buildable library."
+    },
+    "importPath": {
+      "type": "string",
+      "description": "The library name used to import it, like @myorg/my-awesome-lib"
+    },
+    "component": {
+      "type": "boolean",
+      "description": "Generate a default component.",
+      "default": true
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files.",
+      "default": false
+    },
+    "globalCss": {
+      "type": "boolean",
+      "description": "When true, the stylesheet is generated using global CSS instead of CSS modules (e.g. file is '*.css' rather than '*.module.css').",
+      "default": false
+    },
+    "strict": {
+      "type": "boolean",
+      "description": "Whether to enable tsconfig strict mode or not.",
+      "default": true
+    },
+    "setParserOptionsProject": {
+      "type": "boolean",
+      "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
+      "default": false
+    },
+    "standaloneConfig": {
+      "description": "Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "required": ["name"]
+}


### PR DESCRIPTION
This PR fixes issues if there are conflicts between `next/babel` and our own.