### PR TITLE
fix(core): ensure workspace version format is respected when making changes to it

### DIFF
--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -1,5 +1,4 @@
 import type { Tree } from '@nrwl/tao/src/shared/tree';
-import { reformattedWorkspaceJsonOrNull } from '@nrwl/tao/src/shared/workspace';
 import * as path from 'path';
 import type * as Prettier from 'prettier';
 import { getWorkspacePath } from '../utils/get-workspace-layout';
@@ -16,7 +15,6 @@ export async function formatFiles(tree: Tree): Promise<void> {
     prettier = await import('prettier');
   } catch {}
 
-  updateWorkspaceJsonToMatchFormatVersion(tree);
   sortWorkspaceJson(tree);
   sortNxJson(tree);
   sortTsConfig(tree);
@@ -59,24 +57,6 @@ export async function formatFiles(tree: Tree): Promise<void> {
       }
     })
   );
-}
-
-function updateWorkspaceJsonToMatchFormatVersion(tree: Tree) {
-  const path = getWorkspacePath(tree);
-  if (!path) {
-    return;
-  }
-
-  try {
-    const workspaceJson = readJson(tree, path);
-    const reformatted = reformattedWorkspaceJsonOrNull(workspaceJson);
-    if (reformatted) {
-      writeJson(tree, path, reformatted);
-    }
-  } catch (e) {
-    console.error(`Failed to format: ${path}`);
-    console.error(e);
-  }
 }
 
 function sortWorkspaceJson(tree: Tree) {

--- a/packages/devkit/src/generators/project-configuration.spec.ts
+++ b/packages/devkit/src/generators/project-configuration.spec.ts
@@ -15,7 +15,23 @@ import {
 } from './project-configuration';
 import { getWorkspacePath } from '../utils/get-workspace-layout';
 
-const baseTestProjectConfig: ProjectConfiguration = {
+type ProjectConfigurationV1 = Pick<
+  ProjectConfiguration,
+  'root' | 'sourceRoot'
+> & {
+  architect: {
+    [targetName: string]: {
+      builder: string;
+    };
+  };
+};
+
+const baseTestProjectConfigV1: ProjectConfigurationV1 = {
+  root: 'libs/test',
+  sourceRoot: 'libs/test/src',
+  architect: {},
+};
+const baseTestProjectConfigV2: ProjectConfiguration = {
   root: 'libs/test',
   sourceRoot: 'libs/test/src',
   targets: {},
@@ -24,353 +40,519 @@ const baseTestProjectConfig: ProjectConfiguration = {
 describe('project configuration', () => {
   let tree: Tree;
 
-  beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
-  });
-
-  describe('readProjectConfiguration', () => {
-    it('should get info from workspace.json', () => {
-      updateJson(tree, getWorkspacePath(tree), (json) => {
-        json.projects['proj1'] = {
-          root: 'proj1',
-        };
-        return json;
-      });
-
-      const config = readProjectConfiguration(tree, 'proj1');
-      expect(config).toEqual({
-        root: 'proj1',
-      });
-    });
-
-    it('should get info from nx.json', () => {
-      updateJson(tree, getWorkspacePath(tree), (json) => {
-        json.projects['proj1'] = {
-          root: 'proj1',
-        };
-        return json;
-      });
-      updateJson(tree, 'nx.json', (json) => {
-        json.projects['proj1'] = {
-          tags: ['tag1'],
-        };
-        return json;
-      });
-
-      const config = readProjectConfiguration(tree, 'proj1');
-      expect(config).toEqual({
-        root: 'proj1',
-        tags: ['tag1'],
-      });
-    });
-
-    it('should should not fail if projects is not defined in nx.json', () => {
-      updateJson(tree, getWorkspacePath(tree), (json) => {
-        json.projects['proj1'] = {
-          root: 'proj1',
-        };
-        return json;
-      });
-      updateJson(tree, 'nx.json', (json) => {
-        delete json.projects;
-        return json;
-      });
-
-      const config = readProjectConfiguration(tree, 'proj1');
-      expect(config).toEqual({
-        root: 'proj1',
-      });
-    });
-  });
-
-  describe('addProjectConfiguration', () => {
-    it('should create project.json file when adding a project if standalone is true', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
-
-      expect(tree.exists('libs/test/project.json')).toBeTruthy();
-    });
-
-    it('should create project.json file if all other apps in the workspace use project.json', () => {
-      addProjectConfiguration(
-        tree,
-        'project-a',
-        {
-          root: 'apps/project-a',
-          targets: {},
-        },
-        true
-      );
-      addProjectConfiguration(
-        tree,
-        'project-b',
-        {
-          root: 'apps/project-b',
-          targets: {},
-        },
-        true
-      );
-      expect(tree.exists('apps/project-b/project.json')).toBeTruthy();
-    });
-
-    it("should not create project.json file if any other app in the workspace doesn't use project.json", () => {
-      addProjectConfiguration(tree, 'project-a', {
-        root: 'apps/project-a',
-        targets: {},
-      });
-      addProjectConfiguration(tree, 'project-b', {
-        root: 'apps/project-b',
-        targets: {},
-      });
-      expect(tree.exists('apps/project-a/project.json')).toBeFalsy();
-      expect(tree.exists('apps/project-b/project.json')).toBeFalsy();
-    });
-
-    it('should not create project.json file when adding a project if standalone is false', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, false);
-
-      expect(tree.exists('libs/test/project.json')).toBeFalsy();
-    });
-
-    it('should be able to read from standalone projects', () => {
-      tree.write(
-        'libs/test/project.json',
-        JSON.stringify(baseTestProjectConfig, null, 2)
-      );
-      tree.write(
-        'workspace.json',
-        JSON.stringify(
-          {
-            projects: {
-              test: 'libs/test',
-            },
-          },
-          null,
-          2
-        )
-      );
-
-      const projectConfig = readProjectConfiguration(tree, 'test');
-
-      expect(projectConfig).toEqual(baseTestProjectConfig);
-    });
-
-    it('should update project.json file when updating a project', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
-      const expectedProjectConfig = {
-        ...baseTestProjectConfig,
-        targets: { build: { executor: '' } },
-      };
-      updateProjectConfiguration(tree, 'test', expectedProjectConfig);
-
-      expect(readJson(tree, 'libs/test/project.json')).toEqual(
-        expectedProjectConfig
-      );
-    });
-
-    it('should update workspace.json file when updating an inline project', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, false);
-      const expectedProjectConfig = {
-        ...baseTestProjectConfig,
-        targets: { build: { executor: '' } },
-      };
-      updateProjectConfiguration(tree, 'test', expectedProjectConfig);
-
-      expect(readJson(tree, 'workspace.json').projects.test).toEqual(
-        expectedProjectConfig
-      );
-    });
-
-    it('should remove project.json file when removing project configuration', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
-      removeProjectConfiguration(tree, 'test');
-
-      expect(readJson(tree, 'workspace.json').projects.test).toBeUndefined();
-      expect(tree.exists('test/project.json')).toBeFalsy();
-    });
-
-    it('should support workspaces with standalone and inline projects', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
-      addProjectConfiguration(tree, 'test2', baseTestProjectConfig, false);
-      const configurations = getProjects(tree);
-      expect(configurations.get('test')).toEqual(baseTestProjectConfig);
-      expect(configurations.get('test2')).toEqual(baseTestProjectConfig);
-    });
-  });
-
-  describe('updateWorkspaceConfiguration', () => {
-    let workspaceConfiguration: WorkspaceConfiguration;
+  describe('workspace v1', () => {
     beforeEach(() => {
-      workspaceConfiguration = readWorkspaceConfiguration(tree);
+      tree = createTreeWithEmptyWorkspace(1);
     });
 
-    it('should update properties in workspace.json', () => {
-      workspaceConfiguration.version = 3;
+    describe('readProjectConfiguration', () => {
+      it('should get info from workspace.json', () => {
+        updateJson(tree, getWorkspacePath(tree), (json) => {
+          json.projects['proj1'] = {
+            root: 'proj1',
+          };
+          return json;
+        });
 
-      updateWorkspaceConfiguration(tree, workspaceConfiguration);
+        const config = readProjectConfiguration(tree, 'proj1');
+        expect(config).toEqual({
+          root: 'proj1',
+        });
+      });
 
-      expect(readJson(tree, 'workspace.json').version).toEqual(3);
+      it('should get info from nx.json', () => {
+        updateJson(tree, getWorkspacePath(tree), (json) => {
+          json.projects['proj1'] = {
+            root: 'proj1',
+          };
+          return json;
+        });
+        updateJson(tree, 'nx.json', (json) => {
+          json.projects['proj1'] = {
+            tags: ['tag1'],
+          };
+          return json;
+        });
+
+        const config = readProjectConfiguration(tree, 'proj1');
+        expect(config).toEqual({
+          root: 'proj1',
+          tags: ['tag1'],
+        });
+      });
+
+      it('should should not fail if projects is not defined in nx.json', () => {
+        updateJson(tree, getWorkspacePath(tree), (json) => {
+          json.projects['proj1'] = {
+            root: 'proj1',
+          };
+          return json;
+        });
+        updateJson(tree, 'nx.json', (json) => {
+          delete json.projects;
+          return json;
+        });
+
+        const config = readProjectConfiguration(tree, 'proj1');
+        expect(config).toEqual({
+          root: 'proj1',
+        });
+      });
     });
 
-    it('should update properties in nx.json', () => {
-      workspaceConfiguration.npmScope = 'new-npmScope';
+    describe('addProjectConfiguration', () => {
+      it('should throw when standalone is true', () => {
+        expect(() =>
+          addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true)
+        ).toThrow();
+      });
 
-      updateWorkspaceConfiguration(tree, workspaceConfiguration);
+      it('should update workspace.json file correctly', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2);
 
-      expect(readJson(tree, 'nx.json').npmScope).toEqual('new-npmScope');
+        expect(readJson(tree, 'workspace.json').projects.test).toEqual(
+          baseTestProjectConfigV1
+        );
+      });
     });
 
-    it('should not update unknown properties', () => {
-      workspaceConfiguration['$schema'] = 'schema';
+    describe('updateWorkspaceConfiguration', () => {
+      let workspaceConfiguration: WorkspaceConfiguration;
 
-      updateWorkspaceConfiguration(tree, workspaceConfiguration);
+      beforeEach(() => {
+        workspaceConfiguration = readWorkspaceConfiguration(tree);
+      });
 
-      expect(readJson(tree, 'workspace.json').$schema).not.toBeDefined();
-      expect(readJson(tree, 'nx.json').$schema).not.toBeDefined();
+      it('should update properties in workspace.json', () => {
+        workspaceConfiguration.version = 2;
+
+        updateWorkspaceConfiguration(tree, workspaceConfiguration);
+
+        expect(readJson(tree, 'workspace.json').version).toEqual(2);
+      });
+
+      it('should update properties in nx.json', () => {
+        workspaceConfiguration.npmScope = 'new-npmScope';
+
+        updateWorkspaceConfiguration(tree, workspaceConfiguration);
+
+        expect(readJson(tree, 'nx.json').npmScope).toEqual('new-npmScope');
+      });
+
+      it('should not update unknown properties', () => {
+        workspaceConfiguration['$schema'] = 'schema';
+
+        updateWorkspaceConfiguration(tree, workspaceConfiguration);
+
+        expect(readJson(tree, 'workspace.json').$schema).not.toBeDefined();
+        expect(readJson(tree, 'nx.json').$schema).not.toBeDefined();
+      });
+
+      it('should skip properties that are identical to the extends property', () => {
+        workspaceConfiguration['$schema'] = 'schema';
+
+        updateWorkspaceConfiguration(tree, workspaceConfiguration);
+
+        expect(readJson(tree, 'workspace.json').$schema).not.toBeDefined();
+        expect(readJson(tree, 'nx.json').$schema).not.toBeDefined();
+      });
     });
 
-    it('should skip properties that are identical to the extends property', () => {
-      workspaceConfiguration['$schema'] = 'schema';
+    describe('without nx.json', () => {
+      beforeEach(() => tree.delete('nx.json'));
 
-      updateWorkspaceConfiguration(tree, workspaceConfiguration);
+      afterEach(() => expect(tree.exists('nx.json')).toEqual(false));
 
-      expect(readJson(tree, 'workspace.json').$schema).not.toBeDefined();
-      expect(readJson(tree, 'nx.json').$schema).not.toBeDefined();
+      it('should throw when standalone is true', () => {
+        expect(() =>
+          addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true)
+        ).toThrow();
+      });
+
+      it('should update workspace.json file correctly when adding a project', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, false);
+
+        expect(readJson(tree, 'workspace.json').projects.test).toEqual(
+          baseTestProjectConfigV1
+        );
+      });
+
+      it('should update workspace.json file correctly when updating a project', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, false);
+        const updatedProjectConfiguration = {
+          ...baseTestProjectConfigV2,
+          targets: { build: { executor: '' } },
+        };
+        const expectedProjectConfiguration = {
+          ...baseTestProjectConfigV1,
+          architect: { build: { builder: '' } },
+        };
+        updateProjectConfiguration(tree, 'test', updatedProjectConfiguration);
+
+        expect(readJson(tree, 'workspace.json').projects.test).toEqual(
+          expectedProjectConfiguration
+        );
+      });
+
+      it('should remove project configuration', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, false);
+        removeProjectConfiguration(tree, 'test');
+
+        expect(readJson(tree, 'workspace.json').projects.test).toBeUndefined();
+      });
     });
   });
 
