### PR TITLE
fix(angular): support workspaces using a root tsconfig.json instead of tsconfig.base.json

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -185,6 +185,27 @@ describe('app', () => {
       const workspaceJson = readJson(appTree, '/workspace.json');
       expect(workspaceJson.projects['app'].projectType).toEqual('application');
     });
+
+    it('should extend from tsconfig.base.json', async () => {
+      // ACT
+      await generateApp(appTree, 'app');
+
+      // ASSERT
+      const appTsConfig = readJson(appTree, 'apps/app/tsconfig.json');
+      expect(appTsConfig.extends).toBe('../../tsconfig.base.json');
+    });
+
+    it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+      // ARRANGE
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      // ACT
+      await generateApp(appTree, 'app');
+
+      // ASSERT
+      const appTsConfig = readJson(appTree, 'apps/app/tsconfig.json');
+      expect(appTsConfig.extends).toBe('../../tsconfig.json');
+    });
   });
 
   describe('nested', () => {
@@ -257,6 +278,27 @@ describe('app', () => {
           expectedValue: ['../../../.eslintrc.json'],
         },
       ].forEach(hasJsonValue);
+    });
+
+    it('should extend from tsconfig.base.json', async () => {
+      // ACT
+      await generateApp(appTree, 'app', { directory: 'myDir' });
+
+      // ASSERT
+      const appTsConfig = readJson(appTree, 'apps/my-dir/app/tsconfig.json');
+      expect(appTsConfig.extends).toBe('../../../tsconfig.base.json');
+    });
+
+    it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+      // ARRANGE
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      // ACT
+      await generateApp(appTree, 'app', { directory: 'myDir' });
+
+      // ASSERT
+      const appTsConfig = readJson(appTree, 'apps/my-dir/app/tsconfig.json');
+      expect(appTsConfig.extends).toBe('../../../tsconfig.json');
     });
   });
 

