### PR TITLE
Fix remove failing sass migration

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -183,10 +183,6 @@
           "version": "11.1.2",
           "alwaysAddToPackageJson": false
         },
-        "sass": {
-          "version": "1.43.2",
-          "alwaysAddToPackageJson": false
-        },
         "@emotion/server": {
           "version": "11.4.0",
           "alwaysAddToPackageJson": false

--- a/packages/web/migrations.json
+++ b/packages/web/migrations.json
@@ -46,15 +46,5 @@
       "factory": "./src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0"
     }
   },
-  "packageJsonUpdates": {
-    "13.0.0": {
-      "version": "13.0.0-beta.1",
-      "packages": {
-        "sass": {
-          "version": "1.43.2",
-          "alwaysAddToPackageJson": false
-        }
-      }
-    }
-  }
+  "packageJsonUpdates": {}
 }


### PR DESCRIPTION
Removing the sass upgrade since we don't actually need it, and it's causing migration issues.

Fixes #7458