### PR TITLE
fix(core): fix --with-deps arg support and deprecate its usage

### DIFF
--- a/packages/workspace/src/command-line/run-many.ts
+++ b/packages/workspace/src/command-line/run-many.ts
@@ -5,7 +5,6 @@ import type { NxArgs, RawNxArgs } from './utils';
 import {
   createProjectGraphAsync,
   isWorkspaceProject,
-  withDeps,
 } from '../core/project-graph';
 import type { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
 import { readEnvironment } from '../core/file-utils';
@@ -55,11 +54,6 @@ function projectsToRun(nxArgs: NxArgs, projectGraph: ProjectGraph) {
     let selectedProjects = nxArgs.projects.map((name) =>
       allProjects.find((project) => project.name === name)
     );
-    if (nxArgs.withDeps) {
-      selectedProjects = Object.values(
-        withDeps(projectGraph, selectedProjects).nodes
-      );
-    }
     return runnableForTarget(selectedProjects, nxArgs.target, true).reduce(
       (m, c) => ((m[c.name] = c), m),
       {}

--- a/packages/workspace/src/command-line/run-one.ts
+++ b/packages/workspace/src/command-line/run-one.ts
@@ -4,7 +4,6 @@ import type { ProjectGraph } from '@nrwl/devkit';
 import { readEnvironment } from '../core/file-utils';
 import { RunOneReporter } from '../tasks-runner/run-one-reporter';
 import { splitArgsIntoNxArgsAndOverrides } from './utils';
-import { projectHasTarget } from '../utilities/project-graph-utils';
 import { connectToNxCloudUsingScan } from './connect-to-nx-cloud';
 import { performance } from 'perf_hooks';
 
@@ -32,12 +31,7 @@ export async function runOne(opts: {
   await connectToNxCloudUsingScan(nxArgs.scan);
 
   const projectGraph = await createProjectGraphAsync('4.0');
-  const { projects, projectsMap } = getProjects(
-    projectGraph,
-    nxArgs.withDeps,
-    opts.project,
-    opts.target
-  );
+  const { projects, projectsMap } = getProjects(projectGraph, opts.project);
   const env = readEnvironment(opts.target, projectsMap);
   const reporter = new RunOneReporter(opts.project);
 
@@ -52,30 +46,11 @@ export async function runOne(opts: {
   );
 }
 
-function getProjects(
-  projectGraph: ProjectGraph,
-  includeDeps: boolean,
-  project: string,
-  target: string
-): any {
+function getProjects(projectGraph: ProjectGraph, project: string): any {
   let projects = [projectGraph.nodes[project]];
   let projectsMap = {
     [project]: projectGraph.nodes[project],
   };
 
-  if (includeDeps) {
-    const s = require(`../core/project-graph`);
-    const deps = s.onlyWorkspaceProjects(
-      s.withDeps(projectGraph, projects)
-    ).nodes;
-    const projectsWithTarget = Object.values(deps).filter((p: any) =>
-      projectHasTarget(p, target)
-    );
-    return {
-      projects: projectsWithTarget,
-      projectsMap: deps,
-    };
-  } else {
-    return { projects, projectsMap };
-  }
+  return { projects, projectsMap };
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running a task passing the `--with-deps` command, the task and its dependencies are not run in the right order.
There's no indication that `--with-deps` is deprecated.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running a task passing the `--with-deps` command should run the task and its dependencies in the right order.
Log a deprecation warning when `--with-deps` is used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6414 
