### PR TITLE
feat(angular): support migrating angular cli workspaces using cypress for e2e tests

### DIFF
--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -8,9 +8,9 @@ using a monorepo approach. If you are currently using an Angular CLI workspace, 
 - The major version of your `Angular CLI` must align with the version of `Nx` you are upgrading to. For example, if you're using Angular CLI version 7, you must transition using the latest version 7 release of Nx.
 - Currently, transforming an Angular CLI workspace to an Nx workspace automatically only supports a single project. If you have more than one project in your Angular CLI workspace, you can still migrate manually.
 
-## Using ng add and preserving your existing structure
+## Using the Nx CLI while preserving the existing structure
 
-To add Nx to an existing Angular CLI workspace to an Nx workspace, with keeping your existing file structure in place, use the `ng add` command with the `--preserveAngularCLILayout` option:
+To use the Nx CLI in an existing Angular CLI workspace while keeping your existing file structure in place, use the `ng add` command with the `--preserveAngularCLILayout` option:
 
 ```bash
 ng add @nrwl/workspace --preserveAngularCLILayout
@@ -19,14 +19,14 @@ ng add @nrwl/workspace --preserveAngularCLILayout
 This installs the `@nrwl/workspace` package into your workspace and applies the following changes to your workspace:
 
 - Adds and installs the `@nrwl/workspace` package in your development dependencies.
-- Creates an nx.json file in the root of your workspace.
-- Adds a `decorate-angular-cli.js` to the root of your workspace, and a `postinstall` script in your `package.json` to run the script when your dependencies are updated. The script forwards the `ng` commands to the Nx CLI(nx) to enable features such as Computation Caching.
+- Creates an `nx.json` file in the root of your workspace.
+- Adds a `decorate-angular-cli.js` to the root of your workspace, and a `postinstall` script in your `package.json` to run the script when your dependencies are updated. The script forwards the `ng` commands to the Nx CLI (`nx`) to enable features such as [Computation Caching](/using-nx/caching).
 
-After the process completes, you continue using the same serve/build/lint/test commands.
+After the process completes, you can continue using the same `serve/build/lint/test` commands you are used to.
 
-## Using ng add
+## Transforming an Angular CLI workspace to an Nx workspace
 
-To transform a Angular CLI workspace to an Nx workspace, use the `ng add` command:
+To transform an Angular CLI workspace to an Nx workspace, run the following command:
 
 ```bash
 ng add @nrwl/workspace
@@ -34,8 +34,8 @@ ng add @nrwl/workspace
 
 This installs the `@nrwl/workspace` package into your workspace and runs a generator (or schematic) to transform your workspace. The generator applies the following changes to your workspace:
 
-- Installs the packages for the `Nx` plugin `@nrwl/angular` in your package.json.
-- Creates an nx.json file in the root of your workspace.
+- Installs the packages for the `Nx` plugin `@nrwl/angular` in your `package.json`.
+- Creates an `nx.json` file in the root of your workspace.
 - Creates configuration files for Prettier.
 - Creates an `apps` folder for generating applications.
 - Creates a `libs` folder for generating libraries.
@@ -45,7 +45,7 @@ This installs the `@nrwl/workspace` package into your workspace and runs a gener
 - Updates your `package.json` with scripts to run various `Nx` workspace commands.
 - Updates your `angular.json` configuration to reflect the new paths.
 
-After the changes are applied, your workspace file structure should look similar to below:
+After the changes are applied, your workspace file structure should look similar to the one below:
 
 ```treeview
 <workspace name>/
@@ -61,20 +61,26 @@ After the changes are applied, your workspace file structure should look similar
 │   │   │   ├── polyfills.ts
 │   │   │   ├── styles.css
 │   │   │   └── test.ts
-│   │   ├── browserslist
+│   │   ├── .browserslistrc
 │   │   ├── karma.conf.js
 │   │   ├── tsconfig.app.json
 │   │   └── tsconfig.spec.json
 │   └── <app name>-e2e/
 │       ├── src/
-│       ├── protractor.conf.js
+│       ├── protractor.conf.js | cypress.json
 │       └── tsconfig.json
 ├── libs/
 ├── tools/
-├── README.md
+├── .editorconfig
+├── .gitignore
+├── .prettierignore
+├── .prettierrc
 ├── angular.json
+├── decorate-angular-cli.js
+├── karma.conf.js
 ├── nx.json
 ├── package.json
+├── README.md
 └── tsconfig.base.json
 ```
 

