### PR TITLE
fix(testing): remove 'swc' option from `--compiler` for jest generators

### DIFF
--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -58,13 +58,11 @@ describe('jest', () => {
       expect(packageJson.devDependencies['babel-jest']).toBeDefined();
     });
 
-    it('should support swc compiler', () => {
-      jestInitGenerator(tree, { compiler: 'swc' });
-      const packageJson = readJson(tree, 'package.json');
-      // expect(packageJson.devDependencies['@swc/jest']).toBeDefined();
-      // TODO: change back to @swc/jest when we use @swc/jest
-      expect(packageJson.devDependencies['ts-jest']).toBeDefined();
-    });
+    // it('should support swc compiler', () => {
+    //   jestInitGenerator(tree, { compiler: 'swc' });
+    //   const packageJson = readJson(tree, 'package.json');
+    //   expect(packageJson.devDependencies['@swc/jest']).toBeDefined()
+    // });
   });
 
   describe('adds jest extension', () => {

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -61,7 +61,9 @@ describe('jest', () => {
     it('should support swc compiler', () => {
       jestInitGenerator(tree, { compiler: 'swc' });
       const packageJson = readJson(tree, 'package.json');
-      expect(packageJson.devDependencies['@swc/jest']).toBeDefined();
+      // expect(packageJson.devDependencies['@swc/jest']).toBeDefined();
+      // TODO: change back to @swc/jest when we use @swc/jest
+      expect(packageJson.devDependencies['ts-jest']).toBeDefined();
     });
   });
 

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -66,12 +66,11 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
     '@types/jest': jestTypesVersion,
   };
 
+  // TODO: revert to @swc/jest when https://github.com/swc-project/cli/issues/20 is addressed
+  // } else if (options.compiler === 'swc') {
+  //   devDeps['@swc/jest'] = swcJestVersion;
   if (options.compiler === 'babel' || options.babelJest) {
     devDeps['babel-jest'] = babelJestVersion;
-  } else if (options.compiler === 'swc') {
-    // TODO: revert to @swc/jest when https://github.com/swc-project/cli/issues/20 is addressed
-    // devDeps['@swc/jest'] = swcJestVersion;
-    devDeps['ts-jest'] = tsJestVersion;
   } else {
     devDeps['ts-jest'] = tsJestVersion;
   }

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -69,7 +69,9 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
   if (options.compiler === 'babel' || options.babelJest) {
     devDeps['babel-jest'] = babelJestVersion;
   } else if (options.compiler === 'swc') {
-    devDeps['@swc/jest'] = swcJestVersion;
+    // TODO: revert to @swc/jest when https://github.com/swc-project/cli/issues/20 is addressed
+    // devDeps['@swc/jest'] = swcJestVersion;
+    devDeps['ts-jest'] = tsJestVersion;
   } else {
     devDeps['ts-jest'] = tsJestVersion;
   }

--- a/packages/jest/src/generators/init/schema.d.ts
+++ b/packages/jest/src/generators/init/schema.d.ts
@@ -1,5 +1,5 @@
 export interface JestInitSchema {
-  compiler?: 'tsc' | 'swc' | 'babel';
+  compiler?: 'tsc' | 'babel';
   /**
    * @deprecated
    */

--- a/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
+++ b/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
@@ -1,18 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`jestProject --babelJest should generate proper jest.transform when --compiler=swc and supportTsx is true 1`] = `
-"module.exports = {
-  displayName: 'lib1',
-  preset: '../../jest.preset.js',
-  transform: {
-    '^.+\\\\\\\\.[tj]sx?$': ['@swc/jest', { jsc: { transform: { react: { runtime: 'automatic' } } } }]
-  },
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../coverage/libs/lib1'
-};
-"
-`;
-
 exports[`jestProject --babelJest should generate proper jest.transform when babelJest and supportTsx is true 1`] = `
 "module.exports = {
   displayName: 'lib1',

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -291,14 +291,14 @@ describe('jestProject', () => {
       expect(tree.read('libs/lib1/jest.config.js', 'utf-8')).toMatchSnapshot();
     });
 
-    it('should generate proper jest.transform when --compiler=swc and supportTsx is true', async () => {
-      await jestProjectGenerator(tree, {
-        ...defaultOptions,
-        project: 'lib1',
-        compiler: 'swc',
-        supportTsx: true,
-      } as JestProjectSchema);
-      expect(tree.read('libs/lib1/jest.config.js', 'utf-8')).toMatchSnapshot();
-    });
+    // it('should generate proper jest.transform when --compiler=swc and supportTsx is true', async () => {
+    //   await jestProjectGenerator(tree, {
+    //     ...defaultOptions,
+    //     project: 'lib1',
+    //     compiler: 'swc',
+    //     supportTsx: true,
+    //   } as JestProjectSchema);
+    //   expect(tree.read('libs/lib1/jest.config.js', 'utf-8')).toMatchSnapshot();
+    // });
   });
 });

--- a/packages/jest/src/generators/jest-project/lib/create-files.ts
+++ b/packages/jest/src/generators/jest-project/lib/create-files.ts
@@ -13,11 +13,11 @@ export function createFiles(tree: Tree, options: JestProjectSchema) {
   const filesFolder =
     options.setupFile === 'angular' ? '../files-angular' : '../files';
 
+  // } else if (options.compiler === 'swc') {
+  //   transformer = '@swc/jest';
   let transformer: string;
   if (options.compiler === 'babel' || options.babelJest) {
     transformer = 'babel-jest';
-  } else if (options.compiler === 'swc') {
-    transformer = '@swc/jest';
   } else {
     transformer = 'ts-jest';
   }

--- a/packages/jest/src/generators/jest-project/schema.d.ts
+++ b/packages/jest/src/generators/jest-project/schema.d.ts
@@ -13,5 +13,5 @@ export interface JestProjectSchema {
    */
   babelJest?: boolean;
   skipFormat?: boolean;
-  compiler?: 'tsc' | 'swc' | 'babel';
+  compiler?: 'tsc' | 'babel';
 }

--- a/packages/jest/src/generators/jest-project/schema.json
+++ b/packages/jest/src/generators/jest-project/schema.json
@@ -42,7 +42,7 @@
     },
     "compiler": {
       "type": "string",
-      "enum": ["tsc", "swc", "babel"],
+      "enum": ["tsc", "babel"],
       "description": "The compiler to use for source and tests",
       "default": "tsc"
     },

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -709,17 +709,17 @@ describe('lib', () => {
         expect(tree.exists('libs/my-lib/.swcrc')).toBeTruthy();
       });
 
-      it('should setup jest project using swc', async () => {
-        await libraryGenerator(tree, {
-          ...defaultOptions,
-          name: 'myLib',
-          buildable: true,
-          compiler: 'swc',
-        });
-
-        const jestConfig = tree.read('libs/my-lib/jest.config.js').toString();
-        expect(jestConfig).toContain('@swc/jest');
-      });
+      // it('should setup jest project using swc', async () => {
+      //   await libraryGenerator(tree, {
+      //     ...defaultOptions,
+      //     name: 'myLib',
+      //     buildable: true,
+      //     compiler: 'swc',
+      //   });
+      //
+      //   const jestConfig = tree.read('libs/my-lib/jest.config.js').toString();
+      //   expect(jestConfig).toContain('@swc/jest');
+      // });
 
       it('should generate a package.json file', async () => {
         await libraryGenerator(tree, {

--- a/packages/js/src/utils/project-generator.ts
+++ b/packages/js/src/utils/project-generator.ts
@@ -225,7 +225,7 @@ async function addJest(
     skipSerializers: true,
     testEnvironment: options.testEnvironment,
     skipFormat: true,
-    compiler: options.compiler,
+    compiler: options.compiler as 'tsc',
   });
 }
 

--- a/packages/react/src/generators/application/lib/add-jest.ts
+++ b/packages/react/src/generators/application/lib/add-jest.ts
@@ -12,6 +12,6 @@ export async function addJest(host: Tree, options: NormalizedSchema) {
     supportTsx: true,
     skipSerializers: true,
     setupFile: 'none',
-    compiler: options.compiler,
+    compiler: options.compiler as 'tsc',
   });
 }

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -90,7 +90,7 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
       setupFile: 'none',
       supportTsx: true,
       skipSerializers: true,
-      compiler: options.compiler,
+      compiler: options.compiler as 'tsc',
     });
     tasks.push(jestTask);
   }

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -398,26 +398,26 @@ describe('app', () => {
       `);
     });
 
