### PR TITLE
fix(angular): support tsconfig.json at root of workspace

### DIFF
--- a/packages/angular/src/migrations/update-12-9-0/update-invalid-import-paths.spec.ts
+++ b/packages/angular/src/migrations/update-12-9-0/update-invalid-import-paths.spec.ts
@@ -82,4 +82,31 @@ describe('Migration to fix invalid import paths in affected workspaces', () => {
     expect(fixedPublishable).toBeTruthy();
     expect(brokenPublishableShouldntExist).toBeFalsy();
   });
+
+  it('should fix the invalid libraries when base tsconfig is not tsconfig.base.json', async () => {
+    // ARRANGE
+    tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+    // ACT
+    await updateInvalidImportPaths(tree);
+
+    // ASSERT
+    const fixedBuildable = readJson(
+      tree,
+      joinPathFragments('libs/dir1/buildable1', 'package.json')
+    );
+
+    const { compilerOptions } = readJson<{
+      compilerOptions: { paths: Record<string, string[]> };
+    }>(tree, 'tsconfig.json');
+    const { paths: tsConfigPaths } = compilerOptions;
+    const fixedPublishable = Boolean(tsConfigPaths['@proj/publishable2']);
+    const brokenPublishableShouldntExist = !Boolean(
+      tsConfigPaths['@proj/publishable2']
+    );
+
+    expect(fixedBuildable.name).toEqual('@proj/dir1/buildable1');
+    expect(fixedPublishable).toBeTruthy();
+    expect(brokenPublishableShouldntExist).toBeFalsy();
+  });
 });

--- a/packages/angular/src/migrations/update-12-9-0/update-invalid-import-paths.ts
+++ b/packages/angular/src/migrations/update-12-9-0/update-invalid-import-paths.ts
@@ -22,7 +22,7 @@ export default async function (tree: Tree) {
   const tsconfigPath = getBaseTsConfigPath(tree);
   if (!tree.exists(tsconfigPath)) {
     logger.error(
-      'Could not find `tsconig.base.json` or `tsconfig.json` at the root of the workspace. Skipping this migration...'
+      'Could not find `tsconfig.base.json` or `tsconfig.json` at the root of the workspace. Skipping this migration...'
     );
     return;
   }

--- a/packages/angular/src/migrations/update-12-9-0/update-invalid-import-paths.ts
+++ b/packages/angular/src/migrations/update-12-9-0/update-invalid-import-paths.ts
@@ -19,9 +19,17 @@ type InvalidLibs = {
 };
 
 export default async function (tree: Tree) {
+  const tsconfigPath = getBaseTsConfigPath(tree);
+  if (!tree.exists(tsconfigPath)) {
+    logger.error(
+      'Could not find `tsconig.base.json` or `tsconfig.json` at the root of the workspace. Skipping this migration...'
+    );
+    return;
+  }
+
   const possibleAffectedLibs = findBuildableAndPublishableLibs(tree);
-  const invalidLibs = findInvalidLibs(tree, possibleAffectedLibs);
-  fixLibs(tree, invalidLibs);
+  const invalidLibs = findInvalidLibs(tree, possibleAffectedLibs, tsconfigPath);
+  fixLibs(tree, invalidLibs, tsconfigPath);
 
   await formatFiles(tree);
 }
@@ -44,8 +52,12 @@ export function findBuildableAndPublishableLibs(tree: Tree): InvalidLibs {
   return { buildableLibs, publishableLibs };
 }
 
-export function findInvalidLibs(tree: Tree, libs: InvalidLibs): InvalidLibs {
-  const { compilerOptions } = readJson(tree, 'tsconfig.base.json');
+export function findInvalidLibs(
+  tree: Tree,
+  libs: InvalidLibs,
+  tsconfigPath: string
+): InvalidLibs {
+  const { compilerOptions } = readJson(tree, tsconfigPath);
   const { paths: tsConfigPaths } = compilerOptions;
 
   const invalidBuildableLibs = libs.buildableLibs.filter((lib) =>
@@ -69,12 +81,18 @@ function checkInvalidLib(
   return !tsConfigPaths[name];
 }
 
-function fixLibs(tree: Tree, { buildableLibs, publishableLibs }: InvalidLibs) {
-  const { compilerOptions } = readJson(tree, 'tsconfig.base.json');
+function fixLibs(
+  tree: Tree,
+  { buildableLibs, publishableLibs }: InvalidLibs,
+  tsconfigFilePath: string
+) {
+  const { compilerOptions } = readJson(tree, tsconfigFilePath);
   const { paths: tsConfigPaths } = compilerOptions;
 
   buildableLibs.map((lib) => fixBuildableLib(tree, lib, tsConfigPaths));
-  publishableLibs.map((lib) => fixPublishableLib(tree, lib, tsConfigPaths));
+  publishableLibs.map((lib) =>
+    fixPublishableLib(tree, lib, tsConfigPaths, tsconfigFilePath)
+  );
 }
 
 function fixBuildableLib(
@@ -105,7 +123,8 @@ function fixBuildableLib(
 function fixPublishableLib(
   tree: Tree,
   lib: AffectedLib,
-  tsConfigPaths: Record<string, string>
+  tsConfigPaths: Record<string, string>,
+  tsconfigFilePath: string
 ) {
   const srcRoot = joinPathFragments(lib.sourceRoot, 'index.ts');
   const { name: pkgName } = readJson(
@@ -128,7 +147,7 @@ function fixPublishableLib(
 
   for (const [invalidPathKey, tsLibSrcRoot] of Object.entries(tsConfigPaths)) {
     if (tsLibSrcRoot[0] === srcRoot) {
-      updateJson(tree, 'tsconfig.base.json', (tsconfig) => {
+      updateJson(tree, tsconfigFilePath, (tsconfig) => {
         tsconfig.compilerOptions.paths[invalidPathKey] = undefined;
         tsconfig.compilerOptions.paths[pkgName] = tsLibSrcRoot;
 
@@ -137,4 +156,10 @@ function fixPublishableLib(
       break;
     }
   }
+}
+
+function getBaseTsConfigPath(tree: Tree) {
+  return tree.exists('tsconfig.base.json')
+    ? 'tsconfig.base.json'
+    : 'tsconfig.json';
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Invalid imports migration fails when the base tsconfig path is `tsconfig.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Support for base tsconfig path to `tsconfig.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7223
