### PR TITLE
fix(core): Leave passthrough parameters untouched

### DIFF
--- a/packages/cli/lib/parse-run-one-options.ts
+++ b/packages/cli/lib/parse-run-one-options.ts
@@ -76,6 +76,7 @@ export function parseRunOneOptions(
     },
     configuration: {
       'strip-dashed': true,
+      'dot-notation': false,
     },
   });
 

--- a/packages/tao/index.ts
+++ b/packages/tao/index.ts
@@ -3,7 +3,12 @@ import { dirname, join } from 'path';
 import { existsSync } from 'fs-extra';
 import * as yargsParser from 'yargs-parser';
 
-const argv = yargsParser(process.argv.slice(2));
+const argv = yargsParser(process.argv.slice(2), {
+  configuration: {
+    'strip-dashed': true,
+    'dot-notation': false,
+  },
+});
 
 export async function invokeCommand(
   command: string,

--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -48,6 +48,10 @@ function parseRunOpts(
       alias: {
         c: 'configuration',
       },
+      configuration: {
+        'strip-dashed': false,
+        'dot-notation': false,
+      },
     })
   );
   const help = runOptions.help as boolean;

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -84,6 +84,7 @@ export function splitArgsIntoNxArgsAndOverrides(
   const overrides = yargsParser(args._ as string[], {
     configuration: {
       'strip-dashed': true,
+      'dot-notation': false,
     },
   });
   // This removes the overrides from the nxArgs._

--- a/packages/workspace/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.spec.ts
@@ -73,6 +73,32 @@ describe('Command Runner Builder', () => {
     });
   });
 
+  it('should add args containing spaces to in the command', async () => {
+    const exec = jest.spyOn(require('child_process'), 'execSync');
+
+    await runCommands(
+      {
+        command: `echo`,
+        a: 123,
+        b: '4 5 6',
+        c: '4 "5" 6',
+      },
+      context
+    );
+    expect(exec).toHaveBeenCalledWith(
+      `echo --a=123 --b="4 5 6" --c="4 \"5\" 6"`,
+      {
+        stdio: [0, 1, 2],
+        cwd: undefined,
+        env: {
+          ...process.env,
+          ...env(),
+        },
+        maxBuffer: LARGE_BUFFER,
+      }
+    );
+  });
+
   it('should forward args by default when using commands (plural)', async () => {
     const exec = jest.spyOn(require('child_process'), 'exec');
 

--- a/packages/workspace/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.ts
@@ -249,7 +249,11 @@ function transformCommand(
     return command.replace(regex, (_, group: string) => args[camelCase(group)]);
   } else if (Object.keys(args).length > 0 && forwardAllArgs) {
     const stringifiedArgs = Object.keys(args)
-      .map((a) => `--${a}=${args[a]}`)
+      .map((a) =>
+        typeof args[a] === 'string' && args[a].includes(' ')
+          ? `--${a}="${args[a].replace(/"/g, '"')}"`
+          : `--${a}=${args[a]}`
+      )
       .join(' ');
     return `${command} ${stringifiedArgs}`;
   } else {


### PR DESCRIPTION
## Current Behavior
Previously when the passing through complex parameters nx would alter
the original parameters in the following  scenarios:
- When passing through parameters, dot notation parameters would be
parsed and no longer would be pass through the the following process
correctly ( `--cucumberOpts.timeout=10000"` would instead be passed as
`"--cucumberOpts=[Object]"`)
- strings with spaces (delimited by quotes) would be rendered as
multiple words instead (`'--tags="not @exclude"` would be passed as
`'--tags=not @exclude' where '@exclude'` no longer is part of the tags
param)

This would that when running nx  cli to run a command the targeted command 
would not get the correct parameters


## Expected Behavior

The targeted command should receive the parameters names and values as pristine as possible so that
given a target command `wdio run wdio.conf.js`  called via 
`nx run test app-test --  --cucumberOpts.timeout=3000 --tags="not @exclude"`

would pass the correct parameters 

`wdio run wdio.conf.js --cucumberOpts.timeout=3000 --tags="not @exclude"`

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- This is the behavior we have today -->

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

This PR fixes  issue #7064

Fixes #7064
