### PR TITLE
feat(testing): add --compiler=tsc|swc|babel option for jest project generator

### DIFF
--- a/docs/angular/api-web/generators/application.md
+++ b/docs/angular/api-web/generators/application.md
@@ -33,14 +33,6 @@ nx g application ... --dry-run
 
 ## Options
 
-### babelJest
-
-Default: `false`
-
-Type: `boolean`
-
-Use babel instead ts-jest
-
 ### compiler
 
 Default: `babel`

--- a/docs/node/api-web/generators/application.md
+++ b/docs/node/api-web/generators/application.md
@@ -33,14 +33,6 @@ nx g application ... --dry-run
 
 ## Options
 
-### babelJest
-
-Default: `false`
-
-Type: `boolean`
-
-Use babel instead ts-jest
-
 ### compiler
 
 Default: `babel`

--- a/docs/react/api-web/generators/application.md
+++ b/docs/react/api-web/generators/application.md
@@ -33,14 +33,6 @@ nx g application ... --dry-run
 
 ## Options
 
-### babelJest
-
-Default: `false`
-
-Type: `boolean`
-
-Use babel instead ts-jest
-
 ### compiler
 
 Default: `babel`

--- a/packages/gatsby/src/generators/application/lib/add-jest.ts
+++ b/packages/gatsby/src/generators/application/lib/add-jest.ts
@@ -12,7 +12,7 @@ export async function addJest(host: Tree, options: NormalizedSchema) {
     supportTsx: true,
     skipSerializers: true,
     setupFile: 'none',
-    babelJest: true,
+    compiler: 'babel',
   });
 
   updateJson(host, `${options.projectRoot}/tsconfig.spec.json`, (json) => {

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -37,11 +37,31 @@ describe('jest', () => {
     expect(packageJson.devDependencies['ts-jest']).toBeDefined();
   });
 
-  describe('--babelJest', () => {
+  describe('Deprecated: --babelJest', () => {
     it('should add babel dependencies', async () => {
       jestInitGenerator(tree, { babelJest: true });
       const packageJson = readJson(tree, 'package.json');
       expect(packageJson.devDependencies['babel-jest']).toBeDefined();
+    });
+  });
+
+  describe('--compiler', () => {
+    it('should support tsc compiler', () => {
+      jestInitGenerator(tree, { compiler: 'tsc' });
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['ts-jest']).toBeDefined();
+    });
+
+    it('should support babel compiler', () => {
+      jestInitGenerator(tree, { compiler: 'babel' });
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['babel-jest']).toBeDefined();
+    });
+
+    it('should support swc compiler', () => {
+      jestInitGenerator(tree, { compiler: 'swc' });
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@swc/jest']).toBeDefined();
     });
   });
 

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -3,8 +3,9 @@ import {
   jestTypesVersion,
   jestVersion,
   nxVersion,
-  tslibVersion,
+  swcJestVersion,
   tsJestVersion,
+  tslibVersion,
 } from '../../utils/versions';
 import { JestInitSchema } from './schema';
 import {
@@ -18,7 +19,7 @@ import {
 interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}
 
 const schemaDefaults = {
-  babelJest: false,
+  compiler: 'tsc',
 } as const;
 
 function removeNrwlJestFromDeps(host: Tree) {
@@ -63,11 +64,14 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
     '@nrwl/jest': nxVersion,
     jest: jestVersion,
     '@types/jest': jestTypesVersion,
-    'ts-jest': tsJestVersion,
   };
 
-  if (options.babelJest) {
+  if (options.compiler === 'babel' || options.babelJest) {
     devDeps['babel-jest'] = babelJestVersion;
+  } else if (options.compiler === 'swc') {
+    devDeps['@swc/jest'] = swcJestVersion;
+  } else {
+    devDeps['ts-jest'] = tsJestVersion;
   }
 
   return addDependenciesToPackageJson(tree, dependencies, devDeps);

--- a/packages/jest/src/generators/init/schema.d.ts
+++ b/packages/jest/src/generators/init/schema.d.ts
@@ -1,3 +1,7 @@
 export interface JestInitSchema {
+  compiler?: 'tsc' | 'swc' | 'babel';
+  /**
+   * @deprecated
+   */
   babelJest?: boolean;
 }

--- a/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
+++ b/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`jestProject --babelJest should generate proper jest.transform when --compiler=swc and supportTsx is true 1`] = `
+"module.exports = {
+  displayName: 'lib1',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\\\\\\\.[tj]sx?$': ['@swc/jest', { jsc: { transform: { react: { runtime: 'automatic' } } } }]
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/lib1'
+};
+"
+`;
+
 exports[`jestProject --babelJest should generate proper jest.transform when babelJest and supportTsx is true 1`] = `
 "module.exports = {
   displayName: 'lib1',
@@ -7,7 +20,7 @@ exports[`jestProject --babelJest should generate proper jest.transform when babe
   transform: {
     '^.+\\\\\\\\.[tj]sx?$': 'babel-jest'
   },
-    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/libs/lib1'
 };
 "
@@ -20,7 +33,7 @@ exports[`jestProject --babelJest should generate proper jest.transform when babe
   transform: {
     '^.+\\\\\\\\.[tj]s$': 'babel-jest'
   },
-    moduleFileExtensions: ['ts', 'js', 'html'],
+  moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/libs/lib1'
 };
 "

--- a/packages/jest/src/generators/jest-project/files/jest.config.js__tmpl__
+++ b/packages/jest/src/generators/jest-project/files/jest.config.js__tmpl__
@@ -9,9 +9,8 @@ module.exports = {
   },<% } %><% if(testEnvironment) { %>
   testEnvironment: '<%= testEnvironment %>',<% } %><% if(skipSerializers){ %>
   transform: {
-    <% if (supportTsx){ %>'^.+\\.[tj]sx?$'<% } else { %>'^.+\\.[tj]s$'<% } %>: <% if (transformer == 'babel-jest') { %>'babel-jest'<% } else { %> 'ts-jest' <% } %>
-  },<% if (supportTsx) { %>
-    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],<% } else { %>
-    moduleFileExtensions: ['ts', 'js', 'html'],<% } %><% } %>
+    <% if (supportTsx){ %>'^.+\\.[tj]sx?$'<% } else { %>'^.+\\.[tj]s$'<% } %>: <% if (supportTsx && transformer === '@swc/jest') { %>['<%= transformer %>', { jsc: { transform: { react: { runtime: 'automatic' } } } }]<% } else { %>'<%= transformer %>'<% } %>
+  },
+  <% if (supportTsx) { %>moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],<% } else { %>moduleFileExtensions: ['ts', 'js', 'html'],<% } %><% } %>
   coverageDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>'
 };

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -19,8 +19,8 @@ describe('jestProject', () => {
     skipSerializers: false,
     testEnvironment: 'jsdom',
     setupFile: 'none',
-    babelJest: false,
     skipFormat: false,
+    compiler: 'tsc',
   };
 
   beforeEach(async () => {
@@ -286,6 +286,16 @@ describe('jestProject', () => {
         ...defaultOptions,
         project: 'lib1',
         babelJest: true,
+        supportTsx: true,
+      } as JestProjectSchema);
+      expect(tree.read('libs/lib1/jest.config.js', 'utf-8')).toMatchSnapshot();
+    });
+
+    it('should generate proper jest.transform when --compiler=swc and supportTsx is true', async () => {
+      await jestProjectGenerator(tree, {
+        ...defaultOptions,
+        project: 'lib1',
+        compiler: 'swc',
         supportTsx: true,
       } as JestProjectSchema);
       expect(tree.read('libs/lib1/jest.config.js', 'utf-8')).toMatchSnapshot();

--- a/packages/jest/src/generators/jest-project/jest-project.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.ts
@@ -27,8 +27,12 @@ function normalizeOptions(options: JestProjectSchema) {
     options.supportTsx = false;
   }
 
-  // if we support TSX or babelJest we don't support angular(html templates)
-  if (options.supportTsx || options.babelJest) {
+  // if we support TSX or compiler is not tsc, then we don't support angular(html templates)
+  if (
+    options.supportTsx ||
+    options.babelJest ||
+    ['swc', 'babel'].includes(options.compiler)
+  ) {
     options.skipSerializers = true;
   }
 

--- a/packages/jest/src/generators/jest-project/lib/create-files.ts
+++ b/packages/jest/src/generators/jest-project/lib/create-files.ts
@@ -13,10 +13,19 @@ export function createFiles(tree: Tree, options: JestProjectSchema) {
   const filesFolder =
     options.setupFile === 'angular' ? '../files-angular' : '../files';
 
+  let transformer: string;
+  if (options.compiler === 'babel' || options.babelJest) {
+    transformer = 'babel-jest';
+  } else if (options.compiler === 'swc') {
+    transformer = '@swc/jest';
+  } else {
+    transformer = 'ts-jest';
+  }
+
   generateFiles(tree, join(__dirname, filesFolder), projectConfig.root, {
     tmpl: '',
     ...options,
-    transformer: options.babelJest ? 'babel-jest' : 'ts-jest',
+    transformer,
     projectRoot: projectConfig.root,
     offsetFromRoot: offsetFromRoot(projectConfig.root),
   });

--- a/packages/jest/src/generators/jest-project/schema.d.ts
+++ b/packages/jest/src/generators/jest-project/schema.d.ts
@@ -8,6 +8,10 @@ export interface JestProjectSchema {
   setupFile?: 'angular' | 'web-components' | 'none';
   skipSerializers?: boolean;
   testEnvironment?: 'node' | 'jsdom' | '';
+  /**
+   * @deprecated
+   */
   babelJest?: boolean;
   skipFormat?: boolean;
+  compiler?: 'tsc' | 'swc' | 'babel';
 }

--- a/packages/jest/src/generators/jest-project/schema.json
+++ b/packages/jest/src/generators/jest-project/schema.json
@@ -40,10 +40,17 @@
       "description": "The test environment for jest",
       "default": "jsdom"
     },
+    "compiler": {
+      "type": "string",
+      "enum": ["tsc", "swc", "babel"],
+      "description": "The compiler to use for source and tests",
+      "default": "tsc"
+    },
     "babelJest": {
       "type": "boolean",
       "alias": "babel-jest",
-      "description": "Use babel-jest instead of ts-jest",
+      "description": "Use babel-jest instead of ts-jest (Deprecated: Use --compiler=babel instead)",
+      "x-deprecated": true,
       "default": false
     },
     "skipFormat": {

--- a/packages/jest/src/utils/versions.ts
+++ b/packages/jest/src/utils/versions.ts
@@ -4,3 +4,4 @@ export const jestTypesVersion = '27.0.2';
 export const tslibVersion = '^2.0.0';
 export const tsJestVersion = '27.0.5';
 export const babelJestVersion = '27.2.3';
+export const swcJestVersion = '0.2.15';

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -126,27 +126,27 @@ describe('lib', () => {
         await libraryGenerator(tree, { ...defaultOptions, name: 'myLib' });
         const tsconfigJson = readJson(tree, 'libs/my-lib/tsconfig.json');
         expect(tsconfigJson).toMatchInlineSnapshot(`
-        Object {
-          "compilerOptions": Object {
-            "forceConsistentCasingInFileNames": true,
-            "module": "CommonJS",
-            "noFallthroughCasesInSwitch": true,
-            "noImplicitReturns": true,
-            "strict": true,
-          },
-          "extends": "../../tsconfig.base.json",
-          "files": Array [],
-          "include": Array [],
-          "references": Array [
-            Object {
-              "path": "./tsconfig.lib.json",
-            },
-            Object {
-              "path": "./tsconfig.spec.json",
-            },
-          ],
-        }
-      `);
+                  Object {
+                    "compilerOptions": Object {
+                      "forceConsistentCasingInFileNames": true,
+                      "module": "CommonJS",
+                      "noFallthroughCasesInSwitch": true,
+                      "noImplicitReturns": true,
+                      "strict": true,
+                    },
+                    "extends": "../../tsconfig.base.json",
+                    "files": Array [],
+                    "include": Array [],
+                    "references": Array [
+                      Object {
+                        "path": "./tsconfig.lib.json",
+                      },
+                      Object {
+                        "path": "./tsconfig.spec.json",
+                      },
+                    ],
+                  }
+              `);
       });
     });
 
