### PR TITLE
fix(angular): add .angular to gitignore only when it hasn't already been added

### DIFF
--- a/packages/angular/src/generators/init/init.spec.ts
+++ b/packages/angular/src/generators/init/init.spec.ts
@@ -327,6 +327,30 @@ describe('init', () => {
       skipFormat: false,
     });
 
-    expect(host.read('.gitignore').toString()).toContain('.angular');
+    expect(host.read('.gitignore', 'utf-8')).toContain('.angular');
+  });
+
+  it('should not add .angular to gitignore when it already exists', async () => {
+    host.write(
+      '.gitignore',
+      `foo
+bar
+
+.angular
+
+`
+    );
+
+    await init(host, {
+      unitTestRunner: UnitTestRunner.Jest,
+      e2eTestRunner: E2eTestRunner.Cypress,
+      linter: Linter.EsLint,
+      skipFormat: false,
+    });
+
+    const angularEntries = host
+      .read('.gitignore', 'utf-8')
+      .match(/^.angular$/gm);
+    expect(angularEntries).toHaveLength(1);
   });
 });

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -147,9 +147,14 @@ function addE2ETestRunner(
       return () => {};
   }
 }
+
 function addGitIgnoreEntry(host: Tree, entry: string) {
   if (host.exists('.gitignore')) {
     let content = host.read('.gitignore', 'utf-8');
+    if (/^\.angular$/gm.test(content)) {
+      return;
+    }
+
     content = `${content}\n${entry}\n`;
     host.write('.gitignore', content);
   } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Whenever an Angular project (app or lib) is created, a new entry for `.angular` is added in the `.gitignore` file.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `.angular` entry should be added just once to the `.gitignore` file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
