### PR TITLE
fix(storybook): make Angular 13 logger devkit-compatible

### DIFF
--- a/packages/storybook/src/executors/utils.ts
+++ b/packages/storybook/src/executors/utils.ts
@@ -232,6 +232,13 @@ export function resolveCommonStorybookOptionMapper(
     }
     const project = context.workspace.projects[buildProjectName];
 
+    const angularDevkitCompatibleLogger = {
+      ...logger,
+      createChild() {
+        return angularDevkitCompatibleLogger;
+      },
+    };
+
     // construct a builder object for Storybook
     storybookOptions.angularBuilderContext = {
       target: {
@@ -245,11 +252,7 @@ export function resolveCommonStorybookOptionMapper(
       getTargetOptions: () => {
         return targetOptions;
       },
-      logger: {
-        createChild(name) {
-          return logger;
-        },
-      },
+      logger: angularDevkitCompatibleLogger,
     };
   } else {
     // keep the backwards compatibility


### PR DESCRIPTION
This PR makes the `storybookOptions.angularBuilderContext.logger` compatible with the [`LoggerApi` in the Angular CLI Devkit](https://github.com/angular/angular-cli/blob/4f8674af2366181ea4fec1904559b14418a5c069/packages/angular_devkit/core/src/logger/logger.ts#L21).

Previously, the logger only contained one method: `createChild`. This creates no problems for most simple Angular projects where the logger is not used, but threw a `context.logger.warn is not a function` error in my project, where [this line in i18n-options.ts](https://github.com/angular/angular-cli/blob/4f8674af2366181ea4fec1904559b14418a5c069/packages/angular_devkit/build_angular/src/utils/i18n-options.ts#L199) wanted to log a warning. This error was thrown in the `build-storybook` command.

This PR only affects code written for Angular 13/Storybook 6.4+ compatibility by @juristr.