### PR TITLE
fix(nest): add missing resource generator option

### DIFF
--- a/packages/nest/src/generators/resource/resource.ts
+++ b/packages/nest/src/generators/resource/resource.ts
@@ -2,6 +2,7 @@ import type { Tree } from '@nrwl/devkit';
 import { convertNxGenerator } from '@nrwl/devkit';
 import type {
   NestGeneratorWithLanguageOption,
+  NestGeneratorWithResourceOption,
   NestGeneratorWithTestOption,
   NormalizedOptions,
 } from '../utils';
@@ -12,7 +13,8 @@ import {
 } from '../utils';
 
 export type ResourceGeneratorOptions = NestGeneratorWithLanguageOption &
-  NestGeneratorWithTestOption;
+  NestGeneratorWithTestOption &
+  NestGeneratorWithResourceOption;
 
 export function resourceGenerator(
   tree: Tree,

--- a/packages/nest/src/generators/utils/types.ts
+++ b/packages/nest/src/generators/utils/types.ts
@@ -16,6 +16,12 @@ export type NestSchematic =
   | 'resolver'
   | 'resource'
   | 'service';
+export type TransportLayer =
+  | 'rest'
+  | 'graphql-code-first'
+  | 'graphql-schema-first'
+  | 'microservice'
+  | 'ws';
 
 export type NestGeneratorOptions = {
   name: string;
@@ -31,6 +37,11 @@ export type NestGeneratorWithLanguageOption = NestGeneratorOptions & {
 
 export type NestGeneratorWithTestOption = NestGeneratorOptions & {
   unitTestRunner?: UnitTestRunner;
+};
+
+export type NestGeneratorWithResourceOption = NestGeneratorOptions & {
+  type?: TransportLayer;
+  crud?: boolean;
 };
 
 export type NormalizedOptions = {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`resourceGenerator` from `@nrwl/nest` was missing `type` and `crud` options from ts typings. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR adds missing typings for `resourceGenerator` according to it's `schema.json` description.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

couldn't find any.
