### PR TITLE
feat(core): merge package json scripts with targets list when building dependency graph

### DIFF
--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -20,6 +20,10 @@ import * as chalk from 'chalk';
 import { logger } from '../shared/logger';
 import { NxJsonConfiguration } from '../shared/nx';
 import { splitTarget } from '../utils/split-target';
+import { readJsonFile } from '../utils/fileutils';
+import { buildTargetFromScript, PackageJson } from '../shared/package-json';
+import { join as joinPathFragments } from 'path';
+import { existsSync } from 'fs';
 
 export interface Target {
   project: string;
@@ -159,15 +163,19 @@ async function iteratorToProcessStatusCode(
 }
 
 function createImplicitTargetConfig(
+  root: string,
   proj: ProjectConfiguration,
   targetName: string
-): TargetConfiguration {
-  return {
-    executor: '@nrwl/workspace:run-script',
-    options: {
-      script: targetName,
-    },
-  };
+): TargetConfiguration | null {
+  const packageJsonPath = joinPathFragments(root, proj.root, 'package.json');
+  if (!existsSync(packageJsonPath)) {
+    return null;
+  }
+  const { scripts, nx } = readJsonFile<PackageJson>(packageJsonPath);
+  if (!(targetName in scripts)) {
+    return null;
+  }
+  return buildTargetFromScript(targetName, nx);
 }
 
 async function runExecutorInternal<T extends { success: boolean }>(
@@ -191,9 +199,8 @@ async function runExecutorInternal<T extends { success: boolean }>(
 
   const ws = new Workspaces(root);
   const proj = workspace.projects[project];
-  const targetConfig = proj.targets
-    ? proj.targets[target]
-    : createImplicitTargetConfig(proj, target);
+  const targetConfig =
+    proj.targets?.[target] || createImplicitTargetConfig(root, proj, target);
 
   if (!targetConfig) {
     throw new Error(

--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -22,7 +22,7 @@ import { NxJsonConfiguration } from '../shared/nx';
 import { splitTarget } from '../utils/split-target';
 import { readJsonFile } from '../utils/fileutils';
 import { buildTargetFromScript, PackageJson } from '../shared/package-json';
-import { join as joinPathFragments } from 'path';
+import { join } from 'path';
 import { existsSync } from 'fs';
 
 export interface Target {
@@ -167,12 +167,12 @@ function createImplicitTargetConfig(
   proj: ProjectConfiguration,
   targetName: string
 ): TargetConfiguration | null {
-  const packageJsonPath = joinPathFragments(root, proj.root, 'package.json');
+  const packageJsonPath = join(root, proj.root, 'package.json');
   if (!existsSync(packageJsonPath)) {
     return null;
   }
   const { scripts, nx } = readJsonFile<PackageJson>(packageJsonPath);
-  if (!(targetName in scripts)) {
+  if (!(targetName in (scripts || {}))) {
     return null;
   }
   return buildTargetFromScript(targetName, nx);

--- a/packages/tao/src/shared/package-json.ts
+++ b/packages/tao/src/shared/package-json.ts
@@ -2,19 +2,19 @@ import { TargetConfiguration } from './workspace';
 
 export type PackageJsonTargetConfiguration = Omit<
   TargetConfiguration,
-  'executor' | 'dependsOn'
+  'executor'
 >;
 
 export interface NxProjectPackageJsonConfiguration {
-  targets: Record<keyof PackageJson['scripts'], PackageJsonTargetConfiguration>;
+  targets: Record<string, PackageJsonTargetConfiguration>;
 }
 
 export interface PackageJson {
   name: string;
-  scripts: Record<string, string>;
-  dependencies: Record<string, string>;
-  devDependencies: Record<string, string>;
-  peerDependencies: Record<string, string>;
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
   nx: NxProjectPackageJsonConfiguration;
 }
 
@@ -27,8 +27,8 @@ export function buildTargetFromScript(
   return {
     executor: '@nrwl/workspace:run-script',
     options: {
-      script,
       ...(nxTargetConfiguration.options || {}),
+      script,
     },
     ...nxTargetConfiguration,
   };

--- a/packages/tao/src/shared/package-json.ts
+++ b/packages/tao/src/shared/package-json.ts
@@ -1,0 +1,35 @@
+import { TargetConfiguration } from './workspace';
+
+export type PackageJsonTargetConfiguration = Omit<
+  TargetConfiguration,
+  'executor' | 'dependsOn'
+>;
+
+export interface NxProjectPackageJsonConfiguration {
+  targets: Record<keyof PackageJson['scripts'], PackageJsonTargetConfiguration>;
+}
+
+export interface PackageJson {
+  name: string;
+  scripts: Record<string, string>;
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+  peerDependencies: Record<string, string>;
+  nx: NxProjectPackageJsonConfiguration;
+}
+
+export function buildTargetFromScript(
+  script: string,
+  nx: NxProjectPackageJsonConfiguration
+) {
+  const nxTargetConfiguration = nx?.targets[script] || {};
+
+  return {
+    executor: '@nrwl/workspace:run-script',
+    options: {
+      script,
+      ...(nxTargetConfiguration.options || {}),
+    },
+    ...nxTargetConfiguration,
+  };
+}

--- a/packages/workspace/src/core/project-graph/build-nodes/workspace-projects.ts
+++ b/packages/workspace/src/core/project-graph/build-nodes/workspace-projects.ts
@@ -1,32 +1,10 @@
-import { defaultFileRead } from '../../file-utils';
 import {
   ProjectGraphBuilder,
   ProjectGraphProcessorContext,
-  TargetConfiguration,
 } from '@nrwl/devkit';
-import {
-  PackageJson,
-  buildTargetFromScript,
-} from '@nrwl/tao/src/shared/package-json';
 import { join } from 'path';
 import { existsSync } from 'fs';
-
-export function mergeNpmScriptsWithTargets(projectRoot: string, targets) {
-  try {
-    const packageJsonString = defaultFileRead(
-      `${projectRoot}/package.json`
-    ).toString();
-    const { scripts, nx }: PackageJson = JSON.parse(packageJsonString);
-    const res: Record<string, TargetConfiguration> = {};
-    // handle no scripts
-    Object.keys(scripts || {}).forEach((script) => {
-      res[script] = buildTargetFromScript(script, nx);
-    });
-    return { ...res, ...(targets || {}) };
-  } catch (e) {
-    return undefined;
-  }
-}
+import { mergeNpmScriptsWithTargets } from '../../../utilities/project-graph-utils';
 
 export function buildWorkspaceProjectNodes(
   ctx: ProjectGraphProcessorContext,

--- a/packages/workspace/src/tasks-runner/utils.ts
+++ b/packages/workspace/src/tasks-runner/utils.ts
@@ -9,7 +9,7 @@ import {
 import { flatten } from 'flat';
 import { output } from '../utilities/output';
 import { Workspaces } from '@nrwl/tao/src/shared/workspace';
-import { mergeNpmScriptsWithTargets } from '@nrwl/workspace/src/core/project-graph/build-nodes';
+import { mergeNpmScriptsWithTargets } from '../utilities/project-graph-utils';
 import { existsSync } from 'fs';
 import { join } from 'path';
 

--- a/packages/workspace/src/tasks-runner/utils.ts
+++ b/packages/workspace/src/tasks-runner/utils.ts
@@ -9,7 +9,9 @@ import {
 import { flatten } from 'flat';
 import { output } from '../utilities/output';
 import { Workspaces } from '@nrwl/tao/src/shared/workspace';
-import { convertNpmScriptsToTargets } from '@nrwl/workspace/src/core/project-graph/build-nodes';
+import { mergeNpmScriptsWithTargets } from '@nrwl/workspace/src/core/project-graph/build-nodes';
+import { existsSync } from 'fs';
+import { join } from 'path';
 
 export function getCommandAsString(task: Task) {
   const execCommand = getPackageManagerCommand().exec;
@@ -146,8 +148,8 @@ export function getExecutorNameForTask(task: Task, workspace: Workspaces) {
   const project =
     workspace.readWorkspaceConfiguration().projects[task.target.project];
 
-  if (!project.targets) {
-    project.targets = convertNpmScriptsToTargets(project.root);
+  if (existsSync(join(project.root, 'package.json'))) {
+    project.targets = mergeNpmScriptsWithTargets(project.root, project.targets);
   }
 
   if (!project.targets[task.target.target]) {

--- a/packages/workspace/src/utilities/project-graph-utils.ts
+++ b/packages/workspace/src/utilities/project-graph-utils.ts
@@ -1,4 +1,14 @@
-import { normalizePath, ProjectGraph, ProjectGraphNode } from '@nrwl/devkit';
+import {
+  normalizePath,
+  ProjectGraph,
+  ProjectGraphNode,
+  readJsonFile,
+  TargetConfiguration,
+} from '@nrwl/devkit';
+import {
+  buildTargetFromScript,
+  PackageJson,
+} from '@nrwl/tao/src/shared/package-json';
 import { relative } from 'path';
 import { readCachedProjectGraph } from '../core/project-graph';
 
@@ -16,6 +26,22 @@ export function projectHasTargetAndConfiguration(
     project.data.targets[target].configurations &&
     project.data.targets[target].configurations[configuration]
   );
+}
+
+export function mergeNpmScriptsWithTargets(projectRoot: string, targets) {
+  try {
+    const { scripts, nx }: PackageJson = readJsonFile(
+      `${projectRoot}/package.json`
+    );
+    const res: Record<string, TargetConfiguration> = {};
+    // handle no scripts
+    Object.keys(scripts || {}).forEach((script) => {
+      res[script] = buildTargetFromScript(script, nx);
+    });
+    return { ...res, ...(targets || {}) };
+  } catch (e) {
+    return undefined;
+  }
 }
 
 export function getSourceDirOfDependentProjects(

--- a/scripts/documentation/generate-cli-data.ts
+++ b/scripts/documentation/generate-cli-data.ts
@@ -1,6 +1,6 @@
 import * as chalk from 'chalk';
 import { readFileSync } from 'fs';
-import { removeSync } from 'fs-extra';
+import { readJsonSync, removeSync } from 'fs-extra';
 import { join } from 'path';
 import { dedent } from 'tslint/lib/utils';
 import { Framework, Frameworks } from './frameworks';
@@ -9,7 +9,10 @@ import {
   generateMarkdownFile,
   sortAlphabeticallyFunction,
 } from './utils';
+import { register as registerTsConfigPaths } from 'tsconfig-paths';
+
 import { examples } from '../../packages/workspace/src/command-line/examples';
+
 const importFresh = require('import-fresh');
 
 const sharedCommands = [
@@ -43,9 +46,16 @@ export async function generateCLIDocumentation() {
    */
   process.env.NX_GENERATE_DOCS_PROCESS = 'true';
 
+  const config = readJsonSync(
+    join(__dirname, '../../tsconfig.base.json')
+  ).compilerOptions;
+  registerTsConfigPaths(config);
+
   console.log(`\n${chalk.blue('i')} Generating Documentation for Nx Commands`);
 
-  const { commandsObject } = importFresh('../../packages/workspace');
+  const { commandsObject } = importFresh(
+    '../../packages/workspace/src/command-line/nx-commands'
+  );
 
   await Promise.all(
     Frameworks.map(async (framework: Framework) => {


### PR DESCRIPTION
## Current Behavior

If a `project.json` file exists w/ no targets defined, the targets are inferred from `package.json` scripts. Users are unable to specify additional executor properties (such as `outputs`) for these targets, so caching only works on build / test targets and only if outputs fall into one of the legacy interopt categories found at https://github.com/nrwl/nx/blob/738708c11c1f10f2a8bfac6255a1bad938a3f17a/packages/workspace/src/tasks-runner/utils.ts#L77-L83

Additionally, if a user defines **_1_** target in `project.json`, all targets that were being inferred are no longer considered by Nx

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- Targets from `project.json` file are merged w/ generated targets from `package.json`
- Targets located in `package.json` can be configured via an "nx" property on `package.json`
	-  Since these targets are generated from scripts, certain things like executor can't be configured.


