### PR TITLE
feat(core): strict mode by default for workspace libraries

### DIFF
--- a/docs/angular/api-workspace/generators/library.md
+++ b/docs/angular/api-workspace/generators/library.md
@@ -140,7 +140,7 @@ Split the project configuration into <projectRoot>/project.json rather than incl
 
 ### strict
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/node/api-workspace/generators/library.md
+++ b/docs/node/api-workspace/generators/library.md
@@ -140,7 +140,7 @@ Split the project configuration into <projectRoot>/project.json rather than incl
 
 ### strict
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/react/api-workspace/generators/library.md
+++ b/docs/react/api-workspace/generators/library.md
@@ -140,7 +140,7 @@ Split the project configuration into <projectRoot>/project.json rather than incl
 
 ### strict
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/packages/workspace/src/generators/library/library.spec.ts
+++ b/packages/workspace/src/generators/library/library.spec.ts
@@ -16,7 +16,7 @@ describe('lib', () => {
     testEnvironment: 'jsdom',
     js: false,
     pascalCaseFiles: false,
-    strict: false,
+    strict: true,
     standaloneConfig: false,
   };
 
@@ -76,6 +76,12 @@ describe('lib', () => {
       const tsconfigJson = readJson(tree, 'libs/my-lib/tsconfig.json');
       expect(tsconfigJson).toMatchInlineSnapshot(`
         Object {
+          "compilerOptions": Object {
+            "forceConsistentCasingInFileNames": true,
+            "noFallthroughCasesInSwitch": true,
+            "noImplicitReturns": true,
+            "strict": true,
+          },
           "extends": "../../tsconfig.base.json",
           "files": Array [],
           "include": Array [],
@@ -510,13 +516,30 @@ describe('lib', () => {
   });
 
   describe('--strict', () => {
-    it('should update the projects tsconfig with strict true', async () => {
+    it('should update the projects tsconfig with strict false', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
         name: 'myLib',
-        strict: true,
+        strict: false,
       });
-      const tsconfigJson = readJson(tree, '/libs/my-lib/tsconfig.lib.json');
+      const tsconfigJson = readJson(tree, '/libs/my-lib/tsconfig.json');
+
+      expect(tsconfigJson.compilerOptions?.strict).not.toBeDefined();
+      expect(
+        tsconfigJson.compilerOptions?.forceConsistentCasingInFileNames
+      ).not.toBeDefined();
+      expect(tsconfigJson.compilerOptions?.noImplicitReturns).not.toBeDefined();
+      expect(
+        tsconfigJson.compilerOptions?.noFallthroughCasesInSwitch
+      ).not.toBeDefined();
+    });
+
+    it('should default to strict true', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+      });
+      const tsconfigJson = readJson(tree, '/libs/my-lib/tsconfig.json');
 
       expect(tsconfigJson.compilerOptions.strict).toBeTruthy();
       expect(
@@ -526,23 +549,6 @@ describe('lib', () => {
       expect(
         tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
       ).toBeTruthy();
-    });
-
-    it('should default to strict false', async () => {
-      await libraryGenerator(tree, {
-        ...defaultOptions,
-        name: 'myLib',
-      });
-      const tsconfigJson = readJson(tree, '/libs/my-lib/tsconfig.lib.json');
-
-      expect(tsconfigJson.compilerOptions.strict).not.toBeDefined();
-      expect(
-        tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
-      ).not.toBeDefined();
-      expect(tsconfigJson.compilerOptions.noImplicitReturns).not.toBeDefined();
-      expect(
-        tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
-      ).not.toBeDefined();
     });
   });
 
@@ -604,6 +610,10 @@ describe('lib', () => {
       expect(
         readJson(tree, 'libs/my-lib/tsconfig.json').compilerOptions
       ).toEqual({
+        forceConsistentCasingInFileNames: true,
+        noFallthroughCasesInSwitch: true,
+        noImplicitReturns: true,
+        strict: true,
         allowJs: true,
       });
     });

--- a/packages/workspace/src/generators/library/library.ts
+++ b/packages/workspace/src/generators/library/library.ts
@@ -82,8 +82,8 @@ export function addLint(
   });
 }
 
-function updateLibTsConfig(tree: Tree, options: NormalizedSchema) {
-  updateJson(tree, join(options.projectRoot, 'tsconfig.lib.json'), (json) => {
+function updateTsConfig(tree: Tree, options: NormalizedSchema) {
+  updateJson(tree, join(options.projectRoot, 'tsconfig.json'), (json) => {
     if (options.strict) {
       json.compilerOptions = {
         ...json.compilerOptions,
@@ -157,7 +157,7 @@ function createFiles(tree: Tree, options: NormalizedSchema) {
     tree.delete(join(options.projectRoot, 'package.json'));
   }
 
-  updateLibTsConfig(tree, options);
+  updateTsConfig(tree, options);
 }
 
 async function addJest(

--- a/packages/workspace/src/generators/library/schema.json
+++ b/packages/workspace/src/generators/library/schema.json
@@ -80,7 +80,7 @@
     "strict": {
       "type": "boolean",
       "description": "Whether to enable tsconfig strict mode or not.",
-      "default": false
+      "default": true
     },
     "skipBabelrc": {
       "type": "boolean",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/workspace:library` generates libraries with `strict: false`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`strict: true` by default like `@nrwl/angular:library` and `@nrwl/react:library`.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
