### PR TITLE
feat(react): support css prop for emotion

### DIFF
--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -544,6 +544,18 @@ Object {
       expect(content).toContain('<StyledApp>');
     });
 
+    it('should add jsxImportSource to tsconfig.json', async () => {
+      await applicationGenerator(appTree, {
+        ...schema,
+        style: '@emotion/styled',
+      });
+
+      const tsconfigJson = readJson(appTree, 'apps/my-app/tsconfig.json');
+      expect(tsconfigJson.compilerOptions['jsxImportSource']).toEqual(
+        '@emotion/react'
+      );
+    });
+
     it('should exclude styles from workspace.json', async () => {
       await applicationGenerator(appTree, {
         ...schema,

--- a/packages/react/src/generators/application/files/common/tsconfig.json__tmpl__
+++ b/packages/react/src/generators/application/files/common/tsconfig.json__tmpl__
@@ -2,6 +2,7 @@
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
+    <% if (style === '@emotion/styled') { %>"jsxImportSource": "@emotion/react",<% } %>
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true

--- a/packages/react/src/generators/library/files/lib/tsconfig.json__tmpl__
+++ b/packages/react/src/generators/library/files/lib/tsconfig.json__tmpl__
@@ -2,6 +2,7 @@
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
+    <% if (style === '@emotion/styled') { %>"jsxImportSource": "@emotion/react",<% } %>
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -485,6 +485,7 @@ describe('lib', () => {
 
       const workspaceJson = readJson(appTree, '/workspace.json');
       const babelrc = readJson(appTree, 'libs/my-lib/.babelrc');
+      const tsconfigJson = readJson(appTree, 'libs/my-lib/tsconfig.json');
 
       expect(workspaceJson.projects['my-lib'].architect.build).toMatchObject({
         options: {
@@ -492,6 +493,9 @@ describe('lib', () => {
         },
       });
       expect(babelrc.plugins).toEqual(['@emotion/babel-plugin']);
+      expect(tsconfigJson.compilerOptions['jsxImportSource']).toEqual(
+        '@emotion/react'
+      );
     });
 
     it('should support styled-jsx', async () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Emotion's `css` prop does not work because `jsxImportSource` is not specified in `tsconfig.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`css` prop should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://nrwlcommunity.slack.com/archives/CMFKWPU6Q/p1634219035415500
See https://github.com/nrwl/nx/pull/7384 for `@nrwl/next`.
Fixes #4520
