### PR TITLE
feat(core): improve run-command parallel logs

### DIFF
--- a/packages/workspace/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.ts
@@ -190,13 +190,13 @@ function createProcess(
     process.on('exit', processExitListener);
     process.on('SIGTERM', processExitListener);
     childProcess.stdout.on('data', (data) => {
-      process.stdout.write(data);
+      process.stdout.write(`[${command}] ${data}`);
       if (readyWhen && data.toString().indexOf(readyWhen) > -1) {
         res(true);
       }
     });
     childProcess.stderr.on('data', (err) => {
-      process.stderr.write(err);
+      process.stderr.write(`[${command}] ${err}`);
       if (readyWhen && err.toString().indexOf(readyWhen) > -1) {
         res(true);
       }


### PR DESCRIPTION
It appends the executed command on the result line, so it is easier to distinguish from which command the log line is related to. Format is `[command] result line`.

This change only affects the log when `parallel` is `true`.

This allows to search for a specific command while debugging, making it easier to aggregate logs by commands when using external log tooling (like Google Log Explorer).

Here is an example of how it looks like:
```
[nx run nx-dev:generate-og-images] Generating: public/images/open-graph/jest-jest.jpg
[nx run nx-dev:generate-og-images] Generating: public/images/open-graph/storybook-overview-angular.jpg
[nx run nx-dev:build] info  - Generating static pages (211/282)
[nx run nx-dev:generate-og-images] Generating: public/images/open-graph/storybook-overview-react.jpg
[nx run nx-dev:build]
Page                                                Size     First Load JS
┌ ○ / (2354 ms)                                     35.6 kB         547 kB
├   /_app                                           0 B            75.7 kB
├ ● /[...segments] (70426 ms)                       50.6 kB         558 kB
├   ├ /configuration/projectjson (4862 ms)
├   ├ /getting-started/nx-setup (3789 ms)
├   ├ /configuration/packagejson (2536 ms)
├   ├ /getting-started/nx-and-angular (2486 ms)
├   ├ /getting-started/intro (2089 ms)
├   ├ /getting-started/nx-and-typescript (2054 ms)
├   ├ /react-tutorial/05-add-node-app (2030 ms)
├   └ [+270 more paths]
├ ○ /404                                            194 B          75.9 kB
├ ● /community (427 ms)                             4.76 kB         223 kB
└ ○ /conf (508 ms)                                  14.6 kB         236 kB
+ First Load JS shared by all                       75.7 kB
  ├ chunks/framework-fd865f22cad73a01.js            42 kB
  ├ chunks/main-4ce32a13053c6681.js                 28.5 kB
  ├ chunks/pages/_app-33ad5e9b7056a25c.js           4.45 kB
  ├ chunks/webpack-514908bffb652963.js              770 B
  └ css/84a7f648ef6c4110.css                        12.4 kB
[nx run nx-dev:generate-og-images] Generating: public/images/open-graph/node-build.jpg
[nx run nx-dev:generate-og-images] Generating: public/images/open-graph/node-package.jpg
```