### PR TITLE
fix(js): migrate swc executor off of rxjs

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -42,6 +42,8 @@
     "ignore": "^5.0.4",
     "js-tokens": "^4.0.0",
     "minimatch": "3.0.4",
+    "rxjs": "^6.5.4",
+    "rxjs-for-await": "0.0.2",
     "source-map-support": "0.5.19",
     "tree-kill": "1.2.2"
   }

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -42,8 +42,6 @@
     "ignore": "^5.0.4",
     "js-tokens": "^4.0.0",
     "minimatch": "3.0.4",
-    "rxjs": "^6.5.4",
-    "rxjs-for-await": "0.0.2",
     "source-map-support": "0.5.19",
     "tree-kill": "1.2.2"
   }

--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -130,9 +130,9 @@ export async function* swcExecutor(
     );
   } else {
     return yield compileSwc(
-        context,
-        options,
-        processAssetsAndPackageJsonOnce(assetHandler, options, projectRoot)
+      context,
+      options,
+      processAssetsAndPackageJsonOnce(assetHandler, options, projectRoot)
     );
   }
 }

--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -128,13 +128,13 @@ export async function* swcExecutor(
       options,
       processAssetsAndPackageJsonOnce(assetHandler, options, projectRoot)
     );
+  } else {
+    return yield compileSwc(
+        context,
+        options,
+        processAssetsAndPackageJsonOnce(assetHandler, options, projectRoot)
+    );
   }
-
-  return yield compileSwc(
-    context,
-    options,
-    processAssetsAndPackageJsonOnce(assetHandler, options, projectRoot)
-  );
 }
 
 export default swcExecutor;

--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -4,15 +4,9 @@ import {
   FileInputOutput,
 } from '@nrwl/workspace/src/utilities/assets';
 import { join, resolve } from 'path';
-import { eachValueFrom } from 'rxjs-for-await';
-import { map } from 'rxjs/operators';
 import { checkDependencies } from '../../utils/check-dependencies';
 import { CopyAssetsHandler } from '../../utils/copy-assets-handler';
-import {
-  ExecutorEvent,
-  ExecutorOptions,
-  NormalizedExecutorOptions,
-} from '../../utils/schema';
+import { ExecutorOptions, NormalizedExecutorOptions } from '../../utils/schema';
 import { compileTypeScriptFiles } from '../../utils/typescript/compile-typescript-files';
 import { updatePackageJson } from '../../utils/update-package-json';
 import { watchForSingleFileChanges } from '../../utils/watch-for-single-file-changes';
@@ -91,20 +85,10 @@ export async function* tscExecutor(
     });
   }
 
-  return yield* eachValueFrom(
-    compileTypeScriptFiles(options, context, async () => {
-      await assetHandler.processAllAssetsOnce();
-      updatePackageJson(options.main, options.outputPath, projectRoot);
-    }).pipe(
-      map(
-        ({ success }) =>
-          ({
-            success,
-            outfile: options.mainOutputPath,
-          } as ExecutorEvent)
-      )
-    )
-  );
+  return yield* compileTypeScriptFiles(options, context, async () => {
+    await assetHandler.processAllAssetsOnce();
+    updatePackageJson(options.main, options.outputPath, projectRoot);
+  });
 }
 
 export default tscExecutor;

--- a/packages/js/src/utils/create-async-iterable/create-async-iterable.spec.ts
+++ b/packages/js/src/utils/create-async-iterable/create-async-iterable.spec.ts
@@ -28,4 +28,31 @@ describe(createAsyncIterable.name, () => {
       }
     }).rejects.toThrow(/Oops/);
   });
+
+  test('multiple signals in the same macro/microtask', async () => {
+    const it = createAsyncIterable<string>(({ next, done }) => {
+      setTimeout(() => {
+        next('first');
+      });
+
+      setTimeout(() => {
+        // should pass through in the same macro/microtask
+        next('second');
+        next('third');
+        next('fourth');
+        done();
+      }, 10);
+
+      setTimeout(() => {
+        next('should be ignored');
+      }, 20);
+    });
+
+    const results: string[] = [];
+    for await (const x of it) {
+      results.push(x);
+    }
+
+    expect(results).toEqual(['first', 'second', 'third', 'fourth']);
+  });
 });

