### PR TITLE
fix(web): prevent caching in the file-server

### DIFF
--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -7,7 +7,7 @@ import { watch } from 'chokidar';
 import { workspaceLayout } from '@nrwl/workspace/src/core/file-utils';
 
 function getHttpServerArgs(options: Schema) {
-  const args = [] as any[];
+  const args = ['-c-1'];
   if (options.port) {
     args.push(`-p ${options.port}`);
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nrwl/web:file-server` executor spins up the `http-server` with a default caching of 3600ms. This requires consumers to constantly clear the cache when developing to see the changes. Being a development server, caching is not desired, changes should be reflected on every change.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The server used by the `@nrwl/web:file-server` executor should not cache any resources.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
