### PR TITLE
fix(angular): update schemas with missing changes from previous versions

### DIFF
--- a/docs/generated/api-angular/executors/webpack-browser.md
+++ b/docs/generated/api-angular/executors/webpack-browser.md
@@ -125,6 +125,16 @@ Type: `array`
 
 Replace compilation source files with other compilation source files in the build.
 
+### i18nDuplicateTranslation
+
+Default: `warning`
+
+Type: `string`
+
+Possible values: `warning`, `error`, `ignore`
+
+How to handle duplicate translations for i18n.
+
 ### i18nMissingTranslation
 
 Default: `warning`

--- a/docs/generated/api-angular/generators/application.md
+++ b/docs/generated/api-angular/generators/application.md
@@ -229,6 +229,6 @@ Test runner to use for unit tests.
 
 Type: `string`
 
-Possible values: `Emulated`, `Native`, `None`
+Possible values: `Emulated`, `None`, `ShadowDom`
 
 Specifies the view encapsulation strategy.

--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -220,6 +220,12 @@
       "enum": ["warning", "error", "ignore"],
       "default": "warning"
     },
+    "i18nDuplicateTranslation": {
+      "type": "string",
+      "description": "How to handle duplicate translations for i18n.",
+      "enum": ["warning", "error", "ignore"],
+      "default": "warning"
+    },
     "localize": {
       "description": "Translate the bundles in one or more locales.",
       "oneOf": [

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -67,7 +67,7 @@
     },
     "viewEncapsulation": {
       "description": "Specifies the view encapsulation strategy.",
-      "enum": ["Emulated", "Native", "None"],
+      "enum": ["Emulated", "None", "ShadowDom"],
       "type": "string"
     },
     "prefix": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nrwl/angular:application` generator has the wrong enum values for the `viewEncapsulation` option that were changed in Angular v12.1.3 and the `@nrwl/angular:webpack-browser` executor is missing the `i18nDuplicateTranslation` option introduced in Angular v13.2.0.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `@nrwl/angular:application` generator and the `@nrwl/angular:webpack-browser` executor schemas should be in sync with the matching Angular CLI schematic and builder for the shared options.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
