### PR TITLE
fix(core): forward args to target dependencies with the same executor as the target that is being run

### DIFF
--- a/packages/workspace/src/tasks-runner/run-command/index.spec.ts
+++ b/packages/workspace/src/tasks-runner/run-command/index.spec.ts
@@ -749,7 +749,7 @@ describe('createTasksForProjectToRun', () => {
     }
   });
 
-  it('should forward overrides to tasks with the same target name', () => {
+  it('should forward overrides to tasks with the same target executor', () => {
     projectGraph.nodes.app1.data.targets.build.dependsOn = [
       {
         target: 'prebuild',
@@ -760,11 +760,31 @@ describe('createTasksForProjectToRun', () => {
         projects: 'dependencies',
       },
     ];
-    projectGraph.dependencies.app1.push({
-      type: DependencyType.static,
-      source: 'app1',
-      target: 'lib1',
-    });
+    projectGraph.nodes.app1.data.targets.build.executor = 'executor1';
+    projectGraph.nodes.lib1.data.targets.build.executor = 'executor1';
+    projectGraph.nodes.app1.data.targets.prebuild.executor = 'executor2';
+    projectGraph.nodes.lib2 = {
+      data: {
+        root: 'lib2-root',
+        files: [],
+        targets: { build: { executor: 'executor2' } },
+      },
+      name: 'lib2',
+      type: 'lib',
+    };
+    projectGraph.dependencies.lib2 = [];
+    projectGraph.dependencies.app1.push(
+      {
+        type: DependencyType.static,
+        source: 'app1',
+        target: 'lib1',
+      },
+      {
+        type: DependencyType.static,
+        source: 'app1',
+        target: 'lib2',
+      }
+    );
 
     const tasks = createTasksForProjectToRun(
       [projectGraph.nodes.app1],
@@ -795,6 +815,16 @@ describe('createTasksForProjectToRun', () => {
         target: {
           configuration: undefined,
           project: 'lib1',
+          target: 'build',
+        },
+      },
+      {
+        id: 'lib2:build',
+        overrides: {},
+        projectRoot: 'lib2-root',
+        target: {
+          configuration: undefined,
+          project: 'lib2',
           target: 'build',
         },
       },

--- a/packages/workspace/src/tasks-runner/run-command/index.ts
+++ b/packages/workspace/src/tasks-runner/run-command/index.ts
@@ -212,7 +212,7 @@ export function createTasksForProjectToRun(
       },
       defaultDependencyConfigs,
       projectGraph,
-      params.target,
+      project.data.targets?.[params.target]?.executor,
       tasksMap,
       [],
       seenSet
@@ -231,7 +231,7 @@ function addTasksForProjectTarget(
   }: TaskParams,
   defaultDependencyConfigs: Record<string, TargetDependencyConfig[]> = {},
   projectGraph: ProjectGraph,
-  originalTargetName: string,
+  originalTargetExecutor: string,
   tasksMap: Map<string, Task>,
   path: string[],
   seenSet: Set<string>
@@ -240,7 +240,10 @@ function addTasksForProjectTarget(
     project,
     target,
     configuration,
-    overrides: target === originalTargetName ? overrides : {},
+    overrides:
+      project.data.targets?.[target]?.executor === originalTargetExecutor
+        ? overrides
+        : {},
     errorIfCannotFindConfiguration,
   });
 
@@ -262,7 +265,7 @@ function addTasksForProjectTarget(
         dependencyConfig,
         defaultDependencyConfigs,
         projectGraph,
-        originalTargetName,
+        originalTargetExecutor,
         tasksMap,
         path,
         seenSet
@@ -326,7 +329,7 @@ function addTasksForProjectDependencyConfig(
   dependencyConfig: TargetDependencyConfig,
   defaultDependencyConfigs: Record<string, TargetDependencyConfig[]>,
   projectGraph: ProjectGraph,
-  originalTargetName: string,
+  originalTargetExecutor: string,
   tasksMap: Map<string, Task>,
   path: string[],
   seenSet: Set<string>
@@ -368,7 +371,7 @@ function addTasksForProjectDependencyConfig(
             },
             defaultDependencyConfigs,
             projectGraph,
-            originalTargetName,
+            originalTargetExecutor,
             tasksMap,
             [...path, targetIdentifier],
             seenSet
@@ -384,7 +387,7 @@ function addTasksForProjectDependencyConfig(
             dependencyConfig,
             defaultDependencyConfigs,
             projectGraph,
-            originalTargetName,
+            originalTargetExecutor,
             tasksMap,
             path,
             seenSet
@@ -403,7 +406,7 @@ function addTasksForProjectDependencyConfig(
       },
       defaultDependencyConfigs,
       projectGraph,
-      originalTargetName,
+      originalTargetExecutor,
       tasksMap,
       [...path, targetIdentifier],
       seenSet


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running a target that has target dependencies, any additional arg passed will be forwarded to targets with the same as the target that is being run. This was recently added to restore the original behavior of the deprecated `--with-deps` functionality (which target dependencies configuration is the replacement for). This has the issue that different projects might have different executors for the same target name and these different executors might not support the same options.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Additional args should only be forwarded to the targets with the same executor.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8093 
