### PR TITLE
fix(angular): fix invalid style option for nx welcome component when generating an application

### DIFF
--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -86,9 +86,10 @@ export async function applicationGenerator(
   await angularComponentSchematic(host, {
     name: 'NxWelcome',
     inlineTemplate: true,
+    inlineStyle: true,
     prefix: options.prefix,
     skipTests: true,
-    style: 'none',
+    style: options.style,
     flat: true,
     viewEncapsulation: 'None',
     project: options.name,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When creating an application the Nx Welcome component is created with a wrong style option.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The Nx Welcome component should be created correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9161 
Fixes #9169 
