### PR TITLE
fix(storybook): add missing outDir property in tsconfig of Angular Storybook projects

### DIFF
--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -72,6 +72,12 @@
       "cli": "nx",
       "description": "Adjust Storybook tsconfig to add styled-jsx typings",
       "factory": "./src/migrations/update-12-8-0/update-storybook-styled-jsx-typings"
+    },
+    "update-13-3.0": {
+      "version": "13.3.0",
+      "cli": "nx",
+      "description": "Adjust Storybook tsconfig to add outDir for Angular projects.",
+      "factory": "./src/migrations/update-13.3.0/update-angular-storybook-tsconfig-outdir"
     }
   },
   "packageJsonUpdates": {

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -36,7 +36,7 @@ describe('@nrwl/storybook:configuration', () => {
       uiFramework: '@storybook/angular',
       standaloneConfig: false,
     });
-
+  
     // Root
     expect(tree.exists('.storybook/tsconfig.json')).toBeTruthy();
     expect(tree.exists('.storybook/main.js')).toBeTruthy();
@@ -62,7 +62,7 @@ describe('@nrwl/storybook:configuration', () => {
     expect(tree.exists('libs/test-ui-lib/.storybook/main.js')).toBeTruthy();
     expect(tree.exists('libs/test-ui-lib/.storybook/preview.js')).toBeTruthy();
 
-    const storybookTsconfigJson = readJson<{ exclude: string[] }>(
+    const storybookTsconfigJson = readJson<{ exclude: string[], compilerOptions: { outDir: string }}>(
       tree,
       'libs/test-ui-lib/.storybook/tsconfig.json'
     );
@@ -78,7 +78,8 @@ describe('@nrwl/storybook:configuration', () => {
     ).toBeFalsy();
     expect(
       storybookTsconfigJson.exclude.includes('../**/*.spec.jsx')
-    ).toBeFalsy();
+    ).toBeFalsy();    
+    expect(storybookTsconfigJson.compilerOptions.outDir).toEqual('../../../dist/out-tsc');
   });
 
   it('should generate a webpackFinal into the main.js and reference a potential global webpackFinal definition', async () => {

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -36,7 +36,7 @@ describe('@nrwl/storybook:configuration', () => {
       uiFramework: '@storybook/angular',
       standaloneConfig: false,
     });
-  
+
     // Root
     expect(tree.exists('.storybook/tsconfig.json')).toBeTruthy();
     expect(tree.exists('.storybook/main.js')).toBeTruthy();
@@ -62,10 +62,10 @@ describe('@nrwl/storybook:configuration', () => {
     expect(tree.exists('libs/test-ui-lib/.storybook/main.js')).toBeTruthy();
     expect(tree.exists('libs/test-ui-lib/.storybook/preview.js')).toBeTruthy();
 
-    const storybookTsconfigJson = readJson<{ exclude: string[], compilerOptions: { outDir: string }}>(
-      tree,
-      'libs/test-ui-lib/.storybook/tsconfig.json'
-    );
+    const storybookTsconfigJson = readJson<{
+      exclude: string[];
+      compilerOptions: { outDir: string };
+    }>(tree, 'libs/test-ui-lib/.storybook/tsconfig.json');
 
     expect(
       storybookTsconfigJson.exclude.includes('../**/*.spec.ts')
@@ -78,8 +78,10 @@ describe('@nrwl/storybook:configuration', () => {
     ).toBeFalsy();
     expect(
       storybookTsconfigJson.exclude.includes('../**/*.spec.jsx')
-    ).toBeFalsy();    
-    expect(storybookTsconfigJson.compilerOptions.outDir).toEqual('../../../dist/out-tsc');
+    ).toBeFalsy();
+    expect(storybookTsconfigJson.compilerOptions.outDir).toEqual(
+      '../../../dist/out-tsc'
+    );
   });
 
   it('should generate a webpackFinal into the main.js and reference a potential global webpackFinal definition', async () => {

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true
     <% if(uiFramework === '@storybook/react') { %>, "outDir": "" <% } %>
+    <% if(uiFramework === '@storybook/angular') { %>, "outDir": "<%= offsetFromRoot %>../dist/out-tsc" <% } %>
   },
   <% if(uiFramework === '@storybook/react') { %>"files": [
     "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/styled-jsx.d.ts",

--- a/packages/storybook/src/migrations/update-13.3.0/__snapshots__/update-angular-storybook-tsconfig-outdir.spec.ts.snap
+++ b/packages/storybook/src/migrations/update-13.3.0/__snapshots__/update-angular-storybook-tsconfig-outdir.spec.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Add outdir to Storybook tsconfig when uiFramework is angular migration should add outDir compilerOption 1`] = `
+Object {
+  "compilerOptions": Object {
+    "emitDecoratorMetadata": true,
+    "outDir": "../../../../dist/out-tsc",
+  },
+  "exclude": Array [
+    "../**/*.spec.ts",
+  ],
+  "extends": "../tsconfig.json",
+  "include": Array [
+    "../src/**/*",
+    "*.js",
+  ],
+}
+`;

--- a/packages/storybook/src/migrations/update-13.3.0/update-angular-storybook-tsconfig-outdir.spec.ts
+++ b/packages/storybook/src/migrations/update-13.3.0/update-angular-storybook-tsconfig-outdir.spec.ts
@@ -1,0 +1,57 @@
+import { readJson, Tree, writeJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import addOutDirToAngularStorybookTsconfig from './update-angular-storybook-tsconfig-outdir';
+
+describe('Add outdir to Storybook tsconfig when uiFramework is angular migration', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+
+    writeJson(tree, 'workspace.json', {
+      projects: {
+        ['home-ui-angular']: {
+          projectType: 'application',
+          root: 'apps/myapps/ui-angular',
+          sourceRoot: 'apps/myapps/ui-angular/src',
+          targets: {
+            storybook: {
+              builder: '@nrwl/storybook:storybook',
+              options: {
+                uiFramework: '@storybook/angular',
+                port: 4400,
+                config: {
+                  configFolder: 'apps/myapps/ui-angular/.storybook',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    writeJson(tree, 'apps/myapps/ui-angular/.storybook/tsconfig.json', {
+      extends: '../tsconfig.json',
+      compilerOptions: {
+        emitDecoratorMetadata: true,
+        // apps/myapps/ui-angular/.storybook -> should be 4 directories up to root
+        outDir: '../../../../dist/out-tsc'
+      },
+      
+      exclude: [
+        '../**/*.spec.ts',        
+      ],
+      include: ['../src/**/*', '*.js'],
+    });
+  });
+
+  it(`should add outDir compilerOption`, async () => {
+    await addOutDirToAngularStorybookTsconfig(tree);
+
+    const tsConfigContent = readJson(
+      tree,
+      'apps/myapps/ui-angular/.storybook/tsconfig.json'
+    );
+    expect(tsConfigContent).toMatchSnapshot();
+  });
+});

--- a/packages/storybook/src/migrations/update-13.3.0/update-angular-storybook-tsconfig-outdir.spec.ts
+++ b/packages/storybook/src/migrations/update-13.3.0/update-angular-storybook-tsconfig-outdir.spec.ts
@@ -35,12 +35,10 @@ describe('Add outdir to Storybook tsconfig when uiFramework is angular migration
       compilerOptions: {
         emitDecoratorMetadata: true,
         // apps/myapps/ui-angular/.storybook -> should be 4 directories up to root
-        outDir: '../../../../dist/out-tsc'
+        outDir: '../../../../dist/out-tsc',
       },
-      
-      exclude: [
-        '../**/*.spec.ts',        
-      ],
+
+      exclude: ['../**/*.spec.ts'],
       include: ['../src/**/*', '*.js'],
     });
   });

--- a/packages/storybook/src/migrations/update-13.3.0/update-angular-storybook-tsconfig-outdir.ts
+++ b/packages/storybook/src/migrations/update-13.3.0/update-angular-storybook-tsconfig-outdir.ts
@@ -1,0 +1,72 @@
+import {
+  formatFiles,
+  getProjects,
+  joinPathFragments,
+  logger,
+  offsetFromRoot,
+  readJson,
+  Tree,
+  writeJson,
+} from '@nrwl/devkit';
+import * as path from 'path';
+import { isFramework, TsConfig } from '../../utils/utilities';
+
+/**
+ * Migration that adds the outDir property to the compilerOptions in the Storybook configuration.
+ * It will look up all Storybook Projects and update only the one using Angular as uiFramework.
+ * @param tree virtual file system tree representing the physical file system we want to modify
+ */
+export default async function addOutDirToAngularStorybookTsconfig(tree: Tree) {
+  let changesMade = false;
+  const projects = getProjects(tree);
+
+  projects.forEach((projectConfig, projectName) => {
+    const targets = projectConfig.targets;
+    const storybookRoot = path.join(projectConfig.root, '.storybook');
+
+    const paths = {
+      tsConfigStorybook: joinPathFragments(
+        projectConfig.root,
+        '.storybook/tsconfig.json'
+      ),
+    };
+
+    const storybookExecutor =
+      targets &&
+      Object.keys(targets).find(
+        (x) => targets[x].executor === '@nrwl/storybook:storybook'
+      );
+
+    const hasStorybookConfig =
+      storybookExecutor && tree.exists(paths.tsConfigStorybook);
+
+    if (!hasStorybookConfig) {
+      logger.info(
+        `${projectName}: no storybook configured. skipping migration...`
+      );
+      return;
+    }
+
+    const isAngularProject = isFramework('angular', {
+      uiFramework: targets[storybookExecutor].options
+        ?.uiFramework as Parameters<typeof isFramework>[1]['uiFramework'],
+    });
+
+    if (isAngularProject) {
+      const tsConfig = {
+        storybook: readJson<TsConfig>(tree, paths.tsConfigStorybook),
+      };
+
+      tsConfig.storybook.compilerOptions.outDir = `${offsetFromRoot(
+        storybookRoot
+      )}dist/out-tsc`
+
+      writeJson(tree, paths.tsConfigStorybook, tsConfig.storybook);
+      changesMade = true;
+    }
+  });
+
+  if (changesMade) {
+    await formatFiles(tree);
+  }
+}

--- a/packages/storybook/src/migrations/update-13.3.0/update-angular-storybook-tsconfig-outdir.ts
+++ b/packages/storybook/src/migrations/update-13.3.0/update-angular-storybook-tsconfig-outdir.ts
@@ -59,7 +59,7 @@ export default async function addOutDirToAngularStorybookTsconfig(tree: Tree) {
 
       tsConfig.storybook.compilerOptions.outDir = `${offsetFromRoot(
         storybookRoot
-      )}dist/out-tsc`
+      )}dist/out-tsc`;
 
       writeJson(tree, paths.tsConfigStorybook, tsConfig.storybook);
       changesMade = true;


### PR DESCRIPTION
## Current Behavior
After adding allowJs: true to tsconfig.base.json of the repository, the Storybook build fails for Angular projects. This is caused by a missing outDir property inside the ./storybook/tsconfig.json file.

## Expected Behavior
The outDir property is set correctly to be dist/out-tsc. 
The storybook build does not fail.

## Related Issue(s)
https://github.com/nrwl/nx/issues/7825

Fixes #7825
