### PR TITLE
fix(core): flush changes using the tree write file options

### DIFF
--- a/packages/tao/src/commands/generate.ts
+++ b/packages/tao/src/commands/generate.ts
@@ -8,9 +8,7 @@ import {
 } from '../shared/params';
 import { printHelp } from '../shared/print-help';
 import { WorkspaceJsonConfiguration, Workspaces } from '../shared/workspace';
-import { removeSync, ensureDirSync, writeFileSync } from 'fs-extra';
-import * as path from 'path';
-import { FileChange, FsTree } from '../shared/tree';
+import { FileChange, flushChanges, FsTree } from '../shared/tree';
 import { logger } from '../shared/logger';
 import * as chalk from 'chalk';
 
@@ -129,20 +127,6 @@ export function printGenHelp(opts: GenerateOptions, schema: Schema) {
 
 function readDefaultCollection(workspace: WorkspaceJsonConfiguration) {
   return workspace.cli ? workspace.cli.defaultCollection : null;
-}
-
-export function flushChanges(root: string, fileChanges: FileChange[]) {
-  fileChanges.forEach((f) => {
-    const fpath = path.join(root, f.path);
-    if (f.type === 'CREATE') {
-      ensureDirSync(path.dirname(fpath));
-      writeFileSync(fpath, f.content);
-    } else if (f.type === 'UPDATE') {
-      writeFileSync(fpath, f.content);
-    } else if (f.type === 'DELETE') {
-      removeSync(fpath);
-    }
-  });
 }
 
 function printChanges(fileChanges: FileChange[]) {

--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -7,8 +7,7 @@ import { dirSync } from 'tmp';
 import { logger } from '../shared/logger';
 import { convertToCamelCase, handleErrors } from '../shared/params';
 import { getPackageManagerCommand } from '../shared/package-manager';
-import { FsTree } from '../shared/tree';
-import { flushChanges } from './generate';
+import { flushChanges, FsTree } from '../shared/tree';
 import {
   JsonReadOptions,
   readJsonFile,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
To flush the changes made by generators, a function is used that's different from the one defined in https://github.com/nrwl/nx/blob/master/packages/tao/src/shared/tree.ts#L333 and it doesn't have the support for the write file mode.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Flushing the changes made by generators should be done using https://github.com/nrwl/nx/blob/master/packages/tao/src/shared/tree.ts#L333, which already supports the write file mode option.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6590 
