### PR TITLE
fix(angular): remove invalid style option from the library generator defaults

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -133,6 +133,12 @@
       "description": "In Angular version 13, the ESM became a first class citizen. This means the webpack config generated must be modified to support modules.",
       "factory": "./src/migrations/update-13-3-0/update-mfe-webpack-config"
     },
+    "remove-library-generator-style-default": {
+      "cli": "nx",
+      "version": "13.4.5-beta.7",
+      "description": "Remove the default for the invalid 'style' option for the library generator if configured.",
+      "factory": "./src/migrations/update-13-5-0/remove-library-generator-style-default"
+    },
     "fix-incorrect-mfe-setups": {
       "cli": "nx",
       "version": "13.5.0-beta.0",

--- a/packages/angular/src/migrations/update-13-5-0/remove-library-generator-style-default.spec.ts
+++ b/packages/angular/src/migrations/update-13-5-0/remove-library-generator-style-default.spec.ts
@@ -1,0 +1,113 @@
+import {
+  readWorkspaceConfiguration,
+  Tree,
+  updateWorkspaceConfiguration,
+  WorkspaceConfiguration,
+} from '@nrwl/devkit';
+import * as devkit from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import removeLibraryGeneratorStyleDefault from './remove-library-generator-style-default';
+
+describe('remove-library-generator-style-default migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace(2);
+    jest.clearAllMocks();
+  });
+
+  it('should do nothing when angular library generator is not configured', async () => {
+    const workspace: WorkspaceConfiguration = {
+      version: 1,
+      generators: { '@nrwl/angular:application': { style: 'scss' } },
+    };
+    updateWorkspaceConfiguration(tree, workspace);
+
+    await removeLibraryGeneratorStyleDefault(tree);
+
+    expect(readWorkspaceConfiguration(tree)).toStrictEqual(workspace);
+  });
+
+  it('should do nothing when other vertical library generator is configured with the style entry', async () => {
+    const workspace: WorkspaceConfiguration = {
+      version: 1,
+      generators: { '@nrwl/react:library': { style: 'scss' } },
+    };
+    updateWorkspaceConfiguration(tree, workspace);
+
+    await removeLibraryGeneratorStyleDefault(tree);
+
+    expect(readWorkspaceConfiguration(tree)).toStrictEqual(workspace);
+  });
+
+  describe('collection:generator', () => {
+    it('should remove style entry when configured', async () => {
+      const workspace: WorkspaceConfiguration = {
+        version: 1,
+        generators: { '@nrwl/angular:library': { style: 'scss' } },
+      };
+      updateWorkspaceConfiguration(tree, workspace);
+
+      await removeLibraryGeneratorStyleDefault(tree);
+
+      expect(readWorkspaceConfiguration(tree)).toStrictEqual({
+        version: 1,
+        generators: { '@nrwl/angular:library': {} },
+      });
+    });
+
+    it('should do nothing when style is not set', async () => {
+      const workspace: WorkspaceConfiguration = {
+        version: 1,
+        generators: { '@nrwl/angular:library': { linter: 'eslint' } },
+      };
+      updateWorkspaceConfiguration(tree, workspace);
+
+      await removeLibraryGeneratorStyleDefault(tree);
+
+      expect(readWorkspaceConfiguration(tree)).toStrictEqual(workspace);
+    });
+  });
+
+  describe('nested generator', () => {
+    it('should remove style entry when configured', async () => {
+      const workspace: WorkspaceConfiguration = {
+        version: 1,
+        generators: { '@nrwl/angular': { library: { style: 'scss' } } },
+      };
+      updateWorkspaceConfiguration(tree, workspace);
+
+      await removeLibraryGeneratorStyleDefault(tree);
+
+      expect(readWorkspaceConfiguration(tree)).toStrictEqual({
+        version: 1,
+        generators: { '@nrwl/angular': { library: {} } },
+      });
+    });
+
+    it('should do nothing when style is not set', async () => {
+      const workspace: WorkspaceConfiguration = {
+        version: 1,
+        generators: { '@nrwl/angular': { library: { linter: 'eslint' } } },
+      };
+      updateWorkspaceConfiguration(tree, workspace);
+
+      await removeLibraryGeneratorStyleDefault(tree);
+
+      expect(readWorkspaceConfiguration(tree)).toStrictEqual(workspace);
+    });
+  });
+
+  it('should format files', async () => {
+    jest.spyOn(devkit, 'formatFiles');
+    const workspace: WorkspaceConfiguration = {
+      version: 1,
+      generators: { '@nrwl/angular:library': { style: 'scss' } },
+    };
+    updateWorkspaceConfiguration(tree, workspace);
+
+    await removeLibraryGeneratorStyleDefault(tree);
+
+    expect(devkit.formatFiles).toHaveBeenCalled();
+  });
+});

--- a/packages/angular/src/migrations/update-13-5-0/remove-library-generator-style-default.ts
+++ b/packages/angular/src/migrations/update-13-5-0/remove-library-generator-style-default.ts
@@ -1,0 +1,24 @@
+import {
+  formatFiles,
+  readWorkspaceConfiguration,
+  Tree,
+  updateWorkspaceConfiguration,
+} from '@nrwl/devkit';
+
+export default async function (tree: Tree) {
+  const workspace = readWorkspaceConfiguration(tree);
+
+  if (!workspace.generators) {
+    return;
+  }
+
+  if (workspace.generators['@nrwl/angular:library']) {
+    delete workspace.generators['@nrwl/angular:library'].style;
+    updateWorkspaceConfiguration(tree, workspace);
+  } else if (workspace.generators['@nrwl/angular']?.library) {
+    delete workspace.generators['@nrwl/angular'].library.style;
+    updateWorkspaceConfiguration(tree, workspace);
+  }
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Old workspaces might still have a default value for the `style` option of the `@nrwl/angular:library` generator. That option was removed some time ago now but no migration was created to remove it from existing workspaces. It was not an issue until recently when the schema for the generator was corrected to be strict and not allow unknown properties.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
A migration should run to remove the invalid configuration option for existing workspaces.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8252 
