### PR TITLE
fix(web): web executor referencing wrong file

### DIFF
--- a/packages/web/executors.json
+++ b/packages/web/executors.json
@@ -6,7 +6,7 @@
       "description": "Build an application using webpack"
     },
     "rollup": {
-      "implementation": "./src/executors/rollup/rollup.impl",
+      "implementation": "./src/executors/rollup/compat",
       "schema": "./src/executors/rollup/schema.json",
       "description": "Package a library using rollup"
     },


### PR DESCRIPTION
ISSUES CLOSED: #8607

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Rollup build executor (inside `packages/web/executors.json` referencing the wrong file `rollup.impl`)
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Should reference `rollup/compact`
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8607
