### PR TITLE
docs(nxdev): dialog path cleaner update

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -30,7 +30,6 @@ export function DocViewer({
   flavorList,
   navIsOpen,
 }: DocumentationFeatureDocViewerProps) {
-  console.log(document.data);
   return (
     <>
       <Head>

--- a/nx-dev/feature-flavor-selection/src/lib/utils.ts
+++ b/nx-dev/feature-flavor-selection/src/lib/utils.ts
@@ -8,18 +8,17 @@ export function pathCleaner(
   flavors: FlavorMetadata[]
 ) {
   return (path: string): string => {
-    const myPath = path
-      .split('/')
-      .filter(
-        (segment: string) =>
-          !versions.find((v) => [v.alias, v.id].includes(segment))
-      )
-      .filter(
-        (segment: string) =>
-          !flavors.find((f) => [f.alias, f.id].includes(segment))
-      )
-      .join('/');
+    const [first, second, ...others] = path.split('/').filter(Boolean);
+    const cleanPath = [];
 
-    return myPath;
+    if (!versions.find((v) => [v.alias, v.id].includes(first))) {
+      cleanPath.push(first);
+    }
+
+    if (!flavors.find((f) => [f.alias, f.id].includes(second))) {
+      cleanPath.push(second);
+    }
+
+    return '/' + (others ? cleanPath.concat(...others) : cleanPath).join('/');
   };
 }


### PR DESCRIPTION
## What it does?
Updates the `pathCleaner()` util function on the dialog view to focus on the first 2 url segments on nx.dev