### PR TITLE
feat(node): improve @nrwl/node:node executor to handle build process correctly in watch and no-watch mode

### DIFF
--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -94,6 +94,8 @@ export function getBaseWebpackPartial(
     },
     plugins: [
       new ForkTsCheckerWebpackPlugin({
+        // For watch mode, type errors should result in failure.
+        async: false,
         typescript: {
           enabled: true,
           configFile: options.tsConfig,
@@ -103,6 +105,9 @@ export function getBaseWebpackPartial(
     ],
     watch: options.watch,
     watchOptions: {
+      // Delay the next rebuild from first file change, otherwise can lead to
+      // two builds on a single file change.
+      aggregateTimeout: 200,
       poll: options.poll,
     },
     stats: getStatsConfig(options),


### PR DESCRIPTION
## Changes

**Watch mode:**
* Only kill previous process if build succeeds (so  a server isn't killed unless it can be restarted)
* File changes only trigger one build (delay of 200ms before re-building)

**No watch:**
* Wait for app process to finish before exiting.

## Current Behavior

Serve exits before child exits + other weird behavior.

## Expected Behavior

Serve should wait for app process to complete.
