### PR TITLE
fix(angular): handle sass imports without tilde of node_modules packages

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-package.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-package.transform.ts
@@ -24,8 +24,6 @@ import { globFiles } from 'ng-packagr/lib/utils/glob';
 import { ensureUnixPath } from 'ng-packagr/lib/utils/path';
 import * as path from 'path';
 
-type CompilationMode = 'partial' | 'full' | undefined;
-
 export const nxWritePackageTransform = (options: NgPackagrOptions) =>
   transformFromPromise(async (graph) => {
     const entryPoint: EntryPointNode = graph.find(isEntryPointInProgress());
@@ -99,8 +97,6 @@ export const nxWritePackageTransform = (options: NgPackagrOptions) =>
       const relativeUnixFromDestPath = (filePath: string) =>
         ensureUnixPath(path.relative(ngEntryPoint.destinationPath, filePath));
 
-      const { compilationMode } = entryPoint.data.tsConfig.options;
-
       await writePackageJson(
         ngEntryPoint,
         ngPackage,
@@ -112,8 +108,7 @@ export const nxWritePackageTransform = (options: NgPackagrOptions) =>
           // webpack v4+ specific flag to enable advanced optimizations and code splitting
           sideEffects: ngEntryPoint.packageJson.sideEffects ?? false,
         },
-        !!options.watch,
-        compilationMode as CompilationMode
+        !!options.watch
       );
     } catch (error) {
       throw error;
@@ -142,8 +137,7 @@ async function writePackageJson(
   entryPoint: NgEntryPoint,
   pkg: NgPackage,
   additionalProperties: { [key: string]: string | boolean | string[] },
-  isWatchMode: boolean,
-  compilationMode: CompilationMode
+  isWatchMode: boolean
 ): Promise<void> {
   // set additional properties
   const packageJson = { ...entryPoint.packageJson, ...additionalProperties };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Building a library that has SCSS imports without a tilde to node_modules packages with either `@nrwl/angular:ng-packagr-lite` or `@nrwl/angular:package` causes the build to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
SCSS imports should be correctly handled by the `@nrwl/angular:ng-packagr-lite` and `@nrwl/angular:package` executors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8024 
