### PR TITLE
fix(nx-plugin): use nrwl devkit logger in generated executor example

### DIFF
--- a/packages/nx-plugin/src/generators/executor/files/executor/__fileName__/executor.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/executor/files/executor/__fileName__/executor.ts__tmpl__
@@ -1,9 +1,10 @@
+import { logger } from '@nrwl/devkit';
 import { <%= className %>ExecutorSchema } from './schema';
 
 export default async function runExecutor(
   options: <%= className %>ExecutorSchema,
 ) {
-  console.log('Executor ran for <%= className %>', options)
+  logger.info('Executor ran for <%= className %>', options)
   return {
     success: true
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Minor thing, but right now the generated plugin executor example uses `console.log`, which is fine, but we should probably encourage ppl to use the Nrwl devkit logger.