### PR TITLE
fix(angular): ng add works in v2 workspaces

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
     "yargs-parser": "20.0.0",
     "@nrwl/tao": "*",
     "chalk": "4.1.0",
+    "enquirer": "~2.3.6",
     "v8-compile-cache": "2.3.0"
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running `ng add` throws an error within angular cli code if ran inside a workspace with an `angular.json` file and using workspace v2 format.

## Expected Behavior
We intercept `ng add` and provide a recommendation, so that Nx users don't hit an unexpected error message.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
