### PR TITLE
cleanup(angular): add unit and e2e tests for extra reassurance

### DIFF
--- a/e2e/angular-extensions/src/angular-app.test.ts
+++ b/e2e/angular-extensions/src/angular-app.test.ts
@@ -14,7 +14,6 @@ import {
   updateFile,
 } from '@nrwl/e2e/utils';
 import { names } from '@nrwl/devkit';
-import * as http from 'http';
 
 // TODO: Check why this fails on yarn and npm
 describe('Angular Package', () => {
@@ -94,13 +93,7 @@ describe('Angular Package', () => {
 describe('Angular MFE App Serve', () => {
   let hostApp;
   let remoteApp1;
-  let remoteApp2;
   let proj: string;
-
-  beforeAll(() => {
-    // Increase the timeout as there are 3 apps to build and serve
-    jest.setTimeout(300000);
-  });
 
   beforeEach(() => {
     hostApp = uniq('app');
@@ -133,11 +126,10 @@ describe('Angular MFE App Serve', () => {
     // port and process cleanup
     try {
       await promisifiedTreeKill(process.pid, 'SIGKILL');
-      await killPorts(4200);
     } catch (err) {
       expect(err).toBeFalsy();
     }
-  });
+  }, 300000);
 });
 
 describe('Angular App Build and Serve Ops', () => {
@@ -163,7 +155,7 @@ describe('Angular App Build and Serve Ops', () => {
 
     // ASSERT
     expect(serveOutput).toContain('Running target "build" succeeded');
-  });
+  }, 100000);
 
   it('should serve the app successfully', async () => {
     // ACT
@@ -184,5 +176,5 @@ describe('Angular App Build and Serve Ops', () => {
     } catch (err) {
       expect(err).toBeFalsy();
     }
-  });
+  }, 300000);
 });

--- a/packages/angular/src/generators/setup-mfe/setup-mfe.ts
+++ b/packages/angular/src/generators/setup-mfe/setup-mfe.ts
@@ -17,6 +17,7 @@ import {
   getRemotesWithPorts,
   setupServeTarget,
 } from './lib';
+import { webpackVersion } from '../../utils/versions';
 
 export async function setupMfe(host: Tree, options: Schema) {
   const projectConfig = readProjectConfiguration(host, options.appName);
@@ -36,8 +37,8 @@ export async function setupMfe(host: Tree, options: Schema) {
   // add package to install
   const installPackages = addDependenciesToPackageJson(
     host,
-    { '@angular-architects/module-federation': '^12.2.0' },
-    {}
+    { '@angular-architects/module-federation': '~12.2.0' },
+    { webpack: webpackVersion }
   );
 
   // format files

--- a/packages/angular/src/utils/versions.spec.ts
+++ b/packages/angular/src/utils/versions.spec.ts
@@ -1,0 +1,7 @@
+import { angularDevkitVersion } from './versions';
+
+describe('Angular Versions', () => {
+  it('angular CLI package should use ~ package matching', () => {
+    expect(angularDevkitVersion[0]).toEqual('~');
+  });
+});

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -6,3 +6,4 @@ export const ngrxVersion = '~12.4.0';
 export const rxjsVersion = '~6.6.0';
 export const jestPresetAngularVersion = '10.0.1';
 export const angularEslintVersion = '~12.3.0';
+export const webpackVersion = '5.45.1';


### PR DESCRIPTION
After tests didn't fail but issues were introduced, add some extra tests to help catch breaking
changes
