### PR TITLE
cleanup(core): avoid first format to modify nx.json

### DIFF
--- a/packages/workspace/src/generators/workspace/files/nx.json__tmpl__
+++ b/packages/workspace/src/generators/workspace/files/nx.json__tmpl__
@@ -18,12 +18,7 @@
     "default": {
       "runner": "@nrwl/workspace/tasks-runners/default",
       "options": {
-        "cacheableOperations": [
-          "build",
-          "lint",
-          "test",
-          "e2e"
-        ]
+        "cacheableOperations": ["build", "lint", "test", "e2e"]
       }
     }
   },


### PR DESCRIPTION
Getting the `nx.json` code formatting right on brand new workspaces, so the first `nx format` won't update that file

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `nx.json` file on a new workspace is not formatted appropriately, such as the first `nx format` will update that file.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The first `nx format` should not change any generated file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Not quite an issue, just a quick improvement in developer experience, so I didn't bother to create some noise in an issue.