### PR TITLE
fix(misc): handle migrating packages with numbers in the name

### DIFF
--- a/packages/tao/src/commands/migrate.spec.ts
+++ b/packages/tao/src/commands/migrate.spec.ts
@@ -673,6 +673,10 @@ describe('Migration', () => {
     });
 
     it('should handle different variations of the target package', () => {
+      expect(parseMigrationsOptions(['@angular/core'])).toMatchObject({
+        targetPackage: '@angular/core',
+        targetVersion: 'latest',
+      });
       expect(parseMigrationsOptions(['8.12'])).toMatchObject({
         targetPackage: '@nrwl/workspace',
         targetVersion: '8.12.0',
@@ -680,6 +684,10 @@ describe('Migration', () => {
       expect(parseMigrationsOptions(['8'])).toMatchObject({
         targetPackage: '@nrwl/workspace',
         targetVersion: '8.0.0',
+      });
+      expect(parseMigrationsOptions(['12'])).toMatchObject({
+        targetPackage: '@nrwl/workspace',
+        targetVersion: '12.0.0',
       });
       expect(parseMigrationsOptions(['next'])).toMatchObject({
         targetPackage: '@nrwl/workspace',
@@ -695,6 +703,10 @@ describe('Migration', () => {
       });
       expect(parseMigrationsOptions(['mypackage'])).toMatchObject({
         targetPackage: 'mypackage',
+        targetVersion: 'latest',
+      });
+      expect(parseMigrationsOptions(['mypackage2'])).toMatchObject({
+        targetPackage: 'mypackage2',
         targetVersion: 'latest',
       });
       expect(parseMigrationsOptions(['@nrwl/workspace@latest'])).toMatchObject({

--- a/packages/tao/src/commands/migrate.ts
+++ b/packages/tao/src/commands/migrate.ts
@@ -359,7 +359,11 @@ function parseTargetPackageAndVersion(args: string) {
       return { targetPackage, targetVersion };
     }
   } else {
-    if (args.match(/[0-9]/) || args === 'latest' || args === 'next') {
+    if (
+      args.match(/^\d+(?:\.\d+)?(?:\.\d+)?$/) ||
+      args === 'latest' ||
+      args === 'next'
+    ) {
       return {
         targetPackage: '@nrwl/workspace',
         targetVersion: normalizeVersionWithTagCheck(args),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx migrate angular-oauth2-oidc` will be parsed incorrectly to try and migrate `@nrwl/workspace@0.0.0`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx migrate angular-oauth2-oidc` should be parsed correctly to try and migrate `angular-oath2-oidc@latest`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/8586
