### PR TITLE
docs(nxdev): search plugin directory with name & description

### DIFF
--- a/nx-dev/ui-community/src/lib/plugin-directory.tsx
+++ b/nx-dev/ui-community/src/lib/plugin-directory.tsx
@@ -46,7 +46,12 @@ export function PluginDirectory({
       <div className="my-12 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
         {pluginList
           .filter((plugin) =>
-            !!searchTerm ? plugin.name.includes(searchTerm) : true
+            !!searchTerm
+              ? plugin.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                plugin.description
+                  .toLowerCase()
+                  .includes(searchTerm.toLowerCase())
+              : true
           )
           .map((plugin) => (
             <PluginCard


### PR DESCRIPTION
It allows the visitor to search in the plugin directory by checking the name and the description of the plugin on nx.dev.