### PR TITLE
Generate custom preset

### DIFF
--- a/docs/angular/api-nx-plugin/generators/plugin.md
+++ b/docs/angular/api-nx-plugin/generators/plugin.md
@@ -83,6 +83,14 @@ Type: `boolean`
 
 Skip formatting files
 
+### skipPreset
+
+Default: `false`
+
+Type: `boolean`
+
+Do not add a preset generator for custom preset (e.g. create-nx-workspace --preset=my-plugin).
+
 ### skipTsConfig
 
 Default: `false`

--- a/docs/node/api-nx-plugin/generators/plugin.md
+++ b/docs/node/api-nx-plugin/generators/plugin.md
@@ -83,6 +83,14 @@ Type: `boolean`
 
 Skip formatting files
 
+### skipPreset
+
+Default: `false`
+
+Type: `boolean`
+
+Do not add a preset generator for custom preset (e.g. create-nx-workspace --preset=my-plugin).
+
 ### skipTsConfig
 
 Default: `false`

--- a/docs/react/api-nx-plugin/generators/plugin.md
+++ b/docs/react/api-nx-plugin/generators/plugin.md
@@ -83,6 +83,14 @@ Type: `boolean`
 
 Skip formatting files
 
+### skipPreset
+
+Default: `false`
+
+Type: `boolean`
+
+Do not add a preset generator for custom preset (e.g. create-nx-workspace --preset=my-plugin).
+
 ### skipTsConfig
 
 Default: `false`

--- a/docs/shared/nx-plugin.md
+++ b/docs/shared/nx-plugin.md
@@ -28,42 +28,51 @@ After executing the above command, the following tree structure is created:
 my-org/
 ├── e2e/
 │   └── my-plugin-e2e/
-│       ├── jest.config.js
 │       ├── tests/
-│       │   └── my-plugin.test.ts
+│       │   └── my-plugin.spec.ts
+│       ├── jest.config.js
+│       ├── project.json
 │       ├── tsconfig.json
 │       └── tsconfig.spec.json
 ├── packages/
 │   └── my-plugin/
+│       ├── src/
+│       │   ├── executors/
+│       │   │   └── build/
+│       │   │       ├── executor.spec.ts
+│       │   │       ├── executor.ts
+│       │   │       ├── schema.d.ts
+│       │   │       └── schema.json
+│       │   ├── generators/
+│       │   │   ├── my-plugin/
+│       │   │   │   ├── files/
+│       │   │   │   │   └── src/
+│       │   │   │   │       └── index.ts__template__
+│       │   │   │   ├── generator.spec.ts
+│       │   │   │   ├── generator.ts
+│       │   │   │   ├── schema.d.ts
+│       │   │   │   └── schema.json
+│       │   │   └── preset/
+│       │   │       ├── preset.spec.ts
+│       │   │       ├── preset.ts
+│       │   │       ├── schema.d.ts
+│       │   │       └── schema.json
+│       │   └── index.ts
 │       ├── README.md
 │       ├── executors.json
 │       ├── generators.json
 │       ├── jest.config.js
 │       ├── package.json
-│       ├── src/
-│       │   ├── executors/
-│       │   │   └── my-plugin/
-│       │   │       ├── executor.spec.ts
-│       │   │       ├── executor.ts
-│       │   │       ├── schema.d.ts
-│       │   │       └── schema.json
-│       │   ├── index.ts
-│       │   └── generators/
-│       │       └── my-plugin/
-│       │           ├── files/
-│       │           │   └── src/
-│       │           │       └── index.ts.__template__
-│       │           ├── schema.d.ts
-│       │           ├── schema.json
-│       │           ├── generator.spec.ts
-│       │           └── generator.ts
+│       ├── project.json
 │       ├── tsconfig.json
 │       ├── tsconfig.lib.json
-│       └── tsconfig.spec.json
-├── tools
+│     └── tsconfig.spec.json
+├── tools/
 │   ├── generators/
 │   └── tsconfig.tools.json
+├── README.md
 ├── jest.config.js
+├── jest.preset.js
 ├── nx.json
 ├── package.json
 ├── tsconfig.base.json
@@ -73,7 +82,7 @@ my-org/
 
 > If you do not want to create a new workspace, install the `@nrwl/nx-plugin` dependency in an already existing workspace with npm or yarn. Then run `nx g @nrwl/nx-plugin:plugin [pluginName]`.
 
-A new plugin is created with a default generator, executor, and e2e app.
+A new plugin is created with a default generator, a custom preset generator, an executor, and an e2e app. The custom preset generator is used when invoking `npx create-nx-workspace --preset=@my-org/my-plugin`.
 
 ## Generator
 
@@ -84,7 +93,7 @@ The created generator contains boilerplate that will do the following:
 - Add the plugin's project to the `nx.json` file
 - Add files to the disk using templates
 
