### PR TITLE
fix(core): fix parsing for --parallel

### DIFF
--- a/packages/workspace/src/command-line/utils.spec.ts
+++ b/packages/workspace/src/command-line/utils.spec.ts
@@ -212,6 +212,88 @@ describe('splitArgs', () => {
       exclude: 'file',
     });
   });
+
+  describe('--parallel', () => {
+    it('should be a number', () => {
+      const parallel = splitArgsIntoNxArgsAndOverrides(
+        {
+          _: [],
+          $0: '',
+          parallel: '5',
+        },
+        'affected'
+      ).nxArgs.parallel;
+
+      expect(parallel).toEqual(5);
+    });
+
+    it('should default to 3', () => {
+      const parallel = splitArgsIntoNxArgsAndOverrides(
+        {
+          _: [],
+          $0: '',
+          parallel: '',
+        },
+        'affected'
+      ).nxArgs.parallel;
+
+      expect(parallel).toEqual(3);
+    });
+
+    it('should be 3 when set to true', () => {
+      const parallel = splitArgsIntoNxArgsAndOverrides(
+        {
+          _: [],
+          $0: '',
+          parallel: 'true',
+        },
+        'affected'
+      ).nxArgs.parallel;
+
+      expect(parallel).toEqual(3);
+    });
+
+    it('should be 1 when set to false', () => {
+      const parallel = splitArgsIntoNxArgsAndOverrides(
+        {
+          _: [],
+          $0: '',
+          parallel: 'false',
+        },
+        'affected'
+      ).nxArgs.parallel;
+
+      expect(parallel).toEqual(1);
+    });
+
+    it('should use the maxParallel option when given', () => {
+      const parallel = splitArgsIntoNxArgsAndOverrides(
+        {
+          _: [],
+          $0: '',
+          parallel: '',
+          maxParallel: 5,
+        },
+        'affected'
+      ).nxArgs.parallel;
+
+      expect(parallel).toEqual(5);
+    });
+
+    it('should use the maxParallel option when given', () => {
+      const parallel = splitArgsIntoNxArgsAndOverrides(
+        {
+          _: [],
+          $0: '',
+          parallel: '',
+          maxParallel: 5,
+        },
+        'affected'
+      ).nxArgs.parallel;
+
+      expect(parallel).toEqual(5);
+    });
+  });
 });
 
 describe('getAffectedConfig', () => {

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -192,7 +192,11 @@ export function splitArgsIntoNxArgsAndOverrides(
 
   if (args['parallel'] === 'false' || args['parallel'] === false) {
     nxArgs['parallel'] = 1;
-  } else if (args['parallel'] === 'true' || args['parallel'] === true) {
+  } else if (
+    args['parallel'] === 'true' ||
+    args['parallel'] === true ||
+    args['parallel'] === ''
+  ) {
     nxArgs['parallel'] = Number(
       nxArgs['maxParallel'] || nxArgs['max-parallel'] || 3
     );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`--parallel` causes the command to not work (it gets parsed as `--parallel=0` which makes no sense..

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`--parallel` is the same as `--parallel=3` or `--parallel=true`
