### PR TITLE
docs(nxdev): updated generator doc

### DIFF
--- a/docs/shared/generators/creating-files.md
+++ b/docs/shared/generators/creating-files.md
@@ -112,8 +112,8 @@ This is my <%= uppercase(name) %>
 
 ```typescript
 // typescript file
-function uppercase(val) {
-  val.toUppercase();
+function uppercase(val: string) {
+  return val.toUpperCase();
 }
 
 // later

--- a/nx-dev/nx-dev/public/documentation/latest/shared/generators/creating-files.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/generators/creating-files.md
@@ -112,8 +112,8 @@ This is my <%= uppercase(name) %>
 
 ```typescript
 // typescript file
-function uppercase(val) {
-  val.toUppercase();
+function uppercase(val: string) {
+  return val.toUpperCase();
 }
 
 // later

--- a/nx-dev/nx-dev/public/documentation/previous/shared/generators/creating-files.md
+++ b/nx-dev/nx-dev/public/documentation/previous/shared/generators/creating-files.md
@@ -112,8 +112,8 @@ This is my <%= uppercase(name) %>
 
 ```typescript
 // typescript file
-function uppercase(val) {
-  val.toUppercase();
+function uppercase(val: string) {
+  return val.toUpperCase();
 }
 
 // later


### PR DESCRIPTION
Adjusted function `uppercase` to a valid typescript function.

`return` keyword was missing in the example.

`toUppercase` -> toUpper**C**ase

`val:string`