### PR TITLE
fix(angular): do not require v8-compile-cache when it is an angular workspace

### DIFF
--- a/packages/cli/bin/nx.ts
+++ b/packages/cli/bin/nx.ts
@@ -1,16 +1,17 @@
 #!/usr/bin/env node
-import 'v8-compile-cache';
+import { findWorkspaceRoot } from '../lib/find-workspace-root';
+const workspace = findWorkspaceRoot(process.cwd());
+if (workspace.type === 'nx') {
+  require('v8-compile-cache');
+}
 // polyfill rxjs observable to avoid issues with multiple version fo Observable installed in node_modules
 // https://twitter.com/BenLesh/status/1192478226385428483?s=20
 if (!(Symbol as any).observable)
   (Symbol as any).observable = Symbol('observable polyfill');
 import * as chalk from 'chalk';
-import { findWorkspaceRoot } from '../lib/find-workspace-root';
 import { initLocal } from '../lib/init-local';
 import { output } from '../lib/output';
 import { detectPackageManager } from '@nrwl/tao/src/shared/package-manager';
-
-const workspace = findWorkspaceRoot(process.cwd());
 
 if (!workspace) {
   output.log({


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
In an Angular workspace, when an unknown command to the Nx CLI is used we fall back to using the Angular CLI. The Nx CLI uses the `v8-compile-cache` package to improve the performance. With the Angular 13 upgrade, this started to fail due to the `v8-compile-cache` package not supporting ESM.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The Nx CLI should fall back successfully to use the Angular CLI when needed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7824 
