### PR TITLE
fix(core): fix reading nx.json without projects property

### DIFF
--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -221,6 +221,7 @@ export function readNxJson(): NxJsonConfiguration {
   const workspace = readWorkspaceConfig({ format: 'nx', path: appRootPath });
   Object.entries(workspace.projects).forEach(
     ([project, projectConfig]: [string, NxJsonProjectConfiguration]) => {
+      config.projects ??= {};
       if (!config.projects[project]) {
         const { tags, implicitDependencies } = projectConfig;
         config.projects[project] = { tags, implicitDependencies };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When having a workspace with all its projects using project configuration, removing the optional `projects` property from `nx.json`, causes running any target to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Removing the optional `projects` property from `nx.json` when having a workspace with all its projects using project configuration, should not cause any issue and all targets should run successfully.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6611 
