### PR TITLE
fix(angular): fix tailwind css support in libraries using components with inline styles

### DIFF
--- a/e2e/angular-extensions/src/tailwind.test.ts
+++ b/e2e/angular-extensions/src/tailwind.test.ts
@@ -12,390 +12,387 @@ import {
 } from '@nrwl/e2e/utils';
 
 describe('Tailwind support', () => {
-  it('tests are disabled', () => {
-    expect(1).toEqual(1);
+  let project: string;
+
+  const defaultButtonBgColor = 'bg-blue-700';
+
+  const buildLibWithTailwind = {
+    name: uniq('build-lib-with-tailwind'),
+    buttonBgColor: 'bg-green-800',
+  };
+  const pubLibWithTailwind = {
+    name: uniq('pub-lib-with-tailwind'),
+    buttonBgColor: 'bg-red-900',
+  };
+
+  const spacing = {
+    root: {
+      sm: '2px',
+      md: '4px',
+      lg: '8px',
+    },
+    projectVariant1: {
+      sm: '1px',
+      md: '2px',
+      lg: '4px',
+    },
+    projectVariant2: {
+      sm: '4px',
+      md: '8px',
+      lg: '16px',
+    },
+    projectVariant3: {
+      sm: '8px',
+      md: '16px',
+      lg: '32px',
+    },
+  };
+
+  const createWorkspaceTailwindConfigFile = () => {
+    const tailwindConfigFile = 'tailwind.config.js';
+
+    const tailwindConfig = `module.exports = {
+      mode: 'jit',
+      purge: ['./apps/**/*.{html,ts}', './libs/**/*.{html,ts}'],
+      darkMode: false,
+      theme: {
+        spacing: {
+          sm: '${spacing.root.sm}',
+          md: '${spacing.root.md}',
+          lg: '${spacing.root.lg}',
+        },
+      },
+      variants: { extend: {} },
+      plugins: [],
+    };
+    `;
+
+    updateFile(tailwindConfigFile, tailwindConfig);
+  };
+
+  const createTailwindConfigFile = (
+    tailwindConfigFile = 'tailwind.config.js',
+    libSpacing: typeof spacing['projectVariant1']
+  ) => {
+    const tailwindConfig = `const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+    const { join } = require('path');
+  
+    module.exports = {
+      mode: 'jit',
+      purge: [
+        join(__dirname, 'src/**/*.{html,ts}'),
+        ...createGlobPatternsForDependencies(__dirname),
+      ],
+      darkMode: false,
+      theme: {
+        spacing: {
+          sm: '${libSpacing.sm}',
+          md: '${libSpacing.md}',
+          lg: '${libSpacing.lg}',
+        },
+      },
+      variants: { extend: {} },
+      plugins: [],
+    };
+    `;
+
+    updateFile(tailwindConfigFile, tailwindConfig);
+  };
+
+  const updateTailwindConfig = (
+    tailwindConfigPath: string,
+    projectSpacing: typeof spacing['root']
+  ) => {
+    const tailwindConfig = readFile(tailwindConfigPath);
+
+    const tailwindConfigUpdated = tailwindConfig.replace(
+      'theme: {',
+      `theme: {
+        spacing: {
+          sm: '${projectSpacing.sm}',
+          md: '${projectSpacing.md}',
+          lg: '${projectSpacing.lg}',
+        },`
+    );
+
+    updateFile(tailwindConfigPath, tailwindConfigUpdated);
+  };
+
+  beforeAll(() => {
+    project = newProject();
+
+    // Create tailwind config in the workspace root
+    createWorkspaceTailwindConfigFile();
   });
-  // let project: string;
-  //
-  // const defaultButtonBgColor = 'bg-blue-700';
-  //
-  // const buildLibWithTailwind = {
-  //   name: uniq('build-lib-with-tailwind'),
-  //   buttonBgColor: 'bg-green-800',
-  // };
-  // const pubLibWithTailwind = {
-  //   name: uniq('pub-lib-with-tailwind'),
-  //   buttonBgColor: 'bg-red-900',
-  // };
-  //
-  // const spacing = {
-  //   root: {
-  //     sm: '2px',
-  //     md: '4px',
-  //     lg: '8px',
-  //   },
-  //   projectVariant1: {
-  //     sm: '1px',
-  //     md: '2px',
-  //     lg: '4px',
-  //   },
-  //   projectVariant2: {
-  //     sm: '4px',
-  //     md: '8px',
-  //     lg: '16px',
-  //   },
-  //   projectVariant3: {
-  //     sm: '8px',
-  //     md: '16px',
-  //     lg: '32px',
-  //   },
-  // };
-  //
-  // const createWorkspaceTailwindConfigFile = () => {
-  //   const tailwindConfigFile = 'tailwind.config.js';
-  //
-  //   const tailwindConfig = `module.exports = {
-  //     mode: 'jit',
-  //     purge: ['./apps/**/*.{html,ts}', './libs/**/*.{html,ts}'],
-  //     darkMode: false,
-  //     theme: {
-  //       spacing: {
-  //         sm: '${spacing.root.sm}',
-  //         md: '${spacing.root.md}',
-  //         lg: '${spacing.root.lg}',
-  //       },
-  //     },
-  //     variants: { extend: {} },
-  //     plugins: [],
-  //   };
-  //   `;
-  //
-  //   updateFile(tailwindConfigFile, tailwindConfig);
-  // };
-  //
-  // const createTailwindConfigFile = (
-  //   tailwindConfigFile = 'tailwind.config.js',
-  //   libSpacing: typeof spacing['projectVariant1']
-  // ) => {
-  //   const tailwindConfig = `const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
-  //   const { join } = require('path');
-  //
-  //   module.exports = {
-  //     mode: 'jit',
-  //     purge: [
-  //       join(__dirname, 'src/**/*.{html,ts}'),
-  //       ...createGlobPatternsForDependencies(__dirname),
-  //     ],
-  //     darkMode: false,
-  //     theme: {
-  //       spacing: {
-  //         sm: '${libSpacing.sm}',
-  //         md: '${libSpacing.md}',
-  //         lg: '${libSpacing.lg}',
-  //       },
-  //     },
-  //     variants: { extend: {} },
-  //     plugins: [],
-  //   };
-  //   `;
-  //
-  //   updateFile(tailwindConfigFile, tailwindConfig);
-  // };
-  //
-  // const updateTailwindConfig = (
-  //   tailwindConfigPath: string,
-  //   projectSpacing: typeof spacing['root']
-  // ) => {
-  //   const tailwindConfig = readFile(tailwindConfigPath);
-  //
-  //   const tailwindConfigUpdated = tailwindConfig.replace(
-  //     'theme: {',
-  //     `theme: {
-  //       spacing: {
-  //         sm: '${projectSpacing.sm}',
-  //         md: '${projectSpacing.md}',
-  //         lg: '${projectSpacing.lg}',
-  //       },`
-  //   );
-  //
-  //   updateFile(tailwindConfigPath, tailwindConfigUpdated);
-  // };
-  //
-  // beforeAll(() => {
-  //   project = newProject();
-  //
-  //   // Create tailwind config in the workspace root
-  //   createWorkspaceTailwindConfigFile();
-  // });
-  //
-  // afterAll(() => cleanupProject());
-  //
-  // describe('Libraries', () => {
-  //   const createLibComponent = (
-  //     lib: string,
-  //     buttonBgColor: string = defaultButtonBgColor
-  //   ) => {
-  //     updateFile(
-  //       `libs/${lib}/src/lib/foo.component.ts`,
-  //       `import { Component } from '@angular/core';
-  //
-  //       @Component({
-  //         selector: '${project}-foo',
-  //         template: '<button class="custom-btn text-white ${buttonBgColor}">Click me!</button>',
-  //         styles: [\`
-  //           .custom-btn {
-  //             @apply m-md p-sm;
-  //           }
-  //         \`]
-  //       })
-  //       export class FooComponent {}
-  //     `
-  //     );
-  //
-  //     updateFile(
-  //       `libs/${lib}/src/lib/${lib}.module.ts`,
-  //       `import { NgModule } from '@angular/core';
-  //       import { CommonModule } from '@angular/common';
-  //       import { FooComponent } from './foo.component';
-  //
-  //       @NgModule({
-  //         imports: [CommonModule],
-  //         declarations: [FooComponent],
-  //         exports: [FooComponent],
-  //       })
-  //       export class LibModule {}
-  //     `
-  //     );
-  //
-  //     updateFile(
-  //       `libs/${lib}/src/index.ts`,
-  //       `export * from './lib/foo.component';
-  //       export * from './lib/${lib}.module';
-  //       `
-  //     );
-  //   };
-  //
-  //   const assertLibComponentStyles = (
-  //     lib: string,
-  //     libSpacing: typeof spacing['root']
-  //   ) => {
-  //     const builtComponentContent = readFile(
-  //       `dist/libs/${lib}/esm2020/lib/foo.component.mjs`
-  //     );
-  //     let expectedStylesRegex = new RegExp(
-  //       `styles: \\[\\"\\.custom\\-btn(\\[_ngcontent\\-%COMP%\\])?{margin:${libSpacing.md};padding:${libSpacing.sm}}(\\\\n)?\\"\\]`
-  //     );
-  //
-  //     expect(builtComponentContent).toMatch(expectedStylesRegex);
-  //   };
-  //
-  //   it('should generate a buildable library with tailwind and build correctly', () => {
-  //     runCLI(
-  //       `generate @nrwl/angular:lib ${buildLibWithTailwind.name} --buildable --add-tailwind --no-interactive`
-  //     );
-  //     updateTailwindConfig(
-  //       `libs/${buildLibWithTailwind.name}/tailwind.config.js`,
-  //       spacing.projectVariant1
-  //     );
-  //     createLibComponent(
-  //       buildLibWithTailwind.name,
-  //       buildLibWithTailwind.buttonBgColor
-  //     );
-  //
-  //     runCLI(`build ${buildLibWithTailwind.name}`);
-  //
-  //     assertLibComponentStyles(
-  //       buildLibWithTailwind.name,
-  //       spacing.projectVariant1
-  //     );
-  //   });
-  //
-  //   it('should set up tailwind in a previously generated buildable library and build correctly', () => {
-  //     const buildLibSetupTailwind = uniq('build-lib-setup-tailwind');
-  //     runCLI(
-  //       `generate @nrwl/angular:lib ${buildLibSetupTailwind} --buildable --no-interactive`
-  //     );
-  //     runCLI(
-  //       `generate @nrwl/angular:setup-tailwind ${buildLibSetupTailwind} --no-interactive`
-  //     );
-  //     updateTailwindConfig(
-  //       `libs/${buildLibSetupTailwind}/tailwind.config.js`,
-  //       spacing.projectVariant2
-  //     );
-  //     createLibComponent(buildLibSetupTailwind);
-  //
-  //     runCLI(`build ${buildLibSetupTailwind}`);
-  //
-  //     assertLibComponentStyles(buildLibSetupTailwind, spacing.projectVariant2);
-  //   });
-  //
-  //   it('should correctly build a buildable library with a tailwind.config.js file in the project root or workspace root', () => {
-  //     const buildLibNoProjectConfig = uniq('build-lib-no-project-config');
-  //     runCLI(
-  //       `generate @nrwl/angular:lib ${buildLibNoProjectConfig} --buildable --no-interactive`
-  //     );
-  //     createTailwindConfigFile(
-  //       `libs/${buildLibNoProjectConfig}/tailwind.config.js`,
-  //       spacing.projectVariant3
-  //     );
-  //     createLibComponent(buildLibNoProjectConfig);
-  //
-  //     runCLI(`build ${buildLibNoProjectConfig}`);
-  //
-  //     assertLibComponentStyles(
-  //       buildLibNoProjectConfig,
-  //       spacing.projectVariant3
-  //     );
-  //
-  //     // remove tailwind.config.js file from the project root to test the one in the workspace root
-  //     removeFile(`libs/${buildLibNoProjectConfig}/tailwind.config.js`);
-  //
-  //     runCLI(`build ${buildLibNoProjectConfig}`);
-  //
-  //     assertLibComponentStyles(buildLibNoProjectConfig, spacing.root);
-  //   });
-  //
-  //   it('should generate a publishable library with tailwind and build correctly', () => {
-  //     runCLI(
-  //       `generate @nrwl/angular:lib ${pubLibWithTailwind.name} --publishable --add-tailwind --importPath=@${project}/${pubLibWithTailwind.name} --no-interactive`
-  //     );
-  //     updateTailwindConfig(
-  //       `libs/${pubLibWithTailwind.name}/tailwind.config.js`,
-  //       spacing.projectVariant1
-  //     );
-  //     createLibComponent(
-  //       pubLibWithTailwind.name,
-  //       pubLibWithTailwind.buttonBgColor
-  //     );
-  //
-  //     runCLI(`build ${pubLibWithTailwind.name}`);
-  //
-  //     assertLibComponentStyles(
-  //       pubLibWithTailwind.name,
-  //       spacing.projectVariant1
-  //     );
-  //   });
-  //
-  //   it('should set up tailwind in a previously generated publishable library and build correctly', () => {
-  //     const pubLibSetupTailwind = uniq('pub-lib-setup-tailwind');
-  //     runCLI(
-  //       `generate @nrwl/angular:lib ${pubLibSetupTailwind} --publishable --importPath=@${project}/${pubLibSetupTailwind} --no-interactive`
-  //     );
-  //     runCLI(
-  //       `generate @nrwl/angular:setup-tailwind ${pubLibSetupTailwind} --no-interactive`
-  //     );
-  //     updateTailwindConfig(
-  //       `libs/${pubLibSetupTailwind}/tailwind.config.js`,
-  //       spacing.projectVariant2
-  //     );
-  //     createLibComponent(pubLibSetupTailwind);
-  //
-  //     runCLI(`build ${pubLibSetupTailwind}`);
-  //
-  //     assertLibComponentStyles(pubLibSetupTailwind, spacing.projectVariant2);
-  //   });
-  //
-  //   it('should correctly build a publishable library with a tailwind.config.js file in the project root or workspace root', () => {
-  //     const pubLibNoProjectConfig = uniq('pub-lib-no-project-config');
-  //     runCLI(
-  //       `generate @nrwl/angular:lib ${pubLibNoProjectConfig} --publishable --importPath=@${project}/${pubLibNoProjectConfig} --no-interactive`
-  //     );
-  //     createTailwindConfigFile(
-  //       `libs/${pubLibNoProjectConfig}/tailwind.config.js`,
-  //       spacing.projectVariant3
-  //     );
-  //     createLibComponent(pubLibNoProjectConfig);
-  //
-  //     runCLI(`build ${pubLibNoProjectConfig}`);
-  //
-  //     assertLibComponentStyles(pubLibNoProjectConfig, spacing.projectVariant3);
-  //
-  //     // remove tailwind.config.js file from the project root to test the one in the workspace root
-  //     removeFile(`libs/${pubLibNoProjectConfig}/tailwind.config.js`);
-  //
-  //     runCLI(`build ${pubLibNoProjectConfig}`);
-  //
-  //     assertLibComponentStyles(pubLibNoProjectConfig, spacing.root);
-  //   });
-  // });
-  //
-  // describe('Applications', () => {
-  //   const updateAppComponent = (app: string) => {
-  //     updateFile(
-  //       `apps/${app}/src/app/app.component.html`,
-  //       `<button class="custom-btn text-white">Click me!</button>`
-  //     );
-  //
-  //     updateFile(
-  //       `apps/${app}/src/app/app.component.css`,
-  //       `.custom-btn {
-  //         @apply m-md p-sm;
-  //       }`
-  //     );
-  //   };
-  //
-  //   const readAppStylesBundle = (app: string) => {
-  //     const stylesBundlePath = listFiles(`dist/apps/${app}`).find((file) =>
-  //       file.startsWith('styles.')
-  //     );
-  //     const stylesBundle = readFile(`dist/apps/${app}/${stylesBundlePath}`);
-  //
-  //     return stylesBundle;
-  //   };
-  //
-  //   const assertAppComponentStyles = (
-  //     app: string,
-  //     appSpacing: typeof spacing['root']
-  //   ) => {
-  //     const mainBundlePath = listFiles(`dist/apps/${app}`).find((file) =>
-  //       file.startsWith('main.')
-  //     );
-  //     const mainBundle = readFile(`dist/apps/${app}/${mainBundlePath}`);
-  //     let expectedStylesRegex = new RegExp(
-  //       `styles:\\[\\"\\.custom\\-btn\\[_ngcontent\\-%COMP%\\]{margin:${appSpacing.md};padding:${appSpacing.sm}}\\"\\]`
-  //     );
-  //
-  //     expect(mainBundle).toMatch(expectedStylesRegex);
-  //   };
-  //
-  //   it('should build correctly and only output the tailwind utilities used', () => {
-  //     const appWithTailwind = uniq('app-with-tailwind');
-  //     runCLI(
-  //       `generate @nrwl/angular:app ${appWithTailwind} --add-tailwind --no-interactive`
-  //     );
-  //     updateTailwindConfig(
-  //       `apps/${appWithTailwind}/tailwind.config.js`,
-  //       spacing.projectVariant1
-  //     );
-  //     updateFile(
-  //       `apps/${appWithTailwind}/src/app/app.module.ts`,
-  //       `import { NgModule } from '@angular/core';
-  //       import { BrowserModule } from '@angular/platform-browser';
-  //       import { LibModule as LibModule1 } from '@${project}/${buildLibWithTailwind.name}';
-  //       import { LibModule as LibModule2 } from '@${project}/${pubLibWithTailwind.name}';
-  //
-  //       import { AppComponent } from './app.component';
-  //
-  //       @NgModule({
-  //         declarations: [AppComponent],
-  //         imports: [BrowserModule, LibModule1, LibModule2],
-  //         providers: [],
-  //         bootstrap: [AppComponent],
-  //       })
-  //       export class AppModule {}
-  //       `
-  //     );
-  //     updateAppComponent(appWithTailwind);
-  //
-  //     runCLI(`build ${appWithTailwind}`);
-  //
-  //     assertAppComponentStyles(appWithTailwind, spacing.projectVariant1);
-  //     let stylesBundle = readAppStylesBundle(appWithTailwind);
-  //     expect(stylesBundle).toContain('.text-white');
-  //     expect(stylesBundle).not.toContain('.text-black');
-  //     expect(stylesBundle).toContain(`.${buildLibWithTailwind.buttonBgColor}`);
-  //     expect(stylesBundle).toContain(`.${pubLibWithTailwind.buttonBgColor}`);
-  //     expect(stylesBundle).not.toContain(`.${defaultButtonBgColor}`);
-  //   });
-  // });
+
+  afterAll(() => cleanupProject());
+
+  describe('Libraries', () => {
+    const createLibComponent = (
+      lib: string,
+      buttonBgColor: string = defaultButtonBgColor
+    ) => {
+      updateFile(
+        `libs/${lib}/src/lib/foo.component.ts`,
+        `import { Component } from '@angular/core';
+  
+        @Component({
+          selector: '${project}-foo',
+          template: '<button class="custom-btn text-white ${buttonBgColor}">Click me!</button>',
+          styles: [\`
+            .custom-btn {
+              @apply m-md p-sm;
+            }
+          \`]
+        })
+        export class FooComponent {}
+      `
+      );
+
+      updateFile(
+        `libs/${lib}/src/lib/${lib}.module.ts`,
+        `import { NgModule } from '@angular/core';
+        import { CommonModule } from '@angular/common';
+        import { FooComponent } from './foo.component';
+  
+        @NgModule({
+          imports: [CommonModule],
+          declarations: [FooComponent],
+          exports: [FooComponent],
+        })
+        export class LibModule {}
+      `
+      );
+
+      updateFile(
+        `libs/${lib}/src/index.ts`,
+        `export * from './lib/foo.component';
+        export * from './lib/${lib}.module';
+        `
+      );
+    };
+
+    const assertLibComponentStyles = (
+      lib: string,
+      libSpacing: typeof spacing['root']
+    ) => {
+      const builtComponentContent = readFile(
+        `dist/libs/${lib}/esm2020/lib/foo.component.mjs`
+      );
+      let expectedStylesRegex = new RegExp(
+        `styles: \\[\\"\\.custom\\-btn(\\[_ngcontent\\-%COMP%\\])?{margin:${libSpacing.md};padding:${libSpacing.sm}}(\\\\n)?\\"\\]`
+      );
+
+      expect(builtComponentContent).toMatch(expectedStylesRegex);
+    };
+
+    it('should generate a buildable library with tailwind and build correctly', () => {
+      runCLI(
+        `generate @nrwl/angular:lib ${buildLibWithTailwind.name} --buildable --add-tailwind --no-interactive`
+      );
+      updateTailwindConfig(
+        `libs/${buildLibWithTailwind.name}/tailwind.config.js`,
+        spacing.projectVariant1
+      );
+      createLibComponent(
+        buildLibWithTailwind.name,
+        buildLibWithTailwind.buttonBgColor
+      );
+
+      runCLI(`build ${buildLibWithTailwind.name}`);
+
+      assertLibComponentStyles(
+        buildLibWithTailwind.name,
+        spacing.projectVariant1
+      );
+    });
+
+    it('should set up tailwind in a previously generated buildable library and build correctly', () => {
+      const buildLibSetupTailwind = uniq('build-lib-setup-tailwind');
+      runCLI(
+        `generate @nrwl/angular:lib ${buildLibSetupTailwind} --buildable --no-interactive`
+      );
+      runCLI(
+        `generate @nrwl/angular:setup-tailwind ${buildLibSetupTailwind} --no-interactive`
+      );
+      updateTailwindConfig(
+        `libs/${buildLibSetupTailwind}/tailwind.config.js`,
+        spacing.projectVariant2
+      );
+      createLibComponent(buildLibSetupTailwind);
+
+      runCLI(`build ${buildLibSetupTailwind}`);
+
+      assertLibComponentStyles(buildLibSetupTailwind, spacing.projectVariant2);
+    });
+
+    it('should correctly build a buildable library with a tailwind.config.js file in the project root or workspace root', () => {
+      const buildLibNoProjectConfig = uniq('build-lib-no-project-config');
+      runCLI(
+        `generate @nrwl/angular:lib ${buildLibNoProjectConfig} --buildable --no-interactive`
+      );
+      createTailwindConfigFile(
+        `libs/${buildLibNoProjectConfig}/tailwind.config.js`,
+        spacing.projectVariant3
+      );
+      createLibComponent(buildLibNoProjectConfig);
+
+      runCLI(`build ${buildLibNoProjectConfig}`);
+
+      assertLibComponentStyles(
+        buildLibNoProjectConfig,
+        spacing.projectVariant3
+      );
+
+      // remove tailwind.config.js file from the project root to test the one in the workspace root
+      removeFile(`libs/${buildLibNoProjectConfig}/tailwind.config.js`);
+
+      runCLI(`build ${buildLibNoProjectConfig}`);
+
+      assertLibComponentStyles(buildLibNoProjectConfig, spacing.root);
+    });
+
+    it('should generate a publishable library with tailwind and build correctly', () => {
+      runCLI(
+        `generate @nrwl/angular:lib ${pubLibWithTailwind.name} --publishable --add-tailwind --importPath=@${project}/${pubLibWithTailwind.name} --no-interactive`
+      );
+      updateTailwindConfig(
+        `libs/${pubLibWithTailwind.name}/tailwind.config.js`,
+        spacing.projectVariant1
+      );
+      createLibComponent(
+        pubLibWithTailwind.name,
+        pubLibWithTailwind.buttonBgColor
+      );
+
+      runCLI(`build ${pubLibWithTailwind.name}`);
+
+      assertLibComponentStyles(
+        pubLibWithTailwind.name,
+        spacing.projectVariant1
+      );
+    });
+
+    it('should set up tailwind in a previously generated publishable library and build correctly', () => {
+      const pubLibSetupTailwind = uniq('pub-lib-setup-tailwind');
+      runCLI(
+        `generate @nrwl/angular:lib ${pubLibSetupTailwind} --publishable --importPath=@${project}/${pubLibSetupTailwind} --no-interactive`
+      );
+      runCLI(
+        `generate @nrwl/angular:setup-tailwind ${pubLibSetupTailwind} --no-interactive`
+      );
+      updateTailwindConfig(
+        `libs/${pubLibSetupTailwind}/tailwind.config.js`,
+        spacing.projectVariant2
+      );
+      createLibComponent(pubLibSetupTailwind);
+
+      runCLI(`build ${pubLibSetupTailwind}`);
+
+      assertLibComponentStyles(pubLibSetupTailwind, spacing.projectVariant2);
+    });
+
+    it('should correctly build a publishable library with a tailwind.config.js file in the project root or workspace root', () => {
+      const pubLibNoProjectConfig = uniq('pub-lib-no-project-config');
+      runCLI(
+        `generate @nrwl/angular:lib ${pubLibNoProjectConfig} --publishable --importPath=@${project}/${pubLibNoProjectConfig} --no-interactive`
+      );
+      createTailwindConfigFile(
+        `libs/${pubLibNoProjectConfig}/tailwind.config.js`,
+        spacing.projectVariant3
+      );
+      createLibComponent(pubLibNoProjectConfig);
+
+      runCLI(`build ${pubLibNoProjectConfig}`);
+
+      assertLibComponentStyles(pubLibNoProjectConfig, spacing.projectVariant3);
+
+      // remove tailwind.config.js file from the project root to test the one in the workspace root
+      removeFile(`libs/${pubLibNoProjectConfig}/tailwind.config.js`);
+
+      runCLI(`build ${pubLibNoProjectConfig}`);
+
+      assertLibComponentStyles(pubLibNoProjectConfig, spacing.root);
+    });
+  });
+
+  describe('Applications', () => {
+    const updateAppComponent = (app: string) => {
+      updateFile(
+        `apps/${app}/src/app/app.component.html`,
+        `<button class="custom-btn text-white">Click me!</button>`
+      );
+
+      updateFile(
+        `apps/${app}/src/app/app.component.css`,
+        `.custom-btn {
+          @apply m-md p-sm;
+        }`
+      );
+    };
+
+    const readAppStylesBundle = (app: string) => {
+      const stylesBundlePath = listFiles(`dist/apps/${app}`).find((file) =>
+        file.startsWith('styles.')
+      );
+      const stylesBundle = readFile(`dist/apps/${app}/${stylesBundlePath}`);
+
+      return stylesBundle;
+    };
+
+    const assertAppComponentStyles = (
+      app: string,
+      appSpacing: typeof spacing['root']
+    ) => {
+      const mainBundlePath = listFiles(`dist/apps/${app}`).find((file) =>
+        file.startsWith('main.')
+      );
+      const mainBundle = readFile(`dist/apps/${app}/${mainBundlePath}`);
+      let expectedStylesRegex = new RegExp(
+        `styles:\\[\\"\\.custom\\-btn\\[_ngcontent\\-%COMP%\\]{margin:${appSpacing.md};padding:${appSpacing.sm}}\\"\\]`
+      );
+
+      expect(mainBundle).toMatch(expectedStylesRegex);
+    };
+
+    it('should build correctly and only output the tailwind utilities used', () => {
+      const appWithTailwind = uniq('app-with-tailwind');
+      runCLI(
+        `generate @nrwl/angular:app ${appWithTailwind} --add-tailwind --no-interactive`
+      );
+      updateTailwindConfig(
+        `apps/${appWithTailwind}/tailwind.config.js`,
+        spacing.projectVariant1
+      );
+      updateFile(
+        `apps/${appWithTailwind}/src/app/app.module.ts`,
+        `import { NgModule } from '@angular/core';
+        import { BrowserModule } from '@angular/platform-browser';
+        import { LibModule as LibModule1 } from '@${project}/${buildLibWithTailwind.name}';
+        import { LibModule as LibModule2 } from '@${project}/${pubLibWithTailwind.name}';
+
+        import { AppComponent } from './app.component';
+
+        @NgModule({
+          declarations: [AppComponent],
+          imports: [BrowserModule, LibModule1, LibModule2],
+          providers: [],
+          bootstrap: [AppComponent],
+        })
+        export class AppModule {}
+        `
+      );
+      updateAppComponent(appWithTailwind);
+
+      runCLI(`build ${appWithTailwind}`);
+
+      assertAppComponentStyles(appWithTailwind, spacing.projectVariant1);
+      let stylesBundle = readAppStylesBundle(appWithTailwind);
+      expect(stylesBundle).toContain('.text-white');
+      expect(stylesBundle).not.toContain('.text-black');
+      expect(stylesBundle).toContain(`.${buildLibWithTailwind.buttonBgColor}`);
+      expect(stylesBundle).toContain(`.${pubLibWithTailwind.buttonBgColor}`);
+      expect(stylesBundle).not.toContain(`.${defaultButtonBgColor}`);
+    });
+  });
 });

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/compile-ngc.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/compile-ngc.transform.ts
@@ -58,7 +58,7 @@ export const nxCompileNgcTransformFactory = (
           declaration: true,
           target: ts.ScriptTarget.ES2020,
         },
-        entryPoint.cache.stylesheetProcessor,
+        entryPoint.cache.stylesheetProcessor as any,
         null,
         options.watch
       );

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ts/cache-compiler-host.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ts/cache-compiler-host.ts
@@ -1,0 +1,219 @@
+/**
+ * Adapted from the original ng-packagr source.
+ *
+ * Changes made:
+ * - Changed filePath passed to the StylesheetProcessor.parse when is a .ts file and inlineStyleLanguage is set.
+ */
+
+import type { CompilerHost, CompilerOptions } from '@angular/compiler-cli';
+import { createHash } from 'crypto';
+import { FileCache } from 'ng-packagr/lib/file-system/file-cache';
+import { BuildGraph } from 'ng-packagr/lib/graph/build-graph';
+import { Node } from 'ng-packagr/lib/graph/node';
+import { EntryPointNode, fileUrl } from 'ng-packagr/lib/ng-package/nodes';
+import { ensureUnixPath } from 'ng-packagr/lib/utils/path';
+import * as path from 'path';
+import * as ts from 'typescript';
+import {
+  InlineStyleLanguage,
+  StylesheetProcessor,
+} from '../styles/stylesheet-processor';
+
+export function cacheCompilerHost(
+  graph: BuildGraph,
+  entryPoint: EntryPointNode,
+  compilerOptions: CompilerOptions,
+  moduleResolutionCache: ts.ModuleResolutionCache,
+  stylesheetProcessor?: StylesheetProcessor,
+  inlineStyleLanguage?: InlineStyleLanguage,
+  sourcesFileCache: FileCache = entryPoint.cache.sourcesFileCache
+): CompilerHost {
+  const compilerHost = ts.createIncrementalCompilerHost(compilerOptions);
+
+  const getNode = (fileName: string) => {
+    const nodeUri = fileUrl(ensureUnixPath(fileName));
+    let node = graph.get(nodeUri);
+
+    if (!node) {
+      node = new Node(nodeUri);
+      graph.put(node);
+    }
+
+    return node;
+  };
+
+  const addDependee = (fileName: string) => {
+    const node = getNode(fileName);
+    entryPoint.dependsOn(node);
+  };
+
+  return {
+    ...compilerHost,
+
+    // ts specific
+    fileExists: (fileName: string) => {
+      const cache = sourcesFileCache.getOrCreate(fileName);
+      if (cache.exists === undefined) {
+        cache.exists = compilerHost.fileExists.call(this, fileName);
+      }
+
+      return cache.exists;
+    },
+
+    getSourceFile: (fileName: string, languageVersion: ts.ScriptTarget) => {
+      addDependee(fileName);
+      const cache = sourcesFileCache.getOrCreate(fileName);
+      if (!cache.sourceFile) {
+        cache.sourceFile = compilerHost.getSourceFile.call(
+          this,
+          fileName,
+          languageVersion
+        );
+      }
+
+      return cache.sourceFile;
+    },
+
+    writeFile: (
+      fileName: string,
+      data: string,
+      writeByteOrderMark: boolean,
+      onError?: (message: string) => void,
+      sourceFiles?: ReadonlyArray<ts.SourceFile>
+    ) => {
+      if (fileName.endsWith('.d.ts')) {
+        sourceFiles.forEach((source) => {
+          const cache = sourcesFileCache.getOrCreate(source.fileName);
+          if (!cache.declarationFileName) {
+            cache.declarationFileName = ensureUnixPath(fileName);
+          }
+        });
+      } else {
+        fileName = fileName.replace(/\.js(\.map)?$/, '.mjs$1');
+        const outputCache = entryPoint.cache.outputCache;
+
+        outputCache.set(fileName, {
+          content: data,
+          version: createHash('sha256').update(data).digest('hex'),
+        });
+      }
+
+      compilerHost.writeFile.call(
+        this,
+        fileName,
+        data,
+        writeByteOrderMark,
+        onError,
+        sourceFiles
+      );
+    },
+
+    readFile: (fileName: string) => {
+      addDependee(fileName);
+      const cache = sourcesFileCache.getOrCreate(fileName);
+      if (cache.content === undefined) {
+        cache.content = compilerHost.readFile.call(this, fileName);
+      }
+
+      return cache.content;
+    },
+
+    resolveModuleNames: (moduleNames: string[], containingFile: string) => {
+      return moduleNames.map((moduleName) => {
+        const { resolvedModule } = ts.resolveModuleName(
+          moduleName,
+          ensureUnixPath(containingFile),
+          compilerOptions,
+          compilerHost,
+          moduleResolutionCache
+        );
+
+        return resolvedModule;
+      });
+    },
+
+    resourceNameToFileName: (
+      resourceName: string,
+      containingFilePath: string
+    ) => {
+      const resourcePath = path.resolve(
+        path.dirname(containingFilePath),
+        resourceName
+      );
+      const containingNode = getNode(containingFilePath);
+      const resourceNode = getNode(resourcePath);
+      containingNode.dependsOn(resourceNode);
+
+      return resourcePath;
+    },
+
+    readResource: async (fileName: string) => {
+      addDependee(fileName);
+
+      const cache = sourcesFileCache.getOrCreate(fileName);
+      if (cache.content === undefined) {
+        if (/(?:html?|svg)$/.test(path.extname(fileName))) {
+          // template
+          cache.content = compilerHost.readFile.call(this, fileName);
+        } else {
+          // stylesheet
+          cache.content = await stylesheetProcessor.process({
+            filePath: fileName,
+            content: compilerHost.readFile.call(this, fileName),
+          });
+        }
+
+        if (cache.content === undefined) {
+          throw new Error(`Cannot read file ${fileName}.`);
+        }
+
+        cache.exists = true;
+      }
+
+      return cache.content;
+    },
+    transformResource: async (data, context) => {
+      if (context.resourceFile || context.type !== 'style') {
+        return null;
+      }
+
+      if (inlineStyleLanguage) {
+        const key = createHash('sha1').update(data).digest('hex');
+        const fileName = `${context.containingFile}-${key}.${inlineStyleLanguage}`;
+        const cache = sourcesFileCache.getOrCreate(fileName);
+        if (cache.content === undefined) {
+          cache.content = await stylesheetProcessor.process({
+            filePath: context.containingFile, // @leosvelperez: changed from fileName
+            content: data,
+          });
+
+          const virtualFileNode = getNode(fileName);
+          const containingFileNode = getNode(context.containingFile);
+          virtualFileNode.dependsOn(containingFileNode);
+        }
+
+        cache.exists = true;
+
+        return { content: cache.content };
+      }
+
+      return null;
+    },
+  };
+}
+
+export function augmentProgramWithVersioning(program: ts.Program): void {
+  const baseGetSourceFiles = program.getSourceFiles;
+  program.getSourceFiles = function (...parameters) {
+    const files: readonly (ts.SourceFile & { version?: string })[] =
+      baseGetSourceFiles(...parameters);
+
+    for (const file of files) {
+      if (file.version === undefined) {
+        file.version = createHash('sha256').update(file.text).digest('hex');
+      }
+    }
+
+    return files;
+  };
+}

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/ng-package/entry-point/compile-ngc.transform.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/ng-package/entry-point/compile-ngc.transform.ts
@@ -14,13 +14,13 @@ import {
   isEntryPoint,
   isEntryPointInProgress,
 } from 'ng-packagr/lib/ng-package/nodes';
-import { compileSourceFiles } from 'ng-packagr/lib/ngc/compile-source-files';
 import { NgccProcessor } from 'ng-packagr/lib/ngc/ngcc-processor';
 import { setDependenciesTsConfigPaths } from 'ng-packagr/lib/ts/tsconfig';
 import { ngccCompilerCli } from 'ng-packagr/lib/utils/ng-compiler-cli';
 import * as ora from 'ora';
 import * as path from 'path';
 import * as ts from 'typescript';
+import { compileSourceFiles } from '../../ngc/compile-source-files';
 import { StylesheetProcessor as StylesheetProcessorClass } from '../../styles/stylesheet-processor';
 import { NgPackagrOptions } from '../options.di';
 
@@ -85,7 +85,7 @@ export const compileNgcTransformFactory = (
           declaration: true,
           target: ts.ScriptTarget.ES2020,
         },
-        entryPoint.cache.stylesheetProcessor,
+        entryPoint.cache.stylesheetProcessor as any,
         ngccProcessor,
         options.watch
       );

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/ngc/compile-source-files.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/ngc/compile-source-files.ts
@@ -2,7 +2,6 @@
  * Adapted from the original ng-packagr source.
  *
  * Changes made:
