### PR TITLE
fix(core): hash npm projects based on version

### DIFF
--- a/packages/workspace/src/core/hasher/hasher.ts
+++ b/packages/workspace/src/core/hasher/hasher.ts
@@ -15,6 +15,7 @@ import { performance } from 'perf_hooks';
 import { appRootPath } from '../../utils/app-root';
 import { workspaceFileName } from '../file-utils';
 import { defaultHashing, HashingImpl } from './hashing-impl';
+import { isNpmProject } from '../project-graph';
 
 export interface Hash {
   value: string;
@@ -341,6 +342,12 @@ class ProjectHasher {
     if (!this.sourceHashes[projectName]) {
       this.sourceHashes[projectName] = new Promise(async (res) => {
         const p = this.projectGraph.nodes[projectName];
+
+        if (isNpmProject(p)) {
+          res(this.hashing.hashArray([p.data.version]));
+          return;
+        }
+
         const fileNames = p.data.files.map((f) => f.file);
         const values = p.data.files.map((f) => f.hash);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Npm projects were being hashed like workspace projects which errored when trying to selectively remove other projects from the tsconfig

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Npm projects are hashed differently from workspace projects. They are hashed via their version.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6878 
