### PR TITLE
fix(testing): make sure NX_WORKSPACE_ROOT_PATH exists 

### DIFF
--- a/scripts/patched-jest-resolver.js
+++ b/scripts/patched-jest-resolver.js
@@ -1,7 +1,9 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+const { fs } = require('memfs');
 const path_1 = require('path');
 const ts = require('typescript');
+const fileSystem = require('fs');
 function getCompilerSetup(rootDir) {
   const tsConfigPath =
     ts.findConfigFile(rootDir, ts.sys.fileExists, 'tsconfig.spec.json') ||
@@ -28,12 +30,13 @@ if (
   process.argv[1].indexOf('jest-worker') > -1 ||
   (process.argv.length >= 4 && process.argv[3].split(':')[1] === 'test')
 ) {
-  process.env.NX_WORKSPACE_ROOT_PATH = path_1.join(
-    __dirname,
-    '..',
-    'tmp',
-    'unit'
-  );
+  const root = path_1.join(__dirname, '..', 'tmp', 'unit');
+  try {
+    if (!fileSystem.existsSync(root)) {
+      fileSystem.mkdirSync(root);
+    }
+  } catch (_err) {}
+  process.env.NX_WORKSPACE_ROOT_PATH = root;
 }
 
 module.exports = function (path, options) {

--- a/scripts/patched-jest-resolver.js
+++ b/scripts/patched-jest-resolver.js
@@ -1,9 +1,8 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
-const { fs } = require('memfs');
 const path_1 = require('path');
 const ts = require('typescript');
-const fileSystem = require('fs');
+const fs = require('fs');
 function getCompilerSetup(rootDir) {
   const tsConfigPath =
     ts.findConfigFile(rootDir, ts.sys.fileExists, 'tsconfig.spec.json') ||
@@ -32,8 +31,8 @@ if (
 ) {
   const root = path_1.join(__dirname, '..', 'tmp', 'unit');
   try {
-    if (!fileSystem.existsSync(root)) {
-      fileSystem.mkdirSync(root);
+    if (!fs.existsSync(root)) {
+      fs.mkdirSync(root);
     }
   } catch (_err) {}
   process.env.NX_WORKSPACE_ROOT_PATH = root;


### PR DESCRIPTION

in patched_jest_resolver.js the NX_WORKSPACE_ROOT_PATH is setup
and we must ensure that this
directory exists on disk
as otherwise startServer() will fail
as the socket cannot be created in a
non-existing directory

ISSUES CLOSED: #7237

## Current Behavior

clone @nrwl/nx repo
remove unit test workdir : rmdir tmp/unit
run nx test workspace --testFile=packages/workspace/src/core/project-graph/daemon/server.spec.ts
will fail

## Expected Behavior
clone @nrwl/nx repo
remove unit test workdir : rmdir tmp/unit
run nx test workspace --testFile=packages/workspace/src/core/project-graph/daemon/server.spec.ts
will succeed

## Related Issue(s)

Fixes #7237