### PR TITLE
fix(angular): handle scam components when generating storybook stories

### DIFF
--- a/packages/angular/src/generators/stories/stories-app.spec.ts
+++ b/packages/angular/src/generators/stories/stories-app.spec.ts
@@ -1,6 +1,7 @@
 import type { Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { applicationGenerator } from '../application/application';
+import { scamGenerator } from '../scam/scam';
 import { angularStoriesGenerator } from './stories';
 
 describe('angularStories generator: applications', () => {
@@ -19,6 +20,34 @@ describe('angularStories generator: applications', () => {
 
     expect(
       tree.exists(`apps/${appName}/src/app/app.component.stories.ts`)
+    ).toBeTruthy();
+  });
+
+  it('should generate stories file for scam component', async () => {
+    await scamGenerator(tree, { name: 'my-scam', project: appName });
+
+    angularStoriesGenerator(tree, { name: appName });
+
+    expect(
+      tree.exists(
+        `apps/${appName}/src/app/my-scam/my-scam.component.stories.ts`
+      )
+    ).toBeTruthy();
+  });
+
+  it('should generate stories file for inline scam component', async () => {
+    await scamGenerator(tree, {
+      name: 'my-scam',
+      project: appName,
+      inlineScam: true,
+    });
+
+    angularStoriesGenerator(tree, { name: appName });
+
+    expect(
+      tree.exists(
+        `apps/${appName}/src/app/my-scam/my-scam.component.stories.ts`
+      )
     ).toBeTruthy();
   });
 

--- a/packages/angular/src/generators/stories/stories-lib.spec.ts
+++ b/packages/angular/src/generators/stories/stories-lib.spec.ts
@@ -3,6 +3,7 @@ import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { cypressProjectGenerator } from '@nrwl/storybook';
 import { libraryGenerator } from '../library/library';
+import { scamGenerator } from '../scam/scam';
 import { createStorybookTestWorkspaceForLib } from '../utils/testing';
 import { angularStoriesGenerator } from './stories';
 
@@ -227,6 +228,34 @@ describe('angularStories generator: libraries', () => {
       expect(
         tree.exists(
           `apps/${libName}-e2e/src/integration/cmp2/cmp2.component.spec.ts`
+        )
+      ).toBeTruthy();
+    });
+
+    it('should generate stories file for scam component', async () => {
+      await scamGenerator(tree, { name: 'my-scam', project: libName });
+
+      angularStoriesGenerator(tree, { name: libName });
+
+      expect(
+        tree.exists(
+          `libs/${libName}/src/lib/my-scam/my-scam.component.stories.ts`
+        )
+      ).toBeTruthy();
+    });
+
+    it('should generate stories file for inline scam component', async () => {
+      await scamGenerator(tree, {
+        name: 'my-scam',
+        project: libName,
+        inlineScam: true,
+      });
+
+      angularStoriesGenerator(tree, { name: libName });
+
+      expect(
+        tree.exists(
+          `libs/${libName}/src/lib/my-scam/my-scam.component.stories.ts`
         )
       ).toBeTruthy();
     });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating Storybook stories for an Angular project, stories are not generated for SCAM components.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Storybook stories should be generated correctly for all components in an Angular project. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8103 
