### PR TITLE
fix(workspace): skipFormat files when converting to Nx project

### DIFF
--- a/docs/default/api-workspace/generators/convert-to-nx-project.md
+++ b/docs/default/api-workspace/generators/convert-to-nx-project.md
@@ -54,3 +54,11 @@ Should every project be converted?
 Type: `string`
 
 Project name
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -96,6 +96,7 @@ export async function libraryGenerator(host: Tree, schema: Partial<Schema>) {
     await convertToNxProjectGenerator(host, {
       project: options.name,
       all: false,
+      skipFormat: options.skipFormat,
     });
   }
 

--- a/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.spec.ts
+++ b/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.spec.ts
@@ -6,6 +6,7 @@ import {
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import enquirer = require('enquirer');
 import { libraryGenerator } from '../library/library';
+import * as devkit from '@nrwl/devkit';
 
 import convertToNxProject, {
   SCHEMA_OPTIONS_ARE_MUTUALLY_EXCLUSIVE,
@@ -160,5 +161,53 @@ describe('convert-to-nx-project', () => {
       expect(ex).toBeDefined();
     }
     expect.assertions(1);
+  });
+
+  it('should format files by default', async () => {
+    jest.spyOn(devkit, 'formatFiles');
+
+    const tree = createTreeWithEmptyWorkspace(2);
+
+    await libraryGenerator(tree, {
+      name: 'lib',
+      standaloneConfig: false,
+      skipFormat: true,
+    });
+
+    await convertToNxProject(tree, { project: 'lib' });
+
+    expect(devkit.formatFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it('should format files when passing skipFormat false', async () => {
+    jest.spyOn(devkit, 'formatFiles');
+
+    const tree = createTreeWithEmptyWorkspace(2);
+
+    await libraryGenerator(tree, {
+      name: 'lib',
+      standaloneConfig: false,
+      skipFormat: true,
+    });
+
+    await convertToNxProject(tree, { project: 'lib', skipFormat: false });
+
+    expect(devkit.formatFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not format files when passing skipFormat true ', async () => {
+    jest.spyOn(devkit, 'formatFiles');
+
+    const tree = createTreeWithEmptyWorkspace(2);
+
+    await libraryGenerator(tree, {
+      name: 'lib',
+      standaloneConfig: false,
+      skipFormat: true,
+    });
+
+    convertToNxProject(tree, { project: 'lib', skipFormat: true });
+
+    expect(devkit.formatFiles).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.ts
+++ b/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.ts
@@ -76,7 +76,9 @@ To upgrade change the version number at the top of ${getWorkspacePath(
     });
   }
 
-  await formatFiles(host);
+  if (!schema.skipFormat) {
+    await formatFiles(host);
+  }
 }
 
 export default convertToNxProjectGenerator;

--- a/packages/workspace/src/generators/convert-to-nx-project/schema.d.ts
+++ b/packages/workspace/src/generators/convert-to-nx-project/schema.d.ts
@@ -1,4 +1,5 @@
 export interface Schema {
   project?: string;
   all?: boolean;
+  skipFormat?: boolean;
 }

--- a/packages/workspace/src/generators/convert-to-nx-project/schema.json
+++ b/packages/workspace/src/generators/convert-to-nx-project/schema.json
@@ -22,6 +22,11 @@
     "all": {
       "description": "Should every project be converted?",
       "type": "boolean"
+    },
+    "skipFormat": {
+      "description": "Skip formatting files.",
+      "type": "boolean",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
Add the ability to skipFormat files when converting to Nx project

ISSUES CLOSED: #8386

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There is no way to skipFormat when converting library to Nx project
## Expected Behavior
it should be possible to skipFormat when converting library to Nx project

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
