### PR TITLE
fix(core): check if taskRunnerOptions exists

### DIFF
--- a/packages/workspace/src/migrations/update-13-6-0/remove-old-task-runner-options.spec.ts
+++ b/packages/workspace/src/migrations/update-13-6-0/remove-old-task-runner-options.spec.ts
@@ -1,0 +1,44 @@
+import { NxJsonConfiguration, readJson, Tree, writeJson } from '@nrwl/devkit';
+import { createTree } from '@nrwl/devkit/testing';
+import removeOldTaskRunnerOptions from '@nrwl/workspace/src/migrations/update-13-6-0/remove-old-task-runner-options';
+
+describe('removeOldTaskRunnerOptions', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTree();
+  });
+
+  it('should remove scan and analytics', () => {
+    writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+      npmScope: 'scope',
+      tasksRunnerOptions: {
+        default: {
+          runner: 'runner',
+          options: {
+            scan: true,
+            analytics: 'hi',
+          },
+        },
+      },
+    });
+    removeOldTaskRunnerOptions(tree);
+    const result = readJson(tree, 'nx.json');
+    expect(result).toEqual({
+      npmScope: 'scope',
+      tasksRunnerOptions: {
+        default: {
+          runner: 'runner',
+          options: {},
+        },
+      },
+    });
+  });
+
+  it("should not fail if nx.json doesn't have taskRunnerOptions", () => {
+    writeJson(tree, 'nx.json', {});
+    removeOldTaskRunnerOptions(tree);
+    const result = readJson(tree, 'nx.json');
+    expect(result).toEqual({});
+  });
+});

--- a/packages/workspace/src/migrations/update-13-6-0/remove-old-task-runner-options.ts
+++ b/packages/workspace/src/migrations/update-13-6-0/remove-old-task-runner-options.ts
@@ -6,8 +6,8 @@ import {
 
 export function removeOldTaskRunnerOptions(host: Tree) {
   const workspaceConfig = readWorkspaceConfiguration(host);
-  if (workspaceConfig.tasksRunnerOptions['default']) {
-    const options = workspaceConfig.tasksRunnerOptions['default'].options;
+  const options = workspaceConfig.tasksRunnerOptions?.['default']?.options;
+  if (options) {
     delete options.scan;
     delete options.analytics;
     updateWorkspaceConfiguration(host, workspaceConfig);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Migration fails if `taskRunnerOptions` is not in `nx.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Migration does nothing if `tasksRunnerOptions` is not in `nx.json`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/8726
