### PR TITLE
fix(web): remove default `baseHref`  in dev-server

### DIFF
--- a/docs/angular/api-web/executors/dev-server.md
+++ b/docs/angular/api-web/executors/dev-server.md
@@ -14,8 +14,6 @@ This option allows you to whitelist services that are allowed to access the dev 
 
 ### baseHref
 
-Default: `/`
-
 Type: `string`
 
 Base url for the application being built.

--- a/docs/node/api-web/executors/dev-server.md
+++ b/docs/node/api-web/executors/dev-server.md
@@ -14,8 +14,6 @@ This option allows you to whitelist services that are allowed to access the dev 
 
 ### baseHref
 
-Default: `/`
-
 Type: `string`
 
 Base url for the application being built.

--- a/docs/react/api-web/executors/dev-server.md
+++ b/docs/react/api-web/executors/dev-server.md
@@ -14,8 +14,6 @@ This option allows you to whitelist services that are allowed to access the dev 
 
 ### baseHref
 
-Default: `/`
-
 Type: `string`
 
 Base url for the application being built.

--- a/packages/web/src/executors/dev-server/schema.json
+++ b/packages/web/src/executors/dev-server/schema.json
@@ -69,8 +69,7 @@
     },
     "baseHref": {
       "type": "string",
-      "description": "Base url for the application being built.",
-      "default": "/"
+      "description": "Base url for the application being built."
     }
   }
 }


### PR DESCRIPTION
web:dev-server provide default value of `baseHref` that would overwrite option in web:build, it's missing in   #6994