### PR TITLE
fix(angular): prevent adding dependencies when generating apps and specifying skipPackageJson

### DIFF
--- a/docs/generated/api-angular/generators/karma.md
+++ b/docs/generated/api-angular/generators/karma.md
@@ -26,3 +26,13 @@ Show what will be generated without writing to disk:
 ```bash
 nx g karma ... --dry-run
 ```
+
+## Options
+
+### skipPackageJson
+
+Default: `false`
+
+Type: `boolean`
+
+Do not add dependencies to `package.json`.

--- a/docs/generated/api-angular/generators/setup-mfe.md
+++ b/docs/generated/api-angular/generators/setup-mfe.md
@@ -74,3 +74,11 @@ Generate a routing setup to allow a host application to route to the remote appl
 Type: `boolean`
 
 Skip formatting the workspace after the generator completes.
+
+### skipPackageJson
+
+Default: `false`
+
+Type: `boolean`
+
+Do not add dependencies to `package.json`.

--- a/docs/generated/api-angular/generators/setup-tailwind.md
+++ b/docs/generated/api-angular/generators/setup-tailwind.md
@@ -49,6 +49,14 @@ Type: `boolean`
 
 Skips formatting the workspace after the generator completes.
 
+### skipPackageJson
+
+Default: `false`
+
+Type: `boolean`
+
+Do not add dependencies to `package.json`.
+
 ### stylesEntryPoint
 
 Type: `string`

--- a/docs/generated/api-cypress/generators/cypress-project.md
+++ b/docs/generated/api-cypress/generators/cypress-project.md
@@ -87,6 +87,14 @@ Type: `boolean`
 
 Skip formatting files
 
+### skipPackageJson
+
+Default: `false`
+
+Type: `boolean`
+
+Do not add dependencies to `package.json`.
+
 ### standaloneConfig
 
 Type: `boolean`

--- a/packages/angular/src/generators/add-linting/add-linting.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.ts
@@ -10,8 +10,15 @@ export async function addLintingGenerator(
   tree: Tree,
   options: AddLintingGeneratorSchema
 ): Promise<GeneratorCallback> {
-  const installTask = lintInitGenerator(tree, { linter: Linter.EsLint });
-  addAngularEsLintDependencies(tree);
+  const installTask = lintInitGenerator(tree, {
+    linter: Linter.EsLint,
+    skipPackageJson: options.skipPackageJson,
+  });
+
+  if (!options.skipPackageJson) {
+    addAngularEsLintDependencies(tree);
+  }
+
   createEsLintConfiguration(tree, options);
   addProjectLintTarget(tree, options);
 

--- a/packages/angular/src/generators/add-linting/schema.d.ts
+++ b/packages/angular/src/generators/add-linting/schema.d.ts
@@ -4,4 +4,5 @@ export interface AddLintingGeneratorSchema {
   prefix: string;
   setParserOptionsProject?: boolean;
   skipFormat?: boolean;
+  skipPackageJson?: boolean;
 }

--- a/packages/angular/src/generators/add-linting/schema.json
+++ b/packages/angular/src/generators/add-linting/schema.json
@@ -27,6 +27,11 @@
       "type": "boolean",
       "description": "Skip formatting files.",
       "default": false
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`."
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -69,7 +69,7 @@ export async function applicationGenerator(
     viewEncapsulation: options.viewEncapsulation,
     routing: false,
     skipInstall: true,
-    skipPackageJson: false,
+    skipPackageJson: options.skipPackageJson,
   });
 
   createFiles(host, options, appProjectRoot);
@@ -99,6 +99,7 @@ export async function applicationGenerator(
     await setupTailwindGenerator(host, {
       project: options.name,
       skipFormat: true,
+      skipPackageJson: options.skipPackageJson,
     });
   }
 

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -40,6 +40,7 @@ export async function addE2e(
       linter: options.linter,
       skipFormat: options.skipFormat,
       standaloneConfig: options.standaloneConfig,
+      skipPackageJson: options.skipPackageJson,
     });
   }
 
@@ -62,6 +63,7 @@ export async function addE2e(
         ],
         skipFormat: true,
         setParserOptionsProject: options.setParserOptionsProject,
+        skipPackageJson: options.skipPackageJson,
       });
     }
   }

--- a/packages/angular/src/generators/application/lib/add-linting.ts
+++ b/packages/angular/src/generators/application/lib/add-linting.ts
@@ -13,5 +13,6 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
     projectRoot: options.appProjectRoot,
     prefix: options.prefix,
     setParserOptionsProject: options.setParserOptionsProject,
+    skipPackageJson: options.skipPackageJson,
   });
 }

--- a/packages/angular/src/generators/application/lib/add-mfe.ts
+++ b/packages/angular/src/generators/application/lib/add-mfe.ts
@@ -12,5 +12,6 @@ export async function addMfe(host: Tree, options: NormalizedSchema) {
     host: options.host,
     routing: options.routing,
     skipFormat: true,
+    skipPackageJson: options.skipPackageJson,
   });
 }

--- a/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
+++ b/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
@@ -13,6 +13,7 @@ export async function addUnitTestRunner(host: Tree, options: NormalizedSchema) {
       setupFile: 'angular',
       supportTsx: false,
       skipSerializers: false,
+      skipPackageJson: options.skipPackageJson,
     });
   } else if (options.unitTestRunner === UnitTestRunner.Karma) {
     await karmaProjectGenerator(host, {

--- a/packages/angular/src/generators/application/schema.d.ts
+++ b/packages/angular/src/generators/application/schema.d.ts
@@ -29,4 +29,5 @@ export interface Schema {
   port?: number;
   host?: string;
   setParserOptionsProject?: boolean;
+  skipPackageJson?: boolean;
 }

--- a/packages/angular/src/generators/init/schema.d.ts
+++ b/packages/angular/src/generators/init/schema.d.ts
@@ -9,4 +9,5 @@ export interface Schema {
   skipInstall?: boolean;
   style?: Styles;
   linter: Exclude<Linter, Linter.TsLint>;
+  skipPackageJson?: boolean;
 }

--- a/packages/angular/src/generators/init/schema.json
+++ b/packages/angular/src/generators/init/schema.json
@@ -56,6 +56,11 @@
           }
         ]
       }
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`."
     }
   },
   "additionalProperties": false

