### PR TITLE
fix(testing): add number type to cypress ciBuildId

### DIFF
--- a/docs/generated/api-cypress/executors/cypress.md
+++ b/docs/generated/api-cypress/executors/cypress.md
@@ -31,7 +31,7 @@ The browser to run tests in.
 
 ### ciBuildId
 
-Type: `string`
+Type: `string | number `
 
 A unique identifier for a run to enable grouping or parallelization.
 

--- a/packages/cypress/src/executors/cypress/cypress.impl.spec.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.spec.ts
@@ -172,6 +172,42 @@ describe('Cypress builder', () => {
     );
   });
 
+  it('should call `Cypress.run` with provided ciBuildId (type: number)', async () => {
+    const ciBuildId = 1234;
+    const { success } = await cypressExecutor(
+      {
+        ...cypressOptions,
+        ciBuildId,
+      },
+      mockContext
+    );
+    expect(success).toEqual(true);
+    expect(cypressRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ciBuildId: ciBuildId.toString(),
+      })
+    );
+  });
+
+  it('should call `Cypress.run` with provided ciBuildId (type: string)', async () => {
+    const ciBuildId = 'stringBuildId';
+    const { success } = await cypressExecutor(
+      {
+        ...cypressOptions,
+        devServerTarget: undefined,
+        ciBuildId,
+      },
+      mockContext
+    );
+    expect(success).toEqual(true);
+    expect(cypressRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ciBuildId,
+        project: path.dirname(cypressOptions.cypressConfig),
+      })
+    );
+  });
+
   it('should call `Cypress.run` with provided browser', async () => {
     const { success } = await cypressExecutor(
       {

--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -30,7 +30,7 @@ export interface CypressExecutorOptions extends Json {
   env?: Record<string, string>;
   spec?: string;
   copyFiles?: string;
-  ciBuildId?: string;
+  ciBuildId?: string | number;
   group?: string;
   ignoreTestFiles?: string;
   reporter?: string;
@@ -197,7 +197,7 @@ async function runCypress(baseUrl: string, opts: CypressExecutorOptions) {
   options.record = opts.record;
   options.key = opts.key;
   options.parallel = opts.parallel;
-  options.ciBuildId = opts.ciBuildId;
+  options.ciBuildId = opts.ciBuildId?.toString();
   options.group = opts.group;
   options.ignoreTestFiles = opts.ignoreTestFiles;
 

--- a/packages/cypress/src/executors/cypress/schema.json
+++ b/packages/cypress/src/executors/cypress/schema.json
@@ -74,7 +74,14 @@
       "x-deprecated": true
     },
     "ciBuildId": {
-      "type": "string",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        }
+      ],
       "description": "A unique identifier for a run to enable grouping or parallelization."
     },
     "group": {


### PR DESCRIPTION
Expand the Cypress runner ciBuildId parameter to also receive numbers instead of only strings.

ISSUES CLOSED: #8675

## Current Behavior
```sh
> nx run my-project-e2e:e2e--record=true --key=my-key —ciBuildId=30180 
Property 'ciBuildId' does not match the schema. '30180' should be a 'string'.
```

## Expected Behavior
```sh
> nx run my-project-e2e:e2e--record=true --key=my-key —ciBuildId=30180 
--> Cypress starts without a schematic validation issue.
```

## Related Issue(s)

Fixes #8675
