### PR TITLE
docs(core): move misleading migration overview page

### DIFF
--- a/docs/angular/getting-started/nx-setup.md
+++ b/docs/angular/getting-started/nx-setup.md
@@ -30,7 +30,7 @@ If you're ready to fully transform your repo into an Nx workspace, run this comm
 ng add @nrwl/workspace
 ```
 
-For more information on adding Nx to an existing repository see the [migration guides](/{{framework}}/migration/overview)
+For more information on adding Nx to an existing repository see the [migration guide](/angular/migration/migration-angular)
 
 ## Configuration
 

--- a/docs/map.json
+++ b/docs/map.json
@@ -128,11 +128,6 @@
         "id": "migration",
         "itemList": [
           {
-            "name": "Overview",
-            "id": "overview",
-            "file": "shared/migration/overview"
-          },
-          {
             "name": "From Angular CLI",
             "id": "migration-angular"
           },
@@ -149,6 +144,11 @@
             "name": "Preserving Git Histories",
             "id": "preserving-git-histories",
             "file": "shared/migration/preserving-git-histories"
+          },
+          {
+            "name": "Manual migration",
+            "id": "manual",
+            "file": "shared/migration/manual"
           }
         ]
       },
@@ -1440,11 +1440,6 @@
         "id": "migration",
         "itemList": [
           {
-            "name": "Overview",
-            "id": "overview",
-            "file": "shared/migration/overview"
-          },
-          {
             "name": "From CRA",
             "id": "migration-cra"
           },
@@ -1457,6 +1452,11 @@
             "name": "Preserving Git Histories",
             "id": "preserving-git-histories",
             "file": "shared/migration/preserving-git-histories"
+          },
+          {
+            "name": "Manual migration",
+            "id": "manual",
+            "file": "shared/migration/manual"
           }
         ]
       },
@@ -2716,11 +2716,6 @@
         "id": "migration",
         "itemList": [
           {
-            "name": "Overview",
-            "id": "overview",
-            "file": "shared/migration/overview"
-          },
-          {
             "name": "Lerna/Yarn/PNPM",
             "id": "adding-to-monorepo",
             "file": "shared/migration/adding-to-monorepo"
@@ -2729,6 +2724,11 @@
             "name": "Preserving Git Histories",
             "id": "preserving-git-histories",
             "file": "shared/migration/preserving-git-histories"
+          },
+          {
+            "name": "Manual migration",
+            "id": "manual",
+            "file": "shared/migration/manual"
           }
         ]
       },

--- a/docs/node/getting-started/nx-setup.md
+++ b/docs/node/getting-started/nx-setup.md
@@ -30,7 +30,7 @@ If you have an existing Lerna or Yarn workspaces repo, you can gain the benefits
 npx add-nx-to-monorepo
 ```
 
-For more information on adding Nx to an existing repository see the [migration guides](/{{framework}}/migration/overview)
+For more information on adding Nx to an existing repository see the [migration guide](/{{framework}}/migration/manual)
 
 ## Configuration
 

