### PR TITLE
docs(angular): restore preserveAngularCLILayout in the docs until the change renaming it gets released

### DIFF
--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -10,10 +10,10 @@ using a monorepo approach. If you are currently using an Angular CLI workspace, 
 
 ## Using ng add and preserving your existing structure
 
-To add Nx to an existing Angular CLI workspace to an Nx workspace, with keeping your existing file structure in place, use the `ng add` command with the `--preserve-angular-cli-layout` option:
+To add Nx to an existing Angular CLI workspace to an Nx workspace, with keeping your existing file structure in place, use the `ng add` command with the `--preserveAngularCLILayout` option:
 
 ```bash
-ng add @nrwl/workspace --preserve-angular-cli-layout
+ng add @nrwl/workspace --preserveAngularCLILayout
 ```
 
 This installs the `@nrwl/workspace` package into your workspace and applies the following changes to your workspace:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The docs advise using `--preserve-angular-cli-layout` which is a recent change that hasn't been released yet.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The docs should advise using `--preserveAngularCLILayout` until the change renaming the flag is merged.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9120 
