### PR TITLE
fix(angular): consider tailwind usage when invalidating stylesheet caching in publishable libraries

### DIFF
--- a/packages/angular/src/executors/package/ng-packagr-adjustments/ng-package/package.di.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/ng-package/package.di.ts
@@ -18,7 +18,6 @@ import {
 import {
   INIT_TS_CONFIG_TOKEN,
   INIT_TS_CONFIG_TRANSFORM,
-  provideTsConfig,
 } from 'ng-packagr/lib/ng-package/entry-point/init-tsconfig.di';
 import {
   DEFAULT_OPTIONS_PROVIDER,

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/utilities/tailwindcss.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/utilities/tailwindcss.ts
@@ -4,11 +4,21 @@ import { existsSync } from 'fs';
 import { join, relative } from 'path';
 import * as postcssImport from 'postcss-import';
 
-export function getTailwindPostCssPluginsIfPresent(
-  basePath: string,
-  includePaths?: string[],
-  watch?: boolean
-) {
+export interface TailwindSetup {
+  tailwindConfigPath: string;
+  tailwindPackagePath: string;
+}
+
+export const tailwindDirectives = [
+  '@tailwind',
+  '@apply',
+  '@layer',
+  '@variants',
+  '@responsive',
+  '@screen',
+];
+
+export function getTailwindSetup(basePath: string): TailwindSetup | undefined {
   // Try to find TailwindCSS configuration file in the project or workspace root.
   const tailwindConfigFile = 'tailwind.config.js';
   let tailwindConfigPath: string | undefined;
@@ -22,7 +32,7 @@ export function getTailwindPostCssPluginsIfPresent(
 
   // Only load Tailwind CSS plugin if configuration file was found.
   if (!tailwindConfigPath) {
-    return [];
+    return undefined;
   }
 
   let tailwindPackagePath: string | undefined;
@@ -39,13 +49,21 @@ export function getTailwindPostCssPluginsIfPresent(
         ` To enable Tailwind CSS, please install the 'tailwindcss' package.`
     );
 
-    return [];
+    return undefined;
   }
 
   if (!tailwindPackagePath) {
-    return [];
+    return undefined;
   }
 
+  return { tailwindConfigPath, tailwindPackagePath };
+}
+
+export function getTailwindPostCssPlugins(
+  { tailwindConfigPath, tailwindPackagePath }: TailwindSetup,
+  includePaths?: string[],
+  watch?: boolean
+) {
   if (process.env['TAILWIND_MODE'] === undefined) {
     process.env['TAILWIND_MODE'] = watch ? 'watch' : 'build';
   }
@@ -53,7 +71,7 @@ export function getTailwindPostCssPluginsIfPresent(
   return [
     postcssImport({
       addModulesDirectories: includePaths ?? [],
-      resolve: (url: string) => (url.startsWith('~') ? url.substr(1) : url),
+      resolve: (url: string) => (url.startsWith('~') ? url.substring(1) : url),
     }),
     require(tailwindPackagePath)({ config: tailwindConfigPath }),
   ];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The package executor caching for stylesheets is too aggressive and it doesn't consider Tailwind directives which can cause different outputs based on the Tailwind configuration. Therefore, changes to the Tailwind configuration don't get reflected unless the `ng-packagr` cache is cleared.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Changes to the Tailwind configuration of publishable libraries should be respected and reflected in the compiled output.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
