### PR TITLE
feat(angular): pass additional args to custom webpack configuration function

### DIFF
--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -69,7 +69,11 @@ function buildAppWithCustomWebpackConfiguration(
       // The extra Webpack configuration file can export a synchronous or asynchronous function,
       // for instance: `module.exports = async config => { ... }`.
       if (typeof customWebpackConfiguration === 'function') {
-        return customWebpackConfiguration(baseWebpackConfig);
+        return customWebpackConfiguration(
+          baseWebpackConfig,
+          options,
+          context.target
+        );
       } else {
         return merge(
           baseWebpackConfig,


### PR DESCRIPTION
Build target and builder options are needed many times, eg for loaders that need deployUrl or other custom logic that is based on  build configuration

this also aligns with how [@angular-builders/custom-webpack builder is passing options](https://github.com/just-jeb/angular-builders/blob/8cf42d63ce1fc38101d22d85949d5812b8846374/packages/custom-webpack/src/custom-webpack-builder.ts#L48)

I need it for migrating to your builder ;-)

## Current Behavior
only the CLI webpack config is passed on the configuration function, not possible to know the current build target/configuration context

## Expected Behavior
Custom webpack configuration should be able to take in account the current target and the options the builder received.