-There will be a exported default function that will be the main entry for the generator.
+There will be an exported default function that will be the main entry for the generator.
 
 ### Generator options
 

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-js/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-js/generators/application.md
@@ -55,7 +55,7 @@ Type: `string`
 
 Possible values: `tsc`, `swc`
 
-The compiler used by the build and test targets
+The compiler used by the build and test targets (tsc is preferred, swc is experimental)
 
 ### config
 

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-js/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-js/generators/library.md
@@ -63,7 +63,7 @@ Type: `string`
 
 Possible values: `tsc`, `swc`
 
-The compiler used by the build and test targets
+The compiler used by the build and test targets (tsc is preferred, swc is experimental)
 
 ### config
 

--- a/nx-dev/nx-dev/public/documentation/latest/angular/api-nx-plugin/generators/plugin.md
+++ b/nx-dev/nx-dev/public/documentation/latest/angular/api-nx-plugin/generators/plugin.md
@@ -83,6 +83,14 @@ Type: `boolean`
 
 Skip formatting files
 
+### skipPreset
+
+Default: `false`
+
+Type: `boolean`
+
+Do not add a preset generator for custom preset (e.g. create-nx-workspace --preset=my-plugin).
+
 ### skipTsConfig
 
 Default: `false`

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-js/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-js/generators/application.md
@@ -55,7 +55,7 @@ Type: `string`
 
 Possible values: `tsc`, `swc`
 
-The compiler used by the build and test targets
+The compiler used by the build and test targets (tsc is preferred, swc is experimental)
 
 ### config
 

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-js/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-js/generators/library.md
@@ -63,7 +63,7 @@ Type: `string`
 
 Possible values: `tsc`, `swc`
 
-The compiler used by the build and test targets
+The compiler used by the build and test targets (tsc is preferred, swc is experimental)
 
 ### config
 

--- a/nx-dev/nx-dev/public/documentation/latest/node/api-nx-plugin/generators/plugin.md
+++ b/nx-dev/nx-dev/public/documentation/latest/node/api-nx-plugin/generators/plugin.md
@@ -83,6 +83,14 @@ Type: `boolean`
 
 Skip formatting files
 
+### skipPreset
+
+Default: `false`
+
+Type: `boolean`
+
+Do not add a preset generator for custom preset (e.g. create-nx-workspace --preset=my-plugin).
+
 ### skipTsConfig
 
 Default: `false`

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-js/generators/application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-js/generators/application.md
@@ -55,7 +55,7 @@ Type: `string`
 
 Possible values: `tsc`, `swc`
 
-The compiler used by the build and test targets
+The compiler used by the build and test targets (tsc is preferred, swc is experimental)
 
 ### config
 

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-js/generators/library.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-js/generators/library.md
@@ -63,7 +63,7 @@ Type: `string`
 
 Possible values: `tsc`, `swc`
 
-The compiler used by the build and test targets
+The compiler used by the build and test targets (tsc is preferred, swc is experimental)
 
 ### config
 

--- a/nx-dev/nx-dev/public/documentation/latest/react/api-nx-plugin/generators/plugin.md
+++ b/nx-dev/nx-dev/public/documentation/latest/react/api-nx-plugin/generators/plugin.md
@@ -83,6 +83,14 @@ Type: `boolean`
 
 Skip formatting files
 
+### skipPreset
+
+Default: `false`
+
+Type: `boolean`
+
+Do not add a preset generator for custom preset (e.g. create-nx-workspace --preset=my-plugin).
+
 ### skipTsConfig
 
 Default: `false`

--- a/nx-dev/nx-dev/public/documentation/latest/shared/nx-plugin.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/nx-plugin.md
@@ -28,42 +28,51 @@ After executing the above command, the following tree structure is created:
 my-org/
 ├── e2e/
 │   └── my-plugin-e2e/
-│       ├── jest.config.js
 │       ├── tests/
-│       │   └── my-plugin.test.ts
+│       │   └── my-plugin.spec.ts
+│       ├── jest.config.js
+│       ├── project.json
 │       ├── tsconfig.json
 │       └── tsconfig.spec.json
 ├── packages/
 │   └── my-plugin/
+│       ├── src/
+│       │   ├── executors/
+│       │   │   └── build/
+│       │   │       ├── executor.spec.ts
+│       │   │       ├── executor.ts
+│       │   │       ├── schema.d.ts
+│       │   │       └── schema.json
+│       │   ├── generators/
+│       │   │   ├── my-plugin/
+│       │   │   │   ├── files/
+│       │   │   │   │   └── src/
+│       │   │   │   │       └── index.ts__template__
+│       │   │   │   ├── generator.spec.ts
+│       │   │   │   ├── generator.ts
+│       │   │   │   ├── schema.d.ts
+│       │   │   │   └── schema.json
+│       │   │   └── preset/
+│       │   │       ├── preset.spec.ts
+│       │   │       ├── preset.ts
+│       │   │       ├── schema.d.ts
+│       │   │       └── schema.json
+│       │   └── index.ts
 │       ├── README.md
 │       ├── executors.json
 │       ├── generators.json
 │       ├── jest.config.js
 │       ├── package.json
