### PR TITLE
chore(repo): add isOsx for e2e tests and include macos to nightly

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -17,13 +17,20 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
           # - windows-latest
         include:
           - os: ubuntu-latest
             os-name: ubuntu
+          - os: macos-latest
+            os-name: mac
           # - os: windows-latest
           #  os-name: windows
-        # exclude:
+        exclude:
+          - os: macos-latest
+            package_manager: npm
+          - os: macos-latest
+            package_manager: pnpm
         #   - os: windows-latest
         #     package_manager: npm
         #   - os: windows-latest

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -243,6 +243,10 @@ export function isNotWindows() {
   return !isWindows();
 }
 
+export function isOSX() {
+  return process.platform === 'darwin';
+}
+
 export function runCommandAsync(
   command: string,
   opts: RunCmdOpts = {


### PR DESCRIPTION
* Adds `isOSX` function to e2e utilities
* Adds MacOS to nightly github matrix

This is precondition to running mac specific E2E tests as needed by upcoming `react-native`

cc. @xiongemi 