### PR TITLE
docs(core): use project.json instead of workspace.json

### DIFF
--- a/docs/generated/api-js/generators/application.md
+++ b/docs/generated/api-js/generators/application.md
@@ -65,7 +65,7 @@ Type: `string`
 
 Possible values: `workspace`, `project`, `npm-scripts`
 
-Determines how whether the project's executors should be configured in workspace.json, project.json or as npm scripts
+Determines whether the project's executors should be configured in workspace.json, project.json or as npm scripts
 
 ### directory
 

--- a/docs/generated/api-js/generators/library.md
+++ b/docs/generated/api-js/generators/library.md
@@ -73,7 +73,7 @@ Type: `string`
 
 Possible values: `workspace`, `project`, `npm-scripts`
 
-Determines how whether the project's executors should be configured in workspace.json, project.json or as npm scripts
+Determines whether the project's executors should be configured in workspace.json, project.json or as npm scripts
 
 ### directory
 

--- a/docs/shared/console.md
+++ b/docs/shared/console.md
@@ -87,9 +87,9 @@ You can also launch other common Nx commands with the options listed out in the 
 
 #### Projects
 
-Clicking on the name of any project navigates to that project's definition in the `workspace.json` (or `angular.json`) file. Clicking on the name of any executor command navigates to that executor command's definition in the `workspace.json` (or `angular.json`) file.
+Clicking on the name of any project navigates to that project's `project.json` file. Clicking on the name of any executor command navigates to that executor command's definition in the `project.json` file.
 
-Clicking the ![refresh-light.svg](./refresh-light.svg) icon next to the `PROJECTS` header repopulates the Projects pane from the `workspace.json` (or `angular.json`) file.
+Clicking the ![refresh-light.svg](./refresh-light.svg) icon next to the `PROJECTS` header repopulates the Projects pane from the `project.json` files.
 
 Clicking the ![folder-light.svg](./folder-light.svg) icon next to a project reveals that project's folder in the VSCode Explorer pane.
 

--- a/docs/shared/devkit-and-nx-plugins.md
+++ b/docs/shared/devkit-and-nx-plugins.md
@@ -34,7 +34,7 @@ Plugins have:
   - Plugins can provide an array of glob patterns, `projectFilePatterns` that are used to infer project information.
   - Plugins can provide a function `registerProjectTargets` that takes in one of the matched project files, and
     returns an object containing inferred targets from the file.
-  - This allows plugins to add new projects to the workspace when it doesn't contain workspace.json, and infer extra
+  - This allows plugins to add new projects to the workspace when it doesn't contain `workspace.json`, and infer extra
     targets without adding them into project configuration.
 
 All of the core plugins are written using Nx Devkit, and you can use the same utilities to write your own generators and

--- a/docs/shared/guides/setup-incremental-builds-angular.md
+++ b/docs/shared/guides/setup-incremental-builds-angular.md
@@ -99,21 +99,21 @@ To serve an app incrementally use this command:
 nx serve myapp --with-deps --parallel
 ```
 
-Note: you can specify the `--with-deps` and `--parallel` flags as part of the options property on the file-server executor in your `angular.json` or `workspace.json`. The file-server executor will pass those to the `nx build` command it invokes.
+Note: you can specify the `--with-deps` and `--parallel` flags as part of the options property on the file-server executor in your `project.json` file. The file-server executor will pass those to the `nx build` command it invokes.
 
 ```json
