### PR TITLE
chore(react): migrate testing library to v11.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@storybook/react": "~6.3.0",
     "@svgr/webpack": "5.5.0",
     "@tailwindcss/typography": "^0.4.1",
-    "@testing-library/react": "11.2.5",
+    "@testing-library/react": "11.2.6",
     "@types/cytoscape": "^3.14.12",
     "@types/eslint": "^7.2.2",
     "@types/express": "4.17.0",

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -499,6 +499,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "12.10.0": {
+      "version": "12.10.0-beta.2",
+      "packages": {
+        "@testing-library/react": {
+          "version": "11.2.6",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5712,10 +5712,10 @@
     "@types/react-test-renderer" ">=16.9.0"
     react-error-boundary "^3.1.0"
 
-"@testing-library/react@11.2.5":
-  version "11.2.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.5.tgz#ae1c36a66c7790ddb6662c416c27863d87818eb9"
-  integrity sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==
+"@testing-library/react@11.2.6":
+  version "11.2.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.6.tgz#586a23adc63615985d85be0c903f374dab19200b"
+  integrity sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The v12.0.0 migration for `gatsby` installs `@testing-library/react` with `v11.2.6`, while migration for `react` installs `v11.2.5`. Nx has `v11.2.5` in the package.json  This is causing tests to be flaky as they sometimes end up with 11.2.6 and sometimes with 11.2.5.

## Expected Behavior
React and Nx should have `@testing-library/react` migrated to `v11.2.6`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
