### PR TITLE
cleanup(repo): fix id of secondary-entry-point page

### DIFF
--- a/nx-dev/nx-dev/public/documentation/latest/map.json
+++ b/nx-dev/nx-dev/public/documentation/latest/map.json
@@ -439,7 +439,7 @@
           },
           {
             "name": "library-secondary-entry-point generator",
-            "id": "library",
+            "id": "library-secondary-entry-point",
             "file": "angular/api-angular/generators/library-secondary-entry-point"
           },
           {
@@ -1747,7 +1747,7 @@
           },
           {
             "name": "library-secondary-entry-point generator",
-            "id": "library",
+            "id": "library-secondary-entry-point",
             "file": "react/api-angular/generators/library-secondary-entry-point"
           },
           {
@@ -3019,7 +3019,7 @@
           },
           {
             "name": "library-secondary-entry-point generator",
-            "id": "library",
+            "id": "library-secondary-entry-point",
             "file": "node/api-angular/generators/library-secondary-entry-point"
           },
           {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The documentation page for the `secondary-entry-point` generator is not accessible. When you click on entry, you are redirected to the `library generator` documentation.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Page is accessible, deep link is available under `nx.dev/l/a/angular/library-secondary-entry-point`


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
