### PR TITLE
feat(misc): add dep graph search depth

### DIFF
--- a/dep-graph/dep-graph/src/app/app.ts
+++ b/dep-graph/dep-graph/src/app/app.ts
@@ -56,7 +56,7 @@ export class AppComponent {
       dependencies: project.dependencies,
       nodes: nodes,
     };
-
+    window.focusedProject = null;
     window.projectGraphList = this.config.projectGraphs;
     window.selectedProjectGraph = projectGraphId;
     window.workspaceLayout = workspaceLayout;

--- a/dep-graph/dep-graph/src/app/ui-sidebar/display-options-panel.ts
+++ b/dep-graph/dep-graph/src/app/ui-sidebar/display-options-panel.ts
@@ -1,4 +1,5 @@
-import { fromEvent, Subject } from 'rxjs';
+import { BehaviorSubject, combineLatest, Subject } from 'rxjs';
+import { distinctUntilChanged, map, withLatestFrom } from 'rxjs/operators';
 import { removeChildrenFromContainer } from '../util';
 
 export class DisplayOptionsPanel {
@@ -8,15 +9,45 @@ export class DisplayOptionsPanel {
   private selectAllSubject = new Subject<void>();
   private deselectAllSubject = new Subject<void>();
   private groupByFolderSubject = new Subject<boolean>();
+  private searchByDepthSubject = new BehaviorSubject<number>(1);
+  private searchByDepthEnabledSubject = new BehaviorSubject<boolean>(false);
+  private searchDepthChangesSubject = new Subject<'increment' | 'decrement'>();
 
   selectAffected$ = this.selectAffectedSubject.asObservable();
   selectAll$ = this.selectAllSubject.asObservable();
   deselectAll$ = this.deselectAllSubject.asObservable();
   groupByFolder$ = this.groupByFolderSubject.asObservable();
+  searchDepth$ = combineLatest([
+    this.searchByDepthSubject,
+    this.searchByDepthEnabledSubject,
+  ]).pipe(
+    map(([searchDepth, enabled]) => {
+      return enabled ? searchDepth : -1;
+    }),
+    distinctUntilChanged()
+  );
+
+  searchDepthDisplay: HTMLSpanElement;
 
   constructor(showAffected = false, groupByFolder = false) {
     this.showAffected = showAffected;
     this.groupByFolder = groupByFolder;
+
+    this.searchDepthChangesSubject
+      .pipe(withLatestFrom(this.searchByDepthSubject))
+      .subscribe(([action, current]) => {
+        if (action === 'decrement' && current > 1) {
+          this.searchByDepthSubject.next(current - 1);
+        } else if (action === 'increment') {
+          this.searchByDepthSubject.next(current + 1);
+        }
+      });
+
+    this.searchByDepthSubject.subscribe((current) => {
+      if (this.searchDepthDisplay) {
+        this.searchDepthDisplay.innerText = current.toString();
+      }
+    });
   }
 
   render(container: HTMLElement) {
@@ -70,8 +101,50 @@ export class DisplayOptionsPanel {
     groupByFolderLabel.appendChild(groupByFolderCheckbox);
     groupByFolderLabel.appendChild(document.createTextNode('group by folder'));
 
+    const searchDepthLabel = document.createElement('label');
+    searchDepthLabel.appendChild(document.createTextNode('Search Depth'));
+
+    this.searchDepthDisplay = document.createElement('span');
+    this.searchDepthDisplay.innerText = '1';
+    this.searchDepthDisplay.classList.add('search-depth');
+
+    const incrementButton = document.createElement('button');
+    incrementButton.appendChild(document.createTextNode('+'));
+
+    const decrementButton = document.createElement('button');
+    decrementButton.appendChild(document.createTextNode('-'));
+
+    incrementButton.addEventListener('click', () => {
+      this.searchDepthChangesSubject.next('increment');
+    });
+
+    decrementButton.addEventListener('click', () => {
+      this.searchDepthChangesSubject.next('decrement');
+    });
+
+    const searchDepthEnabledLabel = document.createElement('label');
+
+    const searchDepthEnabledCheckbox = document.createElement('input');
+    searchDepthEnabledCheckbox.type = 'checkbox';
+    searchDepthEnabledCheckbox.name = 'displayOptions';
+    searchDepthEnabledCheckbox.value = 'groupByFolder';
+    searchDepthEnabledCheckbox.checked = this.groupByFolder;
+    searchDepthEnabledCheckbox.addEventListener('change', (event: InputEvent) =>
+      this.searchByDepthEnabledSubject.next(
+        (<HTMLInputElement>event.target).checked
+      )
+    );
+
+    searchDepthEnabledLabel.appendChild(searchDepthEnabledCheckbox);
+    searchDepthEnabledLabel.appendChild(document.createTextNode('enabled'));
+
     container.appendChild(header);
     container.appendChild(selectButtonsContainer);
     container.appendChild(groupByFolderLabel);
+    container.appendChild(searchDepthLabel);
+    container.appendChild(decrementButton);
+    container.appendChild(this.searchDepthDisplay);
+    container.appendChild(incrementButton);
+    container.appendChild(searchDepthEnabledLabel);
   }
 }

--- a/dep-graph/dep-graph/src/app/ui-sidebar/text-filter-panel.ts
+++ b/dep-graph/dep-graph/src/app/ui-sidebar/text-filter-panel.ts
@@ -30,6 +30,9 @@ export class TextFilterPanel {
     const inputContainer = document.createElement('div');
     inputContainer.classList.add('flex');
 
+    const label = document.createElement('label');
+    label.appendChild(document.createTextNode('Text Filter'));
+
     this.textInput = document.createElement('input');
     this.textInput.type = 'text';
     this.textInput.name = 'filter';
@@ -65,6 +68,7 @@ export class TextFilterPanel {
       document.createTextNode('include projects in path')
     );
 
+    this.container.appendChild(label);
     this.container.appendChild(inputContainer);
     this.container.appendChild(includeProjectLabel);
   }

--- a/dep-graph/dep-graph/src/assets/graphs/nx-examples.json
+++ b/dep-graph/dep-graph/src/assets/graphs/nx-examples.json
@@ -1,21 +1,13 @@
 {
-  "hash": "47f81f4511f4bd79f8bf936c3c4822446cce23c2472c60e0d65e37fa2efacad8",
-  "layout": { "appsDir": "apps", "libsDir": "libs" },
+  "hash": "3b356da7e311c8952e1cc45fde9f0b418a839d468071030e89bbf33472e40b94",
   "projects": [
     {
       "name": "products-product-detail-page",
       "type": "lib",
       "data": {
         "tags": ["type:feature", "scope:products"],
-        "root": "libs/products/product-detail-page"
-      }
-    },
-    {
-      "name": "shared-product-types",
-      "type": "lib",
-      "data": {
-        "tags": ["type:types", "scope:shared"],
-        "root": "libs/shared/product/types"
+        "root": "libs/products/product-detail-page",
+        "files": []
       }
     },
     {
@@ -23,7 +15,17 @@
       "type": "lib",
       "data": {
         "tags": ["scope:shared", "type:state"],
-        "root": "libs/shared/product/state"
+        "root": "libs/shared/product/state",
+        "files": []
+      }
+    },
+    {
+      "name": "shared-product-types",
+      "type": "lib",
+      "data": {
+        "tags": ["type:types", "scope:shared"],
+        "root": "libs/shared/product/types",
+        "files": []
       }
     },
     {
@@ -31,7 +33,8 @@
       "type": "lib",
       "data": {
         "tags": ["type:data", "scope:shared"],
-        "root": "libs/shared/product/data"
+        "root": "libs/shared/product/data",
+        "files": []
       }
     },
     {
@@ -39,15 +42,8 @@
       "type": "lib",
       "data": {
         "tags": ["scope:products", "type:feature"],
-        "root": "libs/products/home-page"
-      }
-    },
-    {
-      "name": "shared-product-ui",
-      "type": "lib",
-      "data": {
-        "tags": ["scope:shared", "type:ui"],
-        "root": "libs/shared/product/ui"
+        "root": "libs/products/home-page",
+        "files": []
       }
     },
     {
@@ -55,7 +51,17 @@
       "type": "lib",
       "data": {
         "tags": ["scope:shared", "type:state"],
-        "root": "libs/shared/cart/state"
+        "root": "libs/shared/cart/state",
+        "files": []
+      }
+    },
+    {
+      "name": "shared-product-ui",
+      "type": "lib",
+      "data": {
+        "tags": ["scope:shared", "type:ui"],
+        "root": "libs/shared/product/ui",
+        "files": []
       }
     },
     {
@@ -63,7 +69,8 @@
       "type": "lib",
       "data": {
         "tags": ["scope:shared", "type:e2e-utils"],
-        "root": "libs/shared/e2e-utils"
+        "root": "libs/shared/e2e-utils",
+        "files": []
       }
     },
     {
@@ -71,15 +78,8 @@
       "type": "lib",
       "data": {
         "tags": ["scope:cart", "type:feature"],
-        "root": "libs/cart/cart-page"
-      }
-    },
-    {
-      "name": "shared-jsxify",
-      "type": "lib",
-      "data": {
-        "tags": ["scope:shared", "type:types"],
-        "root": "libs/shared/jsxify"
+        "root": "libs/cart/cart-page",
+        "files": []
       }
     },
     {
@@ -87,7 +87,8 @@
       "type": "lib",
       "data": {
         "tags": ["type:assets", "scope:shared"],
-        "root": "libs/shared/assets"
+        "root": "libs/shared/assets",
+        "files": []
       }
     },
     {
@@ -95,7 +96,17 @@
       "type": "lib",
       "data": {
         "tags": ["scope:shared", "type:ui"],
-        "root": "libs/shared/header"
+        "root": "libs/shared/header",
+        "files": []
+      }
+    },
+    {
+      "name": "shared-jsxify",
+      "type": "lib",
+      "data": {
+        "tags": ["scope:shared", "type:types"],
+        "root": "libs/shared/jsxify",
+        "files": []
       }
     },
     {
@@ -103,7 +114,8 @@
       "type": "lib",
       "data": {
         "tags": ["scope:shared", "type:styles"],
-        "root": "libs/shared/styles"
+        "root": "libs/shared/styles",
+        "files": []
       }
     },
     {
@@ -111,7 +123,17 @@
       "type": "e2e",
       "data": {
         "tags": ["scope:products", "type:e2e"],
-        "root": "apps/products-e2e"
+        "root": "apps/products-e2e",
+        "files": []
+      }
+    },
+    {
+      "name": "cart-e2e",
+      "type": "e2e",
+      "data": {
+        "tags": ["scope:cart", "type:e2e"],
+        "root": "apps/cart-e2e",
+        "files": []
       }
     },
     {
@@ -119,150 +141,151 @@
       "type": "app",
       "data": {
         "tags": ["type:app", "scope:products"],
-        "root": "apps/products"
+        "root": "apps/products",
+        "files": []
       }
-    },
-    {
-      "name": "cart-e2e",
-      "type": "e2e",
-      "data": { "tags": ["scope:cart", "type:e2e"], "root": "apps/cart-e2e" }
     },
     {
       "name": "cart",
       "type": "app",
-      "data": { "tags": ["type:app", "scope:cart"], "root": "apps/cart" }
+      "data": {
+        "tags": ["type:app", "scope:cart"],
+        "root": "apps/cart",
+        "files": []
+      }
     }
   ],
   "dependencies": {
     "products-product-detail-page": [
       {
-        "type": "static",
         "source": "products-product-detail-page",
-        "target": "shared-product-state"
+        "target": "shared-product-state",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "products-product-detail-page",
-        "target": "shared-product-ui"
+        "target": "shared-product-ui",
+        "type": "static"
+      }
+    ],
+    "shared-product-state": [
+      {
+        "source": "shared-product-state",
+        "target": "shared-product-data",
+        "type": "static"
+      },
+      {
+        "source": "shared-product-state",
+        "target": "shared-product-types",
+        "type": "static"
       }
     ],
     "shared-product-types": [],
-    "shared-product-state": [
-      {
-        "type": "static",
-        "source": "shared-product-state",
-        "target": "shared-product-data"
-      },
-      {
-        "type": "static",
-        "source": "shared-product-state",
-        "target": "shared-product-types"
-      }
-    ],
     "shared-product-data": [
       {
-        "type": "static",
         "source": "shared-product-data",
-        "target": "shared-product-types"
+        "target": "shared-product-types",
+        "type": "static"
       }
     ],
     "products-home-page": [
       {
-        "type": "static",
         "source": "products-home-page",
-        "target": "shared-product-state"
+        "target": "shared-product-state",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "products-home-page",
-        "target": "shared-product-types"
+        "target": "shared-product-types",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "products-home-page",
-        "target": "shared-product-ui"
-      }
-    ],
-    "shared-product-ui": [
-      {
-        "type": "static",
-        "source": "shared-product-ui",
-        "target": "shared-jsxify"
+        "target": "shared-product-ui",
+        "type": "static"
       }
     ],
     "shared-cart-state": [
       {
-        "type": "static",
         "source": "shared-cart-state",
-        "target": "shared-product-data"
+        "target": "shared-product-data",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "shared-cart-state",
-        "target": "shared-product-state"
+        "target": "shared-product-state",
+        "type": "static"
+      }
+    ],
+    "shared-product-ui": [
+      {
+        "source": "shared-product-ui",
+        "target": "shared-jsxify",
+        "type": "static"
       }
     ],
     "shared-e2e-utils": [],
     "cart-cart-page": [
       {
-        "type": "static",
         "source": "cart-cart-page",
-        "target": "shared-product-ui"
+        "target": "shared-product-ui",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "cart-cart-page",
-        "target": "shared-cart-state"
+        "target": "shared-cart-state",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "cart-cart-page",
-        "target": "shared-product-state"
+        "target": "shared-product-state",
+        "type": "static"
       }
     ],
-    "shared-jsxify": [],
     "shared-assets": [],
     "shared-header": [
-      { "type": "static", "source": "shared-header", "target": "shared-jsxify" }
+      { "source": "shared-header", "target": "shared-jsxify", "type": "static" }
     ],
+    "shared-jsxify": [],
     "shared-styles": [],
     "products-e2e": [
+      { "source": "products-e2e", "target": "products", "type": "implicit" },
       {
-        "type": "static",
         "source": "products-e2e",
-        "target": "shared-e2e-utils"
-      },
-      { "type": "implicit", "source": "products-e2e", "target": "products" }
-    ],
-    "products": [
-      { "type": "static", "source": "products", "target": "shared-header" },
-      {
-        "type": "dynamic",
-        "source": "products",
-        "target": "products-home-page"
-      },
-      {
-        "type": "dynamic",
-        "source": "products",
-        "target": "products-product-detail-page"
-      },
-      { "type": "implicit", "source": "products", "target": "shared-assets" },
-      { "type": "implicit", "source": "products", "target": "shared-styles" }
+        "target": "shared-e2e-utils",
+        "type": "static"
+      }
     ],
     "cart-e2e": [
-      { "type": "static", "source": "cart-e2e", "target": "shared-e2e-utils" },
-      { "type": "implicit", "source": "cart-e2e", "target": "cart" }
+      { "source": "cart-e2e", "target": "cart", "type": "implicit" },
+      { "source": "cart-e2e", "target": "shared-e2e-utils", "type": "static" }
+    ],
+    "products": [
+      { "source": "products", "target": "shared-assets", "type": "implicit" },
+      { "source": "products", "target": "shared-styles", "type": "implicit" },
+      { "source": "products", "target": "shared-header", "type": "static" },
+      {
+        "source": "products",
+        "target": "products-home-page",
+        "type": "static"
+      },
+      {
+        "source": "products",
+        "target": "products-product-detail-page",
+        "type": "static"
+      }
     ],
     "cart": [
-      { "type": "static", "source": "cart", "target": "shared-header" },
-      { "type": "static", "source": "cart", "target": "cart-cart-page" },
-      { "type": "implicit", "source": "cart", "target": "shared-assets" },
-      { "type": "implicit", "source": "cart", "target": "shared-styles" }
+      { "source": "cart", "target": "shared-assets", "type": "implicit" },
+      { "source": "cart", "target": "shared-styles", "type": "implicit" },
+      { "source": "cart", "target": "shared-header", "type": "static" },
+      { "source": "cart", "target": "cart-cart-page", "type": "static" }
     ]
   },
+  "layout": { "appsDir": "apps", "libsDir": "libs" },
   "changes": { "added": [] },
   "affected": [],
   "focus": null,
-  "exclude": [],
-  "groupByFolder": false
+  "groupByFolder": false,
+  "exclude": []
 }

--- a/dep-graph/dep-graph/src/assets/graphs/nx.json
+++ b/dep-graph/dep-graph/src/assets/graphs/nx.json
@@ -1,6 +1,5 @@
 {
-  "hash": "22bf7ee349484feb3446f5ed565db895849cd5ba94ecc8021b08e9f52d6c7f51",
-  "layout": { "appsDir": "", "libsDir": "" },
+  "hash": "7a863cf4ab516fa4d8dcb18f1354f2a542a1a027b4524adefbc87d05b2a1681e",
   "projects": [
     {
       "name": "create-nx-workspace",
@@ -8,7 +7,7 @@
       "data": {
         "tags": [],
         "root": "packages/create-nx-workspace",
-        "sourceRoot": "packages/create-nx-workspace"
+        "files": []
       }
     },
     {
@@ -17,26 +16,18 @@
       "data": {
         "tags": ["scope:nx-dev", "type:data-access"],
         "root": "nx-dev/data-access-documents",
-        "sourceRoot": "nx-dev/data-access-documents/src"
-      }
-    },
-    {
-      "name": "eslint-plugin-nx",
-      "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/eslint-plugin-nx",
-        "sourceRoot": "packages/eslint-plugin-nx"
+        "files": []
       }
     },
     {
       "name": "create-nx-plugin",
       "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/create-nx-plugin",
-        "sourceRoot": "packages/create-nx-plugin"
-      }
+      "data": { "tags": [], "root": "packages/create-nx-plugin", "files": [] }
+    },
+    {
+      "name": "eslint-plugin-nx",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/eslint-plugin-nx", "files": [] }
     },
     {
       "name": "nx-dev-feature-doc-viewer",
@@ -44,7 +35,7 @@
       "data": {
         "tags": ["scope:nx-dev", "type:feature"],
         "root": "nx-dev/feature-doc-viewer",
-        "sourceRoot": "nx-dev/feature-doc-viewer/src"
+        "files": []
       }
     },
     {
@@ -53,17 +44,18 @@
       "data": {
         "tags": ["scope:nx-dev", "type:feature"],
         "root": "nx-dev/feature-analytics",
-        "sourceRoot": "nx-dev/feature-analytics/src"
+        "files": []
       }
     },
     {
       "name": "dep-graph-dep-graph-e2e",
       "type": "e2e",
-      "data": {
-        "tags": [],
-        "root": "dep-graph/dep-graph-e2e",
-        "sourceRoot": "dep-graph/dep-graph-e2e/src"
-      }
+      "data": { "tags": [], "root": "dep-graph/dep-graph-e2e", "files": [] }
+    },
+    {
+      "name": "e2e-angular-extensions",
+      "type": "app",
+      "data": { "tags": [], "root": "e2e/angular-extensions", "files": [] }
     },
     {
       "name": "nx-dev-feature-search",
@@ -71,44 +63,51 @@
       "data": {
         "tags": ["scope:nx-dev", "type:feature"],
         "root": "nx-dev/feature-search",
-        "sourceRoot": "nx-dev/feature-search/src"
+        "files": []
       }
+    },
+    {
+      "name": "nx-dev-ui-member-card",
+      "type": "lib",
+      "data": {
+        "tags": ["scope:nx-dev", "type:ui"],
+        "root": "nx-dev/ui/member-card",
+        "files": []
+      }
+    },
+    {
+      "name": "react-native",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/react-native", "files": [] }
     },
     {
       "name": "dep-graph-dep-graph",
       "type": "app",
-      "data": {
-        "tags": ["core"],
-        "root": "dep-graph/dep-graph",
-        "sourceRoot": "dep-graph/dep-graph/src"
-      }
+      "data": { "tags": ["core"], "root": "dep-graph/dep-graph", "files": [] }
     },
     {
-      "name": "workspace",
+      "name": "nx-dev-feature-conf",
       "type": "lib",
       "data": {
-        "tags": [],
-        "root": "packages/workspace",
-        "sourceRoot": "packages/workspace"
-      }
-    },
-    {
-      "name": "storybook",
-      "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/storybook",
-        "sourceRoot": "packages/storybook"
+        "tags": ["scope:nx-dev", "type:feature"],
+        "root": "nx-dev/feature-conf",
+        "files": []
       }
     },
     {
       "name": "nx-plugin",
       "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/nx-plugin",
-        "sourceRoot": "packages/nx-plugin"
-      }
+      "data": { "tags": [], "root": "packages/nx-plugin", "files": [] }
+    },
+    {
+      "name": "storybook",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/storybook", "files": [] }
+    },
+    {
+      "name": "workspace",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/workspace", "files": [] }
     },
     {
       "name": "nx-dev-e2e",
@@ -116,35 +115,33 @@
       "data": {
         "tags": ["scope:nx-dev", "type:e2e"],
         "root": "nx-dev/nx-dev-e2e",
-        "sourceRoot": "nx-dev/nx-dev-e2e/src"
-      }
-    },
-    {
-      "name": "cypress",
-      "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/cypress",
-        "sourceRoot": "packages/cypress"
-      }
-    },
-    {
-      "name": "express",
-      "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/express",
-        "sourceRoot": "packages/express"
+        "files": []
       }
     },
     {
       "name": "angular",
       "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/angular",
-        "sourceRoot": "packages/angular"
-      }
+      "data": { "tags": [], "root": "packages/angular", "files": [] }
+    },
+    {
+      "name": "cypress",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/cypress", "files": [] }
+    },
+    {
+      "name": "e2e-angular-core",
+      "type": "app",
+      "data": { "tags": [], "root": "e2e/angular-core", "files": [] }
+    },
+    {
+      "name": "e2e-react-native",
+      "type": "app",
+      "data": { "tags": [], "root": "e2e/react-native", "files": [] }
+    },
+    {
+      "name": "express",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/express", "files": [] }
     },
     {
       "name": "nx-dev-ui-common",
@@ -152,107 +149,68 @@
       "data": {
         "tags": ["scope:nx-dev", "type:ui"],
         "root": "nx-dev/ui/common",
-        "sourceRoot": "nx-dev/ui/common/src"
+        "files": []
       }
     },
     {
       "name": "devkit",
       "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/devkit",
-        "sourceRoot": "packages/devkit"
-      }
-    },
-    {
-      "name": "linter",
-      "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/linter",
-        "sourceRoot": "packages/linter"
-      }
+      "data": { "tags": [], "root": "packages/devkit", "files": [] }
     },
     {
       "name": "gatsby",
       "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/gatsby",
-        "sourceRoot": "packages/gatsby"
-      }
+      "data": { "tags": [], "root": "packages/gatsby", "files": [] }
+    },
+    {
+      "name": "linter",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/linter", "files": [] }
+    },
+    {
+      "name": "detox",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/detox", "files": [] }
     },
     {
       "name": "react",
       "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/react",
-        "sourceRoot": "packages/react"
-      }
-    },
-    {
-      "name": "jest",
-      "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/jest",
-        "sourceRoot": "packages/jest"
-      }
-    },
-    {
-      "name": "node",
-      "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/node",
-        "sourceRoot": "packages/node"
-      }
-    },
-    {
-      "name": "next",
-      "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/next",
-        "sourceRoot": "packages/next"
-      }
-    },
-    {
-      "name": "nest",
-      "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/nest",
-        "sourceRoot": "packages/nest"
-      }
-    },
-    {
-      "name": "e2e-storybook",
-      "type": "app",
-      "data": {
-        "tags": [],
-        "root": "e2e/storybook",
-        "sourceRoot": "e2e/storybook"
-      }
-    },
-    {
-      "name": "e2e-workspace",
-      "type": "app",
-      "data": {
-        "tags": [],
-        "root": "e2e/workspace",
-        "sourceRoot": "e2e/workspace"
-      }
+      "data": { "tags": [], "root": "packages/react", "files": [] }
     },
     {
       "name": "e2e-nx-plugin",
       "type": "app",
-      "data": {
-        "tags": [],
-        "root": "e2e/nx-plugin",
-        "sourceRoot": "e2e/nx-plugin"
-      }
+      "data": { "tags": [], "root": "e2e/nx-plugin", "files": [] }
+    },
+    {
+      "name": "e2e-storybook",
+      "type": "app",
+      "data": { "tags": [], "root": "e2e/storybook", "files": [] }
+    },
+    {
+      "name": "e2e-workspace",
+      "type": "app",
+      "data": { "tags": [], "root": "e2e/workspace", "files": [] }
+    },
+    {
+      "name": "jest",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/jest", "files": [] }
+    },
+    {
+      "name": "nest",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/nest", "files": [] }
+    },
+    {
+      "name": "next",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/next", "files": [] }
+    },
+    {
+      "name": "node",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/node", "files": [] }
     },
     {
       "name": "nx-dev",
@@ -260,302 +218,429 @@
       "data": {
         "tags": ["scope:nx-dev", "type:app"],
         "root": "nx-dev/nx-dev",
-        "sourceRoot": "nx-dev/nx-dev"
+        "files": []
       }
     },
     {
-      "name": "tao",
+      "name": "typedoc-theme",
       "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/tao",
-        "sourceRoot": "packages/tao"
-      }
-    },
-    {
-      "name": "web",
-      "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/web",
-        "sourceRoot": "packages/web"
-      }
+      "data": { "tags": [], "root": "typedoc-theme", "files": [] }
     },
     {
       "name": "cli",
       "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "packages/cli",
-        "sourceRoot": "packages/cli"
-      }
+      "data": { "tags": [], "root": "packages/cli", "files": [] }
     },
     {
-      "name": "nx",
+      "name": "tao",
       "type": "lib",
-      "data": { "tags": [], "root": "packages/nx", "sourceRoot": "packages/nx" }
+      "data": { "tags": [], "root": "packages/tao", "files": [] }
     },
     {
-      "name": "e2e-angular",
-      "type": "app",
-      "data": { "tags": [], "root": "e2e/angular", "sourceRoot": "e2e/angular" }
+      "name": "web",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/web", "files": [] }
     },
     {
       "name": "e2e-cypress",
       "type": "app",
-      "data": { "tags": [], "root": "e2e/cypress", "sourceRoot": "e2e/cypress" }
+      "data": { "tags": [], "root": "e2e/cypress", "files": [] }
     },
     {
-      "name": "e2e-linter",
-      "type": "app",
-      "data": { "tags": [], "root": "e2e/linter", "sourceRoot": "e2e/linter" }
+      "name": "nx",
+      "type": "lib",
+      "data": { "tags": [], "root": "packages/nx", "files": [] }
     },
     {
       "name": "e2e-gatsby",
       "type": "app",
-      "data": { "tags": [], "root": "e2e/gatsby", "sourceRoot": "e2e/gatsby" }
+      "data": { "tags": [], "root": "e2e/gatsby", "files": [] }
     },
     {
-      "name": "e2e-utils",
-      "type": "lib",
-      "data": { "tags": [], "root": "e2e/utils", "sourceRoot": "e2e/utils" }
+      "name": "e2e-linter",
+      "type": "app",
+      "data": { "tags": [], "root": "e2e/linter", "files": [] }
+    },
+    {
+      "name": "e2e-detox",
+      "type": "app",
+      "data": { "tags": [], "root": "e2e/detox", "files": [] }
     },
     {
       "name": "e2e-react",
       "type": "app",
-      "data": { "tags": [], "root": "e2e/react", "sourceRoot": "e2e/react" }
+      "data": { "tags": [], "root": "e2e/react", "files": [] }
+    },
+    {
+      "name": "e2e-utils",
+      "type": "lib",
+      "data": { "tags": [], "root": "e2e/utils", "files": [] }
     },
     {
       "name": "e2e-jest",
       "type": "app",
-      "data": { "tags": [], "root": "e2e/jest", "sourceRoot": "e2e/jest" }
+      "data": { "tags": [], "root": "e2e/jest", "files": [] }
     },
     {
       "name": "e2e-next",
       "type": "app",
-      "data": { "tags": [], "root": "e2e/next", "sourceRoot": "e2e/next" }
+      "data": { "tags": [], "root": "e2e/next", "files": [] }
     },
     {
       "name": "e2e-node",
       "type": "app",
-      "data": { "tags": [], "root": "e2e/node", "sourceRoot": "e2e/node" }
+      "data": { "tags": [], "root": "e2e/node", "files": [] }
     },
     {
       "name": "e2e-cli",
       "type": "app",
-      "data": { "tags": [], "root": "e2e/cli", "sourceRoot": "e2e/cli" }
+      "data": { "tags": [], "root": "e2e/cli", "files": [] }
     },
     {
       "name": "e2e-web",
       "type": "app",
-      "data": { "tags": [], "root": "e2e/web", "sourceRoot": "e2e/web" }
+      "data": { "tags": [], "root": "e2e/web", "files": [] }
     },
     {
       "name": "docs",
       "type": "lib",
-      "data": { "tags": ["scope:nx-dev"], "root": "docs", "sourceRoot": "docs" }
+      "data": { "tags": ["scope:nx-dev"], "root": "docs", "files": [] }
     }
   ],
   "dependencies": {
     "create-nx-workspace": [
       {
-        "type": "implicit",
         "source": "create-nx-workspace",
-        "target": "workspace"
+        "target": "workspace",
+        "type": "implicit"
       }
     ],
     "nx-dev-data-access-documents": [],
-    "eslint-plugin-nx": [
-      { "type": "static", "source": "eslint-plugin-nx", "target": "devkit" }
-    ],
     "create-nx-plugin": [
       {
-        "type": "implicit",
         "source": "create-nx-plugin",
-        "target": "nx-plugin"
-      }
+        "target": "nx-plugin",
+        "type": "implicit"
+      },
+      { "source": "create-nx-plugin", "target": "tao", "type": "static" },
+      { "source": "create-nx-plugin", "target": "workspace", "type": "static" }
+    ],
+    "eslint-plugin-nx": [
+      { "source": "eslint-plugin-nx", "target": "tao", "type": "static" },
+      { "source": "eslint-plugin-nx", "target": "workspace", "type": "static" },
+      { "source": "eslint-plugin-nx", "target": "devkit", "type": "static" }
     ],
     "nx-dev-feature-doc-viewer": [
       {
-        "type": "static",
         "source": "nx-dev-feature-doc-viewer",
-        "target": "nx-dev-data-access-documents"
+        "target": "nx-dev-data-access-documents",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-dev-feature-doc-viewer",
-        "target": "nx-dev-feature-analytics"
+        "target": "nx-dev-feature-analytics",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-dev-feature-doc-viewer",
-        "target": "nx-dev-ui-common"
+        "target": "nx-dev-ui-common",
+        "type": "static"
       }
     ],
     "nx-dev-feature-analytics": [],
     "dep-graph-dep-graph-e2e": [
       {
-        "type": "implicit",
         "source": "dep-graph-dep-graph-e2e",
-        "target": "dep-graph-dep-graph"
+        "target": "dep-graph-dep-graph",
+        "type": "implicit"
+      },
+      {
+        "source": "dep-graph-dep-graph-e2e",
+        "target": "cypress",
+        "type": "static"
+      }
+    ],
+    "e2e-angular-extensions": [
+      {
+        "source": "e2e-angular-extensions",
+        "target": "angular",
+        "type": "implicit"
+      },
+      {
+        "source": "e2e-angular-extensions",
+        "target": "e2e-utils",
+        "type": "static"
+      },
+      {
+        "source": "e2e-angular-extensions",
+        "target": "devkit",
+        "type": "static"
       }
     ],
     "nx-dev-feature-search": [],
