### PR TITLE
fix(js): adjust generator arg from name -> project s.t. it is picked up in Nx Console

### DIFF
--- a/docs/angular/api-js/generators/convert-to-swc.md
+++ b/docs/angular/api-js/generators/convert-to-swc.md
@@ -41,7 +41,7 @@ nx g swc mylib
 
 ## Options
 
-### name (_**required**_)
+### project (_**required**_)
 
 Type: `string`
 

--- a/docs/node/api-js/generators/convert-to-swc.md
+++ b/docs/node/api-js/generators/convert-to-swc.md
@@ -41,7 +41,7 @@ nx g swc mylib
 
 ## Options
 
-### name (_**required**_)
+### project (_**required**_)
 
 Type: `string`
 

--- a/docs/react/api-js/generators/convert-to-swc.md
+++ b/docs/react/api-js/generators/convert-to-swc.md
@@ -41,7 +41,7 @@ nx g swc mylib
 
 ## Options
 
-### name (_**required**_)
+### project (_**required**_)
 
 Type: `string`
 

--- a/packages/js/src/generators/convert-to-swc/convert-to-swc.spec.ts
+++ b/packages/js/src/generators/convert-to-swc/convert-to-swc.spec.ts
@@ -36,7 +36,7 @@ describe('convert to swc', () => {
       readProjectConfiguration(tree, 'tsc-lib').targets['build']['executor']
     ).toEqual('@nrwl/js:tsc');
 
-    await convertToSwcGenerator(tree, { name: 'tsc-lib' });
+    await convertToSwcGenerator(tree, { project: 'tsc-lib' });
 
     expect(
       readProjectConfiguration(tree, 'tsc-lib').targets['build']['executor']

--- a/packages/js/src/generators/convert-to-swc/convert-to-swc.ts
+++ b/packages/js/src/generators/convert-to-swc/convert-to-swc.ts
@@ -17,12 +17,12 @@ export async function convertToSwcGenerator(
   schema: ConvertToSwcGeneratorSchema
 ) {
   const options = normalizeOptions(schema);
-  const projectConfiguration = readProjectConfiguration(tree, options.name);
+  const projectConfiguration = readProjectConfiguration(tree, options.project);
 
   updateProjectBuildTargets(
     tree,
     projectConfiguration,
-    options.name,
+    options.project,
     options.targets
   );
 

--- a/packages/js/src/generators/convert-to-swc/schema.d.ts
+++ b/packages/js/src/generators/convert-to-swc/schema.d.ts
@@ -1,4 +1,4 @@
 export interface ConvertToSwcGeneratorSchema {
-  name: string;
+  project: string;
   targets?: string[];
 }

--- a/packages/js/src/generators/convert-to-swc/schema.json
+++ b/packages/js/src/generators/convert-to-swc/schema.json
@@ -11,7 +11,7 @@
     }
   ],
   "properties": {
-    "name": {
+    "project": {
       "type": "string",
       "description": "Library name",
       "$default": {
@@ -31,5 +31,5 @@
       "default": ["build"]
     }
   },
-  "required": ["name"]
+  "required": ["project"]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Right now the generator takes a `name` argument as the project name. That however is not picked up by Nx Console, thus not showing a dropdown with project names, nor being picked up with the right-click.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Changing `name` -> `project` allows Nx Console to properly pick it up.

![image](https://user-images.githubusercontent.com/542458/146950341-61760e45-02fb-49f5-91ed-c312341b215a.png)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
