### PR TITLE
feat(core): expose project root dir to task env

### DIFF
--- a/packages/workspace/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/workspace/src/tasks-runner/forked-process-task-runner.ts
@@ -286,6 +286,7 @@ export class ForkedProcessTaskRunner {
   ) {
     const env: NodeJS.ProcessEnv = {
       NX_TASK_TARGET_PROJECT: task.target.project,
+      NX_TASK_PROJECT_ROOT: task.projectRoot,
       NX_TASK_HASH: task.hash,
     };
 


### PR DESCRIPTION
## Current Behavior

Currently the `workspace` only exposes `NX_TASK_TARGET_PROJECT` and `NX_TASK_HASH`

## Expected Behavior

While I was trying to have a central `jest.config.js` for all my Angular libraries I needed the `projectRoot` too
so exposing it I was able to achieve my objective:

```javascript
// etc/jest.config.js

module.exports = {
  displayName: process.env.NX_TASK_TARGET_PROJECT,
  rootDir: `../../${process.env.NX_TASK_PROJECT_ROOT}`,
  ...
```

This would be helpful for other scripts requiring the rootDir to operate.