### PR TITLE
chore(core): update license-webpack-plugin to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "kill-port": "^1.6.1",
     "less": "3.12.2",
     "less-loader": "^10.1.0",
-    "license-webpack-plugin": "2.3.15",
+    "license-webpack-plugin": "4.0.0",
     "loader-utils": "1.2.3",
     "memfs": "^3.0.1",
     "metro-resolver": "^0.66.2",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -40,7 +40,7 @@
     "fork-ts-checker-webpack-plugin": "6.2.10",
     "fs-extra": "^9.1.0",
     "glob": "7.1.4",
-    "license-webpack-plugin": "2.3.15",
+    "license-webpack-plugin": "4.0.0",
     "rxjs": "^6.5.4",
     "source-map-support": "0.5.19",
     "tree-kill": "1.2.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -72,7 +72,7 @@
     "identity-obj-proxy": "3.0.0",
     "less": "3.12.2",
     "less-loader": "^10.1.0",
-    "license-webpack-plugin": "2.3.15",
+    "license-webpack-plugin": "4.0.0",
     "loader-utils": "1.2.3",
     "mini-css-extract-plugin": "~2.4.7",
     "parse5": "4.0.0",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- `license-webpack-plugin` v2.3.15 is used
- other packages (e.g. `@angular-devkit/build-angular@13.1.1`) use v4.0.0 of the plugin. so it gets installed at least twice in a typical Nx workspace

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- `license-webpack-plugin` v4.0.0 should be used

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
