### PR TITLE
docs(core): improve cli docs

### DIFF
--- a/docs/angular/cli/affected-build.md
+++ b/docs/angular/cli/affected-build.md
@@ -30,12 +30,6 @@ Run the build target for all projects:
 nx affected:build --all
 ```
 
-Run the build target for the affected projects and also all the projects the affected projects depend on.:
-
-```bash
-nx affected:build --with-deps
-```
-
 Run build for all the projects affected by changing the index.ts file:
 
 ```bash
@@ -52,12 +46,6 @@ Run build for all the projects affected by the last commit on master:
 
 ```bash
 nx affected:build --base=master~1 --head=master
-```
-
-Run build for all the projects affected by the last commit on master and their dependencies:
-
-```bash
-nx affected:build --base=master~1 --head=master --with-deps
 ```
 
 ## Options
@@ -94,7 +82,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -104,7 +94,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/angular/cli/affected-dep-graph.md
+++ b/docs/angular/cli/affected-dep-graph.md
@@ -70,7 +70,7 @@ Exclude certain projects from being processed
 
 ### file
 
-output file (e.g. --file=output.json or --file=dep-graph.html)
+Output file (e.g. --file=output.json or --file=dep-graph.html)
 
 ### files
 
@@ -82,7 +82,7 @@ Use to show the dependency graph for a particular project and every node that is
 
 ### groupByFolder
 
-Group projects by folder in dependency graph
+Group projects by folder in the dependency graph
 
 ### head
 
@@ -94,7 +94,7 @@ Show help
 
 ### host
 
-Bind the dep graph server to a specific ip address.
+Bind the dependency graph server to a specific ip address.
 
 ### only-failed
 
@@ -104,7 +104,7 @@ Isolate projects which previously failed
 
 ### port
 
-Bind the dep graph server to a specific port.
+Bind the dependecy graph server to a specific port.
 
 ### runner
 
@@ -136,4 +136,4 @@ Show version number
 
 Default: `false`
 
-Watch for changes to dep graph and update in-browser
+Watch for changes to dependency graph and update in-browser

--- a/docs/angular/cli/affected-e2e.md
+++ b/docs/angular/cli/affected-e2e.md
@@ -82,7 +82,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -92,7 +94,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/angular/cli/affected-lint.md
+++ b/docs/angular/cli/affected-lint.md
@@ -82,7 +82,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -92,7 +94,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/angular/cli/affected-test.md
+++ b/docs/angular/cli/affected-test.md
@@ -82,7 +82,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -92,7 +94,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/angular/cli/affected.md
+++ b/docs/angular/cli/affected.md
@@ -36,12 +36,6 @@ Run the test target for all projects:
 nx affected --target=test --all
 ```
 
-Run the test target for the affected projects and also all the projects the affected projects depend on.:
-
-```bash
-nx affected --target=test --with-deps
-```
-
 Run tests for all the projects affected by changing the index.ts file:
 
 ```bash
@@ -58,12 +52,6 @@ Run tests for all the projects affected by the last commit on master:
 
 ```bash
 nx affected --target=test --base=master~1 --head=master
-```
-
-Run build for all the projects affected by the last commit on master and their dependencies:
-
-```bash
-nx affected --target=build --base=master~1 --head=master --with-deps
 ```
 
 ## Options
@@ -100,7 +88,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -110,7 +100,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/angular/cli/dep-graph.md
+++ b/docs/angular/cli/dep-graph.md
@@ -68,7 +68,7 @@ List of projects delimited by commas to exclude from the dependency graph.
 
 ### file
 
-output file (e.g. --file=output.json or --file=dep-graph.html)
+Output file (e.g. --file=output.json or --file=dep-graph.html)
 
 ### focus
 
@@ -76,7 +76,7 @@ Use to show the dependency graph for a particular project and every node that is
 
 ### groupByFolder
 
-Group projects by folder in dependency graph
+Group projects by folder in the dependency graph
 
 ### help
 
@@ -84,11 +84,11 @@ Show help
 
 ### host
 
-Bind the dep graph server to a specific ip address.
+Bind the dependency graph server to a specific ip address.
 
 ### port
 