@@ -571,40 +571,40 @@ describe('lib', () => {
         ).toEqual(['libs/my-dir/my-lib/**/*.js']);
         expect(readJson(tree, 'libs/my-dir/my-lib/.eslintrc.json'))
           .toMatchInlineSnapshot(`
-        Object {
-          "extends": Array [
-            "../../../.eslintrc.json",
-          ],
-          "ignorePatterns": Array [
-            "!**/*",
-          ],
-          "overrides": Array [
-            Object {
-              "files": Array [
-                "*.ts",
-                "*.tsx",
-                "*.js",
-                "*.jsx",
-              ],
-              "rules": Object {},
-            },
-            Object {
-              "files": Array [
-                "*.ts",
-                "*.tsx",
-              ],
-              "rules": Object {},
-            },
-            Object {
-              "files": Array [
-                "*.js",
-                "*.jsx",
-              ],
-              "rules": Object {},
-            },
-          ],
-        }
-      `);
+                  Object {
+                    "extends": Array [
+                      "../../../.eslintrc.json",
+                    ],
+                    "ignorePatterns": Array [
+                      "!**/*",
+                    ],
+                    "overrides": Array [
+                      Object {
+                        "files": Array [
+                          "*.ts",
+                          "*.tsx",
+                          "*.js",
+                          "*.jsx",
+                        ],
+                        "rules": Object {},
+                      },
+                      Object {
+                        "files": Array [
+                          "*.ts",
+                          "*.tsx",
+                        ],
+                        "rules": Object {},
+                      },
+                      Object {
+                        "files": Array [
+                          "*.js",
+                          "*.jsx",
+                        ],
+                        "rules": Object {},
+                      },
+                    ],
+                  }
+              `);
       });
     });
   });
@@ -636,9 +636,9 @@ describe('lib', () => {
             }
           },
           transform: {
-            '^.+\\\\\\\\.[tj]sx?$':  'ts-jest' 
+            '^.+\\\\\\\\.[tj]sx?$': 'ts-jest'
           },
-            moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+          moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
           coverageDirectory: '../../coverage/libs/my-lib'
         };
         "

--- a/packages/linter/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
+++ b/packages/linter/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
@@ -91,9 +91,9 @@ exports[`@nrwl/linter:workspace-rules-project should generate the required files
     }
   },
   transform: {
-    '^.+\\\\\\\\.[tj]s$':  'ts-jest' 
+    '^.+\\\\\\\\.[tj]s$': 'ts-jest'
   },
