### PR TITLE
fix(misc): make generated schemas compliant with json schema spec

### DIFF
--- a/packages/nx-plugin/src/generators/generator/files/generator/__fileName__/schema.json__tmpl__
+++ b/packages/nx-plugin/src/generators/generator/files/generator/__fileName__/schema.json__tmpl__
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
-  "id": "<%= className %>",
+  "$id": "<%= className %>",
   "title": "",
   "type": "object",
   "properties": {

--- a/packages/workspace/src/generators/workspace-generator/files/schema.json__tmpl__
+++ b/packages/workspace/src/generators/workspace-generator/files/schema.json__tmpl__
@@ -1,6 +1,7 @@
 {
+  "$schema": "http://json-schema.org/schema",
   "cli": "nx",
-  "id": "<%= name %>",
+  "$id": "<%= name %>",
   "type": "object",
   "properties": {
     "name": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The generated `schema.json` for a workspace generator and for an Nx plugin are using the `id` property which is deprecated.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The generated `schema.json` for a workspace generator and for an Nx plugin should use the `$id` property.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
