### PR TITLE
feat(core): include community plugins when running `nx report`

### DIFF
--- a/packages/workspace/src/command-line/report.spec.ts
+++ b/packages/workspace/src/command-line/report.spec.ts
@@ -1,0 +1,122 @@
+import { findInstalledCommunityPlugins } from './report';
+import * as devkit from '@nrwl/devkit';
+import * as fileUtils from '../utilities/fileutils';
+import { join } from 'path';
+
+jest.mock('@nrwl/tao/src/utils/app-root', () => ({
+  appRootPath: '',
+}));
+
+jest.mock('../utilities/fileutils', () => ({
+  ...(jest.requireActual('../utilities/fileutils') as typeof fileUtils),
+  resolve: (file) => `node_modules/${file}`,
+}));
+
+describe('report', () => {
+  describe('findInstalledCommunityPlugins', () => {
+    afterEach(() => jest.resetAllMocks());
+
+    it('should read angular-devkit plugins', () => {
+      jest.spyOn(devkit, 'readJsonFile').mockImplementation((path) => {
+        console.log(path);
+        if (path === 'package.json') {
+          return {
+            dependencies: {
+              'plugin-one': '1.0.0',
+            },
+            devDependencies: {
+              'plugin-two': '2.0.0',
+            },
+          };
+        } else if (
+          path.includes(join('node_modules', 'plugin-one', 'package.json'))
+        ) {
+          return {
+            'ng-update': {},
+            version: '1.0.0',
+          };
+        } else if (
+          path.includes(join('node_modules', 'plugin-two', 'package.json'))
+        ) {
+          return {
+            schematics: {},
+            version: '2.0.0',
+          };
+        }
+      });
+      const plugins = findInstalledCommunityPlugins();
+      expect(plugins).toEqual([
+        { package: 'plugin-one', version: '1.0.0' },
+        { package: 'plugin-two', version: '2.0.0' },
+      ]);
+    });
+
+    it('should read nx devkit plugins', () => {
+      jest.spyOn(devkit, 'readJsonFile').mockImplementation((path) => {
+        if (path === 'package.json') {
+          return {
+            dependencies: {
+              'plugin-one': '1.0.0',
+            },
+            devDependencies: {
+              'plugin-two': '2.0.0',
+            },
+          };
+        } else if (
+          path.includes(join('node_modules', 'plugin-one', 'package.json'))
+        ) {
+          return {
+            'nx-migrations': {},
+            version: '1.0.0',
+          };
+        } else if (
+          path.includes(join('node_modules', 'plugin-two', 'package.json'))
+        ) {
+          return {
+            generators: {},
+            version: '2.0.0',
+          };
+        }
+      });
+      const plugins = findInstalledCommunityPlugins();
+      expect(plugins).toEqual([
+        { package: 'plugin-one', version: '1.0.0' },
+        { package: 'plugin-two', version: '2.0.0' },
+      ]);
+    });
+
+    it('should not include non-plugins', () => {
+      jest.spyOn(devkit, 'readJsonFile').mockImplementation((path) => {
+        if (path === 'package.json') {
+          return {
+            dependencies: {
+              'plugin-one': '1.0.0',
+            },
+            devDependencies: {
+              'plugin-two': '2.0.0',
+              'other-package': '1.44.0',
+            },
+          };
+        } else if (
+          path.includes(join('node_modules', 'plugin-one', 'package.json'))
+        ) {
+          return {
+            'nx-migrations': {},
+          };
+        } else if (
+          path.includes(join('node_modules', 'plugin-two', 'package.json'))
+        ) {
+          return {
+            generators: {},
+          };
+        } else {
+          return {
+            version: '',
+          };
+        }
+      });
+      const plugins = findInstalledCommunityPlugins().map((x) => x.package);
+      expect(plugins).not.toContain('other-package');
+    });
+  });
+});

--- a/packages/workspace/src/utilities/fileutils.ts
+++ b/packages/workspace/src/utilities/fileutils.ts
@@ -8,7 +8,7 @@ import {
   renameSync as fsRenameSync,
 } from 'fs';
 import { ensureDirSync } from 'fs-extra';
-import { basename, dirname, resolve } from 'path';
+import { basename, dirname, resolve as pathResolve } from 'path';
 import {
   parseJson,
   serializeJson,
@@ -40,7 +40,7 @@ export function updateJsonFile(path: string, callback: (a: any) => any) {
 export function copyFile(file: string, target: string) {
   const f = basename(file);
   const source = createReadStream(file);
-  const dest = createWriteStream(resolve(target, f));
+  const dest = createWriteStream(pathResolve(target, f));
   source.pipe(dest);
   source.on('error', (e) => console.error(e));
 }
@@ -62,7 +62,7 @@ export function fileExists(filePath: string): boolean {
 }
 
 export function createDirectory(directoryPath: string) {
-  const parentPath = resolve(directoryPath, '..');
+  const parentPath = pathResolve(directoryPath, '..');
   if (!directoryExists(parentPath)) {
     createDirectory(parentPath);
   }
@@ -84,7 +84,7 @@ export function renameSync(
     }
 
     // Make sure parent path exists
-    const parentPath = resolve(to, '..');
+    const parentPath = pathResolve(to, '..');
     createDirectory(parentPath);
 
     fsRenameSync(from, to);
@@ -102,3 +102,5 @@ export function isRelativePath(path: string): boolean {
     path.startsWith('../')
   );
 }
+
+export const resolve = require.resolve;

--- a/scripts/check-imports.js
+++ b/scripts/check-imports.js
@@ -29,6 +29,7 @@ function check() {
     'packages/create-nx-workspace/bin/create-nx-workspace.ts',
     'packages/create-nx-plugin/bin/create-nx-plugin.ts',
     'packages/workspace/src/command-line/affected.ts',
+    'packages/workspace/src/command-line/report.ts',
     'packages/workspace/src/core/file-utils.ts',
     'packages/workspace/src/generators/preset/preset.ts',
     'packages/workspace/src/generators/init/init.ts',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Running `nx report` only reports the status of certain packages that are hard coded.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nx report` also lists packages that could be causing issues that are installed by the community.
In this case, packages that provide executors or dep-graph plugins could cause issues if not updated, and listing them should help identify when an issue is not caused on the nx side of things.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
