### PR TITLE
fix(storybook): add staticDirs object schema

### DIFF
--- a/docs/generated/api-storybook/executors/storybook.md
+++ b/docs/generated/api-storybook/executors/storybook.md
@@ -79,11 +79,19 @@ Type: `string`
 
 SSL key to use for serving HTTPS.
 
-### staticDir
+### ~~staticDir~~
 
 Type: `array`
 
+**Deprecated:** This field has been renamed to staticDirs.
+
 Directory where to load static files from, array of strings
+
+### staticDirs
+
+Type: `array`
+
+Directory where to load static files from, array of strings or object with from, to keys
 
 ### stylePreprocessorOptions.includePaths
 

--- a/packages/storybook/src/executors/storybook/schema.json
+++ b/packages/storybook/src/executors/storybook/schema.json
@@ -50,8 +50,18 @@
     "staticDir": {
       "type": "array",
       "description": "Directory where to load static files from, array of strings",
+      "default": [],
       "items": {
         "type": "string"
+      },
+      "x-deprecated": "This field has been renamed to staticDirs."
+    },
+    "staticDirs": {
+      "type": "array",
+      "description": "Directory where to load static files from, array of strings or object with from, to keys",
+      "default": [],
+      "items": {
+        "$ref": "#/definitions/staticDirPattern"
       }
     },
     "projectBuildConfig": {
@@ -132,6 +142,28 @@
         {
           "type": "string",
           "description": "The file to include."
+        }
+      ]
+    },
+    "staticDirPattern": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "from": {
+              "type": "string",
+              "description": "From path"
+            },
+            "to": {
+              "type": "string",
+              "description": "To path"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["from", "to"]
+        },
+        {
+          "type": "string"
         }
       ]
     }

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -16,6 +16,7 @@ export interface StorybookExecutorOptions extends CommonNxStorybookConfig {
   sslCert?: string;
   sslKey?: string;
   staticDir?: string[];
+  staticDirs?: string[] | { from: string; to: string }[];
   watch?: boolean;
   docsMode?: boolean;
 }


### PR DESCRIPTION
Storybook has renamed staticDir to staticDirs.

The have also added a way to specify an object:
```
module.exports = {
  staticDirs: [{ from: '../my-custom-assets/images', to: '/assets' }],
};
```

This PR adds the schema for staticDirs, and x-deprecates staticDir.
I don't know if we should do this, because they just fallback if they find staticDir

https://github.com/storybookjs/storybook/blob/92b23c080d03433765cbc7a60553d036a612a501/lib/core-server/src/utils/server-statics.ts#L30


## Background
I needed to copy multiple directories and rename them.
the current string[] makes this impossible.

## Questions

* Should we deprecate `staticDir`?
