### PR TITLE
fix(dep-graph): stop search depth from going below 1

### DIFF
--- a/dep-graph/dep-graph/src/app/machines/dep-graph.machine.ts
+++ b/dep-graph/dep-graph/src/app/machines/dep-graph.machine.ts
@@ -111,13 +111,6 @@ export const depGraphMachine = Machine<
           }),
         ],
       },
-      setSearchDepth: {
-        actions: [
-          assign((ctx, event) => {
-            ctx.searchDepth = event.searchDepth;
-          }),
-        ],
-      },
       incrementSearchDepth: {
         actions: [
           assign((ctx) => {
@@ -128,7 +121,7 @@ export const depGraphMachine = Machine<
       decrementSearchDepth: {
         actions: [
           assign((ctx) => {
-            ctx.searchDepth = ctx.searchDepth - 1;
+            ctx.searchDepth = ctx.searchDepth > 1 ? ctx.searchDepth - 1 : 1;
           }),
         ],
       },

--- a/dep-graph/dep-graph/src/app/machines/dep-graph.spec.ts
+++ b/dep-graph/dep-graph/src/app/machines/dep-graph.spec.ts
@@ -256,5 +256,129 @@ describe('dep-graph machine', () => {
       expect(result.value).toEqual('unselected');
       expect(result.context.selectedProjects).toEqual([]);
     });
+
+    it('should not decrement search depth below 1', () => {
+      let result = depGraphMachine.transition(depGraphMachine.initialState, {
+        type: 'initGraph',
+        projects: mockProjects,
+        dependencies: mockDependencies,
+        affectedProjects: [],
+        workspaceLayout: { appsDir: 'apps', libsDir: 'libs' },
+      });
+
+      result = depGraphMachine.transition(result, {
+        type: 'focusProject',
+        projectName: 'app1',
+      });
+
+      expect(result.context.searchDepth).toEqual(1);
+
+      result = depGraphMachine.transition(result, {
+        type: 'incrementSearchDepth',
+      });
+
+      expect(result.context.searchDepth).toEqual(2);
+
+      result = depGraphMachine.transition(result, {
+        type: 'incrementSearchDepth',
+      });
+
+      result = depGraphMachine.transition(result, {
+        type: 'incrementSearchDepth',
+      });
+
+      expect(result.context.searchDepth).toEqual(4);
+
+      result = depGraphMachine.transition(result, {
+        type: 'decrementSearchDepth',
+      });
+
+      result = depGraphMachine.transition(result, {
+        type: 'decrementSearchDepth',
+      });
+
+      expect(result.context.searchDepth).toEqual(2);
+
+      result = depGraphMachine.transition(result, {
+        type: 'decrementSearchDepth',
+      });
+
+      expect(result.context.searchDepth).toEqual(1);
+
+      result = depGraphMachine.transition(result, {
+        type: 'decrementSearchDepth',
+      });
+
+      expect(result.context.searchDepth).toEqual(1);
+
+      result = depGraphMachine.transition(result, {
+        type: 'decrementSearchDepth',
+      });
+
+      expect(result.context.searchDepth).toEqual(1);
+    });
+  });
+
+  describe('filtering projects by text', () => {
+    it('should not decrement search depth below 1', () => {
+      let result = depGraphMachine.transition(depGraphMachine.initialState, {
+        type: 'initGraph',
+        projects: mockProjects,
+        dependencies: mockDependencies,
+        affectedProjects: [],
+        workspaceLayout: { appsDir: 'apps', libsDir: 'libs' },
+      });
+
+      result = depGraphMachine.transition(result, {
+        type: 'filterByText',
+        search: 'app1',
+      });
+
+      expect(result.context.searchDepth).toEqual(1);
+
+      result = depGraphMachine.transition(result, {
+        type: 'incrementSearchDepth',
+      });
+
+      expect(result.context.searchDepth).toEqual(2);
+
+      result = depGraphMachine.transition(result, {
+        type: 'incrementSearchDepth',
+      });
+
+      result = depGraphMachine.transition(result, {
+        type: 'incrementSearchDepth',
+      });
+
+      expect(result.context.searchDepth).toEqual(4);
+
+      result = depGraphMachine.transition(result, {
+        type: 'decrementSearchDepth',
+      });
+
+      result = depGraphMachine.transition(result, {
+        type: 'decrementSearchDepth',
+      });
+
+      expect(result.context.searchDepth).toEqual(2);
+
+      result = depGraphMachine.transition(result, {
+        type: 'decrementSearchDepth',
+      });
+
+      expect(result.context.searchDepth).toEqual(1);
+
+      result = depGraphMachine.transition(result, {
+        type: 'decrementSearchDepth',
+      });
+
+      expect(result.context.searchDepth).toEqual(1);
+
+      result = depGraphMachine.transition(result, {
+        type: 'decrementSearchDepth',
+      });
+
+      expect(result.context.searchDepth).toEqual(1);
+    });
   });
 });

