### PR TITLE
chore(repo): make circleci jobs parametrised for running on different environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,17 +132,17 @@ commands:
   run-targets:
     parameters:
       run-builds:
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
       run-unit-tests:
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
       run-linting:
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
       run-e2e-tests:
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
       # Filters for tests
       unit-test-filter:
         type: string
@@ -154,28 +154,32 @@ commands:
       - nx/set-shas:
           main-branch-name: 'master'
       - when:
-          condition: << parameters.run-builds >>
+          condition:
+            equal: [<< parameters.run-builds >>, 'true']
           steps:
             - run:
                 name: Run Builds
                 command: |
                   npx nx affected --target=build --base=$NX_BASE --parallel --max-parallel=3
       - when:
-          condition: << parameters.run-unit-tests >>
+          condition:
+            equal: [<< parameters.run-unit-tests >>, 'true']
           steps:
             - run:
                 name: Run Unit Tests
                 command: |
                   npx nx affected --target=test --base=$NX_BASE --parallel --max-parallel=2 --t="<< parameters.unit-test-filter >>"
       - when:
-          condition: << parameters.run-linting >>
+          condition:
+            equal: [<< parameters.run-linting >>, 'true']
           steps:
             - run:
                 name: Run Linting
                 command: |
                   npx nx affected --target=lint --base=$NX_BASE --parallel --max-parallel=4
       - when:
-          condition: << parameters.run-e2e-tests >>
+          condition:
+            equal: [<< parameters.run-e2e-tests >>, 'true']
           steps:
             - run:
                 name: Run E2E Tests
@@ -261,23 +265,23 @@ jobs:
       #      Flags
       # -------------------------
       run-checks:
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
       run-builds:
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
       run-unit-tests:
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
       run-linting:
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
       run-e2e-tests:
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
       run-cypress-tests:
-        type: boolean
-        default: false
+        type: string
+        default: 'false'
       # -------------------------
       #     Filters for tests
       # -------------------------
@@ -298,7 +302,8 @@ jobs:
       - setup:
           os: << parameters.os >>
       - when:
-          condition: << parameters.run-checks >>
+          condition:
+            equal: [<< parameters.run-checks >>, 'true']
           steps:
             - run-checks
       - run-targets:
@@ -343,7 +348,7 @@ workflows:
       # -------------------------
       - main:
           name: pull-request
-          run-checks: true
+          run-checks: 'true'
           filters:
             branches:
               ignore: master
@@ -351,10 +356,10 @@ workflows:
           name: pull-request-osx
           pm: 'yarn'
           os: 'macos'
-          run-checks: false
-          run-builds: false
-          run-unit-tests: false
-          run-linting: false
+          run-checks: 'false'
+          run-builds: 'false'
+          run-unit-tests: 'false'
+          run-linting: 'false'
           e2e-test-filter: 'MACOS-Tests'
           filters:
             branches:
@@ -363,10 +368,10 @@ workflows:
           name: pull-request-android
           pm: 'yarn'
           os: 'android'
-          run-checks: false
-          run-builds: false
-          run-unit-tests: false
-          run-linting: false
+          run-checks: 'false'
+          run-builds: 'false'
+          run-unit-tests: 'false'
+          run-linting: 'false'
           e2e-test-filter: 'Android-Tests'
           filters:
             branches:
@@ -384,7 +389,7 @@ workflows:
       # -------------------------
       - main:
           name: commit-to-master
-          run-cypress-tests: true
+          run-cypress-tests: 'true'
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,10 +165,22 @@ commands:
           condition:
             equal: [<< parameters.run-unit-tests >>, 'true']
           steps:
-            - run:
-                name: Run Unit Tests
-                command: |
-                  npx nx affected --target=test --base=$NX_BASE --parallel --max-parallel=2 -- --t="<< parameters.unit-test-filter >>"
+            - when:
+                condition:
+                  equal: [<< parameters.e2e-test-filter >>, '']
+                steps:
+                  - run:
+                      name: Run Unit Tests
+                      command: |
+                        npx nx affected --target=test --base=$NX_BASE --parallel --max-parallel=2
+            - unless:
+                condition:
+                  equal: [<< parameters.e2e-test-filter >>, '']
+                steps:
+                  - run:
+                      name: Run Unit Tests with Filter "<< parameters.e2e-test-filter >>"
+                      command: |
+                        npx nx affected --target=test --base=$NX_BASE --parallel --max-parallel=2 -- --t="<< parameters.e2e-test-filter >>"
       - when:
           condition:
             equal: [<< parameters.run-linting >>, 'true']
