### PR TITLE
fix(web): fix migration from @nrwl/web:build to @nrwl/web:webpack

### DIFF
--- a/packages/web/migrations.json
+++ b/packages/web/migrations.json
@@ -45,6 +45,12 @@
       "description": "Remove packages installed by Nx 12's `@nrwl/web:webpack5` generator.",
       "factory": "./src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0"
     },
+    "rename-build-to-webpack": {
+      "cli": "nx",
+      "version": "13.3.0-beta.1",
+      "description": "Rename the 'build' executor to 'webpack'",
+      "factory": "./src/migrations/update-13-3-0/rename-build-to-webpack"
+    },
     "rename-package-to-rollup": {
       "cli": "nx",
       "version": "13.3.0-beta.1",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The migration replacing `@nrwl/web:build` with `@nrwl/web:webpack` does not appear in `migrations.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`@nrwl/web:build` should be replaced with `@nrwl/web:webpack` after `nx migrate --run-migrations`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
#7952
Closes #8125