### PR TITLE
feat(core): add allowOverwrites option

### DIFF
--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -140,6 +140,11 @@ export interface TargetConfiguration {
   dependsOn?: TargetDependencyConfig[];
 
   /**
+   * List of overwrites that can be passed to this target.
+   */
+  allowOverwrites?: string[];
+
+  /**
    * Target's options. They are passed in to the executor.
    */
   options?: any;

--- a/packages/workspace/src/tasks-runner/run-command.spec.ts
+++ b/packages/workspace/src/tasks-runner/run-command.spec.ts
@@ -840,6 +840,54 @@ describe('createTasksForProjectToRun', () => {
       },
     ]);
   });
+
+  it('should forward overrides to tasks with allowOverwrites', () => {
+    projectGraph.nodes.app1.data.targets.build.executor = 'executor1';
+    projectGraph.nodes.app1.data.targets.build.dependsOn = [
+      {
+        target: 'prebuild',
+        projects: 'self',
+      },
+    ];
+    projectGraph.nodes.app1.data.targets.prebuild.executor = 'executor2';
+    projectGraph.nodes.app1.data.targets.prebuild.allowOverwrites = [
+      'flagToPass',
+    ];
+
+    const tasks = createTasksForProjectToRun(
+      [projectGraph.nodes.app1],
+      {
+        target: 'build',
+        configuration: undefined,
+        overrides: { flagToPass: 'flag value', flagNotToPass: 'flag value' },
+      },
+      projectGraph,
+      projectGraph.nodes.app1.name
+    );
+
+    expect(tasks).toEqual([
+      {
+        id: 'app1:prebuild',
+        overrides: { flagToPass: 'flag value' },
+        projectRoot: 'app1-root',
+        target: {
+          configuration: undefined,
+          project: 'app1',
+          target: 'prebuild',
+        },
+      },
+      {
+        id: 'app1:build',
+        overrides: { flagToPass: 'flag value', flagNotToPass: 'flag value' },
+        projectRoot: 'app1-root',
+        target: {
+          configuration: undefined,
+          project: 'app1',
+          target: 'build',
+        },
+      },
+    ]);
+  });
 });
 
 describe('getRunner', () => {

--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -5,6 +5,7 @@ import type {
   NxJsonConfiguration,
   ProjectGraph,
   ProjectGraphProjectNode,
+  TargetConfiguration,
   TargetDependencyConfig,
   Task,
 } from '@nrwl/devkit';
@@ -265,10 +266,11 @@ function addTasksForProjectTarget(
     project,
     target,
     configuration,
-    overrides:
-      project.data.targets?.[target]?.executor === originalTargetExecutor
-        ? overrides
-        : {},
+    overrides: getOverwrites(
+      overrides,
+      originalTargetExecutor,
+      project.data.targets?.[target]
+    ),
     errorIfCannotFindConfiguration,
   });
 
@@ -298,6 +300,28 @@ function addTasksForProjectTarget(
     }
   }
   tasksMap.set(task.id, task);
+}
+
+function getOverwrites(
+  overrides: Object,
+  originalTargetExecutor: string,
+  target?: TargetConfiguration
+): Object {
+  if (!target) {
+    return {};
+  }
+
+  if (target.executor === originalTargetExecutor) {
+    return overrides;
+  }
+
+  return (target.allowOverwrites || []).reduce(
+    (res, key) => ({
+      ...res,
+      [key]: overrides[key],
+    }),
+    {}
+  );
 }
 
 export function createTask({


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Having configuration like so:
```json
{
  "root": "apps/api",
  "sourceRoot": "apps/api/src",
  "projectType": "application",
  "prefix": "api",
  "targets": {
    "build": {
      "executor": "api-executors:build",
      "outputs": ["{options.outputPath}"],
      "options": {}
    },
    "deploy": {
      "executor": "api-executors:deploy",
      "dependsOn": [
        {
          "target": "build",
          "projects": "self"
        }
      ],
      "options": {}
    }
  }
}
```

Running `nx run api:deploy --stage my-branch-name` // dynamic - cannot be solved with configuration

It results with:
```
nx run api:build
nx run api:deploy --stage my-branch-name
``` 

## Expected Behavior

With changed configuration:
```json
{
  "root": "apps/api",
  "sourceRoot": "apps/api/src",
  "projectType": "application",
  "prefix": "api",
  "targets": {
    "build": {
      "executor": "api-executors:build",
      "allowOverwrites": ["stage"], <-------- CHANGE
      "outputs": ["{options.outputPath}"],
      "options": {}
    },
    "deploy": {
      "executor": "api-executors:deploy",
      "dependsOn": [
        {
          "target": "build",
          "projects": "self"
        }
      ],
      "options": {}
    }
  }
}
```

Running `nx run api:deploy --stage my-branch-name` // dynamic - cannot be solved with configuration

It results with:
```
nx run api:build --stage my-branch-name
nx run api:deploy --stage my-branch-name
``` 

## Rationale

Having some dynamic overwrites it would be great to configure `build`, `deploy` etc. as in example.
Right now it is not possible. I have spent some time thinking about which angle to use. I did consider updating `dependsOn` to accept arguments to pass. In the end I think this would require too much knowledge on the side of the initial target about its dependants. I feel like it is the target that receives overwrites which knows what kind of overwrites it can use/accept/`allow`.

Things to consider:
* Decide if `target.executor === originalTargetExecutor` or `allowOverwrites` should take precedence. Right now I left `target.executor === originalTargetExecutor` as more important.
* Some kind of "allow all option".

## Related Issue(s)
Relates #8034