--- a/packages/angular/src/generators/karma/karma.spec.ts
+++ b/packages/angular/src/generators/karma/karma.spec.ts
@@ -17,14 +17,14 @@ describe('karma', () => {
       return json;
     });
 
-    karmaGenerator(tree);
+    karmaGenerator(tree, {});
 
     expect(devkit.generateFiles).not.toHaveBeenCalled();
     expect(devkit.addDependenciesToPackageJson).not.toHaveBeenCalled();
   });
 
   it('should add karma dependencies', () => {
-    karmaGenerator(tree);
+    karmaGenerator(tree, {});
 
     const { devDependencies } = devkit.readJson(tree, 'package.json');
     expect(devDependencies['karma']).toBeDefined();
@@ -38,7 +38,7 @@ describe('karma', () => {
   });
 
   it('should add karma configuration', () => {
-    karmaGenerator(tree);
+    karmaGenerator(tree, {});
 
     expect(tree.exists('karma.conf.js')).toBeTruthy();
   });

--- a/packages/angular/src/generators/karma/karma.ts
+++ b/packages/angular/src/generators/karma/karma.ts
@@ -5,28 +5,32 @@ import {
   joinPathFragments,
   readJson,
 } from '@nrwl/devkit';
+import { GeneratorOptions } from './schema';
 
-export function karmaGenerator(tree: Tree) {
+export function karmaGenerator(tree: Tree, options: GeneratorOptions) {
   const packageJson = readJson(tree, 'package.json');
   if (packageJson.devDependencies['karma']) {
     return;
   }
 
   generateFiles(tree, joinPathFragments(__dirname, 'files'), '.', { tmpl: '' });
-  return addDependenciesToPackageJson(
-    tree,
-    {},
-    {
-      karma: '~5.0.0',
-      'karma-chrome-launcher': '~3.1.0',
-      'karma-coverage-istanbul-reporter': '~3.0.2',
-      'karma-jasmine': '~4.0.0',
-      'karma-jasmine-html-reporter': '^1.5.0',
-      'jasmine-core': '~3.6.0',
-      'jasmine-spec-reporter': '~5.0.0',
-      '@types/jasmine': '~3.5.0',
-    }
-  );
+
+  return !options.skipPackageJson
+    ? addDependenciesToPackageJson(
+        tree,
+        {},
+        {
+          karma: '~5.0.0',
+          'karma-chrome-launcher': '~3.1.0',
+          'karma-coverage-istanbul-reporter': '~3.0.2',
+          'karma-jasmine': '~4.0.0',
+          'karma-jasmine-html-reporter': '^1.5.0',
+          'jasmine-core': '~3.6.0',
+          'jasmine-spec-reporter': '~5.0.0',
+          '@types/jasmine': '~3.5.0',
+        }
+      )
+    : () => {};
 }
 
 export default karmaGenerator;

--- a/packages/angular/src/generators/karma/schema.d.ts
+++ b/packages/angular/src/generators/karma/schema.d.ts
@@ -1,0 +1,3 @@
+export interface GeneratorOptions {
+  skipPackageJson?: boolean;
+}

--- a/packages/angular/src/generators/karma/schema.json
+++ b/packages/angular/src/generators/karma/schema.json
@@ -4,7 +4,13 @@
   "title": "Add Karma Configuration to the workspace.",
   "cli": "nx",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`."
+    }
+  },
   "additionalProperties": false,
   "required": []
 }

--- a/packages/angular/src/generators/setup-mfe/schema.d.ts
+++ b/packages/angular/src/generators/setup-mfe/schema.d.ts
@@ -6,4 +6,5 @@ export interface Schema {
   host?: string;
   routing?: boolean;
   skipFormat?: boolean;
+  skipPackageJson?: boolean;
 }

--- a/packages/angular/src/generators/setup-mfe/schema.json
+++ b/packages/angular/src/generators/setup-mfe/schema.json
@@ -40,6 +40,11 @@
     "skipFormat": {
       "type": "boolean",
       "description": "Skip formatting the workspace after the generator completes."
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`."
     }
   },
   "required": ["appName", "mfeType"],

--- a/packages/angular/src/generators/setup-mfe/setup-mfe.ts
+++ b/packages/angular/src/generators/setup-mfe/setup-mfe.ts
@@ -1,4 +1,4 @@
-import type { Tree } from '@nrwl/devkit';
+import type { GeneratorCallback, Tree } from '@nrwl/devkit';
 import type { Schema } from './schema';
 
 import {
@@ -36,15 +36,18 @@ export async function setupMfe(host: Tree, options: Schema) {
 
   fixBootstrap(host, projectConfig.root);
 
-  // add package to install
-  const installPackages = addDependenciesToPackageJson(
-    host,
-    {
-      '@angular-architects/module-federation':
-        angularArchitectsModuleFederationPluginVersion,
-    },
-    {}
-  );
+  let installPackages: GeneratorCallback = () => {};
+  if (!options.skipPackageJson) {
+    // add package to install
+    installPackages = addDependenciesToPackageJson(
+      host,
+      {
+        '@angular-architects/module-federation':
+          angularArchitectsModuleFederationPluginVersion,
+      },
+      {}
+    );
+  }
 
   // format files
   if (!options.skipFormat) {

--- a/packages/angular/src/generators/setup-tailwind/schema.d.ts
+++ b/packages/angular/src/generators/setup-tailwind/schema.d.ts
@@ -3,6 +3,7 @@ export interface GeneratorOptions {
   buildTarget?: string;
   skipFormat?: boolean;
   stylesEntryPoint?: string;
+  skipPackageJson?: boolean;
 }
 
 export interface NormalizedGeneratorOptions extends GeneratorOptions {

--- a/packages/angular/src/generators/setup-tailwind/schema.json
+++ b/packages/angular/src/generators/setup-tailwind/schema.json
@@ -27,6 +27,11 @@
     "stylesEntryPoint": {
       "type": "string",
       "description": "Path to the styles entry point relative to the workspace root. If not provided the generator will do its best to find it and it will error if it can't. This option only applies to applications."
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`."
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/generators/setup-tailwind/setup-tailwind.ts
+++ b/packages/angular/src/generators/setup-tailwind/setup-tailwind.ts
@@ -17,15 +17,17 @@ import { GeneratorOptions } from './schema';
 export async function setupTailwindGenerator(
   tree: Tree,
   rawOptions: GeneratorOptions
-): Promise<GeneratorCallback | undefined> {
+): Promise<GeneratorCallback> {
   const options = normalizeOptions(rawOptions);
   const project = readProjectConfiguration(tree, options.project);
 
   const tailwindInstalledVersion = detectTailwindInstalledVersion(tree);
 
-  let installTask: GeneratorCallback | undefined;
-  if (tailwindInstalledVersion === undefined) {
-    installTask = addTailwindRequiredPackages(tree);
+  let installTask: GeneratorCallback = () => {};
+  if (!options.skipPackageJson) {
+    if (tailwindInstalledVersion === undefined) {
+      installTask = addTailwindRequiredPackages(tree);
+    }
   }
 
   addTailwindConfig(tree, options, project, tailwindInstalledVersion ?? '3');

--- a/packages/cypress/src/generators/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.ts
@@ -141,17 +141,20 @@ export async function addLinter(host: Tree, options: CypressProjectSchema) {
       `${options.projectRoot}/**/*.${options.js ? 'js' : '{js,ts}'}`,
     ],
     setParserOptionsProject: options.setParserOptionsProject,
+    skipPackageJson: options.skipPackageJson,
   });
 
   if (!options.linter || options.linter !== Linter.EsLint) {
     return installTask;
   }
 
-  const installTask2 = addDependenciesToPackageJson(
-    host,
-    {},
-    { 'eslint-plugin-cypress': eslintPluginCypressVersion }
-  );
+  const installTask2 = !options.skipPackageJson
+    ? addDependenciesToPackageJson(
+        host,
+        {},
+        { 'eslint-plugin-cypress': eslintPluginCypressVersion }
+      )
+    : () => {};
 
   updateJson(host, join(options.projectRoot, '.eslintrc.json'), (json) => {
     json.extends = ['plugin:cypress/recommended', ...json.extends];

--- a/packages/cypress/src/generators/cypress-project/schema.d.ts
+++ b/packages/cypress/src/generators/cypress-project/schema.d.ts
@@ -10,4 +10,5 @@ export interface Schema {
   skipFormat?: boolean;
   setParserOptionsProject?: boolean;
   standaloneConfig?: boolean;
+  skipPackageJson?: boolean;
 }

--- a/packages/cypress/src/generators/cypress-project/schema.json
+++ b/packages/cypress/src/generators/cypress-project/schema.json
@@ -53,6 +53,11 @@
     "standaloneConfig": {
       "description": "Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json",
       "type": "boolean"
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`."
     }
   },
   "required": ["name"]

--- a/packages/cypress/src/generators/init/init.spec.ts
+++ b/packages/cypress/src/generators/init/init.spec.ts
@@ -21,7 +21,7 @@ describe('init', () => {
       json.devDependencies[existing] = existingVersion;
       return json;
     });
-    cypressInitGenerator(tree);
+    cypressInitGenerator(tree, {});
     const packageJson = readJson(tree, 'package.json');
 
     expect(packageJson.devDependencies.cypress).toBeDefined();

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -6,6 +6,7 @@ import {
 } from '@nrwl/devkit';
 
 import { cypressVersion, nxVersion } from '../../utils/versions';
+import { Schema } from './schema';
 
 function updateDependencies(host: Tree) {
   updateJson(host, 'package.json', (json) => {
@@ -24,8 +25,8 @@ function updateDependencies(host: Tree) {
   );
 }
 
-export function cypressInitGenerator(host: Tree) {
-  return updateDependencies(host);
+export function cypressInitGenerator(host: Tree, options: Schema) {
+  return !options.skipPackageJson ? updateDependencies(host) : () => {};
 }
 
 export default cypressInitGenerator;

--- a/packages/cypress/src/generators/init/schema.d.ts
+++ b/packages/cypress/src/generators/init/schema.d.ts
@@ -1,1 +1,3 @@
-export interface Schema {}
+export interface Schema {
+  skipPackageJson?: boolean;
+}

--- a/packages/cypress/src/generators/init/schema.json
+++ b/packages/cypress/src/generators/init/schema.json
@@ -4,5 +4,11 @@
   "cli": "nx",
   "title": "Add Cypress Configuration to the workspace",
   "type": "object",
-  "properties": {}
+  "properties": {
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`."
+    }
+  }
 }

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -1,6 +1,7 @@
 import {
   addDependenciesToPackageJson,
   convertNxGenerator,
+  GeneratorCallback,
   stripIndents,
   Tree,
   updateJson,
@@ -99,8 +100,13 @@ function updateExtensions(host: Tree) {
 export function jestInitGenerator(tree: Tree, schema: JestInitSchema) {
   const options = normalizeOptions(schema);
   createJestConfig(tree);
-  const installTask = updateDependencies(tree, options);
-  removeNrwlJestFromDeps(tree);
+
+  let installTask: GeneratorCallback = () => {};
+  if (!options.skipPackageJson) {
+    installTask = updateDependencies(tree, options);
+    removeNrwlJestFromDeps(tree);
+  }
+
   updateExtensions(tree);
   return installTask;
 }

--- a/packages/jest/src/generators/init/schema.d.ts
+++ b/packages/jest/src/generators/init/schema.d.ts
@@ -1,5 +1,6 @@
 export interface JestInitSchema {
   compiler?: 'tsc' | 'babel' | 'swc';
+  skipPackageJson?: boolean;
   /**
    * @deprecated
    */

--- a/packages/jest/src/generators/init/schema.json
+++ b/packages/jest/src/generators/init/schema.json
@@ -10,6 +10,11 @@
       "alias": "babel-jest",
       "description": "Use babel-jest instead of ts-jest",
       "default": false
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`."
     }
   },
   "required": []

--- a/packages/jest/src/generators/jest-project/schema.d.ts
+++ b/packages/jest/src/generators/jest-project/schema.d.ts
@@ -14,4 +14,5 @@ export interface JestProjectSchema {
   babelJest?: boolean;
   skipFormat?: boolean;
   compiler?: 'tsc' | 'babel' | 'swc';
+  skipPackageJson?: boolean;
 }

--- a/packages/jest/src/generators/jest-project/schema.json
+++ b/packages/jest/src/generators/jest-project/schema.json
@@ -57,6 +57,11 @@
       "description": "Skip formatting files",
       "type": "boolean",
       "default": false
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`."
     }
   },
   "required": []

--- a/packages/linter/src/generators/lint-project/lint-project.ts
+++ b/packages/linter/src/generators/lint-project/lint-project.ts
@@ -17,6 +17,7 @@ interface LintProjectOptions {
   tsConfigPaths?: string[];
   skipFormat: boolean;
   setParserOptionsProject?: boolean;
+  skipPackageJson?: boolean;
 }
 
 function createTsLintConfiguration(
@@ -87,6 +88,7 @@ export async function lintProjectGenerator(
 ) {
   const installTask = lintInitGenerator(tree, {
     linter: options.linter,
+    skipPackageJson: options.skipPackageJson,
   });
   const projectConfig = readProjectConfiguration(tree, options.project);
 

--- a/packages/next/src/generators/init/init.ts
+++ b/packages/next/src/generators/init/init.ts
@@ -44,7 +44,7 @@ export async function nextInitGenerator(host: Tree, schema: InitSchema) {
     tasks.push(jestTask);
   }
   if (!schema.e2eTestRunner || schema.e2eTestRunner === 'cypress') {
-    const cypressTask = cypressInitGenerator(host);
+    const cypressTask = cypressInitGenerator(host, {});
     tasks.push(cypressTask);
   }
 

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -82,7 +82,7 @@ export async function reactInitGenerator(host: Tree, schema: InitSchema) {
     tasks.push(jestTask);
   }
   if (!schema.e2eTestRunner || schema.e2eTestRunner === 'cypress') {
-    const cypressTask = cypressInitGenerator(host);
+    const cypressTask = cypressInitGenerator(host, {});
     tasks.push(cypressTask);
   }
 

--- a/packages/storybook/src/generators/cypress-project/cypress-project.ts
+++ b/packages/storybook/src/generators/cypress-project/cypress-project.ts
@@ -42,7 +42,7 @@ export async function cypressProjectGenerator(
   const tasks: GeneratorCallback[] = [];
 
   if (!projectAlreadyHasCypress(tree)) {
-    tasks.push(_cypressInitGenerator(tree));
+    tasks.push(_cypressInitGenerator(tree, {}));
   }
 
   const installTask = await _cypressProjectGenerator(tree, {

--- a/packages/web/src/generators/init/init.ts
+++ b/packages/web/src/generators/init/init.ts
@@ -52,7 +52,7 @@ export async function webInitGenerator(tree: Tree, schema: Schema) {
     tasks.push(jestTask);
   }
   if (!schema.e2eTestRunner || schema.e2eTestRunner === 'cypress') {
-    const cypressTask = cypressInitGenerator(tree);
+    const cypressTask = cypressInitGenerator(tree, {});
     tasks.push(cypressTask);
   }
   const installTask = updateDependencies(tree);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating Angular applications if the flag `--skipPackageJson` is passed, it doesn't prevent adding dependencies to the `package.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Passing the `skipPackageJson` flag when generating an Angular app should prevent adding dependencies to the `package.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8149
