### PR TITLE
fix(core): fix typing of dependsOn property

### DIFF
--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -137,7 +137,7 @@ export interface TargetConfiguration {
   /**
    * This describes other targets that a target depends on.
    */
-  dependsOn?: [TargetDependencyConfig];
+  dependsOn?: TargetDependencyConfig[];
 
   /**
    * Target's options. They are passed in to the executor.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`TargetConfiguration`'s `dependsOn` property is mistakenly typed as a tuple of a single `TargetDependencyConfig`, which causes code like this to be marked as erroneous by the compiler:

```typescript
project.targets['mytarget'] = {
  dependsOn: [
    {
      target: 'dep1',
      projects: 'self',
    },
    {
      target: 'dep2',
      projects: 'self',
    },
  ],
  // [...]
};
``` 
`Source has 2 element(s) but target allows only 1.ts(2322)`

## Expected Behavior
`dependsOn` should be typed as an array to allow multiple dependencies.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
