### PR TITLE
feat(nextjs): migration to enable SWC for nextjs apps

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -78,6 +78,12 @@
       "version": "13.0.3-beta.1",
       "description": "Fix setup for less stylesheets",
       "factory": "./src/migrations/update-13-0-3/fix-less"
+    },
+    "enable-swc": {
+      "cli": "nx",
+      "version": "13.1.1-beta.1",
+      "description": "Enables SWC for Next.js apps.",
+      "factory": "./src/migrations/update-13-0-3/enable-swc"
     }
   },
   "packageJsonUpdates": {

--- a/packages/next/src/generators/application/lib/create-application-files.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.ts
@@ -40,7 +40,8 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
   }
 
   // SWC will be disabled if custom babelrc is provided.
-  if (options.swc) {
+  // Check for `!== false` because `create-nx-workspace` is not passing default values.
+  if (options.swc !== false) {
     host.delete(`${options.appProjectRoot}/.babelrc`);
   }
 

--- a/packages/next/src/generators/application/lib/update-jest-config.ts
+++ b/packages/next/src/generators/application/lib/update-jest-config.ts
@@ -13,6 +13,9 @@ export function updateJestConfig(host: Tree, options: NormalizedSchema) {
       'transform: {',
       "transform: {\n    '^(?!.*\\\\.(js|jsx|ts|tsx|css|json)$)': '@nrwl/react/plugins/jest',"
     )
-    .replace(`'babel-jest'`, `['babel-jest', { presets: ['next/babel'] }]`);
+    .replace(
+      `'babel-jest'`,
+      `['babel-jest', { presets: ['@nrwl/next/babel'] }]`
+    );
   host.write(configPath, content);
 }

--- a/packages/next/src/migrations/update-13-1-1/enable-swc.spec.ts
+++ b/packages/next/src/migrations/update-13-1-1/enable-swc.spec.ts
@@ -1,0 +1,83 @@
+import { Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+import { applicationGenerator } from '../../generators/application/application';
+import { update } from './enable-swc';
+
+describe('Migration: enable SWC', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should remove .babelrc file and fix jest config', async () => {
+    await applicationGenerator(tree, {
+      style: 'none',
+      name: 'demo',
+      skipFormat: false,
+      swc: false,
+    });
+
+    // Config that isn't configured properly
+    tree.write(
+      'apps/demo/jest.config.js',
+      `
+module.exports = {
+  displayName: 'napp4',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^(?!.*\\\\.(js|jsx|ts|tsx|css|json)$)': '@nrwl/react/plugins/jest',
+    '^.+\\\\.[tj]sx?$': 'babel-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/apps/demo',
+};
+
+`
+    );
+
+    await update(tree);
+
+    const result = tree.read('apps/demo/jest.config.js').toString();
+
+    expect(result).toMatch(`['babel-jest', { presets: ['@nrwl/next/babel'] }]`);
+
+    expect(tree.exists('apps/demo/.babelrc')).toBe(false);
+  });
+
+  it('should skip migration if SWC already enabled', async () => {
+    await applicationGenerator(tree, {
+      style: 'none',
+      name: 'demo',
+      skipFormat: false,
+      swc: true,
+    });
+
+    // Config that isn't configured properly
+    tree.write(
+      'apps/demo/jest.config.js',
+      `
+module.exports = {
+  displayName: 'napp4',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^(?!.*\\\\.(js|jsx|ts|tsx|css|json)$)': '@nrwl/react/plugins/jest',
+    '^.+\\\\.[tj]sx?$': 'babel-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/apps/demo',
+};
+
+`
+    );
+
+    await update(tree);
+
+    const result = tree.read('apps/demo/jest.config.js').toString();
+
+    expect(result).not.toMatch(
+      `['babel-jest', { presets: ['@nrwl/next/babel'] }]`
+    );
+  });
+});

--- a/packages/next/src/migrations/update-13-1-1/enable-swc.ts
+++ b/packages/next/src/migrations/update-13-1-1/enable-swc.ts
@@ -1,0 +1,40 @@
+import {
+  formatFiles,
+  getProjects,
+  joinPathFragments,
+  Tree,
+} from '@nrwl/devkit';
+
+export async function update(host: Tree) {
+  const projects = getProjects(host);
+
+  projects.forEach((project) => {
+    const nextConfigPath = joinPathFragments(project.root, 'next.config.js');
+    const jestConfigPath = joinPathFragments(project.root, 'jest.config.js');
+    const babelConfigPath = joinPathFragments(project.root, '.babelrc');
+
+    if (
+      !host.exists(nextConfigPath) ||
+      !host.exists(jestConfigPath) ||
+      !host.exists(babelConfigPath)
+    )
+      return;
+
+    const content = host.read(jestConfigPath).toString();
+
+    if (content.match(/:\s+'babel-jest'/)) {
+      const updated = content.replace(
+        /:\s+'babel-jest'/,
+        `: ['babel-jest', { presets: ['@nrwl/next/babel'] }]`
+      );
+      host.write(jestConfigPath, updated);
+    }
+
+    // Deleting custom babel config enables SWC
+    host.delete(babelConfigPath);
+  });
+
+  await formatFiles(host);
+}
+
+export default update;


### PR DESCRIPTION
This PR adds a migration to enable SWC for all Next.js apps. 

The migration does two things:

- Delete custom `.babelrc` files for next.js apps to enable SWC.
- Update `jest.config.js` file so the `@nrwl/next/babel` preset is used for tests still without relying on custom `.babelrc` file).

