### PR TITLE
chore(core): disable commit gpgsign

### DIFF
--- a/e2e/workspace-integrations/src/workspace.test.ts
+++ b/e2e/workspace-integrations/src/workspace.test.ts
@@ -502,6 +502,7 @@ describe('affected (with git)', () => {
     runCommand(`git init`);
     runCommand(`git config user.email "test@test.com"`);
     runCommand(`git config user.name "Test"`);
+    runCommand(`git config commit.gpgsign false`);
     runCommand(
       `git add . && git commit -am "initial commit" && git checkout -b main`
     );

--- a/packages/workspace/src/core/hasher/git-hasher.spec.ts
+++ b/packages/workspace/src/core/hasher/git-hasher.spec.ts
@@ -12,6 +12,7 @@ describe('git-hasher', () => {
     run(`git init`);
     run(`git config user.email "test@test.com"`);
     run(`git config user.name "test"`);
+    run(`git config commit.gpgsign false`);
 
     warnSpy.mockClear();
   });


### PR DESCRIPTION
When running tests locally, if global Git config is set to sign commits with gpg, then tests are failing with `gpg failed to sign the data`, this fixes this issue.