### PR TITLE
fix(misc): @nrwl/workspace:init should add .prettierignore correctly

### DIFF
--- a/packages/node/src/executors/package/schema.json
+++ b/packages/node/src/executors/package/schema.json
@@ -97,6 +97,11 @@
             "output": {
               "type": "string",
               "description": "Absolute path within the output."
+            },
+            "dot": {
+              "type": "boolean",
+              "description": "Wether or not files beginning with '.' should be included. Defaults to false",
+              "default": false
             }
           },
           "additionalProperties": false,

--- a/packages/node/src/executors/package/schema.json
+++ b/packages/node/src/executors/package/schema.json
@@ -97,11 +97,6 @@
             "output": {
               "type": "string",
               "description": "Absolute path within the output."
-            },
-            "dot": {
-              "type": "boolean",
-              "description": "Wether or not files beginning with '.' should be included. Defaults to false",
-              "default": false
             }
           },
           "additionalProperties": false,

--- a/packages/workspace/project.json
+++ b/packages/workspace/project.json
@@ -28,6 +28,11 @@
           },
           {
             "input": "packages/workspace",
+            "glob": "**/files/**/.prettierignore",
+            "output": "/"
+          },
+          {
+            "input": "packages/workspace",
             "glob": "**/files/**/.gitkeep",
             "output": "/"
           },


### PR DESCRIPTION
Current Behavior
@nrwl/workspace:init fails if .prettierignore doesn't exist

Expected Behavior
@nrwl/workspace:init creates .prettierignore if it doesn't exist

Related Issue(s)
Fixes #7651