### PR TITLE
fix(dep-graph): set the number of workers with environment variables

### DIFF
--- a/packages/workspace/src/core/project-graph/build-project-graph.ts
+++ b/packages/workspace/src/core/project-graph/build-project-graph.ts
@@ -197,7 +197,7 @@ function buildExplicitDependencies(
   // files we need to process is >= 100 and there are more than 2 CPUs
   // to be able to use at least 2 workers (1 worker per CPU and
   // 1 CPU for the main thread)
-  if (totalNumOfFilesToProcess < 100 || os.cpus().length < 3) {
+  if (totalNumOfFilesToProcess < 100 || getNumberOfWorkers() <= 2) {
     return buildExplicitDependenciesWithoutWorkers(
       jsPluginConfig,
       ctx,
@@ -296,7 +296,7 @@ function buildExplicitDependenciesUsingWorkers(
   totalNumOfFilesToProcess: number,
   builder: ProjectGraphBuilder
 ) {
-  const numberOfWorkers = os.cpus().length - 1;
+  const numberOfWorkers = getNumberOfWorkers();
   const bins = splitFilesIntoBins(
     ctx,
     totalNumOfFilesToProcess,
@@ -347,6 +347,10 @@ function buildExplicitDependenciesUsingWorkers(
       w.postMessage({ filesToProcess: bins.shift() });
     }
   });
+}
+
+function getNumberOfWorkers(): number {
+  return +process.env.NX_PROJECT_GRAPH_MAX_WORKERS ?? os.cpus().length - 1;
 }
 
 function createContext(


### PR DESCRIPTION
With docker, the result of os.cpus() can be wrong (https://github.com/nodejs/node/issues/28762). In my company CI, it's lead to random failure with error 137.

## Current Behavior
In my company we have a server with 64 cores to run our build pipline, but when we run the container with the limit of 4 cores, os.cpus().length return 64 instead 4. 
It's a known issue in node.js https://github.com/nodejs/node/issues/28762.

## Expected Behavior
Run only the right number of workers.
