### PR TITLE
fix(core): allow tsConfig without compilerOptions to work

### DIFF
--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.spec.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.spec.ts
@@ -1,9 +1,11 @@
 import { NxJsonConfiguration, WorkspaceJsonConfiguration } from '@nrwl/devkit';
 import {
+  createCache as _createCache,
   extractCachedFileData,
   ProjectGraphCache,
   shouldRecomputeWholeGraph,
 } from './nx-deps-cache';
+import { createCache } from './nx-deps-cache';
 
 describe('nx deps utils', () => {
   describe('shouldRecomputeWholeGraph', () => {
@@ -274,6 +276,17 @@ describe('nx deps utils', () => {
           },
         },
       });
+    });
+  });
+
+  describe('createCache', () => {
+    it('should work with empty tsConfig', () => {
+      _createCache(
+        createNxJson({}),
+        createPackageJsonDeps({}),
+        createCache({}),
+        {}
+      );
     });
   });
 

--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
@@ -90,7 +90,7 @@ export function createCache(
   nxJson: NxJsonConfiguration<'*' | string[]>,
   packageJsonDeps: Record<string, string>,
   projectGraph: ProjectGraph<any>,
-  tsConfig: { compilerOptions: { paths?: { [p: string]: any } } }
+  tsConfig: { compilerOptions?: { paths?: { [p: string]: any } } }
 ) {
   const nxJsonPlugins = (nxJson.plugins || []).map((p) => ({
     name: p,
@@ -99,7 +99,8 @@ export function createCache(
   const newValue: ProjectGraphCache = {
     version: projectGraph.version || '5.0',
     deps: packageJsonDeps,
-    pathMappings: tsConfig.compilerOptions.paths || {},
+    // compilerOptions may not exist, especially for repos converted through add-nx-to-monorepo
+    pathMappings: tsConfig.compilerOptions?.paths || {},
     nxJsonPlugins,
     nodes: projectGraph.nodes,
     externalNodes: projectGraph.externalNodes,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If tsConfig does not contain `compilerOptions`, then Nx will error out when trying to read from cache. This  can happen when using `npx add-nx-to-monorepo` for example, and the workspace doesn't already use `compilerOptions`.

## Expected Behavior
Nx should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
