### PR TITLE
docs(angular): fix broken configuration formatting

### DIFF
--- a/docs/angular/guides/configuration.md
+++ b/docs/angular/guides/configuration.md
@@ -239,8 +239,6 @@ In the following example invoking `nx build myapp` builds all the libraries firs
 
 Often the same `dependsOn` configuration has to be defined for every project in the repo. You can define it once in `nx.json` (see below).
 
-````
-
 ### workspace.json
 
 Your `angular.json` file can be renamed to `workspace.json` and Nx will process it in the same way. The `workspace.json` has one additional top level property `version`. Setting `version` to 1 means the `workspace.json` file syntax is identical to `angular.json` When the `version` of `workspace.json` is set to 2, `targets`, `generators` and `executor` properties are used instead of the version 1 properties `architect`, `schematics` and `builder`.
@@ -255,7 +253,7 @@ In version 2 workspaces, project configurations can also be independent files, r
     "mylib": "libs/mylib"
   }
 }
-````
+```
 
 This tells Nx that all configuration for that project is found in the `libs/mylib/project.json` file.
 
@@ -462,7 +460,7 @@ The following command generates a new library: `nx g @nrwl/angular:lib mylib`. A
 
 Default generator options are configured in `nx.json` as well. For instance, the following tells Nx to always pass `--style=scss` when creating new libraries.
 
-````json
+```json
 {
   "generators": {
     "@nrwl/angular:library": {
@@ -470,6 +468,7 @@ Default generator options are configured in `nx.json` as well. For instance, the
     }
   }
 }
+```
 
 ## .nxignore
 
@@ -513,4 +512,3 @@ nx workspace-lint
 ```
 
 This will identify any projects with no files in the configured project root folder, as well as any file that's not part of any project configured in the workspace.
-````


### PR DESCRIPTION
The documentations are rendered incorrectly for the sections about
workspace.json, as well as generators in the angular documentation.
This was caused by two occasions of misplaced code markers.

## Current Behavior

The broken section for `workspace.json`

![image](https://user-images.githubusercontent.com/3329142/144373395-a2cf7b17-61aa-4777-b6d0-8ee15ac0e64a.png)

The broken section for Generators:

![image](https://user-images.githubusercontent.com/3329142/144373447-55a2ba80-e18b-4825-8170-011236b2791a.png)


## Expected Behavior

The expected rendering for `workspace.json`

![image](https://user-images.githubusercontent.com/3329142/144373825-d123f4fe-8ff5-43a1-8ab4-464607984fa4.png)

The expected rendering for Generators

![image](https://user-images.githubusercontent.com/3329142/144373880-b7021866-0085-4999-bcbc-5e13dbd8b511.png)

