### PR TITLE
fix(angular): update ng-packagr executors to support browserlist version ranges

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/styles/stylesheet-processor.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/styles/stylesheet-processor.ts
@@ -319,10 +319,11 @@ function transformSupportedBrowsersToTargets(
     // browserslist uses the name `ios_saf` for iOS Safari whereas esbuild uses `ios`
     if (browserName === 'ios_saf') {
       browserName = 'ios';
-      // browserslist also uses ranges for iOS Safari versions but only the lowest is required
-      // to perform minimum supported feature checks. esbuild also expects a single version.
-      [version] = version.split('-');
     }
+
+    // browserslist uses ranges `15.2-15.3` versions but only the lowest is required
+    // to perform minimum supported feature checks. esbuild also expects a single version.
+    [version] = version.split('-');
 
     if (browserName === 'ie') {
       transformed.push('edge12');

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/styles/stylesheet-processor.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/styles/stylesheet-processor.ts
@@ -319,10 +319,11 @@ function transformSupportedBrowsersToTargets(
     // browserslist uses the name `ios_saf` for iOS Safari whereas esbuild uses `ios`
     if (browserName === 'ios_saf') {
       browserName = 'ios';
-      // browserslist also uses ranges for iOS Safari versions but only the lowest is required
-      // to perform minimum supported feature checks. esbuild also expects a single version.
-      [version] = version.split('-');
     }
+
+    // browserslist uses ranges `15.2-15.3` versions but only the lowest is required
+    // to perform minimum supported feature checks. esbuild also expects a single version.
+    [version] = version.split('-');
 
     if (browserName === 'ie') {
       transformed.push('edge12');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
A recent version of `caniuse-lite` that's used by browserlist changed to report version ranges instead of single versions for all browsers. This breaks the `ng-packagr` processing of the stylesheets and therefore the library build fails.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Libraries should build successfully.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8768
