### PR TITLE
fix(core): update outdated graph version

### DIFF
--- a/packages/workspace/src/core/project-graph/project-graph.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.ts
@@ -28,7 +28,7 @@ export function readCachedProjectGraph(
 }
 
 export async function createProjectGraphAsync(
-  projectGraphVersion = '3.0'
+  projectGraphVersion = '4.0'
 ): Promise<ProjectGraph> {
   /**
    * Using the daemon is currently an undocumented, opt-in feature while we build out its capabilities.


### PR DESCRIPTION
## Expected Behavior
All `projectGraphVersion` should be defaulted to 4.0 in v13

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