- * - Made sure ngccProcessor is optional.
  * - Use custom cacheCompilerHost instead of the one provided by ng-packagr.
  */
 
@@ -18,13 +17,15 @@ import {
   PackageNode,
 } from 'ng-packagr/lib/ng-package/nodes';
 import { NgccProcessor } from 'ng-packagr/lib/ngc/ngcc-processor';
-import { augmentProgramWithVersioning } from 'ng-packagr/lib/ts/cache-compiler-host';
 import { ngccTransformCompilerHost } from 'ng-packagr/lib/ts/ngcc-transform-compiler-host';
 import * as log from 'ng-packagr/lib/utils/log';
 import { ngCompilerCli } from 'ng-packagr/lib/utils/ng-compiler-cli';
 import * as ts from 'typescript';
 import { StylesheetProcessor } from '../styles/stylesheet-processor';
-import { cacheCompilerHost } from '../ts/cache-compiler-host';
+import {
+  augmentProgramWithVersioning,
+  cacheCompilerHost,
+} from '../ts/cache-compiler-host';
 
 export async function compileSourceFiles(
   graph: BuildGraph,
@@ -45,23 +46,19 @@ export async function compileSourceFiles(
   const ngPackageNode: PackageNode = graph.find(isPackage);
   const inlineStyleLanguage = ngPackageNode.data.inlineStyleLanguage;
 
-  let tsCompilerHost = cacheCompilerHost(
-    graph,
-    entryPoint,
-    tsConfigOptions,
-    moduleResolutionCache,
-    stylesheetProcessor,
-    inlineStyleLanguage
-  );
-
-  if (ngccProcessor) {
-    tsCompilerHost = ngccTransformCompilerHost(
-      tsCompilerHost,
+  const tsCompilerHost = ngccTransformCompilerHost(
+    cacheCompilerHost(
+      graph,
+      entryPoint,
       tsConfigOptions,
-      ngccProcessor,
-      moduleResolutionCache
-    );
-  }
+      moduleResolutionCache,
+      stylesheetProcessor,
+      inlineStyleLanguage
+    ),
+    tsConfigOptions,
+    ngccProcessor,
+    moduleResolutionCache
+  );
 
   const cache = entryPoint.cache;
   const sourceFileCache = cache.sourcesFileCache;

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/ts/cache-compiler-host.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/ts/cache-compiler-host.ts
@@ -1,0 +1,219 @@
+/**
+ * Adapted from the original ng-packagr source.
+ *
+ * Changes made:
+ * - Changed filePath passed to the StylesheetProcessor.parse when is a .ts file and inlineStyleLanguage is set.
+ */
+
+import type { CompilerHost, CompilerOptions } from '@angular/compiler-cli';
+import { createHash } from 'crypto';
+import { FileCache } from 'ng-packagr/lib/file-system/file-cache';
+import { BuildGraph } from 'ng-packagr/lib/graph/build-graph';
+import { Node } from 'ng-packagr/lib/graph/node';
+import { EntryPointNode, fileUrl } from 'ng-packagr/lib/ng-package/nodes';
+import { ensureUnixPath } from 'ng-packagr/lib/utils/path';
+import * as path from 'path';
+import * as ts from 'typescript';
+import {
+  InlineStyleLanguage,
+  StylesheetProcessor,
+} from '../styles/stylesheet-processor';
+
+export function cacheCompilerHost(
+  graph: BuildGraph,
+  entryPoint: EntryPointNode,
+  compilerOptions: CompilerOptions,
+  moduleResolutionCache: ts.ModuleResolutionCache,
+  stylesheetProcessor?: StylesheetProcessor,
+  inlineStyleLanguage?: InlineStyleLanguage,
+  sourcesFileCache: FileCache = entryPoint.cache.sourcesFileCache
+): CompilerHost {
+  const compilerHost = ts.createIncrementalCompilerHost(compilerOptions);
+
+  const getNode = (fileName: string) => {
+    const nodeUri = fileUrl(ensureUnixPath(fileName));
+    let node = graph.get(nodeUri);
+
+    if (!node) {
+      node = new Node(nodeUri);
+      graph.put(node);
+    }
+
+    return node;
+  };
+
+  const addDependee = (fileName: string) => {
+    const node = getNode(fileName);
+    entryPoint.dependsOn(node);
+  };
+
+  return {
+    ...compilerHost,
+
+    // ts specific
+    fileExists: (fileName: string) => {
+      const cache = sourcesFileCache.getOrCreate(fileName);
+      if (cache.exists === undefined) {
+        cache.exists = compilerHost.fileExists.call(this, fileName);
+      }
+
+      return cache.exists;
+    },
+
+    getSourceFile: (fileName: string, languageVersion: ts.ScriptTarget) => {
+      addDependee(fileName);
+      const cache = sourcesFileCache.getOrCreate(fileName);
+      if (!cache.sourceFile) {
+        cache.sourceFile = compilerHost.getSourceFile.call(
+          this,
+          fileName,
+          languageVersion
+        );
+      }
+
+      return cache.sourceFile;
+    },
+
+    writeFile: (
+      fileName: string,
+      data: string,
+      writeByteOrderMark: boolean,
+      onError?: (message: string) => void,
+      sourceFiles?: ReadonlyArray<ts.SourceFile>
+    ) => {
+      if (fileName.endsWith('.d.ts')) {
+        sourceFiles.forEach((source) => {
+          const cache = sourcesFileCache.getOrCreate(source.fileName);
+          if (!cache.declarationFileName) {
+            cache.declarationFileName = ensureUnixPath(fileName);
+          }
+        });
+      } else {
+        fileName = fileName.replace(/\.js(\.map)?$/, '.mjs$1');
+        const outputCache = entryPoint.cache.outputCache;
+
+        outputCache.set(fileName, {
+          content: data,
+          version: createHash('sha256').update(data).digest('hex'),
+        });
+      }
+
+      compilerHost.writeFile.call(
+        this,
+        fileName,
+        data,
+        writeByteOrderMark,
+        onError,
+        sourceFiles
+      );
+    },
+
+    readFile: (fileName: string) => {
+      addDependee(fileName);
+      const cache = sourcesFileCache.getOrCreate(fileName);
+      if (cache.content === undefined) {
+        cache.content = compilerHost.readFile.call(this, fileName);
+      }
+
+      return cache.content;
+    },
+
+    resolveModuleNames: (moduleNames: string[], containingFile: string) => {
+      return moduleNames.map((moduleName) => {
+        const { resolvedModule } = ts.resolveModuleName(
+          moduleName,
+          ensureUnixPath(containingFile),
+          compilerOptions,
+          compilerHost,
+          moduleResolutionCache
+        );
+
+        return resolvedModule;
+      });
+    },
+
+    resourceNameToFileName: (
+      resourceName: string,
+      containingFilePath: string
+    ) => {
+      const resourcePath = path.resolve(
+        path.dirname(containingFilePath),
+        resourceName
+      );
+      const containingNode = getNode(containingFilePath);
+      const resourceNode = getNode(resourcePath);
+      containingNode.dependsOn(resourceNode);
+
+      return resourcePath;
+    },
+
+    readResource: async (fileName: string) => {
+      addDependee(fileName);
+
+      const cache = sourcesFileCache.getOrCreate(fileName);
+      if (cache.content === undefined) {
+        if (/(?:html?|svg)$/.test(path.extname(fileName))) {
+          // template
+          cache.content = compilerHost.readFile.call(this, fileName);
+        } else {
+          // stylesheet
+          cache.content = await stylesheetProcessor.process({
+            filePath: fileName,
+            content: compilerHost.readFile.call(this, fileName),
+          });
+        }
+
+        if (cache.content === undefined) {
+          throw new Error(`Cannot read file ${fileName}.`);
+        }
+
+        cache.exists = true;
+      }
+
+      return cache.content;
+    },
+    transformResource: async (data, context) => {
+      if (context.resourceFile || context.type !== 'style') {
+        return null;
+      }
+
+      if (inlineStyleLanguage) {
+        const key = createHash('sha1').update(data).digest('hex');
+        const fileName = `${context.containingFile}-${key}.${inlineStyleLanguage}`;
+        const cache = sourcesFileCache.getOrCreate(fileName);
+        if (cache.content === undefined) {
+          cache.content = await stylesheetProcessor.process({
+            filePath: context.containingFile, // @leosvelperez: changed from fileName
+            content: data,
+          });
+
+          const virtualFileNode = getNode(fileName);
+          const containingFileNode = getNode(context.containingFile);
+          virtualFileNode.dependsOn(containingFileNode);
+        }
+
+        cache.exists = true;
+
+        return { content: cache.content };
+      }
+
+      return null;
+    },
+  };
+}
+
+export function augmentProgramWithVersioning(program: ts.Program): void {
+  const baseGetSourceFiles = program.getSourceFiles;
+  program.getSourceFiles = function (...parameters) {
+    const files: readonly (ts.SourceFile & { version?: string })[] =
+      baseGetSourceFiles(...parameters);
+
+    for (const file of files) {
+      if (file.version === undefined) {
+        file.version = createHash('sha256').update(file.text).digest('hex');
+      }
+    }
+
+    return files;
+  };
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When building an Angular library that has Tailwind CSS configured and there are components using inline styles, the build fails. This happens due to `ng-packagr` sending a wrong file path to PostCSS processing for inline styles. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Building an Angular library that has Tailwind CSS configured and there are components using inline styles should build successfully.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
