### PR TITLE
docs(nxdev): ci-overview redirect rule

### DIFF
--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -5,12 +5,12 @@ const redirects = {
   '/core-concepts/configuration': '/configuration/projectjson',
   '/core-concepts/mental-model': '/using-nx/mental-model',
   '/core-concepts/updating-nx': '/using-nx/updating-nx',
+  '/core-concepts/ci-overview': '/using-nx/ci-overview',
   '/using-nx/nx-devkit': '/getting-started/nx-devkit',
   '/getting-started/nx-cli': '/using-nx/nx-cli',
   '/getting-started/console': '/using-nx/console',
   '/core-extended/affected': '/using-nx/affected',
   '/core-extended/computation-caching': '/using-nx/caching',
-  '/using-nx/ci-overview': '/using-nx/ci-overview',
 };
 
 module.exports = withNx({


### PR DESCRIPTION
## What it does?
Fixes the ` '/core-concepts/ci-overview': '/using-nx/ci-overview',` redirect rule for nx.dev