### PR TITLE
docs(angular): update angular cli migration docs

### DIFF
--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -10,11 +10,13 @@ using a monorepo approach. If you are currently using an Angular CLI workspace, 
 
 ## Using the Nx CLI while preserving the existing structure
 
-To use the Nx CLI in an existing Angular CLI workspace while keeping your existing file structure in place, use the `ng add` command with the `--preserveAngularCLILayout` option:
+To use the Nx CLI in an existing Angular CLI workspace while keeping your existing file structure in place, use the `ng add` command with the `--preserve-angular-cli-layout` option:
 
 ```bash
-ng add @nrwl/workspace --preserveAngularCLILayout
+ng add @nrwl/workspace --preserve-angular-cli-layout
 ```
+
+> **Note**: If you are migrating to an Nx versions previous to `v13.8.4` (e.g. `ng add @nrwl/workspace@12`) use the `--preserveAngularCLILayout` option instead.
 
 This installs the `@nrwl/workspace` package into your workspace and applies the following changes to your workspace:
 


### PR DESCRIPTION
Update Angular CLI migration docs to account for the renaming of the flag `--preserveAngularCLILayout` to `--preserve-angular-cli-layout`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
