### PR TITLE
chore(nextjs): enable SWC for nx.dev

### DIFF
--- a/nx-dev/data-access-documents/.babelrc
+++ b/nx-dev/data-access-documents/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}

--- a/nx-dev/feature-analytics/.babelrc
+++ b/nx-dev/feature-analytics/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}

--- a/nx-dev/feature-analytics/jest.config.js
+++ b/nx-dev/feature-analytics/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   displayName: 'nx-dev-feature-analytics',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.[tj]sx?$': 'babel-jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/nx-dev/feature-analytics',

--- a/nx-dev/feature-conf/.babelrc
+++ b/nx-dev/feature-conf/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}

--- a/nx-dev/feature-conf/jest.config.js
+++ b/nx-dev/feature-conf/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   displayName: 'nx-dev-feature-conf',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.[tj]sx?$': 'babel-jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/nx-dev/feature-conf',

--- a/nx-dev/feature-doc-viewer/.babelrc
+++ b/nx-dev/feature-doc-viewer/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}

--- a/nx-dev/feature-doc-viewer/jest.config.js
+++ b/nx-dev/feature-doc-viewer/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   ...nxPreset,
   displayName: 'nx-dev-feature-doc-viewer',
   transform: {
-    '^.+\\.[tj]sx?$': 'babel-jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/nx-dev/feature-doc-viewer',

--- a/nx-dev/feature-flavor-selection/.babelrc
+++ b/nx-dev/feature-flavor-selection/.babelrc
@@ -1,6 +1,0 @@
-{
-  "presets": [
-    "next/babel"
-  ],
-  "plugins": []
-}

--- a/nx-dev/feature-flavor-selection/jest.config.js
+++ b/nx-dev/feature-flavor-selection/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   displayName: 'nx-dev-feature-flavor-selection',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.[tj]sx?$': 'babel-jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage//nx-dev/feature-flavor-selection',

--- a/nx-dev/feature-search/.babelrc
+++ b/nx-dev/feature-search/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}

--- a/nx-dev/feature-search/jest.config.js
+++ b/nx-dev/feature-search/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   displayName: 'nx-dev-feature-search',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.[tj]sx?$': 'babel-jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/nx-dev/feature-search',

--- a/nx-dev/feature-storage/.babelrc
+++ b/nx-dev/feature-storage/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}

--- a/nx-dev/feature-storage/jest.config.js
+++ b/nx-dev/feature-storage/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   displayName: 'nx-dev-feature-storage',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.[tj]sx?$': 'babel-jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/nx-dev/feature-storage',

--- a/nx-dev/feature-versions-and-flavors/.babelrc
+++ b/nx-dev/feature-versions-and-flavors/.babelrc
@@ -1,6 +1,0 @@
-{
-  "presets": [
-    "next/babel"
-  ],
-  "plugins": []
-}

--- a/nx-dev/feature-versions-and-flavors/jest.config.js
+++ b/nx-dev/feature-versions-and-flavors/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   displayName: 'nx-dev-feature-versions-and-flavors',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.[tj]sx?$': 'babel-jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage//nx-dev/feature-versions-and-flavors',

--- a/nx-dev/nx-dev/.babelrc
+++ b/nx-dev/nx-dev/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}

--- a/nx-dev/nx-dev/jest.config.js
+++ b/nx-dev/nx-dev/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   displayName: 'nx-dev',
   transform: {
     '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nrwl/react/plugins/jest',
-    '^.+\\.[tj]sx?$': 'babel-jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/nx-dev/nx-dev',

--- a/nx-dev/ui/common/.babelrc
+++ b/nx-dev/ui/common/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["@nrwl/react/babel"],
-  "plugins": []
-}

--- a/nx-dev/ui/common/jest.config.js
+++ b/nx-dev/ui/common/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   ...nxPreset,
   displayName: 'nx-dev-ui-common',
   transform: {
-    '^.+\\.[tj]sx?$': 'babel-jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../../coverage/nx-dev/ui/common',

--- a/nx-dev/ui/member-card/.babelrc
+++ b/nx-dev/ui/member-card/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}

--- a/nx-dev/ui/member-card/jest.config.js
+++ b/nx-dev/ui/member-card/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   displayName: 'nx-dev-ui-member-card',
   preset: '../../../jest.preset.js',
   transform: {
-    '^.+\\.[tj]sx?$': 'babel-jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../../coverage/nx-dev/ui/member-card',

--- a/nx-dev/ui/sponsor-card/.babelrc
+++ b/nx-dev/ui/sponsor-card/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}

--- a/nx-dev/ui/sponsor-card/jest.config.js
+++ b/nx-dev/ui/sponsor-card/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   displayName: 'nx-dev-ui-sponsor-card',
   preset: '../../../jest.preset.js',
   transform: {
-    '^.+\\.[tj]sx?$': 'babel-jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../../coverage/nx-dev/ui/sponsor-card',


### PR DESCRIPTION
This MR removes the `.babelrc` files for nx-dev app and libs to enable SWC. Also updates Jest configs to work without `.babelrc.`