@@ -181,11 +193,24 @@ commands:
           condition:
             equal: [<< parameters.run-e2e-tests >>, 'true']
           steps:
-            - run:
-                name: Run E2E Tests
-                command: |
-                  npx nx affected --target=e2e --base=$NX_BASE -- --t="<< parameters.e2e-test-filter >>"
-                no_output_timeout: 45m
+            - when:
+                condition:
+                  equal: [<< parameters.e2e-test-filter >>, '']
+                steps:
+                  - run:
+                      name: Run E2E Tests
+                      command: |
+                        npx nx affected --target=e2e --base=$NX_BASE
+                      no_output_timeout: 45m
+            - unless:
+                condition:
+                  equal: [<< parameters.e2e-test-filter >>, '']
+                steps:
+                  - run:
+                      name: Run E2E Tests with Filter "<< parameters.e2e-test-filter >>"
+                      command: |
+                        npx nx affected --target=e2e --base=$NX_BASE -- --t="<< parameters.e2e-test-filter >>"
+                      no_output_timeout: 45m
 
 # -------------------------
 #          JOBS
@@ -239,9 +264,17 @@ jobs:
         default: pnpm
     executor: << parameters.os >>
     environment:
+      GIT_AUTHOR_NAME: test@test.com
+      GIT_AUTHOR_EMAIL: Test
+      GIT_COMMITTER_EMAIL: test@test.com
+      GIT_COMMITTER_NAME: Test
       NX_E2E_CI_CACHE_KEY: e2e-circleci-<< parameters.os >>-<< parameters.pm >>
+      SELECTED_PM: << parameters.pm >>
+      SELECTED_CLI: << parameters.cli >>
       NX_VERBOSE_LOGGING: 'true'
     steps:
+      - setup:
+          os: << parameters.os >>
       - run:
           name: Stop All Running Agents for This CI Run
           command: npx nx-cloud stop-all-agents
@@ -343,9 +376,9 @@ workflows:
           name: 'agent8'
       - agent:
           name: 'agent9'
-      - agent:
-          name: 'agent10'
-          os: 'macos'
+      # - agent:
+      #     name: 'agent10'
+      #     os: 'macos'
       # -------------------------
       #     Pull request logic
       # -------------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,7 @@ jobs:
       NX_E2E_CI_CACHE_KEY: e2e-circleci-<< parameters.os >>-<< parameters.pm >>
       SELECTED_PM: << parameters.pm >>
       SELECTED_CLI: << parameters.cli >>
+      NX_VERBOSE_LOGGING: 'true'
     steps:
       - setup:
           os: << parameters.os >>
@@ -239,6 +240,7 @@ jobs:
     executor: << parameters.os >>
     environment:
       NX_E2E_CI_CACHE_KEY: e2e-circleci-<< parameters.os >>-<< parameters.pm >>
+      NX_VERBOSE_LOGGING: 'true'
     steps:
       - run:
           name: Stop All Running Agents for This CI Run
@@ -298,6 +300,7 @@ jobs:
       SELECTED_PM: << parameters.pm >>
       NX_E2E_CI_CACHE_KEY: e2e-circleci-<< parameters.os >>-<< parameters.pm >>
       NX_E2E_RUN_CYPRESS: << parameters.run-cypress-tests >>
+      NX_VERBOSE_LOGGING: 'true'
     steps:
       - setup:
           os: << parameters.os >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,13 @@ commands:
       run-e2e-tests:
         type: boolean
         default: true
+      # Filters for tests
+      unit-test-filter:
+        type: string
+        default: ''
+      e2e-test-filter:
+        type: string
+        default: ''
     steps:
       - nx/set-shas:
           main-branch-name: 'master'
@@ -159,7 +166,7 @@ commands:
             - run:
                 name: Run Unit Tests
                 command: |
-                  npx nx affected --target=test --base=$NX_BASE --parallel --max-parallel=2
+                  npx nx affected --target=test --base=$NX_BASE --parallel --max-parallel=2 --t="<< parameters.unit-test-filter >>"
       - when:
           condition: << parameters.run-linting >>
           steps:
@@ -173,7 +180,7 @@ commands:
             - run:
                 name: Run E2E Tests
                 command: |
-                  npx nx affected --target=e2e --base=$NX_BASE
+                  npx nx affected --target=e2e --base=$NX_BASE --t="<< parameters.e2e-test-filter >>"
                 no_output_timeout: 45m
 
 # -------------------------
@@ -215,15 +222,6 @@ jobs:
   #     JOBS: Agent cleanup
   # -------------------------
   agent-cleanup:
