### PR TITLE
fix(testing): remove installation of babel packages for jest projects

### DIFF
--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -41,12 +41,6 @@ describe('jest', () => {
     it('should add babel dependencies', async () => {
       jestInitGenerator(tree, { babelJest: true });
       const packageJson = readJson(tree, 'package.json');
-      expect(packageJson.devDependencies['@babel/core']).toBeDefined();
-      expect(packageJson.devDependencies['@babel/preset-env']).toBeDefined();
-      expect(
-        packageJson.devDependencies['@babel/preset-typescript']
-      ).toBeDefined();
-      expect(packageJson.devDependencies['@babel/preset-react']).toBeDefined();
       expect(packageJson.devDependencies['babel-jest']).toBeDefined();
     });
   });

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -1,9 +1,5 @@
 import {
-  babelCoreVersion,
   babelJestVersion,
-  babelPresetEnvVersion,
-  babelPresetReactVersion,
-  babelPresetTypescriptVersion,
   jestTypesVersion,
   jestVersion,
   nxVersion,
@@ -11,11 +7,11 @@ import {
 } from '../../utils/versions';
 import { JestInitSchema } from './schema';
 import {
-  Tree,
-  updateJson,
   addDependenciesToPackageJson,
   convertNxGenerator,
   stripIndents,
+  Tree,
+  updateJson,
 } from '@nrwl/devkit';
 
 interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}
@@ -67,10 +63,6 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
   };
 
   if (options.babelJest) {
-    devDeps['@babel/core'] = babelCoreVersion;
-    devDeps['@babel/preset-env'] = babelPresetEnvVersion;
-    devDeps['@babel/preset-typescript'] = babelPresetTypescriptVersion;
-    devDeps['@babel/preset-react'] = babelPresetReactVersion;
     devDeps['babel-jest'] = babelJestVersion;
   }
 

--- a/packages/jest/src/utils/versions.ts
+++ b/packages/jest/src/utils/versions.ts
@@ -2,9 +2,4 @@ export const nxVersion = '*';
 export const jestVersion = '27.0.3';
 export const jestTypesVersion = '26.0.24';
 export const tsJestVersion = '27.0.3';
-
-export const babelCoreVersion = '7.12.13';
-export const babelPresetEnvVersion = '7.12.13';
-export const babelPresetTypescriptVersion = '7.12.13';
-export const babelPresetReactVersion = '7.12.13';
 export const babelJestVersion = '27.0.6';


### PR DESCRIPTION
This PR removes the need to install babel packages like  `@babe/core` when jest project is initialized. They have not need been needed for a while now since we moved to our own presets (e.g. `@nrwl/web/babel` and `@nrwl/react/babel`).