### PR TITLE
fix(react): get component name for self-closing elements as well

### DIFF
--- a/packages/react/src/utils/ast-utils.spec.ts
+++ b/packages/react/src/utils/ast-utils.spec.ts
@@ -444,6 +444,16 @@ describe('getComponentName', () => {
       `,
       expectedName: 'Test',
     },
+    {
+      testName: 'using a JSX self closing element',
+      src: `
+      function Test(props: TestProps) {
+        return <img src="something" />;
+      };
+      export default Test;
+      `,
+      expectedName: 'Test',
+    },
   ].forEach((testConfig) => {
     it(`should find the component when ${testConfig.testName}`, () => {
       const source = ts.createSourceFile(

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -477,7 +477,9 @@ export function getComponentName(sourceFile: ts.SourceFile): ts.Node | null {
   if (
     !(
       defaultExport &&
-      findNodes(defaultExport, ts.SyntaxKind.JsxElement).length > 0
+      (findNodes(defaultExport, ts.SyntaxKind.JsxElement).length > 0 ||
+        findNodes(defaultExport, ts.SyntaxKind.JsxSelfClosingElement).length >
+          0)
     )
   ) {
     return null;


### PR DESCRIPTION
ISSUES CLOSED: #8715

## Current Behavior
The getComponentName React utils function would ignore components that use self-closing elements (eg. `<img src="something" />`).

## Expected Behavior
getComponentName should not ignore components with self-closing elements.

## Related Issue(s)
#8715

Fixes #
#8715
