### PR TITLE
fix(core): run command is swallowing errors from angular builders

### DIFF
--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -160,6 +160,10 @@ async function iteratorToProcessStatusCode(
         ? current.value.success
         : prev.value.success;
 
+    if (!success && prev.value.error) {
+      logger.log(prev.value.error);
+    }
+
     return success ? 0 : 1;
   } finally {
     clearInterval(keepProcessAliveInterval);

--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -160,10 +160,6 @@ async function iteratorToProcessStatusCode(
         ? current.value.success
         : prev.value.success;
 
-    if (!success && prev.value.error) {
-      logger.log(prev.value.error);
-    }
-
     return success ? 0 : 1;
   } finally {
     clearInterval(keepProcessAliveInterval);


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Currently, when we `nx run` a target with an Angular builder, we do not output any error logs that the Angular Devkit collects.

This happens because we map the output from the Executor to a status code of `0` or `1`.
We do this within a `handleErrors` function which should catch any thrown `Error` and print the log accordingly.

However, the Angular Devkit does not throw when it encounters an Error. Instead, it builds up an Error string in the `BuilderOutput`. 

As no Error is thrown, we do not print any logs. We do however map correctly to an erroring status code, so at the end of execution, we still tell the user that the command failed, we just don't inform them of why.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should handle scenarios from Angular Devkit where there is no Error thrown, and still print the error logs correctly.

## Additional Information
I do not like how I've solved this. It feels brittle and as though it is being handled in the incorrect place.
However, given the current structure of the `run` command, I cannot think of anywhere else to do it without drastically changing the command, which may have an unintended knock-on effect. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8456
