### PR TITLE
fix(angular): do not format when skipFormat is passed for generating …

### DIFF
--- a/docs/generated/api-angular/generators/karma-project.md
+++ b/docs/generated/api-angular/generators/karma-project.md
@@ -34,3 +34,11 @@ nx g karma-project ... --dry-run
 Type: `string`
 
 The name of the project.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.

--- a/nx-dev/nx-dev/public/documentation/generated/api-angular/generators/karma-project.md
+++ b/nx-dev/nx-dev/public/documentation/generated/api-angular/generators/karma-project.md
@@ -34,3 +34,11 @@ nx g karma-project ... --dry-run
 Type: `string`
 
 The name of the project.
+
+### skipFormat
+
+Default: `false`
+
+Type: `boolean`
+
+Skip formatting files.

--- a/nx-dev/nx-dev/public/documentation/shared/guides/react-native.md
+++ b/nx-dev/nx-dev/public/documentation/shared/guides/react-native.md
@@ -256,6 +256,22 @@ dist/libs/shared-ui-layout/
 
 This dist folder is ready to be published to a registry.
 
+## Environment Variables
+
+The workspace should install[react-native-config](https://github.com/luggit/react-native-config) by default. To use environment variable, create a new `.env` file in the `happynrwl/apps/mobile` folder:
+
+```
+NX_BUILD_NUMBER=123
+```
+
+Then access variables defined there from your app:
+
+```
+import Config from 'react-native-config';
+
+Config.NX_BUILD_NUMBER; // '123'
+```
+
 ## Code Sharing
 
 Without Nx, creating a new shared library can take from several hours to even weeks: a new repo needs to be provisioned, CI needs to be set up, etc... In an Nx Workspace, it only takes minutes.

--- a/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
+++ b/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
@@ -17,6 +17,7 @@ export async function addUnitTestRunner(host: Tree, options: NormalizedSchema) {
   } else if (options.unitTestRunner === UnitTestRunner.Karma) {
     await karmaProjectGenerator(host, {
       project: options.name,
+      skipFormat: true,
     });
   }
 }

--- a/packages/angular/src/generators/karma-project/karma-project.ts
+++ b/packages/angular/src/generators/karma-project/karma-project.ts
@@ -14,7 +14,9 @@ export async function karmaProjectGenerator(
   generateKarmaProjectFiles(tree, options.project);
   updateTsConfigs(tree, options.project);
   updateWorkspaceConfig(tree, options.project);
-  await formatFiles(tree);
+  if (!options.skipFormat) {
+    await formatFiles(tree);
+  }
 }
 
 export default karmaProjectGenerator;

--- a/packages/angular/src/generators/karma-project/schema.d.ts
+++ b/packages/angular/src/generators/karma-project/schema.d.ts
@@ -1,3 +1,4 @@
 export interface KarmaProjectOptions {
   project: string;
+  skipFormat?: boolean;
 }

--- a/packages/angular/src/generators/karma-project/schema.json
+++ b/packages/angular/src/generators/karma-project/schema.json
@@ -11,6 +11,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "skipFormat": {
+      "description": "Skip formatting files.",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -96,7 +96,7 @@ export async function libraryGenerator(host: Tree, schema: Partial<Schema>) {
     await convertToNxProjectGenerator(host, {
       project: options.name,
       all: false,
-      skipFormat: options.skipFormat,
+      skipFormat: true,
     });
   }
 
@@ -116,10 +116,12 @@ async function addUnitTestRunner(host: Tree, options: NormalizedSchema) {
       setupFile: 'angular',
       supportTsx: false,
       skipSerializers: false,
+      skipFormat: true,
     });
   } else if (options.unitTestRunner === 'karma') {
     await karmaProjectGenerator(host, {
       project: options.name,
+      skipFormat: true,
     });
   }
 }
@@ -150,6 +152,7 @@ async function addLinting(host: Tree, options: NormalizedSchema) {
     projectRoot: options.projectRoot,
     prefix: options.prefix,
     setParserOptionsProject: options.setParserOptionsProject,
+    skipFormat: true,
   });
 }
 


### PR DESCRIPTION
…a lib

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Angular library generator formats files even when `skipFormat` is passed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Angular library generator does not format files when `skipFormat` is passed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/8382
