### PR TITLE
chore(nextjs): disable failing e2e test for windows runs

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -3,6 +3,7 @@ import {
   checkFilesExist,
   cleanupProject,
   createFile,
+  isNotWindows,
   killPorts,
   newProject,
   promisifiedTreeKill,
@@ -93,7 +94,7 @@ describe('Next.js Applications', () => {
           import { testFn } from '@${proj}/${jsLib}';
           /* eslint-disable */
           import dynamic from 'next/dynamic';
-          
+
           const TestComponent = dynamic(
               () => import('@${proj}/${reactLib}').then(d => d.${stringUtils.capitalize(
         reactLib
@@ -129,7 +130,7 @@ describe('Next.js Applications', () => {
     await checkApp(appName, {
       checkUnitTest: true,
       checkLint: true,
-      checkE2E: true,
+      checkE2E: isNotWindows(),
       checkExport: false,
     });
 


### PR DESCRIPTION
Disable cypress run on windows until the test is fixed.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