-Bind the dep graph server to a specific port.
+Bind the dependecy graph server to a specific port.
 
 ### version
 
@@ -98,4 +98,4 @@ Show version number
 
 Default: `false`
 
-Watch for changes to dep graph and update in-browser
+Watch for changes to dependency graph and update in-browser

--- a/docs/angular/cli/format-check.md
+++ b/docs/angular/cli/format-check.md
@@ -44,6 +44,8 @@ Show help
 
 ### libs-and-apps
 
+Format only libraries and applications files.
+
 ### only-failed
 
 Default: `false`

--- a/docs/angular/cli/format-write.md
+++ b/docs/angular/cli/format-write.md
@@ -44,6 +44,8 @@ Show help
 
 ### libs-and-apps
 
+Format only libraries and applications files.
+
 ### only-failed
 
 Default: `false`

--- a/docs/angular/cli/migrate.md
+++ b/docs/angular/cli/migrate.md
@@ -1,6 +1,9 @@
 # migrate
 
-Creates a migrations file or runs migrations from the migrations file. - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest) - Run migrations (e.g., nx migrate --run-migrations=migrations.json)
+Creates a migrations file or runs migrations from the migrations file.
+
+- Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
+- Run migrations (e.g., nx migrate --run-migrations=migrations.json)
 
 ## Usage
 
@@ -12,37 +15,37 @@ nx migrate
 
 ### Examples
 
-Update @nrwl/workspace to "next". This will update other packages and will generate migrations.json.:
+Update @nrwl/workspace to "next". This will update other packages and will generate migrations.json:
 
 ```bash
 nx migrate next
 ```
 
-Update @nrwl/workspace to "9.0.0". This will update other packages and will generate migrations.json.:
+Update @nrwl/workspace to "9.0.0". This will update other packages and will generate migrations.json:
 
 ```bash
 nx migrate 9.0.0
 ```
 
-Update @nrwl/workspace and generate the list of migrations starting with version 8.0.0 of @nrwl/workspace and @nrwl/node, regardless of what installed locally.:
+Update @nrwl/workspace and generate the list of migrations starting with version 8.0.0 of @nrwl/workspace and @nrwl/node, regardless of what installed locally:
 
 ```bash
 nx migrate @nrwl/workspace@9.0.0 --from="@nrwl/workspace@8.0.0,@nrwl/node@8.0.0"
 ```
 
-Update @nrwl/workspace to "9.0.0". If it tries to update @nrwl/react or @nrwl/angular, use version "9.0.1".:
+Update @nrwl/workspace to "9.0.0". If it tries to update @nrwl/react or @nrwl/angular, use version "9.0.1":
 
 ```bash
 nx migrate @nrwl/workspace@9.0.0 --to="@nrwl/react@9.0.1,@nrwl/angular@9.0.1"
 ```
 
-Update another-package to "12.0.0". This will update other packages and will generate migrations.json file.:
+Update another-package to "12.0.0". This will update other packages and will generate migrations.json file:
 
 ```bash
 nx migrate another-package@12.0.0
 ```
 
-Run migrations from the migrations.json file. You can modify migrations.json and run this command many times.:
+Run migrations from the migrations.json file. You can modify migrations.json and run this command many times:
 
 ```bash
 nx migrate --run-migrations=migrations.json

--- a/docs/angular/cli/print-affected.md
+++ b/docs/angular/cli/print-affected.md
@@ -12,37 +12,31 @@ nx print-affected
 
 ### Examples
 
-Print information about affected projects and the dependency graph.:
+Print information about affected projects and the dependency graph:
 
 ```bash
 nx print-affected
 ```
 
-Print information about the projects affected by the changes between master and HEAD (e.g,. PR).:
+Print information about the projects affected by the changes between master and HEAD (e.g,. PR):
 
 ```bash
 nx print-affected --base=master --head=HEAD
 ```
 
-Prints information about the affected projects and a list of tasks to test them.:
+Prints information about the affected projects and a list of tasks to test them:
 
 ```bash
 nx print-affected --target=test
 ```
 
-Prints information about the affected projects and a list of tasks to build them and their dependencies.:
-
-```bash
-nx print-affected --target=build --with-deps
-```
-
-Prints the projects property from the print-affected output.:
+Prints the projects property from the print-affected output:
 
 ```bash
 nx print-affected --target=build --select=projects
 ```
 
-Prints the tasks.target.project property from the print-affected output.:
+Prints the tasks.target.project property from the print-affected output:
 
 ```bash
 nx print-affected --target=build --select=tasks.target.project

