### PR TITLE
fix(angular): fix link to docs when ng update command is run

### DIFF
--- a/packages/cli/lib/init-local.ts
+++ b/packages/cli/lib/init-local.ts
@@ -63,7 +63,7 @@ export function initLocal(workspace: Workspace) {
           `- change versions of packages to match organizational requirements`
         );
         console.log(
-          `And, in general, it is lot more reliable for non-trivial workspaces. Read more at: https://nx.dev/latest/angular/workspace/update`
+          `And, in general, it is lot more reliable for non-trivial workspaces. Read more at: https://nx.dev/getting-started/nx-and-angular#ng-update-and-nx-migrate`
         );
         console.log(
           `Run "nx migrate latest" to update to the latest version of Nx.`


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running `ng update` without `FORCE_NG_UPDATE=true`, a message appears with a wrong link to the docs.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The message to know more about `ng update` vs `nx migrate` should have the right link to the docs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8994 
