### PR TITLE
chore(nextjs): removed deprecated target #8236

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -23,17 +23,6 @@ function regexEqual(x, y) {
 }
 
 function withNx(nextConfig = {} as WithNxOptions) {
-  /**
-   * In collaboration with Vercel themselves, we have been advised to set the "experimental-serverless-trace" target
-   * if we detect that the build is running on Vercel to allow for the most ergonomic configuration for Vercel users.
-   */
-  if (process.env.NOW_BUILDER) {
-    console.log(
-      'withNx() plugin: Detected Vercel build environment, applying "experimental-serverless-trace" target'
-    );
-    nextConfig.target = 'experimental-serverless-trace';
-  }
-
   const userWebpack = nextConfig.webpack || ((x) => x);
   return {
     eslint: {


### PR DESCRIPTION
Next.js deprecated support for target in next.config.js and is now automatically support in Vercel and is not necessary to enforce this value when using `withNx(...)`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8236
