### PR TITLE
fix(core): add version field to npm-package generator

### DIFF
--- a/packages/workspace/src/generators/npm-package/npm-package.spec.ts
+++ b/packages/workspace/src/generators/npm-package/npm-package.spec.ts
@@ -46,6 +46,7 @@ describe('@nrwl/workspace:npm-package', () => {
       .toMatchInlineSnapshot(`
       "{
         \\"name\\": \\"@proj/my-package\\",
+        \\"version\\": \\"0.0.0\\",
         \\"scripts\\": {
           \\"test\\": \\"node index.js\\"
         }

--- a/packages/workspace/src/generators/npm-package/npm-package.ts
+++ b/packages/workspace/src/generators/npm-package/npm-package.ts
@@ -30,6 +30,7 @@ function addFiles(
   const packageJsonPath = join(projectRoot, 'package.json');
   writeJson(tree, packageJsonPath, {
     name: join(`@${npmScope}`, options.name),
+    version: '0.0.0',
     scripts: {
       test: 'node index.js',
     },


### PR DESCRIPTION
version field is required when linking deps in a yarn workspace, without it the nx-core guide will
break for readers


Fixes error mentioned in  #8535 
