### PR TITLE
fix(core): always use environment variable for cache directory

### DIFF
--- a/packages/workspace/src/utilities/cache-directory.ts
+++ b/packages/workspace/src/utilities/cache-directory.ts
@@ -2,10 +2,6 @@ import { join } from 'path';
 import { readJsonFile } from './fileutils';
 
 export function readCacheDirectoryProperty(root: string) {
-  const cacheDir = process.env.NX_CACHE_DIRECTORY;
-  if (cacheDir) {
-    return cacheDir;
-  }
   try {
     const nxJson = readJsonFile(join(root, 'nx.json'));
     return nxJson.tasksRunnerOptions.default.options.cacheDirectory;
@@ -15,6 +11,10 @@ export function readCacheDirectoryProperty(root: string) {
 }
 
 export function cacheDirectory(root: string, cacheDirectory: string) {
+  const cacheDirFromEnv = process.env.NX_CACHE_DIRECTORY;
+  if (cacheDirFromEnv) {
+    cacheDirectory = cacheDirFromEnv;
+  }
   if (cacheDirectory) {
     if (cacheDirectory.startsWith('./')) {
       return join(root, cacheDirectory);


### PR DESCRIPTION
In 6c16ee0feead3f01c575af2b998fe614c207ac96 the environment variable was used
while reading from `nx.json`. But in `packages/workspace/src/tasks-runner/cache.ts`
the `cacheDirectory` is used without using `readCacheDirectoryProperty`. Now we
check the environment variable in `cacheDirectory`, so that the environment
variable is always used.

ISSUES CLOSED: #6629

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The cache directory can only be set using `nx.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The cache directory set in `nx.json` can be overwritten using environment variable `NX_CACHE_DIRECTORY`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6629
