### PR TITLE
fix(core): need to read in any base nx.json when building a workspace

### DIFF
--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -145,6 +145,7 @@ export function updateWorkspaceConfiguration(
     workspaceLayout,
     tasksRunnerOptions,
     affected,
+    extends: ext,
   } = workspaceConfig;
 
   const nxJson: Required<NxJsonConfiguration> = {
@@ -158,6 +159,7 @@ export function updateWorkspaceConfiguration(
     cli,
     generators,
     defaultProject,
+    extends: ext,
   };
 
   if (tree.exists('nx.json')) {

--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -21,7 +21,6 @@ import {
   globForProjectFiles,
   ProjectConfiguration,
   RawWorkspaceJsonConfiguration,
-  readOrExtendNxConfig,
   toNewFormat,
   toNewFormatOrNull,
   toOldFormatOrNull,
@@ -229,13 +228,7 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
     const readJsonFile = (path: string) =>
       super
         .read(path as Path)
-        .pipe(
-          map((data) =>
-            readOrExtendNxConfig(
-              JSON.parse(Buffer.from(data).toString()) as NxJsonConfiguration
-            )
-          )
-        );
+        .pipe(map((data) => JSON.parse(Buffer.from(data).toString())));
 
     const readWorkspaceJsonFile = (
       nxJson: NxJsonConfiguration
@@ -627,17 +620,11 @@ export class NxScopeHostUsedForWrappedSchematics extends NxScopedHost {
         // we have to add them into the file.
         const createdProjectFiles = findCreatedProjects(this.host);
         const deletedProjectFiles = findDeletedProjects(this.host);
-        let nxJsonInTree = nxJsonChange
+        const nxJsonInTree = nxJsonChange
           ? parseJson(nxJsonChange.content.toString())
           : parseJson(this.host.read('nx.json').toString());
         const readJsonWithHost = (file) =>
           parseJson(this.host.read(file).toString());
-
-        if (nxJsonInTree?.extends) {
-          nxJsonInTree = readOrExtendNxConfig(
-            nxJsonInTree as NxJsonConfiguration
-          );
-        }
 
         const staticProjects = buildWorkspaceConfigurationFromGlobs(
           nxJsonInTree,
@@ -1301,8 +1288,8 @@ function saveWorkspaceConfigurationInWrappedSchematic(
       host.write(path, serializeJson(config));
     }
   }
-  const nxJson: NxJsonConfiguration = readOrExtendNxConfig(
-    parseJson(host.read('nx.json').toString()) as NxJsonConfiguration
+  const nxJson: NxJsonConfiguration = parseJson(
+    host.read('nx.json').toString()
   );
   nxJson.generators = workspace.generators || workspace.schematics;
   nxJson.cli = workspace.cli || nxJson.cli;

--- a/packages/tao/src/shared/nx.ts
+++ b/packages/tao/src/shared/nx.ts
@@ -21,6 +21,10 @@ export interface NxAffectedConfig {
  */
 export interface NxJsonConfiguration<T = '*' | string[]> {
   /**
+   * Optional (additional) Nx.json configuration file which becomes a base for this one
+   */
+  extends?: string;
+  /**
    * Map of files to projects that implicitly depend on them
    */
   implicitDependencies?: ImplicitDependencyEntry<T>;

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -159,29 +159,26 @@ export function readPackageJson(): any {
 export function readNxJson(
   path: string = `${appRootPath}/nx.json`
 ): NxJsonConfiguration {
-  const config = readJsonFile<NxJsonConfiguration>(path);
+  let config = readJsonFile<NxJsonConfiguration>(path);
   if (!config.npmScope) {
     throw new Error(`nx.json must define the npmScope property.`);
   }
 
-  const nxJsonExtends = readNxJsonExtends(config as any);
-  if (nxJsonExtends) {
-    return { ...nxJsonExtends, ...config };
-  } else {
-    return config;
+  if (config.extends) {
+    config = {
+      ...resolveNxJsonExtends(config.extends),
+      ...config,
+    };
   }
+
+  return config;
 }
 
-function readNxJsonExtends(nxJson: { extends?: string }) {
-  if (nxJson.extends) {
-    const extendsPath = nxJson.extends;
-    try {
-      return readJsonFile(require.resolve(extendsPath));
-    } catch (e) {
-      throw new Error(`Unable to resolve nx.json extends. Error: ${e.message}`);
-    }
-  } else {
-    return null;
+function resolveNxJsonExtends(extendedNxJsonPath: string) {
+  try {
+    return readJsonFile(require.resolve(extendedNxJsonPath));
+  } catch (e) {
+    throw new Error(`Unable to resolve nx.json extends. Error: ${e.message}`);
   }
 }
 


### PR DESCRIPTION
## Current Behavior

An NX managed monorepo without a `workspace.json` does not execute commands on projects contained in a repo with a "packages" `libsDir`. Although the `nx.json` may contain an `extends` that points towards a `packages/` folder, that base config isn't being read-in everywhere it's needed.

#### Details

The `toProjectName()` helper specifically is deriving an incorrect package name, causing the project not to be recognized on commands like `nx build some-package`. Like many helper functions in the `packages/tao/src/workspace.ts`, it expects an `nx.json` object to be provided.

In other locations like the `devkit`, the extension of an `nx.json` is already happening, but it just hasn't been applied in `@nrwl/tao` just yet. So without creating a dependency on `@nrwl/devkit`, instead a light amount of logic is being borrowed here, and used in both the workspace and ng CLI adapter files.

Because two of these helpers are used externally, it seems like it's necessary to ensure either entry-point still leads to reading in the base `nx.json`. So a small helper function (`readOrExtendNxConfig()`) has been made and is used in 5 locations.

#### Steps to reproduce

Here is a public, open-source repository I've been migrating from Lerna to NX (feel free to clone and use):
* [vanillas](https://github.com/arizonatribe/vanillas-packages)

1. Remove the `package-lock.json` and `node_modules/` - `rm -rf node_modules package-lock.json`
2. Switched to `yarn` and create the lock file - `yarn install`
3. Add NX to the repo - `npx add-nx-to-monorepo`
4. Added the new JS/TS generator - `yarn add --dev @nrwl/js`
5. Create a new (buildable) TS package - `yarn nx g @nrwl/js:lib scalars --buildable`
6. Run (any) NX command on that package/project - `nx test scalars` or `nx build scalars`

```
Could not find project "scalars"
```

The [default nx.json](https://github.com/nrwl/nx/blob/e57cef09014b1732ef3c8b2c383432bba963087b/packages/workspace/presets/npm.json#L18) for an NPM library should be directing NX to the `packages/scalars/`, but instead is pointing towards `libs/packages-scalars/`, which doesn't exist.

This is occurring because `toProjectName()` doesn't recognize the "packages" folder as the workspace's own "libs" folder. 

## Expected Behavior

An NX managed monorepo meeting these conditions:

* uses the `packages/` folder convention
* has no `workspace.json`
* has buildable packages with `project.json` files

Should be able to execute NX commands and have the project be recognized.

Such as
```
nx <build|test> <my-package>
```

## Related Issue(s)

https://github.com/nrwl/add-nx/issues/36