### PR TITLE
feat(storybook): add Webpack 5 support for React Storybook setups

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@nrwl/cypress": "*",
+    "@nrwl/web": "*",
     "@nrwl/devkit": "*",
     "@nrwl/linter": "*",
     "@nrwl/workspace": "*",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "@nrwl/cypress": "*",
-    "@nrwl/web": "*",
     "@nrwl/devkit": "*",
     "@nrwl/linter": "*",
     "@nrwl/workspace": "*",

--- a/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
+++ b/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
@@ -5,20 +5,15 @@ import { constants, copyFileSync, mkdtempSync, statSync } from 'fs';
 
 import * as build from '@storybook/core/standalone';
 
-import { getStorybookFrameworkPath, setStorybookAppProject } from '../utils';
+import {
+  getStorybookFrameworkPath,
+  runStorybookSetupCheck,
+  setStorybookAppProject,
+} from '../utils';
 import { ExecutorContext, logger } from '@nrwl/devkit';
+import { CommonNxStorybookConfig, StorybookConfig } from '../models';
 
-export interface StorybookConfig {
-  configFolder?: string;
-  configPath?: string;
-  pluginPath?: string;
-  srcRoot?: string;
-}
-
-export interface StorybookBuilderOptions {
-  uiFramework: string;
-  projectBuildConfig?: string;
-  config: StorybookConfig;
+export interface StorybookBuilderOptions extends CommonNxStorybookConfig {
   quiet?: boolean;
   outputPath?: string;
   docsMode?: boolean;
@@ -34,6 +29,10 @@ export default async function buildStorybookExecutor(
 
   const { default: frameworkOptions } = await import(frameworkPath);
   const option = storybookOptionMapper(options, frameworkOptions, context);
+
+  // print warnings
+  runStorybookSetupCheck(options);
+
   logger.info(`NX Storybook builder starting ...`);
   await runInstance(option);
   logger.info(`NX Storybook builder finished ...`);

--- a/packages/storybook/src/executors/models.ts
+++ b/packages/storybook/src/executors/models.ts
@@ -1,0 +1,18 @@
+export interface StorybookConfig {
+  configFolder?: string;
+  configPath?: string;
+  pluginPath?: string;
+  srcRoot?: string;
+}
+
+export interface CommonNxStorybookConfig {
+  uiFramework:
+    | '@storybook/angular'
+    | '@storybook/react'
+    | '@storybook/html'
+    | '@storybook/web-components'
+    | '@storybook/vue'
+    | '@storybook/vue3';
+  projectBuildConfig?: string;
+  config: StorybookConfig;
+}

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -1,30 +1,25 @@
 import 'dotenv/config';
 import { basename, join, sep } from 'path';
 import { tmpdir } from 'os';
-import { constants, copyFileSync, existsSync, mkdtempSync, statSync } from 'fs';
+import {
+  constants,
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+} from 'fs';
 
 import { buildDevStandalone } from '@storybook/core/server';
 
-import { getStorybookFrameworkPath, setStorybookAppProject } from '../utils';
+import {
+  getStorybookFrameworkPath,
+  runStorybookSetupCheck,
+  setStorybookAppProject,
+} from '../utils';
 import { ExecutorContext, joinPathFragments, logger } from '@nrwl/devkit';
-
-export interface StorybookConfig {
-  configFolder?: string;
-  configPath?: string;
-  pluginPath?: string;
-  srcRoot?: string;
-}
-
-export interface StorybookExecutorOptions {
-  uiFramework:
-    | '@storybook/angular'
-    | '@storybook/react'
-    | '@storybook/html'
-    | '@storybook/web-components'
-    | '@storybook/vue'
-    | '@storybook/vue3';
-  projectBuildConfig?: string;
-  config: StorybookConfig;
+import { CommonNxStorybookConfig, StorybookConfig } from '../models';
+export interface StorybookExecutorOptions extends CommonNxStorybookConfig {
   host?: string;
   port?: number;
   quiet?: boolean;
@@ -46,7 +41,7 @@ export default async function* storybookExecutor(
   const option = storybookOptionMapper(options, frameworkOptions, context);
 
   // print warnings
-  runStorybookSetupCheck(options, context);
+  runStorybookSetupCheck(options);
 
   await runInstance(option);
 
@@ -108,15 +103,13 @@ function storybookOptionMapper(
   setStorybookAppProject(context, builderOptions.projectBuildConfig);
 
   const storybookConfig = findOrCreateConfig(builderOptions.config, context);
-  const optionsWithFramework = {
+  return {
     ...builderOptions,
     mode: 'dev',
     configDir: storybookConfig,
     ...frameworkOptions,
     frameworkPresets: [...(frameworkOptions.frameworkPresets || [])],
   };
-  optionsWithFramework.config;
-  return optionsWithFramework;
 }
 
 function findOrCreateConfig(
@@ -169,45 +162,4 @@ function createStorybookConfig(
     constants.COPYFILE_EXCL
   );
   return tmpFolder;
-}
-
-function runStorybookSetupCheck(
-  options: StorybookExecutorOptions,
-  context: ExecutorContext
-) {
-  let placesToCheck = [
-    {
-      path: joinPathFragments('.storybook', 'webpack.config.js'),
-      result: false,
-    },
-    {
-      path: joinPathFragments(options.config.configFolder, 'webpack.config.js'),
-      result: false,
-    },
-  ];
-
-  placesToCheck = placesToCheck
-    .map((entry) => {
-      return {
-        ...entry,
-        result: existsSync(entry.path),
-      };
-    })
-    .filter((x) => x.result === true);
-
-  if (placesToCheck.length > 0) {
-    logger.warn(
-      `
-  You have a webpack.config.js files in your Storybook configuration:
-  ${placesToCheck.map((x) => `- "${x.path}"`).join('\n  ')}
-
-  Consider switching to the "webpackFinal" property declared in "main.js" instead.
-  ${
-    options.uiFramework === '@storybook/react'
-      ? 'https://nx.dev/latest/react/storybook/migrate-webpack-final'
-      : 'https://nx.dev/latest/angular/storybook/migrate-webpack-final'
-  }
-    `
-    );
-  }
 }

--- a/packages/storybook/src/executors/utils.ts
+++ b/packages/storybook/src/executors/utils.ts
@@ -2,6 +2,7 @@ import { ExecutorContext, joinPathFragments, logger } from '@nrwl/devkit';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { gte } from 'semver';
+import { isWebpack5 } from '../utils/utilities';
 import { CommonNxStorybookConfig } from './models';
 
 export interface NodePackage {
@@ -72,8 +73,7 @@ export function runStorybookSetupCheck(options: CommonNxStorybookConfig) {
 
 function reactWebpack5Check(options: CommonNxStorybookConfig) {
   if (options.uiFramework === '@storybook/react') {
-    const { isWebpack5 } = require('@nrwl/web/src/webpack/entry');
-    if (isWebpack5) {
+    if (isWebpack5()) {
       // check whether the current Storybook configuration has the webpack 5 builder enabled
       const storybookConfig = readFileSync(
         joinPathFragments(options.config.configFolder, 'main.js'),

--- a/packages/storybook/src/executors/utils.ts
+++ b/packages/storybook/src/executors/utils.ts
@@ -1,6 +1,8 @@
-import { ExecutorContext } from '@nrwl/devkit';
-import { gte } from 'semver';
+import { ExecutorContext, joinPathFragments, logger } from '@nrwl/devkit';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { gte } from 'semver';
+import { CommonNxStorybookConfig } from './models';
 
 export interface NodePackage {
   name: string;
@@ -61,4 +63,72 @@ export function setStorybookAppProject(
   }
 
   process.env.STORYBOOK_ANGULAR_PROJECT = leadingProject;
+}
+
+export function runStorybookSetupCheck(options: CommonNxStorybookConfig) {
+  webpackFinalPropertyCheck(options);
+  reactWebpack5Check(options);
+}
+
+function reactWebpack5Check(options: CommonNxStorybookConfig) {
+  if (options.uiFramework === '@storybook/react') {
+    const { isWebpack5 } = require('@nrwl/web/src/webpack/entry');
+    if (isWebpack5) {
+      // check whether the current Storybook configuration has the webpack 5 builder enabled
+      const storybookConfig = readFileSync(
+        joinPathFragments(options.config.configFolder, 'main.js'),
+        { encoding: 'utf8' }
+      );
+
+      if (!storybookConfig.includes(`builder: 'webpack5'`)) {
+        // storybook needs to be upgraded to webpack 5
+        logger.warn(`
+It looks like you use Webpack 5 but your Storybook setup is not configured to leverage that
+and thus falls back to Webpack 4.
+Make sure you upgrade your Storybook config to use Webpack 5.
+
+  - https://gist.github.com/shilman/8856ea1786dcd247139b47b270912324#upgrade
+      
+`);
+      }
+    }
+  }
+}
+
+function webpackFinalPropertyCheck(options: CommonNxStorybookConfig) {
+  let placesToCheck = [
+    {
+      path: joinPathFragments('.storybook', 'webpack.config.js'),
+      result: false,
+    },
+    {
+      path: joinPathFragments(options.config.configFolder, 'webpack.config.js'),
+      result: false,
+    },
+  ];
+
+  placesToCheck = placesToCheck
+    .map((entry) => {
+      return {
+        ...entry,
+        result: existsSync(entry.path),
+      };
+    })
+    .filter((x) => x.result === true);
+
+  if (placesToCheck.length > 0) {
+    logger.warn(
+      `
+  You have a webpack.config.js files in your Storybook configuration:
+  ${placesToCheck.map((x) => `- "${x.path}"`).join('\n  ')}
+
+  Consider switching to the "webpackFinal" property declared in "main.js" instead.
+  ${
+    options.uiFramework === '@storybook/react'
+      ? 'https://nx.dev/latest/react/storybook/migrate-webpack-final'
+      : 'https://nx.dev/latest/angular/storybook/migrate-webpack-final'
+  }
+    `
+    );
+  }
 }

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -19,7 +19,11 @@ import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-ser
 import { Linter } from '@nrwl/linter';
 import { join } from 'path';
 
-import { isFramework, TsConfig } from '../../utils/utilities';
+import {
+  isFramework,
+  isReactUsingWebpack5,
+  TsConfig,
+} from '../../utils/utilities';
 import { cypressProjectGenerator } from '../cypress-project/cypress-project';
 import { StorybookConfigureSchema } from './schema';
 import { storybookVersion } from '../../utils/versions';
@@ -152,7 +156,9 @@ function createProjectStorybookDir(
     uiFramework,
     offsetFromRoot: offsetFromRoot(root),
     projectType: projectDirectory,
-    useWebpack5: uiFramework === '@storybook/angular',
+    useWebpack5:
+      uiFramework === '@storybook/angular' ||
+      (uiFramework === '@storybook/react' && isReactUsingWebpack5()),
     existsRootWebpackConfig: tree.exists('.storybook/webpack.config.js'),
   });
 

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -19,11 +19,7 @@ import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-ser
 import { Linter } from '@nrwl/linter';
 import { join } from 'path';
 
-import {
-  isFramework,
-  isReactUsingWebpack5,
-  TsConfig,
-} from '../../utils/utilities';
+import { isFramework, isWebpack5, TsConfig } from '../../utils/utilities';
 import { cypressProjectGenerator } from '../cypress-project/cypress-project';
 import { StorybookConfigureSchema } from './schema';
 import { storybookVersion } from '../../utils/versions';
@@ -158,7 +154,7 @@ function createProjectStorybookDir(
     projectType: projectDirectory,
     useWebpack5:
       uiFramework === '@storybook/angular' ||
-      (uiFramework === '@storybook/react' && isReactUsingWebpack5()),
+      (uiFramework === '@storybook/react' && isWebpack5()),
     existsRootWebpackConfig: tree.exists('.storybook/webpack.config.js'),
   });
 

--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -7,7 +7,7 @@ import {
   updateJson,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { isFramework, isReactUsingWebpack5 } from '../../utils/utilities';
+import { isFramework, isWebpack5 } from '../../utils/utilities';
 import {
   babelCoreVersion,
   babelLoaderVersion,
@@ -86,7 +86,7 @@ function checkDependenciesInstalled(host: Tree, schema: Schema) {
       devDependencies['@storybook/react'] = storybookVersion;
     }
 
-    if (isReactUsingWebpack5()) {
+    if (isWebpack5()) {
       if (
         !packageJson.dependencies['@storybook/builder-webpack5'] &&
         !packageJson.devDependencies['@storybook/builder-webpack5']

--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -7,6 +7,7 @@ import {
   updateJson,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
+import { isFramework, isReactUsingWebpack5 } from '../../utils/utilities';
 import {
   babelCoreVersion,
   babelLoaderVersion,
@@ -16,7 +17,6 @@ import {
   svgrVersion,
   urlLoaderVersion,
 } from '../../utils/versions';
-import { isFramework } from '../../utils/utilities';
 import { Schema } from './schema';
 
 function checkDependenciesInstalled(host: Tree, schema: Schema) {
@@ -85,8 +85,23 @@ function checkDependenciesInstalled(host: Tree, schema: Schema) {
     ) {
       devDependencies['@storybook/react'] = storybookVersion;
     }
-  }
 
+    if (isReactUsingWebpack5()) {
+      if (
+        !packageJson.dependencies['@storybook/builder-webpack5'] &&
+        !packageJson.devDependencies['@storybook/builder-webpack5']
+      ) {
+        devDependencies['@storybook/builder-webpack5'] = storybookVersion;
+      }
+
+      if (
+        !packageJson.dependencies['@storybook/manager-webpack5'] &&
+        !packageJson.devDependencies['@storybook/manager-webpack5']
+      ) {
+        devDependencies['@storybook/manager-webpack5'] = storybookVersion;
+      }
+    }
+  }
   if (isFramework('html', schema)) {
     devDependencies['@storybook/html'] = storybookVersion;
   }

--- a/packages/storybook/src/utils/utilities.ts
+++ b/packages/storybook/src/utils/utilities.ts
@@ -74,3 +74,8 @@ export type TsConfig = {
   exclude?: string[];
   references?: Array<{ path: string }>;
 };
+
+export function isReactUsingWebpack5(): boolean {
+  const { isWebpack5 } = require('@nrwl/web/src/webpack/entry');
+  return isWebpack5;
+}

--- a/packages/web/src/generators/migrate-to-webpack-5/migrate-to-webpack-5.spec.ts
+++ b/packages/web/src/generators/migrate-to-webpack-5/migrate-to-webpack-5.spec.ts
@@ -9,7 +9,7 @@ describe('webMigrateToWebpack5Generator', () => {
     tree = createTreeWithEmptyWorkspace();
   });
 
-  it('should add packages needed by Web ', async () => {
+  it('should add packages needed by Web', async () => {
     updateJson(tree, 'package.json', (json) => {
       json.devDependencies = {
         '@nrwl/cli': '100.0.0',
@@ -30,5 +30,260 @@ describe('webMigrateToWebpack5Generator', () => {
     expect(
       json.devDependencies['@pmmmwh/react-refresh-webpack-plugin']
     ).toMatch(/^0\.5/);
+  });
+
+  it('should add packages needed by Storybook if workspace has the @storybook/react package', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = {
+        '@storybook/react': '~6.3.0',
+      };
+      return json;
+    });
+
+    await webMigrateToWebpack5Generator(tree, {});
+
+    const json = readJson(tree, '/package.json');
+
+    expect(json.devDependencies['@storybook/builder-webpack5']).toBe('~6.3.0');
+    expect(json.devDependencies['@storybook/manager-webpack5']).toBe('~6.3.0');
+  });
+
+  it('should not add the webpack Storybook packages again if they already exist', async () => {
+    let newTree = createTreeWithEmptyWorkspace();
+    updateJson(newTree, 'package.json', (json) => {
+      json.dependencies = {
+        '@storybook/react': '~6.3.0',
+        '@storybook/builder-webpack5': '~6.3.0',
+        '@storybook/manager-webpack5': '~6.3.0',
+      };
+      return json;
+    });
+    await webMigrateToWebpack5Generator(newTree, {});
+    const json = readJson(newTree, '/package.json');
+    expect(json.devDependencies['@storybook/builder-webpack5']).toBeUndefined();
+    expect(json.devDependencies['@storybook/manager-webpack5']).toBeUndefined();
+  });
+
+  it('should not add Storybook packages if @storybook/react does not exist', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = {
+        '@storybook/angular': '~6.3.0',
+      };
+      return json;
+    });
+    await webMigrateToWebpack5Generator(tree, {});
+    const json = readJson(tree, '/package.json');
+    expect(json.devDependencies['@storybook/builder-webpack5']).toBeUndefined();
+    expect(json.devDependencies['@storybook/manager-webpack5']).toBeUndefined();
+  });
+
+  describe('updating project-level .storybook/main.js configurations for webpack 5', () => {
+    beforeEach(async () => {
+      updateJson(tree, 'package.json', (json) => {
+        json.devDependencies = {
+          '@storybook/react': '~6.3.0',
+        };
+        return json;
+      });
+
+      updateJson(tree, 'workspace.json', (json) => {
+        json = {
+          ...json,
+          projects: {
+            ...json.projects,
+            'test-one': {
+              targets: {
+                storybook: {
+                  options: {
+                    uiFramework: '@storybook/react',
+                    config: {
+                      configFolder: 'libs/test-one/.storybook',
+                    },
+                  },
+                },
+              },
+            },
+            'test-two': {
+              targets: {
+                storybook: {
+                  options: {
+                    uiFramework: '@storybook/react',
+                    config: {
+                      configFolder: 'libs/test-two/.storybook',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        return json;
+      });
+
+      tree.write(
+        `.storybook/main.js`,
+        `module.exports = {
+          stories: [],
+          addons: ['@storybook/addon-essentials'],
+          // uncomment the property below if you want to apply some webpack config globally
+          // webpackFinal: async (config, { configType }) => {
+          //   // Make whatever fine-grained changes you need that should apply to all storybook configs
+        
+          //   // Return the altered config
+          //   return config;
+          // },
+        };
+        `
+      );
+    });
+
+    it('should update the project-level .storybook/main.js if there is a core object', async () => {
+      tree.write(
+        `libs/test-one/.storybook/main.js`,
+        `const rootMain = require('../../../.storybook/main');
+
+      module.exports = {
+        ...rootMain,
+  
+        core: { ...rootMain.core },
+        stories: [
+          ...rootMain.stories,
+          '../src/lib/**/*.stories.mdx',
+          '../src/lib/**/*.stories.@(js|jsx|ts|tsx)',
+        ],
+        addons: [...rootMain.addons, '@nrwl/react/plugins/storybook'],
+        webpackFinal: async (config, { configType }) => {
+          // apply any global webpack configs that might have been specified in .storybook/main.js
+          if (rootMain.webpackFinal) {
+            config = await rootMain.webpackFinal(config, { configType });
+          }
+      
+          // add your own webpack tweaks if needed
+      
+          return config;
+        },
+      };`
+      );
+
+      tree.write(
+        `libs/test-two/.storybook/main.js`,
+        `const rootMain = require('../../../.storybook/main');
+
+      module.exports = {
+        ...rootMain,
+  
+        core: { ...rootMain.core },
+        stories: [
+          ...rootMain.stories,
+          '../src/lib/**/*.stories.mdx',
+          '../src/lib/**/*.stories.@(js|jsx|ts|tsx)',
+        ],
+        addons: [...rootMain.addons, '@nrwl/react/plugins/storybook'],
+        webpackFinal: async (config, { configType }) => {
+          // apply any global webpack configs that might have been specified in .storybook/main.js
+          if (rootMain.webpackFinal) {
+            config = await rootMain.webpackFinal(config, { configType });
+          }
+      
+          // add your own webpack tweaks if needed
+      
+          return config;
+        },
+      };`
+      );
+
+      await webMigrateToWebpack5Generator(tree, {});
+
+      const projectOne = tree.read(`libs/test-one/.storybook/main.js`, 'utf-8');
+      expect(projectOne).toContain(`builder: 'webpack5'`);
+      const projectTwo = tree.read(`libs/test-two/.storybook/main.js`, 'utf-8');
+      expect(projectTwo).toContain(`builder: 'webpack5'`);
+    });
+
+    it('should update the project-level .storybook/main.js if there is not a core object', async () => {
+      tree.write(
+        `libs/test-one/.storybook/main.js`,
+        `const rootMain = require('../../../.storybook/main');
+
+      module.exports = {
+        ...rootMain,
+  
+        stories: [
+          ...rootMain.stories,
+          '../src/lib/**/*.stories.mdx',
+          '../src/lib/**/*.stories.@(js|jsx|ts|tsx)',
+        ],
+        addons: [...rootMain.addons, '@nrwl/react/plugins/storybook'],
+        webpackFinal: async (config, { configType }) => {
+          // apply any global webpack configs that might have been specified in .storybook/main.js
+          if (rootMain.webpackFinal) {
+            config = await rootMain.webpackFinal(config, { configType });
+          }
+      
+          // add your own webpack tweaks if needed
+      
+          return config;
+        },
+      };`
+      );
+
+      tree.write(
+        `libs/test-two/.storybook/main.js`,
+        `const rootMain = require('../../../.storybook/main');
+
+      module.exports = {
+        ...rootMain,
+  
+        stories: [
+          ...rootMain.stories,
+          '../src/lib/**/*.stories.mdx',
+          '../src/lib/**/*.stories.@(js|jsx|ts|tsx)',
+        ],
+        addons: [...rootMain.addons, '@nrwl/react/plugins/storybook'],
+        webpackFinal: async (config, { configType }) => {
+          // apply any global webpack configs that might have been specified in .storybook/main.js
+          if (rootMain.webpackFinal) {
+            config = await rootMain.webpackFinal(config, { configType });
+          }
+      
+          // add your own webpack tweaks if needed
+      
+          return config;
+        },
+      };`
+      );
+
+      await webMigrateToWebpack5Generator(tree, {});
+      const projectOne = tree.read(`libs/test-one/.storybook/main.js`, 'utf-8');
+      expect(projectOne).toContain(`builder: 'webpack5'`);
+      const projectTwo = tree.read(`libs/test-two/.storybook/main.js`, 'utf-8');
+      expect(projectTwo).toContain(`builder: 'webpack5'`);
+    });
+
+    it('should not do anything if project-level .storybook/main.js is invalid', async () => {
+      tree.write(
+        `libs/test-one/.storybook/main.js`,
+        `const rootMain = require('../../../.storybook/main');
+
+      module.exports = {
+      };`
+      );
+
+      tree.write(
+        `libs/test-two/.storybook/main.js`,
+        `const rootMain = require('../../../.storybook/main');
+
+      module.exports = {
+        ...rootMain,
+        },
+      };`
+      );
+
+      await webMigrateToWebpack5Generator(tree, {});
+      const projectOne = tree.read(`libs/test-one/.storybook/main.js`, 'utf-8');
+      expect(projectOne).not.toContain(`builder: 'webpack5'`);
+      const projectTwo = tree.read(`libs/test-two/.storybook/main.js`, 'utf-8');
+      expect(projectTwo).not.toContain(`builder: 'webpack5'`);
+    });
   });
 });

--- a/packages/web/src/generators/migrate-to-webpack-5/storybook-webpack5-changes.ts
+++ b/packages/web/src/generators/migrate-to-webpack-5/storybook-webpack5-changes.ts
@@ -1,0 +1,187 @@
+import { getProjects, Tree } from '@nrwl/devkit';
+import {
+  logger,
+  formatFiles,
+  applyChangesToString,
+  ChangeType,
+} from '@nrwl/devkit';
+
+import ts = require('typescript');
+import { findNodes } from '@nrwl/workspace/src/utilities/typescript/find-nodes';
+
+export function workspaceHasStorybookForReact(
+  packageJson: any
+): string | undefined {
+  return (
+    packageJson.dependencies['@storybook/react'] ||
+    packageJson.devDependencies['@storybook/react']
+  );
+}
+
+export async function migrateStorybookToWebPack5(tree: Tree) {
+  allReactProjectsWithStorybookConfiguration(tree).forEach((project) => {
+    editProjectMainJs(
+      tree,
+      `${project.storybookConfigPath}/main.js`,
+      project.projectName
+    );
+  });
+  await formatFiles(tree);
+}
+
+export function allReactProjectsWithStorybookConfiguration(tree: Tree): {
+  projectName: string;
+  storybookConfigPath: string;
+}[] {
+  const projects = getProjects(tree);
+  const reactProjectsThatHaveStorybookConfiguration: {
+    projectName: string;
+    storybookConfigPath: string;
+  }[] = [...projects.entries()]
+    ?.filter(
+      ([_, projectConfig]) =>
+        projectConfig.targets &&
+        projectConfig.targets.storybook &&
+        projectConfig.targets.storybook.options
+    )
+    ?.map(([projectName, projectConfig]) => {
+      if (
+        projectConfig.targets &&
+        projectConfig.targets.storybook &&
+        projectConfig.targets.storybook.options?.config?.configFolder &&
+        projectConfig.targets.storybook.options?.uiFramework ===
+          '@storybook/react'
+      ) {
+        return {
+          projectName,
+          storybookConfigPath:
+            projectConfig.targets.storybook.options.config.configFolder,
+        };
+      }
+    });
+  return reactProjectsThatHaveStorybookConfiguration;
+}
+
+export function editProjectMainJs(
+  tree: Tree,
+  projectMainJsFile: string,
+  projectName: string
+) {
+  let newContents: string;
+  let moduleExportsIsEmptyOrNonExistentOrInvalid = false;
+  let alreadyHasBuilder: any;
+  const rootMainJsExists = tree.exists(projectMainJsFile);
+  if (rootMainJsExists) {
+    const file = getTsSourceFile(tree, projectMainJsFile);
+    const appFileContent = tree.read(projectMainJsFile, 'utf-8');
+    newContents = appFileContent;
+    const moduleExportsFull = findNodes(file, [
+      ts.SyntaxKind.ExpressionStatement,
+    ]);
+
+    if (moduleExportsFull && moduleExportsFull[0]) {
+      const moduleExports = moduleExportsFull[0];
+      const listOfStatements = findNodes(moduleExports, [
+        ts.SyntaxKind.SyntaxList,
+      ]);
+
+      /**
+       * Keep the index of the stories node
+       * to put the core object before it
+       * if it does not exist already
+       */
+
+      let indexOfStoriesNode = -1;
+
+      const hasCoreObject = listOfStatements[0]?.getChildren()?.find((node) => {
+        if (
+          node &&
+          node.getText().length > 0 &&
+          indexOfStoriesNode < 0 &&
+          node?.getText().startsWith('stories')
+        ) {
+          indexOfStoriesNode = node.getStart();
+        }
+        return (
+          node?.kind === ts.SyntaxKind.PropertyAssignment &&
+          node?.getText().startsWith('core')
+        );
+      });
+
+      if (hasCoreObject) {
+        const contentsOfCoreNode = hasCoreObject.getChildren().find((node) => {
+          return node.kind === ts.SyntaxKind.ObjectLiteralExpression;
+        });
+        const everyAttributeInsideCoreNode = contentsOfCoreNode
+          .getChildren()
+          .find((node) => node.kind === ts.SyntaxKind.SyntaxList);
+
+        alreadyHasBuilder = everyAttributeInsideCoreNode
+          .getChildren()
+          .find((node) => node.getText() === "builder: 'webpack5'");
+
+        if (!alreadyHasBuilder) {
+          newContents = applyChangesToString(newContents, [
+            {
+              type: ChangeType.Insert,
+              index: contentsOfCoreNode.getEnd() - 1,
+              text: ", builder: 'webpack5'",
+            },
+          ]);
+        }
+      } else if (indexOfStoriesNode >= 0) {
+        /**
+         * Does not have core object,
+         * so just write one, at the start.
+         */
+        newContents = applyChangesToString(newContents, [
+          {
+            type: ChangeType.Insert,
+            index: indexOfStoriesNode - 1,
+            text: "core: { ...rootMain.core, builder: 'webpack5' }, ",
+          },
+        ]);
+      } else {
+        /**
+         * Module exports is empty or does not
+         * contain stories - most probably invalid
+         */
+        moduleExportsIsEmptyOrNonExistentOrInvalid = true;
+      }
+    } else {
+      /**
+       * module.exports does not exist
+       */
+      moduleExportsIsEmptyOrNonExistentOrInvalid = true;
+    }
+  } else {
+    moduleExportsIsEmptyOrNonExistentOrInvalid = true;
+  }
+
+  if (moduleExportsIsEmptyOrNonExistentOrInvalid) {
+    logger.info(
+      `Please configure Storybook for project "${projectName}"", since it has not been configured properly.`
+    );
+    return;
+  }
+
+  if (!alreadyHasBuilder) {
+    tree.write(projectMainJsFile, newContents);
+  }
+}
+
+export function getTsSourceFile(host: Tree, path: string): ts.SourceFile {
+  const buffer = host.read(path);
+  if (!buffer) {
+    throw new Error(`Could not read TS file (${path}).`);
+  }
+  const content = buffer.toString();
+  const source = ts.createSourceFile(
+    path,
+    content,
+    ts.ScriptTarget.Latest,
+    true
+  );
+
+  return source;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Right now, [React with Webpack 5 is just an opt-in](https://nx.dev/latest/react/guides/webpack-5), which is also why the current Storybook generator doesn't use the Webpack 5 setup by default.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR adds two things:

a) a warning if an existing Storybook configuration doesn't use the Webpack 5 configuration

![image](https://user-images.githubusercontent.com/542458/130250605-8eda447f-f2e9-419e-bb49-deda8de13960.png)

b) Detects whether the React setup uses Webpack 5 and makes sure to generate proper Webpack 5 setup for Storybook react stories

### Newest changes:

#### User migrates to Webpack 5 

User uses [this guide](https://nx.dev/l/a/guides/webpack-5). 
When they run
```
npx nx g @nrwl/web:webpack5
```
to migrate their React projects, this generator will also do the following:
1. Check if they have the `@storybook/react` package installed
2. It will install `@storybook/builder-webpack5` and `@storybook/manager-webpack5` if they are not already installed
3. It will add the `builder: 'webpack5'` option in the Storybook configurations (`.storybook/main.js`) of their React projects

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6703
