### PR TITLE
fix(angular): handle projects with no targets in angular 13 migration

### DIFF
--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -19,7 +19,7 @@ import { switchMap } from 'rxjs/operators';
 import { existsSync } from 'fs';
 import { merge } from 'webpack-merge';
 
-type BrowserBuilderSchema = Schema & {
+export type BrowserBuilderSchema = Schema & {
   customWebpackConfig?: {
     path: string;
   };

--- a/packages/angular/src/migrations/update-13-2-0/update-angular-config.spec.ts
+++ b/packages/angular/src/migrations/update-13-2-0/update-angular-config.spec.ts
@@ -75,4 +75,19 @@ describe('update-angular-config migration', () => {
     expect(targets.build.options.somethingThatShouldNotBeRemoved).toBeDefined();
     expect(targets.build.options.extractCss).toBeUndefined();
   });
+
+  it('should not fail for projects with no targets', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'testing', {
+      root: 'apps/testing',
+    });
+
+    // ACT
+    await updateAngularConfig(tree);
+
+    // ASSERT
+    const { targets } = readProjectConfiguration(tree, 'testing');
+    expect(targets).toBeUndefined();
+  });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Projects with no `target` cause the Angular 13 migration to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Projects with no `target` should not cause the Anglar 13 migration to fail.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/7718
