### PR TITLE
feat(core): generator to create workspace.json if its missing

### DIFF
--- a/docs/angular/api-workspace/generators/create-workspace-json.md
+++ b/docs/angular/api-workspace/generators/create-workspace-json.md
@@ -1,0 +1,33 @@
+# @nrwl/workspace:create-workspace-json
+
+Create a workspace.json file for a workspace that does not have one
+
+## Usage
+
+```bash
+nx generate create-workspace-json ...
+```
+
+By default, Nx will search for `create-workspace-json` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/workspace:create-workspace-json ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g create-workspace-json ... --dry-run
+```
+
+## Options
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files

--- a/docs/map.json
+++ b/docs/map.json
@@ -344,6 +344,11 @@
             "file": "angular/api-workspace/generators/convert-to-nx-project"
           },
           {
+            "name": "create-workspace-json generator",
+            "id": "create-workspace-json-generator",
+            "file": "angular/api-workspace/generators/create-workspace-json"
+          },
+          {
             "name": "run-commands executor",
             "id": "run-commands-executor",
             "file": "angular/api-workspace/executors/run-commands"
@@ -1673,6 +1678,11 @@
             "file": "react/api-workspace/generators/convert-to-nx-project"
           },
           {
+            "name": "create-workspace-json generator",
+            "id": "create-workspace-json-generator",
+            "file": "react/api-workspace/generators/create-workspace-json"
+          },
+          {
             "name": "run-commands executor",
             "id": "run-commands-executor",
             "file": "react/api-workspace/executors/run-commands"
@@ -2964,6 +2974,11 @@
             "name": "convert-to-nx-project generator",
             "id": "convert-to-nx-project-generator",
             "file": "node/api-workspace/generators/convert-to-nx-project"
+          },
+          {
+            "name": "create-workspace-json generator",
+            "id": "create-workspace-json-generator",
+            "file": "node/api-workspace/generators/create-workspace-json"
           },
           {
             "name": "run-commands executor",

--- a/docs/node/api-workspace/generators/create-workspace-json.md
+++ b/docs/node/api-workspace/generators/create-workspace-json.md
@@ -1,0 +1,33 @@
+# @nrwl/workspace:create-workspace-json
+
+Create a workspace.json file for a workspace that does not have one
+
+## Usage
+
+```bash
+nx generate create-workspace-json ...
+```
+
+By default, Nx will search for `create-workspace-json` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/workspace:create-workspace-json ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g create-workspace-json ... --dry-run
+```
+
+## Options
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files

