### PR TITLE
fix(core): handle empty root path in angular.json

### DIFF
--- a/packages/workspace/src/core/file-graph/project-file-map.ts
+++ b/packages/workspace/src/core/file-graph/project-file-map.ts
@@ -23,7 +23,7 @@ export function createProjectFileMap(
         if (seen.has(f.file)) {
           return;
         }
-        if (f.file.startsWith(p.root)) {
+        if (f.file.startsWith(p.root || p.sourceRoot)) {
           fileMap[projectName].push(f);
           seen.add(f.file);
         }


### PR DESCRIPTION
dep-graph may fail for default angular cli project due to empty root path in angular.json, this MR handles with case by falling back to use sourceRoot

Fixes #7008
