### PR TITLE
docs(nx): fix extra close array bracket in project.json configuration

### DIFF
--- a/docs/shared/configuration/projectjson.md
+++ b/docs/shared/configuration/projectjson.md
@@ -61,7 +61,7 @@ Let's look at the following `project.json`:
     }
   },
   "tags": ["scope:myteam"],
-  "implicitDependencies": ["anotherlib"]]
+  "implicitDependencies": ["anotherlib"]
 }
 ```
 


### PR DESCRIPTION
An extra close array after `implicitDependencies` causes a json file error. Removing this in the documentation

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
N/A

## Expected Behavior
N/A

## Related Issue(s)
N/A

Fixes #
