### PR TITLE
fix(angular): apply root config rules over rules from angular eslint …

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -84,6 +84,12 @@
       "version": "12.3.5-beta.0",
       "description": "Convert targets using @nrwl/angular:webpack-browser with the buildTarget option set to use the @nrwl/angular:delegate-build executor instead.",
       "factory": "./src/migrations/update-12-3-0/convert-webpack-browser-build-target-to-delegate-build"
+    },
+    "move-extends-into-overrides": {
+      "cli": "nx",
+      "version": "12.9.0-beta.0",
+      "description": "Move extends in .eslintrc.json into the overrides so that the root config applies over the config extended by the override",
+      "factory": "./src/migrations/update-12-9-0/move-extends-into-overrides"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/generators/add-linting/__snapshots__/add-linting.spec.ts.snap
+++ b/packages/angular/src/generators/add-linting/__snapshots__/add-linting.spec.ts.snap
@@ -2,9 +2,6 @@
 
 exports[`addLinting generator should correctly generate the .eslintrc.json file 1`] = `
 Object {
-  "extends": Array [
-    "../../.eslintrc.json",
-  ],
   "ignorePatterns": Array [
     "!**/*",
   ],
@@ -13,6 +10,7 @@ Object {
       "extends": Array [
         "plugin:@nrwl/nx/angular",
         "plugin:@angular-eslint/template/process-inline-templates",
+        "../../.eslintrc.json",
       ],
       "files": Array [
         "*.ts",
@@ -39,6 +37,7 @@ Object {
     Object {
       "extends": Array [
         "plugin:@nrwl/nx/angular-template",
+        "../../.eslintrc.json",
       ],
       "files": Array [
         "*.html",

--- a/packages/angular/src/generators/add-linting/lib/create-eslint-configuration.ts
+++ b/packages/angular/src/generators/add-linting/lib/create-eslint-configuration.ts
@@ -12,7 +12,6 @@ export function createEsLintConfiguration(
   const ignorePatterns = ['!**/*'];
 
   const configJson = {
-    extends: [rootConfig],
     ignorePatterns,
     overrides: [
       {
@@ -20,6 +19,7 @@ export function createEsLintConfiguration(
         extends: [
           'plugin:@nrwl/nx/angular',
           'plugin:@angular-eslint/template/process-inline-templates',
+          rootConfig,
         ],
         /**
          * NOTE: We no longer set parserOptions.project by default when creating new projects.
@@ -60,7 +60,7 @@ export function createEsLintConfiguration(
       },
       {
         files: ['*.html'],
-        extends: ['plugin:@nrwl/nx/angular-template'],
+        extends: ['plugin:@nrwl/nx/angular-template', rootConfig],
         /**
          * Having an empty rules object present makes it more obvious to the user where they would
          * extend things from if they needed to

--- a/packages/angular/src/migrations/update-12-9-0/move-extends-into-overrides.spec.ts
+++ b/packages/angular/src/migrations/update-12-9-0/move-extends-into-overrides.spec.ts
@@ -1,0 +1,46 @@
+import { createTree } from '@nrwl/devkit/testing';
+import { readJson, Tree, writeJson } from '@nrwl/devkit';
+import moveExtendsIntoOverrides from '@nrwl/angular/src/migrations/update-12-9-0/move-extends-into-overrides';
+
+describe('moveExtendsIntoOverrides', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTree();
+    writeJson(tree, '.eslintrc.json', {});
+  });
+
+  it('should change configs that have extends', async () => {
+    writeJson(tree, 'proj/.eslintrc.json', {
+      extends: '../.eslintrc.json',
+      overrides: [
+        {
+          extends: 'some-config',
+        },
+        {
+          extends: ['some-config'],
+        },
+        {},
+      ],
+    });
+    await moveExtendsIntoOverrides(tree);
+    expect(readJson(tree, 'proj/.eslintrc.json')).toEqual({
+      overrides: [
+        {
+          extends: ['some-config', '../.eslintrc.json'],
+        },
+        {
+          extends: ['some-config', '../.eslintrc.json'],
+        },
+        {
+          extends: ['../.eslintrc.json'],
+        },
+      ],
+    });
+  });
+
+  it('should not change configs without extends', async () => {
+    writeJson(tree, 'proj/.eslintrc.json', {});
+    await moveExtendsIntoOverrides(tree);
+    expect(readJson(tree, 'proj/.eslintrc.json')).toEqual({});
+  });
+});

--- a/packages/angular/src/migrations/update-12-9-0/move-extends-into-overrides.ts
+++ b/packages/angular/src/migrations/update-12-9-0/move-extends-into-overrides.ts
@@ -1,0 +1,59 @@
+import {
+  Tree,
+  updateJson,
+  visitNotIgnoredFiles,
+  normalizePath,
+  formatFiles,
+} from '@nrwl/devkit';
+import { basename, relative } from 'path';
+
+export default async function moveExtendsIntoOverrides(tree: Tree) {
+  if (!tree.exists('.eslintrc.json')) {
+    return;
+  }
+
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (basename(filePath) !== '.eslintrc.json') {
+      return;
+    }
+
+    updateJson<{
+      extends?: string | string[];
+      overrides?: Array<{ extends: string | string[] }>;
+    }>(tree, filePath, (json) => {
+      if (
+        !json.extends ||
+        !json.overrides ||
+        json.overrides.every((override) => !override.extends)
+      ) {
+        return json;
+      }
+
+      const baseExtends = normalizeExtends(json.extends);
+      for (const override of json.overrides) {
+        override.extends = [
+          ...normalizeExtends(override.extends),
+          ...baseExtends,
+        ];
+      }
+
+      delete json.extends;
+
+      return json;
+    });
+  });
+
+  await formatFiles(tree);
+}
+
+function normalizeExtends(extensions: string | string[]) {
+  if (!extensions) {
+    return [];
+  }
+
+  if (!Array.isArray(extensions)) {
+    return [extensions];
+  }
+
+  return extensions;
+}


### PR DESCRIPTION
…plugins

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The way `.eslintrc.json` files are generated for Angular projects are such that rules from `@angular-eslint` override config in the `.eslintrc.json` in the root of the workspace. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`.eslintrc.json` files are generated such that rules from the root `.eslintrc.json` overrides config from `@angular-eslint` making it easier to disable rules etc.

There's also a migration for existing projects. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
