### PR TITLE
fix(core): use fs/promises instead of promisifying with the util module

### DIFF
--- a/packages/workspace/src/tasks-runner/cache.ts
+++ b/packages/workspace/src/tasks-runner/cache.ts
@@ -1,27 +1,21 @@
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import { Task } from '@nrwl/devkit';
-import { exists, lstat, readdir } from 'fs';
 import {
   copy,
-  ensureDir,
-  ensureDirSync,
   mkdir,
+  mkdirSync,
   readFile,
   remove,
   unlink,
   writeFile,
+  existsSync,
+  lstat,
+  readdir,
 } from 'fs-extra';
 import { dirname, join, resolve, sep } from 'path';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { spawn, exec } from 'child_process';
 import { cacheDir } from '../utilities/cache-directory';
-
-const util = require('util');
-
-const readFileAsync = util.promisify(readFile);
-const existsAsync = util.promisify(exists);
-const lstatAsync = util.promisify(lstat);
-const readdirAsync = util.promisify(readdir);
 
 export type CachedResult = {
   terminalOutput: string;
@@ -106,10 +100,10 @@ export class Cache {
       await Promise.all(
         outputs.map(async (f) => {
           const src = join(this.root, f);
-          if (await existsAsync(src)) {
+          if (existsSync(src)) {
             const cached = join(td, 'outputs', f);
             const directory = resolve(cached, '..');
-            await ensureDir(directory);
+            await mkdir(directory, { recursive: true });
             await this.copy(src, directory);
           }
         })
@@ -144,11 +138,11 @@ export class Cache {
       await Promise.all(
         outputs.map(async (f) => {
           const cached = join(cachedResult.outputsPath, f);
-          if (await existsAsync(cached)) {
+          if (existsSync(cached)) {
             const src = join(this.root, f);
             await this.remove(src);
             const directory = resolve(src, '..');
-            await ensureDir(directory);
+            await mkdir(directory, { recursive: true });
             await this.copy(cached, directory);
           }
         })
@@ -166,7 +160,7 @@ export class Cache {
       const hashFile = this.getFileNameWithLatestRecordedHashForOutput(output);
       try {
         await unlink(hashFile);
-      } catch (e) {}
+      } catch {}
     }
   }
 
@@ -186,15 +180,15 @@ export class Cache {
     );
   }
 
-  private copy(src: string, directory: string) {
+  private copy(src: string, directory: string): Promise<void> {
     if (this.useFsExtraToCopyAndRemove) {
       return copy(src, directory);
     }
 
-    return new Promise((res, rej) => {
+    return new Promise<void>((res, rej) => {
       exec(`cp -a "${src}" "${directory}"`, (error) => {
         if (!error) {
-          res(null);
+          res();
         } else {
           this.useFsExtraToCopyAndRemove = true;
           copy(src, directory).then(res, rej);
@@ -203,15 +197,15 @@ export class Cache {
     });
   }
 
-  private remove(folder: string) {
+  private remove(folder: string): Promise<void> {
     if (this.useFsExtraToCopyAndRemove) {
       return remove(folder);
     }
 
-    return new Promise((res, rej) => {
+    return new Promise<void>((res, rej) => {
       exec(`rm -rf "${folder}"`, (error) => {
         if (!error) {
-          res(null);
+          res();
         } else {
           this.useFsExtraToCopyAndRemove = true;
           remove(folder).then(res, rej);
@@ -227,7 +221,7 @@ export class Cache {
     for (const output of outputs) {
       const hashFile = this.getFileNameWithLatestRecordedHashForOutput(output);
       try {
-        await ensureDir(dirname(hashFile));
+        await mkdir(dirname(hashFile), { recursive: true });
         await writeFile(hashFile, hash);
       } catch {}
     }
@@ -248,12 +242,11 @@ export class Cache {
     output: string
   ): Promise<string | null> {
     try {
-      return (
-        await readFileAsync(
-          this.getFileNameWithLatestRecordedHashForOutput(output)
-        )
-      ).toString();
-    } catch (e) {
+      return await readFile(
+        this.getFileNameWithLatestRecordedHashForOutput(output),
+        'utf-8'
+      );
+    } catch {
       return null;
     }
   }
@@ -267,24 +260,23 @@ export class Cache {
       const rootOutputPath = join(this.root, output);
 
       if (
-        (await existsAsync(cacheOutputPath)) &&
-        (await lstatAsync(cacheOutputPath)).isFile()
+        existsSync(cacheOutputPath) &&
+        (await lstat(cacheOutputPath)).isFile()
       ) {
         return (
-          (await existsAsync(join(cachedResult.outputsPath, output))) &&
-          !(await existsAsync(join(this.root, output)))
+          existsSync(join(cachedResult.outputsPath, output)) &&
+          !existsSync(join(this.root, output))
         );
       }
 
       const haveDifferentAmountOfFiles =
-        (await existsAsync(cacheOutputPath)) &&
-        (await existsAsync(rootOutputPath)) &&
-        (await readdirAsync(cacheOutputPath)).length !==
-          (await readdirAsync(rootOutputPath)).length;
+        existsSync(cacheOutputPath) &&
+        existsSync(rootOutputPath) &&
+        (await readdir(cacheOutputPath)).length !==
+          (await readdir(rootOutputPath)).length;
 
       if (
-        ((await existsAsync(cacheOutputPath)) &&
-          !(await existsAsync(rootOutputPath))) ||
+        (existsSync(cacheOutputPath) && !existsSync(rootOutputPath)) ||
         haveDifferentAmountOfFiles
       ) {
         return true;
@@ -304,7 +296,7 @@ export class Cache {
     const tdCommit = join(this.cachePath, `${task.hash}.commit`);
     const td = join(this.cachePath, task.hash);
 
-    if (await existsAsync(tdCommit)) {
+    if (existsSync(tdCommit)) {
       const terminalOutput = await readFile(
         join(td, 'terminalOutput'),
         'utf-8'
@@ -312,7 +304,7 @@ export class Cache {
       let code = 0;
       try {
         code = Number(await readFile(join(td, 'code'), 'utf-8'));
-      } catch (e) {}
+      } catch {}
       return {
         terminalOutput,
         outputsPath: join(td, 'outputs'),
@@ -324,19 +316,19 @@ export class Cache {
   }
 
   private createCacheDir() {
-    ensureDirSync(cacheDir);
+    mkdirSync(cacheDir, { recursive: true });
     return cacheDir;
   }
 
   private createTerminalOutputsDir() {
     const path = join(this.cachePath, 'terminalOutputs');
-    ensureDirSync(path);
+    mkdirSync(path, { recursive: true });
     return path;
   }
 
   private ensureLatestOutputsHashesDir() {
     const path = join(this.cachePath, 'latestOutputsHashes');
-    ensureDirSync(path);
+    mkdirSync(path, { recursive: true });
     return path;
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- the task-runners cache (`packages/workspace/src/tasks-runner/cache.ts`) uses `promisify` of the `util` module instead of `fs/promises`
- ensureDir and mkdir are both imported but ensureDir is only a wrapper for mkdir`s recursive option
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- the task-runners cache should use fs/promises which is avialable since nodejs 10
- mkdirSync with the recursive option should be used when possible

