### PR TITLE
fix(angular): support module syntax for mfes

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -126,6 +126,12 @@
       "version": "13.2.0",
       "description": "In Angular version 13, the `teardown` flag in `TestBed` will be enabled by default. This migration automatically opts out existing apps from the new teardown behavior.",
       "factory": "./src/migrations/update-13-2-0/opt-out-testbed-teardown"
+    },
+    "update-mfe-config-to-module-syntax": {
+      "cli": "nx",
+      "version": "13.3.0-beta.0",
+      "description": "In Angular version 13, the ESM became a first class citizen. This means the webpack config generated must be modified to support modules.",
+      "factory": "./src/migrations/update-13-3-0/update-mfe-webpack-config"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -32,6 +32,9 @@ module.exports = {
     runtimeChunk: false,
     minimize: false,
   },
+  experiments: {
+    outputModule: true
+  },
   resolve: {
     alias: {
       ...sharedMappings.getAliases(),
@@ -40,8 +43,8 @@ module.exports = {
   plugins: [
     new ModuleFederationPlugin({
       remotes: {
-    		\\"remote1\\": 'remote1@http://localhost:4201/remoteEntry.js',
-    		\\"remote2\\": 'remote2@http://localhost:4202/remoteEntry.js',
+    		\\"remote1\\": 'http://localhost:4201/remoteEntry.js',
+    		\\"remote2\\": 'http://localhost:4202/remoteEntry.js',
       
       },
       shared: {
@@ -50,6 +53,9 @@ module.exports = {
         \\"@angular/common/http\\": { singleton: true, strictVersion: true },
         \\"@angular/router\\": { singleton: true, strictVersion: true },
         ...sharedMappings.getDescriptors(),
+      },
+      library: { 
+        type: 'module' 
       },
     }),
     sharedMappings.getPlugin(),
@@ -90,6 +96,9 @@ module.exports = {
     runtimeChunk: false,
     minimize: false,
   },
+  experiments: {
+    outputModule: true
+  },
   resolve: {
     alias: {
       ...sharedMappings.getAliases(),
@@ -98,7 +107,7 @@ module.exports = {
   plugins: [
     new ModuleFederationPlugin({
       remotes: {
-    		\\"remote1\\": 'remote1@http://localhost:4200/remoteEntry.js',
+    		\\"remote1\\": 'http://localhost:4200/remoteEntry.js',
       
       },
       shared: {
@@ -107,6 +116,9 @@ module.exports = {
         \\"@angular/common/http\\": { singleton: true, strictVersion: true },
         \\"@angular/router\\": { singleton: true, strictVersion: true },
         ...sharedMappings.getDescriptors(),
+      },
+      library: { 
+        type: 'module' 
       },
     }),
     sharedMappings.getPlugin(),
@@ -147,6 +159,9 @@ module.exports = {
     runtimeChunk: false,
     minimize: false,
   },
+  experiments: {
+    outputModule: true
+  },
   resolve: {
     alias: {
       ...sharedMappings.getAliases(),
@@ -163,6 +178,9 @@ module.exports = {
         \\"@angular/common/http\\": { singleton: true, strictVersion: true },
         \\"@angular/router\\": { singleton: true, strictVersion: true },
         ...sharedMappings.getDescriptors(),
+      },
+      library: { 
+        type: 'module' 
       },
     }),
     sharedMappings.getPlugin(),
@@ -203,6 +221,9 @@ module.exports = {
     runtimeChunk: false,
     minimize: false,
   },
+  experiments: {
+    outputModule: true
+  },
   resolve: {
     alias: {
       ...sharedMappings.getAliases(),
@@ -221,6 +242,9 @@ module.exports = {
         \\"@angular/common/http\\": { singleton: true, strictVersion: true },
         \\"@angular/router\\": { singleton: true, strictVersion: true },
         ...sharedMappings.getDescriptors(),
+      },
+      library: { 
+        type: 'module' 
       },
     }),
     sharedMappings.getPlugin(),

--- a/packages/angular/src/generators/setup-mfe/__snapshots__/setup-mfe.spec.ts.snap
+++ b/packages/angular/src/generators/setup-mfe/__snapshots__/setup-mfe.spec.ts.snap
@@ -62,6 +62,9 @@ module.exports = {
     runtimeChunk: false,
     minimize: false,
   },
+  experiments: {
+    outputModule: true
+  },
   resolve: {
     alias: {
       ...sharedMappings.getAliases(),
@@ -70,8 +73,8 @@ module.exports = {
   plugins: [
     new ModuleFederationPlugin({
       remotes: {
-    		\\"remote1\\": 'remote1@http://localhost:4201/remoteEntry.js',
-    		\\"remote2\\": 'remote2@http://localhost:4202/remoteEntry.js',
+    		\\"remote1\\": 'http://localhost:4201/remoteEntry.js',
+    		\\"remote2\\": 'http://localhost:4202/remoteEntry.js',
       
       },
       shared: {
@@ -80,6 +83,9 @@ module.exports = {
         \\"@angular/common/http\\": { singleton: true, strictVersion: true },
         \\"@angular/router\\": { singleton: true, strictVersion: true },
         ...sharedMappings.getDescriptors(),
+      },
+      library: { 
+        type: 'module' 
       },
     }),
     sharedMappings.getPlugin(),
@@ -120,6 +126,9 @@ module.exports = {
     runtimeChunk: false,
     minimize: false,
   },
+  experiments: {
+    outputModule: true
+  },
   resolve: {
     alias: {
       ...sharedMappings.getAliases(),
@@ -128,7 +137,7 @@ module.exports = {
   plugins: [
     new ModuleFederationPlugin({
       remotes: {
-    		\\"remote1\\": 'remote1@http://localhost:4200/remoteEntry.js',
+    		\\"remote1\\": 'http://localhost:4200/remoteEntry.js',
       
       },
       shared: {
@@ -137,6 +146,9 @@ module.exports = {
         \\"@angular/common/http\\": { singleton: true, strictVersion: true },
         \\"@angular/router\\": { singleton: true, strictVersion: true },
         ...sharedMappings.getDescriptors(),
+      },
+      library: { 
+        type: 'module' 
       },
     }),
     sharedMappings.getPlugin(),
@@ -177,6 +189,9 @@ module.exports = {
     runtimeChunk: false,
     minimize: false,
   },
+  experiments: {
+    outputModule: true
+  },
   resolve: {
     alias: {
       ...sharedMappings.getAliases(),
@@ -193,6 +208,9 @@ module.exports = {
         \\"@angular/common/http\\": { singleton: true, strictVersion: true },
         \\"@angular/router\\": { singleton: true, strictVersion: true },
         ...sharedMappings.getDescriptors(),
+      },
+      library: { 
+        type: 'module' 
       },
     }),
     sharedMappings.getPlugin(),
@@ -233,6 +251,9 @@ module.exports = {
     runtimeChunk: false,
     minimize: false,
   },
+  experiments: {
+    outputModule: true
+  },
   resolve: {
     alias: {
       ...sharedMappings.getAliases(),
@@ -251,6 +272,9 @@ module.exports = {
         \\"@angular/common/http\\": { singleton: true, strictVersion: true },
         \\"@angular/router\\": { singleton: true, strictVersion: true },
         ...sharedMappings.getDescriptors(),
+      },
+      library: { 
+        type: 'module' 
       },
     }),
     sharedMappings.getPlugin(),

--- a/packages/angular/src/generators/setup-mfe/files/webpack/webpack.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-mfe/files/webpack/webpack.config.js__tmpl__
@@ -29,6 +29,9 @@ module.exports = {
     runtimeChunk: false,
     minimize: false,
   },
+  experiments: {
+    outputModule: true
+  },
   resolve: {
     alias: {
       ...sharedMappings.getAliases(),
@@ -42,11 +45,14 @@ module.exports = {
         './Module': '<%= sourceRoot %>/src/app/remote-entry/entry.module.ts',
       },<% } %><% if(type === 'host') { %>
       remotes: {
-      <% remotes.forEach(function(remote) { %>"<%= remote.remoteName %>": "<%= remote.remoteName %>@http://localhost:<%= remote.port %>/remoteEntry.js",<% }); %>
+      <% remotes.forEach(function(remote) { %>"<%= remote.remoteName %>": "http://localhost:<%= remote.port %>/remoteEntry.js",<% }); %>
       },<% } %>
       shared: {<% sharedLibraries.forEach(function (lib) { %>
         "<%= lib %>": { singleton: true, strictVersion: true },<% }); %>
         ...sharedMappings.getDescriptors(),
+      },
+      library: { 
+        type: 'module' 
       },
     }),
     sharedMappings.getPlugin(),

--- a/packages/angular/src/generators/setup-mfe/lib/add-remote-to-host.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/add-remote-to-host.ts
@@ -31,7 +31,7 @@ export function addRemoteToHost(host: Tree, options: Schema) {
     const endOfPropertiesPos = mfRemotesNode.properties.end;
 
     const updatedConfig = `${hostWebpackConfig.slice(0, endOfPropertiesPos)}
-    \t\t"${options.appName}": '${options.appName}@http://localhost:${
+    \t\t"${options.appName}": 'http://localhost:${
       options.port ?? 4200
     }/remoteEntry.js',${hostWebpackConfig.slice(endOfPropertiesPos)}`;
 

--- a/packages/angular/src/generators/setup-mfe/lib/setup-serve-target.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/setup-serve-target.ts
@@ -15,6 +15,9 @@ export function setupServeTarget(host: Tree, options: Schema) {
     options: {
       ...appConfig.targets['serve'].options,
       port: options.port ?? undefined,
+      publicHost: options.host
+        ? undefined
+        : `http://localhost:${options.port ?? 4200}`,
     },
   };
 

--- a/packages/angular/src/generators/setup-mfe/setup-mfe.spec.ts
+++ b/packages/angular/src/generators/setup-mfe/setup-mfe.spec.ts
@@ -151,7 +151,7 @@ describe('Init MFE', () => {
     const webpackContents = host.read(`apps/app1/webpack.config.js`, 'utf-8');
 
     expect(webpackContents).toContain(
-      '"remote1": "remote1@http://localhost:4200/remoteEntry.js"'
+      '"remote1": "http://localhost:4200/remoteEntry.js"'
     );
   });
   it('should update the implicit dependencies of the host when --remotes flag supplied', async () => {

--- a/packages/angular/src/migrations/update-13-3-0/update-mfe-webpack-config.spec.ts
+++ b/packages/angular/src/migrations/update-13-3-0/update-mfe-webpack-config.spec.ts
@@ -1,9 +1,61 @@
-import { addProjectConfiguration } from '@nrwl/devkit';
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import updateMfeConfig, { removeRemoteName } from './update-mfe-webpack-config';
 
 describe('update-mfe-webpack-config', () => {
   describe('run the migration', () => {
+    it('shouldnt run for non mfe configs', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace(2);
+      addProjectConfiguration(tree, 'app', {
+        root: 'apps/testing',
+        targets: {
+          build: {
+            executor: '@nrwl/angular:webpack-browser',
+            options: {
+              customWebpackConfig: { path: 'apps/testing/webpack.config.js' },
+            },
+          },
+          serve: {
+            executor: '@nrwl/angular:webpack-server',
+            options: {
+              port: 4201,
+            },
+          },
+        },
+      });
+
+      const webpackConfig = `// const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+      module.exports = {
+        optimization: {
+          runtimeChunk: false,
+          minimize: false,
+        },
+      };`;
+      tree.write('apps/testing/webpack.config.js', webpackConfig);
+
+      // ACT
+      await updateMfeConfig(tree);
+
+      // ASSERT
+      const updatedConfig = tree.read(
+        'apps/testing/webpack.config.js',
+        'utf-8'
+      );
+      expect(updatedConfig).toMatchInlineSnapshot(`
+        "// const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+              module.exports = {
+                optimization: {
+                  runtimeChunk: false,
+                  minimize: false,
+                },
+              };"
+      `);
+    });
+
     it('should run the migration successfully for a host config', async () => {
       // ARRANGE
       const tree = createTreeWithEmptyWorkspace(2);
@@ -14,6 +66,12 @@ describe('update-mfe-webpack-config', () => {
             executor: '@nrwl/angular:webpack-browser',
             options: {
               customWebpackConfig: { path: 'apps/testing/webpack.config.js' },
+            },
+          },
+          serve: {
+            executor: '@nrwl/angular:webpack-server',
+            options: {
+              port: 4201,
             },
           },
         },
@@ -153,6 +211,171 @@ describe('update-mfe-webpack-config', () => {
                 ],
               };"
       `);
+      const project = readProjectConfiguration(tree, 'app');
+      expect(project.targets.serve.options.publicHost).toEqual(
+        'http://localhost:4201'
+      );
+    });
+
+    it('should add outputModule to experiments object when something else exists in experiments', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace(2);
+      addProjectConfiguration(tree, 'app', {
+        root: 'apps/testing',
+        targets: {
+          build: {
+            executor: '@nrwl/angular:webpack-browser',
+            options: {
+              customWebpackConfig: { path: 'apps/testing/webpack.config.js' },
+            },
+          },
+          serve: {
+            executor: '@nrwl/angular:webpack-server',
+            options: {
+              port: 4201,
+            },
+          },
+        },
+      });
+
+      const webpackConfig = `const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+      const mf = require('@angular-architects/module-federation/webpack');
+      const path = require('path');
+      
+      /**
+       * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+       * builder as it will generate a temporary tsconfig file which contains any required remappings of
+       * shred libraries.
+       * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+       * built files for the buildable library.
+       * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+       * the location of the generated temporary tsconfig file.
+       */
+      const tsConfigPath =
+        process.env.NX_TSCONFIG_PATH ??
+        path.join(__dirname, '../../tsconfig.base.json');
+      
+      const workspaceRootPath = path.join(__dirname, '../../');
+      const sharedMappings = new mf.SharedMappings();
+      sharedMappings.register(
+        tsConfigPath,
+        [
+          /* mapped paths to share */
+        ],
+        workspaceRootPath
+      );
+      
+      module.exports = {
+        output: {
+          uniqueName: 'login',
+          publicPath: 'auto',
+        },
+        optimization: {
+          runtimeChunk: false,
+          minimize: false,
+        },
+        resolve: {
+          alias: {
+            ...sharedMappings.getAliases(),
+          },
+        },
+        experiments: {
+          something: true
+        },
+        plugins: [
+          new ModuleFederationPlugin({
+            remotes: {
+              login: 'login@http://localhost:4201/remoteEnrry.js',
+              todo: 'todo@http://localhost:4202/remoteEntry.js',
+            },
+            shared: {
+              '@angular/core': { singleton: true, strictVersion: true },
+              '@angular/common': { singleton: true, strictVersion: true },
+              '@angular/common/http': { singleton: true, strictVersion: true },
+              '@angular/router': { singleton: true, strictVersion: true },
+              ...sharedMappings.getDescriptors(),
+            },
+          }),
+          sharedMappings.getPlugin(),
+        ],
+      };`;
+      tree.write('apps/testing/webpack.config.js', webpackConfig);
+
+      // ACT
+      await updateMfeConfig(tree);
+
+      // ASSERT
+      const updatedConfig = tree.read(
+        'apps/testing/webpack.config.js',
+        'utf-8'
+      );
+      expect(updatedConfig).toMatchInlineSnapshot(`
+        "const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+              const mf = require('@angular-architects/module-federation/webpack');
+              const path = require('path');
+              
+              /**
+               * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+               * builder as it will generate a temporary tsconfig file which contains any required remappings of
+               * shred libraries.
+               * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+               * built files for the buildable library.
+               * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+               * the location of the generated temporary tsconfig file.
+               */
+              const tsConfigPath =
+                process.env.NX_TSCONFIG_PATH ??
+                path.join(__dirname, '../../tsconfig.base.json');
+              
+              const workspaceRootPath = path.join(__dirname, '../../');
+              const sharedMappings = new mf.SharedMappings();
+              sharedMappings.register(
+                tsConfigPath,
+                [
+                  /* mapped paths to share */
+                ],
+                workspaceRootPath
+              );
+              
+              module.exports = {
+                output: {
+                  uniqueName: 'login',
+                  publicPath: 'auto',
+                },
+                optimization: {
+                  runtimeChunk: false,
+                  minimize: false,
+                },
+                resolve: {
+                  alias: {
+                    ...sharedMappings.getAliases(),
+                  },
+                },
+                experiments: {
+        outputModule: true,
+                  something: true
+                },
+                plugins: [
+                  new ModuleFederationPlugin({
+          library: {
+              type: 'module'
+          },
+                    remotes: {
+            login: 'http://localhost:4201/remoteEnrry.js',
+        todo: 'http://localhost:4202/remoteEntry.js'
+          },
+                    shared: {
+                      '@angular/core': { singleton: true, strictVersion: true },
+                      '@angular/common': { singleton: true, strictVersion: true },
+                      '@angular/common/http': { singleton: true, strictVersion: true },
+                      '@angular/router': { singleton: true, strictVersion: true },
+                      ...sharedMappings.getDescriptors(),
+                    },
+                  }),
+                  sharedMappings.getPlugin(),
+                ],
+              };"
+      `);
     });
 
     it('should run the migration successfully for a remote config', async () => {
@@ -165,6 +388,12 @@ describe('update-mfe-webpack-config', () => {
             executor: '@nrwl/angular:webpack-browser',
             options: {
               customWebpackConfig: { path: 'apps/testing/webpack.config.js' },
+            },
+          },
+          serve: {
+            executor: '@nrwl/angular:webpack-server',
+            options: {
+              port: 4201,
             },
           },
         },
@@ -306,12 +535,16 @@ describe('update-mfe-webpack-config', () => {
                 ],
               };"
       `);
+      const project = readProjectConfiguration(tree, 'app');
+      expect(project.targets.serve.options.publicHost).toEqual(
+        'http://localhost:4201'
+      );
     });
-  }),
-    describe('removeRemoteName', () => {
-      it('should remove the names correctly', () => {
-        // ARRANGE
-        const webpackConfig = `const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+  });
+  describe('removeRemoteName', () => {
+    it('should remove the names correctly', () => {
+      // ARRANGE
+      const webpackConfig = `const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
         const mf = require('@angular-architects/module-federation/webpack');
         const path = require('path');
         
@@ -375,11 +608,11 @@ describe('update-mfe-webpack-config', () => {
           ],
         };`;
 
-        // ACT
-        const updatedConfig = removeRemoteName(webpackConfig);
+      // ACT
+      const updatedConfig = removeRemoteName(webpackConfig);
 
-        // ASSERT
-        expect(updatedConfig).toMatchInlineSnapshot(`
+      // ASSERT
+      expect(updatedConfig).toMatchInlineSnapshot(`
                   "const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
                           const mf = require('@angular-architects/module-federation/webpack');
                           const path = require('path');
@@ -444,6 +677,6 @@ describe('update-mfe-webpack-config', () => {
                             ],
                           };"
               `);
-      });
     });
+  });
 });

--- a/packages/angular/src/migrations/update-13-3-0/update-mfe-webpack-config.spec.ts
+++ b/packages/angular/src/migrations/update-13-3-0/update-mfe-webpack-config.spec.ts
@@ -1,0 +1,449 @@
+import { addProjectConfiguration } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import updateMfeConfig, { removeRemoteName } from './update-mfe-webpack-config';
+
+describe('update-mfe-webpack-config', () => {
+  describe('run the migration', () => {
+    it('should run the migration successfully for a host config', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace(2);
+      addProjectConfiguration(tree, 'app', {
+        root: 'apps/testing',
+        targets: {
+          build: {
+            executor: '@nrwl/angular:webpack-browser',
+            options: {
+              customWebpackConfig: { path: 'apps/testing/webpack.config.js' },
+            },
+          },
+        },
+      });
+
+      const webpackConfig = `const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+      const mf = require('@angular-architects/module-federation/webpack');
+      const path = require('path');
+      
+      /**
+       * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+       * builder as it will generate a temporary tsconfig file which contains any required remappings of
+       * shred libraries.
+       * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+       * built files for the buildable library.
+       * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+       * the location of the generated temporary tsconfig file.
+       */
+      const tsConfigPath =
+        process.env.NX_TSCONFIG_PATH ??
+        path.join(__dirname, '../../tsconfig.base.json');
+      
+      const workspaceRootPath = path.join(__dirname, '../../');
+      const sharedMappings = new mf.SharedMappings();
+      sharedMappings.register(
+        tsConfigPath,
+        [
+          /* mapped paths to share */
+        ],
+        workspaceRootPath
+      );
+      
+      module.exports = {
+        output: {
+          uniqueName: 'login',
+          publicPath: 'auto',
+        },
+        optimization: {
+          runtimeChunk: false,
+          minimize: false,
+        },
+        resolve: {
+          alias: {
+            ...sharedMappings.getAliases(),
+          },
+        },
+        plugins: [
+          new ModuleFederationPlugin({
+            remotes: {
+              login: 'login@http://localhost:4201/remoteEnrry.js',
+              todo: 'todo@http://localhost:4202/remoteEntry.js',
+            },
+            shared: {
+              '@angular/core': { singleton: true, strictVersion: true },
+              '@angular/common': { singleton: true, strictVersion: true },
+              '@angular/common/http': { singleton: true, strictVersion: true },
+              '@angular/router': { singleton: true, strictVersion: true },
+              ...sharedMappings.getDescriptors(),
+            },
+          }),
+          sharedMappings.getPlugin(),
+        ],
+      };`;
+      tree.write('apps/testing/webpack.config.js', webpackConfig);
+
+      // ACT
+      await updateMfeConfig(tree);
+
+      // ASSERT
+      const updatedConfig = tree.read(
+        'apps/testing/webpack.config.js',
+        'utf-8'
+      );
+      expect(updatedConfig).toMatchInlineSnapshot(`
+        "const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+              const mf = require('@angular-architects/module-federation/webpack');
+              const path = require('path');
+              
+              /**
+               * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+               * builder as it will generate a temporary tsconfig file which contains any required remappings of
+               * shred libraries.
+               * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+               * built files for the buildable library.
+               * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+               * the location of the generated temporary tsconfig file.
+               */
+              const tsConfigPath =
+                process.env.NX_TSCONFIG_PATH ??
+                path.join(__dirname, '../../tsconfig.base.json');
+              
+              const workspaceRootPath = path.join(__dirname, '../../');
+              const sharedMappings = new mf.SharedMappings();
+              sharedMappings.register(
+                tsConfigPath,
+                [
+                  /* mapped paths to share */
+                ],
+                workspaceRootPath
+              );
+              
+              module.exports = {
+          experiments: {
+            outputModule: true  
+          },
+                output: {
+                  uniqueName: 'login',
+                  publicPath: 'auto',
+                },
+                optimization: {
+                  runtimeChunk: false,
+                  minimize: false,
+                },
+                resolve: {
+                  alias: {
+                    ...sharedMappings.getAliases(),
+                  },
+                },
+                plugins: [
+                  new ModuleFederationPlugin({
+          library: {
+              type: 'module'
+          },
+                    remotes: {
+            login: 'http://localhost:4201/remoteEnrry.js',
+        todo: 'http://localhost:4202/remoteEntry.js'
+          },
+                    shared: {
+                      '@angular/core': { singleton: true, strictVersion: true },
+                      '@angular/common': { singleton: true, strictVersion: true },
+                      '@angular/common/http': { singleton: true, strictVersion: true },
+                      '@angular/router': { singleton: true, strictVersion: true },
+                      ...sharedMappings.getDescriptors(),
+                    },
+                  }),
+                  sharedMappings.getPlugin(),
+                ],
+              };"
+      `);
+    });
+
+    it('should run the migration successfully for a remote config', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace(2);
+      addProjectConfiguration(tree, 'app', {
+        root: 'apps/testing',
+        targets: {
+          build: {
+            executor: '@nrwl/angular:webpack-browser',
+            options: {
+              customWebpackConfig: { path: 'apps/testing/webpack.config.js' },
+            },
+          },
+        },
+      });
+
+      const webpackConfig = `const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+      const mf = require('@angular-architects/module-federation/webpack');
+      const path = require('path');
+      
+      /**
+       * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+       * builder as it will generate a temporary tsconfig file which contains any required remappings of
+       * shred libraries.
+       * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+       * built files for the buildable library.
+       * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+       * the location of the generated temporary tsconfig file.
+       */
+      const tsConfigPath =
+        process.env.NX_TSCONFIG_PATH ??
+        path.join(__dirname, '../../tsconfig.base.json');
+      
+      const workspaceRootPath = path.join(__dirname, '../../');
+      const sharedMappings = new mf.SharedMappings();
+      sharedMappings.register(
+        tsConfigPath,
+        [
+          /* mapped paths to share */
+        ],
+        workspaceRootPath
+      );
+      
+      module.exports = {
+        output: {
+          uniqueName: 'login',
+          publicPath: 'auto',
+        },
+        optimization: {
+          runtimeChunk: false,
+          minimize: false,
+        },
+        resolve: {
+          alias: {
+            ...sharedMappings.getAliases(),
+          },
+        },
+        plugins: [
+          new ModuleFederationPlugin({
+            name: 'login',
+            filename: 'remoteEntry.mjs',
+            exposes: {
+              './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+            },
+            shared: {
+              '@angular/core': { singleton: true, strictVersion: true },
+              '@angular/common': { singleton: true, strictVersion: true },
+              '@angular/common/http': { singleton: true, strictVersion: true },
+              '@angular/router': { singleton: true, strictVersion: true },
+              ...sharedMappings.getDescriptors(),
+            },
+          }),
+          sharedMappings.getPlugin(),
+        ],
+      };`;
+      tree.write('apps/testing/webpack.config.js', webpackConfig);
+
+      // ACT
+      await updateMfeConfig(tree);
+
+      // ASSERT
+      const updatedConfig = tree.read(
+        'apps/testing/webpack.config.js',
+        'utf-8'
+      );
+      expect(updatedConfig).toMatchInlineSnapshot(`
+        "const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+              const mf = require('@angular-architects/module-federation/webpack');
+              const path = require('path');
+              
+              /**
+               * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+               * builder as it will generate a temporary tsconfig file which contains any required remappings of
+               * shred libraries.
+               * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+               * built files for the buildable library.
+               * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+               * the location of the generated temporary tsconfig file.
+               */
+              const tsConfigPath =
+                process.env.NX_TSCONFIG_PATH ??
+                path.join(__dirname, '../../tsconfig.base.json');
+              
+              const workspaceRootPath = path.join(__dirname, '../../');
+              const sharedMappings = new mf.SharedMappings();
+              sharedMappings.register(
+                tsConfigPath,
+                [
+                  /* mapped paths to share */
+                ],
+                workspaceRootPath
+              );
+              
+              module.exports = {
+          experiments: {
+            outputModule: true  
+          },
+                output: {
+                  uniqueName: 'login',
+                  publicPath: 'auto',
+                },
+                optimization: {
+                  runtimeChunk: false,
+                  minimize: false,
+                },
+                resolve: {
+                  alias: {
+                    ...sharedMappings.getAliases(),
+                  },
+                },
+                plugins: [
+                  new ModuleFederationPlugin({
+          library: {
+              type: 'module'
+          },
+                    name: 'login',
+                    filename: 'remoteEntry.mjs',
+                    exposes: {
+                      './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+                    },
+                    shared: {
+                      '@angular/core': { singleton: true, strictVersion: true },
+                      '@angular/common': { singleton: true, strictVersion: true },
+                      '@angular/common/http': { singleton: true, strictVersion: true },
+                      '@angular/router': { singleton: true, strictVersion: true },
+                      ...sharedMappings.getDescriptors(),
+                    },
+                  }),
+                  sharedMappings.getPlugin(),
+                ],
+              };"
+      `);
+    });
+  }),
+    describe('removeRemoteName', () => {
+      it('should remove the names correctly', () => {
+        // ARRANGE
+        const webpackConfig = `const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+        const mf = require('@angular-architects/module-federation/webpack');
+        const path = require('path');
+        
+        /**
+         * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+         * builder as it will generate a temporary tsconfig file which contains any required remappings of
+         * shred libraries.
+         * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+         * built files for the buildable library.
+         * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+         * the location of the generated temporary tsconfig file.
+         */
+        const tsConfigPath =
+          process.env.NX_TSCONFIG_PATH ??
+          path.join(__dirname, '../../tsconfig.base.json');
+        
+        const workspaceRootPath = path.join(__dirname, '../../');
+        const sharedMappings = new mf.SharedMappings();
+        sharedMappings.register(
+          tsConfigPath,
+          [
+            /* mapped paths to share */
+          ],
+          workspaceRootPath
+        );
+        
+        module.exports = {
+          output: {
+            uniqueName: 'login',
+            publicPath: 'auto',
+          },
+          optimization: {
+            runtimeChunk: false,
+            minimize: false,
+          },
+          resolve: {
+            alias: {
+              ...sharedMappings.getAliases(),
+            },
+          },
+          plugins: [
+            new ModuleFederationPlugin({
+              name: 'login',
+              filename: 'remoteEntry.mjs',
+              remotes: {
+                login: "login@http://localhost:4201/remoteEnrry.js",
+                todo: "todo@http://localhost:4202/remoteEntry.js",
+              },
+              exposes: {
+                './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+              },
+              shared: {
+                '@angular/core': { singleton: true, strictVersion: true },
+                '@angular/common': { singleton: true, strictVersion: true },
+                '@angular/common/http': { singleton: true, strictVersion: true },
+                '@angular/router': { singleton: true, strictVersion: true },
+                ...sharedMappings.getDescriptors(),
+              },
+            }),
+            sharedMappings.getPlugin(),
+          ],
+        };`;
+
+        // ACT
+        const updatedConfig = removeRemoteName(webpackConfig);
+
+        // ASSERT
+        expect(updatedConfig).toMatchInlineSnapshot(`
+                  "const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+                          const mf = require('@angular-architects/module-federation/webpack');
+                          const path = require('path');
+                          
+                          /**
+                           * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
+                           * builder as it will generate a temporary tsconfig file which contains any required remappings of
+                           * shred libraries.
+                           * A remapping will occur when a library is buildable, as webpack needs to know the location of the
+                           * built files for the buildable library.
+                           * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
+                           * the location of the generated temporary tsconfig file.
+                           */
+                          const tsConfigPath =
+                            process.env.NX_TSCONFIG_PATH ??
+                            path.join(__dirname, '../../tsconfig.base.json');
+                          
+                          const workspaceRootPath = path.join(__dirname, '../../');
+                          const sharedMappings = new mf.SharedMappings();
+                          sharedMappings.register(
+                            tsConfigPath,
+                            [
+                              /* mapped paths to share */
+                            ],
+                            workspaceRootPath
+                          );
+                          
+                          module.exports = {
+                            output: {
+                              uniqueName: 'login',
+                              publicPath: 'auto',
+                            },
+                            optimization: {
+                              runtimeChunk: false,
+                              minimize: false,
+                            },
+                            resolve: {
+                              alias: {
+                                ...sharedMappings.getAliases(),
+                              },
+                            },
+                            plugins: [
+                              new ModuleFederationPlugin({
+                                name: 'login',
+                                filename: 'remoteEntry.mjs',
+                                remotes: {
+                      login: 'http://localhost:4201/remoteEnrry.js',
+                  todo: 'http://localhost:4202/remoteEntry.js'
+                    },
+                                exposes: {
+                                  './Module': 'apps/login/src/app/remote-entry/entry.module.ts',
+                                },
+                                shared: {
+                                  '@angular/core': { singleton: true, strictVersion: true },
+                                  '@angular/common': { singleton: true, strictVersion: true },
+                                  '@angular/common/http': { singleton: true, strictVersion: true },
+                                  '@angular/router': { singleton: true, strictVersion: true },
+                                  ...sharedMappings.getDescriptors(),
+                                },
+                              }),
+                              sharedMappings.getPlugin(),
+                            ],
+                          };"
+              `);
+      });
+    });
+});

--- a/packages/angular/src/migrations/update-13-3-0/update-mfe-webpack-config.ts
+++ b/packages/angular/src/migrations/update-13-3-0/update-mfe-webpack-config.ts
@@ -1,0 +1,127 @@
+import { Tree } from '@nrwl/devkit';
+import { logger, formatFiles } from '@nrwl/devkit';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+import { Identifier, Node, StringLiteral } from 'typescript';
+
+export default async function (tree: Tree) {
+  const NRWL_WEBPACK_BROWSER_BUILDER = '@nrwl/angular:webpack-browser';
+  const CUSTOM_WEBPACK_OPTION = 'customWebpackConfig';
+
+  forEachExecutorOptions(
+    tree,
+    NRWL_WEBPACK_BROWSER_BUILDER,
+    (opts, projectName) => {
+      // Update the webpack config
+      const webpackPath = opts[CUSTOM_WEBPACK_OPTION]?.path;
+      if (!tree.exists(webpackPath)) {
+        logger.warn(
+          `Webpack config file for project: ${projectName} does not exist. Skipping project.`
+        );
+        return;
+      }
+      const webpackConfig = tree.read(webpackPath, 'utf-8');
+      if (!webpackConfig.includes('ModuleFederationPlugin')) {
+        return;
+      }
+
+      let updatedWebpackFile = addExperimentsObject(webpackConfig);
+      updatedWebpackFile = addLibraryModuleType(updatedWebpackFile);
+      updatedWebpackFile = removeRemoteName(updatedWebpackFile);
+      tree.write(webpackPath, updatedWebpackFile);
+    }
+  );
+
+  await formatFiles(tree);
+}
+
+export function addExperimentsObject(webpackConfig: string) {
+  const WEBPACK_EXPERIMENTS_QUERY =
+    'PropertyAssignment > Identifier[name=experiments] ~ ObjectLiteralExpression';
+  const ast = tsquery.ast(webpackConfig);
+  const webpackExperimentsNode = tsquery(ast, WEBPACK_EXPERIMENTS_QUERY);
+
+  if (webpackExperimentsNode && webpackExperimentsNode.length > 0) {
+    if (webpackExperimentsNode[0].getText().includes('outputModule')) {
+      return webpackConfig;
+    }
+  }
+
+  const WEBPACK_EXPORT = 'module.exports = {';
+  const openingBracePos =
+    webpackConfig.indexOf(WEBPACK_EXPORT) + WEBPACK_EXPORT.length;
+
+  return `${webpackConfig.slice(0, openingBracePos)}
+  experiments: {
+    outputModule: true  
+  },${webpackConfig.slice(openingBracePos)}`;
+}
+
+export function addLibraryModuleType(webpackConfig: string) {
+  const LIBRARY_NODE_QUERY =
+    'PropertyAssignment > Identifier[name=library] ~ ObjectLiteralExpression';
+  const ast = tsquery.ast(webpackConfig);
+  const libraryModuleNode = tsquery(ast, LIBRARY_NODE_QUERY);
+
+  if (libraryModuleNode && libraryModuleNode.length > 0) {
+    return webpackConfig;
+  }
+
+  const MODULE_FEDERATION_PLUGIN_INSTANTIATION = 'new ModuleFederationPlugin({';
+  const openingBracePos =
+    webpackConfig.indexOf(MODULE_FEDERATION_PLUGIN_INSTANTIATION) +
+    +MODULE_FEDERATION_PLUGIN_INSTANTIATION.length;
+  return `${webpackConfig.slice(0, openingBracePos)}
+  library: {
+      type: 'module'
+  },${webpackConfig.slice(openingBracePos)}`;
+}
+
+export function removeRemoteName(webpackConfig: string) {
+  const REMOTES_QUERY = 'Identifier[name=remotes] ~ ObjectLiteralExpression';
+
+  const ast = tsquery.ast(webpackConfig);
+  const remotesObjectNode = tsquery(ast, REMOTES_QUERY, {
+    visitAllChildren: true,
+  })[0] as Node;
+
+  if (!remotesObjectNode) {
+    return webpackConfig;
+  }
+
+  const remoteProps = tsquery(remotesObjectNode, 'PropertyAssignment', {
+    visitAllChildren: true,
+  });
+
+  const updatedRemoteProps: string[] = [];
+  for (const prop of remoteProps) {
+    const stringValue = tsquery(prop, 'StringLiteral', {
+      visitAllChildren: true,
+    })[0] as StringLiteral;
+
+    if (!stringValue.getText().match(/\w*@*http/)) {
+      continue;
+    }
+
+    const identifier = tsquery(prop, 'Identifier', {
+      visitAllChildren: true,
+    })[0] as Identifier;
+
+    const updatedRemoteStringValue = stringValue
+      .getText()
+      .slice(stringValue.getText().indexOf('@') + 1, -1);
+
+    updatedRemoteProps.push(
+      `${identifier.getText()}: '${updatedRemoteStringValue}'`
+    );
+  }
+
+  const updatedRemotesObject = `{
+    ${updatedRemoteProps.join(',\n')}
+  }`;
+
+  return `${webpackConfig.slice(
+    0,
+    remotesObjectNode.getStart()
+  )}${updatedRemotesObject}${webpackConfig.slice(remotesObjectNode.getEnd())}`;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Since Angular 13, MFEs are broken due to incorrect module syntax being output

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Change webpack config generated for MFEs to support module syntax

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