-│       ├── src/
-│       │   ├── executors/
-│       │   │   └── my-plugin/
-│       │   │       ├── executor.spec.ts
-│       │   │       ├── executor.ts
-│       │   │       ├── schema.d.ts
-│       │   │       └── schema.json
-│       │   ├── index.ts
-│       │   └── generators/
-│       │       └── my-plugin/
-│       │           ├── files/
-│       │           │   └── src/
-│       │           │       └── index.ts.__template__
-│       │           ├── schema.d.ts
-│       │           ├── schema.json
-│       │           ├── generator.spec.ts
-│       │           └── generator.ts
+│       ├── project.json
 │       ├── tsconfig.json
 │       ├── tsconfig.lib.json
-│       └── tsconfig.spec.json
-├── tools
+│     └── tsconfig.spec.json
+├── tools/
 │   ├── generators/
 │   └── tsconfig.tools.json
+├── README.md
 ├── jest.config.js
+├── jest.preset.js
 ├── nx.json
 ├── package.json
 ├── tsconfig.base.json
@@ -73,7 +82,7 @@ my-org/
 
 > If you do not want to create a new workspace, install the `@nrwl/nx-plugin` dependency in an already existing workspace with npm or yarn. Then run `nx g @nrwl/nx-plugin:plugin [pluginName]`.
 
-A new plugin is created with a default generator, executor, and e2e app.
+A new plugin is created with a default generator, a custom preset generator, an executor, and an e2e app. The custom preset generator is used when invoking `npx create-nx-workspace --preset=@my-org/my-plugin`.
 
 ## Generator
 
@@ -84,7 +93,7 @@ The created generator contains boilerplate that will do the following:
 - Add the plugin's project to the `nx.json` file
 - Add files to the disk using templates
 
-There will be a exported default function that will be the main entry for the generator.
+There will be an exported default function that will be the main entry for the generator.
 
 ### Generator options
 

--- a/packages/nx-plugin/src/generators/plugin/files/generator/preset/preset.spec.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/plugin/files/generator/preset/preset.spec.ts__tmpl__
@@ -1,0 +1,18 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { Tree } from '@nrwl/devkit';
+
+import preset from './preset';
+import { <%= className %>PresetGeneratorSchema } from './schema';
+
+describe('<%= name %> generator', () => {
+  let appTree: Tree;
+  const options: <%= className %>PresetGeneratorSchema = { name: 'test' };
+
+  beforeEach(() => {
+    appTree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should run successfully', async () => {
+    await preset(appTree, options);
+  })
+});

