### PR TITLE
fix(devkit): move files to a directory using normalized paths to handle windows correctly

### DIFF
--- a/packages/devkit/src/utils/move-dir.ts
+++ b/packages/devkit/src/utils/move-dir.ts
@@ -1,4 +1,5 @@
 import { Tree } from '@nrwl/tao/src/shared/tree';
+import { relative } from 'path';
 import { visitNotIgnoredFiles } from '../generators/visit-not-ignored-files';
 import { normalizePath } from './path';
 
@@ -11,7 +12,7 @@ export function moveFilesToNewDirectory(
   newDir = normalizePath(newDir);
   visitNotIgnoredFiles(tree, oldDir, (file) => {
     try {
-      tree.rename(file, file.replace(oldDir, newDir));
+      tree.rename(file, `${newDir}/${relative(oldDir, file)}`);
     } catch (e) {
       if (!tree.exists(oldDir)) {
         console.warn(`Path ${oldDir} does not exist`);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When moving files to a directory using the `moveFilesToNewDirectory` exported by the Nx DevKit, if it's done in a Windows env and the old directory has more than one segment, the files are not moved. This happens because of a mismatch of path separators.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Moving files to a different directory should work as expected across different OSs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7070 
