### PR TITLE
fix(web): default react builds to production when NODE_ENV is not set explicitly

### DIFF
--- a/packages/web/src/executors/build/build.impl.ts
+++ b/packages/web/src/executors/build/build.impl.ts
@@ -127,6 +127,9 @@ export async function* run(
       `Node version ${nodeVersion} is not supported. Supported range is "${supportedRange.raw}".`
     );
   }
+
+  process.env.NODE_ENV ||= 'production';
+
   const metadata = context.workspace.projects[context.projectName];
 
   if (!options.buildLibsFromSource && context.targetName) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently, react builds are not set to default to production (Look at the **_styles size_**)

![image](https://user-images.githubusercontent.com/338948/141594648-6863aa69-f9d2-4ccf-b6d7-a5c9aa2f5c94.png)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running  `yarn nx run project:build:production` will now default NODE_ENV to production

![image](https://user-images.githubusercontent.com/338948/141594722-2537305e-84c6-4442-91ee-4ed94a3fab45.png)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7410
