### PR TITLE
fix(linter): enforce fresh graph if rule not run by nx command

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -15,6 +15,7 @@ import {
   MappedProjectGraph,
   hasBannedImport,
   isDirectDependency,
+  isTerminalRun,
 } from '@nrwl/workspace/src/utils/runtime-lint-utils';
 import {
   AST_NODE_TYPES,
@@ -133,7 +134,11 @@ export default createESLintRule<Options, MessageIds>({
     const projectPath = normalizePath(
       (global as any).projectPath || appRootPath
     );
-    if (!(global as any).projectGraph) {
+    /**
+     * Only reuse graph when running from terminal
+     * Enforce every IDE change to get a fresh nxdeps.json
+     */
+    if (!(global as any).projectGraph || !isTerminalRun()) {
       const nxJson = readNxJson();
       (global as any).npmScope = nxJson.npmScope;
       (global as any).workspaceLayout = nxJson.workspaceLayout;

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -267,3 +267,10 @@ export function mapProjectGraphFiles<T>(
     nodes,
   };
 }
+
+export function isTerminalRun(): boolean {
+  return (
+    process.argv.length > 1 &&
+    !!process.argv[1].match(/@nrwl\/cli\/lib\/run-cli\.js$/)
+  );
+}


### PR DESCRIPTION
Running enforce-module-boundaries uses the project graph loaded from the `nxdeps.json`. This loading happens only once per project or IDE session causing random errors.

## Current Behavior
ESLint server running inside the IDE will get load the project graph only initially, running subsequently on an outdated version of the graph. In order to pick up the latest changes to the graph, a user must restart the ESLint server.

## Expected Behavior
ESLint server running in the IDE should get a fresh project graph updated by the daemon upon every run caused by a change in the code. This should not affect the performance when running the enforce-module-boundaries rule from the terminal.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8313 
