### PR TITLE
feat(node): add outputFileName to build executor

### DIFF
--- a/docs/angular/api-node/executors/build.md
+++ b/docs/angular/api-node/executors/build.md
@@ -110,6 +110,14 @@ Type: `boolean`
 
 Defines the optimization level of the build.
 
+### outFileName
+
+Default: `main.js`
+
+Type: `string`
+
+Name of the main output file. (defaults to 'main.js')
+
 ### outputPath
 
 Type: `string`

--- a/docs/angular/api-node/executors/build.md
+++ b/docs/angular/api-node/executors/build.md
@@ -110,7 +110,7 @@ Type: `boolean`
 
 Defines the optimization level of the build.
 
-### outFileName
+### outputFileName
 
 Default: `main.js`
 

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -110,6 +110,14 @@ Type: `boolean`
 
 Defines the optimization level of the build.
 
+### outFileName
+
+Default: `main.js`
+
+Type: `string`
+
+Name of the main output file. (defaults to 'main.js')
+
 ### outputPath
 
 Type: `string`

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -110,7 +110,7 @@ Type: `boolean`
 
 Defines the optimization level of the build.
 
-### outFileName
+### outputFileName
 
 Default: `main.js`
 

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -110,6 +110,14 @@ Type: `boolean`
 
 Defines the optimization level of the build.
 
+### outFileName
+
+Default: `main.js`
+
+Type: `string`
+
+Name of the main output file. (defaults to 'main.js')
+
 ### outputPath
 
 Type: `string`

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -110,7 +110,7 @@ Type: `boolean`
 
 Defines the optimization level of the build.
 
