### PR TITLE
chore(repo): revert pre-loading of nrwl/cypress on e2e tests

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -28,7 +28,7 @@ jobs:
           #  os-name: windows
         exclude:
           - os: macos-latest
-            package_manager: yarn
+            package_manager: npm
           - os: macos-latest
             package_manager: pnpm
         #   - os: windows-latest

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -28,7 +28,7 @@ jobs:
           #  os-name: windows
         exclude:
           - os: macos-latest
-            package_manager: npm
+            package_manager: yarn
           - os: macos-latest
             package_manager: pnpm
         #   - os: windows-latest

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -23,7 +23,7 @@ jobs:
           - os: ubuntu-latest
             os-name: ubuntu
           - os: macos-latest
-            os-name: mac
+            os-name: osx
           # - os: windows-latest
           #  os-name: windows
         exclude:

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -169,7 +169,6 @@ export function newProject({ name = uniq('proj') } = {}): string {
       }
 
       const packages = [
-        `@nrwl/cypress`,
         `@nrwl/angular`,
         `@nrwl/eslint-plugin-nx`,
         `@nrwl/express`,

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -169,9 +169,9 @@ export function newProject({ name = uniq('proj') } = {}): string {
       }
 
       const packages = [
+        `@nrwl/cypress`,
         `@nrwl/angular`,
         `@nrwl/eslint-plugin-nx`,
-        `@nrwl/cypress`,
         `@nrwl/express`,
         `@nrwl/gatsby`,
         `@nrwl/jest`,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Installing @nrwl/cypress clashes with @nrwl/angular that depends on @nrwl/cypress leaving the repo without cypress installed and failing all the cypress tests.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
