### PR TITLE
feat(angular): allow for full ivy compilation in buildable libraries

### DIFF
--- a/docs/angular/api-angular/generators/library.md
+++ b/docs/angular/api-angular/generators/library.md
@@ -50,6 +50,14 @@ Type: `string`
 
 A directory where the library is placed.
 
+### enableIvy
+
+Default: `false`
+
+Type: `boolean`
+
+Enable full Ivy compilation in libraries tsconfig (Should not be used for publishable libraries yet)
+
 ### importPath
 
 Type: `string`

--- a/docs/angular/api-angular/generators/library.md
+++ b/docs/angular/api-angular/generators/library.md
@@ -44,19 +44,19 @@ Type: `boolean`
 
 Generate a buildable library.
 
+### compilationMode
+
+Type: `string`
+
+Possible values: `full`, `partial`
+
+Specifies the compilation mode to use. If not specified, it will default to `partial` for publishable libraries and to `full` for buildable libraries. The `full` value can not be used for publishable libraries.
+
 ### directory
 
 Type: `string`
 
 A directory where the library is placed.
-
-### enableIvy
-
-Default: `false`
-
-Type: `boolean`
-
-Enable full Ivy compilation in libraries tsconfig (Should not be used for publishable libraries yet)
 
 ### importPath
 

--- a/docs/node/api-angular/generators/library.md
+++ b/docs/node/api-angular/generators/library.md
@@ -50,6 +50,14 @@ Type: `string`
 
 A directory where the library is placed.
 
+### enableIvy
+
+Default: `false`
+
+Type: `boolean`
+
+Enable full Ivy compilation in libraries tsconfig (Should not be used for publishable libraries yet)
+
 ### importPath
 
 Type: `string`

--- a/docs/node/api-angular/generators/library.md
+++ b/docs/node/api-angular/generators/library.md
@@ -44,19 +44,19 @@ Type: `boolean`
 
 Generate a buildable library.
 
+### compilationMode
+
+Type: `string`
+
+Possible values: `full`, `partial`
+
+Specifies the compilation mode to use. If not specified, it will default to `partial` for publishable libraries and to `full` for buildable libraries. The `full` value can not be used for publishable libraries.
+
 ### directory
 
 Type: `string`
 
 A directory where the library is placed.
-
-### enableIvy
-
-Default: `false`
-
-Type: `boolean`
-
-Enable full Ivy compilation in libraries tsconfig (Should not be used for publishable libraries yet)
 
 ### importPath
 

--- a/docs/react/api-angular/generators/library.md
+++ b/docs/react/api-angular/generators/library.md
@@ -50,6 +50,14 @@ Type: `string`
 
 A directory where the library is placed.
 
+### enableIvy
+
+Default: `false`
+
+Type: `boolean`
+
+Enable full Ivy compilation in libraries tsconfig (Should not be used for publishable libraries yet)
+
 ### importPath
 
 Type: `string`

--- a/docs/react/api-angular/generators/library.md
+++ b/docs/react/api-angular/generators/library.md
@@ -44,19 +44,19 @@ Type: `boolean`
 
 Generate a buildable library.
 
+### compilationMode
+
+Type: `string`
+
+Possible values: `full`, `partial`
+
+Specifies the compilation mode to use. If not specified, it will default to `partial` for publishable libraries and to `full` for buildable libraries. The `full` value can not be used for publishable libraries.
+
 ### directory
 
 Type: `string`
 
 A directory where the library is placed.
-
-### enableIvy
-
-Default: `false`
-
-Type: `boolean`
-
-Enable full Ivy compilation in libraries tsconfig (Should not be used for publishable libraries yet)
 
 ### importPath
 

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-package.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-package.transform.ts
@@ -215,16 +215,6 @@ async function writePackageJson(
     }
   }
 
