### PR TITLE
fix(linter): avoid secondary entrypoints flagging as circular dependencies

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -21,7 +21,7 @@ import {
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { joinPathFragments, normalizePath } from '@nrwl/devkit';
+import { normalizePath } from '@nrwl/devkit';
 import {
   ProjectType,
   readCachedProjectGraph,
@@ -33,7 +33,7 @@ import {
   findFilesInCircularPath,
 } from '@nrwl/workspace/src/utils/graph-utils';
 import { isRelativePath } from '@nrwl/workspace/src/utilities/fileutils';
-import { existsSync } from 'fs';
+import { isSecondaryEntrypoint as isAngularSecondaryEntrypoint } from '../utils/angular';
 
 type Options = [
   {
@@ -234,17 +234,11 @@ export default createESLintRule<Options, MessageIds>({
       if (sourceProject === targetProject) {
         // we only allow relative paths within the same project
         // and if it's not a secondary entrypoint in an angular lib
-        const ngPackageExistsForSecondaryEntry = sourceFilePath.endsWith(
-          'src/index.ts'
-        )
-          ? existsSync(
-              joinPathFragments(sourceFilePath, '../../', 'ng-package.json')
-            )
-          : false;
+
         if (
           !allowCircularSelfDependency &&
           !isRelativePath(imp) &&
-          !ngPackageExistsForSecondaryEntry
+          !isAngularSecondaryEntrypoint(sourceFilePath)
         ) {
           context.report({
             node,

--- a/packages/eslint-plugin-nx/src/utils/angular.ts
+++ b/packages/eslint-plugin-nx/src/utils/angular.ts
@@ -1,0 +1,8 @@
+import { joinPathFragments } from '@nrwl/devkit';
+import { existsSync } from 'fs';
+
+export function isSecondaryEntrypoint(path: string) {
+  return path.endsWith('src/index.ts')
+    ? existsSync(joinPathFragments(path, '../../', 'ng-package.json'))
+    : false;
+}


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Importing from secondary entry points is flagging as a circular dependency by eslint-module-boundaries
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Importing from secondary entry points should not flag as a circular dependency by eslint-module-boundaries

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

ISSUES CLOSED: #8059
