### PR TITLE
chore(gatsby): add migration for update gatsby packages

### DIFF
--- a/packages/gatsby/migrations.json
+++ b/packages/gatsby/migrations.json
@@ -220,6 +220,83 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "12.9.1": {
+      "version": "12.9.1-beta.1",
+      "packages": {
+        "gatsby": {
+          "version": "3.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-image": {
+          "version": "3.11.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-plugin-manifest": {
+          "version": "3.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-plugin-offline": {
+          "version": "4.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-plugin-react-helmet": {
+          "version": "4.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-plugin-sharp": {
+          "version": "3.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-plugin-styled-jsx": {
+          "version": "4.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-source-filesystem": {
+          "version": "3.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-transformer-sharp": {
+          "version": "3.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-plugin-typescript": {
+          "version": "3.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-plugin-emotion": {
+          "version": "6.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-plugin-styled-components": {
+          "version": "4.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-plugin-sass": {
+          "version": "4.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-plugin-less": {
+          "version": "5.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-plugin-pnpm": {
+          "version": "1.2.8",
+          "alwaysAddToPackageJson": false
+        },
+        "gatsby-plugin-stylus": {
+          "version": "3.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "sass": {
+          "version": "1.41.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@testing-library/react": {
+          "version": "12.1.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adds a migration for updating gatsby packages. Will be in Nx 13 unless we decide to patch release 12.9.1.

Either way, users can manually upgrade Gatsby to fix the webpack build issue if needed.