### PR TITLE
fix(core): apply verbose flag to combined options if the schema allow…

### DIFF
--- a/packages/tao/src/commands/generate.ts
+++ b/packages/tao/src/commands/generate.ts
@@ -8,7 +8,7 @@ import {
 } from '../shared/params';
 import { printHelp } from '../shared/print-help';
 import { WorkspaceJsonConfiguration, Workspaces } from '../shared/workspace';
-import { removeSync, ensureDirSync, writeFileSync } from 'fs-extra';
+import { ensureDirSync, removeSync, writeFileSync } from 'fs-extra';
 import * as path from 'path';
 import { FileChange, FsTree } from '../shared/tree';
 import { logger } from '../shared/logger';
@@ -173,7 +173,8 @@ export async function taoNew(cwd: string, args: string[], isVerbose = false) {
       schema,
       opts.interactive,
       null,
-      null
+      null,
+      isVerbose
     );
 
     if (ws.isNxGenerator(opts.collectionName, normalizedGeneratorName)) {
@@ -235,7 +236,8 @@ export async function generate(
       schema,
       opts.interactive,
       ws.calculateDefaultProjectName(cwd, workspaceDefinition),
-      ws.relativeCwd(cwd)
+      ws.relativeCwd(cwd),
+      isVerbose
     );
 
     if (ws.isNxGenerator(opts.collectionName, normalizedGeneratorName)) {

--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -217,7 +217,8 @@ async function runExecutorInternal<T extends { success: boolean }>(
     targetConfig,
     schema,
     project,
-    ws.relativeCwd(cwd)
+    ws.relativeCwd(cwd),
+    isVerbose
   );
 
   if (ws.isNxExecutor(nodeModule, executor)) {

--- a/packages/tao/src/shared/params.spec.ts
+++ b/packages/tao/src/shared/params.spec.ts
@@ -1,6 +1,7 @@
 import * as yargsParser from 'yargs-parser';
 import { logger } from './logger';
 import {
+  applyVerbosity,
   coerceTypesInOptions,
   convertAliases,
   convertSmartDefaultsIntoNamedParams,
@@ -973,6 +974,44 @@ describe('params', () => {
       expect(logger.warn).toHaveBeenCalledWith(
         'Option "a" is deprecated: Deprecated since version x.x.x. Use "b" instead.'
       );
+    });
+  });
+
+  describe('applyVerbosity', () => {
+    const isVerbose = true;
+
+    it('should not apply verbose if additionalProperties is false and verbose is not in schema', () => {
+      const options = {};
+      applyVerbosity(
+        options,
+        { additionalProperties: false, properties: {} },
+        isVerbose
+      );
+
+      expect(options).toEqual({});
+    });
+
+    it('should apply verbose if additionalProperties is true', () => {
+      const options = {};
+      applyVerbosity(
+        options,
+        { additionalProperties: true, properties: {} },
+        isVerbose
+      );
+      expect(options).toEqual({ verbose: isVerbose });
+    });
+
+    it('should apply verbose if additionalProperties is false but verbose is in schema', () => {
+      const options = {};
+      applyVerbosity(
+        options,
+        {
+          additionalProperties: false,
+          properties: { verbose: {} },
+        },
+        isVerbose
+      );
+      expect(options).toEqual({ verbose: isVerbose });
     });
   });
 });

--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -444,13 +444,24 @@ function resolveDefinition(ref: string, definitions: Properties) {
   return definitions[definition];
 }
 
+export function applyVerbosity(
+  options: Record<string, unknown>,
+  schema: Schema,
+  isVerbose: boolean
+) {
+  if (schema.additionalProperties || 'verbose' in schema.properties) {
+    options['verbose'] = isVerbose;
+  }
+}
+
 export function combineOptionsForExecutor(
   commandLineOpts: Options,
   config: string,
   target: TargetConfiguration,
   schema: Schema,
   defaultProjectName: string | null,
-  relativeCwd: string | null
+  relativeCwd: string | null,
+  isVerbose = false
 ) {
   const r = convertAliases(
     coerceTypesInOptions(commandLineOpts, schema),
@@ -470,6 +481,7 @@ export function combineOptionsForExecutor(
   warnDeprecations(combined, schema);
   setDefaults(combined, schema);
   validateOptsAgainstSchema(combined, schema);
+  applyVerbosity(combined, schema, isVerbose);
   return combined;
 }
 
@@ -481,7 +493,8 @@ export async function combineOptionsForGenerator(
   schema: Schema,
   isInteractive: boolean,
   defaultProjectName: string | null,
-  relativeCwd: string | null
+  relativeCwd: string | null,
+  isVerbose = false
 ) {
   const generatorDefaults = wc
     ? getGeneratorDefaults(
@@ -512,6 +525,7 @@ export async function combineOptionsForGenerator(
   setDefaults(combined, schema);
 
   validateOptsAgainstSchema(combined, schema);
+  applyVerbosity(combined, schema, isVerbose);
   return combined;
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`--verbose` flag is swallowed by `nrwl/tao` run after `nrwl/tao` sets an internal `isVerbose` boolean flag based on `--verbose` being passed in. However, `isVerbose` isn't utilized to passthrough `--verbose` to the target executor/generator.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`isVerbose` is utilized to set `--verbose` flag in executors/generators if the their schema allows it (`additionalProperties: true` or `verbose` is defined in `schema.properties`)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6520 #4160
