### PR TITLE
feat(react): add postcssConfig option to apps to enable auto-loading or set a single path

### DIFF
--- a/docs/generated/api-web/executors/webpack.md
+++ b/docs/generated/api-web/executors/webpack.md
@@ -189,6 +189,12 @@ Type: `string`
 
 Polyfills to load before application
 
+### postcssConfig
+
+Type: `string`
+
+Set a path to PostCSS config that applies to the app and all libs. Defaults to `undefined`, which auto-detects postcss.config.js files in each app/lib directory.
+
 ### progress
 
 Default: `false`

--- a/packages/web/migrations.json
+++ b/packages/web/migrations.json
@@ -56,6 +56,12 @@
       "version": "13.3.0-beta.1",
       "description": "Rename the 'package' executor to 'rollup'",
       "factory": "./src/migrations/update-13-3-0/rename-package-to-rollup"
+    },
+    "add-postcss-config-option": {
+      "cli": "nx",
+      "version": "13.8.0-beta.1",
+      "description": "Add a postcss config option to apps to load a single config file for all libs",
+      "factory": "./src/migrations/update-13-8-0/add-postcss-config-option"
     }
   },
   "packageJsonUpdates": {}

--- a/packages/web/src/executors/webpack/schema.json
+++ b/packages/web/src/executors/webpack/schema.json
@@ -223,10 +223,6 @@
       },
       "default": []
     },
-    "webpackConfig": {
-      "type": "string",
-      "description": "Path to a function which takes a webpack config, some context and returns the resulting webpack config"
-    },
     "buildLibsFromSource": {
       "type": "boolean",
       "description": "Read buildable libraries from source instead of building them separately.",
@@ -236,6 +232,14 @@
       "type": "boolean",
       "description": "Generates `index.html` file to the output path. This can be turned off if using a webpack plugin to generate HTML such as `html-webpack-plugin`",
       "default": true
+    },
+    "postcssConfig": {
+      "type": "string",
+      "description": "Set a path to PostCSS config that applies to the app and all libs. Defaults to `undefined`, which auto-detects postcss.config.js files in each app/lib directory."
+    },
+    "webpackConfig": {
+      "type": "string",
+      "description": "Path to a function which takes a webpack config, some context and returns the resulting webpack config"
     }
   },
   "required": ["tsConfig", "main", "index"],

