### PR TITLE
fix(angular): prevent default importPath for publishable libs

### DIFF
--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -987,6 +987,21 @@ describe('lib', () => {
 
       expect.assertions(1);
     });
+
+    it('should fail if no importPath has been used', async () => {
+      try {
+        // ACT
+        await runLibraryGeneratorWithOpts({
+          publishable: true,
+        });
+      } catch (e) {
+        expect(e.message).toContain(
+          'For publishable libs you have to provide a proper "--importPath"'
+        );
+      }
+
+      expect.assertions(1);
+    });
   });
 
   describe('--strict', () => {

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -28,20 +28,21 @@ import { convertToNxProjectGenerator } from '@nrwl/workspace';
 
 export async function libraryGenerator(host: Tree, schema: Partial<Schema>) {
   // Do some validation checks
-  const options = normalizeOptions(host, schema);
-  if (!options.routing && options.lazy) {
+  if (!schema.routing && schema.lazy) {
     throw new Error(`To use --lazy option, --routing must also be set.`);
   }
 
-  if (options.enableIvy === true && !options.buildable) {
+  if (schema.enableIvy === true && !schema.buildable) {
     throw new Error('enableIvy must only be used with buildable.');
   }
 
-  if (options.publishable === true && !options.importPath) {
+  if (schema.publishable === true && !schema.importPath) {
     throw new Error(
       `For publishable libs you have to provide a proper "--importPath" which needs to be a valid npm package name (e.g. my-awesome-lib or @myorg/my-lib)`
     );
   }
+
+  const options = normalizeOptions(host, schema);
 
   await init(host, {
     ...options,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Not providing an `importPath` to a publishable lib will assign it a default path which could be incorrect. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
For publishable libs, force the user to specify a valid npm `importPath`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
