### PR TITLE
feat(node): add tsPlugins to node:package executor

### DIFF
--- a/docs/angular/api-node/executors/package.md
+++ b/docs/angular/api-node/executors/package.md
@@ -74,6 +74,12 @@ Type: `string`
 
 Sets the rootDir for TypeScript compilation. When not defined, it uses the project's root property
 
+### tsPlugins
+
+Type: `array`
+
+List of TypeScript Compiler Plugins.
+
 ### updateBuildableProjectDepsInPackageJson
 
 Default: `true`

--- a/docs/node/api-node/executors/package.md
+++ b/docs/node/api-node/executors/package.md
@@ -74,6 +74,12 @@ Type: `string`
 
 Sets the rootDir for TypeScript compilation. When not defined, it uses the project's root property
 
+### tsPlugins
+
+Type: `array`
+
+List of TypeScript Compiler Plugins.
+
 ### updateBuildableProjectDepsInPackageJson
 
 Default: `true`

--- a/docs/react/api-node/executors/package.md
+++ b/docs/react/api-node/executors/package.md
@@ -74,6 +74,12 @@ Type: `string`
 
 Sets the rootDir for TypeScript compilation. When not defined, it uses the project's root property
 
+### tsPlugins
+
+Type: `array`
+
+List of TypeScript Compiler Plugins.
+
 ### updateBuildableProjectDepsInPackageJson
 
 Default: `true`

--- a/packages/node/src/executors/package/schema.json
+++ b/packages/node/src/executors/package/schema.json
@@ -61,6 +61,14 @@
     "cli": {
       "type": "boolean",
       "description": "Adds a CLI wrapper to main entry-point file."
+    },
+    "tsPlugins": {
+      "type": "array",
+      "description": "List of TypeScript Compiler Plugins.",
+      "default": [],
+      "items": {
+        "$ref": "#/definitions/tsPluginPattern"
+      }
     }
   },
   "required": ["tsConfig", "main"],
@@ -96,6 +104,27 @@
         },
         {
           "type": "string"
+        }
+      ]
+    },
+    "tsPluginPattern": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "options": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false,
+          "required": ["name"]
         }
       ]
     }

--- a/packages/node/src/executors/package/utils/models.ts
+++ b/packages/node/src/executors/package/utils/models.ts
@@ -2,6 +2,7 @@ import {
   AssetGlob,
   FileInputOutput,
 } from '@nrwl/workspace/src/utilities/assets';
