### PR TITLE
fix(angular): newProjectRoot key is removed on Angular CLI conversion

### DIFF
--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -182,10 +182,14 @@ export function updateWorkspaceConfiguration(
   // in project config.
   const workspacePath = getWorkspacePath(tree);
   if (workspacePath) {
-    updateJson<WorkspaceJsonConfiguration>(tree, workspacePath, (json) => ({
-      ...json,
-      version: workspaceConfig.version,
-    }));
+    updateJson<WorkspaceJsonConfiguration>(tree, workspacePath, (json) => {
+      const config = {
+        ...json,
+        version: workspaceConfig.version,
+      };
+      delete (config as any).newProjectRoot;
+      return config;
+    });
   }
 }
 

--- a/packages/workspace/src/generators/init/init.spec.ts
+++ b/packages/workspace/src/generators/init/init.spec.ts
@@ -153,6 +153,62 @@ describe('workspace', () => {
       }
     });
 
+    it('should remove the newProjectRoot key from configuration', async () => {
+      tree.write(
+        '/angular.json',
+        JSON.stringify({
+          version: 1,
+          defaultProject: 'myApp',
+          newProjectRoot: 'projects',
+          projects: {
+            myApp: {
+              root: 'projects/myApp',
+              sourceRoot: 'projects/myApp/src',
+              architect: {
+                build: {
+                  options: {
+                    tsConfig: 'projects/myApp/tsconfig.app.json',
+                  },
+                  configurations: {},
+                },
+                test: {
+                  options: {
+                    tsConfig: 'projects/myApp/tsconfig.spec.json',
+                  },
+                },
+                lint: {
+                  options: {
+                    tsConfig: [
+                      'projects/myApp/tslint.json',
+                      'projects/myApp/tsconfig.app.json',
+                    ],
+                  },
+                },
+                e2e: {
+                  options: {
+                    protractorConfig: 'projects/myApp/e2e/protractor.conf.js',
+                  },
+                },
+              },
+            },
+          },
+        })
+      );
+
+      tree.write('/projects/myApp/tslint.json', '{"rules": {}}');
+      tree.write('/projects/myApp/tsconfig.app.json', '{}');
+      tree.write('/projects/myApp/tsconfig.spec.json', '{}');
+      tree.write('/projects/myApp/e2e/tsconfig.json', '{}');
+      tree.write('/projects/myApp/e2e/protractor.conf.js', '// content');
+      tree.write('/projects/myApp/src/app/app.module.ts', '// content');
+
+      await initGenerator(tree, { name: 'myApp' });
+
+      const a = readJson(tree, '/angular.json');
+
+      expect(a.newProjectRoot).toBeUndefined();
+    });
+
     it('should set the default collection to @nrwl/angular', async () => {
       await initGenerator(tree, { name: 'myApp' });
       expect(readJson(tree, 'nx.json').cli.defaultCollection).toBe(


### PR DESCRIPTION
When converting an Angular CLI project to an NX Workspace, the newProjectRoot key needs to be removed
from the angular.json to ensure generators function properly.

## Current Behavior

The `newProjectRoot` key does not get properly removed from the `angular.json` file.

## Expected Behavior

The `newProjectRoot` key is properly removed and persisted to the `angular.json` file.

## Related Issue(s)

Fixes #8851
