### PR TITLE
feat(web): less loader `javascriptEnabled` option

### DIFF
--- a/docs/generated/packages/web.json
+++ b/docs/generated/packages/web.json
@@ -752,6 +752,11 @@
             "enum": ["babel", "swc"],
             "default": "babel",
             "description": "Which compiler to use."
+          },
+          "javascriptEnabled": {
+            "type": "boolean",
+            "description": "Sets `javascriptEnabled` option for less loader",
+            "default": false
           }
         },
         "required": ["tsConfig", "project", "entryFile", "outputPath"],

--- a/packages/web/src/executors/rollup/rollup.impl.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.ts
@@ -220,6 +220,11 @@ export function createRollupOptions(
         extract: options.extractCss,
         autoModules: true,
         plugins: [autoprefixer],
+        use: {
+          less: {
+            javascriptEnabled: options.javascriptEnabled,
+          },
+        },
       }),
       resolve({
         preferBuiltins: true,

--- a/packages/web/src/executors/rollup/schema.d.ts
+++ b/packages/web/src/executors/rollup/schema.d.ts
@@ -22,4 +22,5 @@ export interface WebRollupOptions {
   deleteOutputPath?: boolean;
   format: string[];
   compiler?: Compiler;
+  javascriptEnabled?: boolean;
 }

--- a/packages/web/src/executors/rollup/schema.json
+++ b/packages/web/src/executors/rollup/schema.json
@@ -114,6 +114,11 @@
       "enum": ["babel", "swc"],
       "default": "babel",
       "description": "Which compiler to use."
+    },
+    "javascriptEnabled": {
+      "type": "boolean",
+      "description": "Sets `javascriptEnabled` option for less loader",
+      "default": false
     }
   },
   "required": ["tsConfig", "project", "entryFile", "outputPath"],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If run project with `antd` library and try to compile custom less styles, we have the following error:
`
Error during bundle: SyntaxError: Inline JavaScript is not enabled. Is it set in your options? in .../node_modules/antd/lib/style/color/bezierEasing.less on line 110, column 1:
109 // https://github.com/ant-design/ant-motion/issues/44
110 .bezierEasingMixin();
111 
`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
So we expect not to have this error =)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
I didn't found any related issue with `javascriptEnabled` keyword, so I don't refer to any issue, unfortunately.

Fixes #
To fix the problem, we need to pass `javascriptEnabled: true` option to less loader inside postcss plugin.