### PR TITLE
feat(core): use package manager workspace globs to find projects

### DIFF
--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -135,6 +135,7 @@ export function updateWorkspaceConfiguration(
     generators,
     implicitDependencies,
     plugins,
+    pluginsConfig,
     npmScope,
     targetDependencies,
     workspaceLayout,
@@ -146,6 +147,7 @@ export function updateWorkspaceConfiguration(
   const nxJson: Required<NxJsonConfiguration> = {
     implicitDependencies,
     plugins,
+    pluginsConfig,
     npmScope,
     targetDependencies,
     workspaceLayout,

--- a/packages/tao/src/shared/nx.ts
+++ b/packages/tao/src/shared/nx.ts
@@ -92,6 +92,12 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
    * Plugins for extending the project graph
    */
   plugins?: string[];
+
+  /**
+   * Configuration for Nx Plugins
+   */
+  pluginsConfig?: Record<string, unknown>;
+
   /**
    * Default project. When project isn't provided, the default project
    * will be used. Convenient for small workspaces with one main application.

--- a/packages/tao/src/shared/workspace.ts
+++ b/packages/tao/src/shared/workspace.ts
@@ -666,22 +666,58 @@ export function toProjectName(
 
 let projectGlobCache: string[];
 let projectGlobCacheKey: string;
-export function globForProjectFiles(root, nxJson?: NxJsonConfiguration) {
+
+function getGlobPatternsFromPlugins(nxJson: NxJsonConfiguration): string[] {
+  const plugins = loadNxPlugins(nxJson?.plugins);
+
+  const patterns = [];
+  for (const plugin of plugins) {
+    if (!plugin.projectFilePatterns) {
+      continue;
+    }
+    for (const filePattern of plugin.projectFilePatterns) {
+      patterns.push('**/' + filePattern);
+    }
+  }
+
+  return patterns;
+}
+
+/**
+ * Get the package.json globs from package manager workspaces
+ */
+function getGlobPatternsFromPackageManagerWorkspaces(root: string): string[] {
+  // TODO: add support for pnpm
+  try {
+    const { workspaces } = readJsonFile(join(root, 'package.json'));
+
+    return (
+      workspaces?.map((pattern) => pattern + '/package.json') ?? [
+        '**/package.json',
+      ]
+    );
+  } catch {
+    return ['**/package.json'];
+  }
+}
+
+export function globForProjectFiles(
+  root: string,
+  nxJson?: NxJsonConfiguration
+) {
   // Deal w/ Caching
   const cacheKey = [root, ...(nxJson?.plugins || [])].join(',');
   if (projectGlobCache && cacheKey === projectGlobCacheKey)
     return projectGlobCache;
   projectGlobCacheKey = cacheKey;
 
-  // Load plugins
-  const plugins = loadNxPlugins(nxJson?.plugins).filter(
-    (x) => !!x.projectFilePatterns
-  );
-  let combinedProjectGlobPattern = `**/+(project.json|package.json${
-    plugins.length
-      ? '|' + plugins.map((x) => x.projectFilePatterns.join('|')).join('|')
-      : ''
-  })`;
+  const projectGlobPatterns: string[] = [
+    '**/project.json',
+    ...getGlobPatternsFromPackageManagerWorkspaces(root),
+    ...getGlobPatternsFromPlugins(nxJson),
+  ];
+
+  const combinedProjectGlobPattern = '{' + projectGlobPatterns.join(',') + '}';
 
   performance.mark('start-glob-for-projects');
   /**

--- a/packages/workspace/src/core/project-graph/build-project-graph.ts
+++ b/packages/workspace/src/core/project-graph/build-project-graph.ts
@@ -169,12 +169,13 @@ async function buildProjectGraphUsingContext(
   return r;
 }
 
-function jsPluginConfig(nxJson: any) {
-  if (nxJson?.pluginsConfig?.['@nrwl/js']) {
-    return nxJson?.pluginsConfig['@nrwl/js'];
-  } else {
-    return {};
-  }
+interface NrwlJsPluginConfig {
+  analyzeSourceFiles?: boolean;
+  analyzePackageJson?: boolean;
+}
+
+function jsPluginConfig(nxJson: NxJsonConfiguration): NrwlJsPluginConfig {
+  return nxJson?.pluginsConfig?.['@nrwl/js'] ?? {};
 }
 
 function buildExplicitDependencies(


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Every single package.json file is used to determine projects for the workspace when `workspace.json` does not exist.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Package manager workspaces glob patterns are used to find projects.

Pnpm is not supported yet.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
