### PR TITLE
fix(angular): update default type for scam generation #8142

### DIFF
--- a/docs/angular/api-angular/generators/scam.md
+++ b/docs/angular/api-angular/generators/scam.md
@@ -147,7 +147,7 @@ The file extension or preprocessor to use for style files, or 'none' to skip gen
 
 ### type
 
-Default: `Component`
+Default: `component`
 
 Type: `string`
 

--- a/docs/node/api-angular/generators/scam.md
+++ b/docs/node/api-angular/generators/scam.md
@@ -147,7 +147,7 @@ The file extension or preprocessor to use for style files, or 'none' to skip gen
 
 ### type
 
-Default: `Component`
+Default: `component`
 
 Type: `string`
 

--- a/docs/react/api-angular/generators/scam.md
+++ b/docs/react/api-angular/generators/scam.md
@@ -147,7 +147,7 @@ The file extension or preprocessor to use for style files, or 'none' to skip gen
 
 ### type
 
-Default: `Component`
+Default: `component`
 
 Type: `string`
 

--- a/packages/angular/src/generators/scam/scam.spec.ts
+++ b/packages/angular/src/generators/scam/scam.spec.ts
@@ -210,4 +210,55 @@ describe('SCAM Generator', () => {
       }
     });
   });
+
+  describe('--type', () => {
+    it('should create the inline scam with default type', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace(2);
+      addProjectConfiguration(tree, 'app1', {
+        projectType: 'application',
+        sourceRoot: 'apps/app1/src',
+        root: 'apps/app1',
+      });
+
+      // ACT
+      await scamGenerator(tree, {
+        name: 'example',
+        project: 'app1',
+        inlineScam: true,
+        type: 'component',
+      });
+
+      // ASSERT
+      const componentSource = tree.read(
+        'apps/app1/src/app/example/example.component.ts',
+        'utf-8'
+      );
+      expect(componentSource).toMatchInlineSnapshot(`
+        "import { Component, OnInit, NgModule } from '@angular/core';
+        import { CommonModule } from '@angular/common';
+
+        @Component({
+          selector: 'example',
+          templateUrl: './example.component.html',
+          styleUrls: ['./example.component.css']
+        })
+        export class ExampleComponent implements OnInit {
+
+          constructor() { }
+
+          ngOnInit(): void {
+          }
+
+        }
+
+        @NgModule({
+          imports: [CommonModule],
+          declarations: [ExampleComponent],
+          exports: [ExampleComponent],
+        })
+        export class ExampleComponentModule {}"
+      `);
+    });
+  });
 });

--- a/packages/angular/src/generators/scam/schema.json
+++ b/packages/angular/src/generators/scam/schema.json
@@ -94,7 +94,7 @@
     "type": {
       "type": "string",
       "description": "Adds a developer-defined type to the filename, in the format \"name.type.ts\".",
-      "default": "Component"
+      "default": "component"
     },
     "prefix": {
       "type": "string",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating a SCAM component through the Nx console, the default type `Component` leads to a failure.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Properly generate a SCAM component with default type set to `component`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8142 
