### PR TITLE
fix(repo): bump @cypress/request to v2.88.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,11 +62,10 @@
     "@ngrx/store": "~13.0.0",
     "@ngrx/store-devtools": "~13.0.0",
     "@nrwl/cli": "13.3.0-beta.2",
-    "@nrwl/js": "13.3.0-beta.2",
-    "@nrwl/workspace": "13.3.0-beta.2",
     "@nrwl/cypress": "13.3.0-beta.2",
     "@nrwl/eslint-plugin-nx": "13.3.0-beta.2",
     "@nrwl/jest": "13.3.0-beta.2",
+    "@nrwl/js": "13.3.0-beta.2",
     "@nrwl/linter": "13.3.0-beta.2",
     "@nrwl/next": "13.3.0-beta.2",
     "@nrwl/node": "13.3.0-beta.2",
@@ -74,6 +73,7 @@
     "@nrwl/react": "13.3.0-beta.2",
     "@nrwl/tao": "13.3.0-beta.2",
     "@nrwl/web": "13.3.0-beta.2",
+    "@nrwl/workspace": "13.3.0-beta.2",
     "@parcel/watcher": "2.0.0-alpha.11",
     "@phenomnomnominal/tsquery": "4.1.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
@@ -270,6 +270,7 @@
     }
   },
   "dependencies": {
+    "@cypress/request": "2.88.9",
     "@docsearch/react": "^1.0.0-alpha.14",
     "@headlessui/react": "^1.1.1",
     "@heroicons/react": "^1.0.1",
@@ -297,7 +298,6 @@
   },
   "resolutions": {
     "ng-packagr/rxjs": "6.6.7",
-    "**/xmlhttprequest-ssl": "~1.6.2",
-    "@cypress/request": "2.88.7"
+    "**/xmlhttprequest-ssl": "~1.6.2"
   }
 }

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -5,11 +5,7 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 
-import {
-  cypressVersion,
-  nxVersion,
-  cypressRequestVersion,
-} from '../../utils/versions';
+import { cypressVersion, nxVersion } from '../../utils/versions';
 
 function updateDependencies(host: Tree) {
   updateJson(host, 'package.json', (json) => {
@@ -23,7 +19,6 @@ function updateDependencies(host: Tree) {
     {},
     {
       ['@nrwl/cypress']: nxVersion,
-      ['@cypress/request']: cypressRequestVersion,
       cypress: cypressVersion,
     }
   );

--- a/packages/cypress/src/utils/versions.ts
+++ b/packages/cypress/src/utils/versions.ts
@@ -1,4 +1,3 @@
 export const nxVersion = '*';
 export const cypressVersion = '^8.3.0';
-export const cypressRequestVersion = '2.88.7'; // TODO: remove this as soon as the `har-validator` is fixed on cypress side (https://github.com/cypress-io/cypress/issues/19097)
 export const eslintPluginCypressVersion = '^2.10.3';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1819,10 +1819,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@cypress/request@^2.88.6":
-  version "2.88.7"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.7.tgz#386d960ab845a96953723348088525d5a75aaac4"
-  integrity sha512-FTULIP2rnDJvZDT9t6B4nSfYR40ue19tVmv3wUcY05R9/FPCoMl1nAPJkzWzBCo7ltVn5ThQTbxiMoGBN7k0ig==
+"@cypress/request@2.88.9", "@cypress/request@^2.88.6":
+  version "2.88.9"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.9.tgz#7428fc66008ec3a4727c189857f6bb7f758f1d92"
+  integrity sha512-6md3dtAd3DXfTEXFb2Yde3TSaqpYsSBw3a1VFwAC9Fscu2B0DtY2Venu35csZyJj09XNkPMGRoE4ZXUdtkI+zg==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -1832,7 +1832,7 @@
     forever-agent "~0.6.1"
     form-data "~2.3.2"
     har-validator "~5.1.3"
-    http-signature "~1.2.0"
+    http-signature "~1.3.6"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
     json-stringify-safe "~5.0.1"
@@ -12637,6 +12637,15 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+http-signature@~1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.3.6.tgz#cb6fbfdf86d1c974f343be94e87f7fc128662cf9"
+  integrity sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^2.0.2"
+    sshpk "^1.14.1"
+
 http-status-codes@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-1.4.0.tgz#6e4c15d16ff3a9e2df03b89f3a55e1aae05fb477"
@@ -14543,6 +14552,11 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
+json-schema@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -14629,6 +14643,16 @@ jsprim@^1.2.2:
     assert-plus "1.0.0"
     extsprintf "1.3.0"
     json-schema "0.2.3"
+    verror "1.10.0"
+
+jsprim@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-2.0.2.tgz#77ca23dbcd4135cd364800d22ff82c2185803d4d"
+  integrity sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==
+  dependencies:
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.4.0"
     verror "1.10.0"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.1.0, jsx-ast-utils@^3.2.1:
@@ -20791,7 +20815,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sshpk@^1.7.0:
+sshpk@^1.14.1, sshpk@^1.7.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
   integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We needed to implement a workaround https://github.com/nrwl/nx/commit/e54e5a2496b63a33c0f31ad8c45bf2b34c8ce466 to compensate for broken `@cypress/request` in order to unblock our repository.

## Expected Behavior
This PR bumps the version of `@cypress/request` to the fixed one - v2.88.9.

## Related Issue(s)
#7880

More details on: cypress-io/cypress#19097 and https://github.com/cypress-io/request/pull/15
