### PR TITLE
docs(nxdev): add auto docs sync build command

### DIFF
--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -65,6 +65,14 @@
         }
       }
     },
+    "deploy-build": {
+      "executor": "@nrwl/workspace:run-commands",
+      "outputs": ["nx-dev/nx-dev/public/documentation"],
+      "options": {
+        "commands": ["nx run nx-dev:sync-documentation", "nx run nx-dev:build"],
+        "parallel": false
+      }
+    },
     "export": {
       "executor": "@nrwl/next:export",
       "options": {


### PR DESCRIPTION
## What it does?
Create a new nx command to automate documentation's sync folder for nx.dev with `nx run nx-dev:deploy-build`. Each nx.dev deploy will take by default, the latest content from `docs/`.