### PR TITLE
docs(core): remove package manager comment from commands

### DIFF
--- a/docs/shared/angular-plugin.md
+++ b/docs/shared/angular-plugin.md
@@ -18,10 +18,10 @@ The Nx Plugin for Angular contains executors, generators, and utilities for mana
 Adding the Angular plugin to an existing Nx workspace can be done with the following:
 
 ```bash
-#yarn
 yarn add -D @nrwl/angular
+```
 
-#npm
+```bash
 npm install -D @nrwl/angular
 ```
 

--- a/docs/shared/cypress-plugin.md
+++ b/docs/shared/cypress-plugin.md
@@ -27,19 +27,17 @@ You can create a new Cypress E2E project for an existing project.
 
 If the `@nrwl/cypress` package is not installed, install the version that matches your `@nrwl/workspace` version.
 
-```sh
-#yarn
+```bash
 yarn add --dev @nrwl/cypress
 ```
 
-```sh
-#npm
+```bash
 npm install --save-dev @nrwl/cypress
 ```
 
 Next, generate an E2E project based on an existing project.
 
-```sh
+```bash
 nx g @nrwl/cypress:cypress-project your-app-name-e2e --project=your-app-name
 ```
 

--- a/docs/shared/express-plugin.md
+++ b/docs/shared/express-plugin.md
@@ -7,12 +7,10 @@ The Express plugin contains generators to add a new Express application to an Nx
 Adding the Express plugin to a workspace can be done with the following:
 
 ```bash
-#yarn
 yarn add -D @nrwl/express
 ```
 
 ```bash
-#npm
 npm install -D @nrwl/express
 ```
 

--- a/docs/shared/node-plugin.md
+++ b/docs/shared/node-plugin.md
@@ -7,12 +7,10 @@ The Node Plugin contains generators and executors to manage Node applications wi
 Installing the Node plugin to a workspace can be done with the following:
 
 ```bash
-#yarn
 yarn add -D @nrwl/node
 ```
 
 ```bash
-#npm
 npm install -D @nrwl/node
 ```
 

--- a/docs/shared/react-native-plugin.md
+++ b/docs/shared/react-native-plugin.md
@@ -13,12 +13,10 @@ The Nx Plugin for React Native contains generators for managing React Native app
 Adding the React plugin to a workspace can be done with the following:
 
 ```bash
-#yarn
 yarn add -D @nrwl/react-native
 ```
 
 ```bash
-#npm
 npm install -D @nrwl/react-native
 ```
 

--- a/docs/shared/react-plugin.md
+++ b/docs/shared/react-plugin.md
@@ -14,12 +14,10 @@ The Nx Plugin for React contains generators for managing React applications and 
 Adding the React plugin to a workspace can be done with the following:
 
 ```bash
-#yarn
 yarn add -D @nrwl/react
 ```
 
 ```bash
-#npm
 npm install -D @nrwl/react
 ```
 

--- a/docs/shared/web-plugin.md
+++ b/docs/shared/web-plugin.md
@@ -11,12 +11,10 @@ The Nx Plugin for Web Components contains generators for managing Web Component 
 Adding the Web plugin to a workspace can be done with the following:
 
 ```bash
-#yarn
 yarn add -D @nrwl/web
 ```
 
 ```bash
-#npm
 npm install -D @nrwl/web
 ```
 


### PR DESCRIPTION
## What it does?

Removes not needed comment from package manager 's command. This was conflicting while copying the code snippet.

Fixes #7879