### PR TITLE
 fix(web): don't allow arbitrary code execution in file-server

### DIFF
--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -1,4 +1,4 @@
-import { exec, execSync } from 'child_process';
+import { execFile, execFileSync } from 'child_process';
 import { ExecutorContext, joinPathFragments, logger } from '@nrwl/devkit';
 import ignore from 'ignore';
 import { readFileSync } from 'fs';
@@ -40,7 +40,7 @@ function getBuildTargetCommand(options: Schema) {
   if (options.maxParallel) {
     cmd.push(`--maxParallel=${options.maxParallel}`);
   }
-  return cmd.join(' ');
+  return cmd;
 }
 
 function getBuildTargetOutputPath(options: Schema, context: ExecutorContext) {
@@ -109,7 +109,8 @@ export default async function* fileServerExecutor(
     if (!running) {
       running = true;
       try {
-        execSync(getBuildTargetCommand(options), {
+        const [cmd, ...args] = getBuildTargetCommand(options);
+        execFileSync(cmd, args, {
           stdio: [0, 1, 2],
         });
       } catch {}
@@ -125,7 +126,7 @@ export default async function* fileServerExecutor(
   const outputPath = getBuildTargetOutputPath(options, context);
   const args = getHttpServerArgs(options);
 
-  const serve = exec(`npx http-server ${outputPath} ${args.join(' ')}`, {
+  const serve = execFile('npx', ['http-server', outputPath, ...args], {
     cwd: context.root,
   });
   const processExitListener = () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

NX executes code embedded in some fields in `nx.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It should not execute arbitrary code embedded in `nx.json`.

## Fix

The Node documentation for `exec` states:

> Never pass unsanitized user input to this function. Any input containing shell metacharacters may be used to trigger arbitrary command execution.

The `outputPath`, `options.buildTarget` and `options.maxParallel` come from `nx.json`. Careful crafting of these fields can result in NX executing arbitrary commands.

This patch fixes this by using `execFile`, which does not spawn a shell.
