### PR TITLE
docs(angular): clarify title of setting up nx in an angular cli project

### DIFF
--- a/docs/angular/getting-started/nx-setup.md
+++ b/docs/angular/getting-started/nx-setup.md
@@ -8,7 +8,7 @@ Creating an Nx workspace is done with a single command. Run the following comman
 npx create-nx-workspace --preset=angular
 ```
 
-## Nx Setup with an Existing Project
+## Adding Nx to an Existing Angular CLI Project
 
 If you have an existing Angular CLI project, you can gain the benefits of Nx's computation cache without modifying the file structure by running this command:
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The title of the section instructing users to use `make-angular-cli-faster` is ambiguous and could be misinterpreted to mean Setting Up Nx to an existing Nx Workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The title of the section instructing users to use `make-angular-cli-faster` specifically states it is for an Angular CLI workspace.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/6692
