### PR TITLE
fix(web): fix stylesOptimization for webpack 5

### DIFF
--- a/e2e/react/src/react-webpack-5.test.ts
+++ b/e2e/react/src/react-webpack-5.test.ts
@@ -23,7 +23,7 @@ describe('Webpack 5: React Apps', () => {
     updateFile(
       `apps/${appName}/src/styles.css`,
       Array.from({ length: 2000 })
-        .map((_, i) => `.class-${i} { color: red; }`)
+        .map((_, i) => `/* this is a comment */\n.class-${i} { color: red; }`)
         .join('\n')
     );
 
@@ -34,6 +34,11 @@ describe('Webpack 5: React Apps', () => {
       `dist/apps/${appName}/runtime.esm.js`,
       `dist/apps/${appName}/main.esm.js`,
       `dist/apps/${appName}/styles.css`
+    );
+
+    // Should be minified
+    expect(readFile(`dist/apps/${appName}/styles.css`)).not.toContain(
+      'this is a comment'
     );
 
     checkFilesDoNotExist(`dist/apps/${appName}/styles.js`);

--- a/packages/web/src/utils/third-party/cli-files/models/webpack-configs/common.ts
+++ b/packages/web/src/utils/third-party/cli-files/models/webpack-configs/common.ts
@@ -297,7 +297,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
   } catch {}
 
   const extraMinimizers = [];
-  if (!isWebpack5 && stylesOptimization) {
+  if (stylesOptimization) {
     extraMinimizers.push(
       new CleanCssWebpackPlugin({
         sourceMap: stylesSourceMap,


### PR DESCRIPTION
## Current Behavior

The output CSS is not minified when running the production build with webpack 5.

## Expected Behavior

The CSS is minified when using `--prod` build flag or `NODE_ENV=production`.

## Related Issue(s)

Fixes #6816
