### PR TITLE
feat(misc): add x-type to app and lib generators

### DIFF
--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -13,6 +13,7 @@
       "factory": "./src/generators/application/application.compat#applicationSchematic",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Creates an Angular application."
     },
     "component-cypress-spec": {
@@ -58,6 +59,7 @@
       "factory": "./src/generators/library/library.compat#librarySchematic",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Creates an Angular library."
     },
     "move": {
@@ -120,6 +122,7 @@
       "factory": "./src/generators/application/application",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Creates an Angular application."
     },
     "setup-mfe": {
@@ -170,6 +173,7 @@
       "factory": "./src/generators/library/library",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Creates an Angular library."
     },
     "move": {

--- a/packages/detox/generators.json
+++ b/packages/detox/generators.json
@@ -13,6 +13,7 @@
       "factory": "./src/generators/application/application#detoxApplicationSchematic",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create a detox application"
     }
   },
@@ -27,6 +28,7 @@
       "factory": "./src/generators/application/application#detoxApplicationGenerator",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create a detox application"
     }
   }

--- a/packages/express/generators.json
+++ b/packages/express/generators.json
@@ -15,6 +15,7 @@
       "factory": "./src/generators/application/application#applicationGenerator",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create an express application"
     }
   },
@@ -31,6 +32,7 @@
       "factory": "./src/generators/application/application#applicationSchematic",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create an express application"
     }
   }

--- a/packages/gatsby/generators.json
+++ b/packages/gatsby/generators.json
@@ -13,6 +13,7 @@
       "factory": "./src/generators/application/application#applicationSchematic",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create an application"
     },
     "component": {
@@ -37,6 +38,7 @@
       "factory": "./src/generators/application/application",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create an application"
     },
     "component": {

--- a/packages/nest/generators.json
+++ b/packages/nest/generators.json
@@ -7,6 +7,7 @@
       "factory": "./src/generators/application/application#applicationSchematic",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create a NestJS application."
     },
     "convert-tslint-to-eslint": {
@@ -25,6 +26,7 @@
       "factory": "./src/generators/library/library#librarySchematic",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Create a new NestJS library."
     },
     "class": {
@@ -103,6 +105,7 @@
       "factory": "./src/generators/application/application",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create a NestJS application."
     },
     "convert-tslint-to-eslint": {
@@ -121,6 +124,7 @@
       "factory": "./src/generators/library/library",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Create a new NestJS library."
     },
     "class": {

--- a/packages/next/generators.json
+++ b/packages/next/generators.json
@@ -13,6 +13,7 @@
       "factory": "./src/generators/application/application#applicationSchematic",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create a Next.js application"
     },
     "page": {
@@ -37,6 +38,7 @@
       "factory": "./src/generators/application/application#applicationGenerator",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create an application"
     },
     "page": {
@@ -53,6 +55,7 @@
       "factory": "./src/generators/library/library#libraryGenerator",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Create a library"
     }
   }

--- a/packages/node/generators.json
+++ b/packages/node/generators.json
@@ -14,12 +14,14 @@
       "factory": "./src/generators/application/application",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create a node application"
     },
     "library": {
       "factory": "./src/generators/library/library",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Create a library"
     },
     "migrate-to-webpack-5": {
@@ -41,12 +43,14 @@
       "factory": "./src/generators/application/application#applicationSchematic",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create a node application"
     },
     "library": {
       "factory": "./src/generators/library/library#librarySchematic",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Create a library"
     },
     "migrate-to-webpack-5": {

--- a/packages/react-native/generators.json
+++ b/packages/react-native/generators.json
@@ -13,12 +13,14 @@
       "factory": "./src/generators/application/application#reactNativeApplicationSchematic",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create an application"
     },
     "library": {
       "factory": "./src/generators/library/library#reactNativeLibrarySchematic",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Create a library"
     },
     "component": {
@@ -39,12 +41,14 @@
       "factory": "./src/generators/application/application#reactNativeApplicationGenerator",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create an application"
     },
     "library": {
       "factory": "./src/generators/library/library#reactNativeLibraryGenerator",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Create a library"
     },
     "component": {

--- a/packages/react/generators.json
+++ b/packages/react/generators.json
@@ -15,6 +15,7 @@
       "factory": "./src/generators/application/application#applicationSchematic",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create an application"
     },
 
@@ -22,6 +23,7 @@
       "factory": "./src/generators/library/library#librarySchematic",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Create a library"
     },
 
@@ -94,6 +96,7 @@
       "factory": "./src/generators/application/application#applicationGenerator",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create an application"
     },
 
@@ -101,6 +104,7 @@
       "factory": "./src/generators/library/library#libraryGenerator",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Create a library"
     },
 

--- a/packages/web/generators.json
+++ b/packages/web/generators.json
@@ -13,6 +13,7 @@
       "factory": "./src/generators/application/application#applicationGenerator",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create an application"
     },
     "migrate-to-webpack-5": {
@@ -33,6 +34,7 @@
       "factory": "./src/generators/application/application#applicationSchematic",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
+      "x-type": "application",
       "description": "Create an application"
     },
     "migrate-to-webpack-5": {

--- a/packages/workspace/generators.json
+++ b/packages/workspace/generators.json
@@ -48,6 +48,7 @@
       "factory": "./src/generators/library/library#librarySchematic",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Create a library"
     },
 
@@ -74,7 +75,8 @@
     "npm-package": {
       "factory": "./src/generators/npm-package/npm-package#npmPackageSchematic",
       "schema": "./src/generators/npm-package/schema.json",
-      "description": "Create a minimal npm package"
+      "description": "Create a minimal npm package",
+      "x-type": "library"
     }
   },
   "generators": {
@@ -124,6 +126,7 @@
       "factory": "./src/generators/library/library#libraryGenerator",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
+      "x-type": "library",
       "description": "Create a library"
     },
 
@@ -150,7 +153,8 @@
     "npm-package": {
       "factory": "./src/generators/npm-package/npm-package#npmPackageGenerator",
       "schema": "./src/generators/npm-package/schema.json",
-      "description": "Create a minimal npm package"
+      "description": "Create a minimal npm package",
+      "x-type": "library"
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There is no `x-type` on any generators.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generators that create new apps and libs have an `x-type` property (either `application` or `library`) that indicate that the generator creates an `application` or `library`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
