### PR TITLE
fix(js): ensure correct path format for asset pattern matching

### DIFF
--- a/packages/js/src/utils/copy-assets-handler.ts
+++ b/packages/js/src/utils/copy-assets-handler.ts
@@ -109,7 +109,8 @@ export class CopyAssetsHandler {
           pattern = ag.pattern;
         }
 
-        const files = await fg(pattern, {
+        // fast-glob only supports Unix paths
+        const files = await fg(pattern.replace(/\\/g, '/'), {
           cwd: this.rootDir,
         });
 


### PR DESCRIPTION
The `fast-glob` we use to find files matching the asset patterns only supports unix-type paths, causing our builds to fail on Windows.

## Current Behavior
The patterns on Windows get normalized to backslash-separated paths, causing the `fast-glob` to miss all of them.

## Expected Behavior
The patterns on Windows should be normalized to Unix paths, before handing out to `fast-glob`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
