### PR TITLE
docs(nxdev): readme typo

### DIFF
--- a/nx-dev/nx-dev/README.md
+++ b/nx-dev/nx-dev/README.md
@@ -1,3 +1,3 @@
 # nx.dev
 
-This folder contains the app and libs to power [nx.dev](https://nx.dev)).
+This folder contains the app and libs to power [nx.dev](https://nx.dev).


### PR DESCRIPTION
## What it does?
Fixes a `readme.md` typo on nx.dev.