### PR TITLE
fix(react): fix external option for @emotion/react

### DIFF
--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -53,6 +53,11 @@
       "version": "14.0.0-beta.0",
       "description": "Add a default development configuration for build and serve targets.",
       "factory": "./src/migrations/update-14-0-0/add-default-development-configurations"
+    },
+    "update-external-emotion-jsx-runtime-14.1.0": {
+      "version": "14.1.0-beta.0",
+      "description": "Update external option in projects for Emotion",
+      "factory": "./src/migrations/update-14-1-0/update-external-emotion-jsx-runtime"
     }
   },
   "packageJsonUpdates": {

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -560,7 +560,7 @@ describe('lib', () => {
 
       expect(workspaceJson.projects['my-lib'].architect.build).toMatchObject({
         options: {
-          external: ['react/jsx-runtime', '@emotion/styled/base'],
+          external: ['@emotion/react/jsx-runtime'],
         },
       });
       expect(babelrc.plugins).toEqual(['@emotion/babel-plugin']);

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -179,10 +179,12 @@ function addProject(host: Tree, options: NormalizedSchema) {
 
   if (options.publishable || options.buildable) {
     const { libsDir } = getWorkspaceLayout(host);
-    const external = ['react/jsx-runtime'];
+    const external: string[] = [];
 
     if (options.style === '@emotion/styled') {
-      external.push('@emotion/styled/base');
+      external.push('@emotion/react/jsx-runtime');
+    } else {
+      external.push('react/jsx-runtime');
     }
 
     targets.build = {

--- a/packages/react/src/migrations/update-14-1-0/update-external-emotion-jsx-runtime.spec.ts
+++ b/packages/react/src/migrations/update-14-1-0/update-external-emotion-jsx-runtime.spec.ts
@@ -1,0 +1,64 @@
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+import { updateExternalEmotionJsxRuntime } from './update-external-emotion-jsx-runtime';
+
+describe('updateExternalEmotionJsxRuntime', () => {
+  it('should update external for Emotion', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'components', {
+      root: 'libs/components',
+      targets: {
+        build: {
+          executor: '@nrwl/web:rollup',
+          options: {
+            external: ['@emotion/styled/base', 'react/jsx-runtime'],
+          },
+        },
+      },
+    });
+    tree.write(
+      'libs/components/.babelrc',
+      JSON.stringify({
+        presets: [
+          [
+            '@nrwl/react/babel',
+            {
+              runtime: 'automatic',
+              importSource: '@emotion/react',
+            },
+          ],
+        ],
+        plugins: ['@emotion/babel-plugin'],
+      })
+    );
+
+    // ACT
+    await updateExternalEmotionJsxRuntime(tree);
+
+    // ASSERT
+    const { targets } = readProjectConfiguration(tree, 'components');
+    expect(targets.build.options.external).toEqual([
+      '@emotion/react/jsx-runtime',
+    ]);
+  });
+
+  it('should not fail for projects with no targets', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'components', {
+      root: 'apps/components',
+    });
+
+    // ACT
+    await updateExternalEmotionJsxRuntime(tree);
+
+    // ASSERT
+    const { targets } = readProjectConfiguration(tree, 'components');
+    expect(targets).toBeUndefined();
+  });
+});

--- a/packages/react/src/migrations/update-14-1-0/update-external-emotion-jsx-runtime.ts
+++ b/packages/react/src/migrations/update-14-1-0/update-external-emotion-jsx-runtime.ts
@@ -1,0 +1,50 @@
+import {
+  Tree,
+  readProjectConfiguration,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import { WebRollupOptions } from '@nrwl/web/src/executors/rollup/schema';
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+
+export async function updateExternalEmotionJsxRuntime(tree: Tree) {
+  forEachExecutorOptions<WebRollupOptions>(
+    tree,
+    '@nrwl/web:rollup',
+    (options: any, projectName, targetName, configurationName) => {
+      const projectConfiguration = readProjectConfiguration(tree, projectName);
+      const config = configurationName
+        ? projectConfiguration.targets[targetName].configurations[
+            configurationName
+          ]
+        : projectConfiguration.targets[targetName].options;
+
+      if (config.external && config.external.length > 0) {
+        const hasEmotionStyledBase = config.external.includes(
+          '@emotion/styled/base'
+        );
+        const hasReactJsxRuntime =
+          config.external.includes('react/jsx-runtime');
+
+        if (hasEmotionStyledBase && hasReactJsxRuntime) {
+          // Replace 'react/jsx-runtime' with '@emotion/react/jsx-runtime'
+          config.external.forEach((value, index) => {
+            if (value === 'react/jsx-runtime') {
+              config.external.splice(index, 1, '@emotion/react/jsx-runtime');
+            }
+          });
+
+          // Remove '@emotion/styled/base'
+          config.external.forEach((value, index) => {
+            if (value === '@emotion/styled/base') {
+              config.external.splice(index, 1);
+            }
+          });
+        }
+
+        updateProjectConfiguration(tree, projectName, projectConfiguration);
+      }
+    }
+  );
+}
+
+export default updateExternalEmotionJsxRuntime;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Both `react/jsx-runtime` and`@emotion/react/jsx-runtime` are included in the outputs of buildable libraries.

```js
import { jsx as jsx$1, jsxs as jsxs$1 } from 'react/jsx-runtime';
import _styled from '@emotion/styled/base';
import { cx } from '@emotion/css';

// 👇 Entire code of @emotion/react/jsx-runtime is included! 😱
/*

Based off glamor's StyleSheet, thanks Sunil ❤️

high performance StyleSheet for css-in-js systems

- uses multiple style tags behind the scenes for millions of rules
- uses `insertRule` for appending in production for *much* faster performance

// usage

import { StyleSheet } from '@emotion/sheet'
:
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Instead of `react/jsx-runtime`, `@emotion/react/jsx-runtime` should be imported in the outputs of the projects using Emotion.


```js
import { jsxs, jsx } from '@emotion/react/jsx-runtime';
import _styled from '@emotion/styled/base';  // 👈 They are automatically imported
import { cx } from '@emotion/css';           // 👈
```


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
#7395