### PR TITLE
fix(dep-graph): fix highlighting in group by folder mode

### DIFF
--- a/dep-graph/dep-graph/src/app/styles-graph/nodes.ts
+++ b/dep-graph/dep-graph/src/app/styles-graph/nodes.ts
@@ -86,10 +86,20 @@ const highlightedNodes: Stylesheet = {
   },
 };
 
-const transparentNodes: Stylesheet = {
-  selector: 'node.transparent',
+const transparentProjectNodes: Stylesheet = {
+  selector: 'node.transparent:childless',
   style: { opacity: 0.5 },
 };
+
+const transparentParentNodes: Stylesheet = {
+  selector: 'node.transparent:parent',
+  style: {
+    'text-opacity': 0.5,
+    'background-opacity': 0.25,
+    'border-opacity': 0.5,
+  },
+};
+
 const highlightedEdges: Stylesheet = {
   selector: 'edge.highlight',
   style: { 'mid-target-arrow-color': NrwlPalette.blue },
@@ -109,7 +119,8 @@ export const nodeStyles = [
   affectedNodes,
   parentNodes,
   highlightedNodes,
-  transparentNodes,
+  transparentProjectNodes,
+  transparentParentNodes,
   highlightedEdges,
   transparentEdges,
 ];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When in group by folder mode, the dep graph hover highlighting has different shades of highlighting when nodes are in different folders
<!-- This is the behavior we have today -->

## Expected Behavior
When in group by folder mode, the dep graph hover highlighting is consistently styled

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