+    "nx-dev-ui-member-card": [],
+    "react-native": [
+      { "source": "react-native", "target": "workspace", "type": "static" },
+      { "source": "react-native", "target": "devkit", "type": "static" },
+      { "source": "react-native", "target": "linter", "type": "static" },
+      { "source": "react-native", "target": "detox", "type": "static" },
+      { "source": "react-native", "target": "jest", "type": "static" },
+      { "source": "react-native", "target": "react", "type": "static" }
+    ],
     "dep-graph-dep-graph": [
-      { "type": "static", "source": "dep-graph-dep-graph", "target": "devkit" }
+      { "source": "dep-graph-dep-graph", "target": "devkit", "type": "static" }
     ],
-    "workspace": [
-      { "type": "static", "source": "workspace", "target": "devkit" }
-    ],
-    "storybook": [
-      { "type": "static", "source": "storybook", "target": "devkit" }
+    "nx-dev-feature-conf": [
+      {
+        "source": "nx-dev-feature-conf",
+        "target": "nx-dev-ui-member-card",
+        "type": "static"
+      }
     ],
     "nx-plugin": [
-      { "type": "static", "source": "nx-plugin", "target": "devkit" }
+      { "source": "nx-plugin", "target": "devkit", "type": "static" },
+      { "source": "nx-plugin", "target": "jest", "type": "static" },
+      { "source": "nx-plugin", "target": "node", "type": "static" },
+      { "source": "nx-plugin", "target": "workspace", "type": "static" },
+      { "source": "nx-plugin", "target": "linter", "type": "static" },
+      { "source": "nx-plugin", "target": "tao", "type": "static" }
+    ],
+    "storybook": [
+      { "source": "storybook", "target": "devkit", "type": "static" },
+      { "source": "storybook", "target": "workspace", "type": "static" },
+      { "source": "storybook", "target": "linter", "type": "static" },
+      { "source": "storybook", "target": "cypress", "type": "static" }
+    ],
+    "workspace": [
+      {
+        "source": "workspace",
+        "target": "dep-graph-dep-graph",
+        "type": "implicit"
+      },
+      { "source": "workspace", "target": "devkit", "type": "static" },
+      { "source": "workspace", "target": "tao", "type": "static" }
     ],
     "nx-dev-e2e": [
-      { "type": "implicit", "source": "nx-dev-e2e", "target": "nx-dev" }
-    ],
-    "cypress": [{ "type": "static", "source": "cypress", "target": "devkit" }],
-    "express": [
-      { "type": "static", "source": "express", "target": "devkit" },
-      { "type": "implicit", "source": "express", "target": "node" }
+      { "source": "nx-dev-e2e", "target": "nx-dev", "type": "implicit" },
+      { "source": "nx-dev-e2e", "target": "cypress", "type": "static" }
     ],
     "angular": [
-      { "type": "static", "source": "angular", "target": "devkit" },
-      { "type": "static", "source": "angular", "target": "linter" },
-      { "type": "static", "source": "angular", "target": "storybook" },
-      { "type": "implicit", "source": "angular", "target": "workspace" },
-      { "type": "implicit", "source": "angular", "target": "cypress" },
-      { "type": "implicit", "source": "angular", "target": "jest" }
+      { "source": "angular", "target": "workspace", "type": "implicit" },
+      { "source": "angular", "target": "cypress", "type": "implicit" },
+      { "source": "angular", "target": "jest", "type": "implicit" },
+      { "source": "angular", "target": "devkit", "type": "static" },
+      { "source": "angular", "target": "tao", "type": "static" },
+      { "source": "angular", "target": "linter", "type": "static" },
+      { "source": "angular", "target": "storybook", "type": "static" }
+    ],
+    "cypress": [
+      { "source": "cypress", "target": "devkit", "type": "static" },
+      { "source": "cypress", "target": "linter", "type": "static" },
+      { "source": "cypress", "target": "workspace", "type": "static" },
+      { "source": "cypress", "target": "tao", "type": "static" }
+    ],
+    "e2e-angular-core": [
+      { "source": "e2e-angular-core", "target": "angular", "type": "implicit" },
+      { "source": "e2e-angular-core", "target": "e2e-utils", "type": "static" },
+      { "source": "e2e-angular-core", "target": "devkit", "type": "static" }
+    ],
+    "e2e-react-native": [
+      {
+        "source": "e2e-react-native",
+        "target": "react-native",
+        "type": "implicit"
+      },
+      { "source": "e2e-react-native", "target": "e2e-utils", "type": "static" }
+    ],
+    "express": [
+      { "source": "express", "target": "node", "type": "implicit" },
+      { "source": "express", "target": "devkit", "type": "static" },
+      { "source": "express", "target": "linter", "type": "static" },
+      { "source": "express", "target": "workspace", "type": "static" }
     ],
     "nx-dev-ui-common": [
       {
-        "type": "static",
         "source": "nx-dev-ui-common",
-        "target": "nx-dev-feature-search"
+        "target": "nx-dev-feature-search",
+        "type": "static"
       }
     ],
-    "devkit": [],
-    "linter": [
-      { "type": "static", "source": "linter", "target": "devkit" },
-      { "type": "implicit", "source": "linter", "target": "eslint-plugin-nx" }
-    ],
+    "devkit": [{ "source": "devkit", "target": "tao", "type": "static" }],
     "gatsby": [
-      { "type": "static", "source": "gatsby", "target": "devkit" },
-      { "type": "static", "source": "gatsby", "target": "react" }
+      { "source": "gatsby", "target": "tao", "type": "static" },
+      { "source": "gatsby", "target": "workspace", "type": "static" },
+      { "source": "gatsby", "target": "devkit", "type": "static" },
+      { "source": "gatsby", "target": "cypress", "type": "static" },
+      { "source": "gatsby", "target": "linter", "type": "static" },
+      { "source": "gatsby", "target": "jest", "type": "static" },
+      { "source": "gatsby", "target": "react", "type": "static" }
+    ],
+    "linter": [
+      { "source": "linter", "target": "eslint-plugin-nx", "type": "implicit" },
+      { "source": "linter", "target": "devkit", "type": "static" },
+      { "source": "linter", "target": "workspace", "type": "static" },
+      { "source": "linter", "target": "tao", "type": "static" }
+    ],
+    "detox": [
+      { "source": "detox", "target": "devkit", "type": "static" },
+      { "source": "detox", "target": "workspace", "type": "static" },
+      { "source": "detox", "target": "linter", "type": "static" },
+      { "source": "detox", "target": "react", "type": "static" },
+      { "source": "detox", "target": "jest", "type": "static" }
     ],
     "react": [
-      { "type": "static", "source": "react", "target": "devkit" },
-      { "type": "static", "source": "react", "target": "storybook" }
-    ],
-    "jest": [{ "type": "static", "source": "jest", "target": "devkit" }],
-    "node": [{ "type": "static", "source": "node", "target": "devkit" }],
-    "next": [
-      { "type": "static", "source": "next", "target": "devkit" },
-      { "type": "static", "source": "next", "target": "react" }
-    ],
-    "nest": [
-      { "type": "static", "source": "nest", "target": "devkit" },
-      { "type": "implicit", "source": "nest", "target": "node" },
-      { "type": "implicit", "source": "nest", "target": "linter" }
-    ],
-    "e2e-storybook": [
-      { "type": "static", "source": "e2e-storybook", "target": "e2e-utils" },
-      { "type": "implicit", "source": "e2e-storybook", "target": "storybook" }
-    ],
-    "e2e-workspace": [
-      { "type": "static", "source": "e2e-workspace", "target": "e2e-utils" },
-      { "type": "static", "source": "e2e-workspace", "target": "devkit" },
-      {
-        "type": "implicit",
-        "source": "e2e-workspace",
-        "target": "create-nx-workspace"
-      }
+      { "source": "react", "target": "workspace", "type": "static" },
+      { "source": "react", "target": "tao", "type": "static" },
+      { "source": "react", "target": "devkit", "type": "static" },
+      { "source": "react", "target": "web", "type": "static" },
+      { "source": "react", "target": "linter", "type": "static" },
+      { "source": "react", "target": "cypress", "type": "static" },
+      { "source": "react", "target": "jest", "type": "static" },
+      { "source": "react", "target": "storybook", "type": "static" }
     ],
     "e2e-nx-plugin": [
-      { "type": "static", "source": "e2e-nx-plugin", "target": "e2e-utils" },
       {
-        "type": "implicit",
         "source": "e2e-nx-plugin",
-        "target": "create-nx-plugin"
-      }
+        "target": "create-nx-plugin",
+        "type": "implicit"
+      },
+      { "source": "e2e-nx-plugin", "target": "e2e-utils", "type": "static" }
+    ],
+    "e2e-storybook": [
+      { "source": "e2e-storybook", "target": "storybook", "type": "implicit" },
+      { "source": "e2e-storybook", "target": "e2e-utils", "type": "static" }
+    ],
+    "e2e-workspace": [
+      {
+        "source": "e2e-workspace",
+        "target": "create-nx-workspace",
+        "type": "implicit"
+      },
+      { "source": "e2e-workspace", "target": "angular", "type": "implicit" },
+      { "source": "e2e-workspace", "target": "react", "type": "implicit" },
+      { "source": "e2e-workspace", "target": "e2e-utils", "type": "static" },
+      { "source": "e2e-workspace", "target": "devkit", "type": "static" },
+      { "source": "e2e-workspace", "target": "workspace", "type": "static" }
+    ],
+    "jest": [
+      { "source": "jest", "target": "devkit", "type": "static" },
+      { "source": "jest", "target": "tao", "type": "static" },
+      { "source": "jest", "target": "workspace", "type": "static" }
+    ],
+    "nest": [
+      { "source": "nest", "target": "node", "type": "implicit" },
+      { "source": "nest", "target": "linter", "type": "implicit" },
+      { "source": "nest", "target": "devkit", "type": "static" },
+      { "source": "nest", "target": "workspace", "type": "static" },
+      { "source": "nest", "target": "tao", "type": "static" }
+    ],
+    "next": [
+      { "source": "next", "target": "tao", "type": "static" },
+      { "source": "next", "target": "workspace", "type": "static" },
+      { "source": "next", "target": "devkit", "type": "static" },
+      { "source": "next", "target": "linter", "type": "static" },
+      { "source": "next", "target": "cypress", "type": "static" },
+      { "source": "next", "target": "jest", "type": "static" },
+      { "source": "next", "target": "react", "type": "static" },
+      { "source": "next", "target": "web", "type": "static" }
+    ],
+    "node": [
+      { "source": "node", "target": "devkit", "type": "static" },
+      { "source": "node", "target": "workspace", "type": "static" },
+      { "source": "node", "target": "linter", "type": "static" },
+      { "source": "node", "target": "jest", "type": "static" },
+      { "source": "node", "target": "tao", "type": "static" }
     ],
     "nx-dev": [
+      { "source": "nx-dev", "target": "docs", "type": "implicit" },
       {
-        "type": "static",
         "source": "nx-dev",
-        "target": "nx-dev-data-access-documents"
-      },
-      { "type": "implicit", "source": "nx-dev", "target": "docs" },
-      {
-        "type": "static",
-        "source": "nx-dev",
-        "target": "nx-dev-feature-analytics"
+        "target": "nx-dev-data-access-documents",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-dev",
-        "target": "nx-dev-feature-doc-viewer"
+        "target": "nx-dev-feature-analytics",
+        "type": "static"
       },
-      { "type": "static", "source": "nx-dev", "target": "nx-dev-ui-common" }
+      {
+        "source": "nx-dev",
+        "target": "nx-dev-feature-doc-viewer",
+        "type": "static"
+      },
+      { "source": "nx-dev", "target": "nx-dev-ui-common", "type": "static" },
+      { "source": "nx-dev", "target": "nx-dev-feature-conf", "type": "static" }
+    ],
+    "typedoc-theme": [],
+    "cli": [
+      { "source": "cli", "target": "workspace", "type": "implicit" },
+      { "source": "cli", "target": "tao", "type": "static" }
     ],
     "tao": [],
