### PR TITLE
fix(devkit): fall back to the target default config when reading target options and the config is not provided

### DIFF
--- a/packages/devkit/src/executors/read-target-options.ts
+++ b/packages/devkit/src/executors/read-target-options.ts
@@ -26,7 +26,7 @@ export function readTargetOptions<T = any>(
 
   return combineOptionsForExecutor(
     {},
-    configuration ?? '',
+    configuration ?? targetConfiguration.defaultConfiguration ?? '',
     targetConfiguration,
     schema,
     defaultProject,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `readTargetOptions` function from the `@nrwl/devkit` doesn't take into account the target default configuration when no configuration is specified.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `readTargetOptions` function from the `@nrwl/devkit` should fall back to the target default configuration when no configuration is specified.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
