### PR TITLE
fix: :bug: cypress.json options not taken into consideration

### DIFF
--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -187,15 +187,26 @@ async function runCypress(baseUrl: string, opts: CypressExecutorOptions) {
 
   options.exit = opts.exit;
   options.headed = opts.headed;
-  options.headless = opts.headless;
+
+  if (opts.headless) {
+    options.headless = opts.headless;
+  }
+
   options.record = opts.record;
   options.key = opts.key;
   options.parallel = opts.parallel;
   options.ciBuildId = opts.ciBuildId;
   options.group = opts.group;
   options.ignoreTestFiles = opts.ignoreTestFiles;
-  options.reporter = opts.reporter;
-  options.reporterOptions = opts.reporterOptions;
+
+  if (opts.reporter) {
+    options.reporter = opts.reporter;
+  }
+
+  if (opts.reporterOptions) {
+    options.reporterOptions = opts.reporterOptions;
+  }
+
   options.testingType = opts.testingType;
 
   const result = await (opts.watch


### PR DESCRIPTION
Only the cypress configuration available through angular.json file are taken into account. If some of those options are missed out from the angular.json, but present in the cypress.json, then those are ignored.
The fix solves the cypress configuration only for `headless`, `reporter` and `reporterOptions` options.

  Node : 14.16.1
  OS   : win32 x64
  npm  : 6.14.12
  
  nx : Not Found
  @nrwl/angular : 12.9.0
  @nrwl/cli : 12.9.0
  @nrwl/cypress : 12.9.0
  @nrwl/devkit : 12.6.0
  @nrwl/eslint-plugin-nx : 12.9.0
  @nrwl/express : Not Found
  @nrwl/jest : 12.9.0
  @nrwl/linter : 12.9.0
  @nrwl/nest : Not Found
  @nrwl/next : Not Found
  @nrwl/node : Not Found
  @nrwl/nx-cloud : Not Found
  @nrwl/react : Not Found
  @nrwl/schematics : Not Found
  @nrwl/tao : 12.6.0
  @nrwl/web : Not Found
  @nrwl/workspace : 12.9.0
  @nrwl/storybook : 12.9.0
  @nrwl/gatsby : Not Found
  typescript : 4.3.5

## Current Behavior
Angular 12 application with e2e tests using cypress 8.3.1. The app-e2e has a `cypress.json` configuration file where among various other options we are using the _reporter_ configuration: 
`{
	"reporter": "junit",
	"reporterOptions": {
		"mochaFile": "../../.cypress/results/results-[hash].xml"
}`

Currently, no results files are generated.

## Expected Behavior
With the same configuration from above, the results xml files should be generated.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
