### PR TITLE
docs(core): add cli overview page and a section documenting how to keep configuration in sync

### DIFF
--- a/docs/angular/getting-started/nx-cli.md
+++ b/docs/angular/getting-started/nx-cli.md
@@ -24,6 +24,8 @@ Nx creates and maintains a dependency graph between projects based on import sta
 
 ## Common Commands
 
+> For a full list of commands you can run `nx help` or visit the [CLI reference](/{{framework}}/cli/overview).
+
 **Invoke a generator:**
 
 ```bash

--- a/docs/angular/guides/configuration.md
+++ b/docs/angular/guides/configuration.md
@@ -489,3 +489,35 @@ The syntax is the same as a [`.gitignore` file](https://git-scm.com/book/en/v2/G
 
 1. Changes to that file are not taken into account in the `affected` calculations.
 2. Even if the file is outside an app or library, `nx workspace-lint` won't warn about it.
+
+## Keeping the configuration in sync
+
+When creating projects, the Nx generators make sure these configuration files are updated accordingly for the new projects. While development continues and the workspace grows, you might need to refactor projects by renaming them, moving them to a different folder, removing them, etc. When this is done manually, you need to ensure your configuration files are kept in sync and that's a cumbersome task. Fortunately, Nx provides some generators and executors to help you with these tasks.
+
+### Moving projects
+
+Projects can be moved or renamed using the [@nrwl/angular:move](/{{framework}}/angular/move) generator.
+
+For instance, if a library under the booking folder is now being shared by multiple apps, you can move it to the shared folder like this:
+
+```bash
+nx g @nrwl/angular:move --project booking-some-library shared/some-library
+```
+
+### Removing projects
+
+Projects can be removed using the [@nrwl/workspace:remove](/{{framework}}/workspace/remove) generator.
+
+```bash
+nx g @nrwl/workspace:remove booking-some-library
+```
+
+### Validating the configuration
+
+If at any point in time you want to check if your configuration is in sync, you can use the [workspace-lint]({{framework}}/cli/workspace-lint) executor:
+
+```bash
+nx workspace-lint
+```
+
+This will identify any projects with no files in the configured project root folder, as well as any file that's not part of any project configured in the workspace.

--- a/docs/map.json
+++ b/docs/map.json
@@ -147,6 +147,12 @@
         "id": "cli",
         "itemList": [
           {
+            "id": "overview",
+            "name": "Overview",
+            "searchResultsName": "CLI Overview",
+            "file": "shared/cli-overview"
+          },
+          {
             "name": "generate",
             "id": "generate",
             "file": "angular/cli/generate"
@@ -183,12 +189,12 @@
           },
           {
             "name": "daemon:start",
-            "id": "daemon:start",
+            "id": "daemon-start",
             "file": "angular/cli/daemon-start"
           },
           {
             "name": "daemon:stop",
-            "id": "daemon:stop",
+            "id": "daemon-stop",
             "file": "angular/cli/daemon-stop"
           },
           {
@@ -1343,6 +1349,12 @@
         "id": "cli",
         "itemList": [
           {
+            "id": "overview",
+            "name": "Overview",
+            "searchResultsName": "CLI Overview",
+            "file": "shared/cli-overview"
+          },
+          {
             "name": "generate",
             "id": "generate",
             "file": "react/cli/generate"
@@ -1379,12 +1391,12 @@
           },
           {
             "name": "daemon:start",
-            "id": "daemon:start",
+            "id": "daemon-start",
             "file": "react/cli/daemon-start"
           },
           {
             "name": "daemon:stop",
-            "id": "daemon:stop",
+            "id": "daemon-stop",
             "file": "react/cli/daemon-stop"
           },
           {
@@ -2508,6 +2520,12 @@
         "id": "cli",
         "itemList": [
           {
+            "id": "overview",
+            "name": "Overview",
+            "searchResultsName": "CLI Overview",
+            "file": "shared/cli-overview"
+          },
+          {
             "name": "generate",
             "id": "generate",
             "file": "node/cli/generate"
@@ -2544,12 +2562,12 @@
           },
           {
             "name": "daemon:start",
-            "id": "daemon:start",
+            "id": "daemon-start",
             "file": "node/cli/daemon-start"
           },
           {
             "name": "daemon:stop",
-            "id": "daemon:stop",
+            "id": "daemon-stop",
             "file": "node/cli/daemon-stop"
           },
           {

--- a/docs/node/getting-started/nx-cli.md
+++ b/docs/node/getting-started/nx-cli.md
@@ -24,6 +24,8 @@ Nx creates and maintains a dependency graph between projects based on import sta
 
 ## Common Commands
 
+> For a full list of commands you can run `nx help` or visit the [CLI reference](/{{framework}}/cli/overview).
+
 **Invoke a generator:**
 
 ```bash

