### PR TITLE
fix(testing): turn swc/jest back on for react, web, and js

### DIFF
--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -58,11 +58,11 @@ describe('jest', () => {
       expect(packageJson.devDependencies['babel-jest']).toBeDefined();
     });
 
-    // it('should support swc compiler', () => {
-    //   jestInitGenerator(tree, { compiler: 'swc' });
-    //   const packageJson = readJson(tree, 'package.json');
-    //   expect(packageJson.devDependencies['@swc/jest']).toBeDefined()
-    // });
+    it('should support swc compiler', () => {
+      jestInitGenerator(tree, { compiler: 'swc' });
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@swc/jest']).toBeDefined();
+    });
   });
 
   describe('adds jest extension', () => {

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -1,4 +1,11 @@
 import {
+  addDependenciesToPackageJson,
+  convertNxGenerator,
+  stripIndents,
+  Tree,
+  updateJson,
+} from '@nrwl/devkit';
+import {
   babelJestVersion,
   jestTypesVersion,
   jestVersion,
@@ -8,13 +15,6 @@ import {
   tslibVersion,
 } from '../../utils/versions';
 import { JestInitSchema } from './schema';
-import {
-  addDependenciesToPackageJson,
-  convertNxGenerator,
-  stripIndents,
-  Tree,
-  updateJson,
-} from '@nrwl/devkit';
 
 interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}
 
@@ -74,9 +74,8 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
     devDeps['babel-jest'] = babelJestVersion;
     // in some cases @nrwl/web will not already be present i.e. node only projects
     devDeps['@nrwl/web'] = nxVersion;
-    // TODO: revert to @swc/jest when https://github.com/swc-project/cli/issues/20 is addressed
-    // } else if (options.compiler === 'swc') {
-    //   devDeps['@swc/jest'] = swcJestVersion;
+  } else if (options.compiler === 'swc') {
+    devDeps['@swc/jest'] = swcJestVersion;
   }
 
   return addDependenciesToPackageJson(tree, dependencies, devDeps);

--- a/packages/jest/src/generators/init/schema.d.ts
+++ b/packages/jest/src/generators/init/schema.d.ts
@@ -1,5 +1,5 @@
 export interface JestInitSchema {
-  compiler?: 'tsc' | 'babel';
+  compiler?: 'tsc' | 'babel' | 'swc';
   /**
    * @deprecated
    */

--- a/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
+++ b/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`jestProject --babelJest should generate proper jest.transform when --compiler=swc and supportTsx is true 1`] = `
+"module.exports = {
+  displayName: 'lib1',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\\\\\\\.[tj]sx?$': ['@swc/jest', { jsc: { transform: { react: { runtime: 'automatic' } } } }]
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/lib1'
+};
+"
+`;
+
 exports[`jestProject --babelJest should generate proper jest.transform when babelJest and supportTsx is true 1`] = `
 "module.exports = {
   displayName: 'lib1',

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -6,10 +6,10 @@ import {
   writeJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { jestConfigObject } from '../../utils/config/functions';
 
 import { jestProjectGenerator } from './jest-project';
 import { JestProjectSchema } from './schema.d';
-import { jestConfigObject } from '../../utils/config/functions';
 
 describe('jestProject', () => {
   let tree: Tree;
@@ -300,14 +300,14 @@ describe('jestProject', () => {
       expect(tree.read('libs/lib1/jest.config.js', 'utf-8')).toMatchSnapshot();
     });
 
-    // it('should generate proper jest.transform when --compiler=swc and supportTsx is true', async () => {
-    //   await jestProjectGenerator(tree, {
-    //     ...defaultOptions,
-    //     project: 'lib1',
-    //     compiler: 'swc',
-    //     supportTsx: true,
-    //   } as JestProjectSchema);
-    //   expect(tree.read('libs/lib1/jest.config.js', 'utf-8')).toMatchSnapshot();
-    // });
+    it('should generate proper jest.transform when --compiler=swc and supportTsx is true', async () => {
+      await jestProjectGenerator(tree, {
+        ...defaultOptions,
+        project: 'lib1',
+        compiler: 'swc',
+        supportTsx: true,
+      } as JestProjectSchema);
+      expect(tree.read('libs/lib1/jest.config.js', 'utf-8')).toMatchSnapshot();
+    });
   });
 });

--- a/packages/jest/src/generators/jest-project/lib/create-files.ts
+++ b/packages/jest/src/generators/jest-project/lib/create-files.ts
@@ -1,4 +1,3 @@
-import { JestProjectSchema } from '../schema';
 import {
   generateFiles,
   offsetFromRoot,
@@ -6,6 +5,7 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { join } from 'path';
+import { JestProjectSchema } from '../schema';
 
 export function createFiles(tree: Tree, options: JestProjectSchema) {
   const projectConfig = readProjectConfiguration(tree, options.project);
@@ -13,11 +13,11 @@ export function createFiles(tree: Tree, options: JestProjectSchema) {
   const filesFolder =
     options.setupFile === 'angular' ? '../files-angular' : '../files';
 
-  // } else if (options.compiler === 'swc') {
-  //   transformer = '@swc/jest';
   let transformer: string;
   if (options.compiler === 'babel' || options.babelJest) {
     transformer = 'babel-jest';
+  } else if (options.compiler === 'swc') {
+    transformer = '@swc/jest';
   } else {
     transformer = 'ts-jest';
   }

--- a/packages/jest/src/generators/jest-project/schema.d.ts
+++ b/packages/jest/src/generators/jest-project/schema.d.ts
@@ -13,5 +13,5 @@ export interface JestProjectSchema {
    */
   babelJest?: boolean;
   skipFormat?: boolean;
-  compiler?: 'tsc' | 'babel';
+  compiler?: 'tsc' | 'babel' | 'swc';
 }

--- a/packages/jest/src/generators/jest-project/schema.json
+++ b/packages/jest/src/generators/jest-project/schema.json
@@ -42,7 +42,7 @@
     },
     "compiler": {
       "type": "string",
-      "enum": ["tsc", "babel"],
+      "enum": ["tsc", "babel", "swc"],
       "description": "The compiler to use for source and tests",
       "default": "tsc"
     },

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -709,17 +709,17 @@ describe('lib', () => {
         expect(tree.exists('libs/my-lib/.swcrc')).toBeTruthy();
       });
 
-      // it('should setup jest project using swc', async () => {
-      //   await libraryGenerator(tree, {
-      //     ...defaultOptions,
-      //     name: 'myLib',
-      //     buildable: true,
-      //     compiler: 'swc',
-      //   });
-      //
-      //   const jestConfig = tree.read('libs/my-lib/jest.config.js').toString();
-      //   expect(jestConfig).toContain('@swc/jest');
-      // });
+      it('should setup jest project using swc', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          buildable: true,
+          compiler: 'swc',
+        });
+
+        const jestConfig = tree.read('libs/my-lib/jest.config.js').toString();
+        expect(jestConfig).toContain('@swc/jest');
+      });
 
       it('should generate a package.json file', async () => {
         await libraryGenerator(tree, {

--- a/packages/js/src/utils/project-generator.ts
+++ b/packages/js/src/utils/project-generator.ts
@@ -225,7 +225,7 @@ async function addJest(
     skipSerializers: true,
     testEnvironment: options.testEnvironment,
     skipFormat: true,
-    compiler: 'tsc',
+    compiler: options.compiler,
   });
 }
 

--- a/packages/react/src/generators/application/lib/add-jest.ts
+++ b/packages/react/src/generators/application/lib/add-jest.ts
@@ -12,6 +12,6 @@ export async function addJest(host: Tree, options: NormalizedSchema) {
     supportTsx: true,
     skipSerializers: true,
     setupFile: 'none',
-    compiler: options.compiler as 'tsc',
+    compiler: options.compiler,
   });
 }

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -1,22 +1,3 @@
-import * as ts from 'typescript';
-import { assertValidStyle } from '../../utils/assertion';
-import {
-  addBrowserRouter,
-  addInitialRoutes,
-  addRoute,
-  findComponentImportPath,
-} from '../../utils/ast-utils';
-import {
-  createReactEslintJson,
-  extraEslintDependencies,
-} from '../../utils/lint';
-import {
-  reactDomVersion,
-  reactRouterDomVersion,
-  reactVersion,
-  typesReactRouterDomVersion,
-} from '../../utils/versions';
-import { Schema } from './schema';
 import {
   addDependenciesToPackageJson,
   addProjectConfiguration,
@@ -35,12 +16,31 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
-import init from '../init/init';
-import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { jestProjectGenerator } from '@nrwl/jest';
-import componentGenerator from '../component/component';
 import { swcCoreVersion } from '@nrwl/js/src/utils/versions';
+import { Linter, lintProjectGenerator } from '@nrwl/linter';
+import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import * as ts from 'typescript';
+import { assertValidStyle } from '../../utils/assertion';
+import {
+  addBrowserRouter,
+  addInitialRoutes,
+  addRoute,
+  findComponentImportPath,
+} from '../../utils/ast-utils';
+import {
+  createReactEslintJson,
+  extraEslintDependencies,
+} from '../../utils/lint';
+import {
+  reactDomVersion,
+  reactRouterDomVersion,
+  reactVersion,
+  typesReactRouterDomVersion,
+} from '../../utils/versions';
+import componentGenerator from '../component/component';
+import init from '../init/init';
+import { Schema } from './schema';
 
 export interface NormalizedSchema extends Schema {
   name: string;
@@ -90,7 +90,7 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
       setupFile: 'none',
       supportTsx: true,
       skipSerializers: true,
-      compiler: options.compiler as 'tsc',
+      compiler: options.compiler,
     });
     tasks.push(jestTask);
   }

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -1,6 +1,6 @@
+import type { NxJsonConfiguration, Tree } from '@nrwl/devkit';
 import { getProjects, readJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import type { Tree, NxJsonConfiguration } from '@nrwl/devkit';
 
 import { applicationGenerator } from './application';
 import { Schema } from './schema';
@@ -398,26 +398,26 @@ describe('app', () => {
       `);
     });
 
