### PR TITLE
fix(nextjs): update babel config for nextjs

### DIFF
--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -39,12 +39,15 @@ describe('next library', () => {
     });
     expect(readJson(appTree, 'libs/my-lib2/.babelrc')).toEqual({
       presets: [
-        'next/babel',
-        {
-          'preset-react': {
-            importSource: '@emotion/react',
+        [
+          'next/babel',
+          {
+            'preset-react': {
+              runtime: 'automatic',
+              importSource: '@emotion/react',
+            },
           },
-        },
+        ],
       ],
       plugins: ['@emotion/babel-plugin'],
     });

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -23,12 +23,15 @@ export async function libraryGenerator(host: Tree, options: Schema) {
   updateJson(host, joinPathFragments(projectRoot, '.babelrc'), (json) => {
     if (options.style === '@emotion/styled') {
       json.presets = [
-        'next/babel',
-        {
-          'preset-react': {
-            importSource: '@emotion/react',
+        [
+          'next/babel',
+          {
+            'preset-react': {
+              runtime: 'automatic',
+              importSource: '@emotion/react',
+            },
           },
-        },
+        ],
       ];
     } else {
       json.presets = ['next/babel'];


### PR DESCRIPTION
1. We should wrap ```next/babel``` preset with its configuration in an outer array.
2. Add `"runtime": "automatic"` to ```preset-react```. The reason is that Jest tests fail with the following error: ```SyntaxError: *.spec.tsx: importSource cannot be set when runtime is classic```
2.1 Babel runtime docs: https://babeljs.io/docs/en/babel-preset-react#runtime

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
