### PR TITLE
docs(storybook): add storybook generator composition configuration and guide

### DIFF
--- a/docs/angular/api-storybook/executors/composition.md
+++ b/docs/angular/api-storybook/executors/composition.md
@@ -1,0 +1,5 @@
+# @nrwl/storybook:composition
+
+Compose Storybooks
+
+Options can be configured in `angular.json` when defining the executor, or when invoking it. Read more about how to configure targets and executors here: https://nx.dev/core-concepts/configuration#targets.

--- a/docs/angular/api-storybook/generators/composition.md
+++ b/docs/angular/api-storybook/generators/composition.md
@@ -1,0 +1,55 @@
+# @nrwl/storybook:composition
+
+Generate Storybook composition setup.
+
+## Usage
+
+```bash
+nx generate composition ...
+```
+
+By default, Nx will search for `composition` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/storybook:composition ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g composition ... --dry-run
+```
+
+## Options
+
+### mainProject (_**required**_)
+
+Type: `string`
+
+The one project that will be used as the main entrypoint for Storybook Composition. This project will run on port 4400 and will not be added as a composition reference. All references will be added to it, instead.
+
+### all
+
+Default: `false`
+
+Type: `boolean`
+
+Compose all Storybook instances.
+
+### projects
+
+Default: ` `
+
+Type: `string`
+
+Projects to add in the composition (comma delimited)
+
+### useExistingPorts
+
+Default: `false`
+
+Type: `boolean`
+
+If false, the Storybook ports in workspace.json/angular.json will be overwritten. If true, the Storybook ports in workspace.json/angular.json will not be overwritten and Storybook Composition will use ordinal numbers to name your instances.

--- a/docs/angular/guides/storybook/storybook-composition.md
+++ b/docs/angular/guides/storybook/storybook-composition.md
@@ -1,0 +1,174 @@
+# Using Storybook Composition with Nx
+
+## What is Storybook Compotision
+
+As explained in the [Storybook official docs](https://storybook.js.org/docs/angular/workflows/storybook-composition), Storybook Composition allows you to embed components from any Storybook inside your local Storybook. If you want to learn more about Storybook Composition, please take a look at the following articles, which explain it in detail:
+
+- [Storybook Composition - Chromatic blog](https://www.chromatic.com/blog/storybook-composition/)
+- [Storybook Composition - Storybook docs](https://storybook.js.org/docs/angular/workflows/storybook-composition)
+
+## How it works
+
+In essence, you have a Storybook running, which will be the host of the embeded Storybooks as well. Then, you provide this "host" Storybook with a URL of a live/running Storybook. The composed Storybook is then displayed in a new Canvas iframe as part of the host Storybook, and is listed on the left-hand-side stories inventory, too. You can read more about this in the docs listed above.
+
+## How to use it
+
+All you need is a URL of a live Storybook, and a "host" Storybook. In the `.storybook/main.js` file of the "host" Storybook, inside `module.exports` you add a new `refs` attribute, which will contain the link(s) for the composed Storybook(s).
+
+In the example below, we have a host Storybook running on local port 4400 (http://localhost:4400) - not displayed here. In it, we want to compose three other Storybooks. The "one-composed" and "two-composed", running on local ports `4401` and `4402` accordingly, as well as the [Storybook website's Storybook](https://next--storybookjs.netlify.app/official-storybook) which is live on the address that you see.
+
+```
+// .storybook/main.js of our Host Storybook - supposably running on port 4400
+
+module.exports = {
+  ...,
+  refs: {
+    'one-composed': {
+      title: 'One composed',
+      url: 'http://localhost:4401',
+    },
+    'two-composed': {
+      title: 'Two composed',
+      url: 'http://localhost:4402',
+    },
+    'storybook-website-storybook': {
+      title: 'The Storybook of the Storybook website',
+      url: 'https://next--storybookjs.netlify.app/official-storybook/',
+    },
+  },
+};
+```
+
+You can always read more in the [official Storybook docs](https://storybook.js.org/docs/angular/workflows/storybook-composition#compose-published-storybooks).
+
+## How to use it in Nx
+
+It's quite easy to use this feature, in Nx and in general, since you do not need to make any code changes, you just need to have the "composed" Storybook instances (the ones you need to "compose") running, choose a "host" Storybook, and just add the composed Storybooks in it's `.storybook/main.js` file.
+
+Nx provides the [`run-many`](https://nx.dev/l/a/cli/run-many) command, which will allow you to easily run multiple Storybooks at the same time. You need to run the `run-many`
+command with the parallel flag set to true `--parallel=true`, because you want to run all your Storybooks in parallel. Since the default amount of parallel activities that you can run
+is set to `3`, you can adjust this command to be of as many Storybooks you want to run in parallel as you need. However, be **very carefull** with putting large numbers in this
+flag, since it can cause big delays or get stuck. You can play around and adjust that number to one your machine runs comfortably with. Keep in mind that you can add in this feature however many live/public Storybooks as you need (Storybooks that you do not run locally).
+
+You can just do:
+
+```
+nx run-many --target=storybook --projects=main-host,one-composed,two-composed,three-composed --parallel=true --maxParallel=4
+```
+
+Before running the above command to actually compose our Storybook instances under the **`main-host`** project, we would need to do the following adjustments to our workspace:
+
+### Adjust the Storybook ports in `project.json`
+
+Take a look in your `project.json` file of each one of your projects (eg. for the `main-host` project, you can find it in the path `apps/main-host/project.json`).
+In your project's targets, in the `storybook` target, you will notice that the default port that Nx assigns to your projects' Storybook is always `4400`:
+
+```
+{
+  ...
+  "targets": {
+    ...
+    "storybook": {
+      ...
+      "options": {
+        ...
+        "port": 4400,
+        ...
+      },
+      ...
+    },
+    ...
+`  },
+}
+```
+
+We can keep this port for the project which will serve as the host of our configuration, but we must change the port numbers of the other projects, the projects which will be composed/composed. The reason for that is the following:
+
+- When the `nx run-many --target=storybook --parallel=true` command executes, it will go and look into your `project.json` file to see the port you have assigned for that project's Storybook.
+- When it finds a port that it is already used, it will change the port number randomly (usually adding `1` until it finds an empty port).
+
+Since we are using the `--parallel=true`, and the commands are executed in parallel, we cannot know for sure the order that the `storybook` command will be executed. So, we cannot be sure which port will correspond to which of the projects.
+
+If we don't change the port numbers, and there are projects that want to use the same port for their Storybooks, the `run-many` command will change that port, and the result will be that we will not know for sure which
+of our projects runs on which port. The problem that this creates is that we will not be able to create the proper configuration for Storybook Composition, since we will not be able to tell which URLs our composed Storybooks run on.
+
+### Add the refs in our host project's `.storybook/main.js` file
+
+Now, we need to add to our host project's `main.js` file (the path of which would be `apps/main-host/.storybook/main.js`) a `refs` object, to configure our composition. An example of such a configuration looks like this:
+
+```
+module.exports = {
+  ...,
+  refs: {
+    one-composed: {
+      title: 'One composed',
+      url: 'http://localhost:4401',
+    },
+    two-composed: {
+      title: 'Two composed',
+      url: 'http://localhost:4402',
+    },
+    three-composed: {
+      title: 'Three composed',
+      url: 'http://localhost:4403',
+    },
+  },
+};
+```
+
+## Storybook Composition generator
+
+You can use the `@nrwl/storybook:composition` generator to make the above process even easier, so that you do not have to think about ports and settings.
+
+### How to use it
+
+Just execute the following in your terminal, and let the promts guide you:
+
+```
+nx generate @nrwl/storybook:composition
+```
+
+Read the docs for this command [here]().
+
+### Options
+
+- `mainProject`: It lets you set the "host" project. It's required.
+
+- `projects`: It lets you provide a list of composed projects
+
+- `useExistingPorts`: If false, it will _change_ the Storybook ports in the chosen projects of your project's `project.json` file, and then use these ports in the `mainProject`'s `.storybook/main.js`, to make sure the
+  projects correspond to the ports. This is equivalent to the "manual" process described above. If true, the ports will be assigned automatically by the `run-many` command, and the generator will only change your `.storybook/main.js` file, however, if two or more Storybooks are assigned to the same port, you will not be able to use composition successfully. You will have to manually change the ports yourself.
+
+- `all`: It will execute the process for all your projects.
+
+### What this generator does
+
+1. It edits the `mainProject`'s `.storybook/main.js` file, according to the options passed in the command. Each time you run it, it will _overwrite_ your `refs` object inside the `mainProject`'s `.storybook/main.js` file with the new options that you pass.
+
+2. If `useExistingPorts` is **not** set (or set to `false`), it _changes_ the ports for Storybook in the projects that you choose in each of your composed projects `project.json` files.
+
+3. If `useExistingPorts` is **not** set (or set to `false`), it edits your project's `e2e` Cypress base URL, to match the new URL set in each project's `project.json` file.
+
+4. It prompts you with the `storybook-composition` executor command that you can copy and run in your terminal, to run your Storybook composition.
+
+### Easiest way to take advantage of this generator
+
+Chances are you will not care about your project's `project.json` Storybook ports changing. Also, chances are you will not care about your main host project's `.storybook/main.js` `refs` object being overwritten.
+So, to try this out quickly, you can do the following:
+
+```
+nx g @nrwl/storybook:composition --mainProject=<YOUR_HOST_PROJECT> --all
+```
+
+### Who this generator is for
+
+This generator is for the developer who wants to see things working locally, and play around with the Storybook Composition feature, see how it works, explore its capabilities.
+
+### Who this generator is _not_ for
+
+If you are an advanced user and you want to link public projects in your published Storybooks, this generator is _not_ for you. You can use the guide above to manually add your public URLs to your host project's `.storybook/main.js` file(s).
+
+### I already have a Storybook composition setup
+
+If you already have a Storybook composition setup and you want to try this generator, do so, but choose as the `mainProject` another "host" project, and not the one you already have a Composition setup for. The reason is that this generator will
+go and overwrite the `refs` object in the main host's project `.storybook/main.js` file.

--- a/docs/map.json
+++ b/docs/map.json
@@ -685,6 +685,11 @@
             "name": "storybook executor",
             "id": "storybook",
             "file": "angular/api-storybook/executors/storybook"
+          },
+          {
+            "name": "storybook composition",
+            "id": "composition",
+            "file": "angular/api-storybook/executors/composition"
           }
         ]
       },
@@ -2023,6 +2028,11 @@
                 "name": "storybook",
                 "id": "storybook",
                 "file": "react/api-storybook/executors/storybook"
+              },
+              {
+                "name": "storybook composition",
+                "id": "composition",
+                "file": "react/api-storybook/executors/composition"
               }
             ]
           }
@@ -3301,6 +3311,11 @@
             "name": "storybook executor",
             "id": "storybook",
             "file": "node/api-storybook/executors/storybook"
