### PR TITLE
fix(angular): configure tailwind content and purge properties for libraries

### DIFF
--- a/e2e/angular-extensions/src/tailwind.test.ts
+++ b/e2e/angular-extensions/src/tailwind.test.ts
@@ -52,9 +52,7 @@ describe('Tailwind support', () => {
     const tailwindConfigFile = 'tailwind.config.js';
 
     const tailwindConfig = `module.exports = {
-      mode: 'jit',
-      purge: ['./apps/**/*.{html,ts}', './libs/**/*.{html,ts}'],
-      darkMode: false,
+      content: ['./apps/**/*.{html,ts}', './libs/**/*.{html,ts}'],
       theme: {
         spacing: {
           sm: '${spacing.root.sm}',
@@ -77,12 +75,10 @@ describe('Tailwind support', () => {
     const { join } = require('path');
   
     module.exports = {
-      mode: 'jit',
-      purge: [
+      content: [
         join(__dirname, 'src/**/*.{html,ts}'),
         ...createGlobPatternsForDependencies(__dirname),
       ],
-      darkMode: false,
       theme: {
         spacing: {
           sm: '${libSpacing.sm}',

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -1366,7 +1366,14 @@ describe('lib', () => {
       // ASSERT
       expect(tree.read('libs/my-lib/tailwind.config.js', 'utf-8'))
         .toMatchInlineSnapshot(`
-        "module.exports = {
+        "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+        const { join } = require('path');
+
+        module.exports = {
+          content: [
+            join(__dirname, 'src/**/*.{html,ts}'),
+            ...createGlobPatternsForDependencies(__dirname),
+          ],
           theme: {
             extend: {},
           },

--- a/packages/angular/src/generators/setup-tailwind/files/v2/tailwind.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-tailwind/files/v2/tailwind.config.js__tmpl__
@@ -1,4 +1,4 @@
-<% if (projectType === 'application') { %>const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
 const { join } = require('path');
 
 module.exports = {
@@ -6,7 +6,7 @@ module.exports = {
   purge: [
     join(__dirname, '<%= relativeSourceRoot %>/**/*.{html,ts}'),
     ...createGlobPatternsForDependencies(__dirname),
-  ],<% } else { %>module.exports = {<% } %>
+  ],
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {},

--- a/packages/angular/src/generators/setup-tailwind/files/v3/tailwind.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-tailwind/files/v3/tailwind.config.js__tmpl__
@@ -1,11 +1,11 @@
-<% if (projectType === 'application') { %>const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
 const { join } = require('path');
 
 module.exports = {
   content: [
     join(__dirname, '<%= relativeSourceRoot %>/**/*.{html,ts}'),
     ...createGlobPatternsForDependencies(__dirname),
-  ],<% } else { %>module.exports = {<% } %>
+  ],
   theme: {
     extend: {},
   },

--- a/packages/angular/src/generators/setup-tailwind/lib/add-tailwind-config.ts
+++ b/packages/angular/src/generators/setup-tailwind/lib/add-tailwind-config.ts
@@ -28,7 +28,6 @@ export function addTailwindConfig(
     joinPathFragments(__dirname, '..', filesDir),
     project.root,
     {
-      projectType: project.projectType,
       relativeSourceRoot: relative(project.root, project.sourceRoot),
       tmpl: '',
     }

--- a/packages/angular/src/generators/setup-tailwind/setup-tailwind.library.spec.ts
+++ b/packages/angular/src/generators/setup-tailwind/setup-tailwind.library.spec.ts
@@ -197,7 +197,14 @@ describe('setupTailwind generator', () => {
 
       expect(tree.read(`libs/${project}/tailwind.config.js`, 'utf-8'))
         .toMatchInlineSnapshot(`
-        "module.exports = {
+        "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+        const { join } = require('path');
+
+        module.exports = {
+          content: [
+            join(__dirname, 'src/**/*.{html,ts}'),
+            ...createGlobPatternsForDependencies(__dirname),
+          ],
           theme: {
             extend: {},
           },
@@ -222,7 +229,14 @@ describe('setupTailwind generator', () => {
 
       expect(tree.read(`libs/${project}/tailwind.config.js`, 'utf-8'))
         .toMatchInlineSnapshot(`
-        "module.exports = {
+        "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+        const { join } = require('path');
+
+        module.exports = {
+          content: [
+            join(__dirname, 'src/**/*.{html,ts}'),
+            ...createGlobPatternsForDependencies(__dirname),
+          ],
           theme: {
             extend: {},
           },
@@ -247,7 +261,15 @@ describe('setupTailwind generator', () => {
 
       expect(tree.read(`libs/${project}/tailwind.config.js`, 'utf-8'))
         .toMatchInlineSnapshot(`
-        "module.exports = {
+        "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+        const { join } = require('path');
+
+        module.exports = {
+          mode: 'jit',
+          purge: [
+            join(__dirname, 'src/**/*.{html,ts}'),
+            ...createGlobPatternsForDependencies(__dirname),
+          ],
           darkMode: false, // or 'media' or 'class'
           theme: {
             extend: {},


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When adding Tailwind CSS support to an Angular library using the `@nrwl/angular:setup-tailwind` generator or the `--add-tailwind` flag of the `@nrwl/angular:library` generator, the tailwind configuration doesn't contain the `content` property for v3 or the `purge` property for v2. Those properties are needed if a library wants to generate its own CSS.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When adding Tailwind CSS support to an Angular library, the `content` property for v3 pr the `purge` property for v2 should be generated to allow the scenario where a library needs to generate its own CSS.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
