### PR TITLE
chore(repo): enable node 15 and 16 in the nightly runs

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -36,8 +36,8 @@ jobs:
         #   - os: windows-latest
         #     package_manager: yarn
         node_version:
-          - '14'
-          # - '15'
+          # - '14'
+          - '15'
         package_manager:
           - npm
           - yarn

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -29,6 +29,7 @@ jobs:
         node_version:
           - '14'
           - '15'
+          - '16'
         package_manager:
           - npm
           - yarn
@@ -48,10 +49,21 @@ jobs:
             node_version: '14'
             package_manager: pnpm
           - os: ubuntu-latest
-            node_version: '14'
+            node_version: '15'
+            package_manager: npm
+          - os: ubuntu-latest
+            node_version: '15'
+            package_manager: yarn
+          - os: ubuntu-latest
+            node_version: '16'
+            package_manager: npm
+          - os: ubuntu-latest
+            node_version: '16'
             package_manager: yarn
           - os: macos-latest
             node_version: '14'
+          - os: macos-latest
+            node_version: '15'
           - os: macos-latest
             package_manager: yarn
           - os: macos-latest

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -26,17 +26,8 @@ jobs:
             os-name: osx
           # - os: windows-latest
           #  os-name: windows
-        exclude:
-          - os: macos-latest
-            package_manager: yarn
-          - os: macos-latest
-            package_manager: pnpm
-        #   - os: windows-latest
-        #     package_manager: npm
-        #   - os: windows-latest
-        #     package_manager: yarn
         node_version:
-          # - '14'
+          - '14'
           - '15'
         package_manager:
           - npm
@@ -52,6 +43,23 @@ jobs:
           - e2e-web
           - e2e-storybook
           - e2e-workspace
+        exclude:
+          - os: ubuntu-latest
+            node_version: '14'
+            package_manager: pnpm
+          - os: ubuntu-latest
+            node_version: '14'
+            package_manager: yarn
+          - os: macos-latest
+            node_version: '14'
+          - os: macos-latest
+            package_manager: yarn
+          - os: macos-latest
+            package_manager: pnpm
+        #   - os: windows-latest
+        #     package_manager: npm
+        #   - os: windows-latest
+        #     package_manager: yarn
       fail-fast: false
 
     name: ${{ matrix.os-name }}/n v${{ matrix.node_version }}/${{ matrix.package_manager }} - ${{ matrix.packages }}

--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -70,7 +70,7 @@ describe('Jest', () => {
     expect(appResult.combinedOutput).toContain(
       'Test Suites: 1 passed, 1 total'
     );
-  }, 90000);
+  }, 300000);
 
   it('should set the NODE_ENV to `test`', async () => {
     const mylib = uniq('mylib');


### PR DESCRIPTION
The nightly runs should have following matrix:
* **Ubuntu**: 
	* npm + v14
	* yarn + v14
	* pnpm + v15
	* pnpm + v16
* **OSX**:
	* npm + v16
	
We already run `pnpm` on v14 as a part of `pull request`/`commit to master` flow.