### PR TITLE
chore(repo): fix failing MacOS and Windows nightly runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,8 +237,8 @@ jobs:
         default: pnpm
     executor: << parameters.os >>
     environment:
-      GIT_AUTHOR_NAME: test@test.com
-      GIT_AUTHOR_EMAIL: Test
+      GIT_AUTHOR_EMAIL: test@test.com
+      GIT_AUTHOR_NAME: Test
       GIT_COMMITTER_EMAIL: test@test.com
       GIT_COMMITTER_NAME: Test
       NX_E2E_CI_CACHE_KEY: e2e-circleci-<< parameters.os >>-<< parameters.pm >>

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -90,6 +90,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node_version }}
+        registry-url: http://localhost:4872
 
     - name: Yarn cache directory path
       id: yarn-cache-dir-path
@@ -134,8 +135,8 @@ jobs:
     - name: Run e2e tests
       run: yarn nx run-many --target=e2e --projects="${{ join(matrix.packages) }}"
       env:
-        GIT_AUTHOR_NAME: test@test.com
-        GIT_AUTHOR_EMAIL: Test
+        GIT_AUTHOR_EMAIL: test@test.com
+        GIT_AUTHOR_NAME: Test
         GIT_COMMITTER_EMAIL: test@test.com
         GIT_COMMITTER_NAME: Test
         NX_E2E_CI_CACHE_KEY: e2e-gha-${{ matrix.os }}-${{ matrix.node_version }}-${{ matrix.package_manager }}


### PR DESCRIPTION
The bug was introduced by `actions/setup-node` v2.4.1, the action now requires explicit `registry-url` for Verdaccio.

## Current Behavior
`npm publish` to Verdaccio fails on MacOS and Windows

## Expected Behavior
`npm publish` should succeed on all machines

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