+import { TsPluginEntry } from '../../../utils/types';
 
 export interface NodePackageBuilderOptions {
   main: string;
@@ -16,6 +17,7 @@ export interface NodePackageBuilderOptions {
   srcRootForCompilationRoot?: string;
   deleteOutputPath: boolean;
   cli?: boolean;
+  tsPlugins?: TsPluginEntry[];
 }
 
 export interface NormalizedBuilderOptions extends NodePackageBuilderOptions {

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -2,7 +2,7 @@ import type {
   CustomTransformerFactory,
   Node,
   Program,
-  TransformerFactory,
+  TransformerFactory as TypescriptTransformerFactory,
 } from 'typescript';
 
 export interface FileReplacement {
@@ -22,7 +22,9 @@ export interface SourceMapOptions {
   hidden: boolean;
 }
 
-type Transformer = TransformerFactory<Node> | CustomTransformerFactory;
+type TransformerFactory =
+  | TypescriptTransformerFactory<Node>
+  | CustomTransformerFactory;
 
 export interface TsPlugin {
   name: string;
@@ -35,18 +37,21 @@ export interface CompilerPlugin {
   before?: (
     options?: Record<string, unknown>,
     program?: Program
-  ) => Transformer;
-  after?: (options?: Record<string, unknown>, program?: Program) => Transformer;
+  ) => TransformerFactory;
+  after?: (
+    options?: Record<string, unknown>,
+    program?: Program
+  ) => TransformerFactory;
   afterDeclarations?: (
     options?: Record<string, unknown>,
     program?: Program
-  ) => Transformer;
+  ) => TransformerFactory;
 }
 
 export interface CompilerPluginHooks {
-  beforeHooks: Array<(program?: Program) => Transformer>;
-  afterHooks: Array<(program?: Program) => Transformer>;
-  afterDeclarationsHooks: Array<(program?: Program) => Transformer>;
+  beforeHooks: Array<(program?: Program) => TransformerFactory>;
+  afterHooks: Array<(program?: Program) => TransformerFactory>;
+  afterDeclarationsHooks: Array<(program?: Program) => TransformerFactory>;
 }
 
 export interface AdditionalEntryPoint {

--- a/packages/workspace/src/utilities/typescript/compilation.ts
+++ b/packages/workspace/src/utilities/typescript/compilation.ts
@@ -1,7 +1,7 @@
 import { logger } from '@nrwl/devkit';
 import { removeSync } from 'fs-extra';
 import * as ts from 'typescript';
-import { Diagnostic } from 'typescript';
+import type { CustomTransformers, Diagnostic, Program } from 'typescript';
 import { readTsConfig } from '../typescript';
 
 export interface TypeScriptCompilationOptions {
@@ -12,6 +12,7 @@ export interface TypeScriptCompilationOptions {
   deleteOutputPath?: boolean;
   rootDir?: string;
   watch?: boolean;
+  getCustomTransformers?(program: Program): CustomTransformers;
 }
 
 export interface TypescriptWatchChangeEvent {
@@ -31,7 +32,7 @@ export function compileTypeScript(options: TypeScriptCompilationOptions): {
     removeSync(normalizedOptions.outputPath);
   }
 
-  return createProgram(tsConfig, normalizedOptions.projectName);
+  return createProgram(tsConfig, normalizedOptions);
 }
 
 export function compileTypeScriptWatcher(
@@ -56,14 +57,83 @@ export function compileTypeScriptWatcher(
     ts.sys
   );
 
-  const original = host.onWatchStatusChange;
+  const originalAfterProgramCreate = host.afterProgramCreate;
+  host.afterProgramCreate = (builderProgram) => {
+    const originalProgramEmit = builderProgram.emit;
+    builderProgram.emit = (
+      targetSourceFile,
+      writeFile,
+      cancellationToken,
+      emitOnlyDtsFiles,
+      customTransformers
+    ) => {
+      const consumerCustomTransfomers = options.getCustomTransformers?.(
+        builderProgram.getProgram()
+      );
+
+      const mergedCustomTransformers = mergeCustomTransformers(
+        customTransformers,
+        consumerCustomTransfomers
+      );
+
+      return originalProgramEmit(
+        targetSourceFile,
+        writeFile,
+        cancellationToken,
+        emitOnlyDtsFiles,
+        mergedCustomTransformers
+      );
+    };
+
+    if (originalAfterProgramCreate) originalAfterProgramCreate(builderProgram);
+  };
+
+  const originalOnWatchStatusChange = host.onWatchStatusChange;
   host.onWatchStatusChange = async (a, b, c, d) => {
-    original?.(a, b, c, d);
+    originalOnWatchStatusChange?.(a, b, c, d);
     await callback?.(a, b, c, d);
   };
 
   ts.createWatchProgram(host);
   return new Promise(() => {});
+}
+
+function mergeCustomTransformers(
+  originalCustomTransfomers: CustomTransformers | undefined,
+  consumerCustomTransformers: CustomTransformers | undefined
+): CustomTransformers | undefined {
+  if (!consumerCustomTransformers) return originalCustomTransfomers;
+
+  const mergedCustomTransformers: CustomTransformers = {};
+  if (consumerCustomTransformers.before) {
+    mergedCustomTransformers.before = originalCustomTransfomers?.before
+      ? [
+          ...originalCustomTransfomers.before,
+          ...consumerCustomTransformers.before,
+        ]
+      : consumerCustomTransformers.before;
+  }
+
+  if (consumerCustomTransformers.after) {
+    mergedCustomTransformers.after = originalCustomTransfomers?.after
+      ? [
+          ...originalCustomTransfomers.after,
+          ...consumerCustomTransformers.after,
+        ]
+      : consumerCustomTransformers.after;
+  }
+
+  if (consumerCustomTransformers.afterDeclarations) {
+    mergedCustomTransformers.afterDeclarations =
+      originalCustomTransfomers?.afterDeclarations
+        ? [
+            ...originalCustomTransfomers.afterDeclarations,
+            ...consumerCustomTransformers.afterDeclarations,
+          ]
+        : consumerCustomTransformers.afterDeclarations;
+  }
+
+  return mergedCustomTransformers;
 }
 
 function getNormalizedTsConfig(options: TypeScriptCompilationOptions) {
@@ -76,7 +146,7 @@ function getNormalizedTsConfig(options: TypeScriptCompilationOptions) {
 
 function createProgram(
   tsconfig: ts.ParsedCommandLine,
-  projectName: string
+  { projectName, getCustomTransformers }: TypeScriptCompilationOptions
 ): { success: boolean } {
   const host = ts.createCompilerHost(tsconfig.options);
   const program = ts.createProgram({
@@ -85,7 +155,13 @@ function createProgram(
     host,
   });
   logger.info(`Compiling TypeScript files for project "${projectName}"...`);
-  const results = program.emit();
+  const results = program.emit(
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    getCustomTransformers?.(program)
+  );
   if (results.emitSkipped) {
     const diagnostics = ts.formatDiagnosticsWithColorAndContext(
       results.diagnostics,


### PR DESCRIPTION
node:build currently has tsPlugins options to invoke TypeScript Plugins (transformers). This PR
brings the same functionality to node:package

ISSUES CLOSED: #7420

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We do not support `tsPlugins` in `nrwl/node:package` executor

## Expected Behavior
`nrwl/node:package` allows to pass in custom Transformers to `tsPlugins` options, similar to `nrwl/node:build`

## Related Issue(s)
#7420 

Fixes #7420 