--- a/docs/react/getting-started/nx-setup.md
+++ b/docs/react/getting-started/nx-setup.md
@@ -30,7 +30,7 @@ If you have an existing Lerna or Yarn monorepo, you can gain the benefits of Nx'
 npx add-nx-to-monorepo
 ```
 
-For more information on adding Nx to an existing repository see the [migration guides](/{{framework}}/migration/overview)
+For more information on adding Nx to an existing repository see the [migration guide](/react/migration/migration-cra)
 
 ## Configuration
 

--- a/docs/shared/migration/manual.md
+++ b/docs/shared/migration/manual.md
@@ -1,4 +1,4 @@
-# Migrating existing code bases
+# Manual migration of existing code bases
 
 ## What you’ll accomplish
 

--- a/docs/shared/migration/preserving-git-histories.md
+++ b/docs/shared/migration/preserving-git-histories.md
@@ -36,4 +36,4 @@ Note that for these files, the file history of the standalone project will be no
 
 ## Using `git mv`
 
-If your standalone project was not an Nx workspace, it's likely that your migration work will also entail moving directories to match a typical Nx Workspace structure. You can find more information in the [Overview](/{{framework}}/migration/overview) page, but when migrating an existing project, you'll want to ensure that you use [`git mv`](https://git-scm.com/docs/git-mv) when moving a file or directory to ensure that file history from the old standalone repo is not lost!
+If your standalone project was not an Nx workspace, it's likely that your migration work will also entail moving directories to match a typical Nx Workspace structure. You can find more information in the [Manual migration](/{{framework}}/migration/manual) page, but when migrating an existing project, you'll want to ensure that you use [`git mv`](https://git-scm.com/docs/git-mv) when moving a file or directory to ensure that file history from the old standalone repo is not lost!

--- a/nx-dev/nx-dev/pages/angular.tsx
+++ b/nx-dev/nx-dev/pages/angular.tsx
@@ -111,9 +111,9 @@ export function AngularPage() {
                       get started by creating a modern Angular workspace with Nx
                     </a>
                     , or{' '}
-                    <Link href="/l/a/migration/overview">
+                    <Link href="/l/a/migration/migration-angular">
                       <a className="underline pointer">
-                        add it to an existing Angular workspace
+                        migrate an existing Angular workspace
                       </a>
                     </Link>{' '}
                     .
@@ -213,7 +213,7 @@ export function AngularPage() {
                 </div>
                 <p className="italic sm:text-lg my-6">
                   If you want to{' '}
-                  <Link href="/l/a/migration/overview">
+                  <Link href="/l/a/migration/migration-angular">
                     <a className="underline pointer">
                       add Nx to an existing Angular project, check out this
                       guide

--- a/nx-dev/nx-dev/pages/react.tsx
+++ b/nx-dev/nx-dev/pages/react.tsx
@@ -230,7 +230,7 @@ export function ReactPage() {
                     </a>
                   </Link>{' '}
                   or{' '}
-                  <Link href="/l/r/migration/migration-cra">
+                  <Link href="/l/r/migration/adding-to-monorepo">
                     <a className="underline pointer">
                       "Adding Nx to Yarn/Lerna monorepo" migration
                     </a>

--- a/nx-dev/nx-dev/public/documentation/latest/angular/getting-started/nx-setup.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/getting-started/nx-setup.md
@@ -30,7 +30,7 @@ If you're ready to fully transform your repo into an Nx workspace, run this comm
 ng add @nrwl/workspace
 ```
 
-For more information on adding Nx to an existing repository see the [migration guides](/{{framework}}/migration/overview)
+For more information on adding Nx to an existing repository see the [migration guide](/angular/migration/migration-angular)
 
 ## Configuration
 

--- a/nx-dev/nx-dev/public/documentation/latest/map.json
+++ b/nx-dev/nx-dev/public/documentation/latest/map.json
@@ -128,11 +128,6 @@
         "id": "migration",
         "itemList": [
           {
-            "name": "Overview",
-            "id": "overview",
-            "file": "shared/migration/overview"
-          },
-          {
             "name": "From Angular CLI",
             "id": "migration-angular"
           },
@@ -149,6 +144,11 @@
             "name": "Preserving Git Histories",
             "id": "preserving-git-histories",
             "file": "shared/migration/preserving-git-histories"
+          },
+          {
+            "name": "Manual migration",
+            "id": "manual",
+            "file": "shared/migration/manual"
           }
         ]
       },
@@ -1440,11 +1440,6 @@
         "id": "migration",
         "itemList": [
           {
-            "name": "Overview",
-            "id": "overview",
-            "file": "shared/migration/overview"
-          },
-          {
             "name": "From CRA",
             "id": "migration-cra"
           },
@@ -1457,6 +1452,11 @@
             "name": "Preserving Git Histories",
             "id": "preserving-git-histories",
             "file": "shared/migration/preserving-git-histories"
+          },
+          {
+            "name": "Manual migration",
+            "id": "manual",
+            "file": "shared/migration/manual"
           }
         ]
       },
