### PR TITLE
fix(core): add project.json to nx implicit dependencies

### DIFF
--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -115,6 +115,12 @@
       "description": "Remove old options that are no longer used",
       "cli": "nx",
       "implementation": "./src/migrations/update-13-6-0/remove-old-task-runner-options"
+    },
+    "13-7-3-add-project-json-to-implicit-deps": {
+      "version": "13.7.3",
+      "description": "Add project.json to nx implicitDependencies",
+      "cli": "nx",
+      "implementation": "./src/migrations/update-13-7-3/add-project-json-to-implicit-deps"
     }
   },
   "packageJsonUpdates": {

--- a/packages/workspace/presets/core.json
+++ b/packages/workspace/presets/core.json
@@ -4,7 +4,8 @@
       "dependencies": "*",
       "devDependencies": "*"
     },
-    ".eslintrc.json": "*"
+    ".eslintrc.json": "*",
+    "packages/**/project.json": "*"
   },
   "targetDependencies": {
     "build": [

--- a/packages/workspace/presets/core.json
+++ b/packages/workspace/presets/core.json
@@ -5,7 +5,9 @@
       "devDependencies": "*"
     },
     ".eslintrc.json": "*",
-    "packages/**/project.json": "*"
+    "packages/**/project.json": {
+      "tags": "*"
+    }
   },
   "targetDependencies": {
     "build": [

--- a/packages/workspace/presets/npm.json
+++ b/packages/workspace/presets/npm.json
@@ -4,7 +4,8 @@
       "dependencies": "*",
       "devDependencies": "*"
     },
-    ".eslintrc.json": "*"
+    ".eslintrc.json": "*",
+    "packages/**/project.json": "*"
   },
   "targetDependencies": {
     "build": [

--- a/packages/workspace/presets/npm.json
+++ b/packages/workspace/presets/npm.json
@@ -5,7 +5,9 @@
       "devDependencies": "*"
     },
     ".eslintrc.json": "*",
-    "packages/**/project.json": "*"
+    "packages/**/project.json": {
+      "tags": "*"
+    }
   },
   "targetDependencies": {
     "build": [

--- a/packages/workspace/src/command-line/run-one.ts
+++ b/packages/workspace/src/command-line/run-one.ts
@@ -27,7 +27,7 @@ export async function runOne(opts: {
   await connectToNxCloudUsingScan(nxArgs.scan);
 
   const projectGraph = await createProjectGraphAsync();
-  const { projects, projectsMap } = getProjects(projectGraph, opts.project);
+  const { projects } = getProjects(projectGraph, opts.project);
   const env = readEnvironment();
 
   await runCommand(

--- a/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
@@ -82,8 +82,12 @@ Object {
   },
   "implicitDependencies": Object {
     ".eslintrc.json": "*",
-    "apps/**/project.json": "*",
-    "libs/**/project.json": "*",
+    "apps/**/project.json": Object {
+      "tags": "*",
+    },
+    "libs/**/project.json": Object {
+      "tags": "*",
+    },
     "package.json": Object {
       "dependencies": "*",
       "devDependencies": "*",

--- a/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
@@ -82,6 +82,8 @@ Object {
   },
   "implicitDependencies": Object {
     ".eslintrc.json": "*",
+    "apps/**/project.json": "*",
+    "libs/**/project.json": "*",
     "package.json": Object {
       "dependencies": "*",
       "devDependencies": "*",

--- a/packages/workspace/src/generators/workspace/files/nx.json__tmpl__
+++ b/packages/workspace/src/generators/workspace/files/nx.json__tmpl__
@@ -13,8 +13,12 @@
       "devDependencies": "*"
     },
     ".eslintrc.json": "*",
-    "apps/**/project.json": "*",
-    "libs/**/project.json": "*"
+    "apps/**/project.json": {
+      "tags": "*"
+    },
+    "libs/**/project.json": {
+      "tags": "*"
+    }
   },
   "tasksRunnerOptions": {
     "default": {

--- a/packages/workspace/src/generators/workspace/files/nx.json__tmpl__
+++ b/packages/workspace/src/generators/workspace/files/nx.json__tmpl__
@@ -12,7 +12,9 @@
       "dependencies": "*",
       "devDependencies": "*"
     },
-    ".eslintrc.json": "*"
+    ".eslintrc.json": "*",
+    "apps/**/project.json": "*",
+    "libs/**/project.json": "*"
   },
   "tasksRunnerOptions": {
     "default": {

--- a/packages/workspace/src/generators/workspace/workspace.spec.ts
+++ b/packages/workspace/src/generators/workspace/workspace.spec.ts
@@ -48,8 +48,12 @@ describe('@nrwl/workspace:workspace', () => {
           devDependencies: '*',
         },
         '.eslintrc.json': '*',
-        'apps/**/project.json': '*',
-        'libs/**/project.json': '*',
+        'apps/**/project.json': {
+          tags: '*',
+        },
+        'libs/**/project.json': {
+          tags: '*',
+        },
       },
       tasksRunnerOptions: {
         default: {

--- a/packages/workspace/src/generators/workspace/workspace.spec.ts
+++ b/packages/workspace/src/generators/workspace/workspace.spec.ts
@@ -48,6 +48,8 @@ describe('@nrwl/workspace:workspace', () => {
           devDependencies: '*',
         },
         '.eslintrc.json': '*',
+        'apps/**/project.json': '*',
+        'libs/**/project.json': '*',
       },
       tasksRunnerOptions: {
         default: {
@@ -123,14 +125,14 @@ describe('@nrwl/workspace:workspace', () => {
 
     const { scripts } = readJson(tree, '/proj/package.json');
     expect(scripts).toMatchInlineSnapshot(`
-Object {
-  "build": "nx build",
-  "ng": "nx",
-  "postinstall": "node ./decorate-angular-cli.js",
-  "start": "nx serve",
-  "test": "nx test",
-}
-`);
+      Object {
+        "build": "nx build",
+        "ng": "nx",
+        "postinstall": "node ./decorate-angular-cli.js",
+        "start": "nx serve",
+        "test": "nx test",
+      }
+    `);
   });
 
   it('should not add decorate-angular-cli when used with nx cli', async () => {
@@ -145,12 +147,12 @@ Object {
 
     const { scripts } = readJson(tree, '/proj/package.json');
     expect(scripts).toMatchInlineSnapshot(`
-Object {
-  "build": "nx build",
-  "start": "nx serve",
-  "test": "nx test",
-}
-`);
+      Object {
+        "build": "nx build",
+        "start": "nx serve",
+        "test": "nx test",
+      }
+    `);
   });
 
   it('should create a workspace using package layout', async () => {

--- a/packages/workspace/src/migrations/update-13-7-3/add-project-json-to-implicit-deps.spec.ts
+++ b/packages/workspace/src/migrations/update-13-7-3/add-project-json-to-implicit-deps.spec.ts
@@ -1,0 +1,127 @@
+import { NxJsonConfiguration, readJson, Tree, writeJson } from '@nrwl/devkit';
+import { createTree } from '@nrwl/devkit/testing';
+import addProjectJsonToImplicitDeps from './add-project-json-to-implicit-deps';
+
+describe('addProjectJsonToImplicitDeps', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTree();
+  });
+
+  it("should not add implicit dependencies if extends preset json's", () => {
+    writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+      npmScope: 'scope',
+      extends: '@nrwl/workspace/presets/core.json',
+    });
+    addProjectJsonToImplicitDeps(tree);
+    const result = readJson(tree, 'nx.json');
+    expect(result).toEqual({
+      npmScope: 'scope',
+      extends: '@nrwl/workspace/presets/core.json',
+    });
+  });
+
+  it('should add implicit dependencies if missing', () => {
+    writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+      npmScope: 'scope',
+    });
+    addProjectJsonToImplicitDeps(tree);
+    const result = readJson(tree, 'nx.json');
+    expect(result).toEqual({
+      npmScope: 'scope',
+      implicitDependencies: {
+        'apps/**/project.json': '*',
+        'libs/**/project.json': '*',
+      },
+    });
+  });
+
+  it('should update implicit dependencies if available', () => {
+    writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+      npmScope: 'scope',
+      implicitDependencies: {
+        'package.json': {
+          dependencies: '*',
+          devDependencies: '*',
+        },
+        '.eslintrc.json': '*',
+      },
+    });
+    addProjectJsonToImplicitDeps(tree);
+    const result = readJson(tree, 'nx.json');
+    expect(result).toEqual({
+      npmScope: 'scope',
+      implicitDependencies: {
+        'package.json': {
+          dependencies: '*',
+          devDependencies: '*',
+        },
+        '.eslintrc.json': '*',
+        'apps/**/project.json': '*',
+        'libs/**/project.json': '*',
+      },
+    });
+  });
+
+  it('should use workspaceLayout folder names if available', () => {
+    writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+      npmScope: 'scope',
+      workspaceLayout: { appsDir: 'appz', libsDir: 'libz' },
+    });
+    addProjectJsonToImplicitDeps(tree);
+    const result = readJson(tree, 'nx.json');
+    expect(result).toEqual({
+      npmScope: 'scope',
+      workspaceLayout: { appsDir: 'appz', libsDir: 'libz' },
+      implicitDependencies: {
+        'appz/**/project.json': '*',
+        'libz/**/project.json': '*',
+      },
+    });
+  });
+
+  it('should create single entry is apps and libs folder are same', () => {
+    writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+      npmScope: 'scope',
+      workspaceLayout: { appsDir: 'packages', libsDir: 'packages' },
+    });
+    addProjectJsonToImplicitDeps(tree);
+    const result = readJson(tree, 'nx.json');
+    expect(result).toEqual({
+      npmScope: 'scope',
+      workspaceLayout: { appsDir: 'packages', libsDir: 'packages' },
+      implicitDependencies: {
+        'packages/**/project.json': '*',
+      },
+    });
+  });
+
+  it('should not update implicit dependencies for apps or libs if already set', () => {
+    writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+      npmScope: 'scope',
+      implicitDependencies: {
+        'package.json': {
+          dependencies: '*',
+          devDependencies: '*',
+        },
+        '.eslintrc.json': '*',
+        'apps/**/project.json': ['testing'],
+      },
+    });
+    addProjectJsonToImplicitDeps(tree);
+    const result = readJson(tree, 'nx.json');
+    expect(result).toEqual({
+      npmScope: 'scope',
+      implicitDependencies: {
+        'package.json': {
+          dependencies: '*',
+          devDependencies: '*',
+        },
+        '.eslintrc.json': '*',
+        'apps/**/project.json': ['testing'],
+        'libs/**/project.json': '*',
+      },
+    });
+  });
+});

