### PR TITLE
Don't disable chalk when FORCE_COLOR is set

### DIFF
--- a/packages/cli/lib/output.ts
+++ b/packages/cli/lib/output.ts
@@ -35,7 +35,9 @@ export interface CLISuccessMessageConfig {
 /**
  * Automatically disable styling applied by chalk if CI=true
  */
-if (isCI() && !process.env.FORCE_COLOR) {
+const forceColor =
+  process.env.FORCE_COLOR === '' || process.env.FORCE_COLOR === 'true';
+if (isCI() && !forceColor) {
   (chalk as any).Level = 0;
 }
 

--- a/packages/cli/lib/output.ts
+++ b/packages/cli/lib/output.ts
@@ -35,7 +35,7 @@ export interface CLISuccessMessageConfig {
 /**
  * Automatically disable styling applied by chalk if CI=true
  */
-if (isCI()) {
+if (isCI() && !process.env.FORCE_COLOR) {
   (chalk as any).Level = 0;
 }
 

--- a/packages/workspace/src/utilities/output.ts
+++ b/packages/workspace/src/utilities/output.ts
@@ -28,7 +28,9 @@ export interface CLISuccessMessageConfig {
 /**
  * Automatically disable styling applied by chalk if CI=true
  */
-if (isCI()) {
+const forceColor =
+  process.env.FORCE_COLOR === '' || process.env.FORCE_COLOR === 'true';
+if (isCI() && !forceColor) {
   (chalk as any).level = 0;
 }
 


### PR DESCRIPTION
My lint output in Jenkins wasn't colored, which is pretty normal because
a lot of apps when running in Jenkins don't think they have a
color-capable terminal to write to, but I expected that setting the
`FORCE_COLOR` environment variable would work to override this, but I
was surprised to find that it didn't help. Looking at the Nx code, I see
that chalk is turned off whenever `CI` is true, which seems like it
should be refined a bit.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
