### PR TITLE
fix(storybook): handle defaultProject issues with projectBuildConfig flag

### DIFF
--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -72,6 +72,12 @@
       "cli": "nx",
       "description": "Adjust Storybook tsconfig to add styled-jsx typings",
       "factory": "./src/migrations/update-12-8-0/update-storybook-styled-jsx-typings"
+    },
+    "update-13.4.6": {
+      "version": "13.4.6-beta.1",
+      "cli": "nx",
+      "description": "Add projectBuildConfig option to project's Storybook config.",
+      "factory": "./src/migrations/update-13-4-6/set-project-build-config"
     }
   },
   "packageJsonUpdates": {

--- a/packages/storybook/src/executors/build-storybook/build-storybook.impl.spec.ts
+++ b/packages/storybook/src/executors/build-storybook/build-storybook.impl.spec.ts
@@ -43,6 +43,7 @@ describe('Build storybook', () => {
     options = {
       uiFramework,
       outputPath,
+      projectBuildConfig: 'proj',
       config,
     };
 

--- a/packages/storybook/src/executors/storybook/storybook.impl.spec.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.spec.ts
@@ -35,6 +35,7 @@ describe('@nrwl/storybook:storybook', () => {
     options = {
       uiFramework: '@storybook/angular',
       port: 4400,
+      projectBuildConfig: 'proj',
       config: {
         configFolder: storybookPath,
       },

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -136,7 +136,7 @@ describe('@nrwl/storybook:configuration', () => {
     expect(tree.read('.storybook/main.js', 'utf-8')).toEqual(newContents);
   });
 
-  it('should update workspace file', async () => {
+  it('should update workspace file for react libs', async () => {
     await configurationGenerator(tree, {
       name: 'test-ui-lib',
       uiFramework: '@storybook/react',
@@ -165,6 +165,45 @@ describe('@nrwl/storybook:configuration', () => {
       outputs: ['{options.outputFile}'],
       options: {
         lintFilePatterns: ['libs/test-ui-lib/**/*.ts'],
+      },
+    });
+  });
+
+  it('should update workspace file for angular libs', async () => {
+    // Setup a new lib
+    await libraryGenerator(tree, {
+      name: 'test-ui-lib-2',
+      standaloneConfig: false,
+    });
+    await configurationGenerator(tree, {
+      name: 'test-ui-lib-2',
+      uiFramework: '@storybook/angular',
+      standaloneConfig: false,
+    });
+    const project = readProjectConfiguration(tree, 'test-ui-lib-2');
+
+    expect(project.targets.storybook).toEqual({
+      executor: '@nrwl/storybook:storybook',
+      configurations: {
+        ci: {
+          quiet: true,
+        },
+      },
+      options: {
+        port: 4400,
+        projectBuildConfig: 'test-ui-lib-2:build-storybook',
+        uiFramework: '@storybook/angular',
+        config: {
+          configFolder: 'libs/test-ui-lib-2/.storybook',
+        },
+      },
+    });
+
+    expect(project.targets.lint).toEqual({
+      executor: '@nrwl/linter:eslint',
+      outputs: ['{options.outputFile}'],
+      options: {
+        lintFilePatterns: ['libs/test-ui-lib-2/**/*.ts'],
       },
     });
   });

--- a/packages/storybook/src/migrations/update-13-4-6/__snapshots__/set-project-build-config.spec.ts.snap
+++ b/packages/storybook/src/migrations/update-13-4-6/__snapshots__/set-project-build-config.spec.ts.snap
@@ -1,0 +1,403 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Set the projectBuildConfig option in the Storybook configuration for Angular projects for all types of angular projects - non-buildable and buildable libs/apps should set the projectBuildConfig in the Storybook config according to the type of project 1`] = `
+Object {
+  "projects": Object {
+    "main-app": Object {
+      "prefix": "katst",
+      "projectType": "application",
+      "root": "apps/main-app",
+      "sourceRoot": "apps/main-app/src",
+      "targets": Object {
+        "build": Object {
+          "executor": "@angular-devkit/build-angular:browser",
+          "outputs": Array [
+            "{options.outputPath}",
+          ],
+        },
+        "build-storybook": Object {
+          "configurations": Object {
+            "ci": Object {
+              "quiet": true,
+            },
+          },
+          "executor": "@nrwl/storybook:build",
+          "options": Object {
+            "config": Object {
+              "configFolder": "apps/main-app/.storybook",
+            },
+            "outputPath": "dist/storybook/main-app",
+            "projectBuildConfig": "main-app",
+            "uiFramework": "@storybook/angular",
+          },
+          "outputs": Array [
+            "{options.outputPath}",
+          ],
+        },
+        "storybook": Object {
+          "configurations": Object {
+            "ci": Object {
+              "quiet": true,
+            },
+          },
+          "executor": "@nrwl/storybook:storybook",
+          "options": Object {
+            "config": Object {
+              "configFolder": "apps/main-app/.storybook",
+            },
+            "port": 4400,
+            "projectBuildConfig": "main-app",
+            "uiFramework": "@storybook/angular",
+          },
+        },
+      },
+    },
+    "ui-one": Object {
+      "projectType": "library",
+      "root": "libs/ui/one",
+      "sourceRoot": "libs/ui/one/src",
+      "targets": Object {
+        "build-storybook": Object {
+          "configurations": Object {
+            "ci": Object {
+              "quiet": true,
+            },
+          },
+          "executor": "@nrwl/storybook:build",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/one/.storybook",
+            },
+            "outputPath": "dist/storybook/ui/one",
+            "projectBuildConfig": "ui-one:build-storybook",
+            "uiFramework": "@storybook/angular",
+          },
+          "outputs": Array [
+            "{options.outputPath}",
+          ],
+        },
+        "storybook": Object {
+          "executor": "@nrwl/storybook:storybook",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/one/.storybook",
+            },
+            "port": 4400,
+            "projectBuildConfig": "ui-one:build-storybook",
+            "uiFramework": "@storybook/angular",
+          },
+        },
+      },
+    },
+    "ui-three": Object {
+      "projectType": "library",
+      "root": "libs/ui/three",
+      "sourceRoot": "libs/ui/three/src",
+      "targets": Object {
+        "build-storybook": Object {
+          "configurations": Object {
+            "ci": Object {
+              "quiet": true,
+            },
+          },
+          "executor": "@nrwl/storybook:build",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/three/.storybook",
+            },
+            "outputPath": "dist/storybook/ui/three",
+            "projectBuildConfig": "ui-three:build-storybook",
+            "uiFramework": "@storybook/angular",
+          },
+          "outputs": Array [
+            "{options.outputPath}",
+          ],
+        },
+        "storybook": Object {
+          "executor": "@nrwl/storybook:storybook",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/three/.storybook",
+            },
+            "port": 4400,
+            "projectBuildConfig": "ui-three:build-storybook",
+            "uiFramework": "@storybook/angular",
+          },
+        },
+      },
+    },
+    "ui-two": Object {
+      "projectType": "library",
+      "root": "libs/ui/two",
+      "sourceRoot": "libs/ui/two/src",
+      "targets": Object {
+        "build-storybook": Object {
+          "configurations": Object {
+            "ci": Object {
+              "quiet": true,
+            },
+          },
+          "executor": "@nrwl/storybook:build",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/two/.storybook",
+            },
+            "outputPath": "dist/storybook/ui/two",
+            "projectBuildConfig": "ui-two:build-storybook",
+            "uiFramework": "@storybook/angular",
+          },
+          "outputs": Array [
+            "{options.outputPath}",
+          ],
+        },
+        "storybook": Object {
+          "executor": "@nrwl/storybook:storybook",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/two/.storybook",
+            },
+            "port": 4400,
+            "projectBuildConfig": "ui-two:build-storybook",
+            "uiFramework": "@storybook/angular",
+          },
+        },
+      },
+    },
+  },
+  "version": 1,
+}
+`;
+
+exports[`Set the projectBuildConfig option in the Storybook configuration for Angular projects for all types of angular projects - non-buildable and buildable libs/apps should still set the projectBuildConfig even if target names are not the default 1`] = `
+Object {
+  "projects": Object {
+    "main-app": Object {
+      "prefix": "katst",
+      "projectType": "application",
+      "root": "apps/main-app",
+      "sourceRoot": "apps/main-app/src",
+      "targets": Object {
+        "lmfkcn": Object {
+          "configurations": Object {
+            "ci": Object {
+              "quiet": true,
+            },
+          },
+          "executor": "@nrwl/storybook:storybook",
+          "options": Object {
+            "config": Object {
+              "configFolder": "apps/main-app/.storybook",
+            },
+            "port": 4400,
+            "projectBuildConfig": "main-app",
+            "uiFramework": "@storybook/angular",
+          },
+        },
+        "njdfvndfjnv": Object {
+          "executor": "@angular-devkit/build-angular:browser",
+          "outputs": Array [
+            "{options.outputPath}",
+          ],
+        },
+        "odmwjbc": Object {
+          "configurations": Object {
+            "ci": Object {
+              "quiet": true,
+            },
+          },
+          "executor": "@nrwl/storybook:build",
+          "options": Object {
+            "config": Object {
+              "configFolder": "apps/main-app/.storybook",
+            },
+            "outputPath": "dist/storybook/main-app",
+            "projectBuildConfig": "main-app",
+            "uiFramework": "@storybook/angular",
+          },
+          "outputs": Array [
+            "{options.outputPath}",
+          ],
+        },
+      },
+    },
+    "ui-one": Object {
+      "projectType": "library",
+      "root": "libs/ui/one",
+      "sourceRoot": "libs/ui/one/src",
+      "targets": Object {
+        "asdgsdfg": Object {
+          "configurations": Object {
+            "ci": Object {
+              "quiet": true,
+            },
+          },
+          "executor": "@nrwl/storybook:build",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/one/.storybook",
+            },
+            "outputPath": "dist/storybook/ui/one",
+            "projectBuildConfig": "ui-one:asdgsdfg",
+            "uiFramework": "@storybook/angular",
+          },
+          "outputs": Array [
+            "{options.outputPath}",
+          ],
+        },
+        "trthrngb": Object {
+          "executor": "@nrwl/storybook:storybook",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/one/.storybook",
+            },
+            "port": 4400,
+            "projectBuildConfig": "ui-one:asdgsdfg",
+            "uiFramework": "@storybook/angular",
+          },
+        },
+      },
+    },
+    "ui-three": Object {
+      "projectType": "library",
+      "root": "libs/ui/three",
+      "sourceRoot": "libs/ui/three/src",
+      "targets": Object {
+        "aaaa": Object {
+          "configurations": Object {
+            "ci": Object {
+              "quiet": true,
+            },
+          },
+          "executor": "@nrwl/storybook:build",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/three/.storybook",
+            },
+            "outputPath": "dist/storybook/ui/three",
+            "projectBuildConfig": "ui-three:aaaa",
+            "uiFramework": "@storybook/angular",
+          },
+          "outputs": Array [
+            "{options.outputPath}",
+          ],
+        },
+        "nmkgd": Object {
+          "executor": "@nrwl/storybook:storybook",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/three/.storybook",
+            },
+            "port": 4400,
+            "projectBuildConfig": "ui-three:aaaa",
+            "uiFramework": "@storybook/angular",
+          },
+        },
+      },
+    },
+    "ui-two": Object {
+      "projectType": "library",
+      "root": "libs/ui/two",
+      "sourceRoot": "libs/ui/two/src",
+      "targets": Object {
+        "sdft": Object {
+          "executor": "@nrwl/storybook:storybook",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/two/.storybook",
+            },
+            "port": 4400,
+            "projectBuildConfig": "ui-two:thjkkb",
+            "uiFramework": "@storybook/angular",
+          },
+        },
+        "thjkkb": Object {
+          "configurations": Object {
+            "ci": Object {
+              "quiet": true,
+            },
+          },
+          "executor": "@nrwl/storybook:build",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/two/.storybook",
+            },
+            "outputPath": "dist/storybook/ui/two",
+            "projectBuildConfig": "ui-two:thjkkb",
+            "uiFramework": "@storybook/angular",
+          },
+          "outputs": Array [
+            "{options.outputPath}",
+          ],
+        },
+      },
+    },
+  },
+  "version": 1,
+}
+`;
+
+exports[`Set the projectBuildConfig option in the Storybook configuration for Angular projects for non-angular projects should not change their Storybook configuration 1`] = `
+Object {
+  "projects": Object {
+    "main-app": Object {
+      "prefix": "katst",
+      "projectType": "application",
+      "root": "apps/main-app",
+      "sourceRoot": "apps/main-app/src",
+      "targets": Object {
+        "storybook": Object {
+          "configurations": Object {
+            "ci": Object {
+              "quiet": true,
+            },
+          },
+          "executor": "@nrwl/storybook:storybook",
+          "options": Object {
+            "config": Object {
+              "configFolder": "apps/main-app/.storybook",
+            },
+            "port": 4400,
+            "uiFramework": "@storybook/react",
+          },
+        },
+      },
+    },
+    "ui-one": Object {
+      "projectType": "library",
+      "root": "libs/ui/one",
+      "sourceRoot": "libs/ui/one/src",
+      "targets": Object {
+        "build-storybook": Object {
+          "configurations": Object {
+            "ci": Object {
+              "quiet": true,
+            },
+          },
+          "executor": "@nrwl/storybook:build",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/one/.storybook",
+            },
+            "outputPath": "dist/storybook/ui/one",
+            "uiFramework": "@storybook/angular",
+          },
+          "outputs": Array [
+            "{options.outputPath}",
+          ],
+        },
+        "storybook": Object {
+          "executor": "@nrwl/storybook:storybook",
+          "options": Object {
+            "config": Object {
+              "configFolder": "libs/ui/one/.storybook",
+            },
+            "port": 4400,
+            "uiFramework": "@storybook/react",
+          },
+        },
+      },
+    },
+  },
+  "version": undefined,
+}
+`;

--- a/packages/storybook/src/migrations/update-13-4-6/set-project-build-config.spec.ts
+++ b/packages/storybook/src/migrations/update-13-4-6/set-project-build-config.spec.ts
@@ -1,0 +1,41 @@
+import { Tree, writeJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { readWorkspace } from 'packages/devkit/src/generators/project-configuration';
+import setProjectBuildConfig from './set-project-build-config';
+import * as defaultConfig from './test-configs/default-config.json';
+import * as customNames from './test-configs/custom-names-config.json';
+import * as nonAngular from './test-configs/non-angular.json';
+
+describe('Set the projectBuildConfig option in the Storybook configuration for Angular projects', () => {
+  let tree: Tree;
+
+  describe('for all types of angular projects - non-buildable and buildable libs/apps', () => {
+    beforeEach(async () => {
+      tree = createTreeWithEmptyWorkspace();
+    });
+
+    it(`should set the projectBuildConfig in the Storybook config according to the type of project`, async () => {
+      writeJson(tree, 'workspace.json', defaultConfig);
+      await setProjectBuildConfig(tree);
+      expect(readWorkspace(tree)).toMatchSnapshot();
+    });
+
+    it(`should still set the projectBuildConfig even if target names are not the default`, async () => {
+      writeJson(tree, 'workspace.json', customNames);
+      await setProjectBuildConfig(tree);
+      expect(readWorkspace(tree)).toMatchSnapshot();
+    });
+  });
+
+  describe('for non-angular projects', () => {
+    beforeEach(async () => {
+      tree = createTreeWithEmptyWorkspace();
+      writeJson(tree, 'workspace.json', nonAngular);
+    });
+
+    it(`should not change their Storybook configuration`, async () => {
+      await setProjectBuildConfig(tree);
+      expect(readWorkspace(tree)).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/storybook/src/migrations/update-13-4-6/set-project-build-config.ts
+++ b/packages/storybook/src/migrations/update-13-4-6/set-project-build-config.ts
@@ -1,0 +1,76 @@
+import {
+  logger,
+  Tree,
+  formatFiles,
+  updateProjectConfiguration,
+  getProjects,
+} from '@nrwl/devkit';
+import { findStorybookAndBuildTargets } from '../../executors/utils';
+
+export default async function setProjectBuildConfig(tree: Tree) {
+  let changesMade = false;
+  const projects = getProjects(tree);
+  [...projects.entries()].forEach(([projectName, projectConfiguration]) => {
+    const { storybookBuildTarget, storybookTarget, buildTarget } =
+      findStorybookAndBuildTargets(projectConfiguration.targets);
+    if (
+      projectName &&
+      storybookTarget &&
+      projectConfiguration?.targets?.[storybookTarget]?.options?.uiFramework ===
+        '@storybook/angular'
+    ) {
+      if (buildTarget) {
+        if (
+          !projectConfiguration.targets[storybookTarget].options
+            .projectBuildConfig
+        ) {
+          projectConfiguration.targets[
+            storybookTarget
+          ].options.projectBuildConfig = projectName;
+          changesMade = true;
+        }
+        if (
+          storybookBuildTarget &&
+          !projectConfiguration.targets[storybookBuildTarget].options
+            .projectBuildConfig
+        ) {
+          projectConfiguration.targets[
+            storybookBuildTarget
+          ].options.projectBuildConfig = projectName;
+          changesMade = true;
+        }
+      } else {
+        if (storybookBuildTarget) {
+          if (
+            !projectConfiguration.targets[storybookTarget].options
+              .projectBuildConfig
+          ) {
+            projectConfiguration.targets[
+              storybookTarget
+            ].options.projectBuildConfig = `${projectName}:${storybookBuildTarget}`;
+            changesMade = true;
+          }
+          if (
+            !projectConfiguration.targets[storybookBuildTarget].options
+              .projectBuildConfig
+          ) {
+            projectConfiguration.targets[
+              storybookBuildTarget
+            ].options.projectBuildConfig = `${projectName}:${storybookBuildTarget}`;
+            changesMade = true;
+          }
+        } else {
+          logger.warn(`Could not find a build target for ${projectName}.`);
+        }
+      }
+
+      if (changesMade) {
+        updateProjectConfiguration(tree, projectName, projectConfiguration);
+      }
+    }
+  });
+
+  if (changesMade) {
+    await formatFiles(tree);
+  }
+}

--- a/packages/storybook/src/migrations/update-13-4-6/test-configs/custom-names-config.json
+++ b/packages/storybook/src/migrations/update-13-4-6/test-configs/custom-names-config.json
@@ -1,0 +1,146 @@
+{
+  "projects": {
+    "ui-one": {
+      "projectType": "library",
+      "root": "libs/ui/one",
+      "sourceRoot": "libs/ui/one/src",
+      "targets": {
+        "trthrngb": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "port": 4400,
+            "config": {
+              "configFolder": "libs/ui/one/.storybook"
+            }
+          }
+        },
+        "asdgsdfg": {
+          "executor": "@nrwl/storybook:build",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "outputPath": "dist/storybook/ui/one",
+            "config": {
+              "configFolder": "libs/ui/one/.storybook"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    },
+    "ui-two": {
+      "projectType": "library",
+      "root": "libs/ui/two",
+      "sourceRoot": "libs/ui/two/src",
+      "targets": {
+        "sdft": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "port": 4400,
+            "config": {
+              "configFolder": "libs/ui/two/.storybook"
+            }
+          }
+        },
+        "thjkkb": {
+          "executor": "@nrwl/storybook:build",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "outputPath": "dist/storybook/ui/two",
+            "config": {
+              "configFolder": "libs/ui/two/.storybook"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    },
+    "ui-three": {
+      "projectType": "library",
+      "root": "libs/ui/three",
+      "sourceRoot": "libs/ui/three/src",
+      "targets": {
+        "nmkgd": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "port": 4400,
+            "config": {
+              "configFolder": "libs/ui/three/.storybook"
+            }
+          }
+        },
+        "aaaa": {
+          "executor": "@nrwl/storybook:build",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "outputPath": "dist/storybook/ui/three",
+            "config": {
+              "configFolder": "libs/ui/three/.storybook"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    },
+    "main-app": {
+      "projectType": "application",
+      "root": "apps/main-app",
+      "sourceRoot": "apps/main-app/src",
+      "prefix": "katst",
+      "architect": {
+        "njdfvndfjnv": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "outputs": ["{options.outputPath}"]
+        },
+        "lmfkcn": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "port": 4400,
+            "config": {
+              "configFolder": "apps/main-app/.storybook"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        },
+        "odmwjbc": {
+          "builder": "@nrwl/storybook:build",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "outputPath": "dist/storybook/main-app",
+            "config": {
+              "configFolder": "apps/main-app/.storybook"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/storybook/src/migrations/update-13-4-6/test-configs/default-config.json
+++ b/packages/storybook/src/migrations/update-13-4-6/test-configs/default-config.json
@@ -1,0 +1,146 @@
+{
+  "projects": {
+    "ui-one": {
+      "projectType": "library",
+      "root": "libs/ui/one",
+      "sourceRoot": "libs/ui/one/src",
+      "targets": {
+        "storybook": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "port": 4400,
+            "config": {
+              "configFolder": "libs/ui/one/.storybook"
+            }
+          }
+        },
+        "build-storybook": {
+          "executor": "@nrwl/storybook:build",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "outputPath": "dist/storybook/ui/one",
+            "config": {
+              "configFolder": "libs/ui/one/.storybook"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    },
+    "ui-two": {
+      "projectType": "library",
+      "root": "libs/ui/two",
+      "sourceRoot": "libs/ui/two/src",
+      "targets": {
+        "storybook": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "port": 4400,
+            "config": {
+              "configFolder": "libs/ui/two/.storybook"
+            }
+          }
+        },
+        "build-storybook": {
+          "executor": "@nrwl/storybook:build",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "outputPath": "dist/storybook/ui/two",
+            "config": {
+              "configFolder": "libs/ui/two/.storybook"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    },
+    "ui-three": {
+      "projectType": "library",
+      "root": "libs/ui/three",
+      "sourceRoot": "libs/ui/three/src",
+      "targets": {
+        "storybook": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "port": 4400,
+            "config": {
+              "configFolder": "libs/ui/three/.storybook"
+            }
+          }
+        },
+        "build-storybook": {
+          "executor": "@nrwl/storybook:build",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "outputPath": "dist/storybook/ui/three",
+            "config": {
+              "configFolder": "libs/ui/three/.storybook"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    },
+    "main-app": {
+      "projectType": "application",
+      "root": "apps/main-app",
+      "sourceRoot": "apps/main-app/src",
+      "prefix": "katst",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "outputs": ["{options.outputPath}"]
+        },
+        "storybook": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "port": 4400,
+            "config": {
+              "configFolder": "apps/main-app/.storybook"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        },
+        "build-storybook": {
+          "builder": "@nrwl/storybook:build",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "outputPath": "dist/storybook/main-app",
+            "config": {
+              "configFolder": "apps/main-app/.storybook"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/storybook/src/migrations/update-13-4-6/test-configs/non-angular.json
+++ b/packages/storybook/src/migrations/update-13-4-6/test-configs/non-angular.json
@@ -1,0 +1,60 @@
+{
+  "projects": {
+    "ui-one": {
+      "projectType": "library",
+      "root": "libs/ui/one",
+      "sourceRoot": "libs/ui/one/src",
+      "targets": {
+        "storybook": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/react",
+            "port": 4400,
+            "config": {
+              "configFolder": "libs/ui/one/.storybook"
+            }
+          }
+        },
+        "build-storybook": {
+          "executor": "@nrwl/storybook:build",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "outputPath": "dist/storybook/ui/one",
+            "config": {
+              "configFolder": "libs/ui/one/.storybook"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    },
+    "main-app": {
+      "projectType": "application",
+      "root": "apps/main-app",
+      "sourceRoot": "apps/main-app/src",
+      "prefix": "katst",
+      "architect": {
+        "storybook": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/react",
+            "port": 4400,
+            "config": {
+              "configFolder": "apps/main-app/.storybook"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Current Behavior
Storybook uses the build config of the default project as specified in `nx.json` and it can lead to issues. Also, if there is no default project specified, Storybook breaks.

## Expected Behavior
* Provide a better error message when there's no default project - explain what the user should do
* Provide a warning when the `projectBuildConfig` is not specified - explain what the user should do
* Create a migrator to add the `projectBuildConfig` in the project's Storybook configuration
* Adjusted storybook-configuration generator to add `projectBuildConfig` option under the `storybook` and `build-storybook` targets in new project configurations

## Related Issue(s)
Potentially linked to the Storybook+Angular 13 issues. Will of course check back if bugs persist.
I know some of these are older than Angular 13, but most of these seem related to the defaultProject issue.

https://github.com/nrwl/nx/issues/8199
https://github.com/nrwl/nx/issues/8527
https://github.com/storybookjs/storybook/issues/16977
https://github.com/nrwl/nx/issues/7897
https://github.com/nrwl/nx/issues/7159
https://github.com/nrwl/nx/issues/8527
https://github.com/nrwl/nx/issues/8373
https://github.com/nrwl/nx/issues/8360
https://github.com/nrwl/nx/issues/8255
https://github.com/nrwl/nx/issues/8115
https://github.com/nrwl/nx/issues/8561


Fixes #
