### PR TITLE
docs(angular): Fix code snippets incorrectly marked as `bash`

### DIFF
--- a/docs/angular/guides/configuration.md
+++ b/docs/angular/guides/configuration.md
@@ -174,7 +174,7 @@ You can select a configuration like this: `nx build myapp --configuration=produc
 
 The following show how the builder options get constructed:
 
-```bash
+```javascript
 require(`@nrwl/jest`).builders['jest']({...options, ...selectedConfiguration, ...commandLineArgs}}) // Pseudocode
 ```
 

--- a/docs/angular/guides/modern-angular/karma-to-jest.md
+++ b/docs/angular/guides/modern-angular/karma-to-jest.md
@@ -53,7 +53,7 @@ Any custom code that was present in Step 1 and 2 should be recreated now in the 
 
 Modify `tsconfig.spec.ts` in the lib’s folder and add Jest typings: add jest under types and remove previous framework (e.g. jasmine)
 
-```bash
+```typescript
 "types": [ "jest", "node" ]
 ```
 

--- a/docs/angular/guides/modern-angular/karma-to-jest.md
+++ b/docs/angular/guides/modern-angular/karma-to-jest.md
@@ -51,9 +51,9 @@ Any custom code that was present in Step 1 and 2 should be recreated now in the 
 
 **Step 5**
 
-Modify `tsconfig.spec.ts` in the lib’s folder and add Jest typings: add jest under types and remove previous framework (e.g. jasmine)
+Modify `tsconfig.spec.json` in the lib’s folder and add Jest typings: add jest under types and remove previous framework (e.g. jasmine)
 
-```typescript
+```json
 "types": [ "jest", "node" ]
 ```
 


### PR DESCRIPTION
I noticed a couple code snippets in the documentation that were incorrectly marked as `bash`. I fixed them in this PR.