### PR TITLE
fix(node): disable name mangling when building for production

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -51,6 +51,7 @@
     "webpack": "^5.58.1",
     "webpack-merge": "^5.8.0",
     "webpack-node-externals": "^3.0.0",
+    "terser-webpack-plugin": "^5.1.1",
     "rxjs-for-await": "0.0.2",
     "ts-node": "~9.1.1"
   }

--- a/packages/node/src/utils/node.config.spec.ts
+++ b/packages/node/src/utils/node.config.spec.ts
@@ -53,6 +53,7 @@ describe('getNodePartial', () => {
       });
 
       expect(result.optimization.minimize).toEqual(true);
+      expect(result.optimization.minimizer).toBeDefined();
     });
 
     it('should concatenate modules', () => {

--- a/packages/node/src/utils/node.config.ts
+++ b/packages/node/src/utils/node.config.ts
@@ -5,6 +5,7 @@ import { merge } from 'webpack-merge';
 import { getBaseWebpackPartial } from './config';
 import { BuildNodeBuilderOptions } from './types';
 import nodeExternals = require('webpack-node-externals');
+import TerserPlugin = require('terser-webpack-plugin');
 
 function getNodePartial(options: BuildNodeBuilderOptions) {
   const webpackConfig: Configuration = {
@@ -18,6 +19,13 @@ function getNodePartial(options: BuildNodeBuilderOptions) {
   if (options.optimization) {
     webpackConfig.optimization = {
       minimize: true,
+      minimizer: [
+        new TerserPlugin({
+          terserOptions: {
+            mangle: false,
+          },
+        }),
+      ],
       concatenateModules: true,
     };
   }


### PR DESCRIPTION
Hello this is my first PR on nx after experiencing and investigating on #8537.
Thanks for the awesome work on nx, BTW :) 

This commit disable name mangling when building for production with optimization on,
in order not to break features relying on runtime reflection.

ISSUES CLOSED: #8537
