### PR TITLE
fix(testing): Create root babel config if one isn't present

### DIFF
--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -97,4 +97,16 @@ describe('Jest', () => {
     ); // text
     expect(result.stdout).toContain('Coverage summary'); // text-summary
   }, 90000);
+
+  it('should be able to test node lib with babel-jest', async () => {
+    const libName = uniq('babel-test-lib');
+    runCLI(
+      `generate @nrwl/node:lib ${libName} --buildable --importPath=@some-org/babel-test --publishable --babelJest`
+    );
+
+    const cliResults = await runCLIAsync(`test ${libName}`);
+    expect(cliResults.combinedOutput).toContain(
+      'Test Suites: 1 passed, 1 total'
+    );
+  });
 });

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -95,6 +95,12 @@
       "cli": "nx",
       "description": "Support .test. file names in tsconfigs",
       "factory": "./src/migrations/update-13-1-2/update-tsconfigs-for-tests"
+    },
+    "add-missing-root-babel-config": {
+      "version": "13.4.4-beta.0",
+      "cli": "nx",
+      "description": "Create a root babel config file if it doesn't exist and using babel-jest in jest.config.js and add @nrwl/web as needed",
+      "factory": "./src/migrations/update-13-4-4/add-missing-root-babel-config"
     }
   },
   "packageJsonUpdates": {

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -70,9 +70,6 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
     'ts-jest': tsJestVersion,
   };
 
-  // TODO: revert to @swc/jest when https://github.com/swc-project/cli/issues/20 is addressed
-  // } else if (options.compiler === 'swc') {
-  //   devDeps['@swc/jest'] = swcJestVersion;
   if (options.compiler === 'babel' || options.babelJest) {
     devDeps['babel-jest'] = babelJestVersion;
     // in some cases @nrwl/web will not already be present i.e. node only projects

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -64,6 +64,10 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
     '@nrwl/jest': nxVersion,
     jest: jestVersion,
     '@types/jest': jestTypesVersion,
+    // because the default jest-preset uses ts-jest,
+    // jest will throw an error if it's not installed
+    // even if not using it in overriding transformers
+    'ts-jest': tsJestVersion,
   };
 
   // TODO: revert to @swc/jest when https://github.com/swc-project/cli/issues/20 is addressed
@@ -71,8 +75,11 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
   //   devDeps['@swc/jest'] = swcJestVersion;
   if (options.compiler === 'babel' || options.babelJest) {
     devDeps['babel-jest'] = babelJestVersion;
-  } else {
-    devDeps['ts-jest'] = tsJestVersion;
+    // in some cases @nrwl/web will not already be present i.e. node only projects
+    devDeps['@nrwl/web'] = nxVersion;
+    // TODO: revert to @swc/jest when https://github.com/swc-project/cli/issues/20 is addressed
+    // } else if (options.compiler === 'swc') {
+    //   devDeps['@swc/jest'] = swcJestVersion;
   }
 
   return addDependenciesToPackageJson(tree, dependencies, devDeps);

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -55,6 +55,15 @@ describe('jestProject', () => {
     expect(tree.exists('libs/lib1/tsconfig.spec.json')).toBeTruthy();
   });
 