-    moduleFileExtensions: ['ts', 'js', 'html'],
+  moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/tools/eslint-rules',\\"moduleNameMapper\\": {\\"@eslint/eslintrc\\":\\"@eslint/eslintrc/dist/eslintrc-universal.cjs\\"}
 };
 "

--- a/packages/linter/src/generators/workspace-rules-project/workspace-rules-project.ts
+++ b/packages/linter/src/generators/workspace-rules-project/workspace-rules-project.ts
@@ -57,7 +57,7 @@ export async function lintWorkspaceRulesProjectGenerator(tree: Tree) {
     supportTsx: false,
     skipSerializers: true,
     setupFile: 'none',
-    babelJest: false,
+    compiler: 'tsc',
   });
 
   // Add extra config to the jest.config.js file to allow ESLint 8 exports mapping to work with jest

--- a/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -11,9 +11,9 @@ exports[`lib --testEnvironment should set target jest testEnvironment to jsdom 1
   },
   testEnvironment: 'node',
   transform: {
-    '^.+\\\\\\\\.[tj]sx?$':  'ts-jest' 
+    '^.+\\\\\\\\.[tj]sx?$': 'ts-jest'
   },
-    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/libs/my-lib'
 };
 "
@@ -30,9 +30,9 @@ exports[`lib --testEnvironment should set target jest testEnvironment to node by
   },
   testEnvironment: 'node',
   transform: {
-    '^.+\\\\\\\\.[tj]sx?$':  'ts-jest' 
+    '^.+\\\\\\\\.[tj]sx?$': 'ts-jest'
   },
