### PR TITLE
docs(core): update contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ To publish packages to a local registry, do the following:
 - Run `npm adduser --registry http://localhost:4873` in Terminal 2 (real credentials are not required, you just need to be logged in. You can use test/test/test@test.io.)
 - Run `yarn local-registry enable` in Terminal 2
 - Run `yarn nx-release 999.9.9 --local` in Terminal 2
-- Run `cd /tmp` in Terminal 2
+- Run `cd ./tmp` in Terminal 2
 - Run `npx create-nx-workspace@999.9.9` in Terminal 2
 
 If you have problems publishing, make sure you use Node 14 and NPM 6 instead of Node 15 and NPM 7.


### PR DESCRIPTION
Updates the contributor guide to `cd ./tmp` instead of `cd /tmp`