@@ -2716,11 +2716,6 @@
         "id": "migration",
         "itemList": [
           {
-            "name": "Overview",
-            "id": "overview",
-            "file": "shared/migration/overview"
-          },
-          {
             "name": "Lerna/Yarn/PNPM",
             "id": "adding-to-monorepo",
             "file": "shared/migration/adding-to-monorepo"
@@ -2729,6 +2724,11 @@
             "name": "Preserving Git Histories",
             "id": "preserving-git-histories",
             "file": "shared/migration/preserving-git-histories"
+          },
+          {
+            "name": "Manual migration",
+            "id": "manual",
+            "file": "shared/migration/manual"
           }
         ]
       },

--- a/nx-dev/nx-dev/public/documentation/latest/node/getting-started/nx-setup.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/getting-started/nx-setup.md
@@ -30,7 +30,7 @@ If you have an existing Lerna or Yarn workspaces repo, you can gain the benefits
 npx add-nx-to-monorepo
 ```
 
-For more information on adding Nx to an existing repository see the [migration guides](/{{framework}}/migration/overview)
+For more information on adding Nx to an existing repository see the [migration guide](/{{framework}}/migration/manual)
 
 ## Configuration
 

--- a/nx-dev/nx-dev/public/documentation/latest/react/getting-started/nx-setup.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/getting-started/nx-setup.md
@@ -30,7 +30,7 @@ If you have an existing Lerna or Yarn monorepo, you can gain the benefits of Nx'
 npx add-nx-to-monorepo
 ```
 
-For more information on adding Nx to an existing repository see the [migration guides](/{{framework}}/migration/overview)
+For more information on adding Nx to an existing repository see the [migration guide](/react/migration/migration-cra)
 
 ## Configuration
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/migration/manual.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/migration/manual.md
@@ -1,4 +1,4 @@
-# Migrating existing code bases
+# Manual migration of existing code bases
 
 ## What you’ll accomplish
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/migration/preserving-git-histories.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/migration/preserving-git-histories.md
@@ -36,4 +36,4 @@ Note that for these files, the file history of the standalone project will be no
 
 ## Using `git mv`
 
