### PR TITLE
fix(core): resolve nested files using tsConfig paths that have similar names

### DIFF
--- a/packages/workspace/src/core/target-project-locator.spec.ts
+++ b/packages/workspace/src/core/target-project-locator.spec.ts
@@ -41,8 +41,11 @@ describe('findTargetProjectWithImport', () => {
           '@proj/proj6': ['../root/libs/proj6/*'],
           '@proj/proj7': ['/libs/proj7/*'],
           '@proj/proj123': ['libs/proj123'],
+          '@proj/proj123/*': ['libs/proj123/*'],
           '@proj/proj1234': ['libs/proj1234'],
+          '@proj/proj1234/*': ['libs/proj1234/*'],
           '@proj/proj1234-child': ['libs/proj1234-child'],
+          '@proj/proj1234-child/*': ['libs/proj1234-child/*'],
         },
       },
     };
@@ -346,6 +349,29 @@ describe('findTargetProjectWithImport', () => {
     );
 
     expect(proj2deep).toEqual('proj2');
+  });
+
+  it('should be able to resolve nested files using tsConfig paths that have similar names', () => {
+    const proj = targetProjectLocator.findProjectWithImport(
+      '@proj/proj123/deep',
+      '',
+      ctx.workspace.npmScope
+    );
+    expect(proj).toEqual('proj123');
+
+    const childProj = targetProjectLocator.findProjectWithImport(
+      '@proj/proj1234-child/deep',
+      '',
+      ctx.workspace.npmScope
+    );
+    expect(childProj).toEqual('proj1234-child');
+
+    const parentProj = targetProjectLocator.findProjectWithImport(
+      '@proj/proj1234/deep',
+      '',
+      ctx.workspace.npmScope
+    );
+    expect(parentProj).toEqual('proj1234');
   });
 
   it('should be able to npm dependencies', () => {

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -115,7 +115,8 @@ export class TargetProjectLocator {
     const wildcardPath = Object.keys(this.paths).find(
       (path) =>
         path.endsWith('/*') &&
-        normalizedImportExpr.startsWith(path.replace(/\/\*$/, ''))
+        (normalizedImportExpr.startsWith(path.replace(/\*$/, '')) ||
+          normalizedImportExpr === path.replace(/\/\*$/, ''))
     );
     if (wildcardPath) {
       return this.paths[wildcardPath];


### PR DESCRIPTION
ISSUES CLOSED: #6672

## Current Behavior
When tsConfig paths with overlapping names were configured (e.g. @my/project/* and @my/project-core/*), the project locator would always return the shorter name first.

## Expected Behavior
@my/project-core/deep should always resolve to the tsConfig path @my/project-core/*.

## Related Issue(s)
Fixes #6672
