### PR TITLE
Jaybell/add standalone config flag to nest lib generator

### DIFF
--- a/docs/angular/api-nest/generators/library.md
+++ b/docs/angular/api-nest/generators/library.md
@@ -120,6 +120,14 @@ Type: `boolean`
 
 Do not update tsconfig.base.json for development experience.
 
+### standaloneConfig
+
+Default: `false`
+
+Type: `boolean`
+
+Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json
+
 ### strict
 
 Default: `false`

--- a/docs/node/api-nest/generators/library.md
+++ b/docs/node/api-nest/generators/library.md
@@ -120,6 +120,14 @@ Type: `boolean`
 
 Do not update tsconfig.base.json for development experience.
 
+### standaloneConfig
+
+Default: `false`
+
+Type: `boolean`
+
+Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json
+
 ### strict
 
 Default: `false`

--- a/docs/react/api-nest/generators/library.md
+++ b/docs/react/api-nest/generators/library.md
@@ -120,6 +120,14 @@ Type: `boolean`
 
 Do not update tsconfig.base.json for development experience.
 
+### standaloneConfig
+
+Default: `false`
+
+Type: `boolean`
+
+Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json
+
 ### strict
 
 Default: `false`

--- a/packages/nest/src/generators/library/lib/normalize-options.ts
+++ b/packages/nest/src/generators/library/lib/normalize-options.ts
@@ -58,5 +58,6 @@ export function toNodeLibraryGeneratorOptions(
     tags: options.tags,
     testEnvironment: options.testEnvironment,
     unitTestRunner: options.unitTestRunner,
+    standaloneConfig: options.standaloneConfig
   };
 }

--- a/packages/nest/src/generators/library/lib/normalize-options.ts
+++ b/packages/nest/src/generators/library/lib/normalize-options.ts
@@ -58,6 +58,6 @@ export function toNodeLibraryGeneratorOptions(
     tags: options.tags,
     testEnvironment: options.testEnvironment,
     unitTestRunner: options.unitTestRunner,
-    standaloneConfig: options.standaloneConfig
+    standaloneConfig: options.standaloneConfig,
   };
 }

--- a/packages/nest/src/generators/library/schema.d.ts
+++ b/packages/nest/src/generators/library/schema.d.ts
@@ -27,6 +27,7 @@ export interface LibraryGeneratorOptions {
     | 'es2020';
   testEnvironment?: 'jsdom' | 'node';
   unitTestRunner?: UnitTestRunner;
+  standaloneConfig?: boolean;
 }
 
 export interface NormalizedOptions extends LibraryGeneratorOptions {

--- a/packages/nest/src/generators/library/schema.json
+++ b/packages/nest/src/generators/library/schema.json
@@ -106,6 +106,11 @@
       "description": "Whether to enable tsconfig strict mode or not.",
       "type": "boolean",
       "default": false
+    },
+    "standaloneConfig": {
+      "description": "Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Cannot use the `standaloneConfig` flag with the nest lib schematic

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
can use the flag

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
