### PR TITLE
fix(core): Fix single file outputs cache regression

### DIFF
--- a/packages/workspace/src/tasks-runner/cache.ts
+++ b/packages/workspace/src/tasks-runner/cache.ts
@@ -219,12 +219,10 @@ export class Cache {
         (await existsAsync(cacheOutputPath)) &&
         (await lstatAsync(cacheOutputPath)).isFile()
       ) {
-        if (
+        return (
           (await existsAsync(join(cachedResult.outputsPath, output))) &&
           !(await existsAsync(join(this.root, output)))
-        ) {
-          return true;
-        }
+        );
       }
 
       const haveDifferentAmountOfFiles =


### PR DESCRIPTION
## Current Behavior
Single file caching is broken (ENOTDIR) after https://github.com/nrwl/nx/commit/b79072a5aed5dc666fef9e738ec873fb7fc76e5d#diff-916c87b54c219ec49ee2383ad896459b8264a73f7d907b82f4bd7357cd18f0e4R218-R227

## Expected Behavior
Single file caching should work

## Related Issue(s)
https://github.com/nrwl/nx/issues/6417

## Related Commit
https://github.com/nrwl/nx/pull/6445