### PR TITLE
fix(web): use cjs format for rollup if umd is not set

### DIFF
--- a/packages/web/src/executors/rollup/rollup.impl.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.ts
@@ -329,7 +329,11 @@ function updatePackageJson(
     /\.[jt]sx?$/,
     '.d.ts'
   );
-  packageJson.main = entryFileTmpl.replace('<%= extension %>', 'umd');
+  if (options.format.includes('umd')) {
+    packageJson.main = entryFileTmpl.replace('<%= extension %>', 'umd');
+  } else if (options.format.includes('cjs')) {
+    packageJson.main = entryFileTmpl.replace('<%= extension %>', 'cjs');
+  }
   packageJson.module = entryFileTmpl.replace('<%= extension %>', 'esm');
   packageJson.typings = `./${typingsFile}`;
   writeJsonFile(`${options.outputPath}/package.json`, packageJson);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
UMD will always be set for the generated package.json `main` property

## Expected Behavior
UMD will only be set for main if the UMD format is generated, otherwise cjs is used, otherwise nothing is used.

## Related Issue(s)

Fixes #
