### PR TITLE
fix(core): git-hasher checkForDeletedFiles will now hard error

### DIFF
--- a/packages/workspace/src/core/hasher/git-hasher.ts
+++ b/packages/workspace/src/core/hasher/git-hasher.ts
@@ -132,10 +132,9 @@ function checkForDeletedFiles(
       statSync(join(path, f)).isFile();
       filesToHash.push(f);
     } catch {
-      console.warn(
-        `Warning: Fell back to using 'fs' to identify ${f} as deleted. Please open an issue at https://github.com/nrwl/nx so we can investigate.`
+      throw new Error(
+        `Error: Fell back to using 'fs' to identify ${f} as deleted. Please open an issue at https://github.com/nrwl/nx so we can investigate.`
       );
-      deletedFiles.push(f);
     }
   });
 


### PR DESCRIPTION
As discussed with Victor, we believe the early issues here have been resolved so upgrading the check to be a hard error. All being well and we don't receive any user reports, the utility can be removed and that should yield a performance improvement as we will no longer need the statSync call.