### PR TITLE
docs(nxdev): help us improve the documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-documentation.md
+++ b/.github/ISSUE_TEMPLATE/3-documentation.md
@@ -1,0 +1,26 @@
+---
+name: "📖 Documentation issue"
+about:  Help improve our docs.
+labels: "type: docs"
+---
+### Documentation issue
+
+<!-- (Update "[ ]" to "[x]" to check a box) -->
+
+- [ ] Reporting a typo
+- [ ] Reporting a documentation bug
+- [ ] Documentation improvement
+- [ ] Documentation feedback
+
+<!--
+  If your issue is not regarding the documentation, please choose an issue type:
+  https://github.com/nrwl/nx/issues/new/choose
+-->
+
+### Is there a specific documentation page you are reporting?
+
+Enter the URL or documentation section here.
+
+### Additional context or description
+
+Provide any additional details here as needed.

--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -50,11 +50,39 @@ export function DocViewer({
           <div
             id="content-wrapper"
             className={cx(
-              'min-w-0 w-full flex-auto lg:static lg:max-h-full lg:overflow-visible pt-16 md:pl-4',
+              'min-w-0 w-full flex-auto flex-col lg:static lg:max-h-full lg:overflow-visible pt-16 md:pl-4',
               navIsOpen && 'overflow-hidden max-h-screen fixed'
             )}
           >
             <Content document={document} />
+            <div className="flex items-center space-x-2 w-full px-4 sm:px-6 xl:px-8 pt-24 pb-24 lg:pb-16">
+              <div className="ml-4 flex flex-grow h-0.5 w-full bg-slate-50 rounded" />
+              <div className="flex-shrink-0 relative z-0 inline-flex shadow-sm rounded-md">
+                <a
+                  aria-hidden="true"
+                  href="https://github.com/nrwl/nx/issues/new?assignees=&labels=type%3A+docs&template=3-documentation.md"
+                  target="_blank"
+                  rel="noreferrer"
+                  title="Report an issue on Github"
+                  className="relative inline-flex items-center px-4 py-2 rounded-l-md border border-gray-200 bg-white text-xs font-medium text-gray-600 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-blue-nx-base focus:border-blue-nx-base"
+                >
+                  Report an issue
+                </a>
+                <a
+                  aria-hidden="true"
+                  href={[
+                    'https://github.com/nrwl/nx/blob/master',
+                    document.filePath,
+                  ].join('/')}
+                  target="_blank"
+                  rel="noreferrer"
+                  title="Edit this page on Github"
+                  className="-ml-px relative inline-flex items-center px-4 py-2 rounded-r-md border border-gray-200 bg-white text-xs font-medium text-gray-600 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-blue-nx-base focus:border-blue-nx-base"
+                >
+                  Edit this page
+                </a>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What it does?
Introduces a new GitHub issue template for Documentation issues/bug as well as two (2) buttons at the bottom of each page for:
- inviting to edit the content of the current `readme` file
- inviting to create an issue (using the new issue template) regarding
  the documentation with the associated tags

### Preview
<img width="1080" alt="preview" src="https://user-images.githubusercontent.com/3447705/151430364-dd251375-7bd0-4b55-a4e0-90df04251994.png">

