### PR TITLE
feat(web): update http-server to 14.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "fork-ts-checker-webpack-plugin": "6.2.10",
     "fs-extra": "^9.1.0",
     "html-webpack-plugin": "^3.2.0",
-    "http-server": "~14.0.0",
+    "http-server": "14.1.0",
     "husky": "^6.0.0",
     "identity-obj-proxy": "3.0.0",
     "ignore": "^5.0.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -111,7 +111,7 @@
     "webpack-subresource-integrity": "^1.5.2",
     "worker-plugin": "3.2.0",
     "webpack-dev-server": "^4.3.1",
-    "http-server": "~14.0.0",
+    "http-server": "14.1.0",
     "ignore": "^5.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13137,6 +13137,25 @@ http-proxy@^1.13.0, http-proxy@^1.18.1:
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
+http-server@14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/http-server/-/http-server-14.1.0.tgz#51d43e03cdbb94f328b24821cad2cefc6c6a2eed"
+  integrity sha512-5lYsIcZtf6pdR8tCtzAHTWrAveo4liUlJdWc7YafwK/maPgYHs+VNP6KpCClmUnSorJrARVMXqtT055zBv11Yg==
+  dependencies:
+    basic-auth "^2.0.1"
+    chalk "^4.1.2"
+    corser "^2.0.1"
+    he "^1.2.0"
+    html-encoding-sniffer "^3.0.0"
+    http-proxy "^1.18.1"
+    mime "^1.6.0"
+    minimist "^1.2.5"
+    opener "^1.5.1"
+    portfinder "^1.0.28"
+    secure-compare "3.0.1"
+    union "~0.5.0"
+    url-join "^4.0.1"
+
 http-server@~14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/http-server/-/http-server-14.0.0.tgz#bd214952a60b93ce8ca9bbe8ba181faf7f9821b0"


### PR DESCRIPTION
Update to http-server 14.1.0, which replaces `colors` with `chalk`.

Fixes #8450
