### PR TITLE
feat(linter): cache --outputFile

### DIFF
--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -815,7 +815,7 @@ describe('cache', () => {
     expect(outputWithBothLintTasksCached).toContain(
       'read the output from cache'
     );
-    expectMatchedOutput(outputWithBothLintTasksCached, [
+    expectCached(outputWithBothLintTasksCached, [
       myapp1,
       myapp2,
       `${myapp1}-e2e`,

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -300,6 +300,9 @@ Object {
           "apps/my-dir/my-app-e2e/**/*.{js,ts}",
         ],
       },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
     },
   },
   "projectType": "application",
@@ -459,6 +462,9 @@ Object {
           "apps/my-app-e2e/**/*.{js,ts}",
         ],
       },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
     },
   },
   "projectType": "application",

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -360,6 +360,9 @@ describe('app', () => {
                 "apps/my-app-e2e/**/*.{js,ts}",
               ],
             },
+            "outputs": Array [
+              "{options.outputFile}",
+            ],
           }
         `);
       });
@@ -392,6 +395,9 @@ describe('app', () => {
                 "apps/my-app-e2e/**/*.ts",
               ],
             },
+            "outputs": Array [
+              "{options.outputFile}",
+            ],
           }
         `);
       });
@@ -566,6 +572,7 @@ describe('app', () => {
             },
             lint: {
               builder: '@nrwl/linter:eslint',
+              outputs: ['{options.outputFile}'],
               options: {
                 lintFilePatterns: ['apps/my-app-e2e/**/*.ts'],
               },

--- a/packages/cypress/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
+++ b/packages/cypress/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
@@ -29,6 +29,9 @@ Object {
           "apps/e2e-app-1/**/*.{js,ts}",
         ],
       },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
     },
   },
 }

