### PR TITLE
feat(react): update complier options for strict mode

### DIFF
--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -19,7 +19,7 @@ describe('app', () => {
     name: 'myApp',
     linter: Linter.EsLint,
     style: 'css',
-    strict: false,
+    strict: true,
     standaloneConfig: false,
   };
 
@@ -76,14 +76,16 @@ describe('app', () => {
           path: './tsconfig.spec.json',
         },
       ]);
-      expect(tsconfig.compilerOptions.strict).not.toBeDefined();
+      expect(tsconfig.compilerOptions.forceConsistentCasingInFileNames).toEqual(
+        true
+      );
+      expect(tsconfig.compilerOptions.strict).toEqual(true);
+      expect(tsconfig.compilerOptions.noImplicitOverride).toEqual(true);
       expect(
-        tsconfig.compilerOptions.forceConsistentCasingInFileNames
-      ).not.toBeDefined();
-      expect(tsconfig.compilerOptions.noImplicitReturns).not.toBeDefined();
-      expect(
-        tsconfig.compilerOptions.noFallthroughCasesInSwitch
-      ).not.toBeDefined();
+        tsconfig.compilerOptions.noPropertyAccessFromIndexSignature
+      ).toEqual(true);
+      expect(tsconfig.compilerOptions.noImplicitReturns).toEqual(true);
+      expect(tsconfig.compilerOptions.noFallthroughCasesInSwitch).toEqual(true);
 
       const tsconfigApp = readJson(appTree, 'apps/my-app/tsconfig.app.json');
       expect(tsconfigApp.compilerOptions.outDir).toEqual('../../dist/out-tsc');
@@ -718,22 +720,26 @@ Object {
     });
   });
 
-  describe('--strict', () => {
-    it('should update tsconfig.json', async () => {
+  describe('--no-strict', () => {
+    it('should not add options for strict mode', async () => {
       await applicationGenerator(appTree, {
         ...schema,
-        strict: true,
+        strict: false,
       });
       const tsconfigJson = readJson(appTree, '/apps/my-app/tsconfig.json');
 
-      expect(tsconfigJson.compilerOptions.strict).toBeTruthy();
       expect(
         tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
-      ).toBeTruthy();
-      expect(tsconfigJson.compilerOptions.noImplicitReturns).toBeTruthy();
+      ).not.toBeDefined();
+      expect(tsconfigJson.compilerOptions.strict).not.toBeDefined();
+      expect(tsconfigJson.compilerOptions.noImplicitOverride).not.toBeDefined();
+      expect(
+        tsconfigJson.compilerOptions.noPropertyAccessFromIndexSignature
+      ).not.toBeDefined();
+      expect(tsconfigJson.compilerOptions.noImplicitReturns).not.toBeDefined();
       expect(
         tsconfigJson.compilerOptions.noFallthroughCasesInSwitch
-      ).toBeTruthy();
+      ).not.toBeDefined();
     });
   });
 

--- a/packages/react/src/generators/application/lib/create-application-files.ts
+++ b/packages/react/src/generators/application/lib/create-application-files.ts
@@ -20,6 +20,8 @@ function updateTsConfig(host: Tree, options: NormalizedSchema) {
           ...json.compilerOptions,
           forceConsistentCasingInFileNames: true,
           strict: true,
+          noImplicitOverride: true,
+          noPropertyAccessFromIndexSignature: true,
           noImplicitReturns: true,
           noFallthroughCasesInSwitch: true,
         };

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -104,6 +104,10 @@ describe('lib', () => {
         tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
       ).toEqual(true);
       expect(tsconfigJson.compilerOptions.strict).toEqual(true);
+      expect(tsconfigJson.compilerOptions.noImplicitOverride).toEqual(true);
+      expect(
+        tsconfigJson.compilerOptions.noPropertyAccessFromIndexSignature
+      ).toEqual(true);
       expect(tsconfigJson.compilerOptions.noImplicitReturns).toEqual(true);
       expect(tsconfigJson.compilerOptions.noFallthroughCasesInSwitch).toEqual(
         true
@@ -630,6 +634,10 @@ describe('lib', () => {
         tsconfigJson.compilerOptions.forceConsistentCasingInFileNames
       ).not.toBeDefined();
       expect(tsconfigJson.compilerOptions.strict).not.toBeDefined();
+      expect(tsconfigJson.compilerOptions.noImplicitOverride).not.toBeDefined();
+      expect(
+        tsconfigJson.compilerOptions.noPropertyAccessFromIndexSignature
+      ).not.toBeDefined();
       expect(tsconfigJson.compilerOptions.noImplicitReturns).not.toBeDefined();
       expect(
         tsconfigJson.compilerOptions.noFallthroughCasesInSwitch

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -226,6 +226,8 @@ function updateTsConfig(tree: Tree, options: NormalizedSchema) {
           ...json.compilerOptions,
           forceConsistentCasingInFileNames: true,
           strict: true,
+          noImplicitOverride: true,
+          noPropertyAccessFromIndexSignature: true,
           noImplicitReturns: true,
           noFallthroughCasesInSwitch: true,
         };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/react:application` and `@nrwl/react:library` generators don't add following compiler options for strict mode.
- [noImplicitOverride](https://www.typescriptlang.org/tsconfig#noImplicitOverride)
- [noPropertyAccessFromIndexSignature](https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature)


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`noImplicitOverride` and `noPropertyAccessFromIndexSignature` are enabled for the newly created projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
#8121
