### PR TITLE
chore(core): remove confusing cli description command

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -203,8 +203,6 @@ function showHelp() {
     packageManager            Package manager to use (npm, yarn, pnpm)
 
     nx-cloud                  Use Nx Cloud (boolean)
-
-    [new workspace options]   any 'new workspace' options
 `);
 }
 


### PR DESCRIPTION
## What it does?

Removes a confusing command statement that does not add much to the CLI's description.

Fixes #5218