### PR TITLE
fix(linter): linter utils should respect nx.json folder configuration

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -128,6 +128,7 @@ export default createESLintRule<Options, MessageIds>({
     if (!(global as any).projectGraph) {
       const nxJson = readNxJson();
       (global as any).npmScope = nxJson.npmScope;
+      (global as any).workspaceLayout = nxJson.workspaceLayout;
 
       /**
        * Because there are a number of ways in which the rule can be invoked (executor vs ESLint CLI vs IDE Plugin),
@@ -145,6 +146,7 @@ export default createESLintRule<Options, MessageIds>({
     }
 
     const npmScope = (global as any).npmScope;
+    const workspaceLayout = (global as any).workspaceLayout;
     const projectGraph = (global as any).projectGraph as MappedProjectGraph;
 
     if (!(global as any).targetProjectLocator) {
@@ -196,7 +198,7 @@ export default createESLintRule<Options, MessageIds>({
           sourceFilePath,
           sourceProject
         ) ||
-        isAbsoluteImportIntoAnotherProject(imp)
+        isAbsoluteImportIntoAnotherProject(imp, workspaceLayout)
       ) {
         context.report({
           node,

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -119,13 +119,15 @@ export function findTargetProject(
   return targetProject;
 }
 
-export function isAbsoluteImportIntoAnotherProject(imp: string) {
-  // TODO: vsavkin: check if this needs to be fixed once we generalize lint rules
+export function isAbsoluteImportIntoAnotherProject(
+  imp: string,
+  workspaceLayout = { libsDir: 'libs', appsDir: 'apps' }
+) {
   return (
-    imp.startsWith('libs/') ||
-    imp.startsWith('/libs/') ||
-    imp.startsWith('apps/') ||
-    imp.startsWith('/apps/')
+    imp.startsWith(`${workspaceLayout.libsDir}/`) ||
+    imp.startsWith(`/${workspaceLayout.libsDir}/`) ||
+    imp.startsWith(`${workspaceLayout.appsDir}/`) ||
+    imp.startsWith(`/${workspaceLayout.appsDir}/`)
   );
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`isAbsoluteImportIntoAnotherProject` has hardcoded `libs` and `apps` as a folder

## Expected Behavior
`isAbsoluteImportIntoAnotherProject` should read "libs" and "apps" from the nx.json

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
