### PR TITLE
fix(core): allow for creating a project graph without any root tsconf…

### DIFF
--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.spec.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.spec.ts
@@ -288,6 +288,17 @@ describe('nx deps utils', () => {
         {}
       );
     });
+
+    it('should work with no tsconfig', () => {
+      const result = _createCache(
+        createNxJson({}),
+        createPackageJsonDeps({}),
+        createCache({}),
+        undefined
+      );
+
+      expect(result).toBeDefined();
+    });
   });
 
   function createCache(p: Partial<ProjectGraphCache>): ProjectGraphCache {

--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
@@ -88,7 +88,7 @@ export function createCache(
     version: projectGraph.version || '5.0',
     deps: packageJsonDeps,
     // compilerOptions may not exist, especially for repos converted through add-nx-to-monorepo
-    pathMappings: tsConfig.compilerOptions?.paths || {},
+    pathMappings: tsConfig?.compilerOptions?.paths || {},
     nxJsonPlugins,
     nodes: projectGraph.nodes,
     externalNodes: projectGraph.externalNodes,

--- a/packages/workspace/src/core/target-project-locator.spec.ts
+++ b/packages/workspace/src/core/target-project-locator.spec.ts
@@ -471,3 +471,364 @@ describe('findTargetProjectWithImport', () => {
     expect(proj5).toEqual('proj5');
   });
 });
