### PR TITLE
fix(storybook): add check if plugins exist or fallback to empty array

### DIFF
--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -89,13 +89,13 @@ export const webpack = async (
     resolve: {
       ...storybookWebpackConfig.resolve,
       plugins: mergePlugins(
-        ...storybookWebpackConfig.resolve.plugins,
-        ...finalConfig.resolve.plugins
+        ...(storybookWebpackConfig.resolve.plugins ?? []),
+        ...(finalConfig.resolve.plugins ?? [])
       ),
     },
     plugins: mergePlugins(
-      ...storybookWebpackConfig.plugins,
-      ...finalConfig.plugins
+      ...(storybookWebpackConfig.plugins ?? []),
+      ...(finalConfig.plugins ?? [])
     ),
   };
 };


### PR DESCRIPTION
As `storybookWebpackConfig.resolve.plugins` may be undefined add a fallback to empty array.

## Current Behavior
When I use the Storybook `core.builder` as a `webpack5` the build of Storybook is failed because of undefined `storybookWebpackConfig.resolve.plugins` which the Nx Storybook plugin try to merge with its own plugins.

## Expected Behavior
The Storybook can be built using the `webpack5` builder. More about it [HERE](https://github.com/storybookjs/storybook/tree/next/lib/builder-webpack5).
