### PR TITLE
docs(core): added env to the jenkins variable for verbosity

### DIFF
--- a/docs/shared/monorepo-ci-jenkins.md
+++ b/docs/shared/monorepo-ci-jenkins.md
@@ -50,8 +50,8 @@ pipeline {
                     steps {
                         sh "npm install"
                         sh "npx nx-cloud start-ci-run"
-                        sh "npx nx affected --base origin/${CHANGE_TARGET} --target=build --parallel=3"
-                        sh "npx nx affected --base origin/${CHANGE_TARGET} --target=test --parallel=2"
+                        sh "npx nx affected --base origin/${env.CHANGE_TARGET} --target=build --parallel=3"
+                        sh "npx nx affected --base origin/${env.CHANGE_TARGET} --target=test --parallel=2"
                         sh "npx nx-cloud stop-all-agents"
                     }
                 }


### PR DESCRIPTION
Added the `env` prefix for the Jenkins environment variable to make it more verbose (mentioned in the previous PR)

Related PR and discussion: https://github.com/nrwl/nx/pull/8852#discussion_r804047091
