### PR TITLE
feat(core): allow configuring runtime cache inputs on the project level

### DIFF
--- a/packages/tao/src/shared/project-graph.ts
+++ b/packages/tao/src/shared/project-graph.ts
@@ -86,6 +86,10 @@ export interface ProjectGraphProjectNode<T = any> {
      */
     implicitDependencies?: string[];
     /**
+     * Runtime cache inputs for the project
+     */
+    runtimeCacheInputs?: string[];
+    /**
      * Files associated to the project
      */
     files: FileData[];

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -97,6 +97,11 @@ export interface ProjectConfiguration {
   implicitDependencies?: string[];
 
   /**
+   * Runtime cache inputs for the project
+   */
+  runtimeCacheInputs?: string[];
+
+  /**
    * List of tags used by nx-enforce-module-boundaries / dep-graph
    */
   tags?: string[];

--- a/packages/workspace/src/core/hasher/hasher.spec.ts
+++ b/packages/workspace/src/core/hasher/hasher.spec.ts
@@ -43,9 +43,9 @@ describe('Hasher', () => {
     'workspace.json': 'workspace.json.hash',
     global1: 'global1.hash',
     global2: 'global2.hash',
-    'echo runtime123': 'runtime123',
-    'echo runtime456': 'runtime456',
-    'echo runtime789': 'runtime789',
+    'echo runtime123': 'runtime123value',
+    'echo runtime456': 'runtime456value',
+    'echo runtime789': 'runtime789value',
   };
 
   function createHashing(): any {
@@ -94,6 +94,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: '',
+              runtimeCacheInputs: ['echo runtime789'],
               files: [{ file: '/file', ext: '.ts', hash: 'file.hash' }],
             },
           },
@@ -120,13 +121,13 @@ describe('Hasher', () => {
     expect(hash.value).toContain('prop-value'); //overrides
     expect(hash.value).toContain('parent'); //project
     expect(hash.value).toContain('build'); //target
-    expect(hash.value).toContain('runtime123'); //target
-    expect(hash.value).toContain('runtime456'); //target
-    expect(hash.value).toContain('runtime789'); //target
+    expect(hash.value).toContain('runtime123value'); //target
+    expect(hash.value).toContain('runtime456value'); //target
+    expect(hash.value).toContain('runtime789value'); //target
 
     expect(hash.details.command).toEqual('parent|build||{"prop":"prop-value"}');
     expect(hash.details.nodes).toEqual({
-      parent: `/file|file.hash|{"root":"libs/parent","runtimeCacheInputs":["echo runtime789"]}|{"compilerOptions":{"paths":{"@nrwl/parent":["libs/parent/src/index.ts"],"@nrwl/child":["libs/child/src/index.ts"]}}}`,
+      parent: `/file|file.hash|{"root":"libs/parent","runtimeCacheInputs":["echo runtime789"]}|{"compilerOptions":{"paths":{"@nrwl/parent":["libs/parent/src/index.ts"],"@nrwl/child":["libs/child/src/index.ts"]}}}|runtime789value`,
     });
     expect(hash.details.implicitDeps).toEqual({
       'nx.json': '{"npmScope":"nrwl"}',
@@ -135,8 +136,8 @@ describe('Hasher', () => {
       'pnpm-lock.yaml': 'pnpm-lock.yaml.hash',
     });
     expect(hash.details.runtime).toEqual({
-      'echo runtime123': 'runtime123',
-      'echo runtime456': 'runtime456',
+      'echo runtime123': 'runtime123value',
+      'echo runtime456': 'runtime456value',
     });
   });
 
@@ -192,8 +193,8 @@ describe('Hasher', () => {
       'pnpm-lock.yaml': 'pnpm-lock.yaml.hash',
     });
     expect(hash.details.runtime).toEqual({
-      'echo runtime123': 'runtime123',
-      'echo runtime456': 'runtime456',
+      'echo runtime123': 'runtime123value',
+      'echo runtime456': 'runtime456value',
     });
   });
 

--- a/packages/workspace/src/core/hasher/hasher.spec.ts
+++ b/packages/workspace/src/core/hasher/hasher.spec.ts
@@ -43,8 +43,8 @@ describe('Hasher', () => {
     'workspace.json': 'workspace.json.hash',
     global1: 'global1.hash',
     global2: 'global2.hash',
-    'echo runtime123': 'runtime123value',
-    'echo runtime456': 'runtime456value',
+    'echo runtime123': 'runtime123',
+    'echo runtime456': 'runtime456',
     'echo runtime789': 'runtime789value',
   };
 
@@ -121,8 +121,8 @@ describe('Hasher', () => {
     expect(hash.value).toContain('prop-value'); //overrides
     expect(hash.value).toContain('parent'); //project
     expect(hash.value).toContain('build'); //target
-    expect(hash.value).toContain('runtime123value'); //target
-    expect(hash.value).toContain('runtime456value'); //target
+    expect(hash.value).toContain('runtime123'); //target
+    expect(hash.value).toContain('runtime456'); //target
     expect(hash.value).toContain('runtime789value'); //target
 
     expect(hash.details.command).toEqual('parent|build||{"prop":"prop-value"}');
@@ -136,8 +136,8 @@ describe('Hasher', () => {
       'pnpm-lock.yaml': 'pnpm-lock.yaml.hash',
     });
     expect(hash.details.runtime).toEqual({
-      'echo runtime123': 'runtime123value',
-      'echo runtime456': 'runtime456value',
+      'echo runtime123': 'runtime123',
+      'echo runtime456': 'runtime456',
     });
   });
 
@@ -193,8 +193,8 @@ describe('Hasher', () => {
       'pnpm-lock.yaml': 'pnpm-lock.yaml.hash',
     });
     expect(hash.details.runtime).toEqual({
-      'echo runtime123': 'runtime123value',
-      'echo runtime456': 'runtime456value',
+      'echo runtime123': 'runtime123',
+      'echo runtime456': 'runtime456',
     });
   });
 

--- a/packages/workspace/src/core/hasher/hasher.ts
+++ b/packages/workspace/src/core/hasher/hasher.ts
@@ -323,7 +323,7 @@ class ProjectHasher {
   async hashProjectsRuntimeInputs(
     runtimeCacheInputs?: string[]
   ): Promise<RuntimeHashResult | undefined> {
-    if (!runtimeCacheInputs || runtimeCacheInputs.length) {
+    if (!runtimeCacheInputs || runtimeCacheInputs.length === 0) {
       return undefined;
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

Not sure if this is something Nx wants to support or has some other idea for but we recently ran into the case of needing to do this. I haven't fully tested it yet but am hoping to do so soon. Opening the PR now to get some feedback on the feature.

## Current Behavior
<!-- This is the behavior we have today -->
Currently we are only able to define `implicitDependencies` on the project level, these need to be project names. We can also use plugins to extend the graph but that only allows us to add Nodes that refer to projects.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We can now configure `runtimeCacheInputs` at the project level. This means a project that depends on some generated files (for example) or needs to have its cache broken for some other reason that cannot be attached to the graph can now do so by configuring it like so:

```
{
  "projectType": "library",
  "root": "packages/ng-lib",
  "sourceRoot": "packages/ng-lib/src",
  "prefix": "all-libs",
  "targets": {
    "build": {

    },
    "test": {

    },
    "lint": {

  },
  "tags": [],
  "runtimeCacheInputs": ["echo $SOMEVAR"]
}
```

Now the results of `$SOMEVAR` will be taken into account when hashing the project.

I did not add the performance marks as I am not sure what the mark should be. The `nx.json` runtimeCacheInputs use 

```
'hasher:runtime inputs hash',
'hasher:runtime inputs hash:start',
'hasher:runtime inputs hash:end'
```

The mark would need to incorporate the project name I think, otherwise the marks will get messed up with projects are hashes in parallel.

Maybe something like this?

```
'hasher:runtime project-inputs hash',
'hasher:runtime project-inputs hash:start',
'hasher:runtime project-inputs hash:end'
```

TODO: Add docs for runtime cache inputs at the project level

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
