### PR TITLE
feat(nextjs): expose environment variables prefixed with NX_

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -38,6 +38,7 @@ describe('Next.js Applications', () => {
       },
     };
     updateFile(`apps/${appName}/proxy.conf.json`, JSON.stringify(proxyConf));
+    updateFile('.env.local', 'NX_CUSTOM_VAR=test value from a file');
 
     updateFile(
       `apps/${appName}/pages/index.tsx`,
@@ -53,7 +54,10 @@ describe('Next.js Applications', () => {
               .then(setGreeting);
           }, []);
 
-          return <h1>{greeting}</h1>;
+          return <>
+            <h1>{greeting}</h1>
+            <h2>{process.env.NX_CUSTOM_VAR}</h2>
+          </>;
         };
         export default Index;
       `
@@ -78,6 +82,7 @@ describe('Next.js Applications', () => {
 
     const data = await getData(port);
     expect(data).toContain(`Welcome to ${appName}`);
+    expect(data).toContain(`test value from a file`);
 
     try {
       await promisifiedTreeKill(p.pid, 'SIGKILL');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Env variables prefixed with `NX_` are not exposed to the client in Next.js apps. This is [inconsistent with React apps in Nx](https://nx.dev/l/r/guides/environment-variables)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Env variables prefixed with `NX_` should be available to use on the client for Next.js apps

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