--- a/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
@@ -169,6 +169,7 @@ describe('schematic:cypress-project', () => {
 
       expect(project.architect.lint).toEqual({
         builder: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
         options: {
           lintFilePatterns: ['apps/my-app-e2e/**/*.{js,ts}'],
         },

--- a/packages/linter/migrations.json
+++ b/packages/linter/migrations.json
@@ -46,6 +46,12 @@
       "version": "12.4.0-beta.0",
       "description": "Remove ESLint parserOptions.project config if no rules requiring type-checking are in use",
       "factory": "./src/migrations/update-12-4-0/remove-eslint-project-config-if-no-type-checking-rules"
+    },
+    "add-outputs": {
+      "cli": "nx",
+      "version": "12.9.0-beta.0",
+      "description": "Add outputs for caching",
+      "factory": "./src/migrations/update-12-9-0/add-outputs"
     }
   },
   "packageJsonUpdates": {

--- a/packages/linter/src/generators/lint-project/lint-project.spec.ts
+++ b/packages/linter/src/generators/lint-project/lint-project.spec.ts
@@ -57,6 +57,9 @@ describe('@nrwl/linter:lint-project', () => {
                 "**/*.ts",
               ],
             },
+            "outputs": Array [
+              "{options.outputFile}",
+            ],
           }
         `);
       });

--- a/packages/linter/src/generators/lint-project/lint-project.ts
+++ b/packages/linter/src/generators/lint-project/lint-project.ts
@@ -93,6 +93,7 @@ export async function lintProjectGenerator(
   if (options.linter === Linter.EsLint) {
     projectConfig.targets['lint'] = {
       executor: '@nrwl/linter:eslint',
+      outputs: ['{options.outputFile}'],
       options: {
         lintFilePatterns: options.eslintFilePatterns,
       },

--- a/packages/linter/src/migrations/update-12-9-0/add-outputs.spec.ts
+++ b/packages/linter/src/migrations/update-12-9-0/add-outputs.spec.ts
@@ -1,0 +1,69 @@
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  TargetConfiguration,
+  Tree,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import addOutputs from './add-outputs';
+
+describe('addOutputs', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    const lintWithoutOutputs: TargetConfiguration = {
+      executor: '@nrwl/linter:eslint',
+      options: {},
+    };
+    const lintWithOutputs: TargetConfiguration = {
+      executor: '@nrwl/linter:eslint',
+      outputs: ['dist'],
+      options: {},
+    };
+    const notLint: TargetConfiguration = {
+      executor: '@nrwl/node:build',
+      options: {},
+    };
+
+    addProjectConfiguration(tree, 'proj', {
+      root: 'proj',
+      targets: {
+        lintWithoutOutputs,
+        lintWithOutputs,
+        notLint,
+      },
+    });
+  });
+
+  it('should add outputs to targets that do not have outputs', async () => {
+    await addOutputs(tree);
+
+    expect(readProjectConfiguration(tree, 'proj')).toMatchInlineSnapshot(`
+Object {
+  "root": "proj",
+  "targets": Object {
+    "lintWithOutputs": Object {
+      "executor": "@nrwl/linter:eslint",
+      "options": Object {},
+      "outputs": Array [
+        "dist",
+      ],
+    },
+    "lintWithoutOutputs": Object {
+      "executor": "@nrwl/linter:eslint",
+      "options": Object {},
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+    "notLint": Object {
+      "executor": "@nrwl/node:build",
+      "options": Object {},
+    },
+  },
+}
+`);
+  });
+});

--- a/packages/linter/src/migrations/update-12-9-0/add-outputs.ts
+++ b/packages/linter/src/migrations/update-12-9-0/add-outputs.ts
@@ -1,0 +1,26 @@
+import {
+  formatFiles,
+  getProjects,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+
+export default async function addOutputs(tree: Tree) {
+  for (const [projectName, project] of getProjects(tree)) {
+    if (!project.targets) {
+      continue;
+    }
+
+    for (const target of Object.values(project.targets)) {
+      if (target.executor !== '@nrwl/linter:eslint' || target.outputs) {
+        continue;
+      }
+
+      target.outputs = ['{options.outputFile}'];
+
+      updateProjectConfiguration(tree, projectName, project);
+    }
+  }
+
+  await formatFiles(tree);
+}

--- a/packages/nest/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
+++ b/packages/nest/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
@@ -28,6 +28,9 @@ Object {
           "apps/nest-app-1/**/*.ts",
         ],
       },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
     },
   },
 }
@@ -314,6 +317,9 @@ Object {
           "libs/nest-lib-1/**/*.ts",
         ],
       },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
     },
   },
 }

--- a/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -59,6 +59,9 @@ Object {
       "libs/my-lib/**/*.ts",
     ],
   },
+  "outputs": Array [
+    "{options.outputFile}",
+  ],
 }
 `;
 

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -27,6 +27,7 @@ describe('lib', () => {
       ).toBeUndefined();
       expect(workspaceJson.projects[libFileName].architect.lint).toEqual({
         builder: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
         options: {
           lintFilePatterns: [`libs/${libFileName}/**/*.ts`],
         },
@@ -212,6 +213,7 @@ describe('lib', () => {
       expect(project.root).toEqual(`libs/${dirFileName}/${libFileName}`);
       expect(project.targets.lint).toEqual({
         executor: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
         options: {
           lintFilePatterns: [`libs/${dirFileName}/${libFileName}/**/*.ts`],
         },

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -75,6 +75,7 @@ describe('app', () => {
       );
       expect(workspaceJson.projects['my-node-app'].architect.lint).toEqual({
         builder: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
         options: {
           lintFilePatterns: ['apps/my-node-app/**/*.ts'],
         },
@@ -182,6 +183,7 @@ describe('app', () => {
         workspaceJson.projects['my-dir-my-node-app'].architect.lint
       ).toEqual({
         builder: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
         options: {
           lintFilePatterns: ['apps/my-dir/my-node-app/**/*.ts'],
         },
@@ -272,6 +274,9 @@ describe('app', () => {
               "apps/my-node-app/**/*.ts",
             ],
           },
+          "outputs": Array [
+            "{options.outputFile}",
+          ],
         }
       `);
     });

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -19,6 +19,7 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-lib'].architect.build).toBeUndefined();
       expect(workspaceJson.projects['my-lib'].architect.lint).toEqual({
         builder: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
         options: {
           lintFilePatterns: ['libs/my-lib/**/*.ts'],
         },
@@ -201,6 +202,7 @@ describe('lib', () => {
       );
       expect(workspaceJson.projects['my-dir-my-lib'].architect.lint).toEqual({
         builder: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
         options: {
           lintFilePatterns: ['libs/my-dir/my-lib/**/*.ts'],
         },
@@ -304,6 +306,9 @@ describe('lib', () => {
               "libs/my-lib/**/*.ts",
             ],
           },
+          "outputs": Array [
+            "{options.outputFile}",
+          ],
         }
       `);
     });

--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -48,6 +48,7 @@ describe('NxPlugin Plugin Generator', () => {
     });
     expect(project.targets.lint).toEqual({
       executor: '@nrwl/linter:eslint',
+      outputs: ['{options.outputFile}'],
       options: {
         lintFilePatterns: ['libs/my-plugin/**/*.ts'],
       },

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -29,6 +29,7 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-lib'].architect.build).toBeUndefined();
       expect(workspaceJson.projects['my-lib'].architect.lint).toEqual({
         builder: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
         options: {
           lintFilePatterns: ['libs/my-lib/**/*.{ts,tsx,js,jsx}'],
         },
@@ -141,6 +142,7 @@ describe('lib', () => {
       );
       expect(workspaceJson.projects['my-dir-my-lib'].architect.lint).toEqual({
         builder: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
         options: {
           lintFilePatterns: ['libs/my-dir/my-lib/**/*.{ts,tsx,js,jsx}'],
         },
@@ -196,6 +198,9 @@ describe('lib', () => {
               "libs/my-lib/**/*.{ts,tsx,js,jsx}",
             ],
           },
+          "outputs": Array [
+            "{options.outputFile}",
+          ],
         }
       `);
     });

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -306,6 +306,7 @@ Object {
     const workspaceJson = getProjects(appTree);
     expect(workspaceJson.get('my-app').targets.lint).toEqual({
       executor: '@nrwl/linter:eslint',
+      outputs: ['{options.outputFile}'],
       options: {
         lintFilePatterns: ['apps/my-app/**/*.{ts,tsx,js,jsx}'],
       },
@@ -326,15 +327,18 @@ Object {
       const workspaceJson = getProjects(appTree);
       expect(workspaceJson.get('my-app').targets.test).toBeUndefined();
       expect(workspaceJson.get('my-app').targets.lint).toMatchInlineSnapshot(`
-        Object {
-          "executor": "@nrwl/linter:eslint",
-          "options": Object {
-            "lintFilePatterns": Array [
-              "apps/my-app/**/*.{ts,tsx,js,jsx}",
-            ],
-          },
-        }
-      `);
+Object {
+  "executor": "@nrwl/linter:eslint",
+  "options": Object {
+    "lintFilePatterns": Array [
+      "apps/my-app/**/*.{ts,tsx,js,jsx}",
+    ],
+  },
+  "outputs": Array [
+    "{options.outputFile}",
+  ],
+}
+`);
     });
   });
 

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -32,6 +32,7 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-lib'].architect.build).toBeUndefined();
       expect(workspaceJson.projects['my-lib'].architect.lint).toEqual({
         builder: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
         options: {
           lintFilePatterns: ['libs/my-lib/**/*.{ts,tsx,js,jsx}'],
         },
@@ -224,6 +225,7 @@ describe('lib', () => {
       );
       expect(workspaceJson.projects['my-dir-my-lib'].architect.lint).toEqual({
         builder: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
         options: {
           lintFilePatterns: ['libs/my-dir/my-lib/**/*.{ts,tsx,js,jsx}'],
         },
@@ -334,6 +336,9 @@ describe('lib', () => {
               "libs/my-lib/**/*.{ts,tsx,js,jsx}",
             ],
           },
+          "outputs": Array [
+            "{options.outputFile}",
+          ],
         }
       `);
     });

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -158,6 +158,7 @@ describe('@nrwl/storybook:configuration', () => {
 
     expect(project.targets.lint).toEqual({
       executor: '@nrwl/linter:eslint',
+      outputs: ['{options.outputFile}'],
       options: {
         lintFilePatterns: ['libs/test-ui-lib/**/*.ts'],
       },

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -74,23 +74,23 @@ describe('app', () => {
       expect(tree.exists('apps/my-app-e2e/cypress.json')).toBeTruthy();
       const tsconfigE2E = readJson(tree, 'apps/my-app-e2e/tsconfig.json');
       expect(tsconfigE2E).toMatchInlineSnapshot(`
-Object {
-  "compilerOptions": Object {
-    "allowJs": true,
-    "outDir": "../../dist/out-tsc",
-    "sourceMap": false,
-    "types": Array [
-      "cypress",
-      "node",
-    ],
-  },
-  "extends": "../../tsconfig.base.json",
-  "include": Array [
-    "src/**/*.ts",
-    "src/**/*.js",
-  ],
-}
-`);
+        Object {
+          "compilerOptions": Object {
+            "allowJs": true,
+            "outDir": "../../dist/out-tsc",
+            "sourceMap": false,
+            "types": Array [
+              "cypress",
+              "node",
+            ],
+          },
+          "extends": "../../tsconfig.base.json",
+          "include": Array [
+            "src/**/*.ts",
+            "src/**/*.js",
+          ],
+        }
+      `);
 
       const eslintJson = readJson(tree, '/apps/my-app/.eslintrc.json');
       expect(eslintJson).toMatchInlineSnapshot(`
@@ -314,6 +314,7 @@ Object {
 
     expect(workspaceJson.projects['my-app'].architect.lint).toEqual({
       builder: '@nrwl/linter:eslint',
+      outputs: ['{options.outputFile}'],
       options: {
         lintFilePatterns: ['apps/my-app/**/*.ts'],
       },
@@ -358,6 +359,9 @@ Object {
               "apps/my-app/**/*.ts",
             ],
           },
+          "outputs": Array [
+            "{options.outputFile}",
+          ],
         }
       `);
     });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When `--outputFile` is passed for ESLint projects, Nx does not properly cache the output file. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `--outputFile` is cached by Nx.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
