### PR TITLE
fix(linter): add setParserOptionsProject option to generators missing it

### DIFF
--- a/docs/angular/api-angular/generators/application.md
+++ b/docs/angular/api-angular/generators/application.md
@@ -138,6 +138,14 @@ Type: `boolean`
 
 Generate a routing module.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/angular/api-express/generators/application.md
+++ b/docs/angular/api-express/generators/application.md
@@ -82,6 +82,14 @@ Type: `boolean`
 
 Use pascal case file names.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/angular/api-nest/generators/application.md
+++ b/docs/angular/api-nest/generators/application.md
@@ -56,6 +56,14 @@ Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/angular/api-nest/generators/library.md
+++ b/docs/angular/api-nest/generators/library.md
@@ -104,6 +104,14 @@ Type: `boolean`
 
 Include a service with the library.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/angular/api-node/generators/library.md
+++ b/docs/angular/api-node/generators/library.md
@@ -114,6 +114,14 @@ Type: `string`
 
 Sets the rootDir for TypeScript compilation. When not defined, it uses the project's root property, or srcRootForCompilationRoot if it is defined.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### simpleModuleName
 
 Default: `false`

--- a/docs/angular/api-nx-plugin/generators/plugin.md
+++ b/docs/angular/api-nx-plugin/generators/plugin.md
@@ -62,6 +62,14 @@ Possible values: `eslint`, `tslint`
 
 The tool to use for running lint checks.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/node/api-angular/generators/application.md
+++ b/docs/node/api-angular/generators/application.md
@@ -138,6 +138,14 @@ Type: `boolean`
 
 Generate a routing module.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/node/api-express/generators/application.md
+++ b/docs/node/api-express/generators/application.md
@@ -82,6 +82,14 @@ Type: `boolean`
 
 Use pascal case file names.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/node/api-nest/generators/application.md
+++ b/docs/node/api-nest/generators/application.md
@@ -56,6 +56,14 @@ Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/node/api-nest/generators/library.md
+++ b/docs/node/api-nest/generators/library.md
@@ -104,6 +104,14 @@ Type: `boolean`
 
 Include a service with the library.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/node/api-node/generators/library.md
+++ b/docs/node/api-node/generators/library.md
@@ -114,6 +114,14 @@ Type: `string`
 
 Sets the rootDir for TypeScript compilation. When not defined, it uses the project's root property, or srcRootForCompilationRoot if it is defined.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### simpleModuleName
 
 Default: `false`

--- a/docs/node/api-nx-plugin/generators/plugin.md
+++ b/docs/node/api-nx-plugin/generators/plugin.md
@@ -62,6 +62,14 @@ Possible values: `eslint`, `tslint`
 
 The tool to use for running lint checks.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/react/api-angular/generators/application.md
+++ b/docs/react/api-angular/generators/application.md
@@ -138,6 +138,14 @@ Type: `boolean`
 
 Generate a routing module.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/react/api-express/generators/application.md
+++ b/docs/react/api-express/generators/application.md
@@ -82,6 +82,14 @@ Type: `boolean`
 
 Use pascal case file names.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/react/api-nest/generators/application.md
+++ b/docs/react/api-nest/generators/application.md
@@ -56,6 +56,14 @@ Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/react/api-nest/generators/library.md
+++ b/docs/react/api-nest/generators/library.md
@@ -104,6 +104,14 @@ Type: `boolean`
 
 Include a service with the library.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/docs/react/api-node/generators/library.md
+++ b/docs/react/api-node/generators/library.md
@@ -114,6 +114,14 @@ Type: `string`
 
 Sets the rootDir for TypeScript compilation. When not defined, it uses the project's root property, or srcRootForCompilationRoot if it is defined.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### simpleModuleName
 
 Default: `false`

--- a/docs/react/api-nx-plugin/generators/plugin.md
+++ b/docs/react/api-nx-plugin/generators/plugin.md
@@ -62,6 +62,14 @@ Possible values: `eslint`, `tslint`
 
 The tool to use for running lint checks.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### skipFormat
 
 Default: `false`

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -58,6 +58,7 @@ export async function addE2e(
           joinPathFragments(options.e2eProjectRoot, '**/*.ts'),
         ],
         skipFormat: true,
+        setParserOptionsProject: options.setParserOptionsProject,
       });
     }
   }

--- a/packages/angular/src/generators/application/schema.d.ts
+++ b/packages/angular/src/generators/application/schema.d.ts
@@ -25,4 +25,5 @@ export interface Schema {
   remotes?: string[];
   port?: number;
   host?: string;
+  setParserOptionsProject?: boolean;
 }

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -150,6 +150,11 @@
     "host": {
       "type": "string",
       "description": "The name of the host application that the remote application will be consumed by."
+    },
+    "setParserOptionsProject": {
+      "type": "boolean",
+      "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
+      "default": false
     }
   },
   "required": []

