### PR TITLE
fix(core): remove generator should work w/o workspace.json

### DIFF
--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -456,11 +456,10 @@ function readRawWorkspaceJson(tree: Tree): RawWorkspaceJsonConfiguration {
     const projects = { ...staticFSWorkspace.projects, ...createdProjects };
     findDeletedProjects(tree).forEach((file) => {
       const matchingStaticProject = Object.entries(projects).find(
-        ([, config]) => {
+        ([, config]) =>
           typeof config === 'string'
             ? config === dirname(file.path)
-            : config.root === dirname(file.path);
-        }
+            : config.root === dirname(file.path)
       );
 
       if (matchingStaticProject) {

--- a/packages/workspace/src/generators/move/lib/update-build-targets.ts
+++ b/packages/workspace/src/generators/move/lib/update-build-targets.ts
@@ -1,18 +1,23 @@
-import { getWorkspacePath, Tree, updateJson } from '@nrwl/devkit';
+import { getProjects, Tree, updateProjectConfiguration } from '@nrwl/devkit';
 import { NormalizedSchema } from '../schema';
 
 /**
  * Update other references to the source project's targets
  */
 export function updateBuildTargets(tree: Tree, schema: NormalizedSchema) {
-  updateJson(tree, getWorkspacePath(tree), (json) => {
-    const strWorkspace = JSON.stringify(json);
-    json = JSON.parse(
-      strWorkspace.replace(
-        new RegExp(`${schema.projectName}:`, 'g'),
-        `${schema.newProjectName}:`
-      )
+  getProjects(tree).forEach((projectConfig, project) => {
+    Object.entries(projectConfig.targets || {}).forEach(
+      ([target, targetConfig]) => {
+        const configString = JSON.stringify(targetConfig);
+        const updated = JSON.parse(
+          configString.replace(
+            new RegExp(`${schema.projectName}:`, 'g'),
+            `${schema.newProjectName}:`
+          )
+        );
+        projectConfig.targets[target] = updated;
+      }
     );
-    return json;
+    updateProjectConfiguration(tree, project, projectConfig);
   });
 }


### PR DESCRIPTION
## Current Behavior
The remove generator tries to update the project configuration after removing it, failing validation

## Expected Behavior
The remove generator updates project configurations before removing it, passing validation

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
