### PR TITLE
fix(core): npmrc should be obeyed during nx migrate

### DIFF
--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import { removeSync } from 'fs-extra';
+import { removeSync, copyFileSync, existsSync } from 'fs-extra';
 import * as yargsParser from 'yargs-parser';
 import { dirname, join } from 'path';
 import { gt, lte } from 'semver';
@@ -13,6 +13,7 @@ import {
   readJsonFile,
   writeJsonFile,
 } from '../utils/fileutils';
+import { appRootPath } from '../utils/app-root';
 
 type Dependencies = 'dependencies' | 'devDependencies';
 
@@ -442,6 +443,14 @@ function createFetcher() {
   ): Promise<MigrationsJson> {
     if (!cache[`${packageName}-${packageVersion}`]) {
       const dir = dirSync().name;
+      const npmrc = checkForNPMRC();
+      if (npmrc) {
+        // Creating a package.json is needed for .npmrc to resolve
+        writeJsonFile(`${dir}/package.json`, {});
+        // Copy npmrc if it exists, so that npm still follows it.
+        copyFileSync(npmrc, `${dir}/.npmrc`);
+      }
+
       logger.info(`Fetching ${packageName}@${packageVersion}`);
       const pmc = getPackageManagerCommand();
       execSync(`${pmc.add} ${packageName}@${packageVersion}`, {
@@ -740,4 +749,17 @@ export async function migrate(root: string, args: string[], isVerbose = false) {
       await runMigrations(root, opts, isVerbose);
     }
   });
+}
+
+/**
+ * Checks for a project level npmrc file by crawling up the file tree until
+ * hitting a package.json file, as this is how npm finds them as well.
+ */
+function checkForNPMRC(): string | null {
+  let directory = process.cwd();
+  while (!existsSync(join(directory, 'package.json'))) {
+    directory = dirname(directory);
+  }
+  const path = join(directory, '.npmrc');
+  return existsSync(path) ? path : null;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Calling `nx migrate 'my-package'` does not obey registry settings from .npmrc. This leads to things like trying to pull latest from npm, or yarn registry instead of the registry pointed to by the workspace.

If an enterprise workspace was using a private registry, and had a custom nx plugin, they would not be able to use nx migrate for their internal migration scripts.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Registries and authorization headers in .npmrc should be obeyed by `nx migrate`

## Workaround
Setting environment config variables does work, such as `export NPM_CONFIG_REGISTRY=....`, but these cannot be scoped to certain scopes etc.
