### PR TITLE
fix(angular): implement webpack mfe workaround

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -126,6 +126,12 @@
       "version": "13.2.0",
       "description": "In Angular version 13, the `teardown` flag in `TestBed` will be enabled by default. This migration automatically opts out existing apps from the new teardown behavior.",
       "factory": "./src/migrations/update-13-2-0/opt-out-testbed-teardown"
+    },
+    "update-mfe-webpack-config": {
+      "cli": "nx",
+      "version": "13.3.0-beta.0",
+      "description": "Since Angular 13, Webpack builds MFE loading scripts with module syntax which is broken. Instead, switch to non-module syntax with standard script tag loading.",
+      "factory": "./src/migrations/update-13-3-0/update-mfe-webpack-config"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/generators/setup-mfe/files/webpack/webpack.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-mfe/files/webpack/webpack.config.js__tmpl__
@@ -24,6 +24,7 @@ module.exports = {
   output: {
     uniqueName: "<%= name %>",
     publicPath: "auto",
+    scriptType: 'text/javascript'
   },
   optimization: {
     runtimeChunk: false,

--- a/packages/angular/src/generators/setup-mfe/lib/setup-serve-target.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/setup-serve-target.ts
@@ -23,8 +23,11 @@ export function setupServeTarget(host: Tree, options: Schema) {
       ? options.remotes.map((r) => `nx serve ${r}`)
       : undefined;
     const commands = remoteServeCommands
-      ? [...remoteServeCommands, `nx serve ${options.appName}`]
-      : [`nx serve ${options.appName}`];
+      ? [
+          ...remoteServeCommands,
+          `nx serve ${options.appName} --liveReload=false`,
+        ]
+      : [`nx serve ${options.appName} --liveReload=false`];
 
     appConfig.targets['serve-mfe'] = {
       executor: '@nrwl/workspace:run-commands',
@@ -43,7 +46,7 @@ export function setupServeTarget(host: Tree, options: Schema) {
       options: {
         ...hostAppConfig.targets['serve-mfe'].options,
         commands: [
-          `nx serve ${options.appName}`,
+          `nx serve ${options.appName} --liveReload=false`,
           ...hostAppConfig.targets['serve-mfe'].options.commands,
         ],
       },

--- a/packages/angular/src/migrations/update-13-3-0/update-mfe-webpack-config.spec.ts
+++ b/packages/angular/src/migrations/update-13-3-0/update-mfe-webpack-config.spec.ts
@@ -1,0 +1,687 @@
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { updateScriptType } from './update-mfe-webpack-config';
+import updateMfeWebpackConfig from './update-mfe-webpack-config';
+
+describe('update-mfe-webpack-config migration', () => {
+  it('should migrate the webpack config for one app', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'app', {
+      root: 'apps/testing',
+      targets: {
+        build: {
+          executor: '@nrwl/angular:webpack-browser',
+          options: {
+            customWebpackConfig: { path: 'apps/testing/webpack.config.js' },
+          },
+        },
+      },
+    });
+
+    const webpackConfig = `const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+    const mf = require('@angular-architects/module-federation/webpack');
+    const path = require('path');
+    
+    /**
+     * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+     * builder as it will generate a temporary tsconfig file which contains any required remappings of
+     * shred libraries.
+     * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+     * built files for the buildable library.
+     * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+     * the location of the generated temporary tsconfig file.
+     */
+    const tsConfigPath =
+      process.env.NX_TSCONFIG_PATH ??
+      path.join(__dirname, '../../tsconfig.base.json');
+    
+    const workspaceRootPath = path.join(__dirname, '../../');
+    const sharedMappings = new mf.SharedMappings();
+    sharedMappings.register(
+      tsConfigPath,
+      [
+        /* mapped paths to share */
+      ],
+      workspaceRootPath
+    );
+    
+    module.exports = {
+      output: {
+        uniqueName: 'login',
+        publicPath: 'auto',
+      },
+      optimization: {
+        runtimeChunk: false,
+        minimize: false,
+      },
+      resolve: {
+        alias: {
+          ...sharedMappings.getAliases(),
+        },
+      },
+      plugins: [
+        new ModuleFederationPlugin({
+          name: 'login',
+          filename: 'remoteEntry.mjs',
+          exposes: {
+            './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+          },
+          shared: {
+            '@angular/core': { singleton: true, strictVersion: true },
+            '@angular/common': { singleton: true, strictVersion: true },
+            '@angular/common/http': { singleton: true, strictVersion: true },
+            '@angular/router': { singleton: true, strictVersion: true },
+            ...sharedMappings.getDescriptors(),
+          },
+        }),
+        sharedMappings.getPlugin(),
+      ],
+    };
+    `;
+
+    tree.write('apps/testing/webpack.config.js', webpackConfig);
+
+    // ACT
+    await updateMfeWebpackConfig(tree);
+
+    // ASSERT
+    const updatedWebpackFile = tree.read(
+      'apps/testing/webpack.config.js',
+      'utf-8'
+    );
+    expect(updatedWebpackFile).toMatchInlineSnapshot(`
+      "const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+          const mf = require('@angular-architects/module-federation/webpack');
+          const path = require('path');
+          
+          /**
+           * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+           * builder as it will generate a temporary tsconfig file which contains any required remappings of
+           * shred libraries.
+           * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+           * built files for the buildable library.
+           * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+           * the location of the generated temporary tsconfig file.
+           */
+          const tsConfigPath =
+            process.env.NX_TSCONFIG_PATH ??
+            path.join(__dirname, '../../tsconfig.base.json');
+          
+          const workspaceRootPath = path.join(__dirname, '../../');
+          const sharedMappings = new mf.SharedMappings();
+          sharedMappings.register(
+            tsConfigPath,
+            [
+              /* mapped paths to share */
+            ],
+            workspaceRootPath
+          );
+          
+          module.exports = {
+            output: {
+              uniqueName: 'login',
+              publicPath: 'auto',
+      scriptType: 'text/javascript',
+            },
+            optimization: {
+              runtimeChunk: false,
+              minimize: false,
+            },
+            resolve: {
+              alias: {
+                ...sharedMappings.getAliases(),
+              },
+            },
+            plugins: [
+              new ModuleFederationPlugin({
+                name: 'login',
+                filename: 'remoteEntry.mjs',
+                exposes: {
+                  './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+                },
+                shared: {
+                  '@angular/core': { singleton: true, strictVersion: true },
+                  '@angular/common': { singleton: true, strictVersion: true },
+                  '@angular/common/http': { singleton: true, strictVersion: true },
+                  '@angular/router': { singleton: true, strictVersion: true },
+                  ...sharedMappings.getDescriptors(),
+                },
+              }),
+              sharedMappings.getPlugin(),
+            ],
+          };
+          "
+    `);
+  });
+
+  it('should migrate the webpack config for multiple apps', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'app', {
+      root: 'apps/testing',
+      targets: {
+        build: {
+          executor: '@nrwl/angular:webpack-browser',
+          options: {
+            customWebpackConfig: { path: 'apps/testing/webpack.config.js' },
+          },
+        },
+      },
+    });
+    addProjectConfiguration(tree, 'other', {
+      root: 'apps/other',
+      targets: {
+        build: {
+          executor: '@nrwl/angular:webpack-browser',
+          options: {
+            customWebpackConfig: { path: 'apps/other/webpack.config.js' },
+          },
+        },
+      },
+    });
+
+    const webpackConfig = `const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+    const mf = require('@angular-architects/module-federation/webpack');
+    const path = require('path');
+    
+    /**
+     * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+     * builder as it will generate a temporary tsconfig file which contains any required remappings of
+     * shred libraries.
+     * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+     * built files for the buildable library.
+     * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+     * the location of the generated temporary tsconfig file.
+     */
+    const tsConfigPath =
+      process.env.NX_TSCONFIG_PATH ??
+      path.join(__dirname, '../../tsconfig.base.json');
+    
+    const workspaceRootPath = path.join(__dirname, '../../');
+    const sharedMappings = new mf.SharedMappings();
+    sharedMappings.register(
+      tsConfigPath,
+      [
+        /* mapped paths to share */
+      ],
+      workspaceRootPath
+    );
+    
+    module.exports = {
+      output: {
+        uniqueName: 'login',
+        publicPath: 'auto',
+      },
+      optimization: {
+        runtimeChunk: false,
+        minimize: false,
+      },
+      resolve: {
+        alias: {
+          ...sharedMappings.getAliases(),
+        },
+      },
+      plugins: [
+        new ModuleFederationPlugin({
+          name: 'login',
+          filename: 'remoteEntry.mjs',
+          exposes: {
+            './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+          },
+          shared: {
+            '@angular/core': { singleton: true, strictVersion: true },
+            '@angular/common': { singleton: true, strictVersion: true },
+            '@angular/common/http': { singleton: true, strictVersion: true },
+            '@angular/router': { singleton: true, strictVersion: true },
+            ...sharedMappings.getDescriptors(),
+          },
+        }),
+        sharedMappings.getPlugin(),
+      ],
+    };
+    `;
+
+    tree.write('apps/testing/webpack.config.js', webpackConfig);
+    tree.write('apps/other/webpack.config.js', webpackConfig);
+
+    // ACT
+    await updateMfeWebpackConfig(tree);
+
+    // ASSERT
+    const updatedApp1WebpackFile = tree.read(
+      'apps/testing/webpack.config.js',
+      'utf-8'
+    );
+    expect(updatedApp1WebpackFile).toMatchInlineSnapshot(`
+      "const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+          const mf = require('@angular-architects/module-federation/webpack');
+          const path = require('path');
+          
+          /**
+           * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+           * builder as it will generate a temporary tsconfig file which contains any required remappings of
+           * shred libraries.
+           * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+           * built files for the buildable library.
+           * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+           * the location of the generated temporary tsconfig file.
+           */
+          const tsConfigPath =
+            process.env.NX_TSCONFIG_PATH ??
+            path.join(__dirname, '../../tsconfig.base.json');
+          
+          const workspaceRootPath = path.join(__dirname, '../../');
+          const sharedMappings = new mf.SharedMappings();
+          sharedMappings.register(
+            tsConfigPath,
+            [
+              /* mapped paths to share */
+            ],
+            workspaceRootPath
+          );
+          
+          module.exports = {
+            output: {
+              uniqueName: 'login',
+              publicPath: 'auto',
+      scriptType: 'text/javascript',
+            },
+            optimization: {
+              runtimeChunk: false,
+              minimize: false,
+            },
+            resolve: {
+              alias: {
+                ...sharedMappings.getAliases(),
+              },
+            },
+            plugins: [
+              new ModuleFederationPlugin({
+                name: 'login',
+                filename: 'remoteEntry.mjs',
+                exposes: {
+                  './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+                },
+                shared: {
+                  '@angular/core': { singleton: true, strictVersion: true },
+                  '@angular/common': { singleton: true, strictVersion: true },
+                  '@angular/common/http': { singleton: true, strictVersion: true },
+                  '@angular/router': { singleton: true, strictVersion: true },
+                  ...sharedMappings.getDescriptors(),
+                },
+              }),
+              sharedMappings.getPlugin(),
+            ],
+          };
+          "
+    `);
+    const updatedApp2WebpackFile = tree.read(
+      'apps/other/webpack.config.js',
+      'utf-8'
+    );
+    expect(updatedApp2WebpackFile).toMatchInlineSnapshot(`
+      "const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+          const mf = require('@angular-architects/module-federation/webpack');
+          const path = require('path');
+          
+          /**
+           * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+           * builder as it will generate a temporary tsconfig file which contains any required remappings of
+           * shred libraries.
+           * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+           * built files for the buildable library.
+           * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+           * the location of the generated temporary tsconfig file.
+           */
+          const tsConfigPath =
+            process.env.NX_TSCONFIG_PATH ??
+            path.join(__dirname, '../../tsconfig.base.json');
+          
+          const workspaceRootPath = path.join(__dirname, '../../');
+          const sharedMappings = new mf.SharedMappings();
+          sharedMappings.register(
+            tsConfigPath,
+            [
+              /* mapped paths to share */
+            ],
+            workspaceRootPath
+          );
+          
+          module.exports = {
+            output: {
+              uniqueName: 'login',
+              publicPath: 'auto',
+      scriptType: 'text/javascript',
+            },
+            optimization: {
+              runtimeChunk: false,
+              minimize: false,
+            },
+            resolve: {
+              alias: {
+                ...sharedMappings.getAliases(),
+              },
+            },
+            plugins: [
+              new ModuleFederationPlugin({
+                name: 'login',
+                filename: 'remoteEntry.mjs',
+                exposes: {
+                  './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+                },
+                shared: {
+                  '@angular/core': { singleton: true, strictVersion: true },
+                  '@angular/common': { singleton: true, strictVersion: true },
+                  '@angular/common/http': { singleton: true, strictVersion: true },
+                  '@angular/router': { singleton: true, strictVersion: true },
+                  ...sharedMappings.getDescriptors(),
+                },
+              }),
+              sharedMappings.getPlugin(),
+            ],
+          };
+          "
+    `);
+  });
+
+  it('should add liveReload=false to the serve commands', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'app', {
+      root: 'apps/testing',
+      targets: {
+        build: {
+          executor: '@nrwl/angular:webpack-browser',
+          options: {
+            customWebpackConfig: { path: 'apps/testing/webpack.config.js' },
+          },
+        },
+        'serve-mfe': {
+          executor: '@nrwl/workspace:run-commands',
+          options: {
+            commands: ['nx serve app1'],
+          },
+        },
+      },
+    });
+
+    const webpackConfig = `const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+    const mf = require('@angular-architects/module-federation/webpack');
+    const path = require('path');
+    
+    /**
+     * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+     * builder as it will generate a temporary tsconfig file which contains any required remappings of
+     * shred libraries.
+     * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+     * built files for the buildable library.
+     * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+     * the location of the generated temporary tsconfig file.
+     */
+    const tsConfigPath =
+      process.env.NX_TSCONFIG_PATH ??
+      path.join(__dirname, '../../tsconfig.base.json');
+    
+    const workspaceRootPath = path.join(__dirname, '../../');
+    const sharedMappings = new mf.SharedMappings();
+    sharedMappings.register(
+      tsConfigPath,
+      [
+        /* mapped paths to share */
+      ],
+      workspaceRootPath
+    );
+    
+    module.exports = {
+      output: {
+        uniqueName: 'login',
+        publicPath: 'auto',
+      },
+      optimization: {
+        runtimeChunk: false,
+        minimize: false,
+      },
+      resolve: {
+        alias: {
+          ...sharedMappings.getAliases(),
+        },
+      },
+      plugins: [
+        new ModuleFederationPlugin({
+          name: 'login',
+          filename: 'remoteEntry.mjs',
+          exposes: {
+            './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+          },
+          shared: {
+            '@angular/core': { singleton: true, strictVersion: true },
+            '@angular/common': { singleton: true, strictVersion: true },
+            '@angular/common/http': { singleton: true, strictVersion: true },
+            '@angular/router': { singleton: true, strictVersion: true },
+            ...sharedMappings.getDescriptors(),
+          },
+        }),
+        sharedMappings.getPlugin(),
+      ],
+    };
+    `;
+
+    tree.write('apps/testing/webpack.config.js', webpackConfig);
+
+    // ACT
+    await updateMfeWebpackConfig(tree);
+
+    // ASSERT
+    const updatedProject = readProjectConfiguration(tree, 'app');
+    expect(updatedProject.targets['serve-mfe'].options.commands).toEqual([
+      'nx serve app1 --liveReload=false',
+    ]);
+  });
+});
+
+describe('add script type to webpack mfe config', () => {
+  it('should add scriptType to webpack config', () => {
+    // ARRANGE
+    const webpackFile = `const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+        const mf = require('@angular-architects/module-federation/webpack');
+        const path = require('path');
+        
+        /**
+         * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+         * builder as it will generate a temporary tsconfig file which contains any required remappings of
+         * shred libraries.
+         * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+         * built files for the buildable library.
+         * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+         * the location of the generated temporary tsconfig file.
+         */
+        const tsConfigPath =
+          process.env.NX_TSCONFIG_PATH ??
+          path.join(__dirname, '../../tsconfig.base.json');
+        
+        const workspaceRootPath = path.join(__dirname, '../../');
+        const sharedMappings = new mf.SharedMappings();
+        sharedMappings.register(
+          tsConfigPath,
+          [
+            /* mapped paths to share */
+          ],
+          workspaceRootPath
+        );
+        
+        module.exports = {
+          output: {
+            uniqueName: 'login',
+            publicPath: 'auto',
+          },
+          optimization: {
+            runtimeChunk: false,
+            minimize: false,
+          },
+          resolve: {
+            alias: {
+              ...sharedMappings.getAliases(),
+            },
+          },
+          plugins: [
+            new ModuleFederationPlugin({
+              name: 'login',
+              filename: 'remoteEntry.mjs',
+              exposes: {
+                './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+              },
+              shared: {
+                '@angular/core': { singleton: true, strictVersion: true },
+                '@angular/common': { singleton: true, strictVersion: true },
+                '@angular/common/http': { singleton: true, strictVersion: true },
+                '@angular/router': { singleton: true, strictVersion: true },
+                ...sharedMappings.getDescriptors(),
+              },
+            }),
+            sharedMappings.getPlugin(),
+          ],
+        };
+        `;
+    // ACT
+    const updatedFile = updateScriptType(webpackFile);
+
+    // ASSERT
+    expect(updatedFile).toMatchInlineSnapshot(`
+      "const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+              const mf = require('@angular-architects/module-federation/webpack');
+              const path = require('path');
+              
+              /**
+               * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+               * builder as it will generate a temporary tsconfig file which contains any required remappings of
+               * shred libraries.
+               * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+               * built files for the buildable library.
+               * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+               * the location of the generated temporary tsconfig file.
+               */
+              const tsConfigPath =
+                process.env.NX_TSCONFIG_PATH ??
+                path.join(__dirname, '../../tsconfig.base.json');
+              
+              const workspaceRootPath = path.join(__dirname, '../../');
+              const sharedMappings = new mf.SharedMappings();
+              sharedMappings.register(
+                tsConfigPath,
+                [
+                  /* mapped paths to share */
+                ],
+                workspaceRootPath
+              );
+              
+              module.exports = {
+                output: {
+                  uniqueName: 'login',
+                  publicPath: 'auto',
+      scriptType: 'text/javascript',
+                },
+                optimization: {
+                  runtimeChunk: false,
+                  minimize: false,
+                },
+                resolve: {
+                  alias: {
+                    ...sharedMappings.getAliases(),
+                  },
+                },
+                plugins: [
+                  new ModuleFederationPlugin({
+                    name: 'login',
+                    filename: 'remoteEntry.mjs',
+                    exposes: {
+                      './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+                    },
+                    shared: {
+                      '@angular/core': { singleton: true, strictVersion: true },
+                      '@angular/common': { singleton: true, strictVersion: true },
+                      '@angular/common/http': { singleton: true, strictVersion: true },
+                      '@angular/router': { singleton: true, strictVersion: true },
+                      ...sharedMappings.getDescriptors(),
+                    },
+                  }),
+                  sharedMappings.getPlugin(),
+                ],
+              };
+              "
+    `);
+  });
+
+  it('should keep file as is when scriptType exists', () => {
+    // ARRANGE
+    const webpackFile = `const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+        const mf = require('@angular-architects/module-federation/webpack');
+        const path = require('path');
+        
+        /**
+         * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+         * builder as it will generate a temporary tsconfig file which contains any required remappings of
+         * shred libraries.
+         * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+         * built files for the buildable library.
+         * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+         * the location of the generated temporary tsconfig file.
+         */
+        const tsConfigPath =
+          process.env.NX_TSCONFIG_PATH ??
+          path.join(__dirname, '../../tsconfig.base.json');
+        
+        const workspaceRootPath = path.join(__dirname, '../../');
+        const sharedMappings = new mf.SharedMappings();
+        sharedMappings.register(
+          tsConfigPath,
+          [
+            /* mapped paths to share */
+          ],
+          workspaceRootPath
+        );
+        
+        module.exports = {
+          output: {
+            uniqueName: 'login',
+            publicPath: 'auto',
+            scriptType: 'text/javascript',
+          },
+          optimization: {
+            runtimeChunk: false,
+            minimize: false,
+          },
+          resolve: {
+            alias: {
+              ...sharedMappings.getAliases(),
+            },
+          },
+          plugins: [
+            new ModuleFederationPlugin({
+              name: 'login',
+              filename: 'remoteEntry.mjs',
+              exposes: {
+                './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+              },
+              shared: {
+                '@angular/core': { singleton: true, strictVersion: true },
+                '@angular/common': { singleton: true, strictVersion: true },
+                '@angular/common/http': { singleton: true, strictVersion: true },
+                '@angular/router': { singleton: true, strictVersion: true },
+                ...sharedMappings.getDescriptors(),
+              },
+            }),
+            sharedMappings.getPlugin(),
+          ],
+        };
+        `;
+    // ACT
+    const updatedFile = updateScriptType(webpackFile);
+
+    // ASSERT
+    expect(updatedFile).toEqual(webpackFile);
+  });
+});

