### PR TITLE
fix(angular): migration versions

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -99,25 +99,25 @@
     },
     "update-angular-config": {
       "cli": "nx",
-      "version": "13.2.0",
+      "version": "13.2.0-bata.1",
       "description": "Remove deprecated options from webpack-server and webpack-browser.",
       "factory": "./src/migrations/update-13-2-0/update-angular-config"
     },
     "update-libraries": {
       "cli": "nx",
-      "version": "13.2.0",
+      "version": "13.2.0-bata.1",
       "description": "Remove enableIvy and add compilationMode to library tsconfig and remove deprecated ng-packagr options.",
       "factory": "./src/migrations/update-13-2-0/update-libraries"
     },
     "update-angular-jest-config": {
       "cli": "nx",
-      "version": "13.2.0",
+      "version": "13.2.0-bata.1",
       "description": "Update jest config to support jest-preset-angular",
       "factory": "./src/migrations/update-13-2-0/update-angular-jest-config"
     },
     "update-testing-imports": {
       "cli": "nx",
-      "version": "13.2.0",
+      "version": "13.2.0-bata.1",
       "description": "Move some imports from @nrwl/angular/testing to jasmine-marbles",
       "factory": "./src/migrations/update-13-2-0/update-testing-imports"
     }


### PR DESCRIPTION

## Current Behavior
Migrations arent being picked up as they're targeting a stable release of Nx

## Expected Behavior
Point the migrations to pre-release version

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
