### PR TITLE
feat(testing): add flag for testing using compiled artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,9 +225,6 @@ jobs:
           command: |
             npx nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --exclude=e2e-detox,e2e-js,e2e-next,e2e-workspace-create,e2e-workspace-integrations,e2e-workspace-core,e2e-react,e2e-web,e2e-angular-extensions,e2e-angular-core,e2e-cli,e2e-nx-plugin,e2e-storybook,e2e-cypress,e2e-node,e2e-linter,e2e-jest,e2e-add-nx-to-monorepo --parallel=1
           no_output_timeout: 45m
-      - store_artifacts:
-          path: ./temp/nx
-          destination: 'build-artifacts'
       - run:
           name: Stop All Running Agents for This CI Run
           command: npx nx-cloud stop-all-agents

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,9 @@ jobs:
           command: |
             npx nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --exclude=e2e-detox,e2e-js,e2e-next,e2e-workspace-create,e2e-workspace-integrations,e2e-workspace-core,e2e-react,e2e-web,e2e-angular-extensions,e2e-angular-core,e2e-cli,e2e-nx-plugin,e2e-storybook,e2e-cypress,e2e-node,e2e-linter,e2e-jest,e2e-add-nx-to-monorepo --parallel=1
           no_output_timeout: 45m
+      - store_artifacts:
+          path: ./temp/nx
+          destination: 'build-artifacts'
       - run:
           name: Stop All Running Agents for This CI Run
           command: npx nx-cloud stop-all-agents

--- a/docs/generated/api-jest/executors/jest.md
+++ b/docs/generated/api-jest/executors/jest.md
@@ -167,6 +167,14 @@ Type: `string`
 
 The name of the file to test.
 
+### testFromSource
+
+Default: `true`
+
+Type: `boolean`
+
+Will use the source in the tests when true otherwise it will use the compiled artifacts
+
 ### testLocationInResults
 
 Type: `boolean`
