### PR TITLE
fix(react-native): use jest-jasmine2 runner

### DIFF
--- a/packages/react-native/src/utils/add-jest.ts
+++ b/packages/react-native/src/utils/add-jest.ts
@@ -24,6 +24,7 @@ export async function addJest(
   const content = `module.exports = {
   displayName: '${projectName}',
   preset: 'react-native',
+  testRunner: 'jest-jasmine2',
   resolver: '@nrwl/jest/plugins/resolver',
   moduleFileExtensions: ['ts', 'js', 'html', 'tsx', 'jsx'],
   setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],


### PR DESCRIPTION
Using jest-circus results in timing issues, which leads to errors when rendering, and timing warnings in core react-native components such as `ActivityBar`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running unit tests result in errors and warnings.

## Expected Behavior

Generated unit tests should pass without errors and warnings.
