### PR TITLE
fix(angular): update tailwind content glob pattern to ignore stories and tests

### DIFF
--- a/e2e/angular-extensions/src/tailwind.test.ts
+++ b/e2e/angular-extensions/src/tailwind.test.ts
@@ -52,7 +52,10 @@ describe('Tailwind support', () => {
     const tailwindConfigFile = 'tailwind.config.js';
 
     const tailwindConfig = `module.exports = {
-      content: ['./apps/**/*.{html,ts}', './libs/**/*.{html,ts}'],
+      content: [
+        './apps/**/!(*.stories|*.spec).{ts,html}',
+        './libs/**/!(*.stories|*.spec).{ts,html}',
+      ],
       theme: {
         spacing: {
           sm: '${spacing.root.sm}',
@@ -76,7 +79,7 @@ describe('Tailwind support', () => {
   
     module.exports = {
       content: [
-        join(__dirname, 'src/**/*.{html,ts}'),
+        join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
         ...createGlobPatternsForDependencies(__dirname),
       ],
       theme: {

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -972,7 +972,7 @@ describe('app', () => {
 
         module.exports = {
           content: [
-            join(__dirname, 'src/**/*.{html,ts}'),
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
             ...createGlobPatternsForDependencies(__dirname),
           ],
           theme: {

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -1371,7 +1371,7 @@ describe('lib', () => {
 
         module.exports = {
           content: [
-            join(__dirname, 'src/**/*.{html,ts}'),
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
             ...createGlobPatternsForDependencies(__dirname),
           ],
           theme: {

--- a/packages/angular/src/generators/setup-tailwind/files/v2/tailwind.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-tailwind/files/v2/tailwind.config.js__tmpl__
@@ -4,7 +4,7 @@ const { join } = require('path');
 module.exports = {
   mode: 'jit',
   purge: [
-    join(__dirname, '<%= relativeSourceRoot %>/**/*.{html,ts}'),
+    join(__dirname, '<%= relativeSourceRoot %>/**/!(*.stories|*.spec).{ts,html}'),
     ...createGlobPatternsForDependencies(__dirname),
   ],
   darkMode: false, // or 'media' or 'class'

--- a/packages/angular/src/generators/setup-tailwind/files/v3/tailwind.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-tailwind/files/v3/tailwind.config.js__tmpl__
@@ -3,7 +3,7 @@ const { join } = require('path');
 
 module.exports = {
   content: [
-    join(__dirname, '<%= relativeSourceRoot %>/**/*.{html,ts}'),
+    join(__dirname, '<%= relativeSourceRoot %>/**/!(*.stories|*.spec).{ts,html}'),
     ...createGlobPatternsForDependencies(__dirname),
   ],
   theme: {

--- a/packages/angular/src/generators/setup-tailwind/setup-tailwind.application.spec.ts
+++ b/packages/angular/src/generators/setup-tailwind/setup-tailwind.application.spec.ts
@@ -333,7 +333,7 @@ describe('setupTailwind generator', () => {
 
         module.exports = {
           content: [
-            join(__dirname, 'src/**/*.{html,ts}'),
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
             ...createGlobPatternsForDependencies(__dirname),
           ],
           theme: {
@@ -362,7 +362,7 @@ describe('setupTailwind generator', () => {
 
         module.exports = {
           content: [
-            join(__dirname, 'src/**/*.{html,ts}'),
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
             ...createGlobPatternsForDependencies(__dirname),
           ],
           theme: {
@@ -392,7 +392,7 @@ describe('setupTailwind generator', () => {
         module.exports = {
           mode: 'jit',
           purge: [
-            join(__dirname, 'src/**/*.{html,ts}'),
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
             ...createGlobPatternsForDependencies(__dirname),
           ],
           darkMode: false, // or 'media' or 'class'

--- a/packages/angular/src/generators/setup-tailwind/setup-tailwind.library.spec.ts
+++ b/packages/angular/src/generators/setup-tailwind/setup-tailwind.library.spec.ts
@@ -202,7 +202,7 @@ describe('setupTailwind generator', () => {
 
         module.exports = {
           content: [
-            join(__dirname, 'src/**/*.{html,ts}'),
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
             ...createGlobPatternsForDependencies(__dirname),
           ],
           theme: {
@@ -234,7 +234,7 @@ describe('setupTailwind generator', () => {
 
         module.exports = {
           content: [
-            join(__dirname, 'src/**/*.{html,ts}'),
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
             ...createGlobPatternsForDependencies(__dirname),
           ],
           theme: {
@@ -267,7 +267,7 @@ describe('setupTailwind generator', () => {
         module.exports = {
           mode: 'jit',
           purge: [
-            join(__dirname, 'src/**/*.{html,ts}'),
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
             ...createGlobPatternsForDependencies(__dirname),
           ],
           darkMode: false, // or 'media' or 'class'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The glob pattern generated for the Tailwind `content` (or `purge`) configuration sets to scan all `.ts` files within the source of the project.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The glob pattern generated for the Tailwind `content` (or `purge`) configuration should not be set to scan Storybook stories or tests files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
