### PR TITLE
fix(angular): remove relative calculation for config paths in wrapped angular devkit schematics

### DIFF
--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -23,7 +23,7 @@ import {
   toOldFormatOrNull,
   workspaceConfigName,
 } from '../shared/workspace';
-import { dirname, extname, resolve, join, relative, basename } from 'path';
+import { dirname, extname, resolve, join, basename } from 'path';
 import { FileBuffer } from '@angular-devkit/core/src/virtual-fs/host/interface';
 import { EMPTY, Observable, of, concat } from 'rxjs';
 import { catchError, map, switchMap, tap, toArray } from 'rxjs/operators';
@@ -1055,9 +1055,7 @@ function splitProjectFileUpdatesFromWorkspaceUpdate(
   for (const [project, config] of Object.entries(workspace.projects)) {
     if (typeof config === 'object' && config.configFilePath) {
       const path = config.configFilePath;
-      workspace.projects[project] = normalize(
-        relative(host.root, dirname(path))
-      );
+      workspace.projects[project] = normalize(dirname(path));
       delete config.configFilePath;
       host.write(path, serializeJson(config));
       r.content = Buffer.from(serializeJson(workspace));


### PR DESCRIPTION
… angular devkit schematics

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When a wrapped angular devkit schematic updates a project in a unit test. The config path written to the `workspace.json` is relative from `/virtual`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When a wrapped angular devkit schematic updates a project in a unit test. The config path written to the `workspace.json` is correct.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7160 
