### PR TITLE
fix(core): update generator logic so empty strings ("") for appsDir and libsDir work properly

### DIFF
--- a/packages/angular/src/generators/application/lib/normalize-options.ts
+++ b/packages/angular/src/generators/application/lib/normalize-options.ts
@@ -1,4 +1,4 @@
-import type { Tree } from '@nrwl/devkit';
+import { joinPathFragments, Tree } from '@nrwl/devkit';
 import type { Schema } from '../schema';
 import type { NormalizedSchema } from './normalized-schema';
 
@@ -22,8 +22,8 @@ export function normalizeOptions(
     e2eProjectName = `${appProjectName}-e2e`;
   }
 
-  const appProjectRoot = `${appsDir}/${appDirectory}`;
-  const e2eProjectRoot = `${appsDir}/${appDirectory}-e2e`;
+  const appProjectRoot = joinPathFragments(appsDir, appDirectory);
+  const e2eProjectRoot = joinPathFragments(appsDir, `${appDirectory}-e2e`);
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -1,4 +1,4 @@
-import { getWorkspaceLayout, Tree } from '@nrwl/devkit';
+import { getWorkspaceLayout, joinPathFragments, Tree } from '@nrwl/devkit';
 import { Schema } from '../schema';
 import { NormalizedSchema } from './normalized-schema';
 import { names } from '@nrwl/devkit';
