### PR TITLE
feat(react): add a hook generator (e.g. useThing)

### DIFF
--- a/docs/angular/api-react/generators/component.md
+++ b/docs/angular/api-react/generators/component.md
@@ -108,6 +108,16 @@ Type: `boolean`
 
 Generate JavaScript files rather than TypeScript files.
 
+### pascalCaseDirectory
+
+Alias(es): R
+
+Default: `false`
+
+Type: `boolean`
+
+Use pascal case directory name (e.g. App/App.tsx).
+
 ### pascalCaseFiles
 
 Alias(es): P

--- a/docs/angular/api-react/generators/hook.md
+++ b/docs/angular/api-react/generators/hook.md
@@ -1,0 +1,113 @@
+# @nrwl/react:hook
+
+Create a hook
+
+## Usage
+
+```bash
+nx generate hook ...
+```
+
+```bash
+nx g h ... # same
+```
+
+By default, Nx will search for `hook` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/react:hook ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g hook ... --dry-run
+```
+
+### Examples
+
+Generate a hook in the mylib library:
+
+```bash
+nx g hook my-hook --project=mylib
+```
+
+## Options
+
+### name (_**required**_)
+
+Type: `string`
+
+The name of the hook.
+
+### project (_**required**_)
+
+Alias(es): p
+
+Type: `string`
+
+The name of the project.
+
+### directory
+
+Alias(es): d
+
+Type: `string`
+
+Create the hook under this directory (can be nested).
+
+### export
+
+Alias(es): e
+
+Default: `false`
+
+Type: `boolean`
+
+When true, the hook is exported from the project index.ts (if it exists).
+
+### flat
+
+Default: `false`
+
+Type: `boolean`
+
+Create hook at the source root rather than its own directory.
+
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files.
+
+### pascalCaseDirectory
+
+Alias(es): R
+
+Default: `false`
+
+Type: `boolean`
+
+Use pascal case directory name (e.g. useHook/useHook.ts).
+
+### pascalCaseFiles
+
+Alias(es): P
+
+Default: `false`
+
+Type: `boolean`
+
+Use pascal case hook file name (e.g. useHook.ts).
+
+### skipTests
+
+Default: `false`
+
+Type: `boolean`
+
+When true, does not create "spec.ts" test files for the new hook.

--- a/docs/map.json
+++ b/docs/map.json
@@ -558,6 +558,11 @@
             "name": "storybook-migrate-defaults-5-to-6 generator",
             "id": "storybook-migrate-defaults-5-to-6",
             "file": "angular/api-react/generators/storybook-migrate-defaults-5-to-6"
+          },
+          {
+            "name": "hook generator",
+            "id": "hook",
+            "file": "angular/api-react/generators/hook"
           }
         ]
       },
@@ -1749,6 +1754,11 @@
             "name": "storybook-migrate-defaults-5-to-6 generator",
             "id": "storybook-migrate-defaults-5-to-6",
             "file": "react/api-react/generators/storybook-migrate-defaults-5-to-6"
+          },
+          {
+            "name": "hook generator",
+            "id": "hook",
+            "file": "react/api-react/generators/hook"
           }
         ]
       },
@@ -2909,6 +2919,11 @@
             "name": "storybook-migrate-defaults-5-to-6 generator",
             "id": "storybook-migrate-defaults-5-to-6",
             "file": "node/api-react/generators/storybook-migrate-defaults-5-to-6"
+          },
+          {
+            "name": "hook generator",
+            "id": "hook",
+            "file": "node/api-react/generators/hook"
           }
         ]
       },

--- a/docs/node/api-react/generators/component.md
+++ b/docs/node/api-react/generators/component.md
@@ -108,6 +108,16 @@ Type: `boolean`
 
 Generate JavaScript files rather than TypeScript files.
 
+### pascalCaseDirectory
+
+Alias(es): R
+
+Default: `false`
+
+Type: `boolean`
+
+Use pascal case directory name (e.g. App/App.tsx).
+
 ### pascalCaseFiles
 
 Alias(es): P

--- a/docs/node/api-react/generators/hook.md
+++ b/docs/node/api-react/generators/hook.md
@@ -1,0 +1,113 @@
+# @nrwl/react:hook
+
+Create a hook
+
+## Usage
+
+```bash
+nx generate hook ...
+```
+
+```bash
+nx g h ... # same
+```
+
+By default, Nx will search for `hook` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/react:hook ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g hook ... --dry-run
+```
+
+### Examples
+
+Generate a hook in the mylib library:
+
+```bash
+nx g hook my-hook --project=mylib
+```
+
+## Options
+
+### name (_**required**_)
+
+Type: `string`
+
+The name of the hook.
+
+### project (_**required**_)
+
+Alias(es): p
+
+Type: `string`
+
+The name of the project.
+
+### directory
+
+Alias(es): d
+
+Type: `string`
+
+Create the hook under this directory (can be nested).
+
+### export
+
+Alias(es): e
+
+Default: `false`
+
+Type: `boolean`
+
+When true, the hook is exported from the project index.ts (if it exists).
+
+### flat
+
+Default: `false`
+
+Type: `boolean`
+
+Create hook at the source root rather than its own directory.
+
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files.
+
+### pascalCaseDirectory
+
+Alias(es): R
+
+Default: `false`
+
+Type: `boolean`
+
+Use pascal case directory name (e.g. useHook/useHook.ts).
+
+### pascalCaseFiles
+
+Alias(es): P
+
+Default: `false`
+
+Type: `boolean`
+
+Use pascal case hook file name (e.g. useHook.ts).
+
+### skipTests
+
+Default: `false`
+
+Type: `boolean`
+
+When true, does not create "spec.ts" test files for the new hook.

