### PR TITLE
fix(nextjs): fix .babelrc for emotion v11

### DIFF
--- a/packages/next/src/generators/application/files/.babelrc__tmpl__
+++ b/packages/next/src/generators/application/files/.babelrc__tmpl__
@@ -1,6 +1,21 @@
 {
-  "presets": ["@nrwl/next/babel"],
+  "presets": [
+    <% if (style === '@emotion/styled') { %>
+    [
+      "@nrwl/next/babel",
+      {
+        "preset-react": {
+          "runtime": "automatic",
+          "importSource": "@emotion/react"
+        }
+      }
+    ]
+    <% } else { %>
+    "@nrwl/next/babel"
+    <% } %>
+  ],
   "plugins": [
+    <% if (style === '@emotion/styled') { %>"@emotion/babel-plugin"<% } %>
     <% if (style === 'styled-components') { %>["styled-components", { "pure": true, "ssr": true }]<% } %>
   ]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/next` generates an application without plugin configuration when `--style=@emotion/styled`.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`presets` and `plugins` options should be configured.
```js
{
  "presets": [
    [
      "@nrwl/next/babel",
      {
        "preset-react": {
          "runtime": "automatic",
          "importSource": "@emotion/react"
        }
      }
    ]
  ],
  "plugins": ["@emotion/babel-plugin"]
}
```


## Related Issue(s)

The Next.js official example says users can overwrite the preset options via `preset-react`.
```js
{
  "presets": [
    [
      "next/babel",
      {
        "preset-react": { // 👈
          "runtime": "automatic",
          "importSource": "@emotion/react"
        }
      }
    ]
  ],
  "plugins": ["@emotion/babel-plugin"]
}
```
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/vercel/next.js/blob/077097b7f8d3d826118518a90f27cebd2b1373e6/examples/with-emotion/.babelrc#L1-L14

Closes #6778