### PR TITLE
fix(nextjs): include typescript in build package.json

### DIFF
--- a/packages/next/src/executors/build/lib/create-package-json.ts
+++ b/packages/next/src/executors/build/lib/create-package-json.ts
@@ -25,8 +25,14 @@ export async function createPackageJson(
   const nrwlWorkspaceNode = depGraph.nodes['npm:@nrwl/workspace'];
 
   if (nrwlWorkspaceNode) {
-    packageJson.devDependencies['@nrwl/workspace'] =
+    packageJson.dependencies['@nrwl/workspace'] =
       nrwlWorkspaceNode.data.version;
   }
+
+  const typescriptNode = depGraph.nodes['npm:typescript'];
+  if (typescriptNode) {
+    packageJson.dependencies['typescript'] = typescriptNode.data.version;
+  }
+
   writeJsonFile(`${options.outputPath}/package.json`, packageJson);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`typescript` isn't included as a dependency in the `package.json` file created during the build

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
similarly to `@nrwl/workspace` package, `typescript` should also be a special case to be included, since it is a genuine dependency of `@nrwl/workspace`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6985 #6886
