### PR TITLE
cleanup(repo): remove unused ext from file data and fix ext regex matcher

### DIFF
--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -13,10 +13,7 @@ import {
 } from '@nrwl/workspace/src/utils/buildable-libs-utils';
 import { joinPathFragments } from '@nrwl/devkit';
 import { join } from 'path';
-import {
-  readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
-} from '@nrwl/workspace/src/core/project-graph';
+import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import { Schema } from '@angular-devkit/build-angular/src/browser/schema';
 import { switchMap } from 'rxjs/operators';
 import { existsSync } from 'fs';
@@ -84,7 +81,7 @@ function run(
   context: BuilderContext
 ): Observable<BuilderOutput> {
   const { target, dependencies } = calculateProjectDependencies(
-    readCachedProjectGraph(NEXT_GRAPH_VERSION),
+    readCachedProjectGraph('4.0'),
     context
   );
 

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -13,7 +13,10 @@ import {
 } from '@nrwl/workspace/src/utils/buildable-libs-utils';
 import { joinPathFragments } from '@nrwl/devkit';
 import { join } from 'path';
-import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
+} from '@nrwl/workspace/src/core/project-graph';
 import { Schema } from '@angular-devkit/build-angular/src/browser/schema';
 import { switchMap } from 'rxjs/operators';
 import { existsSync } from 'fs';
