### PR TITLE
fix(core): convert-nx-executor should be executable in ng workspace

### DIFF
--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -284,9 +284,10 @@ export class Workspaces {
       rawWorkspace,
       this.root
     );
-    const nxJson = readJsonFile<NxJsonConfiguration>(
-      path.join(this.root, 'nx.json')
-    );
+    const nxJsonPath = path.join(this.root, 'nx.json');
+    const nxJson = existsSync(nxJsonPath)
+      ? readJsonFile<NxJsonConfiguration>(nxJsonPath)
+      : ({} as NxJsonConfiguration);
     assertValidWorkspaceConfiguration(nxJson);
     return { ...parsedWorkspace, ...nxJson };
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Angular builders defined with convertNxExecutor fail in an ng workspace

## Expected Behavior
Angular builders defined with convertNxExecutor work in an ng workspace

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7470
