### PR TITLE
fix(nxdev): verify whether srcFolder passed to generateFiles exists

### DIFF
--- a/packages/devkit/src/generators/generate-files.ts
+++ b/packages/devkit/src/generators/generate-files.ts
@@ -66,29 +66,37 @@ export function generateFiles(
   substitutions: { [k: string]: any }
 ): void {
   const ejs = require('ejs');
-  allFilesInDir(srcFolder).forEach((filePath) => {
-    let newContent: Buffer | string;
-    const computedPath = computePath(
-      srcFolder,
-      target,
-      filePath,
-      substitutions
+
+  const files = allFilesInDir(srcFolder);
+  if (files.length === 0) {
+    throw new Error(
+      `generateFiles: No files found in "${srcFolder}". Are you sure you specified the correct path?`
     );
+  } else {
+    files.forEach((filePath) => {
+      let newContent: Buffer | string;
+      const computedPath = computePath(
+        srcFolder,
+        target,
+        filePath,
+        substitutions
+      );
 
-    if (binaryExts.has(path.extname(filePath))) {
-      newContent = readFileSync(filePath);
-    } else {
-      const template = readFileSync(filePath, 'utf-8');
-      try {
-        newContent = ejs.render(template, substitutions, {});
-      } catch (e) {
-        logger.error(`Error in ${filePath.replace(`${tree.root}/`, '')}:`);
-        throw e;
+      if (binaryExts.has(path.extname(filePath))) {
+        newContent = readFileSync(filePath);
+      } else {
+        const template = readFileSync(filePath, 'utf-8');
+        try {
+          newContent = ejs.render(template, substitutions, {});
+        } catch (e) {
+          logger.error(`Error in ${filePath.replace(`${tree.root}/`, '')}:`);
+          throw e;
+        }
       }
-    }
 
-    tree.write(computedPath, newContent);
-  });
+      tree.write(computedPath, newContent);
+    });
+  }
 }
 
 function computePath(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Right now if for some reason you pass a wrong path to the `generateFiles(...)` function, it will just silently succeed, without generating anything.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It should throw some error or at least warning:
![image](https://user-images.githubusercontent.com/542458/135829192-4ffd05fe-ba28-4511-9026-218a50f02952.png)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
