### PR TITLE
feat(core): filter affected projects by glob pattern on tags

### DIFF
--- a/docs/generated/cli/affected-apps.md
+++ b/docs/generated/cli/affected-apps.md
@@ -87,6 +87,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/docs/generated/cli/affected-build.md
+++ b/docs/generated/cli/affected-build.md
@@ -99,6 +99,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/docs/generated/cli/affected-dep-graph.md
+++ b/docs/generated/cli/affected-dep-graph.md
@@ -127,6 +127,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/docs/generated/cli/affected-e2e.md
+++ b/docs/generated/cli/affected-e2e.md
@@ -99,6 +99,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/docs/generated/cli/affected-libs.md
+++ b/docs/generated/cli/affected-libs.md
@@ -87,6 +87,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/docs/generated/cli/affected-lint.md
+++ b/docs/generated/cli/affected-lint.md
@@ -99,6 +99,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/docs/generated/cli/affected-test.md
+++ b/docs/generated/cli/affected-test.md
@@ -99,6 +99,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/docs/generated/cli/affected.md
+++ b/docs/generated/cli/affected.md
@@ -105,6 +105,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### target
 
 Task to run for affected projects

--- a/docs/generated/cli/format-check.md
+++ b/docs/generated/cli/format-check.md
@@ -71,6 +71,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/docs/generated/cli/format-write.md
+++ b/docs/generated/cli/format-write.md
@@ -71,6 +71,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/docs/generated/cli/print-affected.md
+++ b/docs/generated/cli/print-affected.md
@@ -99,6 +99,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/nx-dev/nx-dev/public/documentation/generated/cli/affected-apps.md
+++ b/nx-dev/nx-dev/public/documentation/generated/cli/affected-apps.md
@@ -87,6 +87,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/nx-dev/nx-dev/public/documentation/generated/cli/affected-build.md
+++ b/nx-dev/nx-dev/public/documentation/generated/cli/affected-build.md
@@ -99,6 +99,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/nx-dev/nx-dev/public/documentation/generated/cli/affected-dep-graph.md
+++ b/nx-dev/nx-dev/public/documentation/generated/cli/affected-dep-graph.md
@@ -127,6 +127,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/nx-dev/nx-dev/public/documentation/generated/cli/affected-e2e.md
+++ b/nx-dev/nx-dev/public/documentation/generated/cli/affected-e2e.md
@@ -99,6 +99,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/nx-dev/nx-dev/public/documentation/generated/cli/affected-libs.md
+++ b/nx-dev/nx-dev/public/documentation/generated/cli/affected-libs.md
@@ -87,6 +87,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/nx-dev/nx-dev/public/documentation/generated/cli/affected-lint.md
+++ b/nx-dev/nx-dev/public/documentation/generated/cli/affected-lint.md
@@ -99,6 +99,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/nx-dev/nx-dev/public/documentation/generated/cli/affected-test.md
+++ b/nx-dev/nx-dev/public/documentation/generated/cli/affected-test.md
@@ -99,6 +99,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/nx-dev/nx-dev/public/documentation/generated/cli/affected.md
+++ b/nx-dev/nx-dev/public/documentation/generated/cli/affected.md
@@ -105,6 +105,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### target
 
 Task to run for affected projects

--- a/nx-dev/nx-dev/public/documentation/generated/cli/format-check.md
+++ b/nx-dev/nx-dev/public/documentation/generated/cli/format-check.md
@@ -71,6 +71,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/nx-dev/nx-dev/public/documentation/generated/cli/format-write.md
+++ b/nx-dev/nx-dev/public/documentation/generated/cli/format-write.md
@@ -71,6 +71,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/nx-dev/nx-dev/public/documentation/generated/cli/print-affected.md
+++ b/nx-dev/nx-dev/public/documentation/generated/cli/print-affected.md
@@ -99,6 +99,12 @@ Default: `false`
 
 Rerun the tasks even when the results are available in the cache
 
+### tags
+
+Default: ``
+
+Filter affected projects by tags using glob patterns
+
 ### uncommitted
 
 Uncommitted changes

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -431,6 +431,12 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
     .option('verbose', {
       describe: 'Print additional error stack trace on failure',
     })
