### PR TITLE
fix(js): recommit - expose schematics and builders for angular devkit

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "main": "src/index.js",
   "generators": "./generators.json",
+  "schematics": "./generators.json",
   "executors": "./executors.json",
+  "builders": "./executors.json",
   "dependencies": {
     "@nrwl/workspace": "*",
     "@nrwl/devkit": "*",


### PR DESCRIPTION
ISSUES CLOSED: #8021

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Schematics and Builders weren't exposed leading to Angular Devkit not able to call those.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Expose `schematics` and `builders`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8021
