### PR TITLE
feat(js): update complier options for strict mode

### DIFF
--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -131,7 +131,9 @@ describe('lib', () => {
                       "forceConsistentCasingInFileNames": true,
                       "module": "CommonJS",
                       "noFallthroughCasesInSwitch": true,
+                      "noImplicitOverride": true,
                       "noImplicitReturns": true,
+                      "noPropertyAccessFromIndexSignature": true,
                       "strict": true,
                     },
                     "extends": "../../tsconfig.base.json",
@@ -250,7 +252,7 @@ describe('lib', () => {
       });
     });
 
-    describe('--strict', () => {
+    describe('--no-strict', () => {
       it('should update the projects tsconfig with strict false', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
@@ -259,9 +261,15 @@ describe('lib', () => {
         });
         const tsconfigJson = readJson(tree, '/libs/my-lib/tsconfig.json');
 
-        expect(tsconfigJson.compilerOptions?.strict).not.toBeDefined();
         expect(
           tsconfigJson.compilerOptions?.forceConsistentCasingInFileNames
+        ).not.toBeDefined();
+        expect(tsconfigJson.compilerOptions?.strict).not.toBeDefined();
+        expect(
+          tsconfigJson.compilerOptions?.noImplicitOverride
+        ).not.toBeDefined();
+        expect(
+          tsconfigJson.compilerOptions?.noPropertyAccessFromIndexSignature
         ).not.toBeDefined();
         expect(
           tsconfigJson.compilerOptions?.noImplicitReturns

--- a/packages/js/src/utils/project-generator.ts
+++ b/packages/js/src/utils/project-generator.ts
@@ -143,6 +143,8 @@ function updateTsConfig(tree: Tree, options: NormalizedSchema) {
         ...json.compilerOptions,
         forceConsistentCasingInFileNames: true,
         strict: true,
+        noImplicitOverride: true,
+        noPropertyAccessFromIndexSignature: true,
         noImplicitReturns: true,
         noFallthroughCasesInSwitch: true,
       };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/js:application` and `@nrwl/js:library` generators don't add following two new compiler options for strict mode.
- [noImplicitOverride](https://www.typescriptlang.org/tsconfig#noImplicitOverride)
- [noPropertyAccessFromIndexSignature](https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature)


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`noImplicitOverride` and `noPropertyAccessFromIndexSignature` are enabled for the newly created projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
#8121
