### PR TITLE
chore(repo): fix resolution of @cypress/request until its deps are resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,6 +297,7 @@
   },
   "resolutions": {
     "ng-packagr/rxjs": "6.6.7",
-    "**/xmlhttprequest-ssl": "~1.6.2"
+    "**/xmlhttprequest-ssl": "~1.6.2",
+    "@cypress/request": "2.88.7"
   }
 }

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -5,7 +5,11 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 
-import { cypressVersion, nxVersion } from '../../utils/versions';
+import {
+  cypressVersion,
+  nxVersion,
+  cypressRequestVersion,
+} from '../../utils/versions';
 
 function updateDependencies(host: Tree) {
   updateJson(host, 'package.json', (json) => {
@@ -19,6 +23,7 @@ function updateDependencies(host: Tree) {
     {},
     {
       ['@nrwl/cypress']: nxVersion,
+      ['@cypress/request']: cypressRequestVersion,
       cypress: cypressVersion,
     }
   );

--- a/packages/cypress/src/utils/versions.ts
+++ b/packages/cypress/src/utils/versions.ts
@@ -1,3 +1,4 @@
 export const nxVersion = '*';
 export const cypressVersion = '^8.3.0';
+export const cypressRequestVersion = '2.88.7'; // TODO: remove this as soon as the `har-validator` is fixed on cypress side (https://github.com/cypress-io/cypress/issues/19097)
 export const eslintPluginCypressVersion = '^2.10.3';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
As of version `2.88.8` the `@cypress/request` has dropped the dependency to `har-validator` although the library still depends on it.

## Expected Behavior
Since cypress is targeting `^2.88.6` we should fix it to last good version - `2.88.7` until the issue is resolved.

More details on: https://github.com/cypress-io/cypress/issues/19097

## Related Issue(s)
https://github.com/nrwl/nx/issues/7880

Fixes #7880
