### PR TITLE
feat(linter): log error when the full TypeScript type-checker needs to be made available

### DIFF
--- a/packages/linter/src/executors/eslint/lint.impl.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.ts
@@ -61,6 +61,8 @@ export default async function run(
         const { root } = context.workspace.projects[projectName];
         eslintConfigPathForError = `\`${root}/.eslintrc.json\``;
       }
+      
+      console.error(err);
 
       console.error(`
 Error: You have attempted to use a lint rule which requires the full TypeScript type-checker to be available, but you do not have \`parserOptions.project\` configured to point at your project tsconfig.json files in the relevant TypeScript file "overrides" block of your project ESLint config ${


### PR DESCRIPTION
This will show the `Occurred while linting [filename]` message

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
