### PR TITLE
fix(core): pass overrides (args) to dependent tasks of same target type

### DIFF
--- a/packages/workspace/src/tasks-runner/run-command.spec.ts
+++ b/packages/workspace/src/tasks-runner/run-command.spec.ts
@@ -240,7 +240,9 @@ describe('createTasksForProjectToRun', () => {
       {
         target: 'build',
         configuration: undefined,
-        overrides: {},
+        overrides: {
+          additionalArg: true,
+        },
       },
       projectGraph,
       projectGraph.nodes.app1.name
@@ -249,7 +251,9 @@ describe('createTasksForProjectToRun', () => {
     expect(tasks).toEqual([
       {
         id: 'lib1:build',
-        overrides: {},
+        overrides: {
+          additionalArg: true,
+        },
         projectRoot: 'lib1-root',
         target: {
           configuration: undefined,
@@ -259,7 +263,9 @@ describe('createTasksForProjectToRun', () => {
       },
       {
         id: 'app1:build',
-        overrides: {},
+        overrides: {
+          additionalArg: true,
+        },
         projectRoot: 'app1-root',
         target: {
           configuration: undefined,
@@ -291,7 +297,9 @@ describe('createTasksForProjectToRun', () => {
       {
         target: 'build',
         configuration: undefined,
-        overrides: {},
+        overrides: {
+          additionalArg: true,
+        },
       },
       projectGraph,
       projectGraph.nodes.app1.name
@@ -300,7 +308,9 @@ describe('createTasksForProjectToRun', () => {
     expect(tasks).toEqual([
       {
         id: 'app1:prebuild',
-        overrides: {},
+        overrides: {
+          additionalArg: true,
+        },
         projectRoot: 'app1-root',
         target: {
           configuration: undefined,
@@ -310,7 +320,9 @@ describe('createTasksForProjectToRun', () => {
       },
       {
         id: 'lib1:build',
-        overrides: {},
+        overrides: {
+          additionalArg: true,
+        },
         projectRoot: 'lib1-root',
         target: {
           configuration: undefined,
@@ -320,7 +332,9 @@ describe('createTasksForProjectToRun', () => {
       },
       {
         id: 'app1:build',
-        overrides: {},
+        overrides: {
+          additionalArg: true,
+        },
         projectRoot: 'app1-root',
         target: {
           configuration: undefined,
@@ -355,7 +369,9 @@ describe('createTasksForProjectToRun', () => {
       {
         target: 'build',
         configuration: undefined,
-        overrides: {},
+        overrides: {
+          additionalArg: true,
+        },
       },
       projectGraph,
       projectGraph.nodes.app1.name
@@ -374,7 +390,9 @@ describe('createTasksForProjectToRun', () => {
       },
       {
         id: 'lib1:build',
-        overrides: {},
+        overrides: {
+          additionalArg: true,
+        },
         projectRoot: 'lib1-root',
         target: {
           configuration: undefined,
@@ -384,7 +402,9 @@ describe('createTasksForProjectToRun', () => {
       },
       {
         id: 'app1:build',
-        overrides: {},
+        overrides: {
+          additionalArg: true,
+        },
         projectRoot: 'app1-root',
         target: {
           configuration: undefined,
@@ -438,7 +458,9 @@ describe('createTasksForProjectToRun', () => {
       {
         target: 'build',
         configuration: undefined,
-        overrides: {},
+        overrides: {
+          additionalArg: true,
+        },
       },
       projectGraph,
       projectGraph.nodes.app1.name
@@ -448,13 +470,17 @@ describe('createTasksForProjectToRun', () => {
       id: 'app1:build',
       target: { project: 'app1', target: 'build' },
       projectRoot: 'app1-root',
-      overrides: {},
+      overrides: {
+        additionalArg: true,
+      },
     });
     expect(tasks).toContainEqual({
       id: 'lib2:build',
       target: { project: 'lib2', target: 'build' },
       projectRoot: 'lib2-root',
-      overrides: {},
+      overrides: {
+        additionalArg: true,
+      },
     });
   });
 

--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -200,6 +200,7 @@ function addTasksForProjectTarget(
         {
           target,
           configuration,
+          overrides,
         },
         dependencyConfig,
         defaultDependencyConfigs,
@@ -259,7 +260,11 @@ export function createTask({
 
 function addTasksForProjectDependencyConfig(
   project: ProjectGraphNode,
-  { target, configuration }: Pick<TaskParams, 'target' | 'configuration'>,
+  {
+    target,
+    configuration,
+    overrides,
+  }: Pick<TaskParams, 'target' | 'configuration' | 'overrides'>,
   dependencyConfig: TargetDependencyConfig,
   defaultDependencyConfigs: Record<string, TargetDependencyConfig[]>,
   projectGraph: ProjectGraph,
@@ -296,7 +301,7 @@ function addTasksForProjectDependencyConfig(
             project: projectGraph.nodes[dep.target],
             target: dependencyConfig.target,
             configuration,
-            overrides: {},
+            overrides: target === dependencyConfig.target ? overrides : {},
             errorIfCannotFindConfiguration: false,
           },
           defaultDependencyConfigs,
@@ -312,7 +317,7 @@ function addTasksForProjectDependencyConfig(
 
         addTasksForProjectDependencyConfig(
           projectGraph.nodes[dep.target],
-          { target, configuration },
+          { target, configuration, overrides },
           dependencyConfig,
           defaultDependencyConfigs,
           projectGraph,
@@ -328,7 +333,7 @@ function addTasksForProjectDependencyConfig(
         project,
         target: dependencyConfig.target,
         configuration,
-        overrides: {},
+        overrides,
         errorIfCannotFindConfiguration: true,
       },
       defaultDependencyConfigs,


### PR DESCRIPTION
## Current Behavior

When using `targetDependencies` to get run-many tasks to take order into account by running dependencies first any additional arguments are left off.


## Expected Behavior

After this change, when adding tasks for dependencies if the `target` matches then pass the overrides along. This means if it runs different targets the overrides are not passed, but for matching targets they get passed along

### Why

I have an `up` target which deploys that project. I use this in conjunction with `affected` to only deploy impacted projects. I need the infrastructure projects to be deployed in order, so I add `up` to targetDependencies

```
    "targetDependencies": {
        ...,
        "up": [
            {
                "target": "up",
                "projects": "dependencies"
            }
        ]
    },
```

To deploy, I can run `pnpx nx run-many --all --target=up --env=stg --yes`

The `--env` and `--yes` is important, but dependent tasks are not passed those arguments. 