### PR TITLE
chore(react): updating @reduxjs/toolkit to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@phenomnomnominal/tsquery": "4.1.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "@popperjs/core": "^2.9.2",
-    "@reduxjs/toolkit": "1.5.0",
+    "@reduxjs/toolkit": "1.6.1",
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-image": "^2.1.0",

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -487,7 +487,7 @@
           "alwaysAddToPackageJson": false
         },
         "@reduxjs/toolkit": {
-          "version": "1.5.0",
+          "version": "1.6.1",
           "alwaysAddToPackageJson": false
         },
         "react-redux": {

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -365,7 +365,7 @@ export function addReduxStoreToMain(
   return [
     ...addImport(
       source,
-      `import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
+      `import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';`
     ),
     {
@@ -375,7 +375,7 @@ import { Provider } from 'react-redux';`
 const store = configureStore({
   reducer: {},
   // Additional middleware can be passed to this array
-  middleware: [...getDefaultMiddleware()],
+  middleware: getDefaultMiddleware => getDefaultMiddleware(),
   devTools: process.env.NODE_ENV !== 'production',
   // Optional Redux store enhancers
   enhancers: [],


### PR DESCRIPTION
Updated @reduxjs/toolkit from 1.5.0 to 1.6.1

## Current Behavior
Generating redux slice generates with @reduxjs/toolkit to 1.5.0

## Expected Behavior
Generating redux slice should generate with @reduxjs/toolkit to 1.6.1

## Related Issue(s)
No issues.

Fixes #
Updated middleware generation to new version.
