### PR TITLE
fix(linter): mark `eslint-config-prettier` as optional

### DIFF
--- a/packages/eslint-plugin-nx/package.json
+++ b/packages/eslint-plugin-nx/package.json
@@ -26,6 +26,11 @@
     "@typescript-eslint/parser": "~5.10.0",
     "eslint-config-prettier": "^8.1.0"
   },
+  "peerDependenciesMeta": {
+    "eslint-config-prettier": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@nrwl/devkit": "*",
     "@nrwl/workspace": "*",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`prettier` is a optional peerDependency of `@nrwl/workspace` so users can opt-out of using prettier. But `eslint-config-prettier` is not a optional peerDependency so users get a unmet peer dependency warning. 

https://github.com/nrwl/nx/blob/56eec5fb6e92a5734d2ab0e898d628a86c939f31/packages/workspace/package.json#L53-L61

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
peerDependency `eslint-config-prettier` of `@nrwl/linter` should be optional
