### PR TITLE
docs(misc): update getting started pages

### DIFF
--- a/docs/shared/getting-started/intro.md
+++ b/docs/shared/getting-started/intro.md
@@ -4,53 +4,25 @@ Nx is a smart, fast and extensible build system with first class monorepo suppor
 
 ## Philosophy
 
-Nx has a similar design philosophy to Visual Studio Code. Code is a powerful text editor, and you can be very productive
-with it even if you don't install any extensions. The ecosystem of VSCode's extensions though is what can really level
-up your productivity.
+Nx shares the design philosophy with Visual Studio Code. Code is a powerful text editor, and you can be very productive
+with it even if you don't install any extensions. The ecosystem of VSCode's extensions is what levels up your productivity.
 
-Nx is similar. The core of Nx is generic, simple, and unobtrusive. Nx plugins, although very useful for many projects,
-are completely optional.
+Similarly, the core of Nx is generic, simple, and unobtrusive. Nx plugins, although very useful, are completely optional.
+(Placeholder)
+Because Nx generates the boilerplate for you, most examples use Nx plugins making it easier to demonstrate the features of Nx. The vast majority of features work without the need of plugins.
 
-Most examples on this site use Nx plugins. It's just easier to demonstrate many features Nx offers when Nx generates all
-the boilerplate. However, the vast majority of the features will work the same way in a workspace with no plugins.
+## (PlaceHolder) Why should someone care about nx? What does nx bring to the table?
 
-## Getting Started
+> is this where we talk about this?
 
