### PR TITLE
fix(storybook): add styled-jsx typings to Storybook tsconfig

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -48,6 +48,12 @@
       "version": "12.6.0-beta.0",
       "description": "Add 'next' eslint config",
       "factory": "./src/migrations/update-12-6-0/add-next-eslint"
+    },
+    "fix-nextjs-lib-babel-config-12.8.0": {
+      "cli": "nx",
+      "version": "12.8.0-beta.11",
+      "description": "Adjust the Next.js lib babel configuration for styled-jsx",
+      "factory": "./src/migrations/update-12-8-0/remove-styled-jsx-babel-plugin"
     }
   },
   "packageJsonUpdates": {

--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -29,6 +29,11 @@ describe('next library', () => {
     });
     await libraryGenerator(appTree, {
       ...baseOptions,
+      name: 'myLib-styled-jsx',
+      style: 'styled-jsx',
+    });
+    await libraryGenerator(appTree, {
+      ...baseOptions,
       name: 'myLib3',
       directory: 'myDir',
     });
@@ -47,6 +52,10 @@ describe('next library', () => {
         },
       ],
       plugins: ['@emotion/babel-plugin'],
+    });
+    expect(readJson(appTree, 'libs/my-lib-styled-jsx/.babelrc')).toEqual({
+      presets: ['next/babel'],
+      plugins: [],
     });
     expect(readJson(appTree, 'libs/my-dir/my-lib3/.babelrc')).toEqual({
       presets: ['next/babel'],

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -30,6 +30,13 @@ export async function libraryGenerator(host: Tree, options: Schema) {
           },
         },
       ];
+    } else if (options.style === 'styled-jsx') {
+      // next.js doesn't require the `styled-jsx/babel' plugin as it is already
+      // built-into the `next/babel` preset
+      json.presets = ['next/babel'];
+      json.plugins = (json.plugins || []).filter(
+        (x) => x !== 'styled-jsx/babel'
+      );
     } else {
       json.presets = ['next/babel'];
     }

--- a/packages/next/src/generators/library/schema.d.ts
+++ b/packages/next/src/generators/library/schema.d.ts
@@ -1,4 +1,4 @@
-import { SupportedStyles } from '../../../typings/style';
+import type { SupportedStyles } from '@nrwl/react';
 import { Linter } from '@nrwl/linter';
 
 export interface Schema {

--- a/packages/next/src/migrations/update-12-8-0/remove-styled-jsx-babel-plugin.spec.ts
+++ b/packages/next/src/migrations/update-12-8-0/remove-styled-jsx-babel-plugin.spec.ts
@@ -1,0 +1,56 @@
+import { readJson, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { Linter } from '@nrwl/linter';
+import { libraryGenerator } from '../../generators/library/library';
+import { removeStyledJsxBabelConfig } from './remove-styled-jsx-babel-plugin';
+
+describe('Remove styled-jsx babel plugin for Next libs', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+
+    await libraryGenerator(tree, {
+      name: 'test-lib',
+      style: 'styled-jsx',
+      skipFormat: false,
+      skipTsConfig: false,
+      linter: Linter.EsLint,
+      unitTestRunner: 'jest',
+    });
+  });
+
+  it('should remove styled-jsx babel plugin', async () => {
+    tree.write(
+      'libs/test-lib/.babelrc',
+      JSON.stringify({
+        presets: ['next/babel'],
+        plugins: ['styled-jsx/babel'],
+      })
+    );
+
+    await removeStyledJsxBabelConfig(tree);
+    const result = readJson(tree, 'libs/test-lib/.babelrc');
+    expect(result.plugins).toEqual([]);
+  });
+  it('should remove styled-jsx babel plugin but leave potentially other plugins in there', async () => {
+    tree.write(
+      'libs/test-lib/.babelrc',
+      JSON.stringify({
+        presets: ['next/babel'],
+        plugins: [
+          'some-other/plugin',
+          'styled-jsx/babel',
+          'some-storybook/plugin',
+        ],
+      })
+    );
+
+    await removeStyledJsxBabelConfig(tree);
+    const result = readJson(tree, 'libs/test-lib/.babelrc');
+    expect(result.plugins).toEqual([
+      'some-other/plugin',
+      'some-storybook/plugin',
+    ]);
+  });
+});

