### PR TITLE
fix(web): custom typescript webpack config files are now compatible f…

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -100,6 +100,7 @@
     "terser": "4.3.8",
     "terser-webpack-plugin": "^5.1.1",
     "ts-loader": "^9.2.6",
+    "ts-node": "~9.1.1",
     "tsconfig-paths": "^3.9.0",
     "tsconfig-paths-webpack-plugin": "3.4.1",
     "tslib": "^2.0.0",

--- a/packages/web/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/web/src/executors/dev-server/dev-server.impl.ts
@@ -19,6 +19,7 @@ import {
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import { getEmittedFiles, runWebpackDevServer } from '../../utils/run-webpack';
+import { tsNodeRegister } from '../../utils/webpack/tsNodeRegister';
 
 export interface WebDevServerOptions {
   host: string;
@@ -59,7 +60,12 @@ export default async function* devServerExecutor(
   );
 
   if (buildOptions.webpackConfig) {
-    webpackConfig = require(buildOptions.webpackConfig)(webpackConfig, {
+    const customWebpack = resolveCustomWebpackConfig(
+      buildOptions.webpackConfig,
+      buildOptions.tsConfig
+    );
+
+    webpackConfig = customWebpack(webpackConfig, {
       buildOptions,
       configuration: serveOptions.buildTarget.split(':')[2],
     });
@@ -121,4 +127,16 @@ function getBuildOptions(
     ...buildOptions,
     ...overrides,
   };
+}
+
+function resolveCustomWebpackConfig(path: string, tsConfig: string) {
+  tsNodeRegister(path, tsConfig);
+
+  const customWebpackConfig = require(path);
+  // If the user provides a configuration in TS file
+  // then there are 2 cases for exporing an object. The first one is:
+  // `module.exports = { ... }`. And the second one is:
+  // `export default { ... }`. The ESM format is compiled into:
+  // `{ default: { ... } }`
+  return customWebpackConfig.default || customWebpackConfig;
 }

--- a/packages/web/src/utils/webpack/tsNodeRegister.ts
+++ b/packages/web/src/utils/webpack/tsNodeRegister.ts
@@ -1,0 +1,19 @@
+export function tsNodeRegister(file: string = '', tsConfig?: string) {
+  if (!file?.endsWith('.ts')) return;
+  // Register TS compiler lazily
+  require('ts-node').register({
+    project: tsConfig,
+    compilerOptions: {
+      module: 'CommonJS',
+      types: ['node'],
+    },
+  });
+
+  // Register paths in tsConfig
+  const tsconfigPaths = require('tsconfig-paths');
+  const { absoluteBaseUrl: baseUrl, paths } =
+    tsconfigPaths.loadConfig(tsConfig);
+  if (baseUrl && paths) {
+    tsconfigPaths.register({ baseUrl, paths });
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behaviour we have today -->
Currently, when a custom typescript webpack configuration file is passed in as an option for the build executor (react applications) `nx run project:serve` fails

## Expected Behavior
<!-- This is the behaviour we should expect with the changes in this PR -->
Nx should support custom typescript webpack configs for react applications

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7454 
