### PR TITLE
cleanup(repo): replace deprecated string methods

### DIFF
--- a/packages/cli/lib/decorate-cli.ts
+++ b/packages/cli/lib/decorate-cli.ts
@@ -5,7 +5,7 @@ export function decorateCli() {
   const angularCLIInit = readFileSync(path, 'utf-8');
   const start = angularCLIInit.indexOf(`(options) {`) + 11;
 
-  const newContent = `${angularCLIInit.substr(0, start)}
+  const newContent = `${angularCLIInit.substring(0, start)}
   if (!process.env['NX_CLI_SET']) {
     require('@nrwl/cli/bin/nx');
     return new Promise(function(res, rej) {});

--- a/packages/cypress/src/utils/project-name.ts
+++ b/packages/cypress/src/utils/project-name.ts
@@ -1,7 +1,7 @@
 import { names } from '@nrwl/devkit';
 
 export function getUnscopedLibName(libRoot: string) {
-  return libRoot.substr(libRoot.lastIndexOf('/') + 1);
+  return libRoot.substring(libRoot.lastIndexOf('/') + 1);
 }
 
 export function getE2eProjectName(

--- a/packages/devkit/src/utils/names.ts
+++ b/packages/devkit/src/utils/names.ts
@@ -65,5 +65,5 @@ function toFileName(s: string): string {
  * Capitalizes the first letter of a string
  */
 function toCapitalCase(s: string): string {
-  return s.charAt(0).toUpperCase() + s.substr(1);
+  return s.charAt(0).toUpperCase() + s.substring(1);
 }

--- a/packages/devkit/src/utils/string-change.ts
+++ b/packages/devkit/src/utils/string-change.ts
@@ -84,10 +84,10 @@ export function applyChangesToString(
   for (const change of sortedChanges) {
     const index = getChangeIndex(change) + offset;
     if (isStringInsertion(change)) {
-      text = text.substr(0, index) + change.text + text.substr(index);
+      text = text.substring(0, index) + change.text + text.substring(index);
       offset += change.text.length;
     } else {
-      text = text.substr(0, index) + text.substr(index + change.length);
+      text = text.substring(0, index) + text.substring(index + change.length);
       offset -= change.length;
     }
   }

--- a/packages/js/src/utils/code-frames/highlight.ts
+++ b/packages/js/src/utils/code-frames/highlight.ts
@@ -50,7 +50,7 @@ function getTokenType(match) {
 
     if (
       JSX_TAG.test(token.value) &&
-      (text[offset - 1] === '<' || text.substr(offset - 2, 2) == '</')
+      (text[offset - 1] === '<' || text.substring(offset - 2, 2) == '</')
     ) {
       return 'jsx_tag';
     }

--- a/packages/nest/src/migrations/update-10-0-0/update-10-0-0.ts
+++ b/packages/nest/src/migrations/update-10-0-0/update-10-0-0.ts
@@ -73,7 +73,7 @@ function updateImports(host: Tree) {
         const nodeText = statement.moduleSpecifier.getText(sourceFile);
         const modulePath = statement.moduleSpecifier
           .getText(sourceFile)
-          .substr(1, nodeText.length - 2);
+          .substring(1, nodeText.length - 2);
         if (modulePath === 'type-graphql') {
           changes.push(
             new ReplaceChange(

--- a/packages/react-native/src/generators/init/lib/add-git-ignore-entry.ts
+++ b/packages/react-native/src/generators/init/lib/add-git-ignore-entry.ts
@@ -8,7 +8,7 @@ export function addGitIgnoreEntry(host: Tree) {
     return;
   }
 
-  let content = host.read('.gitignore')?.toString('utf-8').trimRight();
+  let content = host.read('.gitignore')?.toString('utf-8').trimEnd();
 
   const ig = ignore();
   ig.add(host.read('.gitignore').toString());

--- a/packages/react/src/migrations/update-8-3-0/update-8-3-0.ts
+++ b/packages/react/src/migrations/update-8-3-0/update-8-3-0.ts
@@ -122,7 +122,7 @@ function updateImports(host: Tree) {
         const nodeText = statement.moduleSpecifier.getText(sourceFile);
         const modulePath = statement.moduleSpecifier
           .getText(sourceFile)
-          .substr(1, nodeText.length - 2);
+          .substring(1, nodeText.length - 2);
         if (modulePath === 'react-testing-library') {
           changes.push(
             new ReplaceChange(

--- a/packages/react/src/migrations/update-8-9-0/update-8-9-0.ts
+++ b/packages/react/src/migrations/update-8-9-0/update-8-9-0.ts
@@ -98,7 +98,7 @@ function updateImports(host: Tree) {
         const nodeText = statement.moduleSpecifier.getText(sourceFile);
         const modulePath = statement.moduleSpecifier
           .getText(sourceFile)
-          .substr(1, nodeText.length - 2);
+          .substring(1, nodeText.length - 2);
         if (modulePath === 'redux-starter-kit') {
           changes.push(
             new ReplaceChange(

--- a/packages/storybook/src/generators/migrate-stories-to-6-2/migrate-stories-to-6-2.ts
+++ b/packages/storybook/src/generators/migrate-stories-to-6-2/migrate-stories-to-6-2.ts
@@ -167,7 +167,7 @@ function findAllComponentsWithStoriesForSpecificProject(
     const imports = file.statements?.filter(
       (statement) => statement.kind === SyntaxKind.ImportDeclaration
     );
-    const modulePath = moduleFilePath.substr(
+    const modulePath = moduleFilePath.substring(
       0,
       moduleFilePath?.lastIndexOf('/')
     );

--- a/packages/tao/src/commands/generate.ts
+++ b/packages/tao/src/commands/generate.ts
@@ -72,8 +72,8 @@ function parseGenerateOpts(
     const separatorIndex = generatorDescriptor.lastIndexOf(':');
 
     if (separatorIndex > 0) {
-      collectionName = generatorDescriptor.substr(0, separatorIndex);
-      generatorName = generatorDescriptor.substr(separatorIndex + 1);
+      collectionName = generatorDescriptor.substring(0, separatorIndex);
+      generatorName = generatorDescriptor.substring(separatorIndex + 1);
     } else {
       collectionName = defaultCollection;
       generatorName = generatorDescriptor;

--- a/packages/tao/src/commands/ngcli-adapter.ts
+++ b/packages/tao/src/commands/ngcli-adapter.ts
@@ -122,7 +122,7 @@ async function createRecorder(
   const actualConfigName = await host.workspaceConfigName();
   return (event: import('@angular-devkit/schematics').DryRunEvent) => {
     let eventPath = event.path.startsWith('/')
-      ? event.path.substr(1)
+      ? event.path.substring(1)
       : event.path;
 
     if (eventPath === 'workspace.json' || eventPath === 'angular.json') {
@@ -1093,7 +1093,7 @@ export function wrapAngularDevkitSchematic(
       event: import('@angular-devkit/schematics').DryRunEvent
     ) => {
       let eventPath = event.path.startsWith('/')
-        ? event.path.substr(1)
+        ? event.path.substring(1)
         : event.path;
 
       const r = convertEventTypeToHandleMultipleConfigNames(
@@ -1198,14 +1198,14 @@ const loggerColors: Partial<Record<logging.LogLevel, (s: string) => string>> = {
   warn: (s) => chalk.bold(chalk.yellow(s)),
   error: (s) => {
     if (s.startsWith('NX ')) {
-      return `\n${NX_ERROR} ${chalk.bold(chalk.red(s.substr(3)))}\n`;
+      return `\n${NX_ERROR} ${chalk.bold(chalk.red(s.substring(3)))}\n`;
     }
 
     return chalk.bold(chalk.red(s));
   },
   info: (s) => {
     if (s.startsWith('NX ')) {
-      return `\n${NX_PREFIX} ${chalk.bold(s.substr(3))}\n`;
+      return `\n${NX_PREFIX} ${chalk.bold(s.substring(3))}\n`;
     }
 
     return chalk.white(s);

--- a/packages/tao/src/shared/logger.ts
+++ b/packages/tao/src/shared/logger.ts
@@ -10,7 +10,7 @@ export const logger = {
   warn: (s) => console.warn(chalk.bold(chalk.yellow(s))),
   error: (s) => {
     if (typeof s === 'string' && s.startsWith('NX ')) {
-      console.error(`\n${NX_ERROR} ${chalk.bold(chalk.red(s.substr(3)))}\n`);
+      console.error(`\n${NX_ERROR} ${chalk.bold(chalk.red(s.substring(3)))}\n`);
     } else if (s instanceof Error && s.stack) {
       console.error(chalk.bold(chalk.red(s.stack)));
     } else {
@@ -19,7 +19,7 @@ export const logger = {
   },
   info: (s) => {
     if (typeof s === 'string' && s.startsWith('NX ')) {
-      console.info(`\n${NX_PREFIX} ${chalk.bold(s.substr(3))}\n`);
+      console.info(`\n${NX_PREFIX} ${chalk.bold(s.substring(3))}\n`);
     } else {
       console.info(chalk.white(s));
     }

--- a/packages/tao/src/shared/print-help.ts
+++ b/packages/tao/src/shared/print-help.ts
@@ -3,7 +3,7 @@ import * as chalk from 'chalk';
 import { logger, stripIndent } from '../shared/logger';
 
 function formatOption(name: string, description: string) {
-  return `  --${`${name}                     `.substr(0, 22)}${chalk.grey(
+  return `  --${`${name}                     `.substring(0, 22)}${chalk.grey(
     description
   )}`;
 }

--- a/packages/web/src/executors/rollup/rollup.impl.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.ts
@@ -74,7 +74,7 @@ export default async function* rollupExecutor(
 
   const npmDeps = (projectGraph.dependencies[context.projectName] ?? [])
     .filter((d) => d.target.startsWith('npm:'))
-    .map((d) => d.target.substr(4));
+    .map((d) => d.target.substring(4));
 
   const rollupOptions = createRollupOptions(
     options,

--- a/packages/web/src/utils/serve-path.ts
+++ b/packages/web/src/utils/serve-path.ts
@@ -5,7 +5,7 @@ export function buildServePath(browserOptions: WebWebpackExecutorOptions) {
     _findDefaultServePath(browserOptions.baseHref, browserOptions.deployUrl) ||
     '/';
   if (servePath.endsWith('/')) {
-    servePath = servePath.substr(0, servePath.length - 1);
+    servePath = servePath.substring(0, servePath.length - 1);
   }
   if (!servePath.startsWith('/')) {
     servePath = `/${servePath}`;

--- a/packages/web/src/utils/web.config.ts
+++ b/packages/web/src/utils/web.config.ts
@@ -148,7 +148,8 @@ export function getStylesPartial(
     plugins: [
       postcssImports({
         addModulesDirectories: includePaths,
-        resolve: (url: string) => (url.startsWith('~') ? url.substr(1) : url),
+        resolve: (url: string) =>
+          url.startsWith('~') ? url.substring(1) : url,
         load: (filename: string) => {
           return new Promise<string>((resolve, reject) => {
             loader.fs.readFile(filename, (err: Error, data: Buffer) => {

--- a/packages/web/src/utils/webpack/partials/styles.ts
+++ b/packages/web/src/utils/webpack/partials/styles.ts
@@ -39,7 +39,8 @@ export function getStylesConfig(
       plugins: [
         postcssImports({
           addModulesDirectories: includePaths,
-          resolve: (url: string) => (url.startsWith('~') ? url.substr(1) : url),
+          resolve: (url: string) =>
+            url.startsWith('~') ? url.substring(1) : url,
           load: (filename: string) => {
             return new Promise<string>((resolve, reject) => {
               loader.fs.readFile(filename, (err: Error, data: Buffer) => {

--- a/packages/web/src/utils/webpack/plugins/postcss-cli-resources.ts
+++ b/packages/web/src/utils/webpack/plugins/postcss-cli-resources.ts
@@ -70,7 +70,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
     // If starts with a caret, remove and return remainder
     // this supports bypassing asset processing
     if (inputUrl.startsWith('^')) {
-      return inputUrl.substr(1);
+      return inputUrl.substring(1);
     }
     const cacheKey = path.resolve(context, inputUrl);
     const cachedUrl = resourceCache.get(cacheKey);
@@ -78,7 +78,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
       return cachedUrl;
     }
     if (inputUrl.startsWith('~')) {
-      inputUrl = inputUrl.substr(1);
+      inputUrl = inputUrl.substring(1);
     }
     if (inputUrl.startsWith('/')) {
       let outputUrl = '';

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -38,7 +38,7 @@ ${chalk.bold('Smart, Fast and Extensible Build System')}` +
         ? `
 
 ${daemonHelpOutput}
-  `.trimRight()
+  `.trimEnd()
         : '')
   )
   .command(
@@ -195,13 +195,13 @@ ${daemonHelpOutput}
     'daemon',
     `${chalk.bold('EXPERIMENTAL: Nx Daemon')}` +
       (daemonHelpOutput
-        ? stripIndents`${daemonHelpOutput}`.trimRight()
+        ? stripIndents`${daemonHelpOutput}`.trimEnd()
         : `
 
 The Daemon is not currently running you can start it manually by running the following command:
 
 npx nx daemon
-`.trimRight()),
+`.trimEnd()),
     (yargs) => linkToNxDevAndExamples(withDaemonStartOptions(yargs), 'daemon'),
     async (args) => (await import('./daemon')).daemonHandler(args)
   )

--- a/packages/workspace/src/core/hasher/file-hasher-base.ts
+++ b/packages/workspace/src/core/hasher/file-hasher-base.ts
@@ -63,7 +63,7 @@ export abstract class FileHasherBase {
       throw new Error('FileHasher is invoked before being initialized');
     }
     const relativePath = path.startsWith(appRootPath)
-      ? path.substr(appRootPath.length + 1)
+      ? path.substring(appRootPath.length + 1)
       : path;
     if (this.fileHashes[relativePath]) {
       return this.fileHashes[relativePath];

--- a/packages/workspace/src/core/project-graph/build-dependencies/implicit-project-dependencies.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/implicit-project-dependencies.ts
@@ -12,7 +12,7 @@ export function buildImplicitProjectDependencies(
     if (p.implicitDependencies && p.implicitDependencies.length > 0) {
       p.implicitDependencies.forEach((target) => {
         if (target.startsWith('!')) {
-          builder.removeDependency(source, target.substr(1));
+          builder.removeDependency(source, target.substring(1));
         } else {
           builder.addImplicitDependency(source, target);
         }

--- a/packages/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.ts
+++ b/packages/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.ts
@@ -164,6 +164,6 @@ export class TypeScriptImportLocator {
   }
 
   private getStringLiteralValue(node: ts.Node): string {
-    return node.getText().substr(1, node.getText().length - 2);
+    return node.getText().substring(1, node.getText().length - 2);
   }
 }

--- a/packages/workspace/src/generators/move/lib/normalize-schema.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.ts
@@ -9,7 +9,7 @@ export function normalizeSchema(
   projectConfiguration: ProjectConfiguration
 ): NormalizedSchema {
   const destination = schema.destination.startsWith('/')
-    ? normalizeSlashes(schema.destination.substr(1))
+    ? normalizeSlashes(schema.destination.substring(1))
     : schema.destination;
   const newProjectName = getNewProjectName(destination);
   const { npmScope } = getWorkspaceLayout(tree);

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -50,7 +50,7 @@ export function updateImports(
     from:
       fromPath ||
       normalizeSlashes(
-        `@${npmScope}/${project.root.substr(libsDir.length + 1)}`
+        `@${npmScope}/${project.root.substring(libsDir.length + 1)}`
       ),
     to: schema.importPath,
   };
@@ -76,7 +76,7 @@ export function updateImports(
   }
 
   const projectRoot = {
-    from: project.root.substr(libsDir.length + 1),
+    from: project.root.substring(libsDir.length + 1),
     to: schema.destination,
   };
 

--- a/packages/workspace/src/generators/remove/lib/update-tsconfig.ts
+++ b/packages/workspace/src/generators/remove/lib/update-tsconfig.ts
@@ -22,7 +22,7 @@ export function updateTsconfig(
   if (tree.exists(tsConfigPath)) {
     updateJson(tree, tsConfigPath, (json) => {
       delete json.compilerOptions.paths[
-        `@${npmScope}/${project.root.substr(
+        `@${npmScope}/${project.root.substring(
           project.projectType === 'application'
             ? appsDir.length + 1
             : libsDir.length + 1


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- `String.prototype.substr(...)` is used but deprecated (https://github.com/microsoft/TypeScript/blob/e2c00331d6daae6f35ebdef51602d0c8a73738fa/src/lib/es5.d.ts#L486-L492)
- `String.prototype.trimRight(...)` is used but deprecated (https://github.com/microsoft/TypeScript/blob/e2c00331d6daae6f35ebdef51602d0c8a73738fa/src/lib/es2019.string.d.ts#L14-L19)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- `substring(...)` should be used
- `trimEnd(...)` should be used

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
