### PR TITLE
fix(linter): disabled eslint rules dont count as type checked rules

### DIFF
--- a/packages/linter/migrations.json
+++ b/packages/linter/migrations.json
@@ -52,6 +52,12 @@
       "version": "12.9.0-beta.0",
       "description": "Add outputs for caching",
       "factory": "./src/migrations/update-12-9-0/add-outputs"
+    },
+    "remove-eslint-project-config-if-no-type-checking-rules-again": {
+      "cli": "nx",
+      "version": "12.9.0-beta.0",
+      "description": "Remove ESLint parserOptions.project config if no rules requiring type-checking are in use",
+      "factory": "./src/migrations/update-12-4-0/remove-eslint-project-config-if-no-type-checking-rules"
     }
   },
   "packageJsonUpdates": {

--- a/packages/linter/src/utils/rules-requiring-type-checking.ts
+++ b/packages/linter/src/utils/rules-requiring-type-checking.ts
@@ -53,12 +53,20 @@ export function removeParserOptionsProjectIfNotRequired(
   return json;
 }
 
+function determineEnabledRules(rules: Linter.RulesRecord): string[] {
+  return Object.entries(rules)
+    .filter(([key, value]) => {
+      return !(typeof value === 'string' && value === 'off');
+    })
+    .map(([ruleName]) => ruleName);
+}
+
 function getAllRulesInConfig(json: Linter.Config): string[] {
-  let allRules = json.rules ? Object.keys(json.rules) : [];
+  let allRules = json.rules ? determineEnabledRules(json.rules) : [];
   if (json.overrides?.length > 0) {
     for (const o of json.overrides) {
       if (o.rules) {
-        allRules = [...allRules, ...Object.keys(o.rules)];
+        allRules = allRules = [...allRules, ...determineEnabledRules(o.rules)];
       }
     }
   }


### PR DESCRIPTION
## Current Behavior
#5798 migration sped up eslint for projects that don't need type checking. After spending several hours debugging, I found that the migration was not properly being ran for my workspace. It turned out if I remove the `parserOptions.project` in my `.eslintrc.json` file, I would receive no linting errors and reduced the run time from over 3 minutes to under 15 seconds. Upon digging into my `.eslintrc.json` file and looking at how the migration was done, oversight for overrides that [turn off rules](https://eslint.org/docs/2.13.1/user-guide/configuring#configuring-rules) weren't accounted for and continued to keep the full type checking mode in the workspace project. 

## Expected Behavior
The migration should not consider override rules that set the rule to `off` to be an enabled rule. 

To solve the issue on future NX releases, I created a migration that re-runs the previous 12.4.0 migration again with the fixes to save duplication of code and included an additional unit test for the edge case. If this is not acceptable please let me know the best way to go about having the next NX release re-run the previous migration for the next 12.9 release.