@@ -31,7 +31,7 @@ export function normalizeOptions(
 
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
   const fileName = options.simpleModuleName ? name : projectName;
-  const projectRoot = `${libsDir}/${projectDirectory}`;
+  const projectRoot = joinPathFragments(libsDir, projectDirectory);
 
   const moduleName = `${names(fileName).className}Module`;
   const parsedTags = options.tags

--- a/packages/gatsby/src/generators/application/lib/normalize-options.ts
+++ b/packages/gatsby/src/generators/application/lib/normalize-options.ts
@@ -1,4 +1,9 @@
-import { Tree, names, getWorkspaceLayout } from '@nrwl/devkit';
+import {
+  getWorkspaceLayout,
+  joinPathFragments,
+  names,
+  Tree,
+} from '@nrwl/devkit';
 import { Schema } from '../schema';
 import { assertValidStyle } from '@nrwl/react';
 
@@ -23,7 +28,7 @@ export function normalizeOptions(
     : name;
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
   const { appsDir } = getWorkspaceLayout(host);
-  const projectRoot = `${appsDir}/${projectDirectory}`;
+  const projectRoot = joinPathFragments(appsDir, projectDirectory);
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())
     : [];

--- a/packages/next/src/generators/application/lib/normalize-options.ts
+++ b/packages/next/src/generators/application/lib/normalize-options.ts
@@ -1,5 +1,10 @@
 import { assertValidStyle } from '@nrwl/react';
-import { getWorkspaceLayout, names, Tree } from '@nrwl/devkit';
+import {
+  getWorkspaceLayout,
+  joinPathFragments,
+  names,
+  Tree,
+} from '@nrwl/devkit';
 import { Linter } from '@nrwl/linter';
 
 import { Schema } from '../schema';
@@ -28,8 +33,8 @@ export function normalizeOptions(
   const appProjectName = appDirectory.replace(new RegExp('/', 'g'), '-');
   const e2eProjectName = `${appProjectName}-e2e`;
 
-  const appProjectRoot = `${appsDir}/${appDirectory}`;
-  const e2eProjectRoot = `${appsDir}/${appDirectory}-e2e`;
+  const appProjectRoot = joinPathFragments(appsDir, appDirectory);
+  const e2eProjectRoot = joinPathFragments(appsDir, `${appDirectory}-e2e`);
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -16,7 +16,7 @@ export async function libraryGenerator(host: Tree, options: Schema) {
     : name;
 
   const { libsDir } = getWorkspaceLayout(host);
-  const projectRoot = joinPathFragments(`${libsDir}/${projectDirectory}`);
+  const projectRoot = joinPathFragments(libsDir, projectDirectory);
 
   const task = await reactLibraryGenerator(host, options);
 

--- a/packages/nx-plugin/src/generators/plugin/plugin.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.ts
@@ -1,16 +1,17 @@
-import {
-  readProjectConfiguration,
-  names,
-  convertNxGenerator,
-  generateFiles,
-  getWorkspaceLayout,
-  normalizePath,
-  updateProjectConfiguration,
-  addDependenciesToPackageJson,
-  formatFiles,
-  GeneratorCallback,
-} from '@nrwl/devkit';
 import type { Tree } from '@nrwl/devkit';
+import {
+  addDependenciesToPackageJson,
+  convertNxGenerator,
+  formatFiles,
+  generateFiles,
+  GeneratorCallback,
+  getWorkspaceLayout,
+  joinPathFragments,
+  names,
+  normalizePath,
+  readProjectConfiguration,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
 import type { Schema } from './schema';
 import { nxVersion } from '../../utils/versions';
 import * as path from 'path';
@@ -40,7 +41,7 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
 
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
   const fileName = projectName;
-  const projectRoot = normalizePath(`${libsDir}/${projectDirectory}`);
+  const projectRoot = joinPathFragments(libsDir, projectDirectory);
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())

--- a/packages/react-native/src/generators/library/lib/normalize-options.ts
+++ b/packages/react-native/src/generators/library/lib/normalize-options.ts
@@ -29,7 +29,7 @@ export function normalizeOptions(
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
   const fileName = projectName;
   const { libsDir, npmScope } = getWorkspaceLayout(host);
-  const projectRoot = joinPathFragments(`${libsDir}/${projectDirectory}`);
+  const projectRoot = joinPathFragments(libsDir, projectDirectory);
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())

--- a/packages/react-native/src/generators/library/library.ts
+++ b/packages/react-native/src/generators/library/library.ts
@@ -143,7 +143,10 @@ function updateBaseTsConfig(host: Tree, options: NormalizedSchema) {
     const { libsDir } = getWorkspaceLayout(host);
 
     c.paths[options.importPath] = [
-      maybeJs(options, `${libsDir}/${options.projectDirectory}/src/index.ts`),
+      maybeJs(
+        options,
+        joinPathFragments(libsDir, `${options.projectDirectory}/src/index.ts`)
+      ),
     ];
 
     return json;

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -1,5 +1,3 @@
-import { CSS_IN_JS_DEPENDENCIES } from '../../utils/styled';
-
 import * as ts from 'typescript';
 import { assertValidStyle } from '../../utils/assertion';
 import {
@@ -9,8 +7,8 @@ import {
   findComponentImportPath,
 } from '../../utils/ast-utils';
 import {
-  extraEslintDependencies,
   createReactEslintJson,
+  extraEslintDependencies,
 } from '../../utils/lint';
 import {
   reactDomVersion,
@@ -251,7 +249,10 @@ function updateBaseTsConfig(host: Tree, options: NormalizedSchema) {
     const { libsDir } = getWorkspaceLayout(host);
 
     c.paths[options.importPath] = [
-      maybeJs(options, `${libsDir}/${options.projectDirectory}/src/index.ts`),
+      maybeJs(
+        options,
+        joinPathFragments(libsDir, `${options.projectDirectory}/src/index.ts`)
+      ),
     ];
 
     return json;
@@ -380,7 +381,7 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
   const fileName = projectName;
   const { libsDir, npmScope } = getWorkspaceLayout(host);
-  const projectRoot = joinPathFragments(`${libsDir}/${projectDirectory}`);
+  const projectRoot = joinPathFragments(libsDir, projectDirectory);
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -240,8 +240,8 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   const appProjectName = appDirectory.replace(new RegExp('/', 'g'), '-');
   const e2eProjectName = `${appProjectName}-e2e`;
 
-  const appProjectRoot = `${appsDir}/${appDirectory}`;
-  const e2eProjectRoot = `${appsDir}/${appDirectory}-e2e`;
+  const appProjectRoot = joinPathFragments(appsDir, appDirectory);
+  const e2eProjectRoot = joinPathFragments(appsDir, `${appDirectory}-e2e`);
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())

--- a/packages/workspace/src/generators/library/library.ts
+++ b/packages/workspace/src/generators/library/library.ts
@@ -226,7 +226,7 @@ function normalizeOptions(tree: Tree, options: Schema): NormalizedSchema {
 
   const { libsDir, npmScope } = getWorkspaceLayout(tree);
 
-  const projectRoot = `${libsDir}/${projectDirectory}`;
+  const projectRoot = joinPathFragments(libsDir, projectDirectory);
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())


### PR DESCRIPTION
This PR fixes an issue when `libsDir` and `appsDir` are set to empty strings in `nx.json`.

e.g.

```
{
  ...
  "workspaceLayout" {
    "appsDir": "",
    "libsDir": ""
  }
}
```

This is used by Nx repo itself, and potentially other workspaces that want complete freedom in the paths of newly generated libs and apps.

## Current Behavior

Generating apps/libs will result in invalid path configuration in `project.json`/`workspace.json` and `tsconfig.base.json`. 

e.g. 

```
"root": " /my-new-lib"
```

## Expected Behavior

New configuration should be valid.

e.g.

```
"root": "my-new-lib"
```