-    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/libs/my-lib'
 };
 "

--- a/packages/next/src/generators/application/lib/add-jest.ts
+++ b/packages/next/src/generators/application/lib/add-jest.ts
@@ -12,7 +12,7 @@ export async function addJest(host: Tree, options: NormalizedSchema) {
     supportTsx: true,
     skipSerializers: true,
     setupFile: 'none',
-    babelJest: true,
+    compiler: 'babel',
   });
 
   updateJson(host, `${options.appProjectRoot}/tsconfig.spec.json`, (json) => {

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -365,7 +365,7 @@ describe('app', () => {
           transform: {
             '^.+\\\\\\\\.[tj]s$': 'babel-jest'
           },
-            moduleFileExtensions: ['ts', 'js', 'html'],
+          moduleFileExtensions: ['ts', 'js', 'html'],
           coverageDirectory: '../../coverage/apps/my-node-app'
         };
         "

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -440,7 +440,7 @@ describe('lib', () => {
           transform: {
             '^.+\\\\\\\\.[tj]sx?$': 'babel-jest'
           },
-            moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+          moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
           coverageDirectory: '../../coverage/libs/my-lib'
         };
         "

--- a/packages/react-native/src/utils/add-jest.ts
+++ b/packages/react-native/src/utils/add-jest.ts
@@ -17,7 +17,7 @@ export async function addJest(
     supportTsx: true,
     skipSerializers: true,
     setupFile: 'none',
-    babelJest: true,
+    compiler: 'babel',
   });
 
   // overwrite the jest.config.js file because react native needs to have special transform property

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -12,7 +12,7 @@ import { Linter } from '@nrwl/linter';
 describe('app', () => {
   let appTree: Tree;
   let schema: Schema = {
-    babelJest: false,
+    compiler: 'babel',
     e2eTestRunner: 'cypress',
     skipFormat: false,
     unitTestRunner: 'jest',

--- a/packages/react/src/generators/application/lib/add-jest.ts
+++ b/packages/react/src/generators/application/lib/add-jest.ts
@@ -12,6 +12,6 @@ export async function addJest(host: Tree, options: NormalizedSchema) {
     supportTsx: true,
     skipSerializers: true,
     setupFile: 'none',
-    babelJest: true,
+    compiler: options.compiler,
   });
 }

--- a/packages/react/src/generators/application/schema.d.ts
+++ b/packages/react/src/generators/application/schema.d.ts
@@ -8,7 +8,10 @@ export interface Schema {
   directory?: string;
   tags?: string;
   unitTestRunner: 'jest' | 'none';
-  babelJest: boolean;
+  /**
+   * @deprecated
+   */
+  babelJest?: boolean;
   e2eTestRunner: 'cypress' | 'none';
   linter: Linter;
   pascalCaseFiles?: boolean;

--- a/packages/react/src/generators/component-cypress-spec/component-cypress-spec.spec.ts
+++ b/packages/react/src/generators/component-cypress-spec/component-cypress-spec.spec.ts
@@ -147,7 +147,6 @@ describe('react:component-cypress-spec', () => {
   it('should target the correct cypress suite', async () => {
     appTree = await createTestUILib('test-ui-lib');
     await applicationGenerator(appTree, {
-      babelJest: false,
       e2eTestRunner: 'none',
       linter: Linter.EsLint,
       name: `other-e2e`,
@@ -194,7 +193,6 @@ export async function createTestUILib(
   // create some Nx app that we'll use to generate the cypress
   // spec into it. We don't need a real Cypress setup
   await applicationGenerator(appTree, {
-    babelJest: false,
     js: plainJS,
     e2eTestRunner: 'none',
     linter: Linter.EsLint,

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -365,7 +365,7 @@ describe('lib', () => {
   describe('--appProject', () => {
     it('should add new route to existing routing code', async () => {
       await applicationGenerator(appTree, {
-        babelJest: true,
+        compiler: 'babel',
         e2eTestRunner: 'none',
         linter: Linter.EsLint,
         skipFormat: true,
@@ -393,7 +393,6 @@ describe('lib', () => {
 
     it('should initialize routes if none were set up then add new route', async () => {
       await applicationGenerator(appTree, {
-        babelJest: true,
         e2eTestRunner: 'none',
         linter: Linter.EsLint,
         skipFormat: true,

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -90,7 +90,7 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
       setupFile: 'none',
       supportTsx: true,
       skipSerializers: true,
-      babelJest: true,
+      compiler: options.compiler,
     });
     tasks.push(jestTask);
   }

--- a/packages/react/src/generators/redux/redux.spec.ts
+++ b/packages/react/src/generators/redux/redux.spec.ts
@@ -48,7 +48,6 @@ describe('redux', () => {
   describe('--appProject', () => {
     it('should configure app main', async () => {
       await applicationGenerator(appTree, {
-        babelJest: false,
         e2eTestRunner: 'none',
         linter: Linter.EsLint,
         skipFormat: true,

--- a/packages/react/src/generators/stories/stories-app.spec.ts
+++ b/packages/react/src/generators/stories/stories-app.spec.ts
@@ -94,7 +94,6 @@ export async function createTestUIApp(
   let appTree = createTreeWithEmptyWorkspace();
 
   await applicationGenerator(appTree, {
-    babelJest: false,
     e2eTestRunner: 'cypress',
     linter: Linter.EsLint,
     skipFormat: false,

--- a/packages/react/src/generators/stories/stories-lib.spec.ts
+++ b/packages/react/src/generators/stories/stories-lib.spec.ts
@@ -113,7 +113,6 @@ export async function createTestUILib(
   // spec into it. We don't need a real Cypress setup
 
   await applicationGenerator(appTree, {
-    babelJest: false,
     e2eTestRunner: 'none',
     linter: Linter.EsLint,
     skipFormat: false,

--- a/packages/react/src/generators/storybook-configuration/configuration.spec.ts
+++ b/packages/react/src/generators/storybook-configuration/configuration.spec.ts
@@ -188,7 +188,6 @@ export async function createTestAppLib(
   let appTree = createTreeWithEmptyWorkspace();
 
   await applicationGenerator(appTree, {
-    babelJest: false,
     e2eTestRunner: 'none',
     linter: Linter.EsLint,
     skipFormat: false,

--- a/packages/react/src/utils/testing-generators.ts
+++ b/packages/react/src/utils/testing-generators.ts
@@ -1,37 +1,19 @@
 import { addProjectConfiguration, names, Tree } from '@nrwl/devkit';
 import applicationGenerator from '../generators/application/application';
 import { Linter } from '@nrwl/linter';
-import { applicationGenerator as webApplicationGenerator } from '@nrwl/web';
 
 export async function createApp(
   tree: Tree,
   appName: string,
   standaloneConfig?: boolean
 ): Promise<any> {
-  const { fileName } = names(appName);
-
   await applicationGenerator(tree, {
-    babelJest: true,
     e2eTestRunner: 'none',
     linter: Linter.EsLint,
     skipFormat: true,
     style: 'css',
     unitTestRunner: 'none',
     name: appName,
-    standaloneConfig,
-  });
-}
-
-export async function createWebApp(
-  tree: Tree,
-  appName: string,
-  standaloneConfig?: boolean
-): Promise<any> {
-  const { fileName } = names(appName);
-
-  await webApplicationGenerator(tree, {
-    name: appName,
-    skipFormat: true,
     standaloneConfig,
   });
 }

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -375,11 +375,11 @@ describe('app', () => {
     });
   });
 
-  describe('--babelJest', () => {
-    it('should use babel for jest', async () => {
+  describe('--compiler', () => {
+    it('should support babel compiler', async () => {
       await applicationGenerator(tree, {
         name: 'myApp',
-        babelJest: true,
+        compiler: 'babel',
       } as Schema);
 
       expect(tree.read(`apps/my-app/jest.config.js`, 'utf-8'))
@@ -391,7 +391,29 @@ describe('app', () => {
           transform: {
             '^.+\\\\\\\\.[tj]s$': 'babel-jest'
           },
-            moduleFileExtensions: ['ts', 'js', 'html'],
+          moduleFileExtensions: ['ts', 'js', 'html'],
+          coverageDirectory: '../../coverage/apps/my-app'
+        };
+        "
+      `);
+    });
+
+    it('should support swc compiler', async () => {
+      await applicationGenerator(tree, {
+        name: 'myApp',
+        compiler: 'swc',
+      } as Schema);
+
+      expect(tree.read(`apps/my-app/jest.config.js`, 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "module.exports = {
+          displayName: 'my-app',
+          preset: '../../jest.preset.js',
+          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+          transform: {
+            '^.+\\\\\\\\.[tj]s$': '@swc/jest'
+          },
+          moduleFileExtensions: ['ts', 'js', 'html'],
           coverageDirectory: '../../coverage/apps/my-app'
         };
         "

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -221,7 +221,7 @@ export async function applicationGenerator(host: Tree, schema: Schema) {
       project: options.projectName,
       skipSerializers: true,
       setupFile: 'web-components',
-      babelJest: options.babelJest,
+      compiler: options.compiler,
     });
     tasks.push(jestTask);
   }

--- a/packages/web/src/generators/application/schema.d.ts
+++ b/packages/web/src/generators/application/schema.d.ts
@@ -11,7 +11,6 @@ export interface Schema {
   unitTestRunner?: 'jest' | 'none';
   e2eTestRunner?: 'cypress' | 'none';
   linter?: Linter;
-  babelJest?: boolean;
   standaloneConfig?: boolean;
   setParserOptionsProject?: boolean;
 }

--- a/packages/web/src/generators/application/schema.json
+++ b/packages/web/src/generators/application/schema.json
@@ -76,11 +76,6 @@
       "type": "string",
       "description": "Add tags to the application (used for linting)"
     },
-    "babelJest": {
-      "type": "boolean",
-      "description": "Use babel instead ts-jest",
-      "default": false
-    },
     "setParserOptionsProject": {
       "type": "boolean",
       "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",

--- a/scripts/check-versions.ts
+++ b/scripts/check-versions.ts
@@ -24,9 +24,9 @@ const scoped = [
   'babel',
   'emotion',
   'reduxjs',
+  'swc',
   'testing-library',
   'types',
-  'zeit',
 ];
 
 try {


### PR DESCRIPTION
This PR adds the `--compiler` flag for  jest projects. 

## Other notes

* Change previous usages of `--babelJest` to `--compiler=babel|swc` for React.
* Clean up e2e tests for  React
