### PR TITLE
fix(testing): handle migrating base jest config without projects

### DIFF
--- a/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.spec.ts
+++ b/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.spec.ts
@@ -27,6 +27,20 @@ describe('update 12.6.0', () => {
     prettier.resolveConfig = mockResolveConfig as any;
   });
 
+  test('no projects key configured', async () => {
+    tree.write('jest.config.js', 'module.exports = {}');
+
+    await update(tree);
+
+    const result = tree.read('jest.config.js').toString();
+    expect(result).toMatchInlineSnapshot(`
+      "const { getJestProjects } = require('@nrwl/jest');
+
+      module.exports = { projects: getJestProjects() };
+      "
+    `);
+  });
+
   test('all jest projects covered', async () => {
     mockGetJestProjects.mockImplementation(() => ['<rootDir>/test-1']);
     await update(tree);

--- a/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.ts
+++ b/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.ts
@@ -35,6 +35,8 @@ function updateBaseJestConfig(
     return;
   }
   const currentConfig = jestConfigObject(tree, baseJestConfigPath);
+  currentConfig.projects ??= [];
+
   const uncoveredJestProjects = determineUncoveredJestProjects(
     currentConfig.projects as string[]
   );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Running the `update-jest-config-to-use-util` migration errors when the root `jest.config.js` doesn't have the `projects` key set.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When the root `jest.config.js` doesn't have the `projects` key set, the `update-jest-config-to-use-util` migration should still run successfully.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6563 