+
+describe('findTargetProjectWithImport (without tsconfig.json)', () => {
+  let ctx: ProjectGraphProcessorContext;
+  let projects: Record<string, ProjectGraphProjectNode>;
+  let npmProjects: Record<string, ProjectGraphExternalNode>;
+  let fsJson;
+  let targetProjectLocator: TargetProjectLocator;
+
+  beforeEach(() => {
+    const workspaceJson = {
+      projects: {
+        proj1: {},
+      },
+    };
+    const nxJson = {
+      npmScope: 'proj',
+    };
+    fsJson = {
+      './workspace.json': JSON.stringify(workspaceJson),
+      './nx.json': JSON.stringify(nxJson),
+      './libs/proj/index.ts': `import {a} from '@proj/my-second-proj';
+                              import('@proj/project-3');
+                              const a = { loadChildren: '@proj/proj4ab#a' };
+      `,
+      './libs/proj2/index.ts': `export const a = 2;`,
+      './libs/proj2/deep/index.ts': `export const a = 22;`,
+      './libs/proj3a/index.ts': `export const a = 3;`,
+      './libs/proj4ab/index.ts': `export const a = 4;`,
+      './libs/proj5/index.ts': `export const a = 5;`,
+      './libs/proj6/index.ts': `export const a = 6;`,
+      './libs/proj7/index.ts': `export const a = 7;`,
+      './libs/proj123/index.ts': 'export const a = 123',
+      './libs/proj1234/index.ts': 'export const a = 1234',
+      './libs/proj1234-child/index.ts': 'export const a = 12345',
+    };
+    vol.fromJSON(fsJson, '/root');
+    ctx = {
+      workspace: {
+        ...workspaceJson,
+        ...nxJson,
+      } as any,
+      fileMap: {
+        proj: [
+          {
+            file: 'libs/proj/index.ts',
+            hash: 'some-hash',
+          },
+        ],
+        proj2: [
+          {
+            file: 'libs/proj2/index.ts',
+            hash: 'some-hash',
+          },
+          {
+            file: 'libs/proj2/deep/index.ts',
+            hash: 'some-hash',
+            ext: '.ts',
+          },
+        ],
+        proj3a: [
+          {
+            file: 'libs/proj3a/index.ts',
+            hash: 'some-hash',
+          },
+        ],
+        proj4ab: [
+          {
+            file: 'libs/proj4ab/index.ts',
+            hash: 'some-hash',
+          },
+        ],
+        proj5: [
+          {
+            file: 'libs/proj5/index.ts',
+            hash: 'some-hash',
+            ext: '.ts',
+          },
+        ],
+        proj6: [
+          {
+            file: 'libs/proj6/index.ts',
+            hash: 'some-hash',
+            ext: '.ts',
+          },
+        ],
+        proj7: [
+          {
+            file: 'libs/proj7/index.ts',
+            hash: 'some-hash',
+            ext: '.ts',
+          },
+        ],
+        proj123: [
+          {
+            file: 'libs/proj123/index.ts',
+            hash: 'some-hash',
+          },
+        ],
+        proj1234: [
+          {
+            file: 'libs/proj1234/index.ts',
+            hash: 'some-hash',
+          },
+        ],
+        'proj1234-child': [
+          {
+            file: 'libs/proj1234-child/index.ts',
+            hash: 'some-hash',
+          },
+        ],
+      },
+    } as any;
+
+    projects = {
+      proj3a: {
+        name: 'proj3a',
+        type: 'lib',
+        data: {
+          root: 'libs/proj3a',
+          files: [],
+        },
+      },
+      proj2: {
+        name: 'proj2',
+        type: 'lib',
+        data: {
+          root: 'libs/proj2',
+          files: [],
+        },
+      },
+      proj: {
+        name: 'proj',
+        type: 'lib',
+        data: {
+          root: 'libs/proj',
+          files: [],
+        },
+      },
+      proj1234: {
+        name: 'proj1234',
+        type: 'lib',
+        data: {
+          root: 'libs/proj1234',
+          files: [],
+        },
+      },
+      proj123: {
+        name: 'proj123',
+        type: 'lib',
+        data: {
+          root: 'libs/proj123',
+          files: [],
+        },
+      },
+      proj4ab: {
+        name: 'proj4ab',
+        type: 'lib',
+        data: {
+          root: 'libs/proj4ab',
+          files: [],
+        },
+      },
+      proj5: {
+        name: 'proj5',
+        type: 'lib',
+        data: {
+          root: 'libs/proj5',
+          files: [],
+        },
+      },
+      proj6: {
+        name: 'proj6',
+        type: 'lib',
+        data: {
+          root: 'libs/proj6',
+          files: [],
+        },
+      },
+      proj7: {
+        name: 'proj7',
+        type: 'lib',
+        data: {
+          root: 'libs/proj7',
+          files: [],
+        },
+      },
+      'proj1234-child': {
+        name: 'proj1234-child',
+        type: 'lib',
+        data: {
+          root: 'libs/proj1234-child',
+          files: [],
+        },
+      },
+    };
+    npmProjects = {
+      'npm:@ng/core': {
+        name: 'npm:@ng/core',
+        type: 'npm',
+        data: {
+          version: '1',
+          packageName: '@ng/core',
+        },
+      },
+      'npm:@ng/common': {
+        name: 'npm:@ng/common',
+        type: 'npm',
+        data: {
+          version: '1',
+          packageName: '@ng/common',
+        },
+      },
+      'npm:npm-package': {
+        name: 'npm:npm-package',
+        type: 'npm',
+        data: {
+          version: '1',
+          packageName: 'npm-package',
+        },
+      },
+      'npm:@proj/my-second-proj': {
+        name: 'npm:@proj/my-second-proj',
+        type: 'npm',
+        data: {
+          version: '1',
+          packageName: '@proj/my-second-proj',
+        },
+      },
+      'npm:@proj/proj5': {
+        name: 'npm:@proj/proj5',
+        type: 'npm',
+        data: {
+          version: '1',
+          packageName: '@proj/proj5',
+        },
+      },
+      'npm:@proj/proj6': {
+        name: 'npm:@proj/proj6',
+        type: 'npm',
+        data: {
+          version: '1',
+          packageName: '@proj/proj6',
+        },
+      },
+      'npm:@proj/proj7': {
+        name: 'npm:@proj/proj7',
+        type: 'npm',
+        data: {
+          version: '1',
+          packageName: '@proj/proj7',
+        },
+      },
+      'npm:@proj/proj123-base': {
+        name: 'npm:@proj/proj123-base',
+        type: 'npm',
+        data: {
+          version: '1',
+          packageName: '@proj/proj123-base',
+        },
+      },
+    };
+
+    targetProjectLocator = new TargetProjectLocator(projects, npmProjects);
+  });
+
+  it('should work without a tsconfig file', () => {
+    expect(targetProjectLocator).toBeDefined();
+  });
+
+  it('should be able to resolve a module by using relative paths', () => {
+    const res1 = targetProjectLocator.findProjectWithImport(
+      './class.ts',
+      'libs/proj/index.ts',
+      ctx.workspace.npmScope
+    );
+    const res2 = targetProjectLocator.findProjectWithImport(
+      '../index.ts',
+      'libs/proj/src/index.ts',
+      ctx.workspace.npmScope
+    );
+    const res3 = targetProjectLocator.findProjectWithImport(
+      '../proj/../proj2/index.ts',
+      'libs/proj/index.ts',
+      ctx.workspace.npmScope
+    );
+    const res4 = targetProjectLocator.findProjectWithImport(
+      '../proj/../index.ts',
+      'libs/proj/src/index.ts',
+      ctx.workspace.npmScope
+    );
+
+    expect(res1).toEqual('proj');
+    expect(res2).toEqual('proj');
+    expect(res3).toEqual('proj2');
+    expect(res4).toEqual('proj');
+  });
+
+  it('should be able to npm dependencies', () => {
+    const result1 = targetProjectLocator.findProjectWithImport(
+      '@ng/core',
+      'libs/proj1/index.ts',
+      ctx.workspace.npmScope
+    );
+    const result2 = targetProjectLocator.findProjectWithImport(
+      'npm-package',
+      'libs/proj1/index.ts',
+      ctx.workspace.npmScope
+    );
+
+    expect(result1).toEqual('npm:@ng/core');
+    expect(result2).toEqual('npm:npm-package');
+  });
+
+  it('should be able to resolve a module using a normalized path', () => {
+    const proj4ab = targetProjectLocator.findProjectWithImport(
+      '@proj/proj4ab#a',
+      'libs/proj1/index.ts',
+      ctx.workspace.npmScope
+    );
+
+    expect(proj4ab).toEqual('proj4ab');
+  });
+  it('should be able to resolve paths that have similar names', () => {
+    const proj = targetProjectLocator.findProjectWithImport(
+      '@proj/proj123',
+      '',
+      ctx.workspace.npmScope
+    );
+    expect(proj).toEqual('proj123');
+
+    const childProj = targetProjectLocator.findProjectWithImport(
+      '@proj/proj1234-child',
+      '',
+      ctx.workspace.npmScope
+    );
+    expect(childProj).toEqual('proj1234-child');
+
+    const parentProj = targetProjectLocator.findProjectWithImport(
+      '@proj/proj1234',
+      '',
+      ctx.workspace.npmScope
+    );
+    expect(parentProj).toEqual('proj1234');
+  });
+
+  it('should be able to resolve npm projects', () => {
+    const similarImportFromNpm = targetProjectLocator.findProjectWithImport(
+      '@proj/proj123-base',
+      'libs/proj/index.ts',
+      ctx.workspace.npmScope
+    );
+    expect(similarImportFromNpm).toEqual('npm:@proj/proj123-base');
+
+    const similarDeepImportFromNpm = targetProjectLocator.findProjectWithImport(
+      '@proj/proj123-base/deep',
+      'libs/proj/index.ts',
+      ctx.workspace.npmScope
+    );
+    expect(similarDeepImportFromNpm).toEqual('npm:@proj/proj123-base');
+  });
+});

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -75,15 +75,17 @@ export class TargetProjectLocator {
       return npmProject;
     }
 
