### PR TITLE
fix(nextjs): generate nextjs app with correct pages dir for no-html-link-for-pages rule

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -246,7 +246,7 @@ describe('Next.js Applications', () => {
             `</h2>
                 <div>
                   {testFn()}
-                  <TestComponent text="Hello Next.JS" />
+                  <TestComponent text='Hello Next.JS' />
                 </div>
               `
           )}`
@@ -620,6 +620,36 @@ describe('Next.js Applications', () => {
     } catch (err) {
       expect(err).toBeFalsy();
     }
+  }, 300000);
+
+  it('should include nextjs lint rules by default', () => {
+    const appName = uniq('app');
+
+    runCLI(`generate @nrwl/next:app ${appName}`);
+
+    // Create /about page
+    updateFile(
+      `apps/${appName}/pages/about.tsx`,
+      `
+export default function About() {
+  return <h1>About Us</h1>
+}
+`
+    );
+
+    // Link to newly created about page
+    // This should cause a lint error since Link isn't used for internal links
+    updateFile(
+      `apps/${appName}/pages/index.tsx`,
+      `
+export default function Home() {
+  return <a href='/about'>About Us</a>;
+}
+`
+    );
+
+    const lintResults = runCLI(`lint ${appName}`, { silenceError: true });
+    expect(lintResults).toContain('Lint errors found');
   }, 300000);
 });
 

--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -54,6 +54,12 @@
       "version": "12.8.0-beta.11",
       "description": "Adjust the Next.js lib babel configuration for styled-jsx",
       "factory": "./src/migrations/update-12-8-0/remove-styled-jsx-babel-plugin"
+    },
+    "fix-page-dir-for-eslint": {
+      "cli": "nx",
+      "version": "12.10.0-beta.1",
+      "description": "Updates .eslintrc.json file to use the correct pages directory for '@next/next/no-html-link-for-pages'.",
+      "factory": "./src/migrations/update-12-10-0/fix-page-dir-for-eslint"
     }
   },
   "packageJsonUpdates": {

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -309,46 +309,51 @@ describe('app', () => {
 
         const eslintJson = readJson(tree, '/apps/my-app/.eslintrc.json');
         expect(eslintJson).toMatchInlineSnapshot(`
-          Object {
-            "env": Object {
-              "jest": true,
-            },
-            "extends": Array [
-              "plugin:@nrwl/nx/react-typescript",
-              "../../.eslintrc.json",
-              "next",
-              "next/core-web-vitals",
-            ],
-            "ignorePatterns": Array [
-              "!**/*",
-            ],
-            "overrides": Array [
-              Object {
-                "files": Array [
-                  "*.ts",
-                  "*.tsx",
-                  "*.js",
-                  "*.jsx",
-                ],
-                "rules": Object {},
-              },
-              Object {
-                "files": Array [
-                  "*.ts",
-                  "*.tsx",
-                ],
-                "rules": Object {},
-              },
-              Object {
-                "files": Array [
-                  "*.js",
-                  "*.jsx",
-                ],
-                "rules": Object {},
-              },
-            ],
-          }
-        `);
+Object {
+  "env": Object {
+    "jest": true,
+  },
+  "extends": Array [
+    "plugin:@nrwl/nx/react-typescript",
+    "../../.eslintrc.json",
+    "next",
+    "next/core-web-vitals",
+  ],
+  "ignorePatterns": Array [
+    "!**/*",
+  ],
+  "overrides": Array [
+    Object {
+      "files": Array [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx",
+      ],
+      "rules": Object {
+        "@next/next/no-html-link-for-pages": Array [
+          "error",
+          "apps/my-app/pages",
+        ],
+      },
+    },
+    Object {
+      "files": Array [
+        "*.ts",
+        "*.tsx",
+      ],
+      "rules": Object {},
+    },
+    Object {
+      "files": Array [
+        "*.js",
+        "*.jsx",
+      ],
+      "rules": Object {},
+    },
+  ],
+}
+`);
       });
     });
 

