### PR TITLE
fix(angular): angular 13 mfe prod fixes

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -926,6 +926,19 @@ describe('app', () => {
       const projectConfig = readProjectConfiguration(appTree, 'app1');
       expect(projectConfig.targets.serve.options.port).toBe(4205);
     });
+
+    it('should add a port to a mfe app', async () => {
+      // ACT
+      await generateApp(appTree, 'app1', { mfe: true, mfeType: 'remote' });
+      await generateApp(appTree, 'app2', { mfe: true, mfeType: 'remote', port: 4201 });
+
+      // ASSERT
+      const project1Config = readProjectConfiguration(appTree, 'app1');
+      expect(project1Config.targets.serve.options.port).toBe(4200);
+
+      const project2Config = readProjectConfiguration(appTree, 'app2');
+      expect(project2Config.targets.serve.options.port).toBe(4201);
+    });
   });
 });
 

--- a/packages/angular/src/generators/application/lib/normalize-options.ts
+++ b/packages/angular/src/generators/application/lib/normalize-options.ts
@@ -48,6 +48,7 @@ export function normalizeOptions(
     linter: Linter.EsLint,
     strict: true,
     ...options,
+    port: options.port ?? 4200,
     prefix: options.prefix ?? defaultPrefix,
     name: appProjectName,
     appProjectRoot,

--- a/packages/angular/src/generators/setup-mfe/files/webpack/webpack.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-mfe/files/webpack/webpack.config.js__tmpl__
@@ -24,6 +24,7 @@ module.exports = {
   output: {
     uniqueName: "<%= name %>",
     publicPath: "auto",
+    scriptType: 'text/javascript',
   },
   optimization: {
     runtimeChunk: false,


### PR DESCRIPTION
## Current Behavior
1) mfe broken for Angular 13
2) if port not provided, it won't be in `serve.options.port`

## Expected Behavior
1) mfe works with Angular 13
2) if port not provided, default port will be in `serve.options.port` like `publicHost`:
```
serve.options.publicHost: "http://localhost:4200"
```

## Related Issue(s)
Fixes #8306