-    // it('should support swc compiler', async () => {
-    //   await applicationGenerator(tree, {
-    //     name: 'myApp',
-    //     compiler: 'swc',
-    //   } as Schema);
-    //
-    //   expect(tree.read(`apps/my-app/jest.config.js`, 'utf-8'))
-    //     .toMatchInlineSnapshot(`
-    //     "module.exports = {
-    //       displayName: 'my-app',
-    //       preset: '../../jest.preset.js',
-    //       setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-    //       transform: {
-    //         '^.+\\\\\\\\.[tj]s$': '@swc/jest'
-    //       },
-    //       moduleFileExtensions: ['ts', 'js', 'html'],
-    //       coverageDirectory: '../../coverage/apps/my-app'
-    //     };
-    //     "
-    //   `);
-    // });
+    it('should support swc compiler', async () => {
+      await applicationGenerator(tree, {
+        name: 'myApp',
+        compiler: 'swc',
+      } as Schema);
+
+      expect(tree.read(`apps/my-app/jest.config.js`, 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "module.exports = {
+          displayName: 'my-app',
+          preset: '../../jest.preset.js',
+          setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+          transform: {
+            '^.+\\\\\\\\.[tj]s$': '@swc/jest'
+          },
+          moduleFileExtensions: ['ts', 'js', 'html'],
+          coverageDirectory: '../../coverage/apps/my-app'
+        };
+        "
+      `);
+    });
   });
 });

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -1,3 +1,4 @@
+import { cypressProjectGenerator } from '@nrwl/cypress';
 import {
   addDependenciesToPackageJson,
   addProjectConfiguration,
@@ -15,19 +16,18 @@ import {
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
+import { jestProjectGenerator } from '@nrwl/jest';
+import { swcCoreVersion } from '@nrwl/js/src/utils/versions';
+import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 import { join } from 'path';
 
-import { webInitGenerator } from '../init/init';
-import { cypressProjectGenerator } from '@nrwl/cypress';
-import { Linter, lintProjectGenerator } from '@nrwl/linter';
-import { jestProjectGenerator } from '@nrwl/jest';
-
 import { WebWebpackExecutorOptions } from '../../executors/webpack/webpack.impl';
-import { Schema } from './schema';
-import { swcCoreVersion } from '@nrwl/js/src/utils/versions';
 import { swcLoaderVersion } from '../../utils/versions';
+
+import { webInitGenerator } from '../init/init';
+import { Schema } from './schema';
 
 interface NormalizedSchema extends Schema {
   projectName: string;
@@ -221,7 +221,7 @@ export async function applicationGenerator(host: Tree, schema: Schema) {
       project: options.projectName,
       skipSerializers: true,
       setupFile: 'web-components',
-      compiler: options.compiler as 'tsc',
+      compiler: options.compiler,
     });
     tasks.push(jestTask);
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`swc/jest` (`--compiler=swc`) was turned off. New libs/apps generated with `--compiler=swc` do not generate jest config that uses `swc/jest`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
New libs/apps generated with `--compiler=swc` should generate jest config that uses `swc/jest`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
