### PR TITLE
feat(angular): add --export flag to scam

### DIFF
--- a/docs/generated/api-angular/generators/scam.md
+++ b/docs/generated/api-angular/generators/scam.md
@@ -57,6 +57,14 @@ Type: `boolean`
 
 Specifies if the style will contain `:host { display: block; }`.
 
+### export
+
+Default: `false`
+
+Type: `boolean`
+
+Specifies if the SCAM should be exported from the project's entry point (normally `index.ts`). It only applies to libraries.
+
 ### flat
 
 Default: `false`

--- a/packages/angular/src/generators/scam/schema.d.ts
+++ b/packages/angular/src/generators/scam/schema.d.ts
@@ -15,4 +15,5 @@ export interface Schema {
   prefix?: string;
   selector?: string;
   skipSelector?: boolean;
+  export?: boolean;
 }

--- a/packages/angular/src/generators/scam/schema.json
+++ b/packages/angular/src/generators/scam/schema.json
@@ -109,6 +109,11 @@
           "format": "html-selector"
         }
       ]
+    },
+    "export": {
+      "type": "boolean",
+      "description": "Specifies if the SCAM should be exported from the project's entry point (normally `index.ts`). It only applies to libraries.",
+      "default": false
     }
   },
   "required": ["name"]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
No current way to export SCAMs at project entry point

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Allow a flag that will export the SCAM at the project entry point


