### PR TITLE
chore(core): fix migration for new config locations

### DIFF
--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -96,14 +96,22 @@ function ensurePropertiesAreInNewLocations(tree: Tree) {
     return;
   }
   const wc = readWorkspaceConfiguration(tree);
-  updateWorkspaceConfiguration(tree, wc);
   updateJson<WorkspaceConfiguration>(tree, workspacePath, (json) => {
+    wc.generators ??= json.generators ?? (json as any).schematics;
+    if (wc.cli) {
+      wc.cli.defaultCollection ??= json.cli?.defaultCollection;
+      wc.cli.packageManager ??= json.cli?.packageManager;
+    } else if (json.cli) {
+      wc.cli ??= json.cli;
+    }
+    wc.defaultProject ??= json.defaultProject;
     delete json.cli;
     delete json.defaultProject;
     delete (json as any).schematics;
     delete json.generators;
     return json;
   });
+  updateWorkspaceConfiguration(tree, wc);
 }
 
 function sortTsConfig(tree: Tree) {

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -194,7 +194,8 @@ function movePropertiesToNewLocations() {
       nxJson.defaultProject
     ) {
       nxJson.cli ??= workspaceJson.cli;
-      nxJson.generators ??= workspaceJson.generators;
+      nxJson.generators ??=
+        workspaceJson.generators ?? (workspaceJson as any).schematics;
       nxJson.defaultProject ??= workspaceJson.defaultProject;
       delete workspaceJson['cli'];
       delete workspaceJson['generators'];

--- a/packages/workspace/src/migrations/update-13-0-0/config-locations/config-locations.spec.ts
+++ b/packages/workspace/src/migrations/update-13-0-0/config-locations/config-locations.spec.ts
@@ -47,4 +47,51 @@ describe('update to v13 config locations', () => {
     expect(workspaceJson.cli).not.toBeDefined();
     expect(workspaceJson.defaultProject).not.toBeDefined();
   });
+
+  describe('v1 workspace', () => {
+    beforeEach(() => {
+      tree = createTreeWithEmptyWorkspace(1);
+      updateJson(tree, 'workspace.json', (json) => ({
+        ...json,
+        cli: {
+          defaultCollection: '@nrwl/workspace',
+          packageManager: 'npm',
+        },
+        schematics: {
+          '@nrwl/workspace:lib': {
+            name: 'This is a wierd default',
+          },
+        },
+        defaultProject: 'a',
+        projects: {
+          a: {},
+        },
+      }));
+      writeJson(tree, 'nx.json', {
+        npmScope: 'test',
+        projects: {
+          a: {
+            tags: ['test'],
+          },
+        },
+      });
+    });
+
+    it('should move properties to correct place', async () => {
+      await update(tree);
+      const workspaceJson = readJson(tree, 'workspace.json');
+      const nxJson = readJson(tree, 'nx.json');
+      expect(nxJson.projects).not.toBeDefined();
+      expect(nxJson.cli?.defaultCollection).toEqual('@nrwl/workspace');
+      expect(nxJson.cli?.packageManager).toEqual('npm');
+      expect(nxJson.generators).toEqual({
+        '@nrwl/workspace:lib': {
+          name: 'This is a wierd default',
+        },
+      });
+      expect(workspaceJson.projects.a.tags).toEqual(['test']);
+      expect(workspaceJson.cli).not.toBeDefined();
+      expect(workspaceJson.defaultProject).not.toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## Current Behavior
Defaults for schematics in a v1 workspace get dropped during migration

## Expected Behavior
Defaults for schematics are properly relocated during migration

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