--- a/packages/js/src/utils/create-async-iterable/create-async-iterable.spec.ts
+++ b/packages/js/src/utils/create-async-iterable/create-async-iterable.spec.ts
@@ -1,0 +1,95 @@
+import { createAsyncIterable } from './create-async-iteratable';
+
+describe(createAsyncIterable.name, () => {
+  test('simple callback', async () => {
+    const it = createAsyncIterable<string>(({ next, done }) => {
+      setTimeout(() => next('bye'), 10);
+      setTimeout(() => next('hello'), 0);
+      setTimeout(() => done(), 20);
+      setTimeout(() => next('ignored'), 30);
+    });
+    const results: string[] = [];
+    for await (const x of it) {
+      results.push(x);
+    }
+
+    expect(results).toEqual(['hello', 'bye']);
+  });
+
+  test('throwing error', async () => {
+    const it = createAsyncIterable(({ next, error }) => {
+      setTimeout(() => next('hello'), 0);
+      setTimeout(() => error(new Error('Oops')), 10);
+    });
+
+    await expect(async () => {
+      for await (const _x of it) {
+        // nothing
+      }
+    }).rejects.toThrow(/Oops/);
+  });
+
+  test('forked process', async () => {
+    const it = createAsyncIterable<string>(async ({ next, done }) => {
+      const cp = await import('child_process');
+      const path = await import('path');
+
+      const p = cp.fork(path.join(__dirname, 'fixtures/test.js'));
+      p.on('message', (data) => {
+        next(data as string);
+      });
+      p.on('exit', () => {
+        done();
+      });
+      p.send('Alice');
+      p.send('Bob');
+      p.send('Bye');
+    });
+
+    const results: string[] = [];
+
+    for await (const x of it) {
+      results.push(x);
+    }
+
+    expect(results).toEqual(['Hello Alice', 'Hello Bob', 'Bye']);
+  });
+
+  // test('forked process with abort controller', async () => {
+  //   const it = createAsyncIterable<string>(async ({ next, error, done }) => {
+  //     const cp = await import('child_process');
+  //     const path = await import('path');
+  //     const controller = new AbortController();
+  //     const { signal } = controller;
+  //
+  //     const p = cp.fork(path.join(__dirname, 'fixtures/test.js'), { signal });
+  //     p.on('message', (data) => {
+  //       next(data as string);
+  //     });
+  //     p.on('exit', () => {
+  //       done();
+  //     });
+  //     p.on('error', (err) => {
+  //       error(err);
+  //     });
+  //     p.send('Alice');
+  //     setTimeout(() => {
+  //       controller.abort();
+  //     }, 100);
+  //     setTimeout(() => {
+  //       p.send('Bob');
+  //       p.send('Fred');
+  //     }, 110);
+  //   });
+  //
+  //   const results: string[] = [];
+  //
+  //   await expect(async () => {
+  //     for await (const x of it) {
+  //       results.push(x);
+  //     }
+  //   }).rejects.toThrow(/The operation was aborted/);
+  //
+  //   expect(results).toEqual(['Hello Alice']);
+  // });
+});

--- a/packages/js/src/utils/create-async-iterable/create-async-iterable.spec.ts
+++ b/packages/js/src/utils/create-async-iterable/create-async-iterable.spec.ts
@@ -28,30 +28,4 @@ describe(createAsyncIterable.name, () => {
       }
     }).rejects.toThrow(/Oops/);
   });
-
-  test('forked process', async () => {
-    const it = createAsyncIterable<string>(async ({ next, done }) => {
-      const cp = await import('child_process');
-      const path = await import('path');
-
-      const p = cp.fork(path.join(__dirname, 'fixtures/test.js'));
-      p.on('message', (data) => {
-        next(data as string);
-      });
-      p.on('exit', () => {
-        done();
-      });
-      p.send('Alice');
-      p.send('Bob');
-      p.send('Bye');
-    });
-
-    const results: string[] = [];
-
-    for await (const x of it) {
-      results.push(x);
-    }
-
-    expect(results).toEqual(['Hello Alice', 'Hello Bob', 'Bye']);
-  });
 });

--- a/packages/js/src/utils/create-async-iterable/create-async-iterable.spec.ts
+++ b/packages/js/src/utils/create-async-iterable/create-async-iterable.spec.ts
@@ -54,42 +54,4 @@ describe(createAsyncIterable.name, () => {
 
     expect(results).toEqual(['Hello Alice', 'Hello Bob', 'Bye']);
   });
-
-  // test('forked process with abort controller', async () => {
-  //   const it = createAsyncIterable<string>(async ({ next, error, done }) => {
-  //     const cp = await import('child_process');
-  //     const path = await import('path');
-  //     const controller = new AbortController();
-  //     const { signal } = controller;
-  //
-  //     const p = cp.fork(path.join(__dirname, 'fixtures/test.js'), { signal });
-  //     p.on('message', (data) => {
-  //       next(data as string);
-  //     });
-  //     p.on('exit', () => {
-  //       done();
-  //     });
-  //     p.on('error', (err) => {
-  //       error(err);
-  //     });
-  //     p.send('Alice');
-  //     setTimeout(() => {
-  //       controller.abort();
-  //     }, 100);
-  //     setTimeout(() => {
-  //       p.send('Bob');
-  //       p.send('Fred');
-  //     }, 110);
-  //   });
-  //
-  //   const results: string[] = [];
-  //
-  //   await expect(async () => {
-  //     for await (const x of it) {
-  //       results.push(x);
-  //     }
-  //   }).rejects.toThrow(/The operation was aborted/);
-  //
-  //   expect(results).toEqual(['Hello Alice']);
-  // });
 });

