### PR TITLE
fix(misc): collect dependencies starting from the library entry file when auto-generating package.json dependencies

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-lite.impl.spec.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-lite.impl.spec.ts
@@ -3,6 +3,7 @@ jest.mock('@nrwl/workspace/src/utilities/buildable-libs-utils');
 jest.mock('ng-packagr');
 
 import type { ExecutorContext } from '@nrwl/devkit';
+import * as devkit from '@nrwl/devkit';
 import * as buildableLibsUtils from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import * as ngPackagr from 'ng-packagr';
 import { BehaviorSubject } from 'rxjs';
@@ -25,7 +26,7 @@ describe('NgPackagrLite executor', () => {
 
   beforeEach(async () => {
     (
-      buildableLibsUtils.calculateProjectDependencies as jest.Mock
+      buildableLibsUtils.calculateDependenciesFromEntryPoint as jest.Mock
     ).mockImplementation(() => ({
       target: {},
       dependencies: [],
@@ -42,6 +43,11 @@ describe('NgPackagrLite executor', () => {
       watch: ngPackagrWatchMock,
       withBuildTransform: ngPackagrWithBuildTransformMock,
       withTsConfig: ngPackagrWithTsConfigMock,
+    }));
+    jest.spyOn(devkit, 'readJsonFile').mockImplementation(() => ({
+      lib: {
+        entryFile: 'src/index.ts',
+      },
     }));
 
     context = {

--- a/packages/angular/src/executors/package/package.impl.spec.ts
+++ b/packages/angular/src/executors/package/package.impl.spec.ts
@@ -3,6 +3,7 @@ jest.mock('@nrwl/workspace/src/utilities/buildable-libs-utils');
 jest.mock('ng-packagr');
 
 import type { ExecutorContext } from '@nrwl/devkit';
+import * as devkit from '@nrwl/devkit';
 import * as buildableLibsUtils from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import * as ngPackagr from 'ng-packagr';
 import { BehaviorSubject } from 'rxjs';
@@ -25,7 +26,7 @@ describe('Package executor', () => {
 
   beforeEach(async () => {
     (
-      buildableLibsUtils.calculateProjectDependencies as jest.Mock
+      buildableLibsUtils.calculateDependenciesFromEntryPoint as jest.Mock
     ).mockImplementation(() => ({
       target: {},
       dependencies: [],
@@ -41,6 +42,11 @@ describe('Package executor', () => {
       watch: ngPackagrWatchMock,
       withBuildTransform: ngPackagrWithBuildTransformMock,
       withTsConfig: ngPackagrWithTsConfigMock,
+    }));
+    jest.spyOn(devkit, 'readJsonFile').mockImplementation(() => ({
+      lib: {
+        entryFile: 'src/index.ts',
+      },
     }));
 
     context = {

--- a/packages/node/src/executors/package/package.impl.ts
+++ b/packages/node/src/executors/package/package.impl.ts
@@ -2,7 +2,7 @@ import { ExecutorContext } from '@nrwl/devkit';
 import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import { copyAssetFiles } from '@nrwl/workspace/src/utilities/assets';
 import {
-  calculateProjectDependencies,
+  calculateDependenciesFromEntryPoint,
   checkDependentProjectsHaveBeenBuilt,
   updateBuildableProjectPackageJsonDependencies,
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
@@ -18,12 +18,13 @@ export async function packageExecutor(
 ) {
   const libRoot = context.workspace.projects[context.projectName].root;
   const normalizedOptions = normalizeOptions(options, context, libRoot);
-  const { target, dependencies } = calculateProjectDependencies(
+  const { target, dependencies } = calculateDependenciesFromEntryPoint(
     readCachedProjectGraph(),
     context.root,
     context.projectName,
     context.targetName,
-    context.configurationName
+    context.configurationName,
+    normalizedOptions.main
   );
   const dependentsBuilt = checkDependentProjectsHaveBeenBuilt(
     context.root,

--- a/packages/web/src/executors/package/package.impl.ts
+++ b/packages/web/src/executors/package/package.impl.ts
@@ -11,7 +11,7 @@ import type { ExecutorContext, ProjectGraphNode } from '@nrwl/devkit';
 import { logger, names, readJsonFile, writeJsonFile } from '@nrwl/devkit';
 import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import {
-  calculateProjectDependencies,
+  calculateDependenciesFromEntryPoint,
   checkDependentProjectsHaveBeenBuilt,
   computeCompilerOptionsPaths,
   DependentBuildableProjectNode,
@@ -46,12 +46,13 @@ export default async function* run(
   const project = context.workspace.projects[context.projectName];
   const projectGraph = readCachedProjectGraph();
   const sourceRoot = project.sourceRoot;
-  const { target, dependencies } = calculateProjectDependencies(
+  const { target, dependencies } = calculateDependenciesFromEntryPoint(
     projectGraph,
     context.root,
     context.projectName,
     context.targetName,
-    context.configurationName
+    context.configurationName,
+    rawOptions.entryFile
   );
   if (
     !checkDependentProjectsHaveBeenBuilt(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When using the `@nrwl/{angular,node,web}:package` executors with `"updateBuildableProjectDepsInPackageJson": true` (or without specifying it, default value is `true`), the built library `package.json` will contain auto-generated dependencies (or peerDependencies) based of the project dependencies. This is done by collecting the dependencies from the project graph.

This approach has the issue that there's no distinction in the project graph between the projects' runtime vs non-runtime dependencies (e.g. test). To solve that limitation there's a check to filter out any given dependency that is part of the `devDependencies` in the workspace `package.json`, but that's not totally reliable since some dependencies might be used in runtime code in some projects and might be used in non-runtime code in other projects within the same workspace. As a result, the generated `package.json` can contain dependencies that are not used by the library's runtime code.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Auto-generating the `package.json` dependencies when packaging a library should only be done using runtime dependencies. A safer approach is to collect the dependencies starting from the library entry point file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7257