### PR TITLE
fix(js): adjust destination directory for swc executor

### DIFF
--- a/docs/generated/api-js/executors/swc.md
+++ b/docs/generated/api-js/executors/swc.md
@@ -35,6 +35,14 @@ Type: `array`
 
 List of static assets.
 
+### dts
+
+Default: `true`
+
+Type: `boolean`
+
+Whether to emit Type Declarations using tsc.
+
 ### skipTypeCheck
 
 Default: `false`

--- a/docs/generated/api-js/executors/swc.md
+++ b/docs/generated/api-js/executors/swc.md
@@ -35,14 +35,6 @@ Type: `array`
 
 List of static assets.
 
-### dts
-
-Default: `true`
-
-Type: `boolean`
-
-Whether to emit Type Declarations using tsc.
-
 ### skipTypeCheck
 
 Default: `false`

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -38,7 +38,13 @@
     "swcExclude": {
       "type": "array",
       "description": "List of SWC Glob/Regex to be excluded from compilation (https://swc.rs/docs/configuration/compilation#exclude)",
-      "default": ["./src/**/.*.spec.ts$", "./**/.*.js$"]
+      "default": [
+        "./src/**/.*.spec.ts$",
+        "./**/.*.spec.ts$",
+        "./src/**/jest-setup.ts$",
+        "./**/jest-setup.ts$",
+        "./**/.*.js$"
+      ]
     }
   },
   "required": ["main", "outputPath", "tsConfig"],

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -35,6 +35,11 @@
       "description": "Whether to skip TypeScript type checking.",
       "default": false
     },
+    "dts": {
+      "type": "boolean",
+      "description": "Whether to emit Type Declarations using tsc.",
+      "default": true
+    },
     "swcExclude": {
       "type": "array",
       "description": "List of SWC Glob/Regex to be excluded from compilation (https://swc.rs/docs/configuration/compilation#exclude)",

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -35,11 +35,6 @@
       "description": "Whether to skip TypeScript type checking.",
       "default": false
     },
