### PR TITLE
fix(angular): ignore unmatching jest configs

### DIFF
--- a/packages/angular/src/migrations/update-13-2-0/update-angular-jest-config.spec.ts
+++ b/packages/angular/src/migrations/update-13-2-0/update-angular-jest-config.spec.ts
@@ -195,4 +195,47 @@ transform: {
 transformIgnorePatterns: ['node_modules/(?!.*(@angular))'],
 };`);
   });
+
+  it('should not transform contents of unmatching configs', () => {
+    // ARRANGE
+    const jestConfig = `module.exports = {
+      preset: '../../jest.preset.js',
+      coverageDirectory: '../../coverage/libs/common-platform',
+      setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+      globals: {
+        'ts-jest': {
+          stringifyContentPathRegex: '\\\\.(html|svg)$',
+          astTransformers: [
+            'jest-preset-angular/build/InlineFilesTransformer',
+            'jest-preset-angular/build/StripStylesTransformer',
+          ],
+          tsconfig: '<rootDir>/tsconfig.spec.json',
+        },
+      },
+      displayName: 'common-platform',
+    };
+    `;
+
+    // ACT
+    const updatedFile = replaceTransformAndAddIgnorePattern(jestConfig);
+
+    // ASSERT
+    expect(updatedFile).toEqual(`module.exports = {
+      preset: '../../jest.preset.js',
+      coverageDirectory: '../../coverage/libs/common-platform',
+      setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+      globals: {
+        'ts-jest': {
+          stringifyContentPathRegex: '\\\\.(html|svg)$',
+          astTransformers: [
+            'jest-preset-angular/build/InlineFilesTransformer',
+            'jest-preset-angular/build/StripStylesTransformer',
+          ],
+          tsconfig: '<rootDir>/tsconfig.spec.json',
+        },
+      },
+      displayName: 'common-platform',
+    };
+    `);
+  });
 });

--- a/packages/angular/src/migrations/update-13-2-0/update-angular-jest-config.ts
+++ b/packages/angular/src/migrations/update-13-2-0/update-angular-jest-config.ts
@@ -57,6 +57,10 @@ export function replaceTransformAndAddIgnorePattern(fileContents: string) {
     }
   )[0] as Node;
 
+  if (!transformerExpressionNode) {
+    return fileContents;
+  }
+
   const transformerIndex = transformerExpressionNode.pos;
   const transformerEndIndex = transformerExpressionNode.end;
 
@@ -75,6 +79,10 @@ export function replaceTransformAndAddIgnorePattern(fileContents: string) {
   const transformObjectNode = tsquery(ast, TRANSFORM_OBJECT_AST_QUERY, {
     visitAllChildren: true,
   })[0] as PropertyAssignment;
+
+  if (!transformObjectNode) {
+    return updatedFileContents;
+  }
 
   let transformEndIndex = transformObjectNode.getEnd();
   if (updatedFileContents.charAt(transformEndIndex) == ',') {


### PR DESCRIPTION

## Current Behavior
Migration is trying to process jest configs that do not match the conditions needed for AST transformation

## Expected Behavior
Ignoring unmatching jest configs

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
