### PR TITLE
fix(linter): install experimental utils with workspace-rule generator. fixes #6967

### DIFF
--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-cypress/executors/cypress.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-cypress/executors/cypress.md
@@ -56,13 +56,21 @@ Type: `string`
 
 A named group for recorded runs in the Cypress dashboard.
 
-### headless
+### headed
 
 Default: `false`
 
 Type: `boolean`
 
-Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode
+Displays the browser instead of running headlessly. Set this to 'true' if your run depends on a Chrome extension being loaded.
+
+### ~~headless~~
+
+Default: `false`
+
+Type: `boolean`
+
+**Deprecated:** Hide the browser instead of running headed (default for cypress run).
 
 ### ignoreTestFiles
 

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-cypress/executors/cypress.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-cypress/executors/cypress.md
@@ -56,13 +56,21 @@ Type: `string`
 
 A named group for recorded runs in the Cypress dashboard.
 
-### headless
+### headed
 
 Default: `false`
 
 Type: `boolean`
 
-Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode
+Displays the browser instead of running headlessly. Set this to 'true' if your run depends on a Chrome extension being loaded.
+
+### ~~headless~~
+
+Default: `false`
+
+Type: `boolean`
+
+**Deprecated:** Hide the browser instead of running headed (default for cypress run).
 
 ### ignoreTestFiles
 

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-cypress/executors/cypress.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-cypress/executors/cypress.md
@@ -56,13 +56,21 @@ Type: `string`
 
 A named group for recorded runs in the Cypress dashboard.
 
-### headless
+### headed
 
 Default: `false`
 
 Type: `boolean`
 
-Whether or not to open the Cypress application to run the tests. If set to 'true', will run in headless mode
+Displays the browser instead of running headlessly. Set this to 'true' if your run depends on a Chrome extension being loaded.
+
+### ~~headless~~
+
+Default: `false`
+
+Type: `boolean`
+
+**Deprecated:** Hide the browser instead of running headed (default for cypress run).
 
 ### ignoreTestFiles
 

--- a/packages/linter/src/generators/workspace-rule/__snapshots__/workspace-rule.spec.ts.snap
+++ b/packages/linter/src/generators/workspace-rule/__snapshots__/workspace-rule.spec.ts.snap
@@ -171,6 +171,23 @@ ruleTester.run(RULE_NAME, rule, {
 "
 `;
 
+exports[`@nrwl/linter:workspace-rule should install necessary depenedencies 1`] = `
+"{
+  \\"name\\": \\"test-name\\",
+  \\"dependencies\\": {
+    \\"tslib\\": \\"^2.0.0\\"
+  },
+  \\"devDependencies\\": {
+    \\"@nrwl/jest\\": \\"*\\",
+    \\"@types/jest\\": \\"26.0.24\\",
+    \\"@typescript-eslint/experimental-utils\\": \\"~4.28.3\\",
+    \\"jest\\": \\"27.0.3\\",
+    \\"ts-jest\\": \\"27.0.3\\"
+  }
+}
+"
+`;
+
 exports[`@nrwl/linter:workspace-rule should update the plugin index.ts with the new rule 1`] = `
 "import { RULE_NAME as myRuleName, rule as myRule } from './rules/my-rule';
 /**

--- a/packages/linter/src/generators/workspace-rule/workspace-rule.spec.ts
+++ b/packages/linter/src/generators/workspace-rule/workspace-rule.spec.ts
@@ -24,6 +24,15 @@ describe('@nrwl/linter:workspace-rule', () => {
     ).toMatchSnapshot();
   });
 
+  it('should install necessary depenedencies', async () => {
+    await lintWorkspaceRuleGenerator(tree, {
+      name: 'my-rule',
+      directory: 'rules',
+    });
+
+    expect(tree.read('package.json', 'utf-8')).toMatchSnapshot();
+  });
+
   it('should update the plugin index.ts with the new rule', async () => {
     await lintWorkspaceRuleGenerator(tree, {
       name: 'my-rule',
@@ -52,19 +61,25 @@ describe('@nrwl/linter:workspace-rule', () => {
     });
 
     // NOTE: formatFiles() will have been run so the real formatting will look better than this snapshot
-    expect(tree.read('tools/eslint-rules/index.ts', 'utf-8'))
-      .toMatchInlineSnapshot(`
+    expect(
+      tree.read('tools/eslint-rules/index.ts', 'utf-8')
+    ).toMatchInlineSnapshot(
+      `
       "import { RULE_NAME as myRuleName, rule as myRule } from './rules/my-rule';
       /**
        * Import your custom workspace rules at the top of this file.
-       * 
+       * ` +
+        `
        * For example:
-       * 
+       * ` +
+        `
        * import { RULE_NAME as myCustomRuleName, rule as myCustomRule } from './rules/my-custom-rule';
-       * 
+       * ` +
+        `
        * In order to quickly get started with writing rules you can use the
        * following generator command and provide your desired rule name:
-       * 
+       * ` +
+        `
        * \`\`\`sh
        * npx nx g @nrwl/linter:workspace-rule {{ NEW_RULE_NAME }}
        * \`\`\`
@@ -73,9 +88,11 @@ describe('@nrwl/linter:workspace-rule', () => {
       module.exports = {
         /**
          * Apply the imported custom rules here.
-         * 
+         * ` +
+        `
          * For example (using the example import above):
-         * 
+         * ` +
+        `
          * rules: {
          *  [myCustomRuleName]: myCustomRule
          * }
@@ -84,7 +101,8 @@ describe('@nrwl/linter:workspace-rule', () => {
       }
       };
       "
-    `);
+    `
+    );
 
     // ------------------------------------------- EXISTING RULE, NO TRAILING COMMA
 

--- a/packages/linter/src/generators/workspace-rule/workspace-rule.ts
+++ b/packages/linter/src/generators/workspace-rule/workspace-rule.ts
@@ -1,4 +1,5 @@
 import {
+  addDependenciesToPackageJson,
   applyChangesToString,
   ChangeType,
   convertNxGenerator,
@@ -11,6 +12,7 @@ import {
 import { camelize } from '@nrwl/workspace/src/utils/strings';
 import { join } from 'path';
 import * as ts from 'typescript';
+import { typescriptESLintVersion } from '../../utils/versions';
 import { workspaceLintPluginDir } from '../../utils/workspace-lint-rules';
 import { lintWorkspaceRulesProjectGenerator } from '../workspace-rules-project/workspace-rules-project';
 
@@ -24,9 +26,7 @@ export async function lintWorkspaceRuleGenerator(
   options: LintWorkspaceRuleGeneratorOptions
 ) {
   // Ensure that the workspace rules project has been created
-  const projectGeneratorCallback = await lintWorkspaceRulesProjectGenerator(
-    tree
-  );
+  await lintWorkspaceRulesProjectGenerator(tree);
 
   const ruleDir = joinPathFragments(
     workspaceLintPluginDir,
@@ -112,7 +112,13 @@ export async function lintWorkspaceRuleGenerator(
        }
 `);
 
-  return projectGeneratorCallback;
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    {
+      '@typescript-eslint/experimental-utils': typescriptESLintVersion,
+    }
+  );
 }
 
 export const lintWorkspaceRuleSchematic = convertNxGenerator(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Using the eslint workspace generator:
```
nx g @nrwl/linter:workspace-rule my-custom-rule
```
does not install necessary `@typescript-eslint/experimental-utils`

## Expected Behavior
Using the eslint workspace rule generator should install all necessary deps.

## Related Issue(s)
https://github.com/nrwl/nx/issues/6967

Fixes #6967 
