### PR TITLE
fix(linter): make eslint peer dependency optional

### DIFF
--- a/packages/linter/package.json
+++ b/packages/linter/package.json
@@ -38,5 +38,10 @@
     "@nrwl/jest": "*",
     "tmp": "~0.2.1",
     "tslib": "^2.3.0"
+  },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Peer dependency on eslint is not optional.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Peer dependency on eslint is optional

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
