### PR TITLE
fix(devkit): add transparent support for v1 format

### DIFF
--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -1,10 +1,12 @@
-import type { Tree } from '@nrwl/tao/src/shared/tree';
-import { reformattedWorkspaceJsonOrNull } from '@nrwl/tao/src/shared/workspace';
+import { sortObjectByKeys } from '@nrwl/tao/src/utils/object-sort';
 import * as path from 'path';
-import type * as Prettier from 'prettier';
+
 import { getWorkspacePath } from '../utils/get-workspace-layout';
 import { readJson, writeJson } from '../utils/json';
-import { sortObjectByKeys } from '@nrwl/tao/src/utils/object-sort';
+import { updateWorkspaceJsonToMatchFormatVersion } from './update-workspace-json-to-match-format-version';
+
+import type { Tree } from '@nrwl/tao/src/shared/tree';
+import type * as Prettier from 'prettier';
 
 /**
  * Formats all the created or updated files using Prettier
@@ -16,7 +18,10 @@ export async function formatFiles(tree: Tree): Promise<void> {
     prettier = await import('prettier');
   } catch {}
 
+  // Calling formatFiles() within generators to support old workspace format is weird,
+  // should be removed but it's breaking change for devkit users.
   updateWorkspaceJsonToMatchFormatVersion(tree);
+
   sortWorkspaceJson(tree);
   sortNxJson(tree);
   sortTsConfig(tree);
@@ -59,24 +64,6 @@ export async function formatFiles(tree: Tree): Promise<void> {
       }
     })
   );
-}
-
-function updateWorkspaceJsonToMatchFormatVersion(tree: Tree) {
-  const path = getWorkspacePath(tree);
-  if (!path) {
-    return;
-  }
-
-  try {
-    const workspaceJson = readJson(tree, path);
-    const reformatted = reformattedWorkspaceJsonOrNull(workspaceJson);
-    if (reformatted) {
-      writeJson(tree, path, reformatted);
-    }
-  } catch (e) {
-    console.error(`Failed to format: ${path}`);
-    console.error(e);
-  }
 }
 
 function sortWorkspaceJson(tree: Tree) {

--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -11,6 +11,7 @@ import {
 } from '../utils/get-workspace-layout';
 import { readJson, updateJson, writeJson } from '../utils/json';
 import { joinPathFragments } from '../utils/path';
+import { updateWorkspaceJsonToMatchFormatVersion } from './update-workspace-json-to-match-format-version';
 
 import type { Tree } from '@nrwl/tao/src/shared/tree';
 import type {
@@ -196,6 +197,8 @@ export function updateWorkspaceConfiguration(
       }
     });
   }
+
+  updateWorkspaceJsonToMatchFormatVersion(tree);
 }
 
 function readNxJsonExtends(tree: Tree, nxJson: { extends?: string }) {
@@ -334,6 +337,8 @@ function setProjectConfiguration(
       mode
     );
   }
+
+  updateWorkspaceJsonToMatchFormatVersion(tree);
 }
 
 function addProjectToWorkspaceJson(
@@ -372,6 +377,7 @@ function addProjectToWorkspaceJson(
     workspaceJson.projects[projectName] = workspaceConfiguration;
   }
   writeJson(tree, path, workspaceJson);
+  updateWorkspaceJsonToMatchFormatVersion(tree);
 }
 
 function addProjectToNxJson(

--- a/packages/devkit/src/generators/update-workspace-json-to-match-format-version.ts
+++ b/packages/devkit/src/generators/update-workspace-json-to-match-format-version.ts
@@ -1,0 +1,24 @@
+import { reformattedWorkspaceJsonOrNull } from '@nrwl/tao/src/shared/workspace';
+
+import { getWorkspacePath } from '../utils/get-workspace-layout';
+import { readJson, writeJson } from '../utils/json';
+
+import type { Tree } from '@nrwl/tao/src/shared/tree';
+
+export function updateWorkspaceJsonToMatchFormatVersion(tree: Tree): void {
+  const path = getWorkspacePath(tree);
+  if (!path) {
+    return;
+  }
+
+  try {
+    const workspaceJson = readJson(tree, path);
+    const reformatted = reformattedWorkspaceJsonOrNull(workspaceJson);
+    if (reformatted) {
+      writeJson(tree, path, reformatted);
+    }
+  } catch (e) {
+    console.error(`Failed to format: ${path}`);
+    console.error(e);
+  }
+}

--- a/packages/linter/src/utils/convert-tslint-to-eslint/__snapshots__/project-converter.spec.ts.snap
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/__snapshots__/project-converter.spec.ts.snap
@@ -96,7 +96,7 @@ Object {
       },
     },
   },
-  "version": 1,
+  "version": 2,
 }
 `;
 
@@ -136,7 +136,7 @@ Object {
       },
     },
   },
-  "version": 1,
+  "version": 2,
 }
 `;
 
@@ -179,7 +179,7 @@ Object {
       },
     },
   },
-  "version": 1,
+  "version": 2,
 }
 `;
 
@@ -211,7 +211,7 @@ Object {
       },
     },
   },
-  "version": 1,
+  "version": 2,
 }
 `;
 
@@ -257,7 +257,7 @@ Object {
       },
     },
   },
-  "version": 1,
+  "version": 2,
 }
 `;
 
@@ -307,7 +307,7 @@ Object {
       },
     },
   },
-  "version": 1,
+  "version": 2,
 }
 `;
 
@@ -357,7 +357,7 @@ Object {
       },
     },
   },
-  "version": 1,
+  "version": 2,
 }
 `;
 

--- a/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.spec.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.spec.ts
@@ -47,7 +47,7 @@ describe('ProjectConverter', () => {
     process.argv = process.argv.filter(
       (a) => !['--dry-run', '--dryRun', '-d'].includes(a)
     );
-    host = createTreeWithEmptyWorkspace();
+    host = createTreeWithEmptyWorkspace(2);
     addProjectConfiguration(host, projectName, {
       root: projectRoot,
       projectType: 'application',

--- a/packages/workspace/src/generators/init/init.ts
+++ b/packages/workspace/src/generators/init/init.ts
@@ -257,15 +257,15 @@ function updateTsConfigsJson(host: Tree, options: Schema) {
   const tsConfigPath = getRootTsConfigPath(host);
   const appOffset = offsetFromRoot(app.root);
 
-  updateJson(host, app.targets.build.options.tsConfig, (json) => {
+  updateJson(host, app.architect.build.options.tsConfig, (json) => {
     json.extends = `${appOffset}${tsConfigPath}`;
     json.compilerOptions = json.compilerOptions || {};
     json.compilerOptions.outDir = `${appOffset}dist/out-tsc`;
     return json;
   });
 
-  if (app.targets.test) {
-    updateJson(host, app.targets.test.options.tsConfig, (json) => {
+  if (app.architect.test) {
+    updateJson(host, app.architect.test.options.tsConfig, (json) => {
       json.extends = `${appOffset}${tsConfigPath}`;
       json.compilerOptions = json.compilerOptions || {};
       json.compilerOptions.outDir = `${appOffset}dist/out-tsc`;
@@ -273,8 +273,8 @@ function updateTsConfigsJson(host: Tree, options: Schema) {
     });
   }
 
-  if (app.targets.server) {
-    updateJson(host, app.targets.server.options.tsConfig, (json) => {
+  if (app.architect.server) {
+    updateJson(host, app.architect.server.options.tsConfig, (json) => {
       json.extends = `${appOffset}${tsConfigPath}`;
       json.compilerOptions = json.compilerOptions || {};
       json.compilerOptions.outDir = `${appOffset}dist/out-tsc`;
@@ -283,7 +283,7 @@ function updateTsConfigsJson(host: Tree, options: Schema) {
   }
 
   if (!!e2eProject) {
-    updateJson(host, e2eProject.targets.lint.options.tsConfig, (json) => {
+    updateJson(host, e2eProject.architect.build.options.tsConfig, (json) => {
       json.extends = `${offsetFromRoot(e2eProject.root)}${tsConfigPath}`;
       json.compilerOptions = {
         ...json.compilerOptions,


### PR DESCRIPTION
Provide support for Angular CLI when using devkit project configuration functions without the need to call `formatFiles()`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

To support workspace definition format with devkit generator we have to call the `formatFiles()` function which call `updateWorkspaceJsonToMatchFormatVersion()`.

## Expected Behavior

Transparent support for v1 format without the need to call `formatFiles()`.

## Related Issue(s)

Following to this discussion: https://github.com/nrwl/nx/discussions/6955
