### PR TITLE
chore(repo): skip fetching when publishing locally

### DIFF
--- a/scripts/nx-release.js
+++ b/scripts/nx-release.js
@@ -42,10 +42,12 @@ if (parsedArgs.help) {
   process.exit(0);
 }
 
-console.log('> git fetch --all');
-childProcess.execSync('git fetch --all', {
-  stdio: [0, 1, 2],
-});
+if (!parsedArgs.local) {
+  console.log('> git fetch --all');
+  childProcess.execSync('git fetch --all', {
+    stdio: [0, 1, 2],
+  });
+}
 
 function updatePackageJsonFiles(parsedVersion, isLocal) {
   let pkgFiles = [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

It takes a while to fetch all of the remotes when publishing. This is unnecessary when publishing locally.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Fetching remotes is skipped for local publishes.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