-  describe('without nx.json', () => {
-    beforeEach(() => tree.delete('nx.json'));
-
-    afterEach(() => expect(tree.exists('nx.json')).toEqual(false));
-
-    it('should create project.json file when adding a project if standalone is true', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
-
-      expect(tree.exists('libs/test/project.json')).toBeTruthy();
+  describe('workspace v2', () => {
+    beforeEach(() => {
+      tree = createTreeWithEmptyWorkspace(2);
     });
 
-    it('should create project.json file if all other apps in the workspace use project.json', () => {
-      addProjectConfiguration(
-        tree,
-        'project-a',
-        {
-          root: 'apps/project-a',
-          targets: {},
-        },
-        true
-      );
-      addProjectConfiguration(
-        tree,
-        'project-b',
-        {
-          root: 'apps/project-b',
-          targets: {},
-        },
-        true
-      );
-      expect(tree.exists('apps/project-b/project.json')).toBeTruthy();
+    describe('readProjectConfiguration', () => {
+      it('should get info from workspace.json', () => {
+        updateJson(tree, getWorkspacePath(tree), (json) => {
+          json.projects['proj1'] = {
+            root: 'proj1',
+          };
+          return json;
+        });
+
+        const config = readProjectConfiguration(tree, 'proj1');
+        expect(config).toEqual({
+          root: 'proj1',
+        });
+      });
+
+      it('should get info from nx.json', () => {
+        updateJson(tree, getWorkspacePath(tree), (json) => {
+          json.projects['proj1'] = {
+            root: 'proj1',
+          };
+          return json;
+        });
+        updateJson(tree, 'nx.json', (json) => {
+          json.projects['proj1'] = {
+            tags: ['tag1'],
+          };
+          return json;
+        });
+
+        const config = readProjectConfiguration(tree, 'proj1');
+        expect(config).toEqual({
+          root: 'proj1',
+          tags: ['tag1'],
+        });
+      });
+
+      it('should should not fail if projects is not defined in nx.json', () => {
+        updateJson(tree, getWorkspacePath(tree), (json) => {
+          json.projects['proj1'] = {
+            root: 'proj1',
+          };
+          return json;
+        });
+        updateJson(tree, 'nx.json', (json) => {
+          delete json.projects;
+          return json;
+        });
+
+        const config = readProjectConfiguration(tree, 'proj1');
+        expect(config).toEqual({
+          root: 'proj1',
+        });
+      });
     });
 
-    it("should not create project.json file if any other app in the workspace doesn't use project.json", () => {
-      addProjectConfiguration(
-        tree,
-        'project-a',
-        {
-          root: 'apps/project-a',
-          targets: {},
-        },
-        false
-      );
-      addProjectConfiguration(
-        tree,
-        'project-b',
-        {
-          root: 'apps/project-b',
-          targets: {},
-        },
-        false
-      );
-      expect(tree.exists('apps/project-a/project.json')).toBeFalsy();
-      expect(tree.exists('apps/project-b/project.json')).toBeFalsy();
-    });
+    describe('addProjectConfiguration', () => {
+      it('should create project.json file when adding a project if standalone is true', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true);
 
-    it('should not create project.json file when adding a project if standalone is false', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, false);
+        expect(tree.exists('libs/test/project.json')).toBeTruthy();
+      });
 
-      expect(tree.exists('libs/test/project.json')).toBeFalsy();
-    });
-
-    it('should be able to read from standalone projects', () => {
-      tree.write(
-        'workspace.json',
-        JSON.stringify(
+      it('should create project.json file if all other apps in the workspace use project.json', () => {
+        addProjectConfiguration(
+          tree,
+          'project-a',
           {
-            projects: {
-              test: {
-                root: '/libs/test',
+            root: 'apps/project-a',
+            targets: {},
+          },
+          true
+        );
+        addProjectConfiguration(
+          tree,
+          'project-b',
+          {
+            root: 'apps/project-b',
+            targets: {},
+          },
+          true
+        );
+        expect(tree.exists('apps/project-b/project.json')).toBeTruthy();
+      });
+
+      it("should not create project.json file if any other app in the workspace doesn't use project.json", () => {
+        addProjectConfiguration(tree, 'project-a', {
+          root: 'apps/project-a',
+          targets: {},
+        });
+        addProjectConfiguration(tree, 'project-b', {
+          root: 'apps/project-b',
+          targets: {},
+        });
+        expect(tree.exists('apps/project-a/project.json')).toBeFalsy();
+        expect(tree.exists('apps/project-b/project.json')).toBeFalsy();
+      });
+
+      it('should not create project.json file when adding a project if standalone is false', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, false);
+
+        expect(tree.exists('libs/test/project.json')).toBeFalsy();
+      });
+
+      it('should be able to read from standalone projects', () => {
+        tree.write(
+          'libs/test/project.json',
+          JSON.stringify(baseTestProjectConfigV2, null, 2)
+        );
+        tree.write(
+          'workspace.json',
+          JSON.stringify(
+            {
+              projects: {
+                test: 'libs/test',
               },
             },
-          },
-          null,
-          2
-        )
-      );
+            null,
+            2
+          )
+        );
 
-      const projectConfig = readProjectConfiguration(tree, 'test');
+        const projectConfig = readProjectConfiguration(tree, 'test');
 
-      expect(projectConfig).toEqual({
-        root: '/libs/test',
+        expect(projectConfig).toEqual(baseTestProjectConfigV2);
+      });
+
+      it('should update project.json file when updating a project', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true);
+        const expectedProjectConfig = {
+          ...baseTestProjectConfigV2,
+          targets: { build: { executor: '' } },
+        };
+        updateProjectConfiguration(tree, 'test', expectedProjectConfig);
+
+        expect(readJson(tree, 'libs/test/project.json')).toEqual(
+          expectedProjectConfig
+        );
+      });
+
+      it('should update workspace.json file when updating an inline project', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, false);
+        const expectedProjectConfig = {
+          ...baseTestProjectConfigV2,
+          targets: { build: { executor: '' } },
+        };
+        updateProjectConfiguration(tree, 'test', expectedProjectConfig);
+
+        expect(readJson(tree, 'workspace.json').projects.test).toEqual(
+          expectedProjectConfig
+        );
+      });
+
+      it('should remove project.json file when removing project configuration', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true);
+        removeProjectConfiguration(tree, 'test');
+
+        expect(readJson(tree, 'workspace.json').projects.test).toBeUndefined();
+        expect(tree.exists('test/project.json')).toBeFalsy();
+      });
+
+      it('should support workspaces with standalone and inline projects', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true);
+        addProjectConfiguration(tree, 'test2', baseTestProjectConfigV2, false);
+        const configurations = getProjects(tree);
+        expect(configurations.get('test')).toEqual(baseTestProjectConfigV2);
+        expect(configurations.get('test2')).toEqual(baseTestProjectConfigV2);
       });
     });
 
