### PR TITLE
fix(angular): set the right defaultBase when migrating an angular cli workspace

### DIFF
--- a/e2e/angular-core/src/ng-add.test.ts
+++ b/e2e/angular-core/src/ng-add.test.ts
@@ -147,7 +147,7 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
     const nxJson = readJson('nx.json');
     expect(nxJson).toEqual({
       npmScope: 'projscope',
-      affected: { defaultBase: 'undefined' },
+      affected: { defaultBase: 'main' },
       implicitDependencies: {
         'angular.json': '*',
         'package.json': '*',

--- a/packages/workspace/src/generators/init/init.ts
+++ b/packages/workspace/src/generators/init/init.ts
@@ -424,7 +424,9 @@ async function createAdditionalFiles(host: Tree, options: Schema) {
   const nxJson: NxJsonConfiguration = {
     npmScope: options.npmScope,
     affected: {
-      defaultBase: `${options.defaultBase}` || deduceDefaultBase(),
+      defaultBase: options.defaultBase
+        ? `${options.defaultBase}`
+        : deduceDefaultBase(),
     },
     implicitDependencies: {
       'angular.json': '*',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When migrating an Angular CLI workspace to an Nx workspace, the `defaultBase` is set to `"undefined"` if not specified as an option.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When migrating an Angular CLI workspace to an Nx workspace, the `defaultBase` should be set correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
