### PR TITLE
feat(core): daemon supports incremental file hashing

### DIFF
--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -280,7 +280,7 @@ export function readWorkspaceFiles(projectGraphVersion = '3.0'): FileData[] {
 
   if (defaultFileHasher.usesGitForHashing) {
     const ignoredGlobs = getIgnoredGlobs();
-    const r = defaultFileHasher.workspaceFiles
+    const r = Array.from(defaultFileHasher.workspaceFiles)
       .filter((f) => !ignoredGlobs.ignores(f))
       .map((f) =>
         projectFileDataCompatAdapter(

--- a/packages/workspace/src/core/hasher/git-hasher.ts
+++ b/packages/workspace/src/core/hasher/git-hasher.ts
@@ -94,6 +94,10 @@ function gitLsTree(path: string): Map<string, string> {
   );
 }
 
+export function gitRevParseHead(path: string): string {
+  return spawnProcess('git', ['rev-parse', 'HEAD'], path);
+}
+
 function gitStatus(path: string): {
   status: Map<string, string>;
   deletedFiles: string[];
@@ -166,4 +170,18 @@ export function getFileHashes(path: string): Map<string, string> {
     }
     return new Map<string, string>();
   }
+}
+
+/**
+ * This utility is used to return a Map of filenames to hashes, where those filenames come from
+ * git's knowledge of:
+ *
+ * - files which are untracked (newly created)
+ * - files which are modified in some way (but NOT deleted) and either staged or unstaged
+ */
+export function getUntrackedAndUncommittedFileHashes(
+  path: string
+): Map<string, string> {
+  const { status } = gitStatus(path);
+  return status;
 }

--- a/packages/workspace/src/core/project-graph/daemon/server.ts
+++ b/packages/workspace/src/core/project-graph/daemon/server.ts
@@ -5,6 +5,7 @@ import { connect, createServer, Server } from 'net';
 import { platform } from 'os';
 import { join, resolve } from 'path';
 import { performance, PerformanceObserver } from 'perf_hooks';
+import { defaultFileHasher } from '../../hasher/file-hasher';
 import { createProjectGraph } from '../project-graph';
 
 /**
@@ -80,6 +81,8 @@ const server = createServer((socket) => {
 
   performance.mark('server-connection');
   serverLog('Connection Received');
+
+  defaultFileHasher.init();
 
   const projectGraph = createProjectGraph(
     undefined,

--- a/packages/workspace/src/core/project-graph/daemon/server.ts
+++ b/packages/workspace/src/core/project-graph/daemon/server.ts
@@ -67,13 +67,16 @@ function formatLogMessage(message) {
  * For now we just invoke the existing `createProjectGraph()` utility and return the project
  * graph upon connection to the server
  */
+let performanceObserver: PerformanceObserver | undefined;
 const server = createServer((socket) => {
-  const obs = new PerformanceObserver((list) => {
-    const entry = list.getEntries()[0];
-    // Slight indentation to improve readability of the overall log file
-    serverLog(`  Time taken for '${entry.name}'`, `${entry.duration}ms`);
-  });
-  obs.observe({ entryTypes: ['measure'], buffered: false });
+  if (!performanceObserver) {
+    performanceObserver = new PerformanceObserver((list) => {
+      const entry = list.getEntries()[0];
+      // Slight indentation to improve readability of the overall log file
+      serverLog(`  Time taken for '${entry.name}'`, `${entry.duration}ms`);
+    });
+  }
+  performanceObserver.observe({ entryTypes: ['measure'], buffered: false });
 
   performance.mark('server-connection');
   serverLog('Connection Received');


### PR DESCRIPTION
The daemon now performs the standard full initialization of the defaultFileHasher on first load, but then caches the latest SHA and, if unchanged, only performs incremental file hashing thereafter based on the untracked, unstaged and staged file changes (excluding deleted files).

This also fixed two bugs (extra performance observer logs and missing init call to the file hasher)