### PR TITLE
docs(core): update webpack 5 guide

### DIFF
--- a/docs/shared/guides/webpack-5.md
+++ b/docs/shared/guides/webpack-5.md
@@ -1,12 +1,18 @@
 # Webpack 5 Migration
 
-Nx 12 is the last version to support Webpack 4. You can enable Webpack 5 in your workspace by following the steps outlined in this document.
+Starting in Nx 13, we only support Webpack 5, which is automatically enabled for all workspaces.
 
-In Nx 13, we will only support Webpack 5. Workspaces with custom webpack config need to ensure they have Webpack 5 compatible webpack plugins before Nx 13 is released. If you do not use custom webpack config then the migration should be seamless.
+Workspaces with custom webpack configuration should make sure that all their plugins and loaders are compatible with Webpack 5.
+For additional help on the migration, check out Webpack's ["To v5 from v4" guide](https://webpack.js.org/migrate/5/).
 
-This guide includes instructions and information on how you can update your workspace to Webpack 5.
+Nx 12 is the last Nx version to support Webpack 4 so if you cannot upgrade to Webpack 5 then you may stay on this
+version, but we highly suggest you upgrade as soon as possible to benefit from future patches and features.
 
-## Webpack 5 for React Apps
+## Nx 12: Testing Webpack 5 Compatibility
+
+If you are still on Nx 12, you can try out Webpack 5 without upgrading fully to Nx 13.
+
+### Webpack 5 for React Apps
 
 For React apps (i.e. generated with `@nrwl/react:app`) webpack 4 is the default version used by Nx.
 
@@ -16,7 +22,7 @@ To opt into webpack 5 your can run the migration generator from:
 npx nx g @nrwl/web:webpack5
 ```
 
-## Webpack 5 for Node Apps
+### Webpack 5 for Node Apps
 
 For Node apps (i.e. generated with `@nrwl/node:app`) webpack 4 is the default version used by Nx.
 
@@ -26,26 +32,29 @@ To opt into webpack 5 your can run the migration generator from:
 npx nx g @nrwl/node:webpack5
 ```
 
-**Note:** If you already ran the `@nrwl/web:webpack5` generator, there is no need to also run the `@nrwl/node:webpack` generator. They both install the same packages and are interchangeable.
+**Note:** If you already ran the `@nrwl/web:webpack5` generator, there is no need to also run the `@nrwl/node:webpack`
+generator. They both install the same packages and are interchangeable.
 
-## Webpack 5 for Next.js Apps
+### Webpack 5 for Next.js Apps
 
-As of Next.js 11 and Nx 12.6.0, webpack 5 is the default version used. If you use a custom webpack setup, you can opt out of webpack 5 by add this to your `next.config.js` file.
+As of Next.js 11 and Nx 12.6.0, Webpack 5 is the default version used. Check your `next.config.js` file to ensure it is
+enabled.
 
 ```js
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const withNx = require('@nrwl/next/plugins/with-nx');
 
 const nextConfig = {
-  webpack5: false,
+  webpack5: true,
 };
 
 module.exports = withNx(nextConfig);
 ```
 
