### PR TITLE
chore(storybook): reuse the same workspace for e2e tests

### DIFF
--- a/e2e/storybook/src/storybook.test.ts
+++ b/e2e/storybook/src/storybook.test.ts
@@ -2,7 +2,6 @@ import {
   checkFilesExist,
   killPorts,
   newProject,
-  readFile,
   runCLI,
   runCommandUntil,
   tmpProjPath,
@@ -11,12 +10,15 @@ import {
 import { writeFileSync } from 'fs';
 
 describe('Storybook schematics', () => {
+  let proj: string;
+  beforeAll(() => {
+    proj = newProject();
+  });
+
   describe('serve storybook', () => {
     afterEach(() => killPorts());
 
     it('should run a React based Storybook setup', async () => {
-      newProject();
-
       const reactStorybookLib = uniq('test-ui-lib-react');
       runCLI(`generate @nrwl/react:lib ${reactStorybookLib} --no-interactive`);
       runCLI(
@@ -36,8 +38,6 @@ describe('Storybook schematics', () => {
 
   describe('build storybook', () => {
     it('should build a React based storybook', () => {
-      newProject();
-
       const reactStorybookLib = uniq('test-ui-lib-react');
       runCLI(`generate @nrwl/react:lib ${reactStorybookLib} --no-interactive`);
       runCLI(
@@ -50,8 +50,6 @@ describe('Storybook schematics', () => {
     }, 1000000);
 
     it('should lint a React based storybook without errors', () => {
-      newProject();
-
       const reactStorybookLib = uniq('test-ui-lib-react');
       runCLI(`generate @nrwl/react:lib ${reactStorybookLib} --no-interactive`);
       runCLI(
@@ -64,8 +62,6 @@ describe('Storybook schematics', () => {
     }, 1000000);
 
     it('should build a React based storybook that references another lib', () => {
-      const proj = newProject();
-
       const reactStorybookLib = uniq('test-ui-lib-react');
       runCLI(`generate @nrwl/react:lib ${reactStorybookLib} --no-interactive`);
       runCLI(
@@ -132,50 +128,3 @@ describe('Storybook schematics', () => {
     }, 1000000);
   });
 });
-
-export function createTestUILib(libName: string): void {
-  runCLI(`g @nrwl/angular:library ${libName} --no-interactive`);
-  runCLI(
-    `g @nrwl/angular:component test-button --project=${libName} --no-interactive`
-  );
-
-  writeFileSync(
-    tmpProjPath(`libs/${libName}/src/lib/test-button/test-button.component.ts`),
-    `
-      import { Component, OnInit, Input } from '@angular/core';
-
-      export type ButtonStyle = 'default' | 'primary' | 'accent';
-
-      @Component({
-        selector: 'proj-test-button',
-        templateUrl: './test-button.component.html',
-        styleUrls: ['./test-button.component.css']
-      })
-      export class TestButtonComponent implements OnInit {
-        @Input('buttonType') type = 'button';
-        @Input() style: ButtonStyle = 'default';
-        @Input() age: number;
-        @Input() isDisabled = false;
-
-        constructor() { }
-
-        ngOnInit() {
-        }
-
-      }
-      `
-  );
-
-  writeFileSync(
-    tmpProjPath(
-      `libs/${libName}/src/lib/test-button/test-button.component.html`
-    ),
-    `
-    <button [disabled]="isDisabled" [attr.type]="type" [ngClass]="style">Click me</button>
-    <p>You are {{age}} years old.</p>
-    `
-  );
-  runCLI(
-    `g @nrwl/angular:component test-other --project=${libName} --no-interactive`
-  );
-}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A workspace is created for each storybook e2e test.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The same workspace is used for the e2e tests but a new project is created for each of them.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
