### PR TITLE
fix(angular): handle different workspace format version when falling back to the angular cli

### DIFF
--- a/packages/cli/lib/init-local.ts
+++ b/packages/cli/lib/init-local.ts
@@ -103,6 +103,7 @@ export function initLocal(workspace: Workspace) {
             })
         );
       } else {
+        require('@nrwl/tao/src/compat/compat');
         loadCli(workspace, '@angular/cli/lib/init.js');
       }
     }

--- a/packages/tao/src/compat/compat.ts
+++ b/packages/tao/src/compat/compat.ts
@@ -58,12 +58,12 @@ if (!patched) {
         `@angular-devkit/core/src/workspace/json/reader`,
       ]);
       const originalReadJsonWorkspace = readJsonUtils.readJsonWorkspace;
-      readJsonUtils.readJsonWorkspace = (
+      readJsonUtils.readJsonWorkspace = async (
         path,
         host: { readFile: (p) => Promise<string> }
       ) => {
         try {
-          return originalReadJsonWorkspace(path, host);
+          return await originalReadJsonWorkspace(path, host);
         } catch {
           logger.debug(
             '[NX] Angular devkit readJsonWorkspace fell back to Nx workspaces logic'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When a command that's unknown to the Nx CLI is used in an Angular workspace, the Nx CLI falls back to the Angular CLI to run the command. If this is done in a workspace with a different workspace configuration format version, it fails with an error stating that the workspace format version is invalid.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
When falling back to the Angular CLI, it should be able to read the workspace config regardless of the format version.

Fixes #
