### PR TITLE
chore(repo): use npx on e2e ng calls to fix windows failures

### DIFF
--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -108,5 +108,5 @@ describe('Jest', () => {
     expect(cliResults.combinedOutput).toContain(
       'Test Suites: 1 passed, 1 total'
     );
-  });
+  }, 90000);
 });

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -424,7 +424,7 @@ export function runNgAdd(
 ): string {
   try {
     packageInstall('@nrwl/workspace');
-    return execSync(`./node_modules/.bin/ng add @nrwl/workspace ${command}`, {
+    return execSync(`npx ng add @nrwl/workspace ${command}`, {
       cwd: tmpProjPath(),
       env: { ...(opts.env || process.env), NX_INVOKED_BY_RUNNER: undefined },
       encoding: 'utf-8',


### PR DESCRIPTION
Windows CI runs `ng` command from plain command prompt, so accessing it via node_modules path does not work because of invalid path separators.

Using `npx` overcomes that limitation.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
