### PR TITLE
feat(core): detect package manager used to invoke create-nx-(plugin|workspace)

### DIFF
--- a/e2e/workspace/src/create-nx-workspace.test.ts
+++ b/e2e/workspace/src/create-nx-workspace.test.ts
@@ -257,23 +257,32 @@ describe('create-nx-workspace', () => {
 
     it('should use npm when invoked with npx', () => {
       setupProject('npm');
-      checkFilesExist(`package-lock.json`);
-      checkFilesDoNotExist(`yarn.lock`, `pnpm-lock.yam`);
+      checkFilesExist(packageManagerLockFile['npm']);
+      checkFilesDoNotExist(
+        packageManagerLockFile['yarn'],
+        packageManagerLockFile['pnpm']
+      );
       process.env.SELECTED_PM = packageManager;
     }, 90000);
 
     it('should use pnpm when invoked with pnpx', () => {
       setupProject('pnpm');
-      checkFilesExist(`pnpm-lock.yaml`);
-      checkFilesDoNotExist(`yarn.lock`, `package-lock.json`);
+      checkFilesExist(packageManagerLockFile['pnpm']);
+      checkFilesDoNotExist(
+        packageManagerLockFile['yarn'],
+        packageManagerLockFile['npm']
+      );
       process.env.SELECTED_PM = packageManager;
     }, 90000);
 
     // skipping due to packageManagerCommand for createWorkspace not using yarn create nx-workspace
     xit('should use yarn when invoked with yarn create', () => {
       setupProject('yarn');
-      checkFilesExist(`yarn.lock`);
-      checkFilesDoNotExist(`pnpm-lock.yaml`, `package-lock.json`);
+      checkFilesExist(packageManagerLockFile['yarn']);
+      checkFilesDoNotExist(
+        packageManagerLockFile['pnpm'],
+        packageManagerLockFile['npm']
+      );
       process.env.SELECTED_PM = packageManager;
     }, 90000);
   });

--- a/e2e/workspace/src/create-nx-workspace.test.ts
+++ b/e2e/workspace/src/create-nx-workspace.test.ts
@@ -255,20 +255,18 @@ describe('create-nx-workspace', () => {
       });
     }
 
-    afterEach(() => {
-      process.env.SELECTED_PM = packageManager;
-    });
-
     it('should use npm when invoked with npx', () => {
       setupProject('npm');
       checkFilesExist(`package-lock.json`);
       checkFilesDoNotExist(`yarn.lock`, `pnpm-lock.yam`);
+      process.env.SELECTED_PM = packageManager;
     }, 90000);
 
     it('should use pnpm when invoked with pnpx', () => {
       setupProject('pnpm');
       checkFilesExist(`pnpm-lock.yaml`);
       checkFilesDoNotExist(`yarn.lock`, `package-lock.json`);
+      process.env.SELECTED_PM = packageManager;
     }, 90000);
 
     // skipping due to packageManagerCommand for createWorkspace not using yarn create nx-workspace
@@ -276,6 +274,7 @@ describe('create-nx-workspace', () => {
       setupProject('yarn');
       checkFilesExist(`yarn.lock`);
       checkFilesDoNotExist(`pnpm-lock.yaml`, `package-lock.json`);
+      process.env.SELECTED_PM = packageManager;
     }, 90000);
   });
 });

