### PR TITLE
fix(core): nx daemon shouldn't cause flickering on windows

### DIFF
--- a/packages/workspace/src/core/hasher/spawn-process.ts
+++ b/packages/workspace/src/core/hasher/spawn-process.ts
@@ -13,7 +13,12 @@ export function spawnProcess(
   args: string[],
   cwd: string
 ): string {
-  const r = spawnSync(command, args, { cwd, maxBuffer: 50 * 1024 * 1024 });
+  const r = spawnSync(command, args, {
+    cwd,
+    maxBuffer: 50 * 1024 * 1024,
+    windowsHide: true,
+    shell: false,
+  });
   if (r.status !== 0) {
     throw new Error(
       `Failed to run ${command} ${args.join(' ')}.\n${r.stdout}\n${r.stderr}`

--- a/packages/workspace/src/core/project-graph/daemon/client/client.ts
+++ b/packages/workspace/src/core/project-graph/daemon/client/client.ts
@@ -24,6 +24,8 @@ export async function startInBackground(): Promise<ChildProcess['pid']> {
       cwd: __dirname,
       stdio: ['ignore', out, err],
       detached: true,
+      windowsHide: true,
+      shell: false,
     });
     backgroundProcess.unref();
 


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Running `nx daemon` and changing files causes strange window flickers when running on windows

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running `nx daemon` and changing files doesn't cause strange window flickers

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
