### PR TITLE
fix(react-native): add test-setup to exclude in tsconfig

### DIFF
--- a/packages/react-native/src/generators/application/files/app/tsconfig.app.json.template
+++ b/packages/react-native/src/generators/application/files/app/tsconfig.app.json.template
@@ -4,6 +4,6 @@
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "types": ["node"]
   },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "test-setup.ts"],
   "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"]
 }

--- a/packages/react-native/src/generators/library/files/lib/tsconfig.lib.json__tmpl__
+++ b/packages/react-native/src/generators/library/files/lib/tsconfig.lib.json__tmpl__
@@ -4,6 +4,6 @@
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "types": ["node"]
   },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "test-setup.ts"],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
add test-setup.ts to exclude in tsconfig so it does not throw error when trying to build lib

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
