### PR TITLE
feat(angular): allow exporting function and promise within the custom Webpack config

### DIFF
--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -69,9 +69,21 @@ function buildAppWithCustomWebpackConfiguration(
   pathToWebpackConfig: string
 ) {
   return executeBrowserBuilder(options, context, {
-    webpackConfiguration: (baseWebpackConfig) => {
+    webpackConfiguration: async (baseWebpackConfig) => {
       const customWebpackConfiguration = require(pathToWebpackConfig);
-      return merge(baseWebpackConfig, customWebpackConfiguration);
+      // The extra Webpack configuration file can export a synchronous or asynchronous function,
+      // for instance: `module.exports = async config => { ... }`.
+      if (typeof customWebpackConfiguration === 'function') {
+        return customWebpackConfiguration(baseWebpackConfig);
+      } else {
+        return merge(
+          baseWebpackConfig,
+          // The extra Webpack configuration file can also export a Promise, for instance:
+          // `module.exports = new Promise(...)`. If it exports a single object, but not a Promise,
+          // then await will just resolve that object.
+          await customWebpackConfiguration
+        );
+      }
     },
   });
 }


### PR DESCRIPTION
## Current Behavior

Webpack supports 4 possible configuration options:

1. config object
2. promise that resolves to config object
3. function that modifies the configuration
4. async function that modifies the configuration

The current implementation allows only the first option. E.g. it's not possible to export a function that modifies `config.plugins`.

## Expected Behavior

All options are supported.