### PR TITLE
fix(node): webpack/terser stripping class names breaking reflection 

### DIFF
--- a/packages/node/src/utils/node.config.ts
+++ b/packages/node/src/utils/node.config.ts
@@ -23,6 +23,7 @@ function getNodePartial(options: BuildNodeBuilderOptions) {
         new TerserPlugin({
           terserOptions: {
             mangle: false,
+            keep_classnames: true,
           },
         }),
       ],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When building an app with `optimization: true`, Terser will be instanciated in Webpack's configuration which will apply some optimization mechanisms like minifying the code, etc...

But it will also strip most class names if they are not referenced elsewhere. Thus breaking any reflection mechanism.

**Example 1:**
In the context of a Nest.js migration using TypeORM, if your migration is as simple as it seems, it will be only referenced when instantiating the Nest's `TypeORMModule`. As the class is only referenced in the `migrations` array, Terser will remove the class's name as it seems unneeded. Unfortunately, the class name is used by TypeORM to recognize the migration name and timestamp. **TypeORM is blocked.**

```
{"context":"TypeOrmModule","level":"error","message":"Unable to connect to the database. Retrying (1)...","trace":"TypeORMError:  migration name is wrong. Migration class name should have a JavaScript timestamp appended.\n    at new TypeORMError [stripped for readability]"}
```

**Example 2:**
Still in a Nest.js context, when using a class as a provider, Nest will use the class name as the provider symbol for further injection. Stripping the class name can either (1) prevent Nest from injecting the provider correctly or, worse (2), inject another class which differs from the one intended.

In my workspace, I've disabled the optimizations by setting `optimization: false` but Webpack will then produce a development bundle, still interpolating some values like `NODE_ENV` by hardcoding it to `development`. This same bundle cannot be used in production because it is well known that some dependencies use conditionals like `if (NODE_ENV == 'production')`. So my company is blocked: either our apps won't boot or they cannot be deployed to production because their behaviors could be undefined.

**IMO, I consider this a critical issue.**

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

In the best world, Terser should be smart enough, but this is highly runtime code which is really hard to find statically. Here I'm telling Terser to keep all the class names which will have an impact on the bundle size, but as **the current version of Nx is breaking most (to not say all) Nest apps**, I consider this a non-issue.

Do not hesitate to challenge my fix proposal, but keep in mind that what can be done on a second time should be done in another PR, to ship this fix ASAP.

To avoid any issue in the future, it could be relevant to add a dummy Nest app as a e2e test to ensure reflection still works.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

I guess it fixes #8441 and fixes #8446, but it also shows that #8537 was not fixed properly, I guess this PR fixes it too.

