### PR TITLE
fix(web): webpack.WebpackError is not a constructor (due to using webpack 4)

### DIFF
--- a/packages/web/src/utils/third-party/cli-files/plugins/bundle-budget.ts
+++ b/packages/web/src/utils/third-party/cli-files/plugins/bundle-budget.ts
@@ -87,14 +87,23 @@ export class BundleBudgetPlugin {
     if (threshold) {
       if (threshold > size.size) {
         const sizeDifference = formatSize(threshold - size.size);
-        messages.push(
-          new webpack.WebpackError(
+        if (typeof webpack.WebpackError === 'function') {
+          messages.push(
+            new webpack.WebpackError(
+              `budgets, minimum exceeded for ${size.label}. ` +
+                `Budget ${formatSize(
+                  threshold
+                )} was not reached by ${sizeDifference}.`
+            )
+          );
+        } else {
+          messages.push(
             `budgets, minimum exceeded for ${size.label}. ` +
               `Budget ${formatSize(
                 threshold
               )} was not reached by ${sizeDifference}.`
-          )
-        );
+          );
+        }
       }
     }
   }
@@ -111,14 +120,23 @@ export class BundleBudgetPlugin {
     if (threshold) {
       if (threshold < size.size) {
         const sizeDifference = formatSize(size.size - threshold);
-        messages.push(
-          new webpack.WebpackError(
+        if (typeof webpack === 'function') {
+          messages.push(
+            new webpack.WebpackError(
+              `budgets, maximum exceeded for ${size.label}. ` +
+                `Budget ${formatSize(
+                  threshold
+                )} was exceeded by ${sizeDifference}.`
+            )
+          );
+        } else {
+          messages.push(
             `budgets, maximum exceeded for ${size.label}. ` +
               `Budget ${formatSize(
                 threshold
               )} was exceeded by ${sizeDifference}.`
-          )
-        );
+          );
+        }
       }
     }
   }

--- a/packages/web/src/utils/third-party/cli-files/plugins/index-html-webpack-plugin.ts
+++ b/packages/web/src/utils/third-party/cli-files/plugins/index-html-webpack-plugin.ts
@@ -59,11 +59,21 @@ export class IndexHtmlWebpackPlugin extends IndexHtmlGenerator {
     });
 
     function addWarning(compilation: any, message: string): void {
-      compilation.warnings.push(new this.webpack.WebpackError(message));
+      //TODO: the else branch can be removed in NX 13
+      if (typeof this.webpack.WebpackError === 'function') {
+        compilation.warnings.push(new this.webpack.WebpackError(message));
+      } else {
+        compilation.warnings.push(message);
+      }
     }
 
     function addError(compilation: any, message: string): void {
-      compilation.errors.push(new this.webpack.WebpackError(message));
+      //TODO: the else branch can be removed in NX 13
+      if (typeof this.webpack.WebpackError === 'function') {
+        compilation.errors.push(new this.webpack.WebpackError(message));
+      } else {
+        compilation.errors.push(message);
+      }
     }
 
     const callback = async (assets: Record<string, unknown>) => {


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
When using webpack 4 with the `@nrwl/web` plugin, we dynamically import webpack from the entry. The export can be the webpack4 or webpack5 instance depending on configuration. 
The `IndexHtmlWebpackPlugin` as well as the `BundleBudgetPlugin` add error messages in some scenario. The problem is,that they use the `webpack.WebpackError` class which was only introduced in webpack5 and is therefore not available if we are using webpack4.

## Expected Behavior
Don't use the `webpack.WebpackError` class when using webpack4, to not run into errors during build.

## Related Issue(s)
#6519

Fixes #
Guard against using the error class, when using webpack4.
