### PR TITLE
fix(angular): do not ignore any mjs files for jest

### DIFF
--- a/packages/angular/src/migrations/update-13-2-0/__snapshots__/update-angular-jest-config.spec.ts.snap
+++ b/packages/angular/src/migrations/update-13-2-0/__snapshots__/update-angular-jest-config.spec.ts.snap
@@ -15,7 +15,7 @@ exports[`update-angular-jest-config migration should migrate the jest config 1`]
         transform: {
 '^.+\\\\.(ts|mjs|js|html)$': 'jest-preset-angular',
         },
-transformIgnorePatterns: ['node_modules/(?!.*(@angular))'],
+transformIgnorePatterns: ['node_modules/(?!.*\\\\.mjs$)'],
         snapshotSerializers: [
           'jest-preset-angular/build/serializers/no-ng-attributes',
           'jest-preset-angular/build/serializers/ng-snapshot',

--- a/packages/angular/src/migrations/update-13-2-0/update-angular-jest-config.spec.ts
+++ b/packages/angular/src/migrations/update-13-2-0/update-angular-jest-config.spec.ts
@@ -93,7 +93,7 @@ coverageDirectory: '../../coverage/apps/app1',
 transform: {
 '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
 },
-transformIgnorePatterns: ['node_modules/(?!.*(@angular))'],
+transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
 snapshotSerializers: [
   'jest-preset-angular/build/serializers/no-ng-attributes',
   'jest-preset-angular/build/serializers/ng-snapshot',
@@ -145,7 +145,7 @@ transform: {
 '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
 '^.+\\.(json)$': 'json_transformer',
 },
-transformIgnorePatterns: ['node_modules/(?!.*(@angular))'],
+transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
 snapshotSerializers: [
   'jest-preset-angular/build/serializers/no-ng-attributes',
   'jest-preset-angular/build/serializers/ng-snapshot',
@@ -192,7 +192,7 @@ transform: {
 '^.+\\.(json)$': 'json_transformer',
 '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
 },
-transformIgnorePatterns: ['node_modules/(?!.*(@angular))'],
+transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
 };`);
   });
 

--- a/packages/angular/src/migrations/update-13-2-0/update-angular-jest-config.ts
+++ b/packages/angular/src/migrations/update-13-2-0/update-angular-jest-config.ts
@@ -72,7 +72,7 @@ export function replaceTransformAndAddIgnorePattern(fileContents: string) {
   const TRANSFORM_OBJECT_AST_QUERY =
     'PropertyAssignment:has(Identifier[name=transform])';
   let TRANSFORM_IGNORE_PATTERN_STRING =
-    "transformIgnorePatterns: ['node_modules/(?!.*(@angular))'],";
+    "transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],";
 
   ast = tsquery.ast(updatedFileContents);
 

--- a/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
+++ b/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
@@ -41,7 +41,7 @@ exports[`jestProject --setup-file should have setupFilesAfterEnv and globals.ts-
   transform: {
     '^.+\\\\\\\\.(ts|mjs|js|html)$': 'jest-preset-angular'
   },
-  transformIgnorePatterns: ['node_modules/(?!.*(@angular))'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\\\\\\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/packages/jest/src/generators/jest-project/files-angular/jest.config.js__tmpl__
+++ b/packages/jest/src/generators/jest-project/files-angular/jest.config.js__tmpl__
@@ -18,7 +18,7 @@ module.exports = {
   transform: {
     '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular'
   },
-  transformIgnorePatterns: ['node_modules/(?!.*(@angular))']<% if(!skipSerializers) { %>,
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)']<% if(!skipSerializers) { %>,
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Only `@angular` `node_modules` are processed by `jest-preset-angular`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The new Angular Package Format for Angular 13 ships esm modules... so many libraries may be published with `.mjs` files that need processing. The new pattern matches any `.mjs` files in `node_modules`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
