### PR TITLE
feat(react): buildable React libraries now generate smaller ESM packages

### DIFF
--- a/packages/web/src/executors/package/package.impl.ts
+++ b/packages/web/src/executors/package/package.impl.ts
@@ -194,9 +194,12 @@ export function createRollupOptions(
       getBabelInputPlugin({
         // Let's `@nrwl/web/babel` preset know that we are packaging.
         caller: {
-          // Ignored since this is for our custom babel-loader + babel preset
           // @ts-ignore
+          // Ignoring type checks for caller since we have custom attributes
           isNxPackage: true,
+          // Always target esnext and let rollup handle cjs/umd
+          supportsStaticESM: true,
+          isModern: true,
         },
         cwd: join(context.root, sourceRoot),
         rootMode: 'upward',


### PR DESCRIPTION
This PR updates our `@nrwl/web:package` executor and @nrwl/web/babel` preset so that generated ESM package excludes unnecessary babel built-ins.

## Current Behavior

`nx build mylib --f esm` results in a larger bundle than `nx build mylib --f umd` 

## Expected Behavior

ESM should be smaller than UMD.