@@ -204,14 +212,6 @@ Node module that implements a custom results processor. (https://jestjs.io/docs/
 Type: `number`
 
 Default timeout of a test in milliseconds. Default value: 5000. (https://jestjs.io/docs/cli#--testtimeoutnumber)
-
-### testWithArtifacts
-
-Default: `false`
-
-Type: `boolean`
-
-Tells jest to check to ensure all dependencies of the project being tested have been built so that the prebuilt artifacts can be used instead of transpiling on the fly.
 
 ### ~~tsConfig~~
 

--- a/docs/generated/api-jest/executors/jest.md
+++ b/docs/generated/api-jest/executors/jest.md
@@ -205,6 +205,14 @@ Type: `number`
 
 Default timeout of a test in milliseconds. Default value: 5000. (https://jestjs.io/docs/cli#--testtimeoutnumber)
 
+### testWithArtifacts
+
+Default: `false`
+
+Type: `boolean`
+
+Tells jest to check to ensure all dependencies of the project being tested have been built so that the prebuilt artifacts can be used instead of transpiling on the fly.
+
 ### ~~tsConfig~~
 
 Type: `string`

--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -8,7 +8,10 @@ import {
 } from '@nrwl/e2e/utils';
 
 describe('Jest', () => {
-  beforeEach(() => newProject());
+  let proj: string;
+  beforeEach(() => {
+    proj = newProject();
+  });
 
   it('should be able test projects using jest', async () => {
     const mylib = uniq('mylib');
@@ -35,7 +38,7 @@ describe('Jest', () => {
     updateFile(
       `libs/${testLib}/src/lib/${testLib}.ts`,
       `
-      import { ${buildLib} } from '@proj/${buildLib}';
+      import { ${buildLib} } from '@${proj}/${buildLib}';
       
       export function ${testLib}(): string {
         return ${buildLib}();

--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -20,7 +20,7 @@ describe('Jest', () => {
     );
   }, 500000);
 
-  it.only('should run tests from compiled artifacts', async () => {
+  it('should run tests from compiled artifacts', async () => {
     const testLib = uniq('testlib');
     const buildLib = uniq('buildlib');
 

--- a/nx-dev/nx-dev/public/documentation/generated/api-jest/executors/jest.md
+++ b/nx-dev/nx-dev/public/documentation/generated/api-jest/executors/jest.md
@@ -167,6 +167,14 @@ Type: `string`
 
 The name of the file to test.
 
+### testFromSource
+
+Default: `true`
+
+Type: `boolean`
+
+Will use the source in the tests when true otherwise it will use the compiled artifacts
+
 ### testLocationInResults
 
 Type: `boolean`
@@ -204,14 +212,6 @@ Node module that implements a custom results processor. (https://jestjs.io/docs/
 Type: `number`
 
 Default timeout of a test in milliseconds. Default value: 5000. (https://jestjs.io/docs/cli#--testtimeoutnumber)
-
-### testWithArtifacts
-
-Default: `false`
-
-Type: `boolean`
-
-Tells jest to check to ensure all dependencies of the project being tested have been built so that the prebuilt artifacts can be used instead of transpiling on the fly.
 
 ### ~~tsConfig~~
 

--- a/nx-dev/nx-dev/public/documentation/generated/api-jest/executors/jest.md
+++ b/nx-dev/nx-dev/public/documentation/generated/api-jest/executors/jest.md
@@ -205,6 +205,14 @@ Type: `number`
 
 Default timeout of a test in milliseconds. Default value: 5000. (https://jestjs.io/docs/cli#--testtimeoutnumber)
 
+### testWithArtifacts
+
+Default: `false`
+
+Type: `boolean`
+
+Tells jest to check to ensure all dependencies of the project being tested have been built so that the prebuilt artifacts can be used instead of transpiling on the fly.
+
 ### ~~tsConfig~~
 
 Type: `string`

--- a/packages/jest/src/executors/jest/jest.impl.spec.ts
+++ b/packages/jest/src/executors/jest/jest.impl.spec.ts
@@ -24,6 +24,7 @@ describe('Jest Executor', () => {
   let mockContext: ExecutorContext;
   const defaultOptions: Omit<JestExecutorOptions, 'jestConfig'> = {
     testPathPattern: [],
+    testFromSource: true,
   };
 
   beforeEach(async () => {
@@ -113,6 +114,7 @@ describe('Jest Executor', () => {
           coverageReporters: ['test'],
           coverageDirectory: '/test/coverage',
           watch: false,
+          testFromSource: true,
         },
         mockContext
       );
@@ -193,6 +195,7 @@ describe('Jest Executor', () => {
           watch: false,
           watchAll: false,
           testLocationInResults: true,
+          testFromSource: true,
         },
         mockContext
       );

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -127,7 +127,7 @@ export async function jestExecutor(
 ): Promise<{ success: boolean }> {
   const config = await jestConfigParser(options, context);
 
-  const { results } = await runCLI(config, [options.jestConfig]);
+  const { results } = await runCLI(config, [config.config]);
 
   return { success: results.success };
 }
@@ -261,7 +261,11 @@ export async function jestConfigParser(
       'utf8'
     );
 
-    config.config = path.join(`tmp/${projectRoot}`, 'jest.config.js');
+    config.config = path.join(
+      process.cwd(),
+      `tmp/${projectRoot}`,
+      'jest.config.js'
+    );
   }
 
   return config;

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -47,6 +47,28 @@ const createTmpJestConfig = (
   `;
 };
 
+/**
+ * Attempt to find the compiled index.js to use as the entry point for this library
+ *
+ * Built in library schematics are as follows for the package.json index file:
+ *
+ * Nest: 'main'
+ * Angular: 'esm2020', 'es2020', 'module' (No order, as of Angular 13 all three point to the same artifacts)
+ * Node: 'main'
+ * React: 'main', 'module' (Cannot use `module` as Jest does not support it yet)
+ * TS (@nrwl/js): 'main'
+ * Web: 'main'
+ *
+ * @param distPackageJson
+ */
+export function findIndexFile(distPackageJson: any): string | undefined {
+  if (distPackageJson['main']) {
+    return distPackageJson['main'];
+  }
+
+  return distPackageJson['esm2020'];
+}
+
 export function createJestOverrides(
   root: string,
   context: ExecutorContext,
@@ -68,7 +90,7 @@ export function createJestOverrides(
         path.join(context.cwd, 'dist', node.data.root, 'package.json')
       );
 
-      const indexFile = distPackageJson['main'] ?? distPackageJson['esm2015'];
+      const indexFile = findIndexFile(distPackageJson);
 
       if (!indexFile) {
         return prev;

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -103,13 +103,9 @@ export async function jestExecutor(
   options: JestExecutorOptions,
   context: ExecutorContext
 ): Promise<{ success: boolean }> {
-  await createProjectGraphAsync();
-
   const config = await jestConfigParser(options, context);
 
-  const { results } = await runCLI(config, [
-    options.testFromSource ? config.config : options.jestConfig,
-  ]);
+  const { results } = await runCLI(config, [options.jestConfig]);
 
   return { success: results.success };
 }
@@ -213,6 +209,8 @@ export async function jestConfigParser(
    * using ts-jest to compile the dependencies
    */
   if (!options.testFromSource && !options.watch && !options.watchAll) {
+    // We only need to create the cached project graph if not testing from source
+    await createProjectGraphAsync();
     const projGraph = readCachedProjectGraph();
     const { dependencies } = calculateProjectDependencies(
       projGraph,

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -127,7 +127,13 @@ export async function jestExecutor(
 ): Promise<{ success: boolean }> {
   const config = await jestConfigParser(options, context);
 
-  const { results } = await runCLI(config, [config.config]);
+  /*
+   * If config.config exists that means we are running tests using artifacts
+   * `testFromSource: false` otherwise default to the projects jest config
+   */
+  const { results } = await runCLI(config, [
+    config.config ?? options.jestConfig,
+  ]);
 
   return { success: results.success };
 }

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -15,7 +15,10 @@ import {
   TaskGraph,
 } from '@nrwl/devkit';
 import { getSummary } from './summary';
-import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  createProjectGraphAsync,
+  readCachedProjectGraph,
+} from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
   DependentBuildableProjectNode,
@@ -100,6 +103,8 @@ export async function jestExecutor(
   options: JestExecutorOptions,
   context: ExecutorContext
 ): Promise<{ success: boolean }> {
+  await createProjectGraphAsync();
+
   const config = await jestConfigParser(options, context);
 
   const { results } = await runCLI(config, [

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -6,11 +6,85 @@ import { makeEmptyAggregatedTestResult, addResult } from '@jest/test-result';
 import * as path from 'path';
 import { JestExecutorOptions } from './schema';
 import { Config } from '@jest/types';
-import { ExecutorContext, TaskGraph } from '@nrwl/devkit';
+import {
+  ExecutorContext,
+  offsetFromRoot,
+  ProjectGraphProjectNode,
+  readJsonFile,
+  TaskGraph,
+} from '@nrwl/devkit';
 import { join } from 'path';
 import { getSummary } from './summary';
+import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import {
+  calculateProjectDependencies,
+  DependentBuildableProjectNode,
+} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { mkdirSync, writeFileSync } from 'fs';
 
 process.env.NODE_ENV ??= 'test';
+
+const createTmpJestConfig = (projectName: string, root: string) => {
+  const offset = offsetFromRoot(root);
+  return `const path = require('path')
+module.exports = {
+  displayName: '${projectName}',
+  preset: '${offset}jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/${offset}tmp/${root}tsconfig.spec.json'
+    }
+  },
+  rootDir: path.join(__dirname, '../${offset}${root}'),
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\\\.[tj]s$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../${offset}coverage/${root}'
+};
+`;
+};
+
+const createTmpTsconfigSpecJson = (
+  projectRoot: string,
+  context: ExecutorContext,
+  dependencies: DependentBuildableProjectNode[]
+) => {
+  const offset = offsetFromRoot(projectRoot);
+
+  const sourcePath = `../${offset}${projectRoot}`;
+
+  const tsConfig = readJsonFile(
+    path.join(context.cwd, projectRoot, 'tsconfig.spec.json')
+  );
+
+  const tsAliasPrefix = `${context.workspace.npmScope}/`;
+
+  tsConfig.extends = `${sourcePath}/tsconfig.json`;
+  // Will override the includes array from
+  // "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+  // to:
+  // "include": ["../libs/lib1/**/*.test.ts", "../libs/lib1/**/*.spec.ts", "../libs/lib1/**/*.d.ts"]
+  tsConfig.include = tsConfig.include.map(
+    (includePath) => `${sourcePath}/${includePath}`
+  );
+  tsConfig.compilerOptions.paths = dependencies
+    .filter((dep) => !dep.node.name.startsWith('npm:'))
+    .reduce((prev, dep) => {
+      const node = dep.node as ProjectGraphProjectNode;
+
+      return {
+        ...prev,
+        // Will set the path alias for this dependency to something like: "@scope/lib1": ["../dist/libs/lib1"]
+        [`${tsAliasPrefix}${node.data.root.replace(node.type, '')}`]: [
+          `../${offset}${node.data.targets['build'].options['outputPath']}`,
+        ],
+      };
+    }, {});
+
+  return tsConfig;
+};
 
 export async function jestExecutor(
   options: JestExecutorOptions,
@@ -115,6 +189,53 @@ export async function jestConfigParser(
     options.coverageReporters.length > 0
   ) {
     config.coverageReporters = options.coverageReporters;
+  }
+
+  /*
+   * Will enable jest to run tests using already compiled artifacts instead of
+   * using ts-jest to compile the dependencies
+   */
+  if (options.testWithArtifacts && !options.watch && !options.watchAll) {
+    const projGraph = readCachedProjectGraph();
+    const { dependencies } = calculateProjectDependencies(
+      projGraph,
+      context.root,
+      context.projectName,
+      context.targetName,
+      context.configurationName
+    );
+
+    const projectRoot = context.workspace.projects[context.projectName].root;
+
+    const temporaryJestConfig = createTmpJestConfig(
+      context.projectName,
+      projectRoot
+    );
+
+    const tmpProjectFolder = path.join(context.cwd, `tmp/${projectRoot}`);
+    mkdirSync(tmpProjectFolder, { recursive: true });
+
+    // Write the temporary jest config with correct paths
+    writeFileSync(
+      path.join(tmpProjectFolder, 'jest.config.js'),
+      temporaryJestConfig,
+      'utf8'
+    );
+
+    const temporaryTsConfig = createTmpTsconfigSpecJson(
+      projectRoot,
+      context,
+      dependencies
+    );
+
+    // Write the temporary tsconfig spec json
+    writeFileSync(
+      path.join(tmpProjectFolder, `tsconfig.spec.json`),
+      JSON.stringify(temporaryTsConfig),
+      'utf8'
+    );
+
+    config.config = path.join(`tmp/${projectRoot}`, 'jest.config.js');
   }
 
   return config;

--- a/packages/jest/src/executors/jest/schema.d.ts
+++ b/packages/jest/src/executors/jest/schema.d.ts
@@ -34,5 +34,5 @@ export interface JestExecutorOptions {
   watchAll?: boolean;
   testLocationInResults?: boolean;
   testTimeout?: number;
-  testWithArtifacts?: boolean;
+  testFromSource?: boolean;
 }

--- a/packages/jest/src/executors/jest/schema.d.ts
+++ b/packages/jest/src/executors/jest/schema.d.ts
@@ -34,4 +34,5 @@ export interface JestExecutorOptions {
   watchAll?: boolean;
   testLocationInResults?: boolean;
   testTimeout?: number;
+  testWithArtifacts?: boolean;
 }

--- a/packages/jest/src/executors/jest/schema.json
+++ b/packages/jest/src/executors/jest/schema.json
@@ -171,10 +171,10 @@
       "description": "Default timeout of a test in milliseconds. Default value: 5000. (https://jestjs.io/docs/cli#--testtimeoutnumber)",
       "type": "number"
     },
-    "testWithArtifacts": {
-      "description": "Tells jest to check to ensure all dependencies of the project being tested have been built so that the prebuilt artifacts can be used instead of transpiling on the fly.",
+    "testFromSource": {
+      "description": "Will use the source in the tests when true otherwise it will use the compiled artifacts",
       "type": "boolean",
-      "default": false
+      "default": true
     }
   },
   "required": ["jestConfig"]

--- a/packages/jest/src/executors/jest/schema.json
+++ b/packages/jest/src/executors/jest/schema.json
@@ -170,6 +170,11 @@
     "testTimeout": {
       "description": "Default timeout of a test in milliseconds. Default value: 5000. (https://jestjs.io/docs/cli#--testtimeoutnumber)",
       "type": "number"
+    },
+    "testWithArtifacts": {
+      "description": "Tells jest to check to ensure all dependencies of the project being tested have been built so that the prebuilt artifacts can be used instead of transpiling on the fly.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["jestConfig"]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When testing using @nrwl/jest right now ts-jest needs to compile all of the dependencies to be able to run the tests.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Will be able to setup targetDependencies

```
"test": [
      {
        "target": "build",
        "projects": "dependencies"
      }
    ]
```

such that when running tests each of the libraries dependencies are built (or pulled from cache) and then those artifacts are used for testing instead of compiling on the fly using ts-jest. This allows us to leverage buildable libraries at test time rather than just at compile time.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6253