--- a/packages/workspace/src/migrations/update-13-7-3/add-project-json-to-implicit-deps.spec.ts
+++ b/packages/workspace/src/migrations/update-13-7-3/add-project-json-to-implicit-deps.spec.ts
@@ -31,8 +31,12 @@ describe('addProjectJsonToImplicitDeps', () => {
     expect(result).toEqual({
       npmScope: 'scope',
       implicitDependencies: {
-        'apps/**/project.json': '*',
-        'libs/**/project.json': '*',
+        'apps/**/project.json': {
+          tags: '*',
+        },
+        'libs/**/project.json': {
+          tags: '*',
+        },
       },
     });
   });
@@ -58,8 +62,12 @@ describe('addProjectJsonToImplicitDeps', () => {
           devDependencies: '*',
         },
         '.eslintrc.json': '*',
-        'apps/**/project.json': '*',
-        'libs/**/project.json': '*',
+        'apps/**/project.json': {
+          tags: '*',
+        },
+        'libs/**/project.json': {
+          tags: '*',
+        },
       },
     });
   });
@@ -75,8 +83,12 @@ describe('addProjectJsonToImplicitDeps', () => {
       npmScope: 'scope',
       workspaceLayout: { appsDir: 'appz', libsDir: 'libz' },
       implicitDependencies: {
-        'appz/**/project.json': '*',
-        'libz/**/project.json': '*',
+        'appz/**/project.json': {
+          tags: '*',
+        },
+        'libz/**/project.json': {
+          tags: '*',
+        },
       },
     });
   });
