### PR TITLE
fix(storybook): add Emotion v11 support to current Nx Storybook setup

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,6 +48,7 @@
     "url-loader": "^3.0.0",
     "webpack": "4.46.0",
     "webpack-merge": "4.2.1",
-    "@storybook/node-logger": "6.1.20"
+    "@storybook/node-logger": "6.1.20",
+    "semver": "7.3.4"
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Right now the Storybook + Emotion v11 is broken. There's more in this issue here:
https://github.com/storybookjs/storybook/issues/13277

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR detects whether Emotion v11 is being used and applies a patch to the Storybook webpack config to make sure Emotion v11 works seamlessly. **Note,** this only works if you use the `@nrwl/react/storybook` preset [described in this doc](https://nx.dev/latest/react/storybook/migrate-webpack-final). All
newly generated Nx v12.7+ workspace Storybook configurations will already use this out of the box.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
