### PR TITLE
docs(nxdev): community page open graph title fix

### DIFF
--- a/nx-dev/nx-dev/pages/community.tsx
+++ b/nx-dev/nx-dev/pages/community.tsx
@@ -39,7 +39,7 @@ export function Community(props: CommunityProps) {
         description="There are many ways you can connect with the open-source Nx community. The community is rich and dynamic offering Nx plugins and help on multiple platforms like Github, Slack and Twitter"
         openGraph={{
           url: 'https://nx.dev' + router.asPath,
-          title: 'Nx and Modern Angular',
+          title: 'Nx Community and Plugin Listing',
           description:
             'There are many ways you can connect with the open-source Nx community. The community is rich and dynamic offering Nx plugins and help on multiple platforms like Github, Slack and Twitter',
           images: [


### PR DESCRIPTION
## What it does?
Fixes the open graph meta title content for the nx.dev community page.