### PR TITLE
fix(devkit): add '.tgz' to binaryExts array

### DIFF
--- a/packages/devkit/src/generators/generate-files.ts
+++ b/packages/devkit/src/generators/generate-files.ts
@@ -23,6 +23,7 @@ const binaryExts = new Set([
   '.jpx',
   '.heic',
   '.cur',
+  '.tgz',
 
   // Java files
   '.jar',


### PR DESCRIPTION
devkit's generateFiles function excludes parsing binary files with the templating engine.
This patch adds .tgz files to the list of binary files to ignore.

## Current Behavior
When a custom generator includes archive files with the `.tgz` extension they are corrupted during the call to generateFiles due to being parsed by the template engine.

## Expected Behavior
That archive files should be copied uncorrupted to generated app.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
