### PR TITLE
fix(node): the type keyword may either be a string or an array

### DIFF
--- a/packages/tao/src/shared/params.spec.ts
+++ b/packages/tao/src/shared/params.spec.ts
@@ -803,6 +803,29 @@ describe('params', () => {
         ).not.toThrow();
       });
 
+      describe('array', () => {
+        it('should handle validating patterns', () => {
+          const schema = {
+            properties: {
+              a: {
+                type: ['string', 'boolean'],
+              },
+            },
+          };
+          expect(() =>
+            validateOptsAgainstSchema({ a: 'abc' }, schema)
+          ).not.toThrow();
+          expect(() =>
+            validateOptsAgainstSchema({ a: true }, schema)
+          ).not.toThrow();
+          expect(() =>
+            validateOptsAgainstSchema({ a: 123 }, schema)
+          ).toThrowErrorMatchingInlineSnapshot(
+            `"Property 'a' does not match the schema. '123' should be a 'string,boolean'."`
+          );
+        });
+      });
+
       describe('string', () => {
         it('should handle validating patterns', () => {
           const schema = {


### PR DESCRIPTION
ISSUES CLOSED: #8112

## Current Behavior
It is not provided that the type field can be an array during schema validation.

## Expected Behavior
The type keyword may either be a string or an array. If it is an array, it must be an array of strings, where each string is the name of one of the basic types, and each element is unique. In this case, the JSON snippet is valid if it matches any of the given types.

## Related Issue(s)
I haven't opened the issue, I want to close the next one #8112.

Fixes #8112
