### PR TITLE
fix(nextjs): fix buildable nextjs libs

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -100,6 +100,9 @@ describe('Next.js Applications', () => {
       `generate @nrwl/react:lib ${buildableLibName} --no-interactive --style=none --buildable`
     );
 
+    // Check that the buildable lib builds as well
+    runCLI(`build ${buildableLibName}`);
+
     const mainPath = `apps/${appName}/pages/index.tsx`;
     updateFile(
       mainPath,

--- a/packages/web/src/executors/package/package.impl.ts
+++ b/packages/web/src/executors/package/package.impl.ts
@@ -203,6 +203,7 @@ export function createRollupOptions(
         babelrc: true,
         extensions: fileExtensions,
         babelHelpers: 'bundled',
+        skipPreflightCheck: true, // pre-flight check may yield false positives and also slows down the build
         exclude: /node_modules/,
         plugins: [
           format === 'esm'


### PR DESCRIPTION
The rollup babel plugin performs a pre-flight check to validate a small piece of code before building the full source.

This is leading to errors that aren't actually errors.

## Issues

Fixes #6739