### PR TITLE
fix(workspace): define fileExist method for ts host

### DIFF
--- a/packages/workspace/src/utilities/typescript.ts
+++ b/packages/workspace/src/utilities/typescript.ts
@@ -35,7 +35,10 @@ function readTsConfigOptions(tsConfigPath: string) {
     tsModule.sys.readFile
   );
   // we don't need to scan the files, we only care about options
-  const host = { readDirectory: () => [] };
+  const host = {
+    readDirectory: () => [],
+    fileExists: tsModule.sys.fileExists,
+  };
   return tsModule.parseJsonConfigFileContent(
     readResult.config,
     host,


### PR DESCRIPTION
Hello! Simple commit made directly from the github.com editor, based on a comment of the issue and some other related code that I found in the repository. Hope it's ok!

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
After version 12.6.0, trying to build any lib/app causes the error mentioned in the issue because the typescript expects a `fileExists` method on the `host` object passed to the compilation.

## Expected Behavior
Builds without errors.

## Related Issue(s)
https://github.com/nrwl/nx/issues/6500

Fixes #6500
