### PR TITLE
docs(core): update global configuration docs

### DIFF
--- a/docs/shared/guides/lerna-and-nx.md
+++ b/docs/shared/guides/lerna-and-nx.md
@@ -208,6 +208,10 @@ The following 10-min video walks you through the steps of adding Nx to a Lerna r
 offers. Although the video uses Lerna, everything said applies to Yarn Workspaces or PNPM. Basically, any time you
 hear "Lerna" you can substitute it for Yarn or PNPM.
 
+When running `npx add-nx-to-monorepo`, a `workspace.json` file is not required (nor created by default). Instead, Nx is able
+to infer the projects in your repository by looking for existing `package.json` files. These can be mixed with `project.json`
+files and traditional configuration settings described in the [configuration guide]({{framework}}/configuration).
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/BO1rwynFBLM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Clarifying Misconceptions


### PR DESCRIPTION
## Current Behavior
- Some upcoming features affecting global configuration are not documented properly
- It is a bit confusing to locate what changed between schema v1 and v2, as well as the steps to update a repo between them

## Expected Behavior
- Upcoming features affecting global configuration are documented properly
- The differences between v1 schema and latest are obvious, with steps listed to bridge the gap

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
