### PR TITLE
feat(testing): allow generating new Cypress e2e projects

### DIFF
--- a/docs/angular/api-cypress/generators/cypress-project.md
+++ b/docs/angular/api-cypress/generators/cypress-project.md
@@ -1,0 +1,88 @@
+---
+title: '@nrwl/cypress:cypress-project generator'
+description: 'Add a Cypress E2E Project'
+---
+
+# @nrwl/cypress:cypress-project
+
+Add a Cypress E2E Project
+
+## Usage
+
+```bash
+nx generate cypress-project ...
+```
+
+By default, Nx will search for `cypress-project` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/cypress:cypress-project ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g cypress-project ... --dry-run
+```
+
+## Options
+
+### name (_**required**_)
+
+Type: `string`
+
+Name of the E2E Project
+
+### directory
+
+Type: `string`
+
+A directory where the project is placed
+
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
+### linter
+
+Default: `eslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`, `none`
+
+The tool to use for running lint checks.
+
+### project
+
+Type: `string`
+
+The name of the frontend project to test.
+
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files
+
+### standaloneConfig
+
+Type: `boolean`
+
+Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/docs/map.json
+++ b/docs/map.json
@@ -653,6 +653,11 @@
             "name": "cypress executor",
             "id": "cypress",
             "file": "angular/api-cypress/executors/cypress"
+          },
+          {
+            "name": "cypress-project generator",
+            "id": "cypress-project",
+            "file": "angular/api-cypress/generators/cypress-project"
           }
         ]
       },
@@ -2017,6 +2022,11 @@
             "name": "cypress executor",
             "id": "cypress",
             "file": "react/api-cypress/executors/cypress"
+          },
+          {
+            "name": "cypress-project generator",
+            "id": "cypress-project",
+            "file": "react/api-cypress/generators/cypress-project"
           }
         ]
       },
@@ -3345,6 +3355,11 @@
             "name": "cypress executor",
             "id": "cypress",
             "file": "node/api-cypress/executors/cypress"
+          },
+          {
+            "name": "cypress-project generator",
+            "id": "cypress-project",
+            "file": "node/api-cypress/generators/cypress-project"
           }
         ]
       },

--- a/docs/node/api-cypress/generators/cypress-project.md
+++ b/docs/node/api-cypress/generators/cypress-project.md
@@ -1,0 +1,88 @@
+---
+title: '@nrwl/cypress:cypress-project generator'
+description: 'Add a Cypress E2E Project'
+---
+
+# @nrwl/cypress:cypress-project
+
+Add a Cypress E2E Project
+
+## Usage
+
+```bash
+nx generate cypress-project ...
+```
+
+By default, Nx will search for `cypress-project` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/cypress:cypress-project ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g cypress-project ... --dry-run
+```
+
+## Options
+
+### name (_**required**_)
+
+Type: `string`
+
+Name of the E2E Project
+
+### directory
+
+Type: `string`
+
+A directory where the project is placed
+
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
+### linter
+
+Default: `eslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`, `none`
+
+The tool to use for running lint checks.
+
+### project
+
+Type: `string`
+
+The name of the frontend project to test.
+
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files
+
+### standaloneConfig
+
+Type: `boolean`
+
+Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/docs/react/api-cypress/generators/cypress-project.md
+++ b/docs/react/api-cypress/generators/cypress-project.md
@@ -1,0 +1,88 @@
+---
+title: '@nrwl/cypress:cypress-project generator'
+description: 'Add a Cypress E2E Project'
+---
+
+# @nrwl/cypress:cypress-project
+
+Add a Cypress E2E Project
+
+## Usage
+
+```bash
+nx generate cypress-project ...
+```
+
+By default, Nx will search for `cypress-project` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/cypress:cypress-project ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g cypress-project ... --dry-run
+```
+
+## Options
+
+### name (_**required**_)
+
+Type: `string`
+
+Name of the E2E Project
+
+### directory
+
+Type: `string`
+
+A directory where the project is placed
+
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
+### linter
+
+Default: `eslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`, `none`
+
+The tool to use for running lint checks.
+
+### project
+
+Type: `string`
+
+The name of the frontend project to test.
+
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files
+
+### standaloneConfig
+
+Type: `boolean`
+
+Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-cypress/generators/cypress-project.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-cypress/generators/cypress-project.md
@@ -1,0 +1,88 @@
+---
+title: '@nrwl/cypress:cypress-project generator'
+description: 'Add a Cypress E2E Project'
+---
+
+# @nrwl/cypress:cypress-project
+
+Add a Cypress E2E Project
+
+## Usage
+
+```bash
+nx generate cypress-project ...
+```
+
+By default, Nx will search for `cypress-project` in the default collection provisioned in `angular.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/cypress:cypress-project ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g cypress-project ... --dry-run
+```
+
+## Options
+
+### name (_**required**_)
+
+Type: `string`
+
+Name of the E2E Project
+
+### directory
+
+Type: `string`
+
+A directory where the project is placed
+
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
+### linter
+
+Default: `eslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`, `none`
+
+The tool to use for running lint checks.
+
+### project
+
+Type: `string`
+
+The name of the frontend project to test.
+
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files
+
+### standaloneConfig
+
+Type: `boolean`
+
+Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/map.json
+++ b/nx-dev/nx-dev/public/documentation/latest/map.json
@@ -653,6 +653,11 @@
             "name": "cypress executor",
             "id": "cypress",
             "file": "angular/api-cypress/executors/cypress"
+          },
+          {
+            "name": "cypress-project generator",
+            "id": "cypress-project",
+            "file": "angular/api-cypress/generators/cypress-project"
           }
         ]
       },
@@ -2017,6 +2022,11 @@
             "name": "cypress executor",
             "id": "cypress",
             "file": "react/api-cypress/executors/cypress"
+          },
+          {
+            "name": "cypress-project generator",
+            "id": "cypress-project",
+            "file": "react/api-cypress/generators/cypress-project"
           }
         ]
       },
@@ -3345,6 +3355,11 @@
             "name": "cypress executor",
             "id": "cypress",
             "file": "node/api-cypress/executors/cypress"
+          },
+          {
+            "name": "cypress-project generator",
+            "id": "cypress-project",
+            "file": "node/api-cypress/generators/cypress-project"
           }
         ]
       },

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-cypress/generators/cypress-project.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-cypress/generators/cypress-project.md
@@ -1,0 +1,88 @@
+---
+title: '@nrwl/cypress:cypress-project generator'
+description: 'Add a Cypress E2E Project'
+---
+
+# @nrwl/cypress:cypress-project
+
+Add a Cypress E2E Project
+
+## Usage
+
+```bash
+nx generate cypress-project ...
+```
+
+By default, Nx will search for `cypress-project` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/cypress:cypress-project ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g cypress-project ... --dry-run
+```
+
+## Options
+
+### name (_**required**_)
+
+Type: `string`
+
+Name of the E2E Project
+
+### directory
+
+Type: `string`
+
+A directory where the project is placed
+
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
+### linter
+
+Default: `eslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`, `none`
+
+The tool to use for running lint checks.
+
+### project
+
+Type: `string`
+
+The name of the frontend project to test.
+
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files
+
+### standaloneConfig
+
+Type: `boolean`
+
+Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-cypress/generators/cypress-project.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-cypress/generators/cypress-project.md
@@ -1,0 +1,88 @@
+---
+title: '@nrwl/cypress:cypress-project generator'
+description: 'Add a Cypress E2E Project'
+---
+
+# @nrwl/cypress:cypress-project
+
+Add a Cypress E2E Project
+
+## Usage
+
+```bash
+nx generate cypress-project ...
+```
+
+By default, Nx will search for `cypress-project` in the default collection provisioned in `workspace.json`.
+
+You can specify the collection explicitly as follows:
+
+```bash
+nx g @nrwl/cypress:cypress-project ...
+```
+
+Show what will be generated without writing to disk:
+
+```bash
+nx g cypress-project ... --dry-run
+```
+
+## Options
+
+### name (_**required**_)
+
+Type: `string`
+
+Name of the E2E Project
+
+### directory
+
+Type: `string`
+
+A directory where the project is placed
+
+### js
+
+Default: `false`
+
+Type: `boolean`
+
+Generate JavaScript files rather than TypeScript files
+
+### linter
+
+Default: `eslint`
+
+Type: `string`
+
+Possible values: `eslint`, `tslint`, `none`
+
+The tool to use for running lint checks.
+
+### project
+
+Type: `string`
+
+The name of the frontend project to test.
+
+### setParserOptionsProject
+
+Default: `false`
+
+Type: `boolean`
+
+Whether or not to configure the ESLint "parserOptions.project" option. We do not do this by default for lint performance reasons.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files
+
+### standaloneConfig
+
+Type: `boolean`
+
+Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json

--- a/packages/cypress/generators.json
+++ b/packages/cypress/generators.json
@@ -12,8 +12,7 @@
     "cypress-project": {
       "factory": "./src/generators/cypress-project/cypress-project#cypressProjectSchematic",
       "schema": "./src/generators/cypress-project/schema.json",
-      "description": "Add a Cypress E2E Project",
-      "hidden": true
+      "description": "Add a Cypress E2E Project"
     }
   },
   "generators": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

You cannot add Cypress e2e project later. They just come as an option when generating an app.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It makes sense to be able to add Cypress e2e projects later as well, say you wanna migrate from protractor, or just add multiple ones.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
