### PR TITLE
fix(testing): fix remove typescript plugin migration when project has…

### DIFF
--- a/packages/cypress/src/migrations/update-12-8-0/remove-typescript-plugin.ts
+++ b/packages/cypress/src/migrations/update-12-8-0/remove-typescript-plugin.ts
@@ -3,7 +3,6 @@ import {
   ChangeType,
   formatFiles,
   getProjects,
-  logger,
   ProjectConfiguration,
   readJson,
   StringDeletion,
@@ -117,6 +116,9 @@ function getCypressConfigs(target: TargetConfiguration): string[] {
 }
 
 function getCypressTargets(proj: ProjectConfiguration) {
+  if (!proj.targets) {
+    return [];
+  }
   return Object.values(proj.targets).filter(
     (target) => target.executor === '@nrwl/cypress:cypress'
   );


### PR DESCRIPTION
… no targets

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cypress migration fails when project has no targets

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Cypress migration does nothing when project has no targets

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
