### PR TITLE
fix(core): exclude nxWorkspaceRoot from args when calling custom preset

### DIFF
--- a/packages/workspace/src/generators/library/library.spec.ts
+++ b/packages/workspace/src/generators/library/library.spec.ts
@@ -185,9 +185,9 @@ describe('lib', () => {
             }
           },
           transform: {
-            '^.+\\\\\\\\.[tj]sx?$':  'ts-jest' 
+            '^.+\\\\\\\\.[tj]sx?$': 'ts-jest'
           },
-            moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+          moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
           coverageDirectory: '../../coverage/libs/my-lib'
         };
         "
@@ -784,7 +784,7 @@ describe('lib', () => {
           transform: {
             '^.+\\\\\\\\.[tj]sx?$': 'babel-jest'
           },
-            moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+          moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
           coverageDirectory: '../../coverage/libs/my-lib'
         };
         "

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -101,7 +101,9 @@ function generatePreset(host: Tree, opts: NormalizedSchema) {
           acc.push(`${key}`);
         } else if (value === false) {
           acc.push(`--no-${key}`);
-        } else {
+          // nxWorkspaceRoot breaks Tao CLI if incorrectly set, so need to exclude it.
+          // TODO(jack): Should read in the preset schema and only pass the options specified.
+        } else if (key !== 'nxWorkspaceRoot') {
           // string, number (don't handle arrays or nested objects)
           acc.push(`--${key}=${value}`);
         }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`--nxWorkspace` is passed to Tao CLI when calling custom preset, thus the root is wrong and command fails.

## Expected Behavior
Custom preset should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
