### PR TITLE
fix(react-native): deprecation warning because of rmDirSync

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -32,6 +32,7 @@
     "@nrwl/workspace": "*",
     "chalk": "^4.1.0",
     "enhanced-resolve": "^5.8.3",
+    "fs-extra": "^9.1.0",
     "ignore": "^5.0.4",
     "metro-resolver": "^0.66.2",
     "node-fetch": "^2.6.1",

--- a/packages/react-native/src/utils/ensure-node-modules-symlink.spec.ts
+++ b/packages/react-native/src/utils/ensure-node-modules-symlink.spec.ts
@@ -1,6 +1,6 @@
 import { tmpdir } from 'os';
 import { join } from 'path';
-import * as fs from 'fs';
+import * as fs from 'fs-extra';
 import { ensureNodeModulesSymlink } from './ensure-node-modules-symlink';
 
 const workspaceDir = join(tmpdir(), 'nx-react-native-test');
@@ -9,8 +9,7 @@ const appDirAbsolutePath = join(workspaceDir, appDir);
 
 describe('ensureNodeModulesSymlink', () => {
   beforeEach(() => {
-    if (fs.existsSync(workspaceDir))
-      fs.rmdirSync(workspaceDir, { recursive: true });
+    if (fs.existsSync(workspaceDir)) fs.removeSync(workspaceDir);
     fs.mkdirSync(workspaceDir);
     fs.mkdirSync(appDirAbsolutePath, { recursive: true });
     fs.mkdirSync(appDirAbsolutePath, { recursive: true });
@@ -36,8 +35,7 @@ describe('ensureNodeModulesSymlink', () => {
   });
 
   afterEach(() => {
-    if (fs.existsSync(workspaceDir))
-      fs.rmdirSync(workspaceDir, { recursive: true });
+    if (fs.existsSync(workspaceDir)) fs.removeSync(workspaceDir);
   });
 
   it('should create symlinks', () => {

--- a/packages/react-native/src/utils/ensure-node-modules-symlink.ts
+++ b/packages/react-native/src/utils/ensure-node-modules-symlink.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import { platform } from 'os';
-import * as fs from 'fs';
-import chalk = require('chalk');
+import { removeSync, existsSync, symlinkSync } from 'fs-extra';
 
 /**
  * This function symlink workspace node_modules folder with app project's node_mdules folder.
@@ -16,7 +15,7 @@ export function ensureNodeModulesSymlink(
   projectRoot: string
 ): void {
   const worksapceNodeModulesPath = join(workspaceRoot, 'node_modules');
-  if (!fs.existsSync(worksapceNodeModulesPath)) {
+  if (!existsSync(worksapceNodeModulesPath)) {
     throw new Error(`Cannot find ${worksapceNodeModulesPath}`);
   }
 
@@ -24,8 +23,8 @@ export function ensureNodeModulesSymlink(
   // `mklink /D` requires admin privilege in Windows so we need to use junction
   const symlinkType = platform() === 'win32' ? 'junction' : 'dir';
 
-  if (fs.existsSync(appNodeModulesPath)) {
-    fs.rmdirSync(appNodeModulesPath, { recursive: true });
+  if (existsSync(appNodeModulesPath)) {
+    removeSync(appNodeModulesPath);
   }
-  fs.symlinkSync(worksapceNodeModulesPath, appNodeModulesPath, symlinkType);
+  symlinkSync(worksapceNodeModulesPath, appNodeModulesPath, symlinkType);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Node should not print any deprecation warnings

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7739
