### PR TITLE
docs(nextjs): page generator examples no longer shows component examples

### DIFF
--- a/docs/angular/api-next/generators/page.md
+++ b/docs/angular/api-next/generators/page.md
@@ -29,16 +29,10 @@ nx g page ... --dry-run
 
 ### Examples
 
-Generate a component in the mylib library:
+Generate a page in the my-app application:
 
 ```bash
-nx g component my-component --project=mylib
-```
-
-Generate a class component in the mylib library:
-
-```bash
-nx g component my-component --project=mylib --classComponent
+nx nx g page my-new-page --project=my-app
 ```
 
 ## Options

--- a/docs/node/api-next/generators/page.md
+++ b/docs/node/api-next/generators/page.md
@@ -29,16 +29,10 @@ nx g page ... --dry-run
 
 ### Examples
 
-Generate a component in the mylib library:
+Generate a page in the my-app application:
 
 ```bash
-nx g component my-component --project=mylib
-```
-
-Generate a class component in the mylib library:
-
-```bash
-nx g component my-component --project=mylib --classComponent
+nx nx g page my-new-page --project=my-app
 ```
 
 ## Options

--- a/docs/react/api-next/generators/page.md
+++ b/docs/react/api-next/generators/page.md
@@ -29,16 +29,10 @@ nx g page ... --dry-run
 
 ### Examples
 
-Generate a component in the mylib library:
+Generate a page in the my-app application:
 
 ```bash
-nx g component my-component --project=mylib
-```
-
-Generate a class component in the mylib library:
-
-```bash
-nx g component my-component --project=mylib --classComponent
+nx nx g page my-new-page --project=my-app
 ```
 
 ## Options

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-next/generators/page.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-next/generators/page.md
@@ -29,16 +29,10 @@ nx g page ... --dry-run
 
 ### Examples
 
-Generate a component in the mylib library:
+Generate a page in the my-app application:
 
 ```bash
-nx g component my-component --project=mylib
-```
-
-Generate a class component in the mylib library:
-
-```bash
-nx g component my-component --project=mylib --classComponent
+nx g page my-new-page --project=my-app
 ```
 
 ## Options

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-next/generators/page.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-next/generators/page.md
@@ -29,16 +29,10 @@ nx g page ... --dry-run
 
 ### Examples
 
-Generate a component in the mylib library:
+Generate a page in the my-app application:
 
 ```bash
-nx g component my-component --project=mylib
-```
-
-Generate a class component in the mylib library:
-
-```bash
-nx g component my-component --project=mylib --classComponent
+nx g page my-new-page --project=my-app
 ```
 
 ## Options

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-next/generators/page.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-next/generators/page.md
@@ -29,16 +29,10 @@ nx g page ... --dry-run
 
 ### Examples
 
-Generate a component in the mylib library:
+Generate a page in the my-app application:
 
 ```bash
-nx g component my-component --project=mylib
-```
-
-Generate a class component in the mylib library:
-
-```bash
-nx g component my-component --project=mylib --classComponent
+nx g page my-new-page --project=my-app
 ```
 
 ## Options

--- a/packages/next/src/generators/page/schema.json
+++ b/packages/next/src/generators/page/schema.json
@@ -6,12 +6,8 @@
   "type": "object",
   "examples": [
     {
-      "command": "g component my-component --project=mylib",
-      "description": "Generate a component in the mylib library"
-    },
-    {
-      "command": "g component my-component --project=mylib --classComponent",
-      "description": "Generate a class component in the mylib library"
+      "command": "nx g page my-new-page --project=my-app",
+      "description": "Generate a page in the my-app application"
     }
   ],
   "properties": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8239 
