### PR TITLE
docs(misc): advise using the @nrwl/angular:move generator for angular projects

### DIFF
--- a/docs/shared/workspace/grouping-libraries.md
+++ b/docs/shared/workspace/grouping-libraries.md
@@ -12,6 +12,8 @@ For instance, if a library under the `booking` folder is now being shared by mul
 nx g move --project booking-some-library shared/some-library
 ```
 
+> **Note**: For Angular projects, you should use the [`@nrwl/angular:move` generator](/angular/move) instead.
+
 ## Remove Generator
 
 Similarly, if you no longer need a library, you can remove it with the [`@nrwl/workspace:remove` generator](/workspace/remove).


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
In the "Grouping Libraries" docs, the `@nrwl/workspace:move` generator is correctly advised to be used to move or rename projects, but there's no mention of using the `@nrwl/angular:move` generator for Angular projects. This can lead folks to use the former for Angular projects and therefore, the projects are not moved/renamed correctly. Discovering the `@nrwl/angular:move` generator is not straightforward.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should have a note in the "Grouping Libraries" docs advising to use the `@nrwl/angular:move` generator for Angular projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
