### PR TITLE
fix(misc): fix jest migrate 13.4.4 script handling missing transform

### DIFF
--- a/packages/jest/src/migrations/update-13-4-4/add-missing-root-babel-config.ts
+++ b/packages/jest/src/migrations/update-13-4-4/add-missing-root-babel-config.ts
@@ -5,8 +5,8 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
-import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
 import { JestExecutorOptions } from '@nrwl/jest/src/executors/jest/schema';
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
 import { jestConfigObject } from '../../utils/config/functions';
 import { nxVersion } from '../../utils/versions';
 
@@ -33,12 +33,14 @@ function checkIfProjectNeedsUpdate(tree: Tree): boolean {
 
       const config = jestConfigObject(tree, jestConfigPath);
 
-      for (const transformer of Object.values(config.transform)) {
-        if (
-          (typeof transformer === 'string' && transformer === 'babel-jest') ||
-          (Array.isArray(transformer) && transformer[0] === 'babel-jest')
-        ) {
-          shouldUpdate = true;
+      if (config.transform) {
+        for (const transformer of Object.values(config.transform)) {
+          if (
+            (typeof transformer === 'string' && transformer === 'babel-jest') ||
+            (Array.isArray(transformer) && transformer[0] === 'babel-jest')
+          ) {
+            shouldUpdate = true;
+          }
         }
       }
     }


### PR DESCRIPTION
Fix issue for migrating jest plugin to 13.4.4 when the projects
 may have a custom preset that
excludes the transform property
 from the jest.config.js.
 Just adds an if statement around the
loop for the transform property

ISSUES CLOSED: #8566


## Current Behavior
Migration script for jest 13.4.4 fails when using a custom preset that removes the `transform` property from the jest.config.js

## Expected Behavior
Migration script passes

## Related Issue(s)

Fixes #8566 
