### PR TITLE
fix(nextjs): use correct e2e test command for non-Angular projects

### DIFF
--- a/packages/workspace/src/generators/workspace/files/README.md__tmpl__
+++ b/packages/workspace/src/generators/workspace/files/README.md__tmpl__
@@ -159,7 +159,7 @@ Run `nx affected:test` to execute the unit tests affected by a change.
 
 ## Running end-to-end tests
 
-Run `ng e2e my-app` to execute the end-to-end tests via [Cypress](https://www.cypress.io).
+Run `nx e2e my-app-e2e` to execute the end-to-end tests via [Cypress](https://www.cypress.io).
 
 Run `nx affected:e2e` to execute the end-to-end tests affected by a change.
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
After running `npx create-nx-workspace` and creating a new NextJS project. 
When we run the command `ng e2e my-app` and it throws an error:
`npm ERR! could not determine executable to run`

## Expected Behavior
Run the e2e tests for Next.js projects correctly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
