### PR TITLE
cleanup(core): remove checking results.json in e2e tests

### DIFF
--- a/e2e/workspace/src/workspace.test.ts
+++ b/e2e/workspace/src/workspace.test.ts
@@ -296,13 +296,6 @@ describe('run-many', () => {
     expect(failedTests).toContain(`- ${myapp}`);
     expect(failedTests).toContain(`- ${myapp2}`);
     expect(failedTests).toContain(`Failed tasks:`);
-    expect(readJson('node_modules/.cache/nx/results.json')).toEqual({
-      command: 'test',
-      results: {
-        [myapp]: false,
-        [myapp2]: true,
-      },
-    });
 
     // Fix failing Unit Test
     updateFile(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

E2e  tests for `workspace` test underlying behavior of rerunning failed projects.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

E2e  tests for `workspace` do not check underlying behavior.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
