### PR TITLE
docs(nxdev): use alias version & flavor for internal links

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -78,10 +78,10 @@ export function DocViewer({
           >
             <Content
               document={document}
-              flavor={flavor.id}
-              flavorList={flavorList.map((flavor) => flavor.id)}
-              version={version.path}
-              versionList={versionList.map((version) => version.id)}
+              flavor={flavor.alias}
+              flavorList={flavorList.map((flavor) => flavor.alias)}
+              version={version.alias}
+              versionList={versionList.map((version) => version.alias)}
             />
           </div>
         </div>


### PR DESCRIPTION
## What it does?
This PR updates the content viewer on nx.dev to use `alias` flavor and version on internal links.