### PR TITLE
fix(angular): ensure createProjectGraphAsync is called before readCachedProjectGraph

### DIFF
--- a/packages/angular/src/executors/package/package.impl.ts
+++ b/packages/angular/src/executors/package/package.impl.ts
@@ -1,6 +1,9 @@
 import * as ng from '@angular/compiler-cli';
 import type { ExecutorContext } from '@nrwl/devkit';
-import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  createProjectGraphAsync,
+  readCachedProjectGraph,
+} from '@nrwl/workspace/src/core/project-graph';
 import type { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import {
   calculateProjectDependencies,
@@ -50,6 +53,7 @@ export function createLibraryExecutor(
     options: BuildAngularLibraryExecutorOptions,
     context: ExecutorContext
   ) {
+    await createProjectGraphAsync();
     const { target, dependencies } = calculateProjectDependencies(
       readCachedProjectGraph('4.0'),
       context.root,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Building an angular lib with nx `12.7.1` fails with:

```
Error reading '/home/circleci/repo/node_modules/.cache/nx/nxdeps.json'. Continue the process without the cache.
Error: UnexpectedEndOfString in JSON at position 1638386
    at Object.parseJson (/home/circleci/repo/node_modules/@nrwl/tao/src/utils/json.js:30:15)
    at Object.readJsonFile (/home/circleci/repo/node_modules/@nrwl/tao/src/utils/fileutils.js:20:19)
    at Object.readCache (/home/circleci/repo/node_modules/@nrwl/workspace/src/core/nx-deps/nx-deps-cache.js:38:32)
    at Object.readCachedProjectGraph (/home/circleci/repo/node_modules/@nrwl/workspace/src/core/project-graph/project-graph.js:24:47)
    at /home/circleci/repo/node_modules/@nrwl/angular/src/executors/package/package.impl.js:34:114
    at Generator.next (<anonymous>)
    at resume (/home/circleci/repo/node_modules/tslib/tslib.js:221:48)
    at /home/circleci/repo/node_modules/tslib/tslib.js:220:125
    at new Promise (<anonymous>)
    at Object.i.<computed> [as next] (/home/circleci/repo/node_modules/tslib/tslib.js:220:67)
    at /home/circleci/repo/node_modules/@nrwl/tao/src/commands/run.js:92:35
    at Generator.next (<anonymous>)
    at /home/circleci/repo/node_modules/tslib/tslib.js:117:75
    at new Promise (<anonymous>)
    at Object.__awaiter (/home/circleci/repo/node_modules/tslib/tslib.js:113:16)
    at iteratorToProcessStatusCode (/home/circleci/repo/node_modules/@nrwl/tao/src/commands/run.js:78:20)

      [readCachedProjectGraph] ERROR: No cached ProjectGraph is available.

      If you are leveraging `readCachedProjectGraph()` directly then you will need to refactor your usage to first ensure that
      the ProjectGraph is created by calling `await createProjectGraphAsync()` somewhere before attempting to read the data.

      If you encounter this error as part of running standard `nx` commands then please open an issue on https://github.com/nrwl/nx
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The library compiles without issue

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

N/A