### PR TITLE
fix(core): remove .eslintrc double extends update on move

### DIFF
--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
@@ -9,7 +9,6 @@ import { Linter } from '../../../utils/lint';
 import { libraryGenerator } from '../../library/library';
 import { NormalizedSchema } from '../schema';
 import { updateEslintrcJson } from './update-eslintrc-json';
-import { updateProjectRootFiles } from './update-project-root-files';
 
 describe('updateEslint', () => {
   let tree: Tree;
@@ -55,7 +54,6 @@ describe('updateEslint', () => {
     );
     const projectConfig = readProjectConfiguration(tree, 'my-lib');
 
-    updateProjectRootFiles(tree, schema, projectConfig);
     updateEslintrcJson(tree, schema, projectConfig);
 
     expect(
@@ -87,7 +85,6 @@ describe('updateEslint', () => {
       relativeToRootDestination: 'libs/test',
     };
 
-    updateProjectRootFiles(tree, newSchema, projectConfig);
     updateEslintrcJson(tree, newSchema, projectConfig);
 
     expect(readJson(tree, '/libs/test/.eslintrc.json')).toEqual(
@@ -118,7 +115,6 @@ describe('updateEslint', () => {
     );
     const projectConfig = readProjectConfiguration(tree, 'my-lib');
 
-    updateProjectRootFiles(tree, schema, projectConfig);
     updateEslintrcJson(tree, schema, projectConfig);
 
     expect(
@@ -148,7 +144,6 @@ describe('updateEslint', () => {
     );
     const projectConfig = readProjectConfiguration(tree, 'my-lib');
 
-    updateProjectRootFiles(tree, schema, projectConfig);
     updateEslintrcJson(tree, schema, projectConfig);
 
     expect(

--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
@@ -9,6 +9,7 @@ import { Linter } from '../../../utils/lint';
 import { libraryGenerator } from '../../library/library';
 import { NormalizedSchema } from '../schema';
 import { updateEslintrcJson } from './update-eslintrc-json';
+import { updateProjectRootFiles } from './update-project-root-files';
 
 describe('updateEslint', () => {
   let tree: Tree;
@@ -54,6 +55,7 @@ describe('updateEslint', () => {
     );
     const projectConfig = readProjectConfiguration(tree, 'my-lib');
 
+    updateProjectRootFiles(tree, schema, projectConfig);
     updateEslintrcJson(tree, schema, projectConfig);
 
     expect(
@@ -61,6 +63,36 @@ describe('updateEslint', () => {
     ).toEqual(
       expect.objectContaining({
         extends: ['../../../.eslintrc.json'],
+      })
+    );
+  });
+
+  it('should update .eslintrc.json extends path when project is moved from subdirectory', async () => {
+    await libraryGenerator(tree, {
+      name: 'test',
+      directory: 'api',
+      linter: Linter.EsLint,
+      standaloneConfig: false,
+    });
+    // This step is usually handled elsewhere
+    tree.rename('libs/api/test/.eslintrc.json', 'libs/test/.eslintrc.json');
+    const projectConfig = readProjectConfiguration(tree, 'api-test');
+
+    const newSchema = {
+      projectName: 'api-test',
+      destination: 'test',
+      importPath: '@proj/test',
+      updateImportPath: true,
+      newProjectName: 'test',
+      relativeToRootDestination: 'libs/test',
+    };
+
+    updateProjectRootFiles(tree, newSchema, projectConfig);
+    updateEslintrcJson(tree, newSchema, projectConfig);
+
+    expect(readJson(tree, '/libs/test/.eslintrc.json')).toEqual(
+      expect.objectContaining({
+        extends: ['../../.eslintrc.json'],
       })
     );
   });
@@ -86,6 +118,7 @@ describe('updateEslint', () => {
     );
     const projectConfig = readProjectConfiguration(tree, 'my-lib');
 
+    updateProjectRootFiles(tree, schema, projectConfig);
     updateEslintrcJson(tree, schema, projectConfig);
 
     expect(
@@ -115,6 +148,7 @@ describe('updateEslint', () => {
     );
     const projectConfig = readProjectConfiguration(tree, 'my-lib');
 
+    updateProjectRootFiles(tree, schema, projectConfig);
     updateEslintrcJson(tree, schema, projectConfig);
 
     expect(

--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
@@ -1,9 +1,4 @@
-import {
-  offsetFromRoot,
-  ProjectConfiguration,
-  Tree,
-  updateJson,
-} from '@nrwl/devkit';
+import { ProjectConfiguration, Tree, updateJson } from '@nrwl/devkit';
 import { join } from 'path';
 import { NormalizedSchema } from '../schema';
 
@@ -18,19 +13,6 @@ interface PartialEsLintRcJson {
   overrides?: PartialEsLintrcOverride[];
 }
 
-function offsetFilePath(
-  project: ProjectConfiguration,
-  pathToFile: string,
-  offset: string
-): string {
-  if (!pathToFile.startsWith('..')) {
-    // not a relative path
-    return pathToFile;
-  }
-  const pathFromRoot = join(project.root, pathToFile);
-  return join(offset, pathFromRoot);
-}
-
 /**
  * Update the .eslintrc file of the project if it exists.
  *
@@ -41,28 +23,14 @@ export function updateEslintrcJson(
   schema: NormalizedSchema,
   project: ProjectConfiguration
 ) {
+  tree['recordedChanges'];
   const eslintRcPath = join(schema.relativeToRootDestination, '.eslintrc.json');
-
   if (!tree.exists(eslintRcPath)) {
     // no .eslintrc found. nothing to do
     return;
   }
 
-  const offset = offsetFromRoot(schema.relativeToRootDestination);
-
   updateJson<PartialEsLintRcJson>(tree, eslintRcPath, (eslintRcJson) => {
-    if (typeof eslintRcJson.extends === 'string') {
-      eslintRcJson.extends = offsetFilePath(
-        project,
-        eslintRcJson.extends,
-        offset
-      );
-    } else {
-      eslintRcJson.extends = eslintRcJson.extends.map((extend: string) =>
-        offsetFilePath(project, extend, offset)
-      );
-    }
-
     eslintRcJson.overrides?.forEach((o) => {
       if (o.parserOptions?.project) {
         o.parserOptions.project = [

--- a/packages/workspace/src/generators/move/lib/update-project-root-files.ts
+++ b/packages/workspace/src/generators/move/lib/update-project-root-files.ts
@@ -40,6 +40,9 @@ export function updateProjectRootFiles(
     if (!extname(file).startsWith('.js')) {
       continue;
     }
+    if (file === '.eslintrc.json') {
+      continue;
+    }
 
     const oldContent = tree.read(
       join(schema.relativeToRootDestination, file),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Both `updateProjectRootFiles` and `updateEslintrcJson` modify relative paths in the `.eslintrc.json`'s `extends`, causing change to be applied twice.

## Expected Behavior
Only `updateProjectRootFiles` should modify relative paths in the `.eslintrc.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
