### PR TITLE
fix(linter): update circular file path message to wrap onto multiple lines

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
@@ -1198,7 +1198,10 @@ Circular file chain:
 Circular file chain:
 - libs/mylib/src/main.ts
 - libs/badcirclelib/src/main.ts
-- [libs/anotherlib/src/main.ts,libs/anotherlib/src/index.ts]`;
+- [
+    libs/anotherlib/src/main.ts,
+    libs/anotherlib/src/index.ts
+  ]`;
     expect(failures.length).toEqual(2);
     expect(failures[0].message).toEqual(message);
     expect(failures[1].message).toEqual(message);

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -302,6 +302,10 @@ export default createESLintRule<Options, MessageIds>({
       if (circularPath.length !== 0) {
         const circularFilePath = findFilesInCircularPath(circularPath);
 
+        // spacer text used for indirect dependencies when printing one line per file.
+        // without this, we can end up with a very long line that does not display well in the terminal.
+        const spacer = '\n    ';
+
         context.report({
           node,
           messageId: 'noCircularDependencies',
@@ -314,7 +318,9 @@ export default createESLintRule<Options, MessageIds>({
             ),
             filePaths: circularFilePath
               .map((files) =>
-                files.length > 1 ? `[${files.join(',')}]` : files[0]
+                files.length > 1
+                  ? `[${spacer}${files.join(`,${spacer}`)}\n  ]`
+                  : files[0]
               )
               .reduce(
                 (acc, files) => `${acc}\n- ${files}`,


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
@nrwl/nx/enforce-module-boundaries reports files in the circular chain on a single long line

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
@nrwl/nx/enforce-module-boundaries reports files in the circular chain on multiple lines
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9032 
