### PR TITLE
fix(core): consider available cpus when deciding whether to use workers to build the project graph

### DIFF
--- a/packages/workspace/src/core/project-graph/build-project-graph.ts
+++ b/packages/workspace/src/core/project-graph/build-project-graph.ts
@@ -165,14 +165,16 @@ async function buildProjectGraphUsingContext(
   return r;
 }
 
-async function buildExplicitDependencies(
+function buildExplicitDependencies(
   ctx: ProjectGraphProcessorContext,
   builder: ProjectGraphBuilder
 ) {
   let totalNumOfFilesToProcess = totalNumberOfFilesToProcess(ctx);
   // using workers has an overhead, so we only do it when the number of
-  // files we need to process is >= 100
-  if (totalNumOfFilesToProcess < 100) {
+  // files we need to process is >= 100 and there are more than 2 CPUs
+  // to be able to use at least 2 workers (1 worker per CPU and
+  // 1 CPU for the main thread)
+  if (totalNumOfFilesToProcess < 100 || os.cpus().length < 3) {
     return buildExplicitDependenciesWithoutWorkers(ctx, builder);
   } else {
     return buildExplicitDependenciesUsingWorkers(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
To build the project graph for workspaces with many files, we use workers to parallelize the processing of the files. If this is done in an environment with only 1 CPU, the project graph is not constructed and the tasks are not executed. This happens because we currently don't take into account the available CPUs when deciding whether to use workers.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The project graph should be constructed correctly regardless of the number of CPUs in the environment. We should consider the available CPUs when deciding whether to use workers to build the project graph.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7536 
