### PR TITLE
fix(node): properly set ng-add as alias for init

### DIFF
--- a/packages/express/generators.json
+++ b/packages/express/generators.json
@@ -7,7 +7,7 @@
       "factory": "./src/generators/init/init#initGenerator",
       "schema": "./src/generators/init/schema.json",
       "description": "Initialize the @nrwl/express plugin",
-      "alias": ["ng-add"],
+      "aliases": ["ng-add"],
       "hidden": true
     },
 
@@ -24,7 +24,7 @@
       "factory": "./src/generators/init/init#initSchematic",
       "schema": "./src/generators/init/schema.json",
       "description": "Initialize the @nrwl/express plugin",
-      "alias": ["ng-add"],
+      "aliases": ["ng-add"],
       "hidden": true
     },
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx add @nrwl/express` calls `@nrwl/workspace:ng-add` because `ng-add` is not properly defined as an alias for `@nrwl/express:init`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx add @nrwl/express` properly calls `@nrwl/express:init`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/8272
