### PR TITLE
docs(nxdev): custom img render for lazy loading

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/content.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/content.tsx
@@ -27,6 +27,9 @@ interface ComponentsConfig {
 }
 
 const components: any = (config: ComponentsConfig) => ({
+  img({ node, alt, src, ...props }) {
+    return <img src={src} alt={alt} loading="lazy" />;
+  },
   code({ node, inline, className, children, ...props }) {
     const language = /language-(\w+)/.exec(className || '')?.[1];
     return !inline && language ? (


### PR DESCRIPTION
## What it does?
This PR adds a custom renderer for the documentation view on nx.dev. It allows us to lazy load images in the documentation producing a performance gain.