### PR TITLE
fix(angular): change --preserveAngularCLILayout to --preserve-angular-cli-layout

### DIFF
--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -10,10 +10,10 @@ using a monorepo approach. If you are currently using an Angular CLI workspace, 
 
 ## Using ng add and preserving your existing structure
 
-To add Nx to an existing Angular CLI workspace to an Nx workspace, with keeping your existing file structure in place, use the `ng add` command with the `--preserveAngularCLILayout` option:
+To add Nx to an existing Angular CLI workspace to an Nx workspace, with keeping your existing file structure in place, use the `ng add` command with the `--preserve-angular-cli-layout` option:
 
 ```bash
-ng add @nrwl/workspace --preserveAngularCLILayout
+ng add @nrwl/workspace --preserve-angular-cli-layout
 ```
 
 This installs the `@nrwl/workspace` package into your workspace and applies the following changes to your workspace:

--- a/e2e/angular-core/src/ng-add.test.ts
+++ b/e2e/angular-core/src/ng-add.test.ts
@@ -288,9 +288,8 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
     // runCommand('mv src-bak src');
   });
 
-  it('should support preserveAngularCLILayout', () => {
-    // TODO: rename this arg so it doesn't split the CLI letters
-    runNgAdd('--preserve-angular-c-l-i-layout');
+  it('should support preserveAngularCliLayout', () => {
+    runNgAdd('--preserve-angular-cli-layout');
 
     const updatedAngularCLIJson = readJson('angular.json');
     expect(updatedAngularCLIJson.projects[project].root).toEqual('');

--- a/packages/workspace/src/generators/init/init.spec.ts
+++ b/packages/workspace/src/generators/init/init.spec.ts
@@ -408,7 +408,7 @@ describe('workspace', () => {
     it('should update package.json', async () => {
       await initGenerator(tree, {
         name: 'myApp',
-        preserveAngularCLILayout: true,
+        preserveAngularCliLayout: true,
       });
 
       const d = readJson(tree, '/package.json').devDependencies;
@@ -419,7 +419,7 @@ describe('workspace', () => {
     it('should create nx.json', async () => {
       await initGenerator(tree, {
         name: 'myApp',
-        preserveAngularCLILayout: true,
+        preserveAngularCliLayout: true,
       });
 
       const nxJson = readJson(tree, '/nx.json');
@@ -429,7 +429,7 @@ describe('workspace', () => {
     it('should create decorate-angular-cli.js', async () => {
       await initGenerator(tree, {
         name: 'myApp',
-        preserveAngularCLILayout: true,
+        preserveAngularCliLayout: true,
       });
       const s = readJson(tree, '/package.json').scripts;
 

--- a/packages/workspace/src/generators/init/init.ts
+++ b/packages/workspace/src/generators/init/init.ts
@@ -629,7 +629,7 @@ function renameDirSyncInTree(tree: Tree, from: string, to: string) {
 }
 
 export async function initGenerator(tree: Tree, schema: Schema) {
-  if (schema.preserveAngularCLILayout) {
+  if (schema.preserveAngularCliLayout) {
     addDependenciesToPackageJson(tree, {}, { '@nrwl/workspace': nxVersion });
     createNxJson(tree);
     decorateAngularClI(tree);

--- a/packages/workspace/src/generators/init/schema.d.ts
+++ b/packages/workspace/src/generators/init/schema.d.ts
@@ -2,6 +2,6 @@ export interface Schema {
   name: string;
   skipInstall?: boolean;
   npmScope?: string;
-  preserveAngularCLILayout?: boolean;
+  preserveAngularCliLayout?: boolean;
   defaultBase?: string;
 }

--- a/packages/workspace/src/generators/init/schema.json
+++ b/packages/workspace/src/generators/init/schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/schema",
   "$id": "SchematicsNxNgAdd",
   "title": "Init Workspace",
-  "cli": true,
+  "cli": "ng",
   "description": "NOTE: Does not work in the --dry-run mode",
   "type": "object",
   "properties": {
@@ -19,7 +19,7 @@
       "description": "Skip installing after adding @nrwl/workspace",
       "default": false
     },
-    "preserveAngularCLILayout": {
+    "preserveAngularCliLayout": {
       "type": "boolean",
       "description": "Preserve the Angular CLI layout instead of moving the app into apps.",
       "default": false


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The Angular CLI deprecated the support for camel case arguments. When migrating an Angular CLI workspace to an Nx workspace using the existing `--preserveAngularCLILayout` flag, a warning is shown advising to use `--preserve-angular-clilayout` which is not correct. Because `CLI` is all pascal case, the accepted dashed flag is `--preserve-angular-c-l-i-layout` which is far from ideal.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When migrating an Angular CLI workspace to an Nx workspace we should be able to use the `--preserve-angular-cli-layout` flag. Docs should be updated to reflect that.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8979 
