### PR TITLE
fix(linter): ensure onlyDependOnLibsWithTags is present before check

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -393,9 +393,10 @@ export default createESLintRule<Options, MessageIds>({
 
         for (let constraint of constraints) {
           if (
+            constraint.onlyDependOnLibsWithTags &&
             hasNoneOfTheseTags(
               targetProject,
-              constraint.onlyDependOnLibsWithTags || []
+              constraint.onlyDependOnLibsWithTags
             )
           ) {
             const allowedTags = constraint.onlyDependOnLibsWithTags


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #6864