--- a/docs/angular/cli/run-many.md
+++ b/docs/angular/cli/run-many.md
@@ -12,28 +12,22 @@ nx run-many
 
 ### Examples
 
-Test all projects.:
+Test all projects:
 
 ```bash
 nx run-many --target=test --all
 ```
 
-Test proj1 and proj2.:
+Test proj1 and proj2:
 
 ```bash
 nx run-many --target=test --projects=proj1,proj2
 ```
 
-Test proj1 and proj2 in parallel.:
+Test proj1 and proj2 in parallel:
 
 ```bash
 nx run-many --target=test --projects=proj1,proj2 --parallel --maxParallel=2
-```
-
-Build proj1 and proj2 and all their dependencies.:
-
-```bash
-nx run-many --target=test --projects=proj1,proj2 --with-deps
 ```
 
 ## Options
@@ -58,7 +52,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -68,7 +64,9 @@ Only run the target on projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### projects
 
@@ -96,8 +94,10 @@ Print additional error stack trace on failure
 
 Show version number
 
-### with-deps
+### ~~with-deps~~
 
 Default: `false`
+
+**Deprecated:** Configure target dependencies instead. It will be removed in v14.
 
 Include dependencies of specified projects when computing what to run

--- a/docs/node/cli/affected-build.md
+++ b/docs/node/cli/affected-build.md
@@ -30,12 +30,6 @@ Run the build target for all projects:
 nx affected:build --all
 ```
 
-Run the build target for the affected projects and also all the projects the affected projects depend on.:
-
-```bash
-nx affected:build --with-deps
-```
-
 Run build for all the projects affected by changing the index.ts file:
 
 ```bash
@@ -52,12 +46,6 @@ Run build for all the projects affected by the last commit on master:
 
 ```bash
 nx affected:build --base=master~1 --head=master
-```
-
-Run build for all the projects affected by the last commit on master and their dependencies:
-
-```bash
-nx affected:build --base=master~1 --head=master --with-deps
 ```
 
 ## Options
@@ -94,7 +82,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -104,7 +94,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/node/cli/affected-dep-graph.md
+++ b/docs/node/cli/affected-dep-graph.md
@@ -70,7 +70,7 @@ Exclude certain projects from being processed
 
 ### file
 
-output file (e.g. --file=output.json or --file=dep-graph.html)
+Output file (e.g. --file=output.json or --file=dep-graph.html)
 
 ### files
 
@@ -82,7 +82,7 @@ Use to show the dependency graph for a particular project and every node that is
 
 ### groupByFolder
 
-Group projects by folder in dependency graph
+Group projects by folder in the dependency graph
 
 ### head
 
@@ -94,7 +94,7 @@ Show help
 
 ### host
 
-Bind the dep graph server to a specific ip address.
+Bind the dependency graph server to a specific ip address.
 
 ### only-failed
 
@@ -104,7 +104,7 @@ Isolate projects which previously failed
 
 ### port
 
-Bind the dep graph server to a specific port.
+Bind the dependecy graph server to a specific port.
 
 ### runner
 
@@ -136,4 +136,4 @@ Show version number
 
 Default: `false`
 
-Watch for changes to dep graph and update in-browser
+Watch for changes to dependency graph and update in-browser

--- a/docs/node/cli/affected-e2e.md
+++ b/docs/node/cli/affected-e2e.md
@@ -82,7 +82,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -92,7 +94,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/node/cli/affected-lint.md
+++ b/docs/node/cli/affected-lint.md
@@ -82,7 +82,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -92,7 +94,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/node/cli/affected-test.md
+++ b/docs/node/cli/affected-test.md
@@ -82,7 +82,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -92,7 +94,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/node/cli/affected.md
+++ b/docs/node/cli/affected.md
@@ -36,12 +36,6 @@ Run the test target for all projects:
 nx affected --target=test --all
 ```
 
-Run the test target for the affected projects and also all the projects the affected projects depend on.:
-
-```bash
-nx affected --target=test --with-deps
-```
-
 Run tests for all the projects affected by changing the index.ts file:
 
 ```bash
