### PR TITLE
fix(web): enable webpack tree shaking by default

### DIFF
--- a/packages/web/src/utils/config.ts
+++ b/packages/web/src/utils/config.ts
@@ -145,7 +145,7 @@ export function getBaseWebpackPartial(
 
   if (options.compiler !== 'swc' && isScriptOptimizeOn) {
     webpackConfig.optimization = {
-      sideEffects: false,
+      sideEffects: true,
       minimizer: [
         new TerserWebpackPlugin({
           parallel: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

webpack tree shaking does not work by default in nx version 13. It worked in version 12.
The reason why it doesn't work is that `optimization.sideEffects` is set to `false`.

> Tells webpack to recognise the sideEffects flag in package.json

cf. [Optimization | webpack](https://webpack.js.org/configuration/optimization/#optimizationsideeffects)

## Current Behavior

<!-- This is the behavior we have today -->

webpack tree shaking does not work.

## Expected Behavior

webpack tree shaking works by default.

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

https://github.com/nrwl/nx/pull/7283#issuecomment-949452148