+          },
+          {
+            "name": "storybook composition",
+            "id": "composition",
+            "file": "node/api-storybook/executors/composition"
           }
         ]
       },

--- a/docs/map.json
+++ b/docs/map.json
@@ -647,9 +647,19 @@
             "file": "angular/guides/storybook/storybook-v6"
           },
           {
+            "id": "setup-storybook-composition",
+            "name": "Setup Storybook Composition",
+            "file": "angular/guides/storybook/storybook-composition"
+          },
+          {
             "name": "configuration generator",
             "id": "configuration",
             "file": "angular/api-storybook/generators/configuration"
+          },
+          {
+            "name": "composition generator",
+            "id": "composition",
+            "file": "angular/api-storybook/generators/composition"
           },
           {
             "name": "migrate-defaults-5-to-6 generator",
@@ -1971,9 +1981,19 @@
             "file": "react/guides/storybook/storybook-v6"
           },
           {
+            "id": "setup-storybook-composition",
+            "name": "Setup Storybook Composition",
+            "file": "react/guides/storybook/storybook-composition"
+          },
+          {
             "name": "configuration generator",
             "id": "configuration",
             "file": "react/api-storybook/generators/configuration"
+          },
+          {
+            "name": "composition generator",
+            "id": "composition",
+            "file": "react/api-storybook/generators/composition"
           },
           {
             "name": "cypress-project generator",
@@ -3251,6 +3271,11 @@
             "name": "configuration generator",
             "id": "configuration",
             "file": "node/api-storybook/generators/configuration"
+          },
+          {
+            "name": "composition generator",
+            "id": "composition",
+            "file": "node/api-storybook/generators/composition"
           },
           {
             "name": "migrate-defaults-5-to-6 generator",

--- a/docs/node/api-storybook/executors/composition.md
+++ b/docs/node/api-storybook/executors/composition.md
@@ -1,0 +1,5 @@
+# @nrwl/storybook:composition
+
+Compose Storybooks
+
+Options can be configured in `workspace.json` when defining the executor, or when invoking it. Read more about how to configure targets and executors here: https://nx.dev/core-concepts/configuration#targets.

--- a/docs/node/api-storybook/generators/composition.md
+++ b/docs/node/api-storybook/generators/composition.md
@@ -1,0 +1,55 @@
+# @nrwl/storybook:composition
+
+Generate Storybook composition setup.
+
+## Usage
+
+```bash
+nx generate composition ...
+```
+
+By default, Nx will search for `composition` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/storybook:composition ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g composition ... --dry-run
+```
+
+## Options
+
+### mainProject (_**required**_)
+
+Type: `string`
+
+The one project that will be used as the main entrypoint for Storybook Composition. This project will run on port 4400 and will not be added as a composition reference. All references will be added to it, instead.
+
+### all
+
+Default: `false`
+
+Type: `boolean`
+
+Compose all Storybook instances.
+
+### projects
+
+Default: ` `
+
+Type: `string`
+
+Projects to add in the composition (comma delimited)
+
+### useExistingPorts
+
+Default: `false`
+
+Type: `boolean`
+
+If false, the Storybook ports in workspace.json/angular.json will be overwritten. If true, the Storybook ports in workspace.json/angular.json will not be overwritten and Storybook Composition will use ordinal numbers to name your instances.

--- a/docs/react/api-storybook/executors/composition.md
+++ b/docs/react/api-storybook/executors/composition.md
@@ -1,0 +1,5 @@
+# @nrwl/storybook:composition
+
+Compose Storybooks
+
+Options can be configured in `workspace.json` when defining the executor, or when invoking it. Read more about how to configure targets and executors here: https://nx.dev/core-concepts/configuration#targets.

--- a/docs/react/api-storybook/generators/composition.md
+++ b/docs/react/api-storybook/generators/composition.md
@@ -1,0 +1,55 @@
+# @nrwl/storybook:composition
+
+Generate Storybook composition setup.
+
+## Usage
+
+```bash
+nx generate composition ...
+```
+
+By default, Nx will search for `composition` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/storybook:composition ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g composition ... --dry-run
+```
+
+## Options
+
+### mainProject (_**required**_)
+
+Type: `string`
+
+The one project that will be used as the main entrypoint for Storybook Composition. This project will run on port 4400 and will not be added as a composition reference. All references will be added to it, instead.
+
+### all
+
+Default: `false`
+
+Type: `boolean`
+
+Compose all Storybook instances.
+
+### projects
+
+Default: ` `
+
+Type: `string`
+
+Projects to add in the composition (comma delimited)
+
+### useExistingPorts
+
+Default: `false`
+
+Type: `boolean`
+
+If false, the Storybook ports in workspace.json/angular.json will be overwritten. If true, the Storybook ports in workspace.json/angular.json will not be overwritten and Storybook Composition will use ordinal numbers to name your instances.

--- a/docs/react/guides/storybook/storybook-composition.md
+++ b/docs/react/guides/storybook/storybook-composition.md
@@ -1,0 +1,174 @@
+# Using Storybook Composition with Nx
+
+## What is Storybook Compotision
+
+As explained in the [Storybook official docs](https://storybook.js.org/docs/angular/workflows/storybook-composition), Storybook Composition allows you to embed components from any Storybook inside your local Storybook. If you want to learn more about Storybook Composition, please take a look at the following articles, which explain it in detail:
+
+- [Storybook Composition - Chromatic blog](https://www.chromatic.com/blog/storybook-composition/)
+- [Storybook Composition - Storybook docs](https://storybook.js.org/docs/angular/workflows/storybook-composition)
+
+## How it works
+
+In essence, you have a Storybook running, which will be the host of the embeded Storybooks as well. Then, you provide this "host" Storybook with a URL of a live/running Storybook. The composed Storybook is then displayed in a new Canvas iframe as part of the host Storybook, and is listed on the left-hand-side stories inventory, too. You can read more about this in the docs listed above.
+
+## How to use it
+
+All you need is a URL of a live Storybook, and a "host" Storybook. In the `.storybook/main.js` file of the "host" Storybook, inside `module.exports` you add a new `refs` attribute, which will contain the link(s) for the composed Storybook(s).
+
+In the example below, we have a host Storybook running on local port 4400 (http://localhost:4400) - not displayed here. In it, we want to compose three other Storybooks. The "one-composed" and "two-composed", running on local ports `4401` and `4402` accordingly, as well as the [Storybook website's Storybook](https://next--storybookjs.netlify.app/official-storybook) which is live on the address that you see.
+
+```
+// .storybook/main.js of our Host Storybook - supposably running on port 4400
+
+module.exports = {
+  ...,
+  refs: {
+    'one-composed': {
+      title: 'One composed',
+      url: 'http://localhost:4401',
+    },
+    'two-composed': {
+      title: 'Two composed',
+      url: 'http://localhost:4402',
+    },
+    'storybook-website-storybook': {
+      title: 'The Storybook of the Storybook website',
+      url: 'https://next--storybookjs.netlify.app/official-storybook/',
+    },
+  },
+};
+```
+
+You can always read more in the [official Storybook docs](https://storybook.js.org/docs/angular/workflows/storybook-composition#compose-published-storybooks).
+
+## How to use it in Nx
+
+It's quite easy to use this feature, in Nx and in general, since you do not need to make any code changes, you just need to have the "composed" Storybook instances (the ones you need to "compose") running, choose a "host" Storybook, and just add the composed Storybooks in it's `.storybook/main.js` file.
+
+Nx provides the [`run-many`](https://nx.dev/l/a/cli/run-many) command, which will allow you to easily run multiple Storybooks at the same time. You need to run the `run-many`
+command with the parallel flag set to true `--parallel=true`, because you want to run all your Storybooks in parallel. Since the default amount of parallel activities that you can run
+is set to `3`, you can adjust this command to be of as many Storybooks you want to run in parallel as you need. However, be **very carefull** with putting large numbers in this
+flag, since it can cause big delays or get stuck. You can play around and adjust that number to one your machine runs comfortably with. Keep in mind that you can add in this feature however many live/public Storybooks as you need (Storybooks that you do not run locally).
+
+You can just do:
+
+```
+nx run-many --target=storybook --projects=main-host,one-composed,two-composed,three-composed --parallel=true --maxParallel=4
+```
+
+Before running the above command to actually compose our Storybook instances under the **`main-host`** project, we would need to do the following adjustments to our workspace:
+
+### Adjust the Storybook ports in `project.json`
+
+Take a look in your `project.json` file of each one of your projects (eg. for the `main-host` project, you can find it in the path `apps/main-host/project.json`).
+In your project's targets, in the `storybook` target, you will notice that the default port that Nx assigns to your projects' Storybook is always `4400`:
+
+```
+{
+  ...
+  "targets": {
+    ...
+    "storybook": {
+      ...
+      "options": {
+        ...
+        "port": 4400,
+        ...
+      },
+      ...
+    },
+    ...
+`  },
+}
+```
+
+We can keep this port for the project which will serve as the host of our configuration, but we must change the port numbers of the other projects, the projects which will be composed/composed. The reason for that is the following:
+
+- When the `nx run-many --target=storybook --parallel=true` command executes, it will go and look into your `project.json` file to see the port you have assigned for that project's Storybook.
+- When it finds a port that it is already used, it will change the port number randomly (usually adding `1` until it finds an empty port).
+
+Since we are using the `--parallel=true`, and the commands are executed in parallel, we cannot know for sure the order that the `storybook` command will be executed. So, we cannot be sure which port will correspond to which of the projects.
+
+If we don't change the port numbers, and there are projects that want to use the same port for their Storybooks, the `run-many` command will change that port, and the result will be that we will not know for sure which
+of our projects runs on which port. The problem that this creates is that we will not be able to create the proper configuration for Storybook Composition, since we will not be able to tell which URLs our composed Storybooks run on.
+
+### Add the refs in our host project's `.storybook/main.js` file
+
+Now, we need to add to our host project's `main.js` file (the path of which would be `apps/main-host/.storybook/main.js`) a `refs` object, to configure our composition. An example of such a configuration looks like this:
+
+```
+module.exports = {
+  ...,
+  refs: {
+    one-composed: {
+      title: 'One composed',
+      url: 'http://localhost:4401',
+    },
+    two-composed: {
+      title: 'Two composed',
+      url: 'http://localhost:4402',
+    },
+    three-composed: {
+      title: 'Three composed',
+      url: 'http://localhost:4403',
+    },
+  },
+};
+```
+
+## Storybook Composition generator
+
+You can use the `@nrwl/storybook:composition` generator to make the above process even easier, so that you do not have to think about ports and settings.
+
+### How to use it
+
+Just execute the following in your terminal, and let the promts guide you:
+
+```
+nx generate @nrwl/storybook:composition
+```
+
+Read the docs for this command [here]().
+
+### Options
+
+- `mainProject`: It lets you set the "host" project. It's required.
+
+- `projects`: It lets you provide a list of composed projects
+
+- `useExistingPorts`: If false, it will _change_ the Storybook ports in the chosen projects of your project's `project.json` file, and then use these ports in the `mainProject`'s `.storybook/main.js`, to make sure the
+  projects correspond to the ports. This is equivalent to the "manual" process described above. If true, the ports will be assigned automatically by the `run-many` command, and the generator will only change your `.storybook/main.js` file, however, if two or more Storybooks are assigned to the same port, you will not be able to use composition successfully. You will have to manually change the ports yourself.
+
+- `all`: It will execute the process for all your projects.
+
+### What this generator does
+
+1. It edits the `mainProject`'s `.storybook/main.js` file, according to the options passed in the command. Each time you run it, it will _overwrite_ your `refs` object inside the `mainProject`'s `.storybook/main.js` file with the new options that you pass.
+
+2. If `useExistingPorts` is **not** set (or set to `false`), it _changes_ the ports for Storybook in the projects that you choose in each of your composed projects `project.json` files.
+
+3. If `useExistingPorts` is **not** set (or set to `false`), it edits your project's `e2e` Cypress base URL, to match the new URL set in each project's `project.json` file.
+
+4. It prompts you with the `storybook-composition` executor command that you can copy and run in your terminal, to run your Storybook composition.
+
+### Easiest way to take advantage of this generator
+
+Chances are you will not care about your project's `project.json` Storybook ports changing. Also, chances are you will not care about your main host project's `.storybook/main.js` `refs` object being overwritten.
+So, to try this out quickly, you can do the following:
+
+```
+nx g @nrwl/storybook:composition --mainProject=<YOUR_HOST_PROJECT> --all
+```
+
+### Who this generator is for
+
+This generator is for the developer who wants to see things working locally, and play around with the Storybook Composition feature, see how it works, explore its capabilities.
+
+### Who this generator is _not_ for
+
+If you are an advanced user and you want to link public projects in your published Storybooks, this generator is _not_ for you. You can use the guide above to manually add your public URLs to your host project's `.storybook/main.js` file(s).
+
+### I already have a Storybook composition setup
+
+If you already have a Storybook composition setup and you want to try this generator, do so, but choose as the `mainProject` another "host" project, and not the one you already have a Composition setup for. The reason is that this generator will
+go and overwrite the `refs` object in the main host's project `.storybook/main.js` file.

--- a/packages/storybook/executors.json
+++ b/packages/storybook/executors.json
@@ -9,6 +9,11 @@
       "implementation": "./src/executors/build-storybook/compat",
       "schema": "./src/executors/build-storybook/schema.json",
       "description": "Build Storybook"
+    },
+    "composition": {
+      "implementation": "./src/executors/composition/compat",
+      "schema": "./src/executors/composition/schema.json",
+      "description": "Compose Storybooks"
     }
   },
   "executors": {
@@ -21,6 +26,11 @@
       "implementation": "./src/executors/build-storybook/build-storybook.impl",
       "schema": "./src/executors/build-storybook/schema.json",
       "description": "Build Storybook"
+    },
+    "composition": {
+      "implementation": "./src/executors/composition/composition.impl",
+      "schema": "./src/executors/composition/schema.json",
+      "description": "Compose Storybooks"
     }
   }
 }

--- a/packages/storybook/generators.json
+++ b/packages/storybook/generators.json
@@ -32,6 +32,12 @@
       "schema": "./src/generators/migrate-stories-to-6-2/schema.json",
       "description": "Migrate stories syntax to 6.2",
       "hidden": false
+    },
+    "composition": {
+      "factory": "./src/generators/composition/composition#compositionSchematic",
+      "schema": "./src/generators/composition/schema.json",
+      "description": "Generate Storybook composition setup.",
+      "hidden": false
     }
   },
   "generators": {
@@ -64,6 +70,12 @@
       "factory": "./src/generators/migrate-stories-to-6-2/migrate-stories-to-6-2",
       "schema": "./src/generators/migrate-stories-to-6-2/schema.json",
       "description": "Generate default Storybook configuration files using Storybook version >=6.x specs, for projects that already have Storybook instances and configurations of versions <6.x.",
+      "hidden": false
+    },
+    "composition": {
+      "factory": "./src/generators/composition/composition",
+      "schema": "./src/generators/composition/schema.json",
+      "description": "Generate Storybook composition setup.",
       "hidden": false
     }
   }

--- a/packages/storybook/index.ts
+++ b/packages/storybook/index.ts
@@ -2,4 +2,5 @@ export { configurationGenerator } from './src/generators/configuration/configura
 export { cypressProjectGenerator } from './src/generators/cypress-project/cypress-project';
 export { migrateDefaultsGenerator } from './src/generators/migrate-defaults-5-to-6/migrate-defaults-5-to-6';
 export { migrateStoriesTo62Generator } from './src/generators/migrate-stories-to-6-2/migrate-stories-to-6-2';
+export { compositionGenerator } from './src/generators/composition/composition';
 export { storybookVersion } from './src/utils/versions';

--- a/packages/storybook/src/executors/composition/compat.ts
+++ b/packages/storybook/src/executors/composition/compat.ts
@@ -1,0 +1,4 @@
+import { convertNxExecutor } from '@nrwl/devkit';
+import { storybookCompositionExecutor } from './composition.impl';
+
+export default convertNxExecutor(storybookCompositionExecutor);

--- a/packages/storybook/src/executors/composition/composition-functions.ts
+++ b/packages/storybook/src/executors/composition/composition-functions.ts
@@ -1,0 +1,108 @@
+import { findNodes } from '@nrwl/workspace/src/utilities/typescript/find-nodes';
+import ts = require('typescript');
+
+export function thereAreProjectsWithConflictingPorts(
+  ports: number[],
+  mainProjectPort: number
+) {
+  ports.push(mainProjectPort);
+  const uniquePorts = [...new Set(ports)];
+  return uniquePorts.length !== ports.length;
+}
+
+export function getProjectNamesAndPorts(
+  mainJsFile: string,
+  mainJsPath: string
+): { [key: string]: number } | undefined {
+  const file = getTsSourceFileFromString(mainJsFile, mainJsPath);
+  const moduleExportsFull = findNodes(file, [
+    ts.SyntaxKind.ExpressionStatement,
+  ]);
+
+  if (!(moduleExportsFull && moduleExportsFull[0])) {
+    return;
+  }
+  const moduleExports = moduleExportsFull[0];
+  const listOfStatements = findNodes(moduleExports, [ts.SyntaxKind.SyntaxList]);
+
+  let indexOfFirstNode = -1;
+
+  const hasRefsObject = listOfStatements[0]?.getChildren()?.find((node) => {
+    if (node && node.getText().length > 0 && indexOfFirstNode < 0) {
+      indexOfFirstNode = node.getStart();
+    }
+    return (
+      node.kind === ts.SyntaxKind.PropertyAssignment &&
+      node.getText().startsWith('refs')
+    );
+  });
+
+  if (!hasRefsObject) {
+    return;
+  }
+
+  const getObjectLiteralFromRefsObject = findNodes(hasRefsObject, [
+    ts.SyntaxKind.ObjectLiteralExpression,
+  ]);
+
+  if (!(getObjectLiteralFromRefsObject && getObjectLiteralFromRefsObject[0])) {
+    return;
+  }
+
+  const projectPortsByName = {};
+  let activeProjectName = '';
+  getObjectLiteralFromRefsObject[0].forEachChild((node) => {
+    node.forEachChild((childNode) => {
+      if (childNode.kind === ts.SyntaxKind.Identifier) {
+        activeProjectName = childNode.getText();
+      }
+      if (childNode.kind === ts.SyntaxKind.ObjectLiteralExpression) {
+        if (
+          childNode.getText().includes('title:') &&
+          childNode.getText().includes('url:')
+        ) {
+          childNode.forEachChild((grandchildNode) => {
+            if (
+              grandchildNode.kind === ts.SyntaxKind.PropertyAssignment &&
+              grandchildNode.getText().startsWith('url:')
+            ) {
+              grandchildNode.forEachChild((greatGrandchildNode) => {
+                if (
+                  greatGrandchildNode.kind === ts.SyntaxKind.StringLiteral &&
+                  greatGrandchildNode.getText().includes(`localhost:`)
+                ) {
+                  const addressParts = greatGrandchildNode
+                    .getText()
+                    .replace(`'`, '')
+                    .split(':');
+                  const port = addressParts.find(
+                    (part) =>
+                      typeof parseInt(part) === 'number' && parseInt(part) > 0
+                  );
+                  if (port) {
+                    projectPortsByName[activeProjectName] = parseInt(port);
+                  }
+                }
+              });
+            }
+          });
+        }
+      }
+    });
+  });
+
+  return projectPortsByName;
+}
+
+export function getTsSourceFileFromString(
+  fileContents: string,
+  path: string
+): ts.SourceFile {
+  const source = ts.createSourceFile(
+    path,
+    fileContents,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  return source;
+}

--- a/packages/storybook/src/executors/composition/composition.impl.spec.ts
+++ b/packages/storybook/src/executors/composition/composition.impl.spec.ts
@@ -1,0 +1,12 @@
+import { ExecutorContext } from '@nrwl/devkit';
+
+import {
+  StorybookCompositionOptions,
+  storybookCompositionExecutor,
+} from './composition.impl';
+
+describe('@nrwl/storybook:composition', () => {
+  let context: ExecutorContext;
+  let options: StorybookCompositionOptions;
+  beforeEach(() => {});
+});

--- a/packages/storybook/src/executors/composition/composition.impl.ts
+++ b/packages/storybook/src/executors/composition/composition.impl.ts
@@ -1,0 +1,39 @@
+import 'dotenv/config';
+
+import { ExecutorContext, logger } from '@nrwl/devkit';
+import type { ProjectConfiguration, Tree } from '@nrwl/devkit';
+
+export interface StorybookCompositionOptions {}
+
+export default async function* storybookExecutor(
+  options: StorybookCompositionOptions,
+  context: ExecutorContext
+) {
+  yield { success: true };
+  const sourceRoot = context.workspace.projects[context.projectName].root;
+
+  /**
+   * Somehow read the main.js file and get the refs object
+   *
+   * then, from the refs object, get the project names
+   */
+
+  const projectNames = [];
+
+  await runInstance(projectNames);
+  // This Promise intentionally never resolves, leaving the process running
+  await new Promise<{ success: boolean }>(() => {});
+}
+
+function runInstance(projectNames: string[]) {
+  const env = process.env.NODE_ENV ?? 'development';
+  process.env.NODE_ENV = env;
+
+  /**
+   *
+   * Write here a command where it runs in parallel all my Storybooks in Storybook composition
+   *
+   * Also, make sure there are no conflicting ports, if there are throw error
+   *
+   */
+}

--- a/packages/storybook/src/executors/composition/composition.impl.ts
+++ b/packages/storybook/src/executors/composition/composition.impl.ts
@@ -1,39 +1,130 @@
 import 'dotenv/config';
 
-import { ExecutorContext, logger } from '@nrwl/devkit';
-import type { ProjectConfiguration, Tree } from '@nrwl/devkit';
+import { ExecutorContext, logger, ProjectConfiguration } from '@nrwl/devkit';
+import { readFileIfExisting } from '@nrwl/workspace/src/core/file-utils';
+import {
+  getProjectNamesAndPorts,
+  thereAreProjectsWithConflictingPorts,
+} from './composition-functions';
+import storybookExecutor from '../storybook/storybook.impl';
 
-export interface StorybookCompositionOptions {}
-
-export default async function* storybookExecutor(
-  options: StorybookCompositionOptions,
+export default async function* storybookCompositionExecutor(
+  options: {},
   context: ExecutorContext
 ) {
-  yield { success: true };
-  const sourceRoot = context.workspace.projects[context.projectName].root;
+  const projectConfiguration: ProjectConfiguration =
+    context.workspace.projects[context.projectName];
 
-  /**
-   * Somehow read the main.js file and get the refs object
-   *
-   * then, from the refs object, get the project names
-   */
+  if (
+    !projectConfiguration?.targets?.storybook?.options?.port ||
+    !projectConfiguration?.targets?.storybook?.options?.config?.configFolder
+  ) {
+    logger.error(`Project ${context.projectName} does not exist, or does not have a valid Storybook configuration.
+        Please try again, and provide a valid project name.`);
+    return;
+  }
 
-  const projectNames = [];
+  const mainProjectPort = projectConfiguration.targets.storybook.options.port;
+  const mainProjectStorybookFolderPath =
+    projectConfiguration.targets.storybook.options.config.configFolder;
 
-  await runInstance(projectNames);
+  const mainJsFile = readFileIfExisting(
+    `${mainProjectStorybookFolderPath}/main.js`
+  );
+
+  const projectPortsByName = getProjectNamesAndPorts(
+    mainJsFile,
+    `${mainProjectStorybookFolderPath}/main.js`
+  );
+  const projectNames = Object.keys(projectPortsByName);
+  const projectPorts = Object.values(projectPortsByName);
+
+  if (!projectNames || !projectPorts) {
+    logger.error(`Project ${context.projectName} does not have a valid Storybook configuration.
+        Please try again, and provide a valid project name.`);
+    return;
+  }
+
+  if (thereAreProjectsWithConflictingPorts(projectPorts, mainProjectPort)) {
+    logger.error(
+      `There are conflicting ports in the Storybook composition. Please, make sure there are no conflicting ports and try running the executor again.`
+    );
+    return;
+  }
+
+  logger.info(
+    `You are now running Storybook Composition using ${context.projectName} as host. 
+    
+    You can see your Storybook composition on
+
+    http://localhost:${mainProjectPort}`
+  );
+
+  // Storybook Executor for main project
+  const mainProjectUiFramework =
+    projectConfiguration.targets.storybook.options.uiFramework;
+  const mainProjectConfig =
+    projectConfiguration.targets.storybook.options.config;
+  const mainProjectStorybookConfigurations =
+    projectConfiguration.targets.storybook.configurations;
+
+  storybookExecutor(
+    {
+      port: mainProjectPort,
+      uiFramework: mainProjectUiFramework,
+      config: mainProjectConfig,
+    },
+    {
+      ...context,
+      projectName: context.projectName,
+      targetName: 'storybook',
+      target: {
+        executor: '@nrwl/storybook:storybook',
+        options: {
+          uiFramework: mainProjectUiFramework,
+          port: mainProjectPort,
+          config: mainProjectConfig,
+        },
+        configurations: mainProjectStorybookConfigurations,
+      },
+    }
+  );
+
+  // Storybook Executor for other projects
+  projectNames.forEach((projectName) => {
+    const composedProjectConfiguration: ProjectConfiguration =
+      context.workspace.projects[projectName];
+    const composedProjectPort = projectPortsByName[projectName];
+    const composedProjectUiFramework =
+      composedProjectConfiguration.targets.storybook.options.uiFramework;
+    const composedProjectConfig =
+      composedProjectConfiguration.targets.storybook.options.config;
+    const composedProjectStorybookConfigurations =
+      composedProjectConfiguration.targets.storybook.configurations;
+
+    storybookExecutor(
+      {
+        port: composedProjectPort,
+        uiFramework: composedProjectUiFramework,
+        config: composedProjectConfig,
+      },
+      {
+        ...context,
+        projectName: projectName,
+        targetName: 'storybook',
+        target: {
+          executor: '@nrwl/storybook:storybook',
+          options: {
+            uiFramework: composedProjectUiFramework,
+            port: composedProjectPort,
+            config: composedProjectConfig,
+          },
+          configurations: composedProjectStorybookConfigurations,
+        },
+      }
+    );
+  });
+
   // This Promise intentionally never resolves, leaving the process running
   await new Promise<{ success: boolean }>(() => {});
-}
-
-function runInstance(projectNames: string[]) {
-  const env = process.env.NODE_ENV ?? 'development';
-  process.env.NODE_ENV = env;
-
-  /**
-   *
-   * Write here a command where it runs in parallel all my Storybooks in Storybook composition
-   *
-   * Also, make sure there are no conflicting ports, if there are throw error
-   *
-   */
 }

--- a/packages/storybook/src/executors/composition/schema.json
+++ b/packages/storybook/src/executors/composition/schema.json
@@ -1,0 +1,7 @@
+{
+  "title": "Storybook Composition",
+  "cli": "nx",
+  "description": "Compose Storybooks and serve them",
+  "type": "object",
+  "properties": {}
+}

--- a/packages/storybook/src/generators/composition/__snapshots__/composition.spec.ts.snap
+++ b/packages/storybook/src/generators/composition/__snapshots__/composition.spec.ts.snap
@@ -1,0 +1,1303 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`composition generator should change the ports on workspace.json if useExistingPorts is false and update the main project's main.js accordingly 1`] = `
+"const rootMain = require('../../../.storybook/main');
+
+
+module.exports = {
+  refs: {\\"test-ui-one\\":{\\"title\\":\\"test-ui-one\\",\\"url\\":\\"http://localhost:4401\\"},\\"test-ui-three\\":{\\"title\\":\\"test-ui-three\\",\\"url\\":\\"http://localhost:4402\\"},\\"test-ui-two\\":{\\"title\\":\\"test-ui-two\\",\\"url\\":\\"http://localhost:4403\\"}},...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+  stories: [
+    ...rootMain.stories,
+    '../src/lib/**/*.stories.mdx',
+    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' ],
+  webpackFinal: async (config, { configType }) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.js
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType });
+    }
+    
+    
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+"
+`;
+
+exports[`composition generator should change the ports on workspace.json if useExistingPorts is false and update the main project's main.js accordingly 2`] = `
+"{
+  \\"version\\": 1,
+  \\"projects\\": {
+    \\"main-host-lib\\": {
+      \\"root\\": \\"libs/main-host-lib\\",
+      \\"sourceRoot\\": \\"libs/main-host-lib/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/main-host-lib/**/*.ts\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/jest:jest\\",
+          \\"outputs\\": [
+            \\"coverage/libs/main-host-lib\\"
+          ],
+          \\"options\\": {
+            \\"jestConfig\\": \\"libs/main-host-lib/jest.config.js\\",
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:storybook\\",
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"port\\": 4400,
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/main-host-lib/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"build-storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"outputPath\\": \\"dist/storybook/main-host-lib\\",
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/main-host-lib/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"storybook-composition\\": {
+          \\"builder\\": \\"@nrwl/storybook:composition\\",
+          \\"options\\": {
+            \\"projects\\": \\"test-ui-one,test-ui-three,test-ui-two\\"
+          }
+        }
+      },
+      \\"tags\\": []
+    },
+    \\"main-host-lib-e2e\\": {
+      \\"root\\": \\"apps/main-host-lib-e2e\\",
+      \\"sourceRoot\\": \\"apps/main-host-lib-e2e/src\\",
+      \\"projectType\\": \\"application\\",
+      \\"architect\\": {
+        \\"e2e\\": {
+          \\"builder\\": \\"@nrwl/cypress:cypress\\",
+          \\"options\\": {
+            \\"cypressConfig\\": \\"apps/main-host-lib-e2e/cypress.json\\",
+            \\"devServerTarget\\": \\"main-host-lib:storybook\\"
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"devServerTarget\\": \\"main-host-lib:storybook:ci\\"
+            }
+          }
+        },
+        \\"lint\\": {
+          \\"builder\\": \\"@angular-devkit/build-angular:tslint\\",
+          \\"options\\": {
+            \\"tsConfig\\": [
+              \\"apps/main-host-lib-e2e/tsconfig.json\\"
+            ],
+            \\"exclude\\": [
+              \\"**/node_modules/**\\",
+              \\"!apps/main-host-lib-e2e/**/*\\"
+            ]
+          }
+        }
+      },
+      \\"tags\\": [],
+      \\"implicitDependencies\\": [
+        \\"main-host-lib\\"
+      ]
+    },
+    \\"test-ui-one\\": {
+      \\"root\\": \\"libs/test-ui-one\\",
+      \\"sourceRoot\\": \\"libs/test-ui-one/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/test-ui-one/**/*.ts\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/jest:jest\\",
+          \\"outputs\\": [
+            \\"coverage/libs/test-ui-one\\"
+          ],
+          \\"options\\": {
+            \\"jestConfig\\": \\"libs/test-ui-one/jest.config.js\\",
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:storybook\\",
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"port\\": 4401,
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-one/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"build-storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"outputPath\\": \\"dist/storybook/test-ui-one\\",
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-one/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        }
+      },
+      \\"tags\\": []
+    },
+    \\"test-ui-one-e2e\\": {
+      \\"root\\": \\"apps/test-ui-one-e2e\\",
+      \\"sourceRoot\\": \\"apps/test-ui-one-e2e/src\\",
+      \\"projectType\\": \\"application\\",
+      \\"architect\\": {
+        \\"e2e\\": {
+          \\"builder\\": \\"@nrwl/cypress:cypress\\",
+          \\"options\\": {
+            \\"cypressConfig\\": \\"apps/test-ui-one-e2e/cypress.json\\",
+            \\"devServerTarget\\": \\"test-ui-one:storybook\\"
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"devServerTarget\\": \\"test-ui-one:storybook:ci\\"
+            }
+          }
+        },
+        \\"lint\\": {
+          \\"builder\\": \\"@angular-devkit/build-angular:tslint\\",
+          \\"options\\": {
+            \\"tsConfig\\": [
+              \\"apps/test-ui-one-e2e/tsconfig.json\\"
+            ],
+            \\"exclude\\": [
+              \\"**/node_modules/**\\",
+              \\"!apps/test-ui-one-e2e/**/*\\"
+            ]
+          }
+        }
+      },
+      \\"tags\\": [],
+      \\"implicitDependencies\\": [
+        \\"test-ui-one\\"
+      ]
+    },
+    \\"test-ui-three\\": {
+      \\"root\\": \\"libs/test-ui-three\\",
+      \\"sourceRoot\\": \\"libs/test-ui-three/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/test-ui-three/**/*.ts\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/jest:jest\\",
+          \\"outputs\\": [
+            \\"coverage/libs/test-ui-three\\"
+          ],
+          \\"options\\": {
+            \\"jestConfig\\": \\"libs/test-ui-three/jest.config.js\\",
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:storybook\\",
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"port\\": 4402,
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-three/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"build-storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"outputPath\\": \\"dist/storybook/test-ui-three\\",
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-three/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        }
+      },
+      \\"tags\\": []
+    },
+    \\"test-ui-three-e2e\\": {
+      \\"root\\": \\"apps/test-ui-three-e2e\\",
+      \\"sourceRoot\\": \\"apps/test-ui-three-e2e/src\\",
+      \\"projectType\\": \\"application\\",
+      \\"architect\\": {
+        \\"e2e\\": {
+          \\"builder\\": \\"@nrwl/cypress:cypress\\",
+          \\"options\\": {
+            \\"cypressConfig\\": \\"apps/test-ui-three-e2e/cypress.json\\",
+            \\"devServerTarget\\": \\"test-ui-three:storybook\\"
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"devServerTarget\\": \\"test-ui-three:storybook:ci\\"
+            }
+          }
+        },
+        \\"lint\\": {
+          \\"builder\\": \\"@angular-devkit/build-angular:tslint\\",
+          \\"options\\": {
+            \\"tsConfig\\": [
+              \\"apps/test-ui-three-e2e/tsconfig.json\\"
+            ],
+            \\"exclude\\": [
+              \\"**/node_modules/**\\",
+              \\"!apps/test-ui-three-e2e/**/*\\"
+            ]
+          }
+        }
+      },
+      \\"tags\\": [],
+      \\"implicitDependencies\\": [
+        \\"test-ui-three\\"
+      ]
+    },
+    \\"test-ui-two\\": {
+      \\"root\\": \\"libs/test-ui-two\\",
+      \\"sourceRoot\\": \\"libs/test-ui-two/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/test-ui-two/**/*.ts\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/jest:jest\\",
+          \\"outputs\\": [
+            \\"coverage/libs/test-ui-two\\"
+          ],
+          \\"options\\": {
+            \\"jestConfig\\": \\"libs/test-ui-two/jest.config.js\\",
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:storybook\\",
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"port\\": 4403,
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-two/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"build-storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"outputPath\\": \\"dist/storybook/test-ui-two\\",
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-two/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        }
+      },
+      \\"tags\\": []
+    },
+    \\"test-ui-two-e2e\\": {
+      \\"root\\": \\"apps/test-ui-two-e2e\\",
+      \\"sourceRoot\\": \\"apps/test-ui-two-e2e/src\\",
+      \\"projectType\\": \\"application\\",
+      \\"architect\\": {
+        \\"e2e\\": {
+          \\"builder\\": \\"@nrwl/cypress:cypress\\",
+          \\"options\\": {
+            \\"cypressConfig\\": \\"apps/test-ui-two-e2e/cypress.json\\",
+            \\"devServerTarget\\": \\"test-ui-two:storybook\\"
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"devServerTarget\\": \\"test-ui-two:storybook:ci\\"
+            }
+          }
+        },
+        \\"lint\\": {
+          \\"builder\\": \\"@angular-devkit/build-angular:tslint\\",
+          \\"options\\": {
+            \\"tsConfig\\": [
+              \\"apps/test-ui-two-e2e/tsconfig.json\\"
+            ],
+            \\"exclude\\": [
+              \\"**/node_modules/**\\",
+              \\"!apps/test-ui-two-e2e/**/*\\"
+            ]
+          }
+        }
+      },
+      \\"tags\\": [],
+      \\"implicitDependencies\\": [
+        \\"test-ui-two\\"
+      ]
+    }
+  }
+}
+"
+`;
+
+exports[`composition generator should not change ports on workspace.json if useExistingPorts is true and update the main project's main.js accordingly 1`] = `
+"const rootMain = require('../../../.storybook/main');
+
+
+module.exports = {
+  refs: {\\"test-ui-one\\":{\\"title\\":\\"test-ui-one\\",\\"url\\":\\"http://localhost:4400\\"},\\"test-ui-three\\":{\\"title\\":\\"test-ui-three\\",\\"url\\":\\"http://localhost:4400\\"},\\"test-ui-two\\":{\\"title\\":\\"test-ui-two\\",\\"url\\":\\"http://localhost:4400\\"}},...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+  stories: [
+    ...rootMain.stories,
+    '../src/lib/**/*.stories.mdx',
+    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' ],
+  webpackFinal: async (config, { configType }) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.js
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType });
+    }
+    
+    
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+"
+`;
+
+exports[`composition generator should not change ports on workspace.json if useExistingPorts is true and update the main project's main.js accordingly 2`] = `
+"{
+  \\"version\\": 1,
+  \\"projects\\": {
+    \\"main-host-lib\\": {
+      \\"root\\": \\"libs/main-host-lib\\",
+      \\"sourceRoot\\": \\"libs/main-host-lib/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/main-host-lib/**/*.ts\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/jest:jest\\",
+          \\"outputs\\": [
+            \\"coverage/libs/main-host-lib\\"
+          ],
+          \\"options\\": {
+            \\"jestConfig\\": \\"libs/main-host-lib/jest.config.js\\",
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:storybook\\",
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"port\\": 4400,
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/main-host-lib/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"build-storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"outputPath\\": \\"dist/storybook/main-host-lib\\",
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/main-host-lib/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"storybook-composition\\": {
+          \\"builder\\": \\"@nrwl/storybook:composition\\",
+          \\"options\\": {
+            \\"projects\\": \\"test-ui-one,test-ui-three,test-ui-two\\"
+          }
+        }
+      },
+      \\"tags\\": []
+    },
+    \\"main-host-lib-e2e\\": {
+      \\"root\\": \\"apps/main-host-lib-e2e\\",
+      \\"sourceRoot\\": \\"apps/main-host-lib-e2e/src\\",
+      \\"projectType\\": \\"application\\",
+      \\"architect\\": {
+        \\"e2e\\": {
+          \\"builder\\": \\"@nrwl/cypress:cypress\\",
+          \\"options\\": {
+            \\"cypressConfig\\": \\"apps/main-host-lib-e2e/cypress.json\\",
+            \\"devServerTarget\\": \\"main-host-lib:storybook\\"
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"devServerTarget\\": \\"main-host-lib:storybook:ci\\"
+            }
+          }
+        },
+        \\"lint\\": {
+          \\"builder\\": \\"@angular-devkit/build-angular:tslint\\",
+          \\"options\\": {
+            \\"tsConfig\\": [
+              \\"apps/main-host-lib-e2e/tsconfig.json\\"
+            ],
+            \\"exclude\\": [
+              \\"**/node_modules/**\\",
+              \\"!apps/main-host-lib-e2e/**/*\\"
+            ]
+          }
+        }
+      },
+      \\"tags\\": [],
+      \\"implicitDependencies\\": [
+        \\"main-host-lib\\"
+      ]
+    },
+    \\"test-ui-one\\": {
+      \\"root\\": \\"libs/test-ui-one\\",
+      \\"sourceRoot\\": \\"libs/test-ui-one/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/test-ui-one/**/*.ts\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/jest:jest\\",
+          \\"outputs\\": [
+            \\"coverage/libs/test-ui-one\\"
+          ],
+          \\"options\\": {
+            \\"jestConfig\\": \\"libs/test-ui-one/jest.config.js\\",
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:storybook\\",
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"port\\": 4400,
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-one/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"build-storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"outputPath\\": \\"dist/storybook/test-ui-one\\",
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-one/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        }
+      },
+      \\"tags\\": []
+    },
+    \\"test-ui-one-e2e\\": {
+      \\"root\\": \\"apps/test-ui-one-e2e\\",
+      \\"sourceRoot\\": \\"apps/test-ui-one-e2e/src\\",
+      \\"projectType\\": \\"application\\",
+      \\"architect\\": {
+        \\"e2e\\": {
+          \\"builder\\": \\"@nrwl/cypress:cypress\\",
+          \\"options\\": {
+            \\"cypressConfig\\": \\"apps/test-ui-one-e2e/cypress.json\\",
+            \\"devServerTarget\\": \\"test-ui-one:storybook\\"
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"devServerTarget\\": \\"test-ui-one:storybook:ci\\"
+            }
+          }
+        },
+        \\"lint\\": {
+          \\"builder\\": \\"@angular-devkit/build-angular:tslint\\",
+          \\"options\\": {
+            \\"tsConfig\\": [
+              \\"apps/test-ui-one-e2e/tsconfig.json\\"
+            ],
+            \\"exclude\\": [
+              \\"**/node_modules/**\\",
+              \\"!apps/test-ui-one-e2e/**/*\\"
+            ]
+          }
+        }
+      },
+      \\"tags\\": [],
+      \\"implicitDependencies\\": [
+        \\"test-ui-one\\"
+      ]
+    },
+    \\"test-ui-three\\": {
+      \\"root\\": \\"libs/test-ui-three\\",
+      \\"sourceRoot\\": \\"libs/test-ui-three/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/test-ui-three/**/*.ts\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/jest:jest\\",
+          \\"outputs\\": [
+            \\"coverage/libs/test-ui-three\\"
+          ],
+          \\"options\\": {
+            \\"jestConfig\\": \\"libs/test-ui-three/jest.config.js\\",
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:storybook\\",
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"port\\": 4400,
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-three/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"build-storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"outputPath\\": \\"dist/storybook/test-ui-three\\",
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-three/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        }
+      },
+      \\"tags\\": []
+    },
+    \\"test-ui-three-e2e\\": {
+      \\"root\\": \\"apps/test-ui-three-e2e\\",
+      \\"sourceRoot\\": \\"apps/test-ui-three-e2e/src\\",
+      \\"projectType\\": \\"application\\",
+      \\"architect\\": {
+        \\"e2e\\": {
+          \\"builder\\": \\"@nrwl/cypress:cypress\\",
+          \\"options\\": {
+            \\"cypressConfig\\": \\"apps/test-ui-three-e2e/cypress.json\\",
+            \\"devServerTarget\\": \\"test-ui-three:storybook\\"
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"devServerTarget\\": \\"test-ui-three:storybook:ci\\"
+            }
+          }
+        },
+        \\"lint\\": {
+          \\"builder\\": \\"@angular-devkit/build-angular:tslint\\",
+          \\"options\\": {
+            \\"tsConfig\\": [
+              \\"apps/test-ui-three-e2e/tsconfig.json\\"
+            ],
+            \\"exclude\\": [
+              \\"**/node_modules/**\\",
+              \\"!apps/test-ui-three-e2e/**/*\\"
+            ]
+          }
+        }
+      },
+      \\"tags\\": [],
+      \\"implicitDependencies\\": [
+        \\"test-ui-three\\"
+      ]
+    },
+    \\"test-ui-two\\": {
+      \\"root\\": \\"libs/test-ui-two\\",
+      \\"sourceRoot\\": \\"libs/test-ui-two/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/test-ui-two/**/*.ts\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/jest:jest\\",
+          \\"outputs\\": [
+            \\"coverage/libs/test-ui-two\\"
+          ],
+          \\"options\\": {
+            \\"jestConfig\\": \\"libs/test-ui-two/jest.config.js\\",
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:storybook\\",
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"port\\": 4400,
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-two/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"build-storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"outputPath\\": \\"dist/storybook/test-ui-two\\",
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-two/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        }
+      },
+      \\"tags\\": []
+    },
+    \\"test-ui-two-e2e\\": {
+      \\"root\\": \\"apps/test-ui-two-e2e\\",
+      \\"sourceRoot\\": \\"apps/test-ui-two-e2e/src\\",
+      \\"projectType\\": \\"application\\",
+      \\"architect\\": {
+        \\"e2e\\": {
+          \\"builder\\": \\"@nrwl/cypress:cypress\\",
+          \\"options\\": {
+            \\"cypressConfig\\": \\"apps/test-ui-two-e2e/cypress.json\\",
+            \\"devServerTarget\\": \\"test-ui-two:storybook\\"
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"devServerTarget\\": \\"test-ui-two:storybook:ci\\"
+            }
+          }
+        },
+        \\"lint\\": {
+          \\"builder\\": \\"@angular-devkit/build-angular:tslint\\",
+          \\"options\\": {
+            \\"tsConfig\\": [
+              \\"apps/test-ui-two-e2e/tsconfig.json\\"
+            ],
+            \\"exclude\\": [
+              \\"**/node_modules/**\\",
+              \\"!apps/test-ui-two-e2e/**/*\\"
+            ]
+          }
+        }
+      },
+      \\"tags\\": [],
+      \\"implicitDependencies\\": [
+        \\"test-ui-two\\"
+      ]
+    }
+  }
+}
+"
+`;
+
+exports[`composition generator should only generate composition for selected projects 1`] = `
+"const rootMain = require('../../../.storybook/main');
+
+
+module.exports = {
+  refs: {\\"test-ui-one\\":{\\"title\\":\\"test-ui-one\\",\\"url\\":\\"http://localhost:4401\\"},\\"test-ui-two\\":{\\"title\\":\\"test-ui-two\\",\\"url\\":\\"http://localhost:4402\\"}},...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+  stories: [
+    ...rootMain.stories,
+    '../src/lib/**/*.stories.mdx',
+    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' ],
+  webpackFinal: async (config, { configType }) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.js
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType });
+    }
+    
+    
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+"
+`;
+
+exports[`composition generator should only generate composition for selected projects 2`] = `
+"{
+  \\"version\\": 1,
+  \\"projects\\": {
+    \\"main-host-lib\\": {
+      \\"root\\": \\"libs/main-host-lib\\",
+      \\"sourceRoot\\": \\"libs/main-host-lib/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/main-host-lib/**/*.ts\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/jest:jest\\",
+          \\"outputs\\": [
+            \\"coverage/libs/main-host-lib\\"
+          ],
+          \\"options\\": {
+            \\"jestConfig\\": \\"libs/main-host-lib/jest.config.js\\",
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:storybook\\",
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"port\\": 4400,
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/main-host-lib/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"build-storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"outputPath\\": \\"dist/storybook/main-host-lib\\",
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/main-host-lib/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"storybook-composition\\": {
+          \\"builder\\": \\"@nrwl/storybook:composition\\",
+          \\"options\\": {
+            \\"projects\\": \\"test-ui-one,test-ui-two\\"
+          }
+        }
+      },
+      \\"tags\\": []
+    },
+    \\"main-host-lib-e2e\\": {
+      \\"root\\": \\"apps/main-host-lib-e2e\\",
+      \\"sourceRoot\\": \\"apps/main-host-lib-e2e/src\\",
+      \\"projectType\\": \\"application\\",
+      \\"architect\\": {
+        \\"e2e\\": {
+          \\"builder\\": \\"@nrwl/cypress:cypress\\",
+          \\"options\\": {
+            \\"cypressConfig\\": \\"apps/main-host-lib-e2e/cypress.json\\",
+            \\"devServerTarget\\": \\"main-host-lib:storybook\\"
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"devServerTarget\\": \\"main-host-lib:storybook:ci\\"
+            }
+          }
+        },
+        \\"lint\\": {
+          \\"builder\\": \\"@angular-devkit/build-angular:tslint\\",
+          \\"options\\": {
+            \\"tsConfig\\": [
+              \\"apps/main-host-lib-e2e/tsconfig.json\\"
+            ],
+            \\"exclude\\": [
+              \\"**/node_modules/**\\",
+              \\"!apps/main-host-lib-e2e/**/*\\"
+            ]
+          }
+        }
+      },
+      \\"tags\\": [],
+      \\"implicitDependencies\\": [
+        \\"main-host-lib\\"
+      ]
+    },
+    \\"test-ui-one\\": {
+      \\"root\\": \\"libs/test-ui-one\\",
+      \\"sourceRoot\\": \\"libs/test-ui-one/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/test-ui-one/**/*.ts\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/jest:jest\\",
+          \\"outputs\\": [
+            \\"coverage/libs/test-ui-one\\"
+          ],
+          \\"options\\": {
+            \\"jestConfig\\": \\"libs/test-ui-one/jest.config.js\\",
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:storybook\\",
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"port\\": 4401,
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-one/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"build-storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"outputPath\\": \\"dist/storybook/test-ui-one\\",
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-one/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        }
+      },
+      \\"tags\\": []
+    },
+    \\"test-ui-one-e2e\\": {
+      \\"root\\": \\"apps/test-ui-one-e2e\\",
+      \\"sourceRoot\\": \\"apps/test-ui-one-e2e/src\\",
+      \\"projectType\\": \\"application\\",
+      \\"architect\\": {
+        \\"e2e\\": {
+          \\"builder\\": \\"@nrwl/cypress:cypress\\",
+          \\"options\\": {
+            \\"cypressConfig\\": \\"apps/test-ui-one-e2e/cypress.json\\",
+            \\"devServerTarget\\": \\"test-ui-one:storybook\\"
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"devServerTarget\\": \\"test-ui-one:storybook:ci\\"
+            }
+          }
+        },
+        \\"lint\\": {
+          \\"builder\\": \\"@angular-devkit/build-angular:tslint\\",
+          \\"options\\": {
+            \\"tsConfig\\": [
+              \\"apps/test-ui-one-e2e/tsconfig.json\\"
+            ],
+            \\"exclude\\": [
+              \\"**/node_modules/**\\",
+              \\"!apps/test-ui-one-e2e/**/*\\"
+            ]
+          }
+        }
+      },
+      \\"tags\\": [],
+      \\"implicitDependencies\\": [
+        \\"test-ui-one\\"
+      ]
+    },
+    \\"test-ui-three\\": {
+      \\"root\\": \\"libs/test-ui-three\\",
+      \\"sourceRoot\\": \\"libs/test-ui-three/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/test-ui-three/**/*.ts\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/jest:jest\\",
+          \\"outputs\\": [
+            \\"coverage/libs/test-ui-three\\"
+          ],
+          \\"options\\": {
+            \\"jestConfig\\": \\"libs/test-ui-three/jest.config.js\\",
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:storybook\\",
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"port\\": 4400,
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-three/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"build-storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"outputPath\\": \\"dist/storybook/test-ui-three\\",
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-three/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        }
+      },
+      \\"tags\\": []
+    },
+    \\"test-ui-three-e2e\\": {
+      \\"root\\": \\"apps/test-ui-three-e2e\\",
+      \\"sourceRoot\\": \\"apps/test-ui-three-e2e/src\\",
+      \\"projectType\\": \\"application\\",
+      \\"architect\\": {
+        \\"e2e\\": {
+          \\"builder\\": \\"@nrwl/cypress:cypress\\",
+          \\"options\\": {
+            \\"cypressConfig\\": \\"apps/test-ui-three-e2e/cypress.json\\",
+            \\"devServerTarget\\": \\"test-ui-three:storybook\\"
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"devServerTarget\\": \\"test-ui-three:storybook:ci\\"
+            }
+          }
+        },
+        \\"lint\\": {
+          \\"builder\\": \\"@angular-devkit/build-angular:tslint\\",
+          \\"options\\": {
+            \\"tsConfig\\": [
+              \\"apps/test-ui-three-e2e/tsconfig.json\\"
+            ],
+            \\"exclude\\": [
+              \\"**/node_modules/**\\",
+              \\"!apps/test-ui-three-e2e/**/*\\"
+            ]
+          }
+        }
+      },
+      \\"tags\\": [],
+      \\"implicitDependencies\\": [
+        \\"test-ui-three\\"
+      ]
+    },
+    \\"test-ui-two\\": {
+      \\"root\\": \\"libs/test-ui-two\\",
+      \\"sourceRoot\\": \\"libs/test-ui-two/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/test-ui-two/**/*.ts\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/jest:jest\\",
+          \\"outputs\\": [
+            \\"coverage/libs/test-ui-two\\"
+          ],
+          \\"options\\": {
+            \\"jestConfig\\": \\"libs/test-ui-two/jest.config.js\\",
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:storybook\\",
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"port\\": 4402,
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-two/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        },
+        \\"build-storybook\\": {
+          \\"builder\\": \\"@nrwl/storybook:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"options\\": {
+            \\"uiFramework\\": \\"@storybook/react\\",
+            \\"outputPath\\": \\"dist/storybook/test-ui-two\\",
+            \\"config\\": {
+              \\"configFolder\\": \\"libs/test-ui-two/.storybook\\"
+            }
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"quiet\\": true
+            }
+          }
+        }
+      },
+      \\"tags\\": []
+    },
+    \\"test-ui-two-e2e\\": {
+      \\"root\\": \\"apps/test-ui-two-e2e\\",
+      \\"sourceRoot\\": \\"apps/test-ui-two-e2e/src\\",
+      \\"projectType\\": \\"application\\",
+      \\"architect\\": {
+        \\"e2e\\": {
+          \\"builder\\": \\"@nrwl/cypress:cypress\\",
+          \\"options\\": {
+            \\"cypressConfig\\": \\"apps/test-ui-two-e2e/cypress.json\\",
+            \\"devServerTarget\\": \\"test-ui-two:storybook\\"
+          },
+          \\"configurations\\": {
+            \\"ci\\": {
+              \\"devServerTarget\\": \\"test-ui-two:storybook:ci\\"
+            }
+          }
+        },
+        \\"lint\\": {
+          \\"builder\\": \\"@angular-devkit/build-angular:tslint\\",
+          \\"options\\": {
+            \\"tsConfig\\": [
+              \\"apps/test-ui-two-e2e/tsconfig.json\\"
+            ],
+            \\"exclude\\": [
+              \\"**/node_modules/**\\",
+              \\"!apps/test-ui-two-e2e/**/*\\"
+            ]
+          }
+        }
+      },
+      \\"tags\\": [],
+      \\"implicitDependencies\\": [
+        \\"test-ui-two\\"
+      ]
+    }
+  }
+}
+"
+`;

--- a/packages/storybook/src/generators/composition/composition-functions.ts
+++ b/packages/storybook/src/generators/composition/composition-functions.ts
@@ -1,0 +1,290 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  getProjects,
+  logger,
+  readJson,
+  readProjectConfiguration,
+  Tree,
+  updateProjectConfiguration,
+  writeJson,
+} from '@nrwl/devkit';
+import { findNodes } from '@nrwl/workspace/src/utilities/typescript/find-nodes';
+import { getTsSourceFile } from '../migrate-stories-to-6-2/migrate-stories-to-6-2';
+import ts = require('typescript');
+import { StorybookCompositionSchema } from './schema';
+
+export interface NormalizedStorybookCompositionSchema {
+  mainProject: string;
+  projects?: string[];
+  all?: boolean;
+  useExistingPorts?: boolean;
+}
+
+export function normalizeSchema(
+  schema: StorybookCompositionSchema
+): NormalizedStorybookCompositionSchema {
+  const normalizedSchema: NormalizedStorybookCompositionSchema = {
+    mainProject: schema?.mainProject,
+    all: schema?.all,
+    useExistingPorts: schema?.useExistingPorts,
+  };
+
+  if (schema?.projects?.length > 0) {
+    schema.projects = schema.projects.replace(' ', '');
+    normalizedSchema.projects =
+      schema.projects.length > 0 ? schema.projects.split(',') : undefined;
+  }
+
+  return normalizedSchema;
+}
+
+export function getMainProjectConfigFolderPath(
+  tree: Tree,
+  mainProject: string
+): string | undefined {
+  const projectConfig = readProjectConfiguration(tree, mainProject);
+  if (
+    projectConfig.targets &&
+    projectConfig.targets.storybook &&
+    projectConfig.targets.storybook.options &&
+    projectConfig.targets.storybook.options.config &&
+    projectConfig.targets.storybook.options.config.configFolder
+  ) {
+    return projectConfig.targets.storybook.options.config.configFolder;
+  }
+}
+
+export function getProjectStorybookPort(
+  tree: Tree,
+  projectName: string
+): number | undefined {
+  const projectConfig = readProjectConfiguration(tree, projectName);
+  if (
+    projectConfig.targets &&
+    projectConfig.targets.storybook &&
+    projectConfig.targets.storybook.options &&
+    projectConfig.targets.storybook.options.port
+  ) {
+    return projectConfig.targets.storybook.options.port;
+  }
+}
+
+export function changePortOnWorkspaceJson(
+  tree: Tree,
+  projectName: string,
+  projectPort: number
+): boolean {
+  const projectConfig = readProjectConfiguration(tree, projectName);
+  if (
+    projectConfig.targets &&
+    projectConfig.targets.storybook &&
+    projectConfig.targets.storybook.options &&
+    projectConfig.targets.storybook.options.port
+  ) {
+    projectConfig.targets.storybook.options.port = projectPort;
+    updateProjectConfiguration(tree, projectName, projectConfig);
+    return true;
+  }
+  return false;
+}
+
+export function constructRefsObject(
+  projectsAndPorts: {
+    projectName: string;
+    projectPort: number;
+  }[]
+): {
+  refs: {
+    [key: string]: {
+      title: string;
+      url: string;
+    };
+  };
+} {
+  const refsObject = {
+    refs: {},
+  };
+  projectsAndPorts.forEach((project) => {
+    refsObject.refs[`${project.projectName}`] = {
+      title: project.projectName,
+      url: `http://localhost:${project.projectPort}`,
+    };
+  });
+  return refsObject;
+}
+
+export function addRefToMainProjectStorybookMainJs(
+  tree: Tree,
+  mainProjectName: string,
+  refsObject: {
+    refs: {
+      [key: string]: {
+        title: string;
+        url: string;
+      };
+    };
+  }
+) {
+  let newContents: string;
+  let moduleExportsIsEmptyOrNonExistent = false;
+  const mainProjectConfigFolderPath = getMainProjectConfigFolderPath(
+    tree,
+    mainProjectName
+  );
+  const mainProjectMainJsPath = `${mainProjectConfigFolderPath}/main.js`;
+  const rootMainJsExists = tree.exists(mainProjectMainJsPath);
+  if (rootMainJsExists) {
+    const file = getTsSourceFile(tree, mainProjectMainJsPath);
+    const appFileContent = tree.read(mainProjectMainJsPath, 'utf-8');
+    newContents = appFileContent;
+    const moduleExportsFull = findNodes(file, [
+      ts.SyntaxKind.ExpressionStatement,
+    ]);
+
+    if (moduleExportsFull && moduleExportsFull[0]) {
+      const moduleExports = moduleExportsFull[0];
+      const listOfStatements = findNodes(moduleExports, [
+        ts.SyntaxKind.SyntaxList,
+      ]);
+
+      let indexOfFirstNode = -1;
+
+      const hasRefsObject = listOfStatements[0]?.getChildren()?.find((node) => {
+        if (node && node.getText().length > 0 && indexOfFirstNode < 0) {
+          indexOfFirstNode = node.getStart();
+        }
+        return (
+          node.kind === ts.SyntaxKind.PropertyAssignment &&
+          node.getText().startsWith('refs')
+        );
+      });
+
+      if (hasRefsObject) {
+        const refsStartIndex = hasRefsObject.getStart();
+        const refsEndIndex = hasRefsObject.getEnd();
+
+        // Delete old one
+        newContents = applyChangesToString(newContents, [
+          {
+            type: ChangeType.Delete,
+            start: refsStartIndex,
+            length: refsEndIndex - refsStartIndex + 1,
+          },
+        ]);
+
+        // Add new one
+        newContents = applyChangesToString(newContents, [
+          {
+            type: ChangeType.Insert,
+            index: indexOfFirstNode,
+            text: `refs: ${JSON.stringify(refsObject.refs)},`,
+          },
+        ]);
+      } else if (indexOfFirstNode >= 0) {
+        /**
+         * Does not have refs object,
+         * so just write one, at the start.
+         */
+        newContents = applyChangesToString(newContents, [
+          {
+            type: ChangeType.Insert,
+            index: indexOfFirstNode,
+            text: `refs: ${JSON.stringify(refsObject.refs)},`,
+          },
+        ]);
+      } else {
+        /**
+         * Module exports is empty, so write all a-new
+         */
+        moduleExportsIsEmptyOrNonExistent = true;
+      }
+    } else {
+      /**
+       * module.exports does not exist, so write all a-new
+       */
+      moduleExportsIsEmptyOrNonExistent = true;
+    }
+  } else {
+    moduleExportsIsEmptyOrNonExistent = true;
+  }
+
+  if (moduleExportsIsEmptyOrNonExistent) {
+    logger.error(`Project ${mainProjectName} does not have a valid Storybook configuration.
+        Please first configure Storybook for ${mainProjectName} and then add Storybook composition.
+        Alternatively, you can choose a different main project.`);
+    return;
+  } else {
+    tree.write(mainProjectMainJsPath, newContents);
+  }
+}
+
+export function fixCypressBaseURL(
+  projectName: string,
+  tree: Tree,
+  port: number
+) {
+  const projectConfig = readProjectConfiguration(tree, projectName);
+  if (projectConfig?.targets?.e2e?.options?.cypressConfig) {
+    const cypressConfig = readJson(
+      tree,
+      projectConfig.targets.e2e.options.cypressConfig
+    );
+    cypressConfig.baseUrl = `http://localhost:${port}`;
+    writeJson(
+      tree,
+      projectConfig.targets.e2e.options.cypressConfig,
+      cypressConfig
+    );
+  }
+}
+
+export function findAllProjectsWithStorybookConfiguration(tree: Tree): {
+  projectName: string;
+  projectPort: number;
+}[] {
+  const projects = getProjects(tree);
+  const projectsThatHaveStorybookConfiguration: {
+    projectName: string;
+    projectPort: number;
+  }[] = [...projects.entries()]
+    ?.filter(
+      ([_, projectConfig]) =>
+        projectConfig.targets &&
+        projectConfig.targets.storybook &&
+        projectConfig.targets.storybook.options
+    )
+    ?.map(([projectName, projectConfig]) => {
+      return {
+        projectName,
+        projectPort: projectConfig.targets.storybook.options.port,
+      };
+    });
+  return projectsThatHaveStorybookConfiguration;
+}
+
+export function addStorybookCompositionTask(
+  tree: Tree,
+  projectName: string,
+  projects: string
+) {
+  const projectConfig = readProjectConfiguration(tree, projectName);
+  projectConfig.targets['storybook-composition'] = {
+    executor: '@nrwl/storybook:composition',
+    options: {
+      projects,
+    },
+  };
+  updateProjectConfiguration(tree, projectName, projectConfig);
+}
+
+export function thereAreProjectsWithConflictingPorts(
+  projectsAndPorts: {
+    projectName: string;
+    projectPort: number;
+  }[]
+) {
+  const ports = projectsAndPorts.map(({ projectPort }) => projectPort);
+  const uniquePorts = [...new Set(ports)];
+  return uniquePorts.length !== ports.length;
+}