-    steps:
-      - run:
-          name: Stop All Running Agents for This CI Run
-          command: npx nx-cloud stop-all-agents
-
-  # -------------------------
-  #     JOBS: Main
-  # -------------------------
-  main:
     parameters:
       os:
         type: string
@@ -234,6 +232,34 @@ jobs:
       pm:
         type: string
         default: pnpm
+    executor: << parameters.os >>
+    environment:
+      NX_E2E_CI_CACHE_KEY: e2e-circleci-<< parameters.os >>-<< parameters.pm >>
+    steps:
+      - run:
+          name: Stop All Running Agents for This CI Run
+          command: npx nx-cloud stop-all-agents
+
+  # -------------------------
+  #     JOBS: Main
+  # -------------------------
+  main:
+    parameters:
+      # -------------------------
+      #  Environment setup
+      # -------------------------
+      os:
+        type: string
+        default: 'linux'
+      cli:
+        type: string
+        default: ''
+      pm:
+        type: string
+        default: pnpm
+      # -------------------------
+      #      Flags
+      # -------------------------
       run-checks:
         type: boolean
         default: true
@@ -252,6 +278,15 @@ jobs:
       run-cypress-tests:
         type: boolean
         default: false
+      # -------------------------
+      #     Filters for tests
+      # -------------------------
+      unit-test-filter:
+        type: string
+        default: ''
+      e2e-test-filter:
+        type: string
+        default: ''
     executor: << parameters.os >>
     environment:
       NX_CLOUD_DISTRIBUTED_EXECUTION: 'true'
@@ -271,6 +306,8 @@ jobs:
           run-unit-tests: << parameters.run-unit-tests >>
           run-linting: << parameters.run-linting >>
           run-e2e-tests: << parameters.run-e2e-tests >>
+          unit-test-filter: << parameters.unit-test-filter >>
+          e2e-test-filter: << parameters.e2e-test-filter >>
 
 # -------------------------
 #        WORKFLOWS
@@ -300,30 +337,48 @@ workflows:
           name: 'agent9'
       - agent:
           name: 'agent10'
+          os: 'macos'
+      # -------------------------
+      #     Pull request logic
+      # -------------------------
       - main:
-          name: 'Pull request'
+          name: pull-request
           run-checks: true
           filters:
             branches:
               ignore: master
       - main:
-          name: 'Commit to master'
+          name: pull-request-osx
+          pm: 'yarn'
+          os: 'macos'
+          run-checks: false
+          run-builds: false
+          run-unit-tests: false
+          run-linting: false
+          e2e-test-filter: 'MACOS-Tests'
+          requires:
+            - pull-request
+          filters:
+            branches:
+              ignore: master
+      - agent-cleanup:
+          requires:
+            - pull-request-osx
+          filters:
+            branches:
+              ignore: master
+      # -------------------------
+      #     Commit to master
+      # -------------------------
+      - main:
+          name: commit-to-master
           run-cypress-tests: true
           filters:
             branches:
               only: master
-      - main:
-          name: 'Partial Test'
-          pm: 'yarn'
-          run-checks: false
-          run-builds: false
-          run-unit-tests: false
-          run-linting: true
-          run-e2e-tests: false
-          filters:
-            branches:
-              ignore: master
-
       - agent-cleanup:
           requires:
-            - main
+            - commit-to-master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ commands:
             - run:
                 name: Run Unit Tests
                 command: |
-                  npx nx affected --target=test --base=$NX_BASE --parallel --max-parallel=2 --t="<< parameters.unit-test-filter >>"
+                  npx nx affected --target=test --base=$NX_BASE --parallel --max-parallel=2 -- --t="<< parameters.unit-test-filter >>"
       - when:
           condition:
             equal: [<< parameters.run-linting >>, 'true']
@@ -184,7 +184,7 @@ commands:
             - run:
                 name: Run E2E Tests
                 command: |
-                  npx nx affected --target=e2e --base=$NX_BASE --t="<< parameters.e2e-test-filter >>"
+                  npx nx affected --target=e2e --base=$NX_BASE -- --t="<< parameters.e2e-test-filter >>"
                 no_output_timeout: 45m
 
 # -------------------------
@@ -355,35 +355,35 @@ workflows:
           filters:
             branches:
               ignore: master
