### PR TITLE
fix(js): remove hardcoded source-maps option from swc compile command

### DIFF
--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -10,7 +10,7 @@ function getSwcCmd(
   { swcrcPath, srcPath, destPath }: SwcCliOptions,
   watch = false
 ) {
-  let swcCmd = `npx swc ${srcPath} -d ${destPath} --source-maps --no-swcrc --config-file=${swcrcPath}`;
+  let swcCmd = `npx swc ${srcPath} -d ${destPath} --no-swcrc --config-file=${swcrcPath}`;
   return watch ? swcCmd.concat(' --watch') : swcCmd;
 }
 


### PR DESCRIPTION
ISSUES CLOSED: #9187

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
https://github.com/nrwl/nx/blob/229f71ef1758ee625869aaa6fa6355dc3284fa5b/packages/js/src/utils/swc/compile-swc.ts#L13
`--source-maps` is hardcoded so adding `"sourceMaps": false,` to your `.swcrc` has no effect.
Is there any reason why this parameter is hardcoded?

## Expected Behavior
I should be able to disable sourcemaps on swc compile.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9187
