### PR TITLE
fix(linter): change typescript-eslint peerDependency version to support newer versions

### DIFF
--- a/packages/eslint-plugin-nx/package.json
+++ b/packages/eslint-plugin-nx/package.json
@@ -23,14 +23,14 @@
   },
   "homepage": "https://nx.dev",
   "peerDependencies": {
-    "@typescript-eslint/parser": "~5.3.0",
+    "@typescript-eslint/parser": "^5.3.0",
     "eslint-config-prettier": "^8.1.0"
   },
   "dependencies": {
     "@nrwl/devkit": "*",
     "@nrwl/workspace": "*",
     "@swc-node/register": "^1.4.2",
-    "@typescript-eslint/experimental-utils": "~5.3.0",
+    "@typescript-eslint/experimental-utils": "^5.3.0",
     "chalk": "4.1.0",
     "confusing-browser-globals": "^1.0.9",
     "tsconfig-paths": "^3.9.0"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/linter` forces users to use `@typescript-eslint/*@~5.3.0`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
users should be able to use newer versions of typescript-eslint see #8693 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8693
