### PR TITLE
docs(nxdev): fix plugins header link

### DIFF
--- a/nx-dev/ui-common/src/lib/header.tsx
+++ b/nx-dev/ui-common/src/lib/header.tsx
@@ -72,7 +72,7 @@ export function Header(props: HeaderProps) {
                 Docs
               </a>
             </Link>
-            <Link href="/getting-started/nx-devkit">
+            <Link href="/using-nx/nx-devkit">
               <a
                 title="Check Nx available plugins"
                 className="px-3 py-2 hidden md:inline-flex text-white leading-tight"


### PR DESCRIPTION
## What it does?
It fixes the header plugins link on nx.dev.