### PR TITLE
feat(testing): add ability to use nx libraries in jest global setup/teardown

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -43,6 +43,7 @@
     "@jest/test-result": "27.2.2",
     "chalk": "4.1.0",
     "jest-config": "27.2.2",
-    "jest-util": "27.2.0"
+    "jest-util": "27.2.0",
+    "tsconfig-paths": "^3.9.0"
   }
 }

--- a/packages/jest/plugins/resolver.ts
+++ b/packages/jest/plugins/resolver.ts
@@ -1,3 +1,8 @@
+// allow tspaths to work within jest global files like setup/teardown
+process.env.TS_NODE_PROJECT =
+  process.env.TS_NODE_PROJECT || 'tsconfig.base.json';
+require('tsconfig-paths/register');
+
 import { dirname, extname } from 'path';
 import { resolve as resolveExports } from 'resolve.exports';
 import type defaultResolver from 'jest-resolve/build/defaultResolver';


### PR DESCRIPTION
auto register tsconfig paths in jest resolver to allow for global setup/teardown files to reference other libs as needed

This removed 1 less configuration that developers need to do when using jest with nx. 

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
unable to use nx libraries within a global setup/teardown file for jest
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
I am able to use nx libraries within a global setup/teardown file provided to jest

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8709
