### PR TITLE
fix(angular): set public host for both projects

### DIFF
--- a/packages/angular/src/generators/setup-mfe/lib/setup-serve-target.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/setup-serve-target.ts
@@ -15,9 +15,7 @@ export function setupServeTarget(host: Tree, options: Schema) {
     options: {
       ...appConfig.targets['serve'].options,
       port: options.port ?? undefined,
-      publicHost: options.host
-        ? undefined
-        : `http://localhost:${options.port ?? 4200}`,
+      publicHost: `http://localhost:${options.port ?? 4200}`,
     },
   };
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`publicHost` is only being set on the host. Remote also needs it.

## Expected Behavior
set `publicHost` on both remote and host to prevent live reload loop

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
