### PR TITLE
fix(core): use defaultConfiguration in run-many and affected when no configuration is specified

### DIFF
--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -227,6 +227,8 @@ export function createTask({
     process.exit(1);
   }
 
+  configuration ??= project.data.targets?.[target]?.defaultConfiguration;
+
   const config = projectHasTargetAndConfiguration(
     project,
     target,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When having a project with say `"defaultConfiguration": "production"` configured and running `nx build project-name`, it will apply the default configuration and run `nx run project-name:build:production`. This is the expected behavior and if we run `nx build project-name` multiple times without any changes, it will use the cache as expected.

However, if we run `nx run-many --target=build --projects=project-name` it misses the cache because it runs `nx run project-name:build` without the default configuration. The same happens when running `nx affected:build` (being `project-name` affected), it misses the cache because it doesn't use the configured default configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Using `run-many` or `affected:*` commands without specifying the configuration should use the `defaultConfiguration` if provided.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