-      - main:
-          name: pull-request-osx
-          pm: 'yarn'
-          os: 'macos'
-          run-checks: 'false'
-          run-builds: 'false'
-          run-unit-tests: 'false'
-          run-linting: 'false'
-          e2e-test-filter: 'MACOS-Tests'
-          filters:
-            branches:
-              ignore: master
-      - main:
-          name: pull-request-android
-          pm: 'yarn'
-          os: 'android'
-          run-checks: 'false'
-          run-builds: 'false'
-          run-unit-tests: 'false'
-          run-linting: 'false'
-          e2e-test-filter: 'Android-Tests'
-          filters:
-            branches:
-              ignore: master
+      # - main:
+      #     name: pull-request-osx
+      #     pm: 'yarn'
+      #     os: 'macos'
+      #     run-checks: 'false'
+      #     run-builds: 'false'
+      #     run-unit-tests: 'false'
+      #     run-linting: 'false'
+      #     e2e-test-filter: 'MACOS-Tests'
+      #     filters:
+      #       branches:
+      #         ignore: master
+      # - main:
+      #     name: pull-request-android
+      #     pm: 'yarn'
+      #     os: 'android'
+      #     run-checks: 'false'
+      #     run-builds: 'false'
+      #     run-unit-tests: 'false'
+      #     run-linting: 'false'
+      #     e2e-test-filter: 'Android-Tests'
+      #     filters:
+      #       branches:
+      #         ignore: master
       - agent-cleanup:
           requires:
             - pull-request
-            - pull-request-osx
-            - pull-request-android
+            # - pull-request-osx
+            # - pull-request-android
           filters:
             branches:
               ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,68 @@ commands:
       - install-pnpm:
           os: << parameters.os >>
 
+  run-checks:
+    steps:
+      - run:
+          name: Check Documentation
+          command: yarn documentation
+      - run:
+          name: Check Imports
+          command: yarn check-imports
+      - run:
+          name: Check Formatting
+          command: yarn check-format
+      - run:
+          name: Check Package dependencies
+          command: yarn depcheck
+
+  run-targets:
+    parameters:
+      run-builds:
+        type: boolean
+        default: true
+      run-unit-tests:
+        type: boolean
+        default: true
+      run-linting:
+        type: boolean
+        default: true
+      run-e2e-tests:
+        type: boolean
+        default: true
+    steps:
+      - nx/set-shas:
+          main-branch-name: 'master'
+      - when:
+          condition: << parameters.run-builds >>
+          steps:
+            - run:
+                name: Run Builds
+                command: |
+                  npx nx affected --target=build --base=$NX_BASE --parallel --max-parallel=3
+      - when:
+          condition: << parameters.run-unit-tests >>
+          steps:
+            - run:
+                name: Run Unit Tests
+                command: |
+                  npx nx affected --target=test --base=$NX_BASE --parallel --max-parallel=2
+      - when:
+          condition: << parameters.run-linting >>
+          steps:
+            - run:
+                name: Run Linting
+                command: |
+                  npx nx affected --target=lint --base=$NX_BASE --parallel --max-parallel=4
+      - when:
+          condition: << parameters.run-e2e-tests >>
+          steps:
+            - run:
+                name: Run E2E Tests
+                command: |
+                  npx nx affected --target=e2e --base=$NX_BASE
+                no_output_timeout: 45m
+
 # -------------------------
 #          JOBS
 # -------------------------
@@ -150,67 +212,18 @@ jobs:
           no_output_timeout: 60m
 
   # -------------------------
-  #     JOBS: Pull request
+  #     JOBS: Agent cleanup
   # -------------------------
-  pr-main:
-    parameters:
-      os:
-        type: string
-        default: 'linux'
-      cli:
-        type: string
-        default: ''
-      pm:
-        type: string
-        default: pnpm
-    executor: << parameters.os >>
-    environment:
-      NX_CLOUD_DISTRIBUTED_EXECUTION: 'true'
-      SELECTED_CLI: << parameters.cli >>
-      SELECTED_PM: << parameters.pm >>
-      NX_E2E_CI_CACHE_KEY: e2e-circleci-<< parameters.os >>-<< parameters.pm >>
+  agent-cleanup:
     steps:
-      - setup:
-          os: << parameters.os >>
-      - run:
-          name: Check Documentation
-          command: yarn documentation
-      - run:
-          name: Check Imports
-          command: yarn check-imports
-      - run:
-          name: Check Formatting
-          command: yarn check-format
-      - run:
-          name: Check Package dependencies
-          command: yarn depcheck
-      - nx/set-shas:
-          main-branch-name: 'master'
-      - run:
-          name: Run Builds
-          command: |
-            npx nx affected --target=build --base=$NX_BASE --parallel --max-parallel=3
-      - run:
-          name: Run Unit Tests
-          command: |
-            npx nx affected --target=test --base=$NX_BASE --parallel --max-parallel=2
-      - run:
-          name: Run Linting
-          command: |
-            npx nx affected --target=lint --base=$NX_BASE --parallel --max-parallel=4
-      - run:
-          name: Run E2E Tests
-          command: |
-            npx nx affected --target=e2e --base=$NX_BASE
-          no_output_timeout: 45m
       - run:
           name: Stop All Running Agents for This CI Run
           command: npx nx-cloud stop-all-agents
 
   # -------------------------
