### PR TITLE
fix(core): fix cache for directory outputs

### DIFF
--- a/packages/workspace/src/core/project-graph/build-project-graph.ts
+++ b/packages/workspace/src/core/project-graph/build-project-graph.ts
@@ -345,7 +345,9 @@ function buildExplicitDependenciesUsingWorkers(
 }
 
 function getNumberOfWorkers(): number {
-  return +process.env.NX_PROJECT_GRAPH_MAX_WORKERS ?? os.cpus().length - 1;
+  return process.env.NX_PROJECT_GRAPH_MAX_WORKERS
+    ? +process.env.NX_PROJECT_GRAPH_MAX_WORKERS
+    : os.cpus().length - 1;
 }
 
 function createContext(


### PR DESCRIPTION
Only use parent directory for outputs if output is a file. Closes #8504.
This bug has been caused by https://github.com/nrwl/nx/commit/16e9f58f765f81e09239df15755b887a43b1f505.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
Closes #8504