### PR TITLE
fix(core): include affected projects when generating dep graph HTML file

### DIFF
--- a/packages/workspace/src/command-line/dep-graph.ts
+++ b/packages/workspace/src/command-line/dep-graph.ts
@@ -227,7 +227,9 @@ export async function generateGraph(
         },
       });
 
-      const depGraphClientResponse = await createDepGraphClientResponse();
+      const depGraphClientResponse = await createDepGraphClientResponse(
+        affectedProjects
+      );
 
       const environmentJs = buildEnvironmentJs(
         args.exclude || [],
@@ -305,8 +307,7 @@ async function startServer(
     startWatcher();
   }
 
-  currentDepGraphClientResponse = await createDepGraphClientResponse();
-  currentDepGraphClientResponse.affected = affected;
+  currentDepGraphClientResponse = await createDepGraphClientResponse(affected);
   currentDepGraphClientResponse.focus = focus;
   currentDepGraphClientResponse.groupByFolder = groupByFolder;
   currentDepGraphClientResponse.exclude = exclude;
@@ -466,7 +467,9 @@ function createFileWatcher(root: string, changeHandler: () => Promise<void>) {
   return { close: () => watcher.close() };
 }
 
-async function createDepGraphClientResponse(): Promise<DepGraphClientResponse> {
+async function createDepGraphClientResponse(
+  affected: string[] = []
+): Promise<DepGraphClientResponse> {
   performance.mark('project graph watch calculation:start');
   await defaultFileHasher.init();
 
@@ -515,5 +518,6 @@ async function createDepGraphClientResponse(): Promise<DepGraphClientResponse> {
     layout,
     projects,
     dependencies,
+    affected,
   };
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
* The static site generated from `nx affected:dep-graph --file dep-graph.html` does not include the affected projects

## Expected Behavior
* The static site generated from `nx affected:dep-graph --file dep-graph.html` includes the affected projects

## Related Issue(s)
Fixes #8657
