### PR TITLE
docs(nxdev): remove black drop on flavour selector

### DIFF
--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -174,7 +174,7 @@ export function DocumentationPage({
         onClose={() => {}}
       >
         <div className="flex items-center justify-center min-h-screen">
-          <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-20 backdrop-filter backdrop-blur" />
+          <Dialog.Overlay className="fixed inset-0 backdrop-filter backdrop-blur" />
           <div className="z-50 bg-white rounded-md w-11/12 max-w-xl filter drop-shadow-2xl">
             <Dialog.Title
               as="h3"


### PR DESCRIPTION
## What it does?
This PR removed the black backdrop on the flavor selector dialog.