### PR TITLE
fix(web): fixes force down compilation for non esm bundles 

### DIFF
--- a/packages/web/src/executors/rollup/rollup.impl.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.ts
@@ -204,11 +204,7 @@ export function createRollupOptions(
           check: true,
           tsconfig: options.tsConfig,
           tsconfigOverride: {
-            compilerOptions: createCompilerOptions(
-              format,
-              options,
-              dependencies
-            ),
+            compilerOptions: createCompilerOptions(options, dependencies),
           },
         }),
       useSwc && swc(),
@@ -294,27 +290,18 @@ export function createRollupOptions(
   });
 }
 
-function createCompilerOptions(format, options, dependencies) {
+function createCompilerOptions(options, dependencies) {
   const compilerOptionPaths = computeCompilerOptionsPaths(
     options.tsConfig,
     dependencies
   );
 
-  const compilerOptions = {
+  return {
     rootDir: options.entryRoot,
     allowJs: false,
     declaration: true,
     paths: compilerOptionPaths,
   };
-
-  if (format !== 'esm') {
-    return {
-      ...compilerOptions,
-      target: 'es5',
-    };
-  }
-
-  return compilerOptions;
 }
 
 function updatePackageJson(


### PR DESCRIPTION
When you are bundling non `esm` files we should not force `es5 ` as the target

ISSUES CLOSED: #8639

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
