### PR TITLE
feat(angular): add secondary entry point generator for publishable libraries

### DIFF
--- a/docs/angular/api-angular/generators/library-secondary-entry-point.md
+++ b/docs/angular/api-angular/generators/library-secondary-entry-point.md
@@ -1,0 +1,49 @@
+# @nrwl/angular:library-secondary-entry-point
+
+Creates a secondary entry point for an Angular publishable library.
+
+## Usage
+
+```bash
+nx generate library-secondary-entry-point ...
+```
+
+```bash
+nx g secondary-entry-point ... # same
+```
+
+By default, Nx will search for `library-secondary-entry-point` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/angular:library-secondary-entry-point ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g library-secondary-entry-point ... --dry-run
+```
+
+## Options
+
+### library (_**required**_)
+
+Type: `string`
+
+The name of the library to create the secondary entry point for.
+
+### name (_**required**_)
+
+Type: `string`
+
+The name of the secondary entry point.
+
+### skipModule
+
+Default: `false`
+
+Type: `boolean`
+
+Skip generating a module for the secondary entry point.

--- a/docs/map.json
+++ b/docs/map.json
@@ -438,6 +438,11 @@
             "file": "angular/api-angular/generators/library"
           },
           {
+            "name": "library-secondary-entry-point generator",
+            "id": "library",
+            "file": "angular/api-angular/generators/library-secondary-entry-point"
+          },
+          {
             "name": "move generator",
             "id": "move",
             "file": "angular/api-angular/generators/move"
@@ -1736,6 +1741,11 @@
             "file": "react/api-angular/generators/library"
           },
           {
+            "name": "library-secondary-entry-point generator",
+            "id": "library",
+            "file": "react/api-angular/generators/library-secondary-entry-point"
+          },
+          {
             "name": "move generator",
             "id": "move",
             "file": "react/api-angular/generators/move"
@@ -2996,6 +3006,11 @@
             "name": "library generator",
             "id": "library",
             "file": "node/api-angular/generators/library"
+          },
+          {
+            "name": "library-secondary-entry-point generator",
+            "id": "library",
+            "file": "node/api-angular/generators/library-secondary-entry-point"
           },
           {
             "name": "move generator",

--- a/docs/node/api-angular/generators/library-secondary-entry-point.md
+++ b/docs/node/api-angular/generators/library-secondary-entry-point.md
@@ -1,0 +1,49 @@
+# @nrwl/angular:library-secondary-entry-point
+
+Creates a secondary entry point for an Angular publishable library.
+
+## Usage
+
+```bash
+nx generate library-secondary-entry-point ...
+```
+
+```bash
+nx g secondary-entry-point ... # same
+```
+
+By default, Nx will search for `library-secondary-entry-point` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/angular:library-secondary-entry-point ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g library-secondary-entry-point ... --dry-run
+```
+
+## Options
+
+### library (_**required**_)
+
+Type: `string`
+
+The name of the library to create the secondary entry point for.
+
+### name (_**required**_)
+
+Type: `string`
+
+The name of the secondary entry point.
+
+### skipModule
+
+Default: `false`
+
+Type: `boolean`
+
+Skip generating a module for the secondary entry point.

