### PR TITLE
fix(core): fix parsing of dot notation flags

### DIFF
--- a/packages/tao/src/commands/run.ts
+++ b/packages/tao/src/commands/run.ts
@@ -60,7 +60,6 @@ function parseRunOpts(
       },
       configuration: {
         'strip-dashed': false,
-        'dot-notation': false,
       },
     })
   );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `nx e2e app1-e2e --env.NX_API_URL=10.0.0.1` will not pass `NX_API_URL` to the cypress env.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `nx e2e app1-e2e --env.NX_API_URL=10.0.0.1` will pass `NX_API_URL` to the cypress env.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/8723
