### PR TITLE
feat(js): export lib and app generator functions

### DIFF
--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,2 +1,4 @@
 export * from './utils/typescript/print-diagnostics';
 export * from './utils/typescript/run-type-check';
+export { libraryGenerator } from './generators/library/library';
+export { applicationGenerator } from './generators/application/application';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Now that @nrwl/js has been merged in we can use the `swc` compiler (yay!) but if we have custom workspace schematics we cannot call the `libraryGenerator` function from `@nrwl/js` like we can with `@nrwl/node`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This exports the lib and app generators like other packages have

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
