### PR TITLE
fix(repo): removed unused packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,6 @@
     "webpack-node-externals": "^3.0.0",
     "webpack-sources": "^3.0.2",
     "webpack-subresource-integrity": "^1.5.2",
-    "worker-plugin": "3.2.0",
     "xstate": "^4.25.0",
     "yargs": "15.4.1",
     "yargs-parser": "20.0.0",

--- a/packages/linter/package.json
+++ b/packages/linter/package.json
@@ -34,8 +34,6 @@
     "@nrwl/devkit": "*",
     "@nrwl/jest": "*",
     "eslint": "8.2.0",
-    "glob": "7.1.4",
-    "minimatch": "3.0.4",
     "tmp": "~0.2.1",
     "tslib": "^2.3.0"
   }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -109,7 +109,6 @@
     "webpack-merge": "^5.8.0",
     "webpack-sources": "^3.0.2",
     "webpack-subresource-integrity": "^1.5.2",
-    "worker-plugin": "3.2.0",
     "webpack-dev-server": "^4.3.1",
     "http-server": "14.1.0",
     "ignore": "^5.0.4"

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -63,7 +63,6 @@
   "dependencies": {
     "@parcel/watcher": "2.0.4",
     "chokidar": "^3.5.1",
-    "cosmiconfig": "^4.0.0",
     "cli-spinners": "2.6.1",
     "fs-extra": "^9.1.0",
     "dotenv": "~10.0.0",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/workspace` depends on:
- `cosmiconfig`

`@nrwl/linter` depends on:
- `glob`
- `minimatch`

`@nrwl/web` depends on:
- `worker-plugin`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This packages are unused and should not be listed as dependency!
