### PR TITLE
feat(angular): allow port to be added to non-mfe app

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -826,6 +826,17 @@ describe('app', () => {
       );
       expect(hostWebpackConfig).toMatchSnapshot();
     });
+
+    it('should add a port to a non-mfe app', async () => {
+      // ACT
+      await generateApp(appTree, 'app1', {
+        port: 4205,
+      });
+
+      // ASSERT
+      const projectConfig = readProjectConfiguration(appTree, 'app1');
+      expect(projectConfig.targets.serve.options.port).toBe(4205);
+    });
   });
 });
 

--- a/packages/angular/src/generators/application/lib/update-config-files.ts
+++ b/packages/angular/src/generators/application/lib/update-config-files.ts
@@ -68,6 +68,16 @@ function updateAppAndE2EProjectConfigurations(
     delete fixedProject.generators;
   }
 
+  if (options.port) {
+    fixedProject.targets.serve = {
+      ...fixedProject.targets.serve,
+      options: {
+        ...fixedProject.targets.serve.options,
+        port: options.port,
+      },
+    };
+  }
+
   updateProjectConfiguration(host, options.name, fixedProject);
 
   if (options.unitTestRunner === UnitTestRunner.None) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Specifying the `--port` option only adds a port when generating an MFE app.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Extend the behaviour to support generating normal apps.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7338
