### PR TITLE
fix(web): fix index html plugin for webpack 5

### DIFF
--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -1,6 +1,7 @@
 import { logger } from '@nrwl/devkit';
 import { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 import * as path from 'path';
+import { basename, resolve } from 'path';
 
 import { getWebConfig } from './web.config';
 import { WebBuildExecutorOptions } from '../executors/build/build.impl';
@@ -8,6 +9,8 @@ import { WebDevServerOptions } from '../executors/dev-server/dev-server.impl';
 import { buildServePath } from './serve-path';
 import { OptimizationOptions } from './shared-models';
 import { readFileSync } from 'fs-extra';
+import { IndexHtmlWebpackPlugin } from './/webpack/plugins/index-html-webpack-plugin';
+import { generateEntryPoints } from './webpack/package-chunk-sort';
 
 export function getDevServerConfig(
   workspaceRoot: string,
@@ -29,6 +32,28 @@ export function getDevServerConfig(
     workspaceRoot,
     serveOptions,
     buildOptions
+  );
+
+  const {
+    deployUrl,
+    subresourceIntegrity,
+    scripts = [],
+    styles = [],
+    index,
+    baseHref,
+  } = buildOptions;
+
+  webpackConfig.plugins.push(
+    new IndexHtmlWebpackPlugin({
+      indexPath: resolve(workspaceRoot, index),
+      outputPath: basename(index),
+      baseHref,
+      entrypoints: generateEntryPoints({ scripts, styles }),
+      deployUrl,
+      sri: subresourceIntegrity,
+      moduleEntrypoints: [],
+      noModuleEntrypoints: ['polyfills-es5'],
+    })
   );
 
   return webpackConfig;

--- a/packages/web/src/utils/webpack/plugins/index-file/augment-index-html.ts
+++ b/packages/web/src/utils/webpack/plugins/index-file/augment-index-html.ts
@@ -1,0 +1,232 @@
+import { createHash } from 'crypto';
+import { htmlRewritingStream } from './html-rewriting-stream';
+
+export type LoadOutputFileFunctionType = (file: string) => Promise<string>;
+
+export type CrossOriginValue = 'none' | 'anonymous' | 'use-credentials';
+
+export interface AugmentIndexHtmlOptions {
+  /* Input contents */
+  html: string;
+  baseHref?: string;
+  deployUrl?: string;
+  sri: boolean;
+  /** crossorigin attribute setting of elements that provide CORS support */
+  crossOrigin?: CrossOriginValue;
+  /*
+   * Files emitted by the build.
+   * Js files will be added without 'nomodule' nor 'module'.
+   */
+  files: FileInfo[];
+  /** Files that should be added using 'nomodule'. */
+  noModuleFiles?: FileInfo[];
+  /** Files that should be added using 'module'. */
+  moduleFiles?: FileInfo[];
+  /*
+   * Function that loads a file used.
+   * This allows us to use different routines within the IndexHtmlWebpackPlugin and
+   * when used without this plugin.
+   */
+  loadOutputFile: LoadOutputFileFunctionType;
+  /** Used to sort the inseration of files in the HTML file */
+  entrypoints: string[];
+  /** Used to set the document default locale */
+  lang?: string;
+}
+
+export interface FileInfo {
+  file: string;
+  name: string;
+  extension: string;
+}
+
+/*
+ * Helper function used by the IndexHtmlWebpackPlugin.
+ * Can also be directly used by builder, e. g. in order to generate an index.html
+ * after processing several configurations in order to build different sets of
+ * bundles for differential serving.
+ */
+export async function augmentIndexHtml(
+  params: AugmentIndexHtmlOptions
+): Promise<string> {
+  const {
+    loadOutputFile,
+    files,
+    noModuleFiles = [],
+    moduleFiles = [],
+    entrypoints,
+    sri,
+    deployUrl = '',
+    lang,
+    baseHref,
+    html,
+  } = params;
+
+  let { crossOrigin = 'none' } = params;
+  if (sri && crossOrigin === 'none') {
+    crossOrigin = 'anonymous';
+  }
+
+  const stylesheets = new Set<string>();
+  const scripts = new Set<string>();
+
+  // Sort files in the order we want to insert them by entrypoint and dedupes duplicates
+  const mergedFiles = [...moduleFiles, ...noModuleFiles, ...files];
+  for (const entrypoint of entrypoints) {
+    for (const { extension, file, name } of mergedFiles) {
+      if (name !== entrypoint) {
+        continue;
+      }
+
+      switch (extension) {
+        case '.js':
+          scripts.add(file);
+          break;
+        case '.css':
+          stylesheets.add(file);
+          break;
+      }
+    }
+  }
+
+  let scriptTags: string[] = [];
+  for (const script of scripts) {
+    const attrs = [`src="${deployUrl}${script}"`];
+
+    if (crossOrigin !== 'none') {
+      attrs.push(`crossorigin="${crossOrigin}"`);
+    }
+
+    // We want to include nomodule or module when a file is not common amongs all
+    // such as runtime.js
+    const scriptPredictor = ({ file }: FileInfo): boolean => file === script;
+    if (!files.some(scriptPredictor)) {
+      // in some cases for differential loading file with the same name is available in both
+      // nomodule and module such as scripts.js
+      // we shall not add these attributes if that's the case
+      const isNoModuleType = noModuleFiles.some(scriptPredictor);
+      const isModuleType = moduleFiles.some(scriptPredictor);
+
+      if (isNoModuleType && !isModuleType) {
+        attrs.push('nomodule', 'defer');
+      } else if (isModuleType && !isNoModuleType) {
+        attrs.push('type="module"');
+      } else {
+        attrs.push('defer');
+      }
+    } else {
+      attrs.push('defer');
+    }
+
+    if (sri) {
+      const content = await loadOutputFile(script);
+      attrs.push(generateSriAttributes(content));
+    }
+
+    scriptTags.push(`<script ${attrs.join(' ')}></script>`);
+  }
+
+  let linkTags: string[] = [];
+  for (const stylesheet of stylesheets) {
+    const attrs = [`rel="stylesheet"`, `href="${deployUrl}${stylesheet}"`];
+
+    if (crossOrigin !== 'none') {
+      attrs.push(`crossorigin="${crossOrigin}"`);
+    }
+
+    if (sri) {
+      const content = await loadOutputFile(stylesheet);
+      attrs.push(generateSriAttributes(content));
+    }
+
+    linkTags.push(`<link ${attrs.join(' ')}>`);
+  }
+
+  const { rewriter, transformedContent } = await htmlRewritingStream(html);
+  const baseTagExists = html.includes('<base');
+
+  rewriter
+    .on('startTag', (tag) => {
+      switch (tag.tagName) {
+        case 'html':
+          // Adjust document locale if specified
+          if (isString(lang)) {
+            updateAttribute(tag, 'lang', lang);
+          }
+          break;
+        case 'head':
+          // Base href should be added before any link, meta tags
+          if (!baseTagExists && isString(baseHref)) {
+            rewriter.emitStartTag(tag);
+            rewriter.emitRaw(`<base href='${baseHref}'>`);
+
+            return;
+          }
+          break;
+        case 'base':
+          // Adjust base href if specified
+          if (isString(baseHref)) {
+            updateAttribute(tag, 'href', baseHref);
+          }
+          break;
+      }
+
+      rewriter.emitStartTag(tag);
+    })
+    .on('endTag', (tag) => {
+      switch (tag.tagName) {
+        case 'head':
+          for (const linkTag of linkTags) {
+            rewriter.emitRaw(linkTag);
+          }
+
+          linkTags = [];
+          break;
+        case 'body':
+          // Add script tags
+          for (const scriptTag of scriptTags) {
+            rewriter.emitRaw(scriptTag);
+          }
+
+          scriptTags = [];
+          break;
+      }
+
+      rewriter.emitEndTag(tag);
+    });
+
+  const content = await transformedContent;
+
+  if (linkTags.length || scriptTags.length) {
+    // In case no body/head tags are not present (dotnet partial templates)
+    return linkTags.join('') + scriptTags.join('') + content;
+  }
+
+  return content;
+}
+
+function generateSriAttributes(content: string): string {
+  const algo = 'sha384';
+  const hash = createHash(algo).update(content, 'utf8').digest('base64');
+
+  return `integrity="${algo}-${hash}"`;
+}
+
+function updateAttribute(
+  tag: { attrs: { name: string; value: string }[] },
+  name: string,
+  value: string
+): void {
+  const index = tag.attrs.findIndex((a) => a.name === name);
+  const newValue = { name, value };
+
+  if (index === -1) {
+    tag.attrs.push(newValue);
+  } else {
+    tag.attrs[index] = newValue;
+  }
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}

--- a/packages/web/src/utils/webpack/plugins/index-file/html-rewriting-stream.ts
+++ b/packages/web/src/utils/webpack/plugins/index-file/html-rewriting-stream.ts
@@ -1,0 +1,43 @@
+import { Readable, Writable } from 'stream';
+
+export async function htmlRewritingStream(content: string): Promise<{
+  rewriter: import('parse5-html-rewriting-stream');
+  transformedContent: Promise<string>;
+}> {
+  const chunks: Buffer[] = [];
+  const rewriter = new (await import('parse5-html-rewriting-stream'))();
+
+  return {
+    rewriter,
+    transformedContent: new Promise((resolve) => {
+      new Readable({
+        encoding: 'utf8',
+        read(): void {
+          this.push(Buffer.from(content));
+          this.push(null);
+        },
+      })
+        .pipe(rewriter)
+        .pipe(
+          new Writable({
+            write(
+              chunk: string | Buffer,
+              encoding: string | undefined,
+              callback: Function
+            ): void {
+              chunks.push(
+                typeof chunk === 'string'
+                  ? Buffer.from(chunk, encoding as BufferEncoding)
+                  : chunk
+              );
+              callback();
+            },
+            final(callback: (error?: Error) => void): void {
+              callback();
+              resolve(Buffer.concat(chunks).toString());
+            },
+          })
+        );
+    }),
+  };
+}

--- a/packages/web/src/utils/webpack/plugins/index-file/index-html-generator.ts
+++ b/packages/web/src/utils/webpack/plugins/index-file/index-html-generator.ts
@@ -1,0 +1,145 @@
+import * as fs from 'fs';
+import { join } from 'path';
+import { interpolateEnvironmentVariablesToIndex } from '../../../interpolate-env-variables-to-index';
+import {
+  augmentIndexHtml,
+  CrossOriginValue,
+  FileInfo,
+} from './augment-index-html';
+
+function stripBom(data: string) {
+  return data.replace(/^\uFEFF/, '');
+}
+
+type IndexHtmlGeneratorPlugin = (
+  html: string,
+  options: IndexHtmlGeneratorProcessOptions
+) => Promise<string | IndexHtmlTransformResult>;
+
+export interface IndexHtmlGeneratorProcessOptions {
+  lang?: string | undefined;
+  baseHref?: string | undefined;
+  outputPath: string;
+  files: FileInfo[];
+  noModuleFiles: FileInfo[];
+  moduleFiles: FileInfo[];
+}
+
+export interface IndexHtmlGeneratorOptions {
+  indexPath: string;
+  deployUrl?: string;
+  sri?: boolean;
+  entrypoints: string[];
+  postTransform?: IndexHtmlTransform;
+  crossOrigin?: CrossOriginValue;
+  optimization?: any;
+  WOFFSupportNeeded?: boolean;
+}
+
+export type IndexHtmlTransform = (content: string) => Promise<string>;
+
+export interface IndexHtmlTransformResult {
+  content: string;
+  warnings: string[];
+  errors: string[];
+}
+
+export class IndexHtmlGenerator {
+  private readonly plugins: IndexHtmlGeneratorPlugin[];
+
+  constructor(readonly options: IndexHtmlGeneratorOptions) {
+    const extraPlugins: IndexHtmlGeneratorPlugin[] = [];
+    this.plugins = [
+      augmentIndexHtmlPlugin(this),
+      ...extraPlugins,
+      postTransformPlugin(this),
+    ];
+  }
+
+  async process(
+    options: IndexHtmlGeneratorProcessOptions
+  ): Promise<IndexHtmlTransformResult> {
+    let content = stripBom(await this.readIndex(this.options.indexPath));
+    content = interpolateEnvironmentVariablesToIndex(
+      content,
+      this.options.deployUrl
+    );
+    const warnings: string[] = [];
+    const errors: string[] = [];
+
+    for (const plugin of this.plugins) {
+      const result = await plugin(content, options);
+      if (typeof result === 'string') {
+        content = result;
+      } else {
+        content = result.content;
+
+        if (result.warnings.length) {
+          warnings.push(...result.warnings);
+        }
+
+        if (result.errors.length) {
+          errors.push(...result.errors);
+        }
+      }
+    }
+
+    return {
+      content,
+      warnings,
+      errors,
+    };
+  }
+
+  async readAsset(path: string): Promise<string> {
+    return fs.promises.readFile(path, 'utf-8');
+  }
+
+  protected async readIndex(path: string): Promise<string> {
+    return fs.promises.readFile(path, 'utf-8');
+  }
+}
+
+function augmentIndexHtmlPlugin(
+  generator: IndexHtmlGenerator
+): IndexHtmlGeneratorPlugin {
+  const {
+    deployUrl,
+    crossOrigin,
+    sri = false,
+    entrypoints,
+  } = generator.options;
+
+  return async (html, options) => {
+    const {
+      lang,
+      baseHref,
+      outputPath = '',
+      noModuleFiles,
+      files,
+      moduleFiles,
+    } = options;
+
+    return augmentIndexHtml({
+      html,
+      baseHref,
+      deployUrl,
+      crossOrigin,
+      sri,
+      lang,
+      entrypoints,
+      loadOutputFile: (filePath) =>
+        generator.readAsset(join(outputPath, filePath)),
+      noModuleFiles,
+      moduleFiles,
+      files,
+    });
+  };
+}
+
+function postTransformPlugin({
+  options,
+}: IndexHtmlGenerator): IndexHtmlGeneratorPlugin {
+  return async (html) =>
+    options.postTransform ? options.postTransform(html) : html;
+}

--- a/packages/web/src/utils/webpack/plugins/index-html-webpack-plugin.ts
+++ b/packages/web/src/utils/webpack/plugins/index-html-webpack-plugin.ts
@@ -1,0 +1,135 @@
+import * as webpack from 'webpack';
+import { basename, dirname, extname } from 'path';
+import { FileInfo } from './index-file/augment-index-html';
+import {
+  IndexHtmlGenerator,
+  IndexHtmlGeneratorOptions,
+  IndexHtmlGeneratorProcessOptions,
+} from './index-file/index-html-generator';
+
+export interface IndexHtmlWebpackPluginOptions
+  extends IndexHtmlGeneratorOptions,
+    Omit<
+      IndexHtmlGeneratorProcessOptions,
+      'files' | 'noModuleFiles' | 'moduleFiles'
+    > {
+  noModuleEntrypoints: string[];
+  moduleEntrypoints: string[];
+}
+
+type Compiler = any;
+
+const PLUGIN_NAME = 'index-html-webpack-plugin';
+
+export class IndexHtmlWebpackPlugin extends IndexHtmlGenerator {
+  private _compilation: any | undefined;
+
+  get compilation(): any {
+    if (this._compilation) {
+      return this._compilation;
+    }
+
+    throw new Error('compilation is undefined.');
+  }
+
+  constructor(readonly options: IndexHtmlWebpackPluginOptions) {
+    super(options);
+  }
+
+  apply(compiler: Compiler) {
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+      this._compilation = compilation;
+      compilation.hooks.processAssets.tapPromise(
+        {
+          name: PLUGIN_NAME,
+          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE + 1,
+        },
+        callback
+      );
+    });
+
+    function addWarning(compilation: any, message: string): void {
+      compilation.warnings.push(new this.webpack.WebpackError(message));
+    }
+
+    function addError(compilation: any, message: string): void {
+      compilation.errors.push(new this.webpack.WebpackError(message));
+    }
+
+    const callback = async (assets: Record<string, unknown>) => {
+      // Get all files for selected entrypoints
+      const files: FileInfo[] = [];
+      const noModuleFiles: FileInfo[] = [];
+      const moduleFiles: FileInfo[] = [];
+
+      try {
+        for (const [entryName, entrypoint] of this.compilation.entrypoints) {
+          const entryFiles: FileInfo[] = entrypoint
+            ?.getFiles()
+            ?.filter((f) => !f.endsWith('.hot-update.js'))
+            ?.map(
+              (f: string): FileInfo => ({
+                name: entryName,
+                file: f,
+                extension: extname(f),
+              })
+            );
+
+          if (!entryFiles) {
+            continue;
+          }
+
+          if (this.options.noModuleEntrypoints.includes(entryName)) {
+            noModuleFiles.push(...entryFiles);
+          } else if (this.options.moduleEntrypoints.includes(entryName)) {
+            moduleFiles.push(...entryFiles);
+          } else {
+            files.push(...entryFiles);
+          }
+        }
+
+        const { content, warnings, errors } = await this.process({
+          files,
+          noModuleFiles,
+          moduleFiles,
+          outputPath: dirname(this.options.outputPath),
+          baseHref: this.options.baseHref,
+          lang: this.options.lang,
+        });
+
+        assets[this.options.outputPath] = new webpack.sources.RawSource(
+          content
+        );
+
+        warnings.forEach((msg) => addWarning(this.compilation, msg));
+        errors.forEach((msg) => addError(this.compilation, msg));
+      } catch (error) {
+        addError(this.compilation, error.message);
+      }
+    };
+  }
+
+  async readAsset(path: string): Promise<string> {
+    const data = this.compilation.assets[basename(path)].source();
+
+    return typeof data === 'string' ? data : data.toString();
+  }
+
+  protected async readIndex(path: string): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      this.compilation.inputFileSystem.readFile(
+        path,
+        (err?: Error, data?: string | Buffer) => {
+          if (err) {
+            reject(err);
+
+            return;
+          }
+
+          this.compilation.fileDependencies.add(path);
+          resolve(data?.toString() ?? '');
+        }
+      );
+    });
+  }
+}


### PR DESCRIPTION
This PR adds the `IndexHtmlWebpackPlugin` back to webpack config for `dev-server` only. Previously, this was added to both `build` and `serve` which caused double the amount of work during builds.