### PR TITLE
docs(core): fix broken link

### DIFF
--- a/docs/shared/devkit-and-nx-plugins.md
+++ b/docs/shared/devkit-and-nx-plugins.md
@@ -27,7 +27,7 @@ Plugins have:
 
   - Plugins can provide a function `processProjectGraph` to add extra edges to the project graph.
   - This allows plugins to influence the behavior of `nx affected` and the project graph visualization.
-  - See [project graph plugins]('./workspace/project-graph-plugins') for more information.
+  - See [project graph plugins](structure/project-graph-plugins) for more information.
 
 - **Project Inference Extensions**
 


### PR DESCRIPTION
The rendered docs at <https://nx.dev/using-nx/nx-devkit> link to
<https://nx.dev/using-nx/'./workspace/project-graph-plugins'> which just
redirects to the intro page.
<https://nx.dev/structure/project-graph-plugins> is likely the intended
target.