### PR TITLE
fix(angular): lock version of angular-devkit to ~12.1.0

### DIFF
--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -13,6 +13,7 @@ import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-
 import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
 import {
   angularVersion,
+  angularDevkitVersion,
   jestPresetAngularVersion,
   rxjsVersion,
 } from '../../utils/versions';
@@ -91,7 +92,7 @@ function updateDependencies(host: Tree) {
     {
       '@angular/compiler-cli': angularVersion,
       '@angular/language-service': angularVersion,
-      '@angular-devkit/build-angular': angularVersion,
+      '@angular-devkit/build-angular': angularDevkitVersion,
     }
   );
 }

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -1,5 +1,6 @@
 export const nxVersion = '*';
 export const angularVersion = '^12.1.0';
+export const angularDevkitVersion = '~12.1.0';
 export const angularJsVersion = '1.7.9';
 export const ngrxVersion = '~12.2.0';
 export const rxjsVersion = '~6.6.0';

--- a/packages/workspace/src/utils/versions.ts
+++ b/packages/workspace/src/utils/versions.ts
@@ -1,6 +1,6 @@
 export const nxVersion = '*';
 
-export const angularCliVersion = '^12.0.0';
+export const angularCliVersion = '~12.1.0';
 export const typescriptVersion = '~4.3.5';
 export const prettierVersion = '^2.3.1';
 export const typescriptESLintVersion = '4.19.0';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Version of `@angular-devkit` and `@angular/cli` is set to `^12.1.0`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Version of `@angular-devkit` and `@angular/cli` is set to `~12.1.0`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/6612
