### PR TITLE
fix(angular): adds missing @angular/cdk to migrations

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -850,6 +850,10 @@
           "version": "^12.2.0",
           "alwaysAddToPackageJson": false
         },
+        "@angular/cdk": {
+          "version": "^12.2.0",
+          "alwaysAddToPackageJson": false
+        },
         "jest-preset-angular": {
           "version": "9.0.7",
           "alwaysAddToPackageJson": false


### PR DESCRIPTION
If @angular/material is used and updated, without updating the underlaying @angular/cdk (and is used); the application might have trouble starting and result in weird errors that are hard to debug.

Example error:
```
./node_modules/@angular/material/fesm2015/autocomplete.js:536:32-47 - Error: export '_getEventTarget' (imported as '_getEventTarget') was not found in '@angular/cdk/platform' (possible exports: Platform, PlatformModule, _getFocusedElementPierceShadowDom, _getShadowRoot, _supportsShadowDom, getRtlScrollAxisType, getSupportedInputTypes, normalizePassiveListenerOptions, supportsPassiveEventListeners, supportsScrollBehavior)
```

Fixed after updating the @angular/cdk to the same version as @angular/material.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When migrating to Nx 12.9 and using both @angular/material and @angular/cdk, only @angular/material is updated. This causes the weird and hard to debug error, preventing an application from starting or building.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The migration updates both packages in unison as expected by the users of both @angular/cdk and @angular/material.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Didn't make an issue for this, as it seemed easy enough to fix.
