### PR TITLE
fix(nxdev): cover hero background on wide screens

### DIFF
--- a/nx-dev/nx-dev/pages/index.tsx
+++ b/nx-dev/nx-dev/pages/index.tsx
@@ -56,7 +56,7 @@ export function Index(): ReactComponentElement<any> {
           {/*INTRO COMPONENT*/}
           <header
             id="animated-background"
-            className="bg-blue-nx-base transform-gpu bg-clip-border bg-right bg-no-repeat bg-origin-border text-white lg:bg-contain"
+            className="bg-blue-nx-base transform-gpu bg-clip-border bg-right bg-no-repeat bg-origin-border text-white lg:bg-cover"
             style={{
               backgroundImage: 'url(/images/background/hero-bg-large.svg)',
             }}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
On widescreen, the background image on the hero is stuck on the right thanks to `bg-right` and `bg-contain`
![Screenshot 2022-03-04 at 12 38 52](https://user-images.githubusercontent.com/881612/156756941-80a5a03f-e313-4113-9ba9-b12ffae3b6bc.png)

## Expected Behavior
The image should cover the hero block without leaving empty parts on super widescreens.
![Screenshot 2022-03-04 at 12 39 24](https://user-images.githubusercontent.com/881612/156757004-e5a1e06d-b523-4030-9690-40760b53990a.png)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
