### PR TITLE
feat(misc): add generator for simple npm-package

### DIFF
--- a/docs/angular/api-workspace/generators/npm-package.md
+++ b/docs/angular/api-workspace/generators/npm-package.md
@@ -1,0 +1,31 @@
+# @nrwl/workspace:npm-package
+
+Create a minimal npm package
+
+## Usage
+
+```bash
+nx generate npm-package ...
+```
+
+By default, Nx will search for `npm-package` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/workspace:npm-package ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g npm-package ... --dry-run
+```
+
+## Options
+
+### name (_**required**_)
+
+Type: `string`
+
+Package name

--- a/docs/map.json
+++ b/docs/map.json
@@ -309,6 +309,11 @@
             "file": "angular/api-workspace/generators/library"
           },
           {
+            "name": "npm-package generator",
+            "id": "npm-package",
+            "file": "angular/api-workspace/generators/npm-package"
+          },
+          {
             "name": "move generator",
             "id": "move",
             "file": "angular/api-workspace/generators/move"
@@ -1505,6 +1510,11 @@
             "file": "react/api-workspace/generators/library"
           },
           {
+            "name": "npm-package generator",
+            "id": "npm-package",
+            "file": "react/api-workspace/generators/npm-package"
+          },
+          {
             "name": "move generator",
             "id": "move",
             "file": "react/api-workspace/generators/move"
@@ -2668,6 +2678,11 @@
             "name": "library generator",
             "id": "library",
             "file": "node/api-workspace/generators/library"
+          },
+          {
+            "name": "npm-package generator",
+            "id": "npm-package",
+            "file": "node/api-workspace/generators/npm-package"
           },
           {
             "name": "move generator",

--- a/docs/node/api-workspace/generators/npm-package.md
+++ b/docs/node/api-workspace/generators/npm-package.md
@@ -1,0 +1,31 @@
+# @nrwl/workspace:npm-package
+
+Create a minimal npm package
+
+## Usage
+
+```bash
+nx generate npm-package ...
+```
+
+By default, Nx will search for `npm-package` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/workspace:npm-package ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g npm-package ... --dry-run
+```
+
+## Options
+
+### name (_**required**_)
+
+Type: `string`
+
+Package name

