### PR TITLE
fix(jest): fix resolver to try using default resolution before using …

### DIFF
--- a/packages/jest/plugins/resolver.ts
+++ b/packages/jest/plugins/resolver.ts
@@ -48,15 +48,20 @@ module.exports = function (path: string, options: ResolveOptions) {
   ) {
     return require.resolve('identity-obj-proxy');
   }
-  // Try to use the defaultResolver
   try {
-    return options.defaultResolver(path, {
-      ...options,
-      packageFilter: (pkg) => ({
-        ...pkg,
-        main: pkg.main || pkg.es2015 || pkg.module,
-      }),
-    });
+    try {
+      // Try to use the defaultResolver with default options
+      return options.defaultResolver(path, options);
+    } catch {
+      // Try to use the defaultResolver with a packageFilter
+      return options.defaultResolver(path, {
+        ...options,
+        packageFilter: (pkg) => ({
+          ...pkg,
+          main: pkg.main || pkg.es2015 || pkg.module,
+        }),
+      });
+    }
   } catch (e) {
     if (
       path === 'jest-sequencer-@jest/test-sequencer' ||


### PR DESCRIPTION
…a package filter

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Changes to the resolver to work with Angular 13 made it fail for packages like `@heroicons/react`. The resolver used to pick up non-ESM modules from `@heroicons/react` just fine.. but with the package filter, it began to pick up ESM modules without transforming them. :boom: 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The resolver should still use the default Resolver with the default options.. before falling back to using the package filter... and finally it should fallback to typescript.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
