### PR TITLE
fix(testing): support cypress `--tag` arg

### DIFF
--- a/docs/default/api-cypress/executors/cypress.md
+++ b/docs/default/api-cypress/executors/cypress.md
@@ -131,6 +131,14 @@ Type: `string`
 
 A comma delimited glob string that is provided to the Cypress runner to specify which spec files to run. i.e. '**examples/**,**actions.spec**
 
+### tag
+
+Alias(es): t
+
+Type: `string`
+
+A comma delimited list to identify a run with
+
 ### testingType
 
 Default: `e2e`

--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -37,6 +37,7 @@ export interface CypressExecutorOptions extends Json {
   reporterOptions?: string;
   skipServe?: boolean;
   testingType?: 'component' | 'e2e';
+  tag?: string;
 }
 
 export default async function cypressExecutor(
@@ -185,6 +186,7 @@ async function runCypress(baseUrl: string, opts: CypressExecutorOptions) {
     options.spec = opts.spec;
   }
 
+  options.tag = opts.tag;
   options.exit = opts.exit;
   options.headed = opts.headed;
   options.headless = opts.headless;

--- a/packages/cypress/src/executors/cypress/schema.json
+++ b/packages/cypress/src/executors/cypress/schema.json
@@ -103,6 +103,11 @@
       "description": "Specify the type of tests to execute",
       "enum": ["component", "e2e"],
       "default": "e2e"
+    },
+    "tag": {
+      "type": "string",
+      "description": "A comma delimited list to identify a run with",
+      "aliases": ["t"]
     }
   },
   "additionalProperties": true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`--tag` arg does not work as intended (throws error/does not tag e2e run)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`--tag` will tag the cypress run

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://docs.cypress.io/guides/guides/command-line#cypress-run-tag-lt-tag-gt

Fixes #4998 