--- a/docs/react/api-workspace/generators/npm-package.md
+++ b/docs/react/api-workspace/generators/npm-package.md
@@ -1,0 +1,31 @@
+# @nrwl/workspace:npm-package
+
+Create a minimal npm package
+
+## Usage
+
+```bash
+nx generate npm-package ...
+```
+
+By default, Nx will search for `npm-package` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/workspace:npm-package ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g npm-package ... --dry-run
+```
+
+## Options
+
+### name (_**required**_)
+
+Type: `string`
+
+Package name

--- a/e2e/workspace/src/workspace-lib.test.ts
+++ b/e2e/workspace/src/workspace-lib.test.ts
@@ -124,3 +124,14 @@ describe('@nrwl/workspace:library', () => {
     expect(json.typings).toEqual('./src/index.d.ts');
   });
 });
+
+describe('@nrwl/workspace:npm-package', () => {
+  it('should create a minimal npm package', () => {
+    const npmPackage = uniq('npm-package');
+
+    runCLI(`generate @nrwl/workspace:npm-package ${npmPackage}`);
+
+    const result = runCLI(`test ${npmPackage}`);
+    expect(result).toContain('Hello World');
+  });
+});

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -76,7 +76,7 @@ export interface ProjectConfiguration {
   /**
    * Project's targets
    */
-  targets: { [targetName: string]: TargetConfiguration };
+  targets?: { [targetName: string]: TargetConfiguration };
 
   /**
    * Project's location relative to the root of the workspace

--- a/packages/workspace/generators.json
+++ b/packages/workspace/generators.json
@@ -69,6 +69,12 @@
       "factory": "./src/generators/convert-to-nx-project/convert-to-nx-project#convertToNxProjectSchematic",
       "schema": "./src/generators/convert-to-nx-project/schema.json",
       "description": "Moves a project's configuration outside of workspace.json"
+    },
+
+    "npm-package": {
+      "factory": "./src/generators/npm-package/npm-package#npmPackageSchematic",
+      "schema": "./src/generators/npm-package/schema.json",
+      "description": "Create a minimal npm package"
     }
   },
   "generators": {
@@ -139,6 +145,12 @@
       "factory": "./src/generators/convert-to-nx-project/convert-to-nx-project#convertToNxProjectGenerator",
       "schema": "./src/generators/convert-to-nx-project/schema.json",
       "description": "Moves a project's configuration outside of workspace.json"
+    },
+
+    "npm-package": {
+      "factory": "./src/generators/npm-package/npm-package#npmPackageGenerator",
+      "schema": "./src/generators/npm-package/schema.json",
+      "description": "Create a minimal npm package"
     }
   }
 }

--- a/packages/workspace/generators.ts
+++ b/packages/workspace/generators.ts
@@ -1,4 +1,5 @@
 export { libraryGenerator } from './src/generators/library/library';
+export { npmPackageGenerator } from './src/generators/npm-package/npm-package';
 export { moveGenerator } from './src/generators/move/move';
 export { removeGenerator } from './src/generators/remove/remove';
 export { runCommandsGenerator } from './src/generators/run-commands/run-commands';

--- a/packages/workspace/src/generators/npm-package/files/index.js.template
+++ b/packages/workspace/src/generators/npm-package/files/index.js.template
@@ -1,0 +1,1 @@
+console.log('Hello World');

--- a/packages/workspace/src/generators/npm-package/npm-package.spec.ts
+++ b/packages/workspace/src/generators/npm-package/npm-package.spec.ts
@@ -1,0 +1,90 @@
+import {
+  readJson,
+  readWorkspaceConfiguration,
+  Tree,
+  updateWorkspaceConfiguration,
+  writeJson,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { npmPackageGenerator } from './npm-package';
+
+describe('@nrwl/workspace:npm-package', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    const workspaceConfig = readWorkspaceConfiguration(tree);
+    workspaceConfig.workspaceLayout = {
+      appsDir: 'packages',
+      libsDir: 'packages',
+    };
+    updateWorkspaceConfiguration(tree, workspaceConfig);
+  });
+
+  it('should generate a minimal package', async () => {
+    await npmPackageGenerator(tree, {
+      name: 'my-package',
+    });
+
+    const { projects } = readJson(tree, 'workspace.json');
+    expect(projects['my-package']).toMatchInlineSnapshot(`
+      Object {
+        "root": "packages/my-package",
+      }
+    `);
+  });
+
+  it('should only generate package.json and index.js', async () => {
+    await npmPackageGenerator(tree, {
+      name: 'my-package',
+    });
+
+    expect(tree.read('packages/my-package/package.json').toString())
+      .toMatchInlineSnapshot(`
+      "{
+        \\"name\\": \\"@proj/my-package\\",
+        \\"scripts\\": {
+          \\"test\\": \\"node index.js\\"
+        }
+      }"
+    `);
+    expect(tree.read('packages/my-package/index.js').toString())
+      .toMatchInlineSnapshot(`
+      "console.log('Hello World');
+      "
+    `);
+  });
+
+  describe('for existing projects', () => {
+    it('should not modify files, only add configuration', async () => {
+      const existingPackageJson = {
+        name: 'my-existing-package',
+        scripts: {
+          'existing-script': 'existing',
+        },
+      };
+
+      const existingIndex = `export * from './src'`;
+      writeJson(tree, 'packages/my-package/package.json', existingPackageJson);
+      tree.write('packages/my-package/index.ts', existingIndex);
+
+      await npmPackageGenerator(tree, {
+        name: 'my-package',
+      });
+
+      const { projects } = readJson(tree, 'workspace.json');
+      expect(projects['my-package']).toMatchInlineSnapshot(`
+      Object {
+        "root": "packages/my-package",
+      }
+    `);
+
+      expect(readJson(tree, 'packages/my-package/package.json')).toEqual(
+        existingPackageJson
+      );
+      expect(tree.read('packages/my-package/index.ts').toString()).toEqual(
+        existingIndex
+      );
+    });
+  });
+});

--- a/packages/workspace/src/generators/npm-package/npm-package.ts
+++ b/packages/workspace/src/generators/npm-package/npm-package.ts
@@ -1,0 +1,59 @@
+import {
+  addProjectConfiguration,
+  convertNxGenerator,
+  formatFiles,
+  generateFiles,
+  getWorkspaceLayout,
+  names,
+  readWorkspaceConfiguration,
+  Tree,
+  writeJson,
+} from '@nrwl/devkit';
+import { join } from 'path';
+
+export interface ProjectOptions {
+  name: string;
+}
+
+function normalizeOptions(options: ProjectOptions): ProjectOptions {
+  options.name = names(options.name).fileName;
+  return options;
+}
+
+function addFiles(
+  projectRoot: string,
+  tree: Tree,
+  npmScope: string,
+  options: ProjectOptions
+) {
+  const packageJsonPath = join(projectRoot, 'package.json');
+  writeJson(tree, packageJsonPath, {
+    name: join(`@${npmScope}`, options.name),
+    scripts: {
+      test: 'node index.js',
+    },
+  });
+
+  generateFiles(tree, join(__dirname, './files'), projectRoot, {});
+}
+
+export async function npmPackageGenerator(tree: Tree, options: ProjectOptions) {
+  options = normalizeOptions(options);
+
+  const { libsDir, npmScope } = getWorkspaceLayout(tree);
+  const projectRoot = join(libsDir, options.name);
+
+  addProjectConfiguration(tree, options.name, {
+    root: projectRoot,
+  });
+
+  const isEmpty = tree.children(projectRoot).length === 0;
+
+  if (isEmpty) {
+    addFiles(projectRoot, tree, npmScope, options);
+  }
+
+  await formatFiles(tree);
+}
+
+export const npmPackageSchematic = convertNxGenerator(npmPackageGenerator);

--- a/packages/workspace/src/generators/npm-package/schema.json
+++ b/packages/workspace/src/generators/npm-package/schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "NxWorkspaceNpmPackage",
+  "title": "Add a minimal npm package",
+  "cli": "nx",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Package name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name of your npm package?",
+      "pattern": "^[a-zA-Z].*$"
+    }
+  },
+  "required": ["name"]
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Projects created by Nx do not showcase how minimal Nx can be.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx projects don't need to be as complicated all the time and can be preferable when developing an npm-package.

Running `nx g @nrwl/workspace:npm-package` will create just a `package.json` with a `test` script which runs a `.js` file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
