### PR TITLE
feat(core): add default path argument for `readNxJson`

### DIFF
--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -209,8 +209,10 @@ export function readPackageJson(): any {
   return readJsonFile(`${appRootPath}/package.json`);
 }
 
-export function readNxJson(): NxJsonConfiguration {
-  const config = readJsonFile<NxJsonConfiguration>(`${appRootPath}/nx.json`);
+export function readNxJson(
+  path: string = `${appRootPath}/nx.json`
+): NxJsonConfiguration {
+  const config = readJsonFile<NxJsonConfiguration>(path);
   if (!config.npmScope) {
     throw new Error(`nx.json must define the npmScope property.`);
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Using `readNxJson` does not accept an arugment to configure the path to read the nx.json file.

## Expected Behavior
Using `readNxJson` now accepts an argument to read the nx.json given the path argument 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
