### PR TITLE
docs(nxdev): flavor interface consolidation

### DIFF
--- a/nx-dev/data-access-documents/src/lib/documents.api.spec.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.spec.ts
@@ -44,6 +44,16 @@ describe('DocumentsApi', () => {
     });
   });
 
+  describe('getFlavors', () => {
+    it('should return versions data', () => {
+      expect(api.getFavors()).toEqual([
+        expect.objectContaining({ id: 'angular' }),
+        expect.objectContaining({ id: 'react' }),
+        expect.objectContaining({ id: 'node' }),
+      ]);
+    });
+  });
+
   describe('getStaticDocumentPaths', () => {
     it.each`
       version       | flavor

--- a/nx-dev/data-access-documents/src/lib/documents.api.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.ts
@@ -1,10 +1,11 @@
 import { readFileSync } from 'fs';
-import { join, relative } from 'path';
+import { join } from 'path';
 import matter from 'gray-matter';
 import { extractTitle } from './documents.utils';
 import {
   DocumentData,
   DocumentMetadata,
+  FlavorMetadata,
   VersionMetadata,
 } from './documents.models';
 
@@ -12,21 +13,12 @@ export interface StaticDocumentPaths {
   params: { segments: string[] };
 }
 
-export const flavorList: {
-  label: string;
-  value: string;
-  default?: boolean;
-}[] = [
-  { label: 'Angular', value: 'angular' },
-  { label: 'React', value: 'react', default: true },
-  { label: 'Node', value: 'node' },
-];
-
 export class DocumentsApi {
   constructor(
     private readonly options: {
       publicDocsRoot: string;
       versions: VersionMetadata[];
+      flavors: FlavorMetadata[];
       documentsMap: Map<string, DocumentMetadata[]>;
     }
   ) {
@@ -43,6 +35,10 @@ export class DocumentsApi {
 
   getVersions(): VersionMetadata[] {
     return this.options.versions;
+  }
+
+  getFavors(): FlavorMetadata[] {
+    return this.options.flavors;
   }
 
   getDocument(

--- a/nx-dev/data-access-documents/src/lib/documents.models.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.models.ts
@@ -5,9 +5,18 @@ export interface DocumentData {
   excerpt?: string;
 }
 
+export interface FlavorMetadata {
+  name: string;
+  id: string;
+  alias: string;
+  path: string;
+  default?: boolean;
+}
+
 export interface VersionMetadata {
   name: string;
   id: string;
+  alias: string;
   release: string;
   path: string;
   default?: boolean;

--- a/nx-dev/data-access-documents/src/lib/test-utils.ts
+++ b/nx-dev/data-access-documents/src/lib/test-utils.ts
@@ -14,6 +14,12 @@ export function createDocumentApiOptions() {
         'versions.json'
       )
     ),
+    flavors: readJsonFile(
+      join(
+        join(__dirname, '../../../nx-dev/public/documentation'),
+        'flavors.json'
+      )
+    ),
     documentsMap: new Map<string, DocumentMetadata[]>([
       [
         'latest',

--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import Head from 'next/head';
 import {
   DocumentData,
+  FlavorMetadata,
   Menu,
   VersionMetadata,
 } from '@nrwl/nx-dev/data-access-documents';
@@ -11,8 +12,8 @@ import Sidebar from './sidebar';
 
 export interface DocumentationFeatureDocViewerProps {
   version: VersionMetadata;
-  flavor: { label: string; value: string };
-  flavorList: { label: string; value: string }[];
+  flavor: FlavorMetadata;
+  flavorList: FlavorMetadata[];
   versionList: VersionMetadata[];
   menu: Menu;
   document: DocumentData;
@@ -77,8 +78,8 @@ export function DocViewer({
           >
             <Content
               document={document}
-              flavor={flavor.value}
-              flavorList={flavorList.map((flavor) => flavor.value)}
+              flavor={flavor.id}
+              flavorList={flavorList.map((flavor) => flavor.id)}
               version={version.path}
               versionList={versionList.map((version) => version.id)}
             />

--- a/nx-dev/feature-doc-viewer/src/lib/sidebar.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/sidebar.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import cx from 'classnames';
 import Link from 'next/link';
 import {
+  FlavorMetadata,
   Menu,
   MenuItem,
   MenuSection,
@@ -14,8 +15,8 @@ export interface SidebarProps {
   menu: Menu;
   version: VersionMetadata;
   versionList: VersionMetadata[];
-  flavorList: any[];
-  flavor: any;
+  flavorList: FlavorMetadata[];
+  flavor: FlavorMetadata;
   navIsOpen?: boolean;
 }
 
@@ -60,16 +61,17 @@ export function Sidebar({
             }))}
             selected={{ label: version.name, value: version.id }}
             onChange={(item) =>
-              router.push(
-                createNextPath(item.value, flavor.value, router.asPath)
-              )
+              router.push(createNextPath(item.value, flavor.id, router.asPath))
             }
           />
         </div>
         <div className="px-1 pt-3 sm:px-3 xl:px-5">
           <Selector
-            data={flavorList}
-            selected={flavor}
+            data={flavorList.map((flavor) => ({
+              label: flavor.name,
+              value: flavor.id,
+            }))}
+            selected={{ label: flavor.name, value: flavor.id }}
             onChange={(item) =>
               router.push(createNextPath(version.id, item.value, router.asPath))
             }
@@ -149,7 +151,7 @@ function SidebarSectionItems({ item }: { item: MenuItem }) {
           const isActiveLink = item.path === withoutAnchors(router?.asPath);
           return (
             <li key={item.id} data-testid={`section-li:${item.id}`}>
-              <Link href={item.path}>
+              <Link href={item.path as string}>
                 <a
                   className={cx(
                     'py-1 transition-colors duration-200 relative block text-gray-500 hover:text-gray-900'

--- a/nx-dev/nx-dev/lib/api.ts
+++ b/nx-dev/nx-dev/lib/api.ts
@@ -1,6 +1,7 @@
 import {
   DocumentMetadata,
   DocumentsApi,
+  FlavorMetadata,
   MenuApi,
   VersionMetadata,
 } from '@nrwl/nx-dev/data-access-documents';
@@ -9,6 +10,7 @@ import {
 // Also provides some test safety.
 import previousDocuments from '../public/documentation/previous/map.json';
 import latestDocuments from '../public/documentation/latest/map.json';
+import flavorsData from '../public/documentation/flavors.json';
 import versionsData from '../public/documentation/versions.json';
 
 export function loadDocumentsData(): Map<string, DocumentMetadata[]> {
@@ -18,6 +20,9 @@ export function loadDocumentsData(): Map<string, DocumentMetadata[]> {
   return map;
 }
 
+export function loadFlavorsData(): FlavorMetadata[] {
+  return flavorsData;
+}
 export function loadVersionsData(): VersionMetadata[] {
   return versionsData;
 }
@@ -25,6 +30,7 @@ export function loadVersionsData(): VersionMetadata[] {
 export const documentsApi = new DocumentsApi({
   publicDocsRoot: 'nx-dev/nx-dev/public/documentation',
   documentsMap: loadDocumentsData(),
+  flavors: loadFlavorsData(),
   versions: loadVersionsData(),
 });
 

--- a/nx-dev/nx-dev/public/documentation/flavors.json
+++ b/nx-dev/nx-dev/public/documentation/flavors.json
@@ -1,0 +1,11 @@
+[
+  { "id": "angular", "name": "Angular", "alias": "a", "path": "angular" },
+  {
+    "id": "react",
+    "name": "React",
+    "alias": "r",
+    "path": "react",
+    "default": true
+  },
+  { "id": "node", "name": "Node", "alias": "n", "path": "node" }
+]

--- a/nx-dev/nx-dev/public/documentation/versions.json
+++ b/nx-dev/nx-dev/public/documentation/versions.json
@@ -2,6 +2,7 @@
   {
     "name": "Latest",
     "id": "latest",
+    "alias": "l",
     "release": "12.9.0",
     "path": "latest",
     "default": true
@@ -9,6 +10,7 @@
   {
     "name": "Previous (v11.6.3)",
     "id": "previous",
+    "alias": "p",
     "release": "11.6.3",
     "path": "previous",
     "default": false


### PR DESCRIPTION
## What it does?
This PR updates the general interface for _Flavors_ to behave like _Versions_ does, striking for consolidation will ease the future updates and usages. It also introduces `alias` property for both interfaces.