### PR TITLE
chore(repo): add tests to make sure migration factory/implementation are correct

### DIFF
--- a/packages/angular/migrations.spec.ts
+++ b/packages/angular/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Angular migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/cypress/migrations.spec.ts
+++ b/packages/cypress/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Cypress migrations', () => {
+  it('should have valid paths', () => {
+    Object.values((json as any)?.schematics || {}).forEach((m: any) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/detox/migrations.spec.ts
+++ b/packages/detox/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Detox migrations', () => {
+  it('should have valid paths', () => {
+    Object.values((json as any)?.schematics || {}).forEach((m: any) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/express/migrations.spec.ts
+++ b/packages/express/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Express migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m: any) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/gatsby/migrations.spec.ts
+++ b/packages/gatsby/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Gatsby migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/jest/migrations.spec.ts
+++ b/packages/jest/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Jest migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/linter/migrations.spec.ts
+++ b/packages/linter/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Linter migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/nest/migrations.spec.ts
+++ b/packages/nest/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Nest migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/next/migrations.spec.ts
+++ b/packages/next/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Next migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/node/migrations.spec.ts
+++ b/packages/node/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Node migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/react-native/migrations.spec.ts
+++ b/packages/react-native/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('React Native migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/react/migrations.spec.ts
+++ b/packages/react/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('React migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/storybook/migrations.spec.ts
+++ b/packages/storybook/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Storybook migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/web/migrations.spec.ts
+++ b/packages/web/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Web migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/workspace/migrations.spec.ts
+++ b/packages/workspace/migrations.spec.ts
@@ -1,0 +1,14 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('Workspace migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m: any) => {
+      expect(() =>
+        require.resolve(
+          path.join(__dirname, `${m.implementation || m.factory}.ts`)
+        )
+      ).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
This PR adds some tests to catch migration path mistakes (in `migrations.json`) for all packages.