### PR TITLE
fix(core): forward args to target dependencies with the same target name as the target that is being run

### DIFF
--- a/packages/workspace/src/tasks-runner/run-command/index.spec.ts
+++ b/packages/workspace/src/tasks-runner/run-command/index.spec.ts
@@ -748,6 +748,68 @@ describe('createTasksForProjectToRun', () => {
       expect(process.exit).toHaveBeenCalledWith(1);
     }
   });
+
+  it('should forward overrides to tasks with the same target name', () => {
+    projectGraph.nodes.app1.data.targets.build.dependsOn = [
+      {
+        target: 'prebuild',
+        projects: 'self',
+      },
+      {
+        target: 'build',
+        projects: 'dependencies',
+      },
+    ];
+    projectGraph.dependencies.app1.push({
+      type: DependencyType.static,
+      source: 'app1',
+      target: 'lib1',
+    });
+
+    const tasks = createTasksForProjectToRun(
+      [projectGraph.nodes.app1],
+      {
+        target: 'build',
+        configuration: undefined,
+        overrides: { myFlag: 'flag value' },
+      },
+      projectGraph,
+      projectGraph.nodes.app1.name
+    );
+
+    expect(tasks).toEqual([
+      {
+        id: 'app1:prebuild',
+        overrides: {},
+        projectRoot: 'app1-root',
+        target: {
+          configuration: undefined,
+          project: 'app1',
+          target: 'prebuild',
+        },
+      },
+      {
+        id: 'lib1:build',
+        overrides: { myFlag: 'flag value' },
+        projectRoot: 'lib1-root',
+        target: {
+          configuration: undefined,
+          project: 'lib1',
+          target: 'build',
+        },
+      },
+      {
+        id: 'app1:build',
+        overrides: { myFlag: 'flag value' },
+        projectRoot: 'app1-root',
+        target: {
+          configuration: undefined,
+          project: 'app1',
+          target: 'build',
+        },
+      },
+    ]);
+  });
 });
 
 describe('getRunner', () => {

--- a/packages/workspace/src/tasks-runner/run-command/index.ts
+++ b/packages/workspace/src/tasks-runner/run-command/index.ts
@@ -212,6 +212,7 @@ export function createTasksForProjectToRun(
       },
       defaultDependencyConfigs,
       projectGraph,
+      params.target,
       tasksMap,
       [],
       seenSet
@@ -230,6 +231,7 @@ function addTasksForProjectTarget(
   }: TaskParams,
   defaultDependencyConfigs: Record<string, TargetDependencyConfig[]> = {},
   projectGraph: ProjectGraph,
+  originalTargetName: string,
   tasksMap: Map<string, Task>,
   path: string[],
   seenSet: Set<string>
@@ -238,7 +240,7 @@ function addTasksForProjectTarget(
     project,
     target,
     configuration,
-    overrides,
+    overrides: target === originalTargetName ? overrides : {},
     errorIfCannotFindConfiguration,
   });
 
@@ -255,10 +257,12 @@ function addTasksForProjectTarget(
         {
           target,
           configuration,
+          overrides,
         },
         dependencyConfig,
         defaultDependencyConfigs,
         projectGraph,
+        originalTargetName,
         tasksMap,
         path,
         seenSet
@@ -314,10 +318,15 @@ export function createTask({
 
 function addTasksForProjectDependencyConfig(
   project: ProjectGraphNode,
-  { target, configuration }: Pick<TaskParams, 'target' | 'configuration'>,
+  {
+    target,
+    configuration,
+    overrides,
+  }: Pick<TaskParams, 'target' | 'configuration' | 'overrides'>,
   dependencyConfig: TargetDependencyConfig,
   defaultDependencyConfigs: Record<string, TargetDependencyConfig[]>,
   projectGraph: ProjectGraph,
+  originalTargetName: string,
   tasksMap: Map<string, Task>,
   path: string[],
   seenSet: Set<string>
@@ -354,11 +363,12 @@ function addTasksForProjectDependencyConfig(
               project: depProject,
               target: dependencyConfig.target,
               configuration,
-              overrides: {},
+              overrides,
               errorIfCannotFindConfiguration: false,
             },
             defaultDependencyConfigs,
             projectGraph,
+            originalTargetName,
             tasksMap,
             [...path, targetIdentifier],
             seenSet
@@ -370,10 +380,11 @@ function addTasksForProjectDependencyConfig(
 
           addTasksForProjectDependencyConfig(
             depProject,
-            { target, configuration },
+            { target, configuration, overrides },
             dependencyConfig,
             defaultDependencyConfigs,
             projectGraph,
+            originalTargetName,
             tasksMap,
             path,
             seenSet
@@ -387,11 +398,12 @@ function addTasksForProjectDependencyConfig(
         project,
         target: dependencyConfig.target,
         configuration,
-        overrides: {},
+        overrides,
         errorIfCannotFindConfiguration: true,
       },
       defaultDependencyConfigs,
       projectGraph,
+      originalTargetName,
       tasksMap,
       [...path, targetIdentifier],
       seenSet


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running a target with either target dependencies configured or with the `--with-deps` flag and passing extra args/flags, the args are only passed to the top-level tasks.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When running a target with either target dependencies configured or with the `--with-deps` flag, any extra args passed should be forwarded to tasks with the same target name as the target that is being run.

Related PR: #7055

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7136
Fixes #7514
