### PR TITLE
fix(angular): don't error when project configuration has no targets

### DIFF
--- a/packages/angular/src/migrations/update-12-3-0/convert-webpack-browser-build-target-to-delegate-build.ts
+++ b/packages/angular/src/migrations/update-12-3-0/convert-webpack-browser-build-target-to-delegate-build.ts
@@ -17,7 +17,7 @@ export default async function convertWebpackBrowserBuildTargetToDelegateBuild(
   const projects = getProjects(host);
 
   for (const [projectName, project] of projects) {
-    const webpackBrowserTargets = Object.values(project.targets).filter(
+    const webpackBrowserTargets = Object.values(project.targets || {}).filter(
       (target) => target.executor === '@nrwl/angular:webpack-browser'
     );
     for (const target of webpackBrowserTargets) {

--- a/packages/angular/src/migrations/update-12-3-0/update-webpack-browser-config.ts
+++ b/packages/angular/src/migrations/update-12-3-0/update-webpack-browser-config.ts
@@ -28,7 +28,7 @@ export default async function updateAngularConfig(host: Tree) {
   const projects = getProjects(host);
 
   for (const [name, project] of projects) {
-    for (const target of Object.values(project.targets)) {
+    for (const target of Object.values(project.targets || {})) {
       if (target.executor === '@nrwl/angular:webpack-browser') {
         updateOptions(target, optionsToUpdate);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Even though a valid project config needs to have a `target` or `architect` node, the migration shouldn't fail, which is the case though right now.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Fixes the migration

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