-  if (!entryPoint.isSecondaryEntryPoint && compilationMode !== 'partial') {
-    const scripts = packageJson.scripts || (packageJson.scripts = {});
-    scripts.prepublishOnly =
-      'node --eval "console.error(\'' +
-      'ERROR: Trying to publish a package that has been compiled by Ivy in full compilation mode. This is not allowed.\\n' +
-      'Please delete and rebuild the package with Ivy partial compilation mode, before attempting to publish.\\n' +
-      '\')" ' +
-      '&& exit 1';
-  }
-
   // keep the dist package.json clean
   // this will not throw if ngPackage field does not exist
   delete packageJson.ngPackage;

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -18,7 +18,10 @@ export function normalizeOptions(
     simpleModuleName: false,
     skipFormat: false,
     unitTestRunner: UnitTestRunner.Jest,
-    enableIvy: false,
+    // Publishable libs cannot use `full` yet, so if its false then use the passed value or default to `full`
+    compilationMode: schema.publishable
+      ? 'partial'
+      : schema.compilationMode ?? 'full',
     ...schema,
   };
 

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -18,6 +18,7 @@ export function normalizeOptions(
     simpleModuleName: false,
     skipFormat: false,
     unitTestRunner: UnitTestRunner.Jest,
+    enableIvy: false,
     ...schema,
   };
 

--- a/packages/angular/src/generators/library/lib/update-tsconfig.ts
+++ b/packages/angular/src/generators/library/lib/update-tsconfig.ts
@@ -39,7 +39,9 @@ function updateProjectIvyConfig(host: Tree, options: NormalizedSchema) {
       host,
       `${options.projectRoot}/tsconfig.lib.prod.json`,
       (json) => {
-        json.angularCompilerOptions['compilationMode'] = 'partial';
+        json.angularCompilerOptions['compilationMode'] = options.enableIvy
+          ? undefined
+          : 'partial';
         return json;
       }
     );

--- a/packages/angular/src/generators/library/lib/update-tsconfig.ts
+++ b/packages/angular/src/generators/library/lib/update-tsconfig.ts
@@ -39,9 +39,8 @@ function updateProjectIvyConfig(host: Tree, options: NormalizedSchema) {
       host,
       `${options.projectRoot}/tsconfig.lib.prod.json`,
       (json) => {
-        json.angularCompilerOptions['compilationMode'] = options.enableIvy
-          ? undefined
-          : 'partial';
+        json.angularCompilerOptions['compilationMode'] =
+          options.compilationMode === 'full' ? undefined : 'partial';
         return json;
       }
     );

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -26,4 +26,5 @@ export interface Schema {
 
   linter: Exclude<Linter, Linter.TsLint>;
   unitTestRunner: UnitTestRunner;
+  enableIvy: boolean;
 }

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -26,5 +26,5 @@ export interface Schema {
 
   linter: Exclude<Linter, Linter.TsLint>;
   unitTestRunner: UnitTestRunner;
-  enableIvy: boolean;
+  compilationMode?: 'full' | 'partial';
 }

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -103,10 +103,10 @@
       "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
       "type": "boolean"
     },
-    "enableIvy": {
-      "description": "Enable full Ivy compilation in libraries tsconfig (Should not be used for publishable libraries yet)",
-      "type": "boolean",
-      "default": false
+    "compilationMode": {
+      "description": "Specifies the compilation mode to use. If not specified, it will default to `partial` for publishable libraries and to `full` for buildable libraries. The `full` value can not be used for publishable libraries.",
+      "type": "string",
+      "enum": ["full", "partial"]
     }
   },
   "required": []

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -102,6 +102,11 @@
     "standaloneConfig": {
       "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
       "type": "boolean"
+    },
+    "enableIvy": {
+      "description": "Enable full Ivy compilation in libraries tsconfig (Should not be used for publishable libraries yet)",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": []


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
As of the Angular v13 upgrade libraries have their tsconfig's generated with compilationMode: 'partial'

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
For buildable (but not publishable) libraries we should be able to enable full ivy compilation since we know they will be used in v13+ angular applications

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
