### PR TITLE
fix(core): throw an error when configuration is invalid/ outdated

### DIFF
--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -4,6 +4,7 @@ import { appRootPath } from '../utils/app-root';
 import { readJsonFile } from '../utils/fileutils';
 import type { NxJsonConfiguration } from './nx';
 import { TaskGraph } from './tasks';
+import { logger } from './logger';
 
 export interface Workspace
   extends WorkspaceJsonConfiguration,
@@ -286,6 +287,7 @@ export class Workspaces {
     const nxJson = readJsonFile<NxJsonConfiguration>(
       path.join(this.root, 'nx.json')
     );
+    assertValidWorkspaceConfiguration(nxJson);
     return { ...parsedWorkspace, ...nxJson };
   }
 
@@ -462,6 +464,18 @@ export class Workspaces {
 
   private resolvePaths() {
     return this.root ? [this.root, __dirname] : [__dirname];
+  }
+}
+
+function assertValidWorkspaceConfiguration(
+  nxJson: NxJsonConfiguration & { projects?: any }
+) {
+  // Assert valid workspace configuration
+  if (nxJson.projects) {
+    logger.error(
+      'NX As of Nx 13, project configuration should be moved from nx.json to workspace.json/project.json. Please run "nx format" to fix this.'
+    );
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When running with outdated configuration, a weird error is thrown.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When running with invalid configuration, an error is thrown to inform the user to run `nx format`:

![image](https://user-images.githubusercontent.com/8104246/138120908-1bbc6c7b-5818-4365-b089-3913665e8814.png)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
