### PR TITLE
fix(web): allow use multiple config in custom webpack configuration file

### DIFF
--- a/packages/web/src/executors/webpack/webpack.impl.ts
+++ b/packages/web/src/executors/webpack/webpack.impl.ts
@@ -1,7 +1,13 @@
 import { ExecutorContext, logger } from '@nrwl/devkit';
 import type { Configuration, Stats } from 'webpack';
 import { from, of } from 'rxjs';
-import { bufferCount, mergeScan, switchMap, tap } from 'rxjs/operators';
+import {
+  bufferCount,
+  mergeScan,
+  switchMap,
+  tap,
+  mergeMap,
+} from 'rxjs/operators';
 import { eachValueFrom } from 'rxjs-for-await';
 import { execSync } from 'child_process';
 import { Range, satisfies } from 'semver';
@@ -188,6 +194,7 @@ export async function* run(
   const configs = getWebpackConfigs(options, context);
   return yield* eachValueFrom(
     from(configs).pipe(
+      mergeMap((config) => (Array.isArray(config) ? from(config) : of(config))),
       // Run build sequentially and bail when first one fails.
       mergeScan(
         (acc, config) => {


### PR DESCRIPTION
When use a custom configuration file for webpack build target, allow running webpack with
multiple configuration options.
ISSUES CLOSED: #9186

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Assigning a custom webpack configuration file does not support the ability to use multiple configurations, as webpack allows.

## Expected Behavior
Being able to define multiple configurations in my custom webpack.config.ts file to feed to webpack

## Related Issue(s)

#9186

Fixes #
