### PR TITLE
fix(core): gracefully handle errors when writing the latest output hash cache files

### DIFF
--- a/packages/workspace/src/tasks-runner/cache.ts
+++ b/packages/workspace/src/tasks-runner/cache.ts
@@ -1,5 +1,5 @@
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
-import { Task } from '@nrwl/devkit';
+import { logger, Task } from '@nrwl/devkit';
 import {
   existsSync,
   mkdirSync,
@@ -151,7 +151,12 @@ export class Cache {
   recordOutputsHash(outputs: string[], hash: string): void {
     outputs.forEach((output) => {
       const hashFile = this.getFileNameWithLatestRecordedHashForOutput(output);
-      writeToFile(hashFile, hash);
+      try {
+        writeToFile(hashFile, hash);
+      } catch (error) {
+        logger.log(`Error writing hashFile: ${hashFile}.`);
+        logger.log(error);
+      }
     });
   }
 

--- a/packages/workspace/src/tasks-runner/cache.ts
+++ b/packages/workspace/src/tasks-runner/cache.ts
@@ -1,5 +1,5 @@
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
-import { logger, Task } from '@nrwl/devkit';
+import { Task } from '@nrwl/devkit';
 import {
   existsSync,
   mkdirSync,
@@ -153,10 +153,7 @@ export class Cache {
       const hashFile = this.getFileNameWithLatestRecordedHashForOutput(output);
       try {
         writeToFile(hashFile, hash);
-      } catch (error) {
-        logger.log(`Error writing hashFile: ${hashFile}.`);
-        logger.log(error);
-      }
+      } catch {}
     });
   }
 


### PR DESCRIPTION
Instead of failing the task run process it will allow the process to continue.

Fixes of #6957
