### PR TITLE
chore(repo): skip daemon cleanup on grouped e2e tests

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -171,6 +171,7 @@ jobs:
         YARN_REGISTRY: http://localhost:4872
         NX_VERBOSE_LOGGING: ${{ 'true' }}
         NX_E2E_SKIP_BUILD_CLEANUP: ${{ 'true' }}
+        NX_E2E_SKIP_DAEMON_CLEANUP: ${{ 'true' }}
         NX_CACHE_DIRECTORY: ${{ matrix.os-cache-dir }}
 
     - name: Setup tmate session

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -87,6 +87,7 @@ jobs:
         YARN_REGISTRY: http://localhost:4872
         NX_VERBOSE_LOGGING: ${{ 'true' }}
         NX_E2E_SKIP_BUILD_CLEANUP: ${{ 'true' }}
+        NX_E2E_SKIP_DAEMON_CLEANUP: ${{ 'true' }}
         NX_CACHE_DIRECTORY: ${{ matrix.os-cache-dir }}
 
     - name: Setup tmate session

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -291,7 +291,9 @@ export async function killPorts(port?: number): Promise<boolean> {
 export async function cleanupProject() {
   if (isCI) {
     // Stopping the daemon is not required for tests to pass, but it cleans up background processes
-    runCLI('reset');
+    if (process.env.NX_E2E_SKIP_DAEMON_CLEANUP !== 'true') {
+      runCLI('reset');
+    }
     try {
       removeSync(tmpProjPath());
     } catch (e) {}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If a machine is reused for running multiple test suites, running daemon cleanup will break the sequence.

## Expected Behavior
We should be able to skip daemon cleanup when machine can be reused.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
