### PR TITLE
fix(dep-graph): set workspaceLayout on initGraph

### DIFF
--- a/dep-graph/dep-graph/src/app/machines/dep-graph.machine.ts
+++ b/dep-graph/dep-graph/src/app/machines/dep-graph.machine.ts
@@ -46,6 +46,7 @@ export const depGraphMachine = Machine<
           ctx.projects = event.projects;
           ctx.affectedProjects = event.affectedProjects;
           ctx.dependencies = event.dependencies;
+          ctx.workspaceLayout = event.workspaceLayout;
         }),
       },
 

--- a/dep-graph/dep-graph/src/app/machines/dep-graph.spec.ts
+++ b/dep-graph/dep-graph/src/app/machines/dep-graph.spec.ts
@@ -78,7 +78,7 @@ export const mockDependencies: Record<string, ProjectGraphDependency[]> = {
 
 describe('dep-graph machine', () => {
   describe('initGraph', () => {
-    it('should set projects and dependencies', () => {
+    it('should set projects, dependencies, and workspaceLayout', () => {
       const result = depGraphMachine.transition(depGraphMachine.initialState, {
         type: 'initGraph',
         projects: mockProjects,
@@ -88,6 +88,10 @@ describe('dep-graph machine', () => {
       });
       expect(result.context.projects).toEqual(mockProjects);
       expect(result.context.dependencies).toEqual(mockDependencies);
+      expect(result.context.workspaceLayout).toEqual({
+        appsDir: 'apps',
+        libsDir: 'libs',
+      });
     });
 
     it('should start with no projects selected', () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
* `workspaceLayout` is not set for the given workspace, resulting in projects not being grouped correctly in the dep graph visualization.

<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
* `workspaceLayout` is set for the given workspace, resulting in projects being grouped correctly in the dep graph visualization.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