--- a/packages/js/src/utils/create-async-iterable/create-async-iteratable.ts
+++ b/packages/js/src/utils/create-async-iterable/create-async-iteratable.ts
@@ -33,16 +33,14 @@ export function createAsyncIterable<T = unknown>(
           if (done || error) return;
           if (pullQueue.length > 0) {
             pullQueue.shift()?.[1](err);
-          } else {
-            error = err;
           }
+          error = err;
         },
         done: () => {
           if (pullQueue.length > 0) {
             pullQueue.shift()?.[0]({ value: undefined, done: true });
-          } else {
-            done = true;
           }
+          done = true;
         },
       });
 

--- a/packages/js/src/utils/create-async-iterable/create-async-iteratable.ts
+++ b/packages/js/src/utils/create-async-iterable/create-async-iteratable.ts
@@ -1,6 +1,6 @@
 export interface AsyncPushCallbacks<T> {
   next: (value: T) => void;
-  done: (value?: T) => void;
+  done: () => void;
   error: (err: unknown) => void;
 }
 
@@ -37,9 +37,9 @@ export function createAsyncIterable<T = unknown>(
             error = err;
           }
         },
-        done: (value) => {
+        done: () => {
           if (pullQueue.length > 0) {
-            pullQueue.shift()?.[0]({ value, done: true });
+            pullQueue.shift()?.[0]({ value: undefined, done: true });
           } else {
             done = true;
           }

--- a/packages/js/src/utils/create-async-iterable/create-async-iteratable.ts
+++ b/packages/js/src/utils/create-async-iterable/create-async-iteratable.ts
@@ -1,0 +1,67 @@
+export interface AsyncPushCallbacks<T> {
+  next: (value: T) => void;
+  done: (value?: T) => void;
+  error: (err: unknown) => void;
+}
+
+export function createAsyncIterable<T = unknown>(
+  listener: (ls: AsyncPushCallbacks<T>) => void
+): AsyncIterable<T> {
+  let done = false;
+  let error: unknown | null = null;
+
+  const pushQueue: T[] = [];
+  const pullQueue: Array<
+    [
+      (x: { value: T | undefined; done: boolean }) => void,
+      (err: unknown) => void
+    ]
+  > = [];
+
+  return {
+    [Symbol.asyncIterator]() {
+      listener({
+        next: (value) => {
+          if (done || error) return;
+          if (pullQueue.length > 0) {
+            pullQueue.shift()?.[0]({ value, done: false });
+          } else {
+            pushQueue.push(value);
+          }
+        },
+        error: (err) => {
+          if (done || error) return;
+          if (pullQueue.length > 0) {
+            pullQueue.shift()?.[1](err);
+          } else {
+            error = err;
+          }
+        },
+        done: (value) => {
+          if (pullQueue.length > 0) {
+            pullQueue.shift()?.[0]({ value, done: true });
+          } else {
+            done = true;
+          }
+        },
+      });
+
+      return {
+        next() {
+          return new Promise<{ value: T | undefined; done: boolean }>(
+            (resolve, reject) => {
+              if (done) resolve({ value: undefined, done: true });
+              if (error) reject(error);
+
+              if (pushQueue.length > 0) {
+                resolve({ value: pushQueue.shift(), done: false });
+              } else {
+                pullQueue.push([resolve, reject]);
+              }
+            }
+          );
+        },
+      };
+    },
+  } as AsyncIterable<T>;
+}

--- a/packages/js/src/utils/create-async-iterable/create-async-iteratable.ts
+++ b/packages/js/src/utils/create-async-iterable/create-async-iteratable.ts
@@ -48,11 +48,12 @@ export function createAsyncIterable<T = unknown>(
         next() {
           return new Promise<{ value: T | undefined; done: boolean }>(
             (resolve, reject) => {
-              if (done) resolve({ value: undefined, done: true });
-              if (error) reject(error);
-
               if (pushQueue.length > 0) {
                 resolve({ value: pushQueue.shift(), done: false });
+              } else if (done) {
+                resolve({ value: undefined, done: true });
+              } else if (error) {
+                reject(error);
               } else {
                 pullQueue.push([resolve, reject]);
               }

--- a/packages/js/src/utils/create-async-iterable/fixtures/test.js
+++ b/packages/js/src/utils/create-async-iterable/fixtures/test.js
@@ -1,0 +1,8 @@
+process.on('message', function (message) {
+  if (message === 'Bye') {
+    process.send('Bye');
+    process.exit(0);
+  } else {
+    process.send(`Hello ${message}`);
+  }
+});

--- a/packages/js/src/utils/create-async-iterable/fixtures/test.js
+++ b/packages/js/src/utils/create-async-iterable/fixtures/test.js
@@ -1,8 +1,0 @@
-process.on('message', function (message) {
-  if (message === 'Bye') {
-    process.send('Bye');
-    process.exit(0);
-  } else {
-    process.send(`Hello ${message}`);
-  }
-});

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -1,164 +1,227 @@
 import { ExecutorContext, logger } from '@nrwl/devkit';
+import { cacheDir } from '@nrwl/workspace/src/utilities/cache-directory';
 import { exec, execSync } from 'child_process';
-import { EMPTY, Observable, zip } from 'rxjs';
-import { concatMap, map } from 'rxjs/operators';
 import { NormalizedSwcExecutorOptions } from '../schema';
 import { printDiagnostics } from '../typescript/print-diagnostics';
-import {
-  runTypeCheck,
-  runTypeCheckWatch,
-  TypeCheckOptions,
-} from '../typescript/run-type-check';
+import { runTypeCheck, TypeCheckOptions } from '../typescript/run-type-check';
 
-export function compileSwc(
+function getSwcCmd(
+  normalizedOptions: NormalizedSwcExecutorOptions,
+  watch = false
+) {
+  const srcPath = `../${normalizedOptions.swcCliOptions.projectDir}`;
+  let swcCmd = `npx swc ${srcPath} -d ${normalizedOptions.swcCliOptions.destPath} --source-maps --no-swcrc --config-file=${normalizedOptions.swcrcPath}`;
+  return watch ? swcCmd.concat(' --watch') : swcCmd;
+}
+
+function getTypeCheckOptions(normalizedOptions: NormalizedSwcExecutorOptions) {
+  const { projectRoot, watch, tsConfig, root, outputPath } = normalizedOptions;
+
+  const typeCheckOptions: TypeCheckOptions = {
+    mode: 'emitDeclarationOnly',
+    tsConfigPath: tsConfig,
+    outDir: outputPath.replace(`/${projectRoot}`, ''),
+    workspaceRoot: root,
+  };
+
+  if (watch) {
+    typeCheckOptions.incremental = true;
+    typeCheckOptions.cacheDir = cacheDir;
+  }
+
+  return typeCheckOptions;
+}
+
+export async function compileSwc(
   context: ExecutorContext,
   normalizedOptions: NormalizedSwcExecutorOptions,
   postCompilationCallback: () => Promise<void>
 ) {
   logger.log(`Compiling with SWC for ${context.projectName}...`);
-  const srcPath = `../${normalizedOptions.swcCliOptions.projectDir}`;
-  let swcCmd = `npx swc ${srcPath} -d ${normalizedOptions.swcCliOptions.destPath} --source-maps --no-swcrc --config-file=${normalizedOptions.swcrcPath}`;
 
-  const postCompilationOperator = () =>
-    concatMap(({ success }) => {
-      if (success) {
-        return postCompilationCallback().then(() => ({ success }));
-      }
-      return EMPTY;
-    });
+  const swcCmdLog = execSync(getSwcCmd(normalizedOptions), {
+    cwd: normalizedOptions.projectRoot,
+  }).toString();
+  logger.log(swcCmdLog.replace(/\n/, ''));
+  const isCompileSuccess = swcCmdLog.includes('Successfully compiled');
 
-  const compile$ = new Observable<{ success: boolean }>((subscriber) => {
-    if (normalizedOptions.watch) {
-      swcCmd += ' --watch';
-      const watchProcess = createSwcWatchProcess(
-        swcCmd,
-        normalizedOptions.projectRoot,
-        (success) => {
-          subscriber.next({ success });
-        }
-      );
-
-      return () => {
-        watchProcess.close();
-        subscriber.complete();
-      };
-    }
-
-    const swcCmdLog = execSync(swcCmd, {
-      cwd: normalizedOptions.projectRoot,
-    }).toString();
-    logger.log(swcCmdLog.replace(/\n/, ''));
-    subscriber.next({ success: swcCmdLog.includes('Successfully compiled') });
-
-    return () => {
-      subscriber.complete();
-    };
-  });
+  await postCompilationCallback();
 
   if (normalizedOptions.skipTypeCheck) {
-    return compile$.pipe(postCompilationOperator());
+    return { success: isCompileSuccess };
   }
 
-  const tsOptions = {
-    outputPath: normalizedOptions.outputPath,
-    projectName: context.projectName,
-    projectRoot: normalizedOptions.projectRoot,
-    tsConfig: normalizedOptions.tsConfig,
-    watch: normalizedOptions.watch,
-  };
-  const outDir = tsOptions.outputPath.replace(`/${tsOptions.projectRoot}`, '');
-  const typeCheck$ = new Observable<{ success: boolean }>((subscriber) => {
-    const typeCheckOptions: TypeCheckOptions = {
-      mode: 'emitDeclarationOnly',
-      tsConfigPath: tsOptions.tsConfig,
-      outDir,
-      workspaceRoot: normalizedOptions.root,
-    };
-    if (normalizedOptions.watch) {
-      let typeCheckRunner: { close: () => void };
-      let preEmit = false;
-      runTypeCheckWatch(
-        typeCheckOptions,
-        (diagnostic, formattedDiagnostic, errorCount) => {
-          // 6031 and 6032 are to skip watchCompilerHost initialization (Start watching for changes... message)
-          // We also skip if preEmit has been set to true, because it means that the first type check before
-          // the WatchCompiler emits.
-          if (preEmit && diagnostic.code !== 6031 && diagnostic.code !== 6032) {
-            const hasErrors = errorCount > 0;
-            if (hasErrors) {
-              void printDiagnostics([formattedDiagnostic]);
-            } else {
-              void printDiagnostics([], [formattedDiagnostic]);
-            }
-            subscriber.next({ success: !hasErrors });
-          }
-        }
-      ).then(({ close, preEmitErrors, preEmitWarnings }) => {
-        const hasErrors = preEmitErrors.length > 0;
-        if (hasErrors) {
-          void printDiagnostics(preEmitErrors, preEmitWarnings);
-        }
-        typeCheckRunner = { close };
-        subscriber.next({ success: !hasErrors });
-        preEmit = true;
-      });
-
-      return () => {
-        if (typeCheckRunner) {
-          typeCheckRunner.close();
-        }
-        subscriber.complete();
-      };
-    }
-
-    runTypeCheck(typeCheckOptions).then(({ errors, warnings }) => {
-      const hasErrors = errors.length > 0;
-      if (hasErrors) {
-        void printDiagnostics(errors, warnings);
-      }
-      subscriber.next({ success: !hasErrors });
-      subscriber.complete();
-    });
-
-    return () => {
-      subscriber.complete();
-    };
-  });
-
-  return zip(compile$, typeCheck$).pipe(
-    map(([compileResult, typeCheckResult]) => ({
-      success: compileResult.success && typeCheckResult.success,
-    })),
-    postCompilationOperator()
+  const { errors, warnings } = await runTypeCheck(
+    getTypeCheckOptions(normalizedOptions)
   );
+  const hasErrors = errors.length > 0;
+  const hasWarnings = warnings.length > 0;
+
+  if (hasErrors || hasWarnings) {
+    await printDiagnostics(errors, warnings);
+  }
+
+  return { success: !hasErrors && isCompileSuccess };
 }
 
-function createSwcWatchProcess(
-  swcCmd: string,
-  cwd: string,
-  callback: (success: boolean) => void
+export async function* compileSwcWatch(
+  context: ExecutorContext,
+  normalizedOptions: NormalizedSwcExecutorOptions,
+  postCompilationCallback: () => Promise<void>
 ) {
-  const watchProcess = exec(swcCmd, { cwd });
+  logger.log(
+    `Compiling with SWC for ${context.projectName}.....................`
+  );
 
-  watchProcess.stdout.on('data', (data) => {
-    process.stdout.write(data);
-    callback(data.includes('Successfully compiled'));
+  const getResult = (success: boolean) => ({
+    success,
+    outfile: normalizedOptions.mainOutputPath,
   });
 
-  watchProcess.stderr.on('data', (err) => {
-    process.stderr.write(err);
-    callback(false);
+  const swcWatcher = exec(getSwcCmd(normalizedOptions, true), {
+    cwd: normalizedOptions.projectRoot,
   });
 
-  const processExitListener = () => watchProcess.kill();
+  const promisifySwcWatcher = () => {
+    let processOnExit: () => void;
+    let stdoutOnData: () => void;
+    let stderrOnData: () => void;
+    let watcherOnExit: () => void;
 
-  process.on('SIGINT', processExitListener);
-  process.on('SIGTERM', processExitListener);
-  process.on('exit', processExitListener);
+    return new Promise<{
+      success: boolean;
+      timestamp: number;
+      exit: boolean;
+    }>((resolve) => {
+      processOnExit = () => {
+        swcWatcher.kill();
+        resolve({ success: true, exit: true, timestamp: Date.now() });
+      };
 
-  watchProcess.on('exit', () => {
-    callback(true);
-  });
+      stdoutOnData = (data?: any) => {
+        process.stdout.write(data);
+        if (!data.startsWith('Watching')) {
+          resolve({
+            success: data.includes('Successfully'),
+            exit: false,
+            timestamp: Date.now(),
+          });
+        }
+      };
 
-  return { close: () => watchProcess.kill() };
+      stderrOnData = (err?: any) => {
+        process.stderr.write(err);
+        resolve({ success: false, exit: false, timestamp: Date.now() });
+      };
+
+      watcherOnExit = () => {
+        resolve({ success: true, exit: true, timestamp: Date.now() });
+      };
+
+      swcWatcher.stdout.on('data', stdoutOnData);
+      swcWatcher.stderr.on('data', stderrOnData);
+
+      process.on('SIGINT', processOnExit);
+      process.on('SIGTERM', processOnExit);
+      process.on('exit', processOnExit);
+
+      swcWatcher.on('exit', watcherOnExit);
+    }).finally(() => {
+      if (processOnExit) {
+        process.off('SIGINT', processOnExit);
+        process.off('SIGTERM', processOnExit);
+        process.off('exit', processOnExit);
+      }
+
+      if (stdoutOnData) {
+        swcWatcher.stdout.off('data', stdoutOnData);
+      }
+
+      if (stderrOnData) {
+        swcWatcher.stderr.off('data', stderrOnData);
+      }
+
+      if (watcherOnExit) {
+        swcWatcher.off('exit', watcherOnExit);
+      }
+    });
+  };
+
+  let typeCheckOptions: TypeCheckOptions;
+
+  // initial
+  const { success: initialSwcStatus } = await promisifySwcWatcher();
+
+  await postCompilationCallback();
+
+  if (normalizedOptions.skipTypeCheck) {
+    yield getResult(initialSwcStatus);
+  } else {
+    typeCheckOptions = getTypeCheckOptions(normalizedOptions);
+    const { errors, warnings } = await runTypeCheck(typeCheckOptions);
+    if (errors.length > 0) {
+      printDiagnostics(errors, warnings);
+      yield getResult(false);
+    } else {
+      if (warnings.length > 0) {
+        printDiagnostics(errors, warnings);
+      }
+      yield getResult(initialSwcStatus);
+    }
+  }
+
+  // watch
+  while (true) {
+    const { success: swcStatus, exit } = await promisifySwcWatcher();
+    if (exit) {
+      return getResult(swcStatus);
+    }
+
+    if (normalizedOptions.skipTypeCheck) {
+      yield getResult(swcStatus);
+    } else {
+      const delayed = delay(5000);
+      yield getResult(
+        await Promise.race([
+          delayed.start().then(() => ({ tscStatus: false, type: 'timeout' })),
+          runTypeCheck(typeCheckOptions).then(({ errors, warnings }) => {
+            const hasErrors = errors.length > 0;
+            if (hasErrors) {
+              printDiagnostics(errors, warnings);
+            }
+            return {
+              tscStatus: !hasErrors,
+              type: 'tsc',
+            };
+          }),
+        ]).then(({ type, tscStatus }) => {
+          if (type === 'tsc') {
+            delayed.cancel();
+            return tscStatus && swcStatus;
+          }
+
+          return swcStatus;
+        })
+      );
+    }
+  }
+}
+
+function delay(ms: number): { start: () => Promise<void>; cancel: () => void } {
+  let timerId: ReturnType<typeof setTimeout> = undefined;
+  return {
+    start() {
+      return new Promise<void>((resolve) => {
+        timerId = setTimeout(() => {
+          resolve();
+        }, ms);
+      });
+    },
+    cancel() {
+      if (timerId) {
+        clearTimeout(timerId);
+        timerId = undefined;
+      }
+    },
+  };
 }

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -91,7 +91,7 @@ export async function* compileSwcWatch(
 
       processOnExit = () => {
         swcWatcher.kill();
-        done(getResult(true));
+        done();
         process.off('SIGINT', processOnExit);
         process.off('SIGTERM', processOnExit);
         process.off('exit', processOnExit);
@@ -152,7 +152,7 @@ export async function* compileSwcWatch(
       };
 
       watcherOnExit = () => {
-        done(getResult(true));
+        done();
         swcWatcher.off('exit', watcherOnExit);
       };
 

--- a/packages/js/src/utils/typescript/compile-typescript-files.ts
+++ b/packages/js/src/utils/typescript/compile-typescript-files.ts
@@ -58,37 +58,9 @@ export async function* compileTypeScriptFiles(
       } else {
         const { success } = compileTypeScript(tscOptions);
         await postCompilationCallback();
-        done(getResult(success));
+        next(getResult(success));
+        done();
       }
     }
   );
-
-  // return new Observable((subscriber) => {
-  //   if (options.watch) {
-  //     const watcher = compileTypeScriptWatcher(
-  //       tscOptions,
-  //       async (d: Diagnostic) => {
-  //         if (d.code === 6194) {
-  //           await postCompleteAction();
-  //           subscriber.next({ success: true });
-  //         }
-  //       }
-  //     );
-  //
-  //     return () => {
-  //       watcher.close();
-  //       subscriber.complete();
-  //     };
-  //   }
-  //
-  //   const result = compileTypeScript(tscOptions);
-  //   (postCompleteAction() as Promise<void>).then(() => {
-  //     subscriber.next(result);
-  //     subscriber.complete();
-  //   });
-  //
-  //   return () => {
-  //     subscriber.complete();
-  //   };
-  // });
 }

--- a/packages/js/src/utils/typescript/compile-typescript-files.ts
+++ b/packages/js/src/utils/typescript/compile-typescript-files.ts
@@ -3,7 +3,6 @@ import {
   compileTypeScript,
   compileTypeScriptWatcher,
 } from '@nrwl/workspace/src/utilities/typescript/compilation';
-import { Observable } from 'rxjs';
 import type {
   CustomTransformers,
   Diagnostic,
@@ -11,15 +10,21 @@ import type {
   SourceFile,
   TransformerFactory,
 } from 'typescript';
+import { createAsyncIterable } from '../create-async-iterable/create-async-iteratable';
 import { NormalizedExecutorOptions } from '../schema';
 import { loadTsPlugins } from './load-ts-plugins';
 
-export function compileTypeScriptFiles(
-  options: NormalizedExecutorOptions,
+export async function* compileTypeScriptFiles(
+  normalizedOptions: NormalizedExecutorOptions,
   context: ExecutorContext,
-  postCompleteAction: () => void | Promise<void>
+  postCompilationCallback: () => void | Promise<void>
 ) {
-  const { compilerPluginHooks } = loadTsPlugins(options.transformers);
+  const getResult = (success: boolean) => ({
+    success,
+    outfile: normalizedOptions.mainOutputPath,
+  });
+
+  const { compilerPluginHooks } = loadTsPlugins(normalizedOptions.transformers);
 
   const getCustomTransformers = (program: Program): CustomTransformers => ({
     before: compilerPluginHooks.beforeHooks.map(
@@ -33,54 +38,57 @@ export function compileTypeScriptFiles(
     ),
   });
 
-  // const tcsOptions = {
-  //   outputPath: options.normalizedOutputPath,
-  //   projectName: context.projectName,
-  //   projectRoot: libRoot,
-  //   tsConfig: tsConfigPath,
-  //   deleteOutputPath: options.deleteOutputPath,
-  //   rootDir: options.srcRootForCompilationRoot,
-  //   watch: options.watch,
-  //   getCustomTransformers,
-  // };
-
   const tscOptions = {
-    outputPath: options.outputPath,
+    outputPath: normalizedOptions.outputPath,
     projectName: context.projectName,
-    projectRoot: options.projectRoot,
-    tsConfig: options.tsConfig,
-    // deleteOutputPath: options.deleteOutputPath,
-    // rootDir: options.srcRootForCompilationRoot,
-    watch: options.watch,
+    projectRoot: normalizedOptions.projectRoot,
+    tsConfig: normalizedOptions.tsConfig,
+    watch: normalizedOptions.watch,
     getCustomTransformers,
   };
 
-  return new Observable((subscriber) => {
-    if (options.watch) {
-      const watcher = compileTypeScriptWatcher(
-        tscOptions,
-        async (d: Diagnostic) => {
+  return yield* createAsyncIterable<{ success: boolean; outfile: string }>(
+    async ({ next, done }) => {
+      if (normalizedOptions.watch) {
+        compileTypeScriptWatcher(tscOptions, async (d: Diagnostic) => {
           if (d.code === 6194) {
-            await postCompleteAction();
-            subscriber.next({ success: true });
+            next(getResult(true));
           }
-        }
-      );
-
-      return () => {
-        watcher.close();
-        subscriber.complete();
-      };
+        });
+      } else {
+        const { success } = compileTypeScript(tscOptions);
+        await postCompilationCallback();
+        done(getResult(success));
+      }
     }
+  );
 
-    const result = compileTypeScript(tscOptions);
-    (postCompleteAction() as Promise<void>).then(() => {
-      subscriber.next(result);
-      subscriber.complete();
-    });
-
-    return () => {
-      subscriber.complete();
-    };
-  });
+  // return new Observable((subscriber) => {
+  //   if (options.watch) {
+  //     const watcher = compileTypeScriptWatcher(
+  //       tscOptions,
+  //       async (d: Diagnostic) => {
+  //         if (d.code === 6194) {
+  //           await postCompleteAction();
+  //           subscriber.next({ success: true });
+  //         }
+  //       }
+  //     );
+  //
+  //     return () => {
+  //       watcher.close();
+  //       subscriber.complete();
+  //     };
+  //   }
+  //
+  //   const result = compileTypeScript(tscOptions);
+  //   (postCompleteAction() as Promise<void>).then(() => {
+  //     subscriber.next(result);
+  //     subscriber.complete();
+  //   });
+  //
+  //   return () => {
+  //     subscriber.complete();
+  //   };
+  // });
 }

--- a/packages/js/src/utils/typescript/run-type-check.ts
+++ b/packages/js/src/utils/typescript/run-type-check.ts
@@ -18,6 +18,7 @@ interface BaseTypeCheckOptions {
   workspaceRoot: string;
   tsConfigPath: string;
   cacheDir?: string;
+  incremental?: boolean;
 }
 
 type Mode = NoEmitMode | EmitDeclarationOnlyMode;
@@ -115,7 +116,7 @@ export async function runTypeCheck(
 
 async function setupTypeScript(options: TypeCheckOptions) {
   const ts = await import('typescript');
-  const { workspaceRoot, tsConfigPath, cacheDir } = options;
+  const { workspaceRoot, tsConfigPath, cacheDir, incremental } = options;
   const config = readTsConfig(tsConfigPath);
   if (config.errors.length) {
     throw new Error(`Invalid config file: ${config.errors}`);
@@ -130,7 +131,9 @@ async function setupTypeScript(options: TypeCheckOptions) {
     ...config.options,
     skipLibCheck: true,
     ...emitOptions,
+    incremental,
   };
+
   return { ts, workspaceRoot, cacheDir, config, compilerOptions };
 }
 

--- a/packages/node/src/executors/package/utils/compile-typescript-files.ts
+++ b/packages/node/src/executors/package/utils/compile-typescript-files.ts
@@ -8,14 +8,14 @@ import {
   compileTypeScriptWatcher,
 } from '@nrwl/workspace/src/utilities/typescript/compilation';
 import { join } from 'path';
-import { NormalizedBuilderOptions } from './models';
-import { loadTsPlugins } from '../../../utils/load-ts-plugins';
 import type {
   CustomTransformers,
   Program,
   SourceFile,
   TransformerFactory,
 } from 'typescript';
+import { loadTsPlugins } from '../../../utils/load-ts-plugins';
+import { NormalizedBuilderOptions } from './models';
 
 export default async function compileTypeScriptFiles(
   options: NormalizedBuilderOptions,

--- a/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
+++ b/packages/workspace/src/core/nx-deps/nx-deps-cache.ts
@@ -4,17 +4,17 @@ import type {
   ProjectFileMap,
   ProjectGraph,
   ProjectGraphDependency,
-  ProjectGraphNode,
   ProjectGraphExternalNode,
+  ProjectGraphNode,
   WorkspaceJsonConfiguration,
 } from '@nrwl/devkit';
 import { readJsonFile, writeJsonFile } from '@nrwl/devkit';
-import { join } from 'path';
 import { existsSync } from 'fs';
 import { ensureDirSync } from 'fs-extra';
-import { directoryExists, fileExists } from '../../utilities/fileutils';
+import { join } from 'path';
 import { performance } from 'perf_hooks';
 import { cacheDir } from '../../utilities/cache-directory';
+import { directoryExists, fileExists } from '../../utilities/fileutils';
 
 export interface ProjectGraphCache {
   version: string;

--- a/packages/workspace/src/core/project-graph/daemon/tmp-dir.ts
+++ b/packages/workspace/src/core/project-graph/daemon/tmp-dir.ts
@@ -3,7 +3,7 @@
  * location within the OS's tmp directory where we write log files for background processes
  * and where we create the actual unix socket/named pipe for the daemon.
  */
-import { writeFileSync, statSync } from 'fs';
+import { statSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { cacheDir } from '../../../utilities/cache-directory';
 


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
- Using `Observable` to push compilation emits to `node:executor`
- TypeCheck is using `createWatchProgram` but this one gives incorrect diagnostic information.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- Using Promise and AsyncIterator to make up for push-based approach 
- TypeCheck is now using `createIncrementalProgram` with `cacheDir` (from `nx.json`) for `.tsbuildinfo`
- No more `rxjs`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
