### PR TITLE
feat(devkit): export getAllFilesRecursivelyFromDir from @nrwl/devkit

### DIFF
--- a/docs/angular/api-nx-devkit/index.md
+++ b/docs/angular/api-nx-devkit/index.md
@@ -104,6 +104,7 @@ It only uses language primitives and immutable objects
 - [detectPackageManager](../../angular/nx-devkit/index#detectpackagemanager)
 - [formatFiles](../../angular/nx-devkit/index#formatfiles)
 - [generateFiles](../../angular/nx-devkit/index#generatefiles)
+- [getAllFilesRecursivelyFromDir](../../angular/nx-devkit/index#getallfilesrecursivelyfromdir)
 - [getPackageManagerCommand](../../angular/nx-devkit/index#getpackagemanagercommand)
 - [getPackageManagerVersion](../../angular/nx-devkit/index#getpackagemanagerversion)
 - [getProjects](../../angular/nx-devkit/index#getprojects)
@@ -782,6 +783,25 @@ doesn't get confused about incorrect TypeScript files.
 #### Returns
 
 `void`
+
+---
+
+### getAllFilesRecursivelyFromDir
+
+▸ **getAllFilesRecursivelyFromDir**(`tree`, `dir`): `string`[]
+
+Returns list of files in a given directory, including all subdirectories
+
+#### Parameters
+
+| Name   | Type                                         |
+| :----- | :------------------------------------------- |
+| `tree` | [`Tree`](../../angular/nx-devkit/index#tree) |
+| `dir`  | `string`                                     |
+
+#### Returns
+
+`string`[]
 
 ---
 

--- a/docs/node/api-nx-devkit/index.md
+++ b/docs/node/api-nx-devkit/index.md
@@ -104,6 +104,7 @@ It only uses language primitives and immutable objects
 - [detectPackageManager](../../node/nx-devkit/index#detectpackagemanager)
 - [formatFiles](../../node/nx-devkit/index#formatfiles)
 - [generateFiles](../../node/nx-devkit/index#generatefiles)
+- [getAllFilesRecursivelyFromDir](../../node/nx-devkit/index#getallfilesrecursivelyfromdir)
 - [getPackageManagerCommand](../../node/nx-devkit/index#getpackagemanagercommand)
 - [getPackageManagerVersion](../../node/nx-devkit/index#getpackagemanagerversion)
 - [getProjects](../../node/nx-devkit/index#getprojects)
@@ -782,6 +783,25 @@ doesn't get confused about incorrect TypeScript files.
 #### Returns
 
 `void`
+
+---
+
+### getAllFilesRecursivelyFromDir
+
+▸ **getAllFilesRecursivelyFromDir**(`tree`, `dir`): `string`[]
+
+Returns list of files in a given directory, including all subdirectories
+
+#### Parameters
+
+| Name   | Type                                      |
+| :----- | :---------------------------------------- |
+| `tree` | [`Tree`](../../node/nx-devkit/index#tree) |
+| `dir`  | `string`                                  |
+
+#### Returns
+
+`string`[]
 
 ---
 

--- a/docs/react/api-nx-devkit/index.md
+++ b/docs/react/api-nx-devkit/index.md
@@ -104,6 +104,7 @@ It only uses language primitives and immutable objects
 - [detectPackageManager](../../react/nx-devkit/index#detectpackagemanager)
 - [formatFiles](../../react/nx-devkit/index#formatfiles)
 - [generateFiles](../../react/nx-devkit/index#generatefiles)
+- [getAllFilesRecursivelyFromDir](../../react/nx-devkit/index#getallfilesrecursivelyfromdir)
 - [getPackageManagerCommand](../../react/nx-devkit/index#getpackagemanagercommand)
 - [getPackageManagerVersion](../../react/nx-devkit/index#getpackagemanagerversion)
 - [getProjects](../../react/nx-devkit/index#getprojects)
@@ -782,6 +783,25 @@ doesn't get confused about incorrect TypeScript files.
 #### Returns
 
 `void`
+
+---
+
+### getAllFilesRecursivelyFromDir
+
+▸ **getAllFilesRecursivelyFromDir**(`tree`, `dir`): `string`[]
+
+Returns list of files in a given directory, including all subdirectories
+
+#### Parameters
+
+| Name   | Type                                       |
+| :----- | :----------------------------------------- |
+| `tree` | [`Tree`](../../react/nx-devkit/index#tree) |
+| `dir`  | `string`                                   |
+
+#### Returns
+
+`string`[]
 
 ---
 

--- a/packages/angular/src/generators/stories/lib/component-info.ts
+++ b/packages/angular/src/generators/stories/lib/component-info.ts
@@ -1,11 +1,14 @@
 import type { Tree } from '@nrwl/devkit';
-import { joinPathFragments, logger } from '@nrwl/devkit';
+import {
+  getAllFilesRecursivelyFromDir,
+  joinPathFragments,
+  logger,
+} from '@nrwl/devkit';
 import { basename, dirname } from 'path';
 import type { Statement } from 'typescript';
 import { SyntaxKind } from 'typescript';
 import { getTsSourceFile } from '../../../utils/nx-devkit/ast-utils';
 import { getModuleDeclaredComponents } from './module-info';
-import { getAllFilesRecursivelyFromDir } from './tree-utilities';
 
 export interface ComponentInfo {
   componentFileName: string;

--- a/packages/devkit/index.ts
+++ b/packages/devkit/index.ts
@@ -253,3 +253,8 @@ export { joinPathFragments, normalizePath } from './src/utils/path';
  * @category Utils
  */
 export { moveFilesToNewDirectory } from './src/utils/move-dir';
+
+/**
+ * @category Utils
+ */
+export { getAllFilesRecursivelyFromDir } from './src/utils/tree-utilities';

--- a/packages/devkit/src/utils/tree-utilities.ts
+++ b/packages/devkit/src/utils/tree-utilities.ts
@@ -3,6 +3,9 @@ import { joinPathFragments } from '@nrwl/devkit';
 import type { Ignore } from 'ignore';
 import ignore from 'ignore';
 
+/**
+ * Returns list of files in a given directory, including all subdirectories
+ */
 export function getAllFilesRecursivelyFromDir(
   tree: Tree,
   dir: string


### PR DESCRIPTION
## Current Behavior
`getAllFilesRecursivelyFromDir` is useful util method, but in order to use it one would need to deep import it.

## Expected Behavior
Expose/export `getAllFilesRecursivelyFromDir` as official util method from @nrwl/devkit.