-    it('should update project.json file when updating a project', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
-      const expectedProjectConfig = {
-        ...baseTestProjectConfig,
-        targets: { build: { executor: '' } },
-      };
-      updateProjectConfiguration(tree, 'test', expectedProjectConfig);
+    describe('updateWorkspaceConfiguration', () => {
+      let workspaceConfiguration: WorkspaceConfiguration;
 
-      expect(readJson(tree, 'libs/test/project.json')).toEqual(
-        expectedProjectConfig
-      );
+      beforeEach(() => {
+        workspaceConfiguration = readWorkspaceConfiguration(tree);
+      });
+
+      it('should update properties in workspace.json', () => {
+        workspaceConfiguration.version = 1;
+
+        updateWorkspaceConfiguration(tree, workspaceConfiguration);
+
+        expect(readJson(tree, 'workspace.json').version).toEqual(1);
+      });
+
+      it('should update properties in nx.json', () => {
+        workspaceConfiguration.npmScope = 'new-npmScope';
+
+        updateWorkspaceConfiguration(tree, workspaceConfiguration);
+
+        expect(readJson(tree, 'nx.json').npmScope).toEqual('new-npmScope');
+      });
+
+      it('should not update unknown properties', () => {
+        workspaceConfiguration['$schema'] = 'schema';
+
+        updateWorkspaceConfiguration(tree, workspaceConfiguration);
+
+        expect(readJson(tree, 'workspace.json').$schema).not.toBeDefined();
+        expect(readJson(tree, 'nx.json').$schema).not.toBeDefined();
+      });
+
+      it('should skip properties that are identical to the extends property', () => {
+        workspaceConfiguration['$schema'] = 'schema';
+
+        updateWorkspaceConfiguration(tree, workspaceConfiguration);
+
+        expect(readJson(tree, 'workspace.json').$schema).not.toBeDefined();
+        expect(readJson(tree, 'nx.json').$schema).not.toBeDefined();
+      });
     });
 
-    it('should update workspace.json file when updating an inline project', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, false);
-      const expectedProjectConfig = {
-        ...baseTestProjectConfig,
-        targets: { build: { executor: '' } },
-      };
-      updateProjectConfiguration(tree, 'test', expectedProjectConfig);
+    describe('without nx.json', () => {
+      beforeEach(() => tree.delete('nx.json'));
 
-      expect(readJson(tree, 'workspace.json').projects.test).toEqual(
-        expectedProjectConfig
-      );
-    });
+      afterEach(() => expect(tree.exists('nx.json')).toEqual(false));
 
-    it('should remove project.json file when removing project configuration', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
-      removeProjectConfiguration(tree, 'test');
+      it('should create project.json file when adding a project if standalone is true', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true);
 
-      expect(tree.exists('test/project.json')).toBeFalsy();
-    });
+        expect(tree.exists('libs/test/project.json')).toBeTruthy();
+      });
 
