### PR TITLE
docs(nxdev): better path interpolation

### DIFF
--- a/docs/angular/getting-started/intro.md
+++ b/docs/angular/getting-started/intro.md
@@ -2,7 +2,9 @@
 
 Nx is a smart and extensible build framework to help you architect, test, and build at any scale — integrating seamlessly with modern technologies and frameworks while providing a distributed graph-based task execution, computation caching, smart rebuilds of affected projects, powerful code generators, editor support, GitHub apps, and more.
 
-Nx helps you develop [Angular](/{{framework}}/angular/overview) applications with fully integrated support for modern tools and libraries like [Jest](/{{framework}}/jest/overview), [Cypress](/{{framework}}/cypress/overview), [ESLint](/{{framework}}/linter/eslint), [Storybook](/{{framework}}/storybook/overview), NgRx and more.
+Nx helps you develop [Angular](/{{framework}}/angular/overview) applications with fully integrated support for
+modern tools and libraries like [Jest](/{{framework}}/jest/overview), [Cypress](/{{framework}}/cypress/overview),
+[ESLint](/{{framework}}/linter/eslint), [Storybook](/{{framework}}/storybook/overview), [NgRx](/angular/guides/misc-ngrx) and more.
 
 ## 10-Minute Nx Overview
 

--- a/docs/angular/migration/migration-angularjs.md
+++ b/docs/angular/migration/migration-angularjs.md
@@ -371,7 +371,8 @@ But migrating AngularJS code means we need to switch some of our tools to a more
 npm install -D @nrwl/web babel-plugin-angularjs-annotate
 ```
 
-Nx already has most of what you need for webpack added as a dependency. `@nrwl/web` contains the [executors](https://nx.dev/latest/angular/executors/using-builders) we need to use to build and serve the application with webpack and `babel-plugin-angularjs-annotate` is going to accomplish the same thing that `browserify-ngannotate` previously did in gulp: add dependency injection annotations.
+Nx already has most of what you need for webpack added as a dependency. `@nrwl/web` contains the [executors](/{{version}}/{{framework}}/executors/using-builders) we need to use to build and serve the application with webpack and
+`babel-plugin-angularjs-annotate` is going to accomplish the same thing that `browserify-ngannotate` previously did in gulp: add dependency injection annotations.
 
 Start with a `webpack.config.js` file in your application’s root directory:
 

--- a/docs/angular/tutorial/01-create-application.md
+++ b/docs/angular/tutorial/01-create-application.md
@@ -126,4 +126,8 @@ yarn nx serve todos
 
 ## Note on `nx serve` and `ng serve`
 
-Internally, the Nx CLI delegates to the Angular CLI when running commands or generating code. The `nx serve` command produces the same result as `ng serve`, and `nx build` produces the same results as `ng build`. However, the Nx CLI supports advanced capabilities that aren't supported by the Angular CLI. For instance, Nx's computation cache only works when using the Nx CLI. In other words, using `nx` instead `ng` results in the same output, but often performs a lot better. [Read more about Nx CLI and Angular CLI.](/angular/getting-started/nx-cli)
+Internally, the Nx CLI delegates to the Angular CLI when running commands or generating code. The `nx serve` command
+produces the same result as `ng serve`, and `nx build` produces the same results as `ng build`. However, the Nx CLI
+supports advanced capabilities that aren't supported by the Angular CLI. For instance, Nx's computation cache only
+works when using the Nx CLI. In other words, using `nx` instead `ng` results in the same output, but often performs
+a lot better. [Read more about Nx CLI and Angular CLI.](/{{framework}}/getting-started/nx-cli)

--- a/docs/node/tutorial/01-create-application.md
+++ b/docs/node/tutorial/01-create-application.md
@@ -113,7 +113,7 @@ Options:
   --help                  Show available options for project target.
 ```
 