--- a/packages/storybook/src/generators/composition/composition.spec.ts
+++ b/packages/storybook/src/generators/composition/composition.spec.ts
@@ -1,0 +1,133 @@
+import { Tree, writeJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { libraryGenerator } from '@nrwl/workspace/generators';
+import configurationGenerator from '../configuration/configuration';
+import { compositionGenerator } from './composition';
+
+let tree: Tree;
+
+describe('composition generator', () => {
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+    await libraryGenerator(tree, {
+      name: 'test-ui-one',
+      standaloneConfig: false,
+    });
+    await libraryGenerator(tree, {
+      name: 'test-ui-two',
+      standaloneConfig: false,
+    });
+    await libraryGenerator(tree, {
+      name: 'test-ui-three',
+      standaloneConfig: false,
+    });
+    await libraryGenerator(tree, {
+      name: 'main-host-lib',
+      standaloneConfig: false,
+    });
+    writeJson(tree, 'package.json', {
+      devDependencies: {
+        '@storybook/addon-essentials': '~6.3.0',
+        '@storybook/react': '~6.3.0',
+      },
+    });
+
+    await configurationGenerator(tree, {
+      name: 'test-ui-one',
+      uiFramework: '@storybook/react',
+      standaloneConfig: false,
+    });
+
+    await configurationGenerator(tree, {
+      name: 'test-ui-two',
+      uiFramework: '@storybook/react',
+      standaloneConfig: false,
+    });
+
+    await configurationGenerator(tree, {
+      name: 'test-ui-three',
+      uiFramework: '@storybook/react',
+      standaloneConfig: false,
+    });
+
+    await configurationGenerator(tree, {
+      name: 'main-host-lib',
+      uiFramework: '@storybook/react',
+      standaloneConfig: false,
+    });
+  });
+
+  it("should change the ports on workspace.json if useExistingPorts is false and update the main project's main.js accordingly", async () => {
+    await compositionGenerator(tree, {
+      mainProject: 'main-host-lib',
+      all: true,
+    });
+    const workspaceJson = JSON.parse(tree.read('workspace.json', 'utf-8'));
+    expect(
+      tree.read('libs/main-host-lib/.storybook/main.js', 'utf-8')
+    ).toMatchSnapshot();
+    expect(tree.read('workspace.json', 'utf-8')).toMatchSnapshot();
+    expect(
+      workspaceJson?.projects?.['test-ui-one']?.architect?.storybook?.options
+        ?.port
+    ).toBe(4401);
+    expect(
+      workspaceJson?.projects?.['test-ui-two']?.architect?.storybook?.options
+        ?.port
+    ).toBe(4403);
+    expect(
+      workspaceJson?.projects?.['test-ui-three']?.architect?.storybook?.options
+        ?.port
+    ).toBe(4402);
+  });
+
+  it("should not change ports on workspace.json if useExistingPorts is true and update the main project's main.js accordingly", async () => {
+    await compositionGenerator(tree, {
+      mainProject: 'main-host-lib',
+      all: true,
+      useExistingPorts: true,
+    });
+    const workspaceJson = JSON.parse(tree.read('workspace.json', 'utf-8'));
+    expect(
+      tree.read('libs/main-host-lib/.storybook/main.js', 'utf-8')
+    ).toMatchSnapshot();
+    expect(tree.read('workspace.json', 'utf-8')).toMatchSnapshot();
+    expect(
+      workspaceJson?.projects?.['test-ui-one']?.architect?.storybook?.options
+        ?.port
+    ).toBe(4400);
+    expect(
+      workspaceJson?.projects?.['test-ui-two']?.architect?.storybook?.options
+        ?.port
+    ).toBe(4400);
+    expect(
+      workspaceJson?.projects?.['test-ui-three']?.architect?.storybook?.options
+        ?.port
+    ).toBe(4400);
+  });
+
+  it('should only generate composition for selected projects', async () => {
+    await compositionGenerator(tree, {
+      mainProject: 'main-host-lib',
+      projects: 'test-ui-one,test-ui-two',
+    });
+
+    const workspaceJson = JSON.parse(tree.read('workspace.json', 'utf-8'));
+    expect(
+      tree.read('libs/main-host-lib/.storybook/main.js', 'utf-8')
+    ).toMatchSnapshot();
+    expect(tree.read('workspace.json', 'utf-8')).toMatchSnapshot();
+    expect(
+      workspaceJson?.projects?.['test-ui-one']?.architect?.storybook?.options
+        ?.port
+    ).toBe(4401);
+    expect(
+      workspaceJson?.projects?.['test-ui-two']?.architect?.storybook?.options
+        ?.port
+    ).toBe(4402);
+    expect(
+      workspaceJson?.projects?.['test-ui-three']?.architect?.storybook?.options
+        ?.port
+    ).toBe(4400);
+  });
+});

