### PR TITLE
fix(storybook): look for config dir/files relative to the project dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nrwl/nx-source",
-  "version": "13.8.3",
+  "version": "999.0.12",
   "description": "Smart, Fast and Extensible Build System",
   "homepage": "https://nx.dev",
   "private": true,

--- a/packages/devkit/src/utils/path.ts
+++ b/packages/devkit/src/utils/path.ts
@@ -8,6 +8,9 @@ function removeWindowsDriveLetter(osSpecificPath: string): string {
  * Coverts an os specific path to a unix style path
  */
 export function normalizePath(osSpecificPath: string): string {
+  /*
+  why not use https://nodejs.org/docs/latest-v14.x/api/path.html#path_path_normalize_path (available since v0.1.23)?
+   */
   return removeWindowsDriveLetter(osSpecificPath).split('\\').join('/');
 }
 

--- a/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
+++ b/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
@@ -1,6 +1,7 @@
 import { ExecutorContext, logger } from '@nrwl/devkit';
 import * as build from '@storybook/core/standalone';
 import 'dotenv/config';
+import { join } from 'path';
 import { CommonNxStorybookConfig } from '../models';
 import {
   getStorybookFrameworkPath,
@@ -54,7 +55,9 @@ function storybookOptionMapper(
       context
     ),
     mode: 'static',
-    outputDir: builderOptions.outputPath,
+    // ensure that Storybook outputs resources to the same dir regardless of the pwd from
+    // which the command is executed
+    outputDir: join(context.root, builderOptions.outputPath),
   };
 
   return storybookOptions;

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -33,7 +33,13 @@ export default async function* storybookExecutor(
   // print warnings
   runStorybookSetupCheck(options);
 
+  // temporarily move up to the root of the workspace because Storybook relies on
+  // `process.cwd()` for certain things, like locating node_modules:
+  // https://github.com/storybookjs/storybook/blob/v6.4.12/app/angular/src/server/framework-preset-angular-ivy.ts#L44
+  const cwd = process.cwd();
+  process.chdir(context.root);
   await runInstance(option);
+  process.chdir(cwd);
 
   yield { success: true };
 

--- a/packages/storybook/src/executors/utils.ts
+++ b/packages/storybook/src/executors/utils.ts
@@ -184,7 +184,7 @@ export function resolveCommonStorybookOptionMapper(
   if (
     builderOptions.uiFramework === '@storybook/angular' &&
     // just for new 6.4 with Angular
-    isStorybookGTE6_4()
+    isStorybookGTE6_4(context.root)
   ) {
     let buildProjectName;
     let targetName = 'build'; // default
@@ -255,7 +255,7 @@ export function resolveCommonStorybookOptionMapper(
         ...project.targets[targetName],
         project: buildProjectName,
       },
-      workspaceRoot: context.cwd,
+      workspaceRoot: context.root,
       getProjectMetadata: () => {
         return project;
       },
@@ -287,8 +287,9 @@ function normalizeTargetString(
   return `${appName}:${defaultTarget}`;
 }
 
-function isStorybookGTE6_4() {
-  const storybookVersion = readCurrentWorkspaceStorybookVersionFromExecutor();
+function isStorybookGTE6_4(workspaceRoot: string) {
+  const storybookVersion =
+    readCurrentWorkspaceStorybookVersionFromExecutor(workspaceRoot);
 
   return gte(
     checkAndCleanWithSemver('@storybook/core', storybookVersion),

--- a/packages/storybook/src/utils/utilities.ts
+++ b/packages/storybook/src/utils/utilities.ts
@@ -90,8 +90,10 @@ export function readCurrentWorkspaceStorybookVersionFromGenerator(
   return determineStorybookWorkspaceVersion(packageJsonContents);
 }
 
-export function readCurrentWorkspaceStorybookVersionFromExecutor() {
-  const packageJsonContents = readJsonFile('package.json');
+export function readCurrentWorkspaceStorybookVersionFromExecutor(
+  workspaceRoot: string
+) {
+  const packageJsonContents = readJsonFile(join(workspaceRoot, 'package.json'));
   return determineStorybookWorkspaceVersion(packageJsonContents);
 }
 


### PR DESCRIPTION
## Summary

When specifying a config file/dir path in the executor options.config object, the `statSync()` call fails if the user does not run the `nx ...` command from the root of the repository/workspace. This is confusing and inconsistent with the way that other executors work, like `@nrwl/jest`.

## Current Behavior

_See related issue_

## Expected Behavior

_See related issue_

## Related Issue(s)

Fixes #9115
