### PR TITLE
fix(web): option --no-runtimeChunk is not working

### DIFF
--- a/packages/web/src/executors/webpack/webpack.impl.ts
+++ b/packages/web/src/executors/webpack/webpack.impl.ts
@@ -50,6 +50,7 @@ export interface WebWebpackExecutorOptions extends BuildBuilderOptions {
 
   vendorChunk?: boolean;
   commonChunk?: boolean;
+  runtimeChunk?: boolean;
 
   namedChunks?: boolean;
 

--- a/packages/web/src/utils/webpack/partials/browser.ts
+++ b/packages/web/src/utils/webpack/partials/browser.ts
@@ -45,7 +45,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
         : false,
     },
     optimization: {
-      runtimeChunk: 'single',
+      runtimeChunk: !!buildOptions.runtimeChunk ? 'single' : false,
       splitChunks: {
         maxAsyncRequests: Infinity,
         cacheGroups: {


### PR DESCRIPTION
## Current Behavior
Run `nx run test:build:production --no-extractLicenses --no-runtimeChunk` the build result contain runtime file

## Expected Behavior
There would be no runtime chunk in the build output

## Related Issue(s)

Fixes #7509