-  #     JOBS: Commit on main
+  #     JOBS: Main
   # -------------------------
-  trunk-main:
+  main:
     parameters:
       os:
         type: string
@@ -221,34 +234,43 @@ jobs:
       pm:
         type: string
         default: pnpm
+      run-checks:
+        type: boolean
+        default: true
+      run-builds:
+        type: boolean
+        default: true
+      run-unit-tests:
+        type: boolean
+        default: true
+      run-linting:
+        type: boolean
+        default: true
+      run-e2e-tests:
+        type: boolean
+        default: true
+      run-cypress-tests:
+        type: boolean
+        default: false
     executor: << parameters.os >>
     environment:
       NX_CLOUD_DISTRIBUTED_EXECUTION: 'true'
       SELECTED_CLI: << parameters.cli >>
       SELECTED_PM: << parameters.pm >>
       NX_E2E_CI_CACHE_KEY: e2e-circleci-<< parameters.os >>-<< parameters.pm >>
-      NX_E2E_RUN_CYPRESS: 'true'
+      NX_E2E_RUN_CYPRESS: << parameters.run-cypress-tests >>
     steps:
       - setup:
           os: << parameters.os >>
-      - nx/set-shas:
-          main-branch-name: 'master'
-      - run:
-          name: Run Builds
-          command: npx nx affected --target=build --base=$NX_BASE --parallel --max-parallel=3
-      - run:
-          name: Run Unit Tests
-          command: npx nx affected --target=test --base=$NX_BASE --parallel --max-parallel=2
-      - run:
-          name: Run Linting
-          command: npx nx affected --target=lint --base=$NX_BASE --parallel --max-parallel=4
-      - run:
-          name: Run E2E Tests
-          command: npx nx affected --target=e2e --base=$NX_BASE
-          no_output_timeout: 45m
-      - run:
-          name: Stop All Running Agents for This CI Run
-          command: npx nx-cloud stop-all-agents
+      - when:
+          condition: << parameters.run-checks >>
+          steps:
+            - run-checks
+      - run-targets:
+          run-builds: << parameters.run-builds >>
+          run-unit-tests: << parameters.run-unit-tests >>
+          run-linting: << parameters.run-linting >>
+          run-e2e-tests: << parameters.run-e2e-tests >>
 
 # -------------------------
 #        WORKFLOWS
@@ -278,11 +300,30 @@ workflows:
           name: 'agent9'
       - agent:
           name: 'agent10'
-      - pr-main:
+      - main:
+          name: 'Pull request'
+          run-checks: true
           filters:
             branches:
               ignore: master
-      - trunk-main:
+      - main:
+          name: 'Commit to master'
+          run-cypress-tests: true
           filters:
             branches:
               only: master
+      - main:
+          name: 'Partial Test'
+          pm: 'yarn'
+          run-checks: false
+          run-builds: false
+          run-unit-tests: false
+          run-linting: true
+          run-e2e-tests: false
+          filters:
+            branches:
+              ignore: master
+
+      - agent-cleanup:
+          requires:
+            - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,14 +356,26 @@ workflows:
           run-unit-tests: false
           run-linting: false
           e2e-test-filter: 'MACOS-Tests'
-          requires:
-            - pull-request
+          filters:
+            branches:
+              ignore: master
+      - main:
+          name: pull-request-android
+          pm: 'yarn'
+          os: 'android'
+          run-checks: false
+          run-builds: false
+          run-unit-tests: false
+          run-linting: false
+          e2e-test-filter: 'Android-Tests'
           filters:
             branches:
               ignore: master
       - agent-cleanup:
           requires:
+            - pull-request
             - pull-request-osx
+            - pull-request-android
           filters:
             branches:
               ignore: master


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Our CircleCI config runs two main jobs:
- **pr-main** responsible for checking the pull requests
- **trunk-main** responsible for checking the commits to master

Most of the code between those two is duplicated, only difference being that `pr-main` checks also docs, format, commit etc. and `trunk-main` runs cypress tests.

Also, both of them are running only on linux with pnpm

## Expected Behavior
* The jobs should be parametrised so that we can reuse the same setup
* We should be able to run both on different environments making sure the agent cleanup is still working
* We should be able to select what targets we want to run and be able to apply filters

## Related Issue(s)
This will allow us to run iOS and Android tests on a separate machines as part of the same workflow.
This is a important for https://github.com/nrwl/nx/pull/6493
