### PR TITLE
fix(linter): Clean up comment after #8147

### DIFF
--- a/packages/eslint-plugin-nx/src/configs/typescript.ts
+++ b/packages/eslint-plugin-nx/src/configs/typescript.ts
@@ -6,11 +6,6 @@ import { appRootPath } from '@nrwl/tao/src/utils/app-root';
  *
  * It should therefore NOT contain any rules or plugins which are specific
  * to one ecosystem, such as React, Angular, Node etc.
- *
- * NOTE: Currently the one exception to this is that there is an override for .tsx
- * for the @typescript-eslint/no-unused-vars rule for backwards compatibility
- * with the original root Nx ESlint config. This will be split out into a dedicated
- * tsx configuration in a follow up PR which handles overrides.
  */
 export default {
   parser: '@typescript-eslint/parser',


### PR DESCRIPTION
PR #8147 removed the ESLint override to turn off @typescript-eslint/no-unused-vars for *.tsx files. This commit removes the comment that references it.

## Current Behavior
A comment in `packages/eslint-plugin-nx/src/configs/typescript.ts` references an override that #8147 removed from the file.

## Expected Behavior
The comment is removed.

## Related Issue(s)
None