### PR TITLE
fix(misc): read settings in .editorconfig when formatting files in generators

### DIFF
--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -33,7 +33,9 @@ export async function formatFiles(tree: Tree): Promise<void> {
         filepath: systemPath,
       };
 
-      const resolvedOptions = await prettier.resolveConfig(systemPath);
+      const resolvedOptions = await prettier.resolveConfig(systemPath, {
+        editorconfig: true,
+      });
       if (!resolvedOptions) {
         return;
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When using `formatFiles` in generators, the [supported settings](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options) in the `.editorconfig` are not being used.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When using `formatFiles` in generators, the [supported settings](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options) in the `.editorconfig` should be used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6605 