@@ -58,12 +52,6 @@ Run tests for all the projects affected by the last commit on master:
 
 ```bash
 nx affected --target=test --base=master~1 --head=master
-```
-
-Run build for all the projects affected by the last commit on master and their dependencies:
-
-```bash
-nx affected --target=build --base=master~1 --head=master --with-deps
 ```
 
 ## Options
@@ -100,7 +88,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -110,7 +100,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/node/cli/dep-graph.md
+++ b/docs/node/cli/dep-graph.md
@@ -68,7 +68,7 @@ List of projects delimited by commas to exclude from the dependency graph.
 
 ### file
 
-output file (e.g. --file=output.json or --file=dep-graph.html)
+Output file (e.g. --file=output.json or --file=dep-graph.html)
 
 ### focus
 
@@ -76,7 +76,7 @@ Use to show the dependency graph for a particular project and every node that is
 
 ### groupByFolder
 
-Group projects by folder in dependency graph
+Group projects by folder in the dependency graph
 
 ### help
 
@@ -84,11 +84,11 @@ Show help
 
 ### host
 
-Bind the dep graph server to a specific ip address.
+Bind the dependency graph server to a specific ip address.
 
 ### port
 
-Bind the dep graph server to a specific port.
+Bind the dependecy graph server to a specific port.
 
 ### version
 
@@ -98,4 +98,4 @@ Show version number
 
 Default: `false`
 
-Watch for changes to dep graph and update in-browser
+Watch for changes to dependency graph and update in-browser

--- a/docs/node/cli/format-check.md
+++ b/docs/node/cli/format-check.md
@@ -44,6 +44,8 @@ Show help
 
 ### libs-and-apps
 
+Format only libraries and applications files.
+
 ### only-failed
 
 Default: `false`

--- a/docs/node/cli/format-write.md
+++ b/docs/node/cli/format-write.md
@@ -44,6 +44,8 @@ Show help
 
 ### libs-and-apps
 
+Format only libraries and applications files.
+
 ### only-failed
 
 Default: `false`

--- a/docs/node/cli/migrate.md
+++ b/docs/node/cli/migrate.md
@@ -1,6 +1,9 @@
 # migrate
 
-Creates a migrations file or runs migrations from the migrations file. - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest) - Run migrations (e.g., nx migrate --run-migrations=migrations.json)
+Creates a migrations file or runs migrations from the migrations file.
+
+- Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
+- Run migrations (e.g., nx migrate --run-migrations=migrations.json)
 
 ## Usage
 
@@ -12,37 +15,37 @@ nx migrate
 
 ### Examples
 
-Update @nrwl/workspace to "next". This will update other packages and will generate migrations.json.:
+Update @nrwl/workspace to "next". This will update other packages and will generate migrations.json:
 
 ```bash
 nx migrate next
 ```
 
-Update @nrwl/workspace to "9.0.0". This will update other packages and will generate migrations.json.:
+Update @nrwl/workspace to "9.0.0". This will update other packages and will generate migrations.json:
 
 ```bash
 nx migrate 9.0.0
 ```
 
-Update @nrwl/workspace and generate the list of migrations starting with version 8.0.0 of @nrwl/workspace and @nrwl/node, regardless of what installed locally.:
+Update @nrwl/workspace and generate the list of migrations starting with version 8.0.0 of @nrwl/workspace and @nrwl/node, regardless of what installed locally:
 
 ```bash
 nx migrate @nrwl/workspace@9.0.0 --from="@nrwl/workspace@8.0.0,@nrwl/node@8.0.0"
 ```
 
