### PR TITLE
chore(node): remove build options deprecated since Nx 11

### DIFF
--- a/docs/angular/api-node/executors/build.md
+++ b/docs/angular/api-node/executors/build.md
@@ -130,16 +130,6 @@ Type: `boolean`
 
 Log progress to the console while building.
 
-### ~~showCircularDependencies~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling.
-
-Show circular dependency warnings on builds.
-
 ### sourceMap
 
 Default: `true`

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -130,16 +130,6 @@ Type: `boolean`
 
 Log progress to the console while building.
 
-### ~~showCircularDependencies~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling.
-
-Show circular dependency warnings on builds.
-
 ### sourceMap
 
 Default: `true`

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -130,16 +130,6 @@ Type: `boolean`
 
 Log progress to the console while building.
 
-### ~~showCircularDependencies~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling.
-
-Show circular dependency warnings on builds.
-
 ### sourceMap
 
 Default: `true`

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "caniuse-lite": "^1.0.30001251",
     "chalk": "4.1.0",
     "chokidar": "^3.5.1",
-    "circular-dependency-plugin": "5.2.0",
     "commitizen": "^4.0.3",
     "confusing-browser-globals": "^1.0.9",
     "conventional-changelog-cli": "^2.0.23",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -35,7 +35,6 @@
     "@nrwl/jest": "*",
     "@nrwl/linter": "*",
     "chalk": "4.1.0",
-    "circular-dependency-plugin": "5.2.0",
     "copy-webpack-plugin": "^9.0.1",
     "fork-ts-checker-webpack-plugin": "6.2.10",
     "fs-extra": "^9.1.0",

--- a/packages/node/src/executors/build/schema.json
+++ b/packages/node/src/executors/build/schema.json
@@ -79,12 +79,6 @@
       "description": "Defines the optimization level of the build.",
       "default": false
     },
-    "showCircularDependencies": {
-      "type": "boolean",
-      "description": "Show circular dependency warnings on builds.",
-      "default": false,
-      "x-deprecated": "The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling."
-    },
     "maxWorkers": {
       "type": "number",
       "description": "Number of workers to use for type checking. (defaults to # of CPUS - 2)"

--- a/packages/node/src/migrations/update-13-0-0/remove-deprecated-options-13-0-0.spec.ts
+++ b/packages/node/src/migrations/update-13-0-0/remove-deprecated-options-13-0-0.spec.ts
@@ -1,0 +1,59 @@
+import { readJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+import subject from './remove-deprecated-options-13-0-0';
+
+describe('Migration: Remove deprecated options', () => {
+  it(`should remove deprecated node build options`, async () => {
+    let tree = createTreeWithEmptyWorkspace();
+
+    tree.write(
+      'workspace.json',
+      JSON.stringify({
+        version: 2,
+        projects: {
+          myapp: {
+            root: 'apps/myapp',
+            sourceRoot: 'apps/myapp/src',
+            projectType: 'application',
+            targets: {
+              build: {
+                executor: '@nrwl/node:build',
+                options: {
+                  showCircularDependencies: false,
+                },
+                configurations: {
+                  production: {
+                    showCircularDependencies: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    await subject(tree);
+
+    expect(readJson(tree, 'workspace.json')).toEqual({
+      version: 2,
+      projects: {
+        myapp: {
+          root: 'apps/myapp',
+          sourceRoot: 'apps/myapp/src',
+          projectType: 'application',
+          targets: {
+            build: {
+              executor: '@nrwl/node:build',
+              options: {},
+              configurations: {
+                production: {},
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/node/src/migrations/update-13-0-0/remove-deprecated-options-13-0-0.ts
+++ b/packages/node/src/migrations/update-13-0-0/remove-deprecated-options-13-0-0.ts
@@ -1,0 +1,45 @@
+import {
+  formatFiles,
+  getProjects,
+  logger,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+
+export default async function update(host: Tree) {
+  const projects = getProjects(host);
+
+  for (const [name, config] of projects.entries()) {
+    if (config.targets.build.executor !== '@nrwl/node:build') return;
+
+    let updated = false;
+
+    if (
+      typeof config.targets.build?.configurations?.production?.[
+        'showCircularDependencies'
+      ] !== 'undefined'
+    ) {
+      delete config.targets.build.configurations.production[
+        'showCircularDependencies'
+      ];
+      updated = true;
+    }
+
+    if (
+      typeof config.targets.build?.options?.['showCircularDependencies'] !==
+      'undefined'
+    ) {
+      delete config.targets.build.options['showCircularDependencies'];
+      updated = true;
+    }
+
+    if (updated) {
+      updateProjectConfiguration(host, name, config);
+      logger.info(
+        `NX Removed legacy build option from "${name}": showCircularDependencies`
+      );
+    }
+  }
+
+  await formatFiles(host);
+}

--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -8,7 +8,6 @@ import { readTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import { BuildBuilderOptions } from './types';
 import { loadTsPlugins } from './load-ts-plugins';
 import CopyWebpackPlugin = require('copy-webpack-plugin');
-import CircularDependencyPlugin = require('circular-dependency-plugin');
 import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 export const OUT_FILENAME = 'main.js';
@@ -165,14 +164,6 @@ export function getBaseWebpackPartial(
       }),
     });
     extraPlugins.push(copyWebpackPluginInstance);
-  }
-
-  if (options.showCircularDependencies) {
-    extraPlugins.push(
-      new CircularDependencyPlugin({
-        exclude: /[\\\/]node_modules[\\\/]/,
-      })
-    );
   }
 
   webpackConfig.plugins = [...webpackConfig.plugins, ...extraPlugins];

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -61,7 +61,6 @@ export interface BuildBuilderOptions {
   watch?: boolean;
   sourceMap?: boolean | SourceMapOptions;
   optimization?: boolean | OptimizationOptions;
-  showCircularDependencies?: boolean;
   maxWorkers?: number;
   memoryLimit?: number;
   poll?: number;


### PR DESCRIPTION
This PR removes options we've deprecated in Nx 11 + provides migration to remove them.