-These guides will help you get started:
+- think (ESBuild)[https://esbuild.github.io/] time to build graph. straight to the point of "this is what we do and
+- solve"
+- why do people care about monorepo tooling?
+- my code is not in a monorepo, so why should I care?
+- or can I even use this outside of a monorepo
 
-- [Installing Nx CLI & creating a new Nx Workspace](/getting-started/nx-setup)
-- [Adding Nx to an existing monorepo](/migration/adding-to-monorepo)
-- [Using Nx without plugins](/getting-started/nx-core)
-- [Nx and TypeScript](/getting-started/nx-and-typescript)
-- [Nx and React](/getting-started/nx-and-react)
-- [Nx and Angular](/getting-started/nx-and-angular)
-- [CI Overview](/using-nx/ci-overview)
+## Next Steps
 
-## Features
+(placeholder) we should just give the "make new repo with nx" option as the next link. bc odds are people see "add to existing repo" and might run into edge cases/stuff we didn't expect initially. Also goal of keeping # of clicks down and getting people lost in the docs on what page they were on when learning would be a good idea
 
-**Best-in-Class Support for Monorepos**
-
-- [Smart rebuilds of affected projects](/using-nx/affected)
-- [Computation caching](/using-nx/caching)
-- [Distributed task execution](/using-nx/dte)
-- [Code sharing and ownership management](/structure/monorepo-tags)
-
-**Integrated Development Experience**
-
-- [High-quality editor plugins](/using-nx/console) & [GitHub apps](https://github.com/apps/nx-cloud)
-- [Powerful code generators](/generators/using-schematics)
-- [Workspace visualizations](/structure/dependency-graph)
-
-**Supports Your Ecosystem**
-
-- [Rich plugin ecosystem](/getting-started/nx-devkit) from Nrwl and the [community](/community)
-- Consistent dev experience for any framework
-- [Automatic upgrade to the latest versions of all frameworks and tools](/using-nx/updating-nx)
-
-## Learn While Doing
-
-- [Using Nx without plugins](/getting-started/nx-core)
-- [Nx and TypeScript](/getting-started/nx-and-typescript)
-- [React: Interactive Nx Tutorial (with videos)](/react-tutorial/01-create-application)
-- [Node: Interactive Nx Tutorial (with videos)](/node-tutorial/01-create-application)
-- [Angular: Interactive Nx Tutorial (with videos)](/angular-tutorial/01-create-application)
+[Start using Nx](/getting-started/nx-setup)

--- a/docs/shared/getting-started/nx-setup.md
+++ b/docs/shared/getting-started/nx-setup.md
@@ -2,14 +2,18 @@
 
 ## Set up a New Nx Workspace
 
-Run the following command to create a new workspace.
+> (placeholder) explain what a "workspace" is or link to a glossary of terms we use?
+
+Create a new Nx workspace by running the follow command and follow the prompts
 
 ```bash
 # pass @latest in case npx cached an older version of create-nx-workspace
 npx create-nx-workspace@latest
 ```
 
-When creating a workspace, you will have to choose a preset, which will preconfigure a few things for you.
+Nx provides a handful of presets to assist in organizing your workspace. You can choose which ever makes the most sense for your project.
+
+(Placeholder) learn more about presets and why would want to use them.
 
 ```bash
 # create an empty workspace set up for building applications
@@ -22,29 +26,17 @@ npx create-nx-workspace --preset=core
 npx create-nx-workspace --preset=ts
 ```
 
-Some presets set up applications, e2e tests, etc.
+Some presets are set up to build apps with common frameworks
 
 ```bash
+npx create-nx-workspace --preset=@nrwl/remix
+
 npx create-nx-workspace --preset=react
+
 npx create-nx-workspace --preset=react-native
+
 npx create-nx-workspace --preset=angular
 ```
-
-## Add Nx to an Existing Project
-
-If you have an existing Lerna or Yarn monorepo, you can gain the benefits of Nx's computation cache and distributed task execution without modifying the file structure by running this command:
-
-```bash
-npx add-nx-to-monorepo
-```
-
-If you have an existing Create React App project, you can gain the benefits of Nx's computation cache and distributed task execution without modifying the file structure by running this command:
-
-```bash
-npx cra-to-nx
-```
-
-For more information on adding Nx to an existing repository see the [migration guide](/migration/migration-cra)
 
 ## Install Nx CLI
 
@@ -54,9 +46,29 @@ To make the developer experience nicer, you may want to install the Nx CLI globa
 npm install -g nx
 ```
 
+Optionally, you can use `npx nx` or `yarn nx` to run the CLI.
+
+## Add Nx to an Existing Project
+
+// (Placeholder) is this only for Lerna or Yarn monorepos?
+
+If you have an existing Lerna or Yarn monorepo, you can gain the benefits of Nx's computation cache and distributed task execution without modifying the file structure by running the following command:
+
+```bash
+npx add-nx-to-monorepo
+```
+
+You can easily add Nx to and existing Create React App project by running the following command:
+
+```bash
+npx cra-to-nx
+```
+
+Learn more about migrating Create React Apps to Nx via our [Create React App migration guide](/migration/migration-cra)
+
 ## Folder Structure
 
-Nx can be added to any workspace, so there is no fixed folder structure. However, if you use one of the existing presets, you will likely see something like this:
+Nx can be added to any workspace, there is no fixed folder structure. However, if you use an existing presets, you will likely see something like this:
 
 ```treeview
 myorg/
@@ -71,12 +83,22 @@ myorg/
 
 `/apps/` contains the application projects. This is the main entry point for a runnable application. We recommend keeping applications as light-weight as possible, with all the heavy lifting being done by libraries that are imported by each application.
 
-`/libs/` contains the library projects. There are many kinds of libraries, and each library defines its own external API so that boundaries between libraries remain clear.
+`/libs/` contains the library projects. There are many kinds of libraries, and each library defines its own external API so that boundaries between libraries remain clear. Here are some [common library type recommendations](/workspace/library-types).
 
 `/tools/` contains scripts that act on your code base. This could be database scripts, [custom executors](/executors/creating-custom-builders), or [workspace generators](/generators/workspace-generators).
 
 `/workspace.json` lists every project in your workspace. (this file is optional)
 
-`/nx.json` configures the Nx CLI itself. It tells Nx what needs to be cached, how to run tasks etc.
+`/nx.json` configures the Nx CLI itself. It tells Nx what needs to be cached, how to run tasks, etc.
 
 `/tsconfig.base.json` sets up the global TypeScript settings and creates aliases for each library to aid when creating TS/JS imports.
+
+## Next Steps
+
+Learn about
+
+- [Nx CLI](/using-nx/nx-cli)
+- [Nx and Angular](/getting-started/nx-and-angular)
+- [Nx and React](/getting-started/nx-and-react)
+- [Nx and TypeScript](/guides/nx-and-ts)
+- [Nx without Plugins](/getting-started/nx-core)

--- a/docs/shared/nx-core.md
+++ b/docs/shared/nx-core.md
@@ -1,7 +1,7 @@
 # Using Nx Core Without Plugins
 
 The core of Nx is generic, simple, and unobtrusive. Nx plugins, although very useful for many projects, are completely
-optional. Most large Nx workspaces use plugins for some things and don't use plugins for others.
+optional. Most large Nx workspaces use plugins for some things but not for others.
 
 This guide will walk you through creating a simple Nx workspace with no plugins. It will help you see what capabilities
 of Nx are completely generic and can be used with any technology or tool.
@@ -10,16 +10,22 @@ of Nx are completely generic and can be used with any technology or tool.
 
 ### Creating a New Workspace
 
-Running `yarn create nx-workspace --preset=core` creates an empty workspace.
+> this tutorial uses yarn workspaces, run `npm i -g yarn` to install yarn.
+
+Running `yarn create nx-workspace myorg --preset=core` creates an empty workspace.
+
+> You can say no to Nx Cloud
 
 This is what is generated:
 
-```text
-packages/
-nx.json
-workspace.json
-tsconfig.base.json
-package.json
+```treeview
+myorg/
+├── packages/
+├── tools/
+├── nx.json
+├── workspace.json
+├── package.json
+└── tsconfig.base.json
 ```
 
 `package.json` contains Nx packages.
@@ -32,11 +38,11 @@ package.json
   "scripts": {},
   "private": true,
   "devDependencies": {
-    "@nrwl/cli": "12.8.0",
-    "@nrwl/tao": "12.8.0",
-    "@nrwl/workspace": "12.8.0",
+    "@nrwl/tao": "13.4.4",
+    "@nrwl/cli": "13.4.4",
+    "@nrwl/workspace": "13.4.4",
     "@types/node": "14.14.33",
-    "typescript": "~4.3.5"
+    "typescript": "~4.4.3"
   }
 }
 ```
@@ -47,9 +53,15 @@ package.json
 {
   "extends": "@nrwl/workspace/presets/core.json",
   "npmScope": "myorg",
+  "affected": {
+    "defaultBase": "main"
+  },
+  "cli": {
+    "defaultCollection": "@nrwl/workspace"
+  },
   "tasksRunnerOptions": {
     "default": {
-      "runner": "@nrwl/workspace/tasks-runners",
+      "runner": "@nrwl/workspace/tasks-runners/default",
       "options": {
         "cacheableOperations": ["build", "lint", "test", "e2e"]
       }
@@ -62,17 +74,18 @@ Finally, `workspace.json` lists the workspace projects, and since we have none, 
 
 ### Creating an NPM Package
 
-Running `nx g npm-package simple` results in:
+Running `yarn nx g npm-package simple` results in:
 
-```text
+```treeview
 packages/
- simple/
-   index.js
-   package.json
-nx.json
-workspace.json
-tsconfig.base.json
-package.json
+├── simple/
+│   ├── index.js
+│   ├── package.json
+│   └── project.json
+├──nx.json
+├──workspace.json
+├── package.json
+└── tsconfig.base.json
 ```
 
 The generated `simple/package.json`:
@@ -94,6 +107,8 @@ cache.
 In this example, we used a generator to create the package, but you could have also created it by hand or copied it
 from another project.
 
+// Placeholder: talk about project.json/workspace.json default now is using project.json
+
 The change in `workspace.json` is the only thing required to make Nx aware of the `simple` package. As long as you
 include the project in `workspace.json`, Nx will include that project source in its graph computation and source
 code analysis. It will, for instance, analyze the project's source code, and it will know when it can reuse the
@@ -101,20 +116,22 @@ computation from the cache and when it has to recompute it from scratch.
 
 ### Creating Second NPM Package and Enabling Yarn Workspaces
 
-Running `nx g npm-package complex` results in:
+Running `yarn nx g npm-package complex` results in:
 
-```text
+```treeview
 packages/
- simple/
-   index.js
-   package.json
- complex/
-   index.js
-   package.json
-nx.json
-workspace.json
-tsconfig.base.json
-package.json
+├── simple/
+│   ├── index.js
+│   ├── package.json
+│   └── project.json
+├── complex/
+│   ├── index.js
+│   ├── package.json
+│   └── project.json
+├── nx.json
+├── workspace.json
+├── package.json
+└── tsconfig.base.json
 ```
 
 Now let's modify `packages/complex/index.js` to include `require('@myorg/simple')`. If you run `yarn nx test complex`,
@@ -147,14 +164,40 @@ Then add the following to the root `package.json` (which enables Yarn Workspaces
 }
 ```
 
-Finally, run `yarn`.
+// placeholder: this does not work? still get cannot find module '@myorg/simple',
 
-`yarn nx test complex` works now.
+```bash
+> nx run complex:test --verbose
+warning package.json: No license field
+$ node index.js --verbose=true
+node:internal/modules/cjs/loader:936
+  throw err;
+  ^
+
+Error: Cannot find module '@myorg/simple'
+Require stack:
+- /Users/caleb/Sandbox/myorg/packages/complex/index.js
+    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
+    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
+    at Module.require (node:internal/modules/cjs/loader:1005:19)
+    at require (node:internal/modules/cjs/helpers:102:18)
+    at Object.<anonymous> (/Users/caleb/Sandbox/myorg/packages/complex/index.js:1:1)
+    at Module._compile (node:internal/modules/cjs/loader:1101:14)
+    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
+    at Module.load (node:internal/modules/cjs/loader:981:32)
+    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
+    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12) {
+  code: 'MODULE_NOT_FOUND',
+  requireStack: [ '/Users/caleb/Sandbox/myorg/packages/complex/index.js' ]
+}
+```
+
+Finally, run `yarn`, then `yarn nx test complex` works now.
 
 ## Using Yarn/PNPM/Lerna
 
-This example uses Yarn to connect the two packages. Most of the time, however, there are better ways to do it. The React,
-Node and Angular plugins for Nx allow different projects in your workspace to import each other without having to maintain
+This example uses Yarn to connect the two packages. Most of the time, however, there are better ways to do it. The [React](/react/overview),
+[Node](node/overview) and [Angular](angular/overview) plugins for Nx allow different projects in your workspace to import each other without having to maintain
 cumbersome `package.json` files. Instead, they use Webpack, Rollup and Jest plugins to enable this use case in a more
 elegant way. [Read about the relationship between Nx and Yarn/Lerna/PNPM](/guides/lerna-and-nx).
 
@@ -172,9 +215,10 @@ that adding a `require()` creates a dependency and that some dependencies cannot
 
 Running `yarn nx run-many --target=test --all` will test all projects in parallel.
 
-Running `yarn nx run-many --target=build --projects=app1,app2` will build `proj1` and `proj2` and their
-dependencies in parallel. Note that if `app1` depends on the output of its dependency (e.g., `shared-components`), Nx
-will build `shared-components` first and only then will build the app.
+// placeholder (should we have people make these projects so they can see more in the dep-graph and commands won't fail?)
+Running `yarn nx run-many --target=build --projects=app1,app2` builds `proj1` and `proj2` and their
+dependencies in parallel. Note that if `app1` depends on the output of its dependency (e.g., a `shared-components` library), Nx
+will build the `shared-components` library first and only then build the app.
 
 ### Nx Knows What Is Affected
 
@@ -182,17 +226,13 @@ Running `yarn nx affected --target=test` will test all the projects affected by 
 
 ### Nx Caches and Distributes Tasks
 
-Running `yarn nx build app1` will cache the file artifacts and the terminal output, so if you run it again the command
-will execute instantly because the results will be retrieved from cache. If you use `Nx Cloud` the cache will be shared
-between you, your teammates, and the CI agents. Nx can also distribute tasks across multiple machines while preserving
-the developer experience of running it on a single machine.
+Running `yarn nx build app1` caches the file artifacts and terminal output. When you run the command again, it will execute instantly because the results are retrieved from the cache. If you use [Nx Cloud](https://nx.app/), the cache is shared between you, your teammates, and the CI agents. Nx distribute tasks across multiple machines while preserving the developer experience of running on a single machine.
 
-This works because Nx's computation caching and distributed task execution work on the process level. It doesn't matter
-what `build` means. It can be an npm script, a custom Nx executor, a Gradle task. Nx will handle it in the same way.
+// placeholder: link to what DTE is?
+This works because Nx's computation caching and distributed task execution work on the process level. It doesn't matter what `build` means. It can be an npm script, a custom Nx executor, a Gradle task. Nx will handle it in the same way.
 
 ## Adding Plugins
 
-As you can see, the core of Nx is generic, simple, and unobtrusive. Nx Plugins are completely optional, but they can
-really level up your developer experience. Watch this video to see the plugins in action.
+As you can see, the core of Nx is generic, simple, and unobtrusive. Nx Plugins are completely optional, but they level up your developer experience. The following video shows plugins in action.
 
 <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/BO1rwynFBLM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"></iframe>

--- a/nx-dev/nx-dev/public/documentation/shared/getting-started/intro.md
+++ b/nx-dev/nx-dev/public/documentation/shared/getting-started/intro.md
@@ -4,53 +4,25 @@ Nx is a smart, fast and extensible build system with first class monorepo suppor
 
 ## Philosophy
 
-Nx has a similar design philosophy to Visual Studio Code. Code is a powerful text editor, and you can be very productive
-with it even if you don't install any extensions. The ecosystem of VSCode's extensions though is what can really level
-up your productivity.
+Nx shares the design philosophy with Visual Studio Code. Code is a powerful text editor, and you can be very productive
+with it even if you don't install any extensions. The ecosystem of VSCode's extensions is what levels up your productivity.
 
-Nx is similar. The core of Nx is generic, simple, and unobtrusive. Nx plugins, although very useful for many projects,
-are completely optional.
+Similarly, the core of Nx is generic, simple, and unobtrusive. Nx plugins, although very useful, are completely optional.
+(Placeholder)
+Because Nx generates the boilerplate for you, most examples use Nx plugins making it easier to demonstrate the features of Nx. The vast majority of features work without the need of plugins.
 
-Most examples on this site use Nx plugins. It's just easier to demonstrate many features Nx offers when Nx generates all
-the boilerplate. However, the vast majority of the features will work the same way in a workspace with no plugins.
+## (PlaceHolder) Why should someone care about nx? What does nx bring to the table?
 
-## Getting Started
+> is this where we talk about this?
 
-These guides will help you get started:
+- think (ESBuild)[https://esbuild.github.io/] time to build graph. straight to the point of "this is what we do and
+- solve"
+- why do people care about monorepo tooling?
+- my code is not in a monorepo, so why should I care?
+- or can I even use this outside of a monorepo
 
-- [Installing Nx CLI & creating a new Nx Workspace](/getting-started/nx-setup)
-- [Adding Nx to an existing monorepo](/migration/adding-to-monorepo)
-- [Using Nx without plugins](/getting-started/nx-core)
-- [Nx and TypeScript](/getting-started/nx-and-typescript)
-- [Nx and React](/getting-started/nx-and-react)
-- [Nx and Angular](/getting-started/nx-and-angular)
-- [CI Overview](/using-nx/ci-overview)
+## Next Steps
 
-## Features
+(placeholder) we should just give the "make new repo with nx" option as the next link. bc odds are people see "add to existing repo" and might run into edge cases/stuff we didn't expect initially. Also goal of keeping # of clicks down and getting people lost in the docs on what page they were on when learning would be a good idea
 
-**Best-in-Class Support for Monorepos**
-
-- [Smart rebuilds of affected projects](/using-nx/affected)
-- [Computation caching](/using-nx/caching)
-- [Distributed task execution](/using-nx/dte)
-- [Code sharing and ownership management](/structure/monorepo-tags)
-
-**Integrated Development Experience**
-
-- [High-quality editor plugins](/using-nx/console) & [GitHub apps](https://github.com/apps/nx-cloud)
-- [Powerful code generators](/generators/using-schematics)
-- [Workspace visualizations](/structure/dependency-graph)
-
-**Supports Your Ecosystem**
-
-- [Rich plugin ecosystem](/getting-started/nx-devkit) from Nrwl and the [community](/community)
-- Consistent dev experience for any framework
-- [Automatic upgrade to the latest versions of all frameworks and tools](/using-nx/updating-nx)
-
-## Learn While Doing
-
-- [Using Nx without plugins](/getting-started/nx-core)
-- [Nx and TypeScript](/getting-started/nx-and-typescript)
-- [React: Interactive Nx Tutorial (with videos)](/react-tutorial/01-create-application)
-- [Node: Interactive Nx Tutorial (with videos)](/node-tutorial/01-create-application)
-- [Angular: Interactive Nx Tutorial (with videos)](/angular-tutorial/01-create-application)
+[Start using Nx](/getting-started/nx-setup)

--- a/nx-dev/nx-dev/public/documentation/shared/getting-started/nx-setup.md
+++ b/nx-dev/nx-dev/public/documentation/shared/getting-started/nx-setup.md
@@ -2,14 +2,18 @@
 
 ## Set up a New Nx Workspace
 
-Run the following command to create a new workspace.
+> (placeholder) explain what a "workspace" is or link to a glossary of terms we use?
+
+Create a new Nx workspace by running the follow command and follow the prompts
 
 ```bash
 # pass @latest in case npx cached an older version of create-nx-workspace
 npx create-nx-workspace@latest
 ```
 
-When creating a workspace, you will have to choose a preset, which will preconfigure a few things for you.
+Nx provides a handful of presets to assist in organizing your workspace. You can choose which ever makes the most sense for your project.
+
+(Placeholder) learn more about presets and why would want to use them.
 
 ```bash
 # create an empty workspace set up for building applications
@@ -22,29 +26,17 @@ npx create-nx-workspace --preset=core
 npx create-nx-workspace --preset=ts
 ```
 
-Some presets set up applications, e2e tests, etc.
+Some presets are set up to build apps with common frameworks
 
 ```bash
+npx create-nx-workspace --preset=@nrwl/remix
+
 npx create-nx-workspace --preset=react
+
 npx create-nx-workspace --preset=react-native
+
 npx create-nx-workspace --preset=angular
 ```
-
-## Add Nx to an Existing Project
-
-If you have an existing Lerna or Yarn monorepo, you can gain the benefits of Nx's computation cache and distributed task execution without modifying the file structure by running this command:
-
-```bash
-npx add-nx-to-monorepo
-```
-
-If you have an existing Create React App project, you can gain the benefits of Nx's computation cache and distributed task execution without modifying the file structure by running this command:
-
-```bash
-npx cra-to-nx
-```
-
-For more information on adding Nx to an existing repository see the [migration guide](/migration/migration-cra)
 
 ## Install Nx CLI
 
@@ -54,9 +46,29 @@ To make the developer experience nicer, you may want to install the Nx CLI globa
 npm install -g nx
 ```
 
+Optionally, you can use `npx nx` or `yarn nx` to run the CLI.
+
+## Add Nx to an Existing Project
+
+// (Placeholder) is this only for Lerna or Yarn monorepos?
+
+If you have an existing Lerna or Yarn monorepo, you can gain the benefits of Nx's computation cache and distributed task execution without modifying the file structure by running the following command:
+
+```bash
+npx add-nx-to-monorepo
+```
+
+You can easily add Nx to and existing Create React App project by running the following command:
+
+```bash
+npx cra-to-nx
+```
+
+Learn more about migrating Create React Apps to Nx via our [Create React App migration guide](/migration/migration-cra)
+
 ## Folder Structure
 
-Nx can be added to any workspace, so there is no fixed folder structure. However, if you use one of the existing presets, you will likely see something like this:
+Nx can be added to any workspace, there is no fixed folder structure. However, if you use an existing presets, you will likely see something like this:
 
 ```treeview
 myorg/
@@ -71,12 +83,22 @@ myorg/
 
 `/apps/` contains the application projects. This is the main entry point for a runnable application. We recommend keeping applications as light-weight as possible, with all the heavy lifting being done by libraries that are imported by each application.
 
-`/libs/` contains the library projects. There are many kinds of libraries, and each library defines its own external API so that boundaries between libraries remain clear.
+`/libs/` contains the library projects. There are many kinds of libraries, and each library defines its own external API so that boundaries between libraries remain clear. Here are some [common library type recommendations](/workspace/library-types).
 
 `/tools/` contains scripts that act on your code base. This could be database scripts, [custom executors](/executors/creating-custom-builders), or [workspace generators](/generators/workspace-generators).
 
 `/workspace.json` lists every project in your workspace. (this file is optional)
 
-`/nx.json` configures the Nx CLI itself. It tells Nx what needs to be cached, how to run tasks etc.
+`/nx.json` configures the Nx CLI itself. It tells Nx what needs to be cached, how to run tasks, etc.
 
 `/tsconfig.base.json` sets up the global TypeScript settings and creates aliases for each library to aid when creating TS/JS imports.
+
+## Next Steps
+
+Learn about
+
+- [Nx CLI](/using-nx/nx-cli)
+- [Nx and Angular](/getting-started/nx-and-angular)
+- [Nx and React](/getting-started/nx-and-react)
+- [Nx and TypeScript](/guides/nx-and-ts)
+- [Nx without Plugins](/getting-started/nx-core)

--- a/nx-dev/nx-dev/public/documentation/shared/nx-core.md
+++ b/nx-dev/nx-dev/public/documentation/shared/nx-core.md
@@ -1,7 +1,7 @@
 # Using Nx Core Without Plugins
 
 The core of Nx is generic, simple, and unobtrusive. Nx plugins, although very useful for many projects, are completely
-optional. Most large Nx workspaces use plugins for some things and don't use plugins for others.
+optional. Most large Nx workspaces use plugins for some things but not for others.
 
 This guide will walk you through creating a simple Nx workspace with no plugins. It will help you see what capabilities
 of Nx are completely generic and can be used with any technology or tool.
@@ -10,16 +10,22 @@ of Nx are completely generic and can be used with any technology or tool.
 
 ### Creating a New Workspace
 
-Running `yarn create nx-workspace --preset=core` creates an empty workspace.
+> this tutorial uses yarn workspaces, run `npm i -g yarn` to install yarn.
+
+Running `yarn create nx-workspace myorg --preset=core` creates an empty workspace.
+
+> You can say no to Nx Cloud
 
 This is what is generated:
 
-```text
-packages/
-nx.json
-workspace.json
-tsconfig.base.json
-package.json
+```treeview
+myorg/
+├── packages/
+├── tools/
+├── nx.json
+├── workspace.json
+├── package.json
+└── tsconfig.base.json
 ```
 
 `package.json` contains Nx packages.
@@ -32,11 +38,11 @@ package.json
   "scripts": {},
   "private": true,
   "devDependencies": {
-    "@nrwl/cli": "12.8.0",
-    "@nrwl/tao": "12.8.0",
-    "@nrwl/workspace": "12.8.0",
+    "@nrwl/tao": "13.4.4",
+    "@nrwl/cli": "13.4.4",
+    "@nrwl/workspace": "13.4.4",
     "@types/node": "14.14.33",
-    "typescript": "~4.3.5"
+    "typescript": "~4.4.3"
   }
 }
 ```
@@ -47,9 +53,15 @@ package.json
 {
   "extends": "@nrwl/workspace/presets/core.json",
   "npmScope": "myorg",
+  "affected": {
+    "defaultBase": "main"
+  },
+  "cli": {
+    "defaultCollection": "@nrwl/workspace"
+  },
   "tasksRunnerOptions": {
     "default": {
-      "runner": "@nrwl/workspace/tasks-runners",
+      "runner": "@nrwl/workspace/tasks-runners/default",
       "options": {
         "cacheableOperations": ["build", "lint", "test", "e2e"]
       }
@@ -62,17 +74,18 @@ Finally, `workspace.json` lists the workspace projects, and since we have none, 
 
 ### Creating an NPM Package
 
-Running `nx g npm-package simple` results in:
+Running `yarn nx g npm-package simple` results in:
 
-```text
+```treeview
 packages/
- simple/
-   index.js
-   package.json
-nx.json
-workspace.json
-tsconfig.base.json
-package.json
+├── simple/
+│   ├── index.js
+│   ├── package.json
+│   └── project.json
+├──nx.json
+├──workspace.json
+├── package.json
+└── tsconfig.base.json
 ```
 
 The generated `simple/package.json`:
@@ -94,6 +107,8 @@ cache.
 In this example, we used a generator to create the package, but you could have also created it by hand or copied it
 from another project.
 
+// Placeholder: talk about project.json/workspace.json default now is using project.json
+
 The change in `workspace.json` is the only thing required to make Nx aware of the `simple` package. As long as you
 include the project in `workspace.json`, Nx will include that project source in its graph computation and source
 code analysis. It will, for instance, analyze the project's source code, and it will know when it can reuse the
@@ -101,20 +116,22 @@ computation from the cache and when it has to recompute it from scratch.
 
 ### Creating Second NPM Package and Enabling Yarn Workspaces
 
-Running `nx g npm-package complex` results in:
+Running `yarn nx g npm-package complex` results in:
 
-```text
+```treeview
 packages/
- simple/
-   index.js
-   package.json
- complex/
-   index.js
-   package.json
-nx.json
-workspace.json
-tsconfig.base.json
-package.json
+├── simple/
+│   ├── index.js
+│   ├── package.json
+│   └── project.json
+├── complex/
+│   ├── index.js
+│   ├── package.json
+│   └── project.json
+├── nx.json
+├── workspace.json
+├── package.json
+└── tsconfig.base.json
 ```
 
 Now let's modify `packages/complex/index.js` to include `require('@myorg/simple')`. If you run `yarn nx test complex`,
@@ -147,14 +164,40 @@ Then add the following to the root `package.json` (which enables Yarn Workspaces
 }
 ```
 
-Finally, run `yarn`.
+// placeholder: this does not work? still get cannot find module '@myorg/simple',
 
-`yarn nx test complex` works now.
+```bash
+> nx run complex:test --verbose
+warning package.json: No license field
+$ node index.js --verbose=true
+node:internal/modules/cjs/loader:936
+  throw err;
+  ^
+
+Error: Cannot find module '@myorg/simple'
+Require stack:
+- /Users/caleb/Sandbox/myorg/packages/complex/index.js
+    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
+    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
+    at Module.require (node:internal/modules/cjs/loader:1005:19)
+    at require (node:internal/modules/cjs/helpers:102:18)
+    at Object.<anonymous> (/Users/caleb/Sandbox/myorg/packages/complex/index.js:1:1)
+    at Module._compile (node:internal/modules/cjs/loader:1101:14)
+    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
+    at Module.load (node:internal/modules/cjs/loader:981:32)
+    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
+    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12) {
+  code: 'MODULE_NOT_FOUND',
+  requireStack: [ '/Users/caleb/Sandbox/myorg/packages/complex/index.js' ]
+}
+```
+
+Finally, run `yarn`, then `yarn nx test complex` works now.
 
 ## Using Yarn/PNPM/Lerna
 
-This example uses Yarn to connect the two packages. Most of the time, however, there are better ways to do it. The React,
-Node and Angular plugins for Nx allow different projects in your workspace to import each other without having to maintain
+This example uses Yarn to connect the two packages. Most of the time, however, there are better ways to do it. The [React](/react/overview),
+[Node](node/overview) and [Angular](angular/overview) plugins for Nx allow different projects in your workspace to import each other without having to maintain
 cumbersome `package.json` files. Instead, they use Webpack, Rollup and Jest plugins to enable this use case in a more
 elegant way. [Read about the relationship between Nx and Yarn/Lerna/PNPM](/guides/lerna-and-nx).
 
@@ -172,9 +215,10 @@ that adding a `require()` creates a dependency and that some dependencies cannot
 
 Running `yarn nx run-many --target=test --all` will test all projects in parallel.
 
-Running `yarn nx run-many --target=build --projects=app1,app2` will build `proj1` and `proj2` and their
-dependencies in parallel. Note that if `app1` depends on the output of its dependency (e.g., `shared-components`), Nx
-will build `shared-components` first and only then will build the app.
+// placeholder (should we have people make these projects so they can see more in the dep-graph and commands won't fail?)
+Running `yarn nx run-many --target=build --projects=app1,app2` builds `proj1` and `proj2` and their
+dependencies in parallel. Note that if `app1` depends on the output of its dependency (e.g., a `shared-components` library), Nx
+will build the `shared-components` library first and only then build the app.
 
 ### Nx Knows What Is Affected
 
@@ -182,17 +226,13 @@ Running `yarn nx affected --target=test` will test all the projects affected by 
 
 ### Nx Caches and Distributes Tasks
 
-Running `yarn nx build app1` will cache the file artifacts and the terminal output, so if you run it again the command
-will execute instantly because the results will be retrieved from cache. If you use `Nx Cloud` the cache will be shared
-between you, your teammates, and the CI agents. Nx can also distribute tasks across multiple machines while preserving
-the developer experience of running it on a single machine.
+Running `yarn nx build app1` caches the file artifacts and terminal output. When you run the command again, it will execute instantly because the results are retrieved from the cache. If you use [Nx Cloud](https://nx.app/), the cache is shared between you, your teammates, and the CI agents. Nx distribute tasks across multiple machines while preserving the developer experience of running on a single machine.
 
-This works because Nx's computation caching and distributed task execution work on the process level. It doesn't matter
-what `build` means. It can be an npm script, a custom Nx executor, a Gradle task. Nx will handle it in the same way.
+// placeholder: link to what DTE is?
+This works because Nx's computation caching and distributed task execution work on the process level. It doesn't matter what `build` means. It can be an npm script, a custom Nx executor, a Gradle task. Nx will handle it in the same way.
 
 ## Adding Plugins
 
-As you can see, the core of Nx is generic, simple, and unobtrusive. Nx Plugins are completely optional, but they can
-really level up your developer experience. Watch this video to see the plugins in action.
+As you can see, the core of Nx is generic, simple, and unobtrusive. Nx Plugins are completely optional, but they level up your developer experience. The following video shows plugins in action.
 
 <iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/BO1rwynFBLM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"></iframe>


### PR DESCRIPTION
update docs to restructure information for first time
update versions and usage of nx cli
leave "placeholder" notes for things topic discussion on if they should/shouldn't be added or how best to tackle that information.

big note is the nx-core page demo still throws errors. not sure if there's a missing configuration/step. but I couldn't get it to work. still receive the error after init the yarn workspace of unable to resolve the myorg/simple package
```bash 
warning package.json: No license field
$ node index.js --verbose=true
node:internal/modules/cjs/loader:936
  throw err;
  ^
Error: Cannot find module '@myorg/simple'
Require stack:
- /Users/caleb/Sandbox/myorg/packages/complex/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/caleb/Sandbox/myorg/packages/complex/index.js:1:1)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/caleb/Sandbox/myorg/packages/complex/index.js' ]
}
```

