### PR TITLE
fix(angular): fix storybook-migrate-defaults-5-to-6 generator default export

### DIFF
--- a/packages/angular/src/generators/storybook-migrate-defaults-5-to-6/storybook-migrate-defaults-5-to-6.ts
+++ b/packages/angular/src/generators/storybook-migrate-defaults-5-to-6/storybook-migrate-defaults-5-to-6.ts
@@ -1,6 +1,5 @@
 import type { GeneratorCallback, Tree } from '@nrwl/devkit';
 import { migrateDefaultsGenerator } from '@nrwl/storybook';
-import storybookConfigurationGenerator from '../storybook-configuration/storybook-configuration';
 import type { StorybookMigrateDefault5to6Schema } from './schema';
 
 export function storybookMigrateDefaults5To6Generator(
@@ -14,4 +13,4 @@ export function storybookMigrateDefaults5To6Generator(
   });
 }
 
-export default storybookConfigurationGenerator;
+export default storybookMigrateDefaults5To6Generator;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Running the `@nrwl/angular:storybook-migrate-defaults-5-to-6` runs the wrong generator.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running the `@nrwl/angular:storybook-migrate-defaults-5-to-6` should run the right generator.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
