### PR TITLE
docs(core): fix grammar in DTE section

### DIFF
--- a/docs/shared/mental-model.md
+++ b/docs/shared/mental-model.md
@@ -272,7 +272,7 @@ paid. One of them is the distributed computation cache, which allows you to shar
 agents.
 
 Another one is config-free distributed task execution (DTE). When using the distributed task execution, Nx is able to
-run any task graph on a many agents instead of locally.
+run any task graph on many agents instead of locally.
 
 When using this, `nx affected --build`, won't run the build locally (which for large workspace can take hours). Instead,
 it will send the Task Graph to Nx Cloud. Nx Cloud Agents will then pick up the task they can run and execute them.

--- a/docs/shared/mental-model.md
+++ b/docs/shared/mental-model.md
@@ -274,10 +274,10 @@ agents.
 Another one is config-free distributed task execution (DTE). When using the distributed task execution, Nx is able to
 run any task graph on many agents instead of locally.
 
-When using this, `nx affected --build`, won't run the build locally (which for large workspace can take hours). Instead,
-it will send the Task Graph to Nx Cloud. Nx Cloud Agents will then pick up the task they can run and execute them.
+When using this, `nx affected --build`, won't run the build locally (which can take hours for large workspaces). Instead,
+it will send the Task Graph to Nx Cloud. Nx Cloud Agents will then pick up the tasks they can run and execute them.
 
-Note this happens transparently. If an agent builds `app1`, it will fetch the outputs for `lib` if it doesn't have it
+Note that this happens transparently. If an agent builds `app1`, it will fetch the outputs for `lib` if it doesn't have them
 already.
 
 As agents complete tasks, the main job where you invoked `nx affected --build` will start receiving created files and


### PR DESCRIPTION
run tasks on many agents instead of run tasks on a many agents

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Currently the DTE section of the mental model core docs has grammar errors

## Expected Behavior
The docs should not have any grammar errors

## Related Issue(s)
Haven't found any
