### PR TITLE
fix(angular): bump jasmine-marbles to 0.8.4 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "is-ci": "^3.0.0",
     "is-windows": "^1.0.2",
     "jasmine-core": "~2.99.1",
-    "jasmine-marbles": "~0.8.3",
+    "jasmine-marbles": "~0.8.4",
     "jasmine-spec-reporter": "~4.2.1",
     "jest": "27.0.3",
     "jest-circus": "27.0.6",

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -867,6 +867,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "12.10.0-beta.1": {
+      "version": "12.10.0-beta.1",
+      "packages": {
+        "jasmine-marbles": {
+          "version": "~0.8.4",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -43,7 +43,7 @@
     "@schematics/angular": "~12.2.0",
     "@phenomnomnominal/tsquery": "4.1.1",
     "ignore": "^5.0.4",
-    "jasmine-marbles": "~0.8.3",
+    "jasmine-marbles": "~0.8.4",
     "rxjs-for-await": "0.0.2",
     "webpack-merge": "5.7.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15270,10 +15270,10 @@ jasmine-core@~2.99.1:
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.99.1.tgz#e6400df1e6b56e130b61c4bcd093daa7f6e8ca15"
   integrity sha1-5kAN8ea1bhMLYcS80JPap/boyhU=
 
-jasmine-marbles@~0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/jasmine-marbles/-/jasmine-marbles-0.8.3.tgz#a27253d1d52dfe49d8f145aba63f0bf18147b4ff"
-  integrity sha512-aaf7ObOC9X1jZ8VyIG49+vOTycRqIWT5Jt3vHHbECE9tN7U05mnpxi20thth02HzasOv/Fmqf+uGhcLE/f8NYg==
+jasmine-marbles@~0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/jasmine-marbles/-/jasmine-marbles-0.8.4.tgz#67f840012634c453e986fcf48860d6ea92ae144e"
+  integrity sha512-zbtuXABpSWrSswYPiZ5m6EQhluNmKcRQs+82AqJHSN+PMx3ASpDmTvRfqe9Pk2hPh9Ge5zrzOsorIlw3kdwTXQ==
   dependencies:
     lodash "^4.17.20"
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`jasmine-marbles` is pinned to `0.8.3`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`jasmine-marbles` is pinned to `0.8.4`, fixing issues with undefined values in assertions and value comparisons with `jasmine` or `expect`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
