### PR TITLE
fix(core): import path for move generator

### DIFF
--- a/packages/workspace/src/generators/move/lib/move-project-configuration.spec.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-configuration.spec.ts
@@ -18,7 +18,7 @@ describe('moveProjectConfiguration', () => {
     schema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
-      importPath: '@proj/subfolder-my-destination',
+      importPath: '@proj/subfolder/my-destination',
       updateImportPath: true,
       newProjectName: 'subfolder-my-destination',
       relativeToRootDestination: 'apps/subfolder/my-destination',
@@ -213,7 +213,7 @@ describe('moveProjectConfiguration', () => {
     const moveSchema: NormalizedSchema = {
       projectName: 'standalone',
       destination: 'parent/standalone',
-      importPath: '@proj/parent-standalone',
+      importPath: '@proj/parent/standalone',
       newProjectName,
       relativeToRootDestination: 'libs/parent/standalone',
       updateImportPath: true,

--- a/packages/workspace/src/generators/move/lib/normalize-schema.spec.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.spec.ts
@@ -34,7 +34,7 @@ describe('normalizeSchema', () => {
   it('should calculate importPath, projectName and relativeToRootDestination correctly', () => {
     const expected: NormalizedSchema = {
       destination: 'my/library',
-      importPath: '@proj/my-library',
+      importPath: '@proj/my/library',
       newProjectName: 'my-library',
       projectName: 'my-library',
       relativeToRootDestination: 'libs/my/library',

--- a/packages/workspace/src/generators/move/lib/normalize-schema.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.ts
@@ -18,7 +18,7 @@ export function normalizeSchema(
     ...schema,
     destination,
     importPath:
-      schema.importPath ?? normalizeSlashes(`@${npmScope}/${newProjectName}`),
+      schema.importPath ?? normalizeSlashes(`@${npmScope}/${destination}`),
     newProjectName,
     relativeToRootDestination: getDestination(
       tree,

--- a/packages/workspace/src/generators/move/lib/update-build-targets.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-build-targets.spec.ts
@@ -15,7 +15,7 @@ describe('updateBuildTargets', () => {
     schema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
-      importPath: '@proj/subfolder-my-destination',
+      importPath: '@proj/subfolder/my-destination',
       updateImportPath: true,
       newProjectName: 'subfolder-my-destination',
       relativeToRootDestination: 'libs/subfolder/my-destination',

--- a/packages/workspace/src/generators/move/lib/update-default-project.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-default-project.spec.ts
@@ -30,7 +30,7 @@ describe('updateDefaultProject', () => {
     const schema: NormalizedSchema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
-      importPath: '@proj/subfolder-my-destination',
+      importPath: '@proj/subfolder/my-destination',
       updateImportPath: true,
       newProjectName: 'subfolder-my-destination',
       relativeToRootDestination: 'libs/subfolder/my-destination',

--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
@@ -18,7 +18,7 @@ describe('updateEslint', () => {
     schema = {
       projectName: 'my-lib',
       destination: 'shared/my-destination',
-      importPath: '@proj/shared-my-destination',
+      importPath: '@proj/shared/my-destination',
       updateImportPath: true,
       newProjectName: 'shared-my-destination',
       relativeToRootDestination: 'libs/shared/my-destination',

--- a/packages/workspace/src/generators/move/lib/update-jest-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-jest-config.spec.ts
@@ -91,7 +91,7 @@ describe('updateJestConfig', () => {
     const schema: NormalizedSchema = {
       projectName: 'some-test-dir-my-source',
       destination: 'other/test/dir/my-destination',
-      importPath: '@proj/other-test-dir-my-destination',
+      importPath: '@proj/other/test/dir/my-destination',
       updateImportPath: true,
       newProjectName: 'other-test-dir-my-destination',
       relativeToRootDestination: 'libs/other/test/dir/my-destination',
@@ -127,7 +127,7 @@ describe('updateJestConfig', () => {
     const schema: NormalizedSchema = {
       projectName: 'some-test-dir-my-source',
       destination: 'other/test/dir/my-destination',
-      importPath: '@proj/other-test-dir-my-destination',
+      importPath: '@proj/other/test/dir/my-destination',
       updateImportPath: true,
       newProjectName: 'other-test-dir-my-destination',
       relativeToRootDestination: 'libs/other/test/dir/my-destination',
@@ -166,7 +166,7 @@ module.exports = {
     const schema: NormalizedSchema = {
       projectName: 'some-test-dir-my-source',
       destination: 'other/test/dir/my-destination',
-      importPath: '@proj/other-test-dir-my-destination',
+      importPath: '@proj/other/test/dir/my-destination',
       updateImportPath: true,
       newProjectName: 'other-test-dir-my-destination',
       relativeToRootDestination: 'libs/other/test/dir/my-destination',
@@ -206,7 +206,7 @@ module.exports = {
     const schema: NormalizedSchema = {
       projectName: 'some-test-dir-my-source',
       destination: 'other/test/dir/my-destination',
-      importPath: '@proj/other-test-dir-my-destination',
+      importPath: '@proj/other/test/dir/my-destination',
       updateImportPath: true,
       newProjectName: 'other-test-dir-my-destination',
       relativeToRootDestination: 'libs/other/test/dir/my-destination',

--- a/packages/workspace/src/generators/move/lib/update-project-root-files.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-project-root-files.spec.ts
@@ -31,7 +31,7 @@ describe('updateProjectRootFiles', () => {
     const schema: NormalizedSchema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
-      importPath: '@proj/subfolder-my-destination',
+      importPath: '@proj/subfolder/my-destination',
       updateImportPath: true,
       newProjectName: 'subfolder-my-destination',
       relativeToRootDestination: 'libs/subfolder/my-destination',

--- a/packages/workspace/src/generators/move/lib/update-readme.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-readme.spec.ts
@@ -13,7 +13,7 @@ describe('updateReadme', () => {
     schema = {
       projectName: 'my-lib',
       destination: 'shared/my-destination',
-      importPath: '@proj/shared-my-destination',
+      importPath: '@proj/shared/my-destination',
       updateImportPath: true,
       newProjectName: 'shared-my-destination',
       relativeToRootDestination: 'libs/shared/my-destination',

--- a/packages/workspace/src/generators/move/lib/update-storybook-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-storybook-config.spec.ts
@@ -47,7 +47,7 @@ describe('updateStorybookConfig', () => {
     const schema: NormalizedSchema = {
       projectName: 'my-source',
       destination: 'namespace/my-destination',
-      importPath: '@proj/namespace-my-destination',
+      importPath: '@proj/namespace/my-destination',
       updateImportPath: true,
       newProjectName: 'namespace-my-destination',
       relativeToRootDestination: 'libs/namespace/my-destination',
@@ -76,7 +76,7 @@ describe('updateStorybookConfig', () => {
     const schema: NormalizedSchema = {
       projectName: 'my-source',
       destination: 'namespace/my-destination',
-      importPath: '@proj/namespace-my-destination',
+      importPath: '@proj/namespace/my-destination',
       updateImportPath: true,
       newProjectName: 'namespace-my-destination',
       relativeToRootDestination: 'libs/namespace/my-destination',


### PR DESCRIPTION
ISSUES CLOSED: #7009 https://github.com/nrwl/nx/issues/7327

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
I have a library that is configured like this in `tsconfig.base.json`:
```
      "@my-org/some/subfolder/mylib": [
        "libs/some/subfolder/mylib/src/index.ts"
      ],
```

When the move generator is used like this:
```
nx g move --project some-subfolder-mylib another/subfolder/mylib
```

the changed `tsconfig.base.json` looks like this:

```
      "@my-org/another-subfolder-mylib": [
        "libs/another/subfolder/mylib/src/index.ts"
      ],
```


## Expected Behavior

I expect `tsconfig.base.json` to look like this:

```
      "@my-org/another/subfolder/mylib": [
        "libs/another/subfolder/mylib/src/index.ts"
      ],
```

## Related Issue(s)
 #7009 https://github.com/nrwl/nx/issues/7327

Fixes #
 #7009 https://github.com/nrwl/nx/issues/7327