### PR TITLE
feat(web): allow unsecure ssl proxy on file-server

### DIFF
--- a/docs/generated/api-web/executors/file-server.md
+++ b/docs/generated/api-web/executors/file-server.md
@@ -53,6 +53,12 @@ Type: `string`
 
 URL to proxy unhandled requests to.
 
+### secure
+
+Type: `boolean`
+
+True if you want to verify the SSL Certs.
+
 ### ssl
 
 Default: `false`

--- a/nx-dev/nx-dev/public/documentation/generated/api-web/executors/file-server.md
+++ b/nx-dev/nx-dev/public/documentation/generated/api-web/executors/file-server.md
@@ -53,6 +53,12 @@ Type: `string`
 
 URL to proxy unhandled requests to.
 
+### secure
+
+Type: `boolean`
+
+True if you want to verify the SSL Certs.
+
 ### ssl
 
 Default: `false`

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -26,6 +26,9 @@ function getHttpServerArgs(options: Schema) {
   if (options.proxyUrl) {
     args.push(`-P ${options.proxyUrl}`);
   }
+  if (typeof options.secure === 'boolean') {
+    args.push(`--proxy-options.secure ${options.secure}`);
+  }
   return args;
 }
 

--- a/packages/web/src/executors/file-server/schema.d.ts
+++ b/packages/web/src/executors/file-server/schema.d.ts
@@ -5,6 +5,7 @@ export interface Schema {
   sslKey?: string;
   sslCert?: string;
   proxyUrl?: string;
+  secure?: boolean;
   buildTarget: string;
   parallel: boolean;
   maxParallel?: number;

--- a/packages/web/src/executors/file-server/schema.json
+++ b/packages/web/src/executors/file-server/schema.json
@@ -48,6 +48,10 @@
     "proxyUrl": {
       "type": "string",
       "description": "URL to proxy unhandled requests to."
+    },
+    "secure": {
+      "type": "boolean",
+      "description": "True if you want to verify the SSL Certs."
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Thanks to https://github.com/http-party/http-server/pull/688 released in v14, it's now possible to forward proxy options to http-server.

It's useful for Nx as the `@nrwl/web:file-server` executor uses it. This pull request aims to fix an issue related to this executor while a self-signed certificate is used.

Example of `@nrwl/web:file-server` configuration using `secure: false` proxy option.
```json
    "serve": {
      "executor": "@nrwl/web:file-server",
      "configurations": {
        "production": {
          "buildTarget": "demo:build:production"
        }
      },
      "options": {
        "buildTarget": "demo:build",
        "host": "local.demo.io",
        "port": 4207,
        "proxyUrl": "https://local.demo.io:4207?", // Fixes 404 on refresh as proposed in https://github.com/nrwl/nx/issues/5118
        "secure": false, // The new option making HTTPs works on refresh
        "ssl": true,
        "sslCert": "demo.crt",
        "sslKey": "demo.key"
      }
    }
```

My proposal simply add a `secure` boolean option in the schema, but maybe you prefer a dedicated entry for proxy-options as supported by the [https://github.com/http-party/node-http-proxy#options][node-http-proxy] library.

## Current Behavior
Using a proxyUrl on a `@nrwl/web:file-server` executor does not work because of security purpose.

## Expected Behavior
`@nrwl/web:file-server` is expected to be used for development only and is most of the time given a self-signed certificate. 

## Related Issue(s)
https://github.com/nrwl/nx/issues/5118
