### PR TITLE
feat(core): add devkit tree method to change the permissions of a file

### DIFF
--- a/packages/devkit/src/utils/invoke-nx-generator.ts
+++ b/packages/devkit/src/utils/invoke-nx-generator.ts
@@ -1,9 +1,14 @@
-import { join, relative } from 'path';
-import type { FileChange, Tree } from '@nrwl/tao/src/shared/tree';
+import { logger, stripIndent } from '@nrwl/tao/src/shared/logger';
+import type {
+  FileChange,
+  Tree,
+  TreeWriteOptions,
+} from '@nrwl/tao/src/shared/tree';
 import type {
   Generator,
   GeneratorCallback,
 } from '@nrwl/tao/src/shared/workspace';
+import { join, relative } from 'path';
 
 class RunCallbackTask {
   constructor(private callback: GeneratorCallback) {}
@@ -148,11 +153,33 @@ class DevkitTreeFromAngularDevkitTree implements Tree {
     this.tree.rename(from, to);
   }
 
-  write(filePath: string, content: Buffer | string): void {
+  write(
+    filePath: string,
+    content: Buffer | string,
+    options?: TreeWriteOptions
+  ): void {
+    if (options?.mode) {
+      this.warnUnsupportedFilePermissionsChange(filePath, options.mode);
+    }
+
     if (this.tree.exists(filePath)) {
       this.tree.overwrite(filePath, content);
     } else {
       this.tree.create(filePath, content);
     }
+  }
+
+  changePermissions(filePath: string, mode: string | number): void {
+    this.warnUnsupportedFilePermissionsChange(filePath, mode);
+  }
+
+  private warnUnsupportedFilePermissionsChange(
+    filePath: string,
+    mode: string | number
+  ) {
+    logger.warn(
+      stripIndent(`The Angular DevKit tree does not support changing a file permissions.
+                  Ignoring changing ${filePath} permissions to ${mode}.`)
+    );
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The DevKit Tree doesn't provide a way to change the permissions of a file other than writing the file, which is not a good DX when there are no changes to be made to the file content.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The DevKit Tree provides a method to change the permissions of a file.

Note: Invoking this in an Nx DevKit generator that is [converted to an Angular DevKit schematic](https://nx.dev/latest/angular/nx-devkit/index#convertnxgenerator) will ignore the change and log a warning. The Angular DevKit Tree does not support changing the permissions of a file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6597 
