### PR TITLE
fix(react): update storybook config to skip type checking

### DIFF
--- a/packages/react/plugins/storybook/index.spec.ts
+++ b/packages/react/plugins/storybook/index.spec.ts
@@ -1,0 +1,39 @@
+import { webpack } from './index';
+import { join } from 'path';
+import { readJsonFile, writeJsonFile } from '@nrwl/tao/src/utils/fileutils';
+import { appRootPath } from '@nrwl/tao/src/utils/app-root';
+jest.mock('@nrwl/web/src/utils/web.config', () => {
+  return {
+    getStylesPartial: () => ({}),
+  };
+});
+
+describe('Storybook webpack config', () => {
+  it('should skip type checking', async () => {
+    // package.json does not exist in appRootPath when running tests in CI
+    if (process.env.CI) {
+      writeJsonFile(join(appRootPath, 'package.json'), {});
+    }
+
+    const config = await webpack(
+      {
+        resolve: {
+          plugins: [],
+        },
+        plugins: [],
+        module: {
+          rules: [],
+        },
+      },
+      {
+        configDir: join(__dirname, '../..'),
+      }
+    );
+
+    expect(
+      config.plugins.find(
+        (p) => p.constructor.name === 'ForkTsCheckerWebpackPlugin'
+      )
+    ).toBeFalsy();
+  });
+});

--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -73,7 +73,11 @@ export const webpack = async (
 
   // ESM build for modern browsers.
   const baseWebpackConfig = mergeWebpack.merge([
-    getBaseWebpackPartial(builderOptions, esm, isScriptOptimizeOn),
+    getBaseWebpackPartial(builderOptions, {
+      esm,
+      isScriptOptimizeOn,
+      skipTypeCheck: true,
+    }),
     getStylesPartial(
       options.workspaceRoot,
       options.configDir,

--- a/packages/web/src/utils/web.config.ts
+++ b/packages/web/src/utils/web.config.ts
@@ -87,13 +87,12 @@ function _getBaseWebpackPartial(
   emitDecoratorMetadata: boolean,
   configuration?: string
 ) {
-  let partial = getBaseWebpackPartial(
-    options,
+  let partial = getBaseWebpackPartial(options, {
     esm,
     isScriptOptimizeOn,
     emitDecoratorMetadata,
-    configuration
-  );
+    configuration,
+  });
   delete partial.resolve.mainFields;
   return partial;
 }


### PR DESCRIPTION
This PR disables type-checking when building storybook, so the behaviour is the same as in Nx 12.

We should be using `{ typecript: { check: true } }` from storybook itself instead of our own type checker.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Our own type checker plugin is being used.

## Expected Behavior
We should not have our own type checker plugin.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
