### PR TITLE
fix(dep-graph): add implicitDependencies from package.json when building the ProjectConfiguration

### DIFF
--- a/packages/tao/src/shared/package-json.ts
+++ b/packages/tao/src/shared/package-json.ts
@@ -6,6 +6,8 @@ export type PackageJsonTargetConfiguration = Omit<
 >;
 
 export interface NxProjectPackageJsonConfiguration {
+  implicitDependencies?: string[];
+  tags?: string[];
   targets?: Record<string, PackageJsonTargetConfiguration>;
 }
 

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -10,6 +10,7 @@ import ignore, { Ignore } from 'ignore';
 import { basename, dirname, join } from 'path';
 import { performance } from 'perf_hooks';
 import { loadNxPlugins } from './nx-plugin';
+import { PackageJson } from '@nrwl/tao/src/shared/package-json';
 
 export interface Workspace
   extends WorkspaceJsonConfiguration,
@@ -749,7 +750,7 @@ export function deduplicateProjectFiles(files: string[], ig?: Ignore) {
 
 function buildProjectConfigurationFromPackageJson(
   path: string,
-  packageJson: { name: string; nx: { implicitDependencies?: string[] } },
+  packageJson: PackageJson,
   nxJson: NxJsonConfiguration
 ): ProjectConfiguration & { name: string } {
   const directory = dirname(path).split('\\').join('/');
@@ -758,11 +759,12 @@ function buildProjectConfigurationFromPackageJson(
   if (name.startsWith(npmPrefix)) {
     name = name.replace(npmPrefix, '');
   }
+  const { targets, ...rest } = packageJson.nx ?? {};
   return {
+    name,
     root: directory,
     sourceRoot: directory,
-    name,
-    implicitDependencies: packageJson?.nx?.implicitDependencies,
+    ...rest,
   };
 }
 

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -749,7 +749,7 @@ export function deduplicateProjectFiles(files: string[], ig?: Ignore) {
 
 function buildProjectConfigurationFromPackageJson(
   path: string,
-  packageJson: { name: string },
+  packageJson: { name: string; nx: { implicitDependencies?: string[] } },
   nxJson: NxJsonConfiguration
 ): ProjectConfiguration & { name: string } {
   const directory = dirname(path).split('\\').join('/');
@@ -762,6 +762,7 @@ function buildProjectConfigurationFromPackageJson(
     root: directory,
     sourceRoot: directory,
     name,
+    implicitDependencies: packageJson?.nx?.implicitDependencies,
   };
 }
 


### PR DESCRIPTION
add implicitDependencies from package.json when building the ProjectConfiguration

ISSUES CLOSED: #9065

## Current Behavior
adding `nx.implicitDependencies` within a package.json does not create a dependency link.

## Expected Behavior
adding `nx.implicitDependencies` within a package.json should create the dependency link.

## Related Issue(s)
https://github.com/nrwl/nx/issues/9065

Fixes #9065
