### PR TITLE
docs(core): improve `workspace-lint` description

### DIFF
--- a/docs/generated/cli/workspace-lint.md
+++ b/docs/generated/cli/workspace-lint.md
@@ -1,11 +1,11 @@
 ---
 title: 'workspace-lint - CLI command'
-description: 'Lint workspace or list of files.  Note: To exclude files from this lint rule, you can add them to the `.nxignore` file'
+description: 'Lint nx specific workspace files (nx.json, workspace.json) and check existence of the configured packages and apps.  Note: To exclude files from this lint rule, you can add them to the `.nxignore` file'
 ---
 
 # workspace-lint
 
-Lint workspace or list of files. Note: To exclude files from this lint rule, you can add them to the `.nxignore` file
+Lint nx specific workspace files (nx.json, workspace.json) and check existence of the configured packages and apps. Note: To exclude files from this lint rule, you can add them to the `.nxignore` file
 
 ## Usage
 

--- a/nx-dev/nx-dev/public/documentation/generated/cli/workspace-lint.md
+++ b/nx-dev/nx-dev/public/documentation/generated/cli/workspace-lint.md
@@ -1,11 +1,11 @@
 ---
 title: 'workspace-lint - CLI command'
-description: 'Lint workspace or list of files.  Note: To exclude files from this lint rule, you can add them to the `.nxignore` file'
+description: 'Lint nx specific workspace files (nx.json, workspace.json) and check existence of the configured packages and apps.  Note: To exclude files from this lint rule, you can add them to the `.nxignore` file'
 ---
 
 # workspace-lint
 
-Lint workspace or list of files. Note: To exclude files from this lint rule, you can add them to the `.nxignore` file
+Lint nx specific workspace files (nx.json, workspace.json) and check existence of the configured packages and apps. Note: To exclude files from this lint rule, you can add them to the `.nxignore` file
 
 ## Usage
 

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -228,7 +228,7 @@ npx nx daemon
   .command(
     'workspace-lint [files..]',
     chalk.bold(
-      'Lint workspace or list of files.  Note: To exclude files from this lint rule, you can add them to the `.nxignore` file'
+      'Lint nx specific workspace files (nx.json, workspace.json) and check existence of the configured packages and apps.  Note: To exclude files from this lint rule, you can add them to the `.nxignore` file'
     ),
     noop,
     async (_) => (await import('./lint')).workspaceLint()


### PR DESCRIPTION
## Current Behavior

Current documentation is as shown:
![image](https://user-images.githubusercontent.com/39736248/149367544-5fafb203-3414-47a4-a671-f1f1e87e5fa2.png)
"_Lint workspace or list of files._"

As described in discussion https://github.com/nrwl/nx/discussions/5278 and issue https://github.com/nrwl/nx/issues/5317, this documentation isn't very clear about what exactly this command does.

## Expected Behavior
This PR aims to bring more clarity on what the command actually does and is open to suggestions to perhaps fully address the concerns of #5317.
I've gone ahead and used the text mentioned to @meeroslav in discussion #5278:
"_Lint nx specific workspace files (nx.json, workspace.json) and check existence of the configured packages and apps._"

## Related Issue(s)
Fixes partially #5317