-It helps with good editor integration (see [VSCode Support](https://nx.dev/latest/node/getting-started/console#nx-console-for-vscode)).
+It helps with good editor integration (see [VSCode Support](https://nx.dev/l/node/getting-started/console#nx-console-for-vscode)).
 
 But, most importantly, it provides a holistic dev experience regardless of the tools used, and enables advanced build features like distributed computation caching and distributed builds).
 

--- a/docs/react/getting-started/intro.md
+++ b/docs/react/getting-started/intro.md
@@ -2,7 +2,10 @@
 
 Nx is a smart and extensible build framework to help you architect, test, and build at any scale — integrating seamlessly with modern technologies and frameworks while providing a distributed graph-based task execution, computation caching, smart rebuilds of affected projects, powerful code generators, editor support, GitHub apps, and more
 
-Nx helps you develop [React](/{{framework}}/react/overview) applications with fully integrated support for modern tools and libraries like [Jest](/{{framework}}/jest/overview), [Cypress](/{{framework}}/cypress/overview), [Storybook](/{{framework}}/storybook/overview), [ESLint](/{{framework}}/linter/eslint), and more. Nx also supports React frameworks like [Gatsby](/{{framework}}/gatsby/overview) and [Next.js](/{{version}}/react/guides/nextjs).
+Nx helps you develop [React](/{{framework}}/react/overview) applications with fully integrated support for modern
+tools and libraries like [Jest](/{{framework}}/jest/overview), [Cypress](/{{framework}}/cypress/overview),
+[Storybook](/{{framework}}/storybook/overview), [ESLint](/{{framework}}/linter/eslint), and more. Nx also supports
+React frameworks like [Gatsby](/{{version}}/react/gatsby/overview) and [Next.js](/{{version}}/react/guides/nextjs).
 
 ## 10-Minute Nx Overview
 

--- a/docs/react/migration/migration-cra.md
+++ b/docs/react/migration/migration-cra.md
@@ -14,7 +14,8 @@ Just `cd` into your Create-React-App (CRA) project and run the following command
 npx cra-to-nx
 ```
 
-Then just sit back and wait. After a while, take advantage of the [full magic of Nx](https://nx.dev/latest/react/getting-started/intro). Start from [the commands mentioned in this article](https://nx.dev/latest/react/migration/migration-cra#try-nx).
+Then just sit back and wait. After a while, take advantage of the [full magic of Nx](https://nx.dev/latest/react/getting-started/intro).
+Start from [the commands mentioned in this article](https://nx.dev/latest/react/migration/migration-cra#try-nx).
 
 **Note:** The command will fail if you try execute it and you have uncommitted changes in your repository. Commit any local changes, and then try to run the command.
 

--- a/docs/react/tutorial/06-proxy.md
+++ b/docs/react/tutorial/06-proxy.md
@@ -71,6 +71,6 @@ Options:
   --help                  Show available options for project target.
 ```
 
-It helps with good editor integration (see [VSCode Support](https://nx.dev/latest/react/getting-started/console#nx-console-for-vscode)).
+It helps with good editor integration (see [VSCode Support](/{{framework}}/getting-started/console#nx-console-for-vscode)).
 
 But, most importantly, it provides a holistic dev experience regardless of the tools used, and enables advanced build features like distributed computation caching and distributed builds).

--- a/nx-dev/data-access-documents/src/lib/documents.api.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.ts
@@ -60,12 +60,9 @@ export class DocumentsApi {
     if (!file.data.title) {
       file.data.title = extractTitle(originalContent) ?? path[path.length - 1];
     }
+
     return {
       filePath: docPath,
-      url: `/${version.alias}/${flavor.alias}/${docPath
-        .split('/')
-        .splice(2)
-        .join('/')}`,
       data: file.data,
       content: file.content,
       excerpt: file.excerpt,

--- a/nx-dev/data-access-documents/src/lib/documents.models.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.models.ts
@@ -1,6 +1,5 @@
 export interface DocumentData {
   filePath: string;
-  url: string;
   data: { [key: string]: any };
   content: string;
   excerpt?: string;

--- a/nx-dev/feature-doc-viewer/src/lib/content.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/content.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import autolinkHeadings from 'rehype-autolink-headings';
-import Image from 'next/image';
 import gfm from 'remark-gfm';
 import slug from 'rehype-slug';
-import { DocumentData } from '@nrwl/nx-dev/data-access-documents';
+import {
+  DocumentData,
+  FlavorMetadata,
+  VersionMetadata,
+} from '@nrwl/nx-dev/data-access-documents';
 import { sendCustomEvent } from '@nrwl/nx-dev/feature-analytics';
 import { transformLinkPath } from './renderers/transform-link-path';
 import { transformImagePath } from './renderers/transform-image-path';
@@ -13,10 +16,10 @@ import { CodeBlock } from './code-block';
 
 export interface ContentProps {
   document: DocumentData;
-  flavor: string;
-  flavorList: string[];
-  version: string;
-  versionList: string[];
+  flavor: FlavorMetadata;
+  flavorList: FlavorMetadata[];
+  version: VersionMetadata;
+  versionList: VersionMetadata[];
 }
 
 interface ComponentsConfig {

--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -78,10 +78,10 @@ export function DocViewer({
           >
             <Content
               document={document}
-              flavor={flavor.alias}
-              flavorList={flavorList.map((flavor) => flavor.alias)}
-              version={version.alias}
-              versionList={versionList.map((version) => version.alias)}
+              flavor={flavor}
+              flavorList={flavorList}
+              version={version}
+              versionList={versionList}
             />
           </div>
         </div>

--- a/nx-dev/feature-doc-viewer/src/lib/renderers/transform-image-path.spec.ts
+++ b/nx-dev/feature-doc-viewer/src/lib/renderers/transform-image-path.spec.ts
@@ -3,47 +3,50 @@ import { transformImagePath } from './transform-image-path';
 describe('transformImagePath', () => {
   it('should transform relative paths', () => {
     const opts = {
-      version: 'latest',
+      version: {
+        name: 'Latest',
+        id: 'latest',
+        alias: 'l',
+        release: '12.9.0',
+        path: 'latest',
+        default: true,
+      },
       document: {
         content: '',
         excerpt: '',
-        filePath: 'latest/react/test.md',
+        filePath:
+          'nx-dev/nx-dev/public/documentation/latest/angular/migration/migration-angularjs.md',
         data: {},
       },
     };
     const transform = transformImagePath(opts);
 
     expect(transform('./test.png')).toEqual(
-      '/documentation/latest/react/test.png'
+      '/documentation/latest/angular/migration/test.png'
     );
-    expect(transform('../test.png')).toEqual('/documentation/latest/test.png');
-    expect(transform('../../test.png')).toEqual('/documentation/test.png');
-  });
-
-  it('should transform relative paths for previews on vercel', () => {
-    const opts = {
-      version: 'preview',
-      document: {
-        content: '',
-        excerpt: '',
-        filePath: 'react/test.md',
-        data: {},
-      },
-    };
-    const transform = transformImagePath(opts);
-
-    expect(transform('./test.png')).toEqual(
-      '/api/preview-asset?uri=.%2Ftest.png&document=react%2Ftest.md'
+    expect(transform('../test.png')).toEqual(
+      '/documentation/latest/angular/test.png'
+    );
+    expect(transform('../../test.png')).toEqual(
+      '/documentation/latest/test.png'
     );
   });
 
   it('should transform absolute paths', () => {
     const opts = {
-      version: 'latest',
+      version: {
+        name: 'Latest',
+        id: 'latest',
+        alias: 'l',
+        release: '12.9.0',
+        path: 'latest',
+        default: true,
+      },
       document: {
         content: '',
         excerpt: '',
-        filePath: 'latest/b/test.md',
+        filePath:
+          'nx-dev/nx-dev/public/documentation/latest/angular/generators/workspace-generators.md',
         data: {},
       },
     };
@@ -51,23 +54,6 @@ describe('transformImagePath', () => {
 
     expect(transform('/shared/test.png')).toEqual(
       '/documentation/latest/shared/test.png'
-    );
-  });
-
-  it('should support preview links', () => {
-    const opts = {
-      version: 'preview',
-      document: {
-        content: '',
-        excerpt: '',
-        filePath: 'react/test.md',
-        data: {},
-      },
-    };
-    const transform = transformImagePath(opts);
-
-    expect(transform('/shared/test.png')).toEqual(
-      '/api/preview-asset?uri=%2Fshared%2Ftest.png&document=react%2Ftest.md'
     );
   });
 });

--- a/nx-dev/feature-doc-viewer/src/lib/renderers/transform-image-path.ts
+++ b/nx-dev/feature-doc-viewer/src/lib/renderers/transform-image-path.ts
@@ -1,17 +1,17 @@
 import { uriTransformer } from 'react-markdown';
-import { DocumentData } from '@nrwl/nx-dev/data-access-documents';
+import {
+  DocumentData,
+  VersionMetadata,
+} from '@nrwl/nx-dev/data-access-documents';
 import { join } from 'path';
 
 export function transformImagePath({
   version,
   document,
 }: {
-  version: string;
+  version: VersionMetadata;
   document: DocumentData;
 }): (src: string) => string {
-  const isVercel = !!process.env.VERCEL;
-  const isPreview = version === 'preview';
-
   return (src) => {
     const isRelative = src.startsWith('.');
 
@@ -19,26 +19,12 @@ export function transformImagePath({
       return uriTransformer(src);
     }
 
-    if (!isVercel && isPreview) {
-      return uriTransformer(
-        `/api/preview-asset?uri=${encodeURIComponent(
-          src
-        )}&document=${encodeURIComponent(document.filePath)}`
-      );
-    }
-
     if (isRelative) {
       return uriTransformer(
-        join(
-          '/documentation',
-          isPreview ? 'preview' : '',
-          document.filePath,
-          '..',
-          src
-        )
+        join('/', document.filePath.split('/').splice(3).join('/'), '..', src)
       );
     }
 
-    return uriTransformer(`/documentation/${version}`.concat(src));
+    return uriTransformer(`/documentation/${version.id}`.concat(src));
   };
 }

--- a/nx-dev/feature-doc-viewer/src/lib/renderers/transform-link-path.spec.ts
+++ b/nx-dev/feature-doc-viewer/src/lib/renderers/transform-link-path.spec.ts
@@ -3,61 +3,315 @@ import { transformLinkPath } from './transform-link-path';
 describe('transformLinkPath', () => {
   it('should transform path containing version and flavour', () => {
     const transform = transformLinkPath({
-      framework: 'react',
-      frameworkList: ['angular', 'node', 'react'],
-      version: 'latest',
-      versionList: ['latest', 'previous'],
+      framework: {
+        id: 'react',
+        name: 'React',
+        alias: 'r',
+        path: 'react',
+        default: true,
+      },
+      frameworkList: [
+        { id: 'angular', name: 'Angular', alias: 'a', path: 'angular' },
+        {
+          id: 'react',
+          name: 'React',
+          alias: 'r',
+          path: 'react',
+          default: true,
+        },
+        { id: 'node', name: 'Node', alias: 'n', path: 'node' },
+      ],
+      version: {
+        name: 'Latest',
+        id: 'latest',
+        alias: 'l',
+        release: '12.9.0',
+        path: 'latest',
+        default: true,
+      },
+      versionList: [
+        {
+          name: 'Latest',
+          id: 'latest',
+          alias: 'l',
+          release: '12.9.0',
+          path: 'latest',
+          default: true,
+        },
+        {
+          name: 'Previous',
+          id: 'previous',
+          alias: 'p',
+          release: '11.3.0',
+          path: 'previous',
+          default: false,
+        },
+      ],
     });
 
     expect(
       transform('/%7B%7Bversion%7D%7D/%7B%7Bframework%7D%7D/node/overview')
-    ).toEqual('/latest/react/node/overview');
+    ).toEqual('/l/r/node/overview');
   });
   it('should transform path containing flavour only', () => {
     const transform = transformLinkPath({
-      framework: 'react',
-      frameworkList: ['angular', 'node', 'react'],
-      version: 'latest',
-      versionList: ['latest', 'previous'],
+      framework: {
+        id: 'react',
+        name: 'React',
+        alias: 'r',
+        path: 'react',
+        default: true,
+      },
+      frameworkList: [
+        { id: 'angular', name: 'Angular', alias: 'a', path: 'angular' },
+        {
+          id: 'react',
+          name: 'React',
+          alias: 'r',
+          path: 'react',
+          default: true,
+        },
+        { id: 'node', name: 'Node', alias: 'n', path: 'node' },
+      ],
+      version: {
+        name: 'Latest',
+        id: 'latest',
+        alias: 'l',
+        release: '12.9.0',
+        path: 'latest',
+        default: true,
+      },
+      versionList: [
+        {
+          name: 'Latest',
+          id: 'latest',
+          alias: 'l',
+          release: '12.9.0',
+          path: 'latest',
+          default: true,
+        },
+        {
+          name: 'Previous',
+          id: 'previous',
+          alias: 'p',
+          release: '11.3.0',
+          path: 'previous',
+          default: false,
+        },
+      ],
     });
 
-    expect(transform('/latest/%7B%7Bframework%7D%7D/node/overview')).toEqual(
-      '/latest/react/node/overview'
+    expect(transform('/l/%7B%7Bframework%7D%7D/node/overview')).toEqual(
+      '/l/r/node/overview'
     );
   });
   it('should transform path containing version only', () => {
     const transform = transformLinkPath({
-      framework: 'react',
-      frameworkList: ['angular', 'node', 'react'],
-      version: 'latest',
-      versionList: ['latest', 'previous'],
+      framework: {
+        id: 'react',
+        name: 'React',
+        alias: 'r',
+        path: 'react',
+        default: true,
+      },
+      frameworkList: [
+        { id: 'angular', name: 'Angular', alias: 'a', path: 'angular' },
+        {
+          id: 'react',
+          name: 'React',
+          alias: 'r',
+          path: 'react',
+          default: true,
+        },
+        { id: 'node', name: 'Node', alias: 'n', path: 'node' },
+      ],
+      version: {
+        name: 'Latest',
+        id: 'latest',
+        alias: 'l',
+        release: '12.9.0',
+        path: 'latest',
+        default: true,
+      },
+      versionList: [
+        {
+          name: 'Latest',
+          id: 'latest',
+          alias: 'l',
+          release: '12.9.0',
+          path: 'latest',
+          default: true,
+        },
+        {
+          name: 'Previous',
+          id: 'previous',
+          alias: 'p',
+          release: '11.3.0',
+          path: 'previous',
+          default: false,
+        },
+      ],
     });
 
-    expect(transform('/%7B%7Bversion%7D%7D/react/node/overview')).toEqual(
-      '/latest/react/node/overview'
+    expect(transform('/%7B%7Bversion%7D%7D/r/node/overview')).toEqual(
+      '/l/r/node/overview'
     );
   });
   it('should always prepend version if framework detected', () => {
     const transform = transformLinkPath({
-      framework: 'react',
-      frameworkList: ['angular', 'node', 'react'],
-      version: 'latest',
-      versionList: ['latest', 'previous'],
+      framework: {
+        id: 'react',
+        name: 'React',
+        alias: 'r',
+        path: 'react',
+        default: true,
+      },
+      frameworkList: [
+        { id: 'angular', name: 'Angular', alias: 'a', path: 'angular' },
+        {
+          id: 'react',
+          name: 'React',
+          alias: 'r',
+          path: 'react',
+          default: true,
+        },
+        { id: 'node', name: 'Node', alias: 'n', path: 'node' },
+      ],
+      version: {
+        name: 'Latest',
+        id: 'latest',
+        alias: 'l',
+        release: '12.9.0',
+        path: 'latest',
+        default: true,
+      },
+      versionList: [
+        {
+          name: 'Latest',
+          id: 'latest',
+          alias: 'l',
+          release: '12.9.0',
+          path: 'latest',
+          default: true,
+        },
+        {
+          name: 'Previous',
+          id: 'previous',
+          alias: 'p',
+          release: '11.3.0',
+          path: 'previous',
+          default: false,
+        },
+      ],
     });
 
-    expect(transform('/angular/node/overview')).toEqual(
-      '/latest/angular/node/overview'
+    expect(transform('/a/node/overview')).toEqual('/l/a/node/overview');
+    expect(transform('/r/node/overview')).toEqual('/l/r/node/overview');
+  });
+
+  it('should always use version & framework aliasing', () => {
+    const transform = transformLinkPath({
+      framework: {
+        id: 'react',
+        name: 'React',
+        alias: 'r',
+        path: 'react',
+        default: true,
+      },
+      frameworkList: [
+        { id: 'angular', name: 'Angular', alias: 'a', path: 'angular' },
+        {
+          id: 'react',
+          name: 'React',
+          alias: 'r',
+          path: 'react',
+          default: true,
+        },
+        { id: 'node', name: 'Node', alias: 'n', path: 'node' },
+      ],
+      version: {
+        name: 'Latest',
+        id: 'latest',
+        alias: 'l',
+        release: '12.9.0',
+        path: 'latest',
+        default: true,
+      },
+      versionList: [
+        {
+          name: 'Latest',
+          id: 'latest',
+          alias: 'l',
+          release: '12.9.0',
+          path: 'latest',
+          default: true,
+        },
+        {
+          name: 'Previous',
+          id: 'previous',
+          alias: 'p',
+          release: '11.3.0',
+          path: 'previous',
+          default: false,
+        },
+      ],
+    });
+
+    expect(transform('/latest/angular/node/overview')).toEqual(
+      '/l/a/node/overview'
     );
-    expect(transform('/react/node/overview')).toEqual(
-      '/latest/react/node/overview'
+    expect(transform('/latest/a/node/overview')).toEqual('/l/a/node/overview');
+    expect(transform('/previous/react/node/overview')).toEqual(
+      '/p/r/node/overview'
     );
+    expect(transform('/p/react/node/overview')).toEqual('/p/r/node/overview');
   });
   it('should do nothing if unrecognized path', () => {
     const transform = transformLinkPath({
-      framework: 'react',
-      frameworkList: ['angular', 'node', 'react'],
-      version: 'latest',
-      versionList: ['latest', 'previous'],
+      framework: {
+        id: 'react',
+        name: 'React',
+        alias: 'r',
+        path: 'react',
+        default: true,
+      },
+      frameworkList: [
+        { id: 'angular', name: 'Angular', alias: 'a', path: 'angular' },
+        {
+          id: 'react',
+          name: 'React',
+          alias: 'r',
+          path: 'react',
+          default: true,
+        },
+        { id: 'node', name: 'Node', alias: 'n', path: 'node' },
+      ],
+      version: {
+        name: 'Latest',
+        id: 'latest',
+        alias: 'l',
+        release: '12.9.0',
+        path: 'latest',
+        default: true,
+      },
+      versionList: [
+        {
+          name: 'Latest',
+          id: 'latest',
+          alias: 'l',
+          release: '12.9.0',
+          path: 'latest',
+          default: true,
+        },
+        {
+          name: 'Previous',
+          id: 'previous',
+          alias: 'p',
+          release: '11.3.0',
+          path: 'previous',
+          default: false,
+        },
+      ],
     });
 
     expect(transform('/%7B%7Bxxx%7D%7D/%7B%7Byyy%7D%7D/node/overview')).toEqual(
@@ -66,10 +320,50 @@ describe('transformLinkPath', () => {
   });
   it('should not transform path when internal or anchor links', () => {
     const transform = transformLinkPath({
-      framework: 'react',
-      frameworkList: ['angular', 'node', 'react'],
-      version: 'latest',
-      versionList: ['latest', 'previous'],
+      framework: {
+        id: 'react',
+        name: 'React',
+        alias: 'r',
+        path: 'react',
+        default: true,
+      },
+      frameworkList: [
+        { id: 'angular', name: 'Angular', alias: 'a', path: 'angular' },
+        {
+          id: 'react',
+          name: 'React',
+          alias: 'r',
+          path: 'react',
+          default: true,
+        },
+        { id: 'node', name: 'Node', alias: 'n', path: 'node' },
+      ],
+      version: {
+        name: 'Latest',
+        id: 'latest',
+        alias: 'l',
+        release: '12.9.0',
+        path: 'latest',
+        default: true,
+      },
+      versionList: [
+        {
+          name: 'Latest',
+          id: 'latest',
+          alias: 'l',
+          release: '12.9.0',
+          path: 'latest',
+          default: true,
+        },
+        {
+          name: 'Previous',
+          id: 'previous',
+          alias: 'p',
+          release: '11.3.0',
+          path: 'previous',
+          default: false,
+        },
+      ],
     });
 
     expect(transform('#something-path')).toEqual('#something-path');

--- a/nx-dev/feature-doc-viewer/src/lib/renderers/transform-link-path.ts
+++ b/nx-dev/feature-doc-viewer/src/lib/renderers/transform-link-path.ts
@@ -1,22 +1,29 @@
 import { uriTransformer } from 'react-markdown';
+import {
+  FlavorMetadata,
+  VersionMetadata,
+} from '@nrwl/nx-dev/data-access-documents';
 
 export function transformLinkPath(options: {
-  framework: string;
-  frameworkList: string[];
-  version: string;
-  versionList: string[];
-}): (href) => string {
+  framework: FlavorMetadata;
+  frameworkList: FlavorMetadata[];
+  version: VersionMetadata;
+  versionList: VersionMetadata[];
+}): (href: string) => string {
   return (href) =>
     uriTransformer(
       href
         ? interpolation(href, {
             framework: {
               marker: '%7B%7Bframework%7D%7D',
-              value: options.framework,
+              value: options.framework.alias,
             },
-            frameworkList: options.frameworkList,
-            version: { marker: '%7B%7Bversion%7D%7D', value: options.version },
-            versionList: options.versionList,
+            frameworkList: options.frameworkList.map((f) => f.alias),
+            version: {
+              marker: '%7B%7Bversion%7D%7D',
+              value: options.version.alias,
+            },
+            versionList: options.versionList.map((v) => v.alias),
           })
         : href
     );
@@ -74,5 +81,43 @@ function interpolation(
       '/' + config.version.value + (path.startsWith('/') ? path : '/' + path);
   }
 
-  return path;
+  /**
+   * Version aliasing if not done already on supported versions only
+   * /latest/react/gatsby/overview => /l/react/gatsby/overview
+   */
+  const aliasVersion = (path: string): string => {
+    const explodedPath = path.split('/').filter(Boolean);
+    if (
+      !!explodedPath[0] &&
+      explodedPath[0].length > 1 &&
+      config.versionList.includes(explodedPath[0].charAt(0))
+    )
+      return (path =
+        '/' +
+        [explodedPath[0].charAt(0), explodedPath.slice(1).join('/')].join('/'));
+    return path;
+  };
+
+  /**
+   * Framework aliasing if not done already on supported framework only
+   * /l/react/gatsby/overview => /l/r/gatsby/overview
+   */
+  const aliasFramework = (path: string): string => {
+    const explodedPath = path.split('/').filter(Boolean);
+    if (
+      !!explodedPath[1] &&
+      explodedPath[1].length > 1 &&
+      config.frameworkList.includes(explodedPath[1].charAt(0))
+    )
+      return (path =
+        '/' +
+        [
+          explodedPath[0],
+          explodedPath[1].charAt(0),
+          explodedPath.slice(2).join('/'),
+        ].join('/'));
+    return path;
+  };
+
+  return aliasFramework(aliasVersion(path));
 }

--- a/nx-dev/nx-dev/public/documentation/latest/angular/getting-started/intro.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/getting-started/intro.md
@@ -2,7 +2,9 @@
 
 Nx is a smart and extensible build framework to help you architect, test, and build at any scale — integrating seamlessly with modern technologies and frameworks while providing a distributed graph-based task execution, computation caching, smart rebuilds of affected projects, powerful code generators, editor support, GitHub apps, and more.
 
-Nx helps you develop [Angular](/{{framework}}/angular/overview) applications with fully integrated support for modern tools and libraries like [Jest](/{{framework}}/jest/overview), [Cypress](/{{framework}}/cypress/overview), [ESLint](/{{framework}}/linter/eslint), [Storybook](/{{framework}}/storybook/overview), NgRx and more.
+Nx helps you develop [Angular](/{{framework}}/angular/overview) applications with fully integrated support for
+modern tools and libraries like [Jest](/{{framework}}/jest/overview), [Cypress](/{{framework}}/cypress/overview),
+[ESLint](/{{framework}}/linter/eslint), [Storybook](/{{framework}}/storybook/overview), [NgRx](/angular/guides/misc-ngrx) and more.
 
 ## 10-Minute Nx Overview
 

--- a/nx-dev/nx-dev/public/documentation/latest/angular/migration/migration-angularjs.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/migration/migration-angularjs.md
@@ -371,7 +371,8 @@ But migrating AngularJS code means we need to switch some of our tools to a more
 npm install -D @nrwl/web babel-plugin-angularjs-annotate
 ```
 
-Nx already has most of what you need for webpack added as a dependency. `@nrwl/web` contains the [executors](https://nx.dev/latest/angular/executors/using-builders) we need to use to build and serve the application with webpack and `babel-plugin-angularjs-annotate` is going to accomplish the same thing that `browserify-ngannotate` previously did in gulp: add dependency injection annotations.
+Nx already has most of what you need for webpack added as a dependency. `@nrwl/web` contains the [executors](/{{version}}/{{framework}}/executors/using-builders) we need to use to build and serve the application with webpack and
+`babel-plugin-angularjs-annotate` is going to accomplish the same thing that `browserify-ngannotate` previously did in gulp: add dependency injection annotations.
 
 Start with a `webpack.config.js` file in your application’s root directory:
 

--- a/nx-dev/nx-dev/public/documentation/latest/angular/tutorial/01-create-application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/tutorial/01-create-application.md
@@ -126,4 +126,8 @@ yarn nx serve todos
 
 ## Note on `nx serve` and `ng serve`
 
-Internally, the Nx CLI delegates to the Angular CLI when running commands or generating code. The `nx serve` command produces the same result as `ng serve`, and `nx build` produces the same results as `ng build`. However, the Nx CLI supports advanced capabilities that aren't supported by the Angular CLI. For instance, Nx's computation cache only works when using the Nx CLI. In other words, using `nx` instead `ng` results in the same output, but often performs a lot better. [Read more about Nx CLI and Angular CLI.](/angular/getting-started/nx-cli)
+Internally, the Nx CLI delegates to the Angular CLI when running commands or generating code. The `nx serve` command
+produces the same result as `ng serve`, and `nx build` produces the same results as `ng build`. However, the Nx CLI
+supports advanced capabilities that aren't supported by the Angular CLI. For instance, Nx's computation cache only
+works when using the Nx CLI. In other words, using `nx` instead `ng` results in the same output, but often performs
+a lot better. [Read more about Nx CLI and Angular CLI.](/{{framework}}/getting-started/nx-cli)

--- a/nx-dev/nx-dev/public/documentation/latest/node/tutorial/01-create-application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/tutorial/01-create-application.md
@@ -113,7 +113,7 @@ Options:
   --help                  Show available options for project target.
 ```
 
-It helps with good editor integration (see [VSCode Support](https://nx.dev/latest/node/getting-started/console#nx-console-for-vscode)).
+It helps with good editor integration (see [VSCode Support](https://nx.dev/l/node/getting-started/console#nx-console-for-vscode)).
 
 But, most importantly, it provides a holistic dev experience regardless of the tools used, and enables advanced build features like distributed computation caching and distributed builds).
 

--- a/nx-dev/nx-dev/public/documentation/latest/react/getting-started/intro.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/getting-started/intro.md
@@ -2,7 +2,10 @@
 
 Nx is a smart and extensible build framework to help you architect, test, and build at any scale — integrating seamlessly with modern technologies and frameworks while providing a distributed graph-based task execution, computation caching, smart rebuilds of affected projects, powerful code generators, editor support, GitHub apps, and more
 
-Nx helps you develop [React](/{{framework}}/react/overview) applications with fully integrated support for modern tools and libraries like [Jest](/{{framework}}/jest/overview), [Cypress](/{{framework}}/cypress/overview), [Storybook](/{{framework}}/storybook/overview), [ESLint](/{{framework}}/linter/eslint), and more. Nx also supports React frameworks like [Gatsby](/{{framework}}/gatsby/overview) and [Next.js](/{{version}}/react/guides/nextjs).
+Nx helps you develop [React](/{{framework}}/react/overview) applications with fully integrated support for modern
+tools and libraries like [Jest](/{{framework}}/jest/overview), [Cypress](/{{framework}}/cypress/overview),
+[Storybook](/{{framework}}/storybook/overview), [ESLint](/{{framework}}/linter/eslint), and more. Nx also supports
+React frameworks like [Gatsby](/{{version}}/react/gatsby/overview) and [Next.js](/{{version}}/react/guides/nextjs).
 
 ## 10-Minute Nx Overview
 

--- a/nx-dev/nx-dev/public/documentation/latest/react/migration/migration-cra.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/migration/migration-cra.md
@@ -14,7 +14,8 @@ Just `cd` into your Create-React-App (CRA) project and run the following command
 npx cra-to-nx
 ```
 
-Then just sit back and wait. After a while, take advantage of the [full magic of Nx](https://nx.dev/latest/react/getting-started/intro). Start from [the commands mentioned in this article](https://nx.dev/latest/react/migration/migration-cra#try-nx).
+Then just sit back and wait. After a while, take advantage of the [full magic of Nx](https://nx.dev/latest/react/getting-started/intro).
+Start from [the commands mentioned in this article](https://nx.dev/latest/react/migration/migration-cra#try-nx).
 
 **Note:** The command will fail if you try execute it and you have uncommitted changes in your repository. Commit any local changes, and then try to run the command.
 

--- a/nx-dev/nx-dev/public/documentation/latest/react/tutorial/06-proxy.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/tutorial/06-proxy.md
@@ -71,6 +71,6 @@ Options:
   --help                  Show available options for project target.
 ```
 
-It helps with good editor integration (see [VSCode Support](https://nx.dev/latest/react/getting-started/console#nx-console-for-vscode)).
+It helps with good editor integration (see [VSCode Support](/{{framework}}/getting-started/console#nx-console-for-vscode)).
 
 But, most importantly, it provides a holistic dev experience regardless of the tools used, and enables advanced build features like distributed computation caching and distributed builds).


### PR DESCRIPTION
## What it does?
This PR makes some updates on nx.dev's path interpolation for internal links and image.

The way the documentation is written in `/docs` stays the same as before. Meaning, we create internal links with `{{version}}`, `{{framework}}`, `/latest/react/...`, `/{{framework}}/...` etc. That allows us to not change any tooling we have to check and validate the `/docs` content and is easier to create internal link with full marker names.

The application is now making sure the correct alias is set to the correct marker only if needed.