--- a/packages/express/src/generators/application/schema.d.ts
+++ b/packages/express/src/generators/application/schema.d.ts
@@ -14,4 +14,5 @@ export interface Schema {
   js: boolean;
   pascalCaseFiles: boolean;
   standaloneConfig?: boolean;
+  setParserOptionsProject?: boolean;
 }

--- a/packages/express/src/generators/application/schema.json
+++ b/packages/express/src/generators/application/schema.json
@@ -69,6 +69,11 @@
       "description": "Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json",
       "type": "boolean",
       "default": false
+    },
+    "setParserOptionsProject": {
+      "type": "boolean",
+      "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
+      "default": false
     }
   },
   "required": []

--- a/packages/nest/src/generators/application/lib/normalize-options.ts
+++ b/packages/nest/src/generators/application/lib/normalize-options.ts
@@ -38,5 +38,6 @@ export function toNodeApplicationGeneratorOptions(
     standaloneConfig: options.standaloneConfig,
     tags: options.tags,
     unitTestRunner: options.unitTestRunner,
+    setParserOptionsProject: options.setParserOptionsProject,
   };
 }

--- a/packages/nest/src/generators/application/schema.d.ts
+++ b/packages/nest/src/generators/application/schema.d.ts
@@ -11,6 +11,7 @@ export interface ApplicationGeneratorOptions {
   standaloneConfig?: boolean;
   tags?: string;
   unitTestRunner?: UnitTestRunner;
+  setParserOptionsProject?: boolean;
 }
 
 interface NormalizedOptions extends ApplicationGeneratorOptions {

--- a/packages/nest/src/generators/application/schema.json
+++ b/packages/nest/src/generators/application/schema.json
@@ -52,6 +52,11 @@
       "description": "Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json.",
       "type": "boolean",
       "default": false
+    },
+    "setParserOptionsProject": {
+      "type": "boolean",
+      "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/nest/src/generators/library/lib/normalize-options.ts
+++ b/packages/nest/src/generators/library/lib/normalize-options.ts
@@ -59,5 +59,6 @@ export function toNodeLibraryGeneratorOptions(
     testEnvironment: options.testEnvironment,
     unitTestRunner: options.unitTestRunner,
     standaloneConfig: options.standaloneConfig,
+    setParserOptionsProject: options.setParserOptionsProject,
   };
 }

--- a/packages/nest/src/generators/library/schema.d.ts
+++ b/packages/nest/src/generators/library/schema.d.ts
@@ -28,6 +28,7 @@ export interface LibraryGeneratorOptions {
   testEnvironment?: 'jsdom' | 'node';
   unitTestRunner?: UnitTestRunner;
   standaloneConfig?: boolean;
+  setParserOptionsProject?: boolean;
 }
 
 export interface NormalizedOptions extends LibraryGeneratorOptions {

--- a/packages/nest/src/generators/library/schema.json
+++ b/packages/nest/src/generators/library/schema.json
@@ -111,6 +111,11 @@
       "description": "Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json",
       "type": "boolean",
       "default": false
+    },
+    "setParserOptionsProject": {
+      "type": "boolean",
+      "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -40,6 +40,7 @@ export async function libraryGenerator(tree: Tree, schema: Schema) {
     importPath: options.importPath,
     testEnvironment: 'node',
     skipFormat: true,
+    setParserOptionsProject: options.setParserOptionsProject,
   });
   createFiles(tree, options);
 

--- a/packages/node/src/generators/library/schema.d.ts
+++ b/packages/node/src/generators/library/schema.d.ts
@@ -19,4 +19,5 @@ export interface Schema {
   pascalCaseFiles?: boolean;
   strict?: boolean;
   standaloneConfig?: boolean;
+  setParserOptionsProject?: boolean;
 }

--- a/packages/node/src/generators/library/schema.json
+++ b/packages/node/src/generators/library/schema.json
@@ -106,6 +106,11 @@
       "description": "Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json",
       "type": "boolean",
       "default": false
+    },
+    "setParserOptionsProject": {
+      "type": "boolean",
+      "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/generators/plugin/schema.d.ts
+++ b/packages/nx-plugin/src/generators/plugin/schema.d.ts
@@ -10,4 +10,5 @@ export interface Schema {
   unitTestRunner: 'jest' | 'none';
   linter: Linter;
   standaloneConfig?: boolean;
+  setParserOptionsProject?: boolean;
 }

--- a/packages/nx-plugin/src/generators/plugin/schema.json
+++ b/packages/nx-plugin/src/generators/plugin/schema.json
@@ -60,6 +60,11 @@
       "description": "Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json",
       "type": "boolean",
       "default": false
+    },
+    "setParserOptionsProject": {
+      "type": "boolean",
+      "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
+      "default": false
     }
   },
   "required": ["name"],


### PR DESCRIPTION
A couple months ago in #6239 I caught this for @nrwl/web:application, but I've now gone and audited all relevant generators I could find that use the lint generator or core library/application generators.

## Current Behavior
No option is available to pass through setParserOptionsProject to @nrwl/linter

## Expected Behavior
Option is available to pass through setParserOptionsProject to @nrwl/linter

