### PR TITLE
Update version.ts

### DIFF
--- a/packages/nest/src/utils/versions.ts
+++ b/packages/nest/src/utils/versions.ts
@@ -1,7 +1,7 @@
 export const nxVersion = '*';
 
-export const nestJsVersion = '^7.0.0';
-export const nestJsSchematicsVersion = '^7.0.0';
+export const nestJsVersion = '^8.0.0';
+export const nestJsSchematicsVersion = '^8.0.0';
 
 export const rxjsVersion = '~6.6.3';
 


### PR DESCRIPTION
Due to the new updated from @nestjs/swagger ^5.0.0, its only compatible with @nestjs ^8.0.0 so when people goes into the official docs of nestjs website and they try to install swagger via this command `npm install --save @nestjs/swagger swagger-ui-express` they install latest version of swagger which is compatible with nestjs 8+ version. but when people create their Monorepo with Nx and select nest application as template. Nx will install previous version of nestjs (7.0.0) and this will cause problem for developers and take many hours of their time trying to find the solution.
just updating the version of nest generation template in Nx Monorepo from '^7.0.0' to '^8.0.0' will fix the problem.


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When developers create a Nx monorepo with Nest application template. Nx uses previous version of nest(7.0.0) instead of (8.0.0) which cause problem later on in development stage.

## Expected Behavior
It should install the latest version of nestjs which is ^8.0.0 instead of ^7.0.0

## Related Issue(s)
None.

Fixes #
I just changed the version to 8 and it should do fine.