### PR TITLE
docs(core): add missing return type for workspace builders docs

### DIFF
--- a/docs/shared/tools-workspace-builders.md
+++ b/docs/shared/tools-workspace-builders.md
@@ -182,7 +182,7 @@ Here's an example of this (from a hypothetical project), that serves an api (pro
 ```typescript
 import { ExecutorContext, runExecutor } from '@nrwl/devkit';
 
-export type interface MultipleExecutorOptions {}
+export interface MultipleExecutorOptions {}
 
 export default async function multipleExecutor(
   options: MultipleExecutorOptions,

--- a/docs/shared/tools-workspace-builders.md
+++ b/docs/shared/tools-workspace-builders.md
@@ -51,7 +51,7 @@ In our `impl.ts` file, we're creating an `Options` interface that matches the js
 The `impl.ts` contains the actual code for your executor. Your executor's implementation must export a function that takes an options object and returns a `Promise<{ success: boolean }>`.
 
 ```typescript
-import { ExecutorContext } from '@nrwl/devkit';
+import type { ExecutorContext } from '@nrwl/devkit';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
@@ -62,7 +62,7 @@ export interface EchoExecutorOptions {
 export default async function echoExecutor(
   options: EchoExecutorOptions,
   context: ExecutorContext
-) {
+): Promise<{ success: boolean }> {
   console.info(`Executing "echo"...`);
   console.info(`Options: ${JSON.stringify(options, null, 2)}`);
 

--- a/docs/shared/tools-workspace-builders.md
+++ b/docs/shared/tools-workspace-builders.md
@@ -55,7 +55,7 @@ import type { ExecutorContext } from '@nrwl/devkit';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
-export interface EchoExecutorOptions {
+export type interface EchoExecutorOptions {
   textToEcho: string;
 }
 
@@ -182,12 +182,12 @@ Here's an example of this (from a hypothetical project), that serves an api (pro
 ```typescript
 import { ExecutorContext, runExecutor } from '@nrwl/devkit';
 
-export interface MultipleExecutorOptions {}
+export type interface MultipleExecutorOptions {}
 
 export default async function multipleExecutor(
   options: MultipleExecutorOptions,
   context: ExecutorContext
-) {
+): Promise<{ success: boolean }> {
   const result = await Promise.race([
     await runExecutor(
       { project: 'api', target: 'serve' },

--- a/docs/shared/tools-workspace-builders.md
+++ b/docs/shared/tools-workspace-builders.md
@@ -55,7 +55,7 @@ import type { ExecutorContext } from '@nrwl/devkit';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
-export type interface EchoExecutorOptions {
+export interface EchoExecutorOptions {
   textToEcho: string;
 }
 


### PR DESCRIPTION
- added missing return type to `echoExecutor`
- replaced regular import with import type
