### PR TITLE
docs(nxdev): temporary image path fix before docs flattening

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/renderers/transform-image-path.spec.ts
+++ b/nx-dev/feature-doc-viewer/src/lib/renderers/transform-image-path.spec.ts
@@ -45,7 +45,7 @@ describe('transformImagePath', () => {
     const transform = transformImagePath(opts);
 
     expect(transform('/shared/test.png')).toEqual(
-      '/documentation/shared/test.png'
+      '/documentation/latest/shared/test.png'
     );
   });
 });

--- a/nx-dev/feature-doc-viewer/src/lib/renderers/transform-image-path.ts
+++ b/nx-dev/feature-doc-viewer/src/lib/renderers/transform-image-path.ts
@@ -1,8 +1,5 @@
 import { uriTransformer } from 'react-markdown';
-import {
-  DocumentData,
-  VersionMetadata,
-} from '@nrwl/nx-dev/data-access-documents';
+import { DocumentData } from '@nrwl/nx-dev/data-access-documents';
 import { join } from 'path';
 
 export function transformImagePath({
@@ -23,6 +20,7 @@ export function transformImagePath({
       );
     }
 
-    return uriTransformer(`/documentation`.concat(src));
+    // TODO@ben remove `latest` when flattening docs' architecture
+    return uriTransformer(`/documentation/latest`.concat(src));
   };
 }


### PR DESCRIPTION
## What it does?
Temporary adding `latest` version in path for image path interpolation before having nx.dev's docs flattened.