@@ -92,7 +104,9 @@ describe('addProjectJsonToImplicitDeps', () => {
       npmScope: 'scope',
       workspaceLayout: { appsDir: 'packages', libsDir: 'packages' },
       implicitDependencies: {
-        'packages/**/project.json': '*',
+        'packages/**/project.json': {
+          tags: '*',
+        },
       },
     });
   });
@@ -120,7 +134,9 @@ describe('addProjectJsonToImplicitDeps', () => {
         },
         '.eslintrc.json': '*',
         'apps/**/project.json': ['testing'],
-        'libs/**/project.json': '*',
+        'libs/**/project.json': {
+          tags: '*',
+        },
       },
     });
   });

--- a/packages/workspace/src/migrations/update-13-7-3/add-project-json-to-implicit-deps.ts
+++ b/packages/workspace/src/migrations/update-13-7-3/add-project-json-to-implicit-deps.ts
@@ -14,9 +14,13 @@ export function addProjectJsonToImplicitDeps(host: Tree) {
       workspaceConfig.implicitDependencies || {};
     // set implicit dependencies
     workspaceConfig.implicitDependencies[`${appsDir}/**/project.json`] =
-      workspaceConfig.implicitDependencies[`${appsDir}/**/project.json`] || '*';
+      workspaceConfig.implicitDependencies[`${appsDir}/**/project.json`] || {
+        tags: '*',
+      };
     workspaceConfig.implicitDependencies[`${libsDir}/**/project.json`] =
-      workspaceConfig.implicitDependencies[`${libsDir}/**/project.json`] || '*';
+      workspaceConfig.implicitDependencies[`${libsDir}/**/project.json`] || {
+        tags: '*',
+      };
   }
   updateWorkspaceConfiguration(host, workspaceConfig);
 }

