### PR TITLE
fix(web): add default value for project.json schema style

### DIFF
--- a/packages/web/src/executors/build/schema.json
+++ b/packages/web/src/executors/build/schema.json
@@ -94,7 +94,8 @@
       "description": "External Styles which will be included with the application",
       "items": {
         "$ref": "#/definitions/extraEntryPoint"
-      }
+      },
+      "default": []
     },
     "budgets": {
       "description": "Budget thresholds to ensure parts of your application stay within boundaries which you set.",


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->
The `styles` property inside `project.json` is not required. 
So if it is not provided running a build command should not fail

## Current Behavior
<!-- This is the behavior we have today -->
Build command fails when `styles` property is not passed in.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Build command to progress without breaking because the `styles` property was not passed in.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7179 
