### PR TITLE
docs(nxdev): enable svg support on path transform

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/renderers/transform-image-path.ts
+++ b/nx-dev/feature-doc-viewer/src/lib/renderers/transform-image-path.ts
@@ -15,7 +15,7 @@ export function transformImagePath({
   return (src) => {
     const isRelative = src.startsWith('.');
 
-    if (!/\.(gif|jpe?g|tiff?|png|webp|bmp)$/i.test(src)) {
+    if (!/\.(gif|jpe?g|tiff?|png|webp|bmp|svg)$/i.test(src)) {
       return uriTransformer(src);
     }
 


### PR DESCRIPTION
## What it does?
This PR adds the `svg` support to the list of path transformed in nx.dev