--- a/packages/next/src/migrations/update-12-8-0/remove-styled-jsx-babel-plugin.ts
+++ b/packages/next/src/migrations/update-12-8-0/remove-styled-jsx-babel-plugin.ts
@@ -1,0 +1,33 @@
+import {
+  formatFiles,
+  getProjects,
+  Tree,
+  readJson,
+  joinPathFragments,
+  writeJson,
+} from '@nrwl/devkit';
+
+export async function removeStyledJsxBabelConfig(host: Tree) {
+  const projects = getProjects(host);
+
+  projects.forEach((project) => {
+    const babelRcPath = joinPathFragments(project.root, '.babelrc');
+    if (host.exists(babelRcPath)) {
+      const babelRcContent = readJson(host, babelRcPath);
+
+      // check whether next.js project
+      if (babelRcContent.presets.includes('next/babel')) {
+        babelRcContent.plugins = babelRcContent.plugins.filter(
+          (x) => x !== 'styled-jsx/babel'
+        );
+
+        // update .babelrc
+        writeJson(host, babelRcPath, babelRcContent);
+      }
+    }
+  });
+
+  await formatFiles(host);
+}
+
+export default removeStyledJsxBabelConfig;

--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -66,6 +66,12 @@
       "cli": "nx",
       "description": "Update Storybook React typings in tsconfig files",
       "factory": "./src/migrations/update-12-5-9/update-storybook-react-typings"
