### PR TITLE
fix(angular): add migration to opt-out of the new default testbed teardown for existing projects using jest

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -120,6 +120,12 @@
       "version": "13.2.0-beta.1",
       "description": "Move some imports from @nrwl/angular/testing to jasmine-marbles",
       "factory": "./src/migrations/update-13-2-0/update-testing-imports"
+    },
+    "opt-out-testbed-teardown": {
+      "cli": "nx",
+      "version": "13.2.0",
+      "description": "In Angular version 13, the `teardown` flag in `TestBed` will be enabled by default. This migration automatically opts out existing apps from the new teardown behavior.",
+      "factory": "./src/migrations/update-13-2-0/opt-out-testbed-teardown"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/migrations/update-13-2-0/__snapshots__/opt-out-testbed-teardown.spec.ts.snap
+++ b/packages/angular/src/migrations/update-13-2-0/__snapshots__/opt-out-testbed-teardown.spec.ts.snap
@@ -1,0 +1,213 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`opt-out-testbed-teardown migration update configureTestingModule in test files should not be updated when the test setup file had the teardown options already configured 1`] = `
+"describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          });
+        });"
+`;
+
+exports[`opt-out-testbed-teardown migration update configureTestingModule in test files should not be updated when the test setup file was updated 1`] = `
+"describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          });
+        });"
+`;
+
+exports[`opt-out-testbed-teardown migration update configureTestingModule in test files should not re-add the teardown property or overwrite when it is already configured for configureTestingModule call 1`] = `
+"describe('AppComponent1', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+    declarations: [AppComponent],
+    teardown: { destroyAfterEach: false }
+}).compileComponents();
+          });
+        });
+
+        describe('AppComponent2', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+              teardown: { destroyAfterEach: true },
+            }).compileComponents();
+          });
+        });
+
+        describe('AppComponent3', () => {
+          test('some test case', async () => {
+            await TestBed.configureTestingModule({
+    declarations: [AppComponent],
+    teardown: { destroyAfterEach: false }
+}).compileComponents();
+          
+            expect(true).toBe(true);
+          });
+        });
+        "
+`;
+
+exports[`opt-out-testbed-teardown migration update configureTestingModule in test files should update correctly when teardown options and setupFilesAfterEnv are not configured 1`] = `
+"describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+    declarations: [AppComponent],
+    teardown: { destroyAfterEach: false }
+}).compileComponents();
+          });
+        });"
+`;
+
+exports[`opt-out-testbed-teardown migration update configureTestingModule in test files should update correctly when teardown options have not been configured and the initTestEnvironment call is invalid 1`] = `
+"describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+    declarations: [AppComponent],
+    teardown: { destroyAfterEach: false }
+}).compileComponents();
+          });
+        });"
+`;
+
+exports[`opt-out-testbed-teardown migration update configureTestingModule in test files should update correctly when teardown options have not been configured and the specified test setup file does not exist 1`] = `
+"describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+    declarations: [AppComponent],
+    teardown: { destroyAfterEach: false }
+}).compileComponents();
+          });
+        });"
+`;
+
+exports[`opt-out-testbed-teardown migration update configureTestingModule in test files should update correctly when teardown options have not been configured and there is no test setup file configured 1`] = `
+"describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+    declarations: [AppComponent],
+    teardown: { destroyAfterEach: false }
+}).compileComponents();
+          });
+        });"
+`;
+
+exports[`opt-out-testbed-teardown migration update configureTestingModule in test files should update correctly when there are multiple calls to configureTestingModule 1`] = `
+"describe('AppComponent1', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+    declarations: [AppComponent],
+    teardown: { destroyAfterEach: false }
+}).compileComponents();
+          });
+        });
+
+        describe('AppComponent2', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+    declarations: [AppComponent],
+    teardown: { destroyAfterEach: false }
+}).compileComponents();
+          });
+        });
+
+        describe('AppComponent3', () => {
+          test('some test case', async () => {
+            await TestBed.configureTestingModule({
+    declarations: [AppComponent],
+    teardown: { destroyAfterEach: false }
+}).compileComponents();
+          
+            expect(true).toBe(true);
+          });
+        });
+        "
+`;
+
+exports[`opt-out-testbed-teardown migration update initTestEnvironment calls in test setup should not re-add the teardown property twice when it is already being passed to the initTestEnvironment call 1`] = `
+"import \\"jest-preset-angular/setup-jest\\";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), { teardown: { destroyAfterEach: true } });
+        "
+`;
+
+exports[`opt-out-testbed-teardown migration update initTestEnvironment calls in test setup should update correctly when an aotSummaries arrow function is passed to the initTestEnvironment call 1`] = `
+"import \\"jest-preset-angular/setup-jest\\";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), { aotSummaries: () => [], teardown: { destroyAfterEach: false } });
+        "
+`;
+
+exports[`opt-out-testbed-teardown migration update initTestEnvironment calls in test setup should update correctly when an aotSummaries function is passed to the initTestEnvironment call 1`] = `
+"import \\"jest-preset-angular/setup-jest\\";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), { aotSummaries: function () { return []; }, teardown: { destroyAfterEach: false } });
+        "
+`;
+
+exports[`opt-out-testbed-teardown migration update initTestEnvironment calls in test setup should update correctly when an aotSummaries named function is passed to the initTestEnvironment call 1`] = `
+"import \\"jest-preset-angular/setup-jest\\";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), { aotSummaries: function aotSummaries() { return []; }, teardown: { destroyAfterEach: false } });
+        "
+`;
+
+exports[`opt-out-testbed-teardown migration update initTestEnvironment calls in test setup should update correctly when no options are passed to the initTestEnvironment call 1`] = `
+"import \\"jest-preset-angular/setup-jest\\";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), { teardown: { destroyAfterEach: false } });
+        "
+`;
+
+exports[`opt-out-testbed-teardown migration update initTestEnvironment calls in test setup should update correctly when the options passed to the initTestEnvironment call does not have the teardown property 1`] = `
+"import \\"jest-preset-angular/setup-jest\\";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), { aotSummaries: () => [], teardown: { destroyAfterEach: false } });
+        "
+`;
+
+exports[`opt-out-testbed-teardown migration update initTestEnvironment calls in test setup should update correctly when the options passed to the initTestEnvironment call is an empty object 1`] = `
+"import \\"jest-preset-angular/setup-jest\\";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), { teardown: { destroyAfterEach: false } });
+        "
+`;
+
+exports[`opt-out-testbed-teardown migration update initTestEnvironment calls in test setup should update correctly when there are no calls to initTestEnvironment 1`] = `
+"import \\"jest-preset-angular/setup-jest\\";
+      import { getTestBed } from '@angular/core/testing';
+      import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+      getTestBed().resetTestEnvironment();
+      getTestBed().initTestEnvironment(
+        BrowserDynamicTestingModule,
+        platformBrowserDynamicTesting(),
+        { teardown: { destroyAfterEach: false } },
+      );
+    "
+`;

