### PR TITLE
docs(nxdev): internal paths to docs

### DIFF
--- a/docs/react/migration/migration-cra.md
+++ b/docs/react/migration/migration-cra.md
@@ -14,8 +14,8 @@ Just `cd` into your Create-React-App (CRA) project and run the following command
 npx cra-to-nx
 ```
 
-Then just sit back and wait. After a while, take advantage of the [full magic of Nx](https://nx.dev/latest/react/getting-started/intro).
-Start from [the commands mentioned in this article](https://nx.dev/latest/react/migration/migration-cra#try-nx).
+Then just sit back and wait. After a while, take advantage of the [full magic of Nx](https://nx.dev/l/r/getting-started/intro).
+Start from [the commands mentioned in this article](https://nx.dev/l/r/migration/migration-cra#try-nx).
 
 **Note:** The command will fail if you try execute it and you have uncommitted changes in your repository. Commit any local changes, and then try to run the command.
 

--- a/nx-dev/nx-dev/pages/angular.tsx
+++ b/nx-dev/nx-dev/pages/angular.tsx
@@ -111,7 +111,7 @@ export function AngularPage() {
                       get started by creating a modern Angular workspace with Nx
                     </a>
                     , or{' '}
-                    <Link href="/latest/angular/migration/overview">
+                    <Link href="/l/a/migration/overview">
                       <a className="underline pointer">
                         add it to an existing Angular workspace
                       </a>
@@ -189,7 +189,7 @@ export function AngularPage() {
                   dependency graphs, and much, much more.
                 </p>
                 <div className="inline-flex">
-                  <Link href="/latest/angular/tutorial/01-create-application">
+                  <Link href="/l/a/tutorial/01-create-application">
                     <a className="inline-flex items-center font-bold group">
                       <span className="group-hover:underline">
                         Nx Angular App Tutorial
@@ -213,7 +213,7 @@ export function AngularPage() {
                 </div>
                 <p className="italic sm:text-lg my-6">
                   If you want to{' '}
-                  <Link href="/latest/angular/migration/overview">
+                  <Link href="/l/a/migration/overview">
                     <a className="underline pointer">
                       add Nx to an existing Angular project, check out this
                       guide
@@ -429,7 +429,7 @@ export function AngularPage() {
               </h2>
               <div className="mt-8 flex lg:mt-0 lg:flex-shrink-0">
                 <div className="inline-flex rounded-md shadow">
-                  <Link href="/latest/angular/getting-started/intro">
+                  <Link href="/l/a/getting-started/intro">
                     <a className="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-gray-700 bg-white">
                       Get started with Angular
                     </a>
@@ -454,7 +454,7 @@ export function AngularPage() {
                 </p>
                 <ul className="sm:text-lg list-disc list-inside">
                   <li>
-                    <Link href={'/latest/angular/getting-started/intro'}>
+                    <Link href={'/l/a/getting-started/intro'}>
                       <a className="underline pointer">
                         Nx Angular Documentation
                       </a>

--- a/nx-dev/nx-dev/pages/community.tsx
+++ b/nx-dev/nx-dev/pages/community.tsx
@@ -292,7 +292,7 @@ export function Community(props: CommunityProps) {
               </h2>
               <div className="mt-8 flex lg:mt-0 lg:flex-shrink-0">
                 <div className="inline-flex rounded-md shadow">
-                  <Link href="/latest/node/getting-started/intro">
+                  <Link href="/l/r/getting-started/intro">
                     <a className="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-nx-base">
                       Get started with Node
                     </a>

--- a/nx-dev/nx-dev/pages/node.tsx
+++ b/nx-dev/nx-dev/pages/node.tsx
@@ -239,7 +239,7 @@ export function Node() {
                     building Node applications.
                   </p>
                   <div className="inline-flex rounded-md shadow">
-                    <Link href="/latest/node/getting-started/intro">
+                    <Link href="/l/r/getting-started/intro">
                       <a className="inline-flex items-center justify-center px-5 py-2 border border-transparent text-base font-medium rounded-md text-gray-700 bg-white">
                         Nx Node Doc
                       </a>
@@ -317,7 +317,7 @@ export function Node() {
                   dependency graphs, and much, much more.
                 </p>
                 <div className="inline-flex">
-                  <Link href="/latest/node/tutorial/01-create-application">
+                  <Link href="/l/r/tutorial/01-create-application">
                     <a className="inline-flex items-center font-bold group">
                       <span className="group-hover:underline">
                         Nx Node App Tutorial
@@ -340,7 +340,7 @@ export function Node() {
                 </div>
                 <p className="italic sm:text-lg my-6">
                   If you want to add Nx to an existing Node project,{' '}
-                  <Link href="/latest/node/migration/adding-to-monorepo">
+                  <Link href="/l/r/migration/adding-to-monorepo">
                     <a className="underline pointer">check out this guide</a>
                   </Link>
                   .

--- a/nx-dev/nx-dev/pages/react.tsx
+++ b/nx-dev/nx-dev/pages/react.tsx
@@ -167,7 +167,7 @@ export function ReactPage() {
 
                 <p className="sm:text-lg my-6">
                   Refer to our{' '}
-                  <Link href="/latest/react/guides/nextjs">
+                  <Link href="/l/r/guides/nextjs">
                     <a className="font-bold">Next.js guide</a>
                   </Link>{' '}
                   to get started.
@@ -200,7 +200,7 @@ export function ReactPage() {
                   dependency graphs, and much, much more.
                 </p>
                 <div className="inline-flex">
-                  <Link href="/latest/react/tutorial/01-create-application">
+                  <Link href="/l/r/tutorial/01-create-application">
                     <a className="inline-flex items-center font-bold group">
                       <span className="group-hover:underline">
                         Nx React App Tutorial
@@ -224,13 +224,13 @@ export function ReactPage() {
                 <p className="italic sm:text-lg my-6">
                   If you want to add Nx to an existing React project, check out
                   these guides for{' '}
-                  <Link href="/latest/react/migration/migration-cra">
+                  <Link href="/l/r/migration/migration-cra">
                     <a className="underline pointer">
                       "Create React App" migration
                     </a>
                   </Link>{' '}
                   or{' '}
-                  <Link href="/latest/react/migration/migration-cra">
+                  <Link href="/l/r/migration/migration-cra">
                     <a className="underline pointer">
                       "Adding Nx to Yarn/Lerna monorepo" migration
                     </a>
@@ -381,14 +381,14 @@ export function ReactPage() {
                     Use Nx's{' '}
                     <a
                       className="underline pointer"
-                      href="https://nx.dev/latest/react/storybook/overview"
+                      href="https://nx.dev/l/r/storybook/overview"
                     >
                       Storybook
                     </a>{' '}
                     and{' '}
                     <a
                       className="underline pointer"
-                      href="https://nx.dev/latest/react/cypress/overview#cypress-plugin"
+                      href="https://nx.dev/l/r/cypress/overview#cypress-plugin"
                     >
                       Cypress
                     </a>{' '}
@@ -470,7 +470,7 @@ export function ReactPage() {
               </h2>
               <div className="mt-8 flex lg:mt-0 lg:flex-shrink-0">
                 <div className="inline-flex rounded-md shadow">
-                  <Link href="/latest/react/getting-started/intro">
+                  <Link href="/l/r/getting-started/intro">
                     <a className="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-gray-700 bg-white">
                       Get started with React
                     </a>
@@ -495,14 +495,14 @@ export function ReactPage() {
                 </p>
                 <ul className="sm:text-lg list-disc list-inside">
                   <li>
-                    <Link href={'/latest/react/getting-started/intro'}>
+                    <Link href={'/l/r/getting-started/intro'}>
                       <a className="underline pointer">
                         Nx React Documentation
                       </a>
                     </Link>
                   </li>
                   <li>
-                    <Link href={'/latest/react/guides/nextjs'}>
+                    <Link href={'/l/r/guides/nextjs'}>
                       <a className="underline pointer">
                         Nx Next.js Documentation
                       </a>

--- a/nx-dev/nx-dev/public/documentation/latest/react/migration/migration-cra.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/migration/migration-cra.md
@@ -14,8 +14,8 @@ Just `cd` into your Create-React-App (CRA) project and run the following command
 npx cra-to-nx
 ```
 
-Then just sit back and wait. After a while, take advantage of the [full magic of Nx](https://nx.dev/latest/react/getting-started/intro).
-Start from [the commands mentioned in this article](https://nx.dev/latest/react/migration/migration-cra#try-nx).
+Then just sit back and wait. After a while, take advantage of the [full magic of Nx](https://nx.dev/l/react/getting-started/intro).
+Start from [the commands mentioned in this article](https://nx.dev/l/react/migration/migration-cra#try-nx).
 
 **Note:** The command will fail if you try execute it and you have uncommitted changes in your repository. Commit any local changes, and then try to run the command.
 


### PR DESCRIPTION
## What it does?
This PR fixes some internal links on nx.dev pointing to the old url scheme on the documentation.