### PR TITLE
fix(core): display dynamic prompts in angular cli

### DIFF
--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -93,6 +93,9 @@ function createWorkflow(
       workflow.registry
     )
   );
+  if (opts.interactive) {
+    workflow.registry.usePromptProvider(createPromptProvider());
+  }
   return workflow;
 }
 
@@ -613,9 +616,6 @@ export async function generate(
   const logger = getLogger(verbose);
   const fsHost = new NxScopedHost(normalize(root));
   const workflow = createWorkflow(fsHost, root, opts);
-  if (opts.interactive) {
-    workflow.registry.usePromptProvider(createPromptProvider());
-  }
   const collection = getCollection(workflow, opts.collectionName);
   const schematic = collection.createSchematic(opts.generatorName, true);
   return (

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -572,10 +572,9 @@ export function toOldFormatOrNull(w: any) {
 
 export function resolveOldFormatWithInlineProjects(
   w: any,
-  root: string = appRootPath,
-  includeConfigFilePath = false
+  root: string = appRootPath
 ) {
-  const inlined = inlineProjectConfigurations(w, root, includeConfigFilePath);
+  const inlined = inlineProjectConfigurations(w, root);
   const formatted = toOldFormatOrNull(inlined);
   return formatted ? formatted : inlined;
 }
@@ -589,17 +588,13 @@ export function resolveNewFormatWithInlineProjects(
 
 export function inlineProjectConfigurations(
   w: any,
-  root: string = appRootPath,
-  includeConfigFilePath = false
+  root: string = appRootPath
 ) {
   Object.entries(w.projects || {}).forEach(
     ([project, config]: [string, any]) => {
       if (typeof config === 'string') {
         const configFilePath = path.join(root, config, 'project.json');
         const fileConfig = readJsonFile(configFilePath);
-        if (includeConfigFilePath) {
-          fileConfig.configFilePath = configFilePath;
-        }
         w.projects[project] = fileConfig;
       }
     }

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -572,9 +572,12 @@ export function toOldFormatOrNull(w: any) {
 
 export function resolveOldFormatWithInlineProjects(
   w: any,
-  root: string = appRootPath
+  root: string = appRootPath,
+  includeConfigFilePath = false
 ) {
-  return toOldFormatOrNull(inlineProjectConfigurations(w, root));
+  const inlined = inlineProjectConfigurations(w, root, includeConfigFilePath);
+  const formatted = toOldFormatOrNull(inlined);
+  return formatted ? formatted : inlined;
 }
 
 export function resolveNewFormatWithInlineProjects(
@@ -586,13 +589,17 @@ export function resolveNewFormatWithInlineProjects(
 
 export function inlineProjectConfigurations(
   w: any,
-  root: string = appRootPath
+  root: string = appRootPath,
+  includeConfigFilePath = false
 ) {
   Object.entries(w.projects || {}).forEach(
     ([project, config]: [string, any]) => {
       if (typeof config === 'string') {
         const configFilePath = path.join(root, config, 'project.json');
         const fileConfig = readJsonFile(configFilePath);
+        if (includeConfigFilePath) {
+          fileConfig.configFilePath = configFilePath;
+        }
         w.projects[project] = fileConfig;
       }
     }

--- a/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.ts
+++ b/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.ts
@@ -7,6 +7,7 @@ import {
   getProjects,
   getWorkspacePath,
   logger,
+  normalizePath,
   NxJsonConfiguration,
   NxJsonProjectConfiguration,
   ProjectConfiguration,
@@ -72,7 +73,7 @@ To upgrade change the version number at the top of ${getWorkspacePath(
     writeJson(host, configPath, configuration);
 
     updateJson(host, getWorkspacePath(host), (value) => {
-      value.projects[project] = dirname(configPath);
+      value.projects[project] = normalizePath(dirname(configPath));
       return value;
     });
 


### PR DESCRIPTION
## Current Behavior
- Angular schematics that include chain(externalSchematic('@nrwl/angular', 'app', opts)) with an incomplete options block fail.
- Certain combinations of project.json files and wrapped / converted schematics / generators results in an error message stating 'not allowed with v1 schemas'

## Expected Behavior
- Angular schematics that include chain(externalSchematic('@nrwl/angular', 'app', opts)) with an incomplete options block succeed, and prompt for any missing options that have x-prompt attributes.
- Error message not received during valid operations.

## Related Issue(s)

Fixes #6452
Fixes #6968 