### PR TITLE
fix(core): ensure to only passthrough verbose if isVerbose is true

### DIFF
--- a/packages/tao/src/shared/params.spec.ts
+++ b/packages/tao/src/shared/params.spec.ts
@@ -991,7 +991,7 @@ describe('params', () => {
       expect(options).toEqual({});
     });
 
-    it('should apply verbose if additionalProperties is true', () => {
+    it('should apply verbose if additionalProperties is true and isVerbose is truthy', () => {
       const options = {};
       applyVerbosity(
         options,
@@ -1001,7 +1001,7 @@ describe('params', () => {
       expect(options).toEqual({ verbose: isVerbose });
     });
 
-    it('should apply verbose if additionalProperties is false but verbose is in schema', () => {
+    it('should apply verbose if additionalProperties is false but verbose is in schema and isVerbose  is truthy', () => {
       const options = {};
       applyVerbosity(
         options,
@@ -1012,6 +1012,19 @@ describe('params', () => {
         isVerbose
       );
       expect(options).toEqual({ verbose: isVerbose });
+    });
+
+    it('should not apply verbose if isVerbose is falsy', () => {
+      const options = {};
+      applyVerbosity(
+        options,
+        {
+          additionalProperties: false,
+          properties: { verbose: {} },
+        },
+        false
+      );
+      expect(options).toEqual({});
     });
   });
 });

--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -449,8 +449,11 @@ export function applyVerbosity(
   schema: Schema,
   isVerbose: boolean
 ) {
-  if (schema.additionalProperties || 'verbose' in schema.properties) {
-    options['verbose'] = isVerbose;
+  if (
+    (schema.additionalProperties || 'verbose' in schema.properties) &&
+    isVerbose
+  ) {
+    options['verbose'] = true;
   }
 }
 


### PR DESCRIPTION
ISSUES CLOSED: #6606

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`verbose` passthrough was faulty and causing a regression.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`verbose` is now only turned on if `isVerbose`. This is aligned with consumers' intention where they pass `--verbose` (or `--verbose=true`) explicitly. If this is the case, then `verbose` flag is passed through. If not, then `options` will not receive `verbose` flag at all.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6606