--- a/docs/react/api-react/generators/component.md
+++ b/docs/react/api-react/generators/component.md
@@ -108,6 +108,16 @@ Type: `boolean`
 
 Generate JavaScript files rather than TypeScript files.
 
+### pascalCaseDirectory
+
+Alias(es): R
+
+Default: `false`
+
+Type: `boolean`
+
+Use pascal case directory name (e.g. App/App.tsx).
+
 ### pascalCaseFiles
 
 Alias(es): P

--- a/docs/react/api-react/generators/hook.md
+++ b/docs/react/api-react/generators/hook.md
@@ -1,0 +1,113 @@
+# @nrwl/react:hook
+
+Create a hook
+
+## Usage
+
+```bash
+nx generate hook ...
+```
+
+```bash
+nx g h ... # same
+```
+
+By default, Nx will search for `hook` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/react:hook ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g hook ... --dry-run
+```
+
+### Examples
+
+Generate a hook in the mylib library:
+
+```bash
+nx g hook my-hook --project=mylib
+```
+
+## Options
+
+### name (_**required**_)
+
+Type: `string`
+
+The name of the hook.
+
+### project (_**required**_)
+
+Alias(es): p
+
+Type: `string`
+
+The name of the project.
+
+### directory
+
+Alias(es): d
+
+Type: `string`
+
+Create the hook under this directory (can be nested).
+
+### export
+
+Alias(es): e
+
+Default: `false`
+
+Type: `boolean`
+
+When true, the hook is exported from the project index.ts (if it exists).
+
+### flat
+
+Default: `false`
+
+Type: `boolean`
+
+Create hook at the source root rather than its own directory.
+
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files.
+
+### pascalCaseDirectory
+
+Alias(es): R
+
+Default: `false`
+
+Type: `boolean`
+
+Use pascal case directory name (e.g. useHook/useHook.ts).
+
+### pascalCaseFiles
+
+Alias(es): P
+
+Default: `false`
+
+Type: `boolean`
+
+Use pascal case hook file name (e.g. useHook.ts).
+
+### skipTests
+
+Default: `false`
+
+Type: `boolean`
+
+When true, does not create "spec.ts" test files for the new hook.

--- a/nx.json
+++ b/nx.json
@@ -50,6 +50,5 @@
   "workspaceLayout": {
     "libsDir": "",
     "appsDir": ""
-  },
-  "projects": {}
+  }
 }

--- a/packages/react/generators.json
+++ b/packages/react/generators.json
@@ -72,6 +72,13 @@
       "schema": "./src/generators/component-cypress-spec/schema.json",
       "description": "Create a cypress spec for a ui component that has a story",
       "hidden": false
+    },
+
+    "hook": {
+      "factory": "./src/generators/hook/hook#chookSchematic",
+      "schema": "./src/generators/hook/schema.json",
+      "description": "Create a hook",
+      "aliases": "h"
     }
   },
   "generators": {
@@ -144,6 +151,13 @@
       "schema": "./src/generators/component-cypress-spec/schema.json",
       "description": "Create a cypress spec for a ui component that has a story",
       "hidden": false
+    },
+
+    "hook": {
+      "factory": "./src/generators/hook/hook#hookGenerator",
+      "schema": "./src/generators/hook/schema.json",
+      "description": "Create a hook",
+      "aliases": "c"
     }
   }
 }

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -7,6 +7,7 @@ export { assertValidStyle } from './src/utils/assertion';
 export { reactDomVersion, reactVersion } from './src/utils/versions';
 export { applicationGenerator } from './src/generators/application/application';
 export { componentGenerator } from './src/generators/component/component';
+export { hookGenerator } from './src/generators/hook/hook';
 export { componentCypressGenerator } from './src/generators/component-cypress-spec/component-cypress-spec';
 export { componentStoryGenerator } from './src/generators/component-story/component-story';
 export { libraryGenerator } from './src/generators/library/library';

--- a/packages/react/src/generators/component/component.spec.ts
+++ b/packages/react/src/generators/component/component.spec.ts
@@ -136,6 +136,27 @@ describe('component', () => {
     });
   });
 
+  describe('--pascalCaseDirectory', () => {
+    it('should generate component files with pascal case directories', async () => {
+      await componentGenerator(appTree, {
+        name: 'hello-world',
+        style: 'css',
+        project: projectName,
+        pascalCaseFiles: true,
+        pascalCaseDirectory: true,
+      });
+      expect(
+        appTree.exists('libs/my-lib/src/lib/HelloWorld/HelloWorld.tsx')
+      ).toBeTruthy();
+      expect(
+        appTree.exists('libs/my-lib/src/lib/HelloWorld/HelloWorld.spec.tsx')
+      ).toBeTruthy();
+      expect(
+        appTree.exists('libs/my-lib/src/lib/HelloWorld/HelloWorld.module.css')
+      ).toBeTruthy();
+    });
+  });
+
   describe('--style none', () => {
     it('should generate component files without styles', async () => {
       await componentGenerator(appTree, {

--- a/packages/react/src/generators/component/schema.json
+++ b/packages/react/src/generators/component/schema.json
@@ -107,6 +107,12 @@
       "alias": "P",
       "default": false
     },
+    "pascalCaseDirectory": {
+      "type": "boolean",
+      "description": "Use pascal case directory name (e.g. App/App.tsx).",
+      "alias": "R",
+      "default": false
+    },
     "classComponent": {
       "type": "boolean",
       "alias": "C",

--- a/packages/react/src/generators/hook/files/__fileName__.spec.ts__tmpl__
+++ b/packages/react/src/generators/hook/files/__fileName__.spec.ts__tmpl__
@@ -1,0 +1,16 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import <%= hookName %> from './<%= fileName %>';
+
+describe('<%= hookName %>', () => {
+  it('should render successfully', () => {
+    const { result } = renderHook(() => <%= hookName %>());
+
+    expect(result.current.count).toBe(0);
+
+    act(() => {
+      result.current.increment()
+    });
+
+    expect(result.current.count).toBe(1);
+  });
+});

--- a/packages/react/src/generators/hook/files/__fileName__.ts__tmpl__
+++ b/packages/react/src/generators/hook/files/__fileName__.ts__tmpl__
@@ -1,0 +1,15 @@
+import { useState, useCallback } from 'react'
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface <%= hookTypeName %> {
+  count: number;
+  increment: () => void;
+}
+
+export function <%= hookName %>(): <%= hookTypeName %> {
+  const [count, setCount] = useState(0)
+  const increment = useCallback(() => setCount((x) => x + 1), [])
+  return { count, increment }
+};
+
+export default <%= hookName %>;

--- a/packages/react/src/generators/hook/hook.spec.ts
+++ b/packages/react/src/generators/hook/hook.spec.ts
@@ -1,0 +1,207 @@
+import { createApp, createLib } from '../../utils/testing-generators';
+import { logger, readJson, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { hookGenerator } from './hook';
+
+describe('hook', () => {
+  let appTree: Tree;
+  let projectName: string;
+
+  beforeEach(async () => {
+    projectName = 'my-lib';
+    appTree = createTreeWithEmptyWorkspace();
+    await createApp(appTree, 'my-app');
+    await createLib(appTree, projectName);
+    jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    jest.spyOn(logger, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should generate files', async () => {
+    await hookGenerator(appTree, {
+      name: 'form',
+      project: projectName,
+    });
+
+    expect(
+      appTree.exists('libs/my-lib/src/lib/use-form/use-form.ts')
+    ).toBeTruthy();
+    expect(
+      appTree.exists('libs/my-lib/src/lib/use-form/use-form.spec.ts')
+    ).toBeTruthy();
+  });
+
+  it('should generate files for an app', async () => {
+    await hookGenerator(appTree, {
+      name: 'form',
+      project: 'my-app',
+    });
+
+    expect(
+      appTree.exists('apps/my-app/src/app/use-form/use-form.ts')
+    ).toBeTruthy();
+    expect(
+      appTree.exists('apps/my-app/src/app/use-form/use-form.spec.ts')
+    ).toBeTruthy();
+  });
+
+  it('handles "use" in the name', async () => {
+    await hookGenerator(appTree, {
+      name: 'usehello',
+      project: projectName,
+      skipTests: true,
+    });
+
+    expect(
+      appTree.exists('libs/my-lib/src/lib/use-hello/use-hello.ts')
+    ).toBeTruthy();
+    expect(
+      appTree.exists('libs/my-lib/src/lib/use-hello/use-hello.spec.ts')
+    ).toBeFalsy();
+  });
+
+  it('handles "use-" in the name', async () => {
+    await hookGenerator(appTree, {
+      name: 'use-hello',
+      project: projectName,
+      skipTests: true,
+    });
+    expect(
+      appTree.exists('libs/my-lib/src/lib/use-hello/use-hello.ts')
+    ).toBeTruthy();
+    expect(
+      appTree.exists('libs/my-lib/src/lib/use-hello/use-hello.spec.ts')
+    ).toBeFalsy();
+  });
+
+  describe('--export', () => {
+    it('should add to index.ts barrel', async () => {
+      await hookGenerator(appTree, {
+        name: 'hello',
+        project: projectName,
+        export: true,
+      });
+
+      const indexContent = appTree.read('libs/my-lib/src/index.ts', 'utf-8');
+
+      expect(indexContent).toMatch(/lib\/use-hello/);
+    });
+
+    it('should not export from an app', async () => {
+      await hookGenerator(appTree, {
+        name: 'hello',
+        project: 'my-app',
+        export: true,
+      });
+
+      const indexContent = appTree.read('libs/my-lib/src/index.ts', 'utf-8');
+
+      expect(indexContent).not.toMatch(/lib\/use-hello/);
+    });
+  });
+
+  describe('--skipTests', () => {
+    it('should not generate tests', async () => {
+      await hookGenerator(appTree, {
+        name: 'hello',
+        project: projectName,
+        skipTests: true,
+      });
+      expect(
+        appTree.exists('libs/my-lib/src/lib/use-hello/use-hello.ts')
+      ).toBeTruthy();
+      expect(
+        appTree.exists('libs/my-lib/src/lib/use-hello/use-hello.spec.ts')
+      ).toBeFalsy();
+    });
+  });
+
+  describe('--pascalCaseFiles', () => {
+    it('should generate component files with pascal case names', async () => {
+      await hookGenerator(appTree, {
+        name: 'hello',
+        project: projectName,
+        pascalCaseFiles: true,
+      });
+      expect(
+        appTree.exists('libs/my-lib/src/lib/use-hello/useHello.ts')
+      ).toBeTruthy();
+      expect(
+        appTree.exists('libs/my-lib/src/lib/use-hello/useHello.spec.ts')
+      ).toBeTruthy();
+    });
+  });
+
+  describe('--pascalCaseDirectory', () => {
+    it('should generate component files with pascal case directory name', async () => {
+      await hookGenerator(appTree, {
+        name: 'hello',
+        project: projectName,
+        pascalCaseFiles: true,
+        pascalCaseDirectory: true,
+      });
+      expect(
+        appTree.exists('libs/my-lib/src/lib/useHello/useHello.ts')
+      ).toBeTruthy();
+      expect(
+        appTree.exists('libs/my-lib/src/lib/useHello/useHello.spec.ts')
+      ).toBeTruthy();
+    });
+  });
+
+  describe('--directory', () => {
+    it('should create component under the directory', async () => {
+      await hookGenerator(appTree, {
+        name: 'hello',
+        project: projectName,
+        directory: 'hooks',
+        skipTests: true,
+      });
+
+      expect(appTree.exists('/libs/my-lib/src/hooks/use-hello/use-hello.ts'));
+    });
+
+    it('should create with nested directories', async () => {
+      await hookGenerator(appTree, {
+        name: 'helloWorld',
+        project: projectName,
+        directory: 'lib/foo',
+        skipTests: true,
+      });
+
+      expect(
+        appTree.exists(
+          '/libs/my-lib/src/lib/foo/use-hello-world/use-hello-world.ts'
+        )
+      );
+    });
+  });
+
+  describe('--flat', () => {
+    it('should create in project directory rather than in its own folder', async () => {
+      await hookGenerator(appTree, {
+        name: 'hello',
+        project: projectName,
+        flat: true,
+        skipTests: true,
+      });
+
+      expect(appTree.exists('/libs/my-lib/src/lib/use-hello.ts'));
+    });
+
+    it('should work with custom directory path', async () => {
+      await hookGenerator(appTree, {
+        name: 'hello',
+        project: projectName,
+        flat: true,
+        directory: 'hooks',
+        skipTests: true,
+      });
+
+      expect(appTree.exists('/libs/my-lib/src/hooks/use-hello.ts'));
+    });
+  });
+});

--- a/packages/react/src/generators/hook/hook.ts
+++ b/packages/react/src/generators/hook/hook.ts
@@ -1,18 +1,9 @@
 import * as ts from 'typescript';
-import { Schema } from './schema';
 import {
-  reactRouterDomVersion,
-  typesReactRouterDomVersion,
-} from '../../utils/versions';
-import { assertValidStyle } from '../../utils/assertion';
-import { addStyledModuleDependencies } from '../../rules/add-styled-dependencies';
-import {
-  addDependenciesToPackageJson,
   applyChangesToString,
   convertNxGenerator,
   formatFiles,
   generateFiles,
-  GeneratorCallback,
   getProjects,
   joinPathFragments,
   logger,
@@ -20,49 +11,33 @@ import {
   toJS,
   Tree,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
+import { Schema } from './schema';
 import { addImport } from '../../utils/ast-utils';
 
 interface NormalizedSchema extends Schema {
   projectSourceRoot: string;
+  hookName: string;
+  hookTypeName: string;
   fileName: string;
-  className: string;
-  styledModule: null | string;
-  hasStyles: boolean;
 }
 
-export async function componentGenerator(host: Tree, schema: Schema) {
+export async function hookGenerator(host: Tree, schema: Schema) {
   const options = await normalizeOptions(host, schema);
-  createComponentFiles(host, options);
 
-  const tasks: GeneratorCallback[] = [];
-
-  const styledTask = addStyledModuleDependencies(host, options.styledModule);
-  tasks.push(styledTask);
-
+  createFiles(host, options);
   addExportsToBarrel(host, options);
 
-  if (options.routing) {
-    const routingTask = addDependenciesToPackageJson(
-      host,
-      { 'react-router-dom': reactRouterDomVersion },
-      { '@types/react-router-dom': typesReactRouterDomVersion }
-    );
-    tasks.push(routingTask);
-  }
-
-  await formatFiles(host);
-
-  return runTasksInSerial(...tasks);
+  return await formatFiles(host);
 }
 
-function createComponentFiles(host: Tree, options: NormalizedSchema) {
-  const componentDir = joinPathFragments(
+function createFiles(host: Tree, options: NormalizedSchema) {
+  const hookDir = joinPathFragments(
     options.projectSourceRoot,
     options.directory
   );
 
-  generateFiles(host, joinPathFragments(__dirname, './files'), componentDir, {
+  generateFiles(host, joinPathFragments(__dirname, './files'), hookDir, {
     ...options,
     tmpl: '',
   });
@@ -70,25 +45,7 @@ function createComponentFiles(host: Tree, options: NormalizedSchema) {
   for (const c of host.listChanges()) {
     let deleteFile = false;
 
-    if (options.skipTests && /.*spec.tsx/.test(c.path)) {
-      deleteFile = true;
-    }
-
-    if (
-      (options.styledModule || !options.hasStyles) &&
-      c.path.endsWith(`.${options.style}`)
-    ) {
-      deleteFile = true;
-    }
-
-    if (options.globalCss && c.path.endsWith(`.module.${options.style}`)) {
-      deleteFile = true;
-    }
-
-    if (
-      !options.globalCss &&
-      c.path.endsWith(`${options.fileName}.${options.style}`)
-    ) {
+    if (options.skipTests && /.*spec.ts/.test(c.path)) {
       deleteFile = true;
     }
 
@@ -137,8 +94,19 @@ async function normalizeOptions(
 ): Promise<NormalizedSchema> {
   assertValidOptions(options);
 
-  const { className, fileName } = names(options.name);
-  const componentFileName = options.pascalCaseFiles ? className : fileName;
+  let base = options.name;
+  if (base.startsWith('use-')) {
+    base = base.substring(4);
+  } else if (base.startsWith('use')) {
+    base = base.substring(3);
+  }
+
+  const { className, fileName } = names(base);
+  const hookFilename = options.pascalCaseFiles
+    ? 'use'.concat(className)
+    : 'use-'.concat(fileName);
+  const hookName = 'use'.concat(className);
+  const hookTypeName = 'Use'.concat(className);
   const project = getProjects(host).get(options.project);
 
   if (!project) {
@@ -150,11 +118,7 @@ async function normalizeOptions(
 
   const { sourceRoot: projectSourceRoot, projectType } = project;
 
-  const directory = await getDirectory(host, options);
-
-  const styledModule = /^(css|scss|less|styl|none)$/.test(options.style)
-    ? null
-    : options.style;
+  const directory = await getDirectory(host, options, base);
 
   if (options.export && projectType === 'application') {
     logger.warn(
@@ -162,27 +126,22 @@ async function normalizeOptions(
     );
   }
 
-  options.classComponent = options.classComponent ?? false;
-  options.routing = options.routing ?? false;
-  options.globalCss = options.globalCss ?? false;
-
   return {
     ...options,
     directory,
-    styledModule,
-    hasStyles: options.style !== 'none',
-    className,
-    fileName: componentFileName,
+    hookName,
+    hookTypeName,
+    fileName: hookFilename,
     projectSourceRoot,
   };
 }
 
-async function getDirectory(host: Tree, options: Schema) {
-  const genNames = names(options.name);
-  const fileName =
+async function getDirectory(host: Tree, options: Schema, baseHookName) {
+  const { className, fileName } = names(baseHookName);
+  const hookFileName =
     options.pascalCaseDirectory === true
-      ? genNames.className
-      : genNames.fileName;
+      ? 'use'.concat(className)
+      : 'use-'.concat(fileName);
   const workspace = getProjects(host);
   let baseDir: string;
   if (options.directory) {
@@ -193,12 +152,10 @@ async function getDirectory(host: Tree, options: Schema) {
         ? 'app'
         : 'lib';
   }
-  return options.flat ? baseDir : joinPathFragments(baseDir, fileName);
+  return options.flat ? baseDir : joinPathFragments(baseDir, hookFileName);
 }
 
 function assertValidOptions(options: Schema) {
-  assertValidStyle(options.style);
-
   const slashes = ['/', '\\'];
   slashes.forEach((s) => {
     if (options.name.indexOf(s) !== -1) {
@@ -208,12 +165,12 @@ function assertValidOptions(options: Schema) {
         suggestion = `${options.directory}${s}${suggestion}`;
       }
       throw new Error(
-        `Found "${s}" in the component name. Did you mean to use the --directory option (e.g. \`nx g c ${name} --directory ${suggestion}\`)?`
+        `Found "${s}" in the hook name. Did you mean to use the --directory option (e.g. \`nx g c ${name} --directory ${suggestion}\`)?`
       );
     }
   });
 }
 
