### PR TITLE
fix(angular): watch on webpack browser builder

### DIFF
--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -52,16 +52,7 @@ function buildApp(
     }
   }
 
-  const scheduledBuilder = context.scheduleBuilder(
-    '@angular-devkit/build-angular:browser',
-    delegateOptions as Schema & JsonObject,
-    {
-      target: context.target,
-      logger: context.logger as any,
-    }
-  );
-
-  return from(scheduledBuilder).pipe(switchMap((x) => x.result));
+  return executeBrowserBuilder(delegateOptions, context);
 }
 
 function buildAppWithCustomWebpackConfiguration(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Our current method of piping a scheduled builder call to the Angular Devkit returns to terminal because the rxjs stream completes, preventing `watch` flag from working.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use the `executeBrowserBuilder` function from Angular instead of scheduling a builder.

We use the function anyway for the custom webpack config, so it makes sense to remain consistent.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
