### PR TITLE
fix(devkit): normalizing paths when moving files

### DIFF
--- a/packages/devkit/src/utils/move-dir.ts
+++ b/packages/devkit/src/utils/move-dir.ts
@@ -1,11 +1,14 @@
 import { Tree } from '@nrwl/tao/src/shared/tree';
 import { visitNotIgnoredFiles } from '../generators/visit-not-ignored-files';
+import { normalizePath } from './path';
 
 export function moveFilesToNewDirectory(
   tree: Tree,
   oldDir: string,
   newDir: string
 ): void {
+  oldDir = normalizePath(oldDir);
+  newDir = normalizePath(newDir);
   visitNotIgnoredFiles(tree, oldDir, (file) => {
     try {
       tree.rename(file, file.replace(oldDir, newDir));


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The directories passed in to moveDir are not normalized while the file is.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`moveFilesToNewDirectory` works on windows.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6795 