-    it('should remove project configuration', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, false);
-      removeProjectConfiguration(tree, 'test');
+      it('should create project.json file if all other apps in the workspace use project.json', () => {
+        addProjectConfiguration(
+          tree,
+          'project-a',
+          {
+            root: 'apps/project-a',
+            targets: {},
+          },
+          true
+        );
+        addProjectConfiguration(
+          tree,
+          'project-b',
+          {
+            root: 'apps/project-b',
+            targets: {},
+          },
+          true
+        );
+        expect(tree.exists('apps/project-b/project.json')).toBeTruthy();
+      });
 
-      expect(readJson(tree, 'workspace.json').projects.test).toBeUndefined();
-    });
+      it("should not create project.json file if any other app in the workspace doesn't use project.json", () => {
+        addProjectConfiguration(
+          tree,
+          'project-a',
+          {
+            root: 'apps/project-a',
+            targets: {},
+          },
+          false
+        );
+        addProjectConfiguration(
+          tree,
+          'project-b',
+          {
+            root: 'apps/project-b',
+            targets: {},
+          },
+          false
+        );
+        expect(tree.exists('apps/project-a/project.json')).toBeFalsy();
+        expect(tree.exists('apps/project-b/project.json')).toBeFalsy();
+      });
 
-    it('should support workspaces with standalone and inline projects', () => {
-      addProjectConfiguration(tree, 'test', baseTestProjectConfig, true);
-      addProjectConfiguration(tree, 'test2', baseTestProjectConfig, false);
+      it('should not create project.json file when adding a project if standalone is false', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, false);
 
-      const configurations = getProjects(tree);
+        expect(tree.exists('libs/test/project.json')).toBeFalsy();
+      });
 
