### PR TITLE
fix(nextjs): codesplit buildable next libs

### DIFF
--- a/e2e/react/src/react-package.test.ts
+++ b/e2e/react/src/react-package.test.ts
@@ -110,11 +110,11 @@ describe('Build React libraries and apps', () => {
       runCLI(`build ${childLib}`);
       runCLI(`build ${childLib2}`);
 
-      checkFilesExist(`dist/libs/${childLib}/${childLib}.esm.js`);
-      checkFilesExist(`dist/libs/${childLib}/${childLib}.umd.js`);
+      checkFilesExist(`dist/libs/${childLib}/index.esm.js`);
+      checkFilesExist(`dist/libs/${childLib}/index.umd.js`);
 
-      checkFilesExist(`dist/libs/${childLib2}/${childLib2}.esm.js`);
-      checkFilesExist(`dist/libs/${childLib2}/${childLib2}.umd.js`);
+      checkFilesExist(`dist/libs/${childLib2}/index.esm.js`);
+      checkFilesExist(`dist/libs/${childLib2}/index.umd.js`);
 
       checkFilesExist(`dist/libs/${childLib}/assets/hello.txt`);
       checkFilesExist(`dist/libs/${childLib2}/README.md`);
@@ -124,8 +124,8 @@ describe('Build React libraries and apps', () => {
        */
       runCLI(`build ${parentLib}`);
 
-      checkFilesExist(`dist/libs/${parentLib}/${parentLib}.esm.js`);
-      checkFilesExist(`dist/libs/${parentLib}/${parentLib}.umd.js`);
+      checkFilesExist(`dist/libs/${parentLib}/index.esm.js`);
+      checkFilesExist(`dist/libs/${parentLib}/index.umd.js`);
 
       const jsonFile = readJson(`dist/libs/${parentLib}/package.json`);
       expect(jsonFile.peerDependencies).toEqual(
@@ -142,9 +142,9 @@ describe('Build React libraries and apps', () => {
 
       runCLI(`build ${parentLib} --with-deps --skip-nx-cache`);
 
-      checkFilesExist(`dist/libs/${parentLib}/${parentLib}.esm.js`);
-      checkFilesExist(`dist/libs/${childLib}/${childLib}.esm.js`);
-      checkFilesExist(`dist/libs/${childLib2}/${childLib2}.esm.js`);
+      checkFilesExist(`dist/libs/${parentLib}/index.esm.js`);
+      checkFilesExist(`dist/libs/${childLib}/index.esm.js`);
+      checkFilesExist(`dist/libs/${childLib2}/index.esm.js`);
     });
 
     it('should support --format option', () => {
@@ -159,18 +159,18 @@ export async function h() { return 'c'; }
 
       runCLI(`build ${childLib} --format cjs,esm,umd`);
 
-      checkFilesExist(`dist/libs/${childLib}/${childLib}.cjs.js`);
-      checkFilesExist(`dist/libs/${childLib}/${childLib}.esm.js`);
-      checkFilesExist(`dist/libs/${childLib}/${childLib}.umd.js`);
+      checkFilesExist(`dist/libs/${childLib}/index.cjs.js`);
+      checkFilesExist(`dist/libs/${childLib}/index.esm.js`);
+      checkFilesExist(`dist/libs/${childLib}/index.umd.js`);
 
       const cjsPackageSize = getSize(
-        tmpProjPath(`dist/libs/${childLib}/${childLib}.cjs.js`)
+        tmpProjPath(`dist/libs/${childLib}/index.cjs.js`)
       );
       const esmPackageSize = getSize(
-        tmpProjPath(`dist/libs/${childLib}/${childLib}.esm.js`)
+        tmpProjPath(`dist/libs/${childLib}/index.esm.js`)
       );
       const umdPackageSize = getSize(
-        tmpProjPath(`dist/libs/${childLib}/${childLib}.umd.js`)
+        tmpProjPath(`dist/libs/${childLib}/index.umd.js`)
       );
 
       // This is a loose requirement that ESM and CJS packages should be less than the UMD counterpart.
@@ -220,7 +220,7 @@ export async function h() { return 'c'; }
       // What we're testing
       runCLI(`build ${myLib}`);
       // Assertion
-      const content = readFile(`dist/libs/${myLib}/${myLib}.esm.js`);
+      const content = readFile(`dist/libs/${myLib}/index.esm.js`);
 
       /**
        * Then check if the result contains this "promise" polyfill?

--- a/e2e/workspace-integrations/src/workspace.test.ts
+++ b/e2e/workspace-integrations/src/workspace.test.ts
@@ -811,7 +811,7 @@ describe('cache', () => {
       };
       config.targets.build = {
         executor: '@nrwl/workspace:run-commands',
-        outputs: [`dist/libs/${mylib1}/${mylib1}.esm.js`],
+        outputs: [`dist/libs/${mylib1}/index.esm.js`],
         options: {
           commands: [
             {
@@ -836,7 +836,7 @@ describe('cache', () => {
     expect(outputWithBuildTasksCached).toContain('from cache');
     expectCached(outputWithBuildTasksCached, [mylib1]);
     // Ensure that only the specific file in outputs was copied to cache
-    expect(listFiles(`dist/libs/${mylib1}`)).toEqual([`${mylib1}.esm.js`]);
+    expect(listFiles(`dist/libs/${mylib1}`)).toEqual([`index.esm.js`]);
   }, 120000);
 
   function expectCached(

--- a/packages/web/src/executors/package/package.impl.spec.ts
+++ b/packages/web/src/executors/package/package.impl.spec.ts
@@ -46,16 +46,22 @@ describe('packageExecutor', () => {
 
       expect(result.map((x) => x.output)).toEqual([
         {
-          file: '/root/dist/ui/example.esm.js',
+          dir: '/root/dist/ui',
           format: 'esm',
           globals: { 'react/jsx-runtime': 'jsxRuntime' },
           name: 'Example',
+          inlineDynamicImports: false,
+          chunkFileNames: '[name].esm.js',
+          entryFileNames: '[name].esm.js',
         },
         {
-          file: '/root/dist/ui/example.umd.js',
+          dir: '/root/dist/ui',
           format: 'umd',
           globals: { 'react/jsx-runtime': 'jsxRuntime' },
           name: 'Example',
+          inlineDynamicImports: true,
+          chunkFileNames: '[name].umd.js',
+          entryFileNames: '[name].umd.js',
         },
       ]);
     });

--- a/packages/web/src/executors/package/package.impl.ts
+++ b/packages/web/src/executors/package/package.impl.ts
@@ -240,8 +240,12 @@ export function createRollupOptions(
       output: {
         globals,
         format,
-        file: `${options.outputPath}/${context.projectName}.${format}.js`,
+        dir: `${options.outputPath}`,
         name: options.umdName || names(context.projectName).className,
+        entryFileNames: `[name].${format}.js`,
+        chunkFileNames: `[name].${format}.js`,
+        // umd doesn't support code-split bundles
+        inlineDynamicImports: format === 'umd',
       },
       external: (id) =>
         externalPackages.some(
@@ -286,7 +290,7 @@ function updatePackageJson(
   dependencies: DependentBuildableProjectNode[],
   packageJson: any
 ) {
-  const entryFileTmpl = `./${context.projectName}.<%= extension %>.js`;
+  const entryFileTmpl = `./index.<%= extension %>.js`;
   const typingsFile = relative(options.entryRoot, options.entryFile).replace(
     /\.[jt]sx?$/,
     '.d.ts'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->


<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when building buildable libraries that use dynamic imports, or other features that result in code-splitting - rollup currently throws an error

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
buildable libraries should be code-split correctly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
