### PR TITLE
fix(node): fix node optimization option

### DIFF
--- a/packages/node/src/utils/node.config.spec.ts
+++ b/packages/node/src/utils/node.config.spec.ts
@@ -46,22 +46,22 @@ describe('getNodePartial', () => {
   });
 
   describe('the optimization option when true', () => {
-    it('should not minify', () => {
+    it('should minify', () => {
       const result = getNodeWebpackConfig({
         ...input,
         optimization: true,
       });
 
-      expect(result.optimization.minimize).toEqual(false);
+      expect(result.optimization.minimize).toEqual(true);
     });
 
-    it('should not concatenate modules', () => {
+    it('should concatenate modules', () => {
       const result = getNodeWebpackConfig({
         ...input,
         optimization: true,
       });
 
-      expect(result.optimization.concatenateModules).toEqual(false);
+      expect(result.optimization.concatenateModules).toEqual(true);
     });
   });
 

--- a/packages/node/src/utils/node.config.ts
+++ b/packages/node/src/utils/node.config.ts
@@ -17,8 +17,8 @@ function getNodePartial(options: BuildNodeBuilderOptions) {
 
   if (options.optimization) {
     webpackConfig.optimization = {
-      minimize: false,
-      concatenateModules: false,
+      minimize: true,
+      concatenateModules: true,
     };
   }
 


### PR DESCRIPTION
## Current Behavior
Setting `optimization` to `true` doesn't do anything.

## Expected Behavior
I expect `optimization` flag to result in concatenated and minified output.

