### PR TITLE
fix(nextjs): make flat option configurable for page generator

### DIFF
--- a/packages/next/src/generators/page/page.spec.ts
+++ b/packages/next/src/generators/page/page.spec.ts
@@ -24,8 +24,10 @@ describe('component', () => {
       style: 'css',
     });
 
-    expect(tree.exists('apps/my-app/pages/hello.tsx')).toBeTruthy();
-    expect(tree.exists('apps/my-app/pages/hello.module.css')).toBeTruthy();
+    expect(tree.exists('apps/my-app/pages/hello/hello.tsx')).toBeTruthy();
+    expect(
+      tree.exists('apps/my-app/pages/hello/hello.module.css')
+    ).toBeTruthy();
   });
 
   it('should support dynamic routes and directories', async () => {
@@ -36,13 +38,15 @@ describe('component', () => {
       style: 'css',
     });
 
-    expect(tree.exists('apps/my-app/pages/posts/[dynamic].tsx')).toBeTruthy();
     expect(
-      tree.exists('apps/my-app/pages/posts/[dynamic].module.css')
+      tree.exists('apps/my-app/pages/posts/[dynamic]/[dynamic].tsx')
+    ).toBeTruthy();
+    expect(
+      tree.exists('apps/my-app/pages/posts/[dynamic]/[dynamic].module.css')
     ).toBeTruthy();
 
     const content = tree
-      .read('apps/my-app/pages/posts/[dynamic].tsx')
+      .read('apps/my-app/pages/posts/[dynamic]/[dynamic].tsx')
       .toString();
     expect(content).toMatch(/DynamicProps/);
   });

--- a/packages/next/src/generators/page/page.ts
+++ b/packages/next/src/generators/page/page.ts
@@ -19,7 +19,7 @@ export async function pageGenerator(host: Tree, options: Schema) {
     classComponent: false,
     routing: false,
     skipTests: !options.withTests,
-    flat: true,
+    flat: !!options.flat,
   });
 
   const styledTask = addStyleDependencies(host, options.style);

--- a/packages/next/src/generators/page/schema.d.ts
+++ b/packages/next/src/generators/page/schema.d.ts
@@ -8,4 +8,5 @@ export interface Schema {
   fileName?: string;
   withTests?: boolean;
   js?: boolean;
+  flat?: boolean;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`flat` option of the next.js page generator isn't configurable

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`flat` option of the next.js page generator should be configurable, as per the documentation

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7913 
