### PR TITLE
fix(core): use posix paths separator on windows.

### DIFF
--- a/packages/workspace/src/core/hasher/node-based-file-hasher.ts
+++ b/packages/workspace/src/core/hasher/node-based-file-hasher.ts
@@ -1,10 +1,10 @@
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import { performance } from 'perf_hooks';
 import { FileData } from '@nrwl/tao/src/shared/project-graph';
-import { join, relative } from 'path/posix';
+import { relative } from 'path';
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { FileHasherBase } from './file-hasher-base';
-import { stripIndents } from '@nrwl/devkit';
+import { joinPathFragments, stripIndents } from '@nrwl/devkit';
 import ignore from 'ignore';
 
 export class NodeBasedFileHasher extends FileHasherBase {
@@ -42,8 +42,11 @@ export class NodeBasedFileHasher extends FileHasherBase {
     }
     try {
       readdirSync(absoluteDirName).forEach((c) => {
-        const absoluteChild = join(absoluteDirName, c);
-        const relChild = relative(appRootPath, absoluteChild);
+        const absoluteChild = joinPathFragments(absoluteDirName, c);
+        const relChild = relative(appRootPath, absoluteChild).replace(
+          /\\/g,
+          '/'
+        );
         if (this.ignoredGlobs.ignores(relChild)) {
           return;
         }

--- a/packages/workspace/src/core/hasher/node-based-file-hasher.ts
+++ b/packages/workspace/src/core/hasher/node-based-file-hasher.ts
@@ -1,7 +1,7 @@
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import { performance } from 'perf_hooks';
 import { FileData } from '@nrwl/tao/src/shared/project-graph';
-import { join, relative } from 'path';
+import { join, relative } from 'path/posix';
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { FileHasherBase } from './file-hasher-base';
 import { stripIndents } from '@nrwl/devkit';
@@ -68,7 +68,7 @@ function getIgnoredGlobs() {
       node_modules
       tmp
       dist
-      build    
+      build
     `);
   return ig;
 }


### PR DESCRIPTION
Use posix paths separator explicitly when creating a list of files for projects graph.

Closes #8601.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Currently, on Windows machines when .git folder is missing or is not placed in application root folder, file-hasher falls back to using `NodeBasedFileHasher`. This hasher, when creating a list of all files in workspace, uses system-defined slash orientation. For Windows it means that all file paths are stored as (example) `libs\\my-lib\\src\\....`

Later on, when it's time for `createProjectFileMap` (in [file-map-utils.ts](https://github.com/nrwl/nx/blob/4070eaec15f7899000c41bfbcc07ff93ac474bce/packages/workspace/src/core/file-map-utils.ts#L32) ), the paths are compared against the application root path. But root path **is always stored** with Linux-type slashes (e.g. `apps/my-app`). As a result NX is unable to find dependencies between projects and project graph is never built.

## Expected Behavior
NX should be able to create project graph on both Windows and Linux, both with or without `.git` folder present in application root.

## Related Issue(s)
Fixes #8601 