--- a/packages/storybook/src/generators/composition/composition.ts
+++ b/packages/storybook/src/generators/composition/composition.ts
@@ -110,7 +110,8 @@ export async function compositionGenerator(
 
     You can now run the following command to start Storybook composition on http://localhost:4400:
 
-    // TODO: Add new command here
+    nx storybook-composition ${normalizedSchema.mainProject}
+
   `);
 }
 

--- a/packages/storybook/src/generators/composition/composition.ts
+++ b/packages/storybook/src/generators/composition/composition.ts
@@ -1,0 +1,118 @@
+import {
+  convertNxGenerator,
+  formatFiles,
+  logger,
+  stripIndents,
+  Tree,
+} from '@nrwl/devkit';
+import {
+  addRefToMainProjectStorybookMainJs,
+  addStorybookCompositionTask,
+  thereAreProjectsWithConflictingPorts,
+  changePortOnWorkspaceJson,
+  constructRefsObject,
+  findAllProjectsWithStorybookConfiguration,
+  fixCypressBaseURL,
+  getMainProjectConfigFolderPath,
+  getProjectStorybookPort,
+  normalizeSchema,
+} from './composition-functions';
+import { StorybookCompositionSchema } from './schema';
+
+export async function compositionGenerator(
+  tree: Tree,
+  schema: StorybookCompositionSchema
+) {
+  const normalizedSchema = normalizeSchema(schema);
+
+  const mainProjectConfigFolderPath = getMainProjectConfigFolderPath(
+    tree,
+    normalizedSchema.mainProject
+  );
+  if (!mainProjectConfigFolderPath || !mainProjectConfigFolderPath.length) {
+    logger.error(`Project ${normalizedSchema.mainProject} does not exist, or does not have a valid Storybook configuration.
+      Please try again, and provide a valid project name.`);
+    return;
+  }
+
+  const projectsAndPorts: {
+    projectName: string;
+    projectPort: number;
+  }[] = [];
+  let commaSeparatedProjects = '';
+  let projects: { projectName: string; projectPort: number }[] = [];
+
+  if (normalizedSchema.projects && normalizedSchema.all !== true) {
+    projects = normalizedSchema.projects.map((projectName: string) => {
+      return {
+        projectName,
+        projectPort: getProjectStorybookPort(tree, projectName),
+      };
+    });
+  } else {
+    projects = findAllProjectsWithStorybookConfiguration(tree);
+  }
+
+  projects = projects.filter(
+    (project) => project.projectName !== normalizedSchema.mainProject
+  );
+
+  projects.forEach((project, index) => {
+    let portForMainJs = project.projectPort;
+    if (!normalizedSchema.useExistingPorts) {
+      if (changePortOnWorkspaceJson(tree, project.projectName, 4401 + index)) {
+        logger.info(
+          `Updated port for project ${project.projectName} to ${4401 + index}`
+        );
+        portForMainJs = 4401 + index;
+        fixCypressBaseURL(`${project.projectName}-e2e`, tree, 4401 + index);
+      } else {
+        logger.info(
+          `Could not find Storybook configuration for project ${project.projectName} in workspace.json`
+        );
+      }
+    }
+
+    projectsAndPorts.push({
+      projectName: project.projectName,
+      projectPort: portForMainJs,
+    });
+    commaSeparatedProjects =
+      commaSeparatedProjects.length > 0
+        ? commaSeparatedProjects + ',' + project.projectName
+        : project.projectName;
+  });
+
+  addRefToMainProjectStorybookMainJs(
+    tree,
+    normalizedSchema.mainProject,
+    constructRefsObject(projectsAndPorts)
+  );
+
+  addStorybookCompositionTask(
+    tree,
+    normalizedSchema.mainProject,
+    commaSeparatedProjects
+  );
+
+  await formatFiles(tree);
+
+  if (thereAreProjectsWithConflictingPorts(projectsAndPorts)) {
+    logger.warn(stripIndents`
+    Two or more projects have conflicting ports. Before running the storybook-composition task,
+    please make sure you update your project ports in workspace.json and in ${mainProjectConfigFolderPath}/main.js
+    so that they are unique. Avoid using port 4400 as it is reserved for the main project.
+    `);
+  }
+
+  logger.info(stripIndents`
+    Successfully generated Storybook composition for your projects.
+
+    You can now run the following command to start Storybook composition on http://localhost:4400:
+
+    // TODO: Add new command here
+  `);
+}
+
+export default compositionGenerator;
+export const compositionSchematic = convertNxGenerator(compositionGenerator);

--- a/packages/storybook/src/generators/composition/schema.d.ts
+++ b/packages/storybook/src/generators/composition/schema.d.ts
@@ -1,0 +1,6 @@
+export interface StorybookCompositionSchema {
+  mainProject: string;
+  projects?: string;
+  all?: boolean;
+  useExistingPorts?: boolean;
+}

--- a/packages/storybook/src/generators/composition/schema.json
+++ b/packages/storybook/src/generators/composition/schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "composition",
+  "type": "object",
+  "properties": {
+    "mainProject": {
+      "type": "string",
+      "description": "The one project that will be used as the main entrypoint for Storybook Composition. This project will run on port 4400 and will not be added as a composition reference. All references will be added to it, instead.",
+      "$default": {
+        "$source": "projectName",
+        "index": 0
+      },
+      "x-prompt": "Which project do  you want to use as the entrypoint (the project which will host the composition)?"
+    },
+    "projects": {
+      "type": "string",
+      "description": "Projects to add in the composition (comma delimited)",
+      "x-prompt": "Which projects do  you want to add in the composition? (leave blank for all)",
+      "default": " "
+    },
+    "all": {
+      "type": "boolean",
+      "description": "Compose all Storybook instances.",
+      "x-prompt": "Do you want to add all your Storybook instances to the Storybook Composition?",
+      "default": false
+    },
+    "useExistingPorts": {
+      "type": "boolean",
+      "description": "If false, the Storybook ports in workspace.json/angular.json will be overwritten. If true, the Storybook ports in workspace.json/angular.json will not be overwritten and Storybook Composition will use ordinal numbers to name your instances.",
+      "x-prompt": "Do you want to use random ports for your Storybook instances and ordinal names for your compositions?",
+      "default": false
+    }
+  },
+  "required": ["mainProject"]
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Nx is [Storybook-Composition](https://storybook.js.org/docs/react/workflows/storybook-composition)-ready. However no guide is provided, and also no generator is provided.

## Expected Behavior

Now, Nx has a generator that will help first-time [Storybook Composition](https://www.chromatic.com/blog/storybook-composition/) users to set up their environments quickly, and it also includes an extensive guide of how to set up Storybook Composition for your Nx workspace.

## Related Issue(s)
#5561 

## Guide

How to:
```
nx g @nrwl/storybook:composition
```

and the prompts will guide you.
Careful, if you choose `useExistingPorts`, it will make changes to your composed projects' `project.json` files (will just change default storybook ports from 4400 to 4401 etc.)

If you leave projects blank or if you pass `all:true` it will compose all your projects