### PR TITLE
feat(linter): allow banning of transitive dependencies from imports

### DIFF
--- a/packages/eslint-plugin-nx/package.json
+++ b/packages/eslint-plugin-nx/package.json
@@ -14,12 +14,6 @@
     "ESLint",
     "CLI"
   ],
-  "files": [
-    "src",
-    "package.json",
-    "README.md",
-    "LICENSE"
-  ],
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
   "author": "Victor Savkin",

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -40,7 +40,7 @@ type Options = [
     depConstraints: DepConstraint[];
     enforceBuildableLibDependency: boolean;
     allowCircularSelfDependency: boolean;
-    allowTransitiveDependencies: boolean;
+    banTransitiveDependencies: boolean;
   }
 ];
 export type MessageIds =
@@ -72,7 +72,7 @@ export default createESLintRule<Options, MessageIds>({
         properties: {
           enforceBuildableLibDependency: { type: 'boolean' },
           allowCircularSelfDependency: { type: 'boolean' },
-          allowTransitiveDependencies: { type: 'boolean' },
+          banTransitiveDependencies: { type: 'boolean' },
           allow: [{ type: 'string' }],
           depConstraints: [
             {
@@ -110,7 +110,7 @@ export default createESLintRule<Options, MessageIds>({
       depConstraints: [],
       enforceBuildableLibDependency: false,
       allowCircularSelfDependency: false,
-      allowTransitiveDependencies: true,
+      banTransitiveDependencies: false,
     },
   ],
   create(
@@ -121,7 +121,7 @@ export default createESLintRule<Options, MessageIds>({
         depConstraints,
         enforceBuildableLibDependency,
         allowCircularSelfDependency,
-        allowTransitiveDependencies,
+        banTransitiveDependencies,
       },
     ]
   ) {
@@ -244,10 +244,7 @@ export default createESLintRule<Options, MessageIds>({
 
       // project => npm package
       if (targetProject.type === 'npm') {
-        if (
-          !allowTransitiveDependencies &&
-          !isDirectDependency(sourceProject, targetProject)
-        ) {
+        if (banTransitiveDependencies && !isDirectDependency(targetProject)) {
           context.report({
             node,
             messageId: 'noTransitiveDependencies',

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -14,6 +14,7 @@ import {
   onlyLoadChildren,
   MappedProjectGraph,
   hasBannedImport,
+  isDirectDependency,
 } from '@nrwl/workspace/src/utils/runtime-lint-utils';
 import {
   AST_NODE_TYPES,
@@ -22,7 +23,6 @@ import {
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { normalizePath } from '@nrwl/devkit';
 import {
-  isNpmProject,
   ProjectType,
   readCachedProjectGraph,
 } from '@nrwl/workspace/src/core/project-graph';
@@ -40,6 +40,7 @@ type Options = [
     depConstraints: DepConstraint[];
     enforceBuildableLibDependency: boolean;
     allowCircularSelfDependency: boolean;
+    allowTransitiveDependencies: boolean;
   }
 ];
 export type MessageIds =
@@ -52,7 +53,8 @@ export type MessageIds =
   | 'noImportsOfLazyLoadedLibraries'
   | 'projectWithoutTagsCannotHaveDependencies'
   | 'tagConstraintViolation'
-  | 'bannedExternalImportsViolation';
+  | 'bannedExternalImportsViolation'
+  | 'noTransitiveDependencies';
 export const RULE_NAME = 'enforce-module-boundaries';
 
 export default createESLintRule<Options, MessageIds>({
@@ -70,6 +72,7 @@ export default createESLintRule<Options, MessageIds>({
         properties: {
           enforceBuildableLibDependency: { type: 'boolean' },
           allowCircularSelfDependency: { type: 'boolean' },
+          allowTransitiveDependencies: { type: 'boolean' },
           allow: [{ type: 'string' }],
           depConstraints: [
             {
@@ -98,6 +101,7 @@ export default createESLintRule<Options, MessageIds>({
       projectWithoutTagsCannotHaveDependencies: `A project without tags matching at least one constraint cannot depend on any libraries`,
       tagConstraintViolation: `A project tagged with "{{sourceTag}}" can only depend on libs tagged with {{allowedTags}}`,
       bannedExternalImportsViolation: `A project tagged with "{{sourceTag}}" is not allowed to import the "{{package}}" package`,
+      noTransitiveDependencies: `Transitive dependencies are not allowed. Only packages defined in the "package.json" can be imported`,
     },
   },
   defaultOptions: [
@@ -106,6 +110,7 @@ export default createESLintRule<Options, MessageIds>({
       depConstraints: [],
       enforceBuildableLibDependency: false,
       allowCircularSelfDependency: false,
+      allowTransitiveDependencies: true,
     },
   ],
   create(
@@ -116,6 +121,7 @@ export default createESLintRule<Options, MessageIds>({
         depConstraints,
         enforceBuildableLibDependency,
         allowCircularSelfDependency,
+        allowTransitiveDependencies,
       },
     ]
   ) {
@@ -238,6 +244,15 @@ export default createESLintRule<Options, MessageIds>({
 
       // project => npm package
       if (targetProject.type === 'npm') {
+        if (
+          !allowTransitiveDependencies &&
+          !isDirectDependency(sourceProject, targetProject)
+        ) {
+          context.report({
+            node,
+            messageId: 'noTransitiveDependencies',
+          });
+        }
         const constraint = hasBannedImport(
           sourceProject,
           targetProject,

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -193,6 +193,13 @@ export function hasBannedImport(
   );
 }
 
+export function isDirectDependency(
+  source: ProjectGraphNode,
+  target: ProjectGraphNode
+): boolean {
+  return true;
+}
+
 /**
  * Maps import with wildcards to regex pattern
  * @param importDefinition

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,6 +28,7 @@
       "@nrwl/devkit/testing": ["./packages/devkit/testing"],
       "@nrwl/e2e/cli": ["./e2e/cli"],
       "@nrwl/e2e/utils": ["./e2e/utils"],
+      "@nrwl/eslint-plugin-nx": ["./packages/eslint-plugin-nx/src"],
       "@nrwl/express": ["./packages/express"],
       "@nrwl/gatsby": ["./packages/gatsby"],
       "@nrwl/jest": ["./packages/jest"],


### PR DESCRIPTION
Importing transitive dependencies can be dangerous as no one guarantees this dependency will still be there after its parent package has been updated. If a package is to be used directly, it should be explicitly listed in the devDependencies or dependencies. We should be able to restrict all the transitive non-direct dependencies from import.

## Current Behavior
User cannot be restricted from importing transitive dependencies in their projects, except by providing it in every project as `bannedExternalImports`

## Expected Behavior
User should be able to restrict all transitive dependencies from import.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
