### PR TITLE
chore(core): run workspace-lint in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,6 +219,7 @@ commands:
             - run:
                 name: Run Linting
                 command: |
+                  npx nx workspace-lint
                   npx nx affected --target=lint --base=$NX_BASE --head=$NX_HEAD --parallel --max-parallel=4
       - when:
           condition:

--- a/nx-dev/ui/sponsor-card/project.json
+++ b/nx-dev/ui/sponsor-card/project.json
@@ -1,6 +1,6 @@
 {
-  "root": "/nx-dev/ui/sponsor-card",
-  "sourceRoot": "/nx-dev/ui/sponsor-card/src",
+  "root": "nx-dev/ui/sponsor-card",
+  "sourceRoot": "nx-dev/ui/sponsor-card/src",
   "projectType": "library",
   "tags": [],
   "targets": {


### PR DESCRIPTION
I happened to spot that `workspace-lint` is failing in the repo, so this PR fixes the issue and ensures the check is run in CI.