### PR TITLE
Update GitHub brand name usage

### DIFF
--- a/docs/angular/migration/migration-angularjs.md
+++ b/docs/angular/migration/migration-angularjs.md
@@ -30,7 +30,7 @@ At the next prompt, you can choose whether to use [Nx Cloud](https://nx.app) or 
 
 ```bash
 ? What to create in the new workspace empty             [an empty workspace with a layout that works best for building apps]
-? Use Nx Cloud? (It's free and doesn't require registration.) Yes [Faster builds, run details, Github integration. Learn more at https://nx.app]
+? Use Nx Cloud? (It's free and doesn't require registration.) Yes [Faster builds, run details, GitHub integration. Learn more at https://nx.app]
 ```
 
 ## Creating your app

--- a/docs/shared/migration/adding-to-monorepo.md
+++ b/docs/shared/migration/adding-to-monorepo.md
@@ -43,9 +43,9 @@ by your commit. `npx nx dep-graph --watch` watches your workspace for changes an
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/cMZ-ReC-jWU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-### Github Integration
+### GitHub integration
 
-If you said "yes" to Nx Cloud, you can enable Nx Cloud - Github integration to get a much better overview of what
+If you said "yes" to Nx Cloud, you can enable Nx Cloud - GitHub integration to get a much better overview of what
 happens in your PRs.
 
 ![Nx Console screenshot](/shared/github.png)

--- a/nx-dev/nx-dev/public/documentation/latest/angular/migration/migration-angularjs.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/migration/migration-angularjs.md
@@ -30,7 +30,7 @@ At the next prompt, you can choose whether to use [Nx Cloud](https://nx.app) or 
 
 ```bash
 ? What to create in the new workspace empty             [an empty workspace with a layout that works best for building apps]
-? Use Nx Cloud? (It's free and doesn't require registration.) Yes [Faster builds, run details, Github integration. Learn more at https://nx.app]
+? Use Nx Cloud? (It's free and doesn't require registration.) Yes [Faster builds, run details, GitHub integration. Learn more at https://nx.app]
 ```
 
 ## Creating your app

--- a/nx-dev/nx-dev/public/documentation/latest/shared/migration/adding-to-monorepo.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/migration/adding-to-monorepo.md
@@ -43,9 +43,9 @@ by your commit. `npx nx dep-graph --watch` watches your workspace for changes an
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/cMZ-ReC-jWU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-### Github Integration
+### GitHub integration
 
-If you said "yes" to Nx Cloud, you can enable Nx Cloud - Github integration to get a much better overview of what
+If you said "yes" to Nx Cloud, you can enable Nx Cloud - GitHub integration to get a much better overview of what
 happens in your PRs.
 
 ![Nx Console screenshot](/shared/github.png)

--- a/nx-dev/nx-dev/public/documentation/previous/angular/migration/migration-angularjs.md
+++ b/nx-dev/nx-dev/public/documentation/previous/angular/migration/migration-angularjs.md
@@ -30,7 +30,7 @@ At the next prompt, you can choose whether to use [Nx Cloud](https://nx.app) or 
 
 ```bash
 ? What to create in the new workspace empty             [an empty workspace with a layout that works best for building apps]
-? Use Nx Cloud? (It's free and doesn't require registration.) Yes [Faster builds, run details, Github integration. Learn more at https://nx.app]
+? Use Nx Cloud? (It's free and doesn't require registration.) Yes [Faster builds, run details, GitHub integration. Learn more at https://nx.app]
 ```
 
 ## Creating your app

--- a/nx-dev/nx-dev/public/documentation/previous/shared/migration/adding-to-monorepo.md
+++ b/nx-dev/nx-dev/public/documentation/previous/shared/migration/adding-to-monorepo.md
@@ -40,9 +40,9 @@ by your commit.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/cMZ-ReC-jWU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-### Github Integration Works
+### GitHub integration Works
 
-If you said "yes" to Nx Cloud, you can enable Nx Cloud - Github integration to get a much better overview of what
+If you said "yes" to Nx Cloud, you can enable Nx Cloud - GitHub integration to get a much better overview of what
 happens in your PRs.
 
 ![Nx Console screenshot](/shared/github.png)

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -580,7 +580,7 @@ async function askAboutNxCloud(parsedArgs: any) {
           choices: [
             {
               name: 'Yes',
-              hint: 'Faster builds, run details, Github integration. Learn more at https://nx.app',
+              hint: 'Faster builds, run details, GitHub integration. Learn more at https://nx.app',
             },
 
             {

--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -607,7 +607,7 @@ async function generateMigrationsJsonAndUpdatePackageJson(
 
     if (showConnectToCloudMessage()) {
       logger.info(
-        `- You may run "nx connect-to-nx-cloud" to get faster builds, Github integration, and more. Check out https://nx.app`
+        `- You may run "nx connect-to-nx-cloud" to get faster builds, GitHub integration, and more. Check out https://nx.app`
       );
     }
   } catch (e) {


### PR DESCRIPTION
## Current Behavior
GitHub brand name is not correctly used.

`Github` should be replace by `GitHub` according to https://github.com/logos.

I'm facing this small issue/typo right after running following command on a existing project:

```sh
$ npx add-nx-to-monorepo
Need to install the following packages:
  add-nx-to-monorepo
Ok to proceed? (y)

>  NX  🐳 Nx initialization

? Use Nx Cloud? (It's free and doesn't require registration.)
  Yes [Faster builds, run details, Github integration. Learn more at https://nx.app]
❯ No
``` 

## Expected Behavior
The right brand name should be displayed.

## Related Issue(s)
None.
