### PR TITLE
fix(angular): change tsconfig path handling for angular ng-packagr executors to let ng-packagr use default options

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-lite.impl.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-lite.impl.ts
@@ -1,8 +1,9 @@
 import type { ExecutorContext } from '@nrwl/devkit';
-import type { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
-import { updatePaths } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import {
+  createTmpTsConfig,
+  DependentBuildableProjectNode,
+} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import { NgPackagr } from 'ng-packagr';
-import { ngCompilerCli } from 'ng-packagr/lib/utils/ng-compiler-cli';
 import { resolve } from 'path';
 import { createLibraryExecutor } from '../package/package.impl';
 import type { BuildAngularLibraryExecutorOptions } from '../package/schema';
@@ -26,13 +27,13 @@ async function initializeNgPackgrLite(
   packager.withBuildTransform(NX_PACKAGE_TRANSFORM.provide);
 
   if (options.tsConfig) {
-    // read the tsconfig and modify its path in memory to
-    // pass it on to ngpackagr
-    const parsedTSConfig = (await ngCompilerCli()).readConfiguration(
-      options.tsConfig
+    const tsConfigPath = createTmpTsConfig(
+      options.tsConfig,
+      context.root,
+      context.workspace.projects[context.projectName].root,
+      projectDependencies
     );
-    updatePaths(projectDependencies, parsedTSConfig.options.paths);
-    packager.withTsConfig(parsedTSConfig);
+    packager.withTsConfig(tsConfigPath);
   }
 
   return packager;

--- a/packages/angular/src/executors/package/package.impl.spec.ts
+++ b/packages/angular/src/executors/package/package.impl.spec.ts
@@ -1,4 +1,3 @@
-jest.mock('ng-packagr/lib/utils/ng-compiler-cli');
 jest.mock('@nrwl/workspace/src/core/project-graph');
 jest.mock('@nrwl/workspace/src/utilities/buildable-libs-utils');
 jest.mock('ng-packagr');
@@ -6,8 +5,12 @@ jest.mock('ng-packagr');
 import type { ExecutorContext } from '@nrwl/devkit';
 import * as buildableLibsUtils from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import * as ngPackagr from 'ng-packagr';
-import { ngCompilerCli } from 'ng-packagr/lib/utils/ng-compiler-cli';
 import { BehaviorSubject } from 'rxjs';
+import { NX_ENTRY_POINT_PROVIDERS } from './ng-packagr-adjustments/ng-package/entry-point/entry-point.di';
+import {
+  NX_PACKAGE_PROVIDERS,
+  NX_PACKAGE_TRANSFORM,
+} from './ng-packagr-adjustments/ng-package/package.di';
 import packageExecutor from './package.impl';
 import type { BuildAngularLibraryExecutorOptions } from './schema';
 
@@ -45,7 +48,8 @@ describe('Package executor', () => {
       projectName: 'my-lib',
       targetName: 'build',
       configurationName: 'production',
-    } as ExecutorContext;
+      workspace: { projects: { 'my-lib': { root: '/libs/my-lib' } } },
+    } as any;
     options = { project: 'my-lib' };
   });
 
@@ -74,49 +78,54 @@ describe('Package executor', () => {
     expect(result.done).toBe(true);
   });
 
+  it('should instantiate NgPackager with the right providers and set to use the right build transformation provider', async () => {
+    (
+      buildableLibsUtils.checkDependentProjectsHaveBeenBuilt as jest.Mock
+    ).mockReturnValue(true);
+
+    const result = await packageExecutor(options, context).next();
+
+    expect(ngPackagr.NgPackagr).toHaveBeenCalledWith([
+      ...NX_PACKAGE_PROVIDERS,
+      ...NX_ENTRY_POINT_PROVIDERS,
+    ]);
+    expect(ngPackagrWithBuildTransformMock).toHaveBeenCalledWith(
+      NX_PACKAGE_TRANSFORM.provide
+    );
+    expect(result.value).toEqual({ success: true });
+    expect(result.done).toBe(true);
+  });
+
   it('should not set up incremental builds when tsConfig option is not set', async () => {
     (
       buildableLibsUtils.checkDependentProjectsHaveBeenBuilt as jest.Mock
     ).mockReturnValue(true);
-    (ngCompilerCli as jest.Mock).mockImplementation(() =>
-      Promise.resolve({ readConfiguration: jest.fn() })
-    );
 
     const result = await packageExecutor(options, context).next();
 
-    expect((await ngCompilerCli()).readConfiguration).not.toHaveBeenCalled();
-    expect(buildableLibsUtils.updatePaths).not.toHaveBeenCalled();
+    expect(buildableLibsUtils.createTmpTsConfig).not.toHaveBeenCalled();
     expect(ngPackagrWithTsConfigMock).not.toHaveBeenCalled();
     expect(ngPackagrBuildMock).toHaveBeenCalled();
     expect(result.value).toEqual({ success: true });
     expect(result.done).toBe(true);
   });
 
-  it('should process tsConfig for incremental builds when tsConfig option is set and enableIvy is true', async () => {
+  it('should process tsConfig for incremental builds when tsConfig option is set', async () => {
     (
       buildableLibsUtils.checkDependentProjectsHaveBeenBuilt as jest.Mock
     ).mockReturnValue(true);
-    const tsConfig = {
-      options: {
-        paths: { '@myorg/my-package': ['/root/my-package/src/index.ts'] },
-        enableIvy: true,
-      },
-    };
-    (ngCompilerCli as jest.Mock).mockImplementation(() =>
-      Promise.resolve({ readConfiguration: () => tsConfig })
+    const generatedTsConfig = '/root/tmp/my-lib/tsconfig.app.generated.json';
+    (buildableLibsUtils.createTmpTsConfig as jest.Mock).mockImplementation(
+      () => generatedTsConfig
     );
-    const tsConfigPath = '/root/my-lib/tsconfig.app.json';
 
     const result = await packageExecutor(
-      { ...options, tsConfig: tsConfigPath },
+      { ...options, tsConfig: '/root/my-lib/tsconfig.app.json' },
       context
     ).next();
 
-    expect(buildableLibsUtils.updatePaths).toHaveBeenCalledWith(
-      expect.any(Array),
-      tsConfig.options.paths
-    );
-    expect(ngPackagrWithTsConfigMock).toHaveBeenCalledWith(tsConfig);
+    expect(buildableLibsUtils.createTmpTsConfig).toHaveBeenCalled();
+    expect(ngPackagrWithTsConfigMock).toHaveBeenCalledWith(generatedTsConfig);
     expect(ngPackagrBuildMock).toHaveBeenCalled();
     expect(result.value).toEqual({ success: true });
     expect(result.done).toBe(true);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
During the Angular 13 upgrade, some tsconfig default options in the package executor were removed by mistake. These options were added in #7405 and they are set by default within ng-packagr but they are lost when we invoke the `packagr.withTsConfig` with new options.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Building libraries should correctly use the expected default tsconfig options.

Instead of just re-applying #7405, the tsconfig paths processing for incremental builds was refactored to create a temporary config instead of changing the paths in memory. `ng-packager` does merge its default config with the options in the tsconfig when a path is provided to `packagr.withTsConfig` instead of the already parsed configuration. This allows to not have to duplicate and keep in sync the default tsconfig options on our executors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
