### PR TITLE
fix(angular): remove unnecessary addition of module file extensions

### DIFF
--- a/packages/angular/src/migrations/update-13-2-0/__snapshots__/update-angular-jest-config.spec.ts.snap
+++ b/packages/angular/src/migrations/update-13-2-0/__snapshots__/update-angular-jest-config.spec.ts.snap
@@ -21,6 +21,5 @@ transformIgnorePatterns: ['node_modules/(?!.*\\\\.mjs$)'],
           'jest-preset-angular/build/serializers/ng-snapshot',
           'jest-preset-angular/build/serializers/html-comment',
         ],
-       
-moduleFileExtensions: ['mjs', 'ts', 'js', 'html'], };"
+        };"
 `;

--- a/packages/angular/src/migrations/update-13-2-0/update-angular-jest-config.spec.ts
+++ b/packages/angular/src/migrations/update-13-2-0/update-angular-jest-config.spec.ts
@@ -100,7 +100,6 @@ snapshotSerializers: [
         'jest-preset-angular/build/serializers/ng-snapshot',
         'jest-preset-angular/build/serializers/html-comment',
       ],
-      moduleFileExtensions: ['mjs', 'ts', 'js', 'html'],
       };"
     `);
   });
@@ -155,7 +154,6 @@ snapshotSerializers: [
         'jest-preset-angular/build/serializers/ng-snapshot',
         'jest-preset-angular/build/serializers/html-comment',
       ],
-      moduleFileExtensions: ['mjs', 'ts', 'js', 'html'],
       };"
     `);
   });
@@ -200,7 +198,6 @@ transform: {
       '^.+\\\\.(ts|mjs|js|html)$': 'jest-preset-angular',
       },
       transformIgnorePatterns: ['node_modules/(?!.*\\\\.mjs$)'],
-      moduleFileExtensions: ['mjs', 'ts', 'js', 'html'],
       };"
     `);
   });
@@ -246,167 +243,6 @@ transform: {
             },
             displayName: 'common-platform',
           };
