### PR TITLE
fix(core): update webpack 5 migration smartly match expected version and packages before performing removal

### DIFF
--- a/packages/node/src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0.spec.ts
+++ b/packages/node/src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0.spec.ts
@@ -1,0 +1,126 @@
+import { readJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+import subject from './remove-webpack-5-packages-13-0-0';
+
+describe('Migration: Remove webpack 5 packages from Nx12', () => {
+  const webpack5Packages = {
+    webpack: '^5.0.0',
+    'copy-webpack-plugin': '1.0.0',
+    'webpack-merge': '1.0.0',
+    'webpack-node-externals': '1.0.0',
+    'mini-css-extract-plugin': '1.0.0',
+    'source-map-loader': '1.0.0',
+    'terser-webpack-plugin': '1.0.0',
+    'webpack-dev-server': '1.0.0',
+    'webpack-sources': '1.0.0',
+    'react-refresh': '1.0.0',
+    '@pmmmwh/react-refresh-webpack-plugin': '1.0.0',
+  };
+
+  it.each`
+    version
+    ${'5.0.0'}
+    ${'~5.0.0'}
+    ${'^5.0.0'}
+  `(
+    `should remove packages installed via webpack5 generator`,
+    async ({ version }) => {
+      let tree = createTreeWithEmptyWorkspace();
+
+      tree.write(
+        'package.json',
+        JSON.stringify({
+          dependencies: {
+            react: '17.0.0',
+          },
+          devDependencies: {
+            lodash: '1.0.0',
+            ...webpack5Packages,
+            webpack: version,
+          },
+        })
+      );
+
+      await subject(tree);
+
+      expect(readJson(tree, 'package.json')).toEqual({
+        dependencies: {
+          react: '17.0.0',
+        },
+        devDependencies: {
+          lodash: '1.0.0',
+        },
+      });
+    }
+  );
+
+  it.each`
+    version
+    ${'4.0.0'}
+    ${'50.0.0'}
+  `(
+    `should not do anything if the webpack version is not 5`,
+    async ({ version }) => {
+      let tree = createTreeWithEmptyWorkspace();
+
+      tree.write(
+        'package.json',
+        JSON.stringify({
+          dependencies: {
+            react: '17.0.0',
+          },
+          devDependencies: {
+            lodash: '1.0.0',
+            ...webpack5Packages,
+            webpack: version,
+          },
+        })
+      );
+
+      await subject(tree);
+
+      expect(readJson(tree, 'package.json')).toEqual({
+        dependencies: {
+          react: '17.0.0',
+        },
+        devDependencies: {
+          lodash: '1.0.0',
+          ...webpack5Packages,
+          webpack: version,
+        },
+      });
+    }
+  );
+
+  it(`should not remove packages not every expected package is installed`, async () => {
+    let tree = createTreeWithEmptyWorkspace();
+
+    tree.write(
+      'package.json',
+      JSON.stringify({
+        dependencies: {
+          react: '17.0.0',
+        },
+        devDependencies: {
+          lodash: '1.0.0',
+          webpack: '^5.0.0',
+          'copy-webpack-plugin': '1.0.0',
+        },
+      })
+    );
+
+    await subject(tree);
+
+    expect(readJson(tree, 'package.json')).toEqual({
+      dependencies: {
+        react: '17.0.0',
+      },
+      devDependencies: {
+        lodash: '1.0.0',
+        webpack: '^5.0.0',
+        'copy-webpack-plugin': '1.0.0',
+      },
+    });
+  });
+});

--- a/packages/node/src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0.ts
+++ b/packages/node/src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0.ts
@@ -25,7 +25,10 @@ export default async function update(tree: Tree) {
   let task: undefined | GeneratorCallback = undefined;
 
   // Undo the install by `nx g @nrwl/web:webpack5` in Nx 12.
-  if (packageJson.devDependencies['webpack']?.startsWith('^5')) {
+  if (
+    packageJson.devDependencies['webpack']?.match(/^([\^~])?5\./) &&
+    packages.every((p) => packageJson.devDependencies[p])
+  ) {
     task = removeDependenciesFromPackageJson(tree, [], packages);
     await formatFiles(tree);
   }

--- a/packages/web/src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0.spec.ts
+++ b/packages/web/src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0.spec.ts
@@ -1,0 +1,126 @@
+import { readJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+import subject from './remove-webpack-5-packages-13-0-0';
+
+describe('Migration: Remove webpack 5 packages from Nx12', () => {
+  const webpack5Packages = {
+    webpack: '^5.0.0',
+    'copy-webpack-plugin': '1.0.0',
+    'webpack-merge': '1.0.0',
+    'webpack-node-externals': '1.0.0',
+    'mini-css-extract-plugin': '1.0.0',
+    'source-map-loader': '1.0.0',
+    'terser-webpack-plugin': '1.0.0',
+    'webpack-dev-server': '1.0.0',
+    'webpack-sources': '1.0.0',
+    'react-refresh': '1.0.0',
+    '@pmmmwh/react-refresh-webpack-plugin': '1.0.0',
+  };
+
+  it.each`
+    version
+    ${'5.0.0'}
+    ${'~5.0.0'}
+    ${'^5.0.0'}
+  `(
+    `should remove packages installed via webpack5 generator`,
+    async ({ version }) => {
+      let tree = createTreeWithEmptyWorkspace();
+
+      tree.write(
+        'package.json',
+        JSON.stringify({
+          dependencies: {
+            react: '17.0.0',
+          },
+          devDependencies: {
+            lodash: '1.0.0',
+            ...webpack5Packages,
+            webpack: version,
+          },
+        })
+      );
+
+      await subject(tree);
+
+      expect(readJson(tree, 'package.json')).toEqual({
+        dependencies: {
+          react: '17.0.0',
+        },
+        devDependencies: {
+          lodash: '1.0.0',
+        },
+      });
+    }
+  );
+
+  it.each`
+    version
+    ${'4.0.0'}
+    ${'50.0.0'}
+  `(
+    `should not do anything if the webpack version is not 5`,
+    async ({ version }) => {
+      let tree = createTreeWithEmptyWorkspace();
+
+      tree.write(
+        'package.json',
+        JSON.stringify({
+          dependencies: {
+            react: '17.0.0',
+          },
+          devDependencies: {
+            lodash: '1.0.0',
+            ...webpack5Packages,
+            webpack: version,
+          },
+        })
+      );
+
+      await subject(tree);
+
+      expect(readJson(tree, 'package.json')).toEqual({
+        dependencies: {
+          react: '17.0.0',
+        },
+        devDependencies: {
+          lodash: '1.0.0',
+          ...webpack5Packages,
+          webpack: version,
+        },
+      });
+    }
+  );
+
+  it(`should not remove packages not every expected package is installed`, async () => {
+    let tree = createTreeWithEmptyWorkspace();
+
+    tree.write(
+      'package.json',
+      JSON.stringify({
+        dependencies: {
+          react: '17.0.0',
+        },
+        devDependencies: {
+          lodash: '1.0.0',
+          webpack: '^5.0.0',
+          'copy-webpack-plugin': '1.0.0',
+        },
+      })
+    );
+
+    await subject(tree);
+
+    expect(readJson(tree, 'package.json')).toEqual({
+      dependencies: {
+        react: '17.0.0',
+      },
+      devDependencies: {
+        lodash: '1.0.0',
+        webpack: '^5.0.0',
+        'copy-webpack-plugin': '1.0.0',
+      },
+    });
+  });
+});

--- a/packages/web/src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0.ts
+++ b/packages/web/src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0.ts
@@ -25,7 +25,10 @@ export default async function update(tree: Tree) {
   let task: undefined | GeneratorCallback = undefined;
 
   // Undo the install by `nx g @nrwl/web:webpack5` in Nx 12.
-  if (packageJson.devDependencies['webpack']?.startsWith('^5')) {
+  if (
+    packageJson.devDependencies['webpack']?.match(/^([\^~])?5\./) &&
+    packages.every((p) => packageJson.devDependencies[p])
+  ) {
     task = removeDependenciesFromPackageJson(tree, [], packages);
     await formatFiles(tree);
   }


### PR DESCRIPTION
This PR updated the node and web migration to remove previously installed webpack 5 packages in Nx 12.

We will only remove the packages if every expected package is installed to prevent cases where they are actually needed like in Nx repo itself.