### PR TITLE
fix(nest): fixing resource generator options issue

### DIFF
--- a/packages/nest/src/generators/resource/resource.ts
+++ b/packages/nest/src/generators/resource/resource.ts
@@ -32,6 +32,7 @@ function normalizeResourceOptions(
   options: ResourceGeneratorOptions
 ): NormalizedOptions {
   return {
+    ...options,
     ...normalizeOptions(tree, options),
     language: options.language,
     spec: unitTestRunnerToSpec(options.unitTestRunner),

--- a/packages/nest/src/generators/resource/resource.ts
+++ b/packages/nest/src/generators/resource/resource.ts
@@ -32,7 +32,6 @@ function normalizeResourceOptions(
   options: ResourceGeneratorOptions
 ): NormalizedOptions {
   return {
-    ...options,
     ...normalizeOptions(tree, options),
     language: options.language,
     spec: unitTestRunnerToSpec(options.unitTestRunner),

--- a/packages/nest/src/generators/utils/normalize-options.ts
+++ b/packages/nest/src/generators/utils/normalize-options.ts
@@ -13,6 +13,7 @@ export function normalizeOptions(
   const { sourceRoot } = readProjectConfiguration(tree, options.project);
 
   const normalizedOptions: NormalizedOptions = {
+    ...options,
     flat: options.flat,
     name: names(options.name).fileName,
     path: options.directory,


### PR DESCRIPTION
The normalize options function was excluding some important properties such as type causing the generated files not to match the output if it was run using the Nest schematic directly

ISSUES CLOSED: #8243

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Running `nx g @nrwl/nest:resource tenants --project apis-admin-api --type=graphql-code-first --crud` generates REST files rather than GraphQL files.

This is due to some options not being forwarded to the Nest schematics correctly.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Options should not be removed unintentionally.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8243
