### PR TITLE
fix(repo): fix error in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,7 +246,7 @@ Including the issue number that the PR relates to also helps with tracking.
 #### Example
 
 ```
-feat(generators): add an option to generate lazy-loadable modules
+feat(angular): add an option to generate lazy-loadable modules
 
 `nx generate lib mylib --lazy` provisions the mylib project in tslint.json
 


### PR DESCRIPTION
## Current Behavior
The current contributing guidelines are wrong because the provided scope in the commit message example is not among the accepted ones. 

## Expected Behavior
The current commit message example is an accepted one.
