### PR TITLE
fix(nextjs): fix .babelrc for libraries

### DIFF
--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -5,7 +5,7 @@ import { readJson } from '@nrwl/devkit';
 import { Schema } from './schema';
 
 describe('next library', () => {
-  it('should use "next/babel" preset in babelrc', async () => {
+  it('should use "@nrwl/next/babel" preset in babelrc', async () => {
     const baseOptions: Schema = {
       name: '',
       linter: Linter.EsLint,
@@ -39,15 +39,16 @@ describe('next library', () => {
     });
 
     expect(readJson(appTree, 'libs/my-lib/.babelrc')).toEqual({
-      presets: ['next/babel'],
+      presets: ['@nrwl/next/babel'],
       plugins: [],
     });
     expect(readJson(appTree, 'libs/my-lib2/.babelrc')).toEqual({
       presets: [
         [
-          'next/babel',
+          '@nrwl/next/babel',
           {
             'preset-react': {
+              runtime: 'automatic',
               importSource: '@emotion/react',
             },
           },
@@ -56,11 +57,11 @@ describe('next library', () => {
       plugins: ['@emotion/babel-plugin'],
     });
     expect(readJson(appTree, 'libs/my-lib-styled-jsx/.babelrc')).toEqual({
-      presets: ['next/babel'],
+      presets: ['@nrwl/next/babel'],
       plugins: [],
     });
     expect(readJson(appTree, 'libs/my-dir/my-lib3/.babelrc')).toEqual({
-      presets: ['next/babel'],
+      presets: ['@nrwl/next/babel'],
       plugins: [],
     });
   });

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -24,9 +24,10 @@ export async function libraryGenerator(host: Tree, options: Schema) {
     if (options.style === '@emotion/styled') {
       json.presets = [
         [
-          'next/babel',
+          '@nrwl/next/babel',
           {
             'preset-react': {
+              runtime: 'automatic',
               importSource: '@emotion/react',
             },
           },
@@ -35,12 +36,12 @@ export async function libraryGenerator(host: Tree, options: Schema) {
     } else if (options.style === 'styled-jsx') {
       // next.js doesn't require the `styled-jsx/babel' plugin as it is already
       // built-into the `next/babel` preset
-      json.presets = ['next/babel'];
+      json.presets = ['@nrwl/next/babel'];
       json.plugins = (json.plugins || []).filter(
         (x) => x !== 'styled-jsx/babel'
       );
     } else {
-      json.presets = ['next/babel'];
+      json.presets = ['@nrwl/next/babel'];
     }
     return json;
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `.babelrc` generated by `nx g @nrwl/next:library` does not use `@nrwl/next/babel` preset.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It should be generated with `@nrwl/next/babel` preset.

```js
// Example of `nx g @nrwl/next:library --style=@emotion/styled`
{
  "presets": [
    [
      "@nrwl/next/babel",  // 👈 The preset should be changed from next/babel to @nrwl/next/babel
      {
        "preset-react": {
          "runtime": "automatic",
          "importSource": "@emotion/react"
        }
      }
    ]
  ],
  "plugins": ["@emotion/babel-plugin"]
}
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://nrwlcommunity.slack.com/archives/C015WMB2A8P/p1639043467125800
https://nrwlcommunity.slack.com/archives/C015WMB2A8P/p1641384957180500
#6728
