### PR TITLE
fix(core): improve output color consistency across terminal themes

### DIFF
--- a/packages/workspace/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
+++ b/packages/workspace/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
@@ -13,6 +13,9 @@ import { prettyTime } from './pretty-time';
  * are added. It is therefore intended for use on a user's local machines.
  *
  * In CI environments the static equivalent of this life cycle should be used.
+ *
+ * NOTE: output.dim() should be preferred over output.colors.gray() because it
+ * is much more consistently readable across different terminal color themes.
  */
 export async function createRunManyDynamicOutputRenderer({
   projectNames,
@@ -114,7 +117,7 @@ export async function createRunManyDynamicOutputRenderer({
             output.colors.green(figures.tick) +
             output.dim('  nx run ') +
             task.id
-          }  ${output.colors.gray('[local cache]')}`
+          }  ${output.dim('[local cache]')}`
         );
         if (isVerbose) {
           writeCommandOutputBlock(tasksToTerminalOutputs[task.id]);
@@ -126,9 +129,7 @@ export async function createRunManyDynamicOutputRenderer({
             output.colors.green(figures.tick) +
             output.dim('  nx run ') +
             task.id
-          }  ${output.colors.gray(
-            '[existing outputs match the cache, left as is]'
-          )}`
+          }  ${output.dim('[existing outputs match the cache, left as is]')}`
         );
         if (isVerbose) {
           writeCommandOutputBlock(tasksToTerminalOutputs[task.id]);
@@ -140,7 +141,7 @@ export async function createRunManyDynamicOutputRenderer({
             output.colors.green(figures.tick) +
             output.dim('  nx run ') +
             task.id
-          }  ${output.colors.gray('[remote cache]')}`
+          }  ${output.dim('[remote cache]')}`
         );
         if (isVerbose) {
           writeCommandOutputBlock(tasksToTerminalOutputs[task.id]);
@@ -154,7 +155,7 @@ export async function createRunManyDynamicOutputRenderer({
           output.colors.green(figures.tick) +
             output.dim('  nx run ') +
             task.id +
-            output.dim.gray(` (${timeTakenText})`)
+            output.dim(` (${timeTakenText})`)
         );
         if (isVerbose) {
           writeCommandOutputBlock(tasksToTerminalOutputs[task.id]);
@@ -241,7 +242,7 @@ export async function createRunManyDynamicOutputRenderer({
       additionalFooterRows.push(
         `   ${output.colors.green(
           figures.tick
-        )}    ${totalSuccessfulTasks}${`/${totalCompletedTasks}`} succeeded ${output.colors.gray(
+        )}    ${totalSuccessfulTasks}${`/${totalCompletedTasks}`} succeeded ${output.dim(
           `[${totalCachedTasks} read from cache]`
         )}`
       );
@@ -344,7 +345,7 @@ export async function createRunManyDynamicOutputRenderer({
       ];
       if (totalCachedTasks > 0) {
         pinnedFooterLines.push(
-          output.colors.gray(
+          output.dim(
             `${EOL}   Nx read the output from the cache instead of running the command for ${totalCachedTasks} out of ${totalTasks} tasks.`
           )
         );
@@ -385,9 +386,9 @@ export async function createRunManyDynamicOutputRenderer({
           `   ${output.colors.red(
             figures.cross
           )}    ${totalFailedTasks}${`/${totalCompletedTasks}`} failed`,
-          `   ${output.colors.gray(
+          `   ${output.dim(
             figures.tick
-          )}    ${totalSuccessfulTasks}${`/${totalCompletedTasks}`} succeeded ${output.colors.gray(
+          )}    ${totalSuccessfulTasks}${`/${totalCompletedTasks}`} succeeded ${output.dim(
             `[${totalCachedTasks} read from cache]`
           )}`,
         ],

--- a/packages/workspace/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
+++ b/packages/workspace/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
@@ -25,6 +25,9 @@ type State =
  * are added. It is therefore intended for use on a user's local machines.
  *
  * In CI environments the static equivalent of this life cycle should be used.
+ *
+ * NOTE: output.dim() should be preferred over output.colors.gray() because it
+ * is much more consistently readable across different terminal color themes.
  */
 export async function createRunOneDynamicOutputRenderer({
   initiatingProject,
@@ -154,10 +157,10 @@ export async function createRunOneDynamicOutputRenderer({
 
     if (totalSuccessfulTasks > 0) {
       linesToRender.push(
-        output.colors.gray(
-          `   ${output.colors.gray(
+        output.dim(
+          `   ${output.dim(
             figures.tick
-          )}    ${totalSuccessfulTasks}${`/${totalCompletedTasks}`} dependent project tasks succeeded ${output.colors.gray.dim(
+          )}    ${totalSuccessfulTasks}${`/${totalCompletedTasks}`} dependent project tasks succeeded ${output.dim(
             `[${totalCachedTasks} read from cache]`
           )}`
         )
@@ -195,9 +198,9 @@ export async function createRunOneDynamicOutputRenderer({
         if (totalDependentTasksNotFromInitiatingProject > 0) {
           output.addNewline();
           process.stdout.write(
-            `   ${output.colors.gray(
+            `   ${output.dim(
               'Hint: you can run the command with'
-            )} --verbose ${output.colors.gray(
+            )} --verbose ${output.dim(
               'to see the full dependent project outputs'
             )}` + EOL
           );
@@ -299,7 +302,7 @@ export async function createRunOneDynamicOutputRenderer({
       ];
       if (totalCachedTasks > 0) {
         pinnedFooterLines.push(
-          output.colors.gray(
+          output.dim(
             `${EOL}   Nx read the output from the cache instead of running the command for ${totalCachedTasks} out of ${totalTasks} tasks.`
           )
         );
@@ -342,9 +345,9 @@ export async function createRunOneDynamicOutputRenderer({
           `   ${output.colors.red(
             figures.cross
           )}    ${totalFailedTasks}${`/${totalCompletedTasks}`} failed`,
-          `   ${output.colors.gray(
+          `   ${output.dim(
             figures.tick
-          )}    ${totalSuccessfulTasks}${`/${totalCompletedTasks}`} succeeded ${output.colors.gray(
+          )}    ${totalSuccessfulTasks}${`/${totalCompletedTasks}`} succeeded ${output.dim(
             `[${totalCachedTasks} read from cache]`
           )}`,
         ],


### PR DESCRIPTION
I removed all customizations in my VSCode settings and then spent time toggling through many different color themes.

Using the `dim()` util from chalk (via our `output` abstraction) produced much more consistently readable output across the different themes vs the `gray` color util.

Here is a clear example of the comparison using no customizations with the "Tomorrow Night Blue" theme in VSCode.

The Nx Cloud text is still using `gray`, the rest has had the usage of `gray` replaced with `dim` (e.g. in the `nx run` text, the `local cache` text etc):

![image](https://user-images.githubusercontent.com/900523/155841486-36878558-23d2-4f0c-b4dc-95ea6d6e6958.png)
