### PR TITLE
docs(cypress): fix typo

### DIFF
--- a/packages/cypress/README.md
+++ b/packages/cypress/README.md
@@ -14,6 +14,6 @@ Executors and generators adding Cypress tests for frontend applications.
 
 ## How to Use
 
-This package is used by the `@nrwl/web`, `@nrwl/react`, and `@nrwl/angular`. See [https://github.com/nrwl/nx](https://github.com/nrwl/nx) for more information.
+This package is used by `@nrwl/web`, `@nrwl/react`, and `@nrwl/angular`. See [https://github.com/nrwl/nx](https://github.com/nrwl/nx) for more information.
 
 {{resources}}


### PR DESCRIPTION
Remove "the" from the used by 'How to use'

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
n/a Docs change

## Expected Behavior
No change

## Related Issue(s)
None

Fixes #
