### PR TITLE
feat(core): ability to run local nx plugins

### DIFF
--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -6,15 +6,16 @@ import {
   newProject,
   readJson,
   readProjectConfig,
-  readWorkspaceConfig,
   runCLI,
   runCLIAsync,
   uniq,
-  workspaceConfigName,
 } from '@nrwl/e2e/utils';
 
 describe('Nx Plugin', () => {
-  beforeEach(() => newProject());
+  let npmScope: string;
+  beforeEach(() => {
+    npmScope = newProject();
+  });
 
   it('should be able to generate a Nx Plugin ', async () => {
     const plugin = uniq('plugin');
@@ -170,6 +171,23 @@ describe('Nx Plugin', () => {
         },
       }),
     });
+  }, 90000);
+
+  it('should be able to use a local plugin', async () => {
+    const plugin = uniq('plugin');
+    const generator = uniq('generator');
+    const generatedProject = uniq('project');
+
+    runCLI(`generate @nrwl/nx-plugin:plugin ${plugin} --linter=eslint`);
+    runCLI(
+      `generate @nrwl/nx-plugin:generator ${generator} --project=${plugin}`
+    );
+
+    runCLI(
+      `generate @${npmScope}/${plugin}:${generator} --name ${generatedProject}`
+    );
+    expect(() => checkFilesExist(`libs/${generatedProject}`)).not.toThrow();
+    expect(() => runCLI(`build ${generatedProject}`)).not.toThrow();
   }, 90000);
 
   describe('--directory', () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Nx plugins are loaded through a combination of `require.resolve` and `require`. In order for this to work for plugins that were created and live as a project in the workspace, that project must be built and available via NODE_PATH (sometime's done by symlinking outputs to node_modules).

This complicates the setup for workspace executors, as dev's must setup some kind of automated build before the command. This can be done either using targetDependencies or a clever post install script, but neither are really ideal.

- Using target dependencies, you have to set this up for every target name that a custom executor will be used for
- Using post install scripts, or prepare npm scripts, means that the script has to be ran after each change.

## Expected Behavior
Created nx plugins' functionality is available to the CLI, in the same manner that an installed plugin would be.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8824 
Fixes #3231
