### PR TITLE
fix(core): skip caching output properties missing in options and arguments

### DIFF
--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -4,6 +4,7 @@ import {
   newProject,
   readFile,
   readJson,
+  removeFile,
   runCLI,
   uniq,
   updateFile,
@@ -187,5 +188,24 @@ describe('Linter', () => {
     expect(outputForApp.messages[0].message).toBe(
       'Unexpected console statement.'
     );
+  }, 1000000);
+
+  it('linting should cache the output file', () => {
+    newProject();
+    const myapp = uniq('myapp');
+    const outputFile = 'a/b/c/lint-output.json';
+
+    runCLI(`generate @nrwl/react:app ${myapp}`);
+
+    expect(() => checkFilesExist(outputFile)).toThrow();
+    runCLI(`lint ${myapp} --output-file="${outputFile}" --format=json`, {
+      silenceError: true,
+    });
+    expect(() => checkFilesExist(outputFile)).not.toThrow();
+    removeFile(outputFile);
+    runCLI(`lint ${myapp} --output-file="${outputFile}" --format=json`, {
+      silenceError: true,
+    });
+    expect(() => checkFilesExist(outputFile)).not.toThrow();
   }, 1000000);
 });

--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -190,12 +190,17 @@ describe('Linter', () => {
     );
   }, 1000000);
 
-  it('linting should cache the output file', () => {
+  it('linting should cache the output file if defined in outputs', () => {
     newProject();
     const myapp = uniq('myapp');
     const outputFile = 'a/b/c/lint-output.json';
 
     runCLI(`generate @nrwl/react:app ${myapp}`);
+    const workspaceJson = readJson(`workspace.json`);
+    workspaceJson.projects[myapp].targets.lint.outputs = [
+      '{options.outputFile}',
+    ];
+    updateFile('workspace.json', JSON.stringify(workspaceJson, null, 2));
 
     expect(() => checkFilesExist(outputFile)).toThrow();
     runCLI(`lint ${myapp} --output-file="${outputFile}" --format=json`, {

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -547,6 +547,11 @@ export function readFile(f: string) {
   return readFileSync(ff, 'utf-8');
 }
 
+export function removeFile(f: string) {
+  const ff = f.startsWith('/') ? f : tmpProjPath(f);
+  removeSync(ff);
+}
+
 export function rmDist() {
   removeSync(`${tmpProjPath()}/dist`);
 }

--- a/e2e/workspace/src/run-commands.test.ts
+++ b/e2e/workspace/src/run-commands.test.ts
@@ -131,4 +131,21 @@ describe('Run Commands', () => {
       );
     }
   });
+
+  it('run command should not break if output property is missing in options and arguments', () => {
+    const myapp = uniq('myapp');
+
+    runCLI(`generate @nrwl/web:app ${myapp}`);
+    const workspaceJson = readJson(`workspace.json`);
+    workspaceJson.projects[myapp].targets.lint.outputs = [
+      '{options.outputFile}',
+    ];
+    updateFile('workspace.json', JSON.stringify(workspaceJson, null, 2));
+
+    expect(() =>
+      runCLI(`run ${myapp}:lint --format=json`, {
+        silenceError: true,
+      })
+    ).not.toThrow();
+  }, 1000000);
 });

--- a/packages/linter/src/executors/lint/lint.impl.ts
+++ b/packages/linter/src/executors/lint/lint.impl.ts
@@ -60,7 +60,6 @@ export default async function run(
       createProgram(path.resolve(systemRoot, tsConfig))
     );
 
-    let i = 0;
     for (const program of allPrograms) {
       lintReports = [
         ...lintReports,

--- a/packages/workspace/src/tasks-runner/task-orchestrator.ts
+++ b/packages/workspace/src/tasks-runner/task-orchestrator.ts
@@ -131,10 +131,8 @@ export class TaskOrchestrator {
 
   private async applyCachedResult(t: TaskWithCachedResult) {
     const outputs = getOutputs(this.projectGraph.nodes, t.task);
-    const shouldCopyOutputsFromCache = this.cache.shouldCopyOutputsFromCache(
-      t,
-      outputs
-    );
+    const shouldCopyOutputsFromCache =
+      !!outputs.length && this.cache.shouldCopyOutputsFromCache(t, outputs);
     if (shouldCopyOutputsFromCache) {
       this.cache.copyFilesFromCache(t.task.hash, t.cachedResult, outputs);
     }

--- a/packages/workspace/src/tasks-runner/utils.ts
+++ b/packages/workspace/src/tasks-runner/utils.ts
@@ -100,14 +100,9 @@ export function getOutputsForTargetAndConfiguration(
   };
 
   if (targets?.outputs) {
-    return targets.outputs.map((output: string) =>
-      interpolateOutputs(output, options)
-    );
-  }
-
-  // Add linter `outputFile` to outputs
-  if (options.outputFile) {
-    return [options.outputFile];
+    return targets.outputs
+      .map((output: string) => interpolateOutputs(output, options))
+      .filter((output) => !!output);
   }
 
   // Keep backwards compatibility in case `outputs` doesn't exist
@@ -174,7 +169,7 @@ function interpolateOutputs(template: string, data: any): string {
     let path = match.slice(1, -1).trim().split('.').slice(1);
     for (let idx = 0; idx < path.length; idx++) {
       if (!value[path[idx]]) {
-        throw new Error(`Could not interpolate output {${match}}!`);
+        return;
       }
       value = value[path[idx]];
     }

--- a/packages/workspace/src/tasks-runner/utils.ts
+++ b/packages/workspace/src/tasks-runner/utils.ts
@@ -105,6 +105,11 @@ export function getOutputsForTargetAndConfiguration(
     );
   }
 
+  // Add linter `outputFile` to outputs
+  if (options.outputFile) {
+    return [options.outputFile];
+  }
+
   // Keep backwards compatibility in case `outputs` doesn't exist
   if (options.outputPath) {
     return Array.isArray(options.outputPath)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Linter's `outputFile` is not being cached

## Expected Behavior
Linter's `outputFile` should be cached as part of command's outputs

## Related Issue(s)

Fixes #6656
