### PR TITLE
fix(core): deprecate, fix error, and print warning when using --only-…

### DIFF
--- a/docs/generated/cli/affected-apps.md
+++ b/docs/generated/cli/affected-apps.md
@@ -67,9 +67,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### only-failed
+### ~~only-failed~~
 
 Default: `false`
+
+**Deprecated:** The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.
 
 Isolate projects which previously failed
 

--- a/docs/generated/cli/affected-build.md
+++ b/docs/generated/cli/affected-build.md
@@ -79,9 +79,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### only-failed
+### ~~only-failed~~
 
 Default: `false`
+
+**Deprecated:** The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.
 
 Isolate projects which previously failed
 

--- a/docs/generated/cli/affected-e2e.md
+++ b/docs/generated/cli/affected-e2e.md
@@ -79,9 +79,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### only-failed
+### ~~only-failed~~
 
 Default: `false`
+
+**Deprecated:** The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.
 
 Isolate projects which previously failed
 

--- a/docs/generated/cli/affected-graph.md
+++ b/docs/generated/cli/affected-graph.md
@@ -101,9 +101,11 @@ Show help
 
 Bind the project graph server to a specific ip address.
 
-### only-failed
+### ~~only-failed~~
 
 Default: `false`
+
+**Deprecated:** The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.
 
 Isolate projects which previously failed
 

--- a/docs/generated/cli/affected-libs.md
+++ b/docs/generated/cli/affected-libs.md
@@ -67,9 +67,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### only-failed
+### ~~only-failed~~
 
 Default: `false`
+
+**Deprecated:** The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.
 
 Isolate projects which previously failed
 

--- a/docs/generated/cli/affected-lint.md
+++ b/docs/generated/cli/affected-lint.md
@@ -79,9 +79,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### only-failed
+### ~~only-failed~~
 
 Default: `false`
+
+**Deprecated:** The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.
 
 Isolate projects which previously failed
 

--- a/docs/generated/cli/affected-test.md
+++ b/docs/generated/cli/affected-test.md
@@ -79,9 +79,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### only-failed
+### ~~only-failed~~
 
 Default: `false`
+
+**Deprecated:** The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.
 
 Isolate projects which previously failed
 

--- a/docs/generated/cli/affected.md
+++ b/docs/generated/cli/affected.md
@@ -85,9 +85,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### only-failed
+### ~~only-failed~~
 
 Default: `false`
+
+**Deprecated:** The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.
 
 Isolate projects which previously failed
 

--- a/docs/generated/cli/format-check.md
+++ b/docs/generated/cli/format-check.md
@@ -51,9 +51,11 @@ Show help
 
 Format only libraries and applications files.
 
-### only-failed
+### ~~only-failed~~
 
 Default: `false`
+
+**Deprecated:** The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.
 
 Isolate projects which previously failed
 

--- a/docs/generated/cli/format-write.md
+++ b/docs/generated/cli/format-write.md
@@ -51,9 +51,11 @@ Show help
 
 Format only libraries and applications files.
 
-### only-failed
+### ~~only-failed~~
 
 Default: `false`
+
+**Deprecated:** The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.
 
 Isolate projects which previously failed
 

--- a/docs/generated/cli/print-affected.md
+++ b/docs/generated/cli/print-affected.md
@@ -79,9 +79,11 @@ Latest commit of the current branch (usually HEAD)
 
 Show help
 
-### only-failed
+### ~~only-failed~~
 
 Default: `false`
+
+**Deprecated:** The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.
 
 Isolate projects which previously failed
 

--- a/docs/generated/cli/run-many.md
+++ b/docs/generated/cli/run-many.md
@@ -55,9 +55,11 @@ Exclude certain projects from being processed
 
 Show help
 
-### only-failed
+### ~~only-failed~~
 
 Default: `false`
+
+**Deprecated:** The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.
 
 Only run the target on projects which previously failed
 

--- a/packages/workspace/src/command-line/nx-commands.ts
+++ b/packages/workspace/src/command-line/nx-commands.ts
@@ -443,6 +443,8 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
       type: 'string',
     })
     .options('only-failed', {
+      deprecated:
+        'The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.',
       describe: 'Isolate projects which previously failed',
       type: 'boolean',
       default: false,
@@ -498,6 +500,8 @@ function withRunManyOptions(yargs: yargs.Argv): yargs.Argv {
         'Configure target dependencies instead. It will be removed in v14.',
     })
     .options('only-failed', {
+      deprecated:
+        'The command to rerun failed projects will appear if projects fail. This now does nothing and will be removed in v15.',
       describe: 'Only run the target on projects which previously failed',
       type: 'boolean',
       default: false,

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -114,6 +114,13 @@ export function splitArgsIntoNxArgsAndOverrides(
     nxArgs.configuration = 'production';
   }
 
+  // TODO(v15): onlyFailed should not be an option
+  if (options.printWarnings && nxArgs.onlyFailed) {
+    output.warn({
+      title: `--onlyFailed is deprecated. All tasks will be run.`,
+    });
+  }
+
   if (mode === 'affected') {
     if (options.printWarnings && nxArgs.all) {
       output.warn({

--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -84,11 +84,6 @@ export async function runCommand(
   terminalOutputStrategy: 'default' | 'hide-cached-output' | 'run-one',
   initiatingProject: string | null
 ) {
-  if (nxArgs.onlyFailed || nxArgs['only-failed']) {
-    output.warn({
-      title: '--only-failed has been removed. Nx is executing all the tasks.',
-    });
-  }
   const { tasksRunner, runnerOptions } = getRunner(nxArgs, nxJson);
 
   // Doing this for backwards compatibility, should be removed in v14


### PR DESCRIPTION
…failed

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Using `--only-failed` throws an error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`--only-failed` is now deprecated as caching offers a better alternative.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/7847
