### PR TITLE
feat(angular): add --export flag to scam-directive

### DIFF
--- a/docs/generated/api-angular/generators/scam-directive.md
+++ b/docs/generated/api-angular/generators/scam-directive.md
@@ -35,6 +35,14 @@ Type: `string`
 
 The name of the directive.
 
+### export
+
+Default: `false`
+
+Type: `boolean`
+
+Specifies if the SCAM should be exported from the project's entry point (normally `index.ts`). It only applies to libraries.
+
 ### flat
 
 Default: `true`

--- a/packages/angular/src/generators/scam-directive/lib/create-module.spec.ts
+++ b/packages/angular/src/generators/scam-directive/lib/create-module.spec.ts
@@ -1,4 +1,4 @@
-import { addProjectConfiguration } from '@nrwl/devkit';
+import { addProjectConfiguration, logger } from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { createScamDirective } from './create-module';
@@ -59,6 +59,106 @@ describe('Create module in the tree', () => {
       })
       export class ExampleDirectiveModule {}"
     `);
+  });
+
+  it('should create the scam directive and export it correctly', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'lib1', {
+      projectType: 'library',
+      sourceRoot: 'lib1/lib1/src',
+      root: 'lib1/lib1',
+    });
+
+    const angularDirectiveSchematic = wrapAngularDevkitSchematic(
+      '@schematics/angular',
+      'directive'
+    );
+    await angularDirectiveSchematic(tree, {
+      name: 'example',
+      project: 'lib1',
+      skipImport: true,
+      export: false,
+      flat: false,
+    });
+
+    // ACT
+    createScamDirective(tree, {
+      name: 'example',
+      project: 'lib1',
+      inlineScam: true,
+      flat: false,
+      export: true,
+    });
+
+    // ASSERT
+    const directiveSource = tree.read(
+      'lib1/lib1/src/lib/example/example.directive.ts',
+      'utf-8'
+    );
+
+    expect(directiveSource).toMatchInlineSnapshot(`
+      "import { Directive, NgModule } from '@angular/core';
+      import { CommonModule } from '@angular/common';
+
+      @Directive({
+        selector: '[example]'
+      })
+      export class ExampleDirective {
+
+        constructor() { }
+
+      }
+
+      @NgModule({
+        imports: [CommonModule],
+        declarations: [ExampleDirective],
+        exports: [ExampleDirective],
+      })
+      export class ExampleDirectiveModule {}"
+    `);
+
+    const entryPointSource = tree.read('lib1/lib1/src/index.ts', 'utf-8');
+
+    expect(entryPointSource).toMatchInlineSnapshot(`null`);
+  });
+
+  it('should warn if export=true and project is application', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'app1', {
+      projectType: 'application',
+      sourceRoot: 'apps/app1/src',
+      root: 'apps/app1',
+    });
+
+    const angularDirectiveSchematic = wrapAngularDevkitSchematic(
+      '@schematics/angular',
+      'directive'
+    );
+    await angularDirectiveSchematic(tree, {
+      name: 'example',
+      project: 'app1',
+      skipImport: true,
+      export: false,
+      flat: false,
+    });
+
+    const mockLoggerWarn = jest.spyOn(logger, 'warn');
+
+    // ACT
+    createScamDirective(tree, {
+      name: 'example',
+      project: 'app1',
+      inlineScam: true,
+      flat: false,
+      export: true,
+    });
+
+    // ASSERT
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      '--export=true was ignored as the project the SCAM is being generated in is not a library.'
+    );
   });
 
   it('should create the scam directive separately correctly', async () => {

--- a/packages/angular/src/generators/scam-directive/lib/create-module.ts
+++ b/packages/angular/src/generators/scam-directive/lib/create-module.ts
@@ -1,4 +1,4 @@
-import type { Tree } from '@nrwl/devkit';
+import { logger, readJson, Tree } from '@nrwl/devkit';
 import type { Schema } from '../schema';
 
 import {
@@ -81,19 +81,75 @@ export function createScamDirective(tree: Tree, schema: Schema) {
     )}`;
 
     tree.write(directiveFilePath, updatedDirectiveSource);
+    exportScam(tree, schema, directiveFilePath);
     return;
   }
 
+  const scamFilePath = joinPathFragments(
+    directiveDirectory,
+    `${directiveNames.fileName}.module.ts`
+  );
+
   tree.write(
-    joinPathFragments(
-      directiveDirectory,
-      `${directiveNames.fileName}.module.ts`
-    ),
+    scamFilePath,
     createSeparateAngularDirectiveModuleFile(
       `${directiveNames.className}${typeNames.className}`,
       directiveFileName
     )
   );
+
+  exportScam(tree, schema, scamFilePath);
+}
+
+function exportScam(tree: Tree, schema: Schema, scamFilePath: string) {
+  if (!schema.export) {
+    return;
+  }
+
+  const project =
+    schema.project ?? readWorkspaceConfiguration(tree).defaultProject;
+
+  const { root, sourceRoot, projectType } = readProjectConfiguration(
+    tree,
+    project
+  );
+
+  if (projectType === 'application') {
+    logger.warn(
+      '--export=true was ignored as the project the SCAM is being generated in is not a library.'
+    );
+
+    return;
+  }
+
+  const ngPackageJsonPath = joinPathFragments(root, 'ng-package.json');
+  const ngPackageEntryPoint = tree.exists(ngPackageJsonPath)
+    ? readJson(tree, ngPackageJsonPath).lib?.entryFile
+    : undefined;
+
+  const projectEntryPoint = ngPackageEntryPoint
+    ? joinPathFragments(root, ngPackageEntryPoint)
+    : joinPathFragments(sourceRoot, `index.ts`);
+
+  if (!tree.exists(projectEntryPoint)) {
+    // Let's not error, simply warn the user
+    // It's not too much effort to manually do this
+    // It would be more frustrating to have to find the correct path and re-run the command
+    logger.warn(
+      `Could not export SCAM. Unable to determine project's entry point. Path ${projectEntryPoint} does not exist. SCAM has still been created.`
+    );
+
+    return;
+  }
+
+  const relativePathFromEntryPoint = `.${scamFilePath
+    .split(sourceRoot)[1]
+    .replace('.ts', '')}`;
+
+  const updateEntryPointContent = `${tree.read(projectEntryPoint)}
+  export * from "${relativePathFromEntryPoint}";`;
+
+  tree.write(projectEntryPoint, updateEntryPointContent);
 }
 
 function createAngularDirectiveModule(name: string) {

--- a/packages/angular/src/generators/scam-directive/schema.d.ts
+++ b/packages/angular/src/generators/scam-directive/schema.d.ts
@@ -7,4 +7,5 @@ export interface Schema {
   flat?: boolean;
   prefix?: string;
   selector?: string;
+  export?: boolean;
 }

--- a/packages/angular/src/generators/scam-directive/schema.json
+++ b/packages/angular/src/generators/scam-directive/schema.json
@@ -62,6 +62,11 @@
           "format": "html-selector"
         }
       ]
+    },
+    "export": {
+      "type": "boolean",
+      "description": "Specifies if the SCAM should be exported from the project's entry point (normally `index.ts`). It only applies to libraries.",
+      "default": false
     }
   },
   "required": ["name"]


### PR DESCRIPTION
Current Behavior
No current way to export SCAM for directive at project entry point

Expected Behavior
Allow a flag that will export the SCAM for directive at the project entry point