### PR TITLE
fix(storybook): fixed story template for angular

### DIFF
--- a/packages/angular/src/generators/component-story/__snapshots__/component-story.spec.ts.snap
+++ b/packages/angular/src/generators/component-story/__snapshots__/component-story.spec.ts.snap
@@ -15,7 +15,6 @@ export default {
 } as Meta<TestButtonComponent>;
 
 const Template: Story<TestButtonComponent> = (args: TestButtonComponent) => ({
-  component: TestButtonComponent,
   props: args,
 });
 

--- a/packages/angular/src/generators/component-story/files/__componentFileName__.stories.ts__tmpl__
+++ b/packages/angular/src/generators/component-story/files/__componentFileName__.stories.ts__tmpl__
@@ -12,7 +12,6 @@ export default {
 } as Meta<<%=componentName%>>;
 
 const Template: Story<<%=componentName%>> = (args: <%=componentName%>) => ({
-  component: <%=componentName%>,
   props: args,
 });
 

--- a/packages/angular/src/generators/stories/__snapshots__/stories-lib.spec.ts.snap
+++ b/packages/angular/src/generators/stories/__snapshots__/stories-lib.spec.ts.snap
@@ -24,7 +24,6 @@ export default {
 } as Meta<TestButtonComponent>;
 
 const Template: Story<TestButtonComponent> = (args: TestButtonComponent) => ({
-  component: TestButtonComponent,
   props: args,
 });
 


### PR DESCRIPTION
## Current Behavior
The component attribute is in the story template. It was forgotten there, while creating the migrator. So there is a migrator in place, already for this.

## Expected Behavior
[The `component` attribute should not be there.](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-angular-story-component)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
