### PR TITLE
cleanup(core): remove `it.only` from e2e test

### DIFF
--- a/e2e/workspace-integrations/src/workspace-aux-commands.test.ts
+++ b/e2e/workspace-integrations/src/workspace-aux-commands.test.ts
@@ -402,7 +402,7 @@ describe('dep-graph', () => {
     expect(environmentJs).toContain('"affected":[]');
   });
 
-  it.only('affected:dep-graph should include affected projects in environment file', () => {
+  it('affected:dep-graph should include affected projects in environment file', () => {
     runCLI(`affected:dep-graph --file=project-graph.html`);
 
     const environmentJs = readFile('static/environment.js');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
* There's a worksapce-aux-commands e2e tests marked with `it.only`
<!-- This is the behavior we have today -->

## Expected Behavior
* all e2e tests run
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
