### PR TITLE
feat(misc): add --open option for dep-graph command

### DIFF
--- a/docs/angular/cli/affected-dep-graph.md
+++ b/docs/angular/cli/affected-dep-graph.md
@@ -102,6 +102,12 @@ Default: `false`
 
 Isolate projects which previously failed
 
+### open
+
+Default: `true`
+
+Open the dependency graph in the browser.
+
 ### port
 
 Bind the dependecy graph server to a specific port.

--- a/docs/angular/cli/dep-graph.md
+++ b/docs/angular/cli/dep-graph.md
@@ -86,6 +86,12 @@ Show help
 
 Bind the dependency graph server to a specific ip address.
 
+### open
+
+Default: `true`
+
+Open the dependency graph in the browser.
+
 ### port
 
 Bind the dependecy graph server to a specific port.

--- a/docs/node/cli/affected-dep-graph.md
+++ b/docs/node/cli/affected-dep-graph.md
@@ -102,6 +102,12 @@ Default: `false`
 
 Isolate projects which previously failed
 
+### open
+
+Default: `true`
+
+Open the dependency graph in the browser.
+
 ### port
 
 Bind the dependecy graph server to a specific port.

--- a/docs/node/cli/dep-graph.md
+++ b/docs/node/cli/dep-graph.md
@@ -86,6 +86,12 @@ Show help
 
 Bind the dependency graph server to a specific ip address.
 
+### open
+
+Default: `true`
+
+Open the dependency graph in the browser.
+
 ### port
 
 Bind the dependecy graph server to a specific port.

--- a/docs/react/cli/affected-dep-graph.md
+++ b/docs/react/cli/affected-dep-graph.md
@@ -102,6 +102,12 @@ Default: `false`
 
 Isolate projects which previously failed
 
+### open
+
+Default: `true`
+
+Open the dependency graph in the browser.
+
 ### port
 
 Bind the dependecy graph server to a specific port.

--- a/docs/react/cli/dep-graph.md
+++ b/docs/react/cli/dep-graph.md
@@ -86,6 +86,12 @@ Show help
 
 Bind the dependency graph server to a specific ip address.
 
+### open
+
+Default: `true`
+
+Open the dependency graph in the browser.
+
 ### port
 
 Bind the dependecy graph server to a specific port.

--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -1,4 +1,5 @@
 import { joinPathFragments } from '@nrwl/devkit/src/utils/path';
+import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import { watch } from 'chokidar';
 import { createHash } from 'crypto';
 import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
@@ -6,7 +7,7 @@ import { copySync, ensureDirSync } from 'fs-extra';
 import * as http from 'http';
 import ignore from 'ignore';
 import * as open from 'open';
-import { dirname, join, parse, basename } from 'path';
+import { basename, dirname, join, parse } from 'path';
 import { performance } from 'perf_hooks';
 import { URL } from 'url';
 import { workspaceLayout } from '../core/file-utils';
@@ -18,7 +19,6 @@ import {
   ProjectGraphDependency,
   ProjectGraphNode,
 } from '../core/project-graph';
-import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import {
   cacheDirectory,
   readCacheDirectoryProperty,
@@ -201,6 +201,7 @@ export async function generateGraph(
     exclude?: string[];
     groupByFolder?: boolean;
     watch?: boolean;
+    open?: boolean;
   },
   affectedProjects: string[]
 ): Promise<void> {
@@ -329,7 +330,8 @@ export async function generateGraph(
       affectedProjects,
       args.focus,
       args.groupByFolder,
-      args.exclude
+      args.exclude,
+      args.open
     );
   }
 }
@@ -342,7 +344,8 @@ async function startServer(
   affected: string[] = [],
   focus: string = null,
   groupByFolder: boolean = false,
-  exclude: string[] = []
+  exclude: string[] = [],
+  openBrowser: boolean = true
 ) {
   if (watchForchanges) {
     startWatcher();
@@ -411,7 +414,9 @@ async function startServer(
     title: `Dep graph started at http://${host}:${port}`,
   });
 
-  open(`http://${host}:${port}`);
+  if (openBrowser) {
+    open(`http://${host}:${port}`);
+  }
 }
 
 let currentDepGraphClientResponse: DepGraphClientResponse = {

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -508,6 +508,11 @@ function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'Watch for changes to dependency graph and update in-browser',
       type: 'boolean',
       default: false,
+    })
+    .option('open', {
+      describe: 'Open the dependency graph in the browser.',
+      type: 'boolean',
+      default: true,
     });
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
* Running the `dep-graph` command always opens the browser
<!-- This is the behavior we have today -->

## Expected Behavior
* Running the `dep-graph` command opens the browser by default, but setting the `--open=false` option prevents this

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes #3324
