### PR TITLE
fix(react): lock version of mini-css-extract-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "memfs": "^3.0.1",
     "metro-resolver": "^0.66.2",
     "mime": "2.4.4",
-    "mini-css-extract-plugin": "^2.1.0",
+    "mini-css-extract-plugin": "~2.4.7",
     "minimatch": "3.0.4",
     "next": "12.0.7",
     "next-sitemap": "^1.6.108",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -74,7 +74,7 @@
     "less-loader": "^10.1.0",
     "license-webpack-plugin": "2.3.15",
     "loader-utils": "1.2.3",
-    "mini-css-extract-plugin": "^2.1.0",
+    "mini-css-extract-plugin": "~2.4.7",
     "parse5": "4.0.0",
     "parse5-html-rewriting-stream": "6.0.1",
     "open": "^7.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16364,6 +16364,13 @@ mini-css-extract-plugin@2.4.5, mini-css-extract-plugin@^2.1.0:
   dependencies:
     schema-utils "^4.0.0"
 
+mini-css-extract-plugin@~2.4.7:
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.4.7.tgz#b9f4c4f4d727c7a3cd52a11773bb739f00177fac"
+  integrity sha512-euWmddf0sk9Nv1O0gfeeUAvAkoSlWncNLF77C0TP2+WoPvy8mAHKOzMajcCz2dzvyt3CNgxb1obIEVFIRxaipg==
+  dependencies:
+    schema-utils "^4.0.0"
+
 mini-svg-data-uri@^1.2.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.4.3.tgz#43177b2e93766ba338931a3e2a84a3dfd3a222b8"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`2.5.0` of `mini-css-extract-plugin` has a breaking change which breaks web builds.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`mini-css-extract-plugin` is locked to `2.4.x`. This should be updated in the future.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Caused by https://github.com/webpack-contrib/mini-css-extract-plugin/issues/896
Fixes #8540
