### PR TITLE
Fixed issue with webpack plugin

### DIFF
--- a/packages/web/src/utils/webpack/plugins/scripts-webpack-plugin.ts
+++ b/packages/web/src/utils/webpack/plugins/scripts-webpack-plugin.ts
@@ -59,7 +59,7 @@ export class ScriptsWebpackPlugin {
     }
 
     for (let i = 0; i < scripts.length; i++) {
-      const scriptTime = compilation.fileTimestamps.get(scripts[i]);
+      const scriptTime = compilation.fileTimestamps?.get(scripts[i]);
       if (!scriptTime || scriptTime > this._lastBuildTime) {
         this._lastBuildTime = Date.now();
         return false;


### PR DESCRIPTION
feat(nx): resolved issue with live reload failing

## Current Behavior
when running nx serve with scripts added in projects.json -> targets > build > options > scripts the live reload is failing.

## Expected Behavior
Safely revive webpack from failing when user makes changes in code. (Live reload shouldn't fail)

## Related Issue(s)
https://github.com/nrwl/nx/issues/8230

Fixes #8230
