### PR TITLE
cleanup(core): improve list command performance

### DIFF
--- a/docs/generated/cli/list.md
+++ b/docs/generated/cli/list.md
@@ -37,8 +37,6 @@ Show help
 
 ### plugin
 
-Default: `null`
-
 The name of an installed plugin to query
 
 ### version

--- a/packages/workspace/src/command-line/list.ts
+++ b/packages/workspace/src/command-line/list.ts
@@ -1,4 +1,3 @@
-import * as yargs from 'yargs';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import { output } from '../utilities/output';
 import {
@@ -11,23 +10,10 @@ import {
   listPluginCapabilities,
 } from '../utilities/plugins';
 
-export interface YargsListArgs extends yargs.Arguments, ListArgs {}
-
-interface ListArgs {
-  plugin?: string;
+export interface ListArgs {
+  /** The name of an installed plugin to query  */
+  plugin?: string | undefined;
 }
-
-export const list = {
-  command: 'list [plugin]',
-  describe:
-    'Lists installed plugins, capabilities of installed plugins and other available plugins.',
-  builder: (yargs: yargs.Argv) =>
-    yargs.positional('plugin', {
-      default: null,
-      description: 'The name of an installed plugin to query',
-    }),
-  handler: listHandler,
-};
 
 /**
  * List available plugins or capabilities within a specific plugin
@@ -37,7 +23,7 @@ export const list = {
  * Must be run within an Nx workspace
  *
  */
-async function listHandler(args: YargsListArgs) {
+export async function listHandler(args: ListArgs): Promise<void> {
   if (args.plugin) {
     listPluginCapabilities(args.plugin);
   } else {

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -11,6 +11,7 @@ import { generateDaemonHelpOutput } from '../core/project-graph/daemon/client/ge
 import { nxVersion } from '../utils/versions';
 import { examples } from './examples';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
+import type { ListArgs } from './list';
 
 const noop = (yargs: yargs.Argv): yargs.Argv => yargs;
 
@@ -291,7 +292,17 @@ npx nx daemon
     }
   )
   .command(require('./report').report)
-  .command(require('./list').list)
+  .command<ListArgs>({
+    command: 'list [plugin]',
+    describe:
+      'Lists installed plugins, capabilities of installed plugins and other available plugins.',
+    builder: (yargs) =>
+      yargs.positional('plugin', {
+        type: 'string',
+        description: 'The name of an installed plugin to query',
+      }),
+    handler: async (args) => (await import('./list')).listHandler(args),
+  })
   .command({
     command: 'reset',
     describe:

--- a/packages/workspace/src/utilities/plugins/community-plugins.ts
+++ b/packages/workspace/src/utilities/plugins/community-plugins.ts
@@ -32,17 +32,13 @@ export async function fetchCommunityPlugins(): Promise<CommunityPlugin[]> {
 }
 
 export function listCommunityPlugins(
-  installedPlugins: PluginCapabilities[],
+  installedPlugins: Map<string, PluginCapabilities>,
   communityPlugins?: CommunityPlugin[]
 ): void {
   if (!communityPlugins) return;
 
-  const installedPluginsMap: Set<string> = new Set<string>(
-    installedPlugins.map((p) => p.name)
-  );
-
   const availableCommunityPlugins = communityPlugins.filter(
-    (p) => !installedPluginsMap.has(p.name)
+    (p) => !installedPlugins.has(p.name)
   );
 
   output.log({

--- a/packages/workspace/src/utilities/plugins/core-plugins.ts
+++ b/packages/workspace/src/utilities/plugins/core-plugins.ts
@@ -61,15 +61,11 @@ export function fetchCorePlugins() {
 }
 
 export function listCorePlugins(
-  installedPlugins: PluginCapabilities[],
+  installedPlugins: Map<string, PluginCapabilities>,
   corePlugins: CorePlugin[]
 ): void {
-  const installedPluginsMap: Set<string> = new Set<string>(
-    installedPlugins.map((p) => p.name)
-  );
-
   const alsoAvailable = corePlugins.filter(
-    (p) => !installedPluginsMap.has(p.name)
+    (p) => !installedPlugins.has(p.name)
   );
 
   if (alsoAvailable.length) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- `installedPlugins` are returned as Array but is converted to a Set`two times (in `listCorePlugins` & `listCommunityPlugins`). 
- `installedPlugins` is used like a Map in `list...` Methods (even the variable is called ...Map) 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- `installedPlugins` should be returned as Map to improve performance
- improved yargs command initialization