### PR TITLE
feat(angular): pass additional args to devServer custom configuration function

### DIFF
--- a/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
+++ b/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
@@ -53,7 +53,11 @@ export function webpackServer(schema: Schema, context: BuilderContext) {
             // The extra Webpack configuration file can export a synchronous or asynchronous function,
             // for instance: `module.exports = async config => { ... }`.
             if (typeof customWebpackConfiguration === 'function') {
-              return customWebpackConfiguration(baseWebpackConfig);
+              return customWebpackConfiguration(
+                baseWebpackConfig,
+                selectedConfiguration,
+                context.target
+              );
             } else {
               return merge(
                 baseWebpackConfig,


### PR DESCRIPTION
continuing what added in #8608 , pass the same additional args also to the webpack-server builder

Sorry I missed this one .

## Current Behavior
Only the CLI webpack config is passed on the configuration function, not possible to know the current build target/configuration context, this is a different now in the browser builder
## Expected Behavior
Custom webpack configuration should be able to take in account the current target and the options the builder received.
This would align with the change done in browser builder

