### PR TITLE
feat(angular): allow for passing in parser options flag to lib generation

### DIFF
--- a/docs/angular/api-angular/generators/library.md
+++ b/docs/angular/api-angular/generators/library.md
@@ -118,6 +118,14 @@ Type: `boolean`
 
 Add router configuration. See `lazy` for more information.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### simpleModuleName
 
 Default: `false`

--- a/docs/node/api-angular/generators/library.md
+++ b/docs/node/api-angular/generators/library.md
@@ -118,6 +118,14 @@ Type: `boolean`
 
 Add router configuration. See `lazy` for more information.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### simpleModuleName
 
 Default: `false`

--- a/docs/react/api-angular/generators/library.md
+++ b/docs/react/api-angular/generators/library.md
@@ -118,6 +118,14 @@ Type: `boolean`
 
 Add router configuration. See `lazy` for more information.
 
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
 ### simpleModuleName
 
 Default: `false`

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -135,6 +135,7 @@ async function addLinting(host: Tree, options: NormalizedSchema) {
     projectName: options.name,
     projectRoot: options.projectRoot,
     prefix: options.prefix,
+    setParserOptionsProject: options.setParserOptionsProject,
   });
 }
 

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -27,4 +27,5 @@ export interface Schema {
   linter: Exclude<Linter, Linter.TsLint>;
   unitTestRunner: UnitTestRunner;
   compilationMode?: 'full' | 'partial';
+  setParserOptionsProject?: boolean;
 }

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -107,6 +107,11 @@
       "description": "Specifies the compilation mode to use. If not specified, it will default to `partial` for publishable libraries and to `full` for buildable libraries. The `full` value can not be used for publishable libraries.",
       "type": "string",
       "enum": ["full", "partial"]
+    },
+    "setParserOptionsProject": {
+      "type": "boolean",
+      "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
+      "default": false
     }
   },
   "required": []


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
In the Nest lib generator you can supply the parser options to be included in the eslint configuration, you currently cannot supply this to the angular generator

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should be able to generate angular libraries with parser options

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7865 
