### PR TITLE
fix(node): Prevent extra kebab-case files being generated with `--pascalCaseFiles` option 

### DIFF
--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -518,6 +518,15 @@ describe('lib', () => {
       expect(tree.exists('libs/my-lib/src/lib/MyLib.spec.ts')).toBeTruthy();
     });
 
+    it('should not generate files with kebab (default) case names', async () => {
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        pascalCaseFiles: true,
+      } as Schema);
+      expect(tree.exists('libs/my-lib/src/lib/my-lib.spec.ts')).toBeFalsy();
+      expect(tree.exists('libs/my-lib/src/lib/my-lib.ts')).toBeFalsy();
+    });
+
     it('should generate files with upper case names for nested libs as well', async () => {
       await libraryGenerator(tree, {
         name: 'myLib',
@@ -530,6 +539,20 @@ describe('lib', () => {
       expect(
         tree.exists('libs/my-dir/my-lib/src/lib/MyDirMyLib.spec.ts')
       ).toBeTruthy();
+    });
+
+    it('should not generate files with kebab (default) case names for nested libs', async () => {
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        directory: 'myDir',
+        pascalCaseFiles: true,
+      } as Schema);
+      expect(
+        tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.ts')
+      ).toBeFalsy();
+      expect(
+        tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.spec.ts')
+      ).toBeFalsy();
     });
   });
 });

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -516,13 +516,6 @@ describe('lib', () => {
       } as Schema);
       expect(tree.exists('libs/my-lib/src/lib/MyLib.ts')).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/lib/MyLib.spec.ts')).toBeTruthy();
-    });
-
-    it('should not generate files with kebab (default) case names', async () => {
-      await libraryGenerator(tree, {
-        name: 'myLib',
-        pascalCaseFiles: true,
-      } as Schema);
       expect(tree.exists('libs/my-lib/src/lib/my-lib.spec.ts')).toBeFalsy();
       expect(tree.exists('libs/my-lib/src/lib/my-lib.ts')).toBeFalsy();
     });
@@ -539,14 +532,6 @@ describe('lib', () => {
       expect(
         tree.exists('libs/my-dir/my-lib/src/lib/MyDirMyLib.spec.ts')
       ).toBeTruthy();
-    });
-
-    it('should not generate files with kebab (default) case names for nested libs', async () => {
-      await libraryGenerator(tree, {
-        name: 'myLib',
-        directory: 'myDir',
-        pascalCaseFiles: true,
-      } as Schema);
       expect(
         tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.ts')
       ).toBeFalsy();

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -102,9 +102,7 @@ function getCaseAwareFileName(options: {
 }
 
 function createFiles(tree: Tree, options: NormalizedSchema) {
-  const nameFormats = names(options.fileName);
-
-  const { className, name, propertyName, fileName } = names(options.fileName);
+  const { className, name, propertyName } = names(options.fileName);
 
   generateFiles(tree, join(__dirname, './files/lib'), options.projectRoot, {
     ...options,

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -67,7 +67,10 @@ function normalizeOptions(tree: Tree, options: Schema): NormalizedSchema {
     : name;
 
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
-  const fileName = options.simpleModuleName ? name : projectName;
+  const fileName = getCaseAwareFileName({
+    fileName: options.simpleModuleName ? name : projectName,
+    pascalCaseFiles: options.pascalCaseFiles,
+  });
   const projectRoot = joinPathFragments(libsDir, projectDirectory);
 
   const parsedTags = options.tags
@@ -89,18 +92,32 @@ function normalizeOptions(tree: Tree, options: Schema): NormalizedSchema {
   };
 }
 
+function getCaseAwareFileName(options: {
+  pascalCaseFiles: boolean;
+  fileName: string;
+}) {
+  const normalized = names(options.fileName);
+
+  return options.pascalCaseFiles ? normalized.className : normalized.fileName;
+}
+
 function createFiles(tree: Tree, options: NormalizedSchema) {
   const nameFormats = names(options.fileName);
+
+  const { className, name, propertyName, fileName } = names(options.fileName);
+
   generateFiles(tree, join(__dirname, './files/lib'), options.projectRoot, {
     ...options,
-    ...nameFormats,
+    className,
+    name,
+    propertyName,
     tmpl: '',
     offsetFromRoot: offsetFromRoot(options.projectRoot),
   });
 
   if (options.unitTestRunner === 'none') {
     tree.delete(
-      join(options.projectRoot, `./src/lib/${nameFormats.fileName}.spec.ts`)
+      join(options.projectRoot, `./src/lib/${options.fileName}.spec.ts`)
     );
   }
   if (!options.publishable && !options.buildable) {


### PR DESCRIPTION
## Current Behavior

When the `nx generate @nrwl/node:library --name=test-lib --pascalCaseFiles` command is run, there are two sets of initial files that get generated:

- 1️⃣ one set with Pascal case file names 
- 2️⃣ and one set with kebab case file names

![image](https://user-images.githubusercontent.com/417208/132926051-d82e95e0-ed23-494a-8d6a-3a8ffc7d5edf.png)

## Expected Behavior

When the `nx generate @nrwl/node:library --name=test-lib --pascalCaseFiles` command is run, there is one set of initial files that get generated:

- 1️⃣ a set with Pascal case file names 

![image](https://user-images.githubusercontent.com/417208/132926731-f9d645e6-8f38-4c8a-89f8-f24c95b5d3a4.png)


## Related Issue(s)
Fixes #6983
