### PR TITLE
fix(misc): fix dep-graph HTML generation

### DIFF
--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -285,7 +285,7 @@ export async function generateGraph(
 
       html = html.replace(/src="/g, 'src="static/');
       html = html.replace(/href="styles/g, 'href="static/styles');
-      html = html.replace('<base href="/">', '');
+      html = html.replace('<base href="/" />', '');
       html = html.replace(/type="module"/g, '');
 
       writeFileSync(fullFilePath, html);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
* When generating a dep graph output in HTML (`nx dep-graph file=index.html`), the HTML page doesn't render correctly and is non-functional
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
* When generating a dep graph output in HTML (`nx dep-graph file=index.html`), the HTML page renders and works like the served version

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
