### PR TITLE
fix(angular): remove extra comma when generating application with --inlineTemplate

### DIFF
--- a/packages/angular/src/generators/application/lib/update-component-template.ts
+++ b/packages/angular/src/generators/application/lib/update-component-template.ts
@@ -38,6 +38,6 @@ export function updateComponentTemplate(host: Tree, options: NormalizedSchema) {
     ),
     componentPath,
     templateNodeValue,
-    `\`\n${nrwlHomeTemplate.html}\n\`,\n`
+    `\`\n${nrwlHomeTemplate.html}\n\``
   );
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating an Angular application and setting the `--inlineTemplate` flag, the generated component has an extra comma after the `template` variable in the `@Component` decorator.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generating an Angular application with the `--inlineTemplate` flag should generate the component successfully.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6944 
