### PR TITLE
fix(react): apply postcss config from apps to their lib dependencies

### DIFF
--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -74,7 +74,12 @@ export const webpack = async (
   // ESM build for modern browsers.
   const baseWebpackConfig = mergeWebpack([
     getBaseWebpackPartial(builderOptions, esm, isScriptOptimizeOn),
-    getStylesPartial(options.configDir, builderOptions, extractCss),
+    getStylesPartial(
+      options.workspaceRoot,
+      options.configDir,
+      builderOptions,
+      extractCss
+    ),
   ]);
 
   // run it through the React customizations

--- a/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
+++ b/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
@@ -57,6 +57,7 @@ function storybookOptionMapper(
     ...builderOptions,
     mode: 'static',
     outputDir: builderOptions.outputPath,
+    workspaceRoot: context.root,
     configDir: storybookConfig,
     ...frameworkOptions,
     frameworkPresets: [...(frameworkOptions.frameworkPresets || [])],

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -111,6 +111,7 @@ function storybookOptionMapper(
   const optionsWithFramework = {
     ...builderOptions,
     mode: 'dev',
+    workspaceRoot: context.root,
     configDir: storybookConfig,
     ...frameworkOptions,
     frameworkPresets: [...(frameworkOptions.frameworkPresets || [])],

--- a/packages/web/src/executors/build/build.impl.ts
+++ b/packages/web/src/executors/build/build.impl.ts
@@ -90,6 +90,7 @@ function getWebpackConfigs(
     // ESM build for modern browsers.
     getWebConfig(
       context.root,
+      projectRoot,
       sourceRoot,
       options,
       true,
@@ -100,6 +101,7 @@ function getWebpackConfigs(
     isScriptOptimizeOn && buildBrowserFeatures.isDifferentialLoadingNeeded()
       ? getWebConfig(
           context.root,
+          projectRoot,
           sourceRoot,
           options,
           false,

--- a/packages/web/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/web/src/executors/dev-server/dev-server.impl.ts
@@ -46,7 +46,8 @@ export default async function* devServerExecutor(
   context: ExecutorContext
 ) {
   const { webpack } = require('../../webpack/entry');
-  const sourceRoot = context.workspace.projects[context.projectName].sourceRoot;
+  const { root: projectRoot, sourceRoot } =
+    context.workspace.projects[context.projectName];
   const buildOptions = normalizeWebBuildOptions(
     getBuildOptions(serveOptions, context),
     context.root,
@@ -54,6 +55,7 @@ export default async function* devServerExecutor(
   );
   let webpackConfig = getDevServerConfig(
     context.root,
+    projectRoot,
     sourceRoot,
     buildOptions,
     serveOptions

--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -13,13 +13,15 @@ import { OptimizationOptions } from './types';
 import { readFileSync } from 'fs-extra';
 
 export function getDevServerConfig(
-  root: string,
+  workspaceRoot: string,
+  projectRoot: string,
   sourceRoot: string,
   buildOptions: WebBuildBuilderOptions,
   serveOptions: WebDevServerOptions
 ) {
   const webpackConfig = getWebConfig(
-    root,
+    workspaceRoot,
+    projectRoot,
     sourceRoot,
     buildOptions,
     true, // Don't need to support legacy browsers for dev.
@@ -27,7 +29,7 @@ export function getDevServerConfig(
   );
 
   (webpackConfig as any).devServer = getDevServerPartial(
-    root,
+    workspaceRoot,
     serveOptions,
     buildOptions
   );

--- a/packages/web/src/utils/third-party/cli-files/models/webpack-configs/common.ts
+++ b/packages/web/src/utils/third-party/cli-files/models/webpack-configs/common.ts
@@ -54,7 +54,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
   } = require('../../../../../webpack/entry');
   const { ContextReplacementPlugin, debug } = webpack;
 
-  const { root, projectRoot, buildOptions, tsConfig } = wco;
+  const { root, projectRoot, sourceRoot, buildOptions, tsConfig } = wco;
   const { styles: stylesOptimization, scripts: scriptsOptimization } =
     buildOptions.optimization;
   const {
@@ -226,7 +226,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
           sourceMap: scriptsSourceMap,
           filename: `${path.basename(bundleName)}${hash}.js`,
           scripts: script.paths,
-          basePath: projectRoot,
+          basePath: sourceRoot,
         })
       );
     });


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

App's `postcss.config.js` does not affect libs used by the app.

## Expected Behavior
App's `postcss.config.js` should apply to apps as well (same as angular and next.js). This will allow tailwind to work properly.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7040

## Additional notes

- Also updates storybook setup for react so project and workspace roots are passed in separately since they serve two different purposes.