### PR TITLE
cleanup(repo): import ignore instead of require

### DIFF
--- a/packages/nest/src/migrations/update-10-0-0/update-10-0-0.ts
+++ b/packages/nest/src/migrations/update-10-0-0/update-10-0-0.ts
@@ -18,7 +18,7 @@ import {
   isStringLiteral,
   ScriptTarget,
 } from 'typescript';
-const ignore = require('ignore');
+import ignore from 'ignore';
 
 export default function update(): Rule {
   return chain([

--- a/packages/react-native/src/generators/init/lib/add-git-ignore-entry.ts
+++ b/packages/react-native/src/generators/init/lib/add-git-ignore-entry.ts
@@ -8,10 +8,10 @@ export function addGitIgnoreEntry(host: Tree) {
     return;
   }
 
-  let content = host.read('.gitignore')?.toString('utf-8').trimRight();
+  let content = host.read('.gitignore', 'utf-8').trimEnd();
 
   const ig = ignore();
-  ig.add(host.read('.gitignore').toString());
+  ig.add(host.read('.gitignore', 'utf-8'));
 
   if (!ig.ignores('apps/example/ios/Pods/Folly')) {
     content = `${content}\n${gitIgnoreEntriesForReactNative}/\n`;

--- a/packages/react/src/migrations/update-8-10-0/update-8-10-0.ts
+++ b/packages/react/src/migrations/update-8-10-0/update-8-10-0.ts
@@ -16,8 +16,6 @@ import * as path from 'path';
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import { offsetFromRoot } from '@nrwl/devkit';
 
-const ignore = require('ignore');
-
 export default function update(): Rule {
   return chain([
     displayInformation,

--- a/packages/react/src/migrations/update-8-10-1/fix-react-tsconfig-8-10-1.ts
+++ b/packages/react/src/migrations/update-8-10-1/fix-react-tsconfig-8-10-1.ts
@@ -2,8 +2,6 @@ import { chain, noop, Rule, Tree } from '@angular-devkit/schematics';
 import { formatFiles, readWorkspace, updateJsonInTree } from '@nrwl/workspace';
 import * as path from 'path';
 
-const ignore = require('ignore');
-
 export default function update(): Rule {
   return (host: Tree) => {
     const workspace = readWorkspace(host);

--- a/packages/react/src/migrations/update-8-12-0/fix-react-files-8-12-0.ts
+++ b/packages/react/src/migrations/update-8-12-0/fix-react-files-8-12-0.ts
@@ -5,8 +5,6 @@ import {
   updateWorkspaceInTree,
 } from '@nrwl/workspace';
 
-const ignore = require('ignore');
-
 export default function update(): Rule {
   return chain([
     updateWorkspaceInTree(updateBuilderWebpackOption),

--- a/packages/react/src/migrations/update-8-3-0/update-8-3-0.ts
+++ b/packages/react/src/migrations/update-8-3-0/update-8-3-0.ts
@@ -21,8 +21,7 @@ import {
 import { ReplaceChange } from '@nrwl/workspace/src/utils/ast-utils';
 import { relative } from 'path';
 import { testingLibraryReactVersion } from '../../utils/versions';
-
-const ignore = require('ignore');
+import ignore from 'ignore';
 
 export default function update(): Rule {
   return chain([

--- a/packages/react/src/migrations/update-8-9-0/update-8-9-0.ts
+++ b/packages/react/src/migrations/update-8-9-0/update-8-9-0.ts
@@ -18,8 +18,7 @@ import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import * as path from 'path';
 import { relative } from 'path';
 import { ReplaceChange } from '@nrwl/workspace/src/utils/ast-utils';
-
-const ignore = require('ignore');
+import ignore from 'ignore';
 
 export default function update(): Rule {
   return chain([

--- a/packages/workspace/src/core/file-map-utils.spec.ts
+++ b/packages/workspace/src/core/file-map-utils.spec.ts
@@ -1,7 +1,5 @@
 import { createProjectFileMap, updateProjectFileMap } from './file-map-utils';
 
-const ignore = require('ignore');
-
 describe('fileMapUtils', () => {
   describe('createFileMap', () => {
     it('should map files to projects', () => {

--- a/packages/workspace/src/core/file-map-utils.ts
+++ b/packages/workspace/src/core/file-map-utils.ts
@@ -1,8 +1,6 @@
 import type { FileData } from '@nrwl/devkit';
 import { ProjectFileMap } from '@nrwl/devkit';
 
-const ignore = require('ignore');
-
 function sortProjects(workspaceJson: any) {
   // Sorting here so `apps/client-e2e` comes before `apps/client` and has
   // a chance to match prefix first.

--- a/packages/workspace/src/core/file-utils.spec.ts
+++ b/packages/workspace/src/core/file-utils.spec.ts
@@ -1,8 +1,7 @@
 import { calculateFileChanges, WholeFileChange } from './file-utils';
-import { DiffType, JsonChange, jsonDiff } from '../utilities/json-diff';
+import { DiffType } from '../utilities/json-diff';
 import { defaultFileHasher } from './hasher/file-hasher';
-
-const ignore = require('ignore');
+import ignore from 'ignore';
 
 describe('calculateFileChanges', () => {
   beforeEach(() => {

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -8,20 +8,16 @@ import type {
   NxJsonConfiguration,
   ProjectGraphNode,
 } from '@nrwl/devkit';
-import { ProjectFileMap, stripIndents, readJsonFile } from '@nrwl/devkit';
+import { readJsonFile } from '@nrwl/devkit';
 import { execSync } from 'child_process';
-import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { extname, join, relative, sep } from 'path';
-import { performance } from 'perf_hooks';
 import type { NxArgs } from '../command-line/utils';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
-import { appendArray } from '../utilities/array';
 import { fileExists } from '../utilities/fileutils';
 import { jsonDiff } from '../utilities/json-diff';
-import { defaultFileHasher } from './hasher/file-hasher';
 import type { Environment } from './shared-interfaces';
-
-const ignore = require('ignore');
+import ignore from 'ignore';
 
 export interface Change {
   type: string;

--- a/packages/workspace/src/core/hasher/git-based-file-hasher.ts
+++ b/packages/workspace/src/core/hasher/git-based-file-hasher.ts
@@ -3,8 +3,7 @@ import { performance } from 'perf_hooks';
 import { getFileHashes, getGitHashForFiles } from './git-hasher';
 import { existsSync, readFileSync } from 'fs';
 import { FileHasherBase } from './file-hasher-base';
-
-const ignore = require('ignore');
+import ignore from 'ignore';
 
 export class GitBasedFileHasher extends FileHasherBase {
   /**

--- a/packages/workspace/src/core/hasher/node-based-file-hasher.ts
+++ b/packages/workspace/src/core/hasher/node-based-file-hasher.ts
@@ -5,8 +5,7 @@ import { join, relative } from 'path';
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { FileHasherBase } from './file-hasher-base';
 import { stripIndents } from '@nrwl/devkit';
-
-const ignore = require('ignore');
+import ignore from 'ignore';
 
 export class NodeBasedFileHasher extends FileHasherBase {
   ignoredGlobs = getIgnoredGlobs();

--- a/packages/workspace/src/utils/rules/visit-not-ignored-files.ts
+++ b/packages/workspace/src/utils/rules/visit-not-ignored-files.ts
@@ -5,14 +5,14 @@ import {
   SchematicContext,
   Tree,
 } from '@angular-devkit/schematics';
-import ignore from 'ignore';
+import ignore, { Ignore } from 'ignore';
 
 export function visitNotIgnoredFiles(
   visitor: (file: Path, host: Tree, context: SchematicContext) => void | Rule,
   dir: Path = normalize('')
 ): Rule {
   return (host, context) => {
-    let ig;
+    let ig: Ignore | undefined;
     if (host.exists('.gitignore')) {
       ig = ignore();
       ig.add(host.read('.gitignore').toString());


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- replaced require statements of `ignore` with import statements
- removed unused imports of `ignore`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