-    "dts": {
-      "type": "boolean",
-      "description": "Whether to emit Type Declarations using tsc.",
-      "default": true
-    },
     "swcExclude": {
       "type": "array",
       "description": "List of SWC Glob/Regex to be excluded from compilation (https://swc.rs/docs/configuration/compilation#exclude)",

--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -1,4 +1,4 @@
-import { ExecutorContext } from '@nrwl/devkit';
+import { ExecutorContext, logger } from '@nrwl/devkit';
 import {
   assetGlobsToFiles,
   FileInputOutput,
@@ -24,6 +24,10 @@ function normalizeOptions(
   projectRoot?: string
 ): NormalizedSwcExecutorOptions {
   const outputPath = join(contextRoot, options.outputPath);
+
+  if (options.dts == null) {
+    options.dts = true;
+  }
 
   if (options.skipTypeCheck == null) {
     options.skipTypeCheck = false;

--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -25,10 +25,6 @@ function normalizeOptions(
 ): NormalizedSwcExecutorOptions {
   const outputPath = join(contextRoot, options.outputPath);
 
-  if (options.dts == null) {
-    options.dts = true;
-  }
-
   if (options.skipTypeCheck == null) {
     options.skipTypeCheck = false;
   }
@@ -43,11 +39,23 @@ function normalizeOptions(
     outputPath
   );
 
+  /**
+   * Reduce outputPath to root of layout dir (libsDir/appsDir)
+   * in desired build output dir (default is dist)
+   *
+   * dist/packages/lib-one -> dist/packages
+   * build/packages/lib-one -> build/packages
+   * dist/packages/lib-one/nested/nested-lib-one -> dist/packages
+   * dist/libs/lib-one -> dist/libs
+   * dist/apps/app-one -> dist/apps
+   */
+  const swcDestPath =
+    options.outputPath.substring(0, options.outputPath.indexOf(layoutDir)) +
+    layoutDir;
+
   const swcCliOptions = {
     srcPath: projectRoot,
-    destPath:
-      options.outputPath.substring(0, options.outputPath.indexOf(layoutDir)) +
-      layoutDir,
+    destPath: swcDestPath,
     swcrcPath: join(projectRoot, '.swcrc'),
   };
 

--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -39,23 +39,16 @@ function normalizeOptions(
     outputPath
   );
 
-  /**
-   * Reduce outputPath to root of layout dir (libsDir/appsDir)
-   * in desired build output dir (default is dist)
-   *
-   * dist/packages/lib-one -> dist/packages
-   * build/packages/lib-one -> build/packages
-   * dist/packages/lib-one/nested/nested-lib-one -> dist/packages
-   * dist/libs/lib-one -> dist/libs
-   * dist/apps/app-one -> dist/apps
-   */
-  const swcDestPath =
-    options.outputPath.substring(0, options.outputPath.indexOf(layoutDir)) +
-    layoutDir;
+  const projectRootParts = projectRoot.split('/');
+  // We pop the last part of the `projectRoot` to pass
+  // the last part (projectDir) and the remainder (projectRootParts) to swc
+  const projectDir = projectRootParts.pop();
+  const swcCwd = projectRootParts.join('/');
 
   const swcCliOptions = {
-    srcPath: projectRoot,
-    destPath: swcDestPath,
+    srcPath: projectDir,
+    destPath: relative(join(contextRoot, swcCwd), outputPath),
+    swcCwd,
     swcrcPath: join(projectRoot, '.swcrc'),
   };
 

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -48,6 +48,7 @@ export interface NormalizedExecutorOptions extends ExecutorOptions {
 
 export interface SwcExecutorOptions extends ExecutorOptions {
   skipTypeCheck?: boolean;
+  dts?: boolean;
   swcExclude?: string[];
 }
 
@@ -61,6 +62,7 @@ export interface NormalizedSwcExecutorOptions
   extends NormalizedExecutorOptions {
   swcExclude: string[];
   skipTypeCheck: boolean;
+  dts: boolean;
   swcCliOptions: SwcCliOptions;
 }
 

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -52,7 +52,8 @@ export interface SwcExecutorOptions extends ExecutorOptions {
 }
 
 export interface SwcCliOptions {
-  projectDir: string;
+  srcPath: string;
+  swcrcPath: string;
   destPath: string;
 }
 
@@ -60,7 +61,6 @@ export interface NormalizedSwcExecutorOptions
   extends NormalizedExecutorOptions {
   swcExclude: string[];
   skipTypeCheck: boolean;
-  swcrcPath: string;
   swcCliOptions: SwcCliOptions;
 }
 

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -53,8 +53,9 @@ export interface SwcExecutorOptions extends ExecutorOptions {
 
 export interface SwcCliOptions {
   srcPath: string;
-  swcrcPath: string;
   destPath: string;
+  swcrcPath: string;
+  swcCwd: string;
 }
 
 export interface NormalizedSwcExecutorOptions

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -48,7 +48,6 @@ export interface NormalizedExecutorOptions extends ExecutorOptions {
 
 export interface SwcExecutorOptions extends ExecutorOptions {
   skipTypeCheck?: boolean;
-  dts?: boolean;
   swcExclude?: string[];
 }
 
@@ -62,7 +61,6 @@ export interface NormalizedSwcExecutorOptions
   extends NormalizedExecutorOptions {
   swcExclude: string[];
   skipTypeCheck: boolean;
-  dts: boolean;
   swcCliOptions: SwcCliOptions;
 }
 

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -2,16 +2,15 @@ import { ExecutorContext, logger } from '@nrwl/devkit';
 import { cacheDir } from '@nrwl/workspace/src/utilities/cache-directory';
 import { exec, execSync } from 'child_process';
 import { createAsyncIterable } from '../create-async-iterable/create-async-iteratable';
-import { NormalizedSwcExecutorOptions } from '../schema';
+import { NormalizedSwcExecutorOptions, SwcCliOptions } from '../schema';
 import { printDiagnostics } from '../typescript/print-diagnostics';
 import { runTypeCheck, TypeCheckOptions } from '../typescript/run-type-check';
 
 function getSwcCmd(
-  normalizedOptions: NormalizedSwcExecutorOptions,
+  { swcrcPath, srcPath, destPath }: SwcCliOptions,
   watch = false
 ) {
-  const srcPath = `../${normalizedOptions.swcCliOptions.projectDir}`;
-  let swcCmd = `npx swc ${srcPath} -d ${normalizedOptions.swcCliOptions.destPath} --source-maps --no-swcrc --config-file=${normalizedOptions.swcrcPath}`;
+  let swcCmd = `npx swc ${srcPath} -d ${destPath} --source-root=${srcPath} --source-maps --no-swcrc --config-file=${swcrcPath}`;
   return watch ? swcCmd.concat(' --watch') : swcCmd;
 }
 
@@ -40,9 +39,9 @@ export async function compileSwc(
 ) {
   logger.log(`Compiling with SWC for ${context.projectName}...`);
 
-  const swcCmdLog = execSync(getSwcCmd(normalizedOptions), {
-    cwd: normalizedOptions.projectRoot,
-  }).toString();
+  const swcCmdLog = execSync(
+    getSwcCmd(normalizedOptions.swcCliOptions)
+  ).toString();
   logger.log(swcCmdLog.replace(/\n/, ''));
   const isCompileSuccess = swcCmdLog.includes('Successfully compiled');
 
@@ -85,9 +84,7 @@ export async function* compileSwcWatch(
       let stderrOnData: () => void;
       let watcherOnExit: () => void;
 
-      const swcWatcher = exec(getSwcCmd(normalizedOptions, true), {
-        cwd: normalizedOptions.projectRoot,
-      });
+      const swcWatcher = exec(getSwcCmd(normalizedOptions.swcCliOptions, true));
 
       processOnExit = () => {
         swcWatcher.kill();

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -10,7 +10,7 @@ function getSwcCmd(
   { swcrcPath, srcPath, destPath }: SwcCliOptions,
   watch = false
 ) {
-  let swcCmd = `npx swc ${srcPath} -d ${destPath} --source-root=${srcPath} --source-maps --no-swcrc --config-file=${swcrcPath}`;
+  let swcCmd = `npx swc ${srcPath} -d ${destPath} --source-maps --no-swcrc --config-file=${swcrcPath}`;
   return watch ? swcCmd.concat(' --watch') : swcCmd;
 }
 
@@ -39,9 +39,9 @@ export async function compileSwc(
 ) {
   logger.log(`Compiling with SWC for ${context.projectName}...`);
 
-  const swcCmdLog = execSync(
-    getSwcCmd(normalizedOptions.swcCliOptions)
-  ).toString();
+  const swcCmdLog = execSync(getSwcCmd(normalizedOptions.swcCliOptions), {
+    cwd: normalizedOptions.swcCliOptions.swcCwd,
+  }).toString();
   logger.log(swcCmdLog.replace(/\n/, ''));
   const isCompileSuccess = swcCmdLog.includes('Successfully compiled');
 
@@ -84,7 +84,10 @@ export async function* compileSwcWatch(
       let stderrOnData: () => void;
       let watcherOnExit: () => void;
 
-      const swcWatcher = exec(getSwcCmd(normalizedOptions.swcCliOptions, true));
+      const swcWatcher = exec(
+        getSwcCmd(normalizedOptions.swcCliOptions, true),
+        { cwd: normalizedOptions.swcCliOptions.swcCwd }
+      );
 
       processOnExit = () => {
         swcWatcher.kill();

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -15,10 +15,11 @@ function getSwcCmd(
 }
 
 function getTypeCheckOptions(normalizedOptions: NormalizedSwcExecutorOptions) {
-  const { projectRoot, watch, tsConfig, root, outputPath } = normalizedOptions;
+  const { projectRoot, watch, tsConfig, root, outputPath, dts } =
+    normalizedOptions;
 
   const typeCheckOptions: TypeCheckOptions = {
-    mode: 'emitDeclarationOnly',
+    mode: dts ? 'emitDeclarationOnly' : 'noEmit',
     tsConfigPath: tsConfig,
     outDir: outputPath.replace(`/${projectRoot}`, ''),
     workspaceRoot: root,

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -15,11 +15,10 @@ function getSwcCmd(
 }
 
 function getTypeCheckOptions(normalizedOptions: NormalizedSwcExecutorOptions) {
-  const { projectRoot, watch, tsConfig, root, outputPath, dts } =
-    normalizedOptions;
+  const { projectRoot, watch, tsConfig, root, outputPath } = normalizedOptions;
 
   const typeCheckOptions: TypeCheckOptions = {
-    mode: dts ? 'emitDeclarationOnly' : 'noEmit',
+    mode: 'emitDeclarationOnly',
     tsConfigPath: tsConfig,
     outDir: outputPath.replace(`/${projectRoot}`, ''),
     workspaceRoot: root,

--- a/packages/js/src/utils/versions.ts
+++ b/packages/js/src/utils/versions.ts
@@ -1,7 +1,5 @@
 export const nxVersion = '*';
 
-export const swcCoreVersion = '1.2.118';
-
-export const swcCliVersion = '~0.1.52';
-
-export const swcHelpersVersion = '~0.2.14';
+export const swcCoreVersion = '~1.2.143';
+export const swcCliVersion = '~0.1.55';
+export const swcHelpersVersion = '~0.3.3';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, we use `cwd` with `exec()` to execute `swc` in the project's root directory (eg: `packages/lib-one`)

`swc` is executed with:
- `srcPath`: `../lib-one`
- `destPath`: `../../dist/packages/lib-one/src`

This results in faulty behavior for libs with nested libs as well as libs with source code outside of `src` directory.

For example (taken from https://github.com/nartc/mapper)
```
.
└── packages
    └── classes (lib)
        ├── experimental (dir)
        │   └── transformer-plugin (lib)
        │       └── src
        │           ├── lib
        │           │   └── ...
        │           └── index.ts
        ├── mapped-types (lib)
        │   └── src
        │       ├── lib
        │       │   └── ...
        │       └── index.ts
        ├── extra (dir)
        │   └── shim.ts (main lib code, should be included)
        └── src (main lib)
            ├── lib
            │   └── ...
            └── index.ts
```

With the above setup, `@automapepr/classes/mapped-types` and `@automapepr/classes/experimental/transformer-plugin` are "secondary entry points" to `@automapepr/classes`. In addition, they have their own `build` target. A complete build of `classes` is:

```shell
npx nx run-many --target=build --projects=classes,classes-mapped-types,classes-experimental-transformer-plugin
```

With `nrwl/js:tsc`, the following artifact is produced:

```
.
└── dist
    └── packages
        └── classes
            ├── experimental
            │   └── transformer-plugin
            │       ├── src
            │       │   ├── lib
            │       │   │   └── ...
            │       │   ├── index.js
            │       │   └── index.d.ts
            │       └── package.json
            ├── mapped-types
            │   ├── src
            │   │   ├── lib
            │   │   │   └── ...
            │   │   ├── index.js
            │   │   └── index.d.ts
            │   └── package.json
            ├── extra
            │   └── shim.js
            ├── src
            │   ├── lib
            │   │   └── ...
            │   ├── index.d.ts
            │   └── index.js
            └── package.json
```

With `nrwl/js:swc`, the following is produced:

```
.
└── dist
    └── packages
        └── classes
            ├── experimental
            │   └── transformer-plugin (here bacause of nx build classes-experimental-transformer-plugin)
            │       └── src
            │           ├── lib
            │           │   └── ...
            │           ├── index.js
            │           └── index.d.ts
            ├── mapped-types (here because of nx build classes-mapped-types)
            │   └── src
            │       ├── lib
            │       │   └── ...
            │       ├── index.js
            │       └── index.d.ts
            └── src
                ├── lib
                │   └── ...
                ├── transformer-plugin (top-level experimental is gone)
                │   └── src
                │       ├── lib
                │       │   └── ...
                │       └── index.js
                ├── src (this is mapped-types, but top-level mapped-types dir is gone)
                │   ├── lib
                │   │   └── ...
                │   └── index.js
                ├── index.js
                ├── index.d.ts
                └── shim.js (no top-level extra dir)
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- `nrwl/js:swc` produces artifacts similarly to `nrwl/js:tsc`. Files are moved correctly into `dist`
- `swc` version is bumped to latest
- `jest-setup` is added to default `exclude`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
