### PR TITLE
chore(nxdev): scripts use fs-extra and child_process

### DIFF
--- a/scripts/documentation/nx-dev-docs-latest-sync.ts
+++ b/scripts/documentation/nx-dev-docs-latest-sync.ts
@@ -1,9 +1,9 @@
 import * as chalk from 'chalk';
 import * as yargs from 'yargs';
 import { watch } from 'chokidar';
-import * as shell from 'shelljs';
 import { BehaviorSubject } from 'rxjs';
 import { debounceTime, filter, switchMapTo, tap } from 'rxjs/operators';
+import { execSync } from 'child_process';
 
 /**
  * Available colours
@@ -24,9 +24,8 @@ const argv = yargs
   }).argv;
 
 function sync(): void {
-  return shell.exec(
-    'rsync -avrR --delete ./docs/./ ./nx-dev/nx-dev/public/documentation',
-    { sync: true }
+  execSync(
+    'rsync -avrR --delete ./docs/./ ./nx-dev/nx-dev/public/documentation'
   );
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
the scripts import the `rimraf` and `shelljs` packages which are both not listed as dependencies in `package.json`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
the scripts use the installed `fs-extra` package and `child_process` module of node

