### PR TITLE
fix(angular): mfe needs specific webpack version due to breaking change

### DIFF
--- a/packages/angular/src/generators/setup-mfe/setup-mfe.ts
+++ b/packages/angular/src/generators/setup-mfe/setup-mfe.ts
@@ -17,6 +17,7 @@ import {
   getRemotesWithPorts,
   setupServeTarget,
 } from './lib';
+import { webpackVersion } from '../../utils/versions';
 
 export async function setupMfe(host: Tree, options: Schema) {
   const projectConfig = readProjectConfiguration(host, options.appName);
@@ -37,7 +38,7 @@ export async function setupMfe(host: Tree, options: Schema) {
   const installPackages = addDependenciesToPackageJson(
     host,
     { '@angular-architects/module-federation': '^12.2.0' },
-    {}
+    { webpack: webpackVersion }
   );
 
   // format files

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -6,3 +6,4 @@ export const ngrxVersion = '~12.2.0';
 export const rxjsVersion = '~6.6.0';
 export const jestPresetAngularVersion = '9.0.4';
 export const angularEslintVersion = '~12.3.0';
+export const webpackVersion = '5.45.1';


### PR DESCRIPTION
Force `webpack@5.45.1` for MFEs to prevent breaking change in `webpack-sources@3.2.0` where it doesn't parse sourcemaps correctly.

```
Potential breaking change in a minor update to webpack to be aware about:
webpack@5.45.1 uses webpack-sources@2.3.1  and it parses sourcemaps in angular apps with no problem
webpack@5.50.0 uses webpack-sources@3.2.0 and it fails to parse angular sourcemaps correctly. It falls over itself with the error above.
at least in the context of MFEs (
```

Fixes #6579