### PR TITLE
fix(angular): add specific storybook prerelease for angular 13 support

### DIFF
--- a/e2e/angular-extensions/src/storybook.test.ts
+++ b/e2e/angular-extensions/src/storybook.test.ts
@@ -15,8 +15,7 @@ import {
 import { writeFileSync } from 'fs';
 
 describe('Angular Package', () => {
-  // TODO(juristr): Re-enable these when storybook supports Angular 13
-  xdescribe('storybook schematics', () => {
+  describe('storybook schematics', () => {
     let proj: string;
 
     beforeEach(() => (proj = newProject()));

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1082,6 +1082,22 @@
         "jest-preset-angular": {
           "version": "11.0.0-rc.3",
           "alwaysAddToPackageJson": false
+        },
+        "@storybook/angular": {
+          "version": "6.4.0-beta.31",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/manager-webpack5": {
+          "version": "6.4.0-beta.31",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/builder-webpack5": {
+          "version": "6.4.0-beta.31",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-essentials": {
+          "version": "6.4.0-beta.31",
+          "alwaysAddToPackageJson": false
         }
       }
     }

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -6,3 +6,4 @@ export const ngrxVersion = '~13.0.0-beta.0';
 export const rxjsVersion = '~7.4.0';
 export const jestPresetAngularVersion = '11.0.0-rc.3';
 export const angularEslintVersion = '~12.6.0';
+export const storybookVersion = '~6.4.0-beta.31';


### PR DESCRIPTION
## Current Behavior
Storybook does not work with Angular 13

## Expected Behavior
Upgrade Storybook to work with Angular 13

## Notes
This isn't the actual version required, this PR is just a precursor to when Storybook do release the correct version