### PR TITLE
chore(dep-graph): remove rxjs dependency

### DIFF
--- a/dep-graph/client/.eslintrc.json
+++ b/dep-graph/client/.eslintrc.json
@@ -7,7 +7,12 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {}
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          { "paths": ["rxjs"], "patterns": ["rxjs/*"] }
+        ]
+      }
     },
     {
       "files": ["*.ts", "*.tsx"],

--- a/dep-graph/client/src/app/machines/interfaces.ts
+++ b/dep-graph/client/src/app/machines/interfaces.ts
@@ -1,13 +1,6 @@
 // nx-ignore-next-line
 import type { ProjectGraphDependency, ProjectGraphNode } from '@nrwl/devkit';
-import { Observable } from 'rxjs';
-import {
-  ActionObject,
-  ActorRef,
-  State,
-  StateNodeConfig,
-  StateValue,
-} from 'xstate';
+import { ActionObject, ActorRef, State, StateNodeConfig } from 'xstate';
 
 // The hierarchical (recursive) schema for the states
 export interface DepGraphSchema {
@@ -150,10 +143,6 @@ export type DepGraphStateNodeConfig = StateNodeConfig<
 export type DepGraphSend = (
   event: DepGraphUIEvents | DepGraphUIEvents[]
 ) => void;
-export type DepGraphStateObservable = Observable<{
-  value: StateValue;
-  context: DepGraphContext;
-}>;
 
 export type DepGraphState = State<
   DepGraphContext,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
* `dep-graph-client` has an outdated import of `rxjs`
* `dep-graph-client` allows imports from `rxjs`
<!-- This is the behavior we have today -->

## Expected Behavior
* `dep-graph-client` hasno dependency on `rxjs`
* `dep-graph-client` blocks imports from `rxjs` using eslint rule
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

