### PR TITLE
fix(storybook): only match exact component name for Storybook

### DIFF
--- a/packages/angular/src/generators/stories/lib/component-info.ts
+++ b/packages/angular/src/generators/stories/lib/component-info.ts
@@ -125,7 +125,11 @@ function getComponentInfoFromDir(
   for (const candidateFile of componentImportPathChildren) {
     if (candidateFile.endsWith('.ts')) {
       const content = tree.read(candidateFile, 'utf-8');
-      if (content.indexOf(`class ${componentName}`) > -1) {
+      const classAndComponentRegex = new RegExp(
+        `@Component[\\s\\S\n]*?\\bclass ${componentName}\\b`,
+        'g'
+      );
+      if (content.match(classAndComponentRegex)) {
         path = candidateFile
           .slice(0, candidateFile.lastIndexOf('/'))
           .replace(moduleFolderPath, '.');


### PR DESCRIPTION
ISSUES CLOSED: #7175

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
In Storybook/Angular, when looking for component classes, it matches both of the following:

```
class KaterinasComponent {
   ...
```
and

```
class KaterinasComponentSomeOtherThing {
   ...
```

## Expected Behavior
Only match exact name of component.

## Related Issue(s)
#7175

Fixes #
#7175