--- a/packages/nx-plugin/src/generators/plugin/files/generator/preset/preset.spec.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/plugin/files/generator/preset/preset.spec.ts__tmpl__
@@ -6,7 +6,7 @@ import { <%= className %>PresetGeneratorSchema } from './schema';
 
 describe('<%= name %> generator', () => {
   let appTree: Tree;
-  const options: <%= className %>PresetGeneratorSchema = { name: 'test' };
+  const options: <%= className %>PresetGeneratorSchema = { message: 'test' };
 
   beforeEach(() => {
     appTree = createTreeWithEmptyWorkspace();
@@ -14,5 +14,7 @@ describe('<%= name %> generator', () => {
 
   it('should run successfully', async () => {
     await preset(appTree, options);
+
+    appTree.exists('message.txt');
   })
 });

--- a/packages/nx-plugin/src/generators/plugin/files/generator/preset/preset.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/plugin/files/generator/preset/preset.ts__tmpl__
@@ -5,7 +5,8 @@ import { <%= className %>PresetGeneratorSchema } from './schema';
 
 // This is the generator that `create-nx-workspace` calls when the npm package is passed as `--preset=[package]`
 // e.g. npx create-nx-workspace --preset=@my-org/my-plugin
-export default async function (tree: Tree, _options: <%= className %>PresetGeneratorSchema): Promise<GeneratorCallback> {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default async function (tree: Tree, options: <%= className %>PresetGeneratorSchema): Promise<GeneratorCallback> {
   const installTask = addDependenciesToPackageJson(tree, {
     // Add dependencies to workspace
   }, {
@@ -14,7 +15,7 @@ export default async function (tree: Tree, _options: <%= className %>PresetGener
 
   // You can create any files you want.
   // See the `generateFiles` function from `@nrwl/devkit` for template files.
-  tree.write('message.txt', 'It works!');
+  tree.write('message.txt', options.message ?? 'It works!');
 
   await formatFiles(tree);
 

--- a/packages/nx-plugin/src/generators/plugin/files/generator/preset/preset.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/plugin/files/generator/preset/preset.ts__tmpl__
@@ -1,0 +1,26 @@
+import { addDependenciesToPackageJson, formatFiles } from "@nrwl/devkit";
+import type { GeneratorCallback, Tree } from "@nrwl/devkit";
+
+import { <%= className %>PresetGeneratorSchema } from './schema';
+
+// This is the generator that `create-nx-workspace` calls when the npm package is passed as `--preset=[package]`
+// e.g. npx create-nx-workspace --preset=@my-org/my-plugin
+export default async function (tree: Tree, _options: <%= className %>PresetGeneratorSchema): Promise<GeneratorCallback> {
+  const installTask = addDependenciesToPackageJson(tree, {
+    // Add dependencies to workspace
+  }, {
+    // Add dev dependencies to workspace
+  });
+
+  // You can create any files you want.
+  // See the `generateFiles` function from `@nrwl/devkit` for template files.
+  tree.write('message.txt', 'It works!');
+
+  await formatFiles(tree);
+
+  return async () => {
+    await installTask();
+
+    // Perform additional tasks...
+  }
+}

--- a/packages/nx-plugin/src/generators/plugin/files/generator/preset/schema.d.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/plugin/files/generator/preset/schema.d.ts__tmpl__
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface <%= className %>PresetGeneratorSchema {}

--- a/packages/nx-plugin/src/generators/plugin/files/generator/preset/schema.d.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/plugin/files/generator/preset/schema.d.ts__tmpl__
@@ -1,2 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface <%= className %>PresetGeneratorSchema {}
+export interface <%= className %>PresetGeneratorSchema {
+  message?: string;
+}

--- a/packages/nx-plugin/src/generators/plugin/files/generator/preset/schema.json__tmpl__
+++ b/packages/nx-plugin/src/generators/plugin/files/generator/preset/schema.json__tmpl__
@@ -5,6 +5,10 @@
   "title": "",
   "type": "object",
   "properties": {
+    "message": {
+      "type: "string",
+      "description": "Message to generate with."
+    }
   },
   "required": [],
   "additionalProperties": true

--- a/packages/nx-plugin/src/generators/plugin/files/generator/preset/schema.json__tmpl__
+++ b/packages/nx-plugin/src/generators/plugin/files/generator/preset/schema.json__tmpl__
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "<%= className %>Preset",
+  "title": "",
+  "type": "object",
+  "properties": {
+  },
+  "required": [],
+  "additionalProperties": true
+}

--- a/packages/nx-plugin/src/generators/plugin/schema.d.ts
+++ b/packages/nx-plugin/src/generators/plugin/schema.d.ts
@@ -6,6 +6,7 @@ export interface Schema {
   importPath?: string;
   skipTsConfig: boolean;
   skipFormat: boolean;
+  skipPreset?: boolean;
   tags?: string;
   unitTestRunner: 'jest' | 'none';
   linter: Linter;

--- a/packages/nx-plugin/src/generators/plugin/schema.json
+++ b/packages/nx-plugin/src/generators/plugin/schema.json
@@ -56,6 +56,11 @@
       "default": false,
       "description": "Do not update tsconfig.json for development experience."
     },
+    "skipPreset": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add a preset generator for custom preset (e.g. create-nx-workspace --preset=my-plugin)."
+    },
     "standaloneConfig": {
       "description": "Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json",
       "type": "boolean"


### PR DESCRIPTION
This PR updates the `@nrwl/nx-plugin:plugin` generator such that it includes a custom preset generator by default (disabled via `--skipPreset`).

This is useful when running `npx create-nx-plugin` since you can then use the new plugin with `create-nx-workspace`.

e.g.

```bash
npx create-nx-workspace --preset=@my-org/my-plugin
```

## Notes
* `@nrwl/nx-plugin:plugin` generates custom preset by default (skipped with `--skipPreset`).
* Provide useful comments in custom preset generator.
* Docs updated at `/l/r/nx-plugin/overview`  to reflect changes.

## Docs preview

https://nx-dev-git-fork-jaysoo-generate-custom-preset-nrwl.vercel.app/l/r/nx-plugin/overview

**Updated tree view:**

<img width="952" alt="Screen Shot 2021-12-30 at 10 30 38 AM" src="https://user-images.githubusercontent.com/53559/147765503-b28c7350-5af5-46df-b2cd-6e7f82e97a58.png">

**Updated notes:**

<img width="933" alt="Screen Shot 2021-12-30 at 10 30 29 AM" src="https://user-images.githubusercontent.com/53559/147765507-63e29798-b175-4cc1-b2a5-699fe39eb7bb.png">

