### PR TITLE
fix(core): add better error message for invalid tools tsconfig

### DIFF
--- a/packages/workspace/src/command-line/workspace-generators.ts
+++ b/packages/workspace/src/command-line/workspace-generators.ts
@@ -65,7 +65,14 @@ function compileTools() {
 }
 
 function getToolsOutDir() {
-  return path.resolve(toolsDir, toolsTsConfig().compilerOptions.outDir);
+  const outDir = toolsTsConfig().compilerOptions.outDir;
+
+  if (!outDir) {
+    logger.error('tsconfig.tools.json must specify an outDir');
+    process.exit(1);
+  }
+
+  return path.resolve(toolsDir, outDir);
 }
 
 function compileToolsDir(outDir: string) {

--- a/packages/workspace/src/command-line/workspace-generators.ts
+++ b/packages/workspace/src/command-line/workspace-generators.ts
@@ -68,7 +68,7 @@ function getToolsOutDir() {
   const outDir = toolsTsConfig().compilerOptions.outDir;
 
   if (!outDir) {
-    logger.error('tsconfig.tools.json must specify an outDir');
+    logger.error(`${toolsTsConfigPath} must specify an outDir`);
     process.exit(1);
   }
 


### PR DESCRIPTION
Add a helpful error message rather than returning a generic type error.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If the user's `tsconfig.tools.json` file does not have the `outDir` compiler option specified, then all workspace-generator commands result in the following error message.
```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:371:5)
    at validateString (node:internal/validators:119:11)
    at Object.resolve (node:path:167:9)
    at getToolsOutDir (C:\Users\bcallaghan\Source\Repos\etogy-workspace\node_modules\@nrwl\workspace\src\command-line\workspace-generators.js:45:17)
    at compileTools (C:\Users\bcallaghan\Source\Repos\etogy-workspace\node_modules\@nrwl\workspace\src\command-line\workspace-generators.js:36:25)
    at Object.<anonymous> (C:\Users\bcallaghan\Source\Repos\etogy-workspace\node_modules\@nrwl\workspace\src\command-line\workspace-generators.js:22:24)
    at Generator.next (<anonymous>)
    at C:\Users\bcallaghan\Source\Repos\etogy-workspace\node_modules\tslib\tslib.js:117:75
    at new Promise (<anonymous>)
    at Object.__awaiter (C:\Users\bcallaghan\Source\Repos\etogy-workspace\node_modules\tslib\tslib.js:113:16) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Instead of throwing the underlying TypeError, workspace-generator commands should check for the `outDir` option and log a specific error message instead. This way, developers will have a better idea on what needs to be fixed in their own workspace.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
N/A