### PR TITLE
fix(angular): move upgrade 12.2 to 12.9.0 migrations

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -739,6 +739,43 @@
     "12.8.0": {
       "version": "12.8.0",
       "packages": {
+        "typescript": {
+          "version": "~4.3.5",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/store": {
+          "version": "~12.4.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/effects": {
+          "version": "~12.4.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/entity": {
+          "version": "~12.4.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/router-store": {
+          "version": "~12.4.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/schematics": {
+          "version": "~12.4.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/store-devtools": {
+          "version": "~12.4.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/component-store": {
+          "version": "~12.4.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "12.9.0": {
+      "version": "12.9.0-beta.0",
+      "packages": {
         "@angular/cli": {
           "version": "~12.2.0",
           "alwaysAddToPackageJson": false
@@ -817,38 +854,6 @@
         },
         "ng-packagr": {
           "version": "~12.2.0",
-          "alwaysAddToPackageJson": false
-        },
-        "typescript": {
-          "version": "~4.3.5",
-          "alwaysAddToPackageJson": false
-        },
-        "@ngrx/store": {
-          "version": "~12.4.0",
-          "alwaysAddToPackageJson": false
-        },
-        "@ngrx/effects": {
-          "version": "~12.4.0",
-          "alwaysAddToPackageJson": false
-        },
-        "@ngrx/entity": {
-          "version": "~12.4.0",
-          "alwaysAddToPackageJson": false
-        },
-        "@ngrx/router-store": {
-          "version": "~12.4.0",
-          "alwaysAddToPackageJson": false
-        },
-        "@ngrx/schematics": {
-          "version": "~12.4.0",
-          "alwaysAddToPackageJson": false
-        },
-        "@ngrx/store-devtools": {
-          "version": "~12.4.0",
-          "alwaysAddToPackageJson": false
-        },
-        "@ngrx/component-store": {
-          "version": "~12.4.0",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -739,10 +739,6 @@
     "12.8.0": {
       "version": "12.8.0",
       "packages": {
-        "typescript": {
-          "version": "~4.3.5",
-          "alwaysAddToPackageJson": false
-        },
         "@ngrx/store": {
           "version": "~12.4.0",
           "alwaysAddToPackageJson": false
@@ -854,6 +850,10 @@
         },
         "ng-packagr": {
           "version": "~12.2.0",
+          "alwaysAddToPackageJson": false
+        },
+        "typescript": {
+          "version": "~4.3.5",
           "alwaysAddToPackageJson": false
         }
       }


### PR DESCRIPTION
Move angular 12.2 upgrade to 12.9.0 migrations