### PR TITLE
feat(linter): omit require and register if plugin folder is missing

### DIFF
--- a/packages/eslint-plugin-nx/src/resolve-workspace-rules.ts
+++ b/packages/eslint-plugin-nx/src/resolve-workspace-rules.ts
@@ -1,4 +1,5 @@
 import type { TSESLint } from '@typescript-eslint/experimental-utils';
+import { existsSync } from 'fs';
 import { WORKSPACE_PLUGIN_DIR, WORKSPACE_RULE_NAMESPACE } from './constants';
 
 type ESLintRules = Record<string, TSESLint.RuleModule<string, unknown[]>>;
@@ -11,38 +12,45 @@ type ESLintRules = Record<string, TSESLint.RuleModule<string, unknown[]>>;
  * tools/eslint-rules and write their rules in JavaScript and the fundamentals will still work (but
  * workspace path mapping will not, for example).
  */
-try {
-  require('ts-node').register({
-    dir: WORKSPACE_PLUGIN_DIR,
-  });
+function registerTSWorkspaceLint() {
+  try {
+    require('ts-node').register({
+      dir: WORKSPACE_PLUGIN_DIR,
+    });
 
-  const tsconfigPaths = require('tsconfig-paths');
+    const tsconfigPaths = require('tsconfig-paths');
 
-  // Load the tsconfig from tools/eslint-rules/tsconfig.json
-  const tsConfigResult = tsconfigPaths.loadConfig(WORKSPACE_PLUGIN_DIR);
+    // Load the tsconfig from tools/eslint-rules/tsconfig.json
+    const tsConfigResult = tsconfigPaths.loadConfig(WORKSPACE_PLUGIN_DIR);
 
-  /**
-   * Register the custom workspace path mappings with node so that workspace libraries
-   * can be imported and used within custom workspace lint rules.
-   */
-  tsconfigPaths.register({
-    baseUrl: tsConfigResult.absoluteBaseUrl,
-    paths: tsConfigResult.paths,
-  });
-} catch (err) {}
+    /**
+     * Register the custom workspace path mappings with node so that workspace libraries
+     * can be imported and used within custom workspace lint rules.
+     */
+    tsconfigPaths.register({
+      baseUrl: tsConfigResult.absoluteBaseUrl,
+      paths: tsConfigResult.paths,
+    });
+  } catch (err) {}
+}
 
 export const workspaceRules = ((): ESLintRules => {
+  // If `tools/eslint-rules` folder doesn't exist, there is no point trying to register and load it
+  if (!existsSync(WORKSPACE_PLUGIN_DIR)) {
+    return {};
+  }
+  // Register `tools/eslint-rules` for TS transpilation
+  registerTSWorkspaceLint();
   try {
     /**
      * Currently we only support applying the rules from the user's workspace plugin object
      * (i.e. not other things that plugings can expose like configs, processors etc)
      */
     const { rules } = require(WORKSPACE_PLUGIN_DIR);
-    const localWorkspaceRules: ESLintRules = rules;
 
     // Apply the namespace to the resolved rules
     const namespacedRules: ESLintRules = {};
-    for (const [ruleName, ruleConfig] of Object.entries(localWorkspaceRules)) {
+    for (const [ruleName, ruleConfig] of Object.entries(rules as ESLintRules)) {
       namespacedRules[`${WORKSPACE_RULE_NAMESPACE}/${ruleName}`] = ruleConfig;
     }
     return namespacedRules;


### PR DESCRIPTION
Avoid using `require` to register and require the workspace lint plugin folder if the folder is missing.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
Related to #7758 

Fixes #
