### PR TITLE
fix(core): catch error when creating new workspace and git is not configured globally

### DIFF
--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -229,7 +229,13 @@ export async function newGenerator(host: Tree, options: Schema) {
     installPackagesTask(host, false, options.directory, options.packageManager);
     await generatePreset(host, options);
     if (!options.skipGit) {
-      await initializeGitRepo(host, options.directory, options);
+      try {
+        await initializeGitRepo(host, options.directory, options);
+      } catch (e) {
+        console.error(
+          `Could not initialize git repository. Error: ${e.message}`
+        );
+      }
     }
   };
 }


### PR DESCRIPTION
ISSUES CLOSED: #8183

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If `user.name` and `user.email` are not configured globally, `npx create-nx-workspace` throws git `tell me who you are` error.

## Expected Behavior
 Catch this error, and continue with workspace creation, without initializing git repository in new workspace, even if `skipGit` flag is not set.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
#8183