### PR TITLE
fix(angular): fixing application generator when using protractor

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -571,10 +571,10 @@ describe('app', () => {
       it('should create the e2e project in v2 workspace', async () => {
         appTree = createTreeWithEmptyWorkspace(2);
 
-        await generateApp(appTree, 'myApp', {
+        expect(() => await generateApp(appTree, 'myApp', {
           e2eTestRunner: E2eTestRunner.Protractor,
           standaloneConfig: true,
-        });
+        })).not.toThrow();
       });
 
       it('should update workspace.json', async () => {

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -7,12 +7,11 @@ import {
   readProjectConfiguration,
   updateJson,
 } from '@nrwl/devkit';
-import type { Schema } from './schema';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
-
 import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
 import { applicationGenerator } from './application';
+import type { Schema } from './schema';
 
 describe('app', () => {
   let appTree: Tree;
@@ -569,6 +568,15 @@ describe('app', () => {
 
   describe('--e2e-test-runner', () => {
     describe(E2eTestRunner.Protractor, () => {
+      it('should create the e2e project in v2 workspace', async () => {
+        appTree = createTreeWithEmptyWorkspace(2);
+
+        await generateApp(appTree, 'myApp', {
+          e2eTestRunner: E2eTestRunner.Protractor,
+          standaloneConfig: true,
+        });
+      });
+
       it('should update workspace.json', async () => {
         await generateApp(appTree, 'myApp', {
           e2eTestRunner: E2eTestRunner.Protractor,

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -571,10 +571,13 @@ describe('app', () => {
       it('should create the e2e project in v2 workspace', async () => {
         appTree = createTreeWithEmptyWorkspace(2);
 
-        expect(() => await generateApp(appTree, 'myApp', {
-          e2eTestRunner: E2eTestRunner.Protractor,
-          standaloneConfig: true,
-        })).not.toThrow();
+        expect(
+          () =>
+            await generateApp(appTree, 'myApp', {
+              e2eTestRunner: E2eTestRunner.Protractor,
+              standaloneConfig: true,
+            })
+        ).not.toThrow();
       });
 
       it('should update workspace.json', async () => {

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -572,7 +572,7 @@ describe('app', () => {
         appTree = createTreeWithEmptyWorkspace(2);
 
         expect(
-          () =>
+          async () =>
             await generateApp(appTree, 'myApp', {
               e2eTestRunner: E2eTestRunner.Protractor,
               standaloneConfig: true,

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -10,7 +10,7 @@ import { removeScaffoldedE2e } from './remove-scaffolded-e2e';
 import { updateE2eProject } from './update-e2e-project';
 import { convertToNxProjectGenerator } from '@nrwl/workspace';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
-import { joinPathFragments } from '@nrwl/devkit';
+import { getWorkspaceLayout, joinPathFragments } from '@nrwl/devkit';
 
 /**
  * Add E2E Config
@@ -45,8 +45,11 @@ export async function addE2e(
 
   if (options.e2eTestRunner === E2eTestRunner.Protractor) {
     updateE2eProject(tree, options);
-    if (options.standaloneConfig) {
-      convertToNxProjectGenerator(tree, {
+    if (
+      options.standaloneConfig ??
+      getWorkspaceLayout(tree).standaloneAsDefault
+    ) {
+      await convertToNxProjectGenerator(tree, {
         project: `${options.e2eProjectName}`,
       });
     }

--- a/packages/angular/src/generators/application/lib/add-protractor.ts
+++ b/packages/angular/src/generators/application/lib/add-protractor.ts
@@ -1,9 +1,12 @@
-import { getWorkspaceLayout, Tree } from '@nrwl/devkit';
-import type { NormalizedSchema } from './normalized-schema';
-
-import { moveFilesToNewDirectory, joinPathFragments } from '@nrwl/devkit';
+import {
+  getWorkspaceLayout,
+  joinPathFragments,
+  moveFilesToNewDirectory,
+  Tree,
+} from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { convertToNxProjectGenerator } from '@nrwl/workspace';
+import type { NormalizedSchema } from './normalized-schema';
 
 export async function addProtractor(host: Tree, options: NormalizedSchema) {
   const protractorSchematic = wrapAngularDevkitSchematic(
@@ -15,15 +18,6 @@ export async function addProtractor(host: Tree, options: NormalizedSchema) {
     relatedAppName: options.name,
     rootSelector: `${options.prefix}-root`,
   });
-
-  if (
-    options.standaloneConfig ??
-    getWorkspaceLayout(host).standaloneAsDefault
-  ) {
-    await convertToNxProjectGenerator(host, {
-      project: options.e2eProjectName,
-    });
-  }
 
   moveFilesToNewDirectory(
     host,

--- a/packages/angular/src/generators/application/lib/add-protractor.ts
+++ b/packages/angular/src/generators/application/lib/add-protractor.ts
@@ -5,7 +5,6 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
-import { convertToNxProjectGenerator } from '@nrwl/workspace';
 import type { NormalizedSchema } from './normalized-schema';
 
 export async function addProtractor(host: Tree, options: NormalizedSchema) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating a new Angular application in an empty workspace (using v2 workspace.json format and standaloneConfig=true) the project fails to generate:

```
nx generate @nrwl/angular:application --name=sample --e2eTestRunner=protractor --standaloneConfig
```

This throws the following error:

```
Cannot find configuration for 'sample-e2e' in /workspace.json.
```

The issue seems to be that it tries to convert the project to use a standalone config before the e2e project has been created. This seems to be a duplicated step as this happens again in the same generator (after the e2e project has been created):

![image](https://user-images.githubusercontent.com/20795331/140207712-e8fc6b03-31b3-4fed-badd-64b71a49f669.png)


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The project should generate successfully.