--- a/packages/angular/src/migrations/update-13-3-0/update-mfe-webpack-config.ts
+++ b/packages/angular/src/migrations/update-13-3-0/update-mfe-webpack-config.ts
@@ -1,0 +1,92 @@
+import {
+  ProjectConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import { logger, formatFiles, getProjects } from '@nrwl/devkit';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+import { Node } from 'typescript';
+
+export default async function (tree: Tree) {
+  const NRWL_WEBPACK_BROWSER_BUILDER = '@nrwl/angular:webpack-browser';
+  const CUSTOM_WEBPACK_OPTION = 'customWebpackConfig';
+
+  const projects = getProjects(tree);
+
+  const projectsToUpdateServeTarget = new Map<string, ProjectConfiguration>();
+  forEachExecutorOptions(
+    tree,
+    NRWL_WEBPACK_BROWSER_BUILDER,
+    (opts, projectName) => {
+      // Update the webpack config
+      const webpackPath = opts[CUSTOM_WEBPACK_OPTION].path;
+      if (!tree.exists(webpackPath)) {
+        logger.warn(
+          `Webpack config file for project: ${projectName} does not exist. Skipping project.`
+        );
+        return;
+      }
+      const webpackConfig = tree.read(webpackPath, 'utf-8');
+      if (!webpackConfig.includes('ModuleFederationPlugin')) {
+        logger.warn(
+          `Webpack config file for project: ${projectName} is not using Module Federation. Skipping project.`
+        );
+        return;
+      }
+
+      const updatedWebpackFile = updateScriptType(webpackConfig);
+      tree.write(webpackPath, updatedWebpackFile);
+
+      // migrate the serve-mfe target to use liveReload=false
+      const project = projects.get(projectName);
+      if ('serve-mfe' in project.targets) {
+        projectsToUpdateServeTarget.set(projectName, project);
+      }
+    }
+  );
+
+  for (const [projectName, project] of projectsToUpdateServeTarget) {
+    const updatedCommands = project.targets['serve-mfe'].options.commands.map(
+      (command: string) => `${command} --liveReload=false`
+    );
+    let updatedProject = project;
+    updatedProject.targets['serve-mfe'].options.commands = updatedCommands;
+    updateProjectConfiguration(tree, projectName, updatedProject);
+  }
+
+  await formatFiles(tree);
+}
+
+export function updateScriptType(webpackConfig: string) {
+  const WEBPACK_OUTPUT_OBJECT_QUERY =
+    'PropertyAssignment > Identifier[name=output] ~ ObjectLiteralExpression';
+
+  const ast = tsquery.ast(webpackConfig);
+  const outputObjectNode = tsquery(ast, WEBPACK_OUTPUT_OBJECT_QUERY, {
+    visitAllChildren: true,
+  })[0] as Node;
+
+  if (!outputObjectNode) {
+    return webpackConfig;
+  }
+
+  if (outputObjectNode.getText().includes('text/javascript')) {
+    return webpackConfig;
+  }
+
+  const WEBPACK_OUTPUT_PROPS_QUERY =
+    'Identifier[name=output] ~ ObjectLiteralExpression > PropertyAssignment:last-child';
+  const outputPropertyNode = tsquery(ast, WEBPACK_OUTPUT_PROPS_QUERY, {
+    visitAllChildren: true,
+  })[0] as Node;
+
+  const outputPropertyEndIndex = outputPropertyNode.end;
+
+  return `${webpackConfig.slice(
+    0,
+    outputPropertyEndIndex
+  )},\nscriptType: 'text/javascript'${webpackConfig.slice(
+    outputPropertyEndIndex
+  )}`;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Since Angular 13 Federated Module loading code generated by Webpack is generated with Modular syntax which falls over.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use the suggested workaround of forcing Webpack to generate non-modular code
This causes live reload to constantly reload the host app
Therefore, also turn off live reload

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