-    "web": [{ "type": "static", "source": "web", "target": "devkit" }],
-    "cli": [{ "type": "implicit", "source": "cli", "target": "workspace" }],
-    "nx": [],
-    "e2e-angular": [
-      { "type": "static", "source": "e2e-angular", "target": "e2e-utils" },
-      { "type": "static", "source": "e2e-angular", "target": "devkit" },
-      { "type": "implicit", "source": "e2e-angular", "target": "angular" }
+    "web": [
+      { "source": "web", "target": "devkit", "type": "static" },
+      { "source": "web", "target": "workspace", "type": "static" },
+      { "source": "web", "target": "cypress", "type": "static" },
+      { "source": "web", "target": "linter", "type": "static" },
+      { "source": "web", "target": "jest", "type": "static" },
+      { "source": "web", "target": "tao", "type": "static" }
     ],
     "e2e-cypress": [
-      { "type": "static", "source": "e2e-cypress", "target": "e2e-utils" },
-      { "type": "implicit", "source": "e2e-cypress", "target": "cypress" }
+      { "source": "e2e-cypress", "target": "cypress", "type": "implicit" },
+      { "source": "e2e-cypress", "target": "e2e-utils", "type": "static" }
+    ],
+    "nx": [{ "source": "nx", "target": "cli", "type": "static" }],
+    "e2e-gatsby": [
+      { "source": "e2e-gatsby", "target": "gatsby", "type": "implicit" },
+      { "source": "e2e-gatsby", "target": "e2e-utils", "type": "static" }
     ],
     "e2e-linter": [
-      { "type": "static", "source": "e2e-linter", "target": "e2e-utils" },
-      { "type": "implicit", "source": "e2e-linter", "target": "linter" }
+      { "source": "e2e-linter", "target": "linter", "type": "implicit" },
+      { "source": "e2e-linter", "target": "e2e-utils", "type": "static" }
     ],
-    "e2e-gatsby": [
-      { "type": "static", "source": "e2e-gatsby", "target": "e2e-utils" },
-      { "type": "implicit", "source": "e2e-gatsby", "target": "gatsby" }
-    ],
-    "e2e-utils": [
-      { "type": "static", "source": "e2e-utils", "target": "devkit" }
+    "e2e-detox": [
+      { "source": "e2e-detox", "target": "detox", "type": "implicit" },
+      { "source": "e2e-detox", "target": "e2e-utils", "type": "static" }
     ],
     "e2e-react": [
-      { "type": "static", "source": "e2e-react", "target": "e2e-utils" },
-      { "type": "static", "source": "e2e-react", "target": "devkit" },
-      { "type": "implicit", "source": "e2e-react", "target": "react" }
+      { "source": "e2e-react", "target": "react", "type": "implicit" },
+      { "source": "e2e-react", "target": "e2e-utils", "type": "static" },
+      { "source": "e2e-react", "target": "devkit", "type": "static" },
+      { "source": "e2e-react", "target": "workspace", "type": "static" }
+    ],
+    "e2e-utils": [
+      { "source": "e2e-utils", "target": "tao", "type": "static" },
+      { "source": "e2e-utils", "target": "devkit", "type": "static" }
     ],
     "e2e-jest": [
-      { "type": "static", "source": "e2e-jest", "target": "e2e-utils" },
-      { "type": "implicit", "source": "e2e-jest", "target": "jest" }
+      { "source": "e2e-jest", "target": "jest", "type": "implicit" },
+      { "source": "e2e-jest", "target": "e2e-utils", "type": "static" }
     ],
     "e2e-next": [
-      { "type": "static", "source": "e2e-next", "target": "e2e-utils" },
-      { "type": "implicit", "source": "e2e-next", "target": "next" }
+      { "source": "e2e-next", "target": "next", "type": "implicit" },
+      { "source": "e2e-next", "target": "workspace", "type": "static" },
+      { "source": "e2e-next", "target": "e2e-utils", "type": "static" }
     ],
     "e2e-node": [
-      { "type": "static", "source": "e2e-node", "target": "e2e-utils" },
-      { "type": "implicit", "source": "e2e-node", "target": "node" }
+      { "source": "e2e-node", "target": "node", "type": "implicit" },
+      { "source": "e2e-node", "target": "e2e-utils", "type": "static" }
     ],
     "e2e-cli": [
-      { "type": "static", "source": "e2e-cli", "target": "e2e-utils" },
-      { "type": "implicit", "source": "e2e-cli", "target": "cli" }
+      { "source": "e2e-cli", "target": "cli", "type": "implicit" },
+      { "source": "e2e-cli", "target": "workspace", "type": "static" },
+      { "source": "e2e-cli", "target": "e2e-utils", "type": "static" }
     ],
     "e2e-web": [
-      { "type": "static", "source": "e2e-web", "target": "e2e-utils" },
-      { "type": "implicit", "source": "e2e-web", "target": "web" }
+      { "source": "e2e-web", "target": "web", "type": "implicit" },
+      { "source": "e2e-web", "target": "e2e-utils", "type": "static" },
+      { "source": "e2e-web", "target": "workspace", "type": "static" }
     ],
     "docs": []
   },
-  "changes": {
-    "added": []
-  },
+  "layout": { "appsDir": "", "libsDir": "" },
+  "changes": { "added": [] },
   "affected": [],
   "focus": null,
-  "exclude": [],
-  "groupByFolder": false
+  "groupByFolder": false,
+  "exclude": []
 }

--- a/dep-graph/dep-graph/src/assets/graphs/ocean.json
+++ b/dep-graph/dep-graph/src/assets/graphs/ocean.json
@@ -1,13 +1,13 @@
 {
-  "hash": "3259329be53c39cccd0f18b6e9cc2fb8c13c49c72e660402cb865353f5bf7fdd",
-  "layout": { "appsDir": "apps", "libsDir": "libs" },
+  "hash": "2b07a7e3a85d36b3b567c3a8e11febc1e73f81d021a42221cba01217bca649e2",
   "projects": [
     {
       "name": "nx-cloud-private-cloud-feature-community-on-public-cloud",
       "type": "lib",
       "data": {
         "tags": [],
-        "root": "libs/nx-cloud/private-cloud/feature-community-on-public-cloud"
+        "root": "libs/nx-cloud/private-cloud/feature-community-on-public-cloud",
+        "files": []
       }
     },
     {
@@ -15,15 +15,17 @@
       "type": "lib",
       "data": {
         "tags": [],
-        "root": "libs/nx-cloud/private-cloud/feature-installation"
+        "root": "libs/nx-cloud/private-cloud/feature-installation",
+        "files": []
       }
     },
     {
-      "name": "nx-cloud-private-cloud-feature-instructions",
+      "name": "nx-cloud-reference-feature-workspace-setup",
       "type": "lib",
       "data": {
-        "tags": [],
-        "root": "libs/nx-cloud/private-cloud/feature-instructions"
+        "tags": ["nx-cloud", "type:feature"],
+        "root": "libs/nx-cloud/reference/feature-workspace-setup",
+        "files": []
       }
     },
     {
@@ -31,7 +33,8 @@
       "type": "lib",
       "data": {
         "tags": [],
-        "root": "libs/nx-cloud/reference/feature-invite-members"
+        "root": "libs/nx-cloud/reference/feature-invite-members",
+        "files": []
       }
     },
     {
@@ -39,7 +42,8 @@
       "type": "lib",
       "data": {
         "tags": ["nx-cloud", "type:data-access"],
-        "root": "libs/nx-cloud/reference/data-access-workspace"
+        "root": "libs/nx-cloud/reference/data-access-workspace",
+        "files": []
       }
     },
     {
@@ -47,15 +51,8 @@
       "type": "lib",
       "data": {
         "tags": ["type:feature"],
-        "root": "libs/nx-cloud/reference/feature-access-token"
-      }
-    },
-    {
-      "name": "nx-cloud-reference-util-org-membership",
-      "type": "lib",
-      "data": {
-        "tags": [],
-        "root": "libs/nx-cloud/reference/util-org-membership"
+        "root": "libs/nx-cloud/reference/feature-access-token",
+        "files": []
       }
     },
     {
@@ -63,7 +60,17 @@
       "type": "lib",
       "data": {
         "tags": [],
-        "root": "libs/nx-cloud/private-cloud/feature-landing"
+        "root": "libs/nx-cloud/private-cloud/feature-landing",
+        "files": []
+      }
+    },
+    {
+      "name": "nx-cloud-reference-util-org-membership",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "libs/nx-cloud/reference/util-org-membership",
+        "files": []
       }
     },
     {
@@ -71,7 +78,8 @@
       "type": "lib",
       "data": {
         "tags": ["scope:nrwlio", "type:feature"],
-        "root": "libs/nrwlio-site/pages/feature-style-guide"
+        "root": "libs/nrwlio-site/pages/feature-style-guide",
+        "files": []
       }
     },
     {
@@ -79,7 +87,8 @@
       "type": "lib",
       "data": {
         "tags": ["scope:nrwlio", "type:feature"],
-        "root": "libs/nrwlio-site/pages/feature-contact-us"
+        "root": "libs/nrwlio-site/pages/feature-contact-us",
+        "files": []
       }
     },
     {
@@ -87,35 +96,53 @@
       "type": "lib",
       "data": {
         "tags": ["nx-cloud", "type:feature"],
-        "root": "libs/nx-cloud/reference/feature-workspace"
+        "root": "libs/nx-cloud/reference/feature-workspace",
+        "files": []
+      }
+    },
+    {
+      "name": "nx-cloud-feature-make-ng-cli-faster",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "libs/nx-cloud/feature-make-ng-cli-faster",
+        "files": []
+      }
+    },
+    {
+      "name": "nx-cloud-private-cloud-feature-home",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "libs/nx-cloud/private-cloud/feature-home",
+        "files": []
+      }
+    },
+    {
+      "name": "nx-cloud-reference-feature-branches",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "libs/nx-cloud/reference/feature-branches",
+        "files": []
       }
     },
     {
       "name": "platform-data-access-nrwl-changelog",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/data-access-nrwl-changelog" }
+      "data": {
+        "tags": [],
+        "root": "libs/platform/data-access-nrwl-changelog",
+        "files": []
+      }
     },
     {
-      "name": "nx-cloud-feature-make-ng-cli-faster",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/feature-make-ng-cli-faster" }
-    },
-    {
-      "name": "nx-cloud-reference-feature-branches",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/reference/feature-branches" }
-    },
-    {
-      "name": "nx-cloud-private-cloud-feature-home",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/private-cloud/feature-home" }
-    },
-    {
-      "name": "nx-docs-site-feature-documentation",
+      "name": "nrwlio-site-pages-feature-about-us",
       "type": "lib",
       "data": {
-        "tags": ["nx:docs-site"],
-        "root": "libs/nx-docs-site/feature-documentation"
+        "tags": [],
+        "root": "libs/nrwlio-site/pages/feature-about-us",
+        "files": []
       }
     },
     {
@@ -123,7 +150,8 @@
       "type": "lib",
       "data": {
         "tags": ["scope:nrwlio", "type:feature"],
-        "root": "libs/nrwlio-site/pages/feature-products"
+        "root": "libs/nrwlio-site/pages/feature-products",
+        "files": []
       }
     },
     {
@@ -131,7 +159,8 @@
       "type": "lib",
       "data": {
         "tags": ["scope:nrwlio", "type:feature"],
-        "root": "libs/nrwlio-site/pages/feature-services"
+        "root": "libs/nrwlio-site/pages/feature-services",
+        "files": []
       }
     },
     {
@@ -139,51 +168,35 @@
       "type": "lib",
       "data": {
         "tags": ["nx-cloud", "type:feature"],
-        "root": "libs/nx-cloud/reference/feature-billing"
+        "root": "libs/nx-cloud/reference/feature-billing",
+        "files": []
       }
-    },
-    {
-      "name": "nrwlio-site-pages-feature-about-us",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/nrwlio-site/pages/feature-about-us" }
     },
     {
       "name": "nrwlio-site-pages-feature-careers",
       "type": "lib",
       "data": {
         "tags": ["scope:nrwlio", "type:feature"],
-        "root": "libs/nrwlio-site/pages/feature-careers"
+        "root": "libs/nrwlio-site/pages/feature-careers",
+        "files": []
       }
     },
     {
       "name": "nx-cloud-feature-terms-of-service",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/feature-terms-of-service" }
+      "data": {
+        "tags": [],
+        "root": "libs/nx-cloud/feature-terms-of-service",
+        "files": []
+      }
     },
     {
       "name": "platform-data-access-live-events",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/data-access-live-events" }
-    },
-    {
-      "name": "nx-docs-site-feature-file-system",
-      "type": "lib",
       "data": {
-        "tags": ["nx:docs-site"],
-        "root": "libs/nx-docs-site/feature-file-system"
-      }
-    },
-    {
-      "name": "platform-feature-nrwl-changelog",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/feature-nrwl-changelog" }
-    },
-    {
-      "name": "platform-feature-live-broadcast",
-      "type": "lib",
-      "data": {
-        "tags": ["type:feature"],
-        "root": "libs/platform/feature-live-broadcast"
+        "tags": [],
+        "root": "libs/platform/data-access-live-events",
+        "files": []
       }
     },
     {
@@ -191,25 +204,35 @@
       "type": "lib",
       "data": {
         "tags": ["scope:nrwlio", "type:data-access"],
-        "root": "libs/nrwlio-site/data-access-graphql"
+        "root": "libs/nrwlio-site/data-access-graphql",
+        "files": []
       }
     },
     {
       "name": "nx-cloud-reference-feature-runs",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/reference/feature-runs" }
+      "data": {
+        "tags": [],
+        "root": "libs/nx-cloud/reference/feature-runs",
+        "files": []
+      }
     },
     {
-      "name": "platform-feature-organizations",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/feature-organizations" }
-    },
-    {
-      "name": "platform-feature-live-workshop",
+      "name": "platform-feature-live-broadcast",
       "type": "lib",
       "data": {
-        "tags": ["type:feature", "platform:client", "scope:live-workshop"],
-        "root": "libs/platform/feature-live-workshop"
+        "tags": ["type:feature"],
+        "root": "libs/platform/feature-live-broadcast",
+        "files": []
+      }
+    },
+    {
+      "name": "platform-feature-nrwl-changelog",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "libs/platform/feature-nrwl-changelog",
+        "files": []
       }
     },
     {
@@ -217,38 +240,53 @@
       "type": "lib",
       "data": {
         "tags": ["scope:nrwlio", "type:feature"],
-        "root": "libs/nrwlio-site/pages/feature-home"
-      }
-    },
-    {
-      "name": "nx-cloud-reference-feature-org",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/reference/feature-org" }
-    },
-    {
-      "name": "nx-docs-site-feature-redirects",
-      "type": "lib",
-      "data": {
-        "tags": ["nx:docs-site"],
-        "root": "libs/nx-docs-site/feature-redirects"
+        "root": "libs/nrwlio-site/pages/feature-home",
+        "files": []
       }
     },
     {
       "name": "nx-cloud-admin-feature-support",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/admin/feature-support" }
+      "data": {
+        "tags": [],
+        "root": "libs/nx-cloud/admin/feature-support",
+        "files": []
+      }
     },
     {
-      "name": "platform-feature-organization",
+      "name": "nx-cloud-reference-feature-org",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/feature-organization" }
+      "data": {
+        "tags": [],
+        "root": "libs/nx-cloud/reference/feature-org",
+        "files": []
+      }
+    },
+    {
+      "name": "platform-feature-live-workshop",
+      "type": "lib",
+      "data": {
+        "tags": ["type:feature", "platform:client", "scope:live-workshop"],
+        "root": "libs/platform/feature-live-workshop",
+        "files": []
+      }
+    },
+    {
+      "name": "platform-feature-organizations",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "libs/platform/feature-organizations",
+        "files": []
+      }
     },
     {
       "name": "platform-data-access-cookbook",
       "type": "lib",
       "data": {
         "tags": ["data-access"],
-        "root": "libs/platform/data-access-cookbook"
+        "root": "libs/platform/data-access-cookbook",
+        "files": []
       }
     },
     {
@@ -256,25 +294,17 @@
       "type": "lib",
       "data": {
         "tags": ["type:feature"],
-        "root": "libs/platform/feature-landing-page"
+        "root": "libs/platform/feature-landing-page",
+        "files": []
       }
     },
     {
-      "name": "platform-data-access-graphql",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/data-access-graphql" }
-    },
-    {
-      "name": "platform-feature-live-events",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/feature-live-events" }
-    },
-    {
-      "name": "platform-data-access-courses",
+      "name": "platform-feature-organization",
       "type": "lib",
       "data": {
-        "tags": ["type:data-access"],
-        "root": "libs/platform/data-access-courses"
+        "tags": [],
+        "root": "libs/platform/feature-organization",
+        "files": []
       }
     },
     {
@@ -282,23 +312,35 @@
       "type": "lib",
       "data": {
         "tags": ["nx-cloud", "type:data-access"],
-        "root": "libs/nx-cloud/data-access-graphql"
+        "root": "libs/nx-cloud/data-access-graphql",
+        "files": []
       }
     },
     {
-      "name": "nx-docs-site-feature-plugins",
+      "name": "platform-data-access-courses",
       "type": "lib",
       "data": {
-        "tags": ["nx:docs-site"],
-        "root": "libs/nx-docs-site/feature-plugins"
+        "tags": ["type:data-access"],
+        "root": "libs/platform/data-access-courses",
+        "files": []
       }
     },
     {
-      "name": "platform-feature-expert-bio",
+      "name": "platform-data-access-graphql",
       "type": "lib",
       "data": {
-        "tags": ["type:feature"],
-        "root": "libs/platform/feature-expert-bio"
+        "tags": [],
+        "root": "libs/platform/data-access-graphql",
+        "files": []
+      }
+    },
+    {
+      "name": "platform-feature-live-events",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "libs/platform/feature-live-events",
+        "files": []
       }
     },
     {
@@ -306,41 +348,26 @@
       "type": "lib",
       "data": {
         "tags": ["scope:nrwlio", "type:ui"],
-        "root": "libs/nrwlio-site/ui/text-sliders"
-      }
-    },
-    {
-      "name": "nx-docs-site-feature-search",
-      "type": "lib",
-      "data": {
-        "tags": ["nx:docs-site"],
-        "root": "libs/nx-docs-site/feature-search"
+        "root": "libs/nrwlio-site/ui/text-sliders",
+        "files": []
       }
     },
     {
       "name": "nx-cloud-feature-promotions",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/feature-promotions" }
-    },
-    {
-      "name": "platform-feature-dashboard",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/feature-dashboard" }
-    },
-    {
-      "name": "platform-data-access-blurb",
-      "type": "lib",
       "data": {
-        "tags": ["type:data-access"],
-        "root": "libs/platform/data-access-blurb"
+        "tags": [],
+        "root": "libs/nx-cloud/feature-promotions",
+        "files": []
       }
     },
     {
-      "name": "nx-docs-site-utils-fetcher",
+      "name": "platform-feature-expert-bio",
       "type": "lib",
       "data": {
-        "tags": ["nx:docs-site"],
-        "root": "libs/nx-docs-site/utils-fetcher"
+        "tags": ["type:feature"],
+        "root": "libs/platform/feature-expert-bio",
+        "files": []
       }
     },
     {
@@ -348,123 +375,143 @@
       "type": "lib",
       "data": {
         "tags": ["scope:design-system", "type:ui"],
-        "root": "libs/design-system/testimonials"
+        "root": "libs/design-system/testimonials",
+        "files": []
       }
     },
     {
       "name": "nx-cloud-ui-breadcrumb-nav",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/ui/breadcrumb-nav" }
-    },
-    {
-      "name": "platform-data-access-book",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/data-access-book" }
-    },
-    {
-      "name": "nx-docs-site-feature-home",
-      "type": "lib",
       "data": {
-        "tags": ["nx:docs-site"],
-        "root": "libs/nx-docs-site/feature-home"
+        "tags": [],
+        "root": "libs/nx-cloud/ui/breadcrumb-nav",
+        "files": []
       }
     },
     {
-      "name": "platform-feature-cookbook",
+      "name": "platform-data-access-blurb",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/feature-cookbook" }
+      "data": {
+        "tags": ["type:data-access"],
+        "root": "libs/platform/data-access-blurb",
+        "files": []
+      }
     },
     {
-      "name": "platform-feature-policies",
+      "name": "platform-feature-dashboard",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/feature-policies" }
-    },
-    {
-      "name": "shared-utils-download-csv",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/shared/utils/download-csv" }
+      "data": {
+        "tags": [],
+        "root": "libs/platform/feature-dashboard",
+        "files": []
+      }
     },
     {
       "name": "nrwlio-site-feature-pages",
       "type": "lib",
       "data": {
         "tags": ["scope:nrwlio", "type:feature"],
-        "root": "libs/nrwlio-site/feature-pages"
+        "root": "libs/nrwlio-site/feature-pages",
+        "files": []
       }
     },
     {
       "name": "nx-cloud-feature-policies",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/feature-policies" }
-    },
-    {
-      "name": "platform-feature-courses",
-      "type": "lib",
       "data": {
-        "tags": ["type:feature"],
-        "root": "libs/platform/feature-courses"
+        "tags": [],
+        "root": "libs/nx-cloud/feature-policies",
+        "files": []
       }
     },
     {
-      "name": "platform-feature-reports",
+      "name": "platform-data-access-book",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/feature-reports" }
+      "data": {
+        "tags": [],
+        "root": "libs/platform/data-access-book",
+        "files": []
+      }
+    },
+    {
+      "name": "platform-feature-cookbook",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "libs/platform/feature-cookbook",
+        "files": []
+      }
+    },
+    {
+      "name": "platform-feature-policies",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "libs/platform/feature-policies",
+        "files": []
+      }
+    },
+    {
+      "name": "shared-utils-download-csv",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "libs/shared/utils/download-csv",
+        "files": []
+      }
     },
     {
       "name": "nx-cloud-feature-landing",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/feature-landing" }
+      "data": {
+        "tags": [],
+        "root": "libs/nx-cloud/feature-landing",
+        "files": []
+      }
     },
     {
       "name": "nx-cloud-feature-pricing",
       "type": "lib",
       "data": {
         "tags": ["nx-cloud", "type:feature"],
-        "root": "libs/nx-cloud/feature-pricing"
+        "root": "libs/nx-cloud/feature-pricing",
+        "files": []
+      }
+    },
+    {
+      "name": "platform-feature-courses",
+      "type": "lib",
+      "data": {
+        "tags": ["type:feature"],
+        "root": "libs/platform/feature-courses",
+        "files": []
+      }
+    },
+    {
+      "name": "platform-feature-reports",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "libs/platform/feature-reports",
+        "files": []
       }
     },
     {
       "name": "platform-feature-topics",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/feature-topics" }
+      "data": {
+        "tags": [],
+        "root": "libs/platform/feature-topics",
+        "files": []
+      }
     },
     {
       "name": "shared-google-analytics",
       "type": "lib",
       "data": {
         "tags": ["scope:shared"],
-        "root": "libs/shared/google-analytics"
-      }
-    },
-    {
-      "name": "platform-feature-users",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/feature-users" }
-    },
-    {
-      "name": "platform-feature-books",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/feature-books" }
-    },
-    {
-      "name": "platform-ui-expert-bio",
-      "type": "lib",
-      "data": { "tags": ["type:ui"], "root": "libs/platform/ui-expert-bio" }
-    },
-    {
-      "name": "nrwlio-site-contentful",
-      "type": "lib",
-      "data": {
-        "tags": ["scope:nrwlio"],
-        "root": "libs/nrwlio-site/contentful"
-      }
-    },
-    {
-      "name": "platform-feature-about",
-      "type": "lib",
-      "data": {
-        "tags": ["type:feature"],
-        "root": "libs/platform/feature-about"
+        "root": "libs/shared/google-analytics",
+        "files": []
       }
     },
     {
@@ -472,20 +519,45 @@
       "type": "lib",
       "data": {
         "tags": ["scope:design-system", "type:ui"],
-        "root": "libs/design-system/contents"
+        "root": "libs/design-system/contents",
+        "files": []
       }
     },
     {
-      "name": "platform-feature-auth",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/feature-auth" }
-    },
-    {
-      "name": "nrwlio-site-ui-styles",
+      "name": "nrwlio-site-contentful",
       "type": "lib",
       "data": {
-        "tags": ["scope:nrwlio", "type:ui"],
-        "root": "libs/nrwlio-site/ui/styles"
+        "tags": ["scope:nrwlio"],
+        "root": "libs/nrwlio-site/contentful",
+        "files": []
+      }
+    },
+    {
+      "name": "platform-feature-about",
+      "type": "lib",
+      "data": {
+        "tags": ["type:feature"],
+        "root": "libs/platform/feature-about",
+        "files": []
+      }
+    },
+    {
+      "name": "platform-feature-books",
+      "type": "lib",
+      "data": { "tags": [], "root": "libs/platform/feature-books", "files": [] }
+    },
+    {
+      "name": "platform-feature-users",
+      "type": "lib",
+      "data": { "tags": [], "root": "libs/platform/feature-users", "files": [] }
+    },
+    {
+      "name": "platform-ui-expert-bio",
+      "type": "lib",
+      "data": {
+        "tags": ["type:ui"],
+        "root": "libs/platform/ui-expert-bio",
+        "files": []
       }
     },
     {
@@ -493,7 +565,8 @@
       "type": "lib",
       "data": {
         "tags": ["scope:nrwlio", "type:ui"],
-        "root": "libs/nrwlio-site/ui/footer"
+        "root": "libs/nrwlio-site/ui/footer",
+        "files": []
       }
     },
     {
@@ -501,7 +574,17 @@
       "type": "lib",
       "data": {
         "tags": ["scope:nrwlio", "type:ui"],
-        "root": "libs/nrwlio-site/ui/header"
+        "root": "libs/nrwlio-site/ui/header",
+        "files": []
+      }
+    },
+    {
+      "name": "nrwlio-site-ui-styles",
+      "type": "lib",
+      "data": {
+        "tags": ["scope:nrwlio", "type:ui"],
+        "root": "libs/nrwlio-site/ui/styles",
+        "files": []
       }
     },
     {
@@ -509,64 +592,32 @@
       "type": "lib",
       "data": {
         "tags": ["nx-cloud", "type:feature"],
-        "root": "libs/nx-cloud/feature-auth"
+        "root": "libs/nx-cloud/feature-auth",
+        "files": []
       }
-    },
-    {
-      "name": "nx-cloud-ui-sparkline",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/ui/sparkline" }
     },
     {
       "name": "nx-cloud-feature-docs",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/feature-docs" }
+      "data": { "tags": [], "root": "libs/nx-cloud/feature-docs", "files": [] }
     },
     {
-      "name": "nx-packages-nx-cloud",
+      "name": "nx-cloud-ui-sparkline",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-packages/nx-cloud" }
+      "data": { "tags": [], "root": "libs/nx-cloud/ui/sparkline", "files": [] }
     },
     {
-      "name": "nx-docs-site-base-ui",
+      "name": "platform-feature-auth",
       "type": "lib",
-      "data": { "tags": ["nx:docs-site"], "root": "libs/nx-docs-site/base-ui" }
-    },
-    {
-      "name": "nrwlio-site-ui-heros",
-      "type": "lib",
-      "data": {
-        "tags": ["scope:nrwlio", "type:ui"],
-        "root": "libs/nrwlio-site/ui/heros"
-      }
-    },
-    {
-      "name": "ui-article-container",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/ui/article-container" }
-    },
-    {
-      "name": "nx-cloud-feature-faq",
-      "type": "lib",
-      "data": {
-        "tags": ["nx-cloud", "type:feature"],
-        "root": "libs/nx-cloud/feature-faq"
-      }
-    },
-    {
-      "name": "design-system-styles",
-      "type": "lib",
-      "data": {
-        "tags": ["scope:design-system", "type:ui"],
-        "root": "libs/design-system/styles"
-      }
+      "data": { "tags": [], "root": "libs/platform/feature-auth", "files": [] }
     },
     {
       "name": "design-system-heroes",
       "type": "lib",
       "data": {
         "tags": ["scope:design-system", "type:ui"],
-        "root": "libs/design-system/heroes"
+        "root": "libs/design-system/heroes",
+        "files": []
       }
     },
     {
@@ -574,2184 +625,2060 @@
       "type": "lib",
       "data": {
         "tags": ["scope:design-system", "type:ui"],
-        "root": "libs/design-system/images"
+        "root": "libs/design-system/images",
+        "files": []
+      }
+    },
+    {
+      "name": "design-system-styles",
+      "type": "lib",
+      "data": {
+        "tags": ["scope:design-system", "type:ui"],
+        "root": "libs/design-system/styles",
+        "files": []
+      }
+    },
+    {
+      "name": "nrwlio-site-ui-heros",
+      "type": "lib",
+      "data": {
+        "tags": ["scope:nrwlio", "type:ui"],
+        "root": "libs/nrwlio-site/ui/heros",
+        "files": []
+      }
+    },
+    {
+      "name": "nx-cloud-feature-faq",
+      "type": "lib",
+      "data": {
+        "tags": ["nx-cloud", "type:feature"],
+        "root": "libs/nx-cloud/feature-faq",
+        "files": []
       }
     },
     {
       "name": "nx-cloud-ui-terminal",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/ui/terminal" }
+      "data": { "tags": [], "root": "libs/nx-cloud/ui/terminal", "files": [] }
     },
     {
-      "name": "platform-components",
+      "name": "nx-packages-nx-cloud",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/components" }
+      "data": { "tags": [], "root": "libs/nx-packages/nx-cloud", "files": [] }
     },
     {
-      "name": "platform-scss-utils",
+      "name": "ui-article-container",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/scss-utils" }
-    },
-    {
-      "name": "nx-docs-site-styles",
-      "type": "lib",
-      "data": { "tags": ["nx:docs-site"], "root": "libs/nx-docs-site/styles" }
-    },
-    {
-      "name": "platform-ui-courses",
-      "type": "lib",
-      "data": { "tags": ["type:ui"], "root": "libs/platform/ui-courses" }
-    },
-    {
-      "name": "platform-ui-twitter",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/ui-twitter" }
+      "data": { "tags": [], "root": "libs/ui/article-container", "files": [] }
     },
     {
       "name": "nrwlio-site-hubspot",
       "type": "lib",
-      "data": { "tags": ["scope:nrwlio"], "root": "libs/nrwlio-site/hubspot" }
+      "data": {
+        "tags": ["scope:nrwlio"],
+        "root": "libs/nrwlio-site/hubspot",
+        "files": []
+      }
     },
     {
-      "name": "shared-ui-markdown",
+      "name": "platform-components",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/shared/ui-markdown" }
+      "data": { "tags": [], "root": "libs/platform/components", "files": [] }
+    },
+    {
+      "name": "platform-scss-utils",
+      "type": "lib",
+      "data": { "tags": [], "root": "libs/platform/scss-utils", "files": [] }
+    },
+    {
+      "name": "platform-ui-courses",
+      "type": "lib",
+      "data": {
+        "tags": ["type:ui"],
+        "root": "libs/platform/ui-courses",
+        "files": []
+      }
+    },
+    {
+      "name": "platform-ui-twitter",
+      "type": "lib",
+      "data": { "tags": [], "root": "libs/platform/ui-twitter", "files": [] }
+    },
+    {
+      "name": "nrwl-api-reporting",
+      "type": "lib",
+      "data": { "tags": [], "root": "libs/nrwl-api/reporting", "files": [] }
     },
     {
       "name": "nrwlio-site-assets",
       "type": "lib",
       "data": {
         "tags": ["scope:nrwlio", "type:ui"],
-        "root": "libs/nrwlio-site/assets"
+        "root": "libs/nrwlio-site/assets",
+        "files": []
       }
-    },
-    {
-      "name": "nx-cloud-ui-styles",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/ui/styles" }
-    },
-    {
-      "name": "nx-cloud-ui-header",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/ui/header" }
-    },
-    {
-      "name": "nx-cloud-ui-footer",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/ui/footer" }
     },
     {
       "name": "nx-cloud-ui-alerts",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/ui/alerts" }
+      "data": { "tags": [], "root": "libs/nx-cloud/ui/alerts", "files": [] }
     },
     {
-      "name": "nrwl-api-reporting",
+      "name": "nx-cloud-ui-footer",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nrwl-api/reporting" }
+      "data": { "tags": [], "root": "libs/nx-cloud/ui/footer", "files": [] }
     },
     {
-      "name": "private-nx-cloud",
-      "type": "app",
-      "data": { "tags": [], "root": "apps/private-nx-cloud/" }
-    },
-    {
-      "name": "ui-floating-items",
+      "name": "nx-cloud-ui-header",
       "type": "lib",
-      "data": {
-        "tags": ["scope:nrwlio", "type:ui"],
-        "root": "libs/ui/floating-items"
-      }
+      "data": { "tags": [], "root": "libs/nx-cloud/ui/header", "files": [] }
+    },
+    {
+      "name": "nx-cloud-ui-styles",
+      "type": "lib",
+      "data": { "tags": [], "root": "libs/nx-cloud/ui/styles", "files": [] }
+    },
+    {
+      "name": "shared-ui-markdown",
+      "type": "lib",
+      "data": { "tags": [], "root": "libs/shared/ui-markdown", "files": [] }
     },
     {
       "name": "design-system-e2e",
       "type": "e2e",
       "data": {
         "tags": ["scope:design-system", "type:ui"],
-        "root": "apps/design-system-e2e"
+        "root": "apps/design-system-e2e",
+        "files": []
       }
     },
     {
-      "name": "nx-docs-site-e2e",
-      "type": "e2e",
-      "data": { "tags": ["nx:docs-site"], "root": "apps/nx-docs-site-e2e" }
-    },
-    {
-      "name": "ui-article-media",
-      "type": "lib",
-      "data": { "tags": [], "root": "libs/ui/article-media" }
+      "name": "private-nx-cloud",
+      "type": "app",
+      "data": { "tags": [], "root": "apps/private-nx-cloud/", "files": [] }
     },
     {
       "name": "nx-cloud-hubspot",
       "type": "lib",
       "data": {
         "tags": ["scope:nx-cloud", "type:util"],
-        "root": "libs/nx-cloud/hubspot"
+        "root": "libs/nx-cloud/hubspot",
+        "files": []
       }
+    },
+    {
+      "name": "ui-article-media",
+      "type": "lib",
+      "data": { "tags": [], "root": "libs/ui/article-media", "files": [] }
     },
     {
       "name": "common-platform",
       "type": "lib",
-      "data": { "tags": ["common:platform"], "root": "libs/common-platform" }
+      "data": {
+        "tags": ["common:platform"],
+        "root": "libs/common-platform",
+        "files": []
+      }
     },
     {
       "name": "nrwlio-site-pwa",
       "type": "lib",
-      "data": { "tags": ["scope:nrwlio"], "root": "libs/nrwlio-site/pwa" }
-    },
-    {
-      "name": "ui-testimonials",
-      "type": "lib",
-      "data": { "tags": ["ui"], "root": "libs/ui/testimonials" }
+      "data": {
+        "tags": ["scope:nrwlio"],
+        "root": "libs/nrwlio-site/pwa",
+        "files": []
+      }
     },
     {
       "name": "nx-cloud-assets",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/nx-cloud/assets" }
+      "data": { "tags": [], "root": "libs/nx-cloud/assets", "files": [] }
     },
     {
-      "name": "platform-utils",
+      "name": "nx-packages-e2e",
+      "type": "e2e",
+      "data": { "tags": [], "root": "apps/nx-packages-e2e", "files": [] }
+    },
+    {
+      "name": "ui-testimonials",
       "type": "lib",
-      "data": { "tags": [], "root": "libs/platform/utils" }
+      "data": { "tags": ["ui"], "root": "libs/ui/testimonials", "files": [] }
     },
     {
       "name": "nx-cloud-utils",
       "type": "lib",
       "data": {
         "tags": ["nx-cloud", "type:util"],
-        "root": "libs/nx-cloud/utils"
+        "root": "libs/nx-cloud/utils",
+        "files": []
       }
     },
     {
-      "name": "nx-docs-site",
-      "type": "app",
-      "data": { "tags": ["nx:docs-site"], "root": "apps/nx-docs-site/" }
+      "name": "platform-utils",
+      "type": "lib",
+      "data": { "tags": [], "root": "libs/platform/utils", "files": [] }
     },
     {
       "name": "design-system",
       "type": "app",
       "data": {
         "tags": ["scope:design-system", "type:ui"],
-        "root": "apps/design-system"
+        "root": "apps/design-system",
+        "files": []
       }
-    },
-    {
-      "name": "platform-e2e",
-      "type": "e2e",
-      "data": { "tags": [], "root": "apps/platform-e2e" }
     },
     {
       "name": "nrwl-api-e2e",
       "type": "e2e",
-      "data": { "tags": [], "root": "apps/nrwl-api-e2e" }
+      "data": { "tags": [], "root": "apps/nrwl-api-e2e", "files": [] }
     },
     {
       "name": "nx-cloud-e2e",
       "type": "e2e",
-      "data": { "tags": [], "root": "apps/nx-cloud-e2e" }
+      "data": { "tags": [], "root": "apps/nx-cloud-e2e", "files": [] }
+    },
+    {
+      "name": "platform-e2e",
+      "type": "e2e",
+      "data": { "tags": [], "root": "apps/platform-e2e", "files": [] }
     },
     {
       "name": "ui-downloads",
       "type": "lib",
-      "data": { "tags": ["ui"], "root": "libs/ui/downloads" }
-    },
-    {
-      "name": "common-site",
-      "type": "lib",
-      "data": { "tags": ["common:site"], "root": "libs/common-site" }
-    },
-    {
-      "name": "ui-contents",
-      "type": "lib",
-      "data": { "tags": ["type:ui"], "root": "libs/ui/contents" }
-    },
-    {
-      "name": "ui-features",
-      "type": "lib",
-      "data": { "tags": ["ui"], "root": "libs/ui/features" }
-    },
-    {
-      "name": "ui-articles",
-      "type": "lib",
-      "data": { "tags": ["ui"], "root": "libs/ui/articles" }
-    },
-    {
-      "name": "ui-callouts",
-      "type": "lib",
-      "data": { "tags": ["ui"], "root": "libs/ui/callouts" }
-    },
-    {
-      "name": "file-server",
-      "type": "app",
-      "data": { "tags": [], "root": "apps/file-server" }
+      "data": { "tags": ["ui"], "root": "libs/ui/downloads", "files": [] }
     },
     {
       "name": "cloud-proxy",
       "type": "app",
-      "data": { "tags": [], "root": "apps/cloud-proxy" }
+      "data": { "tags": [], "root": "apps/cloud-proxy", "files": [] }
+    },
+    {
+      "name": "common-site",
+      "type": "lib",
+      "data": {
+        "tags": ["common:site"],
+        "root": "libs/common-site",
+        "files": []
+      }
+    },
+    {
+      "name": "file-server",
+      "type": "app",
+      "data": { "tags": [], "root": "apps/file-server", "files": [] }
+    },
+    {
+      "name": "ui-articles",
+      "type": "lib",
+      "data": { "tags": ["ui"], "root": "libs/ui/articles", "files": [] }
+    },
+    {
+      "name": "ui-callouts",
+      "type": "lib",
+      "data": { "tags": ["ui"], "root": "libs/ui/callouts", "files": [] }
+    },
+    {
+      "name": "ui-contents",
+      "type": "lib",
+      "data": { "tags": ["type:ui"], "root": "libs/ui/contents", "files": [] }
+    },
+    {
+      "name": "ui-features",
+      "type": "lib",
+      "data": { "tags": ["ui"], "root": "libs/ui/features", "files": [] }
     },
     {
       "name": "nrwlio-e2e",
       "type": "e2e",
-      "data": { "tags": ["scope:nrwlio"], "root": "apps/nrwlio-e2e" }
+      "data": {
+        "tags": ["scope:nrwlio"],
+        "root": "apps/nrwlio-e2e",
+        "files": []
+      }
     },
     {
       "name": "ui-banners",
       "type": "lib",
-      "data": { "tags": ["ui"], "root": "libs/ui/banners" }
+      "data": { "tags": ["ui"], "root": "libs/ui/banners", "files": [] }
     },
     {
       "name": "platform",
       "type": "app",
-      "data": { "tags": [], "root": "apps/platform/" }
+      "data": { "tags": [], "root": "apps/platform/", "files": [] }
     },
     {
       "name": "ui-images",
       "type": "lib",
-      "data": { "tags": ["type:ui"], "root": "libs/ui/images" }
+      "data": { "tags": ["type:ui"], "root": "libs/ui/images", "files": [] }
     },
     {
       "name": "ui-styles",
       "type": "lib",
-      "data": { "tags": ["type:ui"], "root": "libs/ui/styles" }
+      "data": { "tags": ["type:ui"], "root": "libs/ui/styles", "files": [] }
     },
     {
       "name": "nrwl-api",
       "type": "app",
-      "data": { "tags": [], "root": "apps/nrwl-api" }
+      "data": { "tags": [], "root": "apps/nrwl-api", "files": [] }
     },
     {
       "name": "nx-cloud",
       "type": "app",
-      "data": { "tags": ["nx-cloud"], "root": "apps/nx-cloud" }
+      "data": { "tags": ["nx-cloud"], "root": "apps/nx-cloud", "files": [] }
     },
     {
       "name": "ui-heros",
       "type": "lib",
-      "data": { "tags": ["ui"], "root": "libs/ui/heros" }
+      "data": { "tags": ["ui"], "root": "libs/ui/heros", "files": [] }
     },
     {
       "name": "nx-api",
       "type": "app",
-      "data": { "tags": [], "root": "apps/nx-api/" }
+      "data": { "tags": [], "root": "apps/nx-api/", "files": [] }
     },
     {
       "name": "nrwlio",
       "type": "app",
-      "data": { "tags": ["scope:nrwlio"], "root": "apps/nrwlio" }
+      "data": { "tags": ["scope:nrwlio"], "root": "apps/nrwlio", "files": [] }
     },
     {
       "name": "ui-ads",
       "type": "lib",
-      "data": { "tags": ["ui"], "root": "libs/ui/ads" }
+      "data": { "tags": ["ui"], "root": "libs/ui/ads", "files": [] }
     }
   ],
   "dependencies": {
     "nx-cloud-private-cloud-feature-community-on-public-cloud": [
       {
-        "type": "static",
         "source": "nx-cloud-private-cloud-feature-community-on-public-cloud",
-        "target": "nx-cloud-feature-billing"
+        "target": "nx-cloud-feature-billing",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-private-cloud-feature-community-on-public-cloud",
-        "target": "nx-cloud-utils"
+        "target": "nx-cloud-utils",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud-private-cloud-feature-community-on-public-cloud",
-        "target": "nx-cloud-private-cloud-feature-landing"
+        "target": "nx-cloud-private-cloud-feature-landing",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-private-cloud-feature-community-on-public-cloud",
-        "target": "nx-cloud-data-access-workspace"
+        "target": "nx-cloud-data-access-workspace",
+        "type": "static"
       }
     ],
     "nx-cloud-private-cloud-feature-installation": [],
-    "nx-cloud-private-cloud-feature-instructions": [
+    "nx-cloud-reference-feature-workspace-setup": [
       {
-        "type": "static",
-        "source": "nx-cloud-private-cloud-feature-instructions",
-        "target": "ui-images"
+        "source": "nx-cloud-reference-feature-workspace-setup",
+        "target": "nx-cloud-ui-terminal",
+        "type": "static"
+      },
+      {
+        "source": "nx-cloud-reference-feature-workspace-setup",
+        "target": "nx-cloud-ui-alerts",
+        "type": "static"
+      },
+      {
+        "source": "nx-cloud-reference-feature-workspace-setup",
+        "target": "nx-cloud-data-access-workspace",
+        "type": "static"
       }
     ],
     "nx-cloud-reference-feature-invite-members": [
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-invite-members",
-        "target": "nx-cloud-feature-auth"
+        "target": "nx-cloud-feature-auth",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-invite-members",
-        "target": "nx-cloud-utils"
+        "target": "nx-cloud-utils",
+        "type": "static"
       }
     ],
     "nx-cloud-data-access-workspace": [],
     "nx-cloud-reference-feature-access-token": [
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-access-token",
-        "target": "nx-cloud-utils"
+        "target": "nx-cloud-utils",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-access-token",
-        "target": "nx-cloud-ui-alerts"
+        "target": "nx-cloud-ui-alerts",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-access-token",
-        "target": "nx-cloud-reference-util-org-membership"
+        "target": "nx-cloud-reference-util-org-membership",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-access-token",
-        "target": "nx-cloud-data-access-workspace"
+        "target": "nx-cloud-data-access-workspace",
+        "type": "static"
+      }
+    ],
+    "nx-cloud-private-cloud-feature-landing": [
+      {
+        "source": "nx-cloud-private-cloud-feature-landing",
+        "target": "ui-images",
+        "type": "static"
       }
     ],
     "nx-cloud-reference-util-org-membership": [],
