### PR TITLE
fix(core): should infer whole projects if workspace.json is missing

### DIFF
--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -302,7 +302,7 @@ export class Workspaces {
         ? this.readFromWorkspaceJson()
         : buildWorkspaceConfigurationFromGlobs(
             nxJson,
-            globForProjectFiles(this.root),
+            globForProjectFiles(this.root, nxJson),
             (path) => readJsonFile(join(this.root, path))
           );
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Target inference only works when project.json is also present

## Expected Behavior
Target inference only works without project.json

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
