### PR TITLE
fix(web): add scripts default value in schema.json

### DIFF
--- a/packages/web/src/executors/build/schema.json
+++ b/packages/web/src/executors/build/schema.json
@@ -87,7 +87,8 @@
       "description": "External Scripts which will be included before the main application entry",
       "items": {
         "$ref": "#/definitions/extraEntryPoint"
-      }
+      },
+      "default": []
     },
     "styles": {
       "type": "array",


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->
The scripts property inside project.json is not required. So if it is not provided running the build
command should not fail due to the scripts property being missing.

## Current Behavior
Build command fails when scripts property is not passed in i.e. `undefined`.

## Expected Behavior
<!-- This is the behaviour we should expect with the changes in this PR -->
Build command should not fail due to the scripts property being `undefined`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7178
