### PR TITLE
fix(web): file-server withDeps is deprecated

### DIFF
--- a/docs/generated/api-web/executors/file-server.md
+++ b/docs/generated/api-web/executors/file-server.md
@@ -73,10 +73,12 @@ Type: `string`
 
 SSL key to use for serving HTTPS.
 
-### withDeps
+### ~~withDeps~~
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
+
+**Deprecated:** "withDeps" is deprecatedand it will be removed in v14. Configure target dependencies instead: https://nx.dev/configuration/projectjson.
 
 Build the target and all its deps

--- a/docs/generated/api-web/executors/file-server.md
+++ b/docs/generated/api-web/executors/file-server.md
@@ -79,6 +79,6 @@ Default: `false`
 
 Type: `boolean`
 
-**Deprecated:** "withDeps" is deprecatedand it will be removed in v14. Configure target dependencies instead: https://nx.dev/configuration/projectjson.
+**Deprecated:** "withDeps" is deprecated and it will be removed in v14. Configure target dependencies instead: https://nx.dev/configuration/projectjson.
 
 Build the target and all its deps

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -1,5 +1,5 @@
 import { exec, execSync } from 'child_process';
-import { ExecutorContext, joinPathFragments } from '@nrwl/devkit';
+import { ExecutorContext, joinPathFragments, logger } from '@nrwl/devkit';
 import ignore from 'ignore';
 import { readFileSync } from 'fs';
 import { Schema } from './schema';

--- a/packages/web/src/executors/file-server/schema.json
+++ b/packages/web/src/executors/file-server/schema.json
@@ -11,7 +11,8 @@
     "withDeps": {
       "type": "boolean",
       "description": "Build the target and all its deps",
-      "default": true
+      "default": false,
+      "x-deprecated": "\"withDeps\" is deprecatedand it will be removed in v14. Configure target dependencies instead: https://nx.dev/configuration/projectjson."
     },
     "parallel": {
       "type": "boolean",

--- a/packages/web/src/executors/file-server/schema.json
+++ b/packages/web/src/executors/file-server/schema.json
@@ -12,7 +12,7 @@
       "type": "boolean",
       "description": "Build the target and all its deps",
       "default": false,
-      "x-deprecated": "\"withDeps\" is deprecatedand it will be removed in v14. Configure target dependencies instead: https://nx.dev/configuration/projectjson."
+      "x-deprecated": "\"withDeps\" is deprecated and it will be removed in v14. Configure target dependencies instead: https://nx.dev/configuration/projectjson."
     },
     "parallel": {
       "type": "boolean",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`withDeps` is deprecated however it is being set to true by default.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`withDeps` should not be set to true and correct replacement should be defined