-Update @nrwl/workspace to "9.0.0". If it tries to update @nrwl/react or @nrwl/angular, use version "9.0.1".:
+Update @nrwl/workspace to "9.0.0". If it tries to update @nrwl/react or @nrwl/angular, use version "9.0.1":
 
 ```bash
 nx migrate @nrwl/workspace@9.0.0 --to="@nrwl/react@9.0.1,@nrwl/angular@9.0.1"
 ```
 
-Update another-package to "12.0.0". This will update other packages and will generate migrations.json file.:
+Update another-package to "12.0.0". This will update other packages and will generate migrations.json file:
 
 ```bash
 nx migrate another-package@12.0.0
 ```
 
-Run migrations from the migrations.json file. You can modify migrations.json and run this command many times.:
+Run migrations from the migrations.json file. You can modify migrations.json and run this command many times:
 
 ```bash
 nx migrate --run-migrations=migrations.json

--- a/docs/node/cli/print-affected.md
+++ b/docs/node/cli/print-affected.md
@@ -12,37 +12,31 @@ nx print-affected
 
 ### Examples
 
-Print information about affected projects and the dependency graph.:
+Print information about affected projects and the dependency graph:
 
 ```bash
 nx print-affected
 ```
 
-Print information about the projects affected by the changes between master and HEAD (e.g,. PR).:
+Print information about the projects affected by the changes between master and HEAD (e.g,. PR):
 
 ```bash
 nx print-affected --base=master --head=HEAD
 ```
 
-Prints information about the affected projects and a list of tasks to test them.:
+Prints information about the affected projects and a list of tasks to test them:
 
 ```bash
 nx print-affected --target=test
 ```
 
-Prints information about the affected projects and a list of tasks to build them and their dependencies.:
-
-```bash
-nx print-affected --target=build --with-deps
-```
-
-Prints the projects property from the print-affected output.:
+Prints the projects property from the print-affected output:
 
 ```bash
 nx print-affected --target=build --select=projects
 ```
 
-Prints the tasks.target.project property from the print-affected output.:
+Prints the tasks.target.project property from the print-affected output:
 
 ```bash
 nx print-affected --target=build --select=tasks.target.project

--- a/docs/node/cli/run-many.md
+++ b/docs/node/cli/run-many.md
@@ -12,28 +12,22 @@ nx run-many
 
 ### Examples
 
-Test all projects.:
+Test all projects:
 
 ```bash
 nx run-many --target=test --all
 ```
 
-Test proj1 and proj2.:
+Test proj1 and proj2:
 
 ```bash
 nx run-many --target=test --projects=proj1,proj2
 ```
 
-Test proj1 and proj2 in parallel.:
+Test proj1 and proj2 in parallel:
 
 ```bash
 nx run-many --target=test --projects=proj1,proj2 --parallel --maxParallel=2
-```
-
-Build proj1 and proj2 and all their dependencies.:
-
-```bash
-nx run-many --target=test --projects=proj1,proj2 --with-deps
 ```
 
 ## Options
@@ -58,7 +52,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -68,7 +64,9 @@ Only run the target on projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### projects
 
@@ -96,8 +94,10 @@ Print additional error stack trace on failure
 
 Show version number
 
-### with-deps
+### ~~with-deps~~
 
 Default: `false`
+
+**Deprecated:** Configure target dependencies instead. It will be removed in v14.
 
 Include dependencies of specified projects when computing what to run

--- a/docs/react/cli/affected-build.md
+++ b/docs/react/cli/affected-build.md
@@ -30,12 +30,6 @@ Run the build target for all projects:
 nx affected:build --all
 ```
 
-Run the build target for the affected projects and also all the projects the affected projects depend on.:
-
-```bash
-nx affected:build --with-deps
-```
-
 Run build for all the projects affected by changing the index.ts file:
 
 ```bash
@@ -52,12 +46,6 @@ Run build for all the projects affected by the last commit on master:
 
 ```bash
 nx affected:build --base=master~1 --head=master
-```
-
-Run build for all the projects affected by the last commit on master and their dependencies:
-
-```bash
-nx affected:build --base=master~1 --head=master --with-deps
 ```
 
 ## Options
@@ -94,7 +82,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -104,7 +94,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/react/cli/affected-dep-graph.md
+++ b/docs/react/cli/affected-dep-graph.md
@@ -70,7 +70,7 @@ Exclude certain projects from being processed
 
 ### file
 
