### PR TITLE
bugfix(core): fix issue when having a project name with directory in it

### DIFF
--- a/packages/cypress/src/generators/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.ts
@@ -194,9 +194,9 @@ export async function cypressProjectGenerator(host: Tree, schema: Schema) {
 
 function normalizeOptions(host: Tree, options: Schema): CypressProjectSchema {
   const { appsDir } = getWorkspaceLayout(host);
-  const projectName = options.directory
-    ? `${filePathPrefix(options.directory)}-${options.name}`
-    : options.name;
+  const projectName = filePathPrefix(
+    options.directory ? `${options.directory}-${options.name}` : options.name
+  );
   const projectRoot = options.directory
     ? joinPathFragments(
         appsDir,

--- a/packages/detox/src/generators/application/application.spec.ts
+++ b/packages/detox/src/generators/application/application.spec.ts
@@ -1,0 +1,119 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  readProjectConfiguration,
+  Tree,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { Linter } from 'packages/linter/src/generators/utils/linter';
+
+import detoxApplicationGenerator from './application';
+
+describe('detox application generator', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('app at root', () => {
+    beforeEach(async () => {
+      addProjectConfiguration(tree, 'my-app', {
+        root: 'my-app',
+      });
+
+      await detoxApplicationGenerator(tree, {
+        name: 'my-app-e2e',
+        project: 'my-app',
+        linter: Linter.None,
+      });
+    });
+
+    it('should generate files', () => {
+      expect(tree.exists('apps/my-app-e2e/.detoxrc.json')).toBeTruthy();
+      expect(tree.exists('apps/my-app-e2e/src/app.spec.ts')).toBeTruthy();
+    });
+
+    it('should add update `workspace.json` file', async () => {
+      const workspaceJson = readJson(tree, 'workspace.json');
+      const project = workspaceJson.projects['my-app-e2e'];
+
+      expect(project.root).toEqual('apps/my-app-e2e');
+    });
+
+    it('should update nx.json', async () => {
+      const project = readProjectConfiguration(tree, 'my-app-e2e');
+      expect(project.tags).toEqual([]);
+      expect(project.implicitDependencies).toEqual(['my-app']);
+    });
+  });
+
+  describe('with directory specified', () => {
+    beforeEach(async () => {
+      addProjectConfiguration(tree, 'my-dir-my-app', {
+        root: 'my-dir/my-app',
+      });
+
+      await detoxApplicationGenerator(tree, {
+        name: 'my-app-e2e',
+        directory: 'my-dir',
+        project: 'my-dir-my-app',
+        linter: Linter.None,
+      });
+    });
+
+    it('should generate files', () => {
+      expect(tree.exists('apps/my-dir/my-app-e2e/.detoxrc.json')).toBeTruthy();
+      expect(
+        tree.exists('apps/my-dir/my-app-e2e/src/app.spec.ts')
+      ).toBeTruthy();
+    });
+
+    it('should add update `workspace.json` file', async () => {
+      const workspaceJson = readJson(tree, 'workspace.json');
+      const project = workspaceJson.projects['my-dir-my-app-e2e'];
+
+      expect(project.root).toEqual('apps/my-dir/my-app-e2e');
+    });
+
+    it('should update nx.json', async () => {
+      const project = readProjectConfiguration(tree, 'my-dir-my-app-e2e');
+      expect(project.tags).toEqual([]);
+      expect(project.implicitDependencies).toEqual(['my-dir-my-app']);
+    });
+  });
+
+  describe('with directory in name', () => {
+    beforeEach(async () => {
+      addProjectConfiguration(tree, 'my-dir-my-app', {
+        root: 'my-dir/my-app',
+      });
+
+      await detoxApplicationGenerator(tree, {
+        name: 'my-dir/my-app-e2e',
+        project: 'my-dir-my-app',
+        linter: Linter.None,
+      });
+    });
+
+    it('should generate files', () => {
+      expect(tree.exists('apps/my-dir/my-app-e2e/.detoxrc.json')).toBeTruthy();
+      expect(
+        tree.exists('apps/my-dir/my-app-e2e/src/app.spec.ts')
+      ).toBeTruthy();
+    });
+
+    it('should add update `workspace.json` file', async () => {
+      const workspaceJson = readJson(tree, 'workspace.json');
+      const project = workspaceJson.projects['my-dir-my-app-e2e'];
+
+      expect(project.root).toEqual('apps/my-dir/my-app-e2e');
+    });
+
+    it('should update nx.json', async () => {
+      const project = readProjectConfiguration(tree, 'my-dir-my-app-e2e');
+      expect(project.tags).toEqual([]);
+      expect(project.implicitDependencies).toEqual(['my-dir-my-app']);
+    });
+  });
+});

--- a/packages/detox/src/generators/application/lib/add-project.spec.ts
+++ b/packages/detox/src/generators/application/lib/add-project.spec.ts
@@ -10,7 +10,7 @@ import { addProject } from './add-project';
 describe('Add Project', () => {
   let tree: Tree;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'my-app', {
       root: 'my-app',
@@ -26,35 +26,58 @@ describe('Add Project', () => {
     });
   });
 
-  it('should update workspace.json', async () => {
-    addProject(tree, {
-      name: 'my-app-e2e',
-      projectName: 'my-app-e2e',
-      projectRoot: 'apps/my-app-e2e',
-      project: 'my-app',
-      appFileName: 'my-app',
-      appClassName: 'MyApp',
-      linter: Linter.EsLint,
+  describe('app at root', () => {
+    beforeEach(() => {
+      addProject(tree, {
+        name: 'my-app-e2e',
+        projectName: 'my-app-e2e',
+        projectRoot: 'apps/my-app-e2e',
+        project: 'my-app',
+        appFileName: 'my-app',
+        appClassName: 'MyApp',
+        linter: Linter.EsLint,
+      });
     });
-    const project = readProjectConfiguration(tree, 'my-app-e2e');
 
-    expect(project.root).toEqual('apps/my-app-e2e');
-    expect(project.sourceRoot).toEqual('apps/my-app-e2e/src');
+    it('should update workspace.json', () => {
+      const project = readProjectConfiguration(tree, 'my-app-e2e');
+
+      expect(project.root).toEqual('apps/my-app-e2e');
+      expect(project.sourceRoot).toEqual('apps/my-app-e2e/src');
+    });
+
+    it('should update nx.json', () => {
+      const project = readProjectConfiguration(tree, 'my-app-e2e');
+      expect(project.tags).toEqual([]);
+      expect(project.implicitDependencies).toEqual(['my-app']);
+    });
   });
 
-  it('should update nx.json', async () => {
-    addProject(tree, {
-      name: 'my-app-e2e',
-      projectName: 'my-app-e2e',
-      projectRoot: 'apps/my-app-e2e',
-      project: 'my-app',
-      appFileName: 'my-app',
-      appClassName: 'MyApp',
-      linter: Linter.EsLint,
+  describe('app with directory', () => {
+    beforeEach(() => {
+      addProject(tree, {
+        name: 'my-dir-my-app-e2e',
+        projectName: 'my-dir-my-app-e2e',
+        projectRoot: 'apps/my-dir/my-app-e2e',
+        project: 'my-dir-my-app',
+        appFileName: 'my-app',
+        appClassName: 'MyApp',
+        linter: Linter.EsLint,
+      });
     });
 
-    const project = readProjectConfiguration(tree, 'my-app-e2e');
-    expect(project.tags).toEqual([]);
-    expect(project.implicitDependencies).toEqual(['my-app']);
+    it('should update workspace.json', () => {
+      const project = readProjectConfiguration(tree, 'my-dir-my-app-e2e');
+
+      expect(project.root).toEqual('apps/my-dir/my-app-e2e');
+      expect(project.sourceRoot).toEqual('apps/my-dir/my-app-e2e/src');
+    });
+
+    it('should update nx.json', () => {
+      const project = readProjectConfiguration(tree, 'my-dir-my-app-e2e');
+
+      expect(project.tags).toEqual([]);
+      expect(project.implicitDependencies).toEqual(['my-dir-my-app']);
+    });
   });
 });

--- a/packages/detox/src/generators/application/lib/normalize-options.spec.ts
+++ b/packages/detox/src/generators/application/lib/normalize-options.spec.ts
@@ -74,4 +74,24 @@ describe('Normalize Options', () => {
       projectName: 'directory-my-app-e2e',
     });
   });
+
+  it('should normalize options with directory in its name', () => {
+    addProjectConfiguration(appTree, 'my-app', {
+      root: 'apps/my-app',
+      targets: {},
+    });
+    const schema: Schema = {
+      name: 'directory/my-app-e2e',
+      project: 'my-app',
+    };
+    const options = normalizeOptions(appTree, schema);
+    expect(options).toEqual({
+      project: 'my-app',
+      appClassName: 'MyApp',
+      appFileName: 'my-app',
+      projectRoot: 'apps/directory/my-app-e2e',
+      name: 'directory/my-app-e2e',
+      projectName: 'directory-my-app-e2e',
+    });
+  });
 });

--- a/packages/detox/src/generators/application/lib/normalize-options.ts
+++ b/packages/detox/src/generators/application/lib/normalize-options.ts
@@ -28,9 +28,9 @@ export function normalizeOptions(
   const directoryFileName = options.directory
     ? names(options.directory).fileName
     : '';
-  const projectName = directoryFileName
-    ? `${directoryFileName.replace(new RegExp('/', 'g'), '-')}-${fileName}`
-    : fileName;
+  const projectName = (
+    directoryFileName ? `${directoryFileName}-${fileName}` : fileName
+  ).replace(new RegExp('/', 'g'), '-');
   const projectRoot = directoryFileName
     ? joinPathFragments(appsDir, directoryFileName, fileName)
     : joinPathFragments(appsDir, fileName);

--- a/packages/gatsby/src/generators/application/files/src/pages/index.none.tsx__tmpl__
+++ b/packages/gatsby/src/generators/application/files/src/pages/index.none.tsx__tmpl__
@@ -5,7 +5,7 @@ import star from './star.svg';
 
 export function Index() {
   return (
-    <h1>Welcome to <%= name %>!</h1>
+    <h1>Welcome to <%= projectName %>!</h1>
   );
 }
 

--- a/packages/gatsby/src/generators/application/lib/add-cypress.ts
+++ b/packages/gatsby/src/generators/application/lib/add-cypress.ts
@@ -13,6 +13,6 @@ export async function addCypress(host: Tree, options: NormalizedSchema) {
     linter: Linter.EsLint,
     name: `${options.name}-e2e`,
     directory: options.directory,
-    project: options.name,
+    project: options.projectName,
   });
 }

--- a/packages/gatsby/src/generators/application/lib/create-application-files.ts
+++ b/packages/gatsby/src/generators/application/lib/create-application-files.ts
@@ -22,7 +22,7 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
     ...names(options.name),
     offsetFromRoot: offsetFromRoot(options.projectRoot),
     tmpl: '',
-    appContent: createAppJsx(options.name),
+    appContent: createAppJsx(options.projectName),
     pageWrapperStyle: createPageWrapperStyle(),
     pageStyleContent: createPageStyleContent(),
   };

--- a/packages/react-native/src/generators/application/lib/add-detox.ts
+++ b/packages/react-native/src/generators/application/lib/add-detox.ts
@@ -13,6 +13,6 @@ export async function addDetox(host: Tree, options: NormalizedSchema) {
     linter: Linter.EsLint,
     name: `${options.name}-e2e`,
     directory: options.directory,
-    project: options.name,
+    project: options.projectName,
   });
 }

--- a/packages/react-native/src/generators/application/lib/nomalize-options.spec.ts
+++ b/packages/react-native/src/generators/application/lib/nomalize-options.spec.ts
@@ -81,6 +81,28 @@ describe('Normalize Options', () => {
     });
   });
 
