### PR TITLE
chore(nxdev): fix invalid path import

### DIFF
--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -1,7 +1,7 @@
 // nx-ignore-next-line
 const withNx = require('@nrwl/next/plugins/with-nx');
 const { copy } = require('fs-extra');
-const path = require('node:path');
+const path = require('path');
 
 /**
  * TODO@ben: Temporary solution before Nextjs' assets management tasks is up and running


### PR DESCRIPTION
Current import breaks build on mac VM. The `node:path` should be replaced by `path`

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

cc @bcabanes 
