### PR TITLE
fix(angular): scam component default type as lowercase

### DIFF
--- a/docs/angular/api-angular/generators/scam.md
+++ b/docs/angular/api-angular/generators/scam.md
@@ -147,7 +147,7 @@ The file extension or preprocessor to use for style files, or 'none' to skip gen
 
 ### type
 
-Default: `Component`
+Default: `component`
 
 Type: `string`
 

--- a/docs/node/api-angular/generators/scam.md
+++ b/docs/node/api-angular/generators/scam.md
@@ -147,7 +147,7 @@ The file extension or preprocessor to use for style files, or 'none' to skip gen
 
 ### type
 
-Default: `Component`
+Default: `component`
 
 Type: `string`
 

--- a/docs/react/api-angular/generators/scam.md
+++ b/docs/react/api-angular/generators/scam.md
@@ -147,7 +147,7 @@ The file extension or preprocessor to use for style files, or 'none' to skip gen
 
 ### type
 
-Default: `Component`
+Default: `component`
 
 Type: `string`
 

--- a/packages/angular/src/generators/scam/schema.json
+++ b/packages/angular/src/generators/scam/schema.json
@@ -94,7 +94,7 @@
     "type": {
       "type": "string",
       "description": "Adds a developer-defined type to the filename, in the format \"name.type.ts\".",
-      "default": "Component"
+      "default": "component"
     },
     "prefix": {
       "type": "string",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Capital C in default type for Component causing incorrect file names

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Default should be small c

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8142
