### PR TITLE
docs(nxdev): shorter url shemes

### DIFF
--- a/nx-dev/data-access-documents/src/lib/documents.api.spec.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.spec.ts
@@ -44,6 +44,16 @@ describe('DocumentsApi', () => {
     });
   });
 
+  describe('getFlavors', () => {
+    it('should return versions data', () => {
+      expect(api.getFavors()).toEqual([
+        expect.objectContaining({ id: 'angular' }),
+        expect.objectContaining({ id: 'react' }),
+        expect.objectContaining({ id: 'node' }),
+      ]);
+    });
+  });
+
   describe('getStaticDocumentPaths', () => {
     it.each`
       version       | flavor

--- a/nx-dev/data-access-documents/src/lib/documents.api.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.ts
@@ -1,10 +1,11 @@
 import { readFileSync } from 'fs';
-import { join, relative } from 'path';
+import { join } from 'path';
 import matter from 'gray-matter';
 import { extractTitle } from './documents.utils';
 import {
   DocumentData,
   DocumentMetadata,
+  FlavorMetadata,
   VersionMetadata,
 } from './documents.models';
 
@@ -12,21 +13,12 @@ export interface StaticDocumentPaths {
   params: { segments: string[] };
 }
 
-export const flavorList: {
-  label: string;
-  value: string;
-  default?: boolean;
-}[] = [
-  { label: 'Angular', value: 'angular' },
-  { label: 'React', value: 'react', default: true },
-  { label: 'Node', value: 'node' },
-];
-
 export class DocumentsApi {
   constructor(
     private readonly options: {
       publicDocsRoot: string;
       versions: VersionMetadata[];
+      flavors: FlavorMetadata[];
       documentsMap: Map<string, DocumentMetadata[]>;
     }
   ) {
@@ -43,6 +35,10 @@ export class DocumentsApi {
 
   getVersions(): VersionMetadata[] {
     return this.options.versions;
+  }
+
+  getFavors(): FlavorMetadata[] {
+    return this.options.flavors;
   }
 
   getDocument(

--- a/nx-dev/data-access-documents/src/lib/documents.models.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.models.ts
@@ -1,5 +1,6 @@
 export interface DocumentData {
   filePath: string;
+  url: string;
   data: { [key: string]: any };
   content: string;
   excerpt?: string;

--- a/nx-dev/data-access-documents/src/lib/documents.models.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.models.ts
@@ -5,9 +5,18 @@ export interface DocumentData {
   excerpt?: string;
 }
 
+export interface FlavorMetadata {
+  name: string;
+  id: string;
+  alias: string;
+  path: string;
+  default?: boolean;
+}
+
 export interface VersionMetadata {
   name: string;
   id: string;
+  alias: string;
   release: string;
   path: string;
   default?: boolean;

--- a/nx-dev/data-access-documents/src/lib/menu.api.spec.ts
+++ b/nx-dev/data-access-documents/src/lib/menu.api.spec.ts
@@ -8,11 +8,14 @@ describe('MenuApi', () => {
 
   describe('getMenu', () => {
     it('should group by section', () => {
-      const menu = api.getMenu('latest', 'react');
+      const menu = api.getMenu(
+        docsApi.getDefaultVersion(),
+        docsApi.getDefaultFlavor()
+      );
 
       expect(menu).toEqual({
-        version: 'latest',
-        flavor: 'react',
+        version: docsApi.getDefaultVersion(),
+        flavor: docsApi.getDefaultFlavor(),
         sections: expect.arrayContaining([
           expect.objectContaining({ id: 'basic', itemList: expect.any(Array) }),
           expect.objectContaining({ id: 'api', itemList: expect.any(Array) }),
@@ -25,10 +28,16 @@ describe('MenuApi', () => {
     });
 
     it('should add path to menu items', () => {
-      const menu = api.getMenu('latest', 'react');
+      const menu = api.getMenu(
+        docsApi.getDefaultVersion(),
+        docsApi.getDefaultFlavor()
+      );
 
       // first basic section item should have prefix by version and flavor
       // e.g. "latest/react/getting-started/intro"
+      expect(menu?.sections?.[0]?.itemList?.[0]?.itemList?.[0].url).toMatch(
+        /l\/r/
+      );
       expect(menu?.sections?.[0]?.itemList?.[0]?.itemList?.[0].path).toMatch(
         /latest\/react/
       );

--- a/nx-dev/data-access-documents/src/lib/menu.api.ts
+++ b/nx-dev/data-access-documents/src/lib/menu.api.ts
@@ -6,23 +6,24 @@ import {
   getBasicSection,
   getDeepDiveSection,
 } from './menu.utils';
+import { FlavorMetadata, VersionMetadata } from './documents.models';
 
 export class MenuApi {
   private readonly menuCache = new Map<string, Menu>();
 
   constructor(private readonly documentsApi: DocumentsApi) {}
 
-  getMenu(versionId: string, flavorId: string): Menu {
-    const key = `${versionId}-${flavorId}`;
+  getMenu(version: VersionMetadata, flavor: FlavorMetadata): Menu {
+    const key = `${version.id}-${flavor.id}`;
     let menu = this.menuCache.get(key);
 
     if (!menu) {
-      const root = this.documentsApi.getDocuments(versionId);
-      const items = createMenuItems(versionId, flavorId, root);
+      const root = this.documentsApi.getDocuments(version.id);
+      const items = createMenuItems(version, flavor, root);
       if (items) {
         menu = {
-          version: versionId,
-          flavor: flavorId,
+          version: version,
+          flavor: flavor,
           sections: [
             getBasicSection(items),
             getDeepDiveSection(items),
@@ -30,7 +31,7 @@ export class MenuApi {
           ],
         };
       } else {
-        throw new Error(`Cannot find documents for flavor "${flavorId}"`);
+        throw new Error(`Cannot find documents for flavor id: "${flavor.id}"`);
       }
       this.menuCache.set(key, menu);
     }

--- a/nx-dev/data-access-documents/src/lib/menu.models.ts
+++ b/nx-dev/data-access-documents/src/lib/menu.models.ts
@@ -1,8 +1,12 @@
-import { DocumentMetadata } from './documents.models';
+import {
+  DocumentMetadata,
+  FlavorMetadata,
+  VersionMetadata,
+} from './documents.models';
 
 export interface Menu {
-  version: string;
-  flavor: string;
+  version: VersionMetadata;
+  flavor: FlavorMetadata;
   sections: MenuSection[];
 }
 
@@ -15,6 +19,7 @@ export interface MenuSection {
 
 export interface MenuItem extends DocumentMetadata {
   path?: string;
+  url?: string;
   itemList?: MenuItem[];
   disableCollapsible?: boolean;
 }

--- a/nx-dev/data-access-documents/src/lib/menu.utils.ts
+++ b/nx-dev/data-access-documents/src/lib/menu.utils.ts
@@ -1,17 +1,22 @@
-import { DocumentMetadata } from '@nrwl/nx-dev/data-access-documents';
+import {
+  DocumentMetadata,
+  FlavorMetadata,
+  VersionMetadata,
+} from '@nrwl/nx-dev/data-access-documents';
 import { MenuItem, MenuSection } from './menu.models';
 
 export function createMenuItems(
-  versionId: string,
-  flavor: string,
+  version: VersionMetadata,
+  flavor: FlavorMetadata,
   root: DocumentMetadata[]
 ): MenuItem[] {
-  const items = root.find((x) => x.id === flavor)?.itemList;
+  const items = root.find((x) => x.id === flavor.id)?.itemList;
 
   const createPathMetadata = (g: DocumentMetadata, parentId = ''): MenuItem => {
     const pathData = {
       ...g,
-      path: `/${versionId}/${flavor}/${parentId}/${g.id}`,
+      path: `/${version.id}/${flavor.id}/${parentId}/${g.id}`,
+      url: `/${version.alias}/${flavor.alias}/${parentId}/${g.id}`,
     };
 
     if (Array.isArray(g.itemList)) {

--- a/nx-dev/data-access-documents/src/lib/test-utils.ts
+++ b/nx-dev/data-access-documents/src/lib/test-utils.ts
@@ -14,6 +14,12 @@ export function createDocumentApiOptions() {
         'versions.json'
       )
     ),
+    flavors: readJsonFile(
+      join(
+        join(__dirname, '../../../nx-dev/public/documentation'),
+        'flavors.json'
+      )
+    ),
     documentsMap: new Map<string, DocumentMetadata[]>([
       [
         'latest',

--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import Head from 'next/head';
 import {
   DocumentData,
+  FlavorMetadata,
   Menu,
   VersionMetadata,
 } from '@nrwl/nx-dev/data-access-documents';
@@ -11,8 +12,8 @@ import Sidebar from './sidebar';
 
 export interface DocumentationFeatureDocViewerProps {
   version: VersionMetadata;
-  flavor: { label: string; value: string };
-  flavorList: { label: string; value: string }[];
+  flavor: FlavorMetadata;
+  flavorList: FlavorMetadata[];
   versionList: VersionMetadata[];
   menu: Menu;
   document: DocumentData;
@@ -77,8 +78,8 @@ export function DocViewer({
           >
             <Content
               document={document}
-              flavor={flavor.value}
-              flavorList={flavorList.map((flavor) => flavor.value)}
+              flavor={flavor.id}
+              flavorList={flavorList.map((flavor) => flavor.id)}
               version={version.path}
               versionList={versionList.map((version) => version.id)}
             />

--- a/nx-dev/feature-doc-viewer/src/lib/sidebar.spec.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/sidebar.spec.tsx
@@ -10,8 +10,20 @@ describe('Sidebar', () => {
       <Sidebar
         navIsOpen={false}
         menu={{
-          version: 'preview',
-          flavor: 'react',
+          version: {
+            name: 'Latest',
+            id: 'latest',
+            alias: 'l',
+            release: '12.9.0',
+            path: 'latest',
+            default: true,
+          },
+          flavor: {
+            id: 'angular',
+            name: 'Angular',
+            alias: 'a',
+            path: 'angular',
+          },
           sections: [
             {
               id: 'basic',
@@ -22,9 +34,9 @@ describe('Sidebar', () => {
                   id: 'getting-started',
                   name: 'getting started',
                   itemList: [
-                    { id: 'a', name: 'A', path: '/a' },
-                    { id: 'b', name: 'B', path: '/b' },
-                    { id: 'c', name: 'C', path: '/c' },
+                    { id: 'a', name: 'A', path: '/a', url: '/a' },
+                    { id: 'b', name: 'B', path: '/b', url: '/b' },
+                    { id: 'c', name: 'C', path: '/c', url: '/c' },
                   ],
                 },
               ],
@@ -37,37 +49,56 @@ describe('Sidebar', () => {
                   id: 'overview',
                   name: 'overview',
                   itemList: [
-                    { id: 'd', name: 'D', path: '/d' },
-                    { id: 'e', name: 'E', path: '/e' },
+                    { id: 'd', name: 'D', path: '/d', url: '/d' },
+                    { id: 'e', name: 'E', path: '/e', url: '/e' },
                   ],
                 },
               ],
             },
           ],
         }}
-        flavor={{ label: 'Angular', value: 'angular' }}
+        flavor={{
+          id: 'angular',
+          name: 'Angular',
+          alias: 'a',
+          path: 'angular',
+        }}
         flavorList={[
-          { label: 'Angular', value: 'angular' },
-          { label: 'React', value: 'react' },
+          {
+            id: 'angular',
+            name: 'Angular',
+            alias: 'a',
+            path: 'angular',
+          },
+          {
+            id: 'react',
+            name: 'React',
+            alias: 'r',
+            path: 'react',
+            default: true,
+          },
         ]}
         version={{
-          name: 'Latest (v11.4.0)',
+          name: 'Latest',
           id: 'latest',
-          release: '11.4.0',
-          path: '11.4.0',
+          alias: 'l',
+          release: '12.9.0',
+          path: 'latest',
           default: true,
         }}
         versionList={[
           {
-            name: 'Latest (v11.4.0)',
+            name: 'Latest',
             id: 'latest',
-            release: '11.4.0',
-            path: '11.4.0',
+            alias: 'l',
+            release: '12.9.0',
+            path: 'latest',
             default: true,
           },
           {
             name: 'Previous (v10.4.13)',
             id: 'previous',
+            alias: 'p',
             release: '10.4.13',
             path: '10.4.13',
             default: false,

--- a/nx-dev/feature-doc-viewer/src/lib/sidebar.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/sidebar.tsx
@@ -57,11 +57,13 @@ export function Sidebar({
           <Selector
             data={versionList.map((version) => ({
               label: version.name,
-              value: version.id,
+              value: version.alias,
             }))}
-            selected={{ label: version.name, value: version.id }}
+            selected={{ label: version.name, value: version.alias }}
             onChange={(item) =>
-              router.push(createNextPath(item.value, flavor.id, router.asPath))
+              router.push(
+                createNextPath(item.value, flavor.alias, router.asPath)
+              )
             }
           />
         </div>
@@ -69,11 +71,13 @@ export function Sidebar({
           <Selector
             data={flavorList.map((flavor) => ({
               label: flavor.name,
-              value: flavor.id,
+              value: flavor.alias,
             }))}
-            selected={{ label: flavor.name, value: flavor.id }}
+            selected={{ label: flavor.name, value: flavor.alias }}
             onChange={(item) =>
-              router.push(createNextPath(version.id, item.value, router.asPath))
+              router.push(
+                createNextPath(version.alias, item.value, router.asPath)
+              )
             }
           />
         </div>
@@ -148,10 +152,10 @@ function SidebarSectionItems({ item }: { item: MenuItem }) {
       </h5>
       <ul className={cx('mb-6', collapsed ? 'hidden' : '')}>
         {item.itemList.map((item) => {
-          const isActiveLink = item.path === withoutAnchors(router?.asPath);
+          const isActiveLink = item.url === withoutAnchors(router?.asPath);
           return (
             <li key={item.id} data-testid={`section-li:${item.id}`}>
-              <Link href={item.path as string}>
+              <Link href={item.url as string}>
                 <a
                   className={cx(
                     'py-1 transition-colors duration-200 relative block text-gray-500 hover:text-gray-900'

--- a/nx-dev/feature-doc-viewer/src/lib/sidebar.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/sidebar.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import cx from 'classnames';
 import Link from 'next/link';
 import {
+  FlavorMetadata,
   Menu,
   MenuItem,
   MenuSection,
@@ -14,8 +15,8 @@ export interface SidebarProps {
   menu: Menu;
   version: VersionMetadata;
   versionList: VersionMetadata[];
-  flavorList: any[];
-  flavor: any;
+  flavorList: FlavorMetadata[];
+  flavor: FlavorMetadata;
   navIsOpen?: boolean;
 }
 
@@ -60,16 +61,17 @@ export function Sidebar({
             }))}
             selected={{ label: version.name, value: version.id }}
             onChange={(item) =>
-              router.push(
-                createNextPath(item.value, flavor.value, router.asPath)
-              )
+              router.push(createNextPath(item.value, flavor.id, router.asPath))
             }
           />
         </div>
         <div className="px-1 pt-3 sm:px-3 xl:px-5">
           <Selector
-            data={flavorList}
-            selected={flavor}
+            data={flavorList.map((flavor) => ({
+              label: flavor.name,
+              value: flavor.id,
+            }))}
+            selected={{ label: flavor.name, value: flavor.id }}
             onChange={(item) =>
               router.push(createNextPath(version.id, item.value, router.asPath))
             }
@@ -149,7 +151,7 @@ function SidebarSectionItems({ item }: { item: MenuItem }) {
           const isActiveLink = item.path === withoutAnchors(router?.asPath);
           return (
             <li key={item.id} data-testid={`section-li:${item.id}`}>
-              <Link href={item.path}>
+              <Link href={item.path as string}>
                 <a
                   className={cx(
                     'py-1 transition-colors duration-200 relative block text-gray-500 hover:text-gray-900'

--- a/nx-dev/nx-dev/lib/api.ts
+++ b/nx-dev/nx-dev/lib/api.ts
@@ -1,6 +1,7 @@
 import {
   DocumentMetadata,
   DocumentsApi,
+  FlavorMetadata,
   MenuApi,
   VersionMetadata,
 } from '@nrwl/nx-dev/data-access-documents';
@@ -9,6 +10,7 @@ import {
 // Also provides some test safety.
 import previousDocuments from '../public/documentation/previous/map.json';
 import latestDocuments from '../public/documentation/latest/map.json';
+import flavorsData from '../public/documentation/flavors.json';
 import versionsData from '../public/documentation/versions.json';
 
 export function loadDocumentsData(): Map<string, DocumentMetadata[]> {
@@ -18,6 +20,9 @@ export function loadDocumentsData(): Map<string, DocumentMetadata[]> {
   return map;
 }
 
+export function loadFlavorsData(): FlavorMetadata[] {
+  return flavorsData;
+}
 export function loadVersionsData(): VersionMetadata[] {
   return versionsData;
 }
@@ -25,6 +30,7 @@ export function loadVersionsData(): VersionMetadata[] {
 export const documentsApi = new DocumentsApi({
   publicDocsRoot: 'nx-dev/nx-dev/public/documentation',
   documentsMap: loadDocumentsData(),
+  flavors: loadFlavorsData(),
   versions: loadVersionsData(),
 });
 

--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -16,7 +16,7 @@ import { Footer, Header } from '@nrwl/nx-dev/ui/common';
 import { documentsApi, menuApi } from '../lib/api';
 import { useStorage } from '../lib/use-storage';
 
-const flavorList = documentsApi.getFavors();
+const flavorList = documentsApi.getFlavors();
 const versionList = documentsApi.getVersions();
 const defaultVersion = versionList.find((v) => v.default) as VersionMetadata;
 const defaultFlavor = flavorList.find((f) => f.default) as FlavorMetadata;
@@ -40,12 +40,24 @@ export function DocumentationPage({
   flavors,
   isFallback,
 }: DocumentationPageProps) {
+  // console.group('DOCUMENTATION_PAGE');
+  // console.log('hasDocument', !!document);
+  // console.log('menu', menu);
+  // console.log('version', version);
+  // // console.log('versions', versions);
+  // console.log('flavor', flavor);
+  // // console.log('flavors', flavors);
+  // console.log('isFallback', isFallback);
+  // console.groupEnd();
+
   const router = useRouter();
   const { value: storedFlavor, setValue: setStoredFlavor } =
     useStorage('flavor');
   const { setValue: setStoredVersion } = useStorage('version');
   const [dialogOpen, setDialogOpen] = useState(false);
   const [navIsOpen, setNavIsOpen] = useState(false);
+
+  const cleanPath = pathCleaner(versions, flavors);
 
   useEffect(() => {
     if (!navIsOpen) return;
@@ -59,12 +71,12 @@ export function DocumentationPage({
   }, [navIsOpen]);
   useEffect(() => {
     if (!isFallback) {
-      setStoredFlavor(flavor.id);
+      setStoredFlavor(flavor.alias);
     }
   }, [flavor, isFallback, setStoredFlavor]);
   useEffect(() => {
     if (!isFallback) {
-      setStoredVersion(version.id);
+      setStoredVersion(version.alias);
     }
   }, [version, isFallback, setStoredVersion]);
 
@@ -73,12 +85,18 @@ export function DocumentationPage({
 
     // If the stored flavor is different then navigate away.
     // Otherwise replace current URL _if_ it is missing version+flavor.
-    if (flavor.id !== storedFlavor) {
-      router.push(`/${version.id}/${storedFlavor}${router.asPath}`);
-    } else if (!router.asPath.startsWith(`/${version.id}`)) {
-      router.push(`/${version.id}/${storedFlavor}${router.asPath}`, undefined, {
-        shallow: true,
-      });
+    if (flavor.alias !== storedFlavor) {
+      router.push(
+        `/${version.alias}/${storedFlavor}${cleanPath(router.asPath)}`
+      );
+    } else if (!router.asPath.startsWith(`/${version.alias}`)) {
+      router.push(
+        `/${version.alias}/${storedFlavor}${cleanPath(router.asPath)}`,
+        undefined,
+        {
+          shallow: true,
+        }
+      );
     }
   }, [router, version, flavor, storedFlavor, isFallback]);
 
@@ -88,18 +106,18 @@ export function DocumentationPage({
 
   return (
     <>
-      {isFallback && (
-        <Head>
-          <link
-            rel="canonical"
-            href={`/${version.id}/${flavor.id}${router.asPath}`}
-          />
-        </Head>
-      )}
+      <Head>
+        <link
+          rel="canonical"
+          href={`/${version.alias}/${flavor.alias}`.concat(
+            cleanPath(router.asPath)
+          )}
+        />
+      </Head>
       <Header
         showSearch={true}
-        version={{ name: version.name, value: version.id }}
-        flavor={{ name: flavor.name, value: flavor.id }}
+        version={{ name: version.name, value: version.alias }}
+        flavor={{ name: flavor.name, value: flavor.alias }}
       />
       <main>
         <DocViewer
@@ -174,15 +192,15 @@ export function DocumentationPage({
             >
               Before You Continue...
             </Dialog.Title>
-            <Dialog.Description className="mb-4">
+            <Dialog.Description className="m-5">
               Nx is a smart and extensible build framework that has first-class
               support for many frontend and backend technologies.
             </Dialog.Description>
-            <Dialog.Description className="mb-4">
+            <Dialog.Description className="m-5">
               Please select the flavor you want to learn more about.
             </Dialog.Description>
             <div className="p-5 w-full grid grid-cols-3 gap-5 justify-items-center">
-              <Link href={`${version.id}/react${router.asPath}`}>
+              <Link href={`${version.alias}/r${cleanPath(router.asPath)}`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#52C1DE">
                     <path d="M14.23 12.004a2.236 2.236 0 0 1-2.235 2.236 2.236 2.236 0 0 1-2.236-2.236 2.236 2.236 0 0 1 2.235-2.236 2.236 2.236 0 0 1 2.236 2.236zm2.648-10.69c-1.346 0-3.107.96-4.888 2.622-1.78-1.653-3.542-2.602-4.887-2.602-.41 0-.783.093-1.106.278-1.375.793-1.683 3.264-.973 6.365C1.98 8.917 0 10.42 0 12.004c0 1.59 1.99 3.097 5.043 4.03-.704 3.113-.39 5.588.988 6.38.32.187.69.275 1.102.275 1.345 0 3.107-.96 4.888-2.624 1.78 1.654 3.542 2.603 4.887 2.603.41 0 .783-.09 1.106-.275 1.374-.792 1.683-3.263.973-6.365C22.02 15.096 24 13.59 24 12.004c0-1.59-1.99-3.097-5.043-4.032.704-3.11.39-5.587-.988-6.38-.318-.184-.688-.277-1.092-.278zm-.005 1.09v.006c.225 0 .406.044.558.127.666.382.955 1.835.73 3.704-.054.46-.142.945-.25 1.44-.96-.236-2.006-.417-3.107-.534-.66-.905-1.345-1.727-2.035-2.447 1.592-1.48 3.087-2.292 4.105-2.295zm-9.77.02c1.012 0 2.514.808 4.11 2.28-.686.72-1.37 1.537-2.02 2.442-1.107.117-2.154.298-3.113.538-.112-.49-.195-.964-.254-1.42-.23-1.868.054-3.32.714-3.707.19-.09.4-.127.563-.132zm4.882 3.05c.455.468.91.992 1.36 1.564-.44-.02-.89-.034-1.345-.034-.46 0-.915.01-1.36.034.44-.572.895-1.096 1.345-1.565zM12 8.1c.74 0 1.477.034 2.202.093.406.582.802 1.203 1.183 1.86.372.64.71 1.29 1.018 1.946-.308.655-.646 1.31-1.013 1.95-.38.66-.773 1.288-1.18 1.87-.728.063-1.466.098-2.21.098-.74 0-1.477-.035-2.202-.093-.406-.582-.802-1.204-1.183-1.86-.372-.64-.71-1.29-1.018-1.946.303-.657.646-1.313 1.013-1.954.38-.66.773-1.286 1.18-1.868.728-.064 1.466-.098 2.21-.098zm-3.635.254c-.24.377-.48.763-.704 1.16-.225.39-.435.782-.635 1.174-.265-.656-.49-1.31-.676-1.947.64-.15 1.315-.283 2.015-.386zm7.26 0c.695.103 1.365.23 2.006.387-.18.632-.405 1.282-.66 1.933-.2-.39-.41-.783-.64-1.174-.225-.392-.465-.774-.705-1.146zm3.063.675c.484.15.944.317 1.375.498 1.732.74 2.852 1.708 2.852 2.476-.005.768-1.125 1.74-2.857 2.475-.42.18-.88.342-1.355.493-.28-.958-.646-1.956-1.1-2.98.45-1.017.81-2.01 1.085-2.964zm-13.395.004c.278.96.645 1.957 1.1 2.98-.45 1.017-.812 2.01-1.086 2.964-.484-.15-.944-.318-1.37-.5-1.732-.737-2.852-1.706-2.852-2.474 0-.768 1.12-1.742 2.852-2.476.42-.18.88-.342 1.356-.494zm11.678 4.28c.265.657.49 1.312.676 1.948-.64.157-1.316.29-2.016.39.24-.375.48-.762.705-1.158.225-.39.435-.788.636-1.18zm-9.945.02c.2.392.41.783.64 1.175.23.39.465.772.705 1.143-.695-.102-1.365-.23-2.006-.386.18-.63.406-1.282.66-1.933zM17.92 16.32c.112.493.2.968.254 1.423.23 1.868-.054 3.32-.714 3.708-.147.09-.338.128-.563.128-1.012 0-2.514-.807-4.11-2.28.686-.72 1.37-1.536 2.02-2.44 1.107-.118 2.154-.3 3.113-.54zm-11.83.01c.96.234 2.006.415 3.107.532.66.905 1.345 1.727 2.035 2.446-1.595 1.483-3.092 2.295-4.11 2.295-.22-.005-.406-.05-.553-.132-.666-.38-.955-1.834-.73-3.703.054-.46.142-.944.25-1.438zm4.56.64c.44.02.89.034 1.345.034.46 0 .915-.01 1.36-.034-.44.572-.895 1.095-1.345 1.565-.455-.47-.91-.993-1.36-1.565z" />
@@ -192,7 +210,7 @@ export function DocumentationPage({
                   </div>
                 </a>
               </Link>
-              <Link href={`${version.id}/angular${router.asPath}`}>
+              <Link href={`${version.alias}/a${cleanPath(router.asPath)}`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#E23236">
                     <path d="M9.931 12.645h4.138l-2.07-4.908m0-7.737L.68 3.982l1.726 14.771L12 24l9.596-5.242L23.32 3.984 11.999.001zm7.064 18.31h-2.638l-1.422-3.503H8.996l-1.422 3.504h-2.64L12 2.65z" />
@@ -202,7 +220,7 @@ export function DocumentationPage({
                   </div>
                 </a>
               </Link>
-              <Link href={`${version.id}/node${router.asPath}`}>
+              <Link href={`${version.alias}/n${cleanPath(router.asPath)}`}>
                 <a className="w-full bg-white border border-gray-100 shadow-sm hover:shadow-md transition-all ease-out duration-180 rounded-md py-4 px-3 space-x-1 text-base tracking-tight font-bold leading-tight text-center flex flex-col justify-center items-center px-2 py-4 space-y-4">
                   <svg viewBox="0 0 24 24" className="w-1/2" fill="#77AE64">
                     <path d="M11.998,24c-0.321,0-0.641-0.084-0.922-0.247l-2.936-1.737c-0.438-0.245-0.224-0.332-0.08-0.383 c0.585-0.203,0.703-0.25,1.328-0.604c0.065-0.037,0.151-0.023,0.218,0.017l2.256,1.339c0.082,0.045,0.197,0.045,0.272,0l8.795-5.076 c0.082-0.047,0.134-0.141,0.134-0.238V6.921c0-0.099-0.053-0.192-0.137-0.242l-8.791-5.072c-0.081-0.047-0.189-0.047-0.271,0 L3.075,6.68C2.99,6.729,2.936,6.825,2.936,6.921v10.15c0,0.097,0.054,0.189,0.139,0.235l2.409,1.392 c1.307,0.654,2.108-0.116,2.108-0.89V7.787c0-0.142,0.114-0.253,0.256-0.253h1.115c0.139,0,0.255,0.112,0.255,0.253v10.021 c0,1.745-0.95,2.745-2.604,2.745c-0.508,0-0.909,0-2.026-0.551L2.28,18.675c-0.57-0.329-0.922-0.945-0.922-1.604V6.921 c0-0.659,0.353-1.275,0.922-1.603l8.795-5.082c0.557-0.315,1.296-0.315,1.848,0l8.794,5.082c0.57,0.329,0.924,0.944,0.924,1.603 v10.15c0,0.659-0.354,1.273-0.924,1.604l-8.794,5.078C12.643,23.916,12.324,24,11.998,24z M19.099,13.993 c0-1.9-1.284-2.406-3.987-2.763c-2.731-0.361-3.009-0.548-3.009-1.187c0-0.528,0.235-1.233,2.258-1.233 c1.807,0,2.473,0.389,2.747,1.607c0.024,0.115,0.129,0.199,0.247,0.199h1.141c0.071,0,0.138-0.031,0.186-0.081 c0.048-0.054,0.074-0.123,0.067-0.196c-0.177-2.098-1.571-3.076-4.388-3.076c-2.508,0-4.004,1.058-4.004,2.833 c0,1.925,1.488,2.457,3.895,2.695c2.88,0.282,3.103,0.703,3.103,1.269c0,0.983-0.789,1.402-2.642,1.402 c-2.327,0-2.839-0.584-3.011-1.742c-0.02-0.124-0.126-0.215-0.253-0.215h-1.137c-0.141,0-0.254,0.112-0.254,0.253 c0,1.482,0.806,3.248,4.655,3.248C17.501,17.007,19.099,15.91,19.099,13.993z" />
@@ -226,10 +244,25 @@ export async function getStaticProps({
   params: { segments: string[] };
 }) {
   const version =
-    versionList.find((item) => item.id === params.segments[0]) ??
-    defaultVersion;
+    versionList.find((item) =>
+      [item.id, item.alias].includes(params.segments[0])
+    ) ?? defaultVersion;
   const flavor =
-    flavorList.find((item) => item.id === params.segments[1]) ?? defaultFlavor;
+    flavorList.find((item) =>
+      [item.id, item.alias].includes(params.segments[1])
+    ) ?? defaultFlavor;
+
+  // If we use the ID of version or flavor, redirect using the ALIAS instead (redirection is permanent)
+  if (params.segments[0] === version.id || params.segments[1] === flavor.id) {
+    return {
+      redirect: {
+        destination: `/${version.alias}/${flavor.alias}/${params.segments
+          .splice(2)
+          .join('/')}`,
+        permanent: true,
+      },
+    };
+  }
 
   const { document, menu, isFallback } = findDocumentAndMenu(
     version,
@@ -262,7 +295,7 @@ export async function getStaticProps({
 
 export async function getStaticPaths() {
   const allPaths = versionList.flatMap((v) =>
-    documentsApi.getStaticDocumentPaths(v.id)
+    flavorList.flatMap((f) => documentsApi.getStaticDocumentPaths(v, f))
   );
 
   return {
@@ -280,20 +313,38 @@ function findDocumentAndMenu(
   document: undefined | DocumentData;
   isFallback?: boolean;
 } {
-  const isFallback = segments[0] !== version.id;
+  const isFallback =
+    segments[0] !== version.alias || segments[1] !== flavor.alias;
   const path = isFallback ? segments : segments.slice(2);
 
   let menu: undefined | Menu = undefined;
   let document: undefined | DocumentData = undefined;
 
   try {
-    menu = menuApi.getMenu(version.id, flavor.id);
-    document = documentsApi.getDocument(version.id, flavor.id, path);
+    menu = menuApi.getMenu(version, flavor);
+    document = documentsApi.getDocument(version, flavor, path);
   } catch {
     // nothing
   }
-
   return { document, menu, isFallback };
+}
+
+function pathCleaner(versions, flavors) {
+  return (path: string): string => {
+    const myPath = path
+      .split('/')
+      .filter(
+        (segment: string) =>
+          !versions.find((v) => [v.alias, v.id].includes(segment))
+      )
+      .filter(
+        (segment: string) =>
+          !flavors.find((f) => [f.alias, f.value].includes(segment))
+      )
+      .join('/');
+
+    return myPath;
+  };
 }
 
 export default DocumentationPage;

--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -53,7 +53,7 @@
       },
       "configurations": {
         "production": {
-          "buildTarget": "nx-dev:build:production",
+          "buildTarget": "nx-dev:build-base:production",
           "dev": false
         }
       }

--- a/nx-dev/nx-dev/public/documentation/flavors.json
+++ b/nx-dev/nx-dev/public/documentation/flavors.json
@@ -1,0 +1,11 @@
+[
+  { "id": "angular", "name": "Angular", "alias": "a", "path": "angular" },
+  {
+    "id": "react",
+    "name": "React",
+    "alias": "r",
+    "path": "react",
+    "default": true
+  },
+  { "id": "node", "name": "Node", "alias": "n", "path": "node" }
+]

--- a/nx-dev/nx-dev/public/documentation/versions.json
+++ b/nx-dev/nx-dev/public/documentation/versions.json
@@ -2,6 +2,7 @@
   {
     "name": "Latest",
     "id": "latest",
+    "alias": "l",
     "release": "12.9.0",
     "path": "latest",
     "default": true
@@ -9,6 +10,7 @@
   {
     "name": "Previous (v11.6.3)",
     "id": "previous",
+    "alias": "p",
     "release": "11.6.3",
     "path": "previous",
     "default": false

--- a/nx-dev/ui/common/src/lib/header.tsx
+++ b/nx-dev/ui/common/src/lib/header.tsx
@@ -79,7 +79,7 @@ export function Header(props: HeaderProps) {
           <nav className="flex items-justified justify-center space-x-1">
             <Link
               href={
-                version
+                version && flavor
                   ? `/${version.value}/${flavor.value}/getting-started/intro`
                   : `/getting-started/intro`
               }
@@ -90,7 +90,7 @@ export function Header(props: HeaderProps) {
             </Link>
             <Link
               href={
-                version
+                version && flavor
                   ? `/${version.value}/${flavor.value}/core-concepts/nx-devkit`
                   : `/core-concepts/nx-devkit`
               }


### PR DESCRIPTION
## What it does?
This PR updates the url schemes to have shorter _version_ and _flavor_ urls. Use a **permanent** redirection to old plain urls towards the new scheme.

## Notes
This PR needs #7048 