### PR TITLE
fix(nextjs): allow plain url-loader inlining of SVGs not just SVGR

### DIFF
--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -111,6 +111,14 @@ export function createWebpackConfig(
               },
             ],
           },
+          // Fallback to plain URL loader if someone just imports the SVG and references it on the <img src> tag
+          {
+            loader: require.resolve('url-loader'),
+            options: {
+              limit: 10000, // 10kB
+              name: '[name].[hash:7].[ext]',
+            },
+          },
         ],
       });
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Assume someone has the following React component in a library

```tsx
import nextLogo from './nextjs.svg';

export function TopicButton(props: any) {

  return (
    <div>
      <img src={nextLogo} alt="" className="w-12" />
    </div>
  );
}

export default TopicButton;
```

This would work in a React application [given the current settings Nx injects](https://github.com/nrwl/nx/blob/6b6b66c325e609573b28b788af1f66a10a94dacf/packages/react/plugins/webpack.ts#L42-L52).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When I import the same React component into a Next.js app it would fail, even thought the `svgr: true`
is set in the Next.js config. I'd expect this to work :) which is what this PR fixes

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
