### PR TITLE
fix(angular): stop modifying tags that match app name

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -44,13 +44,13 @@ describe('app', () => {
 
     it('should update nx.json', async () => {
       // ACT
-      await generateApp(appTree, 'myApp', { tags: 'one,two' });
+      await generateApp(appTree, 'myApp', { tags: 'one,two,my-app' });
 
       // ASSERT
       const nxJson = readJson<NxJsonConfiguration>(appTree, '/nx.json');
       expect(nxJson.projects).toEqual({
         'my-app': {
-          tags: ['one', 'two'],
+          tags: ['one', 'two', 'my-app'],
         },
         'my-app-e2e': {
           implicitDependencies: ['my-app'],
@@ -190,12 +190,12 @@ describe('app', () => {
     it('should update nx.json', async () => {
       await generateApp(appTree, 'myApp', {
         directory: 'myDir',
-        tags: 'one,two',
+        tags: 'one,two,my-dir-my-app',
       });
       const nxJson = readJson<NxJsonConfiguration>(appTree, '/nx.json');
       expect(nxJson.projects).toEqual({
         'my-dir-my-app': {
-          tags: ['one', 'two'],
+          tags: ['one', 'two', 'my-dir-my-app'],
         },
         'my-dir-my-app-e2e': {
           implicitDependencies: ['my-dir-my-app'],

--- a/packages/workspace/src/utils/cli-config-utils.ts
+++ b/packages/workspace/src/utils/cli-config-utils.ts
@@ -1,5 +1,7 @@
 import { Tree } from '@angular-devkit/schematics';
+
 import { readJsonInTree } from './ast-utils';
+
 import type { NxJsonConfiguration } from '@nrwl/devkit';
 
 export function getWorkspacePath(host: Tree) {
@@ -59,6 +61,7 @@ export function replaceAppNameWithPath(
       'builder',
       'executor',
       'browserTarget',
+      'tags',
     ]; // Some of the properties should not be renamed
     return Object.keys(node).reduce(
       (m, c) => (


### PR DESCRIPTION
ISSUES CLOSED: #7097

## Current Behavior
generating an angular app with a tag that matches the app name will convert the tag to the path name instead.

## Expected Behavior
tags should not be modified, no matter what they are

## Related Issue(s)
https://github.com/nrwl/nx/issues/7097

Fixes #
added `tags` as a forbidden property in the `replaceAppNameWithPath` method