### PR TITLE
Revert "fix(core): prevent overwriting already added tasks when addin…

### DIFF
--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -323,10 +323,7 @@ function addTasksForProjectDependencyConfig(
         const depProject =
           projectGraph.nodes[dep.target] ||
           projectGraph.externalNodes[dep.target];
-        if (
-          projectHasTarget(depProject, dependencyConfig.target) &&
-          !seenSet.has(depProject.name)
-        ) {
+        if (projectHasTarget(depProject, dependencyConfig.target)) {
           addTasksForProjectTarget(
             {
               project: depProject,


### PR DESCRIPTION
…g target dependencies tasks"

This reverts commit babcbf613e70cdc895d425ad8f3ef6f0b1159fb4.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When adding tasks for different targets of the same project, the 2nd task does not get registered.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Both tasks for the different targets of the same project should be registered.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
