### PR TITLE
fix(core): fix dot notation parsing

### DIFF
--- a/packages/cli/lib/parse-run-one-options.spec.ts
+++ b/packages/cli/lib/parse-run-one-options.spec.ts
@@ -68,6 +68,26 @@ describe('parseRunOneOptions', () => {
     });
   });
 
+  it('should handle dot notation', () => {
+    expect(
+      parseRunOneOptions('root', workspaceJson, [
+        'run',
+        'myproj:build',
+        '--env.URL=https://localhost:9999',
+      ])
+    ).toEqual({
+      project: 'myproj',
+      target: 'build',
+      configuration: 'someDefaultConfig',
+      parsedArgs: {
+        _: [],
+        env: {
+          URL: 'https://localhost:9999',
+        },
+      },
+    });
+  });
+
   it('should use defaultProjectName when no provided', () => {
     expect(
       parseRunOneOptions(

--- a/packages/cli/lib/parse-run-one-options.ts
+++ b/packages/cli/lib/parse-run-one-options.ts
@@ -1,5 +1,4 @@
 import yargsParser = require('yargs-parser');
-import * as fs from 'fs';
 import type {
   WorkspaceJsonConfiguration,
   NxJsonConfiguration,
@@ -84,7 +83,6 @@ export function parseRunOneOptions(
     },
     configuration: {
       'strip-dashed': true,
-      'dot-notation': false,
     },
   });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cypress receives improper options when using `--env.URL=http://localhost:9999`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Cypress can accept env variables with `--env.URL=http://localhost:9999`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

This behavior was broken with https://github.com/lcabral37/nx/commit/713928de1bcb7f0667739e1fd545ea0bcb788b80
Fixes https://github.com/nrwl/nx/issues/8723
