### PR TITLE
docs(nxdev): always ask flavor if none saved

### DIFF
--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -86,7 +86,7 @@ export function DocumentationPage({
   }, [router, version, flavor, storedFlavor, isFallback]);
 
   useEffect(() => {
-    setDialogOpen(isFallback && !storedFlavor);
+    setDialogOpen(isFallback || !storedFlavor);
   }, [setDialogOpen, isFallback, storedFlavor]);
 
   return (


### PR DESCRIPTION
## What it does?
The flavor selector will always be shown to people if this is their first visit to nx.dev.