-export default componentGenerator;
+export default hookGenerator;
 
-export const componentSchematic = convertNxGenerator(componentGenerator);
+export const hookSchematic = convertNxGenerator(hookGenerator);

--- a/packages/react/src/generators/hook/schema.d.ts
+++ b/packages/react/src/generators/hook/schema.d.ts
@@ -1,17 +1,11 @@
-import { SupportedStyles } from '../../../typings/style';
-
 export interface Schema {
   name: string;
   project: string;
-  style: SupportedStyles;
   skipTests?: boolean;
   directory?: string;
   export?: boolean;
   pascalCaseFiles?: boolean;
   pascalCaseDirectory?: boolean;
-  classComponent?: boolean;
-  routing?: boolean;
-  js?: boolean;
   flat?: boolean;
-  globalCss?: boolean;
+  js?: boolean;
 }

--- a/packages/react/src/generators/hook/schema.json
+++ b/packages/react/src/generators/hook/schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "NxReactHook",
+  "title": "Create a React Hook for Nx",
+  "type": "object",
+  "examples": [
+    {
+      "command": "g hook my-hook --project=mylib",
+      "description": "Generate a hook in the mylib library"
+    }
+  ],
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "alias": "p",
+      "$default": {
+        "$source": "projectName"
+      },
+      "x-prompt": "What is the name of the project for this hook?"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the hook.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the hook?"
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files.",
+      "default": false
+    },
+    "skipTests": {
+      "type": "boolean",
+      "description": "When true, does not create \"spec.ts\" test files for the new hook.",
+      "default": false
+    },
+    "directory": {
+      "type": "string",
+      "description": "Create the hook under this directory (can be nested).",
+      "alias": "d"
+    },
+    "flat": {
+      "type": "boolean",
+      "description": "Create hook at the source root rather than its own directory.",
+      "default": false
+    },
+    "export": {
+      "type": "boolean",
+      "description": "When true, the hook is exported from the project index.ts (if it exists).",
+      "alias": "e",
+      "default": false,
+      "x-prompt": "Should this hook be exported in the project?"
+    },
+    "pascalCaseFiles": {
+      "type": "boolean",
+      "description": "Use pascal case hook file name (e.g. useHook.ts).",
+      "alias": "P",
+      "default": false
+    },
+    "pascalCaseDirectory": {
+      "type": "boolean",
+      "description": "Use pascal case directory name (e.g. useHook/useHook.ts).",
+      "alias": "R",
+      "default": false
+    }
+  },
+  "required": ["name", "project"]
+}

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -20,6 +20,7 @@ import {
   testingLibraryReactVersion,
   typesReactDomVersion,
   typesReactVersion,
+  testingLibraryReactHooksVersion,
 } from '../../utils/versions';
 
 function setDefault(host: Tree) {
@@ -64,6 +65,7 @@ function updateDependencies(host: Tree) {
       '@types/react': typesReactVersion,
       '@types/react-dom': typesReactDomVersion,
       '@testing-library/react': testingLibraryReactVersion,
+      '@testing-library/react-hooks': testingLibraryReactHooksVersion,
     }
   );
 }

