### PR TITLE
feat(misc): remove ts-node, tslib, and dotenv from empty workspace package.json

### DIFF
--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -135,6 +135,7 @@ function addE2ETestRunner(
           protractor: '~7.0.0',
           'jasmine-core': '~3.6.0',
           'jasmine-spec-reporter': '~5.0.0',
+          'ts-node': '~9.1.1',
           '@types/jasmine': '~3.6.0',
           '@types/jasminewd2': '~2.0.3',
         }

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -3,6 +3,7 @@ import {
   jestTypesVersion,
   jestVersion,
   nxVersion,
+  tslibVersion,
   tsJestVersion,
 } from '../../utils/versions';
 import { JestInitSchema } from './schema';
@@ -55,6 +56,9 @@ function createJestConfig(host: Tree) {
 }
 
 function updateDependencies(tree: Tree, options: NormalizedSchema) {
+  const dependencies = {
+    tslib: tslibVersion,
+  };
   const devDeps = {
     '@nrwl/jest': nxVersion,
     jest: jestVersion,
@@ -66,7 +70,7 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
     devDeps['babel-jest'] = babelJestVersion;
   }
 
-  return addDependenciesToPackageJson(tree, {}, devDeps);
+  return addDependenciesToPackageJson(tree, dependencies, devDeps);
 }
 
 function updateExtensions(host: Tree) {

--- a/packages/jest/src/utils/versions.ts
+++ b/packages/jest/src/utils/versions.ts
@@ -1,5 +1,6 @@
 export const nxVersion = '*';
 export const jestVersion = '27.0.3';
 export const jestTypesVersion = '26.0.24';
+export const tslibVersion = '^2.0.0';
 export const tsJestVersion = '27.0.3';
 export const babelJestVersion = '27.0.6';

--- a/packages/node/src/generators/init/init.spec.ts
+++ b/packages/node/src/generators/init/init.spec.ts
@@ -29,6 +29,7 @@ describe('init', () => {
 
     const packageJson = readJson(tree, 'package.json');
     expect(packageJson.dependencies['@nrwl/node']).toBeUndefined();
+    expect(packageJson.dependencies['tslib']).toBeDefined();
     expect(packageJson.dependencies[existing]).toBeDefined();
     expect(packageJson.devDependencies['@nrwl/node']).toBeDefined();
     expect(packageJson.devDependencies[existing]).toBeDefined();

--- a/packages/node/src/generators/init/init.ts
+++ b/packages/node/src/generators/init/init.ts
@@ -6,7 +6,7 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { nxVersion } from '../../utils/versions';
+import { nxVersion, tslibVersion } from '../../utils/versions';
 import { Schema } from './schema';
 import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-collection';
 import { jestInitGenerator } from '@nrwl/jest';
@@ -17,7 +17,13 @@ function updateDependencies(tree: Tree) {
     return json;
   });
 
-  return addDependenciesToPackageJson(tree, {}, { '@nrwl/node': nxVersion });
+  return addDependenciesToPackageJson(
+    tree,
+    {
+      tslib: tslibVersion,
+    },
+    { '@nrwl/node': nxVersion }
+  );
 }
 
 function normalizeOptions(schema: Schema) {

--- a/packages/node/src/utils/versions.ts
+++ b/packages/node/src/utils/versions.ts
@@ -1,1 +1,3 @@
 export const nxVersion = '*';
+
+export const tslibVersion = '^2.0.0';

--- a/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
@@ -4,16 +4,13 @@ exports[`new --preset angular should generate necessary npm dependencies 1`] = `
 Object {
   "dependencies": Object {
     "@nrwl/angular": "*",
-    "tslib": "^2.0.0",
   },
   "devDependencies": Object {
     "@nrwl/cli": "*",
     "@nrwl/tao": "*",
     "@nrwl/workspace": "*",
     "@types/node": "14.14.33",
-    "dotenv": "~10.0.0",
     "prettier": "^2.3.1",
-    "ts-node": "~9.1.1",
     "typescript": "~4.3.5",
   },
   "license": "MIT",
@@ -48,17 +45,13 @@ Object {
 
 exports[`new --preset empty should generate necessary npm dependencies 1`] = `
 Object {
-  "dependencies": Object {
-    "tslib": "^2.0.0",
-  },
+  "dependencies": Object {},
   "devDependencies": Object {
     "@nrwl/cli": "*",
     "@nrwl/tao": "*",
     "@nrwl/workspace": "*",
     "@types/node": "14.14.33",
-    "dotenv": "~10.0.0",
     "prettier": "^2.3.1",
-    "ts-node": "~9.1.1",
     "typescript": "~4.3.5",
   },
   "license": "MIT",
@@ -93,18 +86,14 @@ Object {
 
 exports[`new --preset react should generate necessary npm dependencies 1`] = `
 Object {
-  "dependencies": Object {
-    "tslib": "^2.0.0",
-  },
+  "dependencies": Object {},
   "devDependencies": Object {
     "@nrwl/cli": "*",
     "@nrwl/react": "*",
     "@nrwl/tao": "*",
     "@nrwl/workspace": "*",
     "@types/node": "14.14.33",
-    "dotenv": "~10.0.0",
     "prettier": "^2.3.1",
-    "ts-node": "~9.1.1",
     "typescript": "~4.3.5",
   },
   "license": "MIT",

--- a/packages/workspace/src/generators/workspace/files/package.json__tmpl__
+++ b/packages/workspace/src/generators/workspace/files/package.json__tmpl__
@@ -31,7 +31,6 @@
   },
   "private": true,
   "dependencies": {
-    "tslib": "^2.0.0"
   },
   "devDependencies": {
      <% if(cli === 'angular') { %>"@angular/cli": "<%= angularCliVersion %>",<% } %>
@@ -39,8 +38,6 @@
     "@nrwl/cli": "<%= nxVersion %>",
     "@nrwl/workspace": "<%= nxVersion %>",
     "@types/node": "14.14.33",
-    "dotenv": "~10.0.0",
-    "ts-node": "~9.1.1",
     "typescript": "<%= typescriptVersion %>",
     "prettier": "<%= prettierVersion %>"
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`ts-node`, `dotenv`, and `tslib` are all a part of an empty workspace while they might not have any use.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`ts-node` was something that was necessary for `protractor` so that has been moved to the protractor initialization.

`dotenv` was something that was necessary before when `@nrwl/workspace` didn't depend on `dotenv` but it does now so it is no longer necessary in the workspace's package.json

`tslib` is necessary for jest and node projects so it has been moved there.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
