### PR TITLE
fix(core): project inference should work if name not specified by package.json

### DIFF
--- a/packages/tao/src/shared/workspace.spec.ts
+++ b/packages/tao/src/shared/workspace.spec.ts
@@ -80,7 +80,7 @@ describe('workspace', () => {
         return domainLibConfig;
       }
       if (path.endsWith('libs/domain/lib4/package.json')) {
-        return { name: 'domain-lib4' };
+        return {};
       }
       throw `${path} not in mock!`;
     });

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -715,7 +715,7 @@ export function buildProjectConfigurationFromPackageJson(
 ): ProjectConfiguration & { name: string } {
   const directory = dirname(path).split('\\').join('/');
   const npmPrefix = `@${nxJson.npmScope}/`;
-  let { name } = packageJson;
+  let name = packageJson.name ?? toProjectName(directory, nxJson);
   if (name.startsWith(npmPrefix)) {
     name = name.replace(npmPrefix, '');
   }


### PR DESCRIPTION
## Current Behavior
Nx errors if not using workspace.json and a package.json file doesn't specify a name

## Expected Behavior
Nx infers the correct project name

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
