### PR TITLE
fix(linter): fix how eslint hasher gets projects from task dependencies

### DIFF
--- a/packages/linter/src/executors/eslint/hasher.ts
+++ b/packages/linter/src/executors/eslint/hasher.ts
@@ -37,6 +37,13 @@ export default async function run(
   };
 }
 
-function allDeps(taskId: string, taskGraph: TaskGraph) {
-  return [...taskGraph.dependencies[taskId].map((d) => allDeps(d, taskGraph))];
+function allDeps(taskId: string, taskGraph: TaskGraph): string[] {
+  return [
+    ...taskGraph.dependencies[taskId].map(
+      (task) => taskGraph.tasks[task].target.project
+    ),
+    ...taskGraph.dependencies[taskId].flatMap((task) =>
+      allDeps(task, taskGraph)
+    ),
+  ];
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Running a target with the `@nrwl/linter:eslint` executor and with `--with-deps` or with target dependencies configured, throws an error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running a target with the `@nrwl/linter:eslint` executor and with `--with-deps` or with target dependencies configured, should run correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6760 