--- a/packages/workspace/src/migrations/update-13-7-3/add-project-json-to-implicit-deps.ts
+++ b/packages/workspace/src/migrations/update-13-7-3/add-project-json-to-implicit-deps.ts
@@ -1,0 +1,24 @@
+import {
+  readWorkspaceConfiguration,
+  Tree,
+  updateWorkspaceConfiguration,
+} from '@nrwl/devkit';
+
+export function addProjectJsonToImplicitDeps(host: Tree) {
+  const workspaceConfig = readWorkspaceConfiguration(host);
+  if (!workspaceConfig.extends) {
+    const appsDir = workspaceConfig.workspaceLayout?.appsDir || 'apps';
+    const libsDir = workspaceConfig.workspaceLayout?.libsDir || 'libs';
+    // make sure dependencies exist
+    workspaceConfig.implicitDependencies =
+      workspaceConfig.implicitDependencies || {};
+    // set implicit dependencies
+    workspaceConfig.implicitDependencies[`${appsDir}/**/project.json`] =
+      workspaceConfig.implicitDependencies[`${appsDir}/**/project.json`] || '*';
+    workspaceConfig.implicitDependencies[`${libsDir}/**/project.json`] =
+      workspaceConfig.implicitDependencies[`${libsDir}/**/project.json`] || '*';
+  }
+  updateWorkspaceConfiguration(host, workspaceConfig);
+}
+
+export default addProjectJsonToImplicitDeps;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `project.json` configuration (including tags) is not set as `implicitDependencies` by default so any changes to those files will not influence the hashing and might use an invalid cached version. This is evident with linting during the tags change. The lint runner does not recognize the change and uses the wrong cached output.

## Expected Behavior
The `project.json` file should be part of `implicitDependencies` so the changes would influence caching.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8427
