### PR TITLE
fix(web): syncs `loose` option between @babel/preset-env and @babel/plugin-proposal-class-properties

### DIFF
--- a/packages/web/babel.ts
+++ b/packages/web/babel.ts
@@ -27,6 +27,10 @@ module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
     (caller) => caller?.emitDecoratorMetadata ?? true
   );
 
+  // Determine settings  for `@babel/plugin-proposal-class-properties`,
+  // so that we can sync the `loose` option with `@babel/preset-env`.
+  const classProperties = options.classProperties ?? { loose: true };
+
   return {
     presets: [
       // Support module/nomodule pattern.
@@ -48,6 +52,8 @@ module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
               bugfixes: true,
               // Exclude transforms that make all code slower
               exclude: ['transform-typeof-symbol'],
+              // This must match the setting for `@babel/plugin-proposal-class-properties`
+              loose: classProperties.loose,
             },
       ],
       require.resolve('@babel/preset-typescript'),
@@ -78,7 +84,7 @@ module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
       ],
       [
         require.resolve('@babel/plugin-proposal-class-properties'),
-        options.classProperties ?? { loose: true },
+        classProperties,
       ],
     ].filter(Boolean),
     overrides: [


### PR DESCRIPTION
## Current Behavior

In `@nrwl/web/babel`, if `options.classProperties.loose` is set to `true` (the default), Babel will complain because that setting will be applied to `@babel/plugin-proposal-class-properties`; however, the same `loose` setting is NOT passed to `@babel/preset-env`.

Abridged error output:

> Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
> The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
> ...

## Expected Behavior

Babel should not complain about the same `loose` option not being passed to `@babel/plugin-proposal-class-properties` and the additional plugins enabled by `@babel/preset-env`.

## Related Issue(s)

Fixes #6683

