### PR TITLE
docs(nxdev): truncate og image content & add ellipsis

### DIFF
--- a/scripts/documentation/open-graph/generate-images.ts
+++ b/scripts/documentation/open-graph/generate-images.ts
@@ -57,7 +57,10 @@ function createOpenGraphImage(
     context.textAlign = 'center';
     context.textBaseline = 'top';
     context.fillStyle = '#fff';
-    context.fillText(content, 600, 372);
+
+    const truncate = (str, n) =>
+      str.length > n ? str.substring(0, n) + '…' : str;
+    context.fillText(truncate(content, 40), 600, 372);
 
     console.log('Generating: ' + resolve(targetFolder + `/${filename}.jpg`));
 


### PR DESCRIPTION
It adds a way to truncate the content displayed in the generated documentation open-graph images on nx.dev
The truncate process is happening when the content is more than 40 characters, for optimal readability. It truncates and add an ellipsis _(...)_ at the end of the string.