### PR TITLE
fix(devkit): normalizePath should not be dependant on host OS

### DIFF
--- a/packages/devkit/src/utils/path.spec.ts
+++ b/packages/devkit/src/utils/path.spec.ts
@@ -1,0 +1,23 @@
+import { normalizePath, joinPathFragments } from './path';
+
+describe('normalizePath', () => {
+  it('should remove drive letters', () => {
+    expect(normalizePath('C:\\some\\path')).toEqual('/some/path');
+  });
+
+  it('should use unix style path separators', () => {
+    expect(normalizePath('some\\path')).toEqual('some/path');
+  });
+
+  it('should work for existing unix paths', () => {
+    expect('/some/unix/path').toEqual('/some/unix/path');
+  });
+});
+
+describe('joinPathFragments', () => {
+  it('should join relative paths', () => {
+    expect(joinPathFragments('C://some/path', '../other-path')).toEqual(
+      '/some/other-path'
+    );
+  });
+});

--- a/packages/devkit/src/utils/path.ts
+++ b/packages/devkit/src/utils/path.ts
@@ -8,7 +8,7 @@ function removeWindowsDriveLetter(osSpecificPath: string): string {
  * Coverts an os specific path to a unix style path
  */
 export function normalizePath(osSpecificPath: string): string {
-  return removeWindowsDriveLetter(osSpecificPath).split(path.sep).join('/');
+  return removeWindowsDriveLetter(osSpecificPath).split('\\').join('/');
 }
 
 /**


### PR DESCRIPTION
Currently, we split on path.sep in normalizePath. This results in differing results based on if the host file system is unix or windows. I would expect that normalizePath(...) should return the same result whether or not it was executed in windows.

## Current Behavior
`normalizePath('..\some\path')` returns
- `'..\some\path'` on unix
- `'../some/path'` on windows

## Expected Behavior
`normalizePath('..\some\path')` returns
- `'../some/path'` on unix
- `'../some/path'` on windows

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
