### PR TITLE
fix(react): enforce valid jest config when creating workspace with react preset

### DIFF
--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -17,6 +17,7 @@ import { join } from 'path';
 import { dirSync } from 'tmp';
 import { check as portCheck } from 'tcp-port-used';
 import {
+  joinPathFragments,
   parseJson,
   ProjectConfiguration,
   WorkspaceJsonConfiguration,
@@ -763,6 +764,13 @@ export function expectNoAngularDevkit() {
   const { list } = getPackageManagerCommand();
   const result = runCommand(`${list} @angular-devkit/core`);
   expect(result).not.toContain('@angular-devkit/core');
+}
+
+export function expectNoTsJestInJestConfig(appName: string) {
+  const jestConfig = readFile(
+    joinPathFragments('apps', appName, 'jest.config.js')
+  );
+  expect(jestConfig).not.toContain('ts-jest');
 }
 
 export function waitUntil(

--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -3,6 +3,7 @@ import {
   checkFilesExist,
   e2eCwd,
   expectNoAngularDevkit,
+  expectNoTsJestInJestConfig,
   getPackageManagerCommand,
   getSelectedPackageManager,
   packageManagerLockFile,
@@ -103,6 +104,7 @@ describe('create-nx-workspace', () => {
     });
 
     expectNoAngularDevkit();
+    expectNoTsJestInJestConfig(appName);
   });
 
   it('should be able to create an next workspace', () => {
@@ -153,6 +155,7 @@ describe('create-nx-workspace', () => {
     });
 
     expectNoAngularDevkit();
+    expectNoTsJestInJestConfig(appName);
   });
 
   it('should be able to create an express workspace', () => {

--- a/packages/react/src/generators/application/lib/normalize-options.ts
+++ b/packages/react/src/generators/application/lib/normalize-options.ts
@@ -33,6 +33,7 @@ export function normalizeOptions(
   options.classComponent = options.classComponent ?? false;
   options.unitTestRunner = options.unitTestRunner ?? 'jest';
   options.e2eTestRunner = options.e2eTestRunner ?? 'cypress';
+  options.compiler = options.compiler ?? 'babel';
 
   return {
     ...options,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
* `create-nx-workspace` uses `ts-jest` in jest config when using `react` preset
<!-- This is the behavior we have today -->

## Expected Behavior
* `create-nx-workspace` uses `babel-jest` for jest config when using `react` preset

<!-- This is the behavior we should expect with the changes in this PR -->
## Additional Info
#8354 reported that the jest config for a React app was different when using the `react` preset on `create-nx-workspace` vs creating an app using the generator. The default React compiler option `babel` wasn’t getting passed to the app generator when invoked from `create-nx-workspace` so the jest generator was defaulting to using `ts-lint`. this change should ensure that the default `babel` compiler is always used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8354
