### PR TITLE
fix(angular): use jasmine-marbles 0.9.1 for rxjs7

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -957,6 +957,10 @@
     "13.2.0": {
       "version": "13.2.0-beta.1",
       "packages": {
+        "jasmine-marbles": {
+          "version": "~0.9.1",
+          "alwaysAddToPackageJson": false
+        },
         "@angular/cli": {
           "version": "~13.0.0",
           "alwaysAddToPackageJson": false

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -957,10 +957,6 @@
     "13.2.0": {
       "version": "13.2.0-beta.1",
       "packages": {
-        "jasmine-marbles": {
-          "version": "~0.9.1",
-          "alwaysAddToPackageJson": false
-        },
         "@angular/cli": {
           "version": "~13.0.0",
           "alwaysAddToPackageJson": false

--- a/packages/angular/src/migrations/update-13-2-0/update-testing-imports.ts
+++ b/packages/angular/src/migrations/update-13-2-0/update-testing-imports.ts
@@ -39,7 +39,7 @@ export default async function (tree: Tree) {
       tree,
       {},
       {
-        'jasmine-marbles': '~0.8.3',
+        'jasmine-marbles': '~0.9.1',
       }
     );
   }

--- a/packages/nest/src/migrations/update-13-2-0/update-to-nest-8.ts
+++ b/packages/nest/src/migrations/update-13-2-0/update-to-nest-8.ts
@@ -78,6 +78,10 @@ function updateVersion(tree: Tree) {
       '@nestjs/testing': nestJsVersion8,
     };
 
+    if (json.devDependencies['jasmine-marbles']) {
+      json.devDependencies['jasmine-marbles'] = '~0.9.1';
+    }
+
     json.dependencies = sortObjectByKeys(json.dependencies);
     json.devDependencies = sortObjectByKeys(json.devDependencies);
 


### PR DESCRIPTION
## Current Behavior
Tests for @ngrx/effects are fail:
```
    Expected: -a-|,
    Received: -?-|,
        
    Expected:
        [{"frame":10,"notification":{"kind":"N","value":{"error":"places error","type":"[places] getPlaces: Failure"}}},{"frame":30,"notification":{"kind":"C"}}]
        
    Received:
        [{"frame":10,"notification":{"kind":"N","value":{"error":"places error","type":"[places] getPlaces: Failure"},"hasValue":true}},{"frame":30,"notification":{"kind":"C","hasValue":false}}],
  138 |
  139 |     afterEach(() => {
> 140 |       expect(effects.getPlaces$).toBeObservable(expected);
      |                                  ^
  141 |     });
```

## Expected Behavior
No tests failed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8060
