### PR TITLE
fix(core): fix error message on formatFiles schematic and generator

### DIFF
--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -160,15 +160,15 @@ function check(patterns: string[]) {
 }
 
 function updateWorkspaceJsonToMatchFormatVersion() {
-  const workspaceConfig = workspaceConfigName(appRootPath);
+  const workspaceConfigPath = workspaceConfigName(appRootPath);
   try {
-    const workspaceJson = readJsonFile(workspaceConfig);
+    const workspaceJson = readJsonFile(workspaceConfigPath);
     const reformatted = reformattedWorkspaceJsonOrNull(workspaceJson);
     if (reformatted) {
-      writeJsonFile(workspaceConfig, reformatted);
+      writeJsonFile(workspaceConfigPath, reformatted);
     }
   } catch (e) {
-    console.error(`Failed to format: ${path}`);
+    console.error(`Failed to format workspace config: ${workspaceConfigPath}`);
     console.error(e);
   }
 }

--- a/packages/workspace/src/utils/rules/format-files.spec.ts
+++ b/packages/workspace/src/utils/rules/format-files.spec.ts
@@ -18,6 +18,27 @@ describe('formatFiles', () => {
       .spyOn(prettier, 'format')
       .mockImplementation((input) => `formatted :: ${input}`);
     tree = Tree.empty();
+
+    tree.create(
+      'workspace.json',
+      `{
+      "version": 1,
+      "projects": {
+        "app1": {
+          "projectType": "application",
+          "schematics": {},
+          "root": "apps/app1",
+          "sourceRoot": "apps/app1/src",
+          "prefix": "nx",
+          "architect": {}
+        }
+      },
+      "cli": {
+        "defaultCollection": "@nrwl/angular"
+      },
+      "defaultProject": "app1"
+    }`
+    );
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -82,6 +103,18 @@ describe('formatFiles', () => {
       filepath: path.join(appRootPath, 'b.ts'),
     });
     expect(result.read('b.ts').toString()).toEqual('formatted :: const a=a');
+  });
+
+  it('should have a readable error when workspace file cannot be formatted', async () => {
+    tree.delete('workspace.json');
+
+    const errorSpy = jest.spyOn(console, 'error');
+
+    await schematicRunner.callRule(formatFiles(), tree).toPromise();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to format workspace config: workspace.json'
+    );
   });
 
   describe('--skip-format', () => {

--- a/packages/workspace/src/utils/rules/format-files.ts
+++ b/packages/workspace/src/utils/rules/format-files.ts
@@ -80,18 +80,20 @@ export function formatFiles(
 }
 
 function updateWorkspaceJsonToMatchFormatVersion(host: Tree) {
-  const workspaceConfig = workspaceConfigName(appRootPath);
+  const workspaceConfigPath = workspaceConfigName(appRootPath);
 
   try {
-    if (workspaceConfig) {
-      const workspaceJson = parseJson(host.read(workspaceConfig).toString());
+    if (workspaceConfigPath) {
+      const workspaceJson = parseJson(
+        host.read(workspaceConfigPath).toString()
+      );
       const reformatted = reformattedWorkspaceJsonOrNull(workspaceJson);
       if (reformatted) {
-        host.overwrite(workspaceConfig, serializeJson(reformatted));
+        host.overwrite(workspaceConfigPath, serializeJson(reformatted));
       }
     }
   } catch (e) {
-    console.error(`Failed to format: ${path}`);
+    console.error(`Failed to format workspace config: ${workspaceConfigPath}`);
     console.error(e);
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
* If formatting the workspace config file throws an error on the `formatFiles` schematic or generator, the error printed is "Failed to format: [object Object]".

<!-- This is the behavior we have today -->

## Expected Behavior
* If formatting the workspace config file throws an error on the `formatFiles` schematic or generator, the error printed is "Failed to format workspace config: <path to workspace config file>".

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