--- a/packages/angular/src/migrations/update-13-2-0/opt-out-testbed-teardown.spec.ts
+++ b/packages/angular/src/migrations/update-13-2-0/opt-out-testbed-teardown.spec.ts
@@ -1,0 +1,749 @@
+import { addProjectConfiguration, logger, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import testbedTeardownOptOutMigration from './opt-out-testbed-teardown';
+
+describe('opt-out-testbed-teardown migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace(2);
+    jest.doMock('@nrwl/tao/src/utils/app-root', () => ({ appRootPath: '' }));
+  });
+
+  it('should warn when the jestConfig property is not configured', async () => {
+    // Arrange
+    jest.spyOn(logger, 'warn');
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: {
+        test: {
+          executor: '@nrwl/jest:jest',
+          options: {},
+        },
+      },
+    });
+
+    // Act
+    await testbedTeardownOptOutMigration(tree);
+
+    // Assert
+    expect(logger.warn).toHaveBeenCalledWith(
+      'The "jestConfig" property is not configured for the test target of the project "app1". Skipping it.'
+    );
+  });
+
+  it('should warn when the specified jestConfig file does not exist', async () => {
+    // Arrange
+    jest.spyOn(logger, 'warn');
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: {
+        test: {
+          executor: '@nrwl/jest:jest',
+          options: {
+            jestConfig: 'some-path/jest.config.js',
+          },
+        },
+      },
+    });
+
+    // Act
+    await testbedTeardownOptOutMigration(tree);
+
+    // Assert
+    expect(logger.warn).toHaveBeenCalledWith(
+      'The specified "jestConfig" path "some-path/jest.config.js" for the project "app1" can not be found. Skipping it.'
+    );
+  });
+
+  describe('update initTestEnvironment calls in test setup', () => {
+    it('should update correctly when there are no calls to initTestEnvironment', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        'import "jest-preset-angular/setup-jest";'
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testSetupFile = tree.read('apps/app1/src/test-setup.ts', 'utf-8');
+      expect(testSetupFile).toMatchSnapshot();
+    });
+
+    it('should update correctly when no options are passed to the initTestEnvironment call', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import "jest-preset-angular/setup-jest";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+        `
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testSetupFile = tree.read('apps/app1/src/test-setup.ts', 'utf-8');
+      expect(testSetupFile).toMatchSnapshot();
+    });
+
+    it('should update correctly when the options passed to the initTestEnvironment call is an empty object', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import "jest-preset-angular/setup-jest";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {});
+        `
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testSetupFile = tree.read('apps/app1/src/test-setup.ts', 'utf-8');
+      expect(testSetupFile).toMatchSnapshot();
+    });
+
+    it('should update correctly when the options passed to the initTestEnvironment call does not have the teardown property', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import "jest-preset-angular/setup-jest";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), { aotSummaries: () => [] });
+        `
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testSetupFile = tree.read('apps/app1/src/test-setup.ts', 'utf-8');
+      expect(testSetupFile).toMatchSnapshot();
+    });
+
+    it('should update correctly when an aotSummaries function is passed to the initTestEnvironment call', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import "jest-preset-angular/setup-jest";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), function() { return []; });
+        `
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testSetupFile = tree.read('apps/app1/src/test-setup.ts', 'utf-8');
+      expect(testSetupFile).toMatchSnapshot();
+    });
+
+    it('should update correctly when an aotSummaries named function is passed to the initTestEnvironment call', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import "jest-preset-angular/setup-jest";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), function aotSummaries() { return []; });
+        `
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testSetupFile = tree.read('apps/app1/src/test-setup.ts', 'utf-8');
+      expect(testSetupFile).toMatchSnapshot();
+    });
+
+    it('should update correctly when an aotSummaries arrow function is passed to the initTestEnvironment call', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import "jest-preset-angular/setup-jest";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), () => []);
+        `
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testSetupFile = tree.read('apps/app1/src/test-setup.ts', 'utf-8');
+      expect(testSetupFile).toMatchSnapshot();
+    });
+
+    it('should not re-add the teardown property twice when it is already being passed to the initTestEnvironment call', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import "jest-preset-angular/setup-jest";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), { teardown: { destroyAfterEach: true } });
+        `
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testSetupFile = tree.read('apps/app1/src/test-setup.ts', 'utf-8');
+      expect(testSetupFile).toMatchSnapshot();
+    });
+  });
+
+  describe('update configureTestingModule in test files', () => {
+    it('should not be updated when the test setup file was updated', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        'import "jest-preset-angular/setup-jest";'
+      );
+      tree.write(
+        'apps/app1/src/app.component.spec.ts',
+        `describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          });
+        });`
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testFile = tree.read(
+        'apps/app1/src/app.component.spec.ts',
+        'utf-8'
+      );
+      expect(testFile).toMatchSnapshot();
+    });
+
+    it('should not be updated when the test setup file had the teardown options already configured', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import "jest-preset-angular/setup-jest";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), { teardown: { destroyAfterEach: true } });
+        `
+      );
+      tree.write(
+        'apps/app1/src/app.component.spec.ts',
+        `describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          });
+        });`
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testFile = tree.read(
+        'apps/app1/src/app.component.spec.ts',
+        'utf-8'
+      );
+      expect(testFile).toMatchSnapshot();
+    });
+
+    it('should update correctly when teardown options and setupFilesAfterEnv are not configured', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/app.component.spec.ts',
+        `describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          });
+        });`
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testFile = tree.read(
+        'apps/app1/src/app.component.spec.ts',
+        'utf-8'
+      );
+      expect(testFile).toMatchSnapshot();
+    });
+
+    it('should update correctly when teardown options have not been configured and there is no test setup file configured', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: [],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/app.component.spec.ts',
+        `describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          });
+        });`
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testFile = tree.read(
+        'apps/app1/src/app.component.spec.ts',
+        'utf-8'
+      );
+      expect(testFile).toMatchSnapshot();
+    });
+
+    it('should update correctly when teardown options have not been configured and the specified test setup file does not exist', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: ['<rootDir>src/test-setup.ts'],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/app.component.spec.ts',
+        `describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          });
+        });`
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testFile = tree.read(
+        'apps/app1/src/app.component.spec.ts',
+        'utf-8'
+      );
+      expect(testFile).toMatchSnapshot();
+    });
+
+    it('should update correctly when teardown options have not been configured and the initTestEnvironment call is invalid', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          setupFilesAfterEnv: ['<rootDir>src/test-setup.ts'],
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import "jest-preset-angular/setup-jest";
+        import { getTestBed } from '@angular/core/testing';
+        import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+        getTestBed().resetTestEnvironment();
+        // this is a type error, missing 2nd parameter
+        getTestBed().initTestEnvironment(BrowserDynamicTestingModule);
+        `
+      );
+      tree.write(
+        'apps/app1/src/app.component.spec.ts',
+        `describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          });
+        });`
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testFile = tree.read(
+        'apps/app1/src/app.component.spec.ts',
+        'utf-8'
+      );
+      expect(testFile).toMatchSnapshot();
+    });
+
+    it('should update correctly when there are multiple calls to configureTestingModule', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/app.component.spec.ts',
+        `describe('AppComponent1', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          });
+        });
+
+        describe('AppComponent2', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          });
+        });
+
+        describe('AppComponent3', () => {
+          test('some test case', async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          
+            expect(true).toBe(true);
+          });
+        });
+        `
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testFile = tree.read(
+        'apps/app1/src/app.component.spec.ts',
+        'utf-8'
+      );
+      expect(testFile).toMatchSnapshot();
+    });
+
+    it('should not re-add the teardown property or overwrite when it is already configured for configureTestingModule call', async () => {
+      // Arrange
+      const jestConfigPath = 'apps/app1/jest.config.js';
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: { jestConfig: jestConfigPath },
+          },
+        },
+      });
+      tree.write(
+        jestConfigPath,
+        `module.exports = {
+          transform: { '^.+.(ts|mjs|js|html)$': 'jest-preset-angular' },
+        };`
+      );
+      tree.write(
+        'apps/app1/src/app.component.spec.ts',
+        `describe('AppComponent1', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          });
+        });
+
+        describe('AppComponent2', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+              teardown: { destroyAfterEach: true },
+            }).compileComponents();
+          });
+        });
+
+        describe('AppComponent3', () => {
+          test('some test case', async () => {
+            await TestBed.configureTestingModule({
+              declarations: [AppComponent],
+            }).compileComponents();
+          
+            expect(true).toBe(true);
+          });
+        });
+        `
+      );
+
+      // Act
+      await testbedTeardownOptOutMigration(tree);
+
+      // Assert
+      const testFile = tree.read(
+        'apps/app1/src/app.component.spec.ts',
+        'utf-8'
+      );
+      expect(testFile).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/angular/src/migrations/update-13-2-0/opt-out-testbed-teardown.ts
+++ b/packages/angular/src/migrations/update-13-2-0/opt-out-testbed-teardown.ts
@@ -1,0 +1,390 @@
+import {
+  formatFiles,
+  getProjects,
+  logger,
+  readProjectConfiguration,
+  Tree,
+  visitNotIgnoredFiles,
+} from '@nrwl/devkit';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import { dirname, extname } from 'path';
+import * as ts from 'typescript';
+
+export default async function (tree: Tree) {
+  const projects = getProjects(tree);
+
+  for (const [projectName, project] of projects.entries()) {
+    // only interested in projects with @nrwl/jest:jest executor
+    if (project.targets?.test?.executor !== '@nrwl/jest:jest') {
+      continue;
+    }
+
+    const jestConfigPath = project.targets.test.options?.jestConfig;
+    // if there's not jestConfigPath, we don't process it
+    if (!jestConfigPath) {
+      logger.warn(
+        `The "jestConfig" property is not configured for the test target of the project "${projectName}". Skipping it.`
+      );
+      continue;
+    }
+
+    if (!tree.exists(jestConfigPath)) {
+      logger.warn(
+        `The specified "jestConfig" path "${jestConfigPath}" for the project "${projectName}" can not be found. Skipping it.`
+      );
+      continue;
+    }
+
+    let jestConfigContents = tree.read(jestConfigPath, 'utf-8');
+    // check if it's an angular project by looking for jest-preset-angular
+    if (!jestConfigContents.includes('jest-preset-angular')) {
+      continue;
+    }
+
+    const { shouldUpdate, testSetupFilePath } = shouldUpdateTeardownConfig(
+      tree,
+      projectName,
+      jestConfigPath,
+      jestConfigContents
+    );
+
+    if (!shouldUpdate) {
+      continue;
+    }
+
+    const printer = ts.createPrinter();
+    if (shouldUpdate === 'testSetup') {
+      optOutTestTeardownFromTestSetupFile(tree, testSetupFilePath, printer);
+    } else {
+      optOutTestTeardownFromTestFiles(tree, projectName, printer);
+    }
+  }
+
+  await formatFiles(tree);
+}
+
+function shouldUpdateTeardownConfig(
+  tree: Tree,
+  projectName: string,
+  jestConfigPath: string,
+  jestConfigContents: string
+): {
+  shouldUpdate: 'testFiles' | 'testSetup' | false;
+  testSetupFilePath?: string;
+} {
+  const jestConfigAst = tsquery.ast(jestConfigContents);
+  const setupFilesAfterEnvSelector =
+    'PropertyAssignment:has(Identifier[name=setupFilesAfterEnv])';
+  const setupFilesAfterEnvProperty = tsquery(
+    jestConfigAst,
+    setupFilesAfterEnvSelector,
+    {
+      visitAllChildren: true,
+    }
+  )[0] as ts.PropertyAssignment;
+
+  // no property specified, we try to migrate test files
+  if (!setupFilesAfterEnvProperty) {
+    return { shouldUpdate: 'testFiles' };
+  }
+
+  const setupFilesValueSelector = 'ArrayLiteralExpression StringLiteral';
+  const setupFilesValue = tsquery(
+    setupFilesAfterEnvProperty,
+    setupFilesValueSelector,
+    {
+      visitAllChildren: true,
+    }
+  )[0] as ts.StringLiteral;
+
+  // not setup file specified, we try to migrate test files
+  if (!setupFilesValue) {
+    return { shouldUpdate: 'testFiles' };
+  }
+
+  const testSetupFilePath = setupFilesValue
+    .getText()
+    .replace('<rootDir>', dirname(jestConfigPath))
+    .replace(/['"]/g, '');
+
+  // the specified file is invalid, we migrate test files
+  if (!tree.exists(testSetupFilePath)) {
+    return { shouldUpdate: 'testFiles' };
+  }
+
+  let testSetupFileContents = tree.read(testSetupFilePath, 'utf-8');
+  const testSetupFileAst = tsquery.ast(testSetupFileContents);
+
+  const initTestEnvironmentSelector =
+    'CallExpression:has(PropertyAccessExpression:has(Identifier[name=initTestEnvironment]))';
+  const initTestEnvironmentCall = tsquery(
+    testSetupFileAst,
+    initTestEnvironmentSelector,
+    {
+      visitAllChildren: true,
+    }
+  )[0] as ts.CallExpression;
+
+  // no initTestEnvironment call, we migrate the test setup file
+  if (!initTestEnvironmentCall) {
+    return { shouldUpdate: 'testSetup', testSetupFilePath };
+  }
+
+  // no third arg, we migrate the test setup file
+  if (initTestEnvironmentCall.arguments.length === 2) {
+    return { shouldUpdate: 'testSetup', testSetupFilePath };
+  }
+
+  // this would be a type error, we migrate test files
+  if (initTestEnvironmentCall.arguments.length < 2) {
+    return { shouldUpdate: 'testFiles' };
+  }
+
+  const optionsArg = initTestEnvironmentCall.arguments[2];
+
+  // the options arg is an object that has a teardown property, no migration is needed
+  if (isObjectLiteralWithTeardown(optionsArg)) {
+    return { shouldUpdate: false };
+  }
+
+  // the options arg is an object that doesn't have a teardown property, we migrate the test setup file
+  if (isObjectLiteralWithoutTeardown(optionsArg)) {
+    return { shouldUpdate: 'testSetup', testSetupFilePath };
+  }
+
+  // the options arg is an `aotSummaries` function, we migrate the test setup file
+  if (isFunction(optionsArg)) {
+    return { shouldUpdate: 'testSetup', testSetupFilePath };
+  }
+
+  // we fallback to migrate the test files
+  return { shouldUpdate: 'testFiles' };
+}
+
+function optOutTestTeardownFromTestFiles(
+  tree: Tree,
+  projectName: string,
+  printer: ts.Printer
+) {
+  const { sourceRoot, root } = readProjectConfiguration(tree, projectName);
+
+  visitNotIgnoredFiles(tree, sourceRoot ?? root, (path) => {
+    if (!['.ts', '.js'].includes(extname(path))) {
+      return;
+    }
+
+    let fileContents = tree.read(path, 'utf-8');
+    const ast = tsquery.ast(fileContents);
+
+    const configureTestingModulePropertyAccessExpressionSelector =
+      'CallExpression > PropertyAccessExpression:has(Identifier[name=configureTestingModule])';
+    const configureTestingModulePropertyAccessExpressions = tsquery(
+      ast,
+      configureTestingModulePropertyAccessExpressionSelector,
+      {
+        visitAllChildren: true,
+      }
+    ) as ts.PropertyAccessExpression[];
+
+    // no calls to configureTestingModule, we skip it
+    if (!configureTestingModulePropertyAccessExpressions.length) {
+      return;
+    }
+
+    // reverse the order to not mess with positions as we update the AST
+    const reversedConfigureTestingModulePropertyAccessExpressions =
+      sortInReverseSourceOrder(configureTestingModulePropertyAccessExpressions);
+
+    reversedConfigureTestingModulePropertyAccessExpressions.forEach(
+      (propertyAccessExpression) => {
+        const configureTestingModuleCall =
+          propertyAccessExpression.parent as ts.CallExpression;
+
+        if (
+          configureTestingModuleCall.arguments.length === 0 ||
+          !isObjectLiteralWithoutTeardown(
+            configureTestingModuleCall.arguments[0]
+          )
+        ) {
+          return;
+        }
+
+        const testModuleMetadata = configureTestingModuleCall.arguments[0];
+
+        const replacement = getTestModuleMetadataLiteralReplacement(
+          testModuleMetadata,
+          printer
+        );
+
+        fileContents = `${fileContents.slice(
+          0,
+          testModuleMetadata.getStart()
+        )}${replacement}${fileContents.slice(testModuleMetadata.getEnd())}`;
+
+        tree.write(path, fileContents);
+      }
+    );
+  });
+}
+
+function optOutTestTeardownFromTestSetupFile(
+  tree: Tree,
+  testSetupFilePath: string,
+  printer: ts.Printer
+) {
+  let testSetupFileContents = tree.read(testSetupFilePath, 'utf-8');
+  const testSetupFileAst = tsquery.ast(testSetupFileContents);
+
+  const initTestEnvironmentSelector =
+    'CallExpression:has(PropertyAccessExpression:has(Identifier[name=initTestEnvironment]))';
+  const initTestEnvironmentCall = tsquery(
+    testSetupFileAst,
+    initTestEnvironmentSelector,
+    {
+      visitAllChildren: true,
+    }
+  )[0] as ts.CallExpression;
+
+  if (!initTestEnvironmentCall) {
+    testSetupFileContents += `
+      import { getTestBed } from '@angular/core/testing';
+      import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+      getTestBed().resetTestEnvironment();
+      getTestBed().initTestEnvironment(
+        BrowserDynamicTestingModule,
+        platformBrowserDynamicTesting(),
+        { teardown: { destroyAfterEach: false } },
+      );
+    `;
+
+    tree.write(testSetupFilePath, testSetupFileContents);
+
+    return;
+  }
+
+  const { span, text } = getInitTestEnvironmentLiteralReplacement(
+    initTestEnvironmentCall,
+    printer
+  );
+
+  testSetupFileContents = `${testSetupFileContents.slice(
+    0,
+    span.start
+  )}${text}${testSetupFileContents.slice(span.end)}`;
+
+  tree.write(testSetupFilePath, testSetupFileContents);
+}
+
+function getInitTestEnvironmentLiteralReplacement(
+  initTestEnvironmentCall: ts.CallExpression,
+  printer: ts.Printer
+) {
+  const literalProperties: ts.ObjectLiteralElementLike[] = [];
+  const options =
+    initTestEnvironmentCall.arguments[
+      initTestEnvironmentCall.arguments.length - 1
+    ];
+  let span: { start: number; end: number };
+  let prefix: string;
+
+  // update the last argument of the initTestEnvironment call
+  if (initTestEnvironmentCall.arguments.length === 3) {
+    if (isFunction(options)) {
+      // If the last argument is a function, add the function as the `aotSummaries` property.
+      literalProperties.push(
+        ts.factory.createPropertyAssignment('aotSummaries', options)
+      );
+    } else if (ts.isObjectLiteralExpression(options)) {
+      // If the property is an object literal, copy over all the properties.
+      literalProperties.push(...options.properties);
+    }
+
+    prefix = '';
+    span = {
+      start: options.getStart(),
+      end: options.getEnd(),
+    };
+  } else {
+    const start = options.getEnd();
+    prefix = ', ';
+    span = { start, end: start };
+  }
+
+  // finally push the teardown object so that it appears last
+  literalProperties.push(createTeardownAssignment());
+
+  return {
+    span,
+    text: `${prefix}${printer.printNode(
+      ts.EmitHint.Unspecified,
+      ts.factory.createObjectLiteralExpression(literalProperties),
+      initTestEnvironmentCall.getSourceFile()
+    )}`,
+  };
+}
+
+function getTestModuleMetadataLiteralReplacement(
+  testModuleMetadataObjectLiteral: ts.ObjectLiteralExpression,
+  printer: ts.Printer
+) {
+  return printer.printNode(
+    ts.EmitHint.Unspecified,
+    ts.factory.createObjectLiteralExpression(
+      [
+        ...testModuleMetadataObjectLiteral.properties,
+        createTeardownAssignment(),
+      ],
+      testModuleMetadataObjectLiteral.properties.length > 0
+    ),
+    testModuleMetadataObjectLiteral.getSourceFile()
+  );
+}
+
+function isObjectLiteralWithTeardown(
+  node: ts.Node
+): node is ts.ObjectLiteralExpression {
+  return (
+    ts.isObjectLiteralExpression(node) &&
+    node.properties.some((prop) => {
+      return prop.name?.getText() === 'teardown';
+    })
+  );
+}
+
+function isObjectLiteralWithoutTeardown(
+  node: ts.Node
+): node is ts.ObjectLiteralExpression {
+  return (
+    ts.isObjectLiteralExpression(node) &&
+    !node.properties.find((prop) => {
+      return prop.name?.getText() === 'teardown';
+    })
+  );
+}
+
+function isFunction(
+  node: ts.Node
+): node is ts.ArrowFunction | ts.FunctionExpression | ts.FunctionDeclaration {
+  return (
+    ts.isArrowFunction(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isFunctionDeclaration(node)
+  );
+}
+
+function createTeardownAssignment(): ts.PropertyAssignment {
+  return ts.factory.createPropertyAssignment(
+    'teardown',
+    ts.factory.createObjectLiteralExpression([
+      ts.factory.createPropertyAssignment(
+        'destroyAfterEach',
+        ts.factory.createFalse()
+      ),
+    ])
+  );
+}
+
+function sortInReverseSourceOrder<T extends ts.Node>(nodes: T[]): T[] {
+  return nodes.sort((a, b) => b.getEnd() - a.getEnd());
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@angular/core` migration for opting out of the new testbed teardown behavior for existing projects doesn't run for all Angular projects in the Nx workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
All existing Angular projects in the Nx workspace should be migrated correctly when upgrading to Nx ^13.2.0. They should be automatically opted out of the new testbed teardown behavior as intended by the Angular migration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7857 
