### PR TITLE
feat(linter): add warning to nx rule when project graph is unavailable

### DIFF
--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -28,7 +28,6 @@ import isCI = require('is-ci');
 
 import chalk = require('chalk');
 import treeKill = require('tree-kill');
-import { Tree } from '../../packages/tao/src/shared/tree';
 
 const kill = require('kill-port');
 export const isWindows = require('is-windows');

--- a/packages/eslint-plugin-nx/package.json
+++ b/packages/eslint-plugin-nx/package.json
@@ -30,6 +30,7 @@
     "@nrwl/devkit": "*",
     "@nrwl/workspace": "*",
     "@typescript-eslint/experimental-utils": "~5.3.0",
+    "chalk": "4.1.0",
     "confusing-browser-globals": "^1.0.9",
     "ts-node": "^9.1.1",
     "tsconfig-paths": "^3.9.0"

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -34,6 +34,7 @@ import {
 } from '@nrwl/workspace/src/utils/graph-utils';
 import { isRelativePath } from '@nrwl/workspace/src/utilities/fileutils';
 import { isSecondaryEntrypoint as isAngularSecondaryEntrypoint } from '../utils/angular';
+import * as chalk from 'chalk';
 
 type Options = [
   {
@@ -145,7 +146,16 @@ export default createESLintRule<Options, MessageIds>({
         (global as any).projectGraph = mapProjectGraphFiles(
           readCachedProjectGraph()
         );
-      } catch {}
+      } catch {
+        const WARNING_PREFIX = `${chalk.reset.keyword('orange')('warning')}`;
+        const RULE_NAME_SUFFIX = `${chalk.reset.dim(
+          '@nrwl/nx/enforce-module-boundaries'
+        )}`;
+        process.stdout
+          .write(`${WARNING_PREFIX} No cached ProjectGraph is available. The rule will be skipped.
+        If you encounter this error as part of running standard \`nx\` commands then please open an issue on https://github.com/nrwl/nx
+        ${RULE_NAME_SUFFIX}\n`);
+      }
     }
 
     if (!(global as any).projectGraph) {


### PR DESCRIPTION
When `enforce-module-boundaries` is run outside of Nx, the project graph might not be available.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We skip the rule, without informing the user of that action

## Expected Behavior
The user should be informed that the rule is skipped due to the graph not being available.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8110