-output file (e.g. --file=output.json or --file=dep-graph.html)
+Output file (e.g. --file=output.json or --file=dep-graph.html)
 
 ### files
 
@@ -82,7 +82,7 @@ Use to show the dependency graph for a particular project and every node that is
 
 ### groupByFolder
 
-Group projects by folder in dependency graph
+Group projects by folder in the dependency graph
 
 ### head
 
@@ -94,7 +94,7 @@ Show help
 
 ### host
 
-Bind the dep graph server to a specific ip address.
+Bind the dependency graph server to a specific ip address.
 
 ### only-failed
 
@@ -104,7 +104,7 @@ Isolate projects which previously failed
 
 ### port
 
-Bind the dep graph server to a specific port.
+Bind the dependecy graph server to a specific port.
 
 ### runner
 
@@ -136,4 +136,4 @@ Show version number
 
 Default: `false`
 
-Watch for changes to dep graph and update in-browser
+Watch for changes to dependency graph and update in-browser

--- a/docs/react/cli/affected-e2e.md
+++ b/docs/react/cli/affected-e2e.md
@@ -82,7 +82,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -92,7 +94,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/react/cli/affected-lint.md
+++ b/docs/react/cli/affected-lint.md
@@ -82,7 +82,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -92,7 +94,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/react/cli/affected-test.md
+++ b/docs/react/cli/affected-test.md
@@ -82,7 +82,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -92,7 +94,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/react/cli/affected.md
+++ b/docs/react/cli/affected.md
@@ -36,12 +36,6 @@ Run the test target for all projects:
 nx affected --target=test --all
 ```
 
-Run the test target for the affected projects and also all the projects the affected projects depend on.:
-
-```bash
-nx affected --target=test --with-deps
-```
-
 Run tests for all the projects affected by changing the index.ts file:
 
 ```bash
@@ -58,12 +52,6 @@ Run tests for all the projects affected by the last commit on master:
 
 ```bash
 nx affected --target=test --base=master~1 --head=master
-```
-
-Run build for all the projects affected by the last commit on master and their dependencies:
-
-```bash
-nx affected --target=build --base=master~1 --head=master --with-deps
 ```
 
 ## Options
@@ -100,7 +88,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -110,7 +100,9 @@ Isolate projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### runner
 

--- a/docs/react/cli/dep-graph.md
+++ b/docs/react/cli/dep-graph.md
@@ -68,7 +68,7 @@ List of projects delimited by commas to exclude from the dependency graph.
 
 ### file
 
-output file (e.g. --file=output.json or --file=dep-graph.html)
+Output file (e.g. --file=output.json or --file=dep-graph.html)
 
 ### focus
 
@@ -76,7 +76,7 @@ Use to show the dependency graph for a particular project and every node that is
 
 ### groupByFolder
 
-Group projects by folder in dependency graph
+Group projects by folder in the dependency graph
 
 ### help
 
@@ -84,11 +84,11 @@ Show help
 
 ### host
 
-Bind the dep graph server to a specific ip address.
+Bind the dependency graph server to a specific ip address.
 
 ### port
 
-Bind the dep graph server to a specific port.
+Bind the dependecy graph server to a specific port.
 
 ### version
 
@@ -98,4 +98,4 @@ Show version number
 
 Default: `false`
 
-Watch for changes to dep graph and update in-browser
+Watch for changes to dependency graph and update in-browser

--- a/docs/react/cli/format-check.md
+++ b/docs/react/cli/format-check.md
@@ -44,6 +44,8 @@ Show help
 
 ### libs-and-apps
 
+Format only libraries and applications files.
+
 ### only-failed
 
 Default: `false`

--- a/docs/react/cli/format-write.md
+++ b/docs/react/cli/format-write.md
@@ -44,6 +44,8 @@ Show help
 
 ### libs-and-apps
 
+Format only libraries and applications files.
+
 ### only-failed
 
 Default: `false`

--- a/docs/react/cli/migrate.md
+++ b/docs/react/cli/migrate.md
@@ -1,6 +1,9 @@
 # migrate
 
