### PR TITLE
docs(core): fix broken link

### DIFF
--- a/docs/shared/devkit-and-nx-plugins.md
+++ b/docs/shared/devkit-and-nx-plugins.md
@@ -27,7 +27,7 @@ Plugins have:
 
   - Plugins can provide a function `processProjectGraph` to add extra edges to the project graph.
   - This allows plugins to influence the behavior of `nx affected` and the project graph visualization.
-  - See [project graph plugins]('./workspace/project-graph-plugins') for more information.
+  - See [project graph plugins](/structure/project-graph-plugins) for more information.
 
 - **Project Inference Extensions**
 

--- a/nx-dev/nx-dev/public/documentation/shared/daemon.md
+++ b/nx-dev/nx-dev/public/documentation/shared/daemon.md
@@ -16,7 +16,7 @@ The Nx Daemon is a process which runs in the background on your local machine. T
 
 > On macOS and linux, the server runs as a unix socket, and on Windows it runs as a named pipe.
 
-The Nx Deamon is more efficient at recomputing the project graph because it watches the files in your workspaces and updates the project graph right away (intelligently throttling to ensure minimal recomputation). It also keeps everything in memory, so the response tends to be a lot faster.
+The Nx Daemon is more efficient at recomputing the project graph because it watches the files in your workspaces and updates the project graph right away (intelligently throttling to ensure minimal recomputation). It also keeps everything in memory, so the response tends to be a lot faster.
 
 In order to be most efficient, the Nx Daemon has some built in mechanisms to automatically shut down (including removing all file watchers) when it is not needed. These include:
 
@@ -27,7 +27,7 @@ If you ever need to manually shut down the Nx Daemon, you can run `nx reset` wit
 
 ## Turning it Off
 
-As of v13.6.0, the Nx Daemon is enabled by default. If you want to turn it off, simply set `useDaemonProcess: false` in the runners options in nx.json. You can also set the `NX_DEAMON` env variable to `false`.
+As of v13.6.0, the Nx Daemon is enabled by default. If you want to turn it off, simply set `useDaemonProcess: false` in the runners options in nx.json. You can also set the `NX_DAEMON` env variable to `false`.
 
 ## Logs
 

--- a/nx-dev/nx-dev/public/documentation/shared/devkit-and-nx-plugins.md
+++ b/nx-dev/nx-dev/public/documentation/shared/devkit-and-nx-plugins.md
@@ -27,7 +27,7 @@ Plugins have:
 
   - Plugins can provide a function `processProjectGraph` to add extra edges to the project graph.
   - This allows plugins to influence the behavior of `nx affected` and the project graph visualization.
-  - See [project graph plugins]('./workspace/project-graph-plugins') for more information.
+  - See [project graph plugins](/structure/project-graph-plugins) for more information.
 
 - **Project Inference Extensions**
 


### PR DESCRIPTION
The rendered docs at <https://nx.dev/using-nx/nx-devkit> link to
<https://nx.dev/using-nx/'./workspace/project-graph-plugins'> which just
redirects to the intro page.
<https://nx.dev/structure/project-graph-plugins> is likely the intended
target.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The link to `project graph plugins` on https://nx.dev/using-nx/nx-devkit leads to https://nx.dev/getting-started/intro

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The link to `project graph plugins` on https://nx.dev/using-nx/nx-devkit leads to https://nx.dev/structure/project-graph-plugins

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes #8795 