--- a/packages/angular/src/generators/application/files/tsconfig.json
+++ b/packages/angular/src/generators/application/files/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "files": [],
   "include": [],
   "references": [

--- a/packages/angular/src/generators/application/lib/create-files.ts
+++ b/packages/angular/src/generators/application/lib/create-files.ts
@@ -2,6 +2,7 @@ import type { Tree } from '@nrwl/devkit';
 import type { NormalizedSchema } from './normalized-schema';
 
 import { generateFiles, joinPathFragments, offsetFromRoot } from '@nrwl/devkit';
+import { getRootTsConfigPath } from '../../utils/typescript';
 
 export function createFiles(
   host: Tree,
@@ -16,7 +17,9 @@ export function createFiles(
     options.appProjectRoot,
     {
       ...options,
-      offsetFromRoot: offsetFromRoot(options.appProjectRoot),
+      rootTsConfigPath: `${offsetFromRoot(
+        options.appProjectRoot
+      )}${getRootTsConfigPath(host)}`,
       tpl: '',
     }
   );

--- a/packages/angular/src/generators/application/lib/update-e2e-project.ts
+++ b/packages/angular/src/generators/application/lib/update-e2e-project.ts
@@ -6,6 +6,7 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
+import { getRootTsConfigPath } from '../../utils/typescript';
 import type { NormalizedSchema } from './normalized-schema';
 
 export function updateE2eProject(tree: Tree, options: NormalizedSchema) {
@@ -60,7 +61,9 @@ export function updateE2eProject(tree: Tree, options: NormalizedSchema) {
   updateJson(tree, `${options.e2eProjectRoot}/tsconfig.json`, (json) => {
     return {
       ...json,
-      extends: `${offsetFromRoot(options.e2eProjectRoot)}tsconfig.base.json`,
+      extends: `${offsetFromRoot(options.e2eProjectRoot)}${getRootTsConfigPath(
+        tree
+      )}`,
     };
   });
 }

--- a/packages/angular/src/generators/library-secondary-entry-point/lib/add-path-mapping.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/lib/add-path-mapping.ts
@@ -1,11 +1,12 @@
 import { Tree, updateJson } from '@nrwl/devkit';
+import { getRootTsConfigPath } from '../../utils/typescript';
 import { NormalizedGeneratorOptions } from '../schema';
 
 export function addPathMapping(
   tree: Tree,
   options: NormalizedGeneratorOptions
 ): void {
-  updateJson(tree, 'tsconfig.base.json', (json) => {
+  updateJson(tree, getRootTsConfigPath(tree), (json) => {
     const c = json.compilerOptions;
     c.paths = c.paths || {};
     c.paths[options.secondaryEntryPoint] = [

--- a/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
@@ -123,6 +123,28 @@ describe('librarySecondaryEntryPoint generator', () => {
     ).toStrictEqual(['libs/lib1/testing/src/index.ts']);
   });
 
+  it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+    tree.rename('tsconfig.base.json', 'tsconfig.json');
+    addProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      projectType: 'library',
+    });
+    tree.write(
+      'libs/lib1/package.json',
+      JSON.stringify({ name: '@my-org/lib1' })
+    );
+
+    await librarySecondaryEntryPointGenerator(tree, {
+      name: 'testing',
+      library: 'lib1',
+    });
+
+    const tsConfig = readJson(tree, 'tsconfig.json');
+    expect(
+      tsConfig.compilerOptions.paths['@my-org/lib1/testing']
+    ).toStrictEqual(['libs/lib1/testing/src/index.ts']);
+  });
+
   it('should add the entry point file patterns to the lint target', async () => {
     addProjectConfiguration(tree, 'lib1', {
       root: 'libs/lib1',

--- a/packages/angular/src/generators/library/files/lib/tsconfig.json__tpl__
+++ b/packages/angular/src/generators/library/files/lib/tsconfig.json__tpl__
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "files": [],
   "include": [],
   "references": [

--- a/packages/angular/src/generators/library/lib/update-project.ts
+++ b/packages/angular/src/generators/library/lib/update-project.ts
@@ -10,6 +10,7 @@ import {
 } from '@nrwl/devkit';
 import { replaceAppNameWithPath } from '@nrwl/workspace';
 import * as path from 'path';
+import { getRootTsConfigPath } from '../../utils/typescript';
 import { NormalizedSchema } from './normalized-schema';
 import { updateNgPackage } from './update-ng-package';
 
@@ -118,7 +119,9 @@ function createFiles(host: Tree, options: NormalizedSchema) {
     options.projectRoot,
     {
       ...options,
-      offsetFromRoot: offsetFromRoot(options.projectRoot),
+      rootTsConfigPath: `${offsetFromRoot(
+        options.projectRoot
+      )}${getRootTsConfigPath(host)}`,
       tpl: '',
     }
   );

--- a/packages/angular/src/generators/library/lib/update-tsconfig.ts
+++ b/packages/angular/src/generators/library/lib/update-tsconfig.ts
@@ -4,10 +4,11 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
+import { getRootTsConfigPath } from '../../utils/typescript';
 import { NormalizedSchema } from './normalized-schema';
 
 function updateRootConfig(host: Tree, options: NormalizedSchema) {
-  updateJson(host, 'tsconfig.base.json', (json) => {
+  updateJson(host, getRootTsConfigPath(host), (json) => {
     const c = json.compilerOptions;
     c.paths = c.paths || {};
     delete c.paths[options.name];

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -305,6 +305,18 @@ describe('lib', () => {
       });
     });
 
+    it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+      // ARRANGE
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      // ACT
+      await runLibraryGeneratorWithOpts();
+
+      // ASSERT
+      const appTsConfig = readJson(tree, 'libs/my-lib/tsconfig.json');
+      expect(appTsConfig.extends).toBe('../../tsconfig.json');
+    });
+
     it('should check for existence of spec files before deleting them', async () => {
       // ARRANGE
       updateJson<NxJsonConfiguration, NxJsonConfiguration>(
@@ -632,6 +644,18 @@ describe('lib', () => {
           },
         ],
       });
+    });
+
+    it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+      // ARRANGE
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      // ACT
+      await runLibraryGeneratorWithOpts({ directory: 'myDir' });
+
+      // ASSERT
+      const appTsConfig = readJson(tree, 'libs/my-dir/my-lib/tsconfig.json');
+      expect(appTsConfig.extends).toBe('../../../tsconfig.json');
     });
   });
 

--- a/packages/angular/src/generators/setup-mfe/files/webpack/webpack.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-mfe/files/webpack/webpack.config.js__tmpl__
@@ -12,7 +12,7 @@ const share = mf.share;
 * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
 * the location of the generated temporary tsconfig file.
 */
-const tsConfigPath = process.env.NX_TSCONFIG_PATH ?? path.join(__dirname, '<%= offsetFromRoot %>tsconfig.base.json');
+const tsConfigPath = process.env.NX_TSCONFIG_PATH ?? path.join(__dirname, '<%= offsetFromRoot + rootTsConfigPath %>');
 
 const workspaceRootPath = path.join(__dirname, '<%= offsetFromRoot %>');
 const sharedMappings = new mf.SharedMappings();

--- a/packages/angular/src/generators/setup-mfe/lib/generate-config.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/generate-config.ts
@@ -6,6 +6,7 @@ import {
   logger,
   offsetFromRoot,
 } from '@nrwl/devkit';
+import { getRootTsConfigPath } from '../../utils/typescript';
 
 const SHARED_SINGLETON_LIBRARIES = [
   '@angular/core',
@@ -42,6 +43,7 @@ export function generateWebpackConfig(
       sourceRoot: appRoot,
       sharedLibraries: SHARED_SINGLETON_LIBRARIES,
       offsetFromRoot: offsetFromRoot(appRoot),
+      rootTsConfigPath: getRootTsConfigPath(host),
     }
   );
 }

--- a/packages/angular/src/generators/setup-mfe/setup-mfe.spec.ts
+++ b/packages/angular/src/generators/setup-mfe/setup-mfe.spec.ts
@@ -47,6 +47,35 @@ describe('Init MFE', () => {
     ['app1', 'host'],
     ['remote1', 'remote'],
   ])(
+    'should support a root tsconfig.json instead of tsconfig.base.json',
+    async (app, type: 'host' | 'remote') => {
+      // ARRANGE
+      host.rename('tsconfig.base.json', 'tsconfig.json');
+
+      // ACT
+      await setupMfe(host, {
+        appName: app,
+        mfeType: type,
+      });
+
+      // ASSERT
+      expect(host.exists(`apps/${app}/webpack.config.js`)).toBeTruthy();
+      expect(host.exists(`apps/${app}/webpack.prod.config.js`)).toBeTruthy();
+
+      const webpackContents = host.read(
+        `apps/${app}/webpack.config.js`,
+        'utf-8'
+      );
+      expect(webpackContents).toContain(
+        "const tsConfigPath = process.env.NX_TSCONFIG_PATH ?? path.join(__dirname, '../../tsconfig.json');"
+      );
+    }
+  );
+
+  test.each([
+    ['app1', 'host'],
+    ['remote1', 'remote'],
+  ])(
     'create bootstrap file with the contents of main.ts',
     async (app, type: 'host' | 'remote') => {
       // ARRANGE

--- a/packages/angular/src/generators/utils/typescript.ts
+++ b/packages/angular/src/generators/utils/typescript.ts
@@ -1,0 +1,13 @@
+import { Tree } from '@nrwl/devkit';
+
+export function getRootTsConfigPath(tree: Tree): string {
+  for (const path of ['tsconfig.base.json', 'tsconfig.json']) {
+    if (tree.exists(path)) {
+      return path;
+    }
+  }
+
+  throw new Error(
+    'Could not find root tsconfig file. Tried with "tsconfig.base.json" and "tsconfig.json".'
+  );
+}

--- a/packages/angular/src/generators/web-worker/lib/update-tsconfig.ts
+++ b/packages/angular/src/generators/web-worker/lib/update-tsconfig.ts
@@ -1,21 +1,17 @@
 import type { Tree } from '@nrwl/devkit';
 import {
-  getWorkspaceLayout,
   joinPathFragments,
   offsetFromRoot,
   readProjectConfiguration,
   updateJson,
 } from '@nrwl/devkit';
+import { getRootTsConfigPath } from '../../utils/typescript';
 
 export function updateTsConfig(tree: Tree, project: string): void {
-  const workerTsConfigPath = joinPathFragments(
-    getWorkspaceLayout(tree).appsDir,
-    project,
-    'tsconfig.worker.json'
-  );
   const { root } = readProjectConfiguration(tree, project);
+  const workerTsConfigPath = joinPathFragments(root, 'tsconfig.worker.json');
   updateJson(tree, workerTsConfigPath, (json) => {
-    json.extends = `${offsetFromRoot(root)}tsconfig.base.json`;
+    json.extends = `${offsetFromRoot(root)}${getRootTsConfigPath(tree)}`;
     return json;
   });
 }

--- a/packages/angular/src/generators/web-worker/web-worker.spec.ts
+++ b/packages/angular/src/generators/web-worker/web-worker.spec.ts
@@ -29,6 +29,16 @@ describe('webWorker generator', () => {
     ).toContain('"extends": "../../tsconfig.base.json"');
   });
 
+  it('should extend from tsconfig.json when used instead of tsconfig.base.json', async () => {
+    tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+    await webWorkerGenerator(tree, { name: 'test-worker', project: appName });
+
+    expect(
+      tree.read(`apps/${appName}/tsconfig.worker.json`, 'utf-8')
+    ).toContain('"extends": "../../tsconfig.json"');
+  });
+
   it('should format files', async () => {
     jest.spyOn(devkit, 'formatFiles');
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Several generators in the Angular plugin don't fall back to locate a root `tsconfig.json` if the expected `tsconfig.base.json` doesn't exist.

Most of the time this should be fine since Nx workspaces by default use `tsconfig.base.json`, but there are still some scenarios where a `tsconfig.json` might still be used. One such scenario is using a package like `make-angular-cli-faster` or migrating an Angular CLI workspace using the `--preserve-angular-cli-layout` flag.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Angular plugin generators should look for a root `tsconfig.json` if the `tsconfig.base.json` file doesn't exist. By default, `tsconfig.base.json` should still be used for everything, but a fallback should be in place.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
