### PR TITLE
fix(nextjs): disable eslint `react/display-name` rule when using styled-component in nextjs for non-component code

### DIFF
--- a/packages/next/src/generators/application/files/pages/_document.tsx__tmpl__
+++ b/packages/next/src/generators/application/files/pages/_document.tsx__tmpl__
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 import { ReactElement } from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';


### PR DESCRIPTION
The `CustomDocument` component is failing linting now and this fixes it.