### PR TITLE
fix(core): handle merging npm scripts with project at the root

### DIFF
--- a/packages/workspace/src/utilities/project-graph-utils.spec.ts
+++ b/packages/workspace/src/utilities/project-graph-utils.spec.ts
@@ -197,5 +197,32 @@ describe('project graph utils', () => {
         },
       });
     });
+
+    it("should work when project root is ''", () => {
+      jsonFileOverrides['package.json'] = {
+        name: 'my-app',
+        scripts: {
+          test: 'echo testing',
+        },
+      };
+
+      const result = mergeNpmScriptsWithTargets('', {
+        build: {
+          executor: '@nrwl/workspace:run-commands',
+          options: { command: 'echo hi' },
+        },
+      });
+
+      expect(result).toEqual({
+        build: {
+          executor: '@nrwl/workspace:run-commands',
+          options: { command: 'echo hi' },
+        },
+        test: {
+          executor: '@nrwl/workspace:run-script',
+          options: { script: 'test' },
+        },
+      });
+    });
   });
 });

--- a/packages/workspace/src/utilities/project-graph-utils.ts
+++ b/packages/workspace/src/utilities/project-graph-utils.ts
@@ -36,7 +36,7 @@ export function mergeNpmScriptsWithTargets(
 ): Record<string, TargetConfiguration> {
   try {
     const { scripts, nx }: PackageJson = readJsonFile(
-      `${projectRoot}/package.json`
+      join(projectRoot, 'package.json')
     );
     const res: Record<string, TargetConfiguration> = {};
     // handle no scripts


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Projects at the root (which happens often when Angular CLI projects are migrated to Nx) will not be able to run their targets.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Projects at the root will be able to run their targets.

Fixes https://github.com/nrwl/nx/issues/8585
