### PR TITLE
fix (angular): allows importing from @nrwl/angular:init

### DIFF
--- a/packages/angular/src/generators/init/init.compat.ts
+++ b/packages/angular/src/generators/init/init.compat.ts
@@ -1,4 +1,4 @@
 import { convertNxGenerator } from '@nrwl/devkit';
-import init from './init';
+import { angularInitGenerator } from './init';
 
-export const initSchematic = convertNxGenerator(init);
+export const initSchematic = convertNxGenerator(angularInitGenerator);

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -20,7 +20,7 @@ import {
 import { karmaGenerator } from '../karma/karma';
 import { Schema } from './schema';
 
-export async function angularInitGenerator (
+export async function angularInitGenerator(
   host: Tree,
   options: Schema
 ): Promise<GeneratorCallback> {

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -20,7 +20,7 @@ import {
 import { karmaGenerator } from '../karma/karma';
 import { Schema } from './schema';
 
-export default async function (
+export async function angularInitGenerator (
   host: Tree,
   options: Schema
 ): Promise<GeneratorCallback> {
@@ -146,3 +146,5 @@ function addE2ETestRunner(
       return () => {};
   }
 }
+
+export default angularInitGenerator;


### PR DESCRIPTION
## Current Behavior
Unable to import the generator @nrwl/angular:init

## Expected Behavior
Should be able to import the @nrwl/angular initGenerator in another generator like you can for other generators. For example:
import { reactInitGenerator } from '@nrwl/react';
import { cypressInitGenerator } from '@nrwl/cypress';

## Related Issue(s)

Fixes #6790
