### PR TITLE
fix(misc): fix list plugins to handle generators/executors collections that are not exported

### DIFF
--- a/packages/workspace/src/utilities/plugins/plugin-capabilities.ts
+++ b/packages/workspace/src/utilities/plugins/plugin-capabilities.ts
@@ -1,25 +1,23 @@
-import * as chalk from 'chalk';
 import { getPackageManagerCommand, readJsonFile } from '@nrwl/devkit';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
+import * as chalk from 'chalk';
+import { dirname, join } from 'path';
 import { output } from '../output';
 import type { PluginCapabilities } from './models';
 import { hasElements } from './shared';
 
 function tryGetCollection<T extends object>(
-  workspaceRoot: string,
-  pluginName: string,
-  jsonFile: string,
+  packageJsonPath: string,
+  collectionFile: string | undefined,
   propName: string
 ): T | null {
-  if (!jsonFile) {
+  if (!collectionFile) {
     return null;
   }
 
   try {
-    const jsonFilePath = require.resolve(`${pluginName}/${jsonFile}`, {
-      paths: [workspaceRoot],
-    });
-    return readJsonFile<T>(jsonFilePath)[propName];
+    const collectionFilePath = join(dirname(packageJsonPath), collectionFile);
+    return readJsonFile<T>(collectionFilePath)[propName];
   } catch {
     return null;
   }
@@ -38,30 +36,14 @@ export function getPluginCapabilities(
       name: pluginName,
       generators:
         tryGetCollection(
-          workspaceRoot,
-          pluginName,
+          packageJsonPath,
           packageJson.generators,
           'generators'
         ) ||
-        tryGetCollection(
-          workspaceRoot,
-          pluginName,
-          packageJson.schematics,
-          'schematics'
-        ),
+        tryGetCollection(packageJsonPath, packageJson.schematics, 'schematics'),
       executors:
-        tryGetCollection(
-          workspaceRoot,
-          pluginName,
-          packageJson.executors,
-          'executors'
-        ) ||
-        tryGetCollection(
-          workspaceRoot,
-          pluginName,
-          packageJson.builders,
-          'builders'
-        ),
+        tryGetCollection(packageJsonPath, packageJson.executors, 'executors') ||
+        tryGetCollection(packageJsonPath, packageJson.builders, 'builders'),
     };
   } catch {
     return null;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Listing any plugin that's using the new APF or that uses the `export` field in the `package.json` and does not export the generators/executors collection file, fails to report any capabilities.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
All plugins should correctly be processed and their capabilities should be listed as expected.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8055 
