### PR TITLE
fix(js): exclude .test.ts files in tsconfig

### DIFF
--- a/packages/js/src/generators/application/files/tsconfig.app.json__tmpl__
+++ b/packages/js/src/generators/application/files/tsconfig.app.json__tmpl__
@@ -6,5 +6,5 @@
     "types": []
   },
   "include": ["**/*.ts"<% if (js) { %>, "**/*.js"<% } %>],
-  "exclude": ["**/*.spec.ts"<% if (js) { %>, "**/*.spec.js"<% } %>]
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"<% if (js) { %>, "**/*.spec.js", "**/*.test.js"<% } %>]
 }

--- a/packages/js/src/generators/library/files/tsconfig.lib.json__tmpl__
+++ b/packages/js/src/generators/library/files/tsconfig.lib.json__tmpl__
@@ -6,5 +6,5 @@
     "types": []
   },
   "include": ["**/*.ts"<% if (js) { %>, "**/*.js"<% } %>],
-  "exclude": ["**/*.spec.ts"<% if (js) { %>, "**/*.spec.js"<% } %>]
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"<% if (js) { %>, "**/*.spec.js", "**/*.test.js"<% } %>]
 }


### PR DESCRIPTION
The `tsconfig.lib.json` and `tsconfig.app.json` files used by the JS/TS generators only exclude `.spec.ts` and `.spec.js` files. As the Nx Jest preset also matches `.test.ts` and `.test.js` files, these should also be excluded.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Files with a `.test.ts` or `.test.js` extension are included in the build, causing it to fail as the Jest types are not in scope.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Files with a `.test.ts` or `.test.js` extension should be excluded from the build.