### PR TITLE
cleanup(angular): remove deprecated options from the ngrx generator

### DIFF
--- a/docs/angular/api-angular/generators/ngrx.md
+++ b/docs/angular/api-angular/generators/ngrx.md
@@ -68,26 +68,6 @@ Type: `boolean`
 
 Only register the root state management setup or feature state.
 
-### ~~onlyAddFiles~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** Use the `skipImport` option instead.
-
-Only add new NgRx files, without changing the module file (e.g., `--onlyAddFiles`).
-
-### ~~onlyEmptyRoot~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** Use the `minimal` option instead.
-
-Do not generate any files. Only generate `StoreModule.forRoot` and `EffectsModule.forRoot` (e.g., `--onlyEmptyRoot`).
-
 ### root
 
 Default: `false`

--- a/docs/node/api-angular/generators/ngrx.md
+++ b/docs/node/api-angular/generators/ngrx.md
@@ -68,26 +68,6 @@ Type: `boolean`
 
 Only register the root state management setup or feature state.
 
-### ~~onlyAddFiles~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** Use the `skipImport` option instead.
-
-Only add new NgRx files, without changing the module file (e.g., `--onlyAddFiles`).
-
-### ~~onlyEmptyRoot~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** Use the `minimal` option instead.
-
-Do not generate any files. Only generate `StoreModule.forRoot` and `EffectsModule.forRoot` (e.g., `--onlyEmptyRoot`).
-
 ### root
 
 Default: `false`

--- a/docs/react/api-angular/generators/ngrx.md
+++ b/docs/react/api-angular/generators/ngrx.md
@@ -68,26 +68,6 @@ Type: `boolean`
 
 Only register the root state management setup or feature state.
 
-### ~~onlyAddFiles~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** Use the `skipImport` option instead.
-
-Only add new NgRx files, without changing the module file (e.g., `--onlyAddFiles`).
-
-### ~~onlyEmptyRoot~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** Use the `minimal` option instead.
-
-Do not generate any files. Only generate `StoreModule.forRoot` and `EffectsModule.forRoot` (e.g., `--onlyEmptyRoot`).
-
 ### root
 
 Default: `false`

--- a/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ngrx should add a root module with feature module when minimal and onlyEmptyRoot are false 1`] = `
+exports[`ngrx should add a root module with feature module when minimal is set to false 1`] = `
 "
      import { NgModule } from '@angular/core';
      import { BrowserModule } from '@angular/platform-browser';
@@ -29,7 +29,7 @@ import { StoreRouterConnectingModule } from '@ngrx/router-store';
   "
 `;
 
-exports[`ngrx should add an empty root module when minimal is true 1`] = `
+exports[`ngrx should add an empty root module when minimal and root are set to true 1`] = `
 "
      import { NgModule } from '@angular/core';
      import { BrowserModule } from '@angular/platform-browser';
