### PR TITLE
fix(gatsby): fix build errors due to incompatible webpack API

### DIFF
--- a/packages/gatsby/src/generators/init/init.ts
+++ b/packages/gatsby/src/generators/init/init.ts
@@ -60,7 +60,7 @@ function updateDependencies(host: Tree) {
       'react-helmet': reactHelmetVersion,
       'gatsby-plugin-typescript': gatsbyPluginTypescriptVersion,
       ...(isPnpm ? { 'gatsby-plugin-pnpm': gatsbyPluginPnpm } : {}),
-      webpack: '^5.39.1',
+      webpack: '~5.39.1',
     },
     {
       '@nrwl/gatsby': nxVersion,


### PR DESCRIPTION
This PR makes the webpack version range more strict since `5.53.0` brought in stricter validation, which resulted in build errors due to Gatsby using the wrong API.

## Current Behavior
Build fails on latest webpack

## Expected Behavior
Build should fail, and we should be using the latest _supported_ webpack version

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
