### PR TITLE
feat(react): support css prop for emotion

### DIFF
--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -92,6 +92,12 @@
       "version": "12.0.0-beta.0",
       "description": "Remove @types/react-redux from package.json since react-redux installs the package automatically now",
       "factory": "./src/migrations/update-12-0-0/remove-react-redux-types-package"
+    },
+    "update-emotion-setup-13.0.0": {
+      "cli": "nx",
+      "version": "13.0.0-beta.0",
+      "description": "Update tsconfig.json to use `jsxImportSource` to support css prop",
+      "factory": "./src/migrations/update-13-0-0/update-emotion-setup"
     }
   },
   "packageJsonUpdates": {

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -537,6 +537,18 @@ Object {
       expect(content).toContain('<StyledApp>');
     });
 
+    it('should add jsxImportSource to tsconfig.json', async () => {
+      await applicationGenerator(appTree, {
+        ...schema,
+        style: '@emotion/styled',
+      });
+
+      const tsconfigJson = readJson(appTree, 'apps/my-app/tsconfig.json');
+      expect(tsconfigJson.compilerOptions['jsxImportSource']).toEqual(
+        '@emotion/react'
+      );
+    });
+
     it('should exclude styles from workspace.json', async () => {
       await applicationGenerator(appTree, {
         ...schema,

--- a/packages/react/src/generators/application/files/common/tsconfig.json__tmpl__
+++ b/packages/react/src/generators/application/files/common/tsconfig.json__tmpl__
@@ -2,6 +2,7 @@
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
+    <% if (style === '@emotion/styled') { %>"jsxImportSource": "@emotion/react",<% } %>
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true

--- a/packages/react/src/generators/library/files/lib/tsconfig.json__tmpl__
+++ b/packages/react/src/generators/library/files/lib/tsconfig.json__tmpl__
@@ -2,6 +2,7 @@
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
+    <% if (style === '@emotion/styled') { %>"jsxImportSource": "@emotion/react",<% } %>
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -488,6 +488,7 @@ describe('lib', () => {
 
       const workspaceJson = readJson(appTree, '/workspace.json');
       const babelrc = readJson(appTree, 'libs/my-lib/.babelrc');
+      const tsconfigJson = readJson(appTree, 'libs/my-lib/tsconfig.json');
 
       expect(workspaceJson.projects['my-lib'].architect.build).toMatchObject({
         options: {
@@ -495,6 +496,9 @@ describe('lib', () => {
         },
       });
       expect(babelrc.plugins).toEqual(['@emotion/babel-plugin']);
+      expect(tsconfigJson.compilerOptions['jsxImportSource']).toEqual(
+        '@emotion/react'
+      );
     });
 
     it('should support styled-jsx', async () => {

--- a/packages/react/src/migrations/update-13-0-0/update-emotion-setup.spec.ts
+++ b/packages/react/src/migrations/update-13-0-0/update-emotion-setup.spec.ts
@@ -1,0 +1,90 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { readJson, Tree } from '@nrwl/devkit';
+import { updateEmotionSetup } from './update-emotion-setup';
+
+describe('Update tsconfig config for Emotion', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it(`should add jsxImportSource if it uses @emotion/react`, async () => {
+    tree.write(
+      'workspace.json',
+      JSON.stringify({
+        projects: {
+          'no-emotion-app': {
+            root: 'apps/no-emotion-app',
+            projectType: 'application',
+          },
+          'plain-react-app': {
+            root: 'apps/plain-react-app',
+            projectType: 'application',
+          },
+          'emotion-app': {
+            root: 'apps/emotion-app',
+            projectType: 'application',
+          },
+        },
+      })
+    );
+    tree.write(
+      'nx.json',
+      JSON.stringify({
+        projects: {
+          'no-emotion-app': {},
+          'plain-react-app': {},
+          'emotion-app': {},
+        },
+      })
+    );
+    tree.write('apps/no-emotion-app/.babelrc', JSON.stringify({}));
+    tree.write(
+      'apps/no-emotion-app/tsconfig.json',
+      JSON.stringify({ compilerOptions: {} })
+    );
+    tree.write(
+      'apps/plain-react-app/.babelrc',
+      JSON.stringify({
+        presets: ['@nrwl/react/babel'],
+        plugins: [],
+      })
+    );
+    tree.write(
+      'apps/plain-react-app/tsconfig.json',
+      JSON.stringify({ compilerOptions: { jsx: 'react-jsx' } })
+    );
+    tree.write(
+      'apps/emotion-app/.babelrc',
+      JSON.stringify({
+        presets: [
+          [
+            '@nrwl/react/babel',
+            {
+              runtime: 'automatic',
+              importSource: '@emotion/react',
+            },
+          ],
+        ],
+        plugins: ['@emotion/babel-plugin'],
+      })
+    );
+    tree.write(
+      'apps/emotion-app/tsconfig.json',
+      JSON.stringify({ compilerOptions: { jsx: 'react-jsx' } })
+    );
+
+    await updateEmotionSetup(tree);
+
+    expect(readJson(tree, 'apps/no-emotion-app/tsconfig.json')).toEqual({
+      compilerOptions: {},
+    });
+    expect(readJson(tree, 'apps/plain-react-app/tsconfig.json')).toEqual({
+      compilerOptions: { jsx: 'react-jsx' },
+    });
+    expect(readJson(tree, 'apps/emotion-app/tsconfig.json')).toEqual({
+      compilerOptions: { jsx: 'react-jsx', jsxImportSource: '@emotion/react' },
+    });
+  });
+});

--- a/packages/react/src/migrations/update-13-0-0/update-emotion-setup.ts
+++ b/packages/react/src/migrations/update-13-0-0/update-emotion-setup.ts
@@ -1,0 +1,42 @@
+import {
+  formatFiles,
+  getProjects,
+  Tree,
+  readJson,
+  updateJson,
+} from '@nrwl/devkit';
+
+export async function updateEmotionSetup(host: Tree) {
+  const projects = getProjects(host);
+
+  projects.forEach((p) => {
+    let hasEmotion = false;
+    const babelrcPath = `${p.root}/.babelrc`;
+    const tsConfigPath = `${p.root}/tsconfig.json`;
+
+    if (host.exists(babelrcPath)) {
+      const babelrc = readJson(host, babelrcPath);
+      if (babelrc.presets) {
+        for (const [idx, preset] of babelrc.presets.entries()) {
+          if (Array.isArray(preset)) {
+            if (!preset[0].includes('@nrwl/react/babel')) continue;
+            const emotionOptions = preset[1];
+            hasEmotion = emotionOptions.importSource === '@emotion/react';
+            break;
+          }
+        }
+      }
+    }
+
+    if (hasEmotion && host.exists(tsConfigPath)) {
+      updateJson(host, tsConfigPath, (json) => {
+        json.compilerOptions.jsxImportSource = '@emotion/react';
+        return json;
+      });
+    }
+  });
+
+  await formatFiles(host);
+}
+
+export default updateEmotionSetup;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Emotion's `css` prop does not work because `jsxImportSource` is not specified in `tsconfig.json`.

![image](https://user-images.githubusercontent.com/2607019/137361973-cb293c94-a70d-4556-a6b5-b8bf876bec43.png)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`css` prop should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://nrwlcommunity.slack.com/archives/CMFKWPU6Q/p1634219035415500
See https://github.com/nrwl/nx/pull/7384 for `@nrwl/next`.
Fixes #4520
Closes #7050