### PR TITLE
fix(core): use pnpm exec instead of pnpx

### DIFF
--- a/packages/create-nx-workspace/bin/package-manager.ts
+++ b/packages/create-nx-workspace/bin/package-manager.ts
@@ -53,12 +53,17 @@ export function getPackageManagerCommand(
       };
 
     case 'pnpm':
+      const [major, minor] = getPackageManagerVersion('pnpm').split('.');
+      let useExec = false;
+      if (+major >= 6 && +minor >= 13) {
+        useExec = true;
+      }
       return {
         install: 'pnpm install --no-frozen-lockfile', // explicitly disable in case of CI
         add: 'pnpm add',
         addDev: 'pnpm add -D',
         rm: 'pnpm rm',
-        exec: 'pnpx',
+        exec: useExec ? 'pnpm exec' : 'pnpx',
         run: (script: string, args: string) => `pnpm run ${script} -- ${args}`,
         list: 'pnpm ls --depth 100',
       };

--- a/packages/tao/src/shared/package-manager.ts
+++ b/packages/tao/src/shared/package-manager.ts
@@ -49,15 +49,22 @@ export function getPackageManagerCommand(
       run: (script: string, args: string) => `yarn ${script} ${args}`,
       list: 'yarn list',
     }),
-    pnpm: () => ({
-      install: 'pnpm install --no-frozen-lockfile', // explicitly disable in case of CI
-      add: 'pnpm add',
-      addDev: 'pnpm add -D',
-      rm: 'pnpm rm',
-      exec: 'pnpx',
-      run: (script: string, args: string) => `pnpm run ${script} -- ${args}`,
-      list: 'pnpm ls --depth 100',
-    }),
+    pnpm: () => {
+      const [major, minor] = getPackageManagerVersion('pnpm').split('.');
+      let useExec = false;
+      if (+major >= 6 && +minor >= 13) {
+        useExec = true;
+      }
+      return {
+        install: 'pnpm install --no-frozen-lockfile', // explicitly disable in case of CI
+        add: 'pnpm add',
+        addDev: 'pnpm add -D',
+        rm: 'pnpm rm',
+        exec: useExec ? 'pnpm exec' : 'pnpx',
+        run: (script: string, args: string) => `pnpm run ${script} -- ${args}`,
+        list: 'pnpm ls --depth 100',
+      };
+    },
     npm: () => {
       process.env.npm_config_legacy_peer_deps ??= 'true';
 


### PR DESCRIPTION
pnpm is deprecating pnpx and suggests using pnpm exec instead.
pnpx still works at the moment, but if for whatever reason it
isn't installed then this pr can make create-nx-worksapce stsill work.

[pnpx documenation](https://pnpm.io/pnpx-cli)

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

`create-nx-workspace` uses `pnpx` for executing commands.

## Expected Behavior

`pnpx` is deprecated and  should be replaced by `pnpm exec` [as described by their 6.13.0 release notes](https://github.com/pnpm/pnpm/releases/tag/v6.13.0)