-Creates a migrations file or runs migrations from the migrations file. - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest) - Run migrations (e.g., nx migrate --run-migrations=migrations.json)
+Creates a migrations file or runs migrations from the migrations file.
+
+- Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
+- Run migrations (e.g., nx migrate --run-migrations=migrations.json)
 
 ## Usage
 
@@ -12,37 +15,37 @@ nx migrate
 
 ### Examples
 
-Update @nrwl/workspace to "next". This will update other packages and will generate migrations.json.:
+Update @nrwl/workspace to "next". This will update other packages and will generate migrations.json:
 
 ```bash
 nx migrate next
 ```
 
-Update @nrwl/workspace to "9.0.0". This will update other packages and will generate migrations.json.:
+Update @nrwl/workspace to "9.0.0". This will update other packages and will generate migrations.json:
 
 ```bash
 nx migrate 9.0.0
 ```
 
-Update @nrwl/workspace and generate the list of migrations starting with version 8.0.0 of @nrwl/workspace and @nrwl/node, regardless of what installed locally.:
+Update @nrwl/workspace and generate the list of migrations starting with version 8.0.0 of @nrwl/workspace and @nrwl/node, regardless of what installed locally:
 
 ```bash
 nx migrate @nrwl/workspace@9.0.0 --from="@nrwl/workspace@8.0.0,@nrwl/node@8.0.0"
 ```
 
-Update @nrwl/workspace to "9.0.0". If it tries to update @nrwl/react or @nrwl/angular, use version "9.0.1".:
+Update @nrwl/workspace to "9.0.0". If it tries to update @nrwl/react or @nrwl/angular, use version "9.0.1":
 
 ```bash
 nx migrate @nrwl/workspace@9.0.0 --to="@nrwl/react@9.0.1,@nrwl/angular@9.0.1"
 ```
 
-Update another-package to "12.0.0". This will update other packages and will generate migrations.json file.:
+Update another-package to "12.0.0". This will update other packages and will generate migrations.json file:
 
 ```bash
 nx migrate another-package@12.0.0
 ```
 
-Run migrations from the migrations.json file. You can modify migrations.json and run this command many times.:
+Run migrations from the migrations.json file. You can modify migrations.json and run this command many times:
 
 ```bash
 nx migrate --run-migrations=migrations.json

--- a/docs/react/cli/print-affected.md
+++ b/docs/react/cli/print-affected.md
@@ -12,37 +12,31 @@ nx print-affected
 
 ### Examples
 
-Print information about affected projects and the dependency graph.:
+Print information about affected projects and the dependency graph:
 
 ```bash
 nx print-affected
 ```
 
-Print information about the projects affected by the changes between master and HEAD (e.g,. PR).:
+Print information about the projects affected by the changes between master and HEAD (e.g,. PR):
 
 ```bash
 nx print-affected --base=master --head=HEAD
 ```
 
-Prints information about the affected projects and a list of tasks to test them.:
+Prints information about the affected projects and a list of tasks to test them:
 
 ```bash
 nx print-affected --target=test
 ```
 
-Prints information about the affected projects and a list of tasks to build them and their dependencies.:
-
-```bash
-nx print-affected --target=build --with-deps
-```
-
-Prints the projects property from the print-affected output.:
+Prints the projects property from the print-affected output:
 
 ```bash
 nx print-affected --target=build --select=projects
 ```
 
-Prints the tasks.target.project property from the print-affected output.:
+Prints the tasks.target.project property from the print-affected output:
 
 ```bash
 nx print-affected --target=build --select=tasks.target.project

--- a/docs/react/cli/run-many.md
+++ b/docs/react/cli/run-many.md
@@ -12,28 +12,22 @@ nx run-many
 
 ### Examples
 
-Test all projects.:
+Test all projects:
 
 ```bash
 nx run-many --target=test --all
 ```
 
-Test proj1 and proj2.:
+Test proj1 and proj2:
 
 ```bash
 nx run-many --target=test --projects=proj1,proj2
 ```
 
