### PR TITLE
feat(core): detect package manager used to invoke create-nx-(plugin|workspace)

### DIFF
--- a/e2e/workspace/src/create-nx-workspace.test.ts
+++ b/e2e/workspace/src/create-nx-workspace.test.ts
@@ -242,4 +242,40 @@ describe('create-nx-workspace', () => {
     checkFilesDoNotExist('package-lock.json');
     process.env.SELECTED_PM = packageManager;
   });
+
+  describe('Use detected package manager', () => {
+    const wsName = uniq('pm');
+
+    function setupProject(envPm: 'npm' | 'yarn' | 'pnpm') {
+      process.env.SELECTED_PM = envPm;
+      runCreateWorkspace(wsName, {
+        preset: 'empty',
+        packageManager: envPm,
+        useDetectedPm: true,
+      });
+    }
+
+    afterEach(() => {
+      process.env.SELECTED_PM = packageManager;
+    });
+
+    it('should use npm when invoked with npx', () => {
+      setupProject('npm');
+      checkFilesExist(`package-lock.json`);
+      checkFilesDoNotExist(`yarn.lock`, `pnpm-lock.yam`);
+    }, 90000);
+
+    it('should use pnpm when invoked with pnpx', () => {
+      setupProject('pnpm');
+      checkFilesExist(`pnpm-lock.yaml`);
+      checkFilesDoNotExist(`yarn.lock`, `package-lock.json`);
+    }, 90000);
+
+    // skipping due to packageManagerCommand for createWorkspace not using yarn create nx-workspace
+    xit('should use yarn when invoked with yarn create', () => {
+      setupProject('yarn');
+      checkFilesExist(`yarn.lock`);
+      checkFilesDoNotExist(`pnpm-lock.yaml`, `package-lock.json`);
+    }, 90000);
+  });
 });

--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -2,6 +2,7 @@
 
 // we can't import from '@nrwl/workspace' because it will require typescript
 import {
+  detectInvokedPackageManager,
   getPackageManagerCommand,
   PackageManager,
 } from '@nrwl/tao/src/shared/package-manager';
@@ -10,10 +11,10 @@ import { readJsonFile, writeJsonFile } from '@nrwl/tao/src/utils/fileutils';
 import { output } from '@nrwl/workspace/src/utilities/output';
 import { execSync } from 'child_process';
 import { removeSync } from 'fs-extra';
-import enquirer = require('enquirer');
 import * as path from 'path';
 import { dirSync } from 'tmp';
 import { showNxWarning } from './shared';
+import enquirer = require('enquirer');
 import yargsParser = require('yargs-parser');
 
 const tsVersion = 'TYPESCRIPT_VERSION';
@@ -63,7 +64,7 @@ function createWorkspace(
     ...process.argv.slice(parsedArgs._[2] ? 3 : 2).map((a) => `"${a}"`),
   ].join(' ');
 
-  const command = `new ${args} --preset=empty --collection=@nrwl/workspace`;
+  const command = `new ${args} --preset=empty --packageManager=${packageManager} --collection=@nrwl/workspace`;
   console.log(command);
 
   const pmc = getPackageManagerCommand(packageManager);
@@ -198,7 +199,8 @@ if (parsedArgs.help) {
   process.exit(0);
 }
 
-const packageManager: PackageManager = parsedArgs.packageManager || 'npm';
+const packageManager: PackageManager =
+  parsedArgs.packageManager || detectInvokedPackageManager();
 determineWorkspaceName(parsedArgs).then((workspaceName) => {
   return determinePluginName(parsedArgs).then((pluginName) => {
     const tmpDir = createSandbox(packageManager);

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { exec, execSync } from 'child_process';
+import { exec } from 'child_process';
 import { writeFileSync } from 'fs';
 import * as enquirer from 'enquirer';
 import * as path from 'path';
@@ -11,6 +11,7 @@ import { output } from './output';
 import * as ora from 'ora';
 
 import {
+  detectInvokedPackageManager,
   getPackageManagerCommand,
   getPackageManagerVersion,
   PackageManager,
@@ -119,7 +120,8 @@ if (parsedArgs.help) {
 }
 
 (async function main() {
-  const packageManager: PackageManager = parsedArgs.packageManager || 'npm';
+  const packageManager: PackageManager =
+    parsedArgs.packageManager || detectInvokedPackageManager();
   const { name, cli, preset, appName, style, nxCloud } = await getConfiguration(
     parsedArgs
   );
@@ -470,7 +472,7 @@ async function createApp(
   const args = unparse(restArgs).join(' ');
 
   const pmc = getPackageManagerCommand(packageManager);
-  const command = `new ${name} ${args} --collection=@nrwl/workspace`;
+  const command = `new ${name} ${args} --packageManager=${packageManager} --collection=@nrwl/workspace`;
 
   let nxWorkspaceRoot = `"${process.cwd().replace(/\\/g, '/')}"`;
 

--- a/packages/create-nx-workspace/bin/package-manager.ts
+++ b/packages/create-nx-workspace/bin/package-manager.ts
@@ -83,3 +83,32 @@ export function getPackageManagerVersion(
 ): string {
   return execSync(`${packageManager} --version`).toString('utf-8').trim();
 }
+
+/**
+ * Detects which package manager was used to invoke create-nx-{plugin|workspace} command
+ * based on the main Module process that invokes the command
+ * - npx returns 'npm'
+ * - pnpx returns 'pnpm'
+ * - yarn create returns 'yarn'
+ *
+ * Default to 'npm'
+ */
+export function detectInvokedPackageManager(): PackageManager {
+  let detectedPackageManager: PackageManager = 'npm';
+  // mainModule is deprecated since Node 14, fallback for older versions
+  const invoker = require.main || process['mainModule'];
+
+  // default to `npm`
+  if (!invoker) {
+    return detectedPackageManager;
+  }
+
+  for (const pkgManager of ['pnpm', 'yarn', 'npm'] as const) {
+    if (invoker.path.includes(pkgManager)) {
+      detectedPackageManager = pkgManager;
+      break;
+    }
+  }
+
+  return detectedPackageManager;
+}

--- a/packages/tao/src/shared/package-manager.ts
+++ b/packages/tao/src/shared/package-manager.ts
@@ -86,3 +86,32 @@ export function getPackageManagerVersion(
 ): string {
   return execSync(`${packageManager} --version`).toString('utf-8').trim();
 }
+
+/**
+ * Detects which package manager was used to invoke create-nx-{plugin|workspace} command
+ * based on the main Module process that invokes the command
+ * - npx returns 'npm'
+ * - pnpx returns 'pnpm'
+ * - yarn create returns 'yarn'
+ *
+ * Default to 'npm'
+ */
+export function detectInvokedPackageManager(): PackageManager {
+  let detectedPackageManager: PackageManager = 'npm';
+  // mainModule is deprecated since Node 14, fallback for older versions
+  const invoker = require.main || process['mainModule'];
+
+  // default to `npm`
+  if (!invoker) {
+    return detectedPackageManager;
+  }
+
+  for (const pkgManager of ['pnpm', 'yarn', 'npm'] as const) {
+    if (invoker.path.includes(pkgManager)) {
+      detectedPackageManager = pkgManager;
+      break;
+    }
+  }
+
+  return detectedPackageManager;
+}


### PR DESCRIPTION
When consumers create a new Workspace (or Plugin) using the create-nx-workspace (or
create-nx-plugin) generator, the package manager used to invoke the generator will be detected and
used as packageManager. For example: pnpx create-nx-workspace will use pnpm, yarn create
nx-workspace will use yarn. Explicit `--packageManager` flag will be priority over the detection.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
