### PR TITLE
fix(core): wait for tasks to be scheduled before checking for work

### DIFF
--- a/packages/workspace/src/tasks-runner/task-orchestrator.ts
+++ b/packages/workspace/src/tasks-runner/task-orchestrator.ts
@@ -384,6 +384,10 @@ export class TaskOrchestrator {
     );
 
     await this.tasksSchedule.scheduleNextTasks();
+
+    // release blocked threads
+    this.waitingForTasks.forEach((f) => f(null));
+    this.waitingForTasks.length = 0;
   }
 
   private complete(
@@ -408,9 +412,6 @@ export class TaskOrchestrator {
         );
       }
     }
-    this.waitingForTasks // release blocked threads
-      .forEach((f) => f(null));
-    this.waitingForTasks.length = 0;
   }
 
   //endregion Lifecycle


### PR DESCRIPTION
Ensure task are scheduled before checking if there is some work to do,
else it can occur that tasks are scheduled, but no check for work is triggered
until the next task completes.

Closes #8888.

This regression has probably been caused by https://github.com/nrwl/nx/commit/8ac7519ada1888345d0acc5ee72e782f919ab9a3.