### PR TITLE
docs(nx-dev): update edit this page link

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -72,7 +72,10 @@ export function DocViewer({
                   aria-hidden="true"
                   href={[
                     'https://github.com/nrwl/nx/blob/master',
-                    document.filePath,
+                    document.filePath.replace(
+                      'nx-dev/nx-dev/public/documentation',
+                      'docs'
+                    ),
                   ].join('/')}
                   target="_blank"
                   rel="noreferrer"


### PR DESCRIPTION
## What it does?
Changes the "edit this page" button link on nx.dev to point towards the documentation source.