### PR TITLE
chore(repo): add logging to failing build during e2e tests

### DIFF
--- a/scripts/e2e-build-package-publish.ts
+++ b/scripts/e2e-build-package-publish.ts
@@ -94,12 +94,13 @@ function build(nxVersion: string) {
     execSync(
       'npx nx run-many --target=build --all --parallel --max-parallel=8',
       {
-        stdio: ['ignore', 'ignore', 'ignore'],
+        stdio: ['pipe', 'pipe', 'pipe'],
       }
     );
+    console.log('Packages built successfully');
   } catch (e) {
-    console.log('Build failed');
-    console.log(e);
+    console.log(e.output.toString());
+    console.log('Build failed. See error above.');
     process.exit(1);
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There are no logs when packages fail to build during e2e tests.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There are logs when packages fail to build during e2e tests.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
