### PR TITLE
fix(core): prevent overwriting nx.json options to undefined

### DIFF
--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -92,7 +92,7 @@ export function splitArgsIntoNxArgsAndOverrides(
   Object.entries(args).forEach(([key, value]) => {
     const dasherized = names(key).fileName;
     if (nxSpecific.includes(dasherized) || dasherized.startsWith('nx-')) {
-      nxArgs[key] = value;
+      if (value !== undefined) nxArgs[key] = value;
     } else if (!ignoreArgs.includes(key)) {
       overrides[key] = value;
     }
@@ -202,8 +202,6 @@ export function splitArgsIntoNxArgsAndOverrides(
     );
   } else if (args['parallel'] !== undefined) {
     nxArgs['parallel'] = Number(args['parallel']);
-  } else {
-    nxArgs['parallel'] = undefined;
   }
 
   return { nxArgs, overrides };


### PR DESCRIPTION
ISSUES CLOSED: #7886

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Some options in `nx.json` are overwritten to `undefined` during executing task runners.
For example, the `parallel` option is ignored. https://github.com/nrwl/nx/issues/7886#issuecomment-979153646

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The options in `nx.json` should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7886
