### PR TITLE
chore(web): update `webpack-subresource-integrity` to 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "webpack-merge": "^5.8.0",
     "webpack-node-externals": "^3.0.0",
     "webpack-sources": "^3.0.2",
-    "webpack-subresource-integrity": "^1.5.2",
+    "webpack-subresource-integrity": "^5.1.0",
     "xstate": "^4.25.0",
     "yargs": "15.4.1",
     "yargs-parser": "20.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -106,7 +106,7 @@
     "webpack": "^5.58.1",
     "webpack-merge": "^5.8.0",
     "webpack-sources": "^3.0.2",
-    "webpack-subresource-integrity": "^1.5.2",
+    "webpack-subresource-integrity": "^5.1.0",
     "webpack-dev-server": "^4.3.1",
     "http-server": "14.1.0",
     "ignore": "^5.0.4"

--- a/packages/web/src/utils/webpack/partials/browser.ts
+++ b/packages/web/src/utils/webpack/partials/browser.ts
@@ -7,19 +7,14 @@
  */
 import { LicenseWebpackPlugin } from 'license-webpack-plugin';
 import { WebpackConfigOptions } from '../../shared-models';
-
-const SubresourceIntegrityPlugin = require('webpack-subresource-integrity');
+import { SubresourceIntegrityPlugin } from 'webpack-subresource-integrity';
 
 export function getBrowserConfig(wco: WebpackConfigOptions) {
   const { buildOptions } = wco;
   const extraPlugins = [];
 
   if (buildOptions.subresourceIntegrity) {
-    extraPlugins.push(
-      new SubresourceIntegrityPlugin({
-        hashFuncNames: ['sha384'],
-      })
-    );
+    extraPlugins.push(new SubresourceIntegrityPlugin());
   }
 
   if (buildOptions.extractLicenses) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24879,7 +24879,7 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack-subresource-integrity@5.1.0:
+webpack-subresource-integrity@5.1.0, webpack-subresource-integrity@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/webpack-subresource-integrity/-/webpack-subresource-integrity-5.1.0.tgz#8b7606b033c6ccac14e684267cb7fb1f5c2a132a"
   integrity sha512-sacXoX+xd8r4WKsy9MvH/q/vBtEHr86cpImXwyg74pFIpERKt6FmB8cXpeuh0ZLgclOlHI4Wcll7+R5L02xk9Q==


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Old version of `webpack-subresource-integrity`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use the current version to avoid installs of multiple versions in one repo. 

`sha-384` i now the default hash function so the plugin options can be removed.  See: https://github.com/waysact/webpack-subresource-integrity/blob/main/MIGRATE-v1-to-v5.md#default-hash-function-only-sha-384

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
