### PR TITLE
fix(angular): support custom webpack config to use typescript

### DIFF
--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -13,7 +13,9 @@
     "jasmine-marbles",
     "rxjs-for-await",
     "webpack-merge",
-    "find-parent-dir"
+    "find-parent-dir",
+    "ts-node",
+    "tsconfig-paths"
   ],
   "keepLifecycleScripts": true
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -51,6 +51,8 @@
     "jasmine-marbles": "~0.8.4",
     "rxjs-for-await": "0.0.2",
     "webpack-merge": "5.7.3",
-    "find-parent-dir": "^0.3.1"
+    "find-parent-dir": "^0.3.1",
+    "ts-node": "~9.1.1",
+    "tsconfig-paths": "^3.9.0"
   }
 }

--- a/packages/angular/src/builders/utilities/webpack.ts
+++ b/packages/angular/src/builders/utilities/webpack.ts
@@ -1,0 +1,33 @@
+export function resolveCustomWebpackConfig(path: string, tsConfig: string) {
+  tsNodeRegister(path, tsConfig);
+
+  const customWebpackConfig = require(path);
+  // If the user provides a configuration in TS file
+  // then there are 2 cases for exporting an object. The first one is:
+  // `module.exports = { ... }`. And the second one is:
+  // `export default { ... }`. The ESM format is compiled into:
+  // `{ default: { ... } }`
+  return customWebpackConfig.default ?? customWebpackConfig;
+}
+
+function tsNodeRegister(file: string, tsConfig?: string) {
+  if (!file?.endsWith('.ts')) return;
+  // Register TS compiler lazily
+  require('ts-node').register({
+    project: tsConfig,
+    compilerOptions: {
+      module: 'CommonJS',
+      types: ['node'],
+    },
+  });
+
+  if (!tsConfig) return;
+
+  // Register paths in tsConfig
+  const tsconfigPaths = require('tsconfig-paths');
+  const { absoluteBaseUrl: baseUrl, paths } =
+    tsconfigPaths.loadConfig(tsConfig);
+  if (baseUrl && paths) {
+    tsconfigPaths.register({ baseUrl, paths });
+  }
+}

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -4,20 +4,21 @@ import {
   createBuilder,
 } from '@angular-devkit/architect';
 import { executeBrowserBuilder } from '@angular-devkit/build-angular';
+import { Schema } from '@angular-devkit/build-angular/src/builders/browser/schema';
 import { JsonObject } from '@angular-devkit/core';
-import { from, Observable, of } from 'rxjs';
+import { joinPathFragments } from '@nrwl/devkit';
+import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import {
   calculateProjectDependencies,
   checkDependentProjectsHaveBeenBuilt,
   createTmpTsConfig,
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
-import { joinPathFragments } from '@nrwl/devkit';
-import { join } from 'path';
-import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
-import { Schema } from '@angular-devkit/build-angular/src/builders/browser/schema';
-import { switchMap } from 'rxjs/operators';
 import { existsSync } from 'fs';
+import { join } from 'path';
+import { from, Observable, of } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 import { merge } from 'webpack-merge';
+import { resolveCustomWebpackConfig } from '../utilities/webpack';
 
 export type BrowserBuilderSchema = Schema & {
   customWebpackConfig?: {
@@ -70,7 +71,10 @@ function buildAppWithCustomWebpackConfiguration(
 ) {
   return executeBrowserBuilder(options, context as any, {
     webpackConfiguration: async (baseWebpackConfig) => {
-      const customWebpackConfiguration = require(pathToWebpackConfig);
+      const customWebpackConfiguration = resolveCustomWebpackConfig(
+        pathToWebpackConfig,
+        options.tsConfig
+      );
       // The extra Webpack configuration file can export a synchronous or asynchronous function,
       // for instance: `module.exports = async config => { ... }`.
       if (typeof customWebpackConfiguration === 'function') {

--- a/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
+++ b/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
@@ -1,16 +1,16 @@
 import { BuilderContext, createBuilder } from '@angular-devkit/architect';
-import { JsonObject } from '@angular-devkit/core';
-import type { Schema } from './schema';
-
-import { parseTargetString, joinPathFragments } from '@nrwl/devkit';
-import { Workspaces } from '@nrwl/tao/src/shared/workspace';
 import {
   DevServerBuilderOptions,
   serveWebpackBrowser,
 } from '@angular-devkit/build-angular/src/builders/dev-server';
+import { JsonObject } from '@angular-devkit/core';
+import { joinPathFragments, parseTargetString } from '@nrwl/devkit';
+import { Workspaces } from '@nrwl/tao/src/shared/workspace';
 import { existsSync } from 'fs';
 import { merge } from 'webpack-merge';
+import { resolveCustomWebpackConfig } from '../utilities/webpack';
 import { normalizeOptions } from './lib';
+import type { Schema } from './schema';
 
 export function webpackServer(schema: Schema, context: BuilderContext) {
   const options = normalizeOptions(schema);
@@ -46,7 +46,10 @@ export function webpackServer(schema: Schema, context: BuilderContext) {
         context as any,
         {
           webpackConfiguration: async (baseWebpackConfig) => {
-            const customWebpackConfiguration = require(pathToWebpackConfig);
+            const customWebpackConfiguration = resolveCustomWebpackConfig(
+              pathToWebpackConfig,
+              buildTarget.options.tsConfig
+            );
             // The extra Webpack configuration file can export a synchronous or asynchronous function,
             // for instance: `module.exports = async config => { ... }`.
             if (typeof customWebpackConfiguration === 'function') {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nrwl/angular:webpack-browser` executor allows passing a custom webpack configuration, but if the configuration uses Typescript the build fails. Likewise, it also fails when using the `@nrwl/angular:webpack-server` executor using a built target that's using the `@nrwl/angular:webpack-browser`. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Building or serving an application with a custom webpack configuration that's using Typescript should work correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7883 