--- a/docs/node/guides/configuration.md
+++ b/docs/node/guides/configuration.md
@@ -500,3 +500,35 @@ The syntax is the same as a [`.gitignore` file](https://git-scm.com/book/en/v2/G
 
 1. Changes to that file are not taken into account in the `affected` calculations.
 2. Even if the file is outside an app or library, `nx workspace-lint` won't warn about it.
+
+## Keeping the configuration in sync
+
+When creating projects, the Nx generators make sure these configuration files are updated accordingly for the new projects. While development continues and the workspace grows, you might need to refactor projects by renaming them, moving them to a different folder, removing them, etc. When this is done manually, you need to ensure your configuration files are kept in sync and that's a cumbersome task. Fortunately, Nx provides some generators and executors to help you with these tasks.
+
+### Moving projects
+
+Projects can be moved or renamed using the [@nrwl/workspace:move](/{{framework}}/workspace/move) generator.
+
+For instance, if a library under the booking folder is now being shared by multiple apps, you can move it to the shared folder like this:
+
+```bash
+nx g @nrwl/workspace:move --project booking-some-library shared/some-library
+```
+
+### Removing projects
+
+Projects can be removed using the [@nrwl/workspace:remove](/{{framework}}/workspace/remove) generator.
+
+```bash
+nx g @nrwl/workspace:remove booking-some-library
+```
+
+### Validating the configuration
+
+If at any point in time you want to check if your configuration is in sync, you can use the [workspace-lint]({{framework}}/cli/workspace-lint) executor:
+
+```bash
+nx workspace-lint
+```
+
+This will identify any projects with no files in the configured project root folder, as well as any file that's not part of any project configured in the workspace.

--- a/docs/react/getting-started/nx-cli.md
+++ b/docs/react/getting-started/nx-cli.md
@@ -24,6 +24,8 @@ Nx creates and maintains a dependency graph between projects based on import sta
 
 ## Common Commands
 
+> For a full list of commands you can run `nx help` or visit the [CLI reference](/{{framework}}/cli/overview).
+
 **Invoke a generator:**
 
 ```bash

--- a/docs/react/guides/configuration.md
+++ b/docs/react/guides/configuration.md
@@ -496,3 +496,35 @@ The syntax is the same as a [`.gitignore` file](https://git-scm.com/book/en/v2/G
 
 1. Changes to that file are not taken into account in the `affected` calculations.
 2. Even if the file is outside an app or library, `nx workspace-lint` won't warn about it.
+
+## Keeping the configuration in sync
+
+When creating projects, the Nx generators make sure these configuration files are updated accordingly for the new projects. While development continues and the workspace grows, you might need to refactor projects by renaming them, moving them to a different folder, removing them, etc. When this is done manually, you need to ensure your configuration files are kept in sync and that's a cumbersome task. Fortunately, Nx provides some generators and executors to help you with these tasks.
+
+### Moving projects
+
+Projects can be moved or renamed using the [@nrwl/workspace:move](/{{framework}}/workspace/move) generator.
+
+For instance, if a library under the booking folder is now being shared by multiple apps, you can move it to the shared folder like this:
+
+```bash
+nx g @nrwl/workspace:move --project booking-some-library shared/some-library
+```
+
+### Removing projects
+
+Projects can be removed using the [@nrwl/workspace:remove](/{{framework}}/workspace/remove) generator.
+
+```bash
+nx g @nrwl/workspace:remove booking-some-library
+```
+
+### Validating the configuration
+
+If at any point in time you want to check if your configuration is in sync, you can use the [workspace-lint]({{framework}}/cli/workspace-lint) executor:
+
+```bash
+nx workspace-lint
+```
+
+This will identify any projects with no files in the configured project root folder, as well as any file that's not part of any project configured in the workspace.

--- a/docs/shared/cli-overview.md
+++ b/docs/shared/cli-overview.md
@@ -1,0 +1,33 @@
+# CLI Overview
+
+The Nx CLI provides the following commands:
+
+- [generate](/{{framework}}/cli/generate): Runs a generator that creates and/or modifies files based on a generator from a collection.
+- [serve](/{{framework}}/cli/serve): Builds and serves an application, rebuilding on file changes.
+- [build](/{{framework}}/cli/build): Compiles an application into an output directory named dist/ at the given output path. Must be executed from within a workspace directory.
+- [test](/{{framework}}/cli/test): Runs unit tests in a project using the configured unit test runner.
+- [lint](/{{framework}}/cli/lint): Runs linting tools on application code in a given project folder using the configured linter.
+- [e2e](/{{framework}}/cli/e2e): Builds and serves an app, then runs end-to-end tests using the configured E2E test runner.
+- [run](/{{framework}}/cli/run): Runs an Architect target with an optional custom builder configuration defined in your project.
+- [affected](/{{framework}}/cli/affected): Run task for affected projects
+- [run-many](/{{framework}}/cli/run-many): Run task for multiple projects
+- [affected:apps](/{{framework}}/cli/affected-apps): Print applications affected by changes
+- [affected:libs](/{{framework}}/cli/affected-libs): Print libraries affected by changes
+- [affected:build](/{{framework}}/cli/affected-build): Build applications and publishable libraries affected by changes
+- [affected:test](/{{framework}}/cli/affected-test): Test projects affected by changes
+- [affected:e2e](/{{framework}}/cli/affected-e2e): Run e2e tests for the applications affected by changes
+- [affected:dep-graph](/{{framework}}/cli/affected-dep-graph): Graph dependencies affected by changes
+- [print-affected](/{{framework}}/cli/print-affected): Graph execution plan
+- [affected:lint](/{{framework}}/cli/affected-lint): Lint projects affected by changes
+- [daemon:start](/{{framework}}/cli/daemon-start): EXPERIMENTAL: Start the project graph daemon server (either in the background or the current process)
+- [daemon:stop](/{{framework}}/cli/daemon-stop): EXPERIMENTAL: Stop the project graph daemon server
+- [dep-graph](/{{framework}}/cli/dep-graph): Graph dependencies within workspace
+- [format:check](/{{framework}}/cli/format-check): Check for un-formatted files
+- [format:write](/{{framework}}/cli/format-write): Overwrite un-formatted files
+- [workspace-lint](/{{framework}}/cli/workspace-lint): Lint workspace or list of files. Note: To exclude files from this lint rule, you can add them to the ".nxignore" file
+- [workspace-generator](/{{framework}}/cli/workspace-generator): Runs a workspace generator from the tools/generators directory
+- [migrate](/{{framework}}/cli/migrate): Creates a migrations file or runs migrations from the migrations file.
+- [report](/{{framework}}/cli/report): Reports useful version numbers to copy into the Nx issue template
+- [list](/{{framework}}/cli/list): Lists installed plugins, capabilities of installed plugins and other available plugins.
+- [clear-cache](/{{framework}}/cli/clear-cache): Clears all the cached Nx artifacts and metadata about the workspace.
+- [connect-to-nx-cloud](/{{framework}}/cli/connect-to-nx-cloud): Makes sure the workspace is connected to Nx Cloud

--- a/scripts/documentation/map-link-checker.ts
+++ b/scripts/documentation/map-link-checker.ts
@@ -5,7 +5,7 @@ import * as chalk from 'chalk';
 console.log(`${chalk.blue('i')} Documentation Map Check`);
 
 const basePath = 'docs';
-const sharedFilesPattern = 'shared/cli';
+const sharedFilesPattern = 'shared/cli/';
 
 const readmePathList: string[] = glob
   .sync(`${basePath}/**/*.md`)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
There's no page where all the Nx CLI commands can be seen, we need to browse the CLI reference command one by one to see their description. The workspace configuration docs don't provide information on how to keep the configuration in sync.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
An Overview page is provided for the CLI reference where the list of commands available is shown with their description. The workspace configuration docs show relevant information about the tools available to help to keep the configuration in sync.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
