### PR TITLE
fix(web): npm dependencies from the project graph

### DIFF
--- a/packages/web/src/executors/package/package.impl.ts
+++ b/packages/web/src/executors/package/package.impl.ts
@@ -73,7 +73,7 @@ export default async function* run(
   const options = normalizePackageOptions(rawOptions, context.root, sourceRoot);
   const packageJson = readJsonFile(options.project);
 
-  const npmDeps = (projectGraph[context.projectName] ?? [])
+  const npmDeps = (projectGraph.dependencies[context.projectName] ?? [])
     .filter((d) => d.target.startsWith('npm:'))
     .map((d) => d.target.substr(4));
 
@@ -239,8 +239,9 @@ export function createRollupOptions(
         name: options.umdName || names(context.projectName).className,
       },
       external: (id) =>
-        externalPackages.includes(id) ||
-        npmDeps.some((name) => id === name || id.startsWith(`${name}/`)), // Could be a deep import
+        externalPackages.some(
+          (name) => id === name || id.startsWith(`${name}/`)
+        ) || npmDeps.some((name) => id === name || id.startsWith(`${name}/`)), // Could be a deep import
       plugins,
     };
 


### PR DESCRIPTION
get the npm dependencies from the project graph correctly. Allow deep import from `externals` passed from settings

## Current Behavior
The npm dependencies are read incorrectly from the project graph. Also, there is no deep analysis of `external` packages, but they are matched directly by id, but the npm dependencies have this logic.

## Expected Behavior
The npm dependencies should be read correctly from the project graph by the project name. `externals` from the build config should allow nested imports as well as npm packages.