--- a/packages/web/src/executors/webpack/webpack.impl.ts
+++ b/packages/web/src/executors/webpack/webpack.impl.ts
@@ -55,6 +55,8 @@ export interface WebWebpackExecutorOptions extends BuildBuilderOptions {
   deleteOutputPath?: boolean;
 
   generateIndexHtml?: boolean;
+
+  postcssConfig?: string;
 }
 
 function getWebpackConfigs(

--- a/packages/web/src/migrations/update-13-8-0/add-postcss-config-option.spec.ts
+++ b/packages/web/src/migrations/update-13-8-0/add-postcss-config-option.spec.ts
@@ -1,0 +1,94 @@
+import { readJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+import migrate from './add-postcss-config-option';
+
+describe('Migration: add PostCSS config option', () => {
+  it(`should add postcssConfig option if file exists`, async () => {
+    let tree = createTreeWithEmptyWorkspace();
+
+    tree.write(
+      'workspace.json',
+      JSON.stringify({
+        version: 2,
+        projects: {
+          myapp: {
+            root: 'apps/myapp',
+            sourceRoot: 'apps/myapp/src',
+            projectType: 'application',
+            targets: {
+              build: {
+                executor: '@nrwl/web:webpack',
+                options: {},
+              },
+            },
+          },
+        },
+      })
+    );
+    tree.write('apps/myapp/postcss.config.js', `module.exports = {};`);
+
+    await migrate(tree);
+
+    expect(readJson(tree, 'workspace.json')).toEqual({
+      version: 2,
+      projects: {
+        myapp: {
+          root: 'apps/myapp',
+          sourceRoot: 'apps/myapp/src',
+          projectType: 'application',
+          targets: {
+            build: {
+              executor: '@nrwl/web:webpack',
+              options: {
+                postcssConfig: 'apps/myapp/postcss.config.js',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+  it(`should not add postcssConfig option if file does not exist`, async () => {
+    let tree = createTreeWithEmptyWorkspace();
+
+    tree.write(
+      'workspace.json',
+      JSON.stringify({
+        version: 2,
+        projects: {
+          myapp: {
+            root: 'apps/myapp',
+            sourceRoot: 'apps/myapp/src',
+            projectType: 'application',
+            targets: {
+              build: {
+                executor: '@nrwl/web:webpack',
+                options: {},
+              },
+            },
+          },
+        },
+      })
+    );
+
+    await migrate(tree);
+
+    expect(readJson(tree, 'workspace.json')).toEqual({
+      version: 2,
+      projects: {
+        myapp: {
+          root: 'apps/myapp',
+          sourceRoot: 'apps/myapp/src',
+          projectType: 'application',
+          targets: {
+            build: {
+              executor: '@nrwl/web:webpack',
+              options: {},
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/web/src/migrations/update-13-8-0/add-postcss-config-option.ts
+++ b/packages/web/src/migrations/update-13-8-0/add-postcss-config-option.ts
@@ -1,0 +1,27 @@
+import {
+  formatFiles,
+  getProjects,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+
+/*
+ * This migration ensures that the previous behavior of applying the app postcss config
+ * is carried over to Nx 13.8.0.
+ */
+export default async function update(host: Tree) {
+  const projects = getProjects(host);
+
+  for (const [name, config] of projects.entries()) {
+    if (config?.targets?.build?.executor !== '@nrwl/web:webpack') continue;
+    const configPath = `${config.root}/postcss.config.js`;
+
+    if (host.exists(configPath)) {
+      config.targets.build.options.postcssConfig = configPath;
+    }
+
+    updateProjectConfiguration(host, name, config);
+  }
+
+  await formatFiles(host);
+}

--- a/packages/web/src/utils/web.config.ts
+++ b/packages/web/src/utils/web.config.ts
@@ -68,7 +68,13 @@ export function getWebConfig(
       esm,
       isScriptOptimizeOn
     ),
-    getStylesPartial(wco.root, wco.projectRoot, wco.buildOptions, true),
+    getStylesPartial(
+      wco.root,
+      wco.projectRoot,
+      wco.buildOptions,
+      true,
+      options.postcssConfig
+    ),
     getCommonPartial(wco),
     getBrowserConfig(wco),
   ]);
@@ -106,7 +112,8 @@ export function getStylesPartial(
   workspaceRoot: string,
   projectRoot: string,
   options: any,
-  extractCss: boolean
+  extractCss: boolean,
+  postcssConfig?: string
 ): Configuration {
   const includePaths: string[] = [];
 
@@ -151,7 +158,11 @@ export function getStylesPartial(
       }),
     ],
   });
-  postcssOptions.config = projectRoot;
+  // If a path to postcssConfig is passed in, set it for app and all libs, otherwise
+  // use automatic detection.
+  if (typeof postcssConfig === 'string') {
+    postcssOptions.config = path.join(workspaceRoot, postcssConfig);
+  }
 
   const commonLoaders = [
     {


### PR DESCRIPTION
This PR adds the ability for users to specify how `postcss.config.js` files should be handled when building an app.

The `@nrwl/web:webpack` executor gets a new option `postcssConfig` that can be set to a string path. If it is set, then that config is applied to all libs, otherwise auto-detection is enabled to pick up `postcss.config.js` files in each lib directory.

## Current Behavior

App's `postcss.config.js` applies to all libs,  and there's no opt-out mechanism.

## Expected Behavior

Allow auto-detection of libs' `postcss.config.js` files, but have an option to just use the app's `postcss.config.js` file if desired.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7468
