### PR TITLE
fix(nextjs): incorrectly named nested page component files

### DIFF
--- a/docs/angular/api-react/generators/component.md
+++ b/docs/angular/api-react/generators/component.md
@@ -89,6 +89,12 @@ Type: `boolean`
 
 When true, the component is exported from the project index.ts (if it exists).
 
+### fileName
+
+Type: `string`
+
+Create a component with this file name.
+
 ### flat
 
 Default: `false`

--- a/docs/node/api-react/generators/component.md
+++ b/docs/node/api-react/generators/component.md
@@ -89,6 +89,12 @@ Type: `boolean`
 
 When true, the component is exported from the project index.ts (if it exists).
 
+### fileName
+
+Type: `string`
+
+Create a component with this file name.
+
 ### flat
 
 Default: `false`

--- a/docs/react/api-react/generators/component.md
+++ b/docs/react/api-react/generators/component.md
@@ -89,6 +89,12 @@ Type: `boolean`
 
 When true, the component is exported from the project index.ts (if it exists).
 
+### fileName
+
+Type: `string`
+
+Create a component with this file name.
+
 ### flat
 
 Default: `false`

--- a/packages/next/src/generators/page/page.spec.ts
+++ b/packages/next/src/generators/page/page.spec.ts
@@ -24,9 +24,9 @@ describe('component', () => {
       style: 'css',
     });
 
-    expect(tree.exists('apps/my-app/pages/hello/hello.tsx')).toBeTruthy();
+    expect(tree.exists('apps/my-app/pages/hello/index.tsx')).toBeTruthy();
     expect(
-      tree.exists('apps/my-app/pages/hello/hello.module.css')
+      tree.exists('apps/my-app/pages/hello/index.module.css')
     ).toBeTruthy();
   });
 
@@ -39,14 +39,14 @@ describe('component', () => {
     });
 
     expect(
-      tree.exists('apps/my-app/pages/posts/[dynamic]/[dynamic].tsx')
+      tree.exists('apps/my-app/pages/posts/[dynamic]/index.tsx')
     ).toBeTruthy();
     expect(
-      tree.exists('apps/my-app/pages/posts/[dynamic]/[dynamic].module.css')
+      tree.exists('apps/my-app/pages/posts/[dynamic]/index.module.css')
     ).toBeTruthy();
 
     const content = tree
-      .read('apps/my-app/pages/posts/[dynamic]/[dynamic].tsx')
+      .read('apps/my-app/pages/posts/[dynamic]/index.tsx')
       .toString();
     expect(content).toMatch(/DynamicProps/);
   });

--- a/packages/next/src/generators/page/page.ts
+++ b/packages/next/src/generators/page/page.ts
@@ -1,5 +1,10 @@
 import { componentGenerator as reactComponentGenerator } from '@nrwl/react';
-import { convertNxGenerator, Tree } from '@nrwl/devkit';
+import {
+  convertNxGenerator,
+  Tree,
+  names,
+  readProjectConfiguration,
+} from '@nrwl/devkit';
 
 import { addStyleDependencies } from '../../utils/styles';
 import { Schema } from './schema';
@@ -11,15 +16,17 @@ import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-ser
  * it is under `pages` folder.
  */
 export async function pageGenerator(host: Tree, options: Schema) {
+  const directory = options.directory ? `pages/${options.directory}` : 'pages';
   const componentTask = await reactComponentGenerator(host, {
     ...options,
-    directory: options.directory ? `pages/${options.directory}` : 'pages',
+    directory,
     pascalCaseFiles: false,
     export: false,
     classComponent: false,
     routing: false,
     skipTests: !options.withTests,
     flat: !!options.flat,
+    fileName: !options.flat ? 'index' : undefined,
   });
 
   const styledTask = addStyleDependencies(host, options.style);

--- a/packages/react/src/generators/component/component.ts
+++ b/packages/react/src/generators/component/component.ts
@@ -138,7 +138,8 @@ async function normalizeOptions(
   assertValidOptions(options);
 
   const { className, fileName } = names(options.name);
-  const componentFileName = options.pascalCaseFiles ? className : fileName;
+  const componentFileName =
+    options.fileName ?? (options.pascalCaseFiles ? className : fileName);
   const project = getProjects(host).get(options.project);
 
   if (!project) {

--- a/packages/react/src/generators/component/schema.d.ts
+++ b/packages/react/src/generators/component/schema.d.ts
@@ -14,4 +14,5 @@ export interface Schema {
   js?: boolean;
   flat?: boolean;
   globalCss?: boolean;
+  fileName?: string;
 }

--- a/packages/react/src/generators/component/schema.json
+++ b/packages/react/src/generators/component/schema.json
@@ -127,6 +127,10 @@
       "type": "boolean",
       "description": "Default is false. When true, the component is generated with *.css/*.scss instead of *.module.css/*.module.scss",
       "default": false
+    },
+    "fileName": {
+      "type": "string",
+      "description": "Create a component with this file name."
     }
   },
   "required": ["name", "project"]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when using `flat = false` option - generated page components are generated with an incorrect file name. files should be named `index.tsx`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
