### PR TITLE
fix(angular): remove numbers from the project name

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -229,6 +229,8 @@ module.exports = {
 "
 `;
 
+exports[`app at the root should accept numbers in the path 1`] = `"src/9-websites/my-app"`;
+
 exports[`app nested should update workspace.json 1`] = `
 Object {
   "architect": Object {

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -257,9 +257,11 @@ describe('app', () => {
 
   describe('at the root', () => {
     beforeEach(() => {
-      appTree = createTreeWithEmptyWorkspace(2, {
+      appTree = createTreeWithEmptyWorkspace(2);
+      updateJson(appTree, 'nx.json', (json) => ({
+        ...json,
         workspaceLayout: { appsDir: '' },
-      });
+      }));
     });
 
     it('should accept numbers in the path', async () => {

--- a/packages/angular/src/generators/application/lib/normalize-options.ts
+++ b/packages/angular/src/generators/application/lib/normalize-options.ts
@@ -17,7 +17,9 @@ export function normalizeOptions(
     : names(options.name).fileName;
 
   let e2eProjectName = `${names(options.name).fileName}-e2e`;
-  const appProjectName = appDirectory.replace(new RegExp('/', 'g'), '-');
+  const appProjectName = appDirectory
+    .replace(new RegExp('/', 'g'), '-')
+    .replace(/-\d+/g, '');
   if (options.e2eTestRunner !== 'cypress') {
     e2eProjectName = `${appProjectName}-e2e`;
   }

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -28,7 +28,9 @@ export function normalizeOptions(
 
   const { libsDir, npmScope, standaloneAsDefault } = getWorkspaceLayout(host);
 
-  const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
+  const projectName = projectDirectory
+    .replace(new RegExp('/', 'g'), '-')
+    .replace(/-\d+/g, '');
   const fileName = options.simpleModuleName ? name : projectName;
   const projectRoot = joinPathFragments(libsDir, projectDirectory);
 

--- a/packages/angular/src/generators/library/lib/update-ng-package.ts
+++ b/packages/angular/src/generators/library/lib/update-ng-package.ts
@@ -1,5 +1,6 @@
 import {
   getWorkspaceLayout,
+  joinPathFragments,
   offsetFromRoot,
   Tree,
   updateJson,
@@ -11,9 +12,12 @@ export function updateNgPackage(host: Tree, options: NormalizedSchema) {
     return;
   }
 
-  const dest = `${offsetFromRoot(options.projectRoot)}dist/${
-    getWorkspaceLayout(host).libsDir
-  }/${options.projectDirectory}`;
+  const dest = joinPathFragments(
+    offsetFromRoot(options.projectRoot),
+    'dist',
+    getWorkspaceLayout(host).libsDir,
+    options.projectDirectory
+  );
 
   updateJson(host, `${options.projectRoot}/ng-package.json`, (json) => {
     let $schema = json.$schema;

--- a/packages/angular/src/generators/library/lib/update-project.ts
+++ b/packages/angular/src/generators/library/lib/update-project.ts
@@ -6,6 +6,7 @@ import {
   updateProjectConfiguration,
   getWorkspaceLayout,
   offsetFromRoot,
+  joinPathFragments,
 } from '@nrwl/devkit';
 import { replaceAppNameWithPath } from '@nrwl/workspace';
 import * as path from 'path';
@@ -138,7 +139,11 @@ function fixProjectWorkspaceConfig(host: Tree, options: NormalizedSchema) {
         ? '@nrwl/angular:package'
         : '@nrwl/angular:ng-packagr-lite',
       outputs: [
-        `dist/${getWorkspaceLayout(host).libsDir}/${options.projectDirectory}`,
+        joinPathFragments(
+          'dist',
+          getWorkspaceLayout(host).libsDir,
+          options.projectDirectory
+        ),
       ],
       ...rest,
     };

--- a/packages/angular/src/generators/library/lib/update-tsconfig.ts
+++ b/packages/angular/src/generators/library/lib/update-tsconfig.ts
@@ -1,4 +1,9 @@
-import { getWorkspaceLayout, Tree, updateJson } from '@nrwl/devkit';
+import {
+  getWorkspaceLayout,
+  joinPathFragments,
+  Tree,
+  updateJson,
+} from '@nrwl/devkit';
 import { NormalizedSchema } from './normalized-schema';
 
 function updateRootConfig(host: Tree, options: NormalizedSchema) {
@@ -14,9 +19,11 @@ function updateRootConfig(host: Tree, options: NormalizedSchema) {
     }
 
     c.paths[options.importPath] = [
-      `${getWorkspaceLayout(host).libsDir}/${
-        options.projectDirectory
-      }/src/index.ts`,
+      joinPathFragments(
+        getWorkspaceLayout(host).libsDir,
+        options.projectDirectory,
+        '/src/index.ts'
+      ),
     ];
 
     return json;

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -612,9 +612,11 @@ describe('lib', () => {
 
   describe('at the root', () => {
     beforeEach(() => {
-      appTree = createTreeWithEmptyWorkspace(2, {
+      appTree = createTreeWithEmptyWorkspace(2);
+      updateJson(appTree, 'nx.json', (json) => ({
+        ...json,
         workspaceLayout: { libsDir: '' },
-      });
+      }));
     });
 
     it('should accept numbers in the path', async () => {

--- a/packages/devkit/src/tests/create-tree-with-empty-workspace.ts
+++ b/packages/devkit/src/tests/create-tree-with-empty-workspace.ts
@@ -4,7 +4,7 @@ import type { Tree } from '@nrwl/tao/src/shared/tree';
 /**
  * Creates a host for testing.
  */
-export function createTreeWithEmptyWorkspace(version = 1, nxConfig = {}): Tree {
+export function createTreeWithEmptyWorkspace(version = 1): Tree {
   const tree = new FsTree('/virtual', false);
 
   tree.write('/workspace.json', JSON.stringify({ version, projects: {} }));
@@ -32,7 +32,6 @@ export function createTreeWithEmptyWorkspace(version = 1, nxConfig = {}): Tree {
           },
         },
       },
-      ...nxConfig,
     })
   );
   tree.write(

--- a/packages/devkit/src/tests/create-tree-with-empty-workspace.ts
+++ b/packages/devkit/src/tests/create-tree-with-empty-workspace.ts
@@ -4,7 +4,7 @@ import type { Tree } from '@nrwl/tao/src/shared/tree';
 /**
  * Creates a host for testing.
  */
-export function createTreeWithEmptyWorkspace(version = 1): Tree {
+export function createTreeWithEmptyWorkspace(version = 1, nxConfig = {}): Tree {
   const tree = new FsTree('/virtual', false);
 
   tree.write('/workspace.json', JSON.stringify({ version, projects: {} }));
@@ -32,6 +32,7 @@ export function createTreeWithEmptyWorkspace(version = 1): Tree {
           },
         },
       },
+      ...nxConfig,
     })
   );
   tree.write(


### PR DESCRIPTION
## Current Behavior

Any number in the directory path can break the Angular CLI application schematic:
```bash
SchematicsException [Error]: Project name "src-9-public-website" is not valid.
New project names must start with a letter, and must contain only alphanumeric characters or dashes.
When adding a dash the segment after the dash must also start with a letter.
src-9-public-website
                  ^
    at Object.validateProjectName (node_modules/@schematics/angular/utility/validation.js:45:15)
```

## Expected Behavior

The schematic should be able to run without exceptions even if numbers are present in the `options.directory`.
