### PR TITLE
feat(nextjs): support css prop for emotion

### DIFF
--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -153,6 +153,20 @@ describe('app', () => {
       expect(indexContent).not.toContain(`import styles from './index.module`);
       expect(indexContent).toContain(`import styled from '@emotion/styled'`);
     });
+
+    it('should add jsxImportSource in tsconfig.json', async () => {
+      await applicationGenerator(tree, {
+        name: 'myApp',
+        style: '@emotion/styled',
+        standaloneConfig: false,
+      });
+
+      const tsconfigJson = readJson(tree, 'apps/my-app/tsconfig.json');
+
+      expect(tsconfigJson.compilerOptions['jsxImportSource']).toEqual(
+        '@emotion/react'
+      );
+    });
   });
 
   describe('--style styled-jsx', () => {

--- a/packages/next/src/generators/application/files/tsconfig.json__tmpl__
+++ b/packages/next/src/generators/application/files/tsconfig.json__tmpl__
@@ -2,6 +2,7 @@
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "compilerOptions": {
     "jsx": "preserve",
+    <% if (style === '@emotion/styled') { %>"jsxImportSource": "@emotion/react",<% } %>
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -93,4 +93,37 @@ describe('next library', () => {
       '../../node_modules/@nrwl/react/typings/image.d.ts'
     );
   });
+
+  it('should add jsxImportSource in tsconfig.json for @emotion/styled', async () => {
+    const baseOptions: Schema = {
+      name: '',
+      linter: Linter.EsLint,
+      skipFormat: false,
+      skipTsConfig: false,
+      unitTestRunner: 'jest',
+      style: 'css',
+      component: true,
+    };
+
+    const appTree = createTreeWithEmptyWorkspace();
+
+    await libraryGenerator(appTree, {
+      ...baseOptions,
+      name: 'myLib',
+    });
+    await libraryGenerator(appTree, {
+      ...baseOptions,
+      name: 'myLib2',
+      style: '@emotion/styled',
+    });
+
+    expect(
+      readJson(appTree, 'libs/my-lib/tsconfig.json').compilerOptions
+        .jsxImportSource
+    ).not.toBeDefined();
+    expect(
+      readJson(appTree, 'libs/my-lib2/tsconfig.json').compilerOptions
+        .jsxImportSource
+    ).toEqual('@emotion/react');
+  });
 });

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -45,6 +45,13 @@ export async function libraryGenerator(host: Tree, options: Schema) {
     return json;
   });
 
+  updateJson(host, joinPathFragments(projectRoot, 'tsconfig.json'), (json) => {
+    if (options.style === '@emotion/styled') {
+      json.compilerOptions.jsxImportSource = '@emotion/react';
+    }
+    return json;
+  });
+
   updateJson(
     host,
     joinPathFragments(projectRoot, 'tsconfig.lib.json'),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Emotion's `css` prop does not work because `jsxImportSource` is not specified in `tsconfig.json`.

![image](https://user-images.githubusercontent.com/2607019/137361973-cb293c94-a70d-4556-a6b5-b8bf876bec43.png)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`css` prop should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://nrwlcommunity.slack.com/archives/CMFKWPU6Q/p1634219035415500
See https://github.com/nrwl/nx/pull/7364 for `@nrwl/react`.
Fixes #4520
Closes #7418