### PR TITLE
chore(angular): make ng-add e2e tests more deterministic when checking the defaultBase

### DIFF
--- a/e2e/angular-core/src/ng-add.test.ts
+++ b/e2e/angular-core/src/ng-add.test.ts
@@ -93,7 +93,7 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
     expect(packageJson.devDependencies['@nrwl/workspace']).not.toBeDefined();
 
     // run ng add
-    runNgAdd('--npm-scope projscope');
+    runNgAdd('--npm-scope projscope --default-base main');
 
     // check that prettier config exits and that files have been moved
     checkFilesExist(


### PR DESCRIPTION
Update the `ng add` e2e test that checks for the default base to be deterministic so results are not based on the agent config. This fixes the failing Window CI runs.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
