### PR TITLE
fix(core): handle optional tasksRunnerOptions when checking whether to use the daemon

### DIFF
--- a/packages/workspace/src/core/project-graph/project-graph.ts
+++ b/packages/workspace/src/core/project-graph/project-graph.ts
@@ -50,7 +50,7 @@ export async function createProjectGraphAsync(
 ): Promise<ProjectGraph> {
   const nxJson = readNxJson();
   const useDaemonProcessOption =
-    nxJson.tasksRunnerOptions['default']?.options?.useDaemonProcess;
+    nxJson.tasksRunnerOptions?.['default']?.options?.useDaemonProcess;
   if (useDaemonProcessOption !== true && process.env.NX_DAEMON !== 'true') {
     return projectGraphAdapter(
       '5.0',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If no `tasksRunnerOptions` is configured on `nx.json`, creating a project graph fails because it tries to read the `default` tasks runner from it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Creating a project graph should succeed regardless of `tasksRunnerOptions` being specified or not.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