+  it('should normalize options that has directory in its name', () => {
+    const schema: Schema = {
+      name: 'directory/my-app',
+      e2eTestRunner: 'none',
+    };
+    const options = normalizeOptions(appTree, schema);
+    expect(options).toEqual({
+      androidProjectRoot: 'apps/directory/my-app/android',
+      appProjectRoot: 'apps/directory/my-app',
+      className: 'DirectoryMyApp',
+      displayName: 'DirectoryMyApp',
+      iosProjectRoot: 'apps/directory/my-app/ios',
+      lowerCaseName: 'directorymyapp',
+      name: 'directory/my-app',
+      parsedTags: [],
+      projectName: 'directory-my-app',
+      entryFile: '/virtual/apps/directory/my-app/src/main.tsx',
+      e2eTestRunner: 'none',
+      unitTestRunner: 'jest',
+    });
+  });
+
   it('should normalize options with display name', () => {
     const schema: Schema = {
       name: 'my-app',

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -195,7 +195,7 @@ Object {
 
     expect(
       appTree.read('apps/my-dir/my-app/src/app/app.tsx').toString()
-    ).toContain('Welcome to my-app');
+    ).toContain('Welcome to my-dir-my-app');
   });
 
   it.each`

--- a/packages/react/src/generators/application/files/css-module/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/css-module/src/app/__fileName__.tsx__tmpl__
@@ -16,7 +16,7 @@ export function App() {
     <div className={styles.app}>
       <header className="flex">
         <Logo width="75" height="75"/>
-        <h1>Welcome to <%= name %>!</h1>
+        <h1>Welcome to <%= projectName %>!</h1>
       </header>
     <main>
       <h2>Resources &amp; Tools</h2>

--- a/packages/react/src/generators/application/files/global-css/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/global-css/src/app/__fileName__.tsx__tmpl__
@@ -16,7 +16,7 @@ export function App() {
      <div className="app">
          <header className="flex">
       <Logo width="75" height="75"/>
-      <h1>Welcome to <%= name %>!</h1>
+      <h1>Welcome to <%= projectName %>!</h1>
     </header>
     <main>
       <h2>Resources &amp; Tools</h2>

--- a/packages/react/src/generators/application/files/none/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/none/src/app/__fileName__.tsx__tmpl__
@@ -12,7 +12,7 @@ export class App extends Component {
 export function App() {
 <% } %>
   return (
-    <h1>Welcome to <%= name %>!</h1>
+    <h1>Welcome to <%= projectName %>!</h1>
   );
 <% if (classComponent) { %>
   }

--- a/packages/react/src/generators/application/files/styled-jsx/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/styled-jsx/src/app/__fileName__.tsx__tmpl__
@@ -146,7 +146,7 @@ export function App() {
 
       <header className="flex">
         <Logo width="75" height="75" />
-        <h1>Welcome to <%= name %>!</h1>
+        <h1>Welcome to <%= projectName %>!</h1>
       </header>
       <main>
         <h2>Resources &amp; Tools</h2>

--- a/packages/react/src/generators/application/files/styled-module/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/styled-module/src/app/__fileName__.tsx__tmpl__
@@ -146,7 +146,7 @@ export function App() {
        <StyledApp>
           <header className="flex">
       <Logo width="75" height="75"/>
-      <h1>Welcome to <%= name %>!</h1>
+      <h1>Welcome to <%= projectName %>!</h1>
     </header>
     <main>
       <h2>Resources &amp; Tools</h2>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
currently if run command `nx g @nrwl/web:app my-scope/web`, it would generate `my-scope/web-e2e` as the key under projects in workspace.json.
Similar issue when you run `nx g @nrwl/react my-scope/react` or `nx g @nrwl/react my-scope/react-native`.
Also, in cypress, the default test expect to find `getGreeting().contains('Welcome to <%= project %>!');`, so change the react and gatsby template to use projectName rather than name.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should generate `my-scope-web-e2e`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
