### PR TITLE
cleanup(nextjs): remove unnecessary type in next-env.d.ts

### DIFF
--- a/packages/next/src/generators/application/files/next-env.d.ts__tmpl__
+++ b/packages/next/src/generators/application/files/next-env.d.ts__tmpl__
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`next-env.d.ts` has `next/types/global` which is not necessary because it was merged into `next/index.d.ts`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`next-env.d.ts` does not have `next/types/global`.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

https://github.com/vercel/next.js/pull/28316