-    "nx-cloud-private-cloud-feature-landing": [
-      {
-        "type": "static",
-        "source": "nx-cloud-private-cloud-feature-landing",
-        "target": "ui-images"
-      }
-    ],
     "nrwlio-site-pages-feature-style-guide": [
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-style-guide",
-        "target": "ui-contents"
+        "target": "ui-contents",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-style-guide",
-        "target": "nrwlio-site-contentful"
+        "target": "nrwlio-site-contentful",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-style-guide",
-        "target": "ui-ads"
+        "target": "ui-ads",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-style-guide",
-        "target": "ui-articles"
+        "target": "ui-articles",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-style-guide",
-        "target": "ui-downloads"
+        "target": "ui-downloads",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-style-guide",
-        "target": "ui-features"
+        "target": "ui-features",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-style-guide",
-        "target": "ui-heros"
+        "target": "ui-heros",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-style-guide",
-        "target": "ui-images"
+        "target": "ui-images",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-style-guide",
-        "target": "ui-testimonials"
+        "target": "ui-testimonials",
+        "type": "static"
       }
     ],
     "nrwlio-site-pages-feature-contact-us": [
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-contact-us",
-        "target": "nrwlio-site-ui-footer"
+        "target": "nrwlio-site-ui-footer",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-contact-us",
-        "target": "nrwlio-site-ui-header"
+        "target": "nrwlio-site-ui-header",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-contact-us",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-contact-us",
-        "target": "nrwlio-site-contentful"
+        "target": "nrwlio-site-contentful",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-contact-us",
-        "target": "nrwlio-site-feature-pages"
+        "target": "nrwlio-site-feature-pages",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-contact-us",
-        "target": "nrwlio-site-hubspot"
+        "target": "nrwlio-site-hubspot",
+        "type": "static"
       }
     ],
     "nx-cloud-reference-feature-workspace": [
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-workspace",
-        "target": "nx-cloud-utils"
+        "target": "nx-cloud-utils",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-workspace",
-        "target": "nx-cloud-data-access-workspace"
+        "target": "nx-cloud-data-access-workspace",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-workspace",
-        "target": "nx-cloud-reference-feature-access-token"
+        "target": "nx-cloud-reference-feature-access-token",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-workspace",
-        "target": "nx-cloud-feature-billing"
+        "target": "nx-cloud-feature-billing",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-workspace",
-        "target": "nx-cloud-reference-util-org-membership"
+        "target": "nx-cloud-reference-util-org-membership",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-workspace",
-        "target": "nx-cloud-ui-alerts"
+        "target": "nx-cloud-ui-alerts",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-workspace",
-        "target": "nx-cloud-ui-breadcrumb-nav"
+        "target": "nx-cloud-ui-breadcrumb-nav",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-workspace",
-        "target": "nx-cloud-ui-terminal"
+        "target": "nx-cloud-ui-terminal",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-workspace",
-        "target": "nx-cloud-ui-sparkline"
+        "target": "nx-cloud-ui-sparkline",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-reference-feature-workspace",
-        "target": "nx-cloud-data-access-graphql"
+        "target": "nx-cloud-reference-feature-workspace-setup",
+        "type": "static"
+      },
+      {
+        "source": "nx-cloud-reference-feature-workspace",
+        "target": "nx-cloud-data-access-graphql",
+        "type": "static"
       }
     ],
