### PR TITLE
chore(core): use extrapolated ts type in create-nx-workspace & create…

### DIFF
--- a/packages/create-nx-plugin/bin/detect-invoked-package-manager.ts
+++ b/packages/create-nx-plugin/bin/detect-invoked-package-manager.ts
@@ -1,4 +1,6 @@
-export type PackageManager = 'yarn' | 'pnpm' | 'npm';
+const packageManagerList = ['npm', 'pnpm', 'yarn'] as const;
+
+export type PackageManager = typeof packageManagerList[number];
 
 /**
  * Detects which package manager was used to invoke create-nx-{plugin|workspace} command
@@ -19,7 +21,7 @@ export function detectInvokedPackageManager(): PackageManager {
     return detectedPackageManager;
   }
 
-  for (const pkgManager of ['pnpm', 'yarn', 'npm'] as const) {
+  for (const pkgManager of packageManagerList) {
     if (invoker.path.includes(pkgManager)) {
       detectedPackageManager = pkgManager;
       break;

--- a/packages/create-nx-plugin/bin/detect-invoked-package-manager.ts
+++ b/packages/create-nx-plugin/bin/detect-invoked-package-manager.ts
@@ -1,4 +1,4 @@
-const packageManagerList = ['npm', 'pnpm', 'yarn'] as const;
+const packageManagerList = ['pnpm', 'yarn', 'npm'] as const;
 
 export type PackageManager = typeof packageManagerList[number];
 

--- a/packages/create-nx-workspace/bin/package-manager.ts
+++ b/packages/create-nx-workspace/bin/package-manager.ts
@@ -110,7 +110,7 @@ export function detectInvokedPackageManager(): PackageManager {
     return detectedPackageManager;
   }
 
-  for (const pkgManager of ['pnpm', 'yarn', 'npm'] as const) {
+  for (const pkgManager of packageManagerList) {
     if (invoker.path.includes(pkgManager)) {
       detectedPackageManager = pkgManager;
       break;

--- a/packages/create-nx-workspace/bin/package-manager.ts
+++ b/packages/create-nx-workspace/bin/package-manager.ts
@@ -7,7 +7,7 @@ import { join } from 'path';
  * we duplicate the helper functions from @nrwl/workspace in this file.
  */
 
-const packageManagerList = ['npm', 'pnpm', 'yarn'] as const;
+const packageManagerList = ['pnpm', 'yarn', 'npm'] as const;
 
 export type PackageManager = typeof packageManagerList[number];
 

--- a/packages/create-nx-workspace/bin/package-manager.ts
+++ b/packages/create-nx-workspace/bin/package-manager.ts
@@ -7,7 +7,9 @@ import { join } from 'path';
  * we duplicate the helper functions from @nrwl/workspace in this file.
  */
 
-export type PackageManager = 'yarn' | 'pnpm' | 'npm';
+const packageManagerList = ['npm', 'pnpm', 'yarn'] as const;
+
+export type PackageManager = typeof packageManagerList[number];
 
 export function detectPackageManager(dir: string = ''): PackageManager {
   return existsSync(join(dir, 'yarn.lock'))


### PR DESCRIPTION
…-nx-plugin

Reduce code below:

```typescript
const packageManagerList = ['pnpm','yarn','npm']

export type PackageManager = 'yarn' | 'pnpm' | 'npm';
```

to be:

```typescript
const packageManagerList = ['pnpm', 'yarn', 'npm'] as const;

export type PackageManager = typeof packageManagerList[number];
```

Only `create-nx-plugin` and `create-nx-workspace` got changed, but I think all places about package manager choice should use this as TypeScript recommends '**deduce is better than define mark manually**'

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
