### PR TITLE
fix(core): fix adding node_modules to path on windows when running migrations

### DIFF
--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -601,7 +601,7 @@ function taoPath() {
 function addToNodePath(dir: string) {
   // NODE_PATH is a delimited list of paths.
   // The delimiter is different for windows.
-  const delimiter = require('os').platform === 'win32' ? ';' : ':';
+  const delimiter = require('os').platform() === 'win32' ? ';' : ':';
 
   const paths = process.env.NODE_PATH
     ? process.env.NODE_PATH.split(delimiter)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When the migrator tool runs on Windows it fails to identify it and the node_modules paths added to the environment have the wrong delimiter. This causes any migration relying on those paths to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Migrations should run successfully on Windows.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7807 
