### PR TITLE
docs(nxdev): add width to open platform logo elements

### DIFF
--- a/nx-dev/ui-home/src/lib/open-platform.tsx
+++ b/nx-dev/ui-home/src/lib/open-platform.tsx
@@ -5,7 +5,7 @@ import { useInView } from 'react-intersection-observer';
 const featureItems: ReactComponentElement<any>[] = [
   <svg
     id="typescript-logo"
-    className="max-h-12 fill-current text-[#3178C6]"
+    className="w-full max-h-12 fill-current text-[#3178C6]"
     role="img"
     viewBox="0 0 24 24"
   >
@@ -13,7 +13,7 @@ const featureItems: ReactComponentElement<any>[] = [
   </svg>,
   <svg
     id="python-logo"
-    className="max-h-12 fill-current text-yellow-500"
+    className="w-full max-h-12 fill-current text-yellow-500"
     role="img"
     viewBox="0 0 24 24"
   >
@@ -21,14 +21,14 @@ const featureItems: ReactComponentElement<any>[] = [
   </svg>,
   <svg
     id="go-logo"
-    className="max-h-12 fill-current text-[#7FD5EA]"
+    className="w-full max-h-12 fill-current text-[#7FD5EA]"
     viewBox="0 0 24 24"
   >
     <path d="M1.811 10.231c-.047 0-.058-.023-.035-.059l.246-.315c.023-.035.081-.058.128-.058h4.172c.046 0 .058.035.035.07l-.199.303c-.023.036-.082.07-.117.07zM.047 11.306c-.047 0-.059-.023-.035-.058l.245-.316c.023-.035.082-.058.129-.058h5.328c.047 0 .07.035.058.07l-.093.28c-.012.047-.058.07-.105.07zm2.828 1.075c-.047 0-.059-.035-.035-.07l.163-.292c.023-.035.07-.07.117-.07h2.337c.047 0 .07.035.07.082l-.023.28c0 .047-.047.082-.082.082zm12.129-2.36c-.736.187-1.239.327-1.963.514-.176.046-.187.058-.34-.117-.174-.199-.303-.327-.548-.444-.737-.362-1.45-.257-2.115.175-.795.514-1.204 1.274-1.192 2.22.011.935.654 1.706 1.577 1.835.795.105 1.46-.175 1.987-.77.105-.13.198-.27.315-.434H10.47c-.245 0-.304-.152-.222-.35.152-.362.432-.97.596-1.274a.315.315 0 01.292-.187h4.253c-.023.316-.023.631-.07.947a4.983 4.983 0 01-.958 2.29c-.841 1.11-1.94 1.8-3.33 1.986-1.145.152-2.209-.07-3.143-.77-.865-.655-1.356-1.52-1.484-2.595-.152-1.274.222-2.419.993-3.424.83-1.086 1.928-1.776 3.272-2.02 1.098-.2 2.15-.07 3.096.571.62.41 1.063.97 1.356 1.648.07.105.023.164-.117.2m3.868 6.461c-1.064-.024-2.034-.328-2.852-1.029a3.665 3.665 0 01-1.262-2.255c-.21-1.32.152-2.489.947-3.529.853-1.122 1.881-1.706 3.272-1.95 1.192-.21 2.314-.095 3.33.595.923.63 1.496 1.484 1.648 2.605.198 1.578-.257 2.863-1.344 3.962-.771.783-1.718 1.273-2.805 1.495-.315.06-.63.07-.934.106zm2.78-4.72c-.011-.153-.011-.27-.034-.387-.21-1.157-1.274-1.81-2.384-1.554-1.087.245-1.788.935-2.045 2.033-.21.912.234 1.835 1.075 2.21.643.28 1.285.244 1.905-.07.923-.48 1.425-1.228 1.484-2.233z" />
   </svg>,
   <svg
     id="rust-logo"
-    className="max-h-12 fill-current text-gray-800"
+    className="w-full max-h-12 fill-current text-gray-800"
     role="img"
     viewBox="0 0 24 24"
   >
@@ -36,7 +36,7 @@ const featureItems: ReactComponentElement<any>[] = [
   </svg>,
   <svg
     id="kotlin-logo"
-    className="max-h-12 fill-current text-purple-500"
+    className="w-full max-h-12 fill-current text-purple-500"
     role="img"
     viewBox="0 0 24 24"
   >
@@ -44,7 +44,7 @@ const featureItems: ReactComponentElement<any>[] = [
   </svg>,
   <svg
     id=".net-logo"
-    className="max-h-12 fill-current text-gray-800"
+    className="w-full max-h-12 fill-current text-gray-800"
     role="img"
     viewBox="0 0 24 24"
   >


### PR DESCRIPTION
## What it does?
Adds explicit width for open platform logos on nx.dev home page to fix Safari rendering issue.