### PR TITLE
docs(nxdev): remove flavour and versions patterns from docs

### DIFF
--- a/docs/default/cli/build.md
+++ b/docs/default/cli/build.md
@@ -21,7 +21,7 @@ nx build <project> [options]
 nx run <project>:build [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/default/cli/e2e.md
+++ b/docs/default/cli/e2e.md
@@ -21,7 +21,7 @@ nx e2e <project>
 nx run <project>:e2e
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/default/cli/generate.md
+++ b/docs/default/cli/generate.md
@@ -17,7 +17,7 @@ nx generate <collection:generator>
 nx g <generator>
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/default/cli/lint.md
+++ b/docs/default/cli/lint.md
@@ -21,7 +21,7 @@ nx lint <project> [options]
 nx run <project>:lint [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/default/cli/run.md
+++ b/docs/default/cli/run.md
@@ -13,7 +13,7 @@ Runs an Architect target with an optional custom builder configuration defined i
 nx run <target> [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/default/cli/serve.md
+++ b/docs/default/cli/serve.md
@@ -21,7 +21,7 @@ nx serve <project> [options]
 nx run <project>:serve [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/default/cli/test.md
+++ b/docs/default/cli/test.md
@@ -21,7 +21,7 @@ nx test <project> [options]
 nx run <project>:test [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/shared/angular-tutorial/01-create-application.md
+++ b/docs/shared/angular-tutorial/01-create-application.md
@@ -134,4 +134,4 @@ a lot better. [Read more about Nx CLI and Angular CLI.](/using-nx/nx-cli)
 
 ## What's Next
 
-- Continue to [Step 2: Add E2E Tests](/latest/angular/tutorial/02-add-e2e-test)
+- Continue to [Step 2: Add E2E Tests](/angular-tutorial/02-add-e2e-test)

--- a/docs/shared/angular-tutorial/02-add-e2e-test.md
+++ b/docs/shared/angular-tutorial/02-add-e2e-test.md
@@ -39,4 +39,4 @@ As you progress through the tutorial, you work on making these E2E tests pass.
 
 ## What's Next
 
-- Continue to [Step 3: Display Todos](/latest/angular/tutorial/03-display-todos)
+- Continue to [Step 3: Display Todos](/angular-tutorial/03-display-todos)

--- a/docs/shared/angular-tutorial/03-display-todos.md
+++ b/docs/shared/angular-tutorial/03-display-todos.md
@@ -82,4 +82,4 @@ The tests should pass now.
 
 ## What's Next
 
-- Continue to [Step 4: Connect to an API](/latest/angular/tutorial/04-connect-to-api)
+- Continue to [Step 4: Connect to an API](/angular-tutorial/04-connect-to-api)

--- a/docs/shared/angular-tutorial/04-connect-to-api.md
+++ b/docs/shared/angular-tutorial/04-connect-to-api.md
@@ -58,4 +58,4 @@ export class AppComponent {
 
 ## What's Next
 
-- Continue to [Step 5: Add Node Application Implementing an API](/latest/angular/tutorial/05-add-node-app)
+- Continue to [Step 5: Add Node Application Implementing an API](/angular-tutorial/05-add-node-app)

--- a/docs/shared/angular-tutorial/05-add-node-app.md
+++ b/docs/shared/angular-tutorial/05-add-node-app.md
@@ -188,4 +188,4 @@ The API starts running on port `3333`.
 
 ## What's Next
 
-- Continue to [Step 6: Proxy](/latest/angular/tutorial/06-proxy)
+- Continue to [Step 6: Proxy](/angular-tutorial/06-proxy)

--- a/docs/shared/angular-tutorial/06-proxy.md
+++ b/docs/shared/angular-tutorial/06-proxy.md
@@ -42,4 +42,4 @@ This configuration tells `nx serve` to forward all requests starting with `/api`
 
 ## What's Next
 
-- Continue to [Step 7: Share Code](/latest/angular/tutorial/07-share-code)
+- Continue to [Step 7: Share Code](/angular-tutorial/07-share-code)

--- a/docs/shared/angular-tutorial/07-share-code.md
+++ b/docs/shared/angular-tutorial/07-share-code.md
@@ -121,4 +121,4 @@ And you should see the application running.
 
 ## What's Next
 
-- Continue to [Step 8: Create Libraries](/latest/angular/tutorial/08-create-libs)
+- Continue to [Step 8: Create Libraries](/angular-tutorial/08-create-libs)

--- a/docs/shared/angular-tutorial/08-create-libs.md
+++ b/docs/shared/angular-tutorial/08-create-libs.md
@@ -167,4 +167,4 @@ npx nx serve todos
 
 ## What's Next
 
-- Continue to [Step 9: Using the Dependency Graph](/latest/angular/tutorial/09-dep-graph)
+- Continue to [Step 9: Using the Dependency Graph](/angular-tutorial/09-dep-graph)

--- a/docs/shared/angular-tutorial/09-dep-graph.md
+++ b/docs/shared/angular-tutorial/09-dep-graph.md
@@ -16,4 +16,4 @@ npx nx dep-graph
 
 ## What's Next
 
-- Continue to [Step 10: Using Computation Caching](/latest/angular/tutorial/10-computation-caching)
+- Continue to [Step 10: Using Computation Caching](/angular-tutorial/10-computation-caching)

--- a/docs/shared/angular-tutorial/10-computation-caching.md
+++ b/docs/shared/angular-tutorial/10-computation-caching.md
@@ -69,4 +69,4 @@ Nx built `api` and retrieved `todos` from its computation cache. Read more about
 
 ## What's Next
 
-- Continue to [Step 11: Test Affected Projects](/latest/angular/tutorial/11-test-affected-projects)
+- Continue to [Step 11: Test Affected Projects](/angular-tutorial/11-test-affected-projects)

--- a/docs/shared/angular-tutorial/11-test-affected-projects.md
+++ b/docs/shared/angular-tutorial/11-test-affected-projects.md
@@ -82,4 +82,4 @@ npx nx affected:build
 
 ## What's Next
 
-- Continue to [Step 12: Summary](/latest/angular/tutorial/12-summary)
+- Continue to [Step 12: Summary](/angular-tutorial/12-summary)

--- a/docs/shared/cli/build.md
+++ b/docs/shared/cli/build.md
@@ -21,7 +21,7 @@ nx build <project> [options]
 nx run <project>:build [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/shared/cli/e2e.md
+++ b/docs/shared/cli/e2e.md
@@ -21,7 +21,7 @@ nx e2e <project>
 nx run <project>:e2e
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/shared/cli/generate.md
+++ b/docs/shared/cli/generate.md
@@ -17,7 +17,7 @@ nx generate <collection:generator>
 nx g <generator>
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/shared/cli/lint.md
+++ b/docs/shared/cli/lint.md
@@ -21,7 +21,7 @@ nx lint <project> [options]
 nx run <project>:lint [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/shared/cli/run.md
+++ b/docs/shared/cli/run.md
@@ -13,7 +13,7 @@ Runs an Architect target with an optional custom builder configuration defined i
 nx run <target> [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/shared/cli/serve.md
+++ b/docs/shared/cli/serve.md
@@ -21,7 +21,7 @@ nx serve <project> [options]
 nx run <project>:serve [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/shared/cli/test.md
+++ b/docs/shared/cli/test.md
@@ -21,7 +21,7 @@ nx test <project> [options]
 nx run <project>:test [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/docs/shared/configuration/projectjson.md
+++ b/docs/shared/configuration/projectjson.md
@@ -450,7 +450,7 @@ a [`.gitignore` file](https://git-scm.com/book/en/v2/Git-Basics-Recording-Change
 ## Validating the configuration
 
 If at any point in time you want to check if your configuration is in sync, you can use
-the [workspace-lint]({{framework}}/cli/workspace-lint) executor:
+the [workspace-lint](/cli/workspace-lint) executor:
 
 ```bash
 nx workspace-lint

--- a/docs/shared/getting-started/nx-and-angular.md
+++ b/docs/shared/getting-started/nx-and-angular.md
@@ -8,20 +8,20 @@ If you're only interested in improving the performance of your monorepo by using
 
 Check out the following guides to get started:
 
-- [Installing Nx CLI & creating a new Nx Workspace](/{{framework}}/getting-started/nx-setup)
-- [Adding Nx to an existing monorepo](/{{framework}}/migration/adding-to-monorepo)
-- [Adding Nx to an Angular CLI project](/{{framework}}/migration/migration-angular)
-- [Migrating from AngularJS](/{{framework}}/migration/migration-angularjs)
-- [Using Nx without plugins](/{{framework}}/getting-started/nx-core)
+- [Installing Nx CLI & creating a new Nx Workspace](//getting-started/nx-setup)
+- [Adding Nx to an existing monorepo](//migration/adding-to-monorepo)
+- [Adding Nx to an Angular CLI project](//migration/migration-angular)
+- [Migrating from AngularJS](//migration/migration-angularjs)
+- [Using Nx without plugins](//getting-started/nx-core)
 - [CI Overview](/using-nx/ci-overview)
 
 It is also a good idea to read the [mental model guide](/using-nx/mental-model) to understand how Nx works.
 
 ## Nx and Angular Plugins
 
-Nx plugins helps you develop [Angular](/{{framework}}/angular/overview) applications with fully integrated support for
-modern tools and libraries like [Jest](/{{framework}}/jest/overview), [Cypress](/{{framework}}/cypress/overview),
-[ESLint](/{{framework}}/linter/eslint), Storybook, [NgRx](/angular/guides/misc-ngrx) and more.
+Nx plugins helps you develop [Angular](//angular/overview) applications with fully integrated support for
+modern tools and libraries like [Jest](//jest/overview), [Cypress](//cypress/overview),
+[ESLint](//linter/eslint), Storybook, [NgRx](/angular/guides/misc-ngrx) and more.
 
 ### 10-min Video Overview
 

--- a/docs/shared/getting-started/nx-and-react.md
+++ b/docs/shared/getting-started/nx-and-react.md
@@ -8,20 +8,20 @@ If you're only interested in improving the performance of your monorepo by using
 
 Check out the following guides to get started:
 
-- [Installing Nx CLI & creating a new Nx Workspace](/{{framework}}/getting-started/nx-setup)
-- [Adding Nx to an existing monorepo](/{{framework}}/migration/adding-to-monorepo)
-- [Migrating from CRA](/{{framework}}/migration/migration-cra)
-- [Using Nx without plugins](/{{framework}}/getting-started/nx-core)
+- [Installing Nx CLI & creating a new Nx Workspace](//getting-started/nx-setup)
+- [Adding Nx to an existing monorepo](//migration/adding-to-monorepo)
+- [Migrating from CRA](//migration/migration-cra)
+- [Using Nx without plugins](//getting-started/nx-core)
 - [CI Overview](/using-nx/ci-overview)
 
 It is also a good idea to read the [mental model guide](/using-nx/mental-model) to understand how Nx works.
 
 ## Nx and React Plugins
 
-Nx plugins help you develop [React](/{{framework}}/react/overview) applications with fully integrated support for modern tools
-and libraries like [Jest](/{{framework}}/jest/overview), [Cypress](/{{framework}}/cypress/overview),
-Storybook, [ESLint](/{{framework}}/linter/eslint), and more. Nx also supports React
-frameworks like [Gatsby](/{{version}}/react/gatsby/overview), [Next.js](/{{version}}/react/guides/nextjs), Remix, and has great support for React Native.
+Nx plugins help you develop [React](//react/overview) applications with fully integrated support for modern tools
+and libraries like [Jest](//jest/overview), [Cypress](//cypress/overview),
+Storybook, [ESLint](//linter/eslint), and more. Nx also supports React
+frameworks like [Gatsby](///gatsby/overview), [Next.js](///guides/nextjs), Remix, and has great support for React Native.
 
 ### 10-min Video Overview
 

--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -97,7 +97,7 @@ Learn more about the advantages of Nx in the following guides:
 
 ## Transitioning Manually
 
-If you are unable to automatically transform your Angular CLI workspace to an Nx workspace using the [ng add]({{framework}}/migration/migration-angular#using-ng-add-preserving-your-existing-structure) method, there are some manual steps you can take to move your project(s) into an Nx workspace.
+If you are unable to automatically transform your Angular CLI workspace to an Nx workspace using the [ng add](/migration/migration-angular#using-ng-add-preserving-your-existing-structure) method, there are some manual steps you can take to move your project(s) into an Nx workspace.
 
 ### Generating a new workspace
 

--- a/nx-dev/nx-dev/public/documentation/latest/default/cli/build.md
+++ b/nx-dev/nx-dev/public/documentation/latest/default/cli/build.md
@@ -21,7 +21,7 @@ nx build <project> [options]
 nx run <project>:build [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/default/cli/e2e.md
+++ b/nx-dev/nx-dev/public/documentation/latest/default/cli/e2e.md
@@ -21,7 +21,7 @@ nx e2e <project>
 nx run <project>:e2e
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/default/cli/generate.md
+++ b/nx-dev/nx-dev/public/documentation/latest/default/cli/generate.md
@@ -17,7 +17,7 @@ nx generate <collection:generator>
 nx g <generator>
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/default/cli/lint.md
+++ b/nx-dev/nx-dev/public/documentation/latest/default/cli/lint.md
@@ -21,7 +21,7 @@ nx lint <project> [options]
 nx run <project>:lint [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/default/cli/run.md
+++ b/nx-dev/nx-dev/public/documentation/latest/default/cli/run.md
@@ -13,7 +13,7 @@ Runs an Architect target with an optional custom builder configuration defined i
 nx run <target> [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/default/cli/serve.md
+++ b/nx-dev/nx-dev/public/documentation/latest/default/cli/serve.md
@@ -21,7 +21,7 @@ nx serve <project> [options]
 nx run <project>:serve [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/default/cli/test.md
+++ b/nx-dev/nx-dev/public/documentation/latest/default/cli/test.md
@@ -21,7 +21,7 @@ nx test <project> [options]
 nx run <project>:test [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/01-create-application.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/01-create-application.md
@@ -134,4 +134,4 @@ a lot better. [Read more about Nx CLI and Angular CLI.](/using-nx/nx-cli)
 
 ## What's Next
 
-- Continue to [Step 2: Add E2E Tests](/latest/angular/tutorial/02-add-e2e-test)
+- Continue to [Step 2: Add E2E Tests](/angular-tutorial/02-add-e2e-test)

--- a/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/02-add-e2e-test.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/02-add-e2e-test.md
@@ -39,4 +39,4 @@ As you progress through the tutorial, you work on making these E2E tests pass.
 
 ## What's Next
 
-- Continue to [Step 3: Display Todos](/latest/angular/tutorial/03-display-todos)
+- Continue to [Step 3: Display Todos](/angular-tutorial/03-display-todos)

--- a/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/03-display-todos.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/03-display-todos.md
@@ -82,4 +82,4 @@ The tests should pass now.
 
 ## What's Next
 
-- Continue to [Step 4: Connect to an API](/latest/angular/tutorial/04-connect-to-api)
+- Continue to [Step 4: Connect to an API](/angular-tutorial/04-connect-to-api)

--- a/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/04-connect-to-api.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/04-connect-to-api.md
@@ -58,4 +58,4 @@ export class AppComponent {
 
 ## What's Next
 
-- Continue to [Step 5: Add Node Application Implementing an API](/latest/angular/tutorial/05-add-node-app)
+- Continue to [Step 5: Add Node Application Implementing an API](/angular-tutorial/05-add-node-app)

--- a/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/05-add-node-app.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/05-add-node-app.md
@@ -188,4 +188,4 @@ The API starts running on port `3333`.
 
 ## What's Next
 
-- Continue to [Step 6: Proxy](/latest/angular/tutorial/06-proxy)
+- Continue to [Step 6: Proxy](/angular-tutorial/06-proxy)

--- a/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/06-proxy.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/06-proxy.md
@@ -42,4 +42,4 @@ This configuration tells `nx serve` to forward all requests starting with `/api`
 
 ## What's Next
 
-- Continue to [Step 7: Share Code](/latest/angular/tutorial/07-share-code)
+- Continue to [Step 7: Share Code](/angular-tutorial/07-share-code)

--- a/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/07-share-code.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/07-share-code.md
@@ -121,4 +121,4 @@ And you should see the application running.
 
 ## What's Next
 
-- Continue to [Step 8: Create Libraries](/latest/angular/tutorial/08-create-libs)
+- Continue to [Step 8: Create Libraries](/angular-tutorial/08-create-libs)

--- a/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/08-create-libs.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/08-create-libs.md
@@ -167,4 +167,4 @@ npx nx serve todos
 
 ## What's Next
 
-- Continue to [Step 9: Using the Dependency Graph](/latest/angular/tutorial/09-dep-graph)
+- Continue to [Step 9: Using the Dependency Graph](/angular-tutorial/09-dep-graph)

--- a/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/09-dep-graph.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/09-dep-graph.md
@@ -16,4 +16,4 @@ npx nx dep-graph
 
 ## What's Next
 
-- Continue to [Step 10: Using Computation Caching](/latest/angular/tutorial/10-computation-caching)
+- Continue to [Step 10: Using Computation Caching](/angular-tutorial/10-computation-caching)

--- a/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/10-computation-caching.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/10-computation-caching.md
@@ -69,4 +69,4 @@ Nx built `api` and retrieved `todos` from its computation cache. Read more about
 
 ## What's Next
 
-- Continue to [Step 11: Test Affected Projects](/latest/angular/tutorial/11-test-affected-projects)
+- Continue to [Step 11: Test Affected Projects](/angular-tutorial/11-test-affected-projects)

--- a/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/11-test-affected-projects.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/angular-tutorial/11-test-affected-projects.md
@@ -82,4 +82,4 @@ npx nx affected:build
 
 ## What's Next
 
-- Continue to [Step 12: Summary](/latest/angular/tutorial/12-summary)
+- Continue to [Step 12: Summary](/angular-tutorial/12-summary)

--- a/nx-dev/nx-dev/public/documentation/latest/shared/cli/build.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/cli/build.md
@@ -21,7 +21,7 @@ nx build <project> [options]
 nx run <project>:build [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/cli/e2e.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/cli/e2e.md
@@ -21,7 +21,7 @@ nx e2e <project>
 nx run <project>:e2e
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/cli/generate.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/cli/generate.md
@@ -17,7 +17,7 @@ nx generate <collection:generator>
 nx g <generator>
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/cli/lint.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/cli/lint.md
@@ -21,7 +21,7 @@ nx lint <project> [options]
 nx run <project>:lint [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/cli/run.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/cli/run.md
@@ -13,7 +13,7 @@ Runs an Architect target with an optional custom builder configuration defined i
 nx run <target> [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/cli/serve.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/cli/serve.md
@@ -21,7 +21,7 @@ nx serve <project> [options]
 nx run <project>:serve [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/cli/test.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/cli/test.md
@@ -21,7 +21,7 @@ nx test <project> [options]
 nx run <project>:test [options]
 ```
 
-[Install `nx` globally]({{framework}}/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
+[Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.
 
 ### Examples
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/configuration/projectjson.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/configuration/projectjson.md
@@ -450,7 +450,7 @@ a [`.gitignore` file](https://git-scm.com/book/en/v2/Git-Basics-Recording-Change
 ## Validating the configuration
 
 If at any point in time you want to check if your configuration is in sync, you can use
-the [workspace-lint]({{framework}}/cli/workspace-lint) executor:
+the [workspace-lint](/cli/workspace-lint) executor:
 
 ```bash
 nx workspace-lint

--- a/nx-dev/nx-dev/public/documentation/latest/shared/getting-started/nx-and-angular.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/getting-started/nx-and-angular.md
@@ -8,20 +8,20 @@ If you're only interested in improving the performance of your monorepo by using
 
 Check out the following guides to get started:
 
-- [Installing Nx CLI & creating a new Nx Workspace](/{{framework}}/getting-started/nx-setup)
-- [Adding Nx to an existing monorepo](/{{framework}}/migration/adding-to-monorepo)
-- [Adding Nx to an Angular CLI project](/{{framework}}/migration/migration-angular)
-- [Migrating from AngularJS](/{{framework}}/migration/migration-angularjs)
-- [Using Nx without plugins](/{{framework}}/getting-started/nx-core)
+- [Installing Nx CLI & creating a new Nx Workspace](//getting-started/nx-setup)
+- [Adding Nx to an existing monorepo](//migration/adding-to-monorepo)
+- [Adding Nx to an Angular CLI project](//migration/migration-angular)
+- [Migrating from AngularJS](//migration/migration-angularjs)
+- [Using Nx without plugins](//getting-started/nx-core)
 - [CI Overview](/using-nx/ci-overview)
 
 It is also a good idea to read the [mental model guide](/using-nx/mental-model) to understand how Nx works.
 
 ## Nx and Angular Plugins
 
-Nx plugins helps you develop [Angular](/{{framework}}/angular/overview) applications with fully integrated support for
-modern tools and libraries like [Jest](/{{framework}}/jest/overview), [Cypress](/{{framework}}/cypress/overview),
-[ESLint](/{{framework}}/linter/eslint), Storybook, [NgRx](/angular/guides/misc-ngrx) and more.
+Nx plugins helps you develop [Angular](//angular/overview) applications with fully integrated support for
+modern tools and libraries like [Jest](//jest/overview), [Cypress](//cypress/overview),
+[ESLint](//linter/eslint), Storybook, [NgRx](/angular/guides/misc-ngrx) and more.
 
 ### 10-min Video Overview
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/getting-started/nx-and-react.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/getting-started/nx-and-react.md
@@ -8,20 +8,20 @@ If you're only interested in improving the performance of your monorepo by using
 
 Check out the following guides to get started:
 
-- [Installing Nx CLI & creating a new Nx Workspace](/{{framework}}/getting-started/nx-setup)
-- [Adding Nx to an existing monorepo](/{{framework}}/migration/adding-to-monorepo)
-- [Migrating from CRA](/{{framework}}/migration/migration-cra)
-- [Using Nx without plugins](/{{framework}}/getting-started/nx-core)
+- [Installing Nx CLI & creating a new Nx Workspace](//getting-started/nx-setup)
+- [Adding Nx to an existing monorepo](//migration/adding-to-monorepo)
+- [Migrating from CRA](//migration/migration-cra)
+- [Using Nx without plugins](//getting-started/nx-core)
 - [CI Overview](/using-nx/ci-overview)
 
 It is also a good idea to read the [mental model guide](/using-nx/mental-model) to understand how Nx works.
 
 ## Nx and React Plugins
 
-Nx plugins help you develop [React](/{{framework}}/react/overview) applications with fully integrated support for modern tools
-and libraries like [Jest](/{{framework}}/jest/overview), [Cypress](/{{framework}}/cypress/overview),
-Storybook, [ESLint](/{{framework}}/linter/eslint), and more. Nx also supports React
-frameworks like [Gatsby](/{{version}}/react/gatsby/overview), [Next.js](/{{version}}/react/guides/nextjs), Remix, and has great support for React Native.
+Nx plugins help you develop [React](//react/overview) applications with fully integrated support for modern tools
+and libraries like [Jest](//jest/overview), [Cypress](//cypress/overview),
+Storybook, [ESLint](//linter/eslint), and more. Nx also supports React
+frameworks like [Gatsby](///gatsby/overview), [Next.js](///guides/nextjs), Remix, and has great support for React Native.
 
 ### 10-min Video Overview
 

--- a/nx-dev/nx-dev/public/documentation/latest/shared/migration/migration-angular.md
+++ b/nx-dev/nx-dev/public/documentation/latest/shared/migration/migration-angular.md
@@ -97,7 +97,7 @@ Learn more about the advantages of Nx in the following guides:
 
 ## Transitioning Manually
 
-If you are unable to automatically transform your Angular CLI workspace to an Nx workspace using the [ng add]({{framework}}/migration/migration-angular#using-ng-add-preserving-your-existing-structure) method, there are some manual steps you can take to move your project(s) into an Nx workspace.
+If you are unable to automatically transform your Angular CLI workspace to an Nx workspace using the [ng add](/migration/migration-angular#using-ng-add-preserving-your-existing-structure) method, there are some manual steps you can take to move your project(s) into an Nx workspace.
 
 ### Generating a new workspace
 


### PR DESCRIPTION
## What it does?
Cleans internal linking by removing extra `{{framework}}` & `{{version}}`.