+    .option('tags', {
+      describe: 'Filter affected projects by tags using glob patterns',
+      default: [],
+      type: 'array',
+      coerce: parseCSV,
+    })
     .conflicts({
       files: ['uncommitted', 'untracked', 'base', 'head', 'all'],
       untracked: ['uncommitted', 'files', 'base', 'head', 'all'],

--- a/packages/workspace/src/command-line/utils.spec.ts
+++ b/packages/workspace/src/command-line/utils.spec.ts
@@ -23,6 +23,7 @@ describe('splitArgs', () => {
       base: 'sha1',
       head: 'sha2',
       skipNxCache: false,
+      tags: [],
     });
   });
 
@@ -53,6 +54,7 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'main',
       skipNxCache: false,
+      tags: [],
     });
   });
 
@@ -75,6 +77,7 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'develop',
       skipNxCache: false,
+      tags: [],
     });
   });
 
@@ -94,6 +97,7 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'main',
       skipNxCache: false,
+      tags: [],
     });
   });
 
@@ -128,6 +132,7 @@ describe('splitArgs', () => {
       base: 'sha1',
       head: 'sha2',
       skipNxCache: false,
+      tags: [],
     });
     expect(overrides).toEqual({
       notNxArg: true,
@@ -155,6 +160,7 @@ describe('splitArgs', () => {
       base: 'envVarSha1',
       head: 'envVarSha2',
       skipNxCache: false,
+      tags: [],
     });
 
     expect(
@@ -171,6 +177,7 @@ describe('splitArgs', () => {
       base: 'envVarSha1',
       head: 'directlyOnCommandSha1',
       skipNxCache: false,
+      tags: [],
     });
 
     expect(
@@ -187,6 +194,7 @@ describe('splitArgs', () => {
       base: 'directlyOnCommandSha2',
       head: 'envVarSha2',
       skipNxCache: false,
+      tags: [],
     });
 
     // Reset process data

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -33,6 +33,7 @@ const runAffected: string[] = [
   'files',
   'plain',
   'select',
+  'tags',
 ];
 
 export interface RawNxArgs extends NxArgs {
@@ -66,6 +67,7 @@ export interface NxArgs {
   'hide-cached-output'?: boolean;
   hideCachedOutput?: boolean;
   scan?: boolean;
+  tags?: string[];
 }
 
 const ignoreArgs = ['$0', '_'];
@@ -183,6 +185,10 @@ export function splitArgsIntoNxArgsAndOverrides(
           )} --head=${output.bold('HEAD')}`,
         });
       }
+    }
+
+    if (!nxArgs.tags) {
+      nxArgs.tags = [];
     }
   }
 


### PR DESCRIPTION
ISSUES CLOSED: #2675

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running affected command you only get `all` affected projects that have the target running affected for

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Can filter affected projects by glob patterns so that you can run a target for all affected projects who have a tag `scope*` (for example) 

Example:

There are two apps in the project `client` and `api` they are configured like so:

```
client:
  tags: ["frontend", "scope:app"]

api:
  tags: ["backend", "scope:server"]
```

Let's say they share a lib `dtos`, if we make a change in `dtos` and then run `nx affected:apps` it should print out `client` and `api` (currently).

What if we have two different CI machines, one does everything for servers and one does everything for apps. With this PR we could do:

```
CI Machine 1
yarn nx affected:* --tags frontend

CI Machine 2
yarn nx affected:* --tags backend
```

A more complex example and what spurred this is, we have the need for some of our docker containers to be built on ARM resources and some to be built on x86 resources (there are definitely different ways to do this but this is just the situation that spurred this). Each of our servers could be tagged with `arm` or `x86` then we could do

```
ARM Machine
yarn nx affected:dockerize --tags arm

x86 Machine
yarn nx affected:dockerize --tags x86
```

The `tags` flag accepts a glob pattern so you could so something like `--tags "scope:*"` to run a target on all affected projects that have a `scope` tag as well.

Currently the CLI will accept `--tags=tag1,tag2,scope*` and then `AND` them together so a project is required to have a tag that matches all of the glob tags passed in. Not sure if this would be better as an `OR` or have it as an `exclude` with `AND` or `OR`. Open to ideas here.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #2675
