### PR TITLE
feat(angular): add --export to scam-pipe generator

### DIFF
--- a/docs/generated/api-angular/generators/scam-pipe.md
+++ b/docs/generated/api-angular/generators/scam-pipe.md
@@ -35,6 +35,14 @@ Type: `string`
 
 The name of the pipe.
 
+### export
+
+Default: `false`
+
+Type: `boolean`
+
+Specifies if the SCAM should be exported from the project's entry point (normally `index.ts`). It only applies to libraries.
+
 ### flat
 
 Default: `true`

--- a/packages/angular/src/generators/scam-pipe/lib/create-module.spec.ts
+++ b/packages/angular/src/generators/scam-pipe/lib/create-module.spec.ts
@@ -1,4 +1,4 @@
-import { addProjectConfiguration } from '@nrwl/devkit';
+import { addProjectConfiguration, logger } from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { createScamPipe } from './create-module';
@@ -59,6 +59,111 @@ describe('Create module in the tree', () => {
         exports: [ExamplePipe],
       })
       export class ExamplePipeModule {}"
+    `);
+  });
+
+  it('should warn when export called for app project', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'app1', {
+      projectType: 'application',
+      sourceRoot: 'apps/app1/src',
+      root: 'apps/app1',
+    });
+
+    const angularComponentSchematic = wrapAngularDevkitSchematic(
+      '@schematics/angular',
+      'pipe'
+    );
+    await angularComponentSchematic(tree, {
+      name: 'example',
+      project: 'app1',
+      skipImport: true,
+      export: false,
+      flat: false,
+    });
+
+    const mockLoggerWarn = jest.spyOn(logger, 'warn');
+
+    // ACT
+    createScamPipe(tree, {
+      name: 'example',
+      project: 'app1',
+      inlineScam: true,
+      flat: false,
+      export: true,
+    });
+
+    // ASSERT
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      '--export=true was ignored as the project the SCAM is being generated in is not a library.'
+    );
+  });
+
+  it('should create the scam pipe inline and export it correctly', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'lib1', {
+      projectType: 'library',
+      sourceRoot: 'libs/lib1/src',
+      root: 'libs/lib1',
+    });
+
+    const angularComponentSchematic = wrapAngularDevkitSchematic(
+      '@schematics/angular',
+      'pipe'
+    );
+    await angularComponentSchematic(tree, {
+      name: 'example',
+      project: 'lib1',
+      skipImport: true,
+      export: false,
+      flat: false,
+    });
+
+    tree.write('libs/lib1/src/index.ts', '');
+
+    // ACT
+    createScamPipe(tree, {
+      name: 'example',
+      project: 'lib1',
+      inlineScam: true,
+      flat: false,
+      export: true,
+    });
+
+    // ASSERT
+    const pipeSource = tree.read(
+      'libs/lib1/src/lib/example/example.pipe.ts',
+      'utf-8'
+    );
+    expect(pipeSource).toMatchInlineSnapshot(`
+      "import { Pipe, PipeTransform, NgModule } from '@angular/core';
+      import { CommonModule } from '@angular/common';
+
+      @Pipe({
+        name: 'example'
+      })
+      export class ExamplePipe implements PipeTransform {
+
+        transform(value: unknown, ...args: unknown[]): unknown {
+          return null;
+        }
+
+      }
+
+      @NgModule({
+        imports: [CommonModule],
+        declarations: [ExamplePipe],
+        exports: [ExamplePipe],
+      })
+      export class ExamplePipeModule {}"
+    `);
+
+    const entryPointSource = tree.read('libs/lib1/src/index.ts', 'utf-8');
+    expect(entryPointSource).toMatchInlineSnapshot(`
+      "
+        export * from \\"./lib/example/example.pipe\\";"
     `);
   });
 

--- a/packages/angular/src/generators/scam-pipe/lib/create-module.ts
+++ b/packages/angular/src/generators/scam-pipe/lib/create-module.ts
@@ -1,4 +1,4 @@
-import type { Tree } from '@nrwl/devkit';
+import { logger, readJson, Tree } from '@nrwl/devkit';
 import type { Schema } from '../schema';
 
 import {
@@ -78,16 +78,75 @@ export function createScamPipe(tree: Tree, schema: Schema) {
     )}`;
 
     tree.write(pipeFilePath, updatedPipeSource);
