### PR TITLE
docs(tools): remove nxdev release tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "check-internal-links": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/internal-link-checker.ts",
     "check-versions": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/check-versions.ts",
     "check-documentation-map": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/map-link-checker.ts",
-    "update-nx-dev-documentation": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/nx-dev-release-content.ts",
     "e2e-start-local-registry": "node ./scripts/e2e-start-local-registry.js",
     "e2e-build-package-publish": "ts-node -P ./scripts/tsconfig.e2e.json ./scripts/e2e-build-package-publish.ts",
     "format": "nx format",


### PR DESCRIPTION
## What it does?
Removes the script call to update nx.dev with a release tag documentation content from the `package.json`, not used anymore.