-If your standalone project was not an Nx workspace, it's likely that your migration work will also entail moving directories to match a typical Nx Workspace structure. You can find more information in the [Overview](/{{framework}}/migration/overview) page, but when migrating an existing project, you'll want to ensure that you use [`git mv`](https://git-scm.com/docs/git-mv) when moving a file or directory to ensure that file history from the old standalone repo is not lost!
+If your standalone project was not an Nx workspace, it's likely that your migration work will also entail moving directories to match a typical Nx Workspace structure. You can find more information in the [Manual migration](/{{framework}}/migration/manual) page, but when migrating an existing project, you'll want to ensure that you use [`git mv`](https://git-scm.com/docs/git-mv) when moving a file or directory to ensure that file history from the old standalone repo is not lost!

--- a/nx-dev/nx-dev/public/documentation/previous/angular/getting-started/nx-setup.md
+++ b/nx-dev/nx-dev/public/documentation/previous/angular/getting-started/nx-setup.md
@@ -30,7 +30,7 @@ If you're ready to fully transform your repo into an Nx workspace, run this comm
 ng add @nrwl/workspace
 ```
 
-For more information on adding Nx to an existing repository see the [migration guides](/{{framework}}/migration/overview)
+For more information on adding Nx to an existing repository see the [migration guide](/{{framework}}/migration/migration-angular)
 
 ## Configuration
 

--- a/nx-dev/nx-dev/public/documentation/previous/map.json
+++ b/nx-dev/nx-dev/public/documentation/previous/map.json
@@ -118,11 +118,6 @@
         "id": "migration",
         "itemList": [
           {
-            "name": "Overview",
-            "id": "overview",
-            "file": "shared/migration/overview"
-          },
-          {
             "name": "From Angular CLI",
             "id": "migration-angular"
           },
@@ -139,6 +134,11 @@
             "name": "Preserving Git Histories",
             "id": "preserving-git-histories",
             "file": "shared/migration/preserving-git-histories"
+          },
+          {
+            "name": "Manual migration",
+            "id": "manual",
+            "file": "shared/migration/manual"
           }
         ]
       },
@@ -1410,11 +1410,6 @@
         "id": "migration",
         "itemList": [
           {
-            "name": "Overview",
-            "id": "overview",
-            "file": "shared/migration/overview"
-          },
-          {
             "name": "From CRA",
             "id": "migration-cra"
           },
@@ -1427,6 +1422,11 @@
             "name": "Preserving Git Histories",
             "id": "preserving-git-histories",
             "file": "shared/migration/preserving-git-histories"
+          },
+          {
+            "name": "Manual migration",
+            "id": "manual",
+            "file": "shared/migration/manual"
           }
         ]
       },
@@ -2687,11 +2687,6 @@
         "id": "migration",
         "itemList": [
           {
-            "name": "Overview",
-            "id": "overview",
-            "file": "shared/migration/overview"
-          },
-          {
             "name": "Lerna/Yarn/PNPM",
             "id": "adding-to-monorepo",
             "file": "shared/migration/adding-to-monorepo"
@@ -2700,6 +2695,11 @@
             "name": "Preserving Git Histories",
             "id": "preserving-git-histories",
             "file": "shared/migration/preserving-git-histories"
+          },
+          {
+            "name": "Manual migration",
+            "id": "manual",
+            "file": "shared/migration/manual"
           }
         ]
       },

--- a/nx-dev/nx-dev/public/documentation/previous/node/getting-started/nx-setup.md
+++ b/nx-dev/nx-dev/public/documentation/previous/node/getting-started/nx-setup.md
@@ -30,7 +30,7 @@ If you have an existing Lerna or Yarn workspaces repo, you can gain the benefits
 npx add-nx-to-monorepo
 ```
 
-For more information on adding Nx to an existing repository see the [migration guides](/{{framework}}/migration/overview)
+For more information on adding Nx to an existing repository see the [migration guide](/{{framework}}/migration/manual)
 
 ## Configuration
 

--- a/nx-dev/nx-dev/public/documentation/previous/react/getting-started/nx-setup.md
+++ b/nx-dev/nx-dev/public/documentation/previous/react/getting-started/nx-setup.md
@@ -30,7 +30,7 @@ If you have an existing Lerna or Yarn workspaces repo, you can gain the benefits
 npx add-nx-to-monorepo
 ```
 
-For more information on adding Nx to an existing repository see the [migration guides](/{{framework}}/migration/overview)
+For more information on adding Nx to an existing repository see the [migration guide](/{{framework}}/migration/migration-cra)
 
 ## Configuration
 

--- a/nx-dev/nx-dev/public/documentation/previous/shared/migration/manual.md
+++ b/nx-dev/nx-dev/public/documentation/previous/shared/migration/manual.md
@@ -1,4 +1,4 @@
-# Migrating existing code bases
+# Manual migration of existing code bases
 
 ## What you’ll accomplish
 

--- a/nx-dev/nx-dev/public/documentation/previous/shared/migration/preserving-git-histories.md
+++ b/nx-dev/nx-dev/public/documentation/previous/shared/migration/preserving-git-histories.md
@@ -36,4 +36,4 @@ Note that for these files, the file history of the standalone project will be no
 
 ## Using `git mv`
 
-If your standalone project was not an Nx workspace, it's likely that your migration work will also entail moving directories to match a typical Nx Workspace structure. You can find more information in the [Overview](/{{framework}}/migration/overview) page, but when migrating an existing project, you'll want to ensure that you use [`git mv`](https://git-scm.com/docs/git-mv) when moving a file or directory to ensure that file history from the old standalone repo is not lost!
+If your standalone project was not an Nx workspace, it's likely that your migration work will also entail moving directories to match a typical Nx Workspace structure. You can find more information in the [Manual migration](/{{framework}}/migration/manual) page, but when migrating an existing project, you'll want to ensure that you use [`git mv`](https://git-scm.com/docs/git-mv) when moving a file or directory to ensure that file history from the old standalone repo is not lost!


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Getting started migration link points to "Migration overview" which explains how to manually generate workspace and move code. Users often miss the side menu for migrating their CRA/CLI solutions.

## Expected Behavior
Getting started should point to `Migrate angular`/`Migrate CRA` depending on the flavour and overview/manual option should be the last in the menu, so that it's used as a last resort, not default migration path.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
