### PR TITLE
feat(core): commands can wait for other commands

### DIFF
--- a/docs/angular/api-workspace/executors/run-commands.md
+++ b/docs/angular/api-workspace/executors/run-commands.md
@@ -133,6 +133,38 @@ nx run frontend:finish-when-ready
 
 The above commands will finish immediately, instead of waiting for 5 seconds.
 
+##### Custom **done** conditions per command and waiting for other commands
+
+Additionally, each command can specify a prior command to wait for using the `waitUntilCommand` property. This can be combined with individual commands having a `readyWhen` condition set to orchestrate some complex scenarios, such as waiting for your API to be stable and serving traffic before starting the web app.
+
+```json
+"serve-with-api": {
+    "executor": "@nrwl/workspace:run-commands",
+    "options": {
+        "commands": [
+            {
+                "name": "serveApi",
+                "command": "nx serve nest-api",
+                "readyWhen": "No issues found."
+            },
+            {
+                "name": "waitForApi",
+                "command": "ECHO 'Waiting for API...' && until curl --silent https://my-api:3333/api/health-check | grep 'OK'; do sleep 0.5; echo '  performing health check...'; done;",
+                "waitUntilCommand": "serveApi"
+            },
+            {
+                "command": "nx serve react-app-vitejs",
+                "waitUntilCommand": "waitForApi"
+            }
+        ]
+    }
+},
+```
+
+```bash
+nx run frontend:serve-with-api
+```
+
 ##### Nx Affected
 
 The true power of `run-commands` comes from the fact that it runs through `nx`, which knows about your dependency graph. So you can run **custom commands** only for the projects that have been affected by a change.

--- a/docs/node/api-workspace/executors/run-commands.md
+++ b/docs/node/api-workspace/executors/run-commands.md
@@ -133,6 +133,38 @@ nx run frontend:finish-when-ready
 
 The above commands will finish immediately, instead of waiting for 5 seconds.
 
+##### Custom **done** conditions per command and waiting for other commands
+
+Additionally, each command can specify a prior command to wait for using the `waitUntilCommand` property. This can be combined with individual commands having a `readyWhen` condition set to orchestrate some complex scenarios, such as waiting for your API to be stable and serving traffic before starting the web app.
+
+```json
+"serve-with-api": {
+    "executor": "@nrwl/workspace:run-commands",
+    "options": {
+        "commands": [
+            {
+                "name": "serveApi",
+                "command": "nx serve nest-api",
+                "readyWhen": "No issues found."
+            },
+            {
+                "name": "waitForApi",
+                "command": "ECHO 'Waiting for API...' && until curl --silent https://my-api:3333/api/health-check | grep 'OK'; do sleep 0.5; echo '  performing health check...'; done;",
+                "waitUntilCommand": "serveApi"
+            },
+            {
+                "command": "nx serve react-app-vitejs",
+                "waitUntilCommand": "waitForApi"
+            }
+        ]
+    }
+},
+```
+
+```bash
+nx run frontend:serve-with-api
+```
+
 ##### Nx Affected
 
 The true power of `run-commands` comes from the fact that it runs through `nx`, which knows about your dependency graph. So you can run **custom commands** only for the projects that have been affected by a change.

--- a/docs/react/api-workspace/executors/run-commands.md
+++ b/docs/react/api-workspace/executors/run-commands.md
@@ -133,6 +133,38 @@ nx run frontend:finish-when-ready
 
 The above commands will finish immediately, instead of waiting for 5 seconds.
 