-    "platform-data-access-nrwl-changelog": [],
     "nx-cloud-feature-make-ng-cli-faster": [
       {
-        "type": "static",
         "source": "nx-cloud-feature-make-ng-cli-faster",
-        "target": "common-site"
+        "target": "common-site",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-make-ng-cli-faster",
-        "target": "common-platform"
+        "target": "common-platform",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-make-ng-cli-faster",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-make-ng-cli-faster",
-        "target": "ui-images"
-      }
-    ],
-    "nx-cloud-reference-feature-branches": [
-      {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-branches",
-        "target": "nx-cloud-ui-breadcrumb-nav"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-branches",
-        "target": "nx-cloud-utils"
+        "target": "ui-images",
+        "type": "static"
       }
     ],
     "nx-cloud-private-cloud-feature-home": [
       {
-        "type": "static",
         "source": "nx-cloud-private-cloud-feature-home",
-        "target": "ui-images"
+        "target": "ui-images",
+        "type": "static"
       }
     ],
-    "nx-docs-site-feature-documentation": [
+    "nx-cloud-reference-feature-branches": [
       {
-        "type": "static",
-        "source": "nx-docs-site-feature-documentation",
-        "target": "common-site"
+        "source": "nx-cloud-reference-feature-branches",
+        "target": "nx-cloud-ui-breadcrumb-nav",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-docs-site-feature-documentation",
-        "target": "shared-ui-markdown"
+        "source": "nx-cloud-reference-feature-branches",
+        "target": "nx-cloud-utils",
+        "type": "static"
+      }
+    ],
+    "platform-data-access-nrwl-changelog": [],
+    "nrwlio-site-pages-feature-about-us": [
+      {
+        "source": "nrwlio-site-pages-feature-about-us",
+        "target": "nrwlio-site-contentful",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-docs-site-feature-documentation",
-        "target": "nx-docs-site-utils-fetcher"
+        "source": "nrwlio-site-pages-feature-about-us",
+        "target": "nrwlio-site-ui-footer",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-docs-site-feature-documentation",
-        "target": "shared-google-analytics"
-      },
-      {
-        "type": "static",
-        "source": "nx-docs-site-feature-documentation",
-        "target": "nx-docs-site-base-ui"
-      },
-      {
-        "type": "static",
-        "source": "nx-docs-site-feature-documentation",
-        "target": "ui-banners"
-      },
-      {
-        "type": "static",
-        "source": "nx-docs-site-feature-documentation",
-        "target": "nx-docs-site-feature-redirects"
+        "source": "nrwlio-site-pages-feature-about-us",
+        "target": "nrwlio-site-ui-header",
+        "type": "static"
       }
     ],
     "nrwlio-site-pages-feature-products": [
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-products",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-products",
-        "target": "nrwlio-site-contentful"
+        "target": "nrwlio-site-contentful",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-products",
-        "target": "nrwlio-site-ui-header"
+        "target": "nrwlio-site-ui-header",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-products",
-        "target": "nrwlio-site-ui-footer"
+        "target": "nrwlio-site-ui-footer",
+        "type": "static"
       }
     ],
     "nrwlio-site-pages-feature-services": [
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-services",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-services",
-        "target": "nrwlio-site-ui-header"
+        "target": "nrwlio-site-ui-header",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-services",
-        "target": "nrwlio-site-ui-footer"
+        "target": "nrwlio-site-ui-footer",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-services",
-        "target": "ui-images"
+        "target": "ui-images",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-services",
-        "target": "ui-heros"
+        "target": "ui-heros",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-services",
-        "target": "ui-ads"
+        "target": "ui-ads",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-services",
-        "target": "nrwlio-site-feature-pages"
+        "target": "nrwlio-site-feature-pages",
+        "type": "static"
       }
     ],
     "nx-cloud-feature-billing": [
       {
-        "type": "static",
         "source": "nx-cloud-feature-billing",
-        "target": "nx-cloud-data-access-graphql"
+        "target": "nx-cloud-data-access-graphql",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-billing",
-        "target": "nx-cloud-feature-auth"
+        "target": "nx-cloud-feature-auth",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-billing",
-        "target": "nx-cloud-data-access-workspace"
+        "target": "nx-cloud-utils",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-billing",
-        "target": "nx-cloud-utils"
+        "target": "nx-cloud-data-access-workspace",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-billing",
-        "target": "nx-cloud-ui-alerts"
-      }
-    ],
-    "nrwlio-site-pages-feature-about-us": [
-      {
-        "type": "static",
-        "source": "nrwlio-site-pages-feature-about-us",
-        "target": "nrwlio-site-contentful"
-      },
-      {
-        "type": "static",
-        "source": "nrwlio-site-pages-feature-about-us",
-        "target": "nrwlio-site-ui-footer"
-      },
-      {
-        "type": "static",
-        "source": "nrwlio-site-pages-feature-about-us",
-        "target": "nrwlio-site-ui-header"
+        "target": "nx-cloud-ui-alerts",
+        "type": "static"
       }
     ],
     "nrwlio-site-pages-feature-careers": [
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-careers",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-careers",
-        "target": "shared-google-analytics"
+        "target": "shared-google-analytics",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-careers",
-        "target": "nrwlio-site-ui-header"
+        "target": "nrwlio-site-ui-header",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-careers",
-        "target": "nrwlio-site-ui-footer"
+        "target": "nrwlio-site-ui-footer",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-careers",
-        "target": "ui-contents"
+        "target": "ui-contents",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-careers",
-        "target": "ui-testimonials"
+        "target": "ui-testimonials",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-careers",
-        "target": "nrwlio-site-hubspot"
+        "target": "nrwlio-site-hubspot",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-careers",
-        "target": "nrwlio-site-feature-pages"
+        "target": "nrwlio-site-feature-pages",
+        "type": "static"
       }
     ],
     "nx-cloud-feature-terms-of-service": [],
     "platform-data-access-live-events": [],
