### PR TITLE
feat(nextjs): add migration for css prop

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -61,6 +61,12 @@
       "description": "Updates .eslintrc.json file to use the correct pages directory for '@next/next/no-html-link-for-pages'.",
       "factory": "./src/migrations/update-12-10-0/fix-page-dir-for-eslint"
     },
+    "update-emotion-setup-13.0.0": {
+      "cli": "nx",
+      "version": "13.0.0-beta.0",
+      "description": "Update tsconfig.json to use `jsxImportSource` to support css prop",
+      "factory": "./src/migrations/update-13-0-0/update-emotion-setup"
+    },
     "update-to-webpack-5": {
       "cli": "nx",
       "version": "13.0.0-beta.1",

--- a/packages/next/src/migrations/update-13-0-0/update-emotion-setup.spec.ts
+++ b/packages/next/src/migrations/update-13-0-0/update-emotion-setup.spec.ts
@@ -1,0 +1,92 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { readJson, Tree } from '@nrwl/devkit';
+import { updateEmotionSetup } from './update-emotion-setup';
+
+describe('Update tsconfig config for Emotion', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it(`should add jsxImportSource if it uses @emotion/react`, async () => {
+    tree.write(
+      'workspace.json',
+      JSON.stringify({
+        projects: {
+          'no-emotion-app': {
+            root: 'apps/no-emotion-app',
+            projectType: 'application',
+          },
+          'plain-next-app': {
+            root: 'apps/plain-next-app',
+            projectType: 'application',
+          },
+          'emotion-app': {
+            root: 'apps/emotion-app',
+            projectType: 'application',
+          },
+        },
+      })
+    );
+    tree.write(
+      'nx.json',
+      JSON.stringify({
+        projects: {
+          'no-emotion-app': {},
+          'plain-next-app': {},
+          'emotion-app': {},
+        },
+      })
+    );
+    tree.write('apps/no-emotion-app/.babelrc', JSON.stringify({}));
+    tree.write(
+      'apps/no-emotion-app/tsconfig.json',
+      JSON.stringify({ compilerOptions: {} })
+    );
+    tree.write(
+      'apps/plain-next-app/.babelrc',
+      JSON.stringify({
+        presets: ['@nrwl/next/babel'],
+        plugins: [],
+      })
+    );
+    tree.write(
+      'apps/plain-next-app/tsconfig.json',
+      JSON.stringify({ compilerOptions: { jsx: 'preserve' } })
+    );
+    tree.write(
+      'apps/emotion-app/.babelrc',
+      JSON.stringify({
+        presets: [
+          [
+            '@nrwl/next/babel',
+            {
+              'preset-react': {
+                runtime: 'automatic',
+                importSource: '@emotion/react',
+              },
+            },
+          ],
+        ],
+        plugins: ['@emotion/babel-plugin'],
+      })
+    );
+    tree.write(
+      'apps/emotion-app/tsconfig.json',
+      JSON.stringify({ compilerOptions: { jsx: 'preserve' } })
+    );
+
+    await updateEmotionSetup(tree);
+
+    expect(readJson(tree, 'apps/no-emotion-app/tsconfig.json')).toEqual({
+      compilerOptions: {},
+    });
+    expect(readJson(tree, 'apps/plain-next-app/tsconfig.json')).toEqual({
+      compilerOptions: { jsx: 'preserve' },
+    });
+    expect(readJson(tree, 'apps/emotion-app/tsconfig.json')).toEqual({
+      compilerOptions: { jsx: 'preserve', jsxImportSource: '@emotion/react' },
+    });
+  });
+});

--- a/packages/next/src/migrations/update-13-0-0/update-emotion-setup.ts
+++ b/packages/next/src/migrations/update-13-0-0/update-emotion-setup.ts
@@ -1,0 +1,42 @@
+import {
+  formatFiles,
+  getProjects,
+  Tree,
+  readJson,
+  updateJson,
+} from '@nrwl/devkit';
+
+export async function updateEmotionSetup(host: Tree) {
+  const projects = getProjects(host);
+
+  projects.forEach((p) => {
+    let hasEmotion = false;
+    const babelrcPath = `${p.root}/.babelrc`;
+    const tsConfigPath = `${p.root}/tsconfig.json`;
+
+    if (host.exists(babelrcPath)) {
+      const babelrc = readJson(host, babelrcPath);
+      if (babelrc.presets) {
+        for (const [idx, preset] of babelrc.presets.entries()) {
+          if (Array.isArray(preset)) {
+            if (!preset[0].includes('@nrwl/next/babel')) continue;
+            const emotionOptions = preset[1]['preset-react'];
+            hasEmotion = emotionOptions?.importSource === '@emotion/react';
+            break;
+          }
+        }
+      }
+    }
+
+    if (hasEmotion && host.exists(tsConfigPath)) {
+      updateJson(host, tsConfigPath, (json) => {
+        json.compilerOptions.jsxImportSource = '@emotion/react';
+        return json;
+      });
+    }
+  });
+
+  await formatFiles(host);
+}
+
+export default updateEmotionSetup;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
No migration for Emotion's `css` prop.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`compilerOptions` in `tsconfig.json` has `"jsxImportSource": @emotion/react` after migration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://nrwlcommunity.slack.com/archives/CMFKWPU6Q/p1634219035415500
#7384
Closes #7418