### PR TITLE
fix(core): Jenkinsfile --base fix

### DIFF
--- a/docs/shared/monorepo-ci-jenkins.md
+++ b/docs/shared/monorepo-ci-jenkins.md
@@ -50,8 +50,8 @@ pipeline {
                     steps {
                         sh "npm install"
                         sh "npx nx-cloud start-ci-run"
-                        sh "npx nx affected --target=build --parallel --max-parallel=3"
-                        sh "npx nx affected --target=test --parallel --max-parallel=2"
+                        sh "npx nx affected --base origin/${CHANGE_TARGET:-main} --target=build --parallel --max-parallel=3"
+                        sh "npx nx affected --base origin/${CHANGE_TARGET:-main} --target=test --parallel --max-parallel=2"
                         sh "npx nx-cloud stop-all-agents"
                     }
                 }


### PR DESCRIPTION
While our team was trying to migrate to Nx, we found out [this issue](https://github.com/nrwl/nx/issues/2170)
The documentation doesn't mention about this behaviour but in our case setting the --base to origin/{current_branch} fixed it. I've set the env variable accordingly in the md file.

## Current Behavior
`nx affected:apps fails with error fatal: Not a valid object name main`

## Expected Behavior
to pass the pipeline stage

## Related Issue(s)
https://github.com/nrwl/nx/issues/2170
