### PR TITLE
feat(angular): add option to skip module creation #7806

### DIFF
--- a/docs/angular/api-angular/generators/library.md
+++ b/docs/angular/api-angular/generators/library.md
@@ -155,6 +155,14 @@ Type: `boolean`
 
 Skip formatting files.
 
+### skipModule
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to skip the creation of a default module when generating the library.
+
 ### skipPackageJson
 
 Default: `false`

--- a/docs/node/api-angular/generators/library.md
+++ b/docs/node/api-angular/generators/library.md
@@ -155,6 +155,14 @@ Type: `boolean`
 
 Skip formatting files.
 
+### skipModule
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to skip the creation of a default module when generating the library.
+
 ### skipPackageJson
 
 Default: `false`

--- a/docs/react/api-angular/generators/library.md
+++ b/docs/react/api-angular/generators/library.md
@@ -155,6 +155,14 @@ Type: `boolean`
 
 Skip formatting files.
 
+### skipModule
+
+Default: `false`
+
+Type: `boolean`
+
+Whether to skip the creation of a default module when generating the library.
+
 ### skipPackageJson
 
 Default: `false`

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -22,6 +22,7 @@ export function normalizeOptions(
     compilationMode: schema.publishable
       ? 'partial'
       : schema.compilationMode ?? 'full',
+    skipModule: schema.skipModule ?? false,
     ...schema,
   };
 

--- a/packages/angular/src/generators/library/lib/update-project.ts
+++ b/packages/angular/src/generators/library/lib/update-project.ts
@@ -54,9 +54,10 @@ function updateFiles(host: Tree, options: NormalizedSchema) {
   if (options.name !== options.fileName) {
     host.delete(path.join(libRoot, `${options.name}.module.ts`));
   }
-  host.write(
-    path.join(libRoot, `${options.fileName}.module.ts`),
-    `
+  if (!options.skipModule) {
+    host.write(
+      path.join(libRoot, `${options.fileName}.module.ts`),
+      `
         import { NgModule } from '@angular/core';
         import { CommonModule } from '@angular/common';
         
@@ -67,12 +68,12 @@ function updateFiles(host: Tree, options: NormalizedSchema) {
         })
         export class ${options.moduleName} { }
         `
-  );
+    );
 
-  if (options.unitTestRunner !== 'none' && options.addModuleSpec) {
-    host.write(
-      path.join(libRoot, `${options.fileName}.module.spec.ts`),
-      `
+    if (options.unitTestRunner !== 'none' && options.addModuleSpec) {
+      host.write(
+        path.join(libRoot, `${options.fileName}.module.spec.ts`),
+        `
     import { async, TestBed } from '@angular/core/testing';
     import { ${options.moduleName} } from './${options.fileName}.module';
     
@@ -93,12 +94,17 @@ function updateFiles(host: Tree, options: NormalizedSchema) {
       });
     });
           `
-    );
+      );
+    }
+  } else {
+    host.delete(joinPathFragments(libRoot, `${options.fileName}.module.ts`));
   }
 
   host.write(
     `${options.projectRoot}/src/index.ts`,
-    `
+    options.skipModule
+      ? ``
+      : `
         export * from './lib/${options.fileName}.module';
         `
   );

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -177,6 +177,21 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-lib'].architect.build).toBeDefined();
     });
 
+    it('should not generate a module file and index.ts should be empty', async () => {
+      // ACT
+      await runLibraryGeneratorWithOpts({
+        skipModule: true,
+      });
+
+      // ASSERT
+      const moduleFileExists = tree.exists(
+        'libs/my-lib/src/lib/my-lib.module.ts'
+      );
+      expect(moduleFileExists).toBeFalsy();
+      const indexApi = tree.read('libs/my-lib/src/index.ts', 'utf-8');
+      expect(indexApi).toEqual(``);
+    });
+
     it('should remove "build" target from workspace.json when a library is not publishable', async () => {
       // ACT
       await runLibraryGeneratorWithOpts({

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -28,4 +28,5 @@ export interface Schema {
   unitTestRunner?: UnitTestRunner;
   compilationMode?: 'full' | 'partial';
   setParserOptionsProject?: boolean;
+  skipModule?: boolean;
 }

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -117,6 +117,11 @@
       "type": "boolean",
       "description": "Whether to configure TailwindCSS for the application. It can only be used with buildable and publishable libraries. Non-buildable libraries will use the application's Tailwind configuration.",
       "default": false
+    },
+    "skipModule": {
+      "type": "boolean",
+      "description": "Whether to skip the creation of a default module when generating the library.",
+      "default": false
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Any time an angular lib is generated, it creates a module.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Some libs may not call for a module to be exposed by default, so provide option to skip the creation of it 
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7806
