### PR TITLE
fix(web): support custom webpack config written in TypeScript for @nrwl/web:webpack executor

### DIFF
--- a/packages/web/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/web/src/executors/dev-server/dev-server.impl.ts
@@ -19,7 +19,7 @@ import {
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
 import { getEmittedFiles, runWebpackDevServer } from '../../utils/run-webpack';
-import { tsNodeRegister } from '../../utils/webpack/tsNodeRegister';
+import { resolveCustomWebpackConfig } from '../../utils/webpack/custom-webpack';
 
 export interface WebDevServerOptions {
   host: string;
@@ -127,16 +127,4 @@ function getBuildOptions(
     ...buildOptions,
     ...overrides,
   };
-}
-
-function resolveCustomWebpackConfig(path: string, tsConfig: string) {
-  tsNodeRegister(path, tsConfig);
-
-  const customWebpackConfig = require(path);
-  // If the user provides a configuration in TS file
-  // then there are 2 cases for exporing an object. The first one is:
-  // `module.exports = { ... }`. And the second one is:
-  // `export default { ... }`. The ESM format is compiled into:
-  // `{ default: { ... } }`
-  return customWebpackConfig.default || customWebpackConfig;
 }

--- a/packages/web/src/executors/webpack/webpack.impl.ts
+++ b/packages/web/src/executors/webpack/webpack.impl.ts
@@ -26,6 +26,7 @@ import {
   CrossOriginValue,
   writeIndexHtml,
 } from '../../utils/webpack/write-index-html';
+import { resolveCustomWebpackConfig } from '../../utils/webpack/custom-webpack';
 
 export interface WebWebpackExecutorOptions extends BuildBuilderOptions {
   index: string;
@@ -106,14 +107,20 @@ function getWebpackConfigs(
       : undefined,
   ]
     .filter(Boolean)
-    .map((config) =>
-      options.webpackConfig
-        ? require(options.webpackConfig)(config, {
-            options,
-            configuration: context.configurationName,
-          })
-        : config
-    );
+    .map((config) => {
+      if (options.webpackConfig) {
+        const customWebpack = resolveCustomWebpackConfig(
+          options.webpackConfig,
+          options.tsConfig
+        );
+        return customWebpack(config, {
+          options,
+          configuration: context.configurationName,
+        });
+      } else {
+        return config;
+      }
+    });
 }
 
 export async function* run(

--- a/packages/web/src/utils/webpack/custom-webpack.ts
+++ b/packages/web/src/utils/webpack/custom-webpack.ts
@@ -17,3 +17,15 @@ export function tsNodeRegister(file: string = '', tsConfig?: string) {
     tsconfigPaths.register({ baseUrl, paths });
   }
 }
+
+export function resolveCustomWebpackConfig(path: string, tsConfig: string) {
+  tsNodeRegister(path, tsConfig);
+
+  const customWebpackConfig = require(path);
+  // If the user provides a configuration in TS file
+  // then there are 2 cases for exporing an object. The first one is:
+  // `module.exports = { ... }`. And the second one is:
+  // `export default { ... }`. The ESM format is compiled into:
+  // `{ default: { ... } }`
+  return customWebpackConfig.default || customWebpackConfig;
+}


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Custom webpack config written in TypeScript is not supported for `@nrwl/web:webpack` executor.

Error is thrown if the custom config is written in TypeScript with es6 syntax.

It is already fixed for `@nrwl/web:dev-server` executor with a recent PR https://github.com/nrwl/nx/pull/7633

However, production build requires `@nrwl/web:webpack` executor, which makes [7633](https://github.com/nrwl/nx/pull/7633) less useful.

## Expected Behavior

Custom webpack config written in TypeScript should be supported.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
N/A
