### PR TITLE
fix(core): use relative config file path in hash

### DIFF
--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -592,8 +592,12 @@ export function inlineProjectConfigurations(
     ([project, config]: [string, any]) => {
       if (typeof config === 'string') {
         const configFilePath = path.join(root, config, 'project.json');
+        const relativeConfigFilePath = path.relative(root, configFilePath);
         const fileConfig = readJsonFile(configFilePath);
-        w.projects[project] = { ...fileConfig, configFilePath };
+        w.projects[project] = {
+          ...fileConfig,
+          configFilePath: relativeConfigFilePath,
+        };
       }
     }
   );


### PR DESCRIPTION
When using `NX_CACHE_DIRECTORY` environment variable, the expectation is that
different `git worktree`s of the same project should share the cache. But, the
project hash used for caching includes the absolute path of `project.json`.
Now we use the relative path instead.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Different `git worktree`s of the same project have their own caches.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Different `git worktree`s of the same project share the cache.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