-For more information about webpack 5 adoption in Next.js, refer to their [webpack 5 guide](https://nextjs.org/docs/messages/webpack5).
+For more information about webpack 5 adoption in Next.js, refer to
+their [webpack 5 guide](https://nextjs.org/docs/messages/webpack5).
 
-## Webpack 5 for Angular Apps
+### Webpack 5 for Angular Apps
 
 As of Angular 12, the tooling of Angular uses webpack 5 and support for webpack 4 has been removed.
 

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-angular/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-angular/generators/application.md
@@ -174,8 +174,6 @@ Skip creating spec files.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-angular/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-angular/generators/library.md
@@ -152,8 +152,6 @@ Do not update `tsconfig.json` for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-express/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-express/generators/application.md
@@ -108,8 +108,6 @@ Do not add dependencies to package.json.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-gatsby/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-gatsby/generators/application.md
@@ -68,8 +68,6 @@ Whether or not to configure the ESLint "parserOptions.project" option. We do not
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-nest/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-nest/generators/application.md
@@ -82,8 +82,6 @@ Do not add dependencies to package.json.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json.

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-nest/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-nest/generators/library.md
@@ -130,8 +130,6 @@ Do not update tsconfig.base.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-next/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-next/generators/application.md
@@ -110,8 +110,6 @@ Skip updating workspace.json with default options based on values provided to th
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-node/executors/build.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-node/executors/build.md
@@ -130,16 +130,6 @@ Type: `boolean`
 
 Log progress to the console while building.
 
-### ~~showCircularDependencies~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling.
-
-Show circular dependency warnings on builds.
-
 ### sourceMap
 
 Default: `true`

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-node/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-node/generators/application.md
@@ -108,8 +108,6 @@ Do not add dependencies to package.json.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-node/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-node/generators/library.md
@@ -148,8 +148,6 @@ Do not update tsconfig.base.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-nx-devkit/index.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-nx-devkit/index.md
@@ -34,8 +34,9 @@ It only uses language primitives and immutable objects
 - [ProjectFileMap](../../angular/nx-devkit/index#projectfilemap)
 - [ProjectGraph](../../angular/nx-devkit/index#projectgraph)
 - [ProjectGraphDependency](../../angular/nx-devkit/index#projectgraphdependency)
-- [ProjectGraphNode](../../angular/nx-devkit/index#projectgraphnode)
+- [ProjectGraphExternalNode](../../angular/nx-devkit/index#projectgraphexternalnode)
 - [ProjectGraphProcessorContext](../../angular/nx-devkit/index#projectgraphprocessorcontext)
+- [ProjectGraphProjectNode](../../angular/nx-devkit/index#projectgraphprojectnode)
 
 ### Tree Interfaces
 
@@ -71,6 +72,10 @@ It only uses language primitives and immutable objects
 ### Package Manager Type aliases
 
 - [PackageManager](../../angular/nx-devkit/index#packagemanager)
+
+### Project Graph Type aliases
+
+- [ProjectGraphNode](../../angular/nx-devkit/index#projectgraphnode)
 
 ### Utils Type aliases
 
@@ -200,21 +205,27 @@ It only uses language primitives and immutable objects
 
 ---
 
-### ProjectGraphNode
+### ProjectGraphExternalNode
 
-• **ProjectGraphNode**<`T`\>: `Object`
-
-#### Type parameters
-
-| Name | Type  |
-| :--- | :---- |
-| `T`  | `any` |
+• **ProjectGraphExternalNode**: `Object`
 
 ---
 
 ### ProjectGraphProcessorContext
 
 • **ProjectGraphProcessorContext**: `Object`
+
+---
+
+### ProjectGraphProjectNode
+
+• **ProjectGraphProjectNode**<`T`\>: `Object`
+
+#### Type parameters
+
+| Name | Type  |
+| :--- | :---- |
+| `T`  | `any` |
 
 ---
 
@@ -355,6 +366,20 @@ It only uses language primitives and immutable objects
 ### PackageManager
 
 Ƭ **PackageManager**: `"yarn"` \| `"pnpm"` \| `"npm"`
+
+---
+
+## Project Graph Type aliases
+
+### ProjectGraphNode
+
+Ƭ **ProjectGraphNode**<`T`\>: [`ProjectGraphProjectNode`](../../angular/nx-devkit/index#projectgraphprojectnode)<`T`\> \| [`ProjectGraphExternalNode`](../../angular/nx-devkit/index#projectgraphexternalnode)
+
+#### Type parameters
+
+| Name | Type  |
+| :--- | :---- |
+| `T`  | `any` |
 
 ---
 
@@ -554,12 +579,12 @@ The utility will update either files.
 
 #### Parameters
 
-| Name                   | Type                                                                         | Default value | Description                                                                                |
-| :--------------------- | :--------------------------------------------------------------------------- | :------------ | :----------------------------------------------------------------------------------------- |
-| `tree`                 | [`Tree`](../../angular/nx-devkit/index#tree)                                 | `undefined`   | the file system tree                                                                       |
-| `projectName`          | `string`                                                                     | `undefined`   | unique name. Often directories are part of the name (e.g., mydir-mylib)                    |
-| `projectConfiguration` | [`ProjectConfiguration`](../../angular/nx-devkit/index#projectconfiguration) | `undefined`   | project configuration                                                                      |
-| `standalone`           | `boolean`                                                                    | `false`       | should the project use package.json? If false, the project config is inside workspace.json |
+| Name                   | Type                                                                         | Description                                                                                |
+| :--------------------- | :--------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------- |
+| `tree`                 | [`Tree`](../../angular/nx-devkit/index#tree)                                 | the file system tree                                                                       |
+| `projectName`          | `string`                                                                     | unique name. Often directories are part of the name (e.g., mydir-mylib)                    |
+| `projectConfiguration` | [`ProjectConfiguration`](../../angular/nx-devkit/index#projectconfiguration) | project configuration                                                                      |
+| `standalone?`          | `boolean`                                                                    | should the project use package.json? If false, the project config is inside workspace.json |
 
 #### Returns
 

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-nx-devkit/ngcli_adapter.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-nx-devkit/ngcli_adapter.md
@@ -37,7 +37,7 @@ Example:
 ```typescript
 mockSchematicsForTesting({
   'mycollection:myschematic': (tree, params) => {
-    tree.write('README');
+    tree.write('README.md');
   },
 });
 ```

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-nx-plugin/generators/plugin.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-nx-plugin/generators/plugin.md
@@ -88,8 +88,6 @@ Do not update tsconfig.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-react/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-react/generators/application.md
@@ -152,8 +152,6 @@ Skip updating workspace.json with default options based on values provided to th
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-react/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-react/generators/library.md
@@ -160,8 +160,6 @@ Do not update tsconfig.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-react/generators/storybook-configuration.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-react/generators/storybook-configuration.md
@@ -80,8 +80,6 @@ The tool to use for running lint checks.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-storybook/executors/storybook.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-storybook/executors/storybook.md
@@ -12,7 +12,7 @@ Default: `@storybook/angular`
 
 Type: `string`
 
-Possible values: `@storybook/angular`, `@storybook/react`, `@storybook/html`, `@storybook/web-components`, `@storybook/vue`, `@storybook/vue3`
+Possible values: `@storybook/angular`, `@storybook/react`, `@storybook/html`, `@storybook/web-components`, `@storybook/vue`, `@storybook/vue3`, `@storybook/svelte`
 
 Storybook framework npm package
 

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-storybook/generators/configuration.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-storybook/generators/configuration.md
@@ -62,8 +62,6 @@ The tool to use for running lint checks.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-storybook/generators/cypress-project.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-storybook/generators/cypress-project.md
@@ -56,8 +56,6 @@ The tool to use for running lint checks.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-web/executors/build.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-web/executors/build.md
@@ -196,16 +196,6 @@ Type: `array`
 
 External Scripts which will be included before the main application entry
 
-### ~~showCircularDependencies~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling.
-
-Show circular dependency warnings on builds.
-
 ### sourceMap
 
 Default: `true`

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-web/executors/dev-server.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-web/executors/dev-server.md
@@ -14,8 +14,6 @@ This option allows you to whitelist services that are allowed to access the dev 
 
 ### baseHref
 
-Default: `/`
-
 Type: `string`
 
 Base url for the application being built.

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-web/executors/package.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-web/executors/package.md
@@ -36,14 +36,6 @@ Type: `array`
 
 List of static assets.
 
-### ~~babelConfig~~
-
-Type: `string`
-
-**Deprecated:** Use the .babelrc file for project instead
-
-Path to a function which takes a babel config and returns an updated babel config
-
 ### buildableProjectDepsInPackageJsonType
 
 Default: `peerDependencies`

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-web/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-web/generators/application.md
@@ -86,8 +86,6 @@ Skip formatting files
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-workspace/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-workspace/generators/library.md
@@ -132,15 +132,13 @@ Do not update tsconfig.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json
 
 ### strict
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/nx-dev/nx-dev/public/documentation/latest/angular/cli/daemon.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/cli/daemon.md
@@ -1,0 +1,27 @@
+# daemon
+
+EXPERIMENTAL: Nx Daemon
+
+The Nx Daemon is a local server which runs in the background in order to intelligently cache information about the workspace's project graph.
+
+## Usage
+
+```bash
+nx daemon
+```
+
+[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+
+## Options
+
+### background
+
+Default: `true`
+
+### help
+
+Show help
+
+### version
+
+Show version number

--- a/nx-dev/nx-dev/public/documentation/latest/angular/cli/reset.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/cli/reset.md
@@ -1,11 +1,11 @@
-# clear-cache
+# reset
 
-Clears all the cached Nx artifacts and metadata about the workspace.
+Clears all the cached Nx artifacts and metadata about the workspace and shuts down the Nx Daemon.
 
 ## Usage
 
 ```bash
-nx clear-cache
+nx reset
 ```
 
 [Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.

--- a/nx-dev/nx-dev/public/documentation/latest/angular/guides/setup-mfe-with-angular.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/guides/setup-mfe-with-angular.md
@@ -98,6 +98,8 @@ _**Note:** We provided `4201` as the `--port`. This helps when developing locall
 
 _**Note:** We provided `--host=dashboard` as an option. This tells the generator that this remote app will be consumed by the Dashboard application. The generator will automatically link these two apps together in the `webpack.config.js`_
 
+_**Note**: The `RemoteEntryModule` generated will be imported in `app.module.ts` file, however, it is not used in the `AppModule` itself. This it to allow TS to find the Module during compilation, allowing it to be included in the built bundle. This is required for the Module Federation Plugin to expose the Module correctly. You can choose to import the `RemoteEntryModule` in the `AppModule` if you wish, however, it is not necessary._
+
 ## What was generated?
 
 Let's take a closer after generating each application.

--- a/nx-dev/nx-dev/public/documentation/latest/map.json
+++ b/nx-dev/nx-dev/public/documentation/latest/map.json
@@ -182,6 +182,11 @@
             "file": "angular/cli/run"
           },
           {
+            "name": "daemon",
+            "id": "daemon",
+            "file": "angular/cli/daemon"
+          },
+          {
             "name": "dep-graph",
             "id": "dep-graph",
             "file": "angular/cli/dep-graph"
@@ -277,9 +282,9 @@
             "file": "angular/cli/connect-to-nx-cloud"
           },
           {
-            "name": "clear-cache",
-            "id": "clear-cache",
-            "file": "angular/cli/clear-cache"
+            "name": "reset",
+            "id": "reset",
+            "file": "angular/cli/reset"
           }
         ]
       },
@@ -1450,6 +1455,11 @@
             "file": "react/cli/run"
           },
           {
+            "name": "daemon",
+            "id": "daemon",
+            "file": "react/cli/daemon"
+          },
+          {
             "name": "dep-graph",
             "id": "dep-graph",
             "file": "react/cli/dep-graph"
@@ -1545,9 +1555,9 @@
             "file": "react/cli/connect-to-nx-cloud"
           },
           {
-            "name": "clear-cache",
-            "id": "clear-cache",
-            "file": "react/cli/clear-cache"
+            "name": "reset",
+            "id": "reset",
+            "file": "react/cli/reset"
           }
         ]
       },
@@ -2682,6 +2692,11 @@
             "file": "node/cli/run"
           },
           {
+            "name": "daemon",
+            "id": "daemon",
+            "file": "node/cli/daemon"
+          },
+          {
             "name": "dep-graph",
             "id": "dep-graph",
             "file": "node/cli/dep-graph"
@@ -2777,9 +2792,9 @@
             "file": "node/cli/connect-to-nx-cloud"
           },
           {
-            "name": "clear-cache",
-            "id": "clear-cache",
-            "file": "node/cli/clear-cache"
+            "name": "reset",
+            "id": "reset",
+            "file": "node/cli/reset"
           }
         ]
       },

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-angular/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-angular/generators/application.md
@@ -174,8 +174,6 @@ Skip creating spec files.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-angular/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-angular/generators/library.md
@@ -152,8 +152,6 @@ Do not update `tsconfig.json` for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-express/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-express/generators/application.md
@@ -108,8 +108,6 @@ Do not add dependencies to package.json.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-gatsby/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-gatsby/generators/application.md
@@ -68,8 +68,6 @@ Whether or not to configure the ESLint "parserOptions.project" option. We do not
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-nest/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-nest/generators/application.md
@@ -82,8 +82,6 @@ Do not add dependencies to package.json.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json.

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-nest/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-nest/generators/library.md
@@ -130,8 +130,6 @@ Do not update tsconfig.base.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-next/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-next/generators/application.md
@@ -110,8 +110,6 @@ Skip updating workspace.json with default options based on values provided to th
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-node/executors/build.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-node/executors/build.md
@@ -130,16 +130,6 @@ Type: `boolean`
 
 Log progress to the console while building.
 
-### ~~showCircularDependencies~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling.
-
-Show circular dependency warnings on builds.
-
 ### sourceMap
 
 Default: `true`

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-node/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-node/generators/application.md
@@ -108,8 +108,6 @@ Do not add dependencies to package.json.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-node/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-node/generators/library.md
@@ -148,8 +148,6 @@ Do not update tsconfig.base.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-nx-devkit/index.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-nx-devkit/index.md
@@ -34,8 +34,9 @@ It only uses language primitives and immutable objects
 - [ProjectFileMap](../../node/nx-devkit/index#projectfilemap)
 - [ProjectGraph](../../node/nx-devkit/index#projectgraph)
 - [ProjectGraphDependency](../../node/nx-devkit/index#projectgraphdependency)
-- [ProjectGraphNode](../../node/nx-devkit/index#projectgraphnode)
+- [ProjectGraphExternalNode](../../node/nx-devkit/index#projectgraphexternalnode)
 - [ProjectGraphProcessorContext](../../node/nx-devkit/index#projectgraphprocessorcontext)
+- [ProjectGraphProjectNode](../../node/nx-devkit/index#projectgraphprojectnode)
 
 ### Tree Interfaces
 
@@ -71,6 +72,10 @@ It only uses language primitives and immutable objects
 ### Package Manager Type aliases
 
 - [PackageManager](../../node/nx-devkit/index#packagemanager)
+
+### Project Graph Type aliases
+
+- [ProjectGraphNode](../../node/nx-devkit/index#projectgraphnode)
 
 ### Utils Type aliases
 
@@ -200,21 +205,27 @@ It only uses language primitives and immutable objects
 
 ---
 
-### ProjectGraphNode
+### ProjectGraphExternalNode
 
-• **ProjectGraphNode**<`T`\>: `Object`
-
-#### Type parameters
-
-| Name | Type  |
-| :--- | :---- |
-| `T`  | `any` |
+• **ProjectGraphExternalNode**: `Object`
 
 ---
 
 ### ProjectGraphProcessorContext
 
 • **ProjectGraphProcessorContext**: `Object`
+
+---
+
+### ProjectGraphProjectNode
+
+• **ProjectGraphProjectNode**<`T`\>: `Object`
+
+#### Type parameters
+
+| Name | Type  |
+| :--- | :---- |
+| `T`  | `any` |
 
 ---
 
@@ -358,6 +369,20 @@ It only uses language primitives and immutable objects
 
 ---
 
+## Project Graph Type aliases
+
+### ProjectGraphNode
+
+Ƭ **ProjectGraphNode**<`T`\>: [`ProjectGraphProjectNode`](../../node/nx-devkit/index#projectgraphprojectnode)<`T`\> \| [`ProjectGraphExternalNode`](../../node/nx-devkit/index#projectgraphexternalnode)
+
+#### Type parameters
+
+| Name | Type  |
+| :--- | :---- |
+| `T`  | `any` |
+
+---
+
 ## Utils Type aliases
 
 ### StringChange
@@ -497,7 +522,7 @@ Implementation of a target of a project that handles multiple projects to be bat
 
 ### logger
 
-• `Const` **logger**: `Object`
+• **logger**: `Object`
 
 #### Type declaration
 
@@ -554,12 +579,12 @@ The utility will update either files.
 
 #### Parameters
 
-| Name                   | Type                                                                      | Default value | Description                                                                                |
-| :--------------------- | :------------------------------------------------------------------------ | :------------ | :----------------------------------------------------------------------------------------- |
-| `tree`                 | [`Tree`](../../node/nx-devkit/index#tree)                                 | `undefined`   | the file system tree                                                                       |
-| `projectName`          | `string`                                                                  | `undefined`   | unique name. Often directories are part of the name (e.g., mydir-mylib)                    |
-| `projectConfiguration` | [`ProjectConfiguration`](../../node/nx-devkit/index#projectconfiguration) | `undefined`   | project configuration                                                                      |
-| `standalone`           | `boolean`                                                                 | `false`       | should the project use package.json? If false, the project config is inside workspace.json |
+| Name                   | Type                                                                      | Description                                                                                |
+| :--------------------- | :------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------- |
+| `tree`                 | [`Tree`](../../node/nx-devkit/index#tree)                                 | the file system tree                                                                       |
+| `projectName`          | `string`                                                                  | unique name. Often directories are part of the name (e.g., mydir-mylib)                    |
+| `projectConfiguration` | [`ProjectConfiguration`](../../node/nx-devkit/index#projectconfiguration) | project configuration                                                                      |
+| `standalone?`          | `boolean`                                                                 | should the project use package.json? If false, the project config is inside workspace.json |
 
 #### Returns
 
@@ -624,9 +649,9 @@ Use this to expose a compatible Angular Builder
 
 #### Parameters
 
-| Name       | Type                                              |
-| :--------- | :------------------------------------------------ |
-| `executor` | [`Executor`](../../node/nx-devkit/index#executor) |
+| Name       | Type                                                      |
+| :--------- | :-------------------------------------------------------- |
+| `executor` | [`Executor`](../../node/nx-devkit/index#executor)<`any`\> |
 
 #### Returns
 
@@ -1392,15 +1417,15 @@ of comments with a replaceCharacter
 
 ### targetToTargetString
 
-▸ **targetToTargetString**(`__namedParameters`): `string`
+▸ **targetToTargetString**(`target`): `string`
 
 Returns a string in the format "project:target[:configuration]" for the target
 
 #### Parameters
 
-| Name                | Type                                          |
-| :------------------ | :-------------------------------------------- |
-| `__namedParameters` | [`Target`](../../node/nx-devkit/index#target) |
+| Name     | Type                                          | Description                                                                                                                                                                                                                                     |
+| :------- | :-------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `target` | [`Target`](../../node/nx-devkit/index#target) | target object Examples: `typescript targetToTargetString({ project: "proj", target: "test" }) // returns "proj:test" targetToTargetString({ project: "proj", target: "test", configuration: "production" }) // returns "proj:test:production" ` |
 
 #### Returns
 

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-nx-plugin/generators/plugin.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-nx-plugin/generators/plugin.md
@@ -88,8 +88,6 @@ Do not update tsconfig.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-react/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-react/generators/application.md
@@ -152,8 +152,6 @@ Skip updating workspace.json with default options based on values provided to th
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-react/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-react/generators/library.md
@@ -160,8 +160,6 @@ Do not update tsconfig.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-react/generators/storybook-configuration.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-react/generators/storybook-configuration.md
@@ -80,8 +80,6 @@ The tool to use for running lint checks.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-storybook/executors/storybook.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-storybook/executors/storybook.md
@@ -12,7 +12,7 @@ Default: `@storybook/angular`
 
 Type: `string`
 
-Possible values: `@storybook/angular`, `@storybook/react`, `@storybook/html`, `@storybook/web-components`, `@storybook/vue`, `@storybook/vue3`
+Possible values: `@storybook/angular`, `@storybook/react`, `@storybook/html`, `@storybook/web-components`, `@storybook/vue`, `@storybook/vue3`, `@storybook/svelte`
 
 Storybook framework npm package
 

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-storybook/generators/configuration.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-storybook/generators/configuration.md
@@ -62,8 +62,6 @@ The tool to use for running lint checks.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-storybook/generators/cypress-project.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-storybook/generators/cypress-project.md
@@ -56,8 +56,6 @@ The tool to use for running lint checks.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-web/executors/build.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-web/executors/build.md
@@ -196,16 +196,6 @@ Type: `array`
 
 External Scripts which will be included before the main application entry
 
-### ~~showCircularDependencies~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling.
-
-Show circular dependency warnings on builds.
-
 ### sourceMap
 
 Default: `true`

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-web/executors/dev-server.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-web/executors/dev-server.md
@@ -14,8 +14,6 @@ This option allows you to whitelist services that are allowed to access the dev 
 
 ### baseHref
 
-Default: `/`
-
 Type: `string`
 
 Base url for the application being built.

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-web/executors/package.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-web/executors/package.md
@@ -36,14 +36,6 @@ Type: `array`
 
 List of static assets.
 
-### ~~babelConfig~~
-
-Type: `string`
-
-**Deprecated:** Use the .babelrc file for project instead
-
-Path to a function which takes a babel config and returns an updated babel config
-
 ### buildableProjectDepsInPackageJsonType
 
 Default: `peerDependencies`

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-web/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-web/generators/application.md
@@ -86,8 +86,6 @@ Skip formatting files
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-workspace/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-workspace/generators/library.md
@@ -132,15 +132,13 @@ Do not update tsconfig.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json
 
 ### strict
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/nx-dev/nx-dev/public/documentation/latest/node/cli/daemon.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/cli/daemon.md
@@ -1,0 +1,27 @@
+# daemon
+
+EXPERIMENTAL: Nx Daemon
+
+The Nx Daemon is a local server which runs in the background in order to intelligently cache information about the workspace's project graph.
+
+## Usage
+
+```bash
+nx daemon
+```
+
+[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+
+## Options
+
+### background
+
+Default: `true`
+
+### help
+
+Show help
+
+### version
+
+Show version number

--- a/nx-dev/nx-dev/public/documentation/latest/node/cli/reset.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/cli/reset.md
@@ -1,11 +1,11 @@
-# clear-cache
+# reset
 
-Clears all the cached Nx artifacts and metadata about the workspace.
+Clears all the cached Nx artifacts and metadata about the workspace and shuts down the Nx Daemon.
 
 ## Usage
 
 ```bash
-nx clear-cache
+nx reset
 ```
 
 [Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-angular/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-angular/generators/application.md
@@ -174,8 +174,6 @@ Skip creating spec files.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-angular/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-angular/generators/library.md
@@ -152,8 +152,6 @@ Do not update `tsconfig.json` for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-express/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-express/generators/application.md
@@ -108,8 +108,6 @@ Do not add dependencies to package.json.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-gatsby/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-gatsby/generators/application.md
@@ -68,8 +68,6 @@ Whether or not to configure the ESLint "parserOptions.project" option. We do not
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-nest/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-nest/generators/application.md
@@ -82,8 +82,6 @@ Do not add dependencies to package.json.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json.

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-nest/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-nest/generators/library.md
@@ -130,8 +130,6 @@ Do not update tsconfig.base.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-next/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-next/generators/application.md
@@ -110,8 +110,6 @@ Skip updating workspace.json with default options based on values provided to th
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-node/executors/build.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-node/executors/build.md
@@ -130,16 +130,6 @@ Type: `boolean`
 
 Log progress to the console while building.
 
-### ~~showCircularDependencies~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling.
-
-Show circular dependency warnings on builds.
-
 ### sourceMap
 
 Default: `true`

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-node/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-node/generators/application.md
@@ -108,8 +108,6 @@ Do not add dependencies to package.json.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-node/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-node/generators/library.md
@@ -148,8 +148,6 @@ Do not update tsconfig.base.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-nx-devkit/index.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-nx-devkit/index.md
@@ -34,8 +34,9 @@ It only uses language primitives and immutable objects
 - [ProjectFileMap](../../react/nx-devkit/index#projectfilemap)
 - [ProjectGraph](../../react/nx-devkit/index#projectgraph)
 - [ProjectGraphDependency](../../react/nx-devkit/index#projectgraphdependency)
-- [ProjectGraphNode](../../react/nx-devkit/index#projectgraphnode)
+- [ProjectGraphExternalNode](../../react/nx-devkit/index#projectgraphexternalnode)
 - [ProjectGraphProcessorContext](../../react/nx-devkit/index#projectgraphprocessorcontext)
+- [ProjectGraphProjectNode](../../react/nx-devkit/index#projectgraphprojectnode)
 
 ### Tree Interfaces
 
@@ -71,6 +72,10 @@ It only uses language primitives and immutable objects
 ### Package Manager Type aliases
 
 - [PackageManager](../../react/nx-devkit/index#packagemanager)
+
+### Project Graph Type aliases
+
+- [ProjectGraphNode](../../react/nx-devkit/index#projectgraphnode)
 
 ### Utils Type aliases
 
@@ -200,21 +205,27 @@ It only uses language primitives and immutable objects
 
 ---
 
-### ProjectGraphNode
+### ProjectGraphExternalNode
 
-• **ProjectGraphNode**<`T`\>: `Object`
-
-#### Type parameters
-
-| Name | Type  |
-| :--- | :---- |
-| `T`  | `any` |
+• **ProjectGraphExternalNode**: `Object`
 
 ---
 
 ### ProjectGraphProcessorContext
 
 • **ProjectGraphProcessorContext**: `Object`
+
+---
+
+### ProjectGraphProjectNode
+
+• **ProjectGraphProjectNode**<`T`\>: `Object`
+
+#### Type parameters
+
+| Name | Type  |
+| :--- | :---- |
+| `T`  | `any` |
 
 ---
 
@@ -358,6 +369,20 @@ It only uses language primitives and immutable objects
 
 ---
 
+## Project Graph Type aliases
+
+### ProjectGraphNode
+
+Ƭ **ProjectGraphNode**<`T`\>: [`ProjectGraphProjectNode`](../../react/nx-devkit/index#projectgraphprojectnode)<`T`\> \| [`ProjectGraphExternalNode`](../../react/nx-devkit/index#projectgraphexternalnode)
+
+#### Type parameters
+
+| Name | Type  |
+| :--- | :---- |
+| `T`  | `any` |
+
+---
+
 ## Utils Type aliases
 
 ### StringChange
@@ -497,7 +522,7 @@ Implementation of a target of a project that handles multiple projects to be bat
 
 ### logger
 
-• `Const` **logger**: `Object`
+• **logger**: `Object`
 
 #### Type declaration
 
@@ -554,12 +579,12 @@ The utility will update either files.
 
 #### Parameters
 
-| Name                   | Type                                                                       | Default value | Description                                                                                |
-| :--------------------- | :------------------------------------------------------------------------- | :------------ | :----------------------------------------------------------------------------------------- |
-| `tree`                 | [`Tree`](../../react/nx-devkit/index#tree)                                 | `undefined`   | the file system tree                                                                       |
-| `projectName`          | `string`                                                                   | `undefined`   | unique name. Often directories are part of the name (e.g., mydir-mylib)                    |
-| `projectConfiguration` | [`ProjectConfiguration`](../../react/nx-devkit/index#projectconfiguration) | `undefined`   | project configuration                                                                      |
-| `standalone`           | `boolean`                                                                  | `false`       | should the project use package.json? If false, the project config is inside workspace.json |
+| Name                   | Type                                                                       | Description                                                                                |
+| :--------------------- | :------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------- |
+| `tree`                 | [`Tree`](../../react/nx-devkit/index#tree)                                 | the file system tree                                                                       |
+| `projectName`          | `string`                                                                   | unique name. Often directories are part of the name (e.g., mydir-mylib)                    |
+| `projectConfiguration` | [`ProjectConfiguration`](../../react/nx-devkit/index#projectconfiguration) | project configuration                                                                      |
+| `standalone?`          | `boolean`                                                                  | should the project use package.json? If false, the project config is inside workspace.json |
 
 #### Returns
 
@@ -624,9 +649,9 @@ Use this to expose a compatible Angular Builder
 
 #### Parameters
 
-| Name       | Type                                               |
-| :--------- | :------------------------------------------------- |
-| `executor` | [`Executor`](../../react/nx-devkit/index#executor) |
+| Name       | Type                                                       |
+| :--------- | :--------------------------------------------------------- |
+| `executor` | [`Executor`](../../react/nx-devkit/index#executor)<`any`\> |
 
 #### Returns
 
@@ -1392,15 +1417,15 @@ of comments with a replaceCharacter
 
 ### targetToTargetString
 
-▸ **targetToTargetString**(`__namedParameters`): `string`
+▸ **targetToTargetString**(`target`): `string`
 
 Returns a string in the format "project:target[:configuration]" for the target
 
 #### Parameters
 
-| Name                | Type                                           |
-| :------------------ | :--------------------------------------------- |
-| `__namedParameters` | [`Target`](../../react/nx-devkit/index#target) |
+| Name     | Type                                           | Description                                                                                                                                                                                                                                     |
+| :------- | :--------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `target` | [`Target`](../../react/nx-devkit/index#target) | target object Examples: `typescript targetToTargetString({ project: "proj", target: "test" }) // returns "proj:test" targetToTargetString({ project: "proj", target: "test", configuration: "production" }) // returns "proj:test:production" ` |
 
 #### Returns
 

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-nx-plugin/generators/plugin.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-nx-plugin/generators/plugin.md
@@ -88,8 +88,6 @@ Do not update tsconfig.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-react/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-react/generators/application.md
@@ -152,8 +152,6 @@ Skip updating workspace.json with default options based on values provided to th
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-react/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-react/generators/library.md
@@ -160,8 +160,6 @@ Do not update tsconfig.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-react/generators/storybook-configuration.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-react/generators/storybook-configuration.md
@@ -80,8 +80,6 @@ The tool to use for running lint checks.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-storybook/executors/storybook.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-storybook/executors/storybook.md
@@ -12,7 +12,7 @@ Default: `@storybook/angular`
 
 Type: `string`
 
-Possible values: `@storybook/angular`, `@storybook/react`, `@storybook/html`, `@storybook/web-components`, `@storybook/vue`, `@storybook/vue3`
+Possible values: `@storybook/angular`, `@storybook/react`, `@storybook/html`, `@storybook/web-components`, `@storybook/vue`, `@storybook/vue3`, `@storybook/svelte`
 
 Storybook framework npm package
 

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-storybook/generators/configuration.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-storybook/generators/configuration.md
@@ -62,8 +62,6 @@ The tool to use for running lint checks.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-storybook/generators/cypress-project.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-storybook/generators/cypress-project.md
@@ -56,8 +56,6 @@ The tool to use for running lint checks.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-web/executors/build.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-web/executors/build.md
@@ -196,16 +196,6 @@ Type: `array`
 
 External Scripts which will be included before the main application entry
 
-### ~~showCircularDependencies~~
-
-Default: `false`
-
-Type: `boolean`
-
-**Deprecated:** The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling.
-
-Show circular dependency warnings on builds.
-
 ### sourceMap
 
 Default: `true`

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-web/executors/dev-server.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-web/executors/dev-server.md
@@ -14,8 +14,6 @@ This option allows you to whitelist services that are allowed to access the dev 
 
 ### baseHref
 
-Default: `/`
-
 Type: `string`
 
 Base url for the application being built.

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-web/executors/package.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-web/executors/package.md
@@ -36,14 +36,6 @@ Type: `array`
 
 List of static assets.
 
-### ~~babelConfig~~
-
-Type: `string`
-
-**Deprecated:** Use the .babelrc file for project instead
-
-Path to a function which takes a babel config and returns an updated babel config
-
 ### buildableProjectDepsInPackageJsonType
 
 Default: `peerDependencies`

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-web/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-web/generators/application.md
@@ -86,8 +86,6 @@ Skip formatting files
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-workspace/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-workspace/generators/library.md
@@ -132,15 +132,13 @@ Do not update tsconfig.json for development experience.
 
 ### standaloneConfig
 
-Default: `false`
-
 Type: `boolean`
 
 Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json
 
 ### strict
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/nx-dev/nx-dev/public/documentation/latest/react/cli/daemon.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/cli/daemon.md
@@ -1,0 +1,27 @@
+# daemon
+
+EXPERIMENTAL: Nx Daemon
+
+The Nx Daemon is a local server which runs in the background in order to intelligently cache information about the workspace's project graph.
+
+## Usage
+
+```bash
+nx daemon
+```
+
+[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+
+## Options
+
+### background
+
+Default: `true`
+
+### help
+
+Show help
+
+### version
+
+Show version number

--- a/nx-dev/nx-dev/public/documentation/latest/react/cli/reset.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/cli/reset.md
@@ -1,11 +1,11 @@
-# clear-cache
+# reset
 
-Clears all the cached Nx artifacts and metadata about the workspace.
+Clears all the cached Nx artifacts and metadata about the workspace and shuts down the Nx Daemon.
 
 ## Usage
 
 ```bash
-nx clear-cache
+nx reset
 ```
 
 [Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.

--- a/nx-dev/nx-dev/public/documentation/latest/shared/guides/webpack-5.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/guides/webpack-5.md
@@ -1,12 +1,18 @@
 # Webpack 5 Migration
 
-Nx 12 is the last version to support Webpack 4. You can enable Webpack 5 in your workspace by following the steps outlined in this document.
+Starting in Nx 13, we only support Webpack 5, which is automatically enabled for all workspaces.
 
-In Nx 13, we will only support Webpack 5. Workspaces with custom webpack config need to ensure they have Webpack 5 compatible webpack plugins before Nx 13 is released. If you do not use custom webpack config then the migration should be seamless.
+Workspaces with custom webpack configuration should make sure that all their plugins and loaders are compatible with Webpack 5.
+For additional help on the migration, check out Webpack's ["To v5 from v4" guide](https://webpack.js.org/migrate/5/).
 
-This guide includes instructions and information on how you can update your workspace to Webpack 5.
+Nx 12 is the last Nx version to support Webpack 4 so if you cannot upgrade to Webpack 5 then you may stay on this
+version, but we highly suggest you upgrade as soon as possible to benefit from future patches and features.
 
-## Webpack 5 for React Apps
+## Nx 12: Testing Webpack 5 Compatibility
+
+If you are still on Nx 12, you can try out Webpack 5 without upgrading fully to Nx 13.
+
+### Webpack 5 for React Apps
 
 For React apps (i.e. generated with `@nrwl/react:app`) webpack 4 is the default version used by Nx.
 
@@ -16,7 +22,7 @@ To opt into webpack 5 your can run the migration generator from:
 npx nx g @nrwl/web:webpack5
 ```
 
-## Webpack 5 for Node Apps
+### Webpack 5 for Node Apps
 
 For Node apps (i.e. generated with `@nrwl/node:app`) webpack 4 is the default version used by Nx.
 
@@ -26,26 +32,29 @@ To opt into webpack 5 your can run the migration generator from:
 npx nx g @nrwl/node:webpack5
 ```
 
-**Note:** If you already ran the `@nrwl/web:webpack5` generator, there is no need to also run the `@nrwl/node:webpack` generator. They both install the same packages and are interchangeable.
+**Note:** If you already ran the `@nrwl/web:webpack5` generator, there is no need to also run the `@nrwl/node:webpack`
+generator. They both install the same packages and are interchangeable.
 
-## Webpack 5 for Next.js Apps
+### Webpack 5 for Next.js Apps
 
-As of Next.js 11 and Nx 12.6.0, webpack 5 is the default version used. If you use a custom webpack setup, you can opt out of webpack 5 by add this to your `next.config.js` file.
+As of Next.js 11 and Nx 12.6.0, Webpack 5 is the default version used. Check your `next.config.js` file to ensure it is
+enabled.
 
 ```js
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const withNx = require('@nrwl/next/plugins/with-nx');
 
 const nextConfig = {
-  webpack5: false,
+  webpack5: true,
 };
 
 module.exports = withNx(nextConfig);
 ```
 
-For more information about webpack 5 adoption in Next.js, refer to their [webpack 5 guide](https://nextjs.org/docs/messages/webpack5).
+For more information about webpack 5 adoption in Next.js, refer to
+their [webpack 5 guide](https://nextjs.org/docs/messages/webpack5).
 
-## Webpack 5 for Angular Apps
+### Webpack 5 for Angular Apps
 
 As of Angular 12, the tooling of Angular uses webpack 5 and support for webpack 4 has been removed.
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/incremental-builds.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/incremental-builds.md
@@ -49,7 +49,7 @@ The above chart has three different test runs:
 
 ## When should I use incremental builds
 
-Whether incremental builds area a good choice depends on your repository. For most small and mid-sized applications, the costs introduced by incremental builds will outweigh the benefits.
+Whether incremental builds are a good choice depends on your repository. For most small and mid-sized applications, the costs introduced by incremental builds will outweigh the benefits.
 
 The upsides of incremental builds:
 


### PR DESCRIPTION
This PR updates the content of the Webpack 5 guide since Nx 13 removed support for v4.

Prod: https://nx.dev/l/r/guides/webpack-5
Preview: https://nx-dev-git-fork-jaysoo-docs-webpack-5-guide-nrwl.vercel.app/l/r/guides/webpack-5#webpack-5-migration