--- a/docs/react/api-angular/generators/library-secondary-entry-point.md
+++ b/docs/react/api-angular/generators/library-secondary-entry-point.md
@@ -1,0 +1,49 @@
+# @nrwl/angular:library-secondary-entry-point
+
+Creates a secondary entry point for an Angular publishable library.
+
+## Usage
+
+```bash
+nx generate library-secondary-entry-point ...
+```
+
+```bash
+nx g secondary-entry-point ... # same
+```
+
+By default, Nx will search for `library-secondary-entry-point` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/angular:library-secondary-entry-point ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g library-secondary-entry-point ... --dry-run
+```
+
+## Options
+
+### library (_**required**_)
+
+Type: `string`
+
+The name of the library to create the secondary entry point for.
+
+### name (_**required**_)
+
+Type: `string`
+
+The name of the secondary entry point.
+
+### skipModule
+
+Default: `false`
+
+Type: `boolean`
+
+Skip generating a module for the secondary entry point.

--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -62,6 +62,12 @@
       "x-type": "library",
       "description": "Creates an Angular library."
     },
+    "library-secondary-entry-point": {
+      "factory": "./src/generators/library-secondary-entry-point/compat",
+      "schema": "./src/generators/library-secondary-entry-point/schema.json",
+      "aliases": ["secondary-entry-point", "entry-point"],
+      "description": "Creates a secondary entry point for an Angular publishable library."
+    },
     "move": {
       "factory": "./src/generators/move/move#angularMoveSchematic",
       "schema": "./src/generators/move/schema.json",
@@ -175,6 +181,12 @@
       "aliases": ["lib"],
       "x-type": "library",
       "description": "Creates an Angular library."
+    },
+    "library-secondary-entry-point": {
+      "factory": "./src/generators/library-secondary-entry-point/library-secondary-entry-point",
+      "schema": "./src/generators/library-secondary-entry-point/schema.json",
+      "aliases": ["secondary-entry-point", "entry-point"],
+      "description": "Creates a secondary entry point for an Angular publishable library."
     },
     "move": {
       "factory": "./src/generators/move/move#angularMoveGenerator",

--- a/packages/angular/generators.ts
+++ b/packages/angular/generators.ts
@@ -5,6 +5,7 @@ export * from './src/generators/init/init';
 export * from './src/generators/karma/karma';
 export * from './src/generators/karma-project/karma-project';
 export * from './src/generators/library/library';
+export * from './src/generators/library-secondary-entry-point/library-secondary-entry-point';
 export * from './src/generators/move/move';
 export * from './src/generators/ngrx/ngrx';
 export * from './src/generators/stories/stories';

--- a/packages/angular/src/generators/library-secondary-entry-point/__snapshots__/library-secondary-entry-point.spec.ts.snap
+++ b/packages/angular/src/generators/library-secondary-entry-point/__snapshots__/library-secondary-entry-point.spec.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`librarySecondaryEntryPoint generator --skipModule should not generate a module 1`] = `
+"
+export const greeting = 'Hello World!';
+
+"
+`;
+
+exports[`librarySecondaryEntryPoint generator should generate files for the secondary entry point 1`] = `
+"
+export * from './lib/testing.module';
+
+"
+`;

--- a/packages/angular/src/generators/library-secondary-entry-point/compat.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/compat.ts
@@ -1,0 +1,4 @@
+import { convertNxGenerator } from '@nrwl/devkit';
+import { librarySecondaryEntryPointGenerator } from './library-secondary-entry-point';
+
+export default convertNxGenerator(librarySecondaryEntryPointGenerator);

--- a/packages/angular/src/generators/library-secondary-entry-point/files/README.md__tmpl__
+++ b/packages/angular/src/generators/library-secondary-entry-point/files/README.md__tmpl__
@@ -1,0 +1,3 @@
+# <%= secondaryEntryPoint %>
+
+Secondary entry point of `<%= mainEntryPoint %>`. It can be used by importing from `<%= secondaryEntryPoint %>`.

--- a/packages/angular/src/generators/library-secondary-entry-point/files/package.json__tmpl__
+++ b/packages/angular/src/generators/library-secondary-entry-point/files/package.json__tmpl__
@@ -1,0 +1,7 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "src/index.ts"
+    }
+  }
+}

--- a/packages/angular/src/generators/library-secondary-entry-point/files/src/index.ts__tmpl__
+++ b/packages/angular/src/generators/library-secondary-entry-point/files/src/index.ts__tmpl__
@@ -1,0 +1,5 @@
+<% if (!skipModule) { %>
+export * from './lib/<%= fileName %>.module';
+<% } else { %>
+export const greeting = 'Hello World!';
+<% } %>

--- a/packages/angular/src/generators/library-secondary-entry-point/files/src/lib/__fileName__.module.ts__tmpl__
+++ b/packages/angular/src/generators/library-secondary-entry-point/files/src/lib/__fileName__.module.ts__tmpl__
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class <%= className %>Module {}

--- a/packages/angular/src/generators/library-secondary-entry-point/lib/add-files.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/lib/add-files.ts
@@ -1,0 +1,29 @@
+import { generateFiles, joinPathFragments, names, Tree } from '@nrwl/devkit';
+import { NormalizedGeneratorOptions } from '../schema';
+
+export function addFiles(
+  tree: Tree,
+  options: NormalizedGeneratorOptions
+): void {
+  const nameVariants = names(options.name);
+
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, '..', 'files'),
+    options.entryPointDestination,
+    {
+      ...options,
+      ...nameVariants,
+      tmpl: '',
+    }
+  );
+
+  if (options.skipModule) {
+    tree.delete(
+      joinPathFragments(
+        options.entryPointDestination,
+        `src/lib/${nameVariants.fileName}.module.ts`
+      )
+    );
+  }
+}

--- a/packages/angular/src/generators/library-secondary-entry-point/lib/add-path-mapping.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/lib/add-path-mapping.ts
@@ -1,0 +1,17 @@
+import { Tree, updateJson } from '@nrwl/devkit';
+import { NormalizedGeneratorOptions } from '../schema';
+
+export function addPathMapping(
+  tree: Tree,
+  options: NormalizedGeneratorOptions
+): void {
+  updateJson(tree, 'tsconfig.base.json', (json) => {
+    const c = json.compilerOptions;
+    c.paths = c.paths || {};
+    c.paths[options.secondaryEntryPoint] = [
+      `${options.libraryProject.root}/${options.name}/src/index.ts`,
+    ];
+
+    return json;
+  });
+}

--- a/packages/angular/src/generators/library-secondary-entry-point/lib/index.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/lib/index.ts
@@ -1,0 +1,4 @@
+export * from './add-files';
+export * from './add-path-mapping';
+export * from './normalize-options';
+export * from './update-linting-file-patterns';

--- a/packages/angular/src/generators/library-secondary-entry-point/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/lib/normalize-options.ts
@@ -1,0 +1,55 @@
+import {
+  getProjects,
+  joinPathFragments,
+  names,
+  readJson,
+  Tree,
+} from '@nrwl/devkit';
+import { GeneratorOptions, NormalizedGeneratorOptions } from '../schema';
+
+export function normalizeOptions(
+  tree: Tree,
+  options: GeneratorOptions
+): NormalizedGeneratorOptions {
+  const name = names(options.name).fileName;
+
+  const projects = getProjects(tree);
+  const libraryProject = projects.get(options.library);
+  if (!libraryProject) {
+    throw new Error(
+      `The specified library "${options.library}" couldn't be found in the workspace.`
+    );
+  }
+
+  if (libraryProject.projectType !== 'library') {
+    throw new Error(
+      `The specified project "${options.library}" is not a library.`
+    );
+  }
+
+  const entryPointDestination = joinPathFragments(
+    libraryProject.root,
+    options.name
+  );
+  if (tree.exists(entryPointDestination)) {
+    throw new Error(
+      `The folder for the secondary entry point "${entryPointDestination}" already exists.`
+    );
+  }
+
+  const { name: mainEntryPoint } = readJson(
+    tree,
+    joinPathFragments(libraryProject.root, 'package.json')
+  );
+  const secondaryEntryPoint = `${mainEntryPoint}/${options.name}`;
+
+  return {
+    ...options,
+    entryPointDestination,
+    mainEntryPoint,
+    name,
+    libraryProject,
+    secondaryEntryPoint,
+    skipModule: options.skipModule ?? false,
+  };
+}

