### PR TITLE
fix(storybook): ensure watch is passed to angular storybook options

### DIFF
--- a/packages/storybook/src/executors/utils.ts
+++ b/packages/storybook/src/executors/utils.ts
@@ -262,6 +262,11 @@ export function resolveCommonStorybookOptionMapper(
       },
       logger: angularDevkitCompatibleLogger,
     };
+
+    // Add watch to angularBuilderOptions for Storybook to merge configs correctly
+    storybookOptions.angularBuilderOptions = {
+      watch: true,
+    };
   } else {
     // keep the backwards compatibility
     setStorybookAppProject(context, builderOptions.projectBuildConfig);


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Hot Reload does not work with Angular 13

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Hot Reload works with Angular 13

## Explanation
Storybook's `app/angular/src/server/framework-preset-angular-cli.ts` file has code in it that merges three configs.

It merges in the following order
 - Config that is passed to the function
 - Config it reads from the Browser Build target that it reads from the `angular.json/workspace.json/project.json`
 - Additional Config Options from a new object `angularBuilderOptions` that was introduced in this commit: https://github.com/storybookjs/storybook/commit/8704f84d293c6a32cf035c2a25a4a385d4e27241

We were passing `watch: true` from our executor, but it was being overridden by the `watch` value it was reading from the `angular.json/workspace.json/project.json`. This is partially because the default build configuration for Angular apps is now `production`. 

Storybook providing the `angularBuilderOptions` and merging it last gave us an option to pass the `watch` flag using it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8484