-          "
-    `);
-  });
-
-  it('should add the mjs extension to a config with existing moduleFileExtensions property', () => {
-    // ARRANGE
-    const jestConfig = `module.exports = {
-      preset: '../../jest.preset.js',
-      coverageDirectory: '../../coverage/libs/common-platform',
-      moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
-      setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-      transform: {
-        '^.+\\.(ts|js|html)$': 'jest-preset-angular',
-        },
-      globals: {
-        'ts-jest': {
-          stringifyContentPathRegex: '\\\\.(html|svg)$',
-          astTransformers: [
-            'jest-preset-angular/build/InlineFilesTransformer',
-            'jest-preset-angular/build/StripStylesTransformer',
-          ],
-          tsconfig: '<rootDir>/tsconfig.spec.json',
-        },
-      },
-      displayName: 'common-platform',
-    };
-    `;
-
-    // ACT
-    const updatedFile = replaceTransformAndAddIgnorePattern(jestConfig);
-
-    // ASSERT
-    expect(updatedFile).toMatchInlineSnapshot(`
-      "module.exports = {
-            preset: '../../jest.preset.js',
-            coverageDirectory: '../../coverage/libs/common-platform',
-            moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html', 'mjs'],
-            setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-            transform: {
-      '^.+\\\\.(ts|mjs|js|html)$': 'jest-preset-angular',
-              },
-      transformIgnorePatterns: ['node_modules/(?!.*\\\\.mjs$)'],
-            globals: {
-              'ts-jest': {
-                stringifyContentPathRegex: '\\\\\\\\.(html|svg)$',
-                astTransformers: [
-                  'jest-preset-angular/build/InlineFilesTransformer',
-                  'jest-preset-angular/build/StripStylesTransformer',
-                ],
-                tsconfig: '<rootDir>/tsconfig.spec.json',
-              },
-            },
-            displayName: 'common-platform',
-          };
-          "
-    `);
-  });
-
-  it('should not add the mjs extension to a config with existing moduleFileExtensions property with mjs extension', () => {
-    // ARRANGE
-    const jestConfig = `module.exports = {
-      preset: '../../jest.preset.js',
-      coverageDirectory: '../../coverage/libs/common-platform',
-      moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html', 'mjs'],
-      setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-      transform: {
-        '^.+\\.(ts|js|html)$': 'jest-preset-angular',
-        },
-      globals: {
-        'ts-jest': {
-          stringifyContentPathRegex: '\\\\.(html|svg)$',
-          astTransformers: [
-            'jest-preset-angular/build/InlineFilesTransformer',
-            'jest-preset-angular/build/StripStylesTransformer',
-          ],
-          tsconfig: '<rootDir>/tsconfig.spec.json',
-        },
-      },
-      displayName: 'common-platform',
-    };
-    `;
-
-    // ACT
-    const updatedFile = replaceTransformAndAddIgnorePattern(jestConfig);
-
-    // ASSERT
-    expect(updatedFile).toMatchInlineSnapshot(`
-      "module.exports = {
-            preset: '../../jest.preset.js',
-            coverageDirectory: '../../coverage/libs/common-platform',
-            moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html', 'mjs'],
-            setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-            transform: {
-      '^.+\\\\.(ts|mjs|js|html)$': 'jest-preset-angular',
-              },
-      transformIgnorePatterns: ['node_modules/(?!.*\\\\.mjs$)'],
-            globals: {
-              'ts-jest': {
-                stringifyContentPathRegex: '\\\\\\\\.(html|svg)$',
-                astTransformers: [
-                  'jest-preset-angular/build/InlineFilesTransformer',
-                  'jest-preset-angular/build/StripStylesTransformer',
-                ],
-                tsconfig: '<rootDir>/tsconfig.spec.json',
-              },
-            },
-            displayName: 'common-platform',
-          };
-          "
-    `);
-  });
-
-  it('should add the moduleFileExtensions property with mjs extension', () => {
-    // ARRANGE
-    const jestConfig = `module.exports = {
-      preset: '../../jest.preset.js',
-      coverageDirectory: '../../coverage/libs/common-platform',
-      setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-      transform: {
-        '^.+\\.(ts|js|html)$': 'jest-preset-angular',
-        },
-      globals: {
-        'ts-jest': {
-          stringifyContentPathRegex: '\\\\.(html|svg)$',
-          astTransformers: [
-            'jest-preset-angular/build/InlineFilesTransformer',
-            'jest-preset-angular/build/StripStylesTransformer',
-          ],
-          tsconfig: '<rootDir>/tsconfig.spec.json',
-        },
-      },
-      displayName: 'common-platform',
-    };
-    `;
-
-    // ACT
-    const updatedFile = replaceTransformAndAddIgnorePattern(jestConfig);
-
-    // ASSERT
-    expect(updatedFile).toMatchInlineSnapshot(`
-      "module.exports = {
-            preset: '../../jest.preset.js',
-            coverageDirectory: '../../coverage/libs/common-platform',
-            setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-            transform: {
-      '^.+\\\\.(ts|mjs|js|html)$': 'jest-preset-angular',
-              },
-      transformIgnorePatterns: ['node_modules/(?!.*\\\\.mjs$)'],
-            globals: {
-              'ts-jest': {
-                stringifyContentPathRegex: '\\\\\\\\.(html|svg)$',
-                astTransformers: [
-                  'jest-preset-angular/build/InlineFilesTransformer',
-                  'jest-preset-angular/build/StripStylesTransformer',
-                ],
-                tsconfig: '<rootDir>/tsconfig.spec.json',
-              },
-            },
-            displayName: 'common-platform',
-         
-      moduleFileExtensions: ['mjs', 'ts', 'js', 'html'], };
           "
     `);
   });

--- a/packages/jest/src/generators/jest-project/files-angular/jest.config.js__tmpl__
+++ b/packages/jest/src/generators/jest-project/files-angular/jest.config.js__tmpl__
@@ -8,12 +8,7 @@ module.exports = {
       stringifyContentPathRegex: '\\.(html|svg)$',
     }
   },<% if(testEnvironment) { %>
-  testEnvironment: '<%= testEnvironment %>',<% } %><% if(skipSerializers){ %>
-  transform: {
-    <% if (supportTsx){ %>'^.+\\.[tj]sx?$'<% } else { %>'^.+\\.[tj]s$'<% } %>: <% if (transformer == 'babel-jest') { %>'babel-jest'<% } else { %> 'ts-jest' <% } %>
-  },<% if (supportTsx) { %>
-    moduleFileExtensions: ['mjs', 'ts', 'tsx', 'js', 'jsx'],<% } else { %>
-    moduleFileExtensions: ['mjs', 'ts', 'js', 'html'],<% } %><% } %>
+  testEnvironment: '<%= testEnvironment %>',<% } %>
   coverageDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>',
   transform: {
     '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`moduleFileExtensions` are added during the Angular 13 migration.. but they aren't added onto new projects... yet tests still work? Those moduleFileExtensions seem unnecessary. :thinking: 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`moduleFileExtensions` are not added for Angular.. and all tests still work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