--- a/packages/angular/src/generators/library-secondary-entry-point/lib/update-linting-file-patterns.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/lib/update-linting-file-patterns.ts
@@ -1,0 +1,20 @@
+import { Tree, updateProjectConfiguration } from '@nrwl/devkit';
+import { NormalizedGeneratorOptions } from '../schema';
+
+export function updateLintingFilePatterns(
+  tree: Tree,
+  options: NormalizedGeneratorOptions
+): void {
+  const { libraryProject } = options;
+
+  if (libraryProject.targets?.lint?.options?.lintFilePatterns) {
+    libraryProject.targets.lint.options.lintFilePatterns.push(
+      ...[
+        `${libraryProject.root}/${options.name}/**/*.ts`,
+        `${libraryProject.root}/${options.name}/**/*.html`,
+      ]
+    );
+
+    updateProjectConfiguration(tree, options.library, libraryProject);
+  }
+}

--- a/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
@@ -1,0 +1,208 @@
+import * as devkit from '@nrwl/devkit';
+import {
+  addProjectConfiguration,
+  readJson,
+  readProjectConfiguration,
+  Tree,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { librarySecondaryEntryPointGenerator } from './library-secondary-entry-point';
+
+describe('librarySecondaryEntryPoint generator', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace(2);
+  });
+
+  it('should throw when the library does not exist in the workspace', async () => {
+    await expect(() =>
+      librarySecondaryEntryPointGenerator(tree, {
+        name: 'testing',
+        library: 'lib1',
+      })
+    ).rejects.toThrow();
+  });
+
+  it('should throw when the project specified as a library it is not a library', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
+    });
+
+    await expect(() =>
+      librarySecondaryEntryPointGenerator(tree, {
+        name: 'testing',
+        library: 'app1',
+      })
+    ).rejects.toThrow();
+  });
+
+  it('should throw when the folder where the secondary entry point should be generate already exists', async () => {
+    addProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      projectType: 'library',
+    });
+    tree.write(
+      'libs/lib1/package.json',
+      JSON.stringify({ name: '@my-org/lib1' })
+    );
+    tree.write('libs/lib1/testing/package.json', '');
+
+    await expect(() =>
+      librarySecondaryEntryPointGenerator(tree, {
+        name: 'testing',
+        library: 'lib1',
+      })
+    ).rejects.toThrow();
+  });
+
+  it('should generate files for the secondary entry point', async () => {
+    addProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      projectType: 'library',
+    });
+    tree.write(
+      'libs/lib1/package.json',
+      JSON.stringify({ name: '@my-org/lib1' })
+    );
+
+    await librarySecondaryEntryPointGenerator(tree, {
+      name: 'testing',
+      library: 'lib1',
+    });
+
+    expect(tree.exists('libs/lib1/testing/package.json')).toBeTruthy();
+    expect(tree.exists('libs/lib1/testing/README.md')).toBeTruthy();
+    expect(tree.exists('libs/lib1/testing/src/index.ts')).toBeTruthy();
+    expect(
+      tree.exists('libs/lib1/testing/src/lib/testing.module.ts')
+    ).toBeTruthy();
+    expect(
+      tree.read('libs/lib1/testing/src/index.ts', 'utf-8')
+    ).toMatchSnapshot();
+  });
+
+  it('should configure the entry file', async () => {
+    addProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      projectType: 'library',
+    });
+    tree.write(
+      'libs/lib1/package.json',
+      JSON.stringify({ name: '@my-org/lib1' })
+    );
+
+    await librarySecondaryEntryPointGenerator(tree, {
+      name: 'testing',
+      library: 'lib1',
+    });
+
+    const packageJson = readJson(tree, 'libs/lib1/testing/package.json');
+    expect(packageJson.ngPackage.lib.entryFile).toBe('src/index.ts');
+  });
+
+  it('should add the path mapping for the entry point', async () => {
+    addProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      projectType: 'library',
+    });
+    tree.write(
+      'libs/lib1/package.json',
+      JSON.stringify({ name: '@my-org/lib1' })
+    );
+
+    await librarySecondaryEntryPointGenerator(tree, {
+      name: 'testing',
+      library: 'lib1',
+    });
+
+    const tsConfig = readJson(tree, 'tsconfig.base.json');
+    expect(
+      tsConfig.compilerOptions.paths['@my-org/lib1/testing']
+    ).toStrictEqual(['libs/lib1/testing/src/index.ts']);
+  });
+
+  it('should add the entry point file patterns to the lint target', async () => {
+    addProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      projectType: 'library',
+      targets: {
+        lint: {
+          executor: '',
+          options: {
+            lintFilePatterns: [
+              'libs/lib1/src/**/*.ts',
+              'libs/lib1/src/**/*.html',
+            ],
+          },
+        },
+      },
+    });
+    tree.write(
+      'libs/lib1/package.json',
+      JSON.stringify({ name: '@my-org/lib1' })
+    );
+
+    await librarySecondaryEntryPointGenerator(tree, {
+      name: 'testing',
+      library: 'lib1',
+    });
+
+    const project = readProjectConfiguration(tree, 'lib1');
+    expect(project.targets!.lint.options.lintFilePatterns).toEqual(
+      expect.arrayContaining([
+        'libs/lib1/testing/**/*.ts',
+        'libs/lib1/testing/**/*.html',
+      ])
+    );
+  });
+
+  it('should format files', async () => {
+    jest.spyOn(devkit, 'formatFiles');
+    addProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      projectType: 'library',
+    });
+    tree.write(
+      'libs/lib1/package.json',
+      JSON.stringify({ name: '@my-org/lib1' })
+    );
+
+    await librarySecondaryEntryPointGenerator(tree, {
+      name: 'testing',
+      library: 'lib1',
+    });
+
+    expect(devkit.formatFiles).toHaveBeenCalled();
+  });
+
+  describe('--skipModule', () => {
+    it('should not generate a module', async () => {
+      addProjectConfiguration(tree, 'lib1', {
+        root: 'libs/lib1',
+        projectType: 'library',
+      });
+      tree.write(
+        'libs/lib1/package.json',
+        JSON.stringify({ name: '@my-org/lib1' })
+      );
+
+      await librarySecondaryEntryPointGenerator(tree, {
+        name: 'testing',
+        library: 'lib1',
+        skipModule: true,
+      });
+
+      expect(
+        tree.exists('libs/lib1/testing/src/lib/testing.module.ts')
+      ).toBeFalsy();
+      expect(tree.exists('libs/lib1/testing/package.json')).toBeTruthy();
+      expect(tree.exists('libs/lib1/testing/README.md')).toBeTruthy();
+      expect(tree.exists('libs/lib1/testing/src/index.ts')).toBeTruthy();
+      expect(
+        tree.read('libs/lib1/testing/src/index.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.ts
@@ -1,0 +1,23 @@
+import { formatFiles, Tree } from '@nrwl/devkit';
+import {
+  addFiles,
+  addPathMapping,
+  normalizeOptions,
+  updateLintingFilePatterns,
+} from './lib';
+import { GeneratorOptions } from './schema';
+
+export async function librarySecondaryEntryPointGenerator(
+  tree: Tree,
+  rawOptions: GeneratorOptions
+) {
+  const options = normalizeOptions(tree, rawOptions);
+
+  addFiles(tree, options);
+  addPathMapping(tree, options);
+  updateLintingFilePatterns(tree, options);
+
+  await formatFiles(tree);
+}
+
+export default librarySecondaryEntryPointGenerator;

--- a/packages/angular/src/generators/library-secondary-entry-point/schema.d.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/schema.d.ts
@@ -1,0 +1,15 @@
+import { ProjectConfiguration } from '@nrwl/devkit';
+
+export interface GeneratorOptions {
+  library: string;
+  name: string;
+  skipModule?: boolean;
+}
+
+export interface NormalizedGeneratorOptions extends GeneratorOptions {
+  entryPointDestination: string;
+  libraryProject: ProjectConfiguration;
+  mainEntryPoint: string;
+  secondaryEntryPoint: string;
+  skipModule: boolean;
+}

--- a/packages/angular/src/generators/library-secondary-entry-point/schema.json
+++ b/packages/angular/src/generators/library-secondary-entry-point/schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "NxAngularLibrarySecondaryEntryPoint",
+  "title": "Creates a secondary entry point for a library",
+  "type": "object",
+  "cli": "nx",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the secondary entry point.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the secondary entry point?",
+      "pattern": "^[a-zA-Z].*$"
+    },
+    "library": {
+      "type": "string",
+      "description": "The name of the library to create the secondary entry point for.",
+      "x-prompt": "What library would you like to create the secondary entry point for?",
+      "pattern": "^[a-zA-Z].*$"
+    },
+    "skipModule": {
+      "type": "boolean",
+      "description": "Skip generating a module for the secondary entry point.",
+      "default": false
+    }
+  },
+  "additionalProperties": false,
+  "required": ["name", "library"]
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Creating a secondary entry point for an Angular publishable library is a manual process.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Secondary entry points for Angular publishable libraries can be created with a generator by running:

```bash
nx generate @nrwl/angular:secondary-entry-point <entry point name> --library <library name the entry point is for>
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4733 
