### PR TITLE
fix(linter): fix broken circular deps output

### DIFF
--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
@@ -183,10 +183,10 @@ export function extractCachedFileData(
   cachedFileData: { [project: string]: { [file: string]: FileData } };
 } {
   const filesToProcess: ProjectFileMap = {};
+  const cachedFileData: Record<string, Record<string, FileData>> = {};
   const currentProjects = Object.keys(fileMap).filter(
     (name) => fileMap[name].length > 0
   );
-  const cachedFileData = {};
   currentProjects.forEach((p) => {
     processProjectNode(p, c.nodes[p], cachedFileData, filesToProcess, fileMap);
   });

--- a/packages/workspace/src/utils/graph-utils.ts
+++ b/packages/workspace/src/utils/graph-utils.ts
@@ -1,4 +1,4 @@
-import type { ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
+import type { FileData, ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
 import { isWorkspaceProject } from '../core/project-graph/operators';
 
 interface Reach {
@@ -120,10 +120,12 @@ export function findFilesInCircularPath(
 
   for (let i = 0; i < circularPath.length - 1; i++) {
     const next = circularPath[i + 1].name;
-    const files = circularPath[i].data.files;
+    const files: FileData[] = circularPath[i].data.files;
     filePathChain.push(
       Object.keys(files)
-        .filter((key) => files[key].deps?.indexOf(next) !== -1)
+        .filter(
+          (key) => files[key].deps && files[key].deps.indexOf(next) !== -1
+        )
         .map((key) => files[key].file)
     );
   }

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -227,8 +227,8 @@ export function mapProjectGraphFiles<T>(
     projectGraph.nodes as Record<string, ProjectGraphProjectNode>
   ).forEach(([name, node]) => {
     const files: Record<string, FileData> = {};
-    node.data.files.forEach(({ file, hash }) => {
-      files[removeExt(file)] = { file, hash };
+    node.data.files.forEach(({ file, hash, deps }) => {
+      files[removeExt(file)] = { file, hash, ...(deps && { deps }) };
     });
     const data = { ...node.data, files };
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
* `mapProjectGraphFiles` loses the `deps` property leading to broken circular dependencies report
* file filter on report is broken

## Expected Behavior
* `mapProjectGraphFiles` keeps the `deps` property
* file filtering based on dependencies should work as expected

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to #7507
