### PR TITLE
fix(misc): format:check not checking all affected files

### DIFF
--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -49,7 +49,13 @@ export async function format(
       chunkList.forEach((chunk) => write(chunk));
       break;
     case 'check':
-      chunkList.forEach((chunk) => check(chunk));
+      const pass = chunkList.reduce(
+        (pass, chunk) => check(chunk) && pass,
+        true
+      );
+      if (!pass) {
+        process.exit(1);
+      }
       break;
   }
 }
@@ -142,18 +148,17 @@ function write(patterns: string[]) {
   }
 }
 
-function check(patterns: string[]) {
-  if (patterns.length > 0) {
-    try {
-      execSync(
-        `node "${PRETTIER_PATH}" --list-different ${patterns.join(' ')}`,
-        {
-          stdio: [0, 1, 2],
-        }
-      );
-    } catch {
-      process.exit(1);
-    }
+function check(patterns: string[]): boolean {
+  if (patterns.length === 0) {
+    return true;
+  }
+  try {
+    execSync(`node "${PRETTIER_PATH}" --list-different ${patterns.join(' ')}`, {
+      stdio: [0, 1, 2],
+    });
+    return true;
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
While running format:write and format:check commands, a list of affected files is split to chunks of 50 files, that was originally meant as compatibility optimization for Windows users (see https://github.com/nrwl/nx/issues/2362).
This causes early exits in cases if there are also incorrectly formatted files in both 1st and following chunks.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

- have >50 files affected by your changes
- have at least 1 file within 1st chunk of 50 files incorrectly formatted AND at least 1 file in the 2nd chunk
- nx format:check will exit after checking 1st chunk and will not print incorrectly formatted files in the following chunks
- nx format:write works correctly and writes all affected files

## Expected Behavior

nx format:check should check and print incorrectly formatted files among all affected files, not only first incorrect chunk.

## Related Issue(s)

Fixes #9151