+    },
+    "update-12-8.0": {
+      "version": "12.8.0-beta.11",
+      "cli": "nx",
+      "description": "Adjust Storybook tsconfig to add styled-jsx typings",
+      "factory": "./src/migrations/update-12-8-0/update-storybook-styled-jsx-typings"
     }
   },
   "packageJsonUpdates": {

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -31,6 +31,14 @@ module.exports = {
 "
 `;
 
+exports[`@nrwl/storybook:configuration should have the proper typings 1`] = `
+Array [
+  "../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts",
+  "../../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+  "../../../node_modules/@nrwl/react/typings/image.d.ts",
+]
+`;
+
 exports[`@nrwl/storybook:configuration should reference the "old" webpack.config.js if there - for backwards compatibility 1`] = `
 "const rootMain = require('../../../.storybook/main');
 const rootWebpackConfig = require('../../../.storybook/webpack.config'); 

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -236,4 +236,22 @@ describe('@nrwl/storybook:configuration', () => {
       }
     `);
   });
+
+  it('should have the proper typings', async () => {
+    await libraryGenerator(tree, {
+      name: 'test-ui-lib2',
+      linter: Linter.EsLint,
+      standaloneConfig: false,
+    });
+
+    await configurationGenerator(tree, {
+      name: 'test-ui-lib2',
+      uiFramework: '@storybook/react',
+      standaloneConfig: false,
+    });
+
+    expect(
+      readJson(tree, 'libs/test-ui-lib2/.storybook/tsconfig.json').files
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
@@ -5,6 +5,7 @@
     <% if(uiFramework === '@storybook/react') { %>, "outDir": "" <% } %>
   },
   <% if(uiFramework === '@storybook/react') { %>"files": [
+    "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/styled-jsx.d.ts",
     "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/cssmodule.d.ts",
     "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/image.d.ts"
   ],<% } %>

--- a/packages/storybook/src/migrations/update-12-8-0/__snapshots__/update-storybook-styled-jsx-typings.spec.ts.snap
+++ b/packages/storybook/src/migrations/update-12-8-0/__snapshots__/update-storybook-styled-jsx-typings.spec.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Add styled-jsx typings to Storybook tsconfig should add styled-jsx typings 1`] = `
+Object {
+  "compilerOptions": Object {
+    "emitDecoratorMetadata": true,
+  },
+  "exclude": Array [
+    "../**/*.spec.ts",
+    "../**/*.spec.js",
+    "../**/*.spec.tsx",
+    "../**/*.spec.jsx",
+  ],
+  "extends": "../tsconfig.json",
+  "files": Array [
+    "../../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+    "../../../node_modules/@nrwl/react/typings/image.d.ts",
+    "../../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts",
+  ],
+  "include": Array [
+    "../src/**/*",
+    "*.js",
+  ],
+}
+`;

--- a/packages/storybook/src/migrations/update-12-8-0/update-storybook-styled-jsx-typings.spec.ts
+++ b/packages/storybook/src/migrations/update-12-8-0/update-storybook-styled-jsx-typings.spec.ts
@@ -1,0 +1,61 @@
+import { readJson, Tree, writeJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import addStyledJsxTypings from './update-storybook-styled-jsx-typings';
+
+describe('Add styled-jsx typings to Storybook tsconfig', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+
+    writeJson(tree, 'workspace.json', {
+      projects: {
+        ['home-ui-react']: {
+          projectType: 'library',
+          root: 'libs/home/ui-react',
+          sourceRoot: 'libs/home/ui-react/src',
+          targets: {
+            storybook: {
+              builder: '@nrwl/storybook:storybook',
+              options: {
+                uiFramework: '@storybook/react',
+                port: 4400,
+                config: {
+                  configFolder: 'libs/home/ui-react/.storybook',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    writeJson(tree, 'libs/home/ui-react/.storybook/tsconfig.json', {
+      extends: '../tsconfig.json',
+      compilerOptions: {
+        emitDecoratorMetadata: true,
+      },
+      files: [
+        '../../../node_modules/@nrwl/react/typings/cssmodule.d.ts',
+        '../../../node_modules/@nrwl/react/typings/image.d.ts',
+      ],
+      exclude: [
+        '../**/*.spec.ts',
+        '../**/*.spec.js',
+        '../**/*.spec.tsx',
+        '../**/*.spec.jsx',
+      ],
+      include: ['../src/**/*', '*.js'],
+    });
+  });
+
+  it(`should add styled-jsx typings`, async () => {
+    await addStyledJsxTypings(tree);
+
+    const tsConfigContent = readJson(
+      tree,
+      'libs/home/ui-react/.storybook/tsconfig.json'
+    );
+    expect(tsConfigContent).toMatchSnapshot();
+  });
+});

--- a/packages/storybook/src/migrations/update-12-8-0/update-storybook-styled-jsx-typings.ts
+++ b/packages/storybook/src/migrations/update-12-8-0/update-storybook-styled-jsx-typings.ts
@@ -1,0 +1,73 @@
+import {
+  formatFiles,
+  getProjects,
+  joinPathFragments,
+  logger,
+  offsetFromRoot,
+  readJson,
+  Tree,
+  writeJson,
+} from '@nrwl/devkit';
+import * as path from 'path';
+import { isFramework, TsConfig } from '../../utils/utilities';
+
+export default async function addStyledJsxTypings(tree: Tree) {
+  let changesMade = false;
+  const projects = getProjects(tree);
+
+  projects.forEach((projectConfig, projectName) => {
+    const targets = projectConfig.targets;
+    const storybookRoot = path.join(projectConfig.root, '.storybook');
+
+    const paths = {
+      tsConfigStorybook: joinPathFragments(
+        projectConfig.root,
+        '.storybook/tsconfig.json'
+      ),
+    };
+
+    const storybookExecutor = Object.keys(targets).find(
+      (x) => targets[x].executor === '@nrwl/storybook:storybook'
+    );
+
+    const hasStorybookConfig =
+      storybookExecutor && tree.exists(paths.tsConfigStorybook);
+
+    if (!hasStorybookConfig) {
+      logger.info(
+        `${projectName}: no storybook configured. skipping migration...`
+      );
+      return;
+    }
+
+    const isReactProject = isFramework('react', {
+      uiFramework: targets[storybookExecutor].options
+        ?.uiFramework as Parameters<typeof isFramework>[1]['uiFramework'],
+    });
+
+    if (isReactProject) {
+      const tsConfig = {
+        storybook: readJson<TsConfig>(tree, paths.tsConfigStorybook),
+      };
+
+      tsConfig.storybook.files = tsConfig.storybook.files || [];
+      tsConfig.storybook.files = uniqueArray([
+        ...tsConfig.storybook.files,
+        `${offsetFromRoot(
+          storybookRoot
+        )}node_modules/@nrwl/react/typings/styled-jsx.d.ts`,
+      ]);
+
+      writeJson(tree, paths.tsConfigStorybook, tsConfig.storybook);
+      changesMade = true;
+    }
+  });
+
+  if (changesMade) {
+    await formatFiles(tree);
+  }
+}
+
+function uniqueArray<T extends Array<any>>(value: T) {
+  return [...new Set(value)] as T;
+}


### PR DESCRIPTION
Has two fixes

- adds missing typings to storybook when using styled-jsx
- removes `styled-jsx/babel` from Next.js libs as the `next/babel` preset already has that built-in. Otherwise it'll lead to runtime errors (e.g. when running Storybook)

**Let's merge both commits** to have them traced in the changelog, rather than doing a squash merge