### PR TITLE
fix(testing): update tsconfig migration to not warn when no file found

### DIFF
--- a/packages/jest/src/migrations/update-13-1-2/update-tsconfigs-for-tests.spec.ts
+++ b/packages/jest/src/migrations/update-13-1-2/update-tsconfigs-for-tests.spec.ts
@@ -13,7 +13,13 @@ const reactTsConfigs = {
       '../../node_modules/@nrwl/react/typings/cssmodule.d.ts',
       '../../node_modules/@nrwl/react/typings/image.d.ts',
     ],
-    exclude: ['**/*.spec.ts', '**/*.spec.tsx', '**/*.spec.js', '**/*.spec.jsx'],
+    exclude: [
+      '**/*.spec.ts',
+      '**/*_spec.ts',
+      '**/*.spec.tsx',
+      '**/*.spec.js',
+      '**/*.spec.jsx',
+    ],
     include: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'],
   },
   lib: {
@@ -26,7 +32,13 @@ const reactTsConfigs = {
       '../../node_modules/@nrwl/react/typings/cssmodule.d.ts',
       '../../node_modules/@nrwl/react/typings/image.d.ts',
     ],
-    exclude: ['**/*.spec.ts', '**/*.spec.tsx', '**/*.spec.js', '**/*.spec.jsx'],
+    exclude: [
+      '**/*.spec.ts',
+      '**/*_spec.ts',
+      '**/*.spec.tsx',
+      '**/*.spec.js',
+      '**/*.spec.jsx',
+    ],
     include: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'],
   },
   spec: {
@@ -38,6 +50,7 @@ const reactTsConfigs = {
     },
     include: [
       '**/*.spec.ts',
+      '**/*_spec.ts',
       '**/*.spec.tsx',
       '**/*.spec.js',
       '**/*.spec.jsx',
@@ -66,6 +79,8 @@ const reactTsConfigs = {
   expectedFilesToContain: [
     '**/*.spec.ts',
     '**/*.test.ts',
+    '**/*_spec.ts',
+    '**/*_test.ts',
     '**/*.spec.tsx',
     '**/*.test.tsx',
     '**/*.spec.js',
@@ -83,7 +98,7 @@ const angularTsConfigs = {
     },
     files: ['src/main.ts', 'src/polyfills.ts'],
     include: ['src/**/*.d.ts'],
-    exclude: ['**/*.spec.ts'],
+    exclude: ['**/*.spec.ts', '**/*_spec.ts'],
   },
   lib: {
     extends: './tsconfig.json',
@@ -107,9 +122,14 @@ const angularTsConfigs = {
       types: ['jest', 'node'],
     },
     files: ['src/test-setup.ts'],
-    include: ['**/*.spec.ts', '**/*.d.ts'],
+    include: ['**/*.spec.ts', '**/*_spec.ts', '**/*.d.ts'],
   },
-  expectedFilesToContain: ['**/*.spec.ts', '**/*.test.ts'],
+  expectedFilesToContain: [
+    '**/*.spec.ts',
+    '**/*.test.ts',
+    '**/*_spec.ts',
+    '**/*_test.ts',
+  ],
 };
 
 const tsConfigLibBase = {

--- a/packages/jest/src/migrations/update-13-1-2/update-tsconfigs-for-tests.spec.ts
+++ b/packages/jest/src/migrations/update-13-1-2/update-tsconfigs-for-tests.spec.ts
@@ -156,6 +156,9 @@ const tsConfigAppBase = {
     },
   ],
 };
+const tsConfigWithExclude = {
+  exclude: ['**/*.spec.ts', '**/*_spec.ts'],
+};
 
 [
   // test TSX/JSX support
@@ -262,6 +265,32 @@ const tsConfigAppBase = {
       expect(tsLibConfig.exclude).toEqual(
         expect.arrayContaining(configs.expectedFilesToContain)
       );
+    });
+
+    it('should not update tsconfig without spec. patterns for include or exclude', async () => {
+      await update(tree);
+      const tsConfig = JSON.parse(
+        tree.read('apps/project-one/tsconfig.json', 'utf-8')
+      );
+      expect(tsConfig).toEqual(tsConfigAppBase);
+    });
+
+    it('should update any tsconfig with spec pattern for include or exclude', async () => {
+      tree.write(
+        'apps/project-one/tsconfig.random.json',
+        String.raw`${JSON.stringify(tsConfigWithExclude, null, 2)}`
+      );
+      await update(tree);
+
+      const randomTsConfig = JSON.parse(
+        tree.read('apps/project-one/tsconfig.random.json', 'utf-8')
+      );
+      expect(randomTsConfig.exclude).toEqual([
+        '**/*.spec.ts',
+        '**/*.test.ts',
+        '**/*_spec.ts',
+        '**/*_test.ts',
+      ]);
     });
   });
 });