@@ -81,7 +84,7 @@ function run(
   context: BuilderContext
 ): Observable<BuilderOutput> {
   const { target, dependencies } = calculateProjectDependencies(
-    readCachedProjectGraph(),
+    readCachedProjectGraph(LATEST_GRAPH_VERSION),
     context
   );
 

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -15,7 +15,7 @@ import { joinPathFragments } from '@nrwl/devkit';
 import { join } from 'path';
 import {
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 import { Schema } from '@angular-devkit/build-angular/src/browser/schema';
 import { switchMap } from 'rxjs/operators';
@@ -84,7 +84,7 @@ function run(
   context: BuilderContext
 ): Observable<BuilderOutput> {
   const { target, dependencies } = calculateProjectDependencies(
-    readCachedProjectGraph(LATEST_GRAPH_VERSION),
+    readCachedProjectGraph(NEXT_GRAPH_VERSION),
     context
   );
 

--- a/packages/angular/src/executors/delegate-build/delegate-build.impl.ts
+++ b/packages/angular/src/executors/delegate-build/delegate-build.impl.ts
@@ -4,10 +4,7 @@ import {
   parseTargetString,
   runExecutor,
 } from '@nrwl/devkit';
-import {
-  readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
-} from '@nrwl/workspace/src/core/project-graph';
+import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
   checkDependentProjectsHaveBeenBuilt,
@@ -20,7 +17,7 @@ export async function* delegateBuildExecutor(
   context: ExecutorContext
 ) {
   const { target, dependencies } = calculateProjectDependencies(
-    readCachedProjectGraph(NEXT_GRAPH_VERSION),
+    readCachedProjectGraph('4.0'),
     context.root,
     context.projectName,
     context.targetName,

--- a/packages/angular/src/executors/delegate-build/delegate-build.impl.ts
+++ b/packages/angular/src/executors/delegate-build/delegate-build.impl.ts
@@ -6,7 +6,7 @@ import {
 } from '@nrwl/devkit';
 import {
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
@@ -20,7 +20,7 @@ export async function* delegateBuildExecutor(
   context: ExecutorContext
 ) {
   const { target, dependencies } = calculateProjectDependencies(
-    readCachedProjectGraph(LATEST_GRAPH_VERSION),
+    readCachedProjectGraph(NEXT_GRAPH_VERSION),
     context.root,
     context.projectName,
     context.targetName,

--- a/packages/angular/src/executors/delegate-build/delegate-build.impl.ts
+++ b/packages/angular/src/executors/delegate-build/delegate-build.impl.ts
@@ -4,7 +4,10 @@ import {
   parseTargetString,
   runExecutor,
 } from '@nrwl/devkit';
-import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
+} from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
   checkDependentProjectsHaveBeenBuilt,
@@ -17,7 +20,7 @@ export async function* delegateBuildExecutor(
   context: ExecutorContext
 ) {
   const { target, dependencies } = calculateProjectDependencies(
-    readCachedProjectGraph(),
+    readCachedProjectGraph(LATEST_GRAPH_VERSION),
     context.root,
     context.projectName,
     context.targetName,

--- a/packages/angular/src/executors/package/package.impl.ts
+++ b/packages/angular/src/executors/package/package.impl.ts
@@ -2,7 +2,7 @@ import * as ng from '@angular/compiler-cli';
 import type { ExecutorContext } from '@nrwl/devkit';
 import {
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 import type { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import {
@@ -54,7 +54,7 @@ export function createLibraryExecutor(
     context: ExecutorContext
   ) {
     const { target, dependencies } = calculateProjectDependencies(
-      readCachedProjectGraph(LATEST_GRAPH_VERSION),
+      readCachedProjectGraph(NEXT_GRAPH_VERSION),
       context.root,
       context.projectName,
       context.targetName,

--- a/packages/angular/src/executors/package/package.impl.ts
+++ b/packages/angular/src/executors/package/package.impl.ts
@@ -1,9 +1,6 @@
 import * as ng from '@angular/compiler-cli';
 import type { ExecutorContext } from '@nrwl/devkit';
-import {
-  readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
-} from '@nrwl/workspace/src/core/project-graph';
+import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import type { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import {
   calculateProjectDependencies,
@@ -54,7 +51,7 @@ export function createLibraryExecutor(
     context: ExecutorContext
   ) {
     const { target, dependencies } = calculateProjectDependencies(
-      readCachedProjectGraph(NEXT_GRAPH_VERSION),
+      readCachedProjectGraph('4.0'),
       context.root,
       context.projectName,
       context.targetName,

--- a/packages/angular/src/executors/package/package.impl.ts
+++ b/packages/angular/src/executors/package/package.impl.ts
@@ -1,6 +1,9 @@
 import * as ng from '@angular/compiler-cli';
 import type { ExecutorContext } from '@nrwl/devkit';
-import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
+} from '@nrwl/workspace/src/core/project-graph';
 import type { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import {
   calculateProjectDependencies,
@@ -51,7 +54,7 @@ export function createLibraryExecutor(
     context: ExecutorContext
   ) {
     const { target, dependencies } = calculateProjectDependencies(
-      readCachedProjectGraph(),
+      readCachedProjectGraph(LATEST_GRAPH_VERSION),
       context.root,
       context.projectName,
       context.targetName,

--- a/packages/angular/src/migrations/update-10-5-0/add-template-support-and-presets-to-eslint.ts
+++ b/packages/angular/src/migrations/update-10-5-0/add-template-support-and-presets-to-eslint.ts
@@ -14,6 +14,7 @@ import { offsetFromRoot } from '@nrwl/devkit';
 import {
   createProjectGraphAsync,
   isNpmProject,
+  LATEST_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 
 /**
@@ -45,7 +46,7 @@ function addHTMLPatternToBuilderConfig(
 async function updateProjectESLintConfigsAndBuilders(
   host: Tree
 ): Promise<Rule> {
-  const graph = await createProjectGraphAsync();
+  const graph = await createProjectGraphAsync(LATEST_GRAPH_VERSION);
 
   /**
    * Make sure user is already using ESLint and is up to date with

--- a/packages/angular/src/migrations/update-10-5-0/add-template-support-and-presets-to-eslint.ts
+++ b/packages/angular/src/migrations/update-10-5-0/add-template-support-and-presets-to-eslint.ts
@@ -14,7 +14,6 @@ import { offsetFromRoot } from '@nrwl/devkit';
 import {
   createProjectGraphAsync,
   isNpmProject,
-  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 
 /**
@@ -46,7 +45,7 @@ function addHTMLPatternToBuilderConfig(
 async function updateProjectESLintConfigsAndBuilders(
   host: Tree
 ): Promise<Rule> {
-  const graph = await createProjectGraphAsync(NEXT_GRAPH_VERSION);
+  const graph = await createProjectGraphAsync('4.0');
 
   /**
    * Make sure user is already using ESLint and is up to date with

--- a/packages/angular/src/migrations/update-10-5-0/add-template-support-and-presets-to-eslint.ts
+++ b/packages/angular/src/migrations/update-10-5-0/add-template-support-and-presets-to-eslint.ts
@@ -14,7 +14,7 @@ import { offsetFromRoot } from '@nrwl/devkit';
 import {
   createProjectGraphAsync,
   isNpmProject,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 
 /**
@@ -46,7 +46,7 @@ function addHTMLPatternToBuilderConfig(
 async function updateProjectESLintConfigsAndBuilders(
   host: Tree
 ): Promise<Rule> {
-  const graph = await createProjectGraphAsync(LATEST_GRAPH_VERSION);
+  const graph = await createProjectGraphAsync(NEXT_GRAPH_VERSION);
 
   /**
    * Make sure user is already using ESLint and is up to date with

--- a/packages/devkit/src/project-graph/interfaces.ts
+++ b/packages/devkit/src/project-graph/interfaces.ts
@@ -9,7 +9,6 @@ import type {
 export interface FileData {
   file: string;
   hash: string;
-  ext: string;
   deps?: string[];
 }
 

--- a/packages/devkit/src/project-graph/interfaces.ts
+++ b/packages/devkit/src/project-graph/interfaces.ts
@@ -9,6 +9,8 @@ import type {
 export interface FileData {
   file: string;
   hash: string;
+  /** @deprecated this field will be removed in v13. Use {@link path.extname} to parse extension */
+  ext?: string;
   deps?: string[];
 }
 
@@ -28,6 +30,7 @@ export interface ProjectGraph<T = any> {
 
   // this is optional otherwise it might break folks who use project graph creation
   allWorkspaceFiles?: FileData[];
+  version?: string;
 }
 
 /**

--- a/packages/devkit/src/project-graph/project-graph-builder.ts
+++ b/packages/devkit/src/project-graph/project-graph-builder.ts
@@ -106,6 +106,13 @@ export class ProjectGraphBuilder {
     }
   }
 
+  /**
+   * Set version of the project graph
+   */
+  setVersion(version: string): void {
+    this.graph.version = version;
+  }
+
   getUpdatedProjectGraph(): ProjectGraph {
     for (const sourceProject of Object.keys(this.graph.nodes)) {
       const alreadySetTargetProjects =

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -24,7 +24,6 @@ import {
   isNpmProject,
   ProjectType,
   readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 import { readNxJson } from '@nrwl/workspace/src/core/file-utils';
 import { TargetProjectLocator } from '@nrwl/workspace/src/core/target-project-locator';
@@ -130,7 +129,7 @@ export default createESLintRule<Options, MessageIds>({
        */
       try {
         (global as any).projectGraph = mapProjectGraphFiles(
-          readCachedProjectGraph(NEXT_GRAPH_VERSION)
+          readCachedProjectGraph('4.0')
         );
       } catch {}
     }

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -24,7 +24,7 @@ import {
   isNpmProject,
   ProjectType,
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 import { readNxJson } from '@nrwl/workspace/src/core/file-utils';
 import { TargetProjectLocator } from '@nrwl/workspace/src/core/target-project-locator';
@@ -130,7 +130,7 @@ export default createESLintRule<Options, MessageIds>({
        */
       try {
         (global as any).projectGraph = mapProjectGraphFiles(
-          readCachedProjectGraph(LATEST_GRAPH_VERSION)
+          readCachedProjectGraph(NEXT_GRAPH_VERSION)
         );
       } catch {}
     }

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -24,6 +24,7 @@ import {
   isNpmProject,
   ProjectType,
   readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 import { readNxJson } from '@nrwl/workspace/src/core/file-utils';
 import { TargetProjectLocator } from '@nrwl/workspace/src/core/target-project-locator';
@@ -129,7 +130,7 @@ export default createESLintRule<Options, MessageIds>({
        */
       try {
         (global as any).projectGraph = mapProjectGraphFiles(
-          readCachedProjectGraph()
+          readCachedProjectGraph(LATEST_GRAPH_VERSION)
         );
       } catch {}
     }

--- a/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/tests/rules/enforce-module-boundaries.spec.ts
@@ -1526,7 +1526,7 @@ linter.defineParser('@typescript-eslint/parser', parser);
 linter.defineRule(enforceModuleBoundariesRuleName, enforceModuleBoundaries);
 
 function createFile(f) {
-  return { file: f, ext: extname(f), hash: '' };
+  return { file: f, hash: '' };
 }
 
 function runRule(

--- a/packages/next/src/executors/export/export.impl.ts
+++ b/packages/next/src/executors/export/export.impl.ts
@@ -15,7 +15,7 @@ import {
 } from '../../utils/types';
 import {
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
@@ -30,7 +30,7 @@ export default async function exportExecutor(
   let dependencies: DependentBuildableProjectNode[] = [];
   if (!options.buildLibsFromSource) {
     const result = calculateProjectDependencies(
-      readCachedProjectGraph(LATEST_GRAPH_VERSION),
+      readCachedProjectGraph(NEXT_GRAPH_VERSION),
       context.root,
       context.projectName,
       'build', // this should be generalized

--- a/packages/next/src/executors/export/export.impl.ts
+++ b/packages/next/src/executors/export/export.impl.ts
@@ -13,10 +13,7 @@ import {
   NextBuildBuilderOptions,
   NextExportBuilderOptions,
 } from '../../utils/types';
-import {
-  readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
-} from '@nrwl/workspace/src/core/project-graph';
+import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
   DependentBuildableProjectNode,
@@ -30,7 +27,7 @@ export default async function exportExecutor(
   let dependencies: DependentBuildableProjectNode[] = [];
   if (!options.buildLibsFromSource) {
     const result = calculateProjectDependencies(
-      readCachedProjectGraph(NEXT_GRAPH_VERSION),
+      readCachedProjectGraph('4.0'),
       context.root,
       context.projectName,
       'build', // this should be generalized

--- a/packages/next/src/executors/export/export.impl.ts
+++ b/packages/next/src/executors/export/export.impl.ts
@@ -13,7 +13,10 @@ import {
   NextBuildBuilderOptions,
   NextExportBuilderOptions,
 } from '../../utils/types';
-import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
+} from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
   DependentBuildableProjectNode,
@@ -27,7 +30,7 @@ export default async function exportExecutor(
   let dependencies: DependentBuildableProjectNode[] = [];
   if (!options.buildLibsFromSource) {
     const result = calculateProjectDependencies(
-      readCachedProjectGraph(),
+      readCachedProjectGraph(LATEST_GRAPH_VERSION),
       context.root,
       context.projectName,
       'build', // this should be generalized

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -24,7 +24,10 @@ import {
 } from '../../utils/types';
 import { customServer } from './lib/custom-server';
 import { defaultServer } from './lib/default-server';
-import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
+} from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
   DependentBuildableProjectNode,
@@ -54,7 +57,7 @@ export default async function* serveExecutor(
   const root = resolve(context.root, buildOptions.root);
   if (!options.buildLibsFromSource) {
     const result = calculateProjectDependencies(
-      readCachedProjectGraph(),
+      readCachedProjectGraph(LATEST_GRAPH_VERSION),
       context.root,
       context.projectName,
       'build', // should be generalized

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -26,7 +26,7 @@ import { customServer } from './lib/custom-server';
 import { defaultServer } from './lib/default-server';
 import {
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
@@ -57,7 +57,7 @@ export default async function* serveExecutor(
   const root = resolve(context.root, buildOptions.root);
   if (!options.buildLibsFromSource) {
     const result = calculateProjectDependencies(
-      readCachedProjectGraph(LATEST_GRAPH_VERSION),
+      readCachedProjectGraph(NEXT_GRAPH_VERSION),
       context.root,
       context.projectName,
       'build', // should be generalized

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -24,10 +24,7 @@ import {
 } from '../../utils/types';
 import { customServer } from './lib/custom-server';
 import { defaultServer } from './lib/default-server';
-import {
-  readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
-} from '@nrwl/workspace/src/core/project-graph';
+import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
   DependentBuildableProjectNode,
@@ -57,7 +54,7 @@ export default async function* serveExecutor(
   const root = resolve(context.root, buildOptions.root);
   if (!options.buildLibsFromSource) {
     const result = calculateProjectDependencies(
-      readCachedProjectGraph(NEXT_GRAPH_VERSION),
+      readCachedProjectGraph('4.0'),
       context.root,
       context.projectName,
       'build', // should be generalized

--- a/packages/node/src/executors/package/package.impl.ts
+++ b/packages/node/src/executors/package/package.impl.ts
@@ -1,8 +1,5 @@
 import { ExecutorContext } from '@nrwl/devkit';
-import {
-  readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
-} from '@nrwl/workspace/src/core/project-graph';
+import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import { copyAssetFiles } from '@nrwl/workspace/src/utilities/assets';
 import {
   calculateProjectDependencies,
@@ -22,7 +19,7 @@ export async function packageExecutor(
   const libRoot = context.workspace.projects[context.projectName].root;
   const normalizedOptions = normalizeOptions(options, context, libRoot);
   const { target, dependencies } = calculateProjectDependencies(
-    readCachedProjectGraph(NEXT_GRAPH_VERSION),
+    readCachedProjectGraph('4.0'),
     context.root,
     context.projectName,
     context.targetName,

--- a/packages/node/src/executors/package/package.impl.ts
+++ b/packages/node/src/executors/package/package.impl.ts
@@ -1,7 +1,7 @@
 import { ExecutorContext } from '@nrwl/devkit';
 import {
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 import { copyAssetFiles } from '@nrwl/workspace/src/utilities/assets';
 import {
@@ -22,7 +22,7 @@ export async function packageExecutor(
   const libRoot = context.workspace.projects[context.projectName].root;
   const normalizedOptions = normalizeOptions(options, context, libRoot);
   const { target, dependencies } = calculateProjectDependencies(
-    readCachedProjectGraph(LATEST_GRAPH_VERSION),
+    readCachedProjectGraph(NEXT_GRAPH_VERSION),
     context.root,
     context.projectName,
     context.targetName,

--- a/packages/node/src/executors/package/package.impl.ts
+++ b/packages/node/src/executors/package/package.impl.ts
@@ -1,5 +1,8 @@
 import { ExecutorContext } from '@nrwl/devkit';
-import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
+} from '@nrwl/workspace/src/core/project-graph';
 import { copyAssetFiles } from '@nrwl/workspace/src/utilities/assets';
 import {
   calculateProjectDependencies,
@@ -19,7 +22,7 @@ export async function packageExecutor(
   const libRoot = context.workspace.projects[context.projectName].root;
   const normalizedOptions = normalizeOptions(options, context, libRoot);
   const { target, dependencies } = calculateProjectDependencies(
-    readCachedProjectGraph(),
+    readCachedProjectGraph(LATEST_GRAPH_VERSION),
     context.root,
     context.projectName,
     context.targetName,

--- a/packages/react/src/migrations/update-9-4-0/babelrc-9-4-0.ts
+++ b/packages/react/src/migrations/update-9-4-0/babelrc-9-4-0.ts
@@ -13,6 +13,7 @@ import { addDepsToPackageJson, formatFiles } from '@nrwl/workspace';
 import {
   createProjectGraphAsync,
   isNpmProject,
+  LATEST_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 
 let addedEmotionPreset = false;
@@ -28,7 +29,7 @@ export default function update(): Rule {
   return async (host: Tree, context: SchematicContext) => {
     const updates = [];
     const conflicts: Array<[string, string]> = [];
-    const projectGraph = await createProjectGraphAsync();
+    const projectGraph = await createProjectGraphAsync(LATEST_GRAPH_VERSION);
     if (host.exists('/babel.config.json')) {
       context.logger.info(
         `

--- a/packages/react/src/migrations/update-9-4-0/babelrc-9-4-0.ts
+++ b/packages/react/src/migrations/update-9-4-0/babelrc-9-4-0.ts
@@ -13,7 +13,6 @@ import { addDepsToPackageJson, formatFiles } from '@nrwl/workspace';
 import {
   createProjectGraphAsync,
   isNpmProject,
-  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 
 let addedEmotionPreset = false;
@@ -29,7 +28,7 @@ export default function update(): Rule {
   return async (host: Tree, context: SchematicContext) => {
     const updates = [];
     const conflicts: Array<[string, string]> = [];
-    const projectGraph = await createProjectGraphAsync(NEXT_GRAPH_VERSION);
+    const projectGraph = await createProjectGraphAsync('4.0');
     if (host.exists('/babel.config.json')) {
       context.logger.info(
         `

--- a/packages/react/src/migrations/update-9-4-0/babelrc-9-4-0.ts
+++ b/packages/react/src/migrations/update-9-4-0/babelrc-9-4-0.ts
@@ -13,7 +13,7 @@ import { addDepsToPackageJson, formatFiles } from '@nrwl/workspace';
 import {
   createProjectGraphAsync,
   isNpmProject,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 
 let addedEmotionPreset = false;
@@ -29,7 +29,7 @@ export default function update(): Rule {
   return async (host: Tree, context: SchematicContext) => {
     const updates = [];
     const conflicts: Array<[string, string]> = [];
-    const projectGraph = await createProjectGraphAsync(LATEST_GRAPH_VERSION);
+    const projectGraph = await createProjectGraphAsync(NEXT_GRAPH_VERSION);
     if (host.exists('/babel.config.json')) {
       context.logger.info(
         `

--- a/packages/web/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/web/src/executors/dev-server/dev-server.impl.ts
@@ -20,10 +20,7 @@ import {
   calculateProjectDependencies,
   createTmpTsConfig,
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
-import {
-  readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
-} from '@nrwl/workspace/src/core/project-graph';
+import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 
 export interface WebDevServerOptions {
   host: string;
@@ -71,7 +68,7 @@ export default async function* devServerExecutor(
 
   if (!buildOptions.buildLibsFromSource) {
     const { target, dependencies } = calculateProjectDependencies(
-      readCachedProjectGraph(NEXT_GRAPH_VERSION),
+      readCachedProjectGraph('4.0'),
       context.root,
       context.projectName,
       'build', // should be generalized

--- a/packages/web/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/web/src/executors/dev-server/dev-server.impl.ts
@@ -20,7 +20,10 @@ import {
   calculateProjectDependencies,
   createTmpTsConfig,
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
-import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
+} from '@nrwl/workspace/src/core/project-graph';
 
 export interface WebDevServerOptions {
   host: string;
@@ -68,7 +71,7 @@ export default async function* devServerExecutor(
 
   if (!buildOptions.buildLibsFromSource) {
     const { target, dependencies } = calculateProjectDependencies(
-      readCachedProjectGraph(),
+      readCachedProjectGraph(LATEST_GRAPH_VERSION),
       context.root,
       context.projectName,
       'build', // should be generalized

--- a/packages/web/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/web/src/executors/dev-server/dev-server.impl.ts
@@ -22,7 +22,7 @@ import {
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import {
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 
 export interface WebDevServerOptions {
@@ -71,7 +71,7 @@ export default async function* devServerExecutor(
 
   if (!buildOptions.buildLibsFromSource) {
     const { target, dependencies } = calculateProjectDependencies(
-      readCachedProjectGraph(LATEST_GRAPH_VERSION),
+      readCachedProjectGraph(NEXT_GRAPH_VERSION),
       context.root,
       context.projectName,
       'build', // should be generalized

--- a/packages/web/src/executors/package/package.impl.ts
+++ b/packages/web/src/executors/package/package.impl.ts
@@ -11,7 +11,10 @@ import { catchError, concatMap, last, tap } from 'rxjs/operators';
 import { eachValueFrom } from 'rxjs-for-await';
 import * as autoprefixer from 'autoprefixer';
 
-import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
+} from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
   checkDependentProjectsHaveBeenBuilt,
@@ -56,7 +59,7 @@ export default async function* run(
   context: ExecutorContext
 ) {
   const project = context.workspace.projects[context.projectName];
-  const projectGraph = readCachedProjectGraph();
+  const projectGraph = readCachedProjectGraph(LATEST_GRAPH_VERSION);
   const sourceRoot = project.sourceRoot;
   const { target, dependencies } = calculateProjectDependencies(
     projectGraph,
@@ -241,9 +244,9 @@ export function createRollupOptions(
 
     const globals = options.globals
       ? options.globals.reduce((acc, item) => {
-          acc[item.moduleId] = item.global;
-          return acc;
-        }, {})
+        acc[item.moduleId] = item.global;
+        return acc;
+      }, {})
       : {};
 
     const externalPackages = dependencies
@@ -338,8 +341,8 @@ function convertCopyAssetsToRollupOptions(
 ): RollupCopyAssetOption[] {
   return assets
     ? assets.map((a) => ({
-        src: join(a.input, a.glob).replace(/\\/g, '/'),
-        dest: join(outputPath, a.output).replace(/\\/g, '/'),
-      }))
+      src: join(a.input, a.glob).replace(/\\/g, '/'),
+      dest: join(outputPath, a.output).replace(/\\/g, '/'),
+    }))
     : undefined;
 }

--- a/packages/web/src/executors/package/package.impl.ts
+++ b/packages/web/src/executors/package/package.impl.ts
@@ -13,7 +13,7 @@ import * as autoprefixer from 'autoprefixer';
 
 import {
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
@@ -59,7 +59,7 @@ export default async function* run(
   context: ExecutorContext
 ) {
   const project = context.workspace.projects[context.projectName];
-  const projectGraph = readCachedProjectGraph(LATEST_GRAPH_VERSION);
+  const projectGraph = readCachedProjectGraph(NEXT_GRAPH_VERSION);
   const sourceRoot = project.sourceRoot;
   const { target, dependencies } = calculateProjectDependencies(
     projectGraph,

--- a/packages/web/src/executors/package/package.impl.ts
+++ b/packages/web/src/executors/package/package.impl.ts
@@ -11,10 +11,7 @@ import { catchError, concatMap, last, tap } from 'rxjs/operators';
 import { eachValueFrom } from 'rxjs-for-await';
 import * as autoprefixer from 'autoprefixer';
 
-import {
-  readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
-} from '@nrwl/workspace/src/core/project-graph';
+import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
   checkDependentProjectsHaveBeenBuilt,
@@ -59,7 +56,7 @@ export default async function* run(
   context: ExecutorContext
 ) {
   const project = context.workspace.projects[context.projectName];
-  const projectGraph = readCachedProjectGraph(NEXT_GRAPH_VERSION);
+  const projectGraph = readCachedProjectGraph('4.0');
   const sourceRoot = project.sourceRoot;
   const { target, dependencies } = calculateProjectDependencies(
     projectGraph,

--- a/packages/web/src/executors/package/package.impl.ts
+++ b/packages/web/src/executors/package/package.impl.ts
@@ -241,9 +241,9 @@ export function createRollupOptions(
 
     const globals = options.globals
       ? options.globals.reduce((acc, item) => {
-        acc[item.moduleId] = item.global;
-        return acc;
-      }, {})
+          acc[item.moduleId] = item.global;
+          return acc;
+        }, {})
       : {};
 
     const externalPackages = dependencies
@@ -338,8 +338,8 @@ function convertCopyAssetsToRollupOptions(
 ): RollupCopyAssetOption[] {
   return assets
     ? assets.map((a) => ({
-      src: join(a.input, a.glob).replace(/\\/g, '/'),
-      dest: join(outputPath, a.output).replace(/\\/g, '/'),
-    }))
+        src: join(a.input, a.glob).replace(/\\/g, '/'),
+        dest: join(outputPath, a.output).replace(/\\/g, '/'),
+      }))
     : undefined;
 }

--- a/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.ts
+++ b/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.ts
@@ -1,14 +1,14 @@
 import { formatFiles, getProjects, Tree, writeJson } from '@nrwl/devkit';
 import {
   createProjectGraphAsync,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
   reverse,
 } from '@nrwl/workspace/src/core/project-graph';
 import { hasDependentAppUsingWebBuild } from './utils';
 
 export async function createBabelrcForWorkspaceLibs(host: Tree) {
   const projects = getProjects(host);
-  const graph = reverse(await createProjectGraphAsync(LATEST_GRAPH_VERSION));
+  const graph = reverse(await createProjectGraphAsync(NEXT_GRAPH_VERSION));
 
   for (const [name, p] of projects.entries()) {
     if (!hasDependentAppUsingWebBuild(name, graph, projects)) {

--- a/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.ts
+++ b/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.ts
@@ -1,14 +1,13 @@
 import { formatFiles, getProjects, Tree, writeJson } from '@nrwl/devkit';
 import {
   createProjectGraphAsync,
-  NEXT_GRAPH_VERSION,
   reverse,
 } from '@nrwl/workspace/src/core/project-graph';
 import { hasDependentAppUsingWebBuild } from './utils';
 
 export async function createBabelrcForWorkspaceLibs(host: Tree) {
   const projects = getProjects(host);
-  const graph = reverse(await createProjectGraphAsync(NEXT_GRAPH_VERSION));
+  const graph = reverse(await createProjectGraphAsync('4.0'));
 
   for (const [name, p] of projects.entries()) {
     if (!hasDependentAppUsingWebBuild(name, graph, projects)) {

--- a/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.ts
+++ b/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.ts
@@ -1,13 +1,14 @@
 import { formatFiles, getProjects, Tree, writeJson } from '@nrwl/devkit';
 import {
   createProjectGraphAsync,
+  LATEST_GRAPH_VERSION,
   reverse,
 } from '@nrwl/workspace/src/core/project-graph';
 import { hasDependentAppUsingWebBuild } from './utils';
 
 export async function createBabelrcForWorkspaceLibs(host: Tree) {
   const projects = getProjects(host);
-  const graph = reverse(await createProjectGraphAsync());
+  const graph = reverse(await createProjectGraphAsync(LATEST_GRAPH_VERSION));
 
   for (const [name, p] of projects.entries()) {
     if (!hasDependentAppUsingWebBuild(name, graph, projects)) {

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -3,7 +3,6 @@ import { filterAffected } from '../core/affected-project-graph';
 import { calculateFileChanges, readEnvironment } from '../core/file-utils';
 import {
   createProjectGraphAsync,
-  NEXT_GRAPH_VERSION,
   onlyWorkspaceProjects,
   ProjectType,
   withDeps,
@@ -38,7 +37,7 @@ export async function affected(
 
   await connectToNxCloudUsingScan(nxArgs.scan);
 
-  const projectGraph = await createProjectGraphAsync(NEXT_GRAPH_VERSION);
+  const projectGraph = await createProjectGraphAsync('4.0');
   const projects = projectsToRun(nxArgs, projectGraph);
   const projectsNotExcluded = applyExclude(projects, nxArgs);
   const env = readEnvironment(nxArgs.target, projectsNotExcluded);

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -3,6 +3,7 @@ import { filterAffected } from '../core/affected-project-graph';
 import { calculateFileChanges, readEnvironment } from '../core/file-utils';
 import {
   createProjectGraphAsync,
+  LATEST_GRAPH_VERSION,
   onlyWorkspaceProjects,
   ProjectType,
   withDeps,
@@ -37,7 +38,7 @@ export async function affected(
 
   await connectToNxCloudUsingScan(nxArgs.scan);
 
-  const projectGraph = await createProjectGraphAsync();
+  const projectGraph = await createProjectGraphAsync(LATEST_GRAPH_VERSION);
   const projects = projectsToRun(nxArgs, projectGraph);
   const projectsNotExcluded = applyExclude(projects, nxArgs);
   const env = readEnvironment(nxArgs.target, projectsNotExcluded);

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -3,7 +3,7 @@ import { filterAffected } from '../core/affected-project-graph';
 import { calculateFileChanges, readEnvironment } from '../core/file-utils';
 import {
   createProjectGraphAsync,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
   onlyWorkspaceProjects,
   ProjectType,
   withDeps,
@@ -38,7 +38,7 @@ export async function affected(
 
   await connectToNxCloudUsingScan(nxArgs.scan);
 
-  const projectGraph = await createProjectGraphAsync(LATEST_GRAPH_VERSION);
+  const projectGraph = await createProjectGraphAsync(NEXT_GRAPH_VERSION);
   const projects = projectsToRun(nxArgs, projectGraph);
   const projectsNotExcluded = applyExclude(projects, nxArgs);
   const env = readEnvironment(nxArgs.target, projectsNotExcluded);

--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -13,7 +13,7 @@ import { workspaceLayout } from '../core/file-utils';
 import { defaultFileHasher } from '../core/hasher/file-hasher';
 import {
   createProjectGraphAsync,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
   onlyWorkspaceProjects,
   ProjectGraph,
   ProjectGraphDependency,
@@ -206,7 +206,7 @@ export async function generateGraph(
   affectedProjects: string[]
 ): Promise<void> {
   let graph = onlyWorkspaceProjects(
-    await createProjectGraphAsync(LATEST_GRAPH_VERSION)
+    await createProjectGraphAsync(NEXT_GRAPH_VERSION)
   );
   const layout = workspaceLayout();
 

--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -13,7 +13,6 @@ import { workspaceLayout } from '../core/file-utils';
 import { defaultFileHasher } from '../core/hasher/file-hasher';
 import {
   createProjectGraphAsync,
-  NEXT_GRAPH_VERSION,
   onlyWorkspaceProjects,
   ProjectGraph,
   ProjectGraphDependency,
@@ -205,9 +204,7 @@ export async function generateGraph(
   },
   affectedProjects: string[]
 ): Promise<void> {
-  let graph = onlyWorkspaceProjects(
-    await createProjectGraphAsync(NEXT_GRAPH_VERSION)
-  );
+  let graph = onlyWorkspaceProjects(await createProjectGraphAsync('4.0'));
   const layout = workspaceLayout();
 
   const projects = Object.values(graph.nodes) as ProjectGraphNode[];

--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -13,6 +13,7 @@ import { workspaceLayout } from '../core/file-utils';
 import { defaultFileHasher } from '../core/hasher/file-hasher';
 import {
   createProjectGraphAsync,
+  LATEST_GRAPH_VERSION,
   onlyWorkspaceProjects,
   ProjectGraph,
   ProjectGraphDependency,
@@ -204,7 +205,9 @@ export async function generateGraph(
   },
   affectedProjects: string[]
 ): Promise<void> {
-  let graph = onlyWorkspaceProjects(await createProjectGraphAsync());
+  let graph = onlyWorkspaceProjects(
+    await createProjectGraphAsync(LATEST_GRAPH_VERSION)
+  );
   const layout = workspaceLayout();
 
   const projects = Object.values(graph.nodes) as ProjectGraphNode[];

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -4,6 +4,7 @@ import { getProjectRoots, parseFiles } from './shared';
 import { fileExists } from '../utilities/fileutils';
 import {
   createProjectGraphAsync,
+  LATEST_GRAPH_VERSION,
   onlyWorkspaceProjects,
 } from '../core/project-graph';
 import { filterAffected } from '../core/affected-project-graph';
@@ -85,7 +86,9 @@ async function getPatternsFromApps(
   affectedFiles: string[],
   matchAllPattern: string
 ): Promise<string[]> {
-  const graph = onlyWorkspaceProjects(await createProjectGraphAsync());
+  const graph = onlyWorkspaceProjects(
+    await createProjectGraphAsync(LATEST_GRAPH_VERSION)
+  );
   const affectedGraph = filterAffected(
     graph,
     calculateFileChanges(affectedFiles)

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -4,7 +4,6 @@ import { getProjectRoots, parseFiles } from './shared';
 import { fileExists } from '../utilities/fileutils';
 import {
   createProjectGraphAsync,
-  NEXT_GRAPH_VERSION,
   onlyWorkspaceProjects,
 } from '../core/project-graph';
 import { filterAffected } from '../core/affected-project-graph';
@@ -86,9 +85,7 @@ async function getPatternsFromApps(
   affectedFiles: string[],
   matchAllPattern: string
 ): Promise<string[]> {
-  const graph = onlyWorkspaceProjects(
-    await createProjectGraphAsync(NEXT_GRAPH_VERSION)
-  );
+  const graph = onlyWorkspaceProjects(await createProjectGraphAsync('4.0'));
   const affectedGraph = filterAffected(
     graph,
     calculateFileChanges(affectedFiles)

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -4,7 +4,7 @@ import { getProjectRoots, parseFiles } from './shared';
 import { fileExists } from '../utilities/fileutils';
 import {
   createProjectGraphAsync,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
   onlyWorkspaceProjects,
 } from '../core/project-graph';
 import { filterAffected } from '../core/affected-project-graph';
@@ -87,7 +87,7 @@ async function getPatternsFromApps(
   matchAllPattern: string
 ): Promise<string[]> {
   const graph = onlyWorkspaceProjects(
-    await createProjectGraphAsync(LATEST_GRAPH_VERSION)
+    await createProjectGraphAsync(NEXT_GRAPH_VERSION)
   );
   const affectedGraph = filterAffected(
     graph,

--- a/packages/workspace/src/command-line/lint.ts
+++ b/packages/workspace/src/command-line/lint.ts
@@ -1,6 +1,7 @@
 import {
   createProjectGraphAsync,
   onlyWorkspaceProjects,
+  LATEST_GRAPH_VERSION,
 } from '../core/project-graph';
 import { WorkspaceIntegrityChecks } from './workspace-integrity-checks';
 import { readWorkspaceFiles, workspaceLayout } from '../core/file-utils';
@@ -8,7 +9,9 @@ import { output } from '../utilities/output';
 import * as path from 'path';
 
 export async function workspaceLint(): Promise<void> {
-  const graph = onlyWorkspaceProjects(await createProjectGraphAsync());
+  const graph = onlyWorkspaceProjects(
+    await createProjectGraphAsync(LATEST_GRAPH_VERSION)
+  );
 
   const cliErrorOutputConfigs = new WorkspaceIntegrityChecks(
     graph,
@@ -25,7 +28,7 @@ export async function workspaceLint(): Promise<void> {
 
 function readAllFilesFromAppsAndLibs() {
   const wl = workspaceLayout();
-  return readWorkspaceFiles()
+  return readWorkspaceFiles(LATEST_GRAPH_VERSION)
     .map((f) => f.file)
     .filter(
       (f) => f.startsWith(`${wl.appsDir}/`) || f.startsWith(`${wl.libsDir}/`)

--- a/packages/workspace/src/command-line/lint.ts
+++ b/packages/workspace/src/command-line/lint.ts
@@ -1,7 +1,6 @@
 import {
   createProjectGraphAsync,
   onlyWorkspaceProjects,
-  NEXT_GRAPH_VERSION,
 } from '../core/project-graph';
 import { WorkspaceIntegrityChecks } from './workspace-integrity-checks';
 import { readWorkspaceFiles, workspaceLayout } from '../core/file-utils';
@@ -9,9 +8,7 @@ import { output } from '../utilities/output';
 import * as path from 'path';
 
 export async function workspaceLint(): Promise<void> {
-  const graph = onlyWorkspaceProjects(
-    await createProjectGraphAsync(NEXT_GRAPH_VERSION)
-  );
+  const graph = onlyWorkspaceProjects(await createProjectGraphAsync('4.0'));
 
   const cliErrorOutputConfigs = new WorkspaceIntegrityChecks(
     graph,
@@ -28,7 +25,7 @@ export async function workspaceLint(): Promise<void> {
 
 function readAllFilesFromAppsAndLibs() {
   const wl = workspaceLayout();
-  return readWorkspaceFiles(NEXT_GRAPH_VERSION)
+  return readWorkspaceFiles('4.0')
     .map((f) => f.file)
     .filter(
       (f) => f.startsWith(`${wl.appsDir}/`) || f.startsWith(`${wl.libsDir}/`)

--- a/packages/workspace/src/command-line/lint.ts
+++ b/packages/workspace/src/command-line/lint.ts
@@ -1,7 +1,7 @@
 import {
   createProjectGraphAsync,
   onlyWorkspaceProjects,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '../core/project-graph';
 import { WorkspaceIntegrityChecks } from './workspace-integrity-checks';
 import { readWorkspaceFiles, workspaceLayout } from '../core/file-utils';
@@ -10,7 +10,7 @@ import * as path from 'path';
 
 export async function workspaceLint(): Promise<void> {
   const graph = onlyWorkspaceProjects(
-    await createProjectGraphAsync(LATEST_GRAPH_VERSION)
+    await createProjectGraphAsync(NEXT_GRAPH_VERSION)
   );
 
   const cliErrorOutputConfigs = new WorkspaceIntegrityChecks(
@@ -28,7 +28,7 @@ export async function workspaceLint(): Promise<void> {
 
 function readAllFilesFromAppsAndLibs() {
   const wl = workspaceLayout();
-  return readWorkspaceFiles(LATEST_GRAPH_VERSION)
+  return readWorkspaceFiles(NEXT_GRAPH_VERSION)
     .map((f) => f.file)
     .filter(
       (f) => f.startsWith(`${wl.appsDir}/`) || f.startsWith(`${wl.libsDir}/`)

--- a/packages/workspace/src/command-line/run-many.ts
+++ b/packages/workspace/src/command-line/run-many.ts
@@ -5,7 +5,6 @@ import type { NxArgs, RawNxArgs } from './utils';
 import {
   createProjectGraphAsync,
   isWorkspaceProject,
-  NEXT_GRAPH_VERSION,
   withDeps,
 } from '../core/project-graph';
 import type { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
@@ -27,7 +26,7 @@ export async function runMany(parsedArgs: yargs.Arguments & RawNxArgs) {
 
   await connectToNxCloudUsingScan(nxArgs.scan);
 
-  const projectGraph = await createProjectGraphAsync(NEXT_GRAPH_VERSION);
+  const projectGraph = await createProjectGraphAsync('4.0');
   const projects = projectsToRun(nxArgs, projectGraph);
   const projectsNotExcluded = applyExclude(projects, nxArgs);
   const env = readEnvironment(nxArgs.target, projectsNotExcluded);

--- a/packages/workspace/src/command-line/run-many.ts
+++ b/packages/workspace/src/command-line/run-many.ts
@@ -5,6 +5,7 @@ import type { NxArgs, RawNxArgs } from './utils';
 import {
   createProjectGraphAsync,
   isWorkspaceProject,
+  LATEST_GRAPH_VERSION,
   withDeps,
 } from '../core/project-graph';
 import type { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
@@ -26,7 +27,7 @@ export async function runMany(parsedArgs: yargs.Arguments & RawNxArgs) {
 
   await connectToNxCloudUsingScan(nxArgs.scan);
 
-  const projectGraph = await createProjectGraphAsync();
+  const projectGraph = await createProjectGraphAsync(LATEST_GRAPH_VERSION);
   const projects = projectsToRun(nxArgs, projectGraph);
   const projectsNotExcluded = applyExclude(projects, nxArgs);
   const env = readEnvironment(nxArgs.target, projectsNotExcluded);

--- a/packages/workspace/src/command-line/run-many.ts
+++ b/packages/workspace/src/command-line/run-many.ts
@@ -5,7 +5,7 @@ import type { NxArgs, RawNxArgs } from './utils';
 import {
   createProjectGraphAsync,
   isWorkspaceProject,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
   withDeps,
 } from '../core/project-graph';
 import type { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
@@ -27,7 +27,7 @@ export async function runMany(parsedArgs: yargs.Arguments & RawNxArgs) {
 
   await connectToNxCloudUsingScan(nxArgs.scan);
 
-  const projectGraph = await createProjectGraphAsync(LATEST_GRAPH_VERSION);
+  const projectGraph = await createProjectGraphAsync(NEXT_GRAPH_VERSION);
   const projects = projectsToRun(nxArgs, projectGraph);
   const projectsNotExcluded = applyExclude(projects, nxArgs);
   const env = readEnvironment(nxArgs.target, projectsNotExcluded);

--- a/packages/workspace/src/command-line/run-one.ts
+++ b/packages/workspace/src/command-line/run-one.ts
@@ -1,8 +1,5 @@
 import { runCommand } from '../tasks-runner/run-command';
-import {
-  createProjectGraphAsync,
-  NEXT_GRAPH_VERSION,
-} from '../core/project-graph';
+import { createProjectGraphAsync } from '../core/project-graph';
 import type { ProjectGraph } from '@nrwl/devkit';
 import { readEnvironment } from '../core/file-utils';
 import { RunOneReporter } from '../tasks-runner/run-one-reporter';
@@ -34,7 +31,7 @@ export async function runOne(opts: {
 
   await connectToNxCloudUsingScan(nxArgs.scan);
 
-  const projectGraph = await createProjectGraphAsync(NEXT_GRAPH_VERSION);
+  const projectGraph = await createProjectGraphAsync('4.0');
   const { projects, projectsMap } = getProjects(
     projectGraph,
     nxArgs.withDeps,

--- a/packages/workspace/src/command-line/run-one.ts
+++ b/packages/workspace/src/command-line/run-one.ts
@@ -1,7 +1,7 @@
 import { runCommand } from '../tasks-runner/run-command';
 import {
   createProjectGraphAsync,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '../core/project-graph';
 import type { ProjectGraph } from '@nrwl/devkit';
 import { readEnvironment } from '../core/file-utils';
@@ -34,7 +34,7 @@ export async function runOne(opts: {
 
   await connectToNxCloudUsingScan(nxArgs.scan);
 
-  const projectGraph = await createProjectGraphAsync(LATEST_GRAPH_VERSION);
+  const projectGraph = await createProjectGraphAsync(NEXT_GRAPH_VERSION);
   const { projects, projectsMap } = getProjects(
     projectGraph,
     nxArgs.withDeps,

--- a/packages/workspace/src/command-line/run-one.ts
+++ b/packages/workspace/src/command-line/run-one.ts
@@ -1,5 +1,8 @@
 import { runCommand } from '../tasks-runner/run-command';
-import { createProjectGraphAsync } from '../core/project-graph';
+import {
+  createProjectGraphAsync,
+  LATEST_GRAPH_VERSION,
+} from '../core/project-graph';
 import type { ProjectGraph } from '@nrwl/devkit';
 import { readEnvironment } from '../core/file-utils';
 import { RunOneReporter } from '../tasks-runner/run-one-reporter';
@@ -31,7 +34,7 @@ export async function runOne(opts: {
 
   await connectToNxCloudUsingScan(nxArgs.scan);
 
-  const projectGraph = await createProjectGraphAsync();
+  const projectGraph = await createProjectGraphAsync(LATEST_GRAPH_VERSION);
   const { projects, projectsMap } = getProjects(
     projectGraph,
     nxArgs.withDeps,

--- a/packages/workspace/src/command-line/workspace-integrity-checks.spec.ts
+++ b/packages/workspace/src/command-line/workspace-integrity-checks.spec.ts
@@ -1,7 +1,6 @@
 import { WorkspaceIntegrityChecks } from './workspace-integrity-checks';
 import * as chalk from 'chalk';
 import { ProjectType } from '../core/project-graph';
-import { extname } from 'path';
 
 describe('WorkspaceIntegrityChecks', () => {
   describe('workspace.json is in sync with the filesystem', () => {
@@ -106,5 +105,5 @@ describe('WorkspaceIntegrityChecks', () => {
 });
 
 function createFile(f) {
-  return { file: f, ext: extname(f), hash: '' };
+  return { file: f, hash: '' };
 }

--- a/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/affected-project-graph.spec.ts
@@ -122,13 +122,11 @@ describe('project graph', () => {
     const affected = filterAffected(graph, [
       {
         file: 'something-for-api.txt',
-        ext: '.txt',
         hash: 'some-hash',
         getChanges: () => [new WholeFileChange()],
       },
       {
         file: 'libs/ui/src/index.ts',
-        ext: '.ts',
         hash: 'some-hash',
         getChanges: () => [new WholeFileChange()],
       },
@@ -182,7 +180,6 @@ describe('project graph', () => {
     const affected = filterAffected(graph, [
       {
         file: 'package.json',
-        ext: '.json',
         hash: 'some-hash',
         getChanges: () => jsonDiff(packageJson, updatedPackageJson),
       },
@@ -238,7 +235,6 @@ describe('project graph', () => {
     const affected = filterAffected(graph, [
       {
         file: 'package.json',
-        ext: '.json',
         hash: 'some-hash',
         getChanges: () => jsonDiff(packageJson, updatedPackageJson),
       },
@@ -259,7 +255,6 @@ describe('project graph', () => {
     const affected = filterAffected(graph, [
       {
         file: 'package.json',
-        ext: '.json',
         hash: 'some-hash',
         getChanges: () => jsonDiff(packageJson, updatedPackageJson),
       },

--- a/packages/workspace/src/core/affected-project-graph/locators/implicit-json-changes.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/implicit-json-changes.spec.ts
@@ -41,7 +41,6 @@ describe('getImplicitlyTouchedProjectsByJsonChanges', () => {
         {
           file: 'package.json',
           hash: 'some-hash',
-          ext: '.json',
           getChanges: () => [getModifiedChange(['some', 'deep-field'])],
         },
       ],
@@ -57,7 +56,6 @@ describe('getImplicitlyTouchedProjectsByJsonChanges', () => {
         {
           file: 'package.json',
           hash: 'some-hash',
-          ext: '.json',
           getChanges: () => [
             getModifiedChange(['some', 'deep-glob-anything']),
             getModifiedChange(['match-anything']),
@@ -77,7 +75,6 @@ describe('getImplicitlyTouchedProjectsByJsonChanges', () => {
         {
           file: 'package.json',
           hash: 'some-hash',
-          ext: '.json',
           getChanges: () => [new WholeFileChange()],
         },
       ],

--- a/packages/workspace/src/core/affected-project-graph/locators/npm-packages.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/npm-packages.spec.ts
@@ -67,7 +67,6 @@ describe('getTouchedNpmPackages', () => {
         {
           file: 'package.json',
           hash: 'some-hash',
-          ext: '.json',
           getChanges: () => [
             {
               type: DiffType.Modified,
@@ -98,7 +97,6 @@ describe('getTouchedNpmPackages', () => {
         {
           file: 'package.json',
           hash: 'some-hash',
-          ext: '.json',
           getChanges: () => [
             {
               type: DiffType.Deleted,
@@ -137,7 +135,6 @@ describe('getTouchedNpmPackages', () => {
         {
           file: 'package.json',
           hash: 'some-hash',
-          ext: '.json',
           getChanges: () => [
             {
               type: DiffType.Added,
@@ -177,7 +174,6 @@ describe('getTouchedNpmPackages', () => {
         {
           file: 'package.json',
           hash: 'some-hash',
-          ext: '.json',
           getChanges: () => [new WholeFileChange()],
         },
       ],

--- a/packages/workspace/src/core/affected-project-graph/locators/nx-json-changes.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/nx-json-changes.spec.ts
@@ -8,7 +8,6 @@ describe('getTouchedProjectsInNxJson', () => {
       [
         {
           file: 'source.ts',
-          ext: '.ts',
           hash: 'some-hash',
           getChanges: () => [new WholeFileChange()],
         },
@@ -31,7 +30,6 @@ describe('getTouchedProjectsInNxJson', () => {
       [
         {
           file: 'nx.json',
-          ext: '.json',
           hash: 'some-hash',
           getChanges: () => [new WholeFileChange()],
         },
@@ -57,7 +55,6 @@ describe('getTouchedProjectsInNxJson', () => {
       [
         {
           file: 'nx.json',
-          ext: '.json',
           hash: 'some-hash',
           getChanges: () => [
             {
@@ -92,7 +89,6 @@ describe('getTouchedProjectsInNxJson', () => {
       [
         {
           file: 'nx.json',
-          ext: '.json',
           hash: 'some-hash',
           getChanges: () => [
             {
@@ -137,7 +133,6 @@ describe('getTouchedProjectsInNxJson', () => {
       [
         {
           file: 'nx.json',
-          ext: '.json',
           hash: 'some-hash',
           getChanges: () => [
             {
@@ -174,7 +169,6 @@ describe('getTouchedProjectsInNxJson', () => {
       [
         {
           file: 'nx.json',
-          ext: '.json',
           hash: 'some-hash',
           getChanges: () => [
             {

--- a/packages/workspace/src/core/affected-project-graph/locators/tsconfig-json-changes.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/tsconfig-json-changes.spec.ts
@@ -45,7 +45,6 @@ describe('getTouchedProjectsFromTsConfig', () => {
           [
             {
               file: 'source.ts',
-              ext: '.ts',
               hash: 'some-hash',
               getChanges: () => [new WholeFileChange()],
             },
@@ -69,7 +68,6 @@ describe('getTouchedProjectsFromTsConfig', () => {
             [
               {
                 file: tsConfig,
-                ext: '.json',
                 hash: 'some-hash',
                 getChanges: () => [new WholeFileChange()],
               },
@@ -89,7 +87,6 @@ describe('getTouchedProjectsFromTsConfig', () => {
             [
               {
                 file: tsConfig,
-                ext: '.json',
                 hash: 'some-hash',
                 getChanges: () =>
                   jsonDiff(
@@ -121,7 +118,6 @@ describe('getTouchedProjectsFromTsConfig', () => {
             [
               {
                 file: tsConfig,
-                ext: '.json',
                 hash: 'some-hash',
                 getChanges: () =>
                   jsonDiff(
@@ -153,7 +149,6 @@ describe('getTouchedProjectsFromTsConfig', () => {
             [
               {
                 file: tsConfig,
-                ext: '.json',
                 hash: 'some-hash',
                 getChanges: () =>
                   jsonDiff(
@@ -187,7 +182,6 @@ describe('getTouchedProjectsFromTsConfig', () => {
             [
               {
                 file: tsConfig,
-                ext: '.json',
                 hash: 'some-hash',
                 getChanges: () =>
                   jsonDiff(
@@ -219,7 +213,6 @@ describe('getTouchedProjectsFromTsConfig', () => {
             [
               {
                 file: tsConfig,
-                ext: '.json',
                 hash: 'some-hash',
                 getChanges: () =>
                   jsonDiff(
@@ -256,7 +249,6 @@ describe('getTouchedProjectsFromTsConfig', () => {
             [
               {
                 file: tsConfig,
-                ext: '.json',
                 hash: 'some-hash',
                 getChanges: () =>
                   jsonDiff(
@@ -291,7 +283,6 @@ describe('getTouchedProjectsFromTsConfig', () => {
             [
               {
                 file: tsConfig,
-                ext: '.json',
                 hash: 'some-hash',
                 getChanges: () =>
                   jsonDiff(

--- a/packages/workspace/src/core/affected-project-graph/locators/workspace-json-changes.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/workspace-json-changes.spec.ts
@@ -8,7 +8,6 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
       [
         {
           file: 'source.ts',
-          ext: '.ts',
           hash: 'some-hash',
           getChanges: () => [new WholeFileChange()],
         },
@@ -31,7 +30,6 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
       [
         {
           file: 'workspace.json',
-          ext: '.json',
           hash: 'some-hash',
           getChanges: () => [new WholeFileChange()],
         },
@@ -56,7 +54,6 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
       [
         {
           file: 'workspace.json',
-          ext: '.json',
           hash: 'some-hash',
           getChanges: () => [
             {
@@ -90,7 +87,6 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
       [
         {
           file: 'workspace.json',
-          ext: '.json',
           hash: 'some-hash',
           getChanges: () => [
             {
@@ -131,7 +127,6 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
       [
         {
           file: 'workspace.json',
-          ext: '.json',
           hash: 'some-hash',
           getChanges: () => [
             {
@@ -166,7 +161,6 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
       [
         {
           file: 'workspace.json',
-          ext: '.json',
           hash: 'some-hash',
           getChanges: () => [
             {

--- a/packages/workspace/src/core/affected-project-graph/locators/workspace-projects.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/workspace-projects.spec.ts
@@ -7,7 +7,6 @@ import {
 function getFileChanges(files: string[]) {
   return files.map((f) => ({
     file: f,
-    ext: `.${f.split('.').pop()}`,
     hash: 'some-hash',
     getChanges: () => [new WholeFileChange()],
   }));

--- a/packages/workspace/src/core/file-graph/file-map.spec.ts
+++ b/packages/workspace/src/core/file-graph/file-map.spec.ts
@@ -22,19 +22,17 @@ describe('createFileMap', () => {
       },
     };
     const files = [
-      { file: 'apps/demo/src/main.ts', hash: 'some-hash', ext: '.ts' },
-      { file: 'apps/demo-e2e/src/main.ts', hash: 'some-hash', ext: '.ts' },
-      { file: 'libs/ui/src/index.ts', hash: 'some-hash', ext: '.ts' },
+      { file: 'apps/demo/src/main.ts', hash: 'some-hash' },
+      { file: 'apps/demo-e2e/src/main.ts', hash: 'some-hash' },
+      { file: 'libs/ui/src/index.ts', hash: 'some-hash' },
     ];
 
     const result = createProjectFileMap(workspaceJson, files);
 
     expect(result).toEqual({
-      demo: [{ file: 'apps/demo/src/main.ts', hash: 'some-hash', ext: '.ts' }],
-      'demo-e2e': [
-        { file: 'apps/demo-e2e/src/main.ts', hash: 'some-hash', ext: '.ts' },
-      ],
-      ui: [{ file: 'libs/ui/src/index.ts', hash: 'some-hash', ext: '.ts' }],
+      demo: [{ file: 'apps/demo/src/main.ts', hash: 'some-hash' }],
+      'demo-e2e': [{ file: 'apps/demo-e2e/src/main.ts', hash: 'some-hash' }],
+      ui: [{ file: 'libs/ui/src/index.ts', hash: 'some-hash' }],
     });
   });
 });

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -125,7 +125,7 @@ function getFileData(filePath: string): FileData {
 export function allFilesInDir(
   dirName: string,
   recurse: boolean = true,
-  projectGraphVersion?: string
+  projectGraphVersion = '3.0'
 ): FileData[] {
   const ignoredGlobs = getIgnoredGlobs();
   const relDirName = relative(appRootPath, dirName);
@@ -244,9 +244,7 @@ export function rootWorkspaceFileNames(): string[] {
   return [`package.json`, workspaceFileName(), `nx.json`, `tsconfig.base.json`];
 }
 
-export function rootWorkspaceFileData(
-  projectGraphVersion?: string
-): FileData[] {
+export function rootWorkspaceFileData(projectGraphVersion = '3.0'): FileData[] {
   return rootWorkspaceFileNames().map((f) =>
     projectFileDataCompatAdapter(
       getFileData(`${appRootPath}/${f}`),
@@ -255,7 +253,7 @@ export function rootWorkspaceFileData(
   );
 }
 
-export function readWorkspaceFiles(projectGraphVersion?: string): FileData[] {
+export function readWorkspaceFiles(projectGraphVersion = '3.0'): FileData[] {
   performance.mark('read workspace files:start');
 
   if (defaultFileHasher.usesGitForHashing) {

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -114,7 +114,6 @@ function getFileData(filePath: string): FileData {
   return {
     file,
     hash: defaultFileHasher.hashFile(filePath),
-    ext: extname(filePath),
   };
 }
 

--- a/packages/workspace/src/core/hasher/hasher.spec.ts
+++ b/packages/workspace/src/core/hasher/hasher.spec.ts
@@ -44,7 +44,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: '',
-              files: [{ file: '/file', ext: '.ts', hash: 'file.hash' }],
+              files: [{ file: '/file.ts', hash: 'file.hash' }],
             },
           },
         },
@@ -75,7 +75,7 @@ describe('Hasher', () => {
 
     expect(hash.details.command).toEqual('proj|build||{"prop":"prop-value"}');
     expect(hash.details.nodes).toEqual({
-      proj: '/file|file.hash|{"root":"proj-from-workspace.json"}|"proj-from-nx.json"',
+      proj: '/file.ts|file.hash|{"root":"proj-from-workspace.json"}|"proj-from-nx.json"',
     });
     expect(hash.details.implicitDeps).toEqual({
       'yarn.lock': 'yarn.lock.hash',
@@ -99,7 +99,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: '',
-              files: [{ file: '/file', ext: '.ts', hash: 'some-hash' }],
+              files: [{ file: '/file.ts', hash: 'some-hash' }],
             },
           },
         },
@@ -143,7 +143,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: '',
-              files: [{ file: '/filea', ext: '.ts', hash: 'a.hash' }],
+              files: [{ file: '/filea.ts', hash: 'a.hash' }],
             },
           },
           child: {
@@ -151,7 +151,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: '',
-              files: [{ file: '/fileb', ext: '.ts', hash: 'b.hash' }],
+              files: [{ file: '/fileb.ts', hash: 'b.hash' }],
             },
           },
         },
@@ -172,8 +172,8 @@ describe('Hasher', () => {
 
     // note that the parent hash is based on parent source files only!
     expect(hash.details.nodes).toEqual({
-      parent: '/filea|a.hash|""|""',
-      child: '/fileb|b.hash|""|""',
+      parent: '/filea.ts|a.hash|""|""',
+      child: '/fileb.ts|b.hash|""|""',
     });
   });
 
@@ -188,7 +188,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: '',
-              files: [{ file: '/filea', ext: '.ts', hash: 'a.hash' }],
+              files: [{ file: '/filea.ts', hash: 'a.hash' }],
             },
           },
           projb: {
@@ -196,7 +196,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: '',
-              files: [{ file: '/fileb', ext: '.ts', hash: 'b.hash' }],
+              files: [{ file: '/fileb.ts', hash: 'b.hash' }],
             },
           },
         },
@@ -223,8 +223,8 @@ describe('Hasher', () => {
     expect(tasksHash.value).toContain('proj'); //project
     expect(tasksHash.value).toContain('build'); //target
     expect(tasksHash.details.nodes).toEqual({
-      proja: '/filea|a.hash|""|""',
-      projb: '/fileb|b.hash|""|""',
+      proja: '/filea.ts|a.hash|""|""',
+      projb: '/fileb.ts|b.hash|""|""',
     });
 
     const hashb = await hasher.hashTaskWithDepsAndContext({
@@ -240,8 +240,8 @@ describe('Hasher', () => {
     expect(hashb.value).toContain('proj'); //project
     expect(hashb.value).toContain('build'); //target
     expect(hashb.details.nodes).toEqual({
-      proja: '/filea|a.hash|""|""',
-      projb: '/fileb|b.hash|""|""',
+      proja: '/filea.ts|a.hash|""|""',
+      projb: '/fileb.ts|b.hash|""|""',
     });
   });
 
@@ -265,12 +265,10 @@ describe('Hasher', () => {
           {
             file: 'global1',
             hash: 'hash1',
-            ext: '',
           },
           {
             file: 'global2',
             hash: 'hash2',
-            ext: '',
           },
         ],
       },

--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.spec.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.spec.ts
@@ -102,7 +102,6 @@ describe('nx deps utils', () => {
               files: [
                 {
                   file: 'index.ts',
-                  ext: 'ts',
                   hash: 'hash1',
                 },
               ],
@@ -116,7 +115,6 @@ describe('nx deps utils', () => {
           mylib: [
             {
               file: 'index.ts',
-              ext: 'ts',
               hash: 'hash1',
             },
           ],
@@ -131,7 +129,6 @@ describe('nx deps utils', () => {
         mylib: {
           'index.ts': {
             file: 'index.ts',
-            ext: 'ts',
             hash: 'hash1',
           },
         },
@@ -148,7 +145,6 @@ describe('nx deps utils', () => {
               files: [
                 {
                   file: 'index.ts',
-                  ext: 'ts',
                   hash: 'hash1',
                 },
               ],
@@ -162,14 +158,12 @@ describe('nx deps utils', () => {
           mylib: [
             {
               file: 'index.ts',
-              ext: 'ts',
               hash: 'hash1',
             },
           ],
           secondlib: [
             {
               file: 'index.ts',
-              ext: 'ts',
               hash: 'hash2',
             },
           ],
@@ -183,7 +177,6 @@ describe('nx deps utils', () => {
         secondlib: [
           {
             file: 'index.ts',
-            ext: 'ts',
             hash: 'hash2',
           },
         ],
@@ -192,13 +185,12 @@ describe('nx deps utils', () => {
         mylib: {
           'index.ts': {
             file: 'index.ts',
-            ext: 'ts',
             hash: 'hash1',
           },
         },
       });
       expect(r.filesToProcess).toEqual({
-        secondlib: [{ ext: 'ts', file: 'index.ts', hash: 'hash2' }],
+        secondlib: [{ file: 'index.ts', hash: 'hash2' }],
       });
     });
 
@@ -212,17 +204,14 @@ describe('nx deps utils', () => {
               files: [
                 {
                   file: 'index1.ts',
-                  ext: 'ts',
                   hash: 'hash1',
                 },
                 {
                   file: 'index2.ts',
-                  ext: 'ts',
                   hash: 'hash2',
                 },
                 {
                   file: 'index3.ts',
-                  ext: 'ts',
                   hash: 'hash3',
                 },
               ],
@@ -236,17 +225,14 @@ describe('nx deps utils', () => {
           mylib: [
             {
               file: 'index1.ts',
-              ext: 'ts',
               hash: 'hash1',
             },
             {
               file: 'index2.ts',
-              ext: 'ts',
               hash: 'hash2b',
             },
             {
               file: 'index4.ts',
-              ext: 'ts',
               hash: 'hash4',
             },
           ],
@@ -260,12 +246,10 @@ describe('nx deps utils', () => {
         mylib: [
           {
             file: 'index2.ts',
-            ext: 'ts',
             hash: 'hash2b',
           },
           {
             file: 'index4.ts',
-            ext: 'ts',
             hash: 'hash4',
           },
         ],
@@ -274,7 +258,6 @@ describe('nx deps utils', () => {
         mylib: {
           'index1.ts': {
             file: 'index1.ts',
-            ext: 'ts',
             hash: 'hash1',
           },
         },

--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
@@ -22,7 +22,6 @@ import {
   cacheDirectory,
   readCacheDirectoryProperty,
 } from '../../utilities/cache-directory';
-import { NEXT_GRAPH_VERSION } from '../project-graph/project-graph';
 
 export interface ProjectGraphCache {
   version: string;
@@ -93,7 +92,7 @@ export function writeCache(
     version: packageJsonDeps[p],
   }));
   const newValue: ProjectGraphCache = {
-    version: projectGraph.version || NEXT_GRAPH_VERSION,
+    version: projectGraph.version || '4.0',
     deps: packageJsonDeps,
     pathMappings: tsConfig.compilerOptions.paths || {},
     nxJsonPlugins,

--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
@@ -119,7 +119,9 @@ export function shouldRecomputeWholeGraph(
   if (
     Object.keys(cache.nodes).some(
       (p) =>
-        (cache.nodes[p].type === 'app' || cache.nodes[p].type === 'lib') &&
+        (cache.nodes[p].type === 'app' ||
+          cache.nodes[p].type === 'lib' ||
+          cache.nodes[p].type === 'e2e') &&
         !workspaceJson.projects[p]
     )
   ) {

--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
@@ -22,6 +22,7 @@ import {
   cacheDirectory,
   readCacheDirectoryProperty,
 } from '../../utilities/cache-directory';
+import { NEXT_GRAPH_VERSION } from '../project-graph/project-graph';
 
 export interface ProjectGraphCache {
   version: string;
@@ -92,7 +93,7 @@ export function writeCache(
     version: packageJsonDeps[p],
   }));
   const newValue: ProjectGraphCache = {
-    version: '3.0',
+    version: projectGraph.version || NEXT_GRAPH_VERSION,
     deps: packageJsonDeps,
     pathMappings: tsConfig.compilerOptions.paths || {},
     nxJsonPlugins,

--- a/packages/workspace/src/core/project-graph/index.ts
+++ b/packages/workspace/src/core/project-graph/index.ts
@@ -3,6 +3,7 @@ export {
   createProjectGraphAsync,
   readCurrentProjectGraph,
   readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
 } from './project-graph';
 export * from './project-graph-models';
 export * from './operators';

--- a/packages/workspace/src/core/project-graph/index.ts
+++ b/packages/workspace/src/core/project-graph/index.ts
@@ -3,8 +3,6 @@ export {
   createProjectGraphAsync,
   readCurrentProjectGraph,
   readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
-  CURRENT_GRAPH_VERSION,
 } from './project-graph';
 export * from './project-graph-models';
 export * from './operators';

--- a/packages/workspace/src/core/project-graph/index.ts
+++ b/packages/workspace/src/core/project-graph/index.ts
@@ -3,7 +3,8 @@ export {
   createProjectGraphAsync,
   readCurrentProjectGraph,
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
+  CURRENT_GRAPH_VERSION,
 } from './project-graph';
 export * from './project-graph-models';
 export * from './operators';

--- a/packages/workspace/src/core/project-graph/project-graph.spec.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.spec.ts
@@ -251,18 +251,24 @@ describe('project graph', () => {
         projectFileDataCompatAdapter({ file: 'a.ts', hash: 'some hash' }, '3.0')
       ).toEqual({ file: 'a.ts', hash: 'some hash', ext: '.ts' });
       expect(
-        projectFileDataCompatAdapter({
-          file: 'a.ts',
-          hash: 'some hash',
-          deps: [],
-        })
+        projectFileDataCompatAdapter(
+          {
+            file: 'a.ts',
+            hash: 'some hash',
+            deps: [],
+          },
+          '3.0'
+        )
       ).toEqual({ file: 'a.ts', hash: 'some hash', ext: '.ts', deps: [] });
       expect(
-        projectFileDataCompatAdapter({
-          file: 'a.ts',
-          hash: 'some hash',
-          ext: '.keepthis',
-        })
+        projectFileDataCompatAdapter(
+          {
+            file: 'a.ts',
+            hash: 'some hash',
+            ext: '.keepthis',
+          },
+          '3.0'
+        )
       ).toEqual({ file: 'a.ts', hash: 'some hash', ext: '.keepthis' });
     });
     it('should map FileData to latest graph version', () => {

--- a/packages/workspace/src/core/project-graph/project-graph.spec.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.spec.ts
@@ -6,7 +6,8 @@ jest.mock('@nrwl/tao/src/utils/app-root', () => ({
 }));
 import {
   createProjectGraphAsync,
-  DEPRECATED_GRAPH_VERSION,
+  CURRENT_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
   projectFileDataCompatAdapter,
   projectNodesCompatAdapter,
 } from './project-graph';
@@ -16,7 +17,6 @@ import {
   DependencyType,
 } from '@nrwl/devkit';
 import { defaultFileHasher } from '../hasher/file-hasher';
-import { LATEST_GRAPH_VERSION } from '.';
 
 describe('project graph', () => {
   let packageJson: any;
@@ -251,7 +251,7 @@ describe('project graph', () => {
       expect(
         projectFileDataCompatAdapter(
           { file: 'a.ts', hash: 'some hash' },
-          DEPRECATED_GRAPH_VERSION
+          CURRENT_GRAPH_VERSION
         )
       ).toEqual({ file: 'a.ts', hash: 'some hash', ext: '.ts' });
       expect(
@@ -273,13 +273,13 @@ describe('project graph', () => {
       expect(
         projectFileDataCompatAdapter(
           { file: 'a.ts', hash: 'some hash', ext: '.ts' },
-          LATEST_GRAPH_VERSION
+          NEXT_GRAPH_VERSION
         )
       ).toEqual({ file: 'a.ts', hash: 'some hash' });
       expect(
         projectFileDataCompatAdapter(
           { file: 'a.ts', hash: 'some hash', ext: '.ts', deps: [] },
-          LATEST_GRAPH_VERSION
+          NEXT_GRAPH_VERSION
         )
       ).toEqual({ file: 'a.ts', hash: 'some hash', deps: [] });
     });
@@ -325,12 +325,12 @@ describe('project graph', () => {
         },
       };
       expect(projectNodesCompatAdapter(nodes)).toEqual(result);
-      expect(
-        projectNodesCompatAdapter(nodes, DEPRECATED_GRAPH_VERSION)
-      ).toEqual(result);
-      expect(
-        projectNodesCompatAdapter(nodes, LATEST_GRAPH_VERSION)
-      ).not.toEqual(result);
+      expect(projectNodesCompatAdapter(nodes, CURRENT_GRAPH_VERSION)).toEqual(
+        result
+      );
+      expect(projectNodesCompatAdapter(nodes, NEXT_GRAPH_VERSION)).not.toEqual(
+        result
+      );
     });
     it('should map nodes to latest graph version', () => {
       const nodes = {
@@ -373,11 +373,11 @@ describe('project graph', () => {
           },
         },
       };
-      expect(projectNodesCompatAdapter(nodes, LATEST_GRAPH_VERSION)).toEqual(
+      expect(projectNodesCompatAdapter(nodes, NEXT_GRAPH_VERSION)).toEqual(
         result
       );
       expect(
-        projectNodesCompatAdapter(nodes, DEPRECATED_GRAPH_VERSION)
+        projectNodesCompatAdapter(nodes, CURRENT_GRAPH_VERSION)
       ).not.toEqual(result);
       expect(projectNodesCompatAdapter(nodes)).not.toEqual(result);
     });

--- a/packages/workspace/src/core/project-graph/project-graph.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.ts
@@ -39,8 +39,8 @@ import {
   buildWorkspaceProjectNodes,
 } from './build-nodes';
 
-export const LATEST_GRAPH_VERSION = '4.0';
-export const DEPRECATED_GRAPH_VERSION = '3.0';
+export const NEXT_GRAPH_VERSION = '4.0';
+export const CURRENT_GRAPH_VERSION = '3.0';
 
 /**
  * Synchronously reads the latest cached copy of the workspace's ProjectGraph.
@@ -102,7 +102,7 @@ export function projectFileDataCompatAdapter(
   version?: string
 ): FileData {
   const { file, hash, ext, deps } = fileData;
-  if (version && version !== DEPRECATED_GRAPH_VERSION) {
+  if (version && version !== CURRENT_GRAPH_VERSION) {
     return { file, hash, ...{ deps } };
   } else {
     return { file, hash, ext: ext || extname(file), ...{ deps } };
@@ -151,7 +151,7 @@ export function createProjectGraph(
   let cachedFileData = {};
   if (
     cache &&
-    cache.version === '3.0' &&
+    cache.version === CURRENT_GRAPH_VERSION &&
     !shouldRecomputeWholeGraph(
       cache,
       packageJsonDeps,
@@ -174,6 +174,9 @@ export function createProjectGraph(
   const projectGraph = buildProjectGraph(context, cachedFileData);
   if (cacheEnabled) {
     writeCache(packageJsonDeps, nxJson, rootTsConfig, projectGraph);
+  }
+  if (projectGraphVersion) {
+    projectGraph.version = projectGraphVersion;
   }
   return addWorkspaceFiles(projectGraph, workspaceFiles);
 }

--- a/packages/workspace/src/core/project-graph/project-graph.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.ts
@@ -47,7 +47,7 @@ export function readCachedProjectGraph(): ProjectGraph {
   if (!projectGraphCache) {
     throw new Error(`
       [readCachedProjectGraph] ERROR: No cached ProjectGraph is available.
-      
+
       If you are leveraging \`readCachedProjectGraph()\` directly then you will need to refactor your usage to first ensure that
       the ProjectGraph is created by calling \`await createProjectGraphAsync()\` somewhere before attempting to read the data.
 

--- a/packages/workspace/src/core/target-project-locator.spec.ts
+++ b/packages/workspace/src/core/target-project-locator.spec.ts
@@ -77,14 +77,12 @@ describe('findTargetProjectWithImport', () => {
           {
             file: 'libs/proj/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         proj2: [
           {
             file: 'libs/proj2/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
           {
             file: 'libs/proj2/deep/index.ts',
@@ -96,14 +94,12 @@ describe('findTargetProjectWithImport', () => {
           {
             file: 'libs/proj3a/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         proj4ab: [
           {
             file: 'libs/proj4ab/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         proj5: [
@@ -131,21 +127,18 @@ describe('findTargetProjectWithImport', () => {
           {
             file: 'libs/proj123/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         proj1234: [
           {
             file: 'libs/proj1234/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         'proj1234-child': [
           {
             file: 'libs/proj1234-child/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
       },

--- a/packages/workspace/src/executors/tsc/tsc.impl.ts
+++ b/packages/workspace/src/executors/tsc/tsc.impl.ts
@@ -1,9 +1,6 @@
 import { ExecutorContext, normalizePath } from '@nrwl/devkit';
 import { basename, dirname, join, relative } from 'path';
-import {
-  readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
-} from '../../core/project-graph';
+import { readCachedProjectGraph } from '../../core/project-graph';
 import { copyAssets } from '../../utilities/assets';
 import {
   calculateProjectDependencies,
@@ -21,7 +18,7 @@ export async function tscExecutor(
   const normalizedOptions = normalizeOptions(options, context);
   // const projectRoot = context.workspace.projects[context.projectName].root;
 
-  const projectGraph = readCachedProjectGraph(NEXT_GRAPH_VERSION);
+  const projectGraph = readCachedProjectGraph('4.0');
   const { target, dependencies } = calculateProjectDependencies(
     projectGraph,
     context.root,

--- a/packages/workspace/src/executors/tsc/tsc.impl.ts
+++ b/packages/workspace/src/executors/tsc/tsc.impl.ts
@@ -2,7 +2,7 @@ import { ExecutorContext, normalizePath } from '@nrwl/devkit';
 import { basename, dirname, join, relative } from 'path';
 import {
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '../../core/project-graph';
 import { copyAssets } from '../../utilities/assets';
 import {
@@ -21,7 +21,7 @@ export async function tscExecutor(
   const normalizedOptions = normalizeOptions(options, context);
   // const projectRoot = context.workspace.projects[context.projectName].root;
 
-  const projectGraph = readCachedProjectGraph(LATEST_GRAPH_VERSION);
+  const projectGraph = readCachedProjectGraph(NEXT_GRAPH_VERSION);
   const { target, dependencies } = calculateProjectDependencies(
     projectGraph,
     context.root,

--- a/packages/workspace/src/executors/tsc/tsc.impl.ts
+++ b/packages/workspace/src/executors/tsc/tsc.impl.ts
@@ -1,6 +1,9 @@
 import { ExecutorContext, normalizePath } from '@nrwl/devkit';
 import { basename, dirname, join, relative } from 'path';
-import { readCachedProjectGraph } from '../../core/project-graph';
+import {
+  readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
+} from '../../core/project-graph';
 import { copyAssets } from '../../utilities/assets';
 import {
   calculateProjectDependencies,
@@ -18,7 +21,7 @@ export async function tscExecutor(
   const normalizedOptions = normalizeOptions(options, context);
   // const projectRoot = context.workspace.projects[context.projectName].root;
 
-  const projectGraph = readCachedProjectGraph();
+  const projectGraph = readCachedProjectGraph(LATEST_GRAPH_VERSION);
   const { target, dependencies } = calculateProjectDependencies(
     projectGraph,
     context.root,

--- a/packages/workspace/src/generators/remove/lib/check-dependencies.ts
+++ b/packages/workspace/src/generators/remove/lib/check-dependencies.ts
@@ -1,6 +1,5 @@
 import {
   createProjectGraphAsync,
-  NEXT_GRAPH_VERSION,
   onlyWorkspaceProjects,
   reverse,
 } from '../../../core/project-graph';
@@ -17,7 +16,7 @@ export async function checkDependencies(_, schema: Schema): Promise<void> {
     return;
   }
 
-  const graph: ProjectGraph = await createProjectGraphAsync(NEXT_GRAPH_VERSION);
+  const graph: ProjectGraph = await createProjectGraphAsync('4.0');
 
   const reverseGraph = onlyWorkspaceProjects(reverse(graph));
 

--- a/packages/workspace/src/generators/remove/lib/check-dependencies.ts
+++ b/packages/workspace/src/generators/remove/lib/check-dependencies.ts
@@ -1,6 +1,6 @@
 import {
   createProjectGraphAsync,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
   onlyWorkspaceProjects,
   reverse,
 } from '../../../core/project-graph';
@@ -17,9 +17,7 @@ export async function checkDependencies(_, schema: Schema): Promise<void> {
     return;
   }
 
-  const graph: ProjectGraph = await createProjectGraphAsync(
-    LATEST_GRAPH_VERSION
-  );
+  const graph: ProjectGraph = await createProjectGraphAsync(NEXT_GRAPH_VERSION);
 
   const reverseGraph = onlyWorkspaceProjects(reverse(graph));
 

--- a/packages/workspace/src/generators/remove/lib/check-dependencies.ts
+++ b/packages/workspace/src/generators/remove/lib/check-dependencies.ts
@@ -1,5 +1,6 @@
 import {
   createProjectGraphAsync,
+  LATEST_GRAPH_VERSION,
   onlyWorkspaceProjects,
   reverse,
 } from '../../../core/project-graph';
@@ -16,7 +17,9 @@ export async function checkDependencies(_, schema: Schema): Promise<void> {
     return;
   }
 
-  const graph: ProjectGraph = await createProjectGraphAsync();
+  const graph: ProjectGraph = await createProjectGraphAsync(
+    LATEST_GRAPH_VERSION
+  );
 
   const reverseGraph = onlyWorkspaceProjects(reverse(graph));
 

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -10,6 +10,7 @@ import {
 import { Rule } from './nxEnforceModuleBoundariesRule';
 import { TargetProjectLocator } from '../core/target-project-locator';
 import { mapProjectGraphFiles } from '../utils/runtime-lint-utils';
+import { FileData } from 'packages/devkit/src/project-graph/interfaces';
 
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('@nrwl/tao/src/utils/app-root', () => ({ appRootPath: '/root' }));
@@ -1155,8 +1156,8 @@ describe('Enforce Module Boundaries (tslint)', () => {
   });
 });
 
-function createFile(f) {
-  return { file: f, ext: extname(f), hash: '' };
+function createFile(f): FileData {
+  return { file: f, hash: '' };
 }
 
 function runRule(

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -6,7 +6,6 @@ import {
   isNpmProject,
   ProjectType,
   readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
 } from '../core/project-graph';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import {
@@ -52,7 +51,7 @@ export class Rule extends Lint.Rules.AbstractRule {
          */
         try {
           (global as any).projectGraph = mapProjectGraphFiles(
-            readCachedProjectGraph(NEXT_GRAPH_VERSION)
+            readCachedProjectGraph('4.0')
           );
         } catch {}
       }

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -6,7 +6,7 @@ import {
   isNpmProject,
   ProjectType,
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '../core/project-graph';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import {
@@ -52,7 +52,7 @@ export class Rule extends Lint.Rules.AbstractRule {
          */
         try {
           (global as any).projectGraph = mapProjectGraphFiles(
-            readCachedProjectGraph(LATEST_GRAPH_VERSION)
+            readCachedProjectGraph(NEXT_GRAPH_VERSION)
           );
         } catch {}
       }

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.ts
@@ -6,6 +6,7 @@ import {
   isNpmProject,
   ProjectType,
   readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
 } from '../core/project-graph';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import {
@@ -51,7 +52,7 @@ export class Rule extends Lint.Rules.AbstractRule {
          */
         try {
           (global as any).projectGraph = mapProjectGraphFiles(
-            readCachedProjectGraph()
+            readCachedProjectGraph(LATEST_GRAPH_VERSION)
           );
         } catch {}
       }

--- a/packages/workspace/src/utilities/create-project-graph-from-tree.ts
+++ b/packages/workspace/src/utilities/create-project-graph-from-tree.ts
@@ -1,10 +1,18 @@
 import { Tree } from '@nrwl/devkit';
-import { createProjectGraph } from '../core/project-graph/project-graph';
+import {
+  createProjectGraph,
+  DEPRECATED_GRAPH_VERSION,
+} from '../core/project-graph/project-graph';
 
 // TODO(v13): remove this deprecated method
 /**
  * @deprecated This method is deprecated and `await {@link createProjectGraphAsync}()` should be used instead
  */
 export function createProjectGraphFromTree(tree: Tree) {
-  return createProjectGraph(undefined, undefined, undefined);
+  return createProjectGraph(
+    undefined,
+    undefined,
+    undefined,
+    DEPRECATED_GRAPH_VERSION
+  );
 }

--- a/packages/workspace/src/utilities/create-project-graph-from-tree.ts
+++ b/packages/workspace/src/utilities/create-project-graph-from-tree.ts
@@ -1,7 +1,7 @@
 import { Tree } from '@nrwl/devkit';
 import {
   createProjectGraph,
-  DEPRECATED_GRAPH_VERSION,
+  CURRENT_GRAPH_VERSION,
 } from '../core/project-graph/project-graph';
 
 // TODO(v13): remove this deprecated method
@@ -13,6 +13,6 @@ export function createProjectGraphFromTree(tree: Tree) {
     undefined,
     undefined,
     undefined,
-    DEPRECATED_GRAPH_VERSION
+    CURRENT_GRAPH_VERSION
   );
 }

--- a/packages/workspace/src/utilities/create-project-graph-from-tree.ts
+++ b/packages/workspace/src/utilities/create-project-graph-from-tree.ts
@@ -1,18 +1,10 @@
 import { Tree } from '@nrwl/devkit';
-import {
-  createProjectGraph,
-  CURRENT_GRAPH_VERSION,
-} from '../core/project-graph/project-graph';
+import { createProjectGraph } from '../core/project-graph/project-graph';
 
 // TODO(v13): remove this deprecated method
 /**
  * @deprecated This method is deprecated and `await {@link createProjectGraphAsync}()` should be used instead
  */
 export function createProjectGraphFromTree(tree: Tree) {
-  return createProjectGraph(
-    undefined,
-    undefined,
-    undefined,
-    CURRENT_GRAPH_VERSION
-  );
+  return createProjectGraph(undefined, undefined, undefined, '3.0');
 }

--- a/packages/workspace/src/utilities/generate-globs.ts
+++ b/packages/workspace/src/utilities/generate-globs.ts
@@ -1,7 +1,10 @@
 import { joinPathFragments } from '@nrwl/devkit';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import { relative, resolve } from 'path';
-import { readCachedProjectGraph } from '../core/project-graph';
+import {
+  readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
+} from '../core/project-graph';
 import {
   getProjectNameFromDirPath,
   getSourceDirOfDependentProjects,
@@ -17,7 +20,7 @@ export function createGlobPatternsForDependencies(
   fileGlobPattern: string
 ): string[] {
   const filenameRelativeToWorkspaceRoot = relative(appRootPath, dirPath);
-  const projectGraph = readCachedProjectGraph();
+  const projectGraph = readCachedProjectGraph(LATEST_GRAPH_VERSION);
 
   // find the project
   let projectName;

--- a/packages/workspace/src/utilities/generate-globs.ts
+++ b/packages/workspace/src/utilities/generate-globs.ts
@@ -3,7 +3,7 @@ import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import { relative, resolve } from 'path';
 import {
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '../core/project-graph';
 import {
   getProjectNameFromDirPath,
@@ -20,7 +20,7 @@ export function createGlobPatternsForDependencies(
   fileGlobPattern: string
 ): string[] {
   const filenameRelativeToWorkspaceRoot = relative(appRootPath, dirPath);
-  const projectGraph = readCachedProjectGraph(LATEST_GRAPH_VERSION);
+  const projectGraph = readCachedProjectGraph(NEXT_GRAPH_VERSION);
 
   // find the project
   let projectName;

--- a/packages/workspace/src/utilities/generate-globs.ts
+++ b/packages/workspace/src/utilities/generate-globs.ts
@@ -1,10 +1,7 @@
 import { joinPathFragments } from '@nrwl/devkit';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import { relative, resolve } from 'path';
-import {
-  readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
-} from '../core/project-graph';
+import { readCachedProjectGraph } from '../core/project-graph';
 import {
   getProjectNameFromDirPath,
   getSourceDirOfDependentProjects,
@@ -20,7 +17,7 @@ export function createGlobPatternsForDependencies(
   fileGlobPattern: string
 ): string[] {
   const filenameRelativeToWorkspaceRoot = relative(appRootPath, dirPath);
-  const projectGraph = readCachedProjectGraph(NEXT_GRAPH_VERSION);
+  const projectGraph = readCachedProjectGraph('4.0');
 
   // find the project
   let projectName;

--- a/packages/workspace/src/utilities/project-graph-utils.ts
+++ b/packages/workspace/src/utilities/project-graph-utils.ts
@@ -1,9 +1,6 @@
 import { normalizePath, ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
 import { relative } from 'path';
-import {
-  readCachedProjectGraph,
-  NEXT_GRAPH_VERSION,
-} from '../core/project-graph';
+import { readCachedProjectGraph } from '../core/project-graph';
 
 export function projectHasTarget(project: ProjectGraphNode, target: string) {
   return project.data && project.data.targets && project.data.targets[target];
@@ -23,7 +20,7 @@ export function projectHasTargetAndConfiguration(
 
 export function getSourceDirOfDependentProjects(
   projectName: string,
-  projectGraph = readCachedProjectGraph(NEXT_GRAPH_VERSION)
+  projectGraph = readCachedProjectGraph('4.0')
 ): string[] {
   if (!projectGraph.nodes[projectName]) {
     throw new Error(
@@ -44,7 +41,7 @@ export function getSourceDirOfDependentProjects(
  */
 export function getProjectNameFromDirPath(
   projRelativeDirPath: string,
-  projectGraph = readCachedProjectGraph(NEXT_GRAPH_VERSION)
+  projectGraph = readCachedProjectGraph('4.0')
 ) {
   let parentNodeName = null;
   for (const [nodeName, node] of Object.entries(projectGraph.nodes)) {
@@ -78,7 +75,7 @@ export function getProjectNameFromDirPath(
  */
 function findAllProjectNodeDependencies(
   parentNodeName: string,
-  projectGraph = readCachedProjectGraph(NEXT_GRAPH_VERSION)
+  projectGraph = readCachedProjectGraph('4.0')
 ): string[] {
   const dependencyNodeNames = new Set<string>();
 

--- a/packages/workspace/src/utilities/project-graph-utils.ts
+++ b/packages/workspace/src/utilities/project-graph-utils.ts
@@ -2,7 +2,7 @@ import { normalizePath, ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
 import { relative } from 'path';
 import {
   readCachedProjectGraph,
-  LATEST_GRAPH_VERSION,
+  NEXT_GRAPH_VERSION,
 } from '../core/project-graph';
 
 export function projectHasTarget(project: ProjectGraphNode, target: string) {
@@ -23,7 +23,7 @@ export function projectHasTargetAndConfiguration(
 
 export function getSourceDirOfDependentProjects(
   projectName: string,
-  projectGraph = readCachedProjectGraph(LATEST_GRAPH_VERSION)
+  projectGraph = readCachedProjectGraph(NEXT_GRAPH_VERSION)
 ): string[] {
   if (!projectGraph.nodes[projectName]) {
     throw new Error(
@@ -44,7 +44,7 @@ export function getSourceDirOfDependentProjects(
  */
 export function getProjectNameFromDirPath(
   projRelativeDirPath: string,
-  projectGraph = readCachedProjectGraph(LATEST_GRAPH_VERSION)
+  projectGraph = readCachedProjectGraph(NEXT_GRAPH_VERSION)
 ) {
   let parentNodeName = null;
   for (const [nodeName, node] of Object.entries(projectGraph.nodes)) {
@@ -78,7 +78,7 @@ export function getProjectNameFromDirPath(
  */
 function findAllProjectNodeDependencies(
   parentNodeName: string,
-  projectGraph = readCachedProjectGraph(LATEST_GRAPH_VERSION)
+  projectGraph = readCachedProjectGraph(NEXT_GRAPH_VERSION)
 ): string[] {
   const dependencyNodeNames = new Set<string>();
 

--- a/packages/workspace/src/utilities/project-graph-utils.ts
+++ b/packages/workspace/src/utilities/project-graph-utils.ts
@@ -1,6 +1,9 @@
 import { normalizePath, ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
 import { relative } from 'path';
-import { readCachedProjectGraph } from '../core/project-graph';
+import {
+  readCachedProjectGraph,
+  LATEST_GRAPH_VERSION,
+} from '../core/project-graph';
 
 export function projectHasTarget(project: ProjectGraphNode, target: string) {
   return project.data && project.data.targets && project.data.targets[target];
@@ -20,7 +23,7 @@ export function projectHasTargetAndConfiguration(
 
 export function getSourceDirOfDependentProjects(
   projectName: string,
-  projectGraph = readCachedProjectGraph()
+  projectGraph = readCachedProjectGraph(LATEST_GRAPH_VERSION)
 ): string[] {
   if (!projectGraph.nodes[projectName]) {
     throw new Error(
@@ -41,7 +44,7 @@ export function getSourceDirOfDependentProjects(
  */
 export function getProjectNameFromDirPath(
   projRelativeDirPath: string,
-  projectGraph = readCachedProjectGraph()
+  projectGraph = readCachedProjectGraph(LATEST_GRAPH_VERSION)
 ) {
   let parentNodeName = null;
   for (const [nodeName, node] of Object.entries(projectGraph.nodes)) {
@@ -75,7 +78,7 @@ export function getProjectNameFromDirPath(
  */
 function findAllProjectNodeDependencies(
   parentNodeName: string,
-  projectGraph = readCachedProjectGraph()
+  projectGraph = readCachedProjectGraph(LATEST_GRAPH_VERSION)
 ): string[] {
   const dependencyNodeNames = new Set<string>();
 

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -385,7 +385,6 @@ export function getFullProjectGraphFromHost(host: Tree): ProjectGraph {
 export function getFileDataInHost(host: Tree, path: Path): FileData {
   return {
     file: path,
-    ext: extname(normalize(path)),
     hash: '',
   };
 }

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -34,7 +34,6 @@ import type {
 import { addInstallTask } from './rules/add-install-task';
 import { findNodes } from '../utilities/typescript/find-nodes';
 import { getSourceNodes } from '../utilities/typescript/get-source-nodes';
-import { CURRENT_GRAPH_VERSION } from '../core/project-graph/project-graph';
 
 function nodesByPosition(first: ts.Node, second: ts.Node): number {
   return first.getStart() - second.getStart();
@@ -369,7 +368,7 @@ export function readJsonInTree<T extends object = any>(
  */
 export function getProjectGraphFromHost(host: Tree): ProjectGraph {
   return onlyWorkspaceProjects(
-    createProjectGraph(undefined, undefined, undefined, CURRENT_GRAPH_VERSION)
+    createProjectGraph(undefined, undefined, undefined, '3.0')
   );
 }
 
@@ -378,12 +377,7 @@ export function getProjectGraphFromHost(host: Tree): ProjectGraph {
  * @deprecated This method is deprecated and `await {@link createProjectGraphAsync}()` should be used instead
  */
 export function getFullProjectGraphFromHost(host: Tree): ProjectGraph {
-  return createProjectGraph(
-    undefined,
-    undefined,
-    undefined,
-    CURRENT_GRAPH_VERSION
-  );
+  return createProjectGraph(undefined, undefined, undefined, '3.0');
 }
 
 // TODO(v13): remove this deprecated method

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -34,7 +34,7 @@ import type {
 import { addInstallTask } from './rules/add-install-task';
 import { findNodes } from '../utilities/typescript/find-nodes';
 import { getSourceNodes } from '../utilities/typescript/get-source-nodes';
-import { DEPRECATED_GRAPH_VERSION } from '../core/project-graph/project-graph';
+import { CURRENT_GRAPH_VERSION } from '../core/project-graph/project-graph';
 
 function nodesByPosition(first: ts.Node, second: ts.Node): number {
   return first.getStart() - second.getStart();
@@ -369,12 +369,7 @@ export function readJsonInTree<T extends object = any>(
  */
 export function getProjectGraphFromHost(host: Tree): ProjectGraph {
   return onlyWorkspaceProjects(
-    createProjectGraph(
-      undefined,
-      undefined,
-      undefined,
-      DEPRECATED_GRAPH_VERSION
-    )
+    createProjectGraph(undefined, undefined, undefined, CURRENT_GRAPH_VERSION)
   );
 }
 
@@ -387,7 +382,7 @@ export function getFullProjectGraphFromHost(host: Tree): ProjectGraph {
     undefined,
     undefined,
     undefined,
-    DEPRECATED_GRAPH_VERSION
+    CURRENT_GRAPH_VERSION
   );
 }
 

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -34,6 +34,7 @@ import type {
 import { addInstallTask } from './rules/add-install-task';
 import { findNodes } from '../utilities/typescript/find-nodes';
 import { getSourceNodes } from '../utilities/typescript/get-source-nodes';
+import { DEPRECATED_GRAPH_VERSION } from '../core/project-graph/project-graph';
 
 function nodesByPosition(first: ts.Node, second: ts.Node): number {
   return first.getStart() - second.getStart();
@@ -367,7 +368,14 @@ export function readJsonInTree<T extends object = any>(
  * Method for utilizing the project graph in schematics
  */
 export function getProjectGraphFromHost(host: Tree): ProjectGraph {
-  return onlyWorkspaceProjects(createProjectGraph());
+  return onlyWorkspaceProjects(
+    createProjectGraph(
+      undefined,
+      undefined,
+      undefined,
+      DEPRECATED_GRAPH_VERSION
+    )
+  );
 }
 
 // TODO(v13): remove this deprecated method
@@ -375,7 +383,12 @@ export function getProjectGraphFromHost(host: Tree): ProjectGraph {
  * @deprecated This method is deprecated and `await {@link createProjectGraphAsync}()` should be used instead
  */
 export function getFullProjectGraphFromHost(host: Tree): ProjectGraph {
-  return createProjectGraph(undefined, undefined, undefined);
+  return createProjectGraph(
+    undefined,
+    undefined,
+    undefined,
+    DEPRECATED_GRAPH_VERSION
+  );
 }
 
 // TODO(v13): remove this deprecated method
@@ -385,6 +398,7 @@ export function getFullProjectGraphFromHost(host: Tree): ProjectGraph {
 export function getFileDataInHost(host: Tree, path: Path): FileData {
   return {
     file: path,
+    ext: extname(normalize(path)),
     hash: '',
   };
 }

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -200,8 +200,8 @@ export function mapProjectGraphFiles<T>(
   const nodes: Record<string, MappedProjectGraphNode> = {};
   Object.entries(projectGraph.nodes).forEach(([name, node]) => {
     const files: Record<string, FileData> = {};
-    node.data.files.forEach(({ file, hash, ext }) => {
-      files[file.slice(0, -ext.length)] = { file, hash, ext };
+    node.data.files.forEach(({ file, hash }) => {
+      files[removeExt(file)] = { file, hash };
     });
     const data = { ...node.data, files };
 

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -42,7 +42,7 @@ function hasTag(proj: ProjectGraphNode, tag: string) {
 }
 
 function removeExt(file: string): string {
-  return file.replace(/\.[^/.]+$/, '');
+  return file.replace(/(?<!(^|\/))\.[^/.]+$/, '');
 }
 
 export function matchImportWithWildcard(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
* The `FileData` model includes extracted file extension which is no longer used anywhere in the Nx.
* The extension removal function `removeExt` does not take into account file names starting with `.` (e.g. `.gitignore`)
<!-- This is the behavior we have today -->

## Expected Behavior
* The `FileData` has `ext` set as optional with appropriate deprecation message and fallback mechanism
* The `removeExt` should correctly strip extension only
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
