### PR TITLE
fix(react): install missing react-test-renderer dependency

### DIFF
--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -21,6 +21,7 @@ import {
   typesReactDomVersion,
   typesReactVersion,
   testingLibraryReactHooksVersion,
+  reactTestRendererVersion,
 } from '../../utils/versions';
 
 function setDefault(host: Tree) {
@@ -66,6 +67,7 @@ function updateDependencies(host: Tree) {
       '@types/react-dom': typesReactDomVersion,
       '@testing-library/react': testingLibraryReactVersion,
       '@testing-library/react-hooks': testingLibraryReactHooksVersion,
+      'react-test-renderer': reactTestRendererVersion,
     }
   );
 }

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -25,6 +25,7 @@ export const testingLibraryReactHooksVersion = '7.0.2';
 
 export const reduxjsToolkitVersion = '1.6.2';
 export const reactReduxVersion = '7.2.5';
+export const reactTestRendererVersion = '17.0.2';
 
 export const eslintPluginImportVersion = '2.25.2';
 export const eslintPluginJsxA11yVersion = '6.4.1';


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently when you install `@nrwl/react` you don't get `react-test-renderer` which is divergent from the official documentation.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
 `react-test-renderer` is also installed as per official react documentation.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7578