--- a/packages/next/src/migrations/update-12-10-0/fix-page-dir-for-eslint.spec.ts
+++ b/packages/next/src/migrations/update-12-10-0/fix-page-dir-for-eslint.spec.ts
@@ -1,0 +1,114 @@
+import { readJson, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+import { applicationGenerator } from '../../generators/application/application';
+import { fixPageDirForEslint } from './fix-page-dir-for-eslint';
+
+describe('Migration: Fix pages directory for ESLint', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+
+    await applicationGenerator(tree, {
+      style: 'none',
+      name: 'demo',
+      skipFormat: false,
+    });
+  });
+
+  it('should fix custom pages path', async () => {
+    // Config that isn't configured properly
+    tree.write(
+      'apps/demo/.eslintrc.json',
+      JSON.stringify({
+        extends: ['next'],
+        overrides: [
+          {
+            files: ['*.ts', '*.tsx', '*.js', '*.jsx'],
+            rules: {
+              'existing-rule': 'error',
+            },
+          },
+        ],
+      })
+    );
+
+    await fixPageDirForEslint(tree);
+
+    const result = readJson(tree, 'apps/demo/.eslintrc.json');
+    expect(result.overrides[0].rules).toEqual({
+      'existing-rule': 'error',
+      '@next/next/no-html-link-for-pages': ['error', 'apps/demo/pages'],
+    });
+  });
+
+  it('should leave existing no-html-link-for-pages rule if it exists', async () => {
+    // Config that isn't configured properly
+    tree.write(
+      'apps/demo/.eslintrc.json',
+      JSON.stringify({
+        extends: ['next'],
+        overrides: [
+          {
+            files: ['*.ts', '*.tsx', '*.js', '*.jsx'],
+            rules: {
+              '@next/next/no-html-link-for-pages': [
+                'error',
+                'apps/demo/some/other/path',
+              ],
+            },
+          },
+        ],
+      })
+    );
+
+    await fixPageDirForEslint(tree);
+
+    const result = readJson(tree, 'apps/demo/.eslintrc.json');
+    expect(result.overrides[0].rules).toEqual({
+      '@next/next/no-html-link-for-pages': [
+        'error',
+        'apps/demo/some/other/path',
+      ],
+    });
+  });
+
+  it('should handle custom overrides configuration', async () => {
+    // Config that isn't configured properly
+    tree.write(
+      'apps/demo/.eslintrc.json',
+      JSON.stringify({
+        extends: ['next', 'plugin:vue/base'],
+        overrides: [
+          { files: ['*.vue'], rule: { 'vue/comment-directive': 'error' } },
+          {
+            files: ['*.ts', '*.tsx', '*.js', '*.jsx'],
+            rules: {
+              '@next/next/no-html-link-for-pages': [
+                'error',
+                'apps/demo/some/other/path',
+              ],
+            },
+          },
+        ],
+      })
+    );
+
+    await fixPageDirForEslint(tree);
+
+    const result = readJson(tree, 'apps/demo/.eslintrc.json');
+    expect(result.overrides).toEqual([
+      { files: ['*.vue'], rule: { 'vue/comment-directive': 'error' } },
+      {
+        files: ['*.ts', '*.tsx', '*.js', '*.jsx'],
+        rules: {
+          '@next/next/no-html-link-for-pages': [
+            'error',
+            'apps/demo/some/other/path',
+          ],
+        },
+      },
+    ]);
+  });
+});

--- a/packages/next/src/migrations/update-12-10-0/fix-page-dir-for-eslint.ts
+++ b/packages/next/src/migrations/update-12-10-0/fix-page-dir-for-eslint.ts
@@ -1,0 +1,45 @@
+import {
+  formatFiles,
+  getProjects,
+  joinPathFragments,
+  readJson,
+  Tree,
+  writeJson,
+} from '@nrwl/devkit';
+
+export async function fixPageDirForEslint(host: Tree) {
+  const projects = getProjects(host);
+
+  projects.forEach((project) => {
+    const eslintRcJson = joinPathFragments(project.root, '.eslintrc.json');
+    if (host.exists(eslintRcJson)) {
+      const config = readJson(host, eslintRcJson);
+      // Ignore non-nextjs projects
+      if (!config?.extends?.includes('next')) return;
+
+      // Find the override that handles both TS and JS files.
+      const commonOverride = config.overrides?.find((o) =>
+        ['*.ts', '*.tsx', '*.js', '*.jsx'].every((ext) => o.files.includes(ext))
+      );
+
+      if (
+        commonOverride &&
+        !commonOverride.rules['@next/next/no-html-link-for-pages']
+      ) {
+        commonOverride.rules = {
+          ...commonOverride.rules,
+          '@next/next/no-html-link-for-pages': [
+            'error',
+            `${project.root}/pages`,
+          ],
+        };
+
+        writeJson(host, eslintRcJson, config);
+      }
+    }
+  });
+
+  await formatFiles(host);
+}
+
+export default fixPageDirForEslint;


### PR DESCRIPTION
This PR includes a fix for new Next.js app to use the correct value for pages directory when linting.

Also includes a migration for existing apps to configure `.eslintrc.json` correctly.


## Current Behavior

Running `nx lint myapp` gives a warning for Next.js apps because `pages` or `src/pages` are not found.

## Expected Behavior

Linting should pick up the correct pages directory.