-Test proj1 and proj2 in parallel.:
+Test proj1 and proj2 in parallel:
 
 ```bash
 nx run-many --target=test --projects=proj1,proj2 --parallel --maxParallel=2
-```
-
-Build proj1 and proj2 and all their dependencies.:
-
-```bash
-nx run-many --target=test --projects=proj1,proj2 --with-deps
 ```
 
 ## Options
@@ -58,7 +52,9 @@ Show help
 
 ### maxParallel
 
-Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)
+Default: `3`
+
+Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.
 
 ### only-failed
 
@@ -68,7 +64,9 @@ Only run the target on projects which previously failed
 
 ### parallel
 
-Parallelize the command (default: false)
+Default: `false`
+
+Parallelize the command
 
 ### projects
 
@@ -96,8 +94,10 @@ Print additional error stack trace on failure
 
 Show version number
 
-### with-deps
+### ~~with-deps~~
 
 Default: `false`
+
+**Deprecated:** Configure target dependencies instead. It will be removed in v14.
 
 Include dependencies of specified projects when computing what to run

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -203,9 +203,9 @@ export const commandsObject = yargs
   .command(
     'migrate',
     `Creates a migrations file or runs migrations from the migrations file.
-     - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
-     - Run migrations (e.g., nx migrate --run-migrations=migrations.json)
-    `,
+- Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
+- Run migrations (e.g., nx migrate --run-migrations=migrations.json)
+`,
     (yargs) => yargs,
     () => {
       if (process.env.NX_MIGRATE_USE_LOCAL === undefined) {
@@ -237,6 +237,7 @@ export const commandsObject = yargs
 function withFormatOptions(yargs: yargs.Argv): yargs.Argv {
   return withAffectedOptions(yargs)
     .option('libs-and-apps', {
+      describe: 'Format only libraries and applications files.',
       type: 'boolean',
     })
     .option('projects', {
@@ -380,6 +381,8 @@ function withRunManyOptions(yargs: yargs.Argv): yargs.Argv {
         'Include dependencies of specified projects when computing what to run',
       type: 'boolean',
       default: false,
+      deprecated:
+        'Configure target dependencies instead. It will be removed in v14.',
     })
     .options('only-failed', {
       describe: 'Only run the target on projects which previously failed',
@@ -404,7 +407,7 @@ function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
   return yargs
     .option('file', {
       describe:
-        'output file (e.g. --file=output.json or --file=dep-graph.html)',
+        'Output file (e.g. --file=output.json or --file=dep-graph.html)',
       type: 'string',
     })
     .option('focus', {
@@ -419,19 +422,19 @@ function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
       coerce: parseCSV,
     })
     .option('groupByFolder', {
-      describe: 'Group projects by folder in dependency graph',
+      describe: 'Group projects by folder in the dependency graph',
       type: 'boolean',
     })
     .option('host', {
-      describe: 'Bind the dep graph server to a specific ip address.',
+      describe: 'Bind the dependency graph server to a specific ip address.',
       type: 'string',
     })
     .option('port', {
-      describe: 'Bind the dep graph server to a specific port.',
+      describe: 'Bind the dependecy graph server to a specific port.',
       type: 'number',
     })
     .option('watch', {
-      describe: 'Watch for changes to dep graph and update in-browser',
+      describe: 'Watch for changes to dependency graph and update in-browser',
       type: 'boolean',
       default: false,
     });
@@ -448,13 +451,15 @@ function parseCSV(args: string[]) {
 function withParallel(yargs: yargs.Argv): yargs.Argv {
   return yargs
     .option('parallel', {
-      describe: 'Parallelize the command (default: false)',
+      describe: 'Parallelize the command',
       type: 'boolean',
+      default: false,
     })
     .option('maxParallel', {
       describe:
-        'Max number of parallel processes. This flag is ignored if the parallel option is set to `false`. (default: 3)',
+        'Max number of parallel processes. This flag is ignored if the parallel option is set to `false`.',
       type: 'number',
+      default: 3,
     });
 }
 


### PR DESCRIPTION
## What it does

- Mark `with-deps` option as deprecated.
- Remove examples using the deprecated option `with-deps`.
- Update the cli docs generator to support deprecated options.
- Improve the punctuation in the examples.
- Other minor formatting improvements.