### PR TITLE
chore(repo): fix copy dep ordering

### DIFF
--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -50,9 +50,6 @@
         "commands": [
           {
             "command": "node ./scripts/copy-readme.js nx"
-          },
-          {
-            "command": "node ./scripts/add-dependency-to-build.js tao nx@*"
           }
         ],
         "parallel": false

--- a/packages/tao/project.json
+++ b/packages/tao/project.json
@@ -61,6 +61,9 @@
           },
           {
             "command": "node ./scripts/copy-readme.js tao"
+          },
+          {
+            "command": "node ./scripts/add-dependency-to-build.js tao nx@*"
           }
         ],
         "parallel": false


### PR DESCRIPTION
## Current Behavior
Running nx-release results in `nx` build executing prior to `tao`, and the dep being added as part of the `nx` build step is overwritten during tao's build execution.

## Expected Behavior
Deps are not dependant on build order
