### PR TITLE
fix(angular): webpack-server needs to work with no defaultConfiguration

### DIFF
--- a/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
+++ b/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
@@ -26,7 +26,9 @@ export function webpackServer(schema: Schema, context: BuilderContext) {
 
   const selectedConfiguration = parsedBrowserTarget.configuration
     ? buildTarget.configurations[parsedBrowserTarget.configuration]
-    : buildTarget.configurations[buildTarget.defaultConfiguration];
+    : buildTarget.defaultConfiguration
+    ? buildTarget.configurations[buildTarget.defaultConfiguration]
+    : buildTarget.options;
 
   const customWebpackConfig: { path: string } =
     selectedConfiguration.customWebpackConfig ??


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
webpack-server builder does not work when there is an invalid default configuration

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
webpack-server needs to work with no defaultConfiguration

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6533 
