### PR TITLE
docs(nxdev): shorten flavour and version urls

### DIFF
--- a/nx-dev/data-access-documents/src/lib/documents.api.spec.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.spec.ts
@@ -6,7 +6,7 @@ describe('DocumentsApi', () => {
 
   describe('getDocument', () => {
     it('should retrieve documents that exist', () => {
-      const result = api.getDocument('latest', 'react', [
+      const result = api.getDocument('latest', 'r', [
         'getting-started',
         'intro',
       ]);
@@ -16,7 +16,7 @@ describe('DocumentsApi', () => {
 
     it('should throw error if segments do not match a file', () => {
       expect(() =>
-        api.getDocument('latest', 'vue', ['does', 'not', 'exist'])
+        api.getDocument('latest', 'v', ['does', 'not', 'exist'])
       ).toThrow();
     });
   });

--- a/nx-dev/data-access-documents/src/lib/documents.api.spec.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.spec.ts
@@ -6,7 +6,7 @@ describe('DocumentsApi', () => {
 
   describe('getDocument', () => {
     it('should retrieve documents that exist', () => {
-      const result = api.getDocument('latest', 'r', [
+      const result = api.getDocument('latest', 'react', [
         'getting-started',
         'intro',
       ]);
@@ -16,7 +16,7 @@ describe('DocumentsApi', () => {
 
     it('should throw error if segments do not match a file', () => {
       expect(() =>
-        api.getDocument('latest', 'v', ['does', 'not', 'exist'])
+        api.getDocument('latest', 'vue', ['does', 'not', 'exist'])
       ).toThrow();
     });
   });

--- a/nx-dev/data-access-documents/src/lib/documents.api.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.ts
@@ -15,11 +15,12 @@ export interface StaticDocumentPaths {
 export const flavorList: {
   label: string;
   value: string;
+  alias: string;
   default?: boolean;
 }[] = [
-  { label: 'Angular', value: 'angular' },
-  { label: 'React', value: 'react', default: true },
-  { label: 'Node', value: 'node' },
+  { label: 'Angular', value: 'a', alias: 'angular' },
+  { label: 'React', value: 'r', alias: 'react', default: true },
+  { label: 'Node', value: 'n', alias: 'node' },
 ];
 
 export class DocumentsApi {
@@ -45,12 +46,8 @@ export class DocumentsApi {
     return this.options.versions;
   }
 
-  getDocument(
-    versionId: string,
-    flavorId: string,
-    path: string[]
-  ): DocumentData {
-    const docPath = this.getFilePath(versionId, flavorId, path);
+  getDocument(version: string, flavor: string, path: string[]): DocumentData {
+    const docPath = this.getFilePath(version, flavor, path);
     const originalContent = readFileSync(docPath, 'utf8');
     const file = matter(originalContent);
 
@@ -121,9 +118,9 @@ export class DocumentsApi {
     throw new Error(`Cannot find root for ${version}`);
   }
 
-  private getFilePath(versionId, flavorId, path): string {
-    let items = this.getDocuments(versionId).find(
-      (item) => item.id === flavorId
+  private getFilePath(version, flavor, path): string {
+    let items = this.getDocuments(version).find(
+      (item) => item.id === flavor
     )?.itemList;
 
     if (!items) {
@@ -139,7 +136,7 @@ export class DocumentsApi {
         throw new Error(`Document not found`);
       }
     }
-    const file = found.file ?? [flavorId, ...path].join('/');
-    return join(this.getDocumentsRoot(versionId), `${file}.md`);
+    const file = found.file ?? [flavor, ...path].join('/');
+    return join(this.getDocumentsRoot(version), `${file}.md`);
   }
 }

--- a/nx-dev/data-access-documents/src/lib/documents.api.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.ts
@@ -56,7 +56,7 @@ export class DocumentsApi {
       file.data.title = extractTitle(originalContent) ?? path[path.length - 1];
     }
     return {
-      filePath: join(this.options.publicDocsRoot, docPath),
+      filePath: docPath,
       data: file.data,
       content: file.content,
       excerpt: file.excerpt,

--- a/nx-dev/data-access-documents/src/lib/documents.models.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.models.ts
@@ -8,6 +8,7 @@ export interface DocumentData {
 export interface VersionMetadata {
   name: string;
   id: string;
+  alias: string;
   release: string;
   path: string;
   default?: boolean;

--- a/nx-dev/data-access-documents/src/lib/menu.api.spec.ts
+++ b/nx-dev/data-access-documents/src/lib/menu.api.spec.ts
@@ -8,7 +8,10 @@ describe('MenuApi', () => {
 
   describe('getMenu', () => {
     it('should group by section', () => {
-      const menu = api.getMenu('latest', 'react');
+      const menu = api.getMenu(
+        { alias: 'l', value: 'latest' },
+        { alias: 'react', value: 'react' }
+      );
 
       expect(menu).toEqual({
         version: 'latest',
@@ -25,12 +28,15 @@ describe('MenuApi', () => {
     });
 
     it('should add path to menu items', () => {
-      const menu = api.getMenu('latest', 'react');
+      const menu = api.getMenu(
+        { alias: 'l', value: 'latest' },
+        { alias: 'react', value: 'react' }
+      );
 
       // first basic section item should have prefix by version and flavor
       // e.g. "latest/react/getting-started/intro"
       expect(menu?.sections?.[0]?.itemList?.[0]?.itemList?.[0].path).toMatch(
-        /latest\/react/
+        /l\/r/
       );
     });
   });

--- a/nx-dev/data-access-documents/src/lib/menu.api.ts
+++ b/nx-dev/data-access-documents/src/lib/menu.api.ts
@@ -12,17 +12,20 @@ export class MenuApi {
 
   constructor(private readonly documentsApi: DocumentsApi) {}
 
-  getMenu(version: string, flavor: { alias: string; value: string }): Menu {
-    const key = `${version}-${flavor.alias}`;
+  getMenu(
+    version: { alias: string; value: string },
+    flavor: { alias: string; value: string }
+  ): Menu {
+    const key = `${version.value}-${flavor.alias}`;
     let menu = this.menuCache.get(key);
 
     if (!menu) {
-      const root = this.documentsApi.getDocuments(version);
-      const items = createMenuItems(version, flavor, root);
+      const root = this.documentsApi.getDocuments(version.value);
+      const items = createMenuItems(version.alias, flavor, root);
 
       if (items) {
         menu = {
-          version: version,
+          version: version.value,
           flavor: flavor.value,
           sections: [
             getBasicSection(items),

--- a/nx-dev/data-access-documents/src/lib/menu.api.ts
+++ b/nx-dev/data-access-documents/src/lib/menu.api.ts
@@ -12,17 +12,18 @@ export class MenuApi {
 
   constructor(private readonly documentsApi: DocumentsApi) {}
 
-  getMenu(versionId: string, flavorId: string): Menu {
-    const key = `${versionId}-${flavorId}`;
+  getMenu(version: string, flavor: { alias: string; value: string }): Menu {
+    const key = `${version}-${flavor.alias}`;
     let menu = this.menuCache.get(key);
 
     if (!menu) {
-      const root = this.documentsApi.getDocuments(versionId);
-      const items = createMenuItems(versionId, flavorId, root);
+      const root = this.documentsApi.getDocuments(version);
+      const items = createMenuItems(version, flavor, root);
+
       if (items) {
         menu = {
-          version: versionId,
-          flavor: flavorId,
+          version: version,
+          flavor: flavor.value,
           sections: [
             getBasicSection(items),
             getDeepDiveSection(items),
@@ -30,7 +31,7 @@ export class MenuApi {
           ],
         };
       } else {
-        throw new Error(`Cannot find documents for flavor "${flavorId}"`);
+        throw new Error(`Cannot find documents for flavor "${flavor.alias}"`);
       }
       this.menuCache.set(key, menu);
     }

--- a/nx-dev/data-access-documents/src/lib/menu.utils.ts
+++ b/nx-dev/data-access-documents/src/lib/menu.utils.ts
@@ -2,7 +2,7 @@ import { DocumentMetadata } from '@nrwl/nx-dev/data-access-documents';
 import { MenuItem, MenuSection } from './menu.models';
 
 export function createMenuItems(
-  versionId: string,
+  version: string,
   flavor: { alias: string; value: string },
   root: DocumentMetadata[]
 ): MenuItem[] {
@@ -11,7 +11,7 @@ export function createMenuItems(
   const createPathMetadata = (g: DocumentMetadata, parentId = ''): MenuItem => {
     const pathData = {
       ...g,
-      path: `/${versionId}/${flavor.value}/${parentId}/${g.id}`,
+      path: `/${version}/${flavor.value}/${parentId}/${g.id}`,
     };
 
     if (Array.isArray(g.itemList)) {

--- a/nx-dev/data-access-documents/src/lib/menu.utils.ts
+++ b/nx-dev/data-access-documents/src/lib/menu.utils.ts
@@ -3,15 +3,15 @@ import { MenuItem, MenuSection } from './menu.models';
 
 export function createMenuItems(
   versionId: string,
-  flavor: string,
+  flavor: { alias: string; value: string },
   root: DocumentMetadata[]
 ): MenuItem[] {
-  const items = root.find((x) => x.id === flavor)?.itemList;
+  const items = root.find((x) => x.id === flavor.alias)?.itemList;
 
   const createPathMetadata = (g: DocumentMetadata, parentId = ''): MenuItem => {
     const pathData = {
       ...g,
-      path: `/${versionId}/${flavor}/${parentId}/${g.id}`,
+      path: `/${versionId}/${flavor.value}/${parentId}/${g.id}`,
     };
 
     if (Array.isArray(g.itemList)) {

--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -79,8 +79,8 @@ export function DocViewer({
               document={document}
               flavor={flavor.value}
               flavorList={flavorList.map((flavor) => flavor.value)}
-              version={version.path}
-              versionList={versionList.map((version) => version.id)}
+              version={version.alias}
+              versionList={versionList.map((version) => version.alias)}
             />
           </div>
         </div>

--- a/nx-dev/feature-doc-viewer/src/lib/sidebar.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/sidebar.tsx
@@ -56,9 +56,9 @@ export function Sidebar({
           <Selector
             data={versionList.map((version) => ({
               label: version.name,
-              value: version.id,
+              value: version.alias,
             }))}
-            selected={{ label: version.name, value: version.id }}
+            selected={{ label: version.name, value: version.alias }}
             onChange={(item) =>
               router.push(
                 createNextPath(item.value, flavor.value, router.asPath)
@@ -71,7 +71,9 @@ export function Sidebar({
             data={flavorList}
             selected={flavor}
             onChange={(item) =>
-              router.push(createNextPath(version.id, item.value, router.asPath))
+              router.push(
+                createNextPath(version.alias, item.value, router.asPath)
+              )
             }
           />
         </div>

--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -50,24 +50,24 @@ export function DocumentationPage({
   const [dialogOpen, setDialogOpen] = useState(false);
   const [navIsOpen, setNavIsOpen] = useState(false);
 
-  const pathCleaner = ((versions, flavors) => {
-    return (path: string): string =>
-      path
+  function pathCleaner(versions, flavors) {
+    return (path: string): string => {
+      const myPath = path
         .split('/')
         .filter(
           (segment: string) =>
-            !versions.find((version) =>
-              [version.alias, version.id].includes(segment)
-            )
+            !versions.find((v) => [v.alias, v.id].includes(segment))
         )
         .filter(
           (segment: string) =>
-            !flavors.find((flavors) =>
-              [flavor.alias, flavor.value].includes(segment)
-            )
+            !flavors.find((f) => [f.alias, f.value].includes(segment))
         )
         .join('/');
-  })(versions, flavors);
+      console.log(myPath);
+      return myPath;
+    };
+  }
+  const cleanPath = pathCleaner(versions, flavors);
 
   useEffect(() => {
     if (!navIsOpen) return;
@@ -97,11 +97,11 @@ export function DocumentationPage({
     // Otherwise replace current URL _if_ it is missing version+flavor.
     if (flavor.value !== storedFlavor) {
       router.push(
-        `/${version.alias}/${storedFlavor}${pathCleaner(router.asPath)}`
+        `/${version.alias}/${storedFlavor}${cleanPath(router.asPath)}`
       );
     } else if (!router.asPath.startsWith(`/${version.alias}`)) {
       router.push(
-        `/${version.alias}/${storedFlavor}${pathCleaner(router.asPath)}`,
+        `/${version.alias}/${storedFlavor}${cleanPath(router.asPath)}`,
         undefined,
         {
           shallow: true,
@@ -121,7 +121,7 @@ export function DocumentationPage({
           <link
             rel="canonical"
             href={`/${version.alias}/${flavor.value}`.concat(
-              pathCleaner(router.asPath)
+              cleanPath(router.asPath)
             )}
           />
         </Head>
@@ -131,7 +131,7 @@ export function DocumentationPage({
           <link
             rel="canonical"
             href={`/${version.alias}/${flavor.value}`.concat(
-              pathCleaner(router.asPath)
+              cleanPath(router.asPath)
             )}
           />
         </Head>
@@ -222,7 +222,7 @@ export function DocumentationPage({
               Please select the flavor you want to learn more about.
             </Dialog.Description>
             <div className="p-5 w-full grid grid-cols-3 gap-5 justify-items-center">
-              <Link href={`${version.alias}/r${pathCleaner(router.asPath)}`}>
+              <Link href={`${version.alias}/r${cleanPath(router.asPath)}`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#52C1DE">
                     <path d="M14.23 12.004a2.236 2.236 0 0 1-2.235 2.236 2.236 2.236 0 0 1-2.236-2.236 2.236 2.236 0 0 1 2.235-2.236 2.236 2.236 0 0 1 2.236 2.236zm2.648-10.69c-1.346 0-3.107.96-4.888 2.622-1.78-1.653-3.542-2.602-4.887-2.602-.41 0-.783.093-1.106.278-1.375.793-1.683 3.264-.973 6.365C1.98 8.917 0 10.42 0 12.004c0 1.59 1.99 3.097 5.043 4.03-.704 3.113-.39 5.588.988 6.38.32.187.69.275 1.102.275 1.345 0 3.107-.96 4.888-2.624 1.78 1.654 3.542 2.603 4.887 2.603.41 0 .783-.09 1.106-.275 1.374-.792 1.683-3.263.973-6.365C22.02 15.096 24 13.59 24 12.004c0-1.59-1.99-3.097-5.043-4.032.704-3.11.39-5.587-.988-6.38-.318-.184-.688-.277-1.092-.278zm-.005 1.09v.006c.225 0 .406.044.558.127.666.382.955 1.835.73 3.704-.054.46-.142.945-.25 1.44-.96-.236-2.006-.417-3.107-.534-.66-.905-1.345-1.727-2.035-2.447 1.592-1.48 3.087-2.292 4.105-2.295zm-9.77.02c1.012 0 2.514.808 4.11 2.28-.686.72-1.37 1.537-2.02 2.442-1.107.117-2.154.298-3.113.538-.112-.49-.195-.964-.254-1.42-.23-1.868.054-3.32.714-3.707.19-.09.4-.127.563-.132zm4.882 3.05c.455.468.91.992 1.36 1.564-.44-.02-.89-.034-1.345-.034-.46 0-.915.01-1.36.034.44-.572.895-1.096 1.345-1.565zM12 8.1c.74 0 1.477.034 2.202.093.406.582.802 1.203 1.183 1.86.372.64.71 1.29 1.018 1.946-.308.655-.646 1.31-1.013 1.95-.38.66-.773 1.288-1.18 1.87-.728.063-1.466.098-2.21.098-.74 0-1.477-.035-2.202-.093-.406-.582-.802-1.204-1.183-1.86-.372-.64-.71-1.29-1.018-1.946.303-.657.646-1.313 1.013-1.954.38-.66.773-1.286 1.18-1.868.728-.064 1.466-.098 2.21-.098zm-3.635.254c-.24.377-.48.763-.704 1.16-.225.39-.435.782-.635 1.174-.265-.656-.49-1.31-.676-1.947.64-.15 1.315-.283 2.015-.386zm7.26 0c.695.103 1.365.23 2.006.387-.18.632-.405 1.282-.66 1.933-.2-.39-.41-.783-.64-1.174-.225-.392-.465-.774-.705-1.146zm3.063.675c.484.15.944.317 1.375.498 1.732.74 2.852 1.708 2.852 2.476-.005.768-1.125 1.74-2.857 2.475-.42.18-.88.342-1.355.493-.28-.958-.646-1.956-1.1-2.98.45-1.017.81-2.01 1.085-2.964zm-13.395.004c.278.96.645 1.957 1.1 2.98-.45 1.017-.812 2.01-1.086 2.964-.484-.15-.944-.318-1.37-.5-1.732-.737-2.852-1.706-2.852-2.474 0-.768 1.12-1.742 2.852-2.476.42-.18.88-.342 1.356-.494zm11.678 4.28c.265.657.49 1.312.676 1.948-.64.157-1.316.29-2.016.39.24-.375.48-.762.705-1.158.225-.39.435-.788.636-1.18zm-9.945.02c.2.392.41.783.64 1.175.23.39.465.772.705 1.143-.695-.102-1.365-.23-2.006-.386.18-.63.406-1.282.66-1.933zM17.92 16.32c.112.493.2.968.254 1.423.23 1.868-.054 3.32-.714 3.708-.147.09-.338.128-.563.128-1.012 0-2.514-.807-4.11-2.28.686-.72 1.37-1.536 2.02-2.44 1.107-.118 2.154-.3 3.113-.54zm-11.83.01c.96.234 2.006.415 3.107.532.66.905 1.345 1.727 2.035 2.446-1.595 1.483-3.092 2.295-4.11 2.295-.22-.005-.406-.05-.553-.132-.666-.38-.955-1.834-.73-3.703.054-.46.142-.944.25-1.438zm4.56.64c.44.02.89.034 1.345.034.46 0 .915-.01 1.36-.034-.44.572-.895 1.095-1.345 1.565-.455-.47-.91-.993-1.36-1.565z" />
@@ -232,7 +232,7 @@ export function DocumentationPage({
                   </div>
                 </a>
               </Link>
-              <Link href={`${version.alias}/a${pathCleaner(router.asPath)}`}>
+              <Link href={`${version.alias}/a${cleanPath(router.asPath)}`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#E23236">
                     <path d="M9.931 12.645h4.138l-2.07-4.908m0-7.737L.68 3.982l1.726 14.771L12 24l9.596-5.242L23.32 3.984 11.999.001zm7.064 18.31h-2.638l-1.422-3.503H8.996l-1.422 3.504h-2.64L12 2.65z" />
@@ -242,7 +242,7 @@ export function DocumentationPage({
                   </div>
                 </a>
               </Link>
-              <Link href={`${version.alias}/n${pathCleaner(router.asPath)}`}>
+              <Link href={`${version.alias}/n${cleanPath(router.asPath)}`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#77AE64">
                     <path d="M11.998,24c-0.321,0-0.641-0.084-0.922-0.247l-2.936-1.737c-0.438-0.245-0.224-0.332-0.08-0.383 c0.585-0.203,0.703-0.25,1.328-0.604c0.065-0.037,0.151-0.023,0.218,0.017l2.256,1.339c0.082,0.045,0.197,0.045,0.272,0l8.795-5.076 c0.082-0.047,0.134-0.141,0.134-0.238V6.921c0-0.099-0.053-0.192-0.137-0.242l-8.791-5.072c-0.081-0.047-0.189-0.047-0.271,0 L3.075,6.68C2.99,6.729,2.936,6.825,2.936,6.921v10.15c0,0.097,0.054,0.189,0.139,0.235l2.409,1.392 c1.307,0.654,2.108-0.116,2.108-0.89V7.787c0-0.142,0.114-0.253,0.256-0.253h1.115c0.139,0,0.255,0.112,0.255,0.253v10.021 c0,1.745-0.95,2.745-2.604,2.745c-0.508,0-0.909,0-2.026-0.551L2.28,18.675c-0.57-0.329-0.922-0.945-0.922-1.604V6.921 c0-0.659,0.353-1.275,0.922-1.603l8.795-5.082c0.557-0.315,1.296-0.315,1.848,0l8.794,5.082c0.57,0.329,0.924,0.944,0.924,1.603 v10.15c0,0.659-0.354,1.273-0.924,1.604l-8.794,5.078C12.643,23.916,12.324,24,11.998,24z M19.099,13.993 c0-1.9-1.284-2.406-3.987-2.763c-2.731-0.361-3.009-0.548-3.009-1.187c0-0.528,0.235-1.233,2.258-1.233 c1.807,0,2.473,0.389,2.747,1.607c0.024,0.115,0.129,0.199,0.247,0.199h1.141c0.071,0,0.138-0.031,0.186-0.081 c0.048-0.054,0.074-0.123,0.067-0.196c-0.177-2.098-1.571-3.076-4.388-3.076c-2.508,0-4.004,1.058-4.004,2.833 c0,1.925,1.488,2.457,3.895,2.695c2.88,0.282,3.103,0.703,3.103,1.269c0,0.983-0.789,1.402-2.642,1.402 c-2.327,0-2.839-0.584-3.011-1.742c-0.02-0.124-0.126-0.215-0.253-0.215h-1.137c-0.141,0-0.254,0.112-0.254,0.253 c0,1.482,0.806,3.248,4.655,3.248C17.501,17.007,19.099,15.91,19.099,13.993z" />

--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -20,13 +20,14 @@ const versionList = documentsApi.getVersions();
 const defaultVersion = versionList.find((v) => v.default) as VersionMetadata;
 const defaultFlavor = flavorList.find((f) => f.default) as {
   value: string;
+  alias: string;
   label: string;
 };
 
 interface DocumentationPageProps {
   version: VersionMetadata;
-  flavor: { label: string; value: string };
-  flavors: { label: string; value: string }[];
+  flavor: { label: string; value: string; alias: string };
+  flavors: { label: string; value: string; alias: string }[];
   versions: VersionMetadata[];
   menu: Menu;
   document: DocumentData;
@@ -48,6 +49,21 @@ export function DocumentationPage({
   const { setValue: setStoredVersion } = useStorage('version');
   const [dialogOpen, setDialogOpen] = useState(false);
   const [navIsOpen, setNavIsOpen] = useState(false);
+
+  const getCanonicalPath = (
+    version: string,
+    flavor: { alias: string; value: string },
+    path: string
+  ) =>
+    `/${version}/${flavor.value}`.concat(
+      path
+        .split('/')
+        .filter(
+          (segment: string) =>
+            ![version, flavor.alias, flavor.value].includes(segment)
+        )
+        .join('/')
+    );
 
   useEffect(() => {
     if (!navIsOpen) return;
@@ -90,6 +106,14 @@ export function DocumentationPage({
 
   return (
     <>
+      {!isFallback && (
+        <Head>
+          <link
+            rel="canonical"
+            href={getCanonicalPath(version.id, flavor, router.asPath)}
+          />
+        </Head>
+      )}
       {isFallback && (
         <Head>
           <link
@@ -186,7 +210,7 @@ export function DocumentationPage({
               </p>
             </Dialog.Description>
             <div className="p-5 w-full grid grid-cols-3 gap-5 justify-items-center">
-              <Link href={`${version.id}/react${router.asPath}`}>
+              <Link href={`${version.id}/r${router.asPath}`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#52C1DE">
                     <path d="M14.23 12.004a2.236 2.236 0 0 1-2.235 2.236 2.236 2.236 0 0 1-2.236-2.236 2.236 2.236 0 0 1 2.235-2.236 2.236 2.236 0 0 1 2.236 2.236zm2.648-10.69c-1.346 0-3.107.96-4.888 2.622-1.78-1.653-3.542-2.602-4.887-2.602-.41 0-.783.093-1.106.278-1.375.793-1.683 3.264-.973 6.365C1.98 8.917 0 10.42 0 12.004c0 1.59 1.99 3.097 5.043 4.03-.704 3.113-.39 5.588.988 6.38.32.187.69.275 1.102.275 1.345 0 3.107-.96 4.888-2.624 1.78 1.654 3.542 2.603 4.887 2.603.41 0 .783-.09 1.106-.275 1.374-.792 1.683-3.263.973-6.365C22.02 15.096 24 13.59 24 12.004c0-1.59-1.99-3.097-5.043-4.032.704-3.11.39-5.587-.988-6.38-.318-.184-.688-.277-1.092-.278zm-.005 1.09v.006c.225 0 .406.044.558.127.666.382.955 1.835.73 3.704-.054.46-.142.945-.25 1.44-.96-.236-2.006-.417-3.107-.534-.66-.905-1.345-1.727-2.035-2.447 1.592-1.48 3.087-2.292 4.105-2.295zm-9.77.02c1.012 0 2.514.808 4.11 2.28-.686.72-1.37 1.537-2.02 2.442-1.107.117-2.154.298-3.113.538-.112-.49-.195-.964-.254-1.42-.23-1.868.054-3.32.714-3.707.19-.09.4-.127.563-.132zm4.882 3.05c.455.468.91.992 1.36 1.564-.44-.02-.89-.034-1.345-.034-.46 0-.915.01-1.36.034.44-.572.895-1.096 1.345-1.565zM12 8.1c.74 0 1.477.034 2.202.093.406.582.802 1.203 1.183 1.86.372.64.71 1.29 1.018 1.946-.308.655-.646 1.31-1.013 1.95-.38.66-.773 1.288-1.18 1.87-.728.063-1.466.098-2.21.098-.74 0-1.477-.035-2.202-.093-.406-.582-.802-1.204-1.183-1.86-.372-.64-.71-1.29-1.018-1.946.303-.657.646-1.313 1.013-1.954.38-.66.773-1.286 1.18-1.868.728-.064 1.466-.098 2.21-.098zm-3.635.254c-.24.377-.48.763-.704 1.16-.225.39-.435.782-.635 1.174-.265-.656-.49-1.31-.676-1.947.64-.15 1.315-.283 2.015-.386zm7.26 0c.695.103 1.365.23 2.006.387-.18.632-.405 1.282-.66 1.933-.2-.39-.41-.783-.64-1.174-.225-.392-.465-.774-.705-1.146zm3.063.675c.484.15.944.317 1.375.498 1.732.74 2.852 1.708 2.852 2.476-.005.768-1.125 1.74-2.857 2.475-.42.18-.88.342-1.355.493-.28-.958-.646-1.956-1.1-2.98.45-1.017.81-2.01 1.085-2.964zm-13.395.004c.278.96.645 1.957 1.1 2.98-.45 1.017-.812 2.01-1.086 2.964-.484-.15-.944-.318-1.37-.5-1.732-.737-2.852-1.706-2.852-2.474 0-.768 1.12-1.742 2.852-2.476.42-.18.88-.342 1.356-.494zm11.678 4.28c.265.657.49 1.312.676 1.948-.64.157-1.316.29-2.016.39.24-.375.48-.762.705-1.158.225-.39.435-.788.636-1.18zm-9.945.02c.2.392.41.783.64 1.175.23.39.465.772.705 1.143-.695-.102-1.365-.23-2.006-.386.18-.63.406-1.282.66-1.933zM17.92 16.32c.112.493.2.968.254 1.423.23 1.868-.054 3.32-.714 3.708-.147.09-.338.128-.563.128-1.012 0-2.514-.807-4.11-2.28.686-.72 1.37-1.536 2.02-2.44 1.107-.118 2.154-.3 3.113-.54zm-11.83.01c.96.234 2.006.415 3.107.532.66.905 1.345 1.727 2.035 2.446-1.595 1.483-3.092 2.295-4.11 2.295-.22-.005-.406-.05-.553-.132-.666-.38-.955-1.834-.73-3.703.054-.46.142-.944.25-1.438zm4.56.64c.44.02.89.034 1.345.034.46 0 .915-.01 1.36-.034-.44.572-.895 1.095-1.345 1.565-.455-.47-.91-.993-1.36-1.565z" />
@@ -196,7 +220,7 @@ export function DocumentationPage({
                   </div>
                 </a>
               </Link>
-              <Link href={`${version.id}/angular${router.asPath}`}>
+              <Link href={`${version.id}/a${router.asPath}`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#E23236">
                     <path d="M9.931 12.645h4.138l-2.07-4.908m0-7.737L.68 3.982l1.726 14.771L12 24l9.596-5.242L23.32 3.984 11.999.001zm7.064 18.31h-2.638l-1.422-3.503H8.996l-1.422 3.504h-2.64L12 2.65z" />
@@ -206,7 +230,7 @@ export function DocumentationPage({
                   </div>
                 </a>
               </Link>
-              <Link href={`${version.id}/node${router.asPath}`}>
+              <Link href={`${version.id}/n${router.asPath}`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#77AE64">
                     <path d="M11.998,24c-0.321,0-0.641-0.084-0.922-0.247l-2.936-1.737c-0.438-0.245-0.224-0.332-0.08-0.383 c0.585-0.203,0.703-0.25,1.328-0.604c0.065-0.037,0.151-0.023,0.218,0.017l2.256,1.339c0.082,0.045,0.197,0.045,0.272,0l8.795-5.076 c0.082-0.047,0.134-0.141,0.134-0.238V6.921c0-0.099-0.053-0.192-0.137-0.242l-8.791-5.072c-0.081-0.047-0.189-0.047-0.271,0 L3.075,6.68C2.99,6.729,2.936,6.825,2.936,6.921v10.15c0,0.097,0.054,0.189,0.139,0.235l2.409,1.392 c1.307,0.654,2.108-0.116,2.108-0.89V7.787c0-0.142,0.114-0.253,0.256-0.253h1.115c0.139,0,0.255,0.112,0.255,0.253v10.021 c0,1.745-0.95,2.745-2.604,2.745c-0.508,0-0.909,0-2.026-0.551L2.28,18.675c-0.57-0.329-0.922-0.945-0.922-1.604V6.921 c0-0.659,0.353-1.275,0.922-1.603l8.795-5.082c0.557-0.315,1.296-0.315,1.848,0l8.794,5.082c0.57,0.329,0.924,0.944,0.924,1.603 v10.15c0,0.659-0.354,1.273-0.924,1.604l-8.794,5.078C12.643,23.916,12.324,24,11.998,24z M19.099,13.993 c0-1.9-1.284-2.406-3.987-2.763c-2.731-0.361-3.009-0.548-3.009-1.187c0-0.528,0.235-1.233,2.258-1.233 c1.807,0,2.473,0.389,2.747,1.607c0.024,0.115,0.129,0.199,0.247,0.199h1.141c0.071,0,0.138-0.031,0.186-0.081 c0.048-0.054,0.074-0.123,0.067-0.196c-0.177-2.098-1.571-3.076-4.388-3.076c-2.508,0-4.004,1.058-4.004,2.833 c0,1.925,1.488,2.457,3.895,2.695c2.88,0.282,3.103,0.703,3.103,1.269c0,0.983-0.789,1.402-2.642,1.402 c-2.327,0-2.839-0.584-3.011-1.742c-0.02-0.124-0.126-0.215-0.253-0.215h-1.137c-0.141,0-0.254,0.112-0.254,0.253 c0,1.482,0.806,3.248,4.655,3.248C17.501,17.007,19.099,15.91,19.099,13.993z" />
@@ -232,9 +256,11 @@ export async function getStaticProps({
   const version =
     versionList.find((item) => item.id === params.segments[0]) ??
     defaultVersion;
-  const flavor: { label: string; value: string } =
-    flavorList.find((item) => item.value === params.segments[1]) ??
-    defaultFlavor;
+  const flavor: { label: string; value: string; alias: string } =
+    flavorList.find(
+      (item) =>
+        item.value === params.segments[1] || item.alias === params.segments[1]
+    ) ?? defaultFlavor;
 
   const { document, menu, isFallback } = findDocumentAndMenu(
     version,
@@ -278,7 +304,7 @@ export async function getStaticPaths() {
 
 function findDocumentAndMenu(
   version: VersionMetadata,
-  flavor: { label: string; value: string },
+  flavor: { label: string; value: string; alias: string },
   segments: string[]
 ): {
   menu: undefined | Menu;
@@ -292,8 +318,12 @@ function findDocumentAndMenu(
   let document: undefined | DocumentData = undefined;
 
   try {
-    menu = menuApi.getMenu(version.id, flavor.value);
-    document = documentsApi.getDocument(version.id, flavor.value, path);
+    menu = menuApi.getMenu(version.id, {
+      alias: flavor.alias,
+      value: flavor.value,
+    });
+
+    document = documentsApi.getDocument(version.id, flavor.alias, path);
   } catch {
     // nothing
   }

--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -51,8 +51,8 @@ export function DocumentationPage({
   const [navIsOpen, setNavIsOpen] = useState(false);
 
   function pathCleaner(versions, flavors) {
-    return (path: string): string => {
-      const myPath = path
+    return (path: string): string =>
+      path
         .split('/')
         .filter(
           (segment: string) =>
@@ -63,9 +63,6 @@ export function DocumentationPage({
             !flavors.find((f) => [f.alias, f.value].includes(segment))
         )
         .join('/');
-      console.log(myPath);
-      return myPath;
-    };
   }
   const cleanPath = pathCleaner(versions, flavors);
 
@@ -232,7 +229,7 @@ export function DocumentationPage({
                   </div>
                 </a>
               </Link>
-              <Link href={`${version.alias}/a${cleanPath(router.asPath)}`}>
+              <Link href={`l/a/getting-started/intro`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#E23236">
                     <path d="M9.931 12.645h4.138l-2.07-4.908m0-7.737L.68 3.982l1.726 14.771L12 24l9.596-5.242L23.32 3.984 11.999.001zm7.064 18.31h-2.638l-1.422-3.503H8.996l-1.422 3.504h-2.64L12 2.65z" />

--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -50,20 +50,24 @@ export function DocumentationPage({
   const [dialogOpen, setDialogOpen] = useState(false);
   const [navIsOpen, setNavIsOpen] = useState(false);
 
-  const getCanonicalPath = (
-    version: string,
-    flavor: { alias: string; value: string },
-    path: string
-  ) =>
-    `/${version}/${flavor.value}`.concat(
+  const pathCleaner = ((versions, flavors) => {
+    return (path: string): string =>
       path
         .split('/')
         .filter(
           (segment: string) =>
-            ![version, flavor.alias, flavor.value].includes(segment)
+            !versions.find((version) =>
+              [version.alias, version.id].includes(segment)
+            )
         )
-        .join('/')
-    );
+        .filter(
+          (segment: string) =>
+            !flavors.find((flavors) =>
+              [flavor.alias, flavor.value].includes(segment)
+            )
+        )
+        .join('/');
+  })(versions, flavors);
 
   useEffect(() => {
     if (!navIsOpen) return;
@@ -82,7 +86,7 @@ export function DocumentationPage({
   }, [flavor, isFallback, setStoredFlavor]);
   useEffect(() => {
     if (!isFallback) {
-      setStoredVersion(version.id);
+      setStoredVersion(version.alias);
     }
   }, [version, isFallback, setStoredVersion]);
 
@@ -92,11 +96,17 @@ export function DocumentationPage({
     // If the stored flavor is different then navigate away.
     // Otherwise replace current URL _if_ it is missing version+flavor.
     if (flavor.value !== storedFlavor) {
-      router.push(`/${version.id}/${storedFlavor}${router.asPath}`);
-    } else if (!router.asPath.startsWith(`/${version.id}`)) {
-      router.push(`/${version.id}/${storedFlavor}${router.asPath}`, undefined, {
-        shallow: true,
-      });
+      router.push(
+        `/${version.alias}/${storedFlavor}${pathCleaner(router.asPath)}`
+      );
+    } else if (!router.asPath.startsWith(`/${version.alias}`)) {
+      router.push(
+        `/${version.alias}/${storedFlavor}${pathCleaner(router.asPath)}`,
+        undefined,
+        {
+          shallow: true,
+        }
+      );
     }
   }, [router, version, flavor, storedFlavor, isFallback]);
 
@@ -110,7 +120,9 @@ export function DocumentationPage({
         <Head>
           <link
             rel="canonical"
-            href={getCanonicalPath(version.id, flavor, router.asPath)}
+            href={`/${version.alias}/${flavor.value}`.concat(
+              pathCleaner(router.asPath)
+            )}
           />
         </Head>
       )}
@@ -118,7 +130,9 @@ export function DocumentationPage({
         <Head>
           <link
             rel="canonical"
-            href={`/${version.id}/${flavor.value}${router.asPath}`}
+            href={`/${version.alias}/${flavor.value}`.concat(
+              pathCleaner(router.asPath)
+            )}
           />
         </Head>
       )}
@@ -201,16 +215,14 @@ export function DocumentationPage({
               Before You Continue...
             </Dialog.Title>
             <Dialog.Description className="m-5">
-              <p className="mb-4">
-                Nx is a smart and extensible build framework that has
-                first-class support for many frontend and backend technologies.
-              </p>
-              <p className="mb-4">
-                Please select the flavor you want to learn more about.
-              </p>
+              Nx is a smart and extensible build framework that has first-class
+              support for many frontend and backend technologies.
+            </Dialog.Description>
+            <Dialog.Description className="m-5">
+              Please select the flavor you want to learn more about.
             </Dialog.Description>
             <div className="p-5 w-full grid grid-cols-3 gap-5 justify-items-center">
-              <Link href={`${version.id}/r${router.asPath}`}>
+              <Link href={`${version.alias}/r${pathCleaner(router.asPath)}`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#52C1DE">
                     <path d="M14.23 12.004a2.236 2.236 0 0 1-2.235 2.236 2.236 2.236 0 0 1-2.236-2.236 2.236 2.236 0 0 1 2.235-2.236 2.236 2.236 0 0 1 2.236 2.236zm2.648-10.69c-1.346 0-3.107.96-4.888 2.622-1.78-1.653-3.542-2.602-4.887-2.602-.41 0-.783.093-1.106.278-1.375.793-1.683 3.264-.973 6.365C1.98 8.917 0 10.42 0 12.004c0 1.59 1.99 3.097 5.043 4.03-.704 3.113-.39 5.588.988 6.38.32.187.69.275 1.102.275 1.345 0 3.107-.96 4.888-2.624 1.78 1.654 3.542 2.603 4.887 2.603.41 0 .783-.09 1.106-.275 1.374-.792 1.683-3.263.973-6.365C22.02 15.096 24 13.59 24 12.004c0-1.59-1.99-3.097-5.043-4.032.704-3.11.39-5.587-.988-6.38-.318-.184-.688-.277-1.092-.278zm-.005 1.09v.006c.225 0 .406.044.558.127.666.382.955 1.835.73 3.704-.054.46-.142.945-.25 1.44-.96-.236-2.006-.417-3.107-.534-.66-.905-1.345-1.727-2.035-2.447 1.592-1.48 3.087-2.292 4.105-2.295zm-9.77.02c1.012 0 2.514.808 4.11 2.28-.686.72-1.37 1.537-2.02 2.442-1.107.117-2.154.298-3.113.538-.112-.49-.195-.964-.254-1.42-.23-1.868.054-3.32.714-3.707.19-.09.4-.127.563-.132zm4.882 3.05c.455.468.91.992 1.36 1.564-.44-.02-.89-.034-1.345-.034-.46 0-.915.01-1.36.034.44-.572.895-1.096 1.345-1.565zM12 8.1c.74 0 1.477.034 2.202.093.406.582.802 1.203 1.183 1.86.372.64.71 1.29 1.018 1.946-.308.655-.646 1.31-1.013 1.95-.38.66-.773 1.288-1.18 1.87-.728.063-1.466.098-2.21.098-.74 0-1.477-.035-2.202-.093-.406-.582-.802-1.204-1.183-1.86-.372-.64-.71-1.29-1.018-1.946.303-.657.646-1.313 1.013-1.954.38-.66.773-1.286 1.18-1.868.728-.064 1.466-.098 2.21-.098zm-3.635.254c-.24.377-.48.763-.704 1.16-.225.39-.435.782-.635 1.174-.265-.656-.49-1.31-.676-1.947.64-.15 1.315-.283 2.015-.386zm7.26 0c.695.103 1.365.23 2.006.387-.18.632-.405 1.282-.66 1.933-.2-.39-.41-.783-.64-1.174-.225-.392-.465-.774-.705-1.146zm3.063.675c.484.15.944.317 1.375.498 1.732.74 2.852 1.708 2.852 2.476-.005.768-1.125 1.74-2.857 2.475-.42.18-.88.342-1.355.493-.28-.958-.646-1.956-1.1-2.98.45-1.017.81-2.01 1.085-2.964zm-13.395.004c.278.96.645 1.957 1.1 2.98-.45 1.017-.812 2.01-1.086 2.964-.484-.15-.944-.318-1.37-.5-1.732-.737-2.852-1.706-2.852-2.474 0-.768 1.12-1.742 2.852-2.476.42-.18.88-.342 1.356-.494zm11.678 4.28c.265.657.49 1.312.676 1.948-.64.157-1.316.29-2.016.39.24-.375.48-.762.705-1.158.225-.39.435-.788.636-1.18zm-9.945.02c.2.392.41.783.64 1.175.23.39.465.772.705 1.143-.695-.102-1.365-.23-2.006-.386.18-.63.406-1.282.66-1.933zM17.92 16.32c.112.493.2.968.254 1.423.23 1.868-.054 3.32-.714 3.708-.147.09-.338.128-.563.128-1.012 0-2.514-.807-4.11-2.28.686-.72 1.37-1.536 2.02-2.44 1.107-.118 2.154-.3 3.113-.54zm-11.83.01c.96.234 2.006.415 3.107.532.66.905 1.345 1.727 2.035 2.446-1.595 1.483-3.092 2.295-4.11 2.295-.22-.005-.406-.05-.553-.132-.666-.38-.955-1.834-.73-3.703.054-.46.142-.944.25-1.438zm4.56.64c.44.02.89.034 1.345.034.46 0 .915-.01 1.36-.034-.44.572-.895 1.095-1.345 1.565-.455-.47-.91-.993-1.36-1.565z" />
@@ -220,7 +232,7 @@ export function DocumentationPage({
                   </div>
                 </a>
               </Link>
-              <Link href={`${version.id}/a${router.asPath}`}>
+              <Link href={`${version.alias}/a${pathCleaner(router.asPath)}`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#E23236">
                     <path d="M9.931 12.645h4.138l-2.07-4.908m0-7.737L.68 3.982l1.726 14.771L12 24l9.596-5.242L23.32 3.984 11.999.001zm7.064 18.31h-2.638l-1.422-3.503H8.996l-1.422 3.504h-2.64L12 2.65z" />
@@ -230,7 +242,7 @@ export function DocumentationPage({
                   </div>
                 </a>
               </Link>
-              <Link href={`${version.id}/n${router.asPath}`}>
+              <Link href={`${version.alias}/n${pathCleaner(router.asPath)}`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#77AE64">
                     <path d="M11.998,24c-0.321,0-0.641-0.084-0.922-0.247l-2.936-1.737c-0.438-0.245-0.224-0.332-0.08-0.383 c0.585-0.203,0.703-0.25,1.328-0.604c0.065-0.037,0.151-0.023,0.218,0.017l2.256,1.339c0.082,0.045,0.197,0.045,0.272,0l8.795-5.076 c0.082-0.047,0.134-0.141,0.134-0.238V6.921c0-0.099-0.053-0.192-0.137-0.242l-8.791-5.072c-0.081-0.047-0.189-0.047-0.271,0 L3.075,6.68C2.99,6.729,2.936,6.825,2.936,6.921v10.15c0,0.097,0.054,0.189,0.139,0.235l2.409,1.392 c1.307,0.654,2.108-0.116,2.108-0.89V7.787c0-0.142,0.114-0.253,0.256-0.253h1.115c0.139,0,0.255,0.112,0.255,0.253v10.021 c0,1.745-0.95,2.745-2.604,2.745c-0.508,0-0.909,0-2.026-0.551L2.28,18.675c-0.57-0.329-0.922-0.945-0.922-1.604V6.921 c0-0.659,0.353-1.275,0.922-1.603l8.795-5.082c0.557-0.315,1.296-0.315,1.848,0l8.794,5.082c0.57,0.329,0.924,0.944,0.924,1.603 v10.15c0,0.659-0.354,1.273-0.924,1.604l-8.794,5.078C12.643,23.916,12.324,24,11.998,24z M19.099,13.993 c0-1.9-1.284-2.406-3.987-2.763c-2.731-0.361-3.009-0.548-3.009-1.187c0-0.528,0.235-1.233,2.258-1.233 c1.807,0,2.473,0.389,2.747,1.607c0.024,0.115,0.129,0.199,0.247,0.199h1.141c0.071,0,0.138-0.031,0.186-0.081 c0.048-0.054,0.074-0.123,0.067-0.196c-0.177-2.098-1.571-3.076-4.388-3.076c-2.508,0-4.004,1.058-4.004,2.833 c0,1.925,1.488,2.457,3.895,2.695c2.88,0.282,3.103,0.703,3.103,1.269c0,0.983-0.789,1.402-2.642,1.402 c-2.327,0-2.839-0.584-3.011-1.742c-0.02-0.124-0.126-0.215-0.253-0.215h-1.137c-0.141,0-0.254,0.112-0.254,0.253 c0,1.482,0.806,3.248,4.655,3.248C17.501,17.007,19.099,15.91,19.099,13.993z" />
@@ -254,12 +266,12 @@ export async function getStaticProps({
   params: { segments: string[] };
 }) {
   const version =
-    versionList.find((item) => item.id === params.segments[0]) ??
-    defaultVersion;
+    versionList.find((item) =>
+      [item.id, item.alias].includes(params.segments[0])
+    ) ?? defaultVersion;
   const flavor: { label: string; value: string; alias: string } =
-    flavorList.find(
-      (item) =>
-        item.value === params.segments[1] || item.alias === params.segments[1]
+    flavorList.find((item) =>
+      [item.value, item.alias].includes(params.segments[1])
     ) ?? defaultFlavor;
 
   const { document, menu, isFallback } = findDocumentAndMenu(
@@ -311,17 +323,23 @@ function findDocumentAndMenu(
   document: undefined | DocumentData;
   isFallback?: boolean;
 } {
-  const isFallback = segments[0] !== version.id;
+  const isFallback = ![version.id, version.alias].includes(segments[0]);
   const path = isFallback ? segments : segments.slice(2);
 
   let menu: undefined | Menu = undefined;
   let document: undefined | DocumentData = undefined;
 
   try {
-    menu = menuApi.getMenu(version.id, {
-      alias: flavor.alias,
-      value: flavor.value,
-    });
+    menu = menuApi.getMenu(
+      {
+        alias: version.alias,
+        value: version.id,
+      },
+      {
+        alias: flavor.alias,
+        value: flavor.value,
+      }
+    );
 
     document = documentsApi.getDocument(version.id, flavor.alias, path);
   } catch {

--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -53,7 +53,7 @@
       },
       "configurations": {
         "production": {
-          "buildTarget": "nx-dev:build:production",
+          "buildTarget": "nx-dev:build-base:production",
           "dev": false
         }
       }

--- a/nx-dev/nx-dev/public/documentation/versions.json
+++ b/nx-dev/nx-dev/public/documentation/versions.json
@@ -2,6 +2,7 @@
   {
     "name": "Latest",
     "id": "latest",
+    "alias": "l",
     "release": "12.9.0",
     "path": "latest",
     "default": true
@@ -9,6 +10,7 @@
   {
     "name": "Previous (v11.6.3)",
     "id": "previous",
+    "alias": "p",
     "release": "11.6.3",
     "path": "previous",
     "default": false


### PR DESCRIPTION
## What it does?
This PR modifies the url schemes by adding the concept of _"alias"_ for the version and the flavour, meaning we can gave a set of shorten urls while being backward compatible.

Support:
```
/l/a/getting-started/nx-cli
/l/angular/getting-started/nx-cli
/latest/angular/getting-started/nx-cli
/l/angular/getting-started/nx-cli
```