### PR TITLE
fix(react): fix react webpack plugin check for babel-loader

### DIFF
--- a/packages/react/plugins/webpack.ts
+++ b/packages/react/plugins/webpack.ts
@@ -58,6 +58,7 @@ function getWebpackConfig(config: Configuration) {
     const babelLoader = config.module.rules.find(
       (rule) =>
         typeof rule !== 'string' &&
+        rule.loader &&
         rule.loader.toString().includes('babel-loader')
     );
     if (babelLoader && typeof babelLoader !== 'string') {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The React webpack plugin check for `babel-loader` doesn't take into account that a rule object might not have a loader and it errors when there isn't a loader. This is currently causing a Cypress e2e test to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The React webpack plugin should handle rules without a loader when searching for `babel-loader`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
