### PR TITLE
fix(storybook): install cypress packages if not installed for e2e apps

### DIFF
--- a/packages/storybook/src/generators/cypress-project/cypress-project.spec.ts
+++ b/packages/storybook/src/generators/cypress-project/cypress-project.spec.ts
@@ -58,4 +58,23 @@ describe('@nrwl/storybook:cypress-project', () => {
       tree.exists('apps/one/two/test-ui-lib-e2e/cypress.json')
     ).toBeTruthy();
   });
+
+  it('should make sure the cypress packages are installed', async () => {
+    expect(
+      readJson(tree, 'package.json').devDependencies['cypress']
+    ).toBeFalsy();
+    await cypressProjectGenerator(tree, {
+      name: 'test-ui-lib',
+      directory: 'one/two',
+      linter: Linter.EsLint,
+      standaloneConfig: false,
+    });
+    expect(
+      readJson(tree, 'package.json').devDependencies['cypress']
+    ).toBeTruthy();
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nrwl/cypress']
+    ).toBeTruthy();
+  });
 });


### PR DESCRIPTION
ISSUES CLOSED: #7158

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If a user generates Storybook configuration with e2e tests, and they don't have cypress already installed, they will not be able to run the e2e tests unless they install the packages manually.

## Expected Behavior
If the cypress packages are not installed, install them!

## Related Issue(s)
#7158

Fixes #
#7158