### PR TITLE
feat(nextjs): disable lint during build

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -555,6 +555,9 @@ export default function Home() {
 
     const lintResults = runCLI(`lint ${appName}`, { silenceError: true });
     expect(lintResults).toContain('Lint errors found');
+
+    // even though there's a lint error - building should not fail
+    expect(() => runCLI(`build ${appName}`)).not.toThrow();
   }, 300000);
 });
 

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -36,6 +36,10 @@ function withNx(nextConfig = {} as WithNxOptions) {
 
   const userWebpack = nextConfig.webpack || ((x) => x);
   return {
+    eslint: {
+      ignoreDuringBuilds: true,
+      ...(nextConfig.eslint ?? {}),
+    },
     ...nextConfig,
     webpack: (config, options) => {
       /*


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Linting is run during the build of a nextjs app.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Linting should not be run during the build of a nextjs app. nextjs apps are configured with a "lint" target that should be used instead. 
This allows users to be more specific about when to run linting. Without this change, in mixed workspaces, running the `lint` command, followed by a `build` command across many projects (with `run-many` or `affected`) would result in nextjs apps being linted twice - which is a waste.

Users are still free to enable the flag and lint during the build, if they wish.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
