### PR TITLE
fix(misc): dep-graph --file option supports absolute paths

### DIFF
--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -23,7 +23,7 @@ import chalk = require('chalk');
 import treeKill = require('tree-kill');
 
 const kill = require('kill-port');
-const isWindows = require('is-windows');
+export const isWindows = require('is-windows');
 
 export const promisifiedTreeKill: (
   pid: number,

--- a/e2e/workspace-integrations/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace-integrations/src/workspace-aux-commands.test.ts
@@ -3,6 +3,7 @@ import {
   checkFilesExist,
   exists,
   isNotWindows,
+  isWindows,
   newProject,
   readFile,
   readJson,
@@ -270,6 +271,24 @@ describe('dep-graph', () => {
     expect(jsonFileContents2.criticalPath).toContain(mylib);
     expect(jsonFileContents2.criticalPath).not.toContain(mylib2);
   }, 1000000);
+
+  if (isNotWindows()) {
+    it('dep-graph should output json to file by absolute path', () => {
+      runCLI(`dep-graph --file=/tmp/project-graph.json`);
+
+      expect(() => checkFilesExist('/tmp/project-graph.json')).not.toThrow();
+    }, 1000000);
+  }
+
+  if (isWindows()) {
+    it('dep-graph should output json to file by absolute path in Windows', () => {
+      runCLI(`dep-graph --file=C:\\tmp\\project-graph.json`);
+
+      expect(() =>
+        checkFilesExist('C:\\tmp\\project-graph.json')
+      ).not.toThrow();
+    }, 1000000);
+  }
 
   it('dep-graph should focus requested project', () => {
     runCLI(`dep-graph --focus=${myapp} --file=project-graph.json`);


### PR DESCRIPTION
## Current Behavior
On Windows:
```
 nx dep-graph --file C://some-file.json
```
results in an error:
```
Error: Path contains invalid characters: D:\<redacted-path-to-workspace>/C:/
    at checkPath (D:\<redacted-path-to-workspace>\node_modules\@nrwl\workspace\node_modules\fs-extra\lib\mkdirs\make-dir.js:20:21)
    at Object.module.exports.makeDirSync (D:\<redacted-path-to-workspace>\node_modules\@nrwl\workspace\node_modules\fs-extra\lib\mkdirs\make-dir.js:95:3)
    at Object.<anonymous> (D:\<redacted-path-to-workspace>\node_modules\@nrwl\workspace\src\command-line\dep-graph.js:182:28)
    at Generator.next (<anonymous>)
    at fulfilled (D:\<redacted-path-to-workspace>\node_modules\tslib\tslib.js:114:62) {
  code: 'EINVAL'
}
```

On MacOS:
```
nx dep-graph --file /tmp/dep-graph.json 
```
results in a badly placed file:
```
>  NX   SUCCESS  JSON output created in /<redacted-path-to-workspace>

  /<redacted-path-to-workspace>//tmp/dep-graph.json
```
## Expected Behavior
On Windows:
```
 nx dep-graph --file C://some-file.json
```
results in:
```
>  NX   SUCCESS  JSON output created in C://

  C://some-file.json
```

On MacOS:
```
nx dep-graph --file /tmp/dep-graph.json 
```
results in
```
>  NX   SUCCESS  JSON output created in /tmp

  /tmp/dep-graph.json
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7202
