### PR TITLE
fix(core): fixing move generator to update all import path

### DIFF
--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -65,6 +65,7 @@ export function updateImports(
 
       visitNotIgnoredFiles(tree, definition.root, (file) => {
         const contents = tree.read(file, 'utf-8');
+        replaceProjectRef.lastIndex = 0;
         if (!replaceProjectRef.test(contents)) {
           return;
         }


### PR DESCRIPTION
There is a known issue with RegExp that exists for many years on test method, that causes test result to depend on previous calls to test method.
So if the first one matches, the second time the test is run, it will not match even if it should.
Indeed, when using the same instance of RegExp with g flag multiple times, the lastIndex of last match is kept and not reseted. So if there is a match on the first file which is done near the end of the file, for the second that should have matched at the begining because there is an occurrence of what we are looking for, it will not be found.

By reseting the last index of the regex, the test returns the correct result every time.
This issue was causing import path to be updated only on approxymately half of files.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If I have two files in directory like my-component.component.ts and my-component.component.spec.ts, both are importing the library that is being moved, only the first one read will be updated. The second one will remain with old import.

## Expected Behavior
All files that contain old import path must be updated with the new one.

## Related Issue(s)
Fixes https://github.com/nrwl/nx/issues/7610
Fix regex usage to match all old import and change it with new import path for all files.