### PR TITLE
fix(core): prettier should be marked as optional

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -55,6 +55,11 @@
   "peerDependencies": {
     "prettier": "^2.3.0"
   },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@parcel/watcher": "2.0.0-alpha.11",
     "@nrwl/cli": "*",


### PR DESCRIPTION
NPM v7+ auto-installs missing peer deps, but supports peerDependenciesMeta to mark them as optional.

## Current Behavior
prettier is auto-installed

## Expected Behavior
prettier can be removed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7421