### PR TITLE
fix(core): default project name should be inferred by cwd on windows

### DIFF
--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -265,7 +265,7 @@ export class Workspaces {
   constructor(private root: string) {}
 
   relativeCwd(cwd: string) {
-    return path.relative(this.root, cwd) || null;
+    return path.relative(this.root, cwd).replace(/\\/g, '/') || null;
   }
 
   calculateDefaultProjectName(


### PR DESCRIPTION
## Current Behavior
Default project inference fails on windows

## Expected Behavior
Default project inference works on windows

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8022
