### PR TITLE
fix(core): default run-many to use provided projects order

### DIFF
--- a/packages/workspace/src/command-line/run-many.ts
+++ b/packages/workspace/src/command-line/run-many.ts
@@ -52,8 +52,8 @@ function projectsToRun(nxArgs: NxArgs, projectGraph: ProjectGraph) {
     );
   } else {
     checkForInvalidProjects(nxArgs, allProjects);
-    let selectedProjects = allProjects.filter(
-      (p) => nxArgs.projects.indexOf(p.name) > -1
+    let selectedProjects = nxArgs.projects.map((name) =>
+      allProjects.find((project) => project.name === name)
     );
     if (nxArgs.withDeps) {
       selectedProjects = Object.values(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Using `run-many` with `--projects`, by default runs the targets for the specified projects in the order the projects appear in the `workspace.json`/`angular.json`. That order is arbitrary in the context of running tasks. It'd be better to have the tasks run in the provided projects order.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Using `run-many` with `--projects`, should by default run the tasks using the provided project order.

Note:
This does not guarantee that tasks run taking into account project dependencies. That needs to be configured using [target dependencies](https://nx.dev/latest/angular/core-concepts/configuration#target-dependencies).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6577 
