### PR TITLE
docs(core): fix debugging nodejs link for nestjs overview

### DIFF
--- a/docs/shared/nest-plugin.md
+++ b/docs/shared/nest-plugin.md
@@ -117,7 +117,7 @@ Nest applications also have the `inspect` flag set, so you can attach your debug
 
 Debugging is set to use a random port that is available on the system. The port can be changed by setting the port option in the `serve` architect in the workspace.json. Or by running the serve command with `--port <number>`.
 
-For additional information on how to debug Node applications, see the [Node.js debugging getting started guide](https://nestjs.org/en/docs/guides/debugging-getting-started/#inspector-clients).
+For additional information on how to debug Node applications, see the [Node.js debugging getting started guide](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients).
 
 ### Lint
 


### PR DESCRIPTION
Fixes the debugging nodejs on the nestjs overview documentation link.

Fixes #8978