### PR TITLE
feat(testing): remediate `headless` option for Cypress 8.x

### DIFF
--- a/docs/angular/api-cypress/executors/cypress.md
+++ b/docs/angular/api-cypress/executors/cypress.md
@@ -56,13 +56,21 @@ Type: `string`
 
 A named group for recorded runs in the Cypress dashboard.
 
-### headless
+### headed
 
 Default: `false`
 
 Type: `boolean`
 
-Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode
+Displays the browser instead of running headlessly. Set this to 'true' if your run depends on a Chrome extension being loaded.
+
+### ~~headless~~
+
+Default: `false`
+
+Type: `boolean`
+
+**Deprecated:** Hide the browser instead of running headed (default for cypress run).
 
 ### ignoreTestFiles
 

--- a/docs/node/api-cypress/executors/cypress.md
+++ b/docs/node/api-cypress/executors/cypress.md
@@ -57,13 +57,21 @@ Type: `string`
 
 A named group for recorded runs in the Cypress dashboard.
 
-### headless
+### headed
 
 Default: `false`
 
 Type: `boolean`
 
-Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode
+Displays the browser instead of running headlessly. Set this to 'true' if your run depends on a Chrome extension being loaded.
+
+### ~~headless~~
+
+Default: `false`
+
+Type: `boolean`
+
+**Deprecated:** Hide the browser instead of running headed (default for cypress run).
 
 ### ignoreTestFiles
 

--- a/docs/react/api-cypress/executors/cypress.md
+++ b/docs/react/api-cypress/executors/cypress.md
@@ -57,13 +57,21 @@ Type: `string`
 
 A named group for recorded runs in the Cypress dashboard.
 
-### headless
+### headed
 
 Default: `false`
 
 Type: `boolean`
 
-Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode
+Displays the browser instead of running headlessly. Set this to 'true' if your run depends on a Chrome extension being loaded.
+
+### ~~headless~~
+
+Default: `false`
+
+Type: `boolean`
+
+**Deprecated:** Hide the browser instead of running headed (default for cypress run).
 
 ### ignoreTestFiles
 

--- a/packages/cypress/src/executors/cypress/cypress.impl.spec.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.spec.ts
@@ -17,7 +17,6 @@ describe('Cypress builder', () => {
     parallel: false,
     tsConfig: 'apps/my-app-e2e/tsconfig.json',
     devServerTarget: 'my-app:serve',
-    headless: true,
     exit: true,
     record: false,
     baseUrl: undefined,
@@ -125,6 +124,32 @@ describe('Cypress builder', () => {
     );
 
     expect(devkit.logger.warn).toHaveBeenCalled();
+  });
+
+  it('should show warnings if using v8 deprecated headless flag', async () => {
+    mockedInstalledCypressVersion.mockReturnValue(8);
+    await cypressExecutor(
+      {
+        ...cypressOptions,
+        headless: true,
+      },
+      mockContext
+    );
+
+    expect(devkit.logger.warn).toHaveBeenCalled();
+  });
+
+  it('should skip warnings if using headless flag used on v7 and lower', async () => {
+    mockedInstalledCypressVersion.mockReturnValue(7);
+    await cypressExecutor(
+      {
+        ...cypressOptions,
+        headless: true,
+      },
+      mockContext
+    );
+
+    expect(devkit.logger.warn).not.toHaveBeenCalled();
   });
 
   it('should call `Cypress.run` with provided baseUrl', async () => {
@@ -335,6 +360,22 @@ describe('Cypress builder', () => {
     expect(cypressRun).toHaveBeenCalledWith(
       expect.objectContaining({
         testingType: 'component',
+      })
+    );
+  });
+
+  it('should forward headed', async () => {
+    const { success } = await cypressExecutor(
+      {
+        ...cypressOptions,
+        headed: true,
+      },
+      mockContext
+    );
+    expect(success).toEqual(true);
+    expect(cypressRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headed: true,
       })
     );
   });

--- a/packages/cypress/src/executors/cypress/schema.json
+++ b/packages/cypress/src/executors/cypress/schema.json
@@ -22,10 +22,16 @@
       "type": "string",
       "description": "Dev server target to run tests against."
     },
+    "headed": {
+      "type": "boolean",
+      "description": "Displays the browser instead of running headlessly. Set this to 'true' if your run depends on a Chrome extension being loaded.",
+      "default": false
+    },
     "headless": {
       "type": "boolean",
-      "description": "Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode",
-      "default": false
+      "description": "Hide the browser instead of running headed (default for cypress run).",
+      "default": false,
+      "x-deprecated": true
     },
     "exit": {
       "type": "boolean",


### PR DESCRIPTION
* feat(testing): warn Cypress 8.x users about deprecation
* feat(testing): add `headed` option to executor
* chore(testing): refactor `CypressExecutorOptions` to match schema
* docs(testing):  update based on schema

CLOSES: #6811

## Current Behavior
The `--headless` flag is used in conjunction with `--watch` to determine which Cypress command is executed. 

## Expected Behavior
1. All Cypress commands continue working as expected, regardless of the user's version of Cypress.
2. Both `--headless` and `--headed` options can be passed down to Cypress.
3. For users with Cypress >= 8, a warning is displayed whenever the user explicitly sets `--headless`

Fixes #6811
