### PR TITLE
fix(linter): add missing @phenomnomnominal/tsquery dependency to package.json

### DIFF
--- a/packages/linter/package.json
+++ b/packages/linter/package.json
@@ -30,6 +30,7 @@
   "builders": "./executors.json",
   "schematics": "./generators.json",
   "dependencies": {
+    "@phenomnomnominal/tsquery": "4.1.1",
     "@nrwl/devkit": "*",
     "@nrwl/jest": "*",
     "eslint": "8.2.0",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running the latest migrations fail due to adding `@phenomnomnominal/tsquery` in this PR #7818

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
