### PR TITLE
chore: add repository directory for all packages.json

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -4,7 +4,8 @@
   "description": "Angular Plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/angular"
   },
   "scripts": {
     "postinstall": "node ./scripts/nx-cli-warning.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,8 @@
   "description": "Smart, Extensible Build Framework",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/cli"
   },
   "keywords": [
     "Monorepo",

--- a/packages/create-nx-plugin/package.json
+++ b/packages/create-nx-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "Smart, Extensible Build Framework",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/create-nx-plugin"
   },
   "keywords": [
     "Monorepo",

--- a/packages/create-nx-workspace/package.json
+++ b/packages/create-nx-workspace/package.json
@@ -4,7 +4,8 @@
   "description": "Smart, Extensible Build Framework",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/create-nx-workspace"
   },
   "keywords": [
     "Monorepo",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -4,7 +4,8 @@
   "description": "Cypress plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/cypress"
   },
   "keywords": [
     "Monorepo",

--- a/packages/detox/package.json
+++ b/packages/detox/package.json
@@ -16,7 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/detox"
   },
   "license": "MIT",
   "author": "Victor Savkin",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -4,7 +4,8 @@
   "description": "Smart, Extensible Build Framework",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/devkit"
   },
   "keywords": [
     "Monorepo",

--- a/packages/eslint-plugin-nx/package.json
+++ b/packages/eslint-plugin-nx/package.json
@@ -4,7 +4,8 @@
   "description": "ESLint Plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/eslint-plugin-nx"
   },
   "keywords": [
     "Monorepo",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -4,7 +4,8 @@
   "description": "Express Plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/express"
   },
   "keywords": [
     "Monorepo",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -4,7 +4,8 @@
   "description": "Gatsby Plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/gatsby"
   },
   "keywords": [
     "Monorepo",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -4,7 +4,8 @@
   "description": "Jest plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/jest"
   },
   "keywords": [
     "Monorepo",

--- a/packages/linter/package.json
+++ b/packages/linter/package.json
@@ -4,7 +4,8 @@
   "description": "Lint Plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/linter"
   },
   "keywords": [
     "Monorepo",

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -4,7 +4,8 @@
   "description": "Nest Plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/nest"
   },
   "keywords": [
     "Monorepo",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -4,7 +4,8 @@
   "description": "Next.js Plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/next"
   },
   "keywords": [
     "Monorepo",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -4,7 +4,8 @@
   "description": "Node Plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/node"
   },
   "keywords": [
     "Monorepo",

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "Plugin for creating plugins for Nx :)",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/nx-plugin"
   },
   "keywords": [
     "Monorepo",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -4,7 +4,8 @@
   "description": "Smart, Extensible Build Framework",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/nx"
   },
   "keywords": [
     "Monorepo",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -16,7 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/react-native"
   },
   "license": "MIT",
   "author": "Victor Savkin",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,8 @@
   "description": "React Plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/react"
   },
   "keywords": [
     "Monorepo",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -4,7 +4,8 @@
   "description": "Storybook plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/storybook"
   },
   "keywords": [
     "Angular",

--- a/packages/tao/package.json
+++ b/packages/tao/package.json
@@ -4,7 +4,8 @@
   "description": "CLI for generating code and running commands",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/tao"
   },
   "keywords": [
     "Monorepo",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,7 +4,8 @@
   "description": "Web Plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/web"
   },
   "keywords": [
     "Monorepo",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -4,7 +4,8 @@
   "description": "Smart, Extensible Build Framework",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrwl/nx.git"
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/workspace"
   },
   "keywords": [
     "Monorepo",


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives

Made the changes with a script to make it easier 🙂

https://gist.github.com/iamandrewluca/5cc85b56a595056f0099d04ed6dd8a79

ps: We will need also to update the generators in nx to add `directory` automatically for all package.json files
