### PR TITLE
fix(devkit): handle other variants of root paths in visitNotIgnoredFiles

### DIFF
--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -35,19 +35,22 @@ describe('visitNotIgnoredFiles', () => {
     expect(visitor).not.toHaveBeenCalledWith('dir/node_modules/file1.ts');
   });
 
-  it('should be able to visit the root', () => {
-    tree.write('.gitignore', 'node_modules');
+  it.each(['', '.', '/', './'])(
+    'should be able to visit the root path "%s"',
+    (dirPath) => {
+      tree.write('.gitignore', 'node_modules');
 
-    tree.write('dir/file1.ts', '');
-    tree.write('dir/node_modules/file1.ts', '');
-    tree.write('dir/dir2/file2.ts', '');
+      tree.write('dir/file1.ts', '');
+      tree.write('dir/node_modules/file1.ts', '');
+      tree.write('dir/dir2/file2.ts', '');
 
-    const visitor = jest.fn();
-    visitNotIgnoredFiles(tree, '', visitor);
+      const visitor = jest.fn();
+      visitNotIgnoredFiles(tree, dirPath, visitor);
 
-    expect(visitor).toHaveBeenCalledWith('.gitignore');
-    expect(visitor).toHaveBeenCalledWith('dir/file1.ts');
-    expect(visitor).toHaveBeenCalledWith('dir/dir2/file2.ts');
-    expect(visitor).not.toHaveBeenCalledWith('dir/node_modules/file1.ts');
-  });
+      expect(visitor).toHaveBeenCalledWith('.gitignore');
+      expect(visitor).toHaveBeenCalledWith('dir/file1.ts');
+      expect(visitor).toHaveBeenCalledWith('dir/dir2/file2.ts');
+      expect(visitor).not.toHaveBeenCalledWith('dir/node_modules/file1.ts');
+    }
+  );
 });

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/tao/src/shared/tree';
-import { join } from 'path';
 import ignore, { Ignore } from 'ignore';
+import { join, relative, sep } from 'path';
 
 /**
  * Utility to act on all files in a tree that are not ignored by git.
@@ -15,6 +15,7 @@ export function visitNotIgnoredFiles(
     ig = ignore();
     ig.add(tree.read('.gitignore', 'utf-8'));
   }
+  dirPath = normalizePathRelativeToRoot(dirPath, tree.root);
   if (dirPath !== '' && ig?.ignores(dirPath)) {
     return;
   }
@@ -29,4 +30,8 @@ export function visitNotIgnoredFiles(
       visitNotIgnoredFiles(tree, fullPath, visitor);
     }
   }
+}
+
+function normalizePathRelativeToRoot(path: string, root: string): string {
+  return relative(root, join(root, path)).split(sep).join('/');
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `visitNotIgnoredFiles` currently supports visiting the root path as long as it is an empty string. Other variants of the root path (e.g. ".") are not supported and cause the `ignore` package to throw an error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `visitNotIgnoredFiles` should handle correctly any variant of a root path.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7642 
