### PR TITLE
chore(repo): disable running detox e2e on CI due to poor perf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
       - run:
           name: Run E2E Tests
           command: |
-            npx nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --exclude=e2e-js,e2e-next,e2e-gatsby,e2e-workspace-create,e2e-workspace-integrations,e2e-workspace-core,e2e-react,e2e-web,e2e-angular-extensions,e2e-angular-core,e2e-cli,e2e-nx-plugin,e2e-storybook,e2e-cypress,e2e-node,e2e-linter,e2e-jest --max-parallel=1
+            npx nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --exclude=e2e-detox,e2e-js,e2e-next,e2e-gatsby,e2e-workspace-create,e2e-workspace-integrations,e2e-workspace-core,e2e-react,e2e-web,e2e-angular-extensions,e2e-angular-core,e2e-cli,e2e-nx-plugin,e2e-storybook,e2e-cypress,e2e-node,e2e-linter,e2e-jest,e2e-add-nx-to-monorepo --max-parallel=1
           no_output_timeout: 45m
       - run:
           name: Stop All Running Agents for This CI Run


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Detox E2E is taking almost a half an hour slowing down every PR that touches core or configs

## Expected Behavior
Detox is enabled only on nightly, until we resolve the poor performance

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

cc @jaysoo @xiongemi 
