### PR TITLE
fix(core): improve migration handling of parallel tasksRunnerOptions

### DIFF
--- a/packages/workspace/src/migrations/update-13-2-0/set-parallel-default.ts
+++ b/packages/workspace/src/migrations/update-13-2-0/set-parallel-default.ts
@@ -4,18 +4,21 @@ import {
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { output } from '../../utilities/output';
 
 export async function setParallelDefault(host: Tree) {
   const config = readWorkspaceConfiguration(host);
-  if (config.tasksRunnerOptions['default'].options.parallel) {
-    config.tasksRunnerOptions['default'].options.parallel =
-      config.tasksRunnerOptions['default'].options.maxParallel || 3;
-    delete config.tasksRunnerOptions['default'].options.maxParallel;
-  } else {
-    config.tasksRunnerOptions['default'].options.parallel = 1;
+  const defaultTaskRunnerOptions =
+    config.tasksRunnerOptions?.['default']?.options;
+  if (defaultTaskRunnerOptions) {
+    if (defaultTaskRunnerOptions.parallel) {
+      defaultTaskRunnerOptions.parallel =
+        defaultTaskRunnerOptions.maxParallel || 3;
+      delete defaultTaskRunnerOptions.maxParallel;
+    } else {
+      defaultTaskRunnerOptions.parallel = 1;
+    }
+    updateWorkspaceConfiguration(host, config);
   }
-  updateWorkspaceConfiguration(host, config);
   await formatFiles(host);
 }
 


### PR DESCRIPTION
## Current Behavior

Upon migrating to latest from any version < 13.2, the `set-parallel-default` migration makes an assumption that `tasksRunnerOptions.default` would always be present resulting in the following migration failure:

```
% nx migrate --run-migrations=migrations.json

>  NX  Running 'yarn' to make sure necessary packages are installed

yarn install v1.22.10
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.28s.

>  NX  Running migrations from 'migrations.json'

Running migration set-parallel-default
Cannot read properties of undefined (reading 'default')
/project/node_modules/yargs/build/lib/yargs.js:1132
                throw err;
                ^

Error: Command failed: /var/folders/0s/pcxnlsz53zg7d8gv5w4wk2qc0000gn/T/tmp-30295-i1Pb3OGPJv1V/node_modules/.bin/tao migrate --run-migrations=migrations.json
```

## Expected Behavior

If `tasksRunnerOptions` is not found in the config, this migration will simply be skipped without error.
