### PR TITLE
docs(core): fix file extension for template

### DIFF
--- a/docs/shared/generators/creating-files.md
+++ b/docs/shared/generators/creating-files.md
@@ -14,7 +14,7 @@ happynrwl/
 │   ├── generators
 │   |   └── my-generator/
 │   |   |    └── files
-│   |   |        └── NOTES.md
+│   |   |        └── NOTES.md.template
 │   |   |    ├── index.ts
 │   |   |    └── schema.json
 ├── nx.json


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
[The guide for Nx generators](https://nx.dev/l/r/generators/creating-files#creating-files-with-a-generator) doesn't tell that `*.template`, which is a valid extension for both Nx generators and [Angular schematics](https://angular.io/guide/schematics-for-libraries#add-template-files), can be used for workspace genarators.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use `*.template` for template files in the guide.

It is good for users to ensure using `.template` to prevent unexpected tsc/babel behaviors like #8220 .

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#8220