-    // TODO(meeroslav): this block is probably obsolete
-    // and existed only because of the incomplete `paths` matching
-    // if import cannot be matched using tsconfig `paths` the compilation would fail anyway
-    const resolvedProject = this.resolveImportWithTypescript(
-      normalizedImportExpr,
-      filePath
-    );
-    if (resolvedProject) {
-      return resolvedProject;
+    if (this.tsConfig.config) {
+      // TODO(meeroslav): this block is probably obsolete
+      // and existed only because of the incomplete `paths` matching
+      // if import cannot be matched using tsconfig `paths` the compilation would fail anyway
+      const resolvedProject = this.resolveImportWithTypescript(
+        normalizedImportExpr,
+        filePath
+      );
+      if (resolvedProject) {
+        return resolvedProject;
+      }
     }
 
     // TODO(meeroslav): this block should be removed as it's going around typescript paths
@@ -191,6 +193,13 @@ export class TargetProjectLocator {
       path = 'tsconfig.json';
       absolutePath = this.getAbsolutePath(path);
       content = readFileIfExisting(absolutePath);
+    }
+    if (!content) {
+      return {
+        path: null,
+        absolutePath: null,
+        config: null,
+      };
     }
     return { path, absolutePath, config: parseJson(content) };
   }


### PR DESCRIPTION
…ig.json at all

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Without a `tsconfig.base.json` or a `tsconfig.json` at the root, the project graph fails to be constructed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Without a `tsconfig.base.json` or a `tsconfig.json` at the root, the project graph is constructed without utilizing typescript.

> Note: Without a `tsconfig.base.json`, typescript won't be used even if a project itself has a `tsconfig.json`. This is a side effect of our current architecture and would require much more changes to make that work. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/8320
