### PR TITLE
chore(core): cleanup the obsolete graph version check from graph builder

### DIFF
--- a/packages/workspace/src/core/project-graph/build-project-graph.ts
+++ b/packages/workspace/src/core/project-graph/build-project-graph.ts
@@ -82,7 +82,6 @@ export async function buildProjectGraphUsingProjectFileMap(
   let cachedFileData = {};
   if (
     cache &&
-    cache.version === '5.0' &&
     !shouldRecomputeWholeGraph(
       cache,
       packageJsonDeps,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We check the graph version twice - once in `buildProjectGraph` and immediately afterwards in `shouldRecomputeWholeGraph`

## Expected Behavior
Only check in `shouldRecomputeWholeGraph` is sufficient

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
