### PR TITLE
fix(linter): remove @typescript-eslint/no-unused-vars override

### DIFF
--- a/e2e/react-native/src/react-native.test.ts
+++ b/e2e/react-native/src/react-native.test.ts
@@ -27,7 +27,7 @@ describe('react native', () => {
     );
 
     updateFile(`apps/${appName}/src/app/App.tsx`, (content) => {
-      let updated = `import ${componentName} from '${proj}/${libName}';\n${content}`;
+      let updated = `// eslint-disable-next-line @typescript-eslint/no-unused-vars\nimport ${componentName} from '${proj}/${libName}';\n${content}`;
       return updated;
     });
 

--- a/packages/eslint-plugin-nx/src/configs/typescript.ts
+++ b/packages/eslint-plugin-nx/src/configs/typescript.ts
@@ -32,12 +32,4 @@ export default {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-parameter-properties': 'off',
   },
-  overrides: [
-    {
-      files: ['*.tsx'],
-      rules: {
-        '@typescript-eslint/no-unused-vars': 'off',
-      },
-    },
-  ],
 };

--- a/packages/react/src/generators/application/files/css-module/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/css-module/src/app/__fileName__.tsx__tmpl__
@@ -1,6 +1,7 @@
 <% if (classComponent) { %>
 import { Component } from 'react';
 <% } %>
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import styles from './<%= fileName %>.module.<%= style %>';
 import NxWelcome from "./nx-welcome";
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`plugin:@nrwl/nx/typescript` ignores `@typescript-eslint/no-unused-vars` in `*.tsx` files, which means users always need to override the rule for React and Next.js projects. https://github.com/nrwl/nx/issues/8134#issuecomment-992528870

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`@typescript-eslint/no-unused-vars` should work out of the box for **`*.tsx`** files.

<img src="https://user-images.githubusercontent.com/2607019/145853352-44e3c670-21bd-4a02-9877-d86c7c1d31ee.png" width="640">


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Originally introduced #3882
Fixes #8134
Closes #8406