### PR TITLE
fix(core): prevent overwriting already added tasks when adding target dependencies tasks

### DIFF
--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -293,7 +293,10 @@ function addTasksForProjectDependencyConfig(
         const depProject =
           projectGraph.nodes[dep.target] ||
           projectGraph.externalNodes[dep.target];
-        if (projectHasTarget(depProject, dependencyConfig.target)) {
+        if (
+          projectHasTarget(depProject, dependencyConfig.target) &&
+          !seenSet.has(depProject.name)
+        ) {
           addTasksForProjectTarget(
             {
               project: depProject,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When collecting target dependencies tasks, there are cases where a task has already been added to the list of tasks but gets processed again as part of target dependencies. Since we don't pass the overrides to the dependencies, this overwrites the previously added top-level task that should have the overrides.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Top-level tasks should always receive the flags passed to the command.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7514 
