### PR TITLE
fix(misc): select correct projects on dep graph when in watch mode

### DIFF
--- a/dep-graph/dep-graph-e2e/cypress-watch-mode.json
+++ b/dep-graph/dep-graph-e2e/cypress-watch-mode.json
@@ -1,0 +1,12 @@
+{
+  "fileServerFolder": ".",
+  "fixturesFolder": "./src/fixtures",
+  "integrationFolder": "./src/watch-mode-integration",
+  "modifyObstructiveCode": false,
+  "pluginsFile": "./src/plugins/index",
+  "supportFile": "./src/support/index.ts",
+  "video": true,
+  "videosFolder": "../../dist/cypress/dep-graph/dep-graph-e2e/videos",
+  "screenshotsFolder": "../../dist/cypress/dep-graph/dep-graph-e2e/screenshots",
+  "chromeWebSecurity": false
+}

--- a/dep-graph/dep-graph-e2e/project.json
+++ b/dep-graph/dep-graph-e2e/project.json
@@ -11,6 +11,14 @@
         "devServerTarget": "dep-graph-dep-graph:serve"
       }
     },
+    "e2e-watch-disabled": {
+      "executor": "@nrwl/cypress:cypress",
+      "options": {
+        "cypressConfig": "dep-graph/dep-graph-e2e/cypress-watch-mode.json",
+        "tsConfig": "dep-graph/dep-graph-e2e/tsconfig.e2e.json",
+        "devServerTarget": "dep-graph-dep-graph:serve:watch"
+      }
+    },
     "lint": {
       "executor": "@nrwl/linter:lint",
       "options": {

--- a/dep-graph/dep-graph-e2e/src/support/app.po.ts
+++ b/dep-graph/dep-graph-e2e/src/support/app.po.ts
@@ -4,7 +4,8 @@ export const getSelectAllButton = () => cy.get('[data-cy=selectAllButton]');
 export const getDeselectAllButton = () => cy.get('[data-cy=deselectAllButton]');
 export const getUnfocusProjectButton = () => cy.get('[data-cy=unfocusButton]');
 
-export const getProjectCheckboxes = () => cy.get('input[name=projectName]');
+export const getProjectCheckboxes = () =>
+  cy.get<JQuery<HTMLInputElement>>('input[name=projectName]');
 
 export const getCheckedProjectCheckboxes = () =>
   cy.get('input[name=projectName]:checked');

--- a/dep-graph/dep-graph-e2e/src/watch-mode-integration/watch-mode.spec.ts
+++ b/dep-graph/dep-graph-e2e/src/watch-mode-integration/watch-mode.spec.ts
@@ -1,0 +1,64 @@
+import { getProjectCheckboxes } from '../support/app.po';
+
+describe('dep-graph-client in watch mode', () => {
+  beforeEach(() => {
+    cy.clock();
+    cy.visit('/');
+    cy.tick(1000);
+  });
+
+  it('should auto-select new libs as they are created', () => {
+    const excludedValues = ['existing-app-1', 'existing-lib-1'];
+
+    cy.tick(5000);
+    checkCheckedBoxes(3, excludedValues);
+
+    cy.tick(5000);
+    checkCheckedBoxes(4, excludedValues);
+
+    cy.tick(5000);
+    checkCheckedBoxes(5, excludedValues);
+  });
+
+  it('should retain selected projects new libs as they are created', () => {
+    cy.contains('existing-app-1').siblings('button').click();
+    cy.contains('existing-lib-1').siblings('button').click();
+
+    cy.tick(5000);
+
+    checkCheckedBoxes(3, []);
+
+    cy.tick(5000);
+    checkCheckedBoxes(4, []);
+
+    cy.tick(5000);
+    checkCheckedBoxes(5, []);
+  });
+
+  it('should not re-add new libs if they were un-selected', () => {
+    cy.tick(5000);
+    cy.contains('3')
+      .find('input')
+      .should('be.checked')
+      .click()
+      .should('not.be.checked');
+
+    cy.tick(5000);
+    cy.tick(5000);
+    cy.contains('3').find('input').should('not.be.checked');
+  });
+});
+
+function checkCheckedBoxes(
+  expectedCheckboxes: number,
+  excludedValues: string[]
+) {
+  getProjectCheckboxes().should((checkboxes) => {
+    expect(checkboxes.length).to.equal(expectedCheckboxes);
+    checkboxes.each(function () {
+      if (!excludedValues.includes(this.value)) {
+        expect(this.checked).to.be.true;
+      }
+    });
+  });
+}

--- a/dep-graph/dep-graph-e2e/tsconfig.e2e.json
+++ b/dep-graph/dep-graph-e2e/tsconfig.e2e.json
@@ -4,7 +4,8 @@
     "sourceMap": false,
     "outDir": "../../dist/out-tsc",
     "allowJs": true,
-    "types": ["cypress", "node"]
+    "types": ["cypress", "node"],
+    "lib": ["DOM"]
   },
   "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/dep-graph/dep-graph/src/app/app.ts
+++ b/dep-graph/dep-graph/src/app/app.ts
@@ -47,10 +47,11 @@ export class AppComponent {
         acc[cur.name] = cur;
         return acc;
       }, {});
-
-    const newProjects = project.changes.added.filter(
-      (addedProject) => !window.graph.nodes[addedProject]
-    );
+    const newProjects = !!window.graph
+      ? project.changes.added.filter(
+          (addedProject) => !window.graph.nodes[addedProject]
+        )
+      : project.changes.added;
     window.projects = project.projects;
     window.graph = <ProjectGraph>{
       dependencies: project.dependencies,

--- a/dep-graph/dep-graph/src/app/mock-project-graph-service.ts
+++ b/dep-graph/dep-graph/src/app/mock-project-graph-service.ts
@@ -47,7 +47,7 @@ export class MockProjectGraphService implements ProjectGraphService {
     groupByFolder: false,
   };
 
-  constructor(updateFrequency: number = 7500) {
+  constructor(updateFrequency: number = 5000) {
     setInterval(() => this.updateResponse(), updateFrequency);
   }
 

--- a/dep-graph/dep-graph/src/app/ui-sidebar/sidebar.ts
+++ b/dep-graph/dep-graph/src/app/ui-sidebar/sidebar.ts
@@ -31,7 +31,6 @@ export class SidebarComponent {
   set projects(projects: ProjectGraphNode[]) {
     this.projectList.projects = projects;
     this.focusedProjectPanel.unfocusProject();
-    this.unfocusProject();
   }
 
   constructor(private affectedProjects: string[]) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- When the dep graph is in watch mode, it de-selects existing projects as new projects are added
- dep graph watch mode does not have e2e tests
<!-- This is the behavior we have today -->

## Expected Behavior
- When the dep graph is in watch mode, selected projects are retained when new projects are added
- dep graph watch mode has e2e tests

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->