@@ -55,48 +55,7 @@ import { StoreRouterConnectingModule } from '@ngrx/router-store';
   "
 `;
 
-exports[`ngrx should add an empty root module when onlyEmptyRoot is true 1`] = `
-"
-     import { NgModule } from '@angular/core';
-     import { BrowserModule } from '@angular/platform-browser';
-     import { RouterModule } from '@angular/router';
-     import { AppComponent } from './app.component';
-import { StoreModule } from '@ngrx/store';
-import { EffectsModule } from '@ngrx/effects';
-import { StoreDevtoolsModule } from '@ngrx/store-devtools';
-import { environment } from '../environments/environment';
-import { StoreRouterConnectingModule } from '@ngrx/router-store';
-     @NgModule({
-       imports: [BrowserModule, RouterModule.forRoot([]), StoreModule.forRoot({}, {
-      metaReducers: !environment.production ? [] : [],
-      runtimeChecks: {
-        strictActionImmutability: true,
-        strictStateImmutability: true
-      }
-    }), EffectsModule.forRoot([]), !environment.production ? StoreDevtoolsModule.instrument() : [], StoreRouterConnectingModule.forRoot()],
-       declarations: [AppComponent],
-       bootstrap: [AppComponent]
-     })
-     export class AppModule {}
-  "
-`;
-
-exports[`ngrx should only add files when onlyAddFiles is true 1`] = `
-"
-     import { NgModule } from '@angular/core';
-     import { BrowserModule } from '@angular/platform-browser';
-     import { RouterModule } from '@angular/router';
-     import { AppComponent } from './app.component';
-     @NgModule({
-       imports: [BrowserModule, RouterModule.forRoot([])],
-       declarations: [AppComponent],
-       bootstrap: [AppComponent]
-     })
-     export class AppModule {}
-  "
-`;
-
-exports[`ngrx should only add files when skipImport is true 1`] = `
+exports[`ngrx should not generate imports when skipImport is true 1`] = `
 "
      import { NgModule } from '@angular/core';
      import { BrowserModule } from '@angular/platform-browser';

--- a/packages/angular/src/generators/ngrx/lib/add-imports-to-module.ts
+++ b/packages/angular/src/generators/ngrx/lib/add-imports-to-module.ts
@@ -73,7 +73,7 @@ export function addImportsToModule(
   sourceFile = addImport(sourceFile, 'StoreModule', '@ngrx/store');
   sourceFile = addImport(sourceFile, 'EffectsModule', '@ngrx/effects');
 
-  if ((options.onlyEmptyRoot || options.minimal) && options.root) {
+  if (options.minimal && options.root) {
     sourceFile = addImport(
       sourceFile,
       'StoreDevtoolsModule',

--- a/packages/angular/src/generators/ngrx/lib/normalize-options.ts
+++ b/packages/angular/src/generators/ngrx/lib/normalize-options.ts
@@ -4,17 +4,8 @@ import type { NgRxGeneratorOptions } from '../schema';
 export function normalizeOptions(
   options: NgRxGeneratorOptions
 ): NgRxGeneratorOptions {
-  const normalizedOptions = {
+  return {
     ...options,
     directory: names(options.directory).fileName,
   };
-
-  if (options.minimal) {
-    normalizedOptions.onlyEmptyRoot = true;
-  }
-  if (options.skipImport) {
-    normalizedOptions.onlyAddFiles = true;
-  }
-
-  return normalizedOptions;
 }

--- a/packages/angular/src/generators/ngrx/ngrx.spec.ts
+++ b/packages/angular/src/generators/ngrx/ngrx.spec.ts
@@ -36,7 +36,7 @@ describe('ngrx', () => {
     ).rejects.toThrowError(`Module does not exist: ${modulePath}.`);
   });
 
-  it('should add an empty root module when minimal is true', async () => {
+  it('should add an empty root module when minimal and root are set to true', async () => {
     await ngrxGenerator(tree, {
       ...defaultOptions,
       root: true,
@@ -48,25 +48,38 @@ describe('ngrx', () => {
     ).toMatchSnapshot();
   });
 
-  it('should add an empty root module when onlyEmptyRoot is true', async () => {
+  it('should not generate files when minimal and root are set to true', async () => {
     await ngrxGenerator(tree, {
       ...defaultOptions,
       root: true,
-      minimal: false,
-      onlyEmptyRoot: true,
+      minimal: true,
     });
 
+    expect(tree.exists('/apps/myapp/src/app/+state/users.actions.ts')).toBe(
+      false
+    );
+    expect(tree.exists('/apps/myapp/src/app/+state/users.effects.ts')).toBe(
+      false
+    );
     expect(
-      tree.read('/apps/myapp/src/app/app.module.ts', 'utf-8')
-    ).toMatchSnapshot();
+      tree.exists('/apps/myapp/src/app/+state/users.effects.spec.ts')
+    ).toBe(false);
+    expect(tree.exists('/apps/myapp/src/app/+state/users.reducer.ts')).toBe(
+      false
+    );
+    expect(tree.exists('/apps/myapp/src/app/+state/users.selectors.ts')).toBe(
+      false
+    );
+    expect(
+      tree.exists('/apps/myapp/src/app/+state/users.selectors.spec.ts')
+    ).toBe(false);
   });
 
-  it('should add a root module with feature module when minimal and onlyEmptyRoot are false', async () => {
+  it('should add a root module with feature module when minimal is set to false', async () => {
     await ngrxGenerator(tree, {
       ...defaultOptions,
       root: true,
       minimal: false,
-      onlyEmptyRoot: false,
     });
 
     expect(
@@ -129,43 +142,11 @@ describe('ngrx', () => {
     ).not.toContain('providers: [UsersFacade]');
   });
 
-  it('should not add facade provider when onlyEmptyRoot is true', async () => {
-    await ngrxGenerator(tree, {
-      ...defaultOptions,
-      root: true,
-      minimal: false,
-      onlyEmptyRoot: true,
-      facade: true,
-    });
-
-    expect(
-      tree.read('/apps/myapp/src/app/app.module.ts', 'utf-8')
-    ).not.toContain('providers: [UsersFacade]');
-  });
-
-  it('should only add files when skipImport is true', async () => {
+  it('should not generate imports when skipImport is true', async () => {
     await ngrxGenerator(tree, {
       ...defaultOptions,
       minimal: false,
       skipImport: true,
-    });
-
-    expectFileToExist('/apps/myapp/src/app/+state/users.actions.ts');
-    expectFileToExist('/apps/myapp/src/app/+state/users.effects.ts');
-    expectFileToExist('/apps/myapp/src/app/+state/users.effects.spec.ts');
-    expectFileToExist('/apps/myapp/src/app/+state/users.reducer.ts');
-    expectFileToExist('/apps/myapp/src/app/+state/users.selectors.ts');
-    expectFileToExist('/apps/myapp/src/app/+state/users.selectors.spec.ts');
-    expect(
-      tree.read('/apps/myapp/src/app/app.module.ts', 'utf-8')
-    ).toMatchSnapshot();
-  });
-
-  it('should only add files when onlyAddFiles is true', async () => {
-    await ngrxGenerator(tree, {
-      ...defaultOptions,
-      minimal: false,
-      onlyAddFiles: true,
     });
 
     expectFileToExist('/apps/myapp/src/app/+state/users.actions.ts');

--- a/packages/angular/src/generators/ngrx/ngrx.ts
+++ b/packages/angular/src/generators/ngrx/ngrx.ts
@@ -19,14 +19,11 @@ export async function ngrxGenerator(
     throw new Error(`Module does not exist: ${normalizedOptions.module}.`);
   }
 
-  if (
-    !normalizedOptions.onlyEmptyRoot ||
-    (!normalizedOptions.root && normalizedOptions.minimal)
-  ) {
+  if (!normalizedOptions.minimal || !normalizedOptions.root) {
     generateNgrxFilesFromTemplates(tree, normalizedOptions);
   }
 
-  if (!normalizedOptions.onlyAddFiles) {
+  if (!normalizedOptions.skipImport) {
     addImportsToModule(tree, normalizedOptions);
     addExportsToBarrel(tree, normalizedOptions);
   }

--- a/packages/angular/src/generators/ngrx/schema.d.ts
+++ b/packages/angular/src/generators/ngrx/schema.d.ts
@@ -11,14 +11,4 @@ export interface NgRxGeneratorOptions {
   skipImport?: boolean;
   skipPackageJson?: boolean;
   syntax?: 'classes' | 'creators';
-
-  /**
-   * @deprecated use `skipImport`.
-   */
-  onlyAddFiles?: boolean;
-
-  /**
-   * @deprecated use `minimal`.
-   */
-  onlyEmptyRoot?: boolean;
 }

--- a/packages/angular/src/generators/ngrx/schema.json
+++ b/packages/angular/src/generators/ngrx/schema.json
@@ -41,22 +41,10 @@
       "default": false,
       "description": "Generate NgRx feature files without registering the feature in the NgModule."
     },
-    "onlyAddFiles": {
-      "type": "boolean",
-      "default": false,
-      "description": "Only add new NgRx files, without changing the module file (e.g., `--onlyAddFiles`).",
-      "x-deprecated": "Use the `skipImport` option instead."
-    },
     "minimal": {
       "type": "boolean",
       "default": true,
       "description": "Only register the root state management setup or feature state."
-    },
-    "onlyEmptyRoot": {
-      "type": "boolean",
-      "default": false,
-      "description": "Do not generate any files. Only generate `StoreModule.forRoot` and `EffectsModule.forRoot` (e.g., `--onlyEmptyRoot`).",
-      "x-deprecated": "Use the `minimal` option instead."
     },
     "skipFormat": {
       "description": "Skip formatting files.",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## What it does

Removes the following previously deprecated options from the `@nrwl/angular:ngrx` generator:

- `onlyAddFiles`
- `onlyEmptyRoot`