-"app0": {
+{
     "projectType": "application",
     ...
-    "architect": {
+    "targets": {
         "build": {
-            "builder": "@nrwl/angular:webpack-browser",
+            "executor": "@nrwl/angular:webpack-browser",
             "outputs": ["{options.outputPath}"],
             "options": { ... }
             "configurations": { ... }
         },
         "serve": {
-            "builder": "@nrwl/web:file-server",
+            "executor": "@nrwl/web:file-server",
             "options": {
                 "buildTarget": "app0:build",
                 "withDeps": true,

--- a/docs/shared/guides/setup-mfe-with-angular.md
+++ b/docs/shared/guides/setup-mfe-with-angular.md
@@ -116,7 +116,7 @@ For both apps, the generator did the following:
 - Added a `bootstrap.ts` file
 - Moved the code that is normally in `main.ts` to `bootstrap.ts`
 - Changed `main.ts` to dynamically import `bootstrap.ts` _(this is required for the Module Federation to correct load versions of shared libraries)_
-- Updated the `build` target in the `workspace.json` to use the `@nrwl/angular:webpack-browser` executor _(this is required as it supports passing a custom webpack configuration to the Angular compiler)_
+- Updated the `build` target in the `project.json` to use the `@nrwl/angular:webpack-browser` executor _(this is required as it supports passing a custom webpack configuration to the Angular compiler)_
 - Updated the `serve` target to use `@nrwl/angular:webpack-server`. _(this is required as we first need webpack to build the app with our custom webpack config)_
 - Installed Manfred Steyer's `@angular-architects/module-federation` package _(Read more on it [here](https://github.com/angular-architects/module-federation-plugin))_
 

--- a/docs/shared/guides/storybook/storybook-v6-angular.md
+++ b/docs/shared/guides/storybook/storybook-v6-angular.md
@@ -28,7 +28,7 @@ In that case, when you run the Nx migration scripts, the scripts will ignore the
 
 The `@nrwl/angular:storybook-migrate-defaults-5-to-6` generator will not exactly do a migration. It will perform the following actions:
 
-- It will generate new Storybook configuration files using the new (`>6.x`) Storybook way. The way it will do that is, it will look into `workspace.json` and it will find all the projects that have a `Storybook` configuration. Using the `configFolder` path provided there, it will go and generate new Storybook instances in all these paths. Finally, it will generate a new Storybook instance at the root directory.
+- It will generate new Storybook configuration files using the new (`>6.x`) Storybook way. The way it will do that is, it will look in all the `project.json` files and it will find all the projects that have a `Storybook` configuration. Using the `configFolder` path provided there, it will go and generate new Storybook instances in all these paths. Finally, it will generate a new Storybook instance at the root directory.
 
 - If you choose to `keepOld`, then it will add all your existing Storybook configuration files into another folder labeled `.old_storybook`.
 

--- a/docs/shared/guides/storybook/storybook-v6-react.md
+++ b/docs/shared/guides/storybook/storybook-v6-react.md
@@ -28,7 +28,7 @@ In that case, when you run the Nx migration scripts, the scripts will ignore the
 
 The `@nrwl/react:storybook-migrate-defaults-5-to-6` generator will not exactly do a migration. It will perform the following actions:
 
-- It will generate new Storybook configuration files using the new (`>6.x`) Storybook way. The way it will do that is, it will look into `workspace.json` and it will find all the projects that have a `Storybook` configuration. Using the `configFolder` path provided there, it will go and generate new Storybook instances in all these paths. Finally, it will generate a new Storybook instance at the root directory.
+- It will generate new Storybook configuration files using the new (`>6.x`) Storybook way. The way it will do that is, it will look in all the `project.json` files and it will find all the projects that have a `Storybook` configuration. Using the `configFolder` path provided there, it will go and generate new Storybook instances in all these paths. Finally, it will generate a new Storybook instance at the root directory.
 
 - If you choose to `keepOld`, then it will add all your existing Storybook configuration files into another folder labeled `.old_storybook`.
 

--- a/docs/shared/mental-model.md
+++ b/docs/shared/mental-model.md
@@ -11,7 +11,7 @@ authored in your repository, such as Webpack, React, Angular, and so forth.
 
 ![project-graph](/shared/mental-model/project-graph.png)
 
-With Nx, nodes in the project graph are defined in `workspace.json`. You can manually define dependencies between the
+With Nx, nodes in the project graph are defined in `project.json` files. You can manually define dependencies between the
 nodes, but you don’t have to do it very often. Nx analyzes files’ source code, your installed dependencies, TypeScript
 files, and others figuring out these dependencies for you. Nx also stores the cached project graph, so it only
 reanalyzes the files you have changed.

--- a/docs/shared/monorepo-nx-enterprise.md
+++ b/docs/shared/monorepo-nx-enterprise.md
@@ -46,7 +46,6 @@ happynrwl/
 │       ├── ui/
 │       └── utils-testing/
 ├── tools/
-├── workspace.json
 ├── nx.json
 ├── package.json
 └── tsconfig.base.json
@@ -74,7 +73,6 @@ happynrwl/
 │       ├── ui/
 │       └── utils-testing/
 ├── tools/
-├── workspace.json
 ├── nx.json
 ├── package.json
 └── tsconfig.base.json
@@ -110,7 +108,6 @@ happynrwl/
 │       ├── ui/
 │       └── utils-testing/
 ├── tools/
-├── workspace.json
 ├── nx.json
 ├── package.json
 └── tsconfig.base.json

--- a/docs/shared/monorepo-tags.md
+++ b/docs/shared/monorepo-tags.md
@@ -8,7 +8,7 @@ To help with that Nx uses code analyses to make sure projects can only depend on
 
 Nx comes with a generic mechanism for expressing constraints: tags.
 
-First, use your project configuration (within `project.json` or `workspace.json`) to annotate your projects with `tags`. In this example, we will use three tags: `scope:client`. `scope:admin`, `scope:shared`.
+First, use your project configuration (in `project.json`) to annotate your projects with `tags`. In this example, we will use three tags: `scope:client`. `scope:admin`, `scope:shared`.
 
 ```jsonc
 // project "client"

--- a/docs/shared/nest-plugin.md
+++ b/docs/shared/nest-plugin.md
@@ -84,7 +84,7 @@ nx generate @nrwl/nest:application <nest-app> --frontendProject my-angular-app
 
 ### Application commands
 
-When a Nest application is added to the workspace.json (or angular.json), the following architect commands are available for execution:
+When a Nest application is added, the following architect commands are available for execution:
 
 #### build
 
@@ -98,7 +98,7 @@ The build command will compile the application using Webpack. It supports a prod
 nx build <nest-app> --configuration=production
 ```
 
-Additional configurations can be added in the workspace.json. Changing the `--configuration` flag with the new configuration name will run that config.
+Additional configurations can be added in the project.json. Changing the `--configuration` flag with the new configuration name will run that config.
 
 #### serve
 
@@ -113,7 +113,7 @@ Nest applications also have the `inspect` flag set, so you can attach your debug
 
 ##### Debugging
 
-Debugging is set to use a random port that is available on the system. The port can be changed by setting the port option in the `serve` architect in the workspace.json. Or by running the serve command with `--port <number>`.
+Debugging is set to use a random port that is available on the system. The port can be changed by setting the port option in the `serve` architect in the project.json. Or by running the serve command with `--port <number>`.
 
 For additional information on how to debug Node applications, see the [Node.js debugging getting started guide](https://nestjs.org/en/docs/guides/debugging-getting-started/#inspector-clients).
 
@@ -162,7 +162,7 @@ nx generate @nrwl/nest:library <nest-lib> --buildable
 
 ### Library commands
 
-When a Nest library is added to the workspace.json (or angular.json), the following architect commands are available for execution:
+When a Nest library is added, the following architect commands are available for execution:
 
 #### lint
 

--- a/docs/shared/node-plugin.md
+++ b/docs/shared/node-plugin.md
@@ -78,7 +78,7 @@ nx g @nrwl/node:application my-new-app \
 
 ### Debugging
 
-Debugging is set to use a random port that is available on the system. The port can be changed by setting the port option in the `serve` architect in the workspace.json. Or by running the serve command with `--port <number>`.
+Debugging is set to use a random port that is available on the system. The port can be changed by setting the port option in the `serve` architect in the project.json. Or by running the serve command with `--port <number>`.
 
 For additional information on how to debug Node applications, see the [Node.js debugging getting started guide](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients).
 

--- a/docs/shared/node-tutorial/01-create-application.md
+++ b/docs/shared/node-tutorial/01-create-application.md
@@ -90,9 +90,9 @@ or
 yarn nx serve todos
 ```
 
-## Workspace.json, Targets, Executors
+## Project.json, Targets, Executors
 
-You configure your workspaces in `workspace.json`. This file contains the workspace projects with their architect targets. For instance, `todos` has the `build`, `serve`, `lint`, and `test` targets. This means that you can run `nx build todos`, `nx serve todos`, etc..
+You configure your projects in `project.json` files. These files contains the workspace projects with their command targets. For instance, `todos` has the `build`, `serve`, `lint`, and `test` targets. This means that you can run `nx build todos`, `nx serve todos`, etc..
 
 Every target uses an executor which actually runs this target. So targets are analogous to typed npm scripts, and executors are analogous to typed shell scripts.
 

--- a/docs/shared/nx-plugin.md
+++ b/docs/shared/nx-plugin.md
@@ -116,7 +116,7 @@ There are additional functions that the `@nrwl/nx-plugin/testing` package export
 
 Sometimes you might want to include some assets with the plugin. This might be a image or some additional binaries.
 
-To make sure that assets are copied to the dist folder, open the `workspace.json` file, and find the plugin's project. Inside the `build` property, add additional assets. By default, all `.md` files in the root, all non-ts files in folders, and the `generators.json` and `executors.json` files are included.
+To make sure that assets are copied to the dist folder, open the plugin's `project.json` file. Inside the `build` property, add additional assets. By default, all `.md` files in the root, all non-ts files in folders, and the `generators.json` and `executors.json` files are included.
 
 ```json
 "build": {

--- a/docs/shared/react-native-plugin.md
+++ b/docs/shared/react-native-plugin.md
@@ -57,7 +57,7 @@ npx nx g @nrwl/react-native:lib your-lib-name
 
 ### Generating Components
 
-To generate a new comopnent inside library run:
+To generate a new component inside library run:
 
 ```bash
 npx nx g @nrwl/react-native:component your-component-name --project=your-lib-name --export

--- a/docs/shared/running-custom-commands.md
+++ b/docs/shared/running-custom-commands.md
@@ -19,26 +19,24 @@ hello:
   echo "Hello, world!"
 ```
 
-##### 2. Update `workspace.json`
+##### 2. Update `project.json`
 
-For each project for which you want to enable `make`, add a target in `workspace.json`:
+For each project for which you want to enable `make`, add a target in its `project.json`:
 
 ```json
 // ...
-"my-app": {
-    "targets": {
-        "make": {
-            "executor": "@nrwl/workspace:run-commands",
-                "options": {
-                "commands": [
-                    {
-                        "command": "make hello"
-                    }
-                ]
-            }
+"targets": {
+    "make": {
+        "executor": "@nrwl/workspace:run-commands",
+            "options": {
+            "commands": [
+                {
+                    "command": "make hello"
+                }
+            ]
         }
-        // ...
     }
+    // ...
 }
 ```
 

--- a/docs/shared/tools-workspace-builders.md
+++ b/docs/shared/tools-workspace-builders.md
@@ -115,30 +115,25 @@ npx tsc tools/executors/echo/impl
 
 This will create the `impl.js` file in your file directory, which will serve as the artifact used by the CLI.
 
-Our last step is to add this executor to a given project’s `targets` object in your project's `workspace.json` or `angular.json` file. The example below adds this executor to a project named 'platform':
+Our last step is to add this executor to a given project’s `targets` object in your project's `project.json` file:
 
 ```json
 {
   //...
-  "projects": {
-    "platform": {
-      //...
-      "targets": {
-        "build": {
-          // ...
-        },
-        "serve": {
-          // ...
-        },
-        "lint": {
-          // ,,,
-        },
-        "echo": {
-          "executor": "./tools/executors/echo:echo",
-          "options": {
-            "textToEcho": "Hello World"
-          }
-        }
+  "targets": {
+    "build": {
+      // ...
+    },
+    "serve": {
+      // ...
+    },
+    "lint": {
+      // ,,,
+    },
+    "echo": {
+      "executor": "./tools/executors/echo:echo",
+      "options": {
+        "textToEcho": "Hello World"
       }
     }
   }

--- a/docs/shared/using-executors.md
+++ b/docs/shared/using-executors.md
@@ -9,43 +9,37 @@ There are two main differences between an executor and a shell script or an npm 
 
 ## Executor definitions
 
-The executors that are available for each project are defined and configured in the `/workspace.json` file.
+The executors that are available for each project are defined and configured in the project's `project.json` file.
 
 ```json
 {
-  "projects": {
-    "cart": {
-      "root": "apps/cart",
-      "sourceRoot": "apps/cart/src",
-      "projectType": "application",
-      "generators": {},
-      "targets": {
-        "build": {
-          "executor": "@nrwl/web:webpack",
-          "options": {
-            "outputPath": "dist/apps/cart",
-            ...
-          },
-          "configurations": {
-            "production": {
-              "sourceMap": false,
-              ...
-            }
-          }
-        },
-        "test": {
-          "executor": "@nrwl/jest:jest",
-          "options": {
-            ...
-          }
+  "root": "apps/cart",
+  "sourceRoot": "apps/cart/src",
+  "projectType": "application",
+  "generators": {},
+  "targets": {
+    "build": {
+      "executor": "@nrwl/web:webpack",
+      "options": {
+        "outputPath": "dist/apps/cart",
+        ...
+      },
+      "configurations": {
+        "production": {
+          "sourceMap": false,
+          ...
         }
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "options": {
+        ...
       }
     }
   }
 }
 ```
-
-> Note: There are a few property keys in `workspace.json` that have interchangeable aliases. You can replace `generators` with `schematics`, `targets` with `architect` or `executor` with `builder`.
 
 Each project has its executors defined in the `targets` property. In this snippet, `cart` has two executors defined - `build` and `test`.
 

--- a/docs/shared/using-nx/caching.md
+++ b/docs/shared/using-nx/caching.md
@@ -50,7 +50,7 @@ work happens. The rest is either left as is or restored from the cache.
 
 ## Source Code Hash Inputs
 
-The result of building/testing an application or a library depends on the source code of that project and all the source codes of all the libraries it depends on (directly or indirectly). It also depends on the configuration files like `package.json`, `workspace.json`, `nx.json`, `tsconfig.base.json`, and `package-lock.json`. The list of these files isn't arbitrary. Nx can deduce most of them by analyzing our codebase. Few have to be listed manually in the `implicitDependencies` property of `nx.json`.
+The result of building/testing an application or a library depends on the source code of that project and all the source codes of all the libraries it depends on (directly or indirectly). It also depends on the configuration files like `package.json`, `nx.json`, `tsconfig.base.json`, and `package-lock.json`. The list of these files isn't arbitrary. Nx can deduce most of them by analyzing our codebase. Few have to be listed manually in the `implicitDependencies` property of `nx.json`.
 
 ```json
 {

--- a/docs/shared/workspace/buildable-and-publishable-libraries.md
+++ b/docs/shared/workspace/buildable-and-publishable-libraries.md
@@ -15,7 +15,7 @@ You might use the `--publishable` option when generating a new Nx library if you
 
 One typical scenario for this may be that you use Nx to develop your organizations UI design system component library (maybe using its Storybook integration), which should be available also to your organizations’ apps that are not hosted within the same monorepo.
 
-A normal Nx library - let’s call it "workspace library" - is not made for building or publishing. Rather it only includes common lint and test targets in its `angular.json` or `workspace.json`. These libraries are directly referenced from one of the monorepo’s applications and built together with them.
+A normal Nx library - let’s call it "workspace library" - is not made for building or publishing. Rather it only includes common lint and test targets in its `project.json` file. These libraries are directly referenced from one of the monorepo’s applications and built together with them.
 
 Keep in mind that the `--publishable` flag does not enable automatic publishing. Rather it adds to your Nx workspace library a builder target that **compiles** and **bundles** your app. The resulting artifact will be ready to be published to some registry (e.g. [npm](https://npmjs.com/)). By having that builder, you can invoke the build via a command like: `nx build mylib` (where "mylib" is the name of the lib) which will then produce an optimized bundle in the `dist/mylib` folder. Nx [also analyzes](/angular/package#updatebuildableprojectdepsinpackagejson) the library’s dependencies and automatically compiles the dependencies in the resulting `package.json` file.
 

--- a/packages/js/src/generators/application/schema.json
+++ b/packages/js/src/generators/application/schema.json
@@ -86,7 +86,7 @@
       "type": "string",
       "enum": ["workspace", "project", "npm-scripts"],
       "default": "project",
-      "description": "Determines how whether the project's executors should be configured in workspace.json, project.json or as npm scripts"
+      "description": "Determines whether the project's executors should be configured in workspace.json, project.json or as npm scripts"
     },
     "compiler": {
       "type": "string",

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -91,7 +91,7 @@
       "type": "string",
       "enum": ["workspace", "project", "npm-scripts"],
       "default": "project",
-      "description": "Determines how whether the project's executors should be configured in workspace.json, project.json or as npm scripts"
+      "description": "Determines whether the project's executors should be configured in workspace.json, project.json or as npm scripts"
     },
     "compiler": {
       "type": "string",


### PR DESCRIPTION
Uses project.json instead of workspace.json in docs wherever possible.