### PR TITLE
fix(storybook): update config to be compatible with webpack 5

### DIFF
--- a/packages/storybook/src/generators/configuration/project-files-5/.storybook/webpack.config.js__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-5/.storybook/webpack.config.js__tmpl__
@@ -56,9 +56,7 @@ module.exports = async ({ config, mode }) => {
         oneOf: [
           // If coming from JS/TS file, then transform into React component using SVGR.
           {
-            issuer: {
-              test: /\.[jt]sx?$/,
-            },
+            issuer: /\.[jt]sx?$/,
             use: [
               {
                 loader: require.resolve('@svgr/webpack'),


### PR DESCRIPTION
This PR fixes an issue with our generated webpack config for SVGR support.

## Current Behavior
Running storybook breaks due to config not matching webpack 5 format.

## Expected Behavior
Running storybook should work.
