### PR TITLE
fix(storybook): apply a webpack tweak for storybook and angular

### DIFF
--- a/packages/angular/src/generators/storybook-configuration/__snapshots__/storybook-configuration.spec.ts.snap
+++ b/packages/angular/src/generators/storybook-configuration/__snapshots__/storybook-configuration.spec.ts.snap
@@ -24,18 +24,7 @@ module.exports = {
     
 
     
-      /**
-       * Remove html raw loader that breaks Jit compilation as suggested here https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004059631.
-       * The issue references:
-       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1003399336
-       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004180729
-       * Here's what should be removed:
-       * {
-       *   test: /\\\\.html$/,
-       *   loader: './node_modules/raw-loader/dist/cjs.js',
-       *   exclude: /\\\\.async\\\\.html$/
-       * },
-       */
+      // remove html raw-loader that breaks Jit compilation
       const rules = (config.module.rules ?? []).filter(
         (rule) =>
           rule.test !== /\\\\.html$/ &&

--- a/packages/angular/src/generators/storybook-configuration/__snapshots__/storybook-configuration.spec.ts.snap
+++ b/packages/angular/src/generators/storybook-configuration/__snapshots__/storybook-configuration.spec.ts.snap
@@ -20,7 +20,29 @@ module.exports = {
     if (rootMain.webpackFinal) {
       config = await rootMain.webpackFinal(config, { configType });
     }
+
     
+
+    
+      /**
+       * Remove html raw loader that breaks Jit compilation as suggested here https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004059631.
+       * The issue references:
+       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1003399336
+       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004180729
+       * Here's what should be removed:
+       * {
+       *   test: /\\\\.html$/,
+       *   loader: './node_modules/raw-loader/dist/cjs.js',
+       *   exclude: /\\\\.async\\\\.html$/
+       * },
+       */
+      const rules = (config.module.rules ?? []).filter(
+        (rule) =>
+          rule.test !== /\\\\.html$/ &&
+          rule.exclude !== /\\\\.async\\\\.html$/ &&
+          !rule.loader?.includes('raw-loader')
+      );
+      config.module.rules = [...rules];
     
 
     // add your own webpack tweaks if needed

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -20,7 +20,29 @@ module.exports = {
     if (rootMain.webpackFinal) {
       config = await rootMain.webpackFinal(config, { configType });
     }
+
     
+
+    
+      /**
+       * Remove html raw loader that breaks Jit compilation as suggested here https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004059631.
+       * The issue references:
+       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1003399336
+       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004180729
+       * Here's what should be removed:
+       * {
+       *   test: /\\\\.html$/,
+       *   loader: './node_modules/raw-loader/dist/cjs.js',
+       *   exclude: /\\\\.async\\\\.html$/
+       * },
+       */
+      const rules = (config.module.rules ?? []).filter(
+        (rule) =>
+          rule.test !== /\\\\.html$/ &&
+          rule.exclude !== /\\\\.async\\\\.html$/ &&
+          !rule.loader?.includes('raw-loader')
+      );
+      config.module.rules = [...rules];
     
 
     // add your own webpack tweaks if needed
@@ -59,11 +81,33 @@ module.exports = {
     if (rootMain.webpackFinal) {
       config = await rootMain.webpackFinal(config, { configType });
     }
-    
+
     // for backwards compatibility call the \`rootWebpackConfig\`
       // this can be removed once that one is migrated fully to
       // use the \`webpackFinal\` property in the \`main.js\` file
       config = rootWebpackConfig({ config });
+    
+
+    
+      /**
+       * Remove html raw loader that breaks Jit compilation as suggested here https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004059631.
+       * The issue references:
+       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1003399336
+       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004180729
+       * Here's what should be removed:
+       * {
+       *   test: /\\\\.html$/,
+       *   loader: './node_modules/raw-loader/dist/cjs.js',
+       *   exclude: /\\\\.async\\\\.html$/
+       * },
+       */
+      const rules = (config.module.rules ?? []).filter(
+        (rule) =>
+          rule.test !== /\\\\.html$/ &&
+          rule.exclude !== /\\\\.async\\\\.html$/ &&
+          !rule.loader?.includes('raw-loader')
+      );
+      config.module.rules = [...rules];
     
 
     // add your own webpack tweaks if needed

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -24,18 +24,7 @@ module.exports = {
     
 
     
-      /**
-       * Remove html raw loader that breaks Jit compilation as suggested here https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004059631.
-       * The issue references:
-       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1003399336
-       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004180729
-       * Here's what should be removed:
-       * {
-       *   test: /\\\\.html$/,
-       *   loader: './node_modules/raw-loader/dist/cjs.js',
-       *   exclude: /\\\\.async\\\\.html$/
-       * },
-       */
+      // remove html raw-loader that breaks Jit compilation
       const rules = (config.module.rules ?? []).filter(
         (rule) =>
           rule.test !== /\\\\.html$/ &&
@@ -89,18 +78,7 @@ module.exports = {
     
 
     
-      /**
-       * Remove html raw loader that breaks Jit compilation as suggested here https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004059631.
-       * The issue references:
-       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1003399336
-       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004180729
-       * Here's what should be removed:
-       * {
-       *   test: /\\\\.html$/,
-       *   loader: './node_modules/raw-loader/dist/cjs.js',
-       *   exclude: /\\\\.async\\\\.html$/
-       * },
-       */
+      // remove html raw-loader that breaks Jit compilation
       const rules = (config.module.rules ?? []).filter(
         (rule) =>
           rule.test !== /\\\\.html$/ &&

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
@@ -17,11 +17,33 @@ module.exports = {
     if (rootMain.webpackFinal) {
       config = await rootMain.webpackFinal(config, { configType });
     }
-    
+
     <% if (existsRootWebpackConfig) { %>// for backwards compatibility call the `rootWebpackConfig`
       // this can be removed once that one is migrated fully to
       // use the `webpackFinal` property in the `main.js` file
       config = rootWebpackConfig({ config });
+    <% } %>
+
+    <% if (uiFramework === '@storybook/angular') { %>
+      /**
+       * Remove html raw loader that breaks Jit compilation as suggested here https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004059631.
+       * The issue references:
+       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1003399336
+       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004180729
+       * Here's what should be removed:
+       * {
+       *   test: /\.html$/,
+       *   loader: './node_modules/raw-loader/dist/cjs.js',
+       *   exclude: /\.async\.html$/
+       * },
+       */
+      const rules = (config.module.rules ?? []).filter(
+        (rule) =>
+          rule.test !== /\.html$/ &&
+          rule.exclude !== /\.async\.html$/ &&
+          !rule.loader?.includes('raw-loader')
+      );
+      config.module.rules = [...rules];
     <% } %>
 
     // add your own webpack tweaks if needed

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
@@ -25,18 +25,7 @@ module.exports = {
     <% } %>
 
     <% if (uiFramework === '@storybook/angular') { %>
-      /**
-       * Remove html raw loader that breaks Jit compilation as suggested here https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004059631.
-       * The issue references:
-       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1003399336
-       * - https://github.com/storybookjs/storybook/issues/16977#issuecomment-1004180729
-       * Here's what should be removed:
-       * {
-       *   test: /\.html$/,
-       *   loader: './node_modules/raw-loader/dist/cjs.js',
-       *   exclude: /\.async\.html$/
-       * },
-       */
+      // remove html raw-loader that breaks Jit compilation
       const rules = (config.module.rules ?? []).filter(
         (rule) =>
           rule.test !== /\.html$/ &&


### PR DESCRIPTION
- [x] remove html raw-loader from the webpack rules array if storybook is used with angular v13;
- [x] update related unit test snapshots; 

the html raw-loader breaks jit compilation when storybook 6.5 aplha is used with angular v13

ISSUES CLOSED: #8360

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8360
