### PR TITLE
fix(angular): support target aliases existing in the angular-cli

### DIFF
--- a/packages/cli/lib/parse-run-one-options.spec.ts
+++ b/packages/cli/lib/parse-run-one-options.spec.ts
@@ -135,4 +135,13 @@ describe('parseRunOneOptions', () => {
   it('should return false when no project specified', () => {
     expect(parseRunOneOptions('root', workspaceJson, ['build'])).toBe(false);
   });
+
+  it('should support aliases', () => {
+    expect(parseRunOneOptions('root', workspaceJson, ['b', 'myproj'])).toEqual({
+      project: 'myproj',
+      target: 'build',
+      configuration: 'someDefaultConfig',
+      parsedArgs: { _: [] },
+    });
+  });
 });

--- a/packages/cli/lib/parse-run-one-options.ts
+++ b/packages/cli/lib/parse-run-one-options.ts
@@ -64,6 +64,16 @@ const invalidTargetNames = [
   'list',
 ];
 
+const targetAliases = {
+  b: 'build',
+  e: 'e2e',
+  'i18n-extract': 'extract-i18n',
+  xi18n: 'extract-i18n',
+  l: 'lint',
+  s: 'serve',
+  t: 'test',
+};
+
 export function parseRunOneOptions(
   root: string,
   workspaceConfiguration: any,
@@ -126,6 +136,11 @@ export function parseRunOneOptions(
     targets = readJsonFile(`${p}/project.json`).targets;
   } else {
     targets = p.architect ?? p.targets;
+  }
+
+  // if it doesn't match an existing target, try to find an alias
+  if (!targets?.[target] && targetAliases[target]) {
+    target = targetAliases[target];
   }
 
   // for backwards compat we require targets to be set when use defaultProjectName


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Target aliases existing in the Angular CLI (e.g. `s`, `b`) are not supported.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Common target aliases supported by the Angular CLI should be supported by the Nx CLI.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
