### PR TITLE
fix(core): handle project graph plugins not providing optional projectFilePatterns property

### DIFF
--- a/packages/tao/src/shared/nx-plugin.ts
+++ b/packages/tao/src/shared/nx-plugin.ts
@@ -64,16 +64,18 @@ export function mergePluginTargetsWithNxTargets(
 ): Record<string, TargetConfiguration> {
   let newTargets: Record<string, TargetConfiguration> = {};
   for (const plugin of plugins) {
+    if (!plugin.projectFilePatterns?.length || !plugin.registerProjectTargets) {
+      continue;
+    }
+
     const projectFiles = sync(`+(${plugin.projectFilePatterns.join('|')})`, {
       cwd: join(appRootPath, projectRoot),
     });
     for (const projectFile of projectFiles) {
-      if (plugin.registerProjectTargets) {
-        newTargets = {
-          ...newTargets,
-          ...plugin.registerProjectTargets(join(projectRoot, projectFile)),
-        };
-      }
+      newTargets = {
+        ...newTargets,
+        ...plugin.registerProjectTargets(join(projectRoot, projectFile)),
+      };
     }
   }
   return { ...newTargets, ...targets };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Project graph plugins can provide a `projectFilePatterns` property to further infer project information. This property was recently introduced and though it's defined as an optional property (as it should), plugins that don't specify it cause any command to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Project graph plugins shouldn't cause commands to fail if they don't provide the `projectFilePatterns` property. The property is optional and it should be handled as such.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