+##### Custom **done** conditions per command and waiting for other commands
+
+Additionally, each command can specify a prior command to wait for using the `waitUntilCommand` property. This can be combined with individual commands having a `readyWhen` condition set to orchestrate some complex scenarios, such as waiting for your API to be stable and serving traffic before starting the web app.
+
+```json
+"serve-with-api": {
+    "executor": "@nrwl/workspace:run-commands",
+    "options": {
+        "commands": [
+            {
+                "name": "serveApi",
+                "command": "nx serve nest-api",
+                "readyWhen": "No issues found."
+            },
+            {
+                "name": "waitForApi",
+                "command": "ECHO 'Waiting for API...' && until curl --silent https://my-api:3333/api/health-check | grep 'OK'; do sleep 0.5; echo '  performing health check...'; done;",
+                "waitUntilCommand": "serveApi"
+            },
+            {
+                "command": "nx serve react-app-vitejs",
+                "waitUntilCommand": "waitForApi"
+            }
+        ]
+    }
+},
+```
+
+```bash
+nx run frontend:serve-with-api
+```
+
 ##### Nx Affected
 
 The true power of `run-commands` comes from the fact that it runs through `nx`, which knows about your dependency graph. So you can run **custom commands** only for the projects that have been affected by a change.

--- a/packages/workspace/docs/run-commands-examples.md
+++ b/packages/workspace/docs/run-commands-examples.md
@@ -120,6 +120,38 @@ Normally, `run-commands` considers the commands done when all of them have finis
 
 The above commands will finish immediately, instead of waiting for 5 seconds.
 
+##### Custom **done** conditions per command and waiting for other commands
+
+Additionally, each command can specify a prior command to wait for using the `waitUntilCommand` property. This can be combined with individual commands having a `readyWhen` condition set to orchestrate some complex scenarios, such as waiting for your API to be stable and serving traffic before starting the web app.
+
+```json
+"serve-with-api": {
+    "executor": "@nrwl/workspace:run-commands",
+    "options": {
+        "commands": [
+            {
+                "name": "serveApi",
+                "command": "nx serve nest-api",
+                "readyWhen": "No issues found."
+            },
+            {
+                "name": "waitForApi",
+                "command": "ECHO 'Waiting for API...' && until curl --silent https://my-api:3333/api/health-check | grep 'OK'; do sleep 0.5; echo '  performing health check...'; done;",
+                "waitUntilCommand": "serveApi"
+            },
+            {
+                "command": "nx serve react-app-vitejs",
+                "waitUntilCommand": "waitForApi"
+            }
+        ]
+    }
+},
+```
+
+```bash
+<%= cli %> run frontend:serve-with-api
+```
+
 ##### Nx Affected
 
 The true power of `run-commands` comes from the fact that it runs through `nx`, which knows about your dependency graph. So you can run **custom commands** only for the projects that have been affected by a change.

--- a/packages/workspace/src/executors/run-commands/schema.json
+++ b/packages/workspace/src/executors/run-commands/schema.json
@@ -24,6 +24,18 @@
               "description": {
                 "type": "string",
                 "description": "An optional description useful for inline documentation purposes. It is not used as part of the execution of the command"
+              },
+              "name": {
+                "type": "string",
+                "description": "(optional) An optional name for the command which can be used if another command depends on this command using `waitUntilCommand`"
+              },
+              "readyWhen": {
+                "type": "string",
+                "description": "(optional) String to appear in `stdout` or `stderr` that indicates that the task is ready.  Meant to be used with `waitUntilCommand` to indicate when a command has completed.  This is useful when running multiple watchers that might require another watcher to be stable, such as serving an API _then_ serving the app"
+              },
+              "waitUntilCommand": {
+                "type": "string",
+                "description": "(optional) An optional description useful for inline documentation purposes. It is not used as part of the execution of the command"
               }
             },
             "additionalProperties": false,


### PR DESCRIPTION
* allows setting `readyWhen` option on individual commands
* allows setting `waitForCommand` on commands that allows commands to fan-in and fan-out

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Currently there is not a way to orchestrate more complex workflows.  The current `readyWhen` setting only works on a per target basis and will complete the entire chain of commands as soon as the condition is met.

## Expected Behavior

This change is fully backwards compatible to the existing API and adds new functionality to allow fanning-in and fanning-out a series of commands to orchestrate more complex workflows.  See updated documentation for an example.

## Related Issue(s)

This is primarily related to #3748 which I believe could solve that use case.  My immediate use case was wanting to serve my API and ensure it’s stable before serving the web app.

* https://github.com/nrwl/nx/issues/3748
* https://github.com/nrwl/nx-console/issues/957


