### PR TITLE
fix(react): component generator outputs correct CSS module setup

### DIFF
--- a/packages/react/src/generators/component/component.spec.ts
+++ b/packages/react/src/generators/component/component.spec.ts
@@ -34,6 +34,12 @@ describe('component', () => {
     expect(
       appTree.exists('libs/my-lib/src/lib/hello/hello.module.css')
     ).toBeTruthy();
+    expect(
+      appTree.read('libs/my-lib/src/lib/hello/hello.tsx').toString()
+    ).toMatch(/import styles from '.\/hello.module.css'/);
+    expect(
+      appTree.read('libs/my-lib/src/lib/hello/hello.tsx').toString()
+    ).toMatch(/<div className={styles\['container']}>/);
   });
 
   it('should generate files with global CSS', async () => {
@@ -52,6 +58,12 @@ describe('component', () => {
     expect(
       appTree.exists('libs/my-lib/src/lib/hello/hello.module.css')
     ).toBeFalsy();
+    expect(
+      appTree.read('libs/my-lib/src/lib/hello/hello.tsx').toString()
+    ).toMatch(/import '.\/hello.css'/);
+    expect(
+      appTree.read('libs/my-lib/src/lib/hello/hello.tsx').toString()
+    ).toMatch(/<div>/);
   });
 
   it('should generate files for an app', async () => {

--- a/packages/react/src/generators/component/files/__fileName__.module.__style__
+++ b/packages/react/src/generators/component/files/__fileName__.module.__style__
@@ -1,0 +1,2 @@
+.container {
+}

--- a/packages/react/src/generators/component/files/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/component/files/__fileName__.tsx__tmpl__
@@ -9,14 +9,19 @@ import { Route, Link } from 'react-router-dom';
 <% if (hasStyles) {
    if (styledModule && styledModule !== 'styled-jsx') {
     var wrapper = 'Styled' + className;
+    var extras = '';
   %>
   import styled from '<%= styledModule %>';
   <% } else {
     var wrapper = 'div';
+    var extras = globalCss ? '' : " className={styles['container']}";
   %>
-  <%- style !== 'styled-jsx' ? globalCss ? `import './${fileName}.${style}';` : `import './${fileName}.module.${style}';`: '' %>
+  <%- style !== 'styled-jsx' ? globalCss ? `import './${fileName}.${style}';` : `import styles from './${fileName}.module.${style}';`: '' %>
   <% }
-} else { var wrapper = 'div'; } %>
+} else {
+    var wrapper = 'div';
+    var extras = '';
+} %>
 
 /* eslint-disable-next-line */
 export interface <%= className %>Props {
@@ -31,7 +36,7 @@ const Styled<%= className %> = styled.div`
 export class <%= className %> extends Component<<%= className %>Props> {
   render() {
     return (
-      <<%= wrapper %>>
+      <<%= wrapper %><%- extras %>>
         <%= styledModule === 'styled-jsx' ? `<style jsx>{\`div { color: pink; }\`}</style>` : `` %>
         <p>Welcome to <%= className %>!</p>
         <% if (routing) { %>
@@ -47,7 +52,7 @@ export class <%= className %> extends Component<<%= className %>Props> {
 <% } else { %>
 export function <%= className %>(props: <%= className %>Props) {
   return (
-    <<%= wrapper %>>
+    <<%= wrapper %><%- extras %>>
       <% if (styledModule === 'styled-jsx') { %><style jsx>{`div { color: pink; }`}</style><% } %>
       <h1>Welcome to <%= className %>!</h1>
       <% if (routing) { %>


### PR DESCRIPTION
This PR addresses the output of components using CSS modules.

## Current Behavior
The import statement is wrong (`import './my-component.css'`)

## Expected Behavior
The import statement  should be correct (`import styles rom './my-component.css'`)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
