### PR TITLE
feat(core): Add support for versioning in the preset package name

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -266,7 +266,10 @@ function determineWorkspaceName(parsedArgs: any): Promise<string> {
 
 async function determineThirdPartyPackage({ preset }) {
   if (preset && Object.values(Preset).indexOf(preset) === -1) {
-    const validateResult = validateNpmPackage(preset);
+    const packageName = preset.match(/.+@/)
+      ? preset[0] + preset.substring(1).split('@')[0]
+      : preset;
+    const validateResult = validateNpmPackage(packageName);
     if (validateResult.validForNewPackages) {
       return Promise.resolve(preset);
     } else {


### PR DESCRIPTION
When you use `npx create-nx-workspace --preset=mypackage@version` the `version` will now be supported.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
