### PR TITLE
fix(angular): init cypress correctly if needed when creating an app

### DIFF
--- a/packages/angular/src/generators/karma/karma.ts
+++ b/packages/angular/src/generators/karma/karma.ts
@@ -13,7 +13,7 @@ export function karmaGenerator(tree: Tree) {
   }
 
   generateFiles(tree, joinPathFragments(__dirname, 'files'), '.', { tmpl: '' });
-  addDependenciesToPackageJson(
+  return addDependenciesToPackageJson(
     tree,
     {},
     {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If an empty workspace has `@nrwl/cypress` and `@nrwl/angular` installed and a new Angular app is generated, the e2e tests will fail because Cypress doesn't get installed. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generating an Angular application should always make sure to install Cypress if needed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6650 