--- a/dep-graph/dep-graph/src/app/machines/focused.state.ts
+++ b/dep-graph/dep-graph/src/app/machines/focused.state.ts
@@ -40,7 +40,7 @@ export const focusedStateConfig: DepGraphStateNodeConfig = {
     decrementSearchDepth: {
       actions: [
         assign((ctx) => {
-          const searchDepth = ctx.searchDepth - 1;
+          const searchDepth = ctx.searchDepth > 1 ? ctx.searchDepth - 1 : 1;
           const selectedProjects = selectProjectsForFocusedProject(
             ctx.projects,
             ctx.dependencies,

--- a/dep-graph/dep-graph/src/app/machines/interfaces.ts
+++ b/dep-graph/dep-graph/src/app/machines/interfaces.ts
@@ -22,7 +22,6 @@ export type DepGraphEvents =
   | { type: 'selectAffected' }
   | { type: 'setGroupByFolder'; groupByFolder: boolean }
   | { type: 'setIncludeProjectsByPath'; includeProjectsByPath: boolean }
-  | { type: 'setSearchDepth'; searchDepth: number }
   | { type: 'incrementSearchDepth' }
   | { type: 'decrementSearchDepth' }
   | { type: 'setSearchDepthEnabled'; searchDepthEnabled: boolean }

--- a/dep-graph/dep-graph/src/app/machines/text-filtered.state.ts
+++ b/dep-graph/dep-graph/src/app/machines/text-filtered.state.ts
@@ -37,17 +37,35 @@ export const textFilteredStateConfig: DepGraphStateNodeConfig = {
         }),
       ],
     },
-    setSearchDepth: {
+    incrementSearchDepth: {
       actions: [
-        assign((ctx, event) => {
-          ctx.searchDepth = event.searchDepth;
+        assign((ctx) => {
+          const searchDepth = ctx.searchDepth + 1;
           ctx.selectedProjects = filterProjectsByText(
             ctx.textFilter,
             ctx.includePath,
-            ctx.searchDepthEnabled ? event.searchDepth : -1,
+            ctx.searchDepthEnabled ? searchDepth : -1,
             ctx.projects,
             ctx.dependencies
           );
+
+          ctx.searchDepth = searchDepth;
+        }),
+      ],
+    },
+    decrementSearchDepth: {
+      actions: [
+        assign((ctx) => {
+          const searchDepth = ctx.searchDepth > 1 ? ctx.searchDepth - 1 : 1;
+          ctx.selectedProjects = filterProjectsByText(
+            ctx.textFilter,
+            ctx.includePath,
+            ctx.searchDepthEnabled ? searchDepth : -1,
+            ctx.projects,
+            ctx.dependencies
+          );
+
+          ctx.searchDepth = searchDepth;
         }),
       ],
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
* search depth in dep graph can go below 1
<!-- This is the behavior we have today -->

## Expected Behavior
* search depth in dep graph cannot go below 1

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
