### PR TITLE
fix(react): migration to 13  

### DIFF
--- a/packages/react/src/migrations/update-13-0-0/__snapshots__/webpack5-changes-utils.spec.ts.snap
+++ b/packages/react/src/migrations/update-13-0-0/__snapshots__/webpack5-changes-utils.spec.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`webpack5ChangesUtils should get project name and storybook configuration for all react projects 1`] = `
+Array [
+  Object {
+    "projectName": "test-one",
+    "storybookConfigPath": "libs/test-one/.storybook",
+  },
+  Object {
+    "projectName": "test-two",
+    "storybookConfigPath": "libs/test-two/.storybook",
+  },
+]
+`;

--- a/packages/react/src/migrations/update-13-0-0/webpack5-changes-utils.spec.ts
+++ b/packages/react/src/migrations/update-13-0-0/webpack5-changes-utils.spec.ts
@@ -1,0 +1,80 @@
+import { Tree, updateJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { allReactProjectsWithStorybookConfiguration } from '@nrwl/react/src/migrations/update-13-0-0/webpack5-changes-utils';
+
+describe('webpack5ChangesUtils', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should get project name and storybook configuration for all react projects', () => {
+    const projects = {
+      'test-one': {
+        targets: {
+          storybook: {
+            options: {
+              uiFramework: '@storybook/react',
+              config: {
+                configFolder: 'libs/test-one/.storybook',
+              },
+            },
+          },
+        },
+      },
+      'test-two': {
+        targets: {
+          storybook: {
+            options: {
+              uiFramework: '@storybook/react',
+              config: {
+                configFolder: 'libs/test-two/.storybook',
+              },
+            },
+          },
+        },
+      },
+    };
+    updateJson(tree, 'workspace.json', (json) => {
+      json = {
+        ...json,
+        projects: {
+          ...json.projects,
+          ...projects,
+        },
+      };
+      return json;
+    });
+
+    const allReactProjects = allReactProjectsWithStorybookConfiguration(tree);
+
+    expect(allReactProjects).toMatchSnapshot();
+  });
+
+  it('should ignore non-react projects with storybook configuration', () => {
+    updateJson(tree, 'workspace.json', (json) => {
+      json = {
+        ...json,
+        projects: {
+          ...json.projects,
+          'test-one': {
+            targets: {
+              storybook: {
+                options: {
+                  uiFramework: '@storybook/angular',
+                  config: {
+                    configFolder: 'libs/test-one/.storybook',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      return json;
+    });
+
+    const allReactProjects = allReactProjectsWithStorybookConfiguration(tree);
+    expect(allReactProjects.length).toBe(0);
+  });
+});

--- a/packages/react/src/migrations/update-13-0-0/webpack5-changes-utils.ts
+++ b/packages/react/src/migrations/update-13-0-0/webpack5-changes-utils.ts
@@ -58,7 +58,8 @@ export function allReactProjectsWithStorybookConfiguration(tree: Tree): {
             projectConfig.targets.storybook.options.config.configFolder,
         };
       }
-    });
+    })
+    ?.filter((entry) => !!entry);
   return reactProjectsThatHaveStorybookConfiguration;
 }
 


### PR DESCRIPTION
Fixes migration to nx 13: when there are no react projects with storybook but other kind of projects uses SB migration to fails

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When there are any projects with storybook (angular, web, etc.) and react projects that none of them use storybook then migration step "Migrate Storybook to use webpack 5" will fail.

## Expected Behavior
Migration ignores other types of projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->