-### outFileName
+### outputFileName
 
 Default: `main.js`
 

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -60,6 +60,12 @@ describe('Node Applications', () => {
   it('should be able to generate the correct outFileName in options', async () => {
     const nodeapp = uniq('nodeapp');
     runCLI(`generate @nrwl/node:app ${nodeapp} --linter=eslint`);
+
+    updateProjectConfig(nodeapp, (config) => {
+      config.targets.build.options.outFileName = 'index.js';
+      return config;
+    });
+
     await runCLIAsync(`build ${nodeapp}`);
     checkFilesExist(`dist/apps/${nodeapp}/index.js`);
   }, 300000);

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -57,6 +57,13 @@ describe('Node Applications', () => {
     expect(result).toContain('Hello World!');
   }, 300000);
 
+  it('should be able to generate the correct outFileName in options', async () => {
+    const nodeapp = uniq('nodeapp');
+    runCLI(`generate @nrwl/node:app ${nodeapp} --linter=eslint`);
+    await runCLIAsync(`build ${nodeapp}`);
+    checkFilesExist(`dist/apps/${nodeapp}/index.js`);
+  }, 300000);
+
   // TODO: This test fails in CI, but succeeds locally. It should be re-enabled once the reasoning is understood.
   xit('should be able to generate an empty application with standalone configuration', async () => {
     const nodeapp = uniq('nodeapp');

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -57,12 +57,12 @@ describe('Node Applications', () => {
     expect(result).toContain('Hello World!');
   }, 300000);
 
-  it('should be able to generate the correct outFileName in options', async () => {
+  it('should be able to generate the correct outputFileName in options', async () => {
     const nodeapp = uniq('nodeapp');
     runCLI(`generate @nrwl/node:app ${nodeapp} --linter=eslint`);
 
     updateProjectConfig(nodeapp, (config) => {
-      config.targets.build.options.outFileName = 'index.js';
+      config.targets.build.options.outputFileName = 'index.js';
       return config;
     });
 

--- a/packages/node/src/executors/build/build.impl.spec.ts
+++ b/packages/node/src/executors/build/build.impl.spec.ts
@@ -64,6 +64,23 @@ describe('Node Build Executor', () => {
     );
   });
 
+  it('should use outFileName if passed in', async () => {
+    await buildExecutor(
+      { ...options, outFileName: 'index.js' },
+      context
+    ).next();
+
+    expect(runWebpack).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: expect.objectContaining({
+          filename: 'index.js',
+          libraryTarget: 'commonjs',
+          path: '/root/dist/apps/wibble',
+        }),
+      })
+    );
+  });
+
   describe('webpackConfig', () => {
     it('should handle custom path', async () => {
       jest.mock(

--- a/packages/node/src/executors/build/build.impl.spec.ts
+++ b/packages/node/src/executors/build/build.impl.spec.ts
@@ -64,9 +64,9 @@ describe('Node Build Executor', () => {
     );
   });
 
-  it('should use outFileName if passed in', async () => {
+  it('should use outputFileName if passed in', async () => {
     await buildExecutor(
-      { ...options, outFileName: 'index.js' },
+      { ...options, outputFileName: 'index.js' },
       context
     ).next();
 

--- a/packages/node/src/executors/build/build.impl.ts
+++ b/packages/node/src/executors/build/build.impl.ts
@@ -13,7 +13,6 @@ import { eachValueFrom } from 'rxjs-for-await';
 import { resolve } from 'path';
 
 import { getNodeWebpackConfig } from '../../utils/node.config';
-import { OUT_FILENAME } from '../../utils/config';
 import { BuildNodeBuilderOptions } from '../../utils/types';
 import { normalizeBuildOptions } from '../../utils/normalize';
 import { generatePackageJson } from '../../utils/generate-package-json';
@@ -90,7 +89,11 @@ export async function* buildExecutor(
       map((stats) => {
         return {
           success: !stats.hasErrors(),
-          outfile: resolve(context.root, options.outputPath, OUT_FILENAME),
+          outfile: resolve(
+            context.root,
+            options.outputPath,
+            options.outFileName
+          ),
         } as NodeBuildEvent;
       })
     )

--- a/packages/node/src/executors/build/build.impl.ts
+++ b/packages/node/src/executors/build/build.impl.ts
@@ -92,7 +92,7 @@ export async function* buildExecutor(
           outfile: resolve(
             context.root,
             options.outputPath,
-            options.outFileName
+            options.outputFileName
           ),
         } as NodeBuildEvent;
       })

--- a/packages/node/src/executors/build/schema.json
+++ b/packages/node/src/executors/build/schema.json
@@ -155,7 +155,7 @@
         }
       }
     },
-    "outFileName": {
+    "outputFileName": {
       "type": "string",
       "description": "Name of the main output file. (defaults to 'main.js')",
       "default": "main.js"

--- a/packages/node/src/executors/build/schema.json
+++ b/packages/node/src/executors/build/schema.json
@@ -154,6 +154,11 @@
           }
         }
       }
+    },
+    "outFileName": {
+      "type": "string",
+      "description": "Name of the main output file. (defaults to 'main.js')",
+      "default": "main.js"
     }
   },
   "required": ["tsConfig", "main"],

--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -14,7 +14,6 @@ import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 // TODO(jack): Remove once the patch lands in original package
 import TsConfigPathsPlugin from './webpack/plugins/tsconfig-paths/tsconfig-paths.plugin';
 
-export const OUT_FILENAME = 'main.js';
 export const OUT_FILENAME_TEMPLATE = '[name].js';
 
 export function getBaseWebpackPartial(
@@ -49,7 +48,7 @@ export function getBaseWebpackPartial(
       filename:
         options.additionalEntryPoints?.length > 0
           ? OUT_FILENAME_TEMPLATE
-          : OUT_FILENAME,
+          : options.outFileName,
       hashFunction: 'xxhash64',
       // Disabled for performance
       pathinfo: false,

--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -48,7 +48,7 @@ export function getBaseWebpackPartial(
       filename:
         options.additionalEntryPoints?.length > 0
           ? OUT_FILENAME_TEMPLATE
-          : options.outFileName,
+          : options.outputFileName,
       hashFunction: 'xxhash64',
       // Disabled for performance
       pathinfo: false,

--- a/packages/node/src/utils/generate-package-json.ts
+++ b/packages/node/src/utils/generate-package-json.ts
@@ -10,7 +10,7 @@ export function generatePackageJson(
   options: BuildNodeBuilderOptions
 ) {
   const packageJson = createPackageJson(projectName, graph, options);
-  packageJson.main = packageJson.main ?? options.outFileName;
+  packageJson.main = packageJson.main ?? options.outputFileName;
   delete packageJson.devDependencies;
   writeJsonFile(`${options.outputPath}/package.json`, packageJson);
 }

--- a/packages/node/src/utils/generate-package-json.ts
+++ b/packages/node/src/utils/generate-package-json.ts
@@ -3,7 +3,6 @@ import { writeJsonFile } from '@nrwl/workspace/src/utilities/fileutils';
 
 import { BuildNodeBuilderOptions } from './types';
 import { createPackageJson } from '@nrwl/workspace/src/utilities/create-package-json';
-import { OUT_FILENAME } from './config';
 
 export function generatePackageJson(
   projectName: string,
@@ -11,7 +10,7 @@ export function generatePackageJson(
   options: BuildNodeBuilderOptions
 ) {
   const packageJson = createPackageJson(projectName, graph, options);
-  packageJson.main = packageJson.main ?? OUT_FILENAME;
+  packageJson.main = packageJson.main ?? options.outFileName;
   delete packageJson.devDependencies;
   writeJsonFile(`${options.outputPath}/package.json`, packageJson);
 }

--- a/packages/node/src/utils/normalize.spec.ts
+++ b/packages/node/src/utils/normalize.spec.ts
@@ -144,4 +144,24 @@ describe('normalizeBuildOptions', () => {
       },
     ]);
   });
+
+  it('should resolve outFileName correctly', () => {
+    const result = normalizeBuildOptions(
+      testOptions,
+      root,
+      sourceRoot,
+      projectRoot
+    );
+    expect(result.outFileName).toEqual('main.js');
+  });
+
+  it('should resolve outFileName to "main.js" if not passed in', () => {
+    const result = normalizeBuildOptions(
+      { ...testOptions, outFileName: 'index.js' },
+      root,
+      sourceRoot,
+      projectRoot
+    );
+    expect(result.outFileName).toEqual('index.js');
+  });
 });

--- a/packages/node/src/utils/normalize.spec.ts
+++ b/packages/node/src/utils/normalize.spec.ts
@@ -145,23 +145,23 @@ describe('normalizeBuildOptions', () => {
     ]);
   });
 
-  it('should resolve outFileName correctly', () => {
+  it('should resolve outputFileName correctly', () => {
     const result = normalizeBuildOptions(
       testOptions,
       root,
       sourceRoot,
       projectRoot
     );
-    expect(result.outFileName).toEqual('main.js');
+    expect(result.outputFileName).toEqual('main.js');
   });
 
-  it('should resolve outFileName to "main.js" if not passed in', () => {
+  it('should resolve outputFileName to "main.js" if not passed in', () => {
     const result = normalizeBuildOptions(
-      { ...testOptions, outFileName: 'index.js' },
+      { ...testOptions, outputFileName: 'index.js' },
       root,
       sourceRoot,
       projectRoot
     );
-    expect(result.outFileName).toEqual('index.js');
+    expect(result.outputFileName).toEqual('index.js');
   });
 });

--- a/packages/node/src/utils/normalize.ts
+++ b/packages/node/src/utils/normalize.ts
@@ -36,7 +36,7 @@ export function normalizeBuildOptions(
       root,
       options.additionalEntryPoints ?? []
     ),
-    outFileName: options.outFileName ?? 'main.js',
+    outputFileName: options.outputFileName ?? 'main.js',
   };
 }
 

--- a/packages/node/src/utils/normalize.ts
+++ b/packages/node/src/utils/normalize.ts
@@ -36,6 +36,7 @@ export function normalizeBuildOptions(
       root,
       options.additionalEntryPoints ?? []
     ),
+    outFileName: options.outFileName ?? 'main.js',
   };
 }
 

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -87,6 +87,7 @@ export interface BuildBuilderOptions {
   tsPlugins?: TsPluginEntry[];
 
   additionalEntryPoints?: AdditionalEntryPoint[];
+  outFileName?: string;
 }
 
 export interface BuildNodeBuilderOptions extends BuildBuilderOptions {

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -87,7 +87,7 @@ export interface BuildBuilderOptions {
   tsPlugins?: TsPluginEntry[];
 
   additionalEntryPoints?: AdditionalEntryPoint[];
-  outFileName?: string;
+  outputFileName?: string;
 }
 
 export interface BuildNodeBuilderOptions extends BuildBuilderOptions {


### PR DESCRIPTION
`outputFileName` allows the consumers to customize the bundle file name that will be output by Webpack.
Default to `main.js`

ISSUES CLOSED: #4969

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