+  it('should generate files w/babel-jest', async () => {
+    await jestProjectGenerator(tree, {
+      ...defaultOptions,
+      project: 'lib1',
+      babelJest: true,
+    } as JestProjectSchema);
+    expect(tree.exists('babel.config.json')).toBeTruthy();
+  });
+
   it('should alter workspace.json', async () => {
     await jestProjectGenerator(tree, {
       ...defaultOptions,

--- a/packages/jest/src/generators/jest-project/lib/create-files.ts
+++ b/packages/jest/src/generators/jest-project/lib/create-files.ts
@@ -1,9 +1,9 @@
 import { JestProjectSchema } from '../schema';
 import {
-  Tree,
-  offsetFromRoot,
   generateFiles,
+  offsetFromRoot,
   readProjectConfiguration,
+  Tree,
 } from '@nrwl/devkit';
 import { join } from 'path';
 
@@ -32,5 +32,14 @@ export function createFiles(tree: Tree, options: JestProjectSchema) {
 
   if (options.setupFile === 'none') {
     tree.delete(join(projectConfig.root, './src/test-setup.ts'));
+  }
+
+  if (options.babelJest && !tree.exists('babel.config.json')) {
+    tree.write(
+      'babel.config.json',
+      JSON.stringify({
+        babelrcRoots: ['*'],
+      })
+    );
   }
 }

--- a/packages/jest/src/migrations/update-13-4-4/add-missing-root-babel-config.spec.ts
+++ b/packages/jest/src/migrations/update-13-4-4/add-missing-root-babel-config.spec.ts
@@ -1,0 +1,113 @@
+import { addProjectConfiguration, readJson, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import update from './add-missing-root-babel-config';
+
+describe('Jest Migration (v13.4.4)', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      'package.json',
+      JSON.stringify({
+        name: 'test',
+        version: '',
+        description: '',
+        devDependencies: {},
+      })
+    );
+    tree.write(
+      'libs/lib-one/jest.config.js',
+      String.raw`module.exports = {
+        transform: {
+        '^.+\\\\.[tj]sx?$': 'babel-jest',
+        }
+  }`
+    );
+
+    addProjectConfiguration(tree, 'lib-one', {
+      root: 'libs/lib-one',
+      sourceRoot: 'libs/lib-one/src',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: '@nrwl/web:build',
+        },
+        test: {
+          executor: '@nrwl/jest:jest',
+          options: {
+            jestConfig: 'libs/lib-one/jest.config.js',
+            passWithNoTests: true,
+          },
+        },
+      },
+    });
+
+    addProjectConfiguration(tree, 'lib-two', {
+      root: 'libs/lib-two',
+      sourceRoot: 'libs/lib-two/src',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: '@nrwl/web:build',
+        },
+        test: {
+          executor: '@nrwl/jest:jest',
+          options: {
+            jestConfig: 'libs/lib-two/jest.config.js',
+            passWithNoTests: true,
+          },
+        },
+      },
+    });
+  });
+
+  it('should create root babel.config.json and install @nrwl/web', async () => {
+    await update(tree);
+    expect(tree.exists('babel.config.json')).toBeTruthy();
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies['@nrwl/web']).toBeTruthy();
+  });
+
+  it('should not change anything if root babel.config.json is found', async () => {
+    tree.write('babel.config.json', '{"babelrcRoots": ["*"]}');
+    await update(tree);
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies['@nrwl/web']).toBeFalsy();
+  });
+
+  it('should update w/ Array value for babel-jest transformer', async () => {
+    tree = createTreeWithEmptyWorkspace();
+
+    tree.write(
+      'libs/lib-three/jest.config.js',
+      String.raw`module.exports = {
+        transform: {
+        '^.+\\\\.[tj]sx?$': ['babel-jest', {someOptionsThatDontMatter: false}],
+        }
+  }`
+    );
+
+    addProjectConfiguration(tree, 'lib-three', {
+      root: 'libs/lib-three',
+      sourceRoot: 'libs/lib-three/src',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: '@nrwl/web:build',
+        },
+        test: {
+          executor: '@nrwl/jest:jest',
+          options: {
+            jestConfig: 'libs/lib-three/jest.config.js',
+            passWithNoTests: true,
+          },
+        },
+      },
+    });
+
+    await update(tree);
+    expect(tree.exists('babel.config.json')).toBeTruthy();
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies['@nrwl/web']).toBeTruthy();
+  });
+});

--- a/packages/jest/src/migrations/update-13-4-4/add-missing-root-babel-config.ts
+++ b/packages/jest/src/migrations/update-13-4-4/add-missing-root-babel-config.ts
@@ -1,0 +1,60 @@
+import {
+  addDependenciesToPackageJson,
+  formatFiles,
+  joinPathFragments,
+  readProjectConfiguration,
+  Tree,
+} from '@nrwl/devkit';
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+import { JestExecutorOptions } from '@nrwl/jest/src/executors/jest/schema';
+import { jestConfigObject } from '../../utils/config/functions';
+import { nxVersion } from '../../utils/versions';
+
+function checkIfProjectNeedsUpdate(tree: Tree): boolean {
+  if (tree.exists('babel.config.json')) {
+    // the project is already running on babel and good to go
+    return false;
+  }
+
+  let shouldUpdate = false;
+  forEachExecutorOptions<JestExecutorOptions>(
+    tree,
+    '@nrwl/jest:jest',
+    (jestOptions, projectName) => {
+      const projectConfig = readProjectConfiguration(tree, projectName);
+      const jestConfigPath = joinPathFragments(
+        projectConfig.root,
+        'jest.config.js'
+      );
+
+      if (!tree.exists(jestConfigPath)) {
+        return;
+      }
+
+      const config = jestConfigObject(tree, jestConfigPath);
+
+      for (const transformer of Object.values(config.transform)) {
+        if (
+          (typeof transformer === 'string' && transformer === 'babel-jest') ||
+          (Array.isArray(transformer) && transformer[0] === 'babel-jest')
+        ) {
+          shouldUpdate = true;
+        }
+      }
+    }
+  );
+
+  return shouldUpdate;
+}
+
+export default async function update(tree: Tree) {
+  const shouldUpdateConfigs = checkIfProjectNeedsUpdate(tree);
+
+  if (shouldUpdateConfigs) {
+    addDependenciesToPackageJson(tree, {}, { '@nrwl/web': nxVersion });
+
+    tree.write('babel.config.json', '{"babelrcRoots": ["*"]}');
+
+    await formatFiles(tree);
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

add changes to create a babel config when one isn't present and babel-jest is selected. 
add `@nrwl/web` as dev dep when babel-jest is selected to have babel deps needed by babel-jest


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6782

TODO: 
- [x] Migration
- [x] Testing
- [x] Validation