--- a/e2e/workspace/src/create-nx-workspace.test.ts
+++ b/e2e/workspace/src/create-nx-workspace.test.ts
@@ -244,11 +244,9 @@ describe('create-nx-workspace', () => {
   });
 
   describe('Use detected package manager', () => {
-    const wsName = uniq('pm');
-
     function setupProject(envPm: 'npm' | 'yarn' | 'pnpm') {
       process.env.SELECTED_PM = envPm;
-      runCreateWorkspace(wsName, {
+      runCreateWorkspace(uniq('pm'), {
         preset: 'empty',
         packageManager: envPm,
         useDetectedPm: true,

--- a/e2e/workspace/src/create-nx-workspace.test.ts
+++ b/e2e/workspace/src/create-nx-workspace.test.ts
@@ -242,4 +242,40 @@ describe('create-nx-workspace', () => {
     checkFilesDoNotExist('package-lock.json');
     process.env.SELECTED_PM = packageManager;
   });
+
+  describe('Use detected package manager', () => {
+    const wsName = uniq('pm');
+
+    function setupProject(envPm: 'npm' | 'yarn' | 'pnpm') {
+      process.env.SELECTED_PM = envPm;
+      runCreateWorkspace(wsName, {
+        preset: 'empty',
+        packageManager: envPm,
+        useDetectedPm: true,
+      });
+    }
+
+    afterEach(() => {
+      process.env.SELECTED_PM = packageManager;
+    });
+
+    it('should use npm when invoked with npx', () => {
+      setupProject('npm');
+      checkFilesExist(`package-lock.json`);
+      checkFilesDoNotExist(`yarn.lock`, `pnpm-lock.yam`);
+    }, 90000);
+
+    it('should use pnpm when invoked with pnpx', () => {
+      setupProject('pnpm');
+      checkFilesExist(`pnpm-lock.yaml`);
+      checkFilesDoNotExist(`yarn.lock`, `package-lock.json`);
+    }, 90000);
+
+    // skipping due to packageManagerCommand for createWorkspace not using yarn create nx-workspace
+    xit('should use yarn when invoked with yarn create', () => {
+      setupProject('yarn');
+      checkFilesExist(`yarn.lock`);
+      checkFilesDoNotExist(`pnpm-lock.yaml`, `package-lock.json`);
+    }, 90000);
+  });
 });

--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -2,6 +2,7 @@
 
 // we can't import from '@nrwl/workspace' because it will require typescript
 import {
+  detectInvokedPackageManager,
   getPackageManagerCommand,
   PackageManager,
 } from '@nrwl/tao/src/shared/package-manager';
@@ -10,10 +11,10 @@ import { readJsonFile, writeJsonFile } from '@nrwl/tao/src/utils/fileutils';
 import { output } from '@nrwl/workspace/src/utilities/output';
 import { execSync } from 'child_process';
 import { removeSync } from 'fs-extra';
-import enquirer = require('enquirer');
 import * as path from 'path';
 import { dirSync } from 'tmp';
 import { showNxWarning } from './shared';
+import enquirer = require('enquirer');
 import yargsParser = require('yargs-parser');
 
 const tsVersion = 'TYPESCRIPT_VERSION';
@@ -63,7 +64,7 @@ function createWorkspace(
     ...process.argv.slice(parsedArgs._[2] ? 3 : 2).map((a) => `"${a}"`),
   ].join(' ');
 
-  const command = `new ${args} --preset=empty --collection=@nrwl/workspace`;
+  const command = `new ${args} --preset=empty --packageManager=${packageManager} --collection=@nrwl/workspace`;
   console.log(command);
 
   const pmc = getPackageManagerCommand(packageManager);
@@ -198,7 +199,8 @@ if (parsedArgs.help) {
   process.exit(0);
 }
 
-const packageManager: PackageManager = parsedArgs.packageManager || 'npm';
+const packageManager: PackageManager =
+  parsedArgs.packageManager || detectInvokedPackageManager();
 determineWorkspaceName(parsedArgs).then((workspaceName) => {
   return determinePluginName(parsedArgs).then((pluginName) => {
     const tmpDir = createSandbox(packageManager);

--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -1,11 +1,7 @@
 #!/usr/bin/env node
 
 // we can't import from '@nrwl/workspace' because it will require typescript
-import {
-  detectInvokedPackageManager,
-  getPackageManagerCommand,
-  PackageManager,
-} from '@nrwl/tao/src/shared/package-manager';
+import { getPackageManagerCommand } from '@nrwl/tao/src/shared/package-manager';
 import type { NxJsonConfiguration } from '@nrwl/tao/src/shared/nx';
 import { readJsonFile, writeJsonFile } from '@nrwl/tao/src/utils/fileutils';
 import { output } from '@nrwl/workspace/src/utilities/output';
@@ -14,6 +10,10 @@ import { removeSync } from 'fs-extra';
 import * as path from 'path';
 import { dirSync } from 'tmp';
 import { showNxWarning } from './shared';
+import {
+  detectInvokedPackageManager,
+  PackageManager,
+} from './detect-invoked-package-manager';
 import enquirer = require('enquirer');
 import yargsParser = require('yargs-parser');
 

--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -59,12 +59,18 @@ function createWorkspace(
   parsedArgs: any,
   name: string
 ) {
+  // Ensure to use packageManager for args
+  // if it's not already passed in from previous process
+  if (!parsedArgs.packageManager) {
+    parsedArgs.packageManager = packageManager;
+  }
+
   const args = [
     name,
     ...process.argv.slice(parsedArgs._[2] ? 3 : 2).map((a) => `"${a}"`),
   ].join(' ');
 
-  const command = `new ${args} --preset=empty --packageManager=${packageManager} --collection=@nrwl/workspace`;
+  const command = `new ${args} --preset=empty --collection=@nrwl/workspace`;
   console.log(command);
 
   const pmc = getPackageManagerCommand(packageManager);

--- a/packages/create-nx-plugin/bin/detect-invoked-package-manager.ts
+++ b/packages/create-nx-plugin/bin/detect-invoked-package-manager.ts
@@ -1,0 +1,30 @@
+export type PackageManager = 'yarn' | 'pnpm' | 'npm';
+
+/**
+ * Detects which package manager was used to invoke create-nx-{plugin|workspace} command
+ * based on the main Module process that invokes the command
+ * - npx returns 'npm'
+ * - pnpx returns 'pnpm'
+ * - yarn create returns 'yarn'
+ *
+ * Default to 'npm'
+ */
+export function detectInvokedPackageManager(): PackageManager {
+  let detectedPackageManager: PackageManager = 'npm';
+  // mainModule is deprecated since Node 14, fallback for older versions
+  const invoker = require.main || process['mainModule'];
+
+  // default to `npm`
+  if (!invoker) {
+    return detectedPackageManager;
+  }
+
+  for (const pkgManager of ['pnpm', 'yarn', 'npm'] as const) {
+    if (invoker.path.includes(pkgManager)) {
+      detectedPackageManager = pkgManager;
+      break;
+    }
+  }
+
+  return detectedPackageManager;
+}

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -473,7 +473,7 @@ async function createApp(
   // Ensure to use packageManager for args
   // if it's not already passed in from previous process
   if (!restArgs.packageManager) {
-    restArgs.packageManage = packageManager;
+    restArgs.packageManager = packageManager;
   }
 
   const args = unparse(restArgs).join(' ');

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { exec, execSync } from 'child_process';
+import { exec } from 'child_process';
 import { writeFileSync } from 'fs';
 import * as enquirer from 'enquirer';
 import * as path from 'path';
@@ -11,6 +11,7 @@ import { output } from './output';
 import * as ora from 'ora';
 
 import {
+  detectInvokedPackageManager,
   getPackageManagerCommand,
   getPackageManagerVersion,
   PackageManager,
@@ -119,7 +120,8 @@ if (parsedArgs.help) {
 }
 
 (async function main() {
-  const packageManager: PackageManager = parsedArgs.packageManager || 'npm';
+  const packageManager: PackageManager =
+    parsedArgs.packageManager || detectInvokedPackageManager();
   const { name, cli, preset, appName, style, nxCloud } = await getConfiguration(
     parsedArgs
   );
@@ -470,7 +472,7 @@ async function createApp(
   const args = unparse(restArgs).join(' ');
 
   const pmc = getPackageManagerCommand(packageManager);
-  const command = `new ${name} ${args} --collection=@nrwl/workspace`;
+  const command = `new ${name} ${args} --packageManager=${packageManager} --collection=@nrwl/workspace`;
 
   let nxWorkspaceRoot = `"${process.cwd().replace(/\\/g, '/')}"`;
 

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -469,10 +469,17 @@ async function createApp(
   parsedArgs: any
 ) {
   const { _, cli, ...restArgs } = parsedArgs;
+
+  // Ensure to use packageManager for args
+  // if it's not already passed in from previous process
+  if (!restArgs.packageManager) {
+    restArgs.packageManage = packageManager;
+  }
+
   const args = unparse(restArgs).join(' ');
 
   const pmc = getPackageManagerCommand(packageManager);
-  const command = `new ${name} ${args} --packageManager=${packageManager} --collection=@nrwl/workspace`;
+  const command = `new ${name} ${args} --collection=@nrwl/workspace`;
 
   let nxWorkspaceRoot = `"${process.cwd().replace(/\\/g, '/')}"`;
 

--- a/packages/create-nx-workspace/bin/package-manager.ts
+++ b/packages/create-nx-workspace/bin/package-manager.ts
@@ -83,3 +83,32 @@ export function getPackageManagerVersion(
 ): string {
   return execSync(`${packageManager} --version`).toString('utf-8').trim();
 }
+
+/**
+ * Detects which package manager was used to invoke create-nx-{plugin|workspace} command
+ * based on the main Module process that invokes the command
+ * - npx returns 'npm'
+ * - pnpx returns 'pnpm'
+ * - yarn create returns 'yarn'
+ *
+ * Default to 'npm'
+ */
+export function detectInvokedPackageManager(): PackageManager {
+  let detectedPackageManager: PackageManager = 'npm';
+  // mainModule is deprecated since Node 14, fallback for older versions
+  const invoker = require.main || process['mainModule'];
+
+  // default to `npm`
+  if (!invoker) {
+    return detectedPackageManager;
+  }
+
+  for (const pkgManager of ['pnpm', 'yarn', 'npm'] as const) {
+    if (invoker.path.includes(pkgManager)) {
+      detectedPackageManager = pkgManager;
+      break;
+    }
+  }
+
+  return detectedPackageManager;
+}

--- a/packages/tao/src/shared/package-manager.ts
+++ b/packages/tao/src/shared/package-manager.ts
@@ -86,32 +86,3 @@ export function getPackageManagerVersion(
 ): string {
   return execSync(`${packageManager} --version`).toString('utf-8').trim();
 }
-
-/**
- * Detects which package manager was used to invoke create-nx-{plugin|workspace} command
- * based on the main Module process that invokes the command
- * - npx returns 'npm'
- * - pnpx returns 'pnpm'
- * - yarn create returns 'yarn'
- *
- * Default to 'npm'
- */
-export function detectInvokedPackageManager(): PackageManager {
-  let detectedPackageManager: PackageManager = 'npm';
-  // mainModule is deprecated since Node 14, fallback for older versions
-  const invoker = require.main || process['mainModule'];
-
-  // default to `npm`
-  if (!invoker) {
-    return detectedPackageManager;
-  }
-
-  for (const pkgManager of ['pnpm', 'yarn', 'npm'] as const) {
-    if (invoker.path.includes(pkgManager)) {
-      detectedPackageManager = pkgManager;
-      break;
-    }
-  }
-
-  return detectedPackageManager;
-}

--- a/packages/tao/src/shared/package-manager.ts
+++ b/packages/tao/src/shared/package-manager.ts
@@ -86,3 +86,32 @@ export function getPackageManagerVersion(
 ): string {
   return execSync(`${packageManager} --version`).toString('utf-8').trim();
 }
+
+/**
+ * Detects which package manager was used to invoke create-nx-{plugin|workspace} command
+ * based on the main Module process that invokes the command
+ * - npx returns 'npm'
+ * - pnpx returns 'pnpm'
+ * - yarn create returns 'yarn'
+ *
+ * Default to 'npm'
+ */
+export function detectInvokedPackageManager(): PackageManager {
+  let detectedPackageManager: PackageManager = 'npm';
+  // mainModule is deprecated since Node 14, fallback for older versions
+  const invoker = require.main || process['mainModule'];
+
+  // default to `npm`
+  if (!invoker) {
+    return detectedPackageManager;
+  }
+
+  for (const pkgManager of ['pnpm', 'yarn', 'npm'] as const) {
+    if (invoker.path.includes(pkgManager)) {
+      detectedPackageManager = pkgManager;
+      break;
+    }
+  }
+
+  return detectedPackageManager;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently you always have to specific —packageManager with create-nx-workspace. yarn create nx-workspace should use yarn as the package manager by default. when using pnpx, we should use pnpm.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When consumers create a new Workspace (or Plugin) using the `create-nx-workspace` (or `create-nx-plugin`) generator, the package manager used to invoke the generator will be detected and used as `packageManager`. For example: `pnpx create-nx-workspace` will use `pnpm`, `yarn create nx-workspace` will use `yarn`. Explicit `--packageManager` flag will be priority over the detection.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