--- a/packages/react/src/migrations/update-12-8-0/update-12-8-0.ts
+++ b/packages/react/src/migrations/update-12-8-0/update-12-8-0.ts
@@ -1,0 +1,13 @@
+import { addDependenciesToPackageJson, Tree } from '@nrwl/devkit';
+
+export async function removeReactReduxTypesFromPackageJson(host: Tree) {
+  return addDependenciesToPackageJson(
+    host,
+    {},
+    {
+      '@testing-library/react-hooks': '^7.0.1',
+    }
+  );
+}
+
+export default removeReactReduxTypesFromPackageJson;

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -21,6 +21,7 @@ export const reactRouterDomVersion = '5.2.0';
 export const typesReactRouterDomVersion = '5.1.7';
 
 export const testingLibraryReactVersion = '11.2.6';
+export const testingLibraryReactHooksVersion = '7.0.1';
 
 export const reduxjsToolkitVersion = '1.5.1';
 export const reactReduxVersion = '7.2.3';


### PR DESCRIPTION
This PR is originally from https://github.com/nrwl/nx/pull/6075 but I fixed some of the files.

It adds a new generator for adding a hook (+tests).

e.g.

```
nx g @nrwl/react:hook useMyHook

# Or leave off "use" (it will be prefixed automatically)
nx g @nrwl/react:hook myHook
```