### PR TITLE
feat(react): improve css-modules import

### DIFF
--- a/packages/react/src/generators/component/files/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/component/files/__fileName__.tsx__tmpl__
@@ -14,7 +14,7 @@ import { Route, Link } from 'react-router-dom';
   <% } else {
     var wrapper = 'div';
   %>
-  <%- style !== 'styled-jsx' ? globalCss ? `import './${fileName}.${style}';` : `import './${fileName}.module.${style}';`: '' %>
+  <%- style !== 'styled-jsx' ? globalCss ? `import './${fileName}.${style}';` : `import styles from './${fileName}.module.${style}';`: '' %>
   <% }
 } else { var wrapper = 'div'; } %>
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
React component generator generates `import './ExampleFileName.module.css';` for css-modules. `import` without `from` is ok for global css files but not enough for css-modules.

## Expected Behavior
React component generator should follow css-modules documentation and generate `import styles from './ExampleFileName.module.css';`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
