### PR TITLE
fix(core): add default export for tasksRunnerV2

### DIFF
--- a/packages/workspace/src/tasks-runner/tasks-runner-v2.ts
+++ b/packages/workspace/src/tasks-runner/tasks-runner-v2.ts
@@ -55,3 +55,5 @@ function convertCompletedTasksToOutputFormat(completedTasks: {
     };
   });
 }
+
+export default tasksRunnerV2;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
In older setups that [tried caching from this blog post](https://blog.nrwl.io/distributed-caching-in-nx-164edfbc68e0), NX 13.3.0 fails to properly initialize a runner.

```json
{
  "tasksRunnerOptions": {
    "default": {
      "runner": "@nrwl/workspace/src/tasks-runner/tasks-runner-v2",
      "options": {
        "cacheableOperations": [
          "build",
          "test",
          "lint"
        ],
        "parallel": 3
      }
    }
  }
}
```

Will provide a task runner not as a function, but as an object due to the lack of an `export default tasksRunnerV2;`. This in return will cause all tasks to fail with the message: `TypeError: tasksRunner is not a function`.

```
  tasksRunner: { tasksRunnerV2: [Function: tasksRunnerV2] },
```

instead of

```
tasksRunner: [Function: tasksRunnerV2],
```

## Expected Behavior
Task runner should be able to run using the older `tasks-runner-v2` runner.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8085
