### PR TITLE
fix(nextjs): use posix path format for generated config.distdir

### DIFF
--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -1,4 +1,8 @@
-import { ExecutorContext, offsetFromRoot } from '@nrwl/devkit';
+import {
+  ExecutorContext,
+  offsetFromRoot,
+  joinPathFragments,
+} from '@nrwl/devkit';
 // ignoring while we support both Next 11.1.0 and versions before it
 // @ts-ignore
 import type { NextConfig } from 'next/dist/server/config-shared';
@@ -165,7 +169,7 @@ export async function prepareConfig(
   config.distDir =
     config.distDir && config.distDir !== '.next'
       ? config.distDir
-      : join(config.outdir, '.next');
+      : joinPathFragments(config.outdir, '.next');
   config.webpack = (a, b) =>
     createWebpackConfig(
       context.root,


### PR DESCRIPTION
ISSUES CLOSED: #8989. See that for context.

## Related Issue(s)

Fixes #8989

I've tested this on Windows, confirming that both building and deploying on Windows still works as expected, as well as building on Windows and deploying on Linux, which did not work before.