-      expect(configurations.get('test')).toEqual(baseTestProjectConfig);
-      expect(configurations.get('test2')).toEqual(baseTestProjectConfig);
+      it('should be able to read from standalone projects', () => {
+        tree.write(
+          'workspace.json',
+          JSON.stringify(
+            {
+              projects: {
+                test: {
+                  root: '/libs/test',
+                },
+              },
+            },
+            null,
+            2
+          )
+        );
+
+        const projectConfig = readProjectConfiguration(tree, 'test');
+
+        expect(projectConfig).toEqual({
+          root: '/libs/test',
+        });
+      });
+
+      it('should update project.json file when updating a project', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true);
+        const expectedProjectConfig = {
+          ...baseTestProjectConfigV2,
+          targets: { build: { executor: '' } },
+        };
+        updateProjectConfiguration(tree, 'test', expectedProjectConfig);
+
+        expect(readJson(tree, 'libs/test/project.json')).toEqual(
+          expectedProjectConfig
+        );
+      });
+
+      it('should update workspace.json file when updating an inline project', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, false);
+        const expectedProjectConfig = {
+          ...baseTestProjectConfigV2,
+          targets: { build: { executor: '' } },
+        };
+        updateProjectConfiguration(tree, 'test', expectedProjectConfig);
+
+        expect(readJson(tree, 'workspace.json').projects.test).toEqual(
+          expectedProjectConfig
+        );
+      });
+
+      it('should remove project.json file when removing project configuration', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true);
+        removeProjectConfiguration(tree, 'test');
+
+        expect(tree.exists('test/project.json')).toBeFalsy();
+      });
+
+      it('should remove project configuration', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, false);
+        removeProjectConfiguration(tree, 'test');
+
+        expect(readJson(tree, 'workspace.json').projects.test).toBeUndefined();
+      });
+
+      it('should support workspaces with standalone and inline projects', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true);
+        addProjectConfiguration(tree, 'test2', baseTestProjectConfigV2, false);
+
+        const configurations = getProjects(tree);
+
+        expect(configurations.get('test')).toEqual(baseTestProjectConfigV2);
+        expect(configurations.get('test2')).toEqual(baseTestProjectConfigV2);
+      });
     });
   });
 });

--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -1,6 +1,7 @@
 import {
   ProjectConfiguration,
   RawWorkspaceJsonConfiguration,
+  reformattedWorkspaceJsonOrNull,
   toNewFormat,
   WorkspaceJsonConfiguration,
 } from '@nrwl/tao/src/shared/workspace';
@@ -173,7 +174,10 @@ export function updateWorkspaceConfiguration(
     tree,
     getWorkspacePath(tree),
     (json) => {
-      return { ...json, ...workspace };
+      return {
+        ...json,
+        ...(reformattedWorkspaceJsonOrNull(workspace) ?? workspace),
+      };
     }
   );
 
@@ -363,15 +367,21 @@ function addProjectToWorkspaceJson(
     if (mode === 'create') {
       workspaceJson.projects[projectName] = project.root;
     }
+  } else if (mode === 'delete') {
+    delete workspaceJson.projects[projectName];
   } else {
-    let workspaceConfiguration: ProjectConfiguration;
+    let projectConfiguration: ProjectConfiguration;
     if (project) {
       const { tags, implicitDependencies, ...c } = project;
-      workspaceConfiguration = c;
+      projectConfiguration = c;
     }
-    workspaceJson.projects[projectName] = workspaceConfiguration;
+    workspaceJson.projects[projectName] = projectConfiguration;
   }
