### PR TITLE
chore(angular): use yarn for buildable libs test

### DIFF
--- a/e2e/angular-extensions/src/angular-app.test.ts
+++ b/e2e/angular-extensions/src/angular-app.test.ts
@@ -26,24 +26,26 @@ describe('Angular Package', () => {
     // This fails with pnpm due to incompatibilities with ngcc.
     // Since this suite has a single test, we wrap everything to avoid the hooks to run and
     // waste time.
-    if (getSelectedPackageManager() !== 'pnpm') {
-      beforeEach(() => {
-        app = uniq('app');
-        buildableLib = uniq('buildlib1');
+    // therefore switch to yarn
+    const previousPackageRunner = process.env.SELECTED_PM;
+    if (getSelectedPackageManager() === 'pnpm') {
+      process.env.SELECTED_PM = 'yarn';
+    }
+    beforeEach(() => {
+      app = uniq('app');
+      buildableLib = uniq('buildlib1');
 
-        proj = newProject();
+      proj = newProject();
 
-        runCLI(
-          `generate @nrwl/angular:app ${app} --style=css --no-interactive`
-        );
-        runCLI(
-          `generate @nrwl/angular:library ${buildableLib} --buildable=true --no-interactive`
-        );
+      runCLI(`generate @nrwl/angular:app ${app} --style=css --no-interactive`);
+      runCLI(
+        `generate @nrwl/angular:library ${buildableLib} --buildable=true --no-interactive`
+      );
 
-        // update the app module to include a ref to the buildable lib
-        updateFile(
-          `apps/${app}/src/app/app.module.ts`,
-          `
+      // update the app module to include a ref to the buildable lib
+      updateFile(
+        `apps/${app}/src/app/app.module.ts`,
+        `
         import { BrowserModule } from '@angular/platform-browser';
         import { NgModule } from '@angular/core';
         import {${
@@ -60,34 +62,33 @@ describe('Angular Package', () => {
         })
         export class AppModule {}
     `
-        );
+      );
 
-        // update the angular.json
-        const workspaceJson = readJson(`angular.json`);
-        workspaceJson.projects[app].architect.build.builder =
-          '@nrwl/angular:webpack-browser';
-        updateFile('angular.json', JSON.stringify(workspaceJson, null, 2));
-      });
+      // update the angular.json
+      const workspaceJson = readJson(`angular.json`);
+      workspaceJson.projects[app].architect.build.builder =
+        '@nrwl/angular:webpack-browser';
+      updateFile('angular.json', JSON.stringify(workspaceJson, null, 2));
+    });
 
-      afterEach(() => removeProject({ onlyOnCI: true }));
+    afterEach(() => removeProject({ onlyOnCI: true }));
 
-      it('should build the dependent buildable lib as well as the app', () => {
-        const libOutput = runCLI(
-          `build ${app} --with-deps --configuration=development`
-        );
-        expect(libOutput).toContain(
-          `Building entry point '@${proj}/${buildableLib}'`
-        );
-        expect(libOutput).toContain(`nx run ${app}:build:development`);
+    it('should build the dependent buildable lib as well as the app', () => {
+      const libOutput = runCLI(
+        `build ${app} --with-deps --configuration=development`
+      );
+      expect(libOutput).toContain(
+        `Building entry point '@${proj}/${buildableLib}'`
+      );
+      expect(libOutput).toContain(`nx run ${app}:build:development`);
 
-        // to proof it has been built from source the "main.js" should actually contain
-        // the path to dist
-        const mainBundle = readFile(`dist/apps/${app}/main.js`);
-        expect(mainBundle).toContain(`dist/libs/${buildableLib}`);
-      });
-    } else {
-      it('Skip tests with pnpm', () => {});
-    }
+      // to proof it has been built from source the "main.js" should actually contain
+      // the path to dist
+      const mainBundle = readFile(`dist/apps/${app}/main.js`);
+      expect(mainBundle).toContain(`dist/libs/${buildableLib}`);
+    });
+
+    process.env.SELECTED_PM = previousPackageRunner;
   });
 });
 

--- a/e2e/angular-extensions/src/angular-app.test.ts
+++ b/e2e/angular-extensions/src/angular-app.test.ts
@@ -23,19 +23,19 @@ describe('Angular Package', () => {
     let buildableLib;
     let proj: string;
 
-    // This fails with pnpm due to incompatibilities with ngcc.
-    // Since this suite has a single test, we wrap everything to avoid the hooks to run and
-    // waste time.
-    // therefore switch to yarn
-    const previousPackageRunner = process.env.SELECTED_PM;
-    if (getSelectedPackageManager() === 'pnpm') {
-      process.env.SELECTED_PM = 'yarn';
-    }
     beforeEach(() => {
       app = uniq('app');
       buildableLib = uniq('buildlib1');
 
-      proj = newProject();
+      // This fails with pnpm due to incompatibilities with ngcc.
+      // Since this suite has a single test, we wrap everything to avoid the hooks to run and
+      // waste time.
+      // therefore switch to yarn
+
+      proj =
+        getSelectedPackageManager() === 'pnpm'
+          ? newProject({ packageManager: 'yarn' })
+          : newProject();
 
       runCLI(`generate @nrwl/angular:app ${app} --style=css --no-interactive`);
       runCLI(
@@ -87,8 +87,6 @@ describe('Angular Package', () => {
       const mainBundle = readFile(`dist/apps/${app}/main.js`);
       expect(mainBundle).toContain(`dist/libs/${buildableLib}`);
     });
-
-    process.env.SELECTED_PM = previousPackageRunner;
   });
 });
 

--- a/e2e/angular-extensions/src/angular-library.test.ts
+++ b/e2e/angular-extensions/src/angular-library.test.ts
@@ -36,7 +36,12 @@ describe('Angular Package', () => {
         childLib = uniq('childlib');
         childLib2 = uniq('childlib2');
 
-        proj = newProject();
+        // These fail with pnpm due to incompatibilities with ngcc for buildable libraries.
+        // therefore switch to yarn
+        proj =
+          getSelectedPackageManager() === 'pnpm' && testConfig !== 'publishable'
+            ? newProject({ packageManager: 'yarn' })
+            : newProject();
 
         if (testConfig === 'buildable') {
           runCLI(
@@ -136,15 +141,6 @@ describe('Angular Package', () => {
 
       afterEach(() => removeProject({ onlyOnCI: true }));
 
-      // These fail with pnpm due to incompatibilities with ngcc for buildable libraries.
-      // therefore switch to yarn
-      const previousPackageRunner = process.env.SELECTED_PM;
-      if (
-        getSelectedPackageManager() === 'pnpm' &&
-        testConfig !== 'publishable'
-      ) {
-        process.env.SELECTED_PM = 'yarn';
-      }
       it('should build the library when it does not have any deps', () => {
         runCLI(`build ${childLib}`);
 
@@ -172,8 +168,6 @@ describe('Angular Package', () => {
         expect(jsonFile.peerDependencies['@angular/common']).toBeDefined();
         expect(jsonFile.peerDependencies['@angular/core']).toBeDefined();
       });
-
-      process.env.SELECTED_PM = previousPackageRunner;
     });
   });
 

--- a/e2e/angular-extensions/src/angular-library.test.ts
+++ b/e2e/angular-extensions/src/angular-library.test.ts
@@ -136,43 +136,44 @@ describe('Angular Package', () => {
 
       afterEach(() => removeProject({ onlyOnCI: true }));
 
-      it('empty test to make jest happy', () => {});
-
       // These fail with pnpm due to incompatibilities with ngcc for buildable libraries.
+      // therefore switch to yarn
+      const previousPackageRunner = process.env.SELECTED_PM;
       if (
-        getSelectedPackageManager() !== 'pnpm' ||
-        testConfig === 'publishable'
+        getSelectedPackageManager() === 'pnpm' &&
+        testConfig !== 'publishable'
       ) {
-        it('should build the library when it does not have any deps', () => {
-          runCLI(`build ${childLib}`);
-
-          checkFilesExist(`dist/libs/${childLib}/package.json`);
-        });
-
-        it('should properly add references to any dependency into the parent package.json', () => {
-          runCLI(`build ${childLib}`);
-          runCLI(`build ${childLib2}`);
-          runCLI(`build ${parentLib}`);
-
-          checkFilesExist(
-            `dist/libs/${childLib}/package.json`,
-            `dist/libs/${childLib2}/package.json`,
-            `dist/libs/${parentLib}/package.json`
-          );
-
-          const jsonFile = readJson(`dist/libs/${parentLib}/package.json`);
-
-          expect(jsonFile.dependencies['tslib']).toMatch(/\^2\.\d+\.\d+/); // match any ^2.x.x
-          expect(
-            jsonFile.peerDependencies[`@${proj}/${childLib}`]
-          ).toBeDefined();
-          expect(
-            jsonFile.peerDependencies[`@${proj}/${childLib2}`]
-          ).toBeDefined();
-          expect(jsonFile.peerDependencies['@angular/common']).toBeDefined();
-          expect(jsonFile.peerDependencies['@angular/core']).toBeDefined();
-        });
+        process.env.SELECTED_PM = 'yarn';
       }
+      it('should build the library when it does not have any deps', () => {
+        runCLI(`build ${childLib}`);
+
+        checkFilesExist(`dist/libs/${childLib}/package.json`);
+      });
+
+      it('should properly add references to any dependency into the parent package.json', () => {
+        runCLI(`build ${childLib}`);
+        runCLI(`build ${childLib2}`);
+        runCLI(`build ${parentLib}`);
+
+        checkFilesExist(
+          `dist/libs/${childLib}/package.json`,
+          `dist/libs/${childLib2}/package.json`,
+          `dist/libs/${parentLib}/package.json`
+        );
+
+        const jsonFile = readJson(`dist/libs/${parentLib}/package.json`);
+
+        expect(jsonFile.dependencies['tslib']).toMatch(/\^2\.\d+\.\d+/); // match any ^2.x.x
+        expect(jsonFile.peerDependencies[`@${proj}/${childLib}`]).toBeDefined();
+        expect(
+          jsonFile.peerDependencies[`@${proj}/${childLib2}`]
+        ).toBeDefined();
+        expect(jsonFile.peerDependencies['@angular/common']).toBeDefined();
+        expect(jsonFile.peerDependencies['@angular/core']).toBeDefined();
+      });
+
+      process.env.SELECTED_PM = previousPackageRunner;
     });
   });
 

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -183,9 +183,10 @@ export function getSelectedPackageManager(): 'npm' | 'yarn' | 'pnpm' {
  * Sets up a new project in the temporary project path
  * for the currently selected CLI.
  */
-export function newProject({ name = uniq('proj') } = {}): string {
-  const packageManager = getSelectedPackageManager();
-
+export function newProject({
+  name = uniq('proj'),
+  packageManager = getSelectedPackageManager(),
+} = {}): string {
   try {
     const useBackupProject = packageManager !== 'pnpm';
     const projScope = useBackupProject ? 'proj' : name;


### PR DESCRIPTION
We currently skip some e2e tests if they're incompatible with PNPM. 
Switch to Yarn before running these tests so that we can still get the confidence of running them on PRs