### PR TITLE
docs(nxdev): flatten storybook executors map links

### DIFF
--- a/docs/map.json
+++ b/docs/map.json
@@ -902,21 +902,16 @@
             "id": "migrate-stories-to-6-2",
             "file": "generated/api-storybook/generators/migrate-stories-to-6-2"
           },
+
           {
-            "id": "executors",
-            "name": "Executors / Builders",
-            "itemList": [
-              {
-                "name": "build",
-                "id": "build",
-                "file": "generated/api-storybook/executors/build"
-              },
-              {
-                "name": "storybook",
-                "id": "storybook",
-                "file": "generated/api-storybook/executors/storybook"
-              }
-            ]
+            "name": "Executors: Build",
+            "id": "executors-build",
+            "file": "generated/api-storybook/executors/build"
+          },
+          {
+            "name": "Executors: Storybook",
+            "id": "executors-storybook",
+            "file": "generated/api-storybook/executors/storybook"
           }
         ]
       },

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -68,6 +68,11 @@ module.exports = withNx({
       destination: '/storybook/overview-angular',
       permanent: true,
     });
+    rules.push({
+      source: '/(l|latest)/(a|angular|r|react)/storybook/executors',
+      destination: '/storybook/executors-storybook',
+      permanent: true,
+    });
 
     // Customs
     for (let s of Object.keys(redirects)) {


### PR DESCRIPTION
## What it does?
Flatten the documentation map for Storybook executors on nx.dev.