### PR TITLE
fix(core): nested node_modules packages shouldn't be inferred as nx projects

### DIFF
--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -663,6 +663,7 @@ export function globForProjectFiles(root) {
    */
   const ALWAYS_IGNORE = [
     join(root, 'node_modules'),
+    '**/node_modules',
     join(root, 'dist'),
     join(root, '.git'),
   ];


### PR DESCRIPTION
## Current Behavior
Packages under nested node_modules are detected as a project when `workspace.json` is not present

## Expected Behavior
Packages under nested node_modules are not detected as a project when `workspace.json` is not present

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
