### PR TITLE
docs(angular): fix embedded link in talk section

### DIFF
--- a/docs/angular/guides/misc-upgrade.md
+++ b/docs/angular/guides/misc-upgrade.md
@@ -28,7 +28,7 @@ Nx sets up the upgrade module for you to help you get started with your upgrade 
 
 In this talk at NgConf, Victor Savkin shows how to upgrade your application gradually, component by component, module by module using NgUpgrade and the Angular Router. He discusses the common problems developers face during such migrations and the patterns that can be used to remedy them.
 
-<a href="https://www.youtube.com/embed/izpqQpD8RQ0" class="embedly-card" data-card-width="100%" data-card-controls="0">Embedded content: https://www.youtube.com/embed/izpqQpD8RQ0</a>
+[![Upgrading Enterprise Angular Applications - Victor Savkin](https://img.youtube.com/vi/izpqQpD8RQ0/0.jpg)](https://www.youtube.com/watch?v=izpqQpD8RQ0 "Upgrading Enterprise Angular Applications - Victor Savkin")
 
 #### Blog: Upgrading Angular Applications
 


### PR DESCRIPTION
## Current Behavior

the old embedded link was not correct rendered. See screenshot:
![image](https://user-images.githubusercontent.com/2271337/133758835-68d350dd-f916-41d5-8faf-c9c73c6026fd.png)

## Expected Behavior

user must see link or embedded video


## Fix

in markdown we can't show video and must change it to the linked image

![image](https://user-images.githubusercontent.com/2271337/133759184-b0f984bd-54d8-4631-a953-12f8dba04123.png)

