### PR TITLE
feat(react-native): bump ios to 12 in generated Podfile

### DIFF
--- a/packages/react-native/src/generators/application/files/app/ios/Podfile.template
+++ b/packages/react-native/src/generators/application/files/app/ios/Podfile.template
@@ -2,7 +2,7 @@ require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 require_relative '../node_modules/@nrwl/react-native/nx_post_install'
 
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 target '<%= className %>' do
   config = use_native_modules!


### PR DESCRIPTION
This PR updates ios from 11 to 12. It looks like there are incompatibilities between installed cocoapod dependencies and what the platform actually provides. e.g. libevent header mismatches