### PR TITLE
docs(react): updating generator command to align with example

### DIFF
--- a/docs/react/guides/nextjs.md
+++ b/docs/react/guides/nextjs.md
@@ -111,7 +111,7 @@ and [Library Types](/{{version}}/{{framework}}/structure/library-types).
 To generate a new library run:
 
 ```bash
-npx nx g @nrwl/react:lib shared-ui-components
+npx nx g @nrwl/react:lib shared-ui-layout
 ```
 
 And you will see the following:


### PR DESCRIPTION
`npx nx g @nrwl/react:lib shared-ui-components` should be `npx nx g @nrwl/react:lib shared-ui-layout` to correspond with the example output and subsquental examples.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
A generator command that illustrates a name of `shared-ui-components` and the following examples in the documentation refers to `shared-ui-layout`.

## Expected Behavior
A generator command where the name correspond with the following examples in the documentation.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
