### PR TITLE
feat(node): add TS plugins support for build executor

### DIFF
--- a/docs/angular/api-node/executors/build.md
+++ b/docs/angular/api-node/executors/build.md
@@ -140,6 +140,12 @@ Type: `boolean`
 
 Generates a 'stats.json' file which can be analyzed using tools such as: 'webpack-bundle-analyzer' or <https://webpack.github.io/analyse>.
 
+### tsPlugins
+
+Type: `array`
+
+List of TypeScript Compiler Plugins.
+
 ### verbose
 
 Default: `false`

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -141,6 +141,12 @@ Type: `boolean`
 
 Generates a 'stats.json' file which can be analyzed using tools such as: 'webpack-bundle-analyzer' or <https://webpack.github.io/analyse>.
 
+### tsPlugins
+
+Type: `array`
+
+List of TypeScript Compiler Plugins.
+
 ### verbose
 
 Default: `false`

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -141,6 +141,12 @@ Type: `boolean`
 
 Generates a 'stats.json' file which can be analyzed using tools such as: 'webpack-bundle-analyzer' or <https://webpack.github.io/analyse>.
 
+### tsPlugins
+
+Type: `array`
+
+List of TypeScript Compiler Plugins.
+
 ### verbose
 
 Default: `false`

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -238,7 +238,7 @@ describe('Build Node apps', () => {
       runCLI(`generate @nrwl/nest:app ${nestapp} --linter=eslint`);
 
       // TODO: update to v5 when Nest8 is supported
-      packageInstall('@nestjs/swagger', nestapp, '4.8.2');
+      packageInstall('@nestjs/swagger', undefined, '4.8.2');
 
       updateWorkspaceConfig((workspace) => {
         workspace.projects[nestapp].targets.build.options.tsPlugins = [

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -247,14 +247,6 @@ describe('Build Node apps', () => {
         return workspace;
       });
 
-      const packageJson = JSON.parse(readFile(`apps/${nestapp}/package.json`));
-
-      expect(packageJson).toEqual(
-        expect.objectContaining({
-          '@nestjs/swagger': '4.8.2',
-        })
-      );
-
       updateFile(
         `apps/${nestapp}/src/app/foo.dto.ts`,
         `

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -7,6 +7,8 @@ import {
   createFile,
   killPorts,
   newProject,
+  packageInstall,
+  promisifiedTreeKill,
   readFile,
   readJson,
   runCLI,
@@ -16,7 +18,6 @@ import {
   uniq,
   updateFile,
   updateWorkspaceConfig,
-  promisifiedTreeKill,
 } from '@nrwl/e2e/utils';
 import { accessSync, constants } from 'fs-extra';
 
@@ -229,6 +230,72 @@ describe('Build Node apps', () => {
       })
     );
   }, 300000);
+
+  describe('NestJS', () => {
+    it('should have plugin output if specified in `tsPlugins`', async () => {
+      newProject();
+      const nestapp = uniq('nestapp');
+      runCLI(`generate @nrwl/nest:app ${nestapp} --linter=eslint`);
+
+      // TODO: update to v5 when Nest8 is supported
+      packageInstall('@nestjs/swagger', nestapp, '4.8.2');
+
+      updateWorkspaceConfig((workspace) => {
+        workspace.projects[nestapp].targets.build.options.tsPlugins = [
+          '@nestjs/swagger/plugin',
+        ];
+        return workspace;
+      });
+
+      const packageJson = JSON.parse(readFile(`apps/${nestapp}/package.json`));
+
+      expect(packageJson).toEqual(
+        expect.objectContaining({
+          '@nestjs/swagger': '4.8.2',
+        })
+      );
+
+      updateFile(
+        `apps/${nestapp}/src/app/foo.dto.ts`,
+        `
+export class FooDto {
+  foo: string;
+  bar: number;
+}`
+      );
+      updateFile(
+        `apps/${nestapp}/src/app/app.controller.ts`,
+        `
+import { Controller, Get } from '@nestjs/common';
+import { FooDto } from './foo.dto';
+
+@Controller()
+export class AppController {
+  @Get('foo')
+  getFoo(): Promise<FooDto> {
+    return Promise.resolve({
+      foo: 'foo',
+      bar: 123
+    })
+  }
+}`
+      );
+
+      await runCLIAsync(`build ${nestapp}`);
+
+      const mainJs = readFile(`dist/apps/${nestapp}/main.js`);
+      expect(stripIndents`${mainJs}`).toContainEqual(
+        stripIndents`
+class FooDto {
+    static _OPENAPI_METADATA_FACTORY() {
+        return { foo: { required: true, type: () => String }, bar: { required: true, type: () => Number } };
+    }
+}
+exports.FooDto = FooDto;
+        `
+      );
+    });
+  });
 });
 
 describe('Node Libraries', () => {

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -276,7 +276,7 @@ export class AppController {
       await runCLIAsync(`build ${nestapp}`);
 
       const mainJs = readFile(`dist/apps/${nestapp}/main.js`);
-      expect(stripIndents`${mainJs}`).toContainEqual(
+      expect(stripIndents`${mainJs}`).toContain(
         stripIndents`
 class FooDto {
     static _OPENAPI_METADATA_FACTORY() {
@@ -286,7 +286,7 @@ class FooDto {
 exports.FooDto = FooDto;
         `
       );
-    });
+    }, 300000);
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@nestjs/core": "^7.0.0",
     "@nestjs/platform-express": "^7.0.0",
     "@nestjs/schematics": "^7.0.0",
+    "@nestjs/swagger": "^4.8.2",
     "@nestjs/testing": "^7.0.0",
     "@ngrx/component-store": "12.2.0",
     "@ngrx/effects": "12.2.0",

--- a/packages/node/src/executors/build/schema.json
+++ b/packages/node/src/executors/build/schema.json
@@ -47,7 +47,10 @@
       "oneOf": [
         {
           "type": "string",
-          "enum": ["none", "all"]
+          "enum": [
+            "none",
+            "all"
+          ]
         },
         {
           "type": "array",
@@ -109,7 +112,10 @@
           }
         },
         "additionalProperties": false,
-        "required": ["replace", "with"]
+        "required": [
+          "replace",
+          "with"
+        ]
       },
       "default": []
     },
@@ -136,10 +142,20 @@
       "type": "boolean",
       "description": "Generates a package.json file with the project's node_module dependencies populated for installing in a container. If a package.json exists in the project's directory, it will be reused with dependencies populated.",
       "default": false
+    },
+    "tsPlugins": {
+      "type": "array",
+      "description": "List of TypeScript Compiler Plugins.",
+      "default": [],
+      "items": {
+        "$ref": "#/definitions/tsPluginPattern"
+      }
     }
   },
-  "required": ["tsConfig", "main"],
-
+  "required": [
+    "tsConfig",
+    "main"
+  ],
   "definitions": {
     "assetPattern": {
       "oneOf": [
@@ -167,10 +183,37 @@
             }
           },
           "additionalProperties": false,
-          "required": ["glob", "input", "output"]
+          "required": [
+            "glob",
+            "input",
+            "output"
+          ]
         },
         {
           "type": "string"
+        }
+      ]
+    },
+    "tsPluginPattern": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "options": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ]
         }
       ]
     }

--- a/packages/node/src/executors/build/schema.json
+++ b/packages/node/src/executors/build/schema.json
@@ -47,10 +47,7 @@
       "oneOf": [
         {
           "type": "string",
-          "enum": [
-            "none",
-            "all"
-          ]
+          "enum": ["none", "all"]
         },
         {
           "type": "array",
@@ -112,10 +109,7 @@
           }
         },
         "additionalProperties": false,
-        "required": [
-          "replace",
-          "with"
-        ]
+        "required": ["replace", "with"]
       },
       "default": []
     },
@@ -152,10 +146,7 @@
       }
     }
   },
-  "required": [
-    "tsConfig",
-    "main"
-  ],
+  "required": ["tsConfig", "main"],
   "definitions": {
     "assetPattern": {
       "oneOf": [
@@ -183,11 +174,7 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "glob",
-            "input",
-            "output"
-          ]
+          "required": ["glob", "input", "output"]
         },
         {
           "type": "string"
@@ -211,9 +198,7 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "name"
-          ]
+          "required": ["name"]
         }
       ]
     }

--- a/packages/node/src/utils/__mocks__/plugin-a.ts
+++ b/packages/node/src/utils/__mocks__/plugin-a.ts
@@ -1,0 +1,1 @@
+export const before = () => {};

--- a/packages/node/src/utils/__mocks__/plugin-b.ts
+++ b/packages/node/src/utils/__mocks__/plugin-b.ts
@@ -1,0 +1,1 @@
+export const after = () => {};

--- a/packages/node/src/utils/load-ts-plugins.spec.ts
+++ b/packages/node/src/utils/load-ts-plugins.spec.ts
@@ -1,0 +1,40 @@
+import { loadTsPlugins } from './load-ts-plugins';
+
+jest.mock('plugin-a');
+jest.mock('plugin-b');
+const mockRequireResolve = jest.fn((path) => path);
+
+describe('loadTsPlugins', () => {
+  it('should return empty hooks if plugins is falsy', () => {
+    const result = loadTsPlugins(undefined);
+    assertEmptyResult(result);
+  });
+
+  it('should return empty hooks if plugins is []', () => {
+    const result = loadTsPlugins([]);
+    assertEmptyResult(result);
+  });
+
+  it('should return correct compiler hooks', () => {
+    const result = loadTsPlugins(
+      ['plugin-a', 'plugin-b'],
+      mockRequireResolve as any
+    );
+
+    expect(result.hasPlugin).toEqual(true);
+    expect(result.compilerPluginHooks).toEqual({
+      beforeHooks: [expect.any(Function)],
+      afterHooks: [expect.any(Function)],
+      afterDeclarationsHooks: [],
+    });
+  });
+
+  function assertEmptyResult(result: ReturnType<typeof loadTsPlugins>) {
+    expect(result.hasPlugin).toEqual(false);
+    expect(result.compilerPluginHooks).toEqual({
+      beforeHooks: [],
+      afterHooks: [],
+      afterDeclarationsHooks: [],
+    });
+  }
+});

--- a/packages/node/src/utils/load-ts-plugins.ts
+++ b/packages/node/src/utils/load-ts-plugins.ts
@@ -1,0 +1,86 @@
+import { logger } from '@nrwl/devkit';
+import { join } from 'path';
+import {
+  CompilerPlugin,
+  CompilerPluginHooks,
+  TsPlugin,
+  TsPluginEntry,
+} from './types';
+
+export function loadTsPlugins(
+  plugins: TsPluginEntry[],
+  moduleResolver: typeof require.resolve = require.resolve
+): {
+  compilerPluginHooks: CompilerPluginHooks;
+  hasPlugin: boolean;
+} {
+  const beforeHooks: CompilerPluginHooks['beforeHooks'] = [];
+  const afterHooks: CompilerPluginHooks['afterHooks'] = [];
+  const afterDeclarationsHooks: CompilerPluginHooks['afterDeclarationsHooks'] =
+    [];
+
+  if (!plugins || !plugins.length)
+    return {
+      compilerPluginHooks: {
+        beforeHooks,
+        afterHooks,
+        afterDeclarationsHooks,
+      },
+      hasPlugin: false,
+    };
+
+  const normalizedPlugins: TsPlugin[] = plugins.map((plugin) =>
+    typeof plugin === 'string' ? { name: plugin, options: {} } : plugin
+  );
+
+  const nodeModulePaths = [
+    join(process.cwd(), 'node_modules'),
+    ...module.paths,
+  ];
+
+  const pluginRefs: CompilerPlugin[] = normalizedPlugins.map(({ name }) => {
+    try {
+      const binaryPath = moduleResolver(name, {
+        paths: nodeModulePaths,
+      });
+      return require(binaryPath);
+    } catch (e) {
+      logger.warn(`"${name}" plugin could not be found!`);
+      return {};
+    }
+  });
+
+  for (let i = 0; i < pluginRefs.length; i++) {
+    const { name: pluginName, options: pluginOptions } = normalizedPlugins[i];
+    const { before, after, afterDeclarations } = pluginRefs[i];
+    if (!before && !after && !afterDeclarations) {
+      logger.warn(
+        `${pluginName} is not a Transformer Plugin. It does not provide neither before(), after(), nor afterDeclarations()`
+      );
+      continue;
+    }
+
+    if (before) {
+      beforeHooks.push(before.bind(before, pluginOptions));
+    }
+
+    if (after) {
+      afterHooks.push(after.bind(after, pluginOptions));
+    }
+
+    if (afterDeclarations) {
+      afterDeclarationsHooks.push(
+        afterDeclarations.bind(afterDeclarations, pluginOptions)
+      );
+    }
+  }
+
+  return {
+    compilerPluginHooks: {
+      beforeHooks,
+      afterHooks,
+      afterDeclarationsHooks,
+    },
+    hasPlugin: true,
+  };
+}

--- a/packages/node/src/utils/node.config.spec.ts
+++ b/packages/node/src/utils/node.config.spec.ts
@@ -1,14 +1,14 @@
 import { join } from 'path';
+import { getNodeWebpackConfig } from './node.config';
+import TsConfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
+import { BuildNodeBuilderOptions } from './types';
+
 jest.mock('tsconfig-paths-webpack-plugin');
 jest.mock('@nrwl/tao/src/utils/app-root', () => ({
   get appRootPath() {
     return join(__dirname, '../../../..');
   },
 }));
-
-import { getNodeWebpackConfig } from './node.config';
-import TsConfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
-import { BuildNodeBuilderOptions } from './types';
 
 describe('getNodePartial', () => {
   let input: BuildNodeBuilderOptions;

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -1,3 +1,5 @@
+import ts = require('typescript');
+
 export interface FileReplacement {
   replace: string;
   with: string;
@@ -13,6 +15,36 @@ export interface SourceMapOptions {
   styles: boolean;
   vendors: boolean;
   hidden: boolean;
+}
+
+type Transformer = ts.TransformerFactory<ts.Node> | ts.CustomTransformerFactory;
+
+export interface TsPlugin {
+  name: string;
+  options: Record<string, unknown>;
+}
+
+export type TsPluginEntry = string | TsPlugin;
+
+export interface CompilerPlugin {
+  before?: (
+    options?: Record<string, unknown>,
+    program?: ts.Program
+  ) => Transformer;
+  after?: (
+    options?: Record<string, unknown>,
+    program?: ts.Program
+  ) => Transformer;
+  afterDeclarations?: (
+    options?: Record<string, unknown>,
+    program?: ts.Program
+  ) => Transformer;
+}
+
+export interface CompilerPluginHooks {
+  beforeHooks: Array<(program?: ts.Program) => Transformer>;
+  afterHooks: Array<(program?: ts.Program) => Transformer>;
+  afterDeclarationsHooks: Array<(program?: ts.Program) => Transformer>;
 }
 
 export interface BuildBuilderOptions {
@@ -40,6 +72,8 @@ export interface BuildBuilderOptions {
   root?: string;
   sourceRoot?: string;
   projectRoot?: string;
+
+  tsPlugins?: TsPluginEntry[];
 }
 
 export interface BuildNodeBuilderOptions extends BuildBuilderOptions {

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -1,4 +1,9 @@
-import ts = require('typescript');
+import type {
+  CustomTransformerFactory,
+  Node,
+  Program,
+  TransformerFactory,
+} from 'typescript';
 
 export interface FileReplacement {
   replace: string;
@@ -17,7 +22,7 @@ export interface SourceMapOptions {
   hidden: boolean;
 }
 
-type Transformer = ts.TransformerFactory<ts.Node> | ts.CustomTransformerFactory;
+type Transformer = TransformerFactory<Node> | CustomTransformerFactory;
 
 export interface TsPlugin {
   name: string;
@@ -29,22 +34,19 @@ export type TsPluginEntry = string | TsPlugin;
 export interface CompilerPlugin {
   before?: (
     options?: Record<string, unknown>,
-    program?: ts.Program
+    program?: Program
   ) => Transformer;
-  after?: (
-    options?: Record<string, unknown>,
-    program?: ts.Program
-  ) => Transformer;
+  after?: (options?: Record<string, unknown>, program?: Program) => Transformer;
   afterDeclarations?: (
     options?: Record<string, unknown>,
-    program?: ts.Program
+    program?: Program
   ) => Transformer;
 }
 
 export interface CompilerPluginHooks {
-  beforeHooks: Array<(program?: ts.Program) => Transformer>;
-  afterHooks: Array<(program?: ts.Program) => Transformer>;
-  afterDeclarationsHooks: Array<(program?: ts.Program) => Transformer>;
+  beforeHooks: Array<(program?: Program) => Transformer>;
+  afterHooks: Array<(program?: Program) => Transformer>;
+  afterDeclarationsHooks: Array<(program?: Program) => Transformer>;
 }
 
 export interface BuildBuilderOptions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3729,6 +3729,11 @@
     tslib "2.1.0"
     uuid "8.3.2"
 
+"@nestjs/mapped-types@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/mapped-types/-/mapped-types-0.4.1.tgz#e7fe038f0bdda7b8f858fa79ca8516b8f9069b1a"
+  integrity sha512-JXrw2LMangSU3vnaXWXVX47GRG1FbbNh4aVBbidDjxT3zlghsoNQY6qyWtT001MCl8lJGo8I6i6+DurBRRxl/Q==
+
 "@nestjs/platform-express@^7.0.0":
   version "7.6.14"
   resolved "https://registry.yarnpkg.com/@nestjs/platform-express/-/platform-express-7.6.14.tgz#b16de114421492b719d924a8abf408071c75898e"
@@ -3750,6 +3755,15 @@
     fs-extra "9.1.0"
     jsonc-parser "3.0.0"
     pluralize "8.0.0"
+
+"@nestjs/swagger@4":
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/swagger/-/swagger-4.8.2.tgz#0a0b3ca1b25146e797ca77addd9fa97f82406c1c"
+  integrity sha512-RSUwcVxrzXF7/b/IZ5lXnYHJ6jIGS9wWRTJKIt1kIaCNWT+0wRfTlAyhQkzs2g35/PTXJEcdIwwY7mBO/bwHzw==
+  dependencies:
+    "@nestjs/mapped-types" "0.4.1"
+    lodash "4.17.21"
+    path-to-regexp "3.2.0"
 
 "@nestjs/testing@^7.0.0":
   version "7.6.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,7 +3756,7 @@
     jsonc-parser "3.0.0"
     pluralize "8.0.0"
 
-"@nestjs/swagger@4":
+"@nestjs/swagger@^4.8.2":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@nestjs/swagger/-/swagger-4.8.2.tgz#0a0b3ca1b25146e797ca77addd9fa97f82406c1c"
   integrity sha512-RSUwcVxrzXF7/b/IZ5lXnYHJ6jIGS9wWRTJKIt1kIaCNWT+0wRfTlAyhQkzs2g35/PTXJEcdIwwY7mBO/bwHzw==


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
TS Plugins aren't supported out of the box. Workarounds have been utilizing custom webpack configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
TS Plugins are supported out of the box.

A plugin is specified as a valid TS Plugin is an object that has either one of the following: `before`, `after`, or `afterDeclarations` with the following shape:

> `options` are the plugin custom configuration

```ts
export interface CompilerPlugin {
  before?: (
    options?: Record<string, unknown>,
    program?: ts.Program
  ) => Transformer;
  after?: (
    options?: Record<string, unknown>,
    program?: ts.Program
  ) => Transformer;
  afterDeclarations?: (
    options?: Record<string, unknown>,
    program?: ts.Program
  ) => Transformer;
}
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #2147 
