### PR TITLE
fix(angular): install @angular/cli if not installed

### DIFF
--- a/packages/angular/src/generators/init/init.spec.ts
+++ b/packages/angular/src/generators/init/init.spec.ts
@@ -33,6 +33,7 @@ describe('init', () => {
     expect(dependencies['@angular/router']).toBeDefined();
     expect(dependencies['rxjs']).toBeDefined();
     expect(dependencies['zone.js']).toBeDefined();
+    expect(devDependencies['@angular/cli']).toBeDefined();
     expect(devDependencies['@angular/compiler-cli']).toBeDefined();
     expect(devDependencies['@angular/language-service']).toBeDefined();
     expect(devDependencies['@angular-devkit/build-angular']).toBeDefined();

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -95,6 +95,7 @@ function updateDependencies(host: Tree): GeneratorCallback {
       'zone.js': '~0.11.4',
     },
     {
+      '@angular/cli': angularDevkitVersion,
       '@angular/compiler-cli': angularVersion,
       '@angular/language-service': angularVersion,
       '@angular-devkit/build-angular': angularDevkitVersion,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When adding the `@nrwl/angular` package to an empty workspace and generating a new Angular project, the `@angular/cli` package does not get installed. This can cause some issues with some tooling relying on it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Creating a new Angular project should install `@angular/cli` if it is not installed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7867 