-    "nx-docs-site-feature-file-system": [],
-    "platform-feature-nrwl-changelog": [
+    "nrwlio-site-data-access-graphql": [],
+    "nx-cloud-reference-feature-runs": [
       {
-        "type": "static",
-        "source": "platform-feature-nrwl-changelog",
-        "target": "platform-utils"
+        "source": "nx-cloud-reference-feature-runs",
+        "target": "nx-cloud-ui-alerts",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "platform-feature-nrwl-changelog",
-        "target": "platform-data-access-nrwl-changelog"
+        "source": "nx-cloud-reference-feature-runs",
+        "target": "nx-cloud-ui-breadcrumb-nav",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "platform-feature-nrwl-changelog",
-        "target": "platform-components"
+        "source": "nx-cloud-reference-feature-runs",
+        "target": "nx-cloud-ui-terminal",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "platform-feature-nrwl-changelog",
-        "target": "platform-data-access-blurb"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-nrwl-changelog",
-        "target": "shared-ui-markdown"
+        "source": "nx-cloud-reference-feature-runs",
+        "target": "nx-cloud-utils",
+        "type": "static"
       }
     ],
     "platform-feature-live-broadcast": [
       {
-        "type": "static",
         "source": "platform-feature-live-broadcast",
-        "target": "platform-utils"
+        "target": "platform-utils",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-live-broadcast",
-        "target": "platform-components"
+        "target": "platform-components",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-live-broadcast",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-live-broadcast",
-        "target": "platform-feature-auth"
+        "target": "platform-feature-auth",
+        "type": "static"
       }
     ],
-    "nrwlio-site-data-access-graphql": [],
-    "nx-cloud-reference-feature-runs": [
+    "platform-feature-nrwl-changelog": [
       {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-runs",
-        "target": "nx-cloud-ui-alerts"
+        "source": "platform-feature-nrwl-changelog",
+        "target": "platform-utils",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-runs",
-        "target": "nx-cloud-ui-breadcrumb-nav"
+        "source": "platform-feature-nrwl-changelog",
+        "target": "platform-data-access-nrwl-changelog",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-runs",
-        "target": "nx-cloud-ui-terminal"
+        "source": "platform-feature-nrwl-changelog",
+        "target": "platform-components",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-runs",
-        "target": "nx-cloud-utils"
-      }
-    ],
-    "platform-feature-organizations": [
-      {
-        "type": "static",
-        "source": "platform-feature-organizations",
-        "target": "platform-data-access-graphql"
+        "source": "platform-feature-nrwl-changelog",
+        "target": "platform-data-access-blurb",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "platform-feature-organizations",
-        "target": "platform-utils"
-      }
-    ],
-    "platform-feature-live-workshop": [
-      {
-        "type": "static",
-        "source": "platform-feature-live-workshop",
-        "target": "platform-utils"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-live-workshop",
-        "target": "platform-data-access-blurb"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-live-workshop",
-        "target": "shared-ui-markdown"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-live-workshop",
-        "target": "platform-components"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-live-workshop",
-        "target": "platform-feature-auth"
+        "source": "platform-feature-nrwl-changelog",
+        "target": "shared-ui-markdown",
+        "type": "static"
       }
     ],
     "nrwlio-site-pages-feature-home": [
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-home",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-home",
-        "target": "nrwlio-site-ui-header"
+        "target": "nrwlio-site-ui-header",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-home",
-        "target": "nrwlio-site-ui-footer"
+        "target": "nrwlio-site-ui-footer",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-home",
-        "target": "ui-floating-items"
+        "target": "nrwlio-site-ui-heros",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-home",
-        "target": "nrwlio-site-ui-heros"
+        "target": "ui-images",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-home",
-        "target": "ui-images"
+        "target": "ui-contents",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-home",
-        "target": "ui-contents"
+        "target": "ui-ads",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-home",
-        "target": "ui-ads"
+        "target": "ui-callouts",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-home",
-        "target": "ui-callouts"
+        "target": "nrwlio-site-contentful",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-pages-feature-home",
-        "target": "nrwlio-site-contentful"
-      },
-      {
-        "type": "static",
-        "source": "nrwlio-site-pages-feature-home",
-        "target": "nrwlio-site-feature-pages"
-      }
-    ],
-    "nx-cloud-reference-feature-org": [
-      {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-org",
-        "target": "nx-cloud-feature-auth"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-org",
-        "target": "nx-cloud-data-access-workspace"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-org",
-        "target": "nx-cloud-reference-feature-workspace"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-org",
-        "target": "ui-images"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-org",
-        "target": "nx-cloud-reference-feature-invite-members"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-org",
-        "target": "nx-cloud-reference-util-org-membership"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-org",
-        "target": "nx-cloud-ui-alerts"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-org",
-        "target": "nx-cloud-ui-breadcrumb-nav"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-org",
-        "target": "nx-cloud-utils"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-reference-feature-org",
-        "target": "nx-cloud-data-access-graphql"
-      }
-    ],
-    "nx-docs-site-feature-redirects": [
-      {
-        "type": "static",
-        "source": "nx-docs-site-feature-redirects",
-        "target": "nx-docs-site-base-ui"
-      },
-      {
-        "type": "static",
-        "source": "nx-docs-site-feature-redirects",
-        "target": "nx-docs-site-utils-fetcher"
+        "target": "nrwlio-site-feature-pages",
+        "type": "static"
       }
     ],
     "nx-cloud-admin-feature-support": [
       {
-        "type": "static",
         "source": "nx-cloud-admin-feature-support",
-        "target": "nx-cloud-data-access-graphql"
+        "target": "nx-cloud-data-access-graphql",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-admin-feature-support",
-        "target": "nx-cloud-utils"
+        "target": "nx-cloud-utils",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-admin-feature-support",
-        "target": "nx-cloud-feature-auth"
+        "target": "nx-cloud-feature-auth",
+        "type": "static"
       }
     ],
-    "platform-feature-organization": [
+    "nx-cloud-reference-feature-org": [
       {
-        "type": "static",
-        "source": "platform-feature-organization",
-        "target": "platform-data-access-graphql"
+        "source": "nx-cloud-reference-feature-org",
+        "target": "nx-cloud-feature-auth",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "platform-feature-organization",
-        "target": "platform-utils"
+        "source": "nx-cloud-reference-feature-org",
+        "target": "nx-cloud-data-access-workspace",
+        "type": "static"
+      },
+      {
+        "source": "nx-cloud-reference-feature-org",
+        "target": "nx-cloud-reference-feature-workspace",
+        "type": "static"
+      },
+      {
+        "source": "nx-cloud-reference-feature-org",
+        "target": "ui-images",
+        "type": "static"
+      },
+      {
+        "source": "nx-cloud-reference-feature-org",
+        "target": "nx-cloud-reference-feature-invite-members",
+        "type": "static"
+      },
+      {
+        "source": "nx-cloud-reference-feature-org",
+        "target": "nx-cloud-reference-util-org-membership",
+        "type": "static"
+      },
+      {
+        "source": "nx-cloud-reference-feature-org",
+        "target": "nx-cloud-ui-alerts",
+        "type": "static"
+      },
+      {
+        "source": "nx-cloud-reference-feature-org",
+        "target": "nx-cloud-ui-breadcrumb-nav",
+        "type": "static"
+      },
+      {
+        "source": "nx-cloud-reference-feature-org",
+        "target": "nx-cloud-utils",
+        "type": "static"
+      },
+      {
+        "source": "nx-cloud-reference-feature-org",
+        "target": "nx-cloud-data-access-graphql",
+        "type": "static"
+      }
+    ],
+    "platform-feature-live-workshop": [
+      {
+        "source": "platform-feature-live-workshop",
+        "target": "platform-utils",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-live-workshop",
+        "target": "platform-data-access-blurb",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-live-workshop",
+        "target": "shared-ui-markdown",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-live-workshop",
+        "target": "platform-components",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-live-workshop",
+        "target": "platform-feature-auth",
+        "type": "static"
+      }
+    ],
+    "platform-feature-organizations": [
+      {
+        "source": "platform-feature-organizations",
+        "target": "platform-data-access-graphql",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-organizations",
+        "target": "platform-utils",
+        "type": "static"
       }
     ],
     "platform-data-access-cookbook": [],
     "platform-feature-landing-page": [
       {
-        "type": "static",
         "source": "platform-feature-landing-page",
-        "target": "platform-utils"
+        "target": "platform-utils",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-landing-page",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       }
     ],
+    "platform-feature-organization": [
+      {
+        "source": "platform-feature-organization",
+        "target": "platform-data-access-graphql",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-organization",
+        "target": "platform-utils",
+        "type": "static"
+      }
+    ],
+    "nx-cloud-data-access-graphql": [],
+    "platform-data-access-courses": [],
     "platform-data-access-graphql": [],
     "platform-feature-live-events": [
       {
-        "type": "static",
         "source": "platform-feature-live-events",
-        "target": "platform-data-access-live-events"
+        "target": "platform-data-access-live-events",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-live-events",
-        "target": "platform-utils"
+        "target": "platform-utils",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-live-events",
-        "target": "platform-data-access-blurb"
+        "target": "platform-data-access-blurb",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-live-events",
-        "target": "platform-feature-live-broadcast"
+        "target": "platform-feature-live-broadcast",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-live-events",
-        "target": "platform-components"
+        "target": "platform-components",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-live-events",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-live-events",
-        "target": "platform-ui-twitter"
+        "target": "platform-ui-twitter",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-live-events",
-        "target": "platform-feature-auth"
+        "target": "platform-feature-auth",
+        "type": "static"
       }
     ],
-    "platform-data-access-courses": [],
-    "nx-cloud-data-access-graphql": [],
-    "nx-docs-site-feature-plugins": [
+    "nrwlio-site-ui-text-sliders": [],
+    "nx-cloud-feature-promotions": [
       {
-        "type": "static",
-        "source": "nx-docs-site-feature-plugins",
-        "target": "nx-docs-site-base-ui"
+        "source": "nx-cloud-feature-promotions",
+        "target": "nx-cloud-feature-auth",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-docs-site-feature-plugins",
-        "target": "nx-docs-site-feature-redirects"
+        "source": "nx-cloud-feature-promotions",
+        "target": "common-platform",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-docs-site-feature-plugins",
-        "target": "nx-docs-site-feature-home"
-      },
-      {
-        "type": "static",
-        "source": "nx-docs-site-feature-plugins",
-        "target": "common-site"
-      },
-      {
-        "type": "static",
-        "source": "nx-docs-site-feature-plugins",
-        "target": "nx-docs-site-utils-fetcher"
+        "source": "nx-cloud-feature-promotions",
+        "target": "common-site",
+        "type": "static"
       }
     ],
     "platform-feature-expert-bio": [
       {
-        "type": "static",
         "source": "platform-feature-expert-bio",
-        "target": "platform-utils"
+        "target": "platform-utils",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-expert-bio",
-        "target": "platform-ui-expert-bio"
+        "target": "platform-ui-expert-bio",
+        "type": "static"
       }
     ],
-    "nrwlio-site-ui-text-sliders": [],
-    "nx-docs-site-feature-search": [],
-    "nx-cloud-feature-promotions": [
-      {
-        "type": "static",
-        "source": "nx-cloud-feature-promotions",
-        "target": "nx-cloud-feature-auth"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-feature-promotions",
-        "target": "common-platform"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-feature-promotions",
-        "target": "common-site"
-      }
-    ],
-    "platform-feature-dashboard": [
-      {
-        "type": "static",
-        "source": "platform-feature-dashboard",
-        "target": "shared-ui-markdown"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-dashboard",
-        "target": "platform-data-access-courses"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-dashboard",
-        "target": "platform-data-access-blurb"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-dashboard",
-        "target": "platform-data-access-graphql"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-dashboard",
-        "target": "platform-utils"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-dashboard",
-        "target": "platform-data-access-book"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-dashboard",
-        "target": "platform-data-access-nrwl-changelog"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-dashboard",
-        "target": "platform-data-access-live-events"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-dashboard",
-        "target": "platform-data-access-cookbook"
-      }
-    ],
-    "platform-data-access-blurb": [],
-    "nx-docs-site-utils-fetcher": [],
     "design-system-testimonials": [
       {
-        "type": "static",
         "source": "design-system-testimonials",
-        "target": "design-system-images"
+        "target": "design-system-styles",
+        "type": "implicit"
       },
       {
-        "type": "static",
         "source": "design-system-testimonials",
-        "target": "shared-ui-markdown"
+        "target": "design-system-images",
+        "type": "static"
       },
       {
-        "type": "implicit",
         "source": "design-system-testimonials",
-        "target": "design-system-styles"
+        "target": "shared-ui-markdown",
+        "type": "static"
       }
     ],
     "nx-cloud-ui-breadcrumb-nav": [],
-    "platform-data-access-book": [],
-    "nx-docs-site-feature-home": [
+    "platform-data-access-blurb": [],
+    "platform-feature-dashboard": [
       {
-        "type": "static",
-        "source": "nx-docs-site-feature-home",
-        "target": "common-site"
+        "source": "platform-feature-dashboard",
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-docs-site-feature-home",
-        "target": "nx-docs-site-utils-fetcher"
+        "source": "platform-feature-dashboard",
+        "target": "platform-data-access-courses",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-docs-site-feature-home",
-        "target": "shared-google-analytics"
+        "source": "platform-feature-dashboard",
+        "target": "platform-data-access-blurb",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-docs-site-feature-home",
-        "target": "nx-docs-site-base-ui"
+        "source": "platform-feature-dashboard",
+        "target": "platform-data-access-graphql",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-docs-site-feature-home",
-        "target": "nx-docs-site-feature-redirects"
+        "source": "platform-feature-dashboard",
+        "target": "platform-utils",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-dashboard",
+        "target": "platform-data-access-book",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-dashboard",
+        "target": "platform-data-access-nrwl-changelog",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-dashboard",
+        "target": "platform-data-access-live-events",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-dashboard",
+        "target": "platform-data-access-cookbook",
+        "type": "static"
       }
     ],
+    "nrwlio-site-feature-pages": [
+      {
+        "source": "nrwlio-site-feature-pages",
+        "target": "shared-ui-markdown",
+        "type": "static"
+      },
+      {
+        "source": "nrwlio-site-feature-pages",
+        "target": "nrwlio-site-ui-header",
+        "type": "static"
+      },
+      {
+        "source": "nrwlio-site-feature-pages",
+        "target": "nrwlio-site-ui-footer",
+        "type": "static"
+      },
+      {
+        "source": "nrwlio-site-feature-pages",
+        "target": "nrwlio-site-contentful",
+        "type": "static"
+      },
+      {
+        "source": "nrwlio-site-feature-pages",
+        "target": "common-platform",
+        "type": "static"
+      }
+    ],
+    "nx-cloud-feature-policies": [],
+    "platform-data-access-book": [],
     "platform-feature-cookbook": [
       {
-        "type": "static",
         "source": "platform-feature-cookbook",
-        "target": "platform-data-access-cookbook"
+        "target": "platform-data-access-cookbook",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-cookbook",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-cookbook",
-        "target": "platform-components"
+        "target": "platform-components",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-cookbook",
-        "target": "platform-data-access-blurb"
+        "target": "platform-data-access-blurb",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-cookbook",
-        "target": "platform-ui-twitter"
+        "target": "platform-ui-twitter",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-cookbook",
-        "target": "platform-feature-auth"
+        "target": "platform-feature-auth",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-cookbook",
-        "target": "platform-utils"
+        "target": "platform-utils",
+        "type": "static"
       }
     ],
     "platform-feature-policies": [
       {
-        "type": "static",
         "source": "platform-feature-policies",
-        "target": "platform-utils"
+        "target": "platform-utils",
+        "type": "static"
       }
     ],
     "shared-utils-download-csv": [],
-    "nrwlio-site-feature-pages": [
-      {
-        "type": "static",
-        "source": "nrwlio-site-feature-pages",
-        "target": "shared-ui-markdown"
-      },
-      {
-        "type": "static",
-        "source": "nrwlio-site-feature-pages",
-        "target": "nrwlio-site-ui-header"
-      },
-      {
-        "type": "static",
-        "source": "nrwlio-site-feature-pages",
-        "target": "nrwlio-site-ui-footer"
-      },
-      {
-        "type": "static",
-        "source": "nrwlio-site-feature-pages",
-        "target": "nrwlio-site-contentful"
-      },
-      {
-        "type": "static",
-        "source": "nrwlio-site-feature-pages",
-        "target": "common-platform"
-      }
-    ],
-    "nx-cloud-feature-policies": [],
-    "platform-feature-courses": [
-      {
-        "type": "static",
-        "source": "platform-feature-courses",
-        "target": "platform-components"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-courses",
-        "target": "platform-data-access-blurb"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-courses",
-        "target": "platform-data-access-courses"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-courses",
-        "target": "platform-feature-auth"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-courses",
-        "target": "platform-ui-courses"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-courses",
-        "target": "platform-ui-twitter"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-courses",
-        "target": "shared-ui-markdown"
-      }
-    ],
-    "platform-feature-reports": [
-      {
-        "type": "static",
-        "source": "platform-feature-reports",
-        "target": "shared-utils-download-csv"
-      }
-    ],
     "nx-cloud-feature-landing": [
       {
-        "type": "static",
         "source": "nx-cloud-feature-landing",
-        "target": "nx-cloud-feature-auth"
+        "target": "nx-cloud-feature-auth",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-landing",
-        "target": "nx-cloud-ui-footer"
+        "target": "nx-cloud-ui-footer",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-landing",
-        "target": "ui-heros"
+        "target": "ui-heros",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-landing",
-        "target": "ui-articles"
+        "target": "ui-articles",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-landing",
-        "target": "ui-floating-items"
+        "target": "ui-ads",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-landing",
-        "target": "ui-ads"
+        "target": "ui-images",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-landing",
-        "target": "ui-images"
-      },
-      {
-        "type": "static",
-        "source": "nx-cloud-feature-landing",
-        "target": "ui-article-media"
+        "target": "ui-article-media",
+        "type": "static"
       }
     ],
     "nx-cloud-feature-pricing": [
       {
-        "type": "static",
         "source": "nx-cloud-feature-pricing",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-pricing",
-        "target": "ui-images"
+        "target": "ui-images",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-pricing",
-        "target": "nx-cloud-data-access-graphql"
+        "target": "nx-cloud-data-access-graphql",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-pricing",
-        "target": "nx-cloud-hubspot"
+        "target": "nx-cloud-hubspot",
+        "type": "static"
+      }
+    ],
+    "platform-feature-courses": [
+      {
+        "source": "platform-feature-courses",
+        "target": "platform-components",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-courses",
+        "target": "platform-data-access-blurb",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-courses",
+        "target": "platform-data-access-courses",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-courses",
+        "target": "platform-feature-auth",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-courses",
+        "target": "platform-ui-courses",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-courses",
+        "target": "platform-ui-twitter",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-courses",
+        "target": "shared-ui-markdown",
+        "type": "static"
+      }
+    ],
+    "platform-feature-reports": [
+      {
+        "source": "platform-feature-reports",
+        "target": "shared-utils-download-csv",
+        "type": "static"
       }
     ],
     "platform-feature-topics": [
       {
-        "type": "static",
         "source": "platform-feature-topics",
-        "target": "platform-components"
+        "target": "platform-components",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-topics",
-        "target": "platform-data-access-blurb"
+        "target": "platform-data-access-blurb",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-topics",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-topics",
-        "target": "platform-ui-twitter"
+        "target": "platform-ui-twitter",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-topics",
-        "target": "platform-feature-auth"
+        "target": "platform-feature-auth",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-topics",
-        "target": "platform-utils"
+        "target": "platform-utils",
+        "type": "static"
       }
     ],
     "shared-google-analytics": [],
-    "platform-feature-users": [
+    "design-system-contents": [
       {
-        "type": "static",
-        "source": "platform-feature-users",
-        "target": "platform-data-access-graphql"
+        "source": "design-system-contents",
+        "target": "design-system-styles",
+        "type": "implicit"
       },
       {
-        "type": "static",
-        "source": "platform-feature-users",
-        "target": "platform-utils"
-      }
-    ],
-    "platform-feature-books": [
-      {
-        "type": "static",
-        "source": "platform-feature-books",
-        "target": "platform-utils"
+        "source": "design-system-contents",
+        "target": "design-system-images",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "platform-feature-books",
-        "target": "platform-data-access-book"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-books",
-        "target": "platform-data-access-blurb"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-books",
-        "target": "platform-components"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-books",
-        "target": "platform-ui-twitter"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-books",
-        "target": "platform-feature-auth"
-      },
-      {
-        "type": "static",
-        "source": "platform-feature-books",
-        "target": "shared-ui-markdown"
-      }
-    ],
-    "platform-ui-expert-bio": [
-      {
-        "type": "static",
-        "source": "platform-ui-expert-bio",
-        "target": "shared-ui-markdown"
+        "source": "design-system-contents",
+        "target": "shared-ui-markdown",
+        "type": "static"
       }
     ],
     "nrwlio-site-contentful": [
       {
-        "type": "static",
         "source": "nrwlio-site-contentful",
-        "target": "ui-ads"
+        "target": "ui-ads",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-contentful",
-        "target": "ui-articles"
+        "target": "ui-articles",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-contentful",
-        "target": "ui-contents"
+        "target": "ui-contents",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-contentful",
-        "target": "ui-downloads"
+        "target": "ui-downloads",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-contentful",
-        "target": "ui-heros"
+        "target": "ui-heros",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-contentful",
-        "target": "ui-features"
+        "target": "ui-features",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-contentful",
-        "target": "ui-testimonials"
+        "target": "ui-testimonials",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-contentful",
-        "target": "nrwlio-site-hubspot"
+        "target": "nrwlio-site-hubspot",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-contentful",
-        "target": "common-platform"
+        "target": "common-platform",
+        "type": "static"
       }
     ],
     "platform-feature-about": [
       {
-        "type": "static",
         "source": "platform-feature-about",
-        "target": "platform-utils"
+        "target": "platform-utils",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-about",
-        "target": "platform-data-access-blurb"
+        "target": "platform-data-access-blurb",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-feature-about",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       }
     ],
-    "design-system-contents": [
+    "platform-feature-books": [
       {
-        "type": "static",
-        "source": "design-system-contents",
-        "target": "design-system-images"
+        "source": "platform-feature-books",
+        "target": "platform-utils",
+        "type": "static"
       },
       {
-        "type": "implicit",
-        "source": "design-system-contents",
-        "target": "design-system-styles"
+        "source": "platform-feature-books",
+        "target": "platform-data-access-book",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "design-system-contents",
-        "target": "shared-ui-markdown"
+        "source": "platform-feature-books",
+        "target": "platform-data-access-blurb",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-books",
+        "target": "platform-components",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-books",
+        "target": "platform-ui-twitter",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-books",
+        "target": "platform-feature-auth",
+        "type": "static"
+      },
+      {
+        "source": "platform-feature-books",
+        "target": "shared-ui-markdown",
+        "type": "static"
       }
     ],
-    "platform-feature-auth": [
+    "platform-feature-users": [
       {
-        "type": "static",
-        "source": "platform-feature-auth",
-        "target": "platform-utils"
+        "source": "platform-feature-users",
+        "target": "platform-data-access-graphql",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "platform-feature-auth",
-        "target": "platform-data-access-graphql"
+        "source": "platform-feature-users",
+        "target": "platform-utils",
+        "type": "static"
       }
     ],
-    "nrwlio-site-ui-styles": [],
+    "platform-ui-expert-bio": [
+      {
+        "source": "platform-ui-expert-bio",
+        "target": "shared-ui-markdown",
+        "type": "static"
+      }
+    ],
     "nrwlio-site-ui-footer": [
       {
-        "type": "static",
         "source": "nrwlio-site-ui-footer",
-        "target": "nrwlio-site-hubspot"
+        "target": "nrwlio-site-hubspot",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio-site-ui-footer",
-        "target": "shared-google-analytics"
+        "target": "shared-google-analytics",
+        "type": "static"
       }
     ],
     "nrwlio-site-ui-header": [],
+    "nrwlio-site-ui-styles": [],
     "nx-cloud-feature-auth": [
       {
-        "type": "static",
         "source": "nx-cloud-feature-auth",
-        "target": "nx-cloud-data-access-graphql"
+        "target": "nx-cloud-data-access-graphql",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-auth",
-        "target": "nx-cloud-utils"
+        "target": "nx-cloud-utils",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-feature-auth",
-        "target": "platform-data-access-graphql"
+        "target": "platform-data-access-graphql",
+        "type": "static"
+      }
+    ],
+    "nx-cloud-feature-docs": [
+      {
+        "source": "nx-cloud-feature-docs",
+        "target": "nx-cloud-data-access-graphql",
+        "type": "static"
       }
     ],
     "nx-cloud-ui-sparkline": [],
-    "nx-cloud-feature-docs": [
+    "platform-feature-auth": [
       {
-        "type": "static",
-        "source": "nx-cloud-feature-docs",
-        "target": "nx-cloud-data-access-graphql"
-      }
-    ],
-    "nx-packages-nx-cloud": [],
-    "nx-docs-site-base-ui": [
-      {
-        "type": "static",
-        "source": "nx-docs-site-base-ui",
-        "target": "nx-docs-site-styles"
+        "source": "platform-feature-auth",
+        "target": "platform-utils",
+        "type": "static"
       },
       {
-        "type": "static",
-        "source": "nx-docs-site-base-ui",
-        "target": "nx-docs-site-feature-search"
-      },
-      {
-        "type": "static",
-        "source": "nx-docs-site-base-ui",
-        "target": "nx-docs-site-utils-fetcher"
+        "source": "platform-feature-auth",
+        "target": "platform-data-access-graphql",
+        "type": "static"
       }
     ],
-    "nrwlio-site-ui-heros": [
-      {
-        "type": "static",
-        "source": "nrwlio-site-ui-heros",
-        "target": "shared-ui-markdown"
-      },
-      {
-        "type": "static",
-        "source": "nrwlio-site-ui-heros",
-        "target": "nrwlio-site-ui-text-sliders"
-      },
-      {
-        "type": "static",
-        "source": "nrwlio-site-ui-heros",
-        "target": "ui-images"
-      }
-    ],
-    "ui-article-container": [],
-    "nx-cloud-feature-faq": [
-      {
-        "type": "static",
-        "source": "nx-cloud-feature-faq",
-        "target": "shared-ui-markdown"
-      }
-    ],
-    "design-system-styles": [],
     "design-system-heroes": [
       {
-        "type": "static",
         "source": "design-system-heroes",
-        "target": "design-system-images"
+        "target": "design-system-styles",
+        "type": "implicit"
       },
       {
-        "type": "implicit",
         "source": "design-system-heroes",
-        "target": "design-system-styles"
+        "target": "design-system-images",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "design-system-heroes",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       }
     ],
     "design-system-images": [
       {
-        "type": "implicit",
         "source": "design-system-images",
-        "target": "design-system-styles"
+        "target": "design-system-styles",
+        "type": "implicit"
+      }
+    ],
+    "design-system-styles": [],
+    "nrwlio-site-ui-heros": [
+      {
+        "source": "nrwlio-site-ui-heros",
+        "target": "shared-ui-markdown",
+        "type": "static"
+      },
+      {
+        "source": "nrwlio-site-ui-heros",
+        "target": "nrwlio-site-ui-text-sliders",
+        "type": "static"
+      },
+      {
+        "source": "nrwlio-site-ui-heros",
+        "target": "ui-images",
+        "type": "static"
+      }
+    ],
+    "nx-cloud-feature-faq": [
+      {
+        "source": "nx-cloud-feature-faq",
+        "target": "shared-ui-markdown",
+        "type": "static"
       }
     ],
     "nx-cloud-ui-terminal": [
       {
-        "type": "static",
         "source": "nx-cloud-ui-terminal",
-        "target": "nx-cloud-utils"
+        "target": "nx-cloud-utils",
+        "type": "static"
       }
     ],
+    "nx-packages-nx-cloud": [],
+    "ui-article-container": [],
+    "nrwlio-site-hubspot": [],
     "platform-components": [
       {
-        "type": "static",
         "source": "platform-components",
-        "target": "platform-data-access-graphql"
+        "target": "platform-data-access-graphql",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform-components",
-        "target": "platform-utils"
+        "target": "platform-utils",
+        "type": "static"
       }
     ],
     "platform-scss-utils": [],
-    "nx-docs-site-styles": [],
     "platform-ui-courses": [
       {
-        "type": "static",
         "source": "platform-ui-courses",
-        "target": "platform-data-access-courses"
+        "target": "platform-data-access-courses",
+        "type": "static"
       }
     ],
     "platform-ui-twitter": [],
-    "nrwlio-site-hubspot": [],
-    "shared-ui-markdown": [],
+    "nrwl-api-reporting": [],
     "nrwlio-site-assets": [],
-    "nx-cloud-ui-styles": [],
+    "nx-cloud-ui-alerts": [],
+    "nx-cloud-ui-footer": [],
     "nx-cloud-ui-header": [
       {
-        "type": "static",
         "source": "nx-cloud-ui-header",
-        "target": "nx-cloud-data-access-graphql"
+        "target": "nx-cloud-data-access-graphql",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-ui-header",
-        "target": "nx-cloud-utils"
+        "target": "nx-cloud-utils",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-ui-header",
-        "target": "nx-cloud-feature-billing"
+        "target": "nx-cloud-feature-billing",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-ui-header",
-        "target": "nx-cloud-admin-feature-support"
+        "target": "nx-cloud-admin-feature-support",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-ui-header",
-        "target": "nx-cloud-feature-auth"
+        "target": "nx-cloud-feature-auth",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud-ui-header",
-        "target": "ui-images"
+        "target": "ui-images",
+        "type": "static"
       }
     ],
-    "nx-cloud-ui-footer": [],
-    "nx-cloud-ui-alerts": [],
-    "nrwl-api-reporting": [],
-    "private-nx-cloud": [],
-    "ui-floating-items": [
-      { "type": "static", "source": "ui-floating-items", "target": "ui-images" }
-    ],
+    "nx-cloud-ui-styles": [],
+    "shared-ui-markdown": [],
     "design-system-e2e": [
       {
-        "type": "implicit",
         "source": "design-system-e2e",
-        "target": "design-system"
+        "target": "design-system",
+        "type": "implicit"
       }
     ],
-    "nx-docs-site-e2e": [
-      {
-        "type": "implicit",
-        "source": "nx-docs-site-e2e",
-        "target": "nx-docs-site"
-      }
-    ],
+    "private-nx-cloud": [],
+    "nx-cloud-hubspot": [],
     "ui-article-media": [
       {
-        "type": "static",
         "source": "ui-article-media",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
-      { "type": "static", "source": "ui-article-media", "target": "ui-images" }
+      { "source": "ui-article-media", "target": "ui-images", "type": "static" }
     ],
-    "nx-cloud-hubspot": [],
     "common-platform": [],
     "nrwlio-site-pwa": [],
-    "ui-testimonials": [
-      { "type": "static", "source": "ui-testimonials", "target": "ui-images" },
+    "nx-cloud-assets": [],
+    "nx-packages-e2e": [
+      { "source": "nx-packages-e2e", "target": "nx-api", "type": "implicit" },
       {
-        "type": "static",
-        "source": "ui-testimonials",
-        "target": "shared-ui-markdown"
+        "source": "nx-packages-e2e",
+        "target": "nx-packages-nx-cloud",
+        "type": "implicit"
       }
     ],
-    "nx-cloud-assets": [],
-    "platform-utils": [
+    "ui-testimonials": [
+      { "source": "ui-testimonials", "target": "ui-images", "type": "static" },
       {
-        "type": "static",
-        "source": "platform-utils",
-        "target": "platform-data-access-graphql"
+        "source": "ui-testimonials",
+        "target": "shared-ui-markdown",
+        "type": "static"
       }
     ],
     "nx-cloud-utils": [
       {
-        "type": "static",
         "source": "nx-cloud-utils",
-        "target": "nx-cloud-data-access-graphql"
+        "target": "nx-cloud-data-access-graphql",
+        "type": "static"
       }
     ],
-    "nx-docs-site": [
+    "platform-utils": [
       {
-        "type": "static",
-        "source": "nx-docs-site",
-        "target": "nx-docs-site-base-ui"
-      },
-      {
-        "type": "static",
-        "source": "nx-docs-site",
-        "target": "common-platform"
-      },
-      {
-        "type": "static",
-        "source": "nx-docs-site",
-        "target": "nx-docs-site-utils-fetcher"
-      },
-      {
-        "type": "static",
-        "source": "nx-docs-site",
-        "target": "nx-docs-site-feature-search"
-      },
-      {
-        "type": "dynamic",
-        "source": "nx-docs-site",
-        "target": "nx-docs-site-feature-plugins"
-      },
-      {
-        "type": "dynamic",
-        "source": "nx-docs-site",
-        "target": "nx-docs-site-feature-documentation"
-      },
-      {
-        "type": "dynamic",
-        "source": "nx-docs-site",
-        "target": "nx-docs-site-feature-home"
-      },
-      {
-        "type": "static",
-        "source": "nx-docs-site",
-        "target": "nx-docs-site-feature-file-system"
+        "source": "platform-utils",
+        "target": "platform-data-access-graphql",
+        "type": "static"
       }
     ],
     "design-system": [
       {
-        "type": "implicit",
         "source": "design-system",
-        "target": "design-system-heroes"
+        "target": "design-system-styles",
+        "type": "implicit"
       },
       {
-        "type": "implicit",
         "source": "design-system",
-        "target": "design-system-contents"
+        "target": "design-system-heroes",
+        "type": "implicit"
       },
       {
-        "type": "implicit",
         "source": "design-system",
-        "target": "design-system-testimonials"
+        "target": "design-system-images",
+        "type": "implicit"
       },
       {
-        "type": "implicit",
         "source": "design-system",
-        "target": "design-system-images"
+        "target": "design-system-contents",
+        "type": "implicit"
       },
       {
-        "type": "implicit",
         "source": "design-system",
-        "target": "design-system-styles"
+        "target": "design-system-testimonials",
+        "type": "implicit"
       }
-    ],
-    "platform-e2e": [
-      { "type": "implicit", "source": "platform-e2e", "target": "platform" }
     ],
     "nrwl-api-e2e": [
-      { "type": "implicit", "source": "nrwl-api-e2e", "target": "nrwl-api" }
+      { "source": "nrwl-api-e2e", "target": "nrwl-api", "type": "static" }
     ],
     "nx-cloud-e2e": [
-      { "type": "implicit", "source": "nx-cloud-e2e", "target": "nrwl-api" },
-      { "type": "implicit", "source": "nx-cloud-e2e", "target": "nx-cloud" }
+      { "source": "nx-cloud-e2e", "target": "nrwl-api", "type": "implicit" }
     ],
+    "platform-e2e": [],
     "ui-downloads": [
       {
-        "type": "static",
         "source": "ui-downloads",
-        "target": "shared-google-analytics"
+        "target": "shared-google-analytics",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "ui-downloads",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
-      { "type": "static", "source": "ui-downloads", "target": "ui-images" }
+      { "source": "ui-downloads", "target": "ui-images", "type": "static" }
     ],
+    "cloud-proxy": [],
     "common-site": [
-      { "type": "static", "source": "common-site", "target": "common-platform" }
+      { "source": "common-site", "target": "common-platform", "type": "static" }
     ],
-    "ui-contents": [
-      {
-        "type": "static",
-        "source": "ui-contents",
-        "target": "shared-ui-markdown"
-      },
-      { "type": "static", "source": "ui-contents", "target": "ui-images" }
-    ],
-    "ui-features": [
-      { "type": "static", "source": "ui-features", "target": "ui-images" },
-      {
-        "type": "static",
-        "source": "ui-features",
-        "target": "shared-ui-markdown"
-      }
-    ],
+    "file-server": [],
     "ui-articles": [
       {
-        "type": "static",
         "source": "ui-articles",
-        "target": "shared-ui-markdown"
+        "target": "shared-ui-markdown",
+        "type": "static"
       },
-      { "type": "static", "source": "ui-articles", "target": "ui-images" }
+      { "source": "ui-articles", "target": "ui-images", "type": "static" }
     ],
     "ui-callouts": [],
-    "file-server": [],
-    "cloud-proxy": [],
-    "nrwlio-e2e": [
-      { "type": "implicit", "source": "nrwlio-e2e", "target": "nrwlio" }
+    "ui-contents": [
+      {
+        "source": "ui-contents",
+        "target": "shared-ui-markdown",
+        "type": "static"
+      },
+      { "source": "ui-contents", "target": "ui-images", "type": "static" }
     ],
+    "ui-features": [
+      { "source": "ui-features", "target": "ui-images", "type": "static" },
+      {
+        "source": "ui-features",
+        "target": "shared-ui-markdown",
+        "type": "static"
+      }
+    ],
+    "nrwlio-e2e": [],
     "ui-banners": [],
     "platform": [
       {
-        "type": "static",
         "source": "platform",
-        "target": "platform-data-access-graphql"
+        "target": "platform-data-access-graphql",
+        "type": "static"
       },
-      { "type": "static", "source": "platform", "target": "platform-utils" },
+      { "source": "platform", "target": "platform-utils", "type": "static" },
       {
-        "type": "static",
         "source": "platform",
-        "target": "platform-data-access-blurb"
-      },
-      {
-        "type": "static",
-        "source": "platform",
-        "target": "platform-components"
+        "target": "platform-data-access-blurb",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform",
-        "target": "platform-feature-auth"
+        "target": "platform-components",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "platform",
-        "target": "platform-feature-landing-page"
+        "target": "platform-feature-auth",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-dashboard"
+        "target": "platform-feature-landing-page",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-books"
+        "target": "platform-feature-dashboard",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-topics"
+        "target": "platform-feature-books",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-cookbook"
+        "target": "platform-feature-topics",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-live-events"
+        "target": "platform-feature-cookbook",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-nrwl-changelog"
+        "target": "platform-feature-live-events",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-users"
+        "target": "platform-feature-nrwl-changelog",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-organizations"
+        "target": "platform-feature-users",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-organization"
+        "target": "platform-feature-organizations",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-courses"
+        "target": "platform-feature-organization",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-expert-bio"
+        "target": "platform-feature-courses",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-policies"
+        "target": "platform-feature-expert-bio",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-live-broadcast"
+        "target": "platform-feature-policies",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-live-workshop"
+        "target": "platform-feature-live-broadcast",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-reports"
+        "target": "platform-feature-live-workshop",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "platform",
-        "target": "platform-feature-about"
+        "target": "platform-feature-reports",
+        "type": "static"
+      },
+      {
+        "source": "platform",
+        "target": "platform-feature-about",
+        "type": "static"
       }
     ],
     "ui-images": [],
     "ui-styles": [],
     "nrwl-api": [
-      { "type": "static", "source": "nrwl-api", "target": "nrwl-api-reporting" }
+      { "source": "nrwl-api", "target": "nrwl-api-reporting", "type": "static" }
     ],
     "nx-cloud": [
+      { "source": "nx-cloud", "target": "nx-cloud-assets", "type": "implicit" },
+      { "source": "nx-cloud", "target": "nx-cloud-utils", "type": "static" },
       {
-        "type": "static",
         "source": "nx-cloud",
-        "target": "nx-cloud-data-access-graphql"
+        "target": "nx-cloud-data-access-graphql",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud",
-        "target": "nx-cloud-feature-auth"
+        "target": "nx-cloud-feature-auth",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud",
-        "target": "nx-cloud-ui-footer"
+        "target": "nx-cloud-ui-footer",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nx-cloud",
-        "target": "nx-cloud-ui-header"
+        "target": "nx-cloud-ui-header",
+        "type": "static"
       },
-      { "type": "static", "source": "nx-cloud", "target": "nx-cloud-utils" },
-      { "type": "static", "source": "nx-cloud", "target": "nx-cloud-hubspot" },
+      { "source": "nx-cloud", "target": "nx-cloud-hubspot", "type": "static" },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-feature-docs"
-      },
-      {
-        "type": "dynamic",
-        "source": "nx-cloud",
-        "target": "nx-cloud-private-cloud-feature-home"
+        "target": "nx-cloud-feature-docs",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-feature-landing"
+        "target": "nx-cloud-private-cloud-feature-home",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-reference-feature-org"
+        "target": "nx-cloud-feature-landing",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-reference-feature-invite-members"
+        "target": "nx-cloud-reference-feature-org",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-reference-feature-runs"
+        "target": "nx-cloud-reference-feature-invite-members",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-reference-feature-branches"
+        "target": "nx-cloud-reference-feature-runs",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-feature-promotions"
+        "target": "nx-cloud-reference-feature-branches",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-feature-policies"
+        "target": "nx-cloud-feature-promotions",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-feature-faq"
+        "target": "nx-cloud-feature-policies",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-feature-terms-of-service"
+        "target": "nx-cloud-feature-faq",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-feature-make-ng-cli-faster"
+        "target": "nx-cloud-feature-terms-of-service",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-feature-pricing"
+        "target": "nx-cloud-feature-make-ng-cli-faster",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-private-cloud-feature-community-on-public-cloud"
+        "target": "nx-cloud-feature-pricing",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-private-cloud-feature-installation"
+        "target": "nx-cloud-private-cloud-feature-community-on-public-cloud",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nx-cloud",
-        "target": "nx-cloud-private-cloud-feature-instructions"
-      },
-      { "type": "implicit", "source": "nx-cloud", "target": "nx-cloud-assets" }
+        "target": "nx-cloud-private-cloud-feature-installation",
+        "type": "static"
+      }
     ],
     "ui-heros": [
-      { "type": "static", "source": "ui-heros", "target": "ui-images" },
-      { "type": "static", "source": "ui-heros", "target": "shared-ui-markdown" }
+      { "source": "ui-heros", "target": "ui-images", "type": "static" },
+      { "source": "ui-heros", "target": "shared-ui-markdown", "type": "static" }
     ],
     "nx-api": [],
     "nrwlio": [
       {
-        "type": "dynamic",
         "source": "nrwlio",
-        "target": "nrwlio-site-pages-feature-home"
+        "target": "nrwlio-site-pages-feature-home",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nrwlio",
-        "target": "nrwlio-site-pages-feature-services"
+        "target": "nrwlio-site-pages-feature-services",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nrwlio",
-        "target": "nrwlio-site-pages-feature-about-us"
+        "target": "nrwlio-site-pages-feature-about-us",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nrwlio",
-        "target": "nrwlio-site-pages-feature-products"
+        "target": "nrwlio-site-pages-feature-products",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nrwlio",
-        "target": "nrwlio-site-pages-feature-contact-us"
+        "target": "nrwlio-site-pages-feature-contact-us",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nrwlio",
-        "target": "nrwlio-site-pages-feature-careers"
+        "target": "nrwlio-site-pages-feature-careers",
+        "type": "static"
       },
       {
-        "type": "dynamic",
         "source": "nrwlio",
-        "target": "nrwlio-site-pages-feature-style-guide"
+        "target": "nrwlio-site-pages-feature-style-guide",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio",
-        "target": "nrwlio-site-data-access-graphql"
+        "target": "nrwlio-site-data-access-graphql",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio",
-        "target": "nrwlio-site-contentful"
+        "target": "nrwlio-site-contentful",
+        "type": "static"
       },
       {
-        "type": "static",
         "source": "nrwlio",
-        "target": "nrwlio-site-feature-pages"
+        "target": "nrwlio-site-feature-pages",
+        "type": "static"
       },
-      { "type": "static", "source": "nrwlio", "target": "nrwlio-site-pwa" },
-      { "type": "static", "source": "nrwlio", "target": "nrwlio-site-hubspot" },
-      { "type": "static", "source": "nrwlio", "target": "common-platform" }
+      { "source": "nrwlio", "target": "nrwlio-site-hubspot", "type": "static" },
+      { "source": "nrwlio", "target": "common-platform", "type": "static" }
     ],
     "ui-ads": [
-      { "type": "static", "source": "ui-ads", "target": "shared-ui-markdown" },
-      { "type": "static", "source": "ui-ads", "target": "ui-images" }
+      { "source": "ui-ads", "target": "shared-ui-markdown", "type": "static" },
+      { "source": "ui-ads", "target": "ui-images", "type": "static" }
     ]
   },
+  "layout": { "appsDir": "apps", "libsDir": "libs" },
   "changes": { "added": [] },
   "affected": [],
   "focus": null,
-  "exclude": [],
-  "groupByFolder": false
+  "groupByFolder": false,
+  "exclude": []
 }

--- a/dep-graph/dep-graph/src/assets/graphs/storybook.json
+++ b/dep-graph/dep-graph/src/assets/graphs/storybook.json
@@ -1,427 +1,2518 @@
 {
-  "hash": "7445d9a8bf17ebecd946963df33923249ab722178149f80394c70138d677eaa9",
-  "layout": { "appsDir": "apps", "libsDir": "libs" },
+  "hash": "c8e83d3404dae40dbf14d99157b763c2d0ad0c5fec363244d2ef84caa1152fef",
   "projects": [
     {
       "name": "@storybook/addon-storyshots-puppeteer",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/storyshots/storyshots-puppeteer" }
+      "data": {
+        "tags": [],
+        "root": "addons/storyshots/storyshots-puppeteer",
+        "files": []
+      }
     },
     {
       "name": "web-components-kitchen-sink",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/web-components-kitchen-sink" }
+      "data": {
+        "tags": [],
+        "root": "examples/web-components-kitchen-sink",
+        "files": []
+      }
     },
     {
       "name": "@storybook/addon-storyshots",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/storyshots/storyshots-core" }
+      "data": {
+        "tags": [],
+        "root": "addons/storyshots/storyshots-core",
+        "files": []
+      }
     },
     {
       "name": "cra-ts-kitchen-sink",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/cra-ts-kitchen-sink" }
+      "data": {
+        "tags": [],
+        "root": "examples/cra-ts-kitchen-sink",
+        "files": []
+      }
     },
     {
       "name": "preact-example",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/preact-kitchen-sink" }
+      "data": {
+        "tags": [],
+        "root": "examples/preact-kitchen-sink",
+        "files": []
+      }
     },
     {
       "name": "server-kitchen-sink",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/server-kitchen-sink" }
+      "data": {
+        "tags": [],
+        "root": "examples/server-kitchen-sink",
+        "files": []
+      }
     },
     {
       "name": "svelte-example",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/svelte-kitchen-sink" }
+      "data": {
+        "tags": [],
+        "root": "examples/svelte-kitchen-sink",
+        "files": []
+      }
     },
     {
       "name": "official-storybook",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/official-storybook" }
+      "data": { "tags": [], "root": "examples/official-storybook", "files": [] }
     },
     {
       "name": "standalone-preview",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/standalone-preview" }
-    },
-    {
-      "name": "cra-ts-essentials",
-      "type": "lib",
-      "data": { "tags": [], "root": "examples/cra-ts-essentials" }
-    },
-    {
-      "name": "html-kitchen-sink",
-      "type": "lib",
-      "data": { "tags": [], "root": "examples/html-kitchen-sink" }
+      "data": { "tags": [], "root": "examples/standalone-preview", "files": [] }
     },
     {
       "name": "@storybook/example-react-ts-webpack4",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/react-ts-webpack4" }
+      "data": { "tags": [], "root": "examples/react-ts-webpack4", "files": [] }
+    },
+    {
+      "name": "cra-ts-essentials",
+      "type": "lib",
+      "data": { "tags": [], "root": "examples/cra-ts-essentials", "files": [] }
+    },
+    {
+      "name": "html-kitchen-sink",
+      "type": "lib",
+      "data": { "tags": [], "root": "examples/html-kitchen-sink", "files": [] }
     },
     {
       "name": "cra-kitchen-sink",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/cra-kitchen-sink" }
+      "data": { "tags": [], "root": "examples/cra-kitchen-sink", "files": [] }
     },
     {
       "name": "vue-example",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/vue-kitchen-sink" }
+      "data": { "tags": [], "root": "examples/vue-kitchen-sink", "files": [] }
     },
     {
       "name": "@storybook/channel-postmessage",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/channel-postmessage" }
+      "data": { "tags": [], "root": "lib/channel-postmessage", "files": [] }
     },
     {
       "name": "@storybook/channel-websocket",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/channel-websocket" }
-    },
-    {
-      "name": "@storybook/manager-webpack4",
-      "type": "lib",
-      "data": { "tags": [], "root": "lib/manager-webpack4" }
-    },
-    {
-      "name": "@storybook/manager-webpack5",
-      "type": "lib",
-      "data": { "tags": [], "root": "lib/manager-webpack5" }
-    },
-    {
-      "name": "angular-cli",
-      "type": "lib",
-      "data": { "tags": [], "root": "examples/angular-cli" }
-    },
-    {
-      "name": "cra-react15",
-      "type": "lib",
-      "data": { "tags": [], "root": "examples/cra-react15" }
+      "data": { "tags": [], "root": "lib/channel-websocket", "files": [] }
     },
     {
       "name": "@storybook/builder-webpack4",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/builder-webpack4" }
+      "data": { "tags": [], "root": "lib/builder-webpack4", "files": [] }
     },
     {
       "name": "@storybook/builder-webpack5",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/builder-webpack5" }
+      "data": { "tags": [], "root": "lib/builder-webpack5", "files": [] }
+    },
+    {
+      "name": "@storybook/manager-webpack4",
+      "type": "lib",
+      "data": { "tags": [], "root": "lib/manager-webpack4", "files": [] }
+    },
+    {
+      "name": "@storybook/manager-webpack5",
+      "type": "lib",
+      "data": { "tags": [], "root": "lib/manager-webpack5", "files": [] }
+    },
+    {
+      "name": "angular-cli",
+      "type": "lib",
+      "data": { "tags": [], "root": "examples/angular-cli", "files": [] }
+    },
+    {
+      "name": "cra-react15",
+      "type": "lib",
+      "data": { "tags": [], "root": "examples/cra-react15", "files": [] }
     },
     {
       "name": "@storybook/addon-backgrounds",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/backgrounds" }
+      "data": { "tags": [], "root": "addons/backgrounds", "files": [] }
     },
     {
       "name": "@storybook/addon-storysource",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/storysource" }
+      "data": { "tags": [], "root": "addons/storysource", "files": [] }
     },
     {
       "name": "@storybook/web-components",
       "type": "lib",
-      "data": { "tags": [], "root": "app/web-components" }
+      "data": { "tags": [], "root": "app/web-components", "files": [] }
     },
     {
       "name": "ember-example",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/ember-cli" }
+      "data": { "tags": [], "root": "examples/ember-cli", "files": [] }
     },
     {
       "name": "vue-3-cli-example",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/vue-3-cli" }
+      "data": { "tags": [], "root": "examples/vue-3-cli", "files": [] }
     },
     {
       "name": "@storybook/addon-essentials",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/essentials" }
-    },
-    {
-      "name": "@storybook/example-react-ts",
-      "type": "lib",
-      "data": { "tags": [], "root": "examples/react-ts" }
-    },
-    {
-      "name": "storybook",
-      "type": "lib",
-      "data": { "tags": [], "root": "lib/cli-storybook" }
+      "data": { "tags": [], "root": "addons/essentials", "files": [] }
     },
     {
       "name": "@storybook/client-logger",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/client-logger" }
+      "data": { "tags": [], "root": "lib/client-logger", "files": [] }
+    },
+    {
+      "name": "@storybook/example-react-ts",
+      "type": "lib",
+      "data": { "tags": [], "root": "examples/react-ts", "files": [] }
     },
     {
       "name": "@storybook/source-loader",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/source-loader" }
+      "data": { "tags": [], "root": "lib/source-loader", "files": [] }
+    },
+    {
+      "name": "storybook",
+      "type": "lib",
+      "data": { "tags": [], "root": "lib/cli-storybook", "files": [] }
     },
     {
       "name": "vue-cli-example",
       "type": "lib",
-      "data": { "tags": [], "root": "examples/vue-cli" }
+      "data": { "tags": [], "root": "examples/vue-cli", "files": [] }
     },
     {
       "name": "@storybook/addon-controls",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/controls" }
+      "data": { "tags": [], "root": "addons/controls", "files": [] }
     },
     {
       "name": "@storybook/addon-toolbars",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/toolbars" }
+      "data": { "tags": [], "root": "addons/toolbars", "files": [] }
     },
     {
       "name": "@storybook/addon-viewport",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/viewport" }
+      "data": { "tags": [], "root": "addons/viewport", "files": [] }
     },
     {
       "name": "@storybook/core-client",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/core-client" }
+      "data": { "tags": [], "root": "lib/core-client", "files": [] }
     },
     {
       "name": "@storybook/core-common",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/core-common" }
+      "data": { "tags": [], "root": "lib/core-common", "files": [] }
     },
     {
       "name": "@storybook/core-events",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/core-events" }
+      "data": { "tags": [], "root": "lib/core-events", "files": [] }
     },
     {
       "name": "@storybook/core-server",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/core-server" }
+      "data": { "tags": [], "root": "lib/core-server", "files": [] }
     },
     {
       "name": "@storybook/node-logger",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/node-logger" }
+      "data": { "tags": [], "root": "lib/node-logger", "files": [] }
     },
     {
       "name": "@storybook/postinstall",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/postinstall" }
+      "data": { "tags": [], "root": "lib/postinstall", "files": [] }
     },
     {
       "name": "@storybook/addon-actions",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/actions" }
+      "data": { "tags": [], "root": "addons/actions", "files": [] }
+    },
+    {
+      "name": "@storybook/addon-measure",
+      "type": "lib",
+      "data": { "tags": [], "root": "addons/measure", "files": [] }
+    },
+    {
+      "name": "@storybook/addon-outline",
+      "type": "lib",
+      "data": { "tags": [], "root": "addons/outline", "files": [] }
     },
     {
       "name": "@storybook/client-api",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/client-api" }
+      "data": { "tags": [], "root": "lib/client-api", "files": [] }
     },
     {
       "name": "@storybook/components",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/components" }
+      "data": { "tags": [], "root": "lib/components", "files": [] }
     },
     {
       "name": "@storybook/csf-tools",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/csf-tools" }
+      "data": { "tags": [], "root": "lib/csf-tools", "files": [] }
     },
     {
       "name": "@storybook/addon-links",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/links" }
+      "data": { "tags": [], "root": "addons/links", "files": [] }
     },
     {
       "name": "@storybook/channels",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/channels" }
+      "data": { "tags": [], "root": "lib/channels", "files": [] }
     },
     {
       "name": "@storybook/addon-a11y",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/a11y" }
+      "data": { "tags": [], "root": "addons/a11y", "files": [] }
     },
     {
       "name": "@storybook/addon-docs",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/docs" }
+      "data": { "tags": [], "root": "addons/docs", "files": [] }
     },
     {
       "name": "@storybook/addon-jest",
       "type": "lib",
-      "data": { "tags": [], "root": "addons/jest" }
+      "data": { "tags": [], "root": "addons/jest", "files": [] }
     },
     {
       "name": "@storybook/angular",
       "type": "lib",
-      "data": { "tags": [], "root": "app/angular" }
+      "data": { "tags": [], "root": "app/angular", "files": [] }
     },
     {
       "name": "@storybook/codemod",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/codemod" }
+      "data": { "tags": [], "root": "lib/codemod", "files": [] }
     },
     {
       "name": "@storybook/theming",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/theming" }
-    },
-    {
-      "name": "@storybook/preact",
-      "type": "lib",
-      "data": { "tags": [], "root": "app/preact" }
-    },
-    {
-      "name": "@storybook/server",
-      "type": "lib",
-      "data": { "tags": [], "root": "app/server" }
-    },
-    {
-      "name": "@storybook/svelte",
-      "type": "lib",
-      "data": { "tags": [], "root": "app/svelte" }
+      "data": { "tags": [], "root": "lib/theming", "files": [] }
     },
     {
       "name": "@storybook/addons",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/addons" }
+      "data": { "tags": [], "root": "lib/addons", "files": [] }
     },
     {
-      "name": "sb",
+      "name": "@storybook/preact",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/cli-sb" }
+      "data": { "tags": [], "root": "app/preact", "files": [] }
     },
     {
       "name": "@storybook/router",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/router" }
+      "data": { "tags": [], "root": "lib/router", "files": [] }
+    },
+    {
+      "name": "@storybook/server",
+      "type": "lib",
+      "data": { "tags": [], "root": "app/server", "files": [] }
+    },
+    {
+      "name": "@storybook/svelte",
+      "type": "lib",
+      "data": { "tags": [], "root": "app/svelte", "files": [] }
+    },
+    {
+      "name": "sb",
+      "type": "lib",
+      "data": { "tags": [], "root": "lib/cli-sb", "files": [] }
     },
     {
       "name": "@storybook/ember",
       "type": "lib",
-      "data": { "tags": [], "root": "app/ember" }
+      "data": { "tags": [], "root": "app/ember", "files": [] }
     },
     {
       "name": "@storybook/react",
       "type": "lib",
-      "data": { "tags": [], "root": "app/react" }
-    },
-    {
-      "name": "@storybook/html",
-      "type": "lib",
-      "data": { "tags": [], "root": "app/html" }
-    },
-    {
-      "name": "@storybook/vue3",
-      "type": "lib",
-      "data": { "tags": [], "root": "app/vue3" }
+      "data": { "tags": [], "root": "app/react", "files": [] }
     },
     {
       "name": "@storybook/core",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/core" }
+      "data": { "tags": [], "root": "lib/core", "files": [] }
     },
     {
-      "name": "@storybook/vue",
+      "name": "@storybook/html",
       "type": "lib",
-      "data": { "tags": [], "root": "app/vue" }
+      "data": { "tags": [], "root": "app/html", "files": [] }
+    },
+    {
+      "name": "@storybook/vue3",
+      "type": "lib",
+      "data": { "tags": [], "root": "app/vue3", "files": [] }
     },
     {
       "name": "@storybook/api",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/api" }
+      "data": { "tags": [], "root": "lib/api", "files": [] }
     },
     {
       "name": "@storybook/cli",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/cli" }
+      "data": { "tags": [], "root": "lib/cli", "files": [] }
+    },
+    {
+      "name": "@storybook/vue",
+      "type": "lib",
+      "data": { "tags": [], "root": "app/vue", "files": [] }
     },
     {
       "name": "@storybook/ui",
       "type": "lib",
-      "data": { "tags": [], "root": "lib/ui" }
+      "data": { "tags": [], "root": "lib/ui", "files": [] }
     }
   ],
   "dependencies": {
-    "@storybook/addon-storyshots-puppeteer": [],
-    "web-components-kitchen-sink": [],
-    "@storybook/addon-storyshots": [],
-    "cra-ts-kitchen-sink": [],
-    "preact-example": [],
-    "server-kitchen-sink": [],
-    "svelte-example": [],
-    "official-storybook": [],
-    "standalone-preview": [],
-    "cra-ts-essentials": [],
-    "html-kitchen-sink": [],
-    "@storybook/example-react-ts-webpack4": [],
-    "cra-kitchen-sink": [],
-    "vue-example": [],
-    "@storybook/channel-postmessage": [],
-    "@storybook/channel-websocket": [],
-    "@storybook/manager-webpack4": [],
-    "@storybook/manager-webpack5": [],
-    "angular-cli": [],
-    "cra-react15": [],
-    "@storybook/builder-webpack4": [],
-    "@storybook/builder-webpack5": [],
-    "@storybook/addon-backgrounds": [],
-    "@storybook/addon-storysource": [],
-    "@storybook/web-components": [],
-    "ember-example": [],
-    "vue-3-cli-example": [],
-    "@storybook/addon-essentials": [],
-    "@storybook/example-react-ts": [],
-    "storybook": [],
+    "@storybook/addon-storyshots-puppeteer": [
+      {
+        "source": "@storybook/addon-storyshots-puppeteer",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      }
+    ],
+    "web-components-kitchen-sink": [
+      {
+        "source": "web-components-kitchen-sink",
+        "target": "@storybook/addon-a11y",
+        "type": "static"
+      },
+      {
+        "source": "web-components-kitchen-sink",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "web-components-kitchen-sink",
+        "target": "@storybook/addon-backgrounds",
+        "type": "static"
+      },
+      {
+        "source": "web-components-kitchen-sink",
+        "target": "@storybook/addon-controls",
+        "type": "static"
+      },
+      {
+        "source": "web-components-kitchen-sink",
+        "target": "@storybook/addon-docs",
+        "type": "static"
+      },
+      {
+        "source": "web-components-kitchen-sink",
+        "target": "@storybook/addon-jest",
+        "type": "static"
+      },
+      {
+        "source": "web-components-kitchen-sink",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "web-components-kitchen-sink",
+        "target": "@storybook/addon-storyshots",
+        "type": "static"
+      },
+      {
+        "source": "web-components-kitchen-sink",
+        "target": "@storybook/addon-storysource",
+        "type": "static"
+      },
+      {
+        "source": "web-components-kitchen-sink",
+        "target": "@storybook/addon-viewport",
+        "type": "static"
+      },
+      {
+        "source": "web-components-kitchen-sink",
+        "target": "@storybook/web-components",
+        "type": "static"
+      }
+    ],
+    "@storybook/addon-storyshots": [
+      {
+        "source": "@storybook/addon-storyshots",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storyshots",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storyshots",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storyshots",
+        "target": "@storybook/core-common",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storyshots",
+        "target": "@storybook/addon-docs",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storyshots",
+        "target": "@storybook/angular",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storyshots",
+        "target": "@storybook/react",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storyshots",
+        "target": "@storybook/vue",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storyshots",
+        "target": "@storybook/vue3",
+        "type": "static"
+      }
+    ],
+    "cra-ts-kitchen-sink": [
+      {
+        "source": "cra-ts-kitchen-sink",
+        "target": "@storybook/addon-a11y",
+        "type": "static"
+      },
+      {
+        "source": "cra-ts-kitchen-sink",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "cra-ts-kitchen-sink",
+        "target": "@storybook/addon-docs",
+        "type": "static"
+      },
+      {
+        "source": "cra-ts-kitchen-sink",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "cra-ts-kitchen-sink",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "cra-ts-kitchen-sink",
+        "target": "@storybook/builder-webpack4",
+        "type": "static"
+      },
+      {
+        "source": "cra-ts-kitchen-sink",
+        "target": "@storybook/react",
+        "type": "static"
+      }
+    ],
+    "preact-example": [
+      {
+        "source": "preact-example",
+        "target": "@storybook/addon-a11y",
+        "type": "static"
+      },
+      {
+        "source": "preact-example",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "preact-example",
+        "target": "@storybook/addon-backgrounds",
+        "type": "static"
+      },
+      {
+        "source": "preact-example",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "preact-example",
+        "target": "@storybook/addon-storyshots",
+        "type": "static"
+      },
+      {
+        "source": "preact-example",
+        "target": "@storybook/addon-storysource",
+        "type": "static"
+      },
+      {
+        "source": "preact-example",
+        "target": "@storybook/addon-viewport",
+        "type": "static"
+      },
+      {
+        "source": "preact-example",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "preact-example",
+        "target": "@storybook/preact",
+        "type": "static"
+      },
+      {
+        "source": "preact-example",
+        "target": "@storybook/source-loader",
+        "type": "static"
+      }
+    ],
+    "server-kitchen-sink": [
+      {
+        "source": "server-kitchen-sink",
+        "target": "@storybook/addon-a11y",
+        "type": "static"
+      },
+      {
+        "source": "server-kitchen-sink",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "server-kitchen-sink",
+        "target": "@storybook/addon-backgrounds",
+        "type": "static"
+      },
+      {
+        "source": "server-kitchen-sink",
+        "target": "@storybook/addon-controls",
+        "type": "static"
+      },
+      {
+        "source": "server-kitchen-sink",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "server-kitchen-sink",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      },
+      {
+        "source": "server-kitchen-sink",
+        "target": "@storybook/server",
+        "type": "static"
+      }
+    ],
+    "svelte-example": [
+      {
+        "source": "svelte-example",
+        "target": "@storybook/addon-a11y",
+        "type": "static"
+      },
+      {
+        "source": "svelte-example",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "svelte-example",
+        "target": "@storybook/addon-backgrounds",
+        "type": "static"
+      },
+      {
+        "source": "svelte-example",
+        "target": "@storybook/addon-controls",
+        "type": "static"
+      },
+      {
+        "source": "svelte-example",
+        "target": "@storybook/addon-docs",
+        "type": "static"
+      },
+      {
+        "source": "svelte-example",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "svelte-example",
+        "target": "@storybook/addon-storyshots",
+        "type": "static"
+      },
+      {
+        "source": "svelte-example",
+        "target": "@storybook/addon-storysource",
+        "type": "static"
+      },
+      {
+        "source": "svelte-example",
+        "target": "@storybook/addon-viewport",
+        "type": "static"
+      },
+      {
+        "source": "svelte-example",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "svelte-example",
+        "target": "@storybook/source-loader",
+        "type": "static"
+      },
+      {
+        "source": "svelte-example",
+        "target": "@storybook/svelte",
+        "type": "static"
+      }
+    ],
+    "official-storybook": [
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addon-a11y",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addon-backgrounds",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addon-controls",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addon-docs",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addon-jest",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addon-storyshots",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addon-storyshots-puppeteer",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addon-storysource",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addon-toolbars",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addon-viewport",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/cli",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/react",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/source-loader",
+        "type": "static"
+      },
+      {
+        "source": "official-storybook",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "standalone-preview": [
+      {
+        "source": "standalone-preview",
+        "target": "@storybook/addon-docs",
+        "type": "static"
+      },
+      {
+        "source": "standalone-preview",
+        "target": "@storybook/react",
+        "type": "static"
+      }
+    ],
+    "@storybook/example-react-ts-webpack4": [
+      {
+        "source": "@storybook/example-react-ts-webpack4",
+        "target": "@storybook/addon-controls",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/example-react-ts-webpack4",
+        "target": "@storybook/addon-essentials",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/example-react-ts-webpack4",
+        "target": "@storybook/builder-webpack4",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/example-react-ts-webpack4",
+        "target": "@storybook/react",
+        "type": "static"
+      }
+    ],
+    "cra-ts-essentials": [
+      {
+        "source": "cra-ts-essentials",
+        "target": "@storybook/addon-essentials",
+        "type": "static"
+      },
+      {
+        "source": "cra-ts-essentials",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "cra-ts-essentials",
+        "target": "@storybook/builder-webpack4",
+        "type": "static"
+      },
+      {
+        "source": "cra-ts-essentials",
+        "target": "@storybook/react",
+        "type": "static"
+      }
+    ],
+    "html-kitchen-sink": [
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/addon-a11y",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/addon-backgrounds",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/addon-controls",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/addon-docs",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/addon-jest",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/addon-storyshots",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/addon-storysource",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/addon-viewport",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/html",
+        "type": "static"
+      },
+      {
+        "source": "html-kitchen-sink",
+        "target": "@storybook/source-loader",
+        "type": "static"
+      }
+    ],
+    "cra-kitchen-sink": [
+      {
+        "source": "cra-kitchen-sink",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "cra-kitchen-sink",
+        "target": "@storybook/addon-a11y",
+        "type": "static"
+      },
+      {
+        "source": "cra-kitchen-sink",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "cra-kitchen-sink",
+        "target": "@storybook/addon-backgrounds",
+        "type": "static"
+      },
+      {
+        "source": "cra-kitchen-sink",
+        "target": "@storybook/addon-docs",
+        "type": "static"
+      },
+      {
+        "source": "cra-kitchen-sink",
+        "target": "@storybook/addon-jest",
+        "type": "static"
+      },
+      {
+        "source": "cra-kitchen-sink",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "cra-kitchen-sink",
+        "target": "@storybook/addon-storyshots",
+        "type": "static"
+      },
+      {
+        "source": "cra-kitchen-sink",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "cra-kitchen-sink",
+        "target": "@storybook/builder-webpack4",
+        "type": "static"
+      },
+      {
+        "source": "cra-kitchen-sink",
+        "target": "@storybook/react",
+        "type": "static"
+      },
+      {
+        "source": "cra-kitchen-sink",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "vue-example": [
+      {
+        "source": "vue-example",
+        "target": "@storybook/addon-a11y",
+        "type": "static"
+      },
+      {
+        "source": "vue-example",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "vue-example",
+        "target": "@storybook/addon-backgrounds",
+        "type": "static"
+      },
+      {
+        "source": "vue-example",
+        "target": "@storybook/addon-controls",
+        "type": "static"
+      },
+      {
+        "source": "vue-example",
+        "target": "@storybook/addon-docs",
+        "type": "static"
+      },
+      {
+        "source": "vue-example",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "vue-example",
+        "target": "@storybook/addon-storyshots",
+        "type": "static"
+      },
+      {
+        "source": "vue-example",
+        "target": "@storybook/addon-storysource",
+        "type": "static"
+      },
+      {
+        "source": "vue-example",
+        "target": "@storybook/addon-viewport",
+        "type": "static"
+      },
+      {
+        "source": "vue-example",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "vue-example",
+        "target": "@storybook/source-loader",
+        "type": "static"
+      },
+      { "source": "vue-example", "target": "@storybook/vue", "type": "static" }
+    ],
+    "@storybook/channel-postmessage": [
+      {
+        "source": "@storybook/channel-postmessage",
+        "target": "@storybook/channels",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/channel-postmessage",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/channel-postmessage",
+        "target": "@storybook/core-events",
+        "type": "static"
+      }
+    ],
+    "@storybook/channel-websocket": [
+      {
+        "source": "@storybook/channel-websocket",
+        "target": "@storybook/channels",
+        "type": "static"
+      }
+    ],
+    "@storybook/builder-webpack4": [
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/channel-postmessage",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/channels",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/core-common",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/router",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/theming",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack4",
+        "target": "@storybook/ui",
+        "type": "static"
+      }
+    ],
+    "@storybook/builder-webpack5": [
+      {
+        "source": "@storybook/builder-webpack5",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack5",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack5",
+        "target": "@storybook/channel-postmessage",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack5",
+        "target": "@storybook/channels",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack5",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack5",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack5",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack5",
+        "target": "@storybook/core-common",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack5",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack5",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack5",
+        "target": "@storybook/router",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/builder-webpack5",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/manager-webpack4": [
+      {
+        "source": "@storybook/manager-webpack4",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/manager-webpack4",
+        "target": "@storybook/core-client",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/manager-webpack4",
+        "target": "@storybook/core-common",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/manager-webpack4",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/manager-webpack4",
+        "target": "@storybook/theming",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/manager-webpack4",
+        "target": "@storybook/ui",
+        "type": "static"
+      }
+    ],
+    "@storybook/manager-webpack5": [
+      {
+        "source": "@storybook/manager-webpack5",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/manager-webpack5",
+        "target": "@storybook/core-client",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/manager-webpack5",
+        "target": "@storybook/core-common",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/manager-webpack5",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/manager-webpack5",
+        "target": "@storybook/theming",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/manager-webpack5",
+        "target": "@storybook/ui",
+        "type": "static"
+      }
+    ],
+    "angular-cli": [
+      {
+        "source": "angular-cli",
+        "target": "@storybook/addon-a11y",
+        "type": "static"
+      },
+      {
+        "source": "angular-cli",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "angular-cli",
+        "target": "@storybook/addon-backgrounds",
+        "type": "static"
+      },
+      {
+        "source": "angular-cli",
+        "target": "@storybook/addon-controls",
+        "type": "static"
+      },
+      {
+        "source": "angular-cli",
+        "target": "@storybook/addon-docs",
+        "type": "static"
+      },
+      {
+        "source": "angular-cli",
+        "target": "@storybook/addon-jest",
+        "type": "static"
+      },
+      {
+        "source": "angular-cli",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "angular-cli",
+        "target": "@storybook/addon-storyshots",
+        "type": "static"
+      },
+      {
+        "source": "angular-cli",
+        "target": "@storybook/addon-storysource",
+        "type": "static"
+      },
+      {
+        "source": "angular-cli",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "angular-cli",
+        "target": "@storybook/angular",
+        "type": "static"
+      },
+      {
+        "source": "angular-cli",
+        "target": "@storybook/source-loader",
+        "type": "static"
+      }
+    ],
+    "cra-react15": [
+      {
+        "source": "cra-react15",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "cra-react15",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "cra-react15",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "cra-react15",
+        "target": "@storybook/builder-webpack4",
+        "type": "static"
+      },
+      {
+        "source": "cra-react15",
+        "target": "@storybook/react",
+        "type": "static"
+      },
+      {
+        "source": "cra-react15",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/addon-backgrounds": [
+      {
+        "source": "@storybook/addon-backgrounds",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-backgrounds",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-backgrounds",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-backgrounds",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-backgrounds",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-backgrounds",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/addon-storysource": [
+      {
+        "source": "@storybook/addon-storysource",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storysource",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storysource",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storysource",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storysource",
+        "target": "@storybook/router",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storysource",
+        "target": "@storybook/source-loader",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-storysource",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/web-components": [
+      {
+        "source": "@storybook/web-components",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/web-components",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/web-components",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/web-components",
+        "target": "@storybook/core-common",
+        "type": "static"
+      }
+    ],
+    "ember-example": [
+      {
+        "source": "ember-example",
+        "target": "@storybook/addon-a11y",
+        "type": "static"
+      },
+      {
+        "source": "ember-example",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "ember-example",
+        "target": "@storybook/addon-backgrounds",
+        "type": "static"
+      },
+      {
+        "source": "ember-example",
+        "target": "@storybook/addon-controls",
+        "type": "static"
+      },
+      {
+        "source": "ember-example",
+        "target": "@storybook/addon-docs",
+        "type": "static"
+      },
+      {
+        "source": "ember-example",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "ember-example",
+        "target": "@storybook/addon-storysource",
+        "type": "static"
+      },
+      {
+        "source": "ember-example",
+        "target": "@storybook/addon-viewport",
+        "type": "static"
+      },
+      {
+        "source": "ember-example",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "ember-example",
+        "target": "@storybook/ember",
+        "type": "static"
+      },
+      {
+        "source": "ember-example",
+        "target": "@storybook/source-loader",
+        "type": "static"
+      }
+    ],
+    "vue-3-cli-example": [
+      {
+        "source": "vue-3-cli-example",
+        "target": "@storybook/vue3",
+        "type": "static"
+      },
+      {
+        "source": "vue-3-cli-example",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "vue-3-cli-example",
+        "target": "@storybook/addon-essentials",
+        "type": "static"
+      },
+      {
+        "source": "vue-3-cli-example",
+        "target": "@storybook/addon-links",
+        "type": "static"
+      },
+      {
+        "source": "vue-3-cli-example",
+        "target": "@storybook/addon-storyshots",
+        "type": "static"
+      }
+    ],
+    "@storybook/addon-essentials": [
+      {
+        "source": "@storybook/addon-essentials",
+        "target": "@storybook/addon-actions",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-essentials",
+        "target": "@storybook/addon-backgrounds",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-essentials",
+        "target": "@storybook/addon-controls",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-essentials",
+        "target": "@storybook/addon-docs",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-essentials",
+        "target": "@storybook/addon-measure",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-essentials",
+        "target": "@storybook/addon-outline",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-essentials",
+        "target": "@storybook/addon-toolbars",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-essentials",
+        "target": "@storybook/addon-viewport",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-essentials",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-essentials",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-essentials",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-essentials",
+        "target": "@storybook/vue",
+        "type": "static"
+      }
+    ],
     "@storybook/client-logger": [],
-    "@storybook/source-loader": [],
-    "vue-cli-example": [],
-    "@storybook/addon-controls": [],
-    "@storybook/addon-toolbars": [],
-    "@storybook/addon-viewport": [],
-    "@storybook/core-client": [],
-    "@storybook/core-common": [],
+    "@storybook/example-react-ts": [
+      {
+        "source": "@storybook/example-react-ts",
+        "target": "@storybook/addon-essentials",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/example-react-ts",
+        "target": "@storybook/addon-storyshots",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/example-react-ts",
+        "target": "@storybook/addon-storysource",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/example-react-ts",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/example-react-ts",
+        "target": "@storybook/react",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/example-react-ts",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/source-loader": [
+      {
+        "source": "@storybook/source-loader",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/source-loader",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      }
+    ],
+    "storybook": [
+      { "source": "storybook", "target": "@storybook/cli", "type": "static" }
+    ],
+    "vue-cli-example": [
+      {
+        "source": "vue-cli-example",
+        "target": "@storybook/addon-controls",
+        "type": "static"
+      },
+      {
+        "source": "vue-cli-example",
+        "target": "@storybook/addon-essentials",
+        "type": "static"
+      },
+      {
+        "source": "vue-cli-example",
+        "target": "@storybook/source-loader",
+        "type": "static"
+      },
+      {
+        "source": "vue-cli-example",
+        "target": "@storybook/vue",
+        "type": "static"
+      }
+    ],
+    "@storybook/addon-controls": [
+      {
+        "source": "@storybook/addon-controls",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-controls",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-controls",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-controls",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-controls",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-controls",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/addon-toolbars": [
+      {
+        "source": "@storybook/addon-toolbars",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-toolbars",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-toolbars",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-toolbars",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-toolbars",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/addon-viewport": [
+      {
+        "source": "@storybook/addon-viewport",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-viewport",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-viewport",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-viewport",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-viewport",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-viewport",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/core-client": [
+      {
+        "source": "@storybook/core-client",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core-client",
+        "target": "@storybook/channel-postmessage",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core-client",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core-client",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core-client",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core-client",
+        "target": "@storybook/ui",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core-client",
+        "target": "@storybook/core-common",
+        "type": "static"
+      }
+    ],
+    "@storybook/core-common": [
+      {
+        "source": "@storybook/core-common",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      }
+    ],
     "@storybook/core-events": [],
-    "@storybook/core-server": [],
+    "@storybook/core-server": [
+      {
+        "source": "@storybook/core-server",
+        "target": "@storybook/builder-webpack4",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core-server",
+        "target": "@storybook/core-client",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core-server",
+        "target": "@storybook/core-common",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core-server",
+        "target": "@storybook/csf-tools",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core-server",
+        "target": "@storybook/manager-webpack4",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core-server",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core-server",
+        "target": "@storybook/builder-webpack5",
+        "type": "static"
+      }
+    ],
     "@storybook/node-logger": [],
     "@storybook/postinstall": [],
-    "@storybook/addon-actions": [],
-    "@storybook/client-api": [],
-    "@storybook/components": [],
+    "@storybook/addon-actions": [
+      {
+        "source": "@storybook/addon-actions",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-actions",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-actions",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-actions",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-actions",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-actions",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/addon-measure": [
+      {
+        "source": "@storybook/addon-measure",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-measure",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-measure",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-measure",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-measure",
+        "target": "@storybook/core-events",
+        "type": "static"
+      }
+    ],
+    "@storybook/addon-outline": [
+      {
+        "source": "@storybook/addon-outline",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-outline",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-outline",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-outline",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-outline",
+        "target": "@storybook/core-events",
+        "type": "static"
+      }
+    ],
+    "@storybook/client-api": [
+      {
+        "source": "@storybook/client-api",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/client-api",
+        "target": "@storybook/channel-postmessage",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/client-api",
+        "target": "@storybook/channels",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/client-api",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/client-api",
+        "target": "@storybook/core-events",
+        "type": "static"
+      }
+    ],
+    "@storybook/components": [
+      {
+        "source": "@storybook/components",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/components",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
     "@storybook/csf-tools": [],
-    "@storybook/addon-links": [],
+    "@storybook/addon-links": [
+      {
+        "source": "@storybook/addon-links",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-links",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-links",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-links",
+        "target": "@storybook/router",
+        "type": "static"
+      }
+    ],
     "@storybook/channels": [],
-    "@storybook/addon-a11y": [],
-    "@storybook/addon-docs": [],
-    "@storybook/addon-jest": [],
-    "@storybook/angular": [],
-    "@storybook/codemod": [],
-    "@storybook/theming": [],
-    "@storybook/preact": [],
-    "@storybook/server": [],
-    "@storybook/svelte": [],
-    "@storybook/addons": [],
-    "sb": [],
-    "@storybook/router": [],
-    "@storybook/ember": [],
-    "@storybook/react": [],
-    "@storybook/html": [],
-    "@storybook/vue3": [],
-    "@storybook/core": [],
-    "@storybook/vue": [],
-    "@storybook/api": [],
-    "@storybook/cli": [],
-    "@storybook/ui": []
+    "@storybook/addon-a11y": [
+      {
+        "source": "@storybook/addon-a11y",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-a11y",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-a11y",
+        "target": "@storybook/channels",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-a11y",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-a11y",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-a11y",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-a11y",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-a11y",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/addon-docs": [
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/builder-webpack4",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/csf-tools",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/postinstall",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/source-loader",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/theming",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/angular",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/react",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/vue",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/web-components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/core-common",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-docs",
+        "target": "@storybook/vue3",
+        "type": "static"
+      }
+    ],
+    "@storybook/addon-jest": [
+      {
+        "source": "@storybook/addon-jest",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-jest",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-jest",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-jest",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addon-jest",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/angular": [
+      {
+        "source": "@storybook/angular",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/angular",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/angular",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/angular",
+        "target": "@storybook/core-common",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/angular",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/angular",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      }
+    ],
+    "@storybook/codemod": [
+      {
+        "source": "@storybook/codemod",
+        "target": "@storybook/csf-tools",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/codemod",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      }
+    ],
+    "@storybook/theming": [
+      {
+        "source": "@storybook/theming",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      }
+    ],
+    "@storybook/addons": [
+      {
+        "source": "@storybook/addons",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addons",
+        "target": "@storybook/channels",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addons",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addons",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addons",
+        "target": "@storybook/router",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/addons",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/preact": [
+      {
+        "source": "@storybook/preact",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/preact",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/preact",
+        "target": "@storybook/core-common",
+        "type": "static"
+      }
+    ],
+    "@storybook/router": [
+      {
+        "source": "@storybook/router",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      }
+    ],
+    "@storybook/server": [
+      {
+        "source": "@storybook/server",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/server",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/server",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/server",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/server",
+        "target": "@storybook/core-common",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/server",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      }
+    ],
+    "@storybook/svelte": [
+      {
+        "source": "@storybook/svelte",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/svelte",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/svelte",
+        "target": "@storybook/core-common",
+        "type": "static"
+      }
+    ],
+    "sb": [{ "source": "sb", "target": "@storybook/cli", "type": "static" }],
+    "@storybook/ember": [
+      {
+        "source": "@storybook/ember",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/ember",
+        "target": "@storybook/core-common",
+        "type": "static"
+      }
+    ],
+    "@storybook/react": [
+      {
+        "source": "@storybook/react",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/react",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/react",
+        "target": "@storybook/core-common",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/react",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/react",
+        "target": "@storybook/client-api",
+        "type": "static"
+      }
+    ],
+    "@storybook/core": [
+      {
+        "source": "@storybook/core",
+        "target": "@storybook/core-client",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/core",
+        "target": "@storybook/core-server",
+        "type": "static"
+      }
+    ],
+    "@storybook/html": [
+      {
+        "source": "@storybook/html",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/html",
+        "target": "@storybook/client-api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/html",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/html",
+        "target": "@storybook/core-common",
+        "type": "static"
+      }
+    ],
+    "@storybook/vue3": [
+      {
+        "source": "@storybook/vue3",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/vue3",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/vue3",
+        "target": "@storybook/core-common",
+        "type": "static"
+      }
+    ],
+    "@storybook/api": [
+      {
+        "source": "@storybook/api",
+        "target": "@storybook/channels",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/api",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/api",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/api",
+        "target": "@storybook/router",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/api",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ],
+    "@storybook/cli": [
+      {
+        "source": "@storybook/cli",
+        "target": "@storybook/codemod",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/cli",
+        "target": "@storybook/core-common",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/cli",
+        "target": "@storybook/node-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/cli",
+        "target": "@storybook/client-api",
+        "type": "static"
+      }
+    ],
+    "@storybook/vue": [
+      {
+        "source": "@storybook/vue",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/vue",
+        "target": "@storybook/core",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/vue",
+        "target": "@storybook/core-common",
+        "type": "static"
+      }
+    ],
+    "@storybook/ui": [
+      {
+        "source": "@storybook/ui",
+        "target": "@storybook/addons",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/ui",
+        "target": "@storybook/api",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/ui",
+        "target": "@storybook/channels",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/ui",
+        "target": "@storybook/client-logger",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/ui",
+        "target": "@storybook/components",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/ui",
+        "target": "@storybook/core-events",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/ui",
+        "target": "@storybook/router",
+        "type": "static"
+      },
+      {
+        "source": "@storybook/ui",
+        "target": "@storybook/theming",
+        "type": "static"
+      }
+    ]
   },
+  "layout": { "appsDir": "apps", "libsDir": "libs" },
   "changes": { "added": [] },
   "affected": [],
   "focus": null,
-  "exclude": [],
-  "groupByFolder": false
+  "groupByFolder": false,
+  "exclude": []
 }

--- a/dep-graph/dep-graph/src/styles.scss
+++ b/dep-graph/dep-graph/src/styles.scss
@@ -248,3 +248,19 @@ html {
   width: 100%;
   height: 100%;
 }
+
+label {
+  display: block;
+}
+
+input[type='text'],
+input[type='number'] {
+  padding: 0.5em 1em;
+  border-radius: 4px;
+  border: 1px solid $color-nrwl-black;
+}
+span.search-depth {
+  display: inline-block;
+  width: 2em;
+  text-align: center;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When using the dep graph visualization, focussing a project or using a text filter with include projects in path will search the entire dependency graph for other projects.

<!-- This is the behavior we have today -->

## Expected Behavior
When using the dep graph visualization, focussing a project or using a text filter with include projects in path, the suer can set a certain depth of search to take place.

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Fixes #5101
