### PR TITLE
fix(core): fix error when tsconfig.base.json is invalid json

### DIFF
--- a/packages/tao/src/utils/fileutils.ts
+++ b/packages/tao/src/utils/fileutils.ts
@@ -35,7 +35,12 @@ export function readJsonFile<T extends object = any>(
   if (options) {
     options.endsWithNewline = content.charCodeAt(content.length - 1) === 10;
   }
-  return parseJson<T>(content, options);
+  try {
+    return parseJson<T>(content, options);
+  } catch (e) {
+    e.message = e.message.replace('JSON', path);
+    throw e;
+  }
 }
 
 /**

--- a/packages/workspace/src/core/project-graph/project-graph.spec.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.spec.ts
@@ -138,6 +138,18 @@ describe('project graph', () => {
     vol.fromJSON(filesJson, '/root');
   });
 
+  it('should throw an appropriate error for an invalid json config', async () => {
+    vol.appendFileSync('/root/tsconfig.base.json', 'invalid');
+    try {
+      await createProjectGraphAsync();
+      fail('Invalid tsconfigs should cause project graph to throw error');
+    } catch (e) {
+      expect(e.message).toMatchInlineSnapshot(
+        `"InvalidSymbol in /root/tsconfig.base.json at position 247"`
+      );
+    }
+  });
+
   it('should create nodes and dependencies with workspace projects', async () => {
     const graph = await createProjectGraphAsync();
 

--- a/packages/workspace/src/core/project-graph/project-graph.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.ts
@@ -42,6 +42,7 @@ import {
 } from './build-nodes';
 import * as serverExec from './daemon/exec';
 import { getProjectGraphFromServer, isServerAvailable } from './daemon/server';
+import { existsSync } from 'fs';
 
 /**
  * Synchronously reads the latest cached copy of the workspace's ProjectGraph.
@@ -367,9 +368,10 @@ function updateProjectGraphWithPlugins(
 }
 
 function readRootTsConfig() {
-  try {
-    return readJsonFile(join(appRootPath, 'tsconfig.base.json'));
-  } catch (e) {
-    return readJsonFile(join(appRootPath, 'tsconfig.json'));
+  for (const tsConfigName of ['tsconfig.base.json', 'tsconfig.json']) {
+    const tsConfigPath = join(appRootPath, tsConfigName);
+    if (existsSync(tsConfigPath)) {
+      return readJsonFile(tsConfigPath);
+    }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When `tsconfig.base.json` exists but is invalid JSON, Nx falls back to reading `tsconfig.json`. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When `tsconfig.base.json` exists but is invalid JSON, Nx throws an error why `tsconfig.base.json` is invalid json.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6961 
