### PR TITLE
fix(web): add back providedExports optimization for webpack

### DIFF
--- a/dep-graph/dep-graph/project.json
+++ b/dep-graph/dep-graph/project.json
@@ -22,6 +22,7 @@
         "namedChunks": false,
         "extractLicenses": true,
         "vendorChunk": false,
+        "webpackConfig": "dep-graph/dep-graph/webpack.config.js",
         "budgets": [
           {
             "type": "initial",

--- a/dep-graph/dep-graph/webpack.config.js
+++ b/dep-graph/dep-graph/webpack.config.js
@@ -1,0 +1,6 @@
+// This is a workaround for a problem in Nx 13.0.0-beta.7
+// TODO(jack): Can remove this after we patch Nx in 13.0.0 beta.8 or final release.
+module.exports = (config) => {
+  config.optimization.providedExports = true;
+  return config;
+};

--- a/packages/web/src/utils/config.ts
+++ b/packages/web/src/utils/config.ts
@@ -112,7 +112,6 @@ export function getBaseWebpackPartial(
   if (isScriptOptimizeOn) {
     webpackConfig.optimization = {
       sideEffects: false,
-      providedExports: false,
       minimizer: [
         new TerserWebpackPlugin({
           parallel: true,


### PR DESCRIPTION
Without this option some packages like rxjs is failing build due to exports not being found.

e.g. https://app.circleci.com/pipelines/github/nrwl/nx/11227/workflows/adfd123f-dbe8-443b-ab5c-d4bd32ff1999/jobs/97706