### PR TITLE
feat(core): show version number when generating a new workspace

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -128,12 +128,13 @@ if (parsedArgs.help) {
 (async function main() {
   const packageManager: PackageManager =
     parsedArgs.packageManager || detectInvokedPackageManager();
+
   const { name, cli, preset, appName, style, nxCloud } = await getConfiguration(
     parsedArgs
   );
 
   output.log({
-    title: 'Nx is creating your workspace.',
+    title: `Nx is creating your v${cliVersion} workspace.`,
     bodyLines: [
       'To make sure the command works reliably in all environments, and that the preset is applied correctly,',
       `Nx will run "${packageManager} install" several times. Please wait.`,


### PR DESCRIPTION
## Current Behavior
Running `npx create-nx-workspace` can potentially fall back to an older cached version of create-nx-workspace. If the user follows this by installing plugins, its easy to end up with mixed versions of nrwl packages, causing errors in a fresh workspace.

## Expected Behavior
The user can see which version of create-nx-workspace is used to create their workspace

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
