### PR TITLE
docs(angular): provide reason for imported remote entry module

### DIFF
--- a/docs/angular/guides/setup-mfe-with-angular.md
+++ b/docs/angular/guides/setup-mfe-with-angular.md
@@ -98,6 +98,8 @@ _**Note:** We provided `4201` as the `--port`. This helps when developing locall
 
 _**Note:** We provided `--host=dashboard` as an option. This tells the generator that this remote app will be consumed by the Dashboard application. The generator will automatically link these two apps together in the `webpack.config.js`_
 
+_**Note**: The `RemoteEntryModule` generated will be imported in `app.module.ts` file, however, it is not used in the `AppModule` itself. This it to allow TS to find the Module during compilation, allowing it to be included in the built bundle. This is required for the Module Federation Plugin to expose the Module correctly. You can choose to import the `RemoteEntryModule` in the `AppModule` if you wish, however, it is not necessary._
+
 ## What was generated?
 
 Let's take a closer after generating each application.

--- a/packages/angular/src/generators/setup-mfe/lib/add-entry-module.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/add-entry-module.ts
@@ -27,7 +27,12 @@ export function addEntryModule(
 
     host.write(
       `${appRoot}/src/app/app.module.ts`,
-      `import { RemoteEntryModule } from './remote-entry/entry.module';
+      `/* 
+      * This RemoteEntryModule is imported here to allow TS to find the Module during 
+      * compilation, allowing it to be included in the built bundle. This is required 
+      * for the Module Federation Plugin to expose the Module correctly.
+      * */
+      import { RemoteEntryModule } from './remote-entry/entry.module';
 ${host.read(`${appRoot}/src/app/app.module.ts`, 'utf-8')}`
     );
   }


### PR DESCRIPTION
## Current Behavior
We give no reason as to why we import RemoteEntryModule in the app.module.ts file of the Remote App

## Expected Behavior
Add information to our guide and add a comment in the file itself

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7293