-  writeJson(tree, path, workspaceJson);
+  writeJson(
+    tree,
+    path,
+    reformattedWorkspaceJsonOrNull(workspaceJson) ?? workspaceJson
+  );
 }
 
 function addProjectToNxJson(

--- a/packages/linter/src/utils/convert-tslint-to-eslint/__snapshots__/project-converter.spec.ts.snap
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/__snapshots__/project-converter.spec.ts.snap
@@ -56,33 +56,11 @@ Object {
 
 exports[`ProjectConverter removeTSLintFromWorkspace() should remove all relevant traces of TSLint from the workspace 2`] = `
 Object {
-  "generators": Object {
-    "@nrwl/angular": Object {
-      "application": Object {
-        "linter": "tslint",
-      },
-      "library": Object {
-        "linter": "tslint",
-      },
-    },
-  },
   "projects": Object {
     "foo": Object {
-      "generators": Object {
-        "@nrwl/angular:application": Object {
-          "e2eTestRunner": "cypress",
-          "linter": "eslint",
-          "unitTestRunner": "jest",
-        },
-        "@nrwl/angular:library": Object {
-          "linter": "tslint",
-        },
-      },
-      "projectType": "application",
-      "root": "apps/foo",
-      "targets": Object {
+      "architect": Object {
         "lint": Object {
-          "executor": "@angular-devkit/build-angular:tslint",
+          "builder": "@angular-devkit/build-angular:tslint",
           "options": Object {
             "exclude": Array [
               "**/node_modules/**",
@@ -93,6 +71,28 @@ Object {
             ],
           },
         },
+      },
+      "projectType": "application",
+      "root": "apps/foo",
+      "schematics": Object {
+        "@nrwl/angular:application": Object {
+          "e2eTestRunner": "cypress",
+          "linter": "eslint",
+          "unitTestRunner": "jest",
+        },
+        "@nrwl/angular:library": Object {
+          "linter": "tslint",
+        },
+      },
+    },
+  },
+  "schematics": Object {
+    "@nrwl/angular": Object {
+      "application": Object {
+        "linter": "tslint",
+      },
+      "library": Object {
+        "linter": "tslint",
       },
     },
   },
@@ -112,17 +112,9 @@ exports[`ProjectConverter removeTSLintFromWorkspace() should remove all relevant
 Object {
   "projects": Object {
     "foo": Object {
-      "generators": Object {
-        "@nrwl/angular:application": Object {
-          "e2eTestRunner": "cypress",
-          "unitTestRunner": "jest",
-        },
-      },
-      "projectType": "application",
-      "root": "apps/foo",
-      "targets": Object {
+      "architect": Object {
         "lint": Object {
-          "executor": "@angular-devkit/build-angular:tslint",
+          "builder": "@angular-devkit/build-angular:tslint",
           "options": Object {
             "exclude": Array [
               "**/node_modules/**",
@@ -133,6 +125,24 @@ Object {
             ],
           },
         },
+      },
+      "projectType": "application",
+      "root": "apps/foo",
+      "schematics": Object {
+        "@nrwl/angular:application": Object {
+          "e2eTestRunner": "cypress",
+          "unitTestRunner": "jest",
+        },
+      },
+    },
+  },
+  "schematics": Object {
+    "@nrwl/angular": Object {
+      "application": Object {
+        "linter": "tslint",
+      },
+      "library": Object {
+        "linter": "tslint",
       },
     },
   },
@@ -142,30 +152,11 @@ Object {
 
 exports[`ProjectConverter removeTSLintFromWorkspace() should remove the entry in generators for convert-tslint-to-eslint because it is no longer needed 1`] = `
 Object {
-  "generators": Object {
-    "@nrwl/angular": Object {
-      "convert-tslint-to-eslint": Object {
-        "removeTSLintIfNoMoreTSLintTargets": true,
-      },
-    },
-  },
   "projects": Object {
     "foo": Object {
-      "generators": Object {
-        "@nrwl/angular:application": Object {
-          "e2eTestRunner": "cypress",
-          "linter": "eslint",
-          "unitTestRunner": "jest",
-        },
-        "@nrwl/angular:library": Object {
-          "linter": "tslint",
-        },
-      },
-      "projectType": "application",
-      "root": "apps/foo",
-      "targets": Object {
+      "architect": Object {
         "lint": Object {
-          "executor": "@angular-devkit/build-angular:tslint",
+          "builder": "@angular-devkit/build-angular:tslint",
           "options": Object {
             "exclude": Array [
               "**/node_modules/**",
@@ -176,6 +167,25 @@ Object {
             ],
           },
         },
+      },
+      "projectType": "application",
+      "root": "apps/foo",
+      "schematics": Object {
+        "@nrwl/angular:application": Object {
+          "e2eTestRunner": "cypress",
+          "linter": "eslint",
+          "unitTestRunner": "jest",
+        },
+        "@nrwl/angular:library": Object {
+          "linter": "tslint",
+        },
+      },
+    },
+  },
+  "schematics": Object {
+    "@nrwl/angular": Object {
+      "convert-tslint-to-eslint": Object {
+        "removeTSLintIfNoMoreTSLintTargets": true,
       },
     },
   },
@@ -187,17 +197,9 @@ exports[`ProjectConverter removeTSLintFromWorkspace() should remove the entry in
 Object {
   "projects": Object {
     "foo": Object {
-      "generators": Object {
-        "@nrwl/angular:application": Object {
-          "e2eTestRunner": "cypress",
-          "unitTestRunner": "jest",
-        },
-      },
-      "projectType": "application",
-      "root": "apps/foo",
-      "targets": Object {
+      "architect": Object {
         "lint": Object {
-          "executor": "@angular-devkit/build-angular:tslint",
+          "builder": "@angular-devkit/build-angular:tslint",
           "options": Object {
             "exclude": Array [
               "**/node_modules/**",
@@ -208,6 +210,21 @@ Object {
             ],
           },
         },
+      },
+      "projectType": "application",
+      "root": "apps/foo",
+      "schematics": Object {
+        "@nrwl/angular:application": Object {
+          "e2eTestRunner": "cypress",
+          "unitTestRunner": "jest",
+        },
+      },
+    },
+  },
+  "schematics": Object {
+    "@nrwl/angular": Object {
+      "convert-tslint-to-eslint": Object {
+        "removeTSLintIfNoMoreTSLintTargets": true,
       },
     },
   },
@@ -217,33 +234,11 @@ Object {
 
 exports[`ProjectConverter setDefaults() should save in workspace.json 1`] = `
 Object {
-  "generators": Object {
-    "@nrwl/angular": Object {
-      "application": Object {
-        "linter": "tslint",
-      },
-      "library": Object {
-        "linter": "tslint",
-      },
-    },
-  },
   "projects": Object {
     "foo": Object {
-      "generators": Object {
-        "@nrwl/angular:application": Object {
-          "e2eTestRunner": "cypress",
-          "linter": "eslint",
-          "unitTestRunner": "jest",
-        },
-        "@nrwl/angular:library": Object {
-          "linter": "tslint",
-        },
-      },
-      "projectType": "application",
-      "root": "apps/foo",
-      "targets": Object {
+      "architect": Object {
         "lint": Object {
-          "executor": "@angular-devkit/build-angular:tslint",
+          "builder": "@angular-devkit/build-angular:tslint",
           "options": Object {
             "exclude": Array [
               "**/node_modules/**",
@@ -255,6 +250,28 @@ Object {
           },
         },
       },
+      "projectType": "application",
+      "root": "apps/foo",
+      "schematics": Object {
+        "@nrwl/angular:application": Object {
+          "e2eTestRunner": "cypress",
+          "linter": "eslint",
+          "unitTestRunner": "jest",
+        },
+        "@nrwl/angular:library": Object {
+          "linter": "tslint",
+        },
+      },
+    },
+  },
+  "schematics": Object {
+    "@nrwl/angular": Object {
+      "application": Object {
+        "linter": "tslint",
+      },
+      "library": Object {
+        "linter": "tslint",
+      },
     },
   },
   "version": 1,
@@ -263,7 +280,37 @@ Object {
 
 exports[`ProjectConverter setDefaults() should save in workspace.json 2`] = `
 Object {
-  "generators": Object {
+  "projects": Object {
+    "foo": Object {
+      "architect": Object {
+        "lint": Object {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": Object {
+            "exclude": Array [
+              "**/node_modules/**",
+              "!apps/foo/**/*",
+            ],
+            "tsConfig": Array [
+              "apps/foo/tsconfig.app.json",
+            ],
+          },
+        },
+      },
+      "projectType": "application",
+      "root": "apps/foo",
+      "schematics": Object {
+        "@nrwl/angular:application": Object {
+          "e2eTestRunner": "cypress",
+          "linter": "eslint",
+          "unitTestRunner": "jest",
+        },
+        "@nrwl/angular:library": Object {
+          "linter": "tslint",
+        },
+      },
+    },
+  },
+  "schematics": Object {
     "@nrwl/angular": Object {
       "application": Object {
         "linter": "tslint",
@@ -277,23 +324,17 @@ Object {
       },
     },
   },
+  "version": 1,
+}
+`;
+
+exports[`ProjectConverter setDefaults() should save in workspace.json 3`] = `
+Object {
   "projects": Object {
     "foo": Object {
-      "generators": Object {
-        "@nrwl/angular:application": Object {
-          "e2eTestRunner": "cypress",
-          "linter": "eslint",
-          "unitTestRunner": "jest",
-        },
-        "@nrwl/angular:library": Object {
-          "linter": "tslint",
-        },
-      },
-      "projectType": "application",
-      "root": "apps/foo",
-      "targets": Object {
+      "architect": Object {
         "lint": Object {
-          "executor": "@angular-devkit/build-angular:tslint",
+          "builder": "@angular-devkit/build-angular:tslint",
           "options": Object {
             "exclude": Array [
               "**/node_modules/**",
@@ -305,15 +346,21 @@ Object {
           },
         },
       },
+      "projectType": "application",
+      "root": "apps/foo",
+      "schematics": Object {
+        "@nrwl/angular:application": Object {
+          "e2eTestRunner": "cypress",
+          "linter": "eslint",
+          "unitTestRunner": "jest",
+        },
+        "@nrwl/angular:library": Object {
+          "linter": "tslint",
+        },
+      },
     },
   },
-  "version": 1,
-}
-`;
-
-exports[`ProjectConverter setDefaults() should save in workspace.json 3`] = `
-Object {
-  "generators": Object {
+  "schematics": Object {
     "@nrwl/angular": Object {
       "application": Object {
         "linter": "tslint",
@@ -324,36 +371,6 @@ Object {
       },
       "library": Object {
         "linter": "tslint",
-      },
-    },
-  },
-  "projects": Object {
-    "foo": Object {
-      "generators": Object {
-        "@nrwl/angular:application": Object {
-          "e2eTestRunner": "cypress",
-          "linter": "eslint",
-          "unitTestRunner": "jest",
-        },
-        "@nrwl/angular:library": Object {
-          "linter": "tslint",
-        },
-      },
-      "projectType": "application",
-      "root": "apps/foo",
-      "targets": Object {
-        "lint": Object {
-          "executor": "@angular-devkit/build-angular:tslint",
-          "options": Object {
-            "exclude": Array [
-              "**/node_modules/**",
-              "!apps/foo/**/*",
-            ],
-            "tsConfig": Array [
-              "apps/foo/tsconfig.app.json",
-            ],
-          },
-        },
       },
     },
   },

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -517,7 +517,7 @@ export function toNewFormatOrNull(w: any) {
       formatted = true;
     }
     Object.values(projectConfig.targets || {}).forEach((target: any) => {
-      if (target.builder) {
+      if (target.builder !== undefined) {
         renamePropertyWithStableKeys(target, 'builder', 'executor');
         formatted = true;
       }
@@ -552,7 +552,7 @@ export function toOldFormatOrNull(w: any) {
       formatted = true;
     }
     Object.values(projectConfig.architect || {}).forEach((target: any) => {
-      if (target.executor) {
+      if (target.executor !== undefined) {
         renamePropertyWithStableKeys(target, 'executor', 'builder');
         formatted = true;
       }

--- a/packages/workspace/src/generators/init/init.spec.ts
+++ b/packages/workspace/src/generators/init/init.spec.ts
@@ -56,6 +56,10 @@ describe('workspace', () => {
         '/tsconfig.spec.json',
         '{"extends": "../tsconfig.json", "compilerOptions": {}}'
       );
+      tree.write(
+        '/e2e/tsconfig.json',
+        '{"extends": "../tsconfig.json", "compilerOptions": {}}'
+      );
       tree.write('/tsconfig.json', '{"compilerOptions": {}}');
       tree.write('/tslint.json', '{"rules": {}}');
       tree.write('/e2e/protractor.conf.js', '// content');
@@ -254,6 +258,7 @@ describe('workspace', () => {
       tree.write('/projects/myApp/tslint.json', '{"rules": {}}');
       tree.write('/projects/myApp/tsconfig.app.json', '{}');
       tree.write('/projects/myApp/tsconfig.spec.json', '{}');
+      tree.write('/projects/myApp/e2e/tsconfig.json', '{}');
       tree.write('/projects/myApp/e2e/protractor.conf.js', '// content');
       tree.write('/projects/myApp/src/app/app.module.ts', '// content');
 

--- a/packages/workspace/src/generators/init/init.ts
+++ b/packages/workspace/src/generators/init/init.ts
@@ -4,6 +4,7 @@ import {
   convertNxGenerator,
   formatFiles,
   generateFiles,
+  getProjects,
   getWorkspacePath,
   installPackagesTask,
   joinPathFragments,
@@ -207,6 +208,7 @@ function updateAngularCLIJson(host: Tree, options: Schema) {
       implicitDependencies: [appName],
       tags: [],
     });
+    delete defaultProject.targets.e2e;
   }
 
   updateProjectConfiguration(host, appName, defaultProject);
@@ -250,9 +252,8 @@ function updateTsConfig(host: Tree) {
 }
 
 function updateTsConfigsJson(host: Tree, options: Schema) {
-  const workspaceJson = readJson(host, 'angular.json');
-  const app = workspaceJson.projects[options.name];
-  const e2eProject = getE2eProject(workspaceJson);
+  const app = readProjectConfiguration(host, options.name);
+  const e2eProject = getE2eProject(host);
   const tsConfigPath = getRootTsConfigPath(host);
   const appOffset = offsetFromRoot(app.root);
 
@@ -359,34 +360,36 @@ function moveOutOfSrc(
   renameSyncInTree(tree, from, to, required);
 }
 
-function getE2eKey(workspaceJson: any) {
-  return Object.keys(workspaceJson.projects).find((key) => {
-    return !!workspaceJson.projects[key]?.architect?.e2e;
-  });
+function getE2eKey(host: Tree) {
+  const projects = getProjects(host);
+  for (const [projectName, project] of projects) {
+    if (project.targets.e2e) {
+      return projectName;
+    }
+  }
 }
 
-function getE2eProject(workspaceJson: any) {
-  const key = getE2eKey(workspaceJson);
+function getE2eProject(host: Tree) {
+  const key = getE2eKey(host);
   if (key) {
-    return workspaceJson.projects[key];
+    return readProjectConfiguration(host, key);
   } else {
     return null;
   }
 }
 
 function moveExistingFiles(host: Tree, options: Schema) {
-  const workspaceJson = readJson(host, getWorkspacePath(host));
-  const app = workspaceJson.projects[options.name];
-  const e2eApp = getE2eProject(workspaceJson);
+  const app = readProjectConfiguration(host, options.name);
+  const e2eApp = getE2eProject(host);
 
   // it is not required to have a browserslist
   moveOutOfSrc(host, options.name, 'browserslist', false);
   moveOutOfSrc(host, options.name, '.browserslistrc', false);
-  moveOutOfSrc(host, options.name, app.architect.build.options.tsConfig);
+  moveOutOfSrc(host, options.name, app.targets.build.options.tsConfig);
 
-  if (app.architect.test) {
-    moveOutOfSrc(host, options.name, app.architect.test.options.karmaConfig);
-    moveOutOfSrc(host, options.name, app.architect.test.options.tsConfig);
+  if (app.targets.test) {
+    moveOutOfSrc(host, options.name, app.targets.test.options.karmaConfig);
+    moveOutOfSrc(host, options.name, app.targets.test.options.tsConfig);
   } else {
     // there could still be a karma.conf.js file in the root
     // so move to new location
@@ -397,18 +400,15 @@ function moveExistingFiles(host: Tree, options: Schema) {
     }
   }
 
-  if (app.architect.server) {
-    moveOutOfSrc(host, options.name, app.architect.server.options.tsConfig);
+  if (app.targets.server) {
+    moveOutOfSrc(host, options.name, app.targets.server.options.tsConfig);
   }
   const oldAppSourceRoot = app.sourceRoot;
   const newAppSourceRoot = joinPathFragments('apps', options.name, 'src');
   renameDirSyncInTree(host, oldAppSourceRoot, newAppSourceRoot);
   if (e2eApp) {
     const oldE2eRoot = joinPathFragments(app.root || '', 'e2e');
-    const newE2eRoot = joinPathFragments(
-      'apps',
-      `${getE2eKey(workspaceJson)}-e2e`
-    );
+    const newE2eRoot = joinPathFragments('apps', `${getE2eKey(host)}-e2e`);
     renameDirSyncInTree(host, oldE2eRoot, newE2eRoot);
   } else {
     console.warn(
@@ -420,7 +420,6 @@ function moveExistingFiles(host: Tree, options: Schema) {
 }
 
 async function createAdditionalFiles(host: Tree, options: Schema) {
-  const workspaceJson = readJson(host, 'angular.json');
   host.write(
     'nx.json',
     serializeJson({
@@ -439,7 +438,7 @@ async function createAdditionalFiles(host: Tree, options: Schema) {
         [options.name]: {
           tags: [],
         },
-        [`${getE2eKey(workspaceJson)}-e2e`]: {
+        [`${getE2eKey(host)}-e2e`]: {
           tags: [],
         },
       },
@@ -503,14 +502,14 @@ function checkCanConvertToWorkspace(host: Tree) {
     if (Object.keys(workspaceJson.projects).length > 2 || hasLibraries) {
       throw new Error('Can only convert projects with one app');
     }
-    const e2eKey = getE2eKey(workspaceJson);
-    const e2eApp = getE2eProject(workspaceJson);
-    if (e2eApp && !host.exists(e2eApp.architect.e2e.options.protractorConfig)) {
+    const e2eKey = getE2eKey(host);
+    const e2eApp = getE2eProject(host);
+    if (e2eApp && !host.exists(e2eApp.targets.e2e.options.protractorConfig)) {
       console.info(
         `Make sure the ${e2eKey}.architect.e2e.options.protractorConfig is valid or the ${e2eKey} project is removed from angular.json.`
       );
       throw new Error(
-        `An e2e project was specified but ${e2eApp.architect.e2e.options.protractorConfig} could not be found.`
+        `An e2e project was specified but ${e2eApp.targets.e2e.options.protractorConfig} could not be found.`
       );
     }
 

--- a/packages/workspace/src/generators/move/lib/move-project-configuration.spec.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-configuration.spec.ts
@@ -14,7 +14,7 @@ describe('moveProjectConfiguration', () => {
   let projectConfig: ProjectConfiguration;
   let schema: NormalizedSchema;
 
-  beforeEach(async () => {
+  const setupWorkspace = (version = 1) => {
     schema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
@@ -24,7 +24,7 @@ describe('moveProjectConfiguration', () => {
       relativeToRootDestination: 'apps/subfolder/my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyWorkspace(version);
 
     addProjectConfiguration(tree, 'my-source', {
       projectType: 'application',
@@ -148,9 +148,11 @@ describe('moveProjectConfiguration', () => {
     });
 
     projectConfig = readProjectConfiguration(tree, 'my-source');
-  });
+  };
 
   it('should rename the project', async () => {
+    setupWorkspace();
+
     moveProjectConfiguration(tree, schema, projectConfig);
 
     expect(() => {
@@ -162,6 +164,8 @@ describe('moveProjectConfiguration', () => {
   });
 
   it('should update paths in only the intended project', async () => {
+    setupWorkspace();
+
     moveProjectConfiguration(tree, schema, projectConfig);
 
     const actualProject = readProjectConfiguration(
@@ -178,6 +182,8 @@ describe('moveProjectConfiguration', () => {
   });
 
   it('should update nx.json', () => {
+    setupWorkspace();
+
     moveProjectConfiguration(tree, schema, projectConfig);
 
     const actualProject = readProjectConfiguration(
@@ -190,6 +196,8 @@ describe('moveProjectConfiguration', () => {
   });
 
   it('should support moving a standalone project', () => {
+    setupWorkspace(2);
+
     const projectName = 'standalone';
     const newProjectName = 'parent-standalone';
     addProjectConfiguration(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When working with generators and the Nx DevKit utilities to make changes to a workspace configuration that it's using the v1 format, the format of the workspace configuration is changed to v2.

A workaround is to call `await formatFiles(tree);` at the end of the generation because this utility makes sure to leave the workspace configuration in the right format. That's not an intuitive solution. We already have in place utilities that make sure that when we read the configuration it will be returned in a consistent way (v2 format), but we don't do the same when we write the configuration to make sure is restored to the original version.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Updating the Nx configuration files should be straightforward and shouldn't require us to do any additional steps to make sure the configuration is written in the right format. The interoperability between the different workspace versions should be transparent to the end-user.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
