### PR TITLE
docs(js): generate missing property in the default docs

### DIFF
--- a/docs/default/api-js/executors/swc.md
+++ b/docs/default/api-js/executors/swc.md
@@ -43,6 +43,12 @@ Type: `boolean`
 
 Whether to skip TypeScript type checking.
 
+### swcExclude
+
+Type: `array`
+
+List of SWC Glob/Regex to be excluded from compilation (https://swc.rs/docs/configuration/compilation#exclude)
+
 ### watch
 
 Default: `false`


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The documentation check in CI is failing due to a property missing in the default docs.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The documentation check should succeed and the docs should be updated.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
