### PR TITLE
feat(js): generated jest project uses swc if --compiler=swc

### DIFF
--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -709,6 +709,18 @@ describe('lib', () => {
         expect(tree.exists('libs/my-lib/.swcrc')).toBeTruthy();
       });
 
+      it('should setup jest project using swc', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          buildable: true,
+          compiler: 'swc',
+        });
+
+        const jestConfig = tree.read('libs/my-lib/jest.config.js').toString();
+        expect(jestConfig).toContain('@swc/jest');
+      });
+
       it('should generate a package.json file', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,

--- a/packages/js/src/utils/project-generator.ts
+++ b/packages/js/src/utils/project-generator.ts
@@ -216,6 +216,7 @@ async function addJest(
     skipSerializers: true,
     testEnvironment: options.testEnvironment,
     skipFormat: true,
+    compiler: options.compiler,
   });
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running `nx g @nrwl/js:lib --compiler swc` uses `ts-jest` for jest tests.

## Expected Behavior
Running `nx g @nrwl/js:lib --compiler swc` uses `@swc/jest` for jest tests.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