--- a/packages/workspace/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/workspace/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -1,5 +1,161 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`workspace move to nx layout cypress should handle project configuration without cypress-run or cypress-open 1`] = `
+Object {
+  "implicitDependencies": Array [
+    "myApp",
+  ],
+  "projectType": "application",
+  "root": "apps/myApp-e2e",
+  "sourceRoot": "apps/myApp-e2e/src",
+  "tags": Array [],
+  "targets": Object {
+    "e2e": Object {
+      "configurations": Object {
+        "production": Object {
+          "devServerTarget": "ng-cypress:serve:production",
+        },
+      },
+      "executor": "@nrwl/cypress:cypress",
+      "options": Object {
+        "cypressConfig": "apps/myApp-e2e/cypress.json",
+        "devServerTarget": "ng-cypress:serve",
+        "watch": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`workspace move to nx layout cypress should migrate e2e tests correctly 1`] = `
+Object {
+  "compilerOptions": Object {
+    "outDir": "../../dist/out-tsc",
+  },
+  "extends": "../../tsconfig.base.json",
+}
+`;
+
+exports[`workspace move to nx layout cypress should migrate e2e tests correctly 2`] = `
+Object {
+  "baseUrl": "http://localhost:4200",
+  "fileServerFolder": ".",
+  "fixturesFolder": "./src/fixtures",
+  "integrationFolder": "./src/integration",
+  "pluginsFile": "./src/plugins/index.ts",
+  "screenshotsFolder": "../../dist/cypress/apps/myApp-e2e/screenshots",
+  "supportFile": "./src/support/index.ts",
+  "videosFolder": "../../dist/cypress/apps/myApp-e2e/videos",
+}
+`;
+
+exports[`workspace move to nx layout cypress should migrate e2e tests correctly 3`] = `
+Object {
+  "implicitDependencies": Array [
+    "myApp",
+  ],
+  "projectType": "application",
+  "root": "apps/myApp-e2e",
+  "sourceRoot": "apps/myApp-e2e/src",
+  "tags": Array [],
+  "targets": Object {
+    "cypress-open": Object {
+      "executor": "@nrwl/cypress:cypress",
+      "options": Object {
+        "cypressConfig": "apps/myApp-e2e/cypress.json",
+        "watch": true,
+      },
+    },
+    "cypress-run": Object {
+      "configurations": Object {
+        "production": Object {
+          "devServerTarget": "ng-cypress:serve:production",
+        },
+      },
+      "executor": "@nrwl/cypress:cypress",
+      "options": Object {
+        "cypressConfig": "apps/myApp-e2e/cypress.json",
+        "devServerTarget": "ng-cypress:serve",
+      },
+    },
+    "e2e": Object {
+      "configurations": Object {
+        "production": Object {
+          "devServerTarget": "ng-cypress:serve:production",
+        },
+      },
+      "executor": "@nrwl/cypress:cypress",
+      "options": Object {
+        "cypressConfig": "apps/myApp-e2e/cypress.json",
+        "devServerTarget": "ng-cypress:serve",
+        "watch": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`workspace move to nx layout cypress should migrate e2e tests when configFile is set to false and there is no cypress.json 1`] = `
+Object {
+  "chromeWebSecurity": false,
+  "fileServerFolder": ".",
+  "fixturesFolder": "./src/fixtures",
+  "integrationFolder": "./src/integration",
+  "modifyObstructiveCode": false,
+  "pluginsFile": "./src/plugins/index.ts",
+  "screenshotsFolder": "../../dist/cypress/apps/myApp-e2e/screenshots",
+  "supportFile": "./src/support/index.ts",
+  "video": true,
+  "videosFolder": "../../dist/cypress/apps/myApp-e2e/videos",
+}
+`;
+
+exports[`workspace move to nx layout cypress should migrate e2e tests when configFile is set to false and there is no cypress.json 2`] = `
+Object {
+  "implicitDependencies": Array [
+    "myApp",
+  ],
+  "projectType": "application",
+  "root": "apps/myApp-e2e",
+  "sourceRoot": "apps/myApp-e2e/src",
+  "tags": Array [],
+  "targets": Object {
+    "cypress-open": Object {
+      "executor": "@nrwl/cypress:cypress",
+      "options": Object {
+        "cypressConfig": "apps/myApp-e2e/cypress.json",
+        "watch": true,
+      },
+    },
+    "cypress-run": Object {
+      "configurations": Object {
+        "production": Object {
+          "devServerTarget": "ng-cypress:serve:production",
+        },
+      },
+      "executor": "@nrwl/cypress:cypress",
+      "options": Object {
+        "cypressConfig": "apps/myApp-e2e/cypress.json",
+        "devServerTarget": "ng-cypress:serve",
+      },
+    },
+    "e2e": Object {
+      "configurations": Object {
+        "production": Object {
+          "devServerTarget": "ng-cypress:serve:production",
+        },
+      },
+      "executor": "@nrwl/cypress:cypress",
+      "options": Object {
+        "cypressConfig": "apps/myApp-e2e/cypress.json",
+        "devServerTarget": "ng-cypress:serve",
+        "watch": true,
+      },
+    },
+  },
+}
+`;
+
 exports[`workspace move to nx layout should create nx.json 1`] = `
 Object {
   "affected": Object {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
It's not possible to migrate an Angular CLI workspace to an Nx workspace when it's using Cypress for the E2E tests.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Angular CLI workspaces that are using Cypress can be migrated to an Nx workspace.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8383 
