### PR TITLE
docs(nxdev): remove hard coded description in doc viewer

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -39,7 +39,6 @@ export function DocViewer({
       <NextSeo
         noindex={version.id === 'previous'}
         title={document.data.title + ' | Nx'}
-        description="Next generation build system with first class monorepo support and powerful integrations."
         openGraph={{
           url: 'https://nx.dev' + router.asPath,
           title: document.data.title,


### PR DESCRIPTION
## What it does?
Removes hard coded description in doc viewer for SEO configuration on nx.dev.