### PR TITLE
fix(core): include e2e apps in affected:apps command

### DIFF
--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -47,7 +47,9 @@ export async function affected(
     switch (command) {
       case 'apps':
         const apps = filteredProjects
-          .filter((p) => p.type === ProjectType.app)
+          .filter(
+            (p) => p.type === ProjectType.app || p.type === ProjectType.e2e
+          )
           .map((p) => p.name);
         if (parsedArgs.plain) {
           console.log(apps.join(' '));


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If a branch is created that only touches an `e2e` app, then when running `nx affected:apps`, nothing will appear.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
If a branch is created that only touches an `e2e` app, then when running `nx affected:apps`, the affected e2e app will appear.

*Potential alternative behavior that could prevent breaking changes?*: alternatively we could add an `nx affected:e2e` command to allow for only printing e2e apps.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
