### PR TITLE
docs(linter): add more information to multiple tag dimensions

### DIFF
--- a/nx-dev/nx-dev/public/documentation/previous/shared/monorepo-tags.md
+++ b/nx-dev/nx-dev/public/documentation/previous/shared/monorepo-tags.md
@@ -46,6 +46,10 @@ First, use `nx.json` to annotate your projects with tags. In this example, we wi
     "components-shared": {
       "tags": ["scope:shared"],
       "implicitDependencies": []
+    },
+    "utils": {
+      "tags": ["scope:shared"],
+      "implicitDependencies": []
     }
   }
 }
@@ -90,7 +94,7 @@ Next you should update your root lint configuration:
 
 ```jsonc
 {
-  // ... more TSLint config here
+  // ... more ESLint config here
 
   // nx-enforce-module-boundaries should already exist at the top-level of your config
   "nx-enforce-module-boundaries": [
@@ -115,7 +119,7 @@ Next you should update your root lint configuration:
     }
   ]
 
-  // ... more TSLint config here
+  // ... more ESLint config here
 }
 ```
 
@@ -148,3 +152,106 @@ The `"allow": []` are the list of imports that won't fail linting.
 ## Multiple Dimensions
 
 The example above shows using a single dimension: `scope`. It's the most commonly used one. But you can find other dimensions useful. You can define which projects contain components, state management code, and features, so you, for instance, can disallow projects containing dumb UI components to depend on state management code. You can define which projects are experimental and which are stable, so stable applications cannot depend on experimental projects etc. You can define which projects have server-side code and which have client-side code to make sure your node app doesn't bundle in your frontend framework.
+
+Let's consider our previous three scopes - `scope:client`. `scope:admin`, `scope:shared`. By using just a single dimension, our `client-e2e` application would be able to import `client` application or `client-feature-main`. This is likely not something we want to allow as it's using framework that our E2E project doesn't have.
+
+Let's add another dimension - `type`. Some of our projects are applications, some are UI features and some are just plain helper libraries. Let's define three new tags: `type:app`, `type:feature`, `type:ui` and `type:util`.
+
+Our `nx.json` might now look like this:
+
+```jsonc
+{
+  // ... more nx.json config here
+
+  "projects": {
+    "client": {
+      "tags": ["scope:client", "type:app"],
+      "implicitDependencies": []
+    },
+    "client-e2e": {
+      "tags": ["scope:client", "type:app"],
+      "implicitDependencies": ["client"]
+    },
+    "admin": {
+      "tags": ["scope:admin", "type:app"],
+      "implicitDependencies": []
+    },
+    "admin-e2e": {
+      "tags": ["scope:admin", "type:app"],
+      "implicitDependencies": ["admin"]
+    },
+    "client-feature-main": {
+      "tags": ["scope:client", "type:feature"],
+      "implicitDependencies": []
+    },
+    "admin-feature-permissions": {
+      "tags": ["scope:admin", "type:feature"],
+      "implicitDependencies": []
+    },
+    "components-shared": {
+      "tags": ["scope:shared", "type:ui"],
+      "implicitDependencies": []
+    },
+    "utils": {
+      "tags": ["scope:shared", "type:util"],
+      "implicitDependencies": []
+    }
+  }
+}
+```
+
+We can now restrict projects within the same group to depend on each other based on the type:
+
+- `app` can only depend on `feature`, `ui` or `util`, but not other apps
+- `feature` cannot depend on app or another feature
+- `ui` can only depend on other `ui`
+- everyone can depend on `util` including `util` itself
+
+```jsonc
+{
+  // ... more ESLint config here
+
+  // nx-enforce-module-boundaries should already exist at the top-level of your config
+  "nx-enforce-module-boundaries": [
+    true,
+    {
+      "allow": [],
+      // update depConstraints based on your tags
+      "depConstraints": [
+        {
+          "sourceTag": "scope:shared",
+          "onlyDependOnLibsWithTags": ["scope:shared"]
+        },
+        {
+          "sourceTag": "scope:admin",
+          "onlyDependOnLibsWithTags": ["scope:shared", "scope:admin"]
+        },
+        {
+          "sourceTag": "scope:client",
+          "onlyDependOnLibsWithTags": ["scope:shared", "scope:client"]
+        },
+        {
+          "sourceTag": "type:app",
+          "onlyDependOnLibsWithTags": ["type:feature", "type:ui", "type:util"]
+        },
+        {
+          "sourceTag": "type:feature",
+          "onlyDependOnLibsWithTags": ["type:ui", "type:util"]
+        },
+        {
+          "sourceTag": "type:ui",
+          "onlyDependOnLibsWithTags": ["type:ui", "type:util"]
+        },
+        {
+          "sourceTag": "type:util",
+          "onlyDependOnLibsWithTags": ["type:util"]
+        }
+      ]
+    }
+  ]
+
+  // ... more ESLint config here
+}
+```
+
+There are no limits to number of tags, but as you add more tags the complexity of your dependency constraints rises exponentially. It's always good to draw a diagram and carefully plan the boundaries.


### PR DESCRIPTION
Adding more information and example to multiple dimensions when tagging the boundaries.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6747 
