### PR TITLE
fix(storybook): if there is no propstype name do not add angle brackets

### DIFF
--- a/packages/react/src/generators/component-story/component-story.spec.ts
+++ b/packages/react/src/generators/component-story/component-story.spec.ts
@@ -156,7 +156,7 @@ describe('react:component-story', () => {
             title: 'Test',
           } as Meta;
           
-          const Template: Story<> = (args) => <Test {...args} />;
+          const Template: Story = (args) => <Test {...args} />;
           
           export const Primary = Template.bind({});
           Primary.args = {};

--- a/packages/react/src/generators/component-story/files/__componentFileName__.stories.__fileExt__
+++ b/packages/react/src/generators/component-story/files/__componentFileName__.stories.__fileExt__
@@ -10,7 +10,7 @@ export default {
    <% } %> 
 }<% if ( !isPlainJs ) { %> as Meta <% } %>;
 
-const Template<% if ( !isPlainJs ) { %>: Story<<%= propsTypeName %>><% } %> = (args) => <<%= componentName %> {...args} />;
+const Template<% if ( !isPlainJs ) { %>: Story<% if ( propsTypeName ) { %><<%= propsTypeName %>><% } %><% } %> = (args) => <<%= componentName %> {...args} />;
 
 export const Primary = Template.bind({})
 Primary.args = {<% for (let prop of props) { %>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Generating stories for React components resulted in an error if the props type name is missing.

```
Template: Story<>
```

## Expected Behavior
Only add the `<>` if there is a props type name.

```
Template: Story
```
or 

```
Template: Story<MyTypeNameProps>
```


