### PR TITLE
feat(core): make it possible to use environment variable to set cache…

### DIFF
--- a/packages/workspace/src/utilities/cache-directory.ts
+++ b/packages/workspace/src/utilities/cache-directory.ts
@@ -2,6 +2,10 @@ import { join } from 'path';
 import { readJsonFile } from './fileutils';
 
 export function readCacheDirectoryProperty(root: string) {
+  const cacheDir = process.env.NX_CACHE_DIRECTORY;
+  if (cacheDir) {
+    return cacheDir;
+  }
   try {
     const nxJson = readJsonFile(join(root, 'nx.json'));
     return nxJson.tasksRunnerOptions.default.options.cacheDirectory;


### PR DESCRIPTION
… directory

Use the environment variable NX_CACHE_DIRECTORY to set the cache directory.
This would override the cache directory set in nx.json.

ISSUES CLOSED: #6629

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The cache directory can only be set using `nx.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The cache directory set in `nx.json` can be overwritten using environment variable `NX_CACHE_DIRECTORY`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6629
