### PR TITLE
fix(core): fix prompt support for enum definitions

### DIFF
--- a/packages/tao/src/shared/params.ts
+++ b/packages/tao/src/shared/params.ts
@@ -649,7 +649,7 @@ async function promptForValues(opts: Options, schema: Schema) {
         question.message = v['x-prompt'];
         if (v.type === 'string' && v.enum && Array.isArray(v.enum)) {
           question.type = 'select';
-          question.choices = v.enum;
+          question.choices = [...v.enum];
         } else {
           question.type = v.type === 'boolean' ? 'confirm' : 'input';
         }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Generators prompts using an enum to display some options causes the generation to fail. The enum array reference is being passed to `enquirer` which mutates its value and causes the schema validation to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generators prompts using an enum to display some options should work correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6647 
