### PR TITLE
fix(core): fix crash in hash of project 

### DIFF
--- a/packages/workspace/src/core/hasher/hasher.spec.ts
+++ b/packages/workspace/src/core/hasher/hasher.spec.ts
@@ -13,7 +13,7 @@ jest.mock('fs');
 
 fs.existsSync = () => true;
 
-describe('Hasher', () => {
+fdescribe('Hasher', () => {
   const nxJson = {
     npmScope: 'nrwl',
   };
@@ -435,5 +435,50 @@ describe('Hasher', () => {
 
     expect(tasksHash.value).toContain('global1.hash');
     expect(tasksHash.value).toContain('global2.hash');
+  });
+
+  it('should hash missing dependent npm project versions', async () => {
+    hashes['/filea'] = 'a.hash';
+    hashes['/fileb'] = 'b.hash';
+    const hasher = new Hasher(
+      {
+        nodes: {
+          app: {
+            name: 'app',
+            type: 'app',
+            data: {
+              root: '',
+              files: [{ file: '/filea.ts', hash: 'a.hash' }],
+            },
+          },
+        },
+        externalNodes: {},
+        dependencies: {
+          'npm:react': [],
+          app: [
+            {
+              source: 'app',
+              target: 'npm:react',
+              type: DependencyType.static,
+            },
+          ],
+        },
+      },
+      {} as any,
+      {},
+      createHashing()
+    );
+
+    const hash = await hasher.hashTaskWithDepsAndContext({
+      target: { project: 'app', target: 'build' },
+      id: 'app-build',
+      overrides: { prop: 'prop-value' },
+    });
+
+    // note that the parent hash is based on parent source files only!
+    expect(hash.details.nodes).toEqual({
+      app: '/filea.ts|a.hash|""|{"compilerOptions":{"paths":{"@nrwl/parent":["libs/parent/src/index.ts"],"@nrwl/child":["libs/child/src/index.ts"]}}}',
+      'npm:react': '__npm:react__',
+    });
   });
 });

--- a/packages/workspace/src/core/hasher/hasher.ts
+++ b/packages/workspace/src/core/hasher/hasher.ts
@@ -344,7 +344,25 @@ class ProjectHasher {
 
         if (!p) {
           const n = this.projectGraph.externalNodes[projectName];
-          res(this.hashing.hashArray([n.data.version]));
+          const version = n?.data?.version;
+          let hash: string;
+          if (version) {
+            hash = this.hashing.hashArray([version]);
+          } else {
+            // unknown dependency
+            // this may occur if a file has a dependency to a npm package
+            // which is not directly registestered in package.json
+            // but only indirectly through dependencies of registered
+            // npm packages
+            // when it is at a later stage registered in package.json
+            // the cache project graph will not know this module but
+            // the new project graph will know it
+            // The actual checksum added here is of no importance as
+            // the version is unknown and may only change when some
+            // other change occurs in package.json and/or package-lock.json
+            hash = `__${projectName}__`;
+          }
+          res(hash);
           return;
         }
 


### PR DESCRIPTION

If some .ts file imports an npm package that is not directly registered as dependency
the caching of
project graph may result in an exception
when switching back and forth between branches where the
npm package
is a dependency and where it is not
This PR will just provide some dummy checksum for
unknown dependencies

ISSUES CLOSED: #7225

## Current Behavior
Had a workspace with `import '@testing-library/dom';`
but this was not present as a dependency in package.json
it was however indirectly available as a derived dependency from `@testing-library/angular`

Now adding the missing dependency to package.json caused hash calculation to fail here in `hasher.js`:

   hashProjectNodeSource(projectName) {
        return tslib_1.__awaiter(this, void 0, void 0, function* () {
            if (!this.sourceHashes[projectName]) {
                this.sourceHashes[projectName] = new Promise((res) => tslib_1.__awaiter(this, void 0, void 0, function* () {
                    var _a, _b;
                    const p = this.projectGraph.nodes[projectName];
                    if (project_graph_1.isNpmProject(p)) {
                        res(this.hashing.hashArray([p.data.version]));
                        return;
                    }
```
for `projectName === '@testing-library/dom'` when running e.g. `nx test xxxx`
because `p === undefined` as `this.projectGraph.nodes['@testing-library/dom']` was never set in the cache because `'@testing-library/dom'` was not a dependency in `package.json`

If doing `NX_CACHE_PROJECT_GRAPH=false nx test xxxx`
the problem goes away


## Expected Behavior
Cache of project graph should work allways when switching betwen branches

## Related Issue(s)


Fixes #7225
