### PR TITLE
feat(react): add migration to replace deprecated node-sass with sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "rollup-plugin-typescript2": "^0.30.0",
     "rxjs": "6.6.7",
     "rxjs-for-await": "0.0.2",
-    "sass": "1.26.3",
+    "sass": "^1.42.1",
     "sass-loader": "8.0.2",
     "semver": "7.3.4",
     "source-map": "0.7.3",

--- a/packages/next/src/utils/styles.ts
+++ b/packages/next/src/utils/styles.ts
@@ -9,7 +9,7 @@ import { CSS_IN_JS_DEPENDENCIES } from '@nrwl/react';
 import {
   babelPluginStyledComponentsVersion,
   emotionServerVersion,
-  nodeSass,
+  sassVersion,
   zeitNextLess,
   zeitNextStylus,
 } from './versions';
@@ -35,9 +35,7 @@ export const NEXT_SPECIFIC_STYLE_DEPENDENCIES = {
   },
   scss: {
     dependencies: {},
-    devDependencies: {
-      'node-sass': nodeSass,
-    },
+    devDependencies: { sass: sassVersion },
   },
   less: {
     dependencies: {

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -2,7 +2,7 @@ export const nxVersion = '*';
 
 export const nextVersion = '11.1.0';
 export const eslintConfigNextVersion = '11.1.0';
-export const nodeSass = '5.0.0';
+export const sassVersion = '1.42.1';
 export const zeitNextLess = '1.0.1';
 export const zeitNextStylus = '1.0.1';
 export const emotionServerVersion = '11.0.0';

--- a/packages/web/migrations.json
+++ b/packages/web/migrations.json
@@ -32,6 +32,12 @@
       "version": "11.5.2-beta.1",
       "description": "Update existing .babelrc files to add missing '@nrwl/web/babel' preset if necessary.",
       "factory": "./src/migrations/update-11-5-2/update-existing-babelrc-files"
+    },
+    "remove-node-sass-13-0-0": {
+      "cli": "nx",
+      "version": "13.0.0-beta.1",
+      "description": "Removes deprecated node-sass package (sass is already a dependency of @nrwl/web).",
+      "factory": "./src/migrations/update-13-0-0/remove-node-sass-13-0-0"
     }
   },
   "packageJsonUpdates": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -87,7 +87,7 @@
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.1",
     "rollup-plugin-typescript2": "^0.30.0",
-    "sass": "^1.26.3",
+    "sass": "^1.42.1",
     "sass-loader": "8.0.2",
     "semver": "7.3.4",
     "source-map": "0.7.3",

--- a/packages/web/src/migrations/update-13-0-0/remove-node-sass-13-0-0.spec.ts
+++ b/packages/web/src/migrations/update-13-0-0/remove-node-sass-13-0-0.spec.ts
@@ -1,0 +1,40 @@
+import { readJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+import subject from './remove-node-sass-13-0-0';
+
+describe('Migration: node-sass to sass', () => {
+  it(`should remove node-sass if present in devDependencies or dependencies`, async () => {
+    let tree = createTreeWithEmptyWorkspace();
+
+    tree.write(
+      'package.json',
+      JSON.stringify({
+        dependencies: { a: '1.0.0' },
+        devDependencies: { b: '1.0.0', 'node-sass': '1.0.0' },
+      })
+    );
+
+    await subject(tree);
+
+    expect(readJson(tree, 'package.json')).toEqual({
+      dependencies: { a: '1.0.0' },
+      devDependencies: { b: '1.0.0' },
+    });
+
+    tree.write(
+      'package.json',
+      JSON.stringify({
+        dependencies: { a: '1.0.0', 'node-sass': '1.0.0' },
+        devDependencies: { b: '1.0.0' },
+      })
+    );
+
+    await subject(tree);
+
+    expect(readJson(tree, 'package.json')).toEqual({
+      dependencies: { a: '1.0.0' },
+      devDependencies: { b: '1.0.0' },
+    });
+  });
+});

--- a/packages/web/src/migrations/update-13-0-0/remove-node-sass-13-0-0.ts
+++ b/packages/web/src/migrations/update-13-0-0/remove-node-sass-13-0-0.ts
@@ -1,0 +1,28 @@
+import {
+  formatFiles,
+  GeneratorCallback,
+  readJson,
+  removeDependenciesFromPackageJson,
+  Tree,
+} from '@nrwl/devkit';
+
+/**
+ * For web/react apps with style scss option, remove node-sass sine it is deprecated.
+ * We already include sass package in `@nrwl/web` deps so no need to install anything extra.
+ */
+export default async function update(tree: Tree) {
+  const packageJson = readJson(tree, 'package.json');
+  let task: undefined | GeneratorCallback = undefined;
+
+  if (packageJson.devDependencies['node-sass']) {
+    task = removeDependenciesFromPackageJson(tree, [], ['node-sass']);
+  }
+
+  if (packageJson.dependencies['node-sass']) {
+    task = removeDependenciesFromPackageJson(tree, ['node-sass'], []);
+  }
+
+  if (task) await formatFiles(tree);
+
+  return task;
+}

--- a/packages/web/src/utils/sass.ts
+++ b/packages/web/src/utils/sass.ts
@@ -1,7 +1,8 @@
-import { stripIndents, logger } from '@nrwl/devkit';
+import { logger, stripIndents } from '@nrwl/devkit';
 
 export let sassImplementation: {} | undefined;
 
+// TODO(jack): Remove in Nx 13
 try {
   sassImplementation = require('node-sass');
   logger.warn(stripIndents`

--- a/packages/web/src/utils/versions.ts
+++ b/packages/web/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = '*';
-export const coreJsVersion = '^3.16.0';
+export const sassVersion = '1.42.1';

--- a/yarn.lock
+++ b/yarn.lock
@@ -22296,13 +22296,6 @@ sass-loader@^10.1.0:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
-sass@1.26.3:
-  version "1.26.3"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.26.3.tgz#412df54486143b76b5a65cdf7569e86f44659f46"
-  integrity sha512-5NMHI1+YFYw4sN3yfKjpLuV9B5l7MqQ6FlkTcC4FT+oHbBRUZoSjHrrt/mE0nFXJyY2kQtU9ou9HxvFVjLFuuw==
-  dependencies:
-    chokidar ">=2.0.0 <4.0.0"
-
 sass@1.36.0:
   version "1.36.0"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.36.0.tgz#5912ef9d5d16714171ba11cb17edb274c4bbc07e"
@@ -22321,6 +22314,13 @@ sass@^1.32.8:
   version "1.32.12"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.12.tgz#a2a47ad0f1c168222db5206444a30c12457abb9f"
   integrity sha512-zmXn03k3hN0KaiVTjohgkg98C3UowhL1/VSGdj4/VAAiMKGQOE80PFPxFP2Kyq0OUskPKcY5lImkhBKEHlypJA==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+
+sass@^1.42.1:
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.42.1.tgz#5ab17bebc1cb1881ad2e0c9a932c66ad64e441e2"
+  integrity sha512-/zvGoN8B7dspKc5mC6HlaygyCBRvnyzzgD5khiaCfglWztY99cYoiTUksVx11NlnemrcfH5CEaCpsUKoW0cQqg==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 


### PR DESCRIPTION
This PR adds a migration for Nx 13 to replace node-sass with sass (if installed) for React and Web applications.