--- a/docs/react/api-workspace/generators/create-workspace-json.md
+++ b/docs/react/api-workspace/generators/create-workspace-json.md
@@ -1,0 +1,33 @@
+# @nrwl/workspace:create-workspace-json
+
+Create a workspace.json file for a workspace that does not have one
+
+## Usage
+
+```bash
+nx generate create-workspace-json ...
+```
+
+By default, Nx will search for `create-workspace-json` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/workspace:create-workspace-json ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g create-workspace-json ... --dry-run
+```
+
+## Options
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files

--- a/packages/workspace/generators.json
+++ b/packages/workspace/generators.json
@@ -72,6 +72,12 @@
       "description": "Moves a project's configuration outside of workspace.json"
     },
 
+    "create-workspace-json": {
+      "factory": "./src/generators/create-workspace-json/create-workspace-json#compat",
+      "schema": "./src/generators/create-workspace-json/schema.json",
+      "description": "Create a workspace.json file for a workspace that does not have one"
+    },
+
     "npm-package": {
       "factory": "./src/generators/npm-package/npm-package#npmPackageSchematic",
       "schema": "./src/generators/npm-package/schema.json",
@@ -148,6 +154,12 @@
       "factory": "./src/generators/convert-to-nx-project/convert-to-nx-project#convertToNxProjectGenerator",
       "schema": "./src/generators/convert-to-nx-project/schema.json",
       "description": "Moves a project's configuration outside of workspace.json"
+    },
+
+    "create-workspace-json": {
+      "factory": "./src/generators/create-workspace-json/create-workspace-json#createWorkspaceJson",
+      "schema": "./src/generators/create-workspace-json/schema.json",
+      "description": "Create a workspace.json file for a workspace that does not have one"
     },
 
     "npm-package": {

--- a/packages/workspace/src/generators/create-workspace-json/create-workspace-json.spec.ts
+++ b/packages/workspace/src/generators/create-workspace-json/create-workspace-json.spec.ts
@@ -1,0 +1,68 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  addProjectConfiguration,
+  getProjects,
+} from 'packages/devkit/src/generators/project-configuration';
+import { writeJson } from 'packages/devkit/src/utils/json';
+import createWorkspaceJson from './create-workspace-json';
+
+describe('workspace-json', () => {
+  it('should work for package.json inferred projects', async () => {
+    // Arrange
+    const tree = createTreeWithEmptyWorkspace(2);
+    tree.delete('workspace.json');
+
+    writeJson(tree, 'libs/my-package/package.json', {
+      name: '@proj/my-package',
+      scripts: {
+        build: 'echo 1',
+      },
+    });
+
+    const opts = {
+      skipFormat: true,
+    };
+
+    // Act
+    await createWorkspaceJson(tree, opts);
+
+    // Asset
+    expect(tree.exists('workspace.json')).toBeTruthy();
+    const pkg = getProjects(tree).get('my-package');
+    expect(pkg).toBeDefined();
+    expect(pkg.targets).not.toBeDefined();
+    expect(tree.exists('libs/my-package/project.json')).toBeTruthy();
+    expect(tree.exists('libs/my-package/package.json')).toBeTruthy();
+  });
+
+  it('should work for project.json inferred projects', async () => {
+    // Arrange
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'apps/my-app',
+      targets: {
+        run: {
+          executor: '@nrwl/workspace:run-commands',
+          options: {
+            command: 'echo 1',
+          },
+        },
+      },
+    });
+    tree.delete('workspace.json');
+
+    const opts = {
+      skipFormat: true,
+    };
+
+    // Act
+    await createWorkspaceJson(tree, opts);
+
+    // Asset
+    expect(tree.exists('workspace.json')).toBeTruthy();
+    const pkg = getProjects(tree).get('my-app');
+    expect(pkg).toBeDefined();
+    expect(pkg.targets).toBeDefined();
+    expect(tree.exists('apps/my-app/project.json')).toBeTruthy();
+  });
+});

--- a/packages/workspace/src/generators/create-workspace-json/create-workspace-json.ts
+++ b/packages/workspace/src/generators/create-workspace-json/create-workspace-json.ts
@@ -1,0 +1,38 @@
+import { Schema } from './schema';
+import {
+  Tree,
+  formatFiles,
+  joinPathFragments,
+  getProjects,
+  writeJson,
+  logger,
+  getWorkspacePath,
+  convertNxGenerator,
+} from '@nrwl/devkit';
+
+export async function createWorkspaceJson(host: Tree, schema: Schema) {
+  if (host.exists('angular.json') || host.exists('workspace.json')) {
+    logger.warn(
+      'Existing workspace config file found: ' + getWorkspacePath(host)
+    );
+    return;
+  }
+  const projects = Array.from(getProjects(host).entries());
+  writeJson(host, 'workspace.json', {
+    version: 2,
+    projects: Object.fromEntries(
+      projects.map(([project, config]) => [project, config.root])
+    ),
+  });
+  projects.forEach(([, config]) => {
+    writeJson(host, joinPathFragments(config.root, 'project.json'), config);
+  });
+
+  if (!schema.skipFormat) {
+    await formatFiles(host);
+  }
+}
+
+export default createWorkspaceJson;
+
+export const compat = convertNxGenerator(createWorkspaceJson);

--- a/packages/workspace/src/generators/create-workspace-json/schema.d.ts
+++ b/packages/workspace/src/generators/create-workspace-json/schema.d.ts
@@ -1,0 +1,3 @@
+export interface Schema {
+  skipFormat: boolean;
+}

--- a/packages/workspace/src/generators/create-workspace-json/schema.json
+++ b/packages/workspace/src/generators/create-workspace-json/schema.json
@@ -1,0 +1,14 @@
+{
+  "cli": "nx",
+  "$id": "WorkspaceJsonGenerator",
+  "title": "Create workspace.json from workspaceless workspace",
+  "type": "object",
+  "properties": {
+    "skipFormat": {
+      "description": "Skip formatting files",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "required": []
+}


### PR DESCRIPTION
## Current Behavior
Workspaces w/o a `workspace.json` or `angular.json` (referred to from here on as workspace-less workspaces) must manually create a workspace file if they wish to have one.

This pain is emphasized due to project configurations that are inferred from package.json files not working w/ a `workspace.json` present. This means they must construct the `workspace.json` file and any missing `project.json` files manually.

## Expected Behavior
We provide a generator to create the `workspace.json`. The generator creates minimal project.json files for previously inferred projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
