### PR TITLE
fix(misc): fix npm-package generator on windows

### DIFF
--- a/packages/workspace/src/generators/npm-package/npm-package.ts
+++ b/packages/workspace/src/generators/npm-package/npm-package.ts
@@ -5,8 +5,8 @@ import {
   generateFiles,
   getWorkspaceLayout,
   getWorkspacePath,
+  joinPathFragments,
   names,
-  readWorkspaceConfiguration,
   Tree,
   writeJson,
 } from '@nrwl/devkit';
@@ -29,7 +29,7 @@ function addFiles(
 ) {
   const packageJsonPath = join(projectRoot, 'package.json');
   writeJson(tree, packageJsonPath, {
-    name: join(`@${npmScope}`, options.name),
+    name: joinPathFragments(`@${npmScope}`, options.name),
     version: '0.0.0',
     scripts: {
       test: 'node index.js',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The wrong package name is generated on windows for `nx g npm-package`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The right package name is generated on windows for `nx g npm-package`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/8743
