### PR TITLE
fix(testing): make cypress peer dependency optional

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -32,9 +32,6 @@
     "requirements": {},
     "migrations": "./migrations.json"
   },
-  "peerDependencies": {
-    "cypress": ">= 3 < 9"
-  },
   "dependencies": {
     "@nrwl/devkit": "*",
     "@nrwl/linter": "*",
@@ -50,5 +47,13 @@
     "rxjs": "^6.5.4",
     "tslib": "^2.0.0",
     "yargs-parser": "20.0.0"
+  },
+  "peerDependencies": {
+    "cypress": ">= 3 < 9"
+  },
+  "peerDependenciesMeta": {
+    "cypress": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When using `@nrwl/next` but not using cypress, there's a peer dependency warning because `@nrwl/cypress` has a peer dependency on `cypress`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When using `@nrwl/next` but not using cypress, there is no peer dependency warning. The peer dependency on `cypress` is marked as optional.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7443 
