### PR TITLE
fix(angular): update ng-package.json dest property when moving a library

### DIFF
--- a/packages/angular/src/generators/move/lib/update-ng-package.ts
+++ b/packages/angular/src/generators/move/lib/update-ng-package.ts
@@ -1,0 +1,30 @@
+import { readProjectConfiguration, Tree, updateJson } from '@nrwl/devkit';
+import { appRootPath } from '@nrwl/tao/src/utils/app-root';
+import { getNewProjectName } from '@nrwl/workspace/src/generators/move/lib/utils';
+import { join, relative } from 'path';
+import { Schema } from '../schema';
+
+export function updateNgPackage(tree: Tree, schema: Schema): void {
+  const newProjectName = getNewProjectName(schema.destination);
+  const project = readProjectConfiguration(tree, newProjectName);
+
+  if (project.projectType === 'application') {
+    return;
+  }
+
+  const ngPackagePath = `${project.root}/ng-package.json`;
+  if (!tree.exists(ngPackagePath)) {
+    return;
+  }
+
+  const rootOffset = relative(join(appRootPath, project.root), appRootPath);
+  let output = `dist/${project.root}`;
+  if (project.targets?.build?.outputs?.length > 0) {
+    output = project.targets.build.outputs[0];
+  }
+
+  updateJson(tree, ngPackagePath, (json) => {
+    json.dest = `${rootOffset}/${output}`;
+    return json;
+  });
+}

--- a/packages/angular/src/generators/move/move.spec.ts
+++ b/packages/angular/src/generators/move/move.spec.ts
@@ -1,4 +1,4 @@
-import { Tree } from '@nrwl/devkit';
+import { readJson, Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { angularMoveGenerator } from './move';
@@ -36,6 +36,19 @@ describe('@nrwl/angular:move', () => {
     expect(tree.exists('libs/mynewlib/src/lib/mynewlib.module.ts')).toEqual(
       true
     );
+  });
+
+  it('should update ng-package.json dest property', async () => {
+    await libraryGenerator(tree, { name: 'mylib2', buildable: true });
+
+    await angularMoveGenerator(tree, {
+      projectName: 'mylib2',
+      destination: 'mynewlib2',
+      updateImportPath: true,
+    });
+
+    const ngPackageJson = readJson(tree, 'libs/mynewlib2/ng-package.json');
+    expect(ngPackageJson.dest).toEqual('../../dist/libs/mynewlib2');
   });
 
   it('should format files', async () => {

--- a/packages/angular/src/generators/move/move.ts
+++ b/packages/angular/src/generators/move/move.ts
@@ -1,6 +1,7 @@
 import { convertNxGenerator, formatFiles, Tree } from '@nrwl/devkit';
 import { moveGenerator } from '@nrwl/workspace';
 import { updateModuleName } from './lib/update-module-name';
+import { updateNgPackage } from './lib/update-ng-package';
 import { Schema } from './schema';
 
 /**
@@ -16,6 +17,7 @@ export async function angularMoveGenerator(
 ): Promise<void> {
   await moveGenerator(tree, { ...schema, skipFormat: true });
   updateModuleName(tree, schema);
+  updateNgPackage(tree, schema);
 
   if (!schema.skipFormat) {
     await formatFiles(tree);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When moving an Angular buildable/publishable library, the property `dest` in the `ng-package.json` is not updated correctly.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Moving an Angular buildable/publishable library should update correctly the property `dest` in the `ng-package.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7061 
