### PR TITLE
fix(node): fix source-map-support dependency

### DIFF
--- a/packages/node/src/executors/execute/execute.impl.spec.ts
+++ b/packages/node/src/executors/execute/execute.impl.spec.ts
@@ -98,7 +98,7 @@ describe('NodeExecuteBuilder', () => {
     expect(fork).toHaveBeenCalledWith('outfile.js', [], {
       execArgv: [
         '-r',
-        'source-map-support/register',
+        require.resolve('source-map-support/register'),
         '--inspect=localhost:9229',
       ],
     });
@@ -120,7 +120,7 @@ describe('NodeExecuteBuilder', () => {
         expect(fork).toHaveBeenCalledWith('outfile.js', [], {
           execArgv: [
             '-r',
-            'source-map-support/register',
+            require.resolve('source-map-support/register'),
             '--inspect=localhost:9229',
           ],
         });
@@ -140,7 +140,7 @@ describe('NodeExecuteBuilder', () => {
         expect(fork).toHaveBeenCalledWith('outfile.js', [], {
           execArgv: [
             '-r',
-            'source-map-support/register',
+            require.resolve('source-map-support/register'),
             '--inspect-brk=localhost:9229',
           ],
         });
@@ -162,7 +162,7 @@ describe('NodeExecuteBuilder', () => {
         expect(fork).toHaveBeenCalledWith('outfile.js', [], {
           execArgv: [
             '-r',
-            'source-map-support/register',
+            require.resolve('source-map-support/register'),
             '--inspect=0.0.0.0:9229',
           ],
         });
@@ -184,7 +184,7 @@ describe('NodeExecuteBuilder', () => {
         expect(fork).toHaveBeenCalledWith('outfile.js', [], {
           execArgv: [
             '-r',
-            'source-map-support/register',
+            require.resolve('source-map-support/register'),
             '--inspect=localhost:1234',
           ],
         });
@@ -205,7 +205,7 @@ describe('NodeExecuteBuilder', () => {
       expect(fork).toHaveBeenCalledWith('outfile.js', [], {
         execArgv: [
           '-r',
-          'source-map-support/register',
+          require.resolve('source-map-support/register'),
           '-r',
           'node-register',
           '--inspect=localhost:9229',
@@ -255,7 +255,7 @@ describe('NodeExecuteBuilder', () => {
     )) {
     }
     expect(fork).toHaveBeenCalledWith('outfile.js', ['arg1', 'arg2'], {
-      execArgv: ['-r', 'source-map-support/register'],
+      execArgv: ['-r', require.resolve('source-map-support/register')],
     });
   });
 

--- a/packages/node/src/executors/execute/execute.impl.ts
+++ b/packages/node/src/executors/execute/execute.impl.ts
@@ -78,7 +78,11 @@ function runProcess(event: NodeBuildEvent, options: NodeExecuteBuilderOptions) {
 }
 
 function getExecArgv(options: NodeExecuteBuilderOptions) {
-  const args = ['-r', 'source-map-support/register', ...options.runtimeArgs];
+  const args = [
+    '-r',
+    require.resolve('source-map-support/register'),
+    ...options.runtimeArgs,
+  ];
 
   if (options.inspect === true) {
     options.inspect = InspectType.Inspect;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

- node:execute generates commands with `-r source-map-support`, which fails

Using `-r source-map-support` makes dangerous assumptions about `node_modules` structure. Specifically, it assumes that `-r <THIS_MODULE>` is available for resolution by node. `pnpm`, for instance, will _not_ create `node_modules/source-map-support` in the top level, because it does not expose transitive dependencies. This isn't strictly a pnpm problem--but rather an incorrect expression of required dependencies in `packages/node/package.json`. I suspect other package managers may not guarantee this dependency in the same path either.  The common package managers (yarn, npm) in their default configurations _will_ write `node_modules/source-map-support`, so it works for 99% of folks, but nonetheless, does not work for all.

## Expected Behavior

- works, regardless of your package manager

## Related Issue(s)

Fixes #
