### PR TITLE
fix(angular): generate ng-package.json for secondary entrypoints

### DIFF
--- a/packages/angular/src/generators/library-secondary-entry-point/files/ng-package.json__tmpl__
+++ b/packages/angular/src/generators/library-secondary-entry-point/files/ng-package.json__tmpl__
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/packages/angular/src/generators/library-secondary-entry-point/files/package.json__tmpl__
+++ b/packages/angular/src/generators/library-secondary-entry-point/files/package.json__tmpl__
@@ -1,7 +1,0 @@
-{
-  "ngPackage": {
-    "lib": {
-      "entryFile": "src/index.ts"
-    }
-  }
-}

--- a/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
@@ -47,7 +47,7 @@ describe('librarySecondaryEntryPoint generator', () => {
       'libs/lib1/package.json',
       JSON.stringify({ name: '@my-org/lib1' })
     );
-    tree.write('libs/lib1/testing/package.json', '');
+    tree.write('libs/lib1/testing/ng-package.json', '');
 
     await expect(() =>
       librarySecondaryEntryPointGenerator(tree, {
@@ -72,7 +72,7 @@ describe('librarySecondaryEntryPoint generator', () => {
       library: 'lib1',
     });
 
-    expect(tree.exists('libs/lib1/testing/package.json')).toBeTruthy();
+    expect(tree.exists('libs/lib1/testing/ng-package.json')).toBeTruthy();
     expect(tree.exists('libs/lib1/testing/README.md')).toBeTruthy();
     expect(tree.exists('libs/lib1/testing/src/index.ts')).toBeTruthy();
     expect(
@@ -98,8 +98,8 @@ describe('librarySecondaryEntryPoint generator', () => {
       library: 'lib1',
     });
 
-    const packageJson = readJson(tree, 'libs/lib1/testing/package.json');
-    expect(packageJson.ngPackage.lib.entryFile).toBe('src/index.ts');
+    const ngPackageJson = readJson(tree, 'libs/lib1/testing/ng-package.json');
+    expect(ngPackageJson.lib.entryFile).toBe('src/index.ts');
   });
 
   it('should add the path mapping for the entry point', async () => {
@@ -197,7 +197,7 @@ describe('librarySecondaryEntryPoint generator', () => {
       expect(
         tree.exists('libs/lib1/testing/src/lib/testing.module.ts')
       ).toBeFalsy();
-      expect(tree.exists('libs/lib1/testing/package.json')).toBeTruthy();
+      expect(tree.exists('libs/lib1/testing/ng-package.json')).toBeTruthy();
       expect(tree.exists('libs/lib1/testing/README.md')).toBeTruthy();
       expect(tree.exists('libs/lib1/testing/src/index.ts')).toBeTruthy();
       expect(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Starting in v13.0.4 of `ng-packagr` a warning is logged when building a secondary entry point that is configured using the `package.json` file instead of the `ng-package.json` file. The former has been deprecated to configure `ng-packagr`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Building secondary entry points should not output any warnings related to the configuration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
