### PR TITLE
fix(angular): entry module should use CommonModule

### DIFF
--- a/packages/angular/src/generators/setup-mfe/files/entry-module-files/entry.module.ts__tmpl__
+++ b/packages/angular/src/generators/setup-mfe/files/entry-module-files/entry.module.ts__tmpl__
@@ -1,5 +1,5 @@
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
 <% if(routing) { %>import { RouterModule } from '@angular/router';<% } %>
 
 import { RemoteEntryComponent } from './entry.component';
@@ -7,7 +7,7 @@ import { RemoteEntryComponent } from './entry.component';
 @NgModule({
   declarations: [RemoteEntryComponent],
   imports: [
-    BrowserModule,
+    CommonModule,
     <% if(routing) { %>RouterModule.forChild([
       {
         path: '',


### PR DESCRIPTION
See: https://angular.io/guide/frequent-ngmodules#browsermodule-and-commonmodule

> For applications that run in the browser, import BrowserModule in the root AppModule because it provides services that are essential to launch and run a browser application. BrowserModule’s providers are for the whole application so it should only be in the root module, not in feature modules. Feature modules only need the common directives in CommonModule; they don’t need to re-install app-wide providers.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
