### PR TITLE
fix(angular): use path property correctly when generating scams #8083

### DIFF
--- a/docs/angular/api-angular/generators/scam.md
+++ b/docs/angular/api-angular/generators/scam.md
@@ -1,6 +1,6 @@
 # @nrwl/angular:scam
 
-Generate a component with an accompanying Single Angular Module Component (SCAM).
+Generate a component with an accompanying Single Component Angular Module (SCAM).
 
 ## Usage
 

--- a/docs/node/api-angular/generators/scam.md
+++ b/docs/node/api-angular/generators/scam.md
@@ -1,6 +1,6 @@
 # @nrwl/angular:scam
 
-Generate a component with an accompanying Single Angular Module Component (SCAM).
+Generate a component with an accompanying Single Component Angular Module (SCAM).
 
 ## Usage
 

--- a/docs/react/api-angular/generators/scam.md
+++ b/docs/react/api-angular/generators/scam.md
@@ -1,6 +1,6 @@
 # @nrwl/angular:scam
 
-Generate a component with an accompanying Single Angular Module Component (SCAM).
+Generate a component with an accompanying Single Component Angular Module (SCAM).
 
 ## Usage
 

--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -113,7 +113,7 @@
     "scam": {
       "factory": "./src/generators/scam/scam.compat",
       "schema": "./src/generators/scam/schema.json",
-      "description": "Generate a component with an accompanying Single Angular Module Component (SCAM)."
+      "description": "Generate a component with an accompanying Single Component Angular Module (SCAM)."
     },
 
     "web-worker": {
@@ -207,7 +207,7 @@
     "scam": {
       "factory": "./src/generators/scam/scam",
       "schema": "./src/generators/scam/schema.json",
-      "description": "Generate a component with an accompanying Single Angular Module Component (SCAM)."
+      "description": "Generate a component with an accompanying Single Component Angular Module (SCAM)."
     },
     "stories": {
       "factory": "./src/generators/stories/stories",

--- a/packages/angular/src/generators/scam/lib/create-module.spec.ts
+++ b/packages/angular/src/generators/scam/lib/create-module.spec.ts
@@ -329,4 +329,130 @@ describe('Create module in the tree', () => {
       export class ExampleRandomModule {}"
     `);
   });
+
+  it('should place the component and scam in the correct folder when --path is used', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'app1', {
+      projectType: 'application',
+      sourceRoot: 'apps/app1/src',
+      root: 'apps/app1',
+    });
+
+    const angularComponentSchematic = wrapAngularDevkitSchematic(
+      '@schematics/angular',
+      'component'
+    );
+    await angularComponentSchematic(tree, {
+      name: 'example',
+      project: 'app1',
+      skipImport: true,
+      export: false,
+      flat: false,
+      path: 'apps/app1/src/app/random',
+    });
+
+    // ACT
+    createScam(tree, {
+      name: 'example',
+      project: 'app1',
+      flat: false,
+      path: 'apps/app1/src/app/random',
+      inlineScam: true,
+    });
+
+    // ASSERT
+    const componentModuleSource = tree.read(
+      'apps/app1/src/app/random/example/example.component.ts',
+      'utf-8'
+    );
+    expect(componentModuleSource).toMatchInlineSnapshot(`
+      "import { Component, OnInit, NgModule } from '@angular/core';
+      import { CommonModule } from '@angular/common';
+
+      @Component({
+        selector: 'example',
+        templateUrl: './example.component.html',
+        styleUrls: ['./example.component.css']
+      })
+      export class ExampleComponent implements OnInit {
+
+        constructor() { }
+
+        ngOnInit(): void {
+        }
+
+      }
+
+      @NgModule({
+        imports: [CommonModule],
+        declarations: [ExampleComponent],
+        exports: [ExampleComponent],
+      })
+      export class ExampleComponentModule {}"
+    `);
+  });
+
+  it('should place the component and scam in the correct folder when --path and --flat is used', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'app1', {
+      projectType: 'application',
+      sourceRoot: 'apps/app1/src',
+      root: 'apps/app1',
+    });
+
+    const angularComponentSchematic = wrapAngularDevkitSchematic(
+      '@schematics/angular',
+      'component'
+    );
+    await angularComponentSchematic(tree, {
+      name: 'example',
+      project: 'app1',
+      skipImport: true,
+      export: false,
+      flat: true,
+      path: 'apps/app1/src/app/random',
+    });
+
+    // ACT
+    createScam(tree, {
+      name: 'example',
+      project: 'app1',
+      flat: true,
+      path: 'apps/app1/src/app/random',
+      inlineScam: true,
+    });
+
+    // ASSERT
+    const componentModuleSource = tree.read(
+      'apps/app1/src/app/random/example.component.ts',
+      'utf-8'
+    );
+    expect(componentModuleSource).toMatchInlineSnapshot(`
+      "import { Component, OnInit, NgModule } from '@angular/core';
+      import { CommonModule } from '@angular/common';
+
+      @Component({
+        selector: 'example',
+        templateUrl: './example.component.html',
+        styleUrls: ['./example.component.css']
+      })
+      export class ExampleComponent implements OnInit {
+
+        constructor() { }
+
+        ngOnInit(): void {
+        }
+
+      }
+
+      @NgModule({
+        imports: [CommonModule],
+        declarations: [ExampleComponent],
+        exports: [ExampleComponent],
+      })
+      export class ExampleComponentModule {}"
+    `);
+  });
 });

--- a/packages/angular/src/generators/scam/lib/create-module.ts
+++ b/packages/angular/src/generators/scam/lib/create-module.ts
@@ -6,6 +6,7 @@ import {
   joinPathFragments,
   names,
   readWorkspaceConfiguration,
+  normalizePath,
 } from '@nrwl/devkit';
 import { insertImport } from '@nrwl/workspace/src/utilities/ast-utils';
 import { createSourceFile, ScriptTarget } from 'typescript';
@@ -21,7 +22,8 @@ export function createScam(tree: Tree, schema: Schema) {
   const componentFileName = `${componentNames.fileName}.${
     schema.type ?? 'component'
   }`;
-  const componentDirectory = schema.flat
+
+  let componentDirectory = schema.flat
     ? joinPathFragments(
         projectConfig.sourceRoot,
         projectConfig.projectType === 'application' ? 'app' : 'lib'
@@ -31,6 +33,13 @@ export function createScam(tree: Tree, schema: Schema) {
         projectConfig.projectType === 'application' ? 'app' : 'lib',
         componentNames.fileName
       );
+
+  if (schema.path) {
+    componentDirectory = schema.flat
+      ? normalizePath(schema.path)
+      : joinPathFragments(schema.path, componentNames.fileName);
+  }
+
   const componentFilePath = joinPathFragments(
     componentDirectory,
     `${componentFileName}.ts`

--- a/packages/angular/src/generators/scam/scam.spec.ts
+++ b/packages/angular/src/generators/scam/scam.spec.ts
@@ -85,4 +85,129 @@ describe('SCAM Generator', () => {
       export class ExampleComponentModule {}"
     `);
   });
+
+  describe('--path', () => {
+    it('should not throw when the path does not exist under project', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace(2);
+      addProjectConfiguration(tree, 'app1', {
+        projectType: 'application',
+        sourceRoot: 'apps/app1/src',
+        root: 'apps/app1',
+      });
+
+      // ACT
+      await scamGenerator(tree, {
+        name: 'example',
+        project: 'app1',
+        path: 'apps/app1/src/app/random',
+        inlineScam: true,
+      });
+
+      // ASSERT
+      const componentSource = tree.read(
+        'apps/app1/src/app/random/example/example.component.ts',
+        'utf-8'
+      );
+      expect(componentSource).toMatchInlineSnapshot(`
+        "import { Component, OnInit, NgModule } from '@angular/core';
+        import { CommonModule } from '@angular/common';
+
+        @Component({
+          selector: 'example',
+          templateUrl: './example.component.html',
+          styleUrls: ['./example.component.css']
+        })
+        export class ExampleComponent implements OnInit {
+
+          constructor() { }
+
+          ngOnInit(): void {
+          }
+
+        }
+
+        @NgModule({
+          imports: [CommonModule],
+          declarations: [ExampleComponent],
+          exports: [ExampleComponent],
+        })
+        export class ExampleComponentModule {}"
+      `);
+    });
+
+    it('should not matter if the path starts with a slash', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace(2);
+      addProjectConfiguration(tree, 'app1', {
+        projectType: 'application',
+        sourceRoot: 'apps/app1/src',
+        root: 'apps/app1',
+      });
+
+      // ACT
+      await scamGenerator(tree, {
+        name: 'example',
+        project: 'app1',
+        path: '/apps/app1/src/app/random',
+        inlineScam: true,
+      });
+
+      // ASSERT
+      const componentSource = tree.read(
+        'apps/app1/src/app/random/example/example.component.ts',
+        'utf-8'
+      );
+      expect(componentSource).toMatchInlineSnapshot(`
+        "import { Component, OnInit, NgModule } from '@angular/core';
+        import { CommonModule } from '@angular/common';
+
+        @Component({
+          selector: 'example',
+          templateUrl: './example.component.html',
+          styleUrls: ['./example.component.css']
+        })
+        export class ExampleComponent implements OnInit {
+
+          constructor() { }
+
+          ngOnInit(): void {
+          }
+
+        }
+
+        @NgModule({
+          imports: [CommonModule],
+          declarations: [ExampleComponent],
+          exports: [ExampleComponent],
+        })
+        export class ExampleComponentModule {}"
+      `);
+    });
+
+    it('should throw when the path does not exist under project', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace(2);
+      addProjectConfiguration(tree, 'app1', {
+        projectType: 'application',
+        sourceRoot: 'apps/app1/src',
+        root: 'apps/app1',
+      });
+
+      // ACT
+      try {
+        await scamGenerator(tree, {
+          name: 'example',
+          project: 'app1',
+          path: 'libs/proj/src/lib/random',
+          inlineScam: true,
+        });
+      } catch (error) {
+        // ASSERT
+        expect(error).toMatchInlineSnapshot(
+          `[Error: The path provided for the SCAM (libs/proj/src/lib/random) does not exist under the project root (apps/app1).]`
+        );
+      }
+    });
+  });
 });


### PR DESCRIPTION

## Current Behavior
Using the `--path` property causes an error because the generator does not consider it.

## Expected Behavior
Use the `--path` property correctly to resolve the new component correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8083
