### PR TITLE
feat(core): print out directly simple create-nx-workspace exceptions

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -564,7 +564,11 @@ function mapErrorToBodyLines(error: {
     // print entire log message only if it's only a single message
     return [`Error: ${error.logMessage}`];
   }
-  return [`Exit code: ${error.code}`, `Log file: ${error.logFile}`];
+  const lines = [`Exit code: ${error.code}`, `Log file: ${error.logFile}`];
+  if (process.env.NX_VERBOSE_LOGGING) {
+    lines.push(`Error: ${error.logMessage}`);
+  }
+  return lines;
 }
 
 function execAndWait(command: string, cwd: string) {

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -459,7 +459,7 @@ async function createSandbox(packageManager: string) {
     installSpinner.fail();
     output.error({
       title: `Nx failed to install dependencies`,
-      bodyLines: [`Exit code: ${e.code}`, `Log file: ${e.logFile}`],
+      bodyLines: mapErrorToBodyLines(e),
     });
     process.exit(1);
   } finally {
@@ -515,7 +515,7 @@ async function createApp(
     workspaceSetupSpinner.fail();
     output.error({
       title: `Nx failed to create a workspace.`,
-      bodyLines: [`Exit code: ${e.code}`, `Log file: ${e.logFile}`],
+      bodyLines: mapErrorToBodyLines(e),
     });
     process.exit(1);
   } finally {
@@ -538,7 +538,7 @@ async function setupNxCloud(name: string, packageManager: PackageManager) {
 
     output.error({
       title: `Nx failed to setup NxCloud`,
-      bodyLines: [`Exit code: ${e.code}`, `Log file: ${e.logFile}`],
+      bodyLines: mapErrorToBodyLines(e),
     });
 
     process.exit(1);
@@ -555,13 +555,25 @@ function printNxCloudSuccessMessage(nxCloudOut: string) {
   });
 }
 
+function mapErrorToBodyLines(error: {
+  logMessage: string;
+  code: number;
+  logFile: string;
+}): string[] {
+  if (error.logMessage.split('\n').filter((line) => !!line).length === 1) {
+    // print entire log message only if it's only a single message
+    return [`Error: ${error.logMessage}`];
+  }
+  return [`Exit code: ${error.code}`, `Log file: ${error.logFile}`];
+}
+
 function execAndWait(command: string, cwd: string) {
   return new Promise((res, rej) => {
     exec(command, { cwd }, (error, stdout, stderr) => {
       if (error) {
         const logFile = path.join(cwd, 'error.log');
         writeFileSync(logFile, `${stdout}\n${stderr}`);
-        rej({ code: error.code, logFile });
+        rej({ code: error.code, logFile, logMessage: stderr });
       } else {
         res({ code: 0, stdout });
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When `create-nx-workspace` fails even the simplest errors like "folder exists" are hidden behind log files.
This makes it even more difficult to debug CI issues as we don't have easy access to logs.

![Screenshot 2021-11-29 at 13 25 29](https://user-images.githubusercontent.com/881612/143867801-32f999e3-51df-47c4-b1ae-d25eeb4263a3.png)

## Expected Behavior
When `create-nx-workspace` fails simple error messages should be printed out directly to user.
For CI purposes the `NX_VERBOSE_LOGGING` should be respected and print entire error output to terminal.

![Screenshot 2021-11-29 at 13 24 28](https://user-images.githubusercontent.com/881612/143867658-9319e4e6-a80c-4503-8f39-204e49f4c19a.png)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
