### PR TITLE
fix(core): configFilePath included in hash

### DIFF
--- a/packages/tao/src/shared/workspace.spec.ts
+++ b/packages/tao/src/shared/workspace.spec.ts
@@ -29,7 +29,6 @@ describe('workspace', () => {
     };
 
     const resolved = inlineProjectConfigurations(inlineConfig);
-    delete resolved.projects.lib1.configFilePath;
     expect(resolved).toEqual({
       ...inlineConfig,
       projects: {

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -593,7 +593,7 @@ export function inlineProjectConfigurations(
       if (typeof config === 'string') {
         const configFilePath = path.join(root, config, 'project.json');
         const fileConfig = readJsonFile(configFilePath);
-        w.projects[project] = { ...fileConfig, configFilePath };
+        w.projects[project] = fileConfig;
       }
     }
   );


### PR DESCRIPTION
## Current Behavior
workspace.readWorkspaceConfiguration() includes `configFilePath`, which is only necessary for `ngcli-adapter` to know where to save configurations. 

## Expected Behavior
workspace.readWorkspaceConfiguration() doesnt include `configFilePath`, which is only necessary for `ngcli-adapter` to know where to save configurations. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6880