+    exportScam(tree, schema, pipeFilePath);
     return;
   }
 
+  const scamFilePath = joinPathFragments(
+    pipeDirectory,
+    `${pipeNames.fileName}.module.ts`
+  );
+
   tree.write(
-    joinPathFragments(pipeDirectory, `${pipeNames.fileName}.module.ts`),
+    scamFilePath,
     createSeparateAngularPipeModuleFile(
       `${pipeNames.className}${typeNames.className}`,
       pipeFileName
     )
   );
+
+  exportScam(tree, schema, scamFilePath);
+}
+
+function exportScam(tree: Tree, schema: Schema, scamFilePath: string) {
+  if (!schema.export) {
+    return;
+  }
+
+  const project =
+    schema.project ?? readWorkspaceConfiguration(tree).defaultProject;
+
+  const { root, sourceRoot, projectType } = readProjectConfiguration(
+    tree,
+    project
+  );
+
+  if (projectType === 'application') {
+    logger.warn(
+      '--export=true was ignored as the project the SCAM is being generated in is not a library.'
+    );
+
+    return;
+  }
+
+  const ngPackageJsonPath = joinPathFragments(root, 'ng-package.json');
+  const ngPackageEntryPoint = tree.exists(ngPackageJsonPath)
+    ? readJson(tree, ngPackageJsonPath).lib?.entryFile
+    : undefined;
+
+  const projectEntryPoint = ngPackageEntryPoint
+    ? joinPathFragments(root, ngPackageEntryPoint)
+    : joinPathFragments(sourceRoot, `index.ts`);
+
+  if (!tree.exists(projectEntryPoint)) {
+    // Let's not error, simply warn the user
+    // It's not too much effort to manually do this
+    // It would be more frustrating to have to find the correct path and re-run the command
+    logger.warn(
+      `Could not export SCAM. Unable to determine project's entry point. Path ${projectEntryPoint} does not exist. SCAM has still been created.`
+    );
+
+    return;
+  }
+
+  const relativePathFromEntryPoint = `.${scamFilePath
+    .split(sourceRoot)[1]
+    .replace('.ts', '')}`;
+
+  const updateEntryPointContent = `${tree.read(projectEntryPoint)}
+  export * from "${relativePathFromEntryPoint}";`;
+
+  tree.write(projectEntryPoint, updateEntryPointContent);
 }
 
 function createAngularPipeModule(name: string) {

--- a/packages/angular/src/generators/scam-pipe/schema.d.ts
+++ b/packages/angular/src/generators/scam-pipe/schema.d.ts
@@ -5,4 +5,5 @@ export interface Schema {
   skipTests?: boolean;
   inlineScam?: boolean;
   flat?: boolean;
+  export?: boolean;
 }

--- a/packages/angular/src/generators/scam-pipe/schema.json
+++ b/packages/angular/src/generators/scam-pipe/schema.json
@@ -43,6 +43,11 @@
       "type": "boolean",
       "description": "Create the new files at the top level of the current project.",
       "default": true
+    },
+    "export": {
+      "type": "boolean",
+      "description": "Specifies if the SCAM should be exported from the project's entry point (normally `index.ts`). It only applies to libraries.",
+      "default": false
     }
   },
   "required": ["name"]


### PR DESCRIPTION
Current Behavior
No current way to export SCAM for pipe at project entry point

Expected Behavior
Allow a flag that will export the SCAM for pipe at the project entry point