### PR TITLE
fix(core): cacheDirectory resolution

### DIFF
--- a/packages/workspace/src/utilities/cache-directory.ts
+++ b/packages/workspace/src/utilities/cache-directory.ts
@@ -1,5 +1,5 @@
 import { NxJsonConfiguration, readJsonFile } from '@nrwl/devkit';
-import { join } from 'path';
+import { join, isAbsolute } from 'path';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 
 function readCacheDirectoryProperty(root: string): string | undefined {
@@ -17,10 +17,10 @@ function cacheDirectory(root: string, cacheDirectory: string) {
     cacheDirectory = cacheDirFromEnv;
   }
   if (cacheDirectory) {
-    if (cacheDirectory.startsWith('./')) {
-      return join(root, cacheDirectory);
-    } else {
+    if (isAbsolute(cacheDirectory)) {
       return cacheDirectory;
+    } else {
+      return join(root, cacheDirectory);
     }
   } else {
     return join(root, 'node_modules', '.cache', 'nx');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Right now if you have 

```
tasksRunnerOptions": {
    "default": {
      "runner": "@nrwl/workspace/tasks-runners/default",
      "options": {
        "cacheDirectory": ".nx/cache",
      }
    }
  },
```

the Daemon fails because it tries to create files relative to the `@nrwl/workspace` package rather than the workspace root.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Paths that don't start with `/` should be treated as relative paths to the workspace root.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