--- a/packages/jest/src/migrations/update-13-1-2/update-tsconfigs-for-tests.spec.ts
+++ b/packages/jest/src/migrations/update-13-1-2/update-tsconfigs-for-tests.spec.ts
@@ -48,6 +48,21 @@ const reactTsConfigs = {
       '../../node_modules/@nrwl/react/typings/image.d.ts',
     ],
   },
+  base: {
+    include: [],
+    files: [],
+    references: [
+      {
+        path: './tsconfig.app.json',
+      },
+      {
+        path: './tsconfig.lib.json',
+      },
+      {
+        path: './tsconfig.spec.json',
+      },
+    ],
+  },
   expectedFilesToContain: [
     '**/*.spec.ts',
     '**/*.test.ts',
@@ -96,6 +111,32 @@ const angularTsConfigs = {
   },
   expectedFilesToContain: ['**/*.spec.ts', '**/*.test.ts'],
 };
+
+const tsConfigLibBase = {
+  include: [],
+  files: [],
+  references: [
+    {
+      path: './tsconfig.lib.json',
+    },
+    {
+      path: './tsconfig.spec.json',
+    },
+  ],
+};
+const tsConfigAppBase = {
+  include: [],
+  files: [],
+  references: [
+    {
+      path: './tsconfig.app.json',
+    },
+    {
+      path: './tsconfig.spec.json',
+    },
+  ],
+};
+
 [
   // test TSX/JSX support
   { name: 'React App', configs: reactTsConfigs },
@@ -116,12 +157,20 @@ const angularTsConfigs = {
         String.raw`${JSON.stringify(configs.spec, null, 2)}`
       );
       tree.write(
+        `apps/project-one/tsconfig.json`,
+        String.raw`${JSON.stringify(tsConfigAppBase, null, 2)}`
+      );
+      tree.write(
         'libs/lib-one/tsconfig.lib.json',
         String.raw`${JSON.stringify(configs.lib, null, 2)}`
       );
       tree.write(
         'libs/lib-one/tsconfig.spec.json',
         String.raw`${JSON.stringify(configs.spec, null, 2)}`
+      );
+      tree.write(
+        `libs/lib-one/tsconfig.json`,
+        String.raw`${JSON.stringify(tsConfigLibBase, null, 2)}`
       );
 
       addProjectConfiguration(tree, 'lib-one', {

--- a/packages/jest/src/migrations/update-13-1-2/update-tsconfigs-for-tests.ts
+++ b/packages/jest/src/migrations/update-13-1-2/update-tsconfigs-for-tests.ts
@@ -83,8 +83,9 @@ function makeAllPatternsFromSpecPatterns(
   return makeUniquePatterns(
     specGlobs.reduce((patterns, current) => {
       patterns.push(current);
-      if (current.includes('.spec.')) {
-        patterns.push(current.replace('.spec.', '.test.'));
+      // .spec. and _spec. can used as testing file name patterns
+      if (current.includes('spec.')) {
+        patterns.push(current.replace('spec.', 'test.'));
       }
       return patterns;
     }, [])

--- a/packages/jest/src/migrations/update-13-1-2/update-tsconfigs-for-tests.ts
+++ b/packages/jest/src/migrations/update-13-1-2/update-tsconfigs-for-tests.ts
@@ -2,10 +2,11 @@ import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-o
 import { JestExecutorOptions } from '@nrwl/jest/src/executors/jest/schema';
 import {
   formatFiles,
-  joinPathFragments,
   readProjectConfiguration,
   Tree,
+  visitNotIgnoredFiles,
 } from '@nrwl/devkit';
+import { basename } from 'path';
 
 function updateTsConfigsForTests(tree: Tree) {
   forEachExecutorOptions<JestExecutorOptions>(
@@ -14,62 +15,54 @@ function updateTsConfigsForTests(tree: Tree) {
     (jestOptions, projectName) => {
       const projectConfig = readProjectConfiguration(tree, projectName);
 
-      const tsConfig = joinPathFragments(projectConfig.root, 'tsconfig.json');
-
-      if (!tree.exists(tsConfig)) {
-        return;
-      }
-
-      const tsConfigContent: TsConfig = JSON.parse(
-        tree.read(tsConfig, 'utf-8')
-      );
-
-      const specTsConfigRef = tsConfigContent?.references.find((ref) =>
-        ref.path.endsWith('tsconfig.spec.json')
-      );
-
-      const appLibTsConfigRefs = tsConfigContent?.references.filter(
-        (ref) =>
-          ref.path.endsWith('tsconfig.app.json') ||
-          ref.path.endsWith('tsconfig.lib.json')
-      );
-
-      if (!specTsConfigRef || appLibTsConfigRefs?.length === 0) {
-        // couldn't find any files to update. just leave it be.
-        return;
-      }
-
-      for (const config of appLibTsConfigRefs) {
-        const tsConfigPath = joinPathFragments(projectConfig.root, config.path);
-        updateTsConfigExclude(tree, tsConfigPath);
-      }
-
-      const tsconfigSpecPath = joinPathFragments(
-        projectConfig.root,
-        specTsConfigRef.path
-      );
-      updateTsConfigInclude(tree, tsconfigSpecPath);
+      visitNotIgnoredFiles(tree, projectConfig.root, (path) => {
+        const fileName = basename(path);
+        if (fileName.startsWith('tsconfig.') && fileName.endsWith('.json')) {
+          updateTsConfigInclude(tree, path);
+          updateTsConfigExclude(tree, path);
+        }
+      });
     }
   );
 
   /**
    * will update the TSConfig file pass in exclude property to include .test. patterns
    * where .spec. patterns are found.
+   * will not update if exclude property is not present.
    */
   function updateTsConfigExclude(tree: Tree, tsConfigPath: string) {
-    const appConfig = JSON.parse(tree.read(tsConfigPath, 'utf-8'));
-    appConfig.exclude = makeAllPatternsFromSpecPatterns(appConfig.exclude);
-    tree.write(tsConfigPath, JSON.stringify(appConfig));
+    try {
+      const appConfig = JSON.parse(tree.read(tsConfigPath, 'utf-8'));
+      if (appConfig.exclude) {
+        appConfig.exclude = makeAllPatternsFromSpecPatterns(
+          appConfig.exclude || []
+        );
+        tree.write(tsConfigPath, JSON.stringify(appConfig));
+      }
+    } catch (error) {
+      // issue trying to parse the tsconfig file bc it's invalid JSON from template markup/comments
+      // ignore and move on
+    }
   }
 
   /**
    * will update the TSConfig file pass in include property to include .test. patterns
    * where .spec. patterns are found.
+   * will not update if include property is not present.
    */
   function updateTsConfigInclude(tree: Tree, tsconfigSpecPath: string) {
-    const specConfig = JSON.parse(tree.read(tsconfigSpecPath, 'utf-8'));
-    specConfig.include = makeAllPatternsFromSpecPatterns(specConfig.include);
-    tree.write(tsconfigSpecPath, JSON.stringify(specConfig));
+    try {
+      const specConfig = JSON.parse(tree.read(tsconfigSpecPath, 'utf-8'));
+      if (specConfig.include) {
+        specConfig.include = makeAllPatternsFromSpecPatterns(
+          specConfig.include
+        );
+        tree.write(tsconfigSpecPath, JSON.stringify(specConfig));
+      }
+    } catch (error) {
+      // issue trying to parse the tsconfig file bc it's invalid JSON from template markup/comments
+      // ignore and move on
+    }
   }
 }
 


### PR DESCRIPTION
use tsconfig.json references to find what other configs need to be updated. if none then we just exit

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when a tsconfig.{app|lib}.json wasn't present in the application (as is common for e2e), then a warning would be logged stating we couldn't find this file. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
no warning is shown when a file isn't found, we just perform a noop.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
