### PR TITLE
chore(repo): configure cypress e2e tests to depend on react

### DIFF
--- a/e2e/cypress/project.json
+++ b/e2e/cypress/project.json
@@ -30,5 +30,5 @@
       "outputs": ["coverage/e2e/cypress"]
     }
   },
-  "implicitDependencies": ["cypress"]
+  "implicitDependencies": ["cypress", "react"]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cypress e2e tests generate a react app but does not implicit depend on the react project.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Cypress e2e tests should run when there are changes to react.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