-    it('should support swc compiler', async () => {
-      await applicationGenerator(tree, {
-        name: 'myApp',
-        compiler: 'swc',
-      } as Schema);
-
-      expect(tree.read(`apps/my-app/jest.config.js`, 'utf-8'))
-        .toMatchInlineSnapshot(`
-        "module.exports = {
-          displayName: 'my-app',
-          preset: '../../jest.preset.js',
-          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-          transform: {
-            '^.+\\\\\\\\.[tj]s$': '@swc/jest'
-          },
-          moduleFileExtensions: ['ts', 'js', 'html'],
-          coverageDirectory: '../../coverage/apps/my-app'
-        };
-        "
-      `);
-    });
+    // it('should support swc compiler', async () => {
+    //   await applicationGenerator(tree, {
+    //     name: 'myApp',
+    //     compiler: 'swc',
+    //   } as Schema);
+    //
+    //   expect(tree.read(`apps/my-app/jest.config.js`, 'utf-8'))
+    //     .toMatchInlineSnapshot(`
+    //     "module.exports = {
+    //       displayName: 'my-app',
+    //       preset: '../../jest.preset.js',
+    //       setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+    //       transform: {
+    //         '^.+\\\\\\\\.[tj]s$': '@swc/jest'
+    //       },
+    //       moduleFileExtensions: ['ts', 'js', 'html'],
+    //       coverageDirectory: '../../coverage/apps/my-app'
+    //     };
+    //     "
+    //   `);
+    // });
   });
 });

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -221,7 +221,7 @@ export async function applicationGenerator(host: Tree, schema: Schema) {
       project: options.projectName,
       skipSerializers: true,
       setupFile: 'web-components',
-      compiler: options.compiler,
+      compiler: options.compiler as 'tsc',
     });
     tasks.push(jestTask);
   }


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

`@swc/jest` reads configuration from `.swcrc` which excludes `.spec.ts` file leading to swc/jest fails to execute because the `spec` are ignored.

Using custom configuration didn't work. SWC CLI still doesn't work with `--ignore` flag (https://github.com/swc-project/cli/issues/20)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This PR removes `swc` option from `--compiler` for Jest generators
