### PR TITLE
fix(node): nrwl/node:package should support dotfile assets

### DIFF
--- a/packages/node/src/executors/package/schema.json
+++ b/packages/node/src/executors/package/schema.json
@@ -97,6 +97,11 @@
             "output": {
               "type": "string",
               "description": "Absolute path within the output."
+            },
+            "dot": {
+              "type": "boolean",
+              "description": "Whether or not files beginning with '.' should be included. Defaults to false",
+              "default": false
             }
           },
           "additionalProperties": false,


### PR DESCRIPTION
## Current Behavior
@nrwl/node:package fails if you add `dot` property to an asset glob

## Expected Behavior
@nrwl/node:package copies dotfiles if `dot` is specified
