### PR TITLE
fix(angular): fix setParserOptionsProject being ignored when generating apps

### DIFF
--- a/packages/angular/src/generators/application/lib/add-linting.ts
+++ b/packages/angular/src/generators/application/lib/add-linting.ts
@@ -12,5 +12,6 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
     projectName: options.name,
     projectRoot: options.appProjectRoot,
     prefix: options.prefix,
+    setParserOptionsProject: options.setParserOptionsProject,
   });
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Generating an Angular application with `--setParserOptionsProject=true`, ignores the option and doesn't generate the expected configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generating an application with `--setParserOptionsProject=true` should generate the expected configuration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
