### PR TITLE
chore(core): update license-webpack-plugin to improve performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "kill-port": "^1.6.1",
     "less": "3.12.2",
     "less-loader": "^10.1.0",
-    "license-webpack-plugin": "4.0.0",
+    "license-webpack-plugin": "^4.0.2",
     "loader-utils": "1.2.3",
     "memfs": "^3.0.1",
     "metro-resolver": "^0.67.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -40,7 +40,7 @@
     "fork-ts-checker-webpack-plugin": "6.2.10",
     "fs-extra": "^9.1.0",
     "glob": "7.1.4",
-    "license-webpack-plugin": "4.0.0",
+    "license-webpack-plugin": "^4.0.2",
     "rxjs": "^6.5.4",
     "source-map-support": "0.5.19",
     "tree-kill": "1.2.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -72,7 +72,7 @@
     "identity-obj-proxy": "3.0.0",
     "less": "3.12.2",
     "less-loader": "^10.1.0",
-    "license-webpack-plugin": "4.0.0",
+    "license-webpack-plugin": "^4.0.2",
     "loader-utils": "1.2.3",
     "mini-css-extract-plugin": "~2.4.7",
     "parse5": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16205,6 +16205,13 @@ license-webpack-plugin@4.0.0:
   dependencies:
     webpack-sources "^3.0.0"
 
+license-webpack-plugin@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/license-webpack-plugin/-/license-webpack-plugin-4.0.2.tgz#1e18442ed20b754b82f1adeff42249b81d11aec6"
+  integrity sha512-771TFWFD70G1wLTC4oU2Cw4qvtmNrIw+wRvBtn+okgHl7slJVi7zfNcdmqDL72BojM30VNJ2UHylr1o77U37Jw==
+  dependencies:
+    webpack-sources "^3.0.0"
+
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz"


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Nx uses `license-webpack-plugin@4.0.0`. `@angular-devkit/build-angular@13.2.4` and other packages use version 4.0.2. This leads to an extra installed module.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx should also use `license-webpack-plugin@4.0.2` and should add the sematic versioning `^` so that future updates to license-webpack-plugin are used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
