### PR TITLE
fix(misc): support workspaces using a root tsconfig.json instead of tsconfig.base.json

### DIFF
--- a/e2e/workspace-integrations/src/workspace.test.ts
+++ b/e2e/workspace-integrations/src/workspace.test.ts
@@ -402,11 +402,18 @@ describe('affected:*', () => {
     expect(affectedLibs).not.toContain(mylib2);
 
     const implicitlyAffectedLibs = runCLI(
-      'affected:libs --files="tsconfig.json"'
+      'affected:libs --files="tsconfig.base.json"'
     );
     expect(implicitlyAffectedLibs).toContain(mypublishablelib);
     expect(implicitlyAffectedLibs).toContain(mylib);
     expect(implicitlyAffectedLibs).toContain(mylib2);
+
+    const noAffectedLibsNonExistentFile = runCLI(
+      'affected:libs --files="tsconfig.json"'
+    );
+    expect(noAffectedLibsNonExistentFile).not.toContain(mypublishablelib);
+    expect(noAffectedLibsNonExistentFile).not.toContain(mylib);
+    expect(noAffectedLibsNonExistentFile).not.toContain(mylib2);
 
     const noAffectedLibs = runCLI('affected:libs --files="README.md"');
     expect(noAffectedLibs).not.toContain(mypublishablelib);

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -185,6 +185,27 @@ describe('app', () => {
       const workspaceJson = readJson(appTree, '/workspace.json');
       expect(workspaceJson.projects['app'].projectType).toEqual('application');
     });
+
+    it('should extend from tsconfig.base.json', async () => {
+      // ACT
+      await generateApp(appTree, 'app');
+
+      // ASSERT
+      const appTsConfig = readJson(appTree, 'apps/app/tsconfig.json');
+      expect(appTsConfig.extends).toBe('../../tsconfig.base.json');
+    });
+
+    it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+      // ARRANGE
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      // ACT
+      await generateApp(appTree, 'app');
+
+      // ASSERT
+      const appTsConfig = readJson(appTree, 'apps/app/tsconfig.json');
+      expect(appTsConfig.extends).toBe('../../tsconfig.json');
+    });
   });
 
   describe('nested', () => {
@@ -257,6 +278,27 @@ describe('app', () => {
           expectedValue: ['../../../.eslintrc.json'],
         },
       ].forEach(hasJsonValue);
+    });
+
+    it('should extend from tsconfig.base.json', async () => {
+      // ACT
+      await generateApp(appTree, 'app', { directory: 'myDir' });
+
+      // ASSERT
+      const appTsConfig = readJson(appTree, 'apps/my-dir/app/tsconfig.json');
+      expect(appTsConfig.extends).toBe('../../../tsconfig.base.json');
+    });
+
+    it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+      // ARRANGE
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      // ACT
+      await generateApp(appTree, 'app', { directory: 'myDir' });
+
+      // ASSERT
+      const appTsConfig = readJson(appTree, 'apps/my-dir/app/tsconfig.json');
+      expect(appTsConfig.extends).toBe('../../../tsconfig.json');
     });
   });
 

--- a/packages/angular/src/generators/application/files/tsconfig.json
+++ b/packages/angular/src/generators/application/files/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "files": [],
   "include": [],
   "references": [

--- a/packages/angular/src/generators/application/lib/create-files.ts
+++ b/packages/angular/src/generators/application/lib/create-files.ts
@@ -1,7 +1,7 @@
 import type { Tree } from '@nrwl/devkit';
-import type { NormalizedSchema } from './normalized-schema';
-
 import { generateFiles, joinPathFragments, offsetFromRoot } from '@nrwl/devkit';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import type { NormalizedSchema } from './normalized-schema';
 
 export function createFiles(
   host: Tree,
@@ -16,7 +16,9 @@ export function createFiles(
     options.appProjectRoot,
     {
       ...options,
-      offsetFromRoot: offsetFromRoot(options.appProjectRoot),
+      rootTsConfigPath: `${offsetFromRoot(
+        options.appProjectRoot
+      )}${getRootTsConfigPathInTree(host)}`,
       tpl: '',
     }
   );

--- a/packages/angular/src/generators/application/lib/create-files.ts
+++ b/packages/angular/src/generators/application/lib/create-files.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
-import { generateFiles, joinPathFragments, offsetFromRoot } from '@nrwl/devkit';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { generateFiles, joinPathFragments } from '@nrwl/devkit';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import type { NormalizedSchema } from './normalized-schema';
 
 export function createFiles(
@@ -16,9 +16,10 @@ export function createFiles(
     options.appProjectRoot,
     {
       ...options,
-      rootTsConfigPath: `${offsetFromRoot(
+      rootTsConfigPath: getRelativePathToRootTsConfig(
+        host,
         options.appProjectRoot
-      )}${getRootTsConfigPathInTree(host)}`,
+      ),
       tpl: '',
     }
   );

--- a/packages/angular/src/generators/application/lib/update-e2e-project.ts
+++ b/packages/angular/src/generators/application/lib/update-e2e-project.ts
@@ -6,7 +6,7 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import type { NormalizedSchema } from './normalized-schema';
 
 export function updateE2eProject(tree: Tree, options: NormalizedSchema) {
@@ -61,9 +61,7 @@ export function updateE2eProject(tree: Tree, options: NormalizedSchema) {
   updateJson(tree, `${options.e2eProjectRoot}/tsconfig.json`, (json) => {
     return {
       ...json,
-      extends: `${offsetFromRoot(
-        options.e2eProjectRoot
-      )}${getRootTsConfigPathInTree(tree)}`,
+      extends: getRelativePathToRootTsConfig(tree, options.e2eProjectRoot),
     };
   });
 }

--- a/packages/angular/src/generators/application/lib/update-e2e-project.ts
+++ b/packages/angular/src/generators/application/lib/update-e2e-project.ts
@@ -6,6 +6,7 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 import type { NormalizedSchema } from './normalized-schema';
 
 export function updateE2eProject(tree: Tree, options: NormalizedSchema) {
@@ -60,7 +61,9 @@ export function updateE2eProject(tree: Tree, options: NormalizedSchema) {
   updateJson(tree, `${options.e2eProjectRoot}/tsconfig.json`, (json) => {
     return {
       ...json,
-      extends: `${offsetFromRoot(options.e2eProjectRoot)}tsconfig.base.json`,
+      extends: `${offsetFromRoot(
+        options.e2eProjectRoot
+      )}${getRootTsConfigPathInTree(tree)}`,
     };
   });
 }

--- a/packages/angular/src/generators/library-secondary-entry-point/lib/add-path-mapping.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/lib/add-path-mapping.ts
@@ -1,11 +1,12 @@
 import { Tree, updateJson } from '@nrwl/devkit';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 import { NormalizedGeneratorOptions } from '../schema';
 
 export function addPathMapping(
   tree: Tree,
   options: NormalizedGeneratorOptions
 ): void {
-  updateJson(tree, 'tsconfig.base.json', (json) => {
+  updateJson(tree, getRootTsConfigPathInTree(tree), (json) => {
     const c = json.compilerOptions;
     c.paths = c.paths || {};
     c.paths[options.secondaryEntryPoint] = [

--- a/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
@@ -123,6 +123,28 @@ describe('librarySecondaryEntryPoint generator', () => {
     ).toStrictEqual(['libs/lib1/testing/src/index.ts']);
   });
 
+  it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+    tree.rename('tsconfig.base.json', 'tsconfig.json');
+    addProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      projectType: 'library',
+    });
+    tree.write(
+      'libs/lib1/package.json',
+      JSON.stringify({ name: '@my-org/lib1' })
+    );
+
+    await librarySecondaryEntryPointGenerator(tree, {
+      name: 'testing',
+      library: 'lib1',
+    });
+
+    const tsConfig = readJson(tree, 'tsconfig.json');
+    expect(
+      tsConfig.compilerOptions.paths['@my-org/lib1/testing']
+    ).toStrictEqual(['libs/lib1/testing/src/index.ts']);
+  });
+
   it('should add the entry point file patterns to the lint target', async () => {
     addProjectConfiguration(tree, 'lib1', {
       root: 'libs/lib1',

--- a/packages/angular/src/generators/library/files/lib/tsconfig.json__tpl__
+++ b/packages/angular/src/generators/library/files/lib/tsconfig.json__tpl__
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "files": [],
   "include": [],
   "references": [

--- a/packages/angular/src/generators/library/lib/update-project.ts
+++ b/packages/angular/src/generators/library/lib/update-project.ts
@@ -1,14 +1,15 @@
 import {
   generateFiles,
+  getWorkspaceLayout,
+  joinPathFragments,
+  offsetFromRoot,
   readProjectConfiguration,
   Tree,
   updateJson,
   updateProjectConfiguration,
-  getWorkspaceLayout,
-  offsetFromRoot,
-  joinPathFragments,
 } from '@nrwl/devkit';
 import { replaceAppNameWithPath } from '@nrwl/workspace';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 import * as path from 'path';
 import { NormalizedSchema } from './normalized-schema';
 import { updateNgPackage } from './update-ng-package';
@@ -118,7 +119,9 @@ function createFiles(host: Tree, options: NormalizedSchema) {
     options.projectRoot,
     {
       ...options,
-      offsetFromRoot: offsetFromRoot(options.projectRoot),
+      rootTsConfigPath: `${offsetFromRoot(
+        options.projectRoot
+      )}${getRootTsConfigPathInTree(host)}`,
       tpl: '',
     }
   );

--- a/packages/angular/src/generators/library/lib/update-project.ts
+++ b/packages/angular/src/generators/library/lib/update-project.ts
@@ -9,7 +9,7 @@ import {
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { replaceAppNameWithPath } from '@nrwl/workspace';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import * as path from 'path';
 import { NormalizedSchema } from './normalized-schema';
 import { updateNgPackage } from './update-ng-package';
@@ -119,9 +119,10 @@ function createFiles(host: Tree, options: NormalizedSchema) {
     options.projectRoot,
     {
       ...options,
-      rootTsConfigPath: `${offsetFromRoot(
+      rootTsConfigPath: getRelativePathToRootTsConfig(
+        host,
         options.projectRoot
-      )}${getRootTsConfigPathInTree(host)}`,
+      ),
       tpl: '',
     }
   );

--- a/packages/angular/src/generators/library/lib/update-tsconfig.ts
+++ b/packages/angular/src/generators/library/lib/update-tsconfig.ts
@@ -4,10 +4,11 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 import { NormalizedSchema } from './normalized-schema';
 
 function updateRootConfig(host: Tree, options: NormalizedSchema) {
-  updateJson(host, 'tsconfig.base.json', (json) => {
+  updateJson(host, getRootTsConfigPathInTree(host), (json) => {
     const c = json.compilerOptions;
     c.paths = c.paths || {};
     delete c.paths[options.name];

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -305,6 +305,18 @@ describe('lib', () => {
       });
     });
 
+    it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+      // ARRANGE
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      // ACT
+      await runLibraryGeneratorWithOpts();
+
+      // ASSERT
+      const appTsConfig = readJson(tree, 'libs/my-lib/tsconfig.json');
+      expect(appTsConfig.extends).toBe('../../tsconfig.json');
+    });
+
     it('should check for existence of spec files before deleting them', async () => {
       // ARRANGE
       updateJson<NxJsonConfiguration, NxJsonConfiguration>(
@@ -632,6 +644,18 @@ describe('lib', () => {
           },
         ],
       });
+    });
+
+    it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+      // ARRANGE
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      // ACT
+      await runLibraryGeneratorWithOpts({ directory: 'myDir' });
+
+      // ASSERT
+      const appTsConfig = readJson(tree, 'libs/my-dir/my-lib/tsconfig.json');
+      expect(appTsConfig.extends).toBe('../../../tsconfig.json');
     });
   });
 

--- a/packages/angular/src/generators/setup-mfe/files/webpack/webpack.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-mfe/files/webpack/webpack.config.js__tmpl__
@@ -12,7 +12,7 @@ const share = mf.share;
 * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
 * the location of the generated temporary tsconfig file.
 */
-const tsConfigPath = process.env.NX_TSCONFIG_PATH ?? path.join(__dirname, '<%= offsetFromRoot %>tsconfig.base.json');
+const tsConfigPath = process.env.NX_TSCONFIG_PATH ?? path.join(__dirname, '<%= rootTsConfigPath %>');
 
 const workspaceRootPath = path.join(__dirname, '<%= offsetFromRoot %>');
 const sharedMappings = new mf.SharedMappings();

--- a/packages/angular/src/generators/setup-mfe/lib/generate-config.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/generate-config.ts
@@ -1,11 +1,12 @@
 import type { Tree } from '@nrwl/devkit';
-import type { Schema } from '../schema';
 import {
   generateFiles,
   joinPathFragments,
   logger,
   offsetFromRoot,
 } from '@nrwl/devkit';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import type { Schema } from '../schema';
 
 const SHARED_SINGLETON_LIBRARIES = [
   '@angular/core',
@@ -30,6 +31,8 @@ export function generateWebpackConfig(
       If this was not the outcome you expected, you can discard the changes we have made, create a backup of your current webpack config, and run the command again.`
     );
   }
+
+  const rootOffset = offsetFromRoot(appRoot);
   generateFiles(
     host,
     joinPathFragments(__dirname, '../files/webpack'),
@@ -41,7 +44,8 @@ export function generateWebpackConfig(
       remotes: remotesWithPorts ?? [],
       sourceRoot: appRoot,
       sharedLibraries: SHARED_SINGLETON_LIBRARIES,
-      offsetFromRoot: offsetFromRoot(appRoot),
+      offsetFromRoot: rootOffset,
+      rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(host),
     }
   );
 }

--- a/packages/angular/src/generators/setup-mfe/lib/generate-config.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/generate-config.ts
@@ -5,7 +5,7 @@ import {
   logger,
   offsetFromRoot,
 } from '@nrwl/devkit';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import type { Schema } from '../schema';
 
 const SHARED_SINGLETON_LIBRARIES = [
@@ -32,7 +32,6 @@ export function generateWebpackConfig(
     );
   }
 
-  const rootOffset = offsetFromRoot(appRoot);
   generateFiles(
     host,
     joinPathFragments(__dirname, '../files/webpack'),
@@ -44,8 +43,8 @@ export function generateWebpackConfig(
       remotes: remotesWithPorts ?? [],
       sourceRoot: appRoot,
       sharedLibraries: SHARED_SINGLETON_LIBRARIES,
-      offsetFromRoot: rootOffset,
-      rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(host),
+      offsetFromRoot: offsetFromRoot(appRoot),
+      rootTsConfigPath: getRelativePathToRootTsConfig(host, appRoot),
     }
   );
 }

--- a/packages/angular/src/generators/setup-mfe/setup-mfe.spec.ts
+++ b/packages/angular/src/generators/setup-mfe/setup-mfe.spec.ts
@@ -47,6 +47,35 @@ describe('Init MFE', () => {
     ['app1', 'host'],
     ['remote1', 'remote'],
   ])(
+    'should support a root tsconfig.json instead of tsconfig.base.json',
+    async (app, type: 'host' | 'remote') => {
+      // ARRANGE
+      host.rename('tsconfig.base.json', 'tsconfig.json');
+
+      // ACT
+      await setupMfe(host, {
+        appName: app,
+        mfeType: type,
+      });
+
+      // ASSERT
+      expect(host.exists(`apps/${app}/webpack.config.js`)).toBeTruthy();
+      expect(host.exists(`apps/${app}/webpack.prod.config.js`)).toBeTruthy();
+
+      const webpackContents = host.read(
+        `apps/${app}/webpack.config.js`,
+        'utf-8'
+      );
+      expect(webpackContents).toContain(
+        "const tsConfigPath = process.env.NX_TSCONFIG_PATH ?? path.join(__dirname, '../../tsconfig.json');"
+      );
+    }
+  );
+
+  test.each([
+    ['app1', 'host'],
+    ['remote1', 'remote'],
+  ])(
     'create bootstrap file with the contents of main.ts',
     async (app, type: 'host' | 'remote') => {
       // ARRANGE

--- a/packages/angular/src/generators/web-worker/lib/update-tsconfig.ts
+++ b/packages/angular/src/generators/web-worker/lib/update-tsconfig.ts
@@ -1,21 +1,17 @@
 import type { Tree } from '@nrwl/devkit';
 import {
-  getWorkspaceLayout,
   joinPathFragments,
   offsetFromRoot,
   readProjectConfiguration,
   updateJson,
 } from '@nrwl/devkit';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 
 export function updateTsConfig(tree: Tree, project: string): void {
-  const workerTsConfigPath = joinPathFragments(
-    getWorkspaceLayout(tree).appsDir,
-    project,
-    'tsconfig.worker.json'
-  );
   const { root } = readProjectConfiguration(tree, project);
+  const workerTsConfigPath = joinPathFragments(root, 'tsconfig.worker.json');
   updateJson(tree, workerTsConfigPath, (json) => {
-    json.extends = `${offsetFromRoot(root)}tsconfig.base.json`;
+    json.extends = offsetFromRoot(root) + getRootTsConfigPathInTree(tree);
     return json;
   });
 }

--- a/packages/angular/src/generators/web-worker/lib/update-tsconfig.ts
+++ b/packages/angular/src/generators/web-worker/lib/update-tsconfig.ts
@@ -1,17 +1,16 @@
 import type { Tree } from '@nrwl/devkit';
 import {
   joinPathFragments,
-  offsetFromRoot,
   readProjectConfiguration,
   updateJson,
 } from '@nrwl/devkit';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 
 export function updateTsConfig(tree: Tree, project: string): void {
   const { root } = readProjectConfiguration(tree, project);
   const workerTsConfigPath = joinPathFragments(root, 'tsconfig.worker.json');
   updateJson(tree, workerTsConfigPath, (json) => {
-    json.extends = offsetFromRoot(root) + getRootTsConfigPathInTree(tree);
+    json.extends = getRelativePathToRootTsConfig(tree, root);
     return json;
   });
 }

--- a/packages/angular/src/generators/web-worker/web-worker.spec.ts
+++ b/packages/angular/src/generators/web-worker/web-worker.spec.ts
@@ -29,6 +29,16 @@ describe('webWorker generator', () => {
     ).toContain('"extends": "../../tsconfig.base.json"');
   });
 
+  it('should extend from tsconfig.json when used instead of tsconfig.base.json', async () => {
+    tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+    await webWorkerGenerator(tree, { name: 'test-worker', project: appName });
+
+    expect(
+      tree.read(`apps/${appName}/tsconfig.worker.json`, 'utf-8')
+    ).toContain('"extends": "../../tsconfig.json"');
+  });
+
   it('should format files', async () => {
     jest.spyOn(devkit, 'formatFiles');
 

--- a/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
@@ -265,6 +265,30 @@ describe('schematic:cypress-project', () => {
       expect(tsconfigJson).toMatchSnapshot();
     });
 
+    it('should extend from tsconfig.base.json', async () => {
+      await cypressProjectGenerator(tree, {
+        ...defaultOptions,
+        name: 'my-app-e2e',
+        project: 'my-app',
+      });
+
+      const tsConfig = readJson(tree, 'apps/my-app-e2e/tsconfig.json');
+      expect(tsConfig.extends).toBe('../../tsconfig.base.json');
+    });
+
+    it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await cypressProjectGenerator(tree, {
+        ...defaultOptions,
+        name: 'my-app-e2e',
+        project: 'my-app',
+      });
+
+      const tsConfig = readJson(tree, 'apps/my-app-e2e/tsconfig.json');
+      expect(tsConfig.extends).toBe('../../tsconfig.json');
+    });
+
     describe('nested', () => {
       it('should update workspace.json', async () => {
         await cypressProjectGenerator(tree, {
@@ -342,6 +366,32 @@ describe('schematic:cypress-project', () => {
         );
 
         expect(tsconfigJson).toMatchSnapshot();
+      });
+
+      it('should extend from tsconfig.base.json', async () => {
+        await cypressProjectGenerator(tree, {
+          ...defaultOptions,
+          name: 'my-app-e2e',
+          project: 'my-app',
+          directory: 'my-dir',
+        });
+
+        const tsConfig = readJson(tree, 'apps/my-dir/my-app-e2e/tsconfig.json');
+        expect(tsConfig.extends).toBe('../../../tsconfig.base.json');
+      });
+
+      it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+        tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+        await cypressProjectGenerator(tree, {
+          ...defaultOptions,
+          name: 'my-app-e2e',
+          project: 'my-app',
+          directory: 'my-dir',
+        });
+
+        const tsConfig = readJson(tree, 'apps/my-dir/my-app-e2e/tsconfig.json');
+        expect(tsConfig.extends).toBe('../../../tsconfig.json');
       });
     });
 

--- a/packages/cypress/src/generators/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.ts
@@ -16,7 +16,7 @@ import {
 } from '@nrwl/devkit';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 
 import { join } from 'path';
 // app
@@ -34,14 +34,13 @@ export interface CypressProjectSchema extends Schema {
 }
 
 function createFiles(tree: Tree, options: CypressProjectSchema) {
-  const rootOffset = offsetFromRoot(options.projectRoot);
   generateFiles(tree, join(__dirname, './files'), options.projectRoot, {
     tmpl: '',
     ...options,
     project: options.project || 'Project',
     ext: options.js ? 'js' : 'ts',
-    offsetFromRoot: rootOffset,
-    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(tree),
+    offsetFromRoot: offsetFromRoot(options.projectRoot),
+    rootTsConfigPath: getRelativePathToRootTsConfig(tree, options.projectRoot),
   });
 
   const cypressVersion = installedCypressVersion();

--- a/packages/cypress/src/generators/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.ts
@@ -16,6 +16,7 @@ import {
 } from '@nrwl/devkit';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 
 import { join } from 'path';
 // app
@@ -33,12 +34,14 @@ export interface CypressProjectSchema extends Schema {
 }
 
 function createFiles(tree: Tree, options: CypressProjectSchema) {
+  const rootOffset = offsetFromRoot(options.projectRoot);
   generateFiles(tree, join(__dirname, './files'), options.projectRoot, {
     tmpl: '',
     ...options,
     project: options.project || 'Project',
     ext: options.js ? 'js' : 'ts',
-    offsetFromRoot: offsetFromRoot(options.projectRoot),
+    offsetFromRoot: rootOffset,
+    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(tree),
   });
 
   const cypressVersion = installedCypressVersion();

--- a/packages/cypress/src/generators/cypress-project/files/tsconfig.json
+++ b/packages/cypress/src/generators/cypress-project/files/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "compilerOptions": {
     "sourceMap": false,
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",

--- a/packages/detox/src/generators/application/application.spec.ts
+++ b/packages/detox/src/generators/application/application.spec.ts
@@ -117,4 +117,34 @@ describe('detox application generator', () => {
       expect(project.implicitDependencies).toEqual(['my-dir-my-app']);
     });
   });
+
+  describe('tsconfig', () => {
+    beforeEach(async () => {
+      addProjectConfiguration(tree, 'my-app', { root: 'my-app' });
+    });
+
+    it('should extend from tsconfig.base.json', async () => {
+      await detoxApplicationGenerator(tree, {
+        name: 'my-app-e2e',
+        project: 'my-app',
+        linter: Linter.None,
+      });
+
+      const tsConfig = readJson(tree, 'apps/my-app-e2e/tsconfig.json');
+      expect(tsConfig.extends).toEqual('../../tsconfig.base.json');
+    });
+
+    it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await detoxApplicationGenerator(tree, {
+        name: 'my-app-e2e',
+        project: 'my-app',
+        linter: Linter.None,
+      });
+
+      const tsConfig = readJson(tree, 'apps/my-app-e2e/tsconfig.json');
+      expect(tsConfig.extends).toEqual('../../tsconfig.json');
+    });
+  });
 });

--- a/packages/detox/src/generators/application/files/app/tsconfig.json
+++ b/packages/detox/src/generators/application/files/app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "files": [],
   "include": [],
   "references": [

--- a/packages/detox/src/generators/application/lib/create-files.ts
+++ b/packages/detox/src/generators/application/lib/create-files.ts
@@ -1,11 +1,14 @@
 import { generateFiles, offsetFromRoot, toJS, Tree } from '@nrwl/devkit';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 import { join } from 'path';
 import { NormalizedSchema } from './normalize-options';
 
 export function createFiles(host: Tree, options: NormalizedSchema) {
+  const rootOffset = offsetFromRoot(options.projectRoot);
   generateFiles(host, join(__dirname, '../files/app'), options.projectRoot, {
     ...options,
-    offsetFromRoot: offsetFromRoot(options.projectRoot),
+    offsetFromRoot: rootOffset,
+    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(host),
   });
   if (options.js) {
     toJS(host);

--- a/packages/detox/src/generators/application/lib/create-files.ts
+++ b/packages/detox/src/generators/application/lib/create-files.ts
@@ -1,14 +1,13 @@
 import { generateFiles, offsetFromRoot, toJS, Tree } from '@nrwl/devkit';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import { join } from 'path';
 import { NormalizedSchema } from './normalize-options';
 
 export function createFiles(host: Tree, options: NormalizedSchema) {
-  const rootOffset = offsetFromRoot(options.projectRoot);
   generateFiles(host, join(__dirname, '../files/app'), options.projectRoot, {
     ...options,
-    offsetFromRoot: rootOffset,
-    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(host),
+    offsetFromRoot: offsetFromRoot(options.projectRoot),
+    rootTsConfigPath: getRelativePathToRootTsConfig(host, options.projectRoot),
   });
   if (options.js) {
     toJS(host);

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -132,12 +132,12 @@ function sortTsConfig(tree: Tree) {
   }
 }
 
-function getRootTsConfigPath(tree: Tree): string | undefined {
+function getRootTsConfigPath(tree: Tree): string | null {
   for (const path of ['tsconfig.base.json', 'tsconfig.json']) {
     if (tree.exists(path)) {
       return path;
     }
   }
 
-  return undefined;
+  return null;
 }

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -116,16 +116,28 @@ function ensurePropertiesAreInNewLocations(tree: Tree) {
 
 function sortTsConfig(tree: Tree) {
   try {
-    const tsconfig = readJson(tree, 'tsconfig.base.json');
-    const sortedPaths = sortObjectByKeys(tsconfig.compilerOptions.paths);
-    writeJson(tree, 'tsconfig.base.json', {
+    const tsConfigPath = getRootTsConfigPath(tree);
+    if (!tsConfigPath) {
+      return;
+    }
+    updateJson(tree, tsConfigPath, (tsconfig) => ({
       ...tsconfig,
       compilerOptions: {
         ...tsconfig.compilerOptions,
-        paths: sortedPaths,
+        paths: sortObjectByKeys(tsconfig.compilerOptions.paths),
       },
-    });
+    }));
   } catch (e) {
     // catch noop
   }
+}
+
+function getRootTsConfigPath(tree: Tree): string | undefined {
+  for (const path of ['tsconfig.base.json', 'tsconfig.json']) {
+    if (tree.exists(path)) {
+      return path;
+    }
+  }
+
+  return undefined;
 }

--- a/packages/js/src/generators/library/files/lib/tsconfig.json__tmpl__
+++ b/packages/js/src/generators/library/files/lib/tsconfig.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "compilerOptions": {
     "module": "CommonJS"<% if (js) { %>,
     "allowJs": true<% } %>

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -16,7 +16,10 @@ import {
 import { jestProjectGenerator } from '@nrwl/jest';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import {
+  getRelativePathToRootTsConfig,
+  getRootTsConfigPathInTree,
+} from '@nrwl/workspace/src/utilities/typescript';
 import { join } from 'path';
 import { LibraryGeneratorSchema } from '../../utils/schema';
 import { addSwcConfig } from '../../utils/swc/add-swc-config';
@@ -162,7 +165,6 @@ function updateTsConfig(tree: Tree, options: NormalizedSchema) {
 function createFiles(tree: Tree, options: NormalizedSchema, filesDir: string) {
   const { className, name, propertyName } = names(options.name);
 
-  const rootOffset = offsetFromRoot(options.projectRoot);
   generateFiles(tree, filesDir, options.projectRoot, {
     ...options,
     dot: '.',
@@ -173,8 +175,8 @@ function createFiles(tree: Tree, options: NormalizedSchema, filesDir: string) {
     cliCommand: 'nx',
     strict: undefined,
     tmpl: '',
-    offsetFromRoot: rootOffset,
-    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(tree),
+    offsetFromRoot: offsetFromRoot(options.projectRoot),
+    rootTsConfigPath: getRelativePathToRootTsConfig(tree, options.projectRoot),
     buildable: options.buildable === true,
     hasUnitTestRunner: options.unitTestRunner !== 'none',
   });

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -16,6 +16,7 @@ import {
 import { jestProjectGenerator } from '@nrwl/jest';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 import { join } from 'path';
 import { LibraryGeneratorSchema } from '../../utils/schema';
 import { addSwcConfig } from '../../utils/swc/add-swc-config';
@@ -161,6 +162,7 @@ function updateTsConfig(tree: Tree, options: NormalizedSchema) {
 function createFiles(tree: Tree, options: NormalizedSchema, filesDir: string) {
   const { className, name, propertyName } = names(options.name);
 
+  const rootOffset = offsetFromRoot(options.projectRoot);
   generateFiles(tree, filesDir, options.projectRoot, {
     ...options,
     dot: '.',
@@ -171,7 +173,8 @@ function createFiles(tree: Tree, options: NormalizedSchema, filesDir: string) {
     cliCommand: 'nx',
     strict: undefined,
     tmpl: '',
-    offsetFromRoot: offsetFromRoot(options.projectRoot),
+    offsetFromRoot: rootOffset,
+    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(tree),
     buildable: options.buildable === true,
     hasUnitTestRunner: options.unitTestRunner !== 'none',
   });
@@ -318,7 +321,7 @@ function getCaseAwareFileName(options: {
 }
 
 function updateRootTsConfig(host: Tree, options: NormalizedSchema) {
-  updateJson(host, 'tsconfig.base.json', (json) => {
+  updateJson(host, getRootTsConfigPathInTree(host), (json) => {
     const c = json.compilerOptions;
     c.paths = c.paths || {};
     delete c.paths[options.name];

--- a/packages/linter/src/generators/workspace-rules-project/files/tsconfig.json__tmpl__
+++ b/packages/linter/src/generators/workspace-rules-project/files/tsconfig.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "compilerOptions": {
     "module": "commonjs"
   },

--- a/packages/linter/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
+++ b/packages/linter/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
@@ -50,6 +50,22 @@ describe('@nrwl/linter:workspace-rules-project', () => {
     ).toMatchSnapshot();
   });
 
+  it('should extend from root tsconfig.base.json', async () => {
+    await lintWorkspaceRulesProjectGenerator(tree);
+
+    const tsConfig = readJson(tree, 'tools/eslint-rules/tsconfig.json');
+    expect(tsConfig.extends).toBe('../../tsconfig.base.json');
+  });
+
+  it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+    tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+    await lintWorkspaceRulesProjectGenerator(tree);
+
+    const tsConfig = readJson(tree, 'tools/eslint-rules/tsconfig.json');
+    expect(tsConfig.extends).toBe('../../tsconfig.json');
+  });
+
   it('should create a project with a test target', async () => {
     await lintWorkspaceRulesProjectGenerator(tree);
 

--- a/packages/linter/src/generators/workspace-rules-project/workspace-rules-project.ts
+++ b/packages/linter/src/generators/workspace-rules-project/workspace-rules-project.ts
@@ -11,6 +11,7 @@ import {
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { addPropertyToJestConfig, jestProjectGenerator } from '@nrwl/jest';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 import { join } from 'path';
 import { workspaceLintPluginDir } from '../../utils/workspace-lint-rules';
 
@@ -33,9 +34,11 @@ export async function lintWorkspaceRulesProjectGenerator(tree: Tree) {
   });
 
   // Generate the required files
+  const rootOffset = offsetFromRoot(WORKSPACE_PLUGIN_DIR);
   generateFiles(tree, join(__dirname, 'files'), workspaceLintPluginDir, {
     tmpl: '',
-    offsetFromRoot: offsetFromRoot(WORKSPACE_PLUGIN_DIR),
+    offsetFromRoot: rootOffset,
+    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(tree),
   });
 
   /**

--- a/packages/linter/src/generators/workspace-rules-project/workspace-rules-project.ts
+++ b/packages/linter/src/generators/workspace-rules-project/workspace-rules-project.ts
@@ -11,7 +11,7 @@ import {
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { addPropertyToJestConfig, jestProjectGenerator } from '@nrwl/jest';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import { join } from 'path';
 import { workspaceLintPluginDir } from '../../utils/workspace-lint-rules';
 
@@ -34,11 +34,10 @@ export async function lintWorkspaceRulesProjectGenerator(tree: Tree) {
   });
 
   // Generate the required files
-  const rootOffset = offsetFromRoot(WORKSPACE_PLUGIN_DIR);
   generateFiles(tree, join(__dirname, 'files'), workspaceLintPluginDir, {
     tmpl: '',
-    offsetFromRoot: rootOffset,
-    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(tree),
+    offsetFromRoot: offsetFromRoot(WORKSPACE_PLUGIN_DIR),
+    rootTsConfigPath: getRelativePathToRootTsConfig(tree, WORKSPACE_PLUGIN_DIR),
   });
 
   /**

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -61,6 +61,30 @@ describe('app', () => {
       expect(tree.exists('apps/my-app/specs/index.spec.tsx')).toBeTruthy();
       expect(tree.exists('apps/my-app/pages/index.module.css')).toBeTruthy();
     });
+
+    it('should extend from root tsconfig.base.json', async () => {
+      await applicationGenerator(tree, {
+        name: 'myApp',
+        style: 'css',
+        standaloneConfig: false,
+      });
+
+      const tsConfig = readJson(tree, 'apps/my-app/tsconfig.json');
+      expect(tsConfig.extends).toBe('../../tsconfig.base.json');
+    });
+
+    it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await applicationGenerator(tree, {
+        name: 'myApp',
+        style: 'css',
+        standaloneConfig: false,
+      });
+
+      const tsConfig = readJson(tree, 'apps/my-app/tsconfig.json');
+      expect(tsConfig.extends).toBe('../../tsconfig.json');
+    });
   });
 
   describe('--style scss', () => {

--- a/packages/next/src/generators/application/files/tsconfig.json__tmpl__
+++ b/packages/next/src/generators/application/files/tsconfig.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "compilerOptions": {
     "jsx": "preserve",
     <% if (style === '@emotion/styled') { %>"jsxImportSource": "@emotion/react",<% } %>

--- a/packages/next/src/generators/application/lib/create-application-files.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.ts
@@ -4,16 +4,18 @@ import {
   createAppJsx,
   createStyleRules,
 } from './create-application-files.helpers';
-import { generateFiles, names, offsetFromRoot, toJS, Tree } from '@nrwl/devkit';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { generateFiles, names, toJS, Tree } from '@nrwl/devkit';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 
 export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
   const templateVariables = {
     ...names(options.name),
     ...options,
     tmpl: '',
-    rootTsConfigPath:
-      offsetFromRoot(options.appProjectRoot) + getRootTsConfigPathInTree(host),
+    rootTsConfigPath: getRelativePathToRootTsConfig(
+      host,
+      options.appProjectRoot
+    ),
     appContent: createAppJsx(options.name),
     styleContent: createStyleRules(),
     pageStyleContent: `.page {}`,

--- a/packages/next/src/generators/application/lib/create-application-files.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.ts
@@ -5,13 +5,15 @@ import {
   createStyleRules,
 } from './create-application-files.helpers';
 import { generateFiles, names, offsetFromRoot, toJS, Tree } from '@nrwl/devkit';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 
 export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
   const templateVariables = {
     ...names(options.name),
     ...options,
     tmpl: '',
-    offsetFromRoot: offsetFromRoot(options.appProjectRoot),
+    rootTsConfigPath:
+      offsetFromRoot(options.appProjectRoot) + getRootTsConfigPathInTree(host),
     appContent: createAppJsx(options.name),
     styleContent: createStyleRules(),
     pageStyleContent: `.page {}`,

--- a/packages/node/src/executors/webpack/webpack.impl.ts
+++ b/packages/node/src/executors/webpack/webpack.impl.ts
@@ -7,10 +7,11 @@ import {
   checkDependentProjectsHaveBeenBuilt,
   createTmpTsConfig,
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { getRootTsConfigPath } from '@nrwl/workspace/src/utilities/typescript';
 
 import { map, tap } from 'rxjs/operators';
 import { eachValueFrom } from 'rxjs-for-await';
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 import { register } from 'ts-node';
 
 import { getNodeWebpackConfig } from '../../utils/node.config';
@@ -18,9 +19,6 @@ import { BuildNodeBuilderOptions } from '../../utils/types';
 import { normalizeBuildOptions } from '../../utils/normalize';
 import { generatePackageJson } from '../../utils/generate-package-json';
 import { runWebpack } from '../../utils/run-webpack';
-
-import { existsSync } from 'fs';
-import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 
 export type NodeBuildEvent = {
   outfile: string;
@@ -110,9 +108,9 @@ export async function* webpackExecutor(
 }
 
 function registerTsNode() {
-  const rootTsConfig = join(appRootPath, 'tsconfig.base.json');
+  const rootTsConfig = getRootTsConfigPath();
   register({
-    ...(existsSync(rootTsConfig) ? { project: rootTsConfig } : null),
+    ...(rootTsConfig ? { project: rootTsConfig } : null),
   });
 }
 

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -165,6 +165,18 @@ describe('app', () => {
         }
       `);
     });
+
+    it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await applicationGenerator(tree, {
+        name: 'myNodeApp',
+        standaloneConfig: false,
+      });
+
+      const tsconfig = readJson(tree, 'apps/my-node-app/tsconfig.json');
+      expect(tsconfig.extends).toBe('../../tsconfig.json');
+    });
   });
 
   describe('nested', () => {

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -28,7 +28,7 @@ import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-ser
 
 import { Schema } from './schema';
 import { initGenerator } from '../init/init';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 
 export interface NormalizedSchema extends Schema {
   appProjectRoot: string;
@@ -109,13 +109,15 @@ function addProject(tree: Tree, options: NormalizedSchema) {
 }
 
 function addAppFiles(tree: Tree, options: NormalizedSchema) {
-  const offset = offsetFromRoot(options.appProjectRoot);
   generateFiles(tree, join(__dirname, './files/app'), options.appProjectRoot, {
     tmpl: '',
     name: options.name,
     root: options.appProjectRoot,
-    offset,
-    rootTsConfigPath: offset + getRootTsConfigPathInTree(tree),
+    offset: offsetFromRoot(options.appProjectRoot),
+    rootTsConfigPath: getRelativePathToRootTsConfig(
+      tree,
+      options.appProjectRoot
+    ),
   });
   if (options.js) {
     toJS(tree);

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -28,6 +28,7 @@ import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-ser
 
 import { Schema } from './schema';
 import { initGenerator } from '../init/init';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 
 export interface NormalizedSchema extends Schema {
   appProjectRoot: string;
@@ -108,11 +109,13 @@ function addProject(tree: Tree, options: NormalizedSchema) {
 }
 
 function addAppFiles(tree: Tree, options: NormalizedSchema) {
+  const offset = offsetFromRoot(options.appProjectRoot);
   generateFiles(tree, join(__dirname, './files/app'), options.appProjectRoot, {
     tmpl: '',
     name: options.name,
     root: options.appProjectRoot,
-    offset: offsetFromRoot(options.appProjectRoot),
+    offset,
+    rootTsConfigPath: offset + getRootTsConfigPathInTree(tree),
   });
   if (options.js) {
     toJS(tree);

--- a/packages/node/src/generators/application/files/app/tsconfig.json
+++ b/packages/node/src/generators/application/files/app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offset %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "files": [],
   "include": [],
   "references": [

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
@@ -54,6 +54,32 @@ describe('NxPlugin e2e-project Generator', () => {
     ).toBeTruthy();
   });
 
+  it('should extend from root tsconfig.base.json', async () => {
+    await e2eProjectGenerator(tree, {
+      pluginName: 'my-plugin',
+      pluginOutputPath: `dist/libs/my-plugin`,
+      npmPackageName: '@proj/my-plugin',
+      standaloneConfig: false,
+    });
+
+    const tsConfig = readJson(tree, 'apps/my-plugin-e2e/tsconfig.json');
+    expect(tsConfig.extends).toEqual('../../tsconfig.base.json');
+  });
+
+  it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+    tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+    await e2eProjectGenerator(tree, {
+      pluginName: 'my-plugin',
+      pluginOutputPath: `dist/libs/my-plugin`,
+      npmPackageName: '@proj/my-plugin',
+      standaloneConfig: false,
+    });
+
+    const tsConfig = readJson(tree, 'apps/my-plugin-e2e/tsconfig.json');
+    expect(tsConfig.extends).toEqual('../../tsconfig.json');
+  });
+
   it('should set project root with the directory option', async () => {
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.ts
@@ -13,6 +13,7 @@ import type { Tree } from '@nrwl/devkit';
 import type { Schema } from './schema';
 import * as path from 'path';
 import { jestProjectGenerator } from '@nrwl/jest';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 
 interface NormalizedSchema extends Schema {
   projectRoot: string;
@@ -51,7 +52,8 @@ function addFiles(host: Tree, options: NormalizedSchema) {
   generateFiles(host, path.join(__dirname, './files'), options.projectRoot, {
     ...options,
     tmpl: '',
-    offsetFromRoot: offsetFromRoot(options.projectRoot),
+    rootTsConfigPath:
+      offsetFromRoot(options.projectRoot) + getRootTsConfigPathInTree(host),
   });
 }
 

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.ts
@@ -7,13 +7,12 @@ import {
   generateFiles,
   addProjectConfiguration,
   updateProjectConfiguration,
-  offsetFromRoot,
 } from '@nrwl/devkit';
 import type { Tree } from '@nrwl/devkit';
 import type { Schema } from './schema';
 import * as path from 'path';
 import { jestProjectGenerator } from '@nrwl/jest';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 
 interface NormalizedSchema extends Schema {
   projectRoot: string;
@@ -52,8 +51,7 @@ function addFiles(host: Tree, options: NormalizedSchema) {
   generateFiles(host, path.join(__dirname, './files'), options.projectRoot, {
     ...options,
     tmpl: '',
-    rootTsConfigPath:
-      offsetFromRoot(options.projectRoot) + getRootTsConfigPathInTree(host),
+    rootTsConfigPath: getRelativePathToRootTsConfig(host, options.projectRoot),
   });
 }
 

--- a/packages/nx-plugin/src/generators/e2e-project/files/tsconfig.json__tmpl__
+++ b/packages/nx-plugin/src/generators/e2e-project/files/tsconfig.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "files": [],
   "include": [],
   "references": [

--- a/packages/react-native/src/generators/application/application.spec.ts
+++ b/packages/react-native/src/generators/application/application.spec.ts
@@ -62,4 +62,18 @@ describe('app', () => {
 
     expect(appTree.exists('apps/my-app/.eslintrc.json')).toBe(true);
   });
+
+  it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+    appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+    await reactNativeApplicationGenerator(appTree, {
+      name: 'myApp',
+      displayName: 'myApp',
+      linter: Linter.EsLint,
+      e2eTestRunner: 'none',
+    });
+
+    const tsconfig = readJson(appTree, 'apps/my-app/tsconfig.json');
+    expect(tsconfig.extends).toEqual('../../tsconfig.json');
+  });
 });

--- a/packages/react-native/src/generators/application/files/app/tsconfig.json.template
+++ b/packages/react-native/src/generators/application/files/app/tsconfig.json.template
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "jsx": "react-native",

--- a/packages/react-native/src/generators/application/lib/create-application-files.ts
+++ b/packages/react-native/src/generators/application/lib/create-application-files.ts
@@ -1,14 +1,16 @@
 import { generateFiles, offsetFromRoot, toJS, Tree } from '@nrwl/devkit';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import { join } from 'path';
 import { NormalizedSchema } from './normalize-options';
 
 export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
-  const rootOffset = offsetFromRoot(options.appProjectRoot);
   generateFiles(host, join(__dirname, '../files/app'), options.appProjectRoot, {
     ...options,
-    offsetFromRoot: rootOffset,
-    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(host),
+    offsetFromRoot: offsetFromRoot(options.appProjectRoot),
+    rootTsConfigPath: getRelativePathToRootTsConfig(
+      host,
+      options.appProjectRoot
+    ),
   });
   if (options.unitTestRunner === 'none') {
     host.delete(join(options.appProjectRoot, `/src/app/App.spec.tsx`));

--- a/packages/react-native/src/generators/application/lib/create-application-files.ts
+++ b/packages/react-native/src/generators/application/lib/create-application-files.ts
@@ -1,11 +1,14 @@
 import { generateFiles, offsetFromRoot, toJS, Tree } from '@nrwl/devkit';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 import { join } from 'path';
 import { NormalizedSchema } from './normalize-options';
 
 export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
+  const rootOffset = offsetFromRoot(options.appProjectRoot);
   generateFiles(host, join(__dirname, '../files/app'), options.appProjectRoot, {
     ...options,
-    offsetFromRoot: offsetFromRoot(options.appProjectRoot),
+    offsetFromRoot: rootOffset,
+    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(host),
   });
   if (options.unitTestRunner === 'none') {
     host.delete(join(options.appProjectRoot, `/src/app/App.spec.tsx`));

--- a/packages/react-native/src/generators/library/files/lib/tsconfig.json__tmpl__
+++ b/packages/react-native/src/generators/library/files/lib/tsconfig.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "compilerOptions": {
     "jsx": "react-jsx",
     "allowJs": true,

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -37,9 +37,20 @@ describe('lib', () => {
       expect(workspaceJson.projects['my-lib'].tags).toEqual(['one', 'two']);
     });
 
-    it('should update tsconfig.base.json', async () => {
+    it('should update root tsconfig.base.json', async () => {
       await libraryGenerator(appTree, defaultSchema);
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
+      expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
+        'libs/my-lib/src/index.ts',
+      ]);
+    });
+
+    it('should update root tsconfig.json when no tsconfig.base.json', async () => {
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await libraryGenerator(appTree, defaultSchema);
+
+      const tsconfigJson = readJson(appTree, '/tsconfig.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
         'libs/my-lib/src/index.ts',
       ]);
@@ -60,7 +71,9 @@ describe('lib', () => {
 
     it('should create a local tsconfig.json', async () => {
       await libraryGenerator(appTree, defaultSchema);
+
       const tsconfigJson = readJson(appTree, 'libs/my-lib/tsconfig.json');
+      expect(tsconfigJson.extends).toBe('../../tsconfig.base.json');
       expect(tsconfigJson.references).toEqual([
         {
           path: './tsconfig.lib.json',
@@ -77,6 +90,15 @@ describe('lib', () => {
       expect(tsconfigJson.compilerOptions.noFallthroughCasesInSwitch).toEqual(
         true
       );
+    });
+
+    it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await libraryGenerator(appTree, defaultSchema);
+
+      const tsconfigJson = readJson(appTree, 'libs/my-lib/tsconfig.json');
+      expect(tsconfigJson.extends).toBe('../../tsconfig.json');
     });
 
     it('should extend the local tsconfig.json with tsconfig.spec.json', async () => {
@@ -140,9 +162,23 @@ describe('lib', () => {
       });
     });
 
-    it('should update tsconfig.base.json', async () => {
+    it('should update root tsconfig.base.json', async () => {
       await libraryGenerator(appTree, { ...defaultSchema, directory: 'myDir' });
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
+      expect(tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']).toEqual(
+        ['libs/my-dir/my-lib/src/index.ts']
+      );
+      expect(
+        tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']
+      ).toBeUndefined();
+    });
+
+    it('should update root tsconfig.json when no tsconfig.base.json', async () => {
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await libraryGenerator(appTree, { ...defaultSchema, directory: 'myDir' });
+
+      const tsconfigJson = readJson(appTree, '/tsconfig.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']).toEqual(
         ['libs/my-dir/my-lib/src/index.ts']
       );
@@ -158,6 +194,7 @@ describe('lib', () => {
         appTree,
         'libs/my-dir/my-lib/tsconfig.json'
       );
+      expect(tsconfigJson.extends).toBe('../../../tsconfig.base.json');
       expect(tsconfigJson.references).toEqual([
         {
           path: './tsconfig.lib.json',
@@ -166,6 +203,18 @@ describe('lib', () => {
           path: './tsconfig.spec.json',
         },
       ]);
+    });
+
+    it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await libraryGenerator(appTree, { ...defaultSchema, directory: 'myDir' });
+
+      const tsconfigJson = readJson(
+        appTree,
+        'libs/my-dir/my-lib/tsconfig.json'
+      );
+      expect(tsconfigJson.extends).toBe('../../../tsconfig.json');
     });
   });
 

--- a/packages/react-native/src/generators/library/library.ts
+++ b/packages/react-native/src/generators/library/library.ts
@@ -19,6 +19,7 @@ import { addLinting } from '../../utils/add-linting';
 import { addJest } from '../../utils/add-jest';
 import { NormalizedSchema, normalizeOptions } from './lib/normalize-options';
 import { Schema } from './schema';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 
 export async function reactNativeLibraryGenerator(
   host: Tree,
@@ -130,7 +131,7 @@ function updateTsConfig(tree: Tree, options: NormalizedSchema) {
 }
 
 function updateBaseTsConfig(host: Tree, options: NormalizedSchema) {
-  updateJson(host, 'tsconfig.base.json', (json) => {
+  updateJson(host, getRootTsConfigPathInTree(host), (json) => {
     const c = json.compilerOptions;
     c.paths = c.paths || {};
     delete c.paths[options.name];
@@ -155,6 +156,7 @@ function updateBaseTsConfig(host: Tree, options: NormalizedSchema) {
 }
 
 function createFiles(host: Tree, options: NormalizedSchema) {
+  const rootOffset = offsetFromRoot(options.projectRoot);
   generateFiles(
     host,
     joinPathFragments(__dirname, './files/lib'),
@@ -163,7 +165,8 @@ function createFiles(host: Tree, options: NormalizedSchema) {
       ...options,
       ...names(options.name),
       tmpl: '',
-      offsetFromRoot: offsetFromRoot(options.projectRoot),
+      offsetFromRoot: rootOffset,
+      rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(host),
     }
   );
 

--- a/packages/react-native/src/generators/library/library.ts
+++ b/packages/react-native/src/generators/library/library.ts
@@ -19,7 +19,10 @@ import { addLinting } from '../../utils/add-linting';
 import { addJest } from '../../utils/add-jest';
 import { NormalizedSchema, normalizeOptions } from './lib/normalize-options';
 import { Schema } from './schema';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import {
+  getRelativePathToRootTsConfig,
+  getRootTsConfigPathInTree,
+} from '@nrwl/workspace/src/utilities/typescript';
 
 export async function reactNativeLibraryGenerator(
   host: Tree,
@@ -156,7 +159,6 @@ function updateBaseTsConfig(host: Tree, options: NormalizedSchema) {
 }
 
 function createFiles(host: Tree, options: NormalizedSchema) {
-  const rootOffset = offsetFromRoot(options.projectRoot);
   generateFiles(
     host,
     joinPathFragments(__dirname, './files/lib'),
@@ -165,8 +167,11 @@ function createFiles(host: Tree, options: NormalizedSchema) {
       ...options,
       ...names(options.name),
       tmpl: '',
-      offsetFromRoot: rootOffset,
-      rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(host),
+      offsetFromRoot: offsetFromRoot(options.projectRoot),
+      rootTsConfigPath: getRelativePathToRootTsConfig(
+        host,
+        options.projectRoot
+      ),
     }
   );
 

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -128,6 +128,22 @@ Object {
 }
 `);
     });
+
+    it('should extend from root tsconfig.base.json', async () => {
+      await applicationGenerator(appTree, schema);
+
+      const tsConfig = readJson(appTree, 'apps/my-app/tsconfig.json');
+      expect(tsConfig.extends).toEqual('../../tsconfig.base.json');
+    });
+
+    it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await applicationGenerator(appTree, schema);
+
+      const tsConfig = readJson(appTree, 'apps/my-app/tsconfig.json');
+      expect(tsConfig.extends).toEqual('../../tsconfig.json');
+    });
   });
 
   describe('nested', () => {

--- a/packages/react/src/generators/application/files/common/tsconfig.json__tmpl__
+++ b/packages/react/src/generators/application/files/common/tsconfig.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "compilerOptions": {
     "jsx": "react-jsx",
     <% if (style === '@emotion/styled') { %>"jsxImportSource": "@emotion/react",<% } %>

--- a/packages/react/src/generators/application/lib/create-application-files.ts
+++ b/packages/react/src/generators/application/lib/create-application-files.ts
@@ -9,6 +9,7 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 import { join } from 'path';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 
 function updateTsConfig(host: Tree, options: NormalizedSchema) {
   updateJson(
@@ -46,11 +47,13 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
     styleSolutionSpecificAppFiles = '../files/css-module';
   }
 
+  const rootOffset = offsetFromRoot(options.appProjectRoot);
   const templateVariables = {
     ...names(options.name),
     ...options,
     tmpl: '',
-    offsetFromRoot: offsetFromRoot(options.appProjectRoot),
+    offsetFromRoot: rootOffset,
+    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(host),
   };
 
   generateFiles(

--- a/packages/react/src/generators/application/lib/create-application-files.ts
+++ b/packages/react/src/generators/application/lib/create-application-files.ts
@@ -9,7 +9,7 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 import { join } from 'path';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 
 function updateTsConfig(host: Tree, options: NormalizedSchema) {
   updateJson(
@@ -47,13 +47,15 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
     styleSolutionSpecificAppFiles = '../files/css-module';
   }
 
-  const rootOffset = offsetFromRoot(options.appProjectRoot);
   const templateVariables = {
     ...names(options.name),
     ...options,
     tmpl: '',
-    offsetFromRoot: rootOffset,
-    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(host),
+    offsetFromRoot: offsetFromRoot(options.appProjectRoot),
+    rootTsConfigPath: getRelativePathToRootTsConfig(
+      host,
+      options.appProjectRoot
+    ),
   };
 
   generateFiles(

--- a/packages/react/src/generators/library/files/lib/tsconfig.json__tmpl__
+++ b/packages/react/src/generators/library/files/lib/tsconfig.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "compilerOptions": {
     "jsx": "react-jsx",
     <% if (style === '@emotion/styled') { %>"jsxImportSource": "@emotion/react",<% } %>

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -68,9 +68,20 @@ describe('lib', () => {
       });
     });
 
-    it('should update tsconfig.base.json', async () => {
+    it('should update root tsconfig.base.json', async () => {
       await libraryGenerator(appTree, defaultSchema);
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
+      expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
+        'libs/my-lib/src/index.ts',
+      ]);
+    });
+
+    it('should update root tsconfig.json when no tsconfig.base.json', async () => {
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await libraryGenerator(appTree, defaultSchema);
+
+      const tsconfigJson = readJson(appTree, '/tsconfig.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
         'libs/my-lib/src/index.ts',
       ]);
@@ -91,7 +102,9 @@ describe('lib', () => {
 
     it('should create a local tsconfig.json', async () => {
       await libraryGenerator(appTree, defaultSchema);
+
       const tsconfigJson = readJson(appTree, 'libs/my-lib/tsconfig.json');
+      expect(tsconfigJson.extends).toBe('../../tsconfig.base.json');
       expect(tsconfigJson.references).toEqual([
         {
           path: './tsconfig.lib.json',
@@ -112,6 +125,15 @@ describe('lib', () => {
       expect(tsconfigJson.compilerOptions.noFallthroughCasesInSwitch).toEqual(
         true
       );
+    });
+
+    it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await libraryGenerator(appTree, defaultSchema);
+
+      const tsconfigJson = readJson(appTree, 'libs/my-lib/tsconfig.json');
+      expect(tsconfigJson.extends).toBe('../../tsconfig.json');
     });
 
     it('should extend the local tsconfig.json with tsconfig.spec.json', async () => {
@@ -254,9 +276,23 @@ describe('lib', () => {
       });
     });
 
-    it('should update tsconfig.base.json', async () => {
+    it('should update root tsconfig.base.json', async () => {
       await libraryGenerator(appTree, { ...defaultSchema, directory: 'myDir' });
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
+      expect(tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']).toEqual(
+        ['libs/my-dir/my-lib/src/index.ts']
+      );
+      expect(
+        tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']
+      ).toBeUndefined();
+    });
+
+    it('should update root tsconfig.json when no tsconfig.base.json', async () => {
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await libraryGenerator(appTree, { ...defaultSchema, directory: 'myDir' });
+
+      const tsconfigJson = readJson(appTree, '/tsconfig.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']).toEqual(
         ['libs/my-dir/my-lib/src/index.ts']
       );
@@ -272,6 +308,7 @@ describe('lib', () => {
         appTree,
         'libs/my-dir/my-lib/tsconfig.json'
       );
+      expect(tsconfigJson.extends).toBe('../../../tsconfig.base.json');
       expect(tsconfigJson.references).toEqual([
         {
           path: './tsconfig.lib.json',
@@ -280,6 +317,18 @@ describe('lib', () => {
           path: './tsconfig.spec.json',
         },
       ]);
+    });
+
+    it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+      appTree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await libraryGenerator(appTree, { ...defaultSchema, directory: 'myDir' });
+
+      const tsconfigJson = readJson(
+        appTree,
+        'libs/my-dir/my-lib/tsconfig.json'
+      );
+      expect(tsconfigJson.extends).toBe('../../../tsconfig.json');
     });
   });
 

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -20,6 +20,7 @@ import { jestProjectGenerator } from '@nrwl/jest';
 import { swcCoreVersion } from '@nrwl/js/src/utils/versions';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 import * as ts from 'typescript';
 import { assertValidStyle } from '../../utils/assertion';
 import {
@@ -239,7 +240,7 @@ function updateTsConfig(tree: Tree, options: NormalizedSchema) {
 }
 
 function updateBaseTsConfig(host: Tree, options: NormalizedSchema) {
-  updateJson(host, 'tsconfig.base.json', (json) => {
+  updateJson(host, getRootTsConfigPathInTree(host), (json) => {
     const c = json.compilerOptions;
     c.paths = c.paths || {};
     delete c.paths[options.name];
@@ -264,6 +265,7 @@ function updateBaseTsConfig(host: Tree, options: NormalizedSchema) {
 }
 
 function createFiles(host: Tree, options: NormalizedSchema) {
+  const rootOffset = offsetFromRoot(options.projectRoot);
   generateFiles(
     host,
     joinPathFragments(__dirname, './files/lib'),
@@ -272,7 +274,8 @@ function createFiles(host: Tree, options: NormalizedSchema) {
       ...options,
       ...names(options.name),
       tmpl: '',
-      offsetFromRoot: offsetFromRoot(options.projectRoot),
+      offsetFromRoot: rootOffset,
+      rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(host),
     }
   );
 

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -20,7 +20,10 @@ import { jestProjectGenerator } from '@nrwl/jest';
 import { swcCoreVersion } from '@nrwl/js/src/utils/versions';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import {
+  getRelativePathToRootTsConfig,
+  getRootTsConfigPathInTree,
+} from '@nrwl/workspace/src/utilities/typescript';
 import * as ts from 'typescript';
 import { assertValidStyle } from '../../utils/assertion';
 import {
@@ -265,7 +268,6 @@ function updateBaseTsConfig(host: Tree, options: NormalizedSchema) {
 }
 
 function createFiles(host: Tree, options: NormalizedSchema) {
-  const rootOffset = offsetFromRoot(options.projectRoot);
   generateFiles(
     host,
     joinPathFragments(__dirname, './files/lib'),
@@ -274,8 +276,11 @@ function createFiles(host: Tree, options: NormalizedSchema) {
       ...options,
       ...names(options.name),
       tmpl: '',
-      offsetFromRoot: rootOffset,
-      rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(host),
+      offsetFromRoot: offsetFromRoot(options.projectRoot),
+      rootTsConfigPath: getRelativePathToRootTsConfig(
+        host,
+        options.projectRoot
+      ),
     }
   );
 

--- a/packages/react/src/generators/redux/redux.ts
+++ b/packages/react/src/generators/redux/redux.ts
@@ -20,6 +20,7 @@ import {
   toJS,
   Tree,
 } from '@nrwl/devkit';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 
 export async function reduxGenerator(host: Tree, schema: Schema) {
   const options = normalizeOptions(host, schema);
@@ -139,7 +140,7 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   const project = projects.get(options.project);
   const { sourceRoot, projectType } = project;
 
-  const tsConfigJson = readJson(host, 'tsconfig.base.json');
+  const tsConfigJson = readJson(host, getRootTsConfigPathInTree(host));
   const tsPaths: { [module: string]: string[] } = tsConfigJson.compilerOptions
     ? tsConfigJson.compilerOptions.paths || {}
     : {};

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -44,6 +44,7 @@ describe('@nrwl/storybook:configuration', () => {
       tree,
       '.storybook/tsconfig.json'
     );
+    expect(rootStorybookTsconfigJson.extends).toBe('../tsconfig.base.json');
     expect(rootStorybookTsconfigJson.exclude).toEqual([
       '../**/*.spec.js',
       '../**/*.test.js',
@@ -79,6 +80,22 @@ describe('@nrwl/storybook:configuration', () => {
     expect(
       storybookTsconfigJson.exclude.includes('../**/*.spec.jsx')
     ).toBeFalsy();
+  });
+
+  it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+    tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+    await configurationGenerator(tree, {
+      name: 'test-ui-lib',
+      uiFramework: '@storybook/angular',
+      standaloneConfig: false,
+    });
+
+    const rootStorybookTsconfigJson = readJson<TsConfig>(
+      tree,
+      '.storybook/tsconfig.json'
+    );
+    expect(rootStorybookTsconfigJson.extends).toBe('../tsconfig.json');
   });
 
   it('should generate a webpackFinal into the main.js and reference a potential global webpackFinal definition', async () => {

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -30,6 +30,7 @@ import { initGenerator } from '../init/init';
 import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
 import { gte } from 'semver';
 import { findStorybookAndBuildTargets } from '../../executors/utils';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 
 export async function configurationGenerator(
   tree: Tree,
@@ -115,7 +116,9 @@ function createRootStorybookDir(
     __dirname,
     workspaceStorybookVersion === '6' ? './root-files' : './root-files-5'
   );
-  generateFiles(tree, templatePath, '', {});
+  generateFiles(tree, templatePath, '', {
+    rootTsConfigPath: getRootTsConfigPathInTree(tree),
+  });
 
   if (js) {
     toJS(tree);
@@ -160,6 +163,7 @@ function createProjectStorybookDir(
     tmpl: '',
     uiFramework,
     offsetFromRoot: offsetFromRoot(root),
+    rootTsConfigPath: getRootTsConfigPathInTree(tree),
     projectType: projectDirectory,
     useWebpack5:
       uiFramework === '@storybook/angular' ||

--- a/packages/storybook/src/generators/configuration/project-files-5/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-5/.storybook/tsconfig.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>../tsconfig.base.json",
+  "extends": "<%= offsetFromRoot %>../<%= rootTsConfigPath %>",
   "compilerOptions": {
     "emitDecoratorMetadata": true
   },

--- a/packages/storybook/src/generators/configuration/project-files-5/.storybook/webpack.config.js__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-5/.storybook/webpack.config.js__tmpl__
@@ -9,7 +9,7 @@ module.exports = async ({ config, mode }) => {
   config = await rootWebpackConfig({ config, mode });
 
   const tsPaths = new TsconfigPathsPlugin({
-    configFile: './tsconfig.base.json',
+    configFile: './<%= rootTsConfigPath %>',
    });
 
   config.resolve.plugins

--- a/packages/storybook/src/generators/configuration/root-files-5/.storybook/tsconfig.json
+++ b/packages/storybook/src/generators/configuration/root-files-5/.storybook/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../<%= rootTsConfigPath %>",
   "exclude": [
     "../**/*.spec.js",
     "../**/*.test.js",

--- a/packages/storybook/src/generators/configuration/root-files/.storybook/tsconfig.json
+++ b/packages/storybook/src/generators/configuration/root-files/.storybook/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../<%= rootTsConfigPath %>",
   "exclude": [
     "../**/*.spec.js",
     "../**/*.test.js",

--- a/packages/storybook/src/generators/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
+++ b/packages/storybook/src/generators/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
@@ -16,6 +16,7 @@ import { StorybookMigrateDefault5to6Schema } from './schema';
 import { storybookVersion } from '../../utils/versions';
 import { join } from 'path';
 import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 
 export function migrateDefaultsGenerator(
   tree: Tree,
@@ -239,6 +240,7 @@ function migrateProjectLevelStorybookInstance(
       tmpl: '',
       uiFramework,
       offsetFromRoot: offsetFromRoot(root),
+      rootTsConfigPath: getRootTsConfigPathInTree(tree),
       projectType: projectDirectory,
       useWebpack5: uiFramework === '@storybook/angular',
       existsRootWebpackConfig: tree.exists('.storybook/webpack.config.js'),
@@ -263,7 +265,7 @@ function migrateRootLevelStorybookInstance(tree: Tree, keepOld: boolean) {
     tree,
     join(__dirname, '../configuration/root-files/.storybook'),
     '.storybook',
-    {}
+    { rootTsConfigPath: getRootTsConfigPathInTree(tree) }
   );
 }
 

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -59,6 +59,7 @@ describe('app', () => {
       expect(tree.exists('apps/my-app/src/app/app.element.css')).toBeTruthy();
 
       const tsconfig = readJson(tree, 'apps/my-app/tsconfig.json');
+      expect(tsconfig.extends).toBe('../../tsconfig.base.json');
       expect(tsconfig.references).toEqual([
         {
           path: './tsconfig.app.json',
@@ -129,6 +130,18 @@ describe('app', () => {
           ],
         }
       `);
+    });
+
+    it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await applicationGenerator(tree, {
+        name: 'myApp',
+        standaloneConfig: false,
+      });
+
+      const tsconfig = readJson(tree, 'apps/my-app/tsconfig.json');
+      expect(tsconfig.extends).toBe('../../tsconfig.json');
     });
   });
 
@@ -208,6 +221,30 @@ describe('app', () => {
           expectedValue: ['../../../.eslintrc.json'],
         },
       ].forEach(hasJsonValue);
+    });
+
+    it('should extend from root tsconfig.base.json', async () => {
+      await applicationGenerator(tree, {
+        name: 'myApp',
+        directory: 'myDir',
+        standaloneConfig: false,
+      });
+
+      const tsconfig = readJson(tree, 'apps/my-dir/my-app/tsconfig.json');
+      expect(tsconfig.extends).toBe('../../../tsconfig.base.json');
+    });
+
+    it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await applicationGenerator(tree, {
+        name: 'myApp',
+        directory: 'myDir',
+        standaloneConfig: false,
+      });
+
+      const tsconfig = readJson(tree, 'apps/my-dir/my-app/tsconfig.json');
+      expect(tsconfig.extends).toBe('../../../tsconfig.json');
     });
 
     it('should create Nx specific template', async () => {

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -20,6 +20,7 @@ import { jestProjectGenerator } from '@nrwl/jest';
 import { swcCoreVersion } from '@nrwl/js/src/utils/versions';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 
 import { join } from 'path';
 
@@ -38,11 +39,13 @@ interface NormalizedSchema extends Schema {
 }
 
 function createApplicationFiles(tree: Tree, options: NormalizedSchema) {
+  const rootOffset = offsetFromRoot(options.appProjectRoot);
   generateFiles(tree, join(__dirname, './files/app'), options.appProjectRoot, {
     ...options,
     ...names(options.name),
     tmpl: '',
-    offsetFromRoot: offsetFromRoot(options.appProjectRoot),
+    offsetFromRoot: rootOffset,
+    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(tree),
   });
   if (options.unitTestRunner === 'none') {
     tree.delete(join(options.appProjectRoot, './src/app/app.element.spec.ts'));

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -20,7 +20,7 @@ import { jestProjectGenerator } from '@nrwl/jest';
 import { swcCoreVersion } from '@nrwl/js/src/utils/versions';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
-import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 
 import { join } from 'path';
 
@@ -39,13 +39,15 @@ interface NormalizedSchema extends Schema {
 }
 
 function createApplicationFiles(tree: Tree, options: NormalizedSchema) {
-  const rootOffset = offsetFromRoot(options.appProjectRoot);
   generateFiles(tree, join(__dirname, './files/app'), options.appProjectRoot, {
     ...options,
     ...names(options.name),
     tmpl: '',
-    offsetFromRoot: rootOffset,
-    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(tree),
+    offsetFromRoot: offsetFromRoot(options.appProjectRoot),
+    rootTsConfigPath: getRelativePathToRootTsConfig(
+      tree,
+      options.appProjectRoot
+    ),
   });
   if (options.unitTestRunner === 'none') {
     tree.delete(join(options.appProjectRoot, './src/app/app.element.spec.ts'));

--- a/packages/web/src/generators/application/files/app/tsconfig.json
+++ b/packages/web/src/generators/application/files/app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= rootTsConfigPath %>",
   "files": [],
   "include": [],
   "references": [

--- a/packages/workspace/src/command-line/format.ts
+++ b/packages/workspace/src/command-line/format.ts
@@ -21,6 +21,10 @@ import {
   writeJsonFile,
 } from '@nrwl/devkit';
 import { sortObjectByKeys } from '@nrwl/tao/src/utils/object-sort';
+import {
+  getRootTsConfigFileName,
+  getRootTsConfigPath,
+} from '../utilities/typescript';
 
 const PRETTIER_PATH = require.resolve('prettier/bin-prettier');
 
@@ -121,7 +125,9 @@ function addRootConfigFiles(
   if (workspaceJsonPath) {
     addToChunkIfNeeded(workspaceJsonPath);
   }
-  ['nx.json', 'tsconfig.base.json'].forEach(addToChunkIfNeeded);
+  ['nx.json', getRootTsConfigFileName()]
+    .filter(Boolean)
+    .forEach(addToChunkIfNeeded);
 
   if (chunk.length > 0) {
     chunkList.push(chunk);
@@ -190,7 +196,7 @@ function sortWorkspaceJson(workspaceJsonPath: string) {
 
 function sortTsConfig() {
   try {
-    const tsconfigPath = path.join(appRootPath, 'tsconfig.base.json');
+    const tsconfigPath = getRootTsConfigPath();
     const tsconfig = readJsonFile(tsconfigPath);
     const sortedPaths = sortObjectByKeys(tsconfig.compilerOptions.paths);
     tsconfig.compilerOptions.paths = sortedPaths;

--- a/packages/workspace/src/core/affected-project-graph/locators/tsconfig-json-changes.spec.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/tsconfig-json-changes.spec.ts
@@ -2,6 +2,7 @@ import { WholeFileChange } from '../../file-utils';
 import { jsonDiff } from '../../../utilities/json-diff';
 import { getTouchedProjectsFromTsConfig } from './tsconfig-json-changes';
 import { DependencyType, ProjectGraph } from '../../project-graph';
+import * as tsUtils from '../../../utilities/typescript';
 
 describe('getTouchedProjectsFromTsConfig', () => {
   let graph: ProjectGraph;
@@ -40,6 +41,13 @@ describe('getTouchedProjectsFromTsConfig', () => {
 
   ['tsconfig.json', 'tsconfig.base.json'].forEach((tsConfig) => {
     describe(`(${tsConfig})`, () => {
+      beforeEach(() => {
+        jest
+          .spyOn(tsUtils, 'getRootTsConfigFileName')
+          .mockReturnValue(tsConfig);
+        jest.clearAllMocks();
+      });
+
       it(`should not return changes when ${tsConfig} is not touched`, () => {
         const result = getTouchedProjectsFromTsConfig(
           [

--- a/packages/workspace/src/core/affected-project-graph/locators/tsconfig-json-changes.ts
+++ b/packages/workspace/src/core/affected-project-graph/locators/tsconfig-json-changes.ts
@@ -4,15 +4,19 @@ import {
   isJsonChange,
   JsonChange,
 } from '../../../utilities/json-diff';
+import { getRootTsConfigFileName } from '../../../utilities/typescript';
 import { TouchedProjectLocator } from '../affected-project-graph-models';
 import { ProjectGraphProjectNode } from '../../project-graph';
 
 export const getTouchedProjectsFromTsConfig: TouchedProjectLocator<
   WholeFileChange | JsonChange
 > = (touchedFiles, _a, _b, _c, graph): string[] => {
+  const rootTsConfig = getRootTsConfigFileName();
+  if (!rootTsConfig) {
+    return [];
+  }
   const tsConfigJsonChanges = touchedFiles.find(
-    (change) =>
-      change.file === 'tsconfig.json' || change.file === 'tsconfig.base.json'
+    (change) => change.file === rootTsConfig
   );
   if (!tsConfigJsonChanges) {
     return [];

--- a/packages/workspace/src/core/hasher/hasher.spec.ts
+++ b/packages/workspace/src/core/hasher/hasher.spec.ts
@@ -6,14 +6,16 @@ jest.doMock('../../utils/app-root', () => {
 });
 
 import fs = require('fs');
+import tsUtils = require('../../utilities/typescript');
 import { DependencyType } from '@nrwl/devkit';
 import { Hasher } from './hasher';
 
 jest.mock('fs');
+jest.mock('../../utilities/typescript');
 
 fs.existsSync = () => true;
 
-fdescribe('Hasher', () => {
+describe('Hasher', () => {
   const nxJson = {
     npmScope: 'nrwl',
   };
@@ -65,6 +67,8 @@ fdescribe('Hasher', () => {
       }
       return file;
     };
+
+    tsUtils.getRootTsConfigFileName = () => 'tsconfig.base.json';
   });
 
   it('should create project hash', async () => {

--- a/packages/workspace/src/core/hasher/hasher.ts
+++ b/packages/workspace/src/core/hasher/hasher.ts
@@ -11,6 +11,7 @@ import { existsSync } from 'fs';
 import * as minimatch from 'minimatch';
 import { join } from 'path';
 import { performance } from 'perf_hooks';
+import { getRootTsConfigFileName } from '../../utilities/typescript';
 import { appRootPath } from '../../utils/app-root';
 import { workspaceFileName } from '../file-utils';
 import { defaultHashing, HashingImpl } from './hashing-impl';
@@ -412,7 +413,7 @@ class ProjectHasher {
 
   private readTsConfig() {
     try {
-      const res = readJsonFile('tsconfig.base.json');
+      const res = readJsonFile(getRootTsConfigFileName());
       res.compilerOptions.paths ??= {};
       return res;
     } catch {

--- a/packages/workspace/src/core/project-graph/build-project-graph.ts
+++ b/packages/workspace/src/core/project-graph/build-project-graph.ts
@@ -30,12 +30,12 @@ import {
   buildNpmPackageNodes,
   buildWorkspaceProjectNodes,
 } from './build-nodes';
-import { existsSync } from 'fs';
 import * as os from 'os';
 import { buildExplicitTypescriptAndPackageJsonDependencies } from './build-dependencies/build-explicit-typescript-and-package-json-dependencies';
 import { loadNxPlugins } from '@nrwl/tao/src/shared/nx-plugin';
 import { defaultFileHasher } from '../hasher/file-hasher';
 import { createProjectFileMap } from '../file-map-utils';
+import { getRootTsConfigPath } from '../../utilities/typescript';
 
 export async function buildProjectGraph() {
   const workspaceJson = readWorkspaceJson();
@@ -397,10 +397,8 @@ function updateProjectGraphWithPlugins(
 }
 
 function readRootTsConfig() {
-  for (const tsConfigName of ['tsconfig.base.json', 'tsconfig.json']) {
-    const tsConfigPath = join(appRootPath, tsConfigName);
-    if (existsSync(tsConfigPath)) {
-      return readJsonFile(tsConfigPath);
-    }
+  const tsConfigPath = getRootTsConfigPath();
+  if (tsConfigPath) {
+    return readJsonFile(tsConfigPath);
   }
 }

--- a/packages/workspace/src/core/target-project-locator.spec.ts
+++ b/packages/workspace/src/core/target-project-locator.spec.ts
@@ -352,6 +352,19 @@ describe('findTargetProjectWithImport', () => {
     expect(proj2deep).toEqual('proj2');
   });
 
+  it('should be able to resolve nested files using tsConfig paths when having a root tsconfig.json instead of tsconfig.base.json', () => {
+    fsJson['./tsconfig.json'] = fsJson['./tsconfig.base.json'];
+    delete fsJson['./tsconfig.base.json'];
+
+    const proj2deep = targetProjectLocator.findProjectWithImport(
+      '@proj/my-second-proj/deep',
+      'libs/proj1/index.ts',
+      ctx.workspace.npmScope
+    );
+
+    expect(proj2deep).toEqual('proj2');
+  });
+
   it('should be able to resolve nested files using tsConfig paths that have similar names', () => {
     const proj = targetProjectLocator.findProjectWithImport(
       '@proj/proj123/deep',

--- a/packages/workspace/src/core/target-project-locator.ts
+++ b/packages/workspace/src/core/target-project-locator.ts
@@ -1,5 +1,7 @@
-import { resolveModuleByImport } from '../utilities/typescript';
-import { readFileIfExisting } from './file-utils';
+import {
+  getRootTsConfigFileName,
+  resolveModuleByImport,
+} from '../utilities/typescript';
 import {
   parseJson,
   ProjectGraphExternalNode,
@@ -8,6 +10,7 @@ import {
 import { isRelativePath } from '../utilities/fileutils';
 import { dirname, join, posix } from 'path';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
+import { readFileSync } from 'fs';
 
 export class TargetProjectLocator {
   private projectRootMappings = createProjectRootMappings(this.nodes);
@@ -164,22 +167,21 @@ export class TargetProjectLocator {
   }
 
   private getRootTsConfig() {
-    let path = 'tsconfig.base.json';
-    let absolutePath = this.getAbsolutePath(path);
-    let content = readFileIfExisting(absolutePath);
-    if (!content) {
-      path = 'tsconfig.json';
-      absolutePath = this.getAbsolutePath(path);
-      content = readFileIfExisting(absolutePath);
-    }
-    if (!content) {
+    const path = getRootTsConfigFileName();
+    if (!path) {
       return {
         path: null,
         absolutePath: null,
         config: null,
       };
     }
-    return { path, absolutePath, config: parseJson(content) };
+
+    const absolutePath = this.getAbsolutePath(path);
+    return {
+      absolutePath,
+      path,
+      config: parseJson(readFileSync(absolutePath, 'utf8')),
+    };
   }
 
   private findMatchingProjectFiles(file: string) {

--- a/packages/workspace/src/generators/init/files/root/tools/tsconfig.tools.json__tmpl__
+++ b/packages/workspace/src/generators/init/files/root/tools/tsconfig.tools.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../<%= rootTsConfigPath %>",
   "compilerOptions": {
     "outDir": "../dist/out-tsc/tools",
     "rootDir": ".",

--- a/packages/workspace/src/generators/init/init.spec.ts
+++ b/packages/workspace/src/generators/init/init.spec.ts
@@ -585,6 +585,7 @@ describe('workspace', () => {
     beforeEach(() => {
       tree.write('/package.json', JSON.stringify({ devDependencies: {} }));
       tree.write('/angular.json', JSON.stringify({ projects: { myproj: {} } }));
+      tree.write('/tsconfig.json', '{"compilerOptions": {}}');
     });
 
     it('should update package.json', async () => {

--- a/packages/workspace/src/generators/init/init.ts
+++ b/packages/workspace/src/generators/init/init.ts
@@ -35,6 +35,7 @@ import {
 } from '../../utils/versions';
 import { DEFAULT_NRWL_PRETTIER_CONFIG } from '../workspace/workspace';
 import { Schema } from './schema';
+import { getRootTsConfigPathInTree } from '../../utilities/typescript';
 
 function updatePackageJson(tree) {
   updateJson(tree, 'package.json', (packageJson) => {
@@ -78,12 +79,6 @@ function updatePackageJson(tree) {
 
     return packageJson;
   });
-}
-
-function getRootTsConfigPath(host: Tree) {
-  return host.exists('tsconfig.base.json')
-    ? 'tsconfig.base.json'
-    : 'tsconfig.json';
 }
 
 function convertPath(name: string, originalPath: string) {
@@ -330,7 +325,7 @@ function updateTsConfig(host: Tree) {
   writeJson(
     host,
     'tsconfig.base.json',
-    setUpCompilerOptions(readJson(host, getRootTsConfigPath(host)))
+    setUpCompilerOptions(readJson(host, getRootTsConfigPathInTree(host)))
   );
   if (host.exists('tsconfig.json')) {
     host.delete('tsconfig.json');
@@ -340,7 +335,7 @@ function updateTsConfig(host: Tree) {
 function updateTsConfigsJson(host: Tree, options: Schema) {
   const app = readProjectConfiguration(host, options.name);
   const e2eProject = getE2eProject(host);
-  const tsConfigPath = getRootTsConfigPath(host);
+  const tsConfigPath = getRootTsConfigPathInTree(host);
   const appOffset = offsetFromRoot(app.root);
 
   updateJson(host, app.targets.build.options.tsConfig, (json) => {
@@ -768,7 +763,7 @@ function createNxJson(host: Tree) {
     );
   }
   const name = Object.keys(projects)[0];
-  const tsConfigPath = getRootTsConfigPath(host);
+  const tsConfigPath = getRootTsConfigPathInTree(host);
   writeJson<NxJsonConfiguration>(host, 'nx.json', {
     npmScope: name,
     implicitDependencies: {
@@ -824,6 +819,7 @@ function addFiles(host: Tree) {
   generateFiles(host, joinPathFragments(__dirname, './files/root'), '.', {
     tmpl: '',
     dot: '.',
+    rootTsConfigPath: getRootTsConfigPathInTree(host),
   });
 
   if (!host.exists('.prettierignore')) {

--- a/packages/workspace/src/generators/library/files/lib/tsconfig.json
+++ b/packages/workspace/src/generators/library/files/lib/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",<% if (js) { %>
+  "extends": "<%= rootTsConfigPath %>",<% if (js) { %>
   "compilerOptions": {
     "allowJs": true
   },<% } %>

--- a/packages/workspace/src/generators/library/library.spec.ts
+++ b/packages/workspace/src/generators/library/library.spec.ts
@@ -108,9 +108,20 @@ describe('lib', () => {
       });
     });
 
-    it('should update root tsconfig.json', async () => {
+    it('should update root tsconfig.base.json', async () => {
       await libraryGenerator(tree, { ...defaultOptions, name: 'myLib' });
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
+      expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
+        'libs/my-lib/src/index.ts',
+      ]);
+    });
+
+    it('should update root tsconfig.json when no tsconfig.base.json', async () => {
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await libraryGenerator(tree, { ...defaultOptions, name: 'myLib' });
+
+      const tsconfigJson = readJson(tree, '/tsconfig.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
         'libs/my-lib/src/index.ts',
       ]);
@@ -153,6 +164,15 @@ describe('lib', () => {
           ],
         }
       `);
+    });
+
+    it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await libraryGenerator(tree, { ...defaultOptions, name: 'myLib' });
+
+      const tsconfigJson = readJson(tree, 'libs/my-lib/tsconfig.json');
+      expect(tsconfigJson.extends).toBe('../../tsconfig.json');
     });
 
     it('should extend the local tsconfig.json with tsconfig.spec.json', async () => {
@@ -301,13 +321,31 @@ describe('lib', () => {
       });
     });
 
-    it('should update tsconfig.json', async () => {
+    it('should update root tsconfig.base.json', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
         name: 'myLib',
         directory: 'myDir',
       });
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
+      expect(tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']).toEqual(
+        ['libs/my-dir/my-lib/src/index.ts']
+      );
+      expect(
+        tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']
+      ).toBeUndefined();
+    });
+
+    it('should update root tsconfig.json when no tsconfig.base.json', async () => {
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        directory: 'myDir',
+      });
+
+      const tsconfigJson = readJson(tree, '/tsconfig.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']).toEqual(
         ['libs/my-dir/my-lib/src/index.ts']
       );
@@ -324,6 +362,7 @@ describe('lib', () => {
       });
 
       const tsconfigJson = readJson(tree, 'libs/my-dir/my-lib/tsconfig.json');
+      expect(tsconfigJson.extends).toBe('../../../tsconfig.base.json');
       expect(tsconfigJson.references).toEqual([
         {
           path: './tsconfig.lib.json',
@@ -332,6 +371,19 @@ describe('lib', () => {
           path: './tsconfig.spec.json',
         },
       ]);
+    });
+
+    it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
+
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        directory: 'myDir',
+      });
+
+      const tsconfigJson = readJson(tree, 'libs/my-dir/my-lib/tsconfig.json');
+      expect(tsconfigJson.extends).toBe('../../../tsconfig.json');
     });
   });
 

--- a/packages/workspace/src/generators/library/library.ts
+++ b/packages/workspace/src/generators/library/library.ts
@@ -16,7 +16,10 @@ import {
 } from '@nrwl/devkit';
 import { join } from 'path';
 import { runTasksInSerial } from '../../utilities/run-tasks-in-serial';
-import { getRootTsConfigPathInTree } from '../../utilities/typescript';
+import {
+  getRelativePathToRootTsConfig,
+  getRootTsConfigPathInTree,
+} from '../../utilities/typescript';
 import { nxVersion } from '../../utils/versions';
 import { Schema } from './schema';
 
@@ -139,7 +142,7 @@ function createFiles(tree: Tree, options: NormalizedSchema) {
     strict: undefined,
     tmpl: '',
     offsetFromRoot: rootOffset,
-    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(tree),
+    rootTsConfigPath: getRelativePathToRootTsConfig(tree, options.projectRoot),
     hasUnitTestRunner: options.unitTestRunner !== 'none',
   });
 

--- a/packages/workspace/src/generators/library/library.ts
+++ b/packages/workspace/src/generators/library/library.ts
@@ -16,6 +16,7 @@ import {
 } from '@nrwl/devkit';
 import { join } from 'path';
 import { runTasksInSerial } from '../../utilities/run-tasks-in-serial';
+import { getRootTsConfigPathInTree } from '../../utilities/typescript';
 import { nxVersion } from '../../utils/versions';
 import { Schema } from './schema';
 
@@ -100,7 +101,7 @@ function updateTsConfig(tree: Tree, options: NormalizedSchema) {
 }
 
 function updateRootTsConfig(host: Tree, options: NormalizedSchema) {
-  updateJson(host, 'tsconfig.base.json', (json) => {
+  updateJson(host, getRootTsConfigPathInTree(host), (json) => {
     const c = json.compilerOptions;
     c.paths = c.paths || {};
     delete c.paths[options.name];
@@ -126,6 +127,7 @@ function updateRootTsConfig(host: Tree, options: NormalizedSchema) {
 function createFiles(tree: Tree, options: NormalizedSchema) {
   const { className, name, propertyName } = names(options.name);
 
+  const rootOffset = offsetFromRoot(options.projectRoot);
   generateFiles(tree, join(__dirname, './files/lib'), options.projectRoot, {
     ...options,
     dot: '.',
@@ -136,7 +138,8 @@ function createFiles(tree: Tree, options: NormalizedSchema) {
     cliCommand: 'nx',
     strict: undefined,
     tmpl: '',
-    offsetFromRoot: offsetFromRoot(options.projectRoot),
+    offsetFromRoot: rootOffset,
+    rootTsConfigPath: rootOffset + getRootTsConfigPathInTree(tree),
     hasUnitTestRunner: options.unitTestRunner !== 'none',
   });
 

--- a/packages/workspace/src/generators/move/lib/update-imports.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.spec.ts
@@ -268,7 +268,7 @@ export MyExtendedClass extends MyClass {};`
     );
   });
 
-  it('should update project ref in the tsconfig file', async () => {
+  it('should update project ref in the root tsconfig.base.json', async () => {
     await libraryGenerator(tree, {
       name: 'my-source',
       standaloneConfig: false,
@@ -278,6 +278,22 @@ export MyExtendedClass extends MyClass {};`
     updateImports(tree, schema, projectConfig);
 
     const tsConfig = readJson(tree, '/tsconfig.base.json');
+    expect(tsConfig.compilerOptions.paths).toEqual({
+      '@proj/my-destination': ['libs/my-destination/src/index.ts'],
+    });
+  });
+
+  it('should update project ref in the root tsconfig.json when no tsconfig.base.json', async () => {
+    tree.rename('tsconfig.base.json', 'tsconfig.json');
+    await libraryGenerator(tree, {
+      name: 'my-source',
+      standaloneConfig: false,
+    });
+    const projectConfig = readProjectConfiguration(tree, 'my-source');
+
+    updateImports(tree, schema, projectConfig);
+
+    const tsConfig = readJson(tree, '/tsconfig.json');
     expect(tsConfig.compilerOptions.paths).toEqual({
       '@proj/my-destination': ['libs/my-destination/src/index.ts'],
     });

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -10,6 +10,7 @@ import {
   writeJson,
 } from '@nrwl/devkit';
 import * as ts from 'typescript';
+import { getRootTsConfigPathInTree } from '../../../utilities/typescript';
 import { findNodes } from '../../../utilities/typescript/find-nodes';
 import { NormalizedSchema } from '../schema';
 import { normalizeSlashes } from './utils';
@@ -34,7 +35,7 @@ export function updateImports(
 
   // use the source root to find the from location
   // this attempts to account for libs that have been created with --importPath
-  const tsConfigPath = 'tsconfig.base.json';
+  const tsConfigPath = getRootTsConfigPathInTree(tree);
   let tsConfig: any;
   let fromPath: string;
   if (tree.exists(tsConfigPath)) {

--- a/packages/workspace/src/generators/remove/lib/update-tsconfig.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/update-tsconfig.spec.ts
@@ -18,7 +18,7 @@ describe('updateTsconfig', () => {
     };
   });
 
-  it('should delete project ref from the tsconfig', async () => {
+  it('should delete project ref from the root tsconfig.base.json', async () => {
     await libraryGenerator(tree, {
       name: 'my-lib',
       standaloneConfig: false,
@@ -28,6 +28,20 @@ describe('updateTsconfig', () => {
     updateTsconfig(tree, schema, project);
 
     const tsConfig = readJson(tree, '/tsconfig.base.json');
+    expect(tsConfig.compilerOptions.paths).toEqual({});
+  });
+
+  it('should delete project ref from the root tsconfig.json when no tsconfig.base.json', async () => {
+    tree.rename('tsconfig.base.json', 'tsconfig.json');
+    await libraryGenerator(tree, {
+      name: 'my-lib',
+      standaloneConfig: false,
+    });
+    const project = readProjectConfiguration(tree, 'my-lib');
+
+    updateTsconfig(tree, schema, project);
+
+    const tsConfig = readJson(tree, '/tsconfig.json');
     expect(tsConfig.compilerOptions.paths).toEqual({});
   });
 });

--- a/packages/workspace/src/generators/remove/lib/update-tsconfig.ts
+++ b/packages/workspace/src/generators/remove/lib/update-tsconfig.ts
@@ -4,6 +4,7 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
+import { getRootTsConfigPathInTree } from '../../../utilities/typescript';
 import { Schema } from '../schema';
 
 /**
@@ -18,7 +19,7 @@ export function updateTsconfig(
 ) {
   const { appsDir, libsDir, npmScope } = getWorkspaceLayout(tree);
 
-  const tsConfigPath = 'tsconfig.base.json';
+  const tsConfigPath = getRootTsConfigPathInTree(tree, false);
   if (tree.exists(tsConfigPath)) {
     updateJson(tree, tsConfigPath, (json) => {
       delete json.compilerOptions.paths[

--- a/packages/workspace/src/generators/remove/lib/update-tsconfig.ts
+++ b/packages/workspace/src/generators/remove/lib/update-tsconfig.ts
@@ -19,7 +19,7 @@ export function updateTsconfig(
 ) {
   const { appsDir, libsDir, npmScope } = getWorkspaceLayout(tree);
 
-  const tsConfigPath = getRootTsConfigPathInTree(tree, false);
+  const tsConfigPath = getRootTsConfigPathInTree(tree);
   if (tree.exists(tsConfigPath)) {
     updateJson(tree, tsConfigPath, (json) => {
       delete json.compilerOptions.paths[

--- a/packages/workspace/src/utilities/typescript.ts
+++ b/packages/workspace/src/utilities/typescript.ts
@@ -1,9 +1,10 @@
-import { dirname } from 'path';
-import type * as ts from 'typescript';
+import { Tree } from '@nrwl/devkit';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
-
-export type { TypeScriptCompilationOptions } from './typescript/compilation';
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import type * as ts from 'typescript';
 export { compileTypeScript } from './typescript/compilation';
+export type { TypeScriptCompilationOptions } from './typescript/compilation';
 export { findNodes } from './typescript/find-nodes';
 export { getSourceNodes } from './typescript/get-source-nodes';
 
@@ -90,4 +91,38 @@ function getCompilerHost(tsConfigPath: string) {
     host.getCanonicalFileName
   );
   return { options, host, moduleResolutionCache };
+}
+
+export function getRootTsConfigPathInTree(
+  tree: Tree,
+  throwIfNotFound: boolean = true
+): string {
+  for (const path of ['tsconfig.base.json', 'tsconfig.json']) {
+    if (tree.exists(path)) {
+      return path;
+    }
+  }
+
+  if (throwIfNotFound) {
+    throw new Error(
+      'Could not find root tsconfig file. Tried with "tsconfig.base.json" and "tsconfig.json".'
+    );
+  }
+}
+
+export function getRootTsConfigFileName(): string | undefined {
+  for (const tsConfigName of ['tsconfig.base.json', 'tsconfig.json']) {
+    const tsConfigPath = join(appRootPath, tsConfigName);
+    if (existsSync(tsConfigPath)) {
+      return tsConfigName;
+    }
+  }
+
+  return undefined;
+}
+
+export function getRootTsConfigPath(): string | undefined {
+  const tsConfigFileName = getRootTsConfigFileName();
+
+  return tsConfigFileName ? join(appRootPath, tsConfigFileName) : undefined;
 }

--- a/packages/workspace/src/utilities/typescript.ts
+++ b/packages/workspace/src/utilities/typescript.ts
@@ -1,4 +1,4 @@
-import { Tree } from '@nrwl/devkit';
+import { offsetFromRoot, Tree } from '@nrwl/devkit';
 import { appRootPath } from '@nrwl/tao/src/utils/app-root';
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
@@ -93,24 +93,24 @@ function getCompilerHost(tsConfigPath: string) {
   return { options, host, moduleResolutionCache };
 }
 
-export function getRootTsConfigPathInTree(
-  tree: Tree,
-  throwIfNotFound: boolean = true
-): string {
+export function getRootTsConfigPathInTree(tree: Tree): string | null {
   for (const path of ['tsconfig.base.json', 'tsconfig.json']) {
     if (tree.exists(path)) {
       return path;
     }
   }
 
-  if (throwIfNotFound) {
-    throw new Error(
-      'Could not find root tsconfig file. Tried with "tsconfig.base.json" and "tsconfig.json".'
-    );
-  }
+  return 'tsconfig.base.json';
 }
 
-export function getRootTsConfigFileName(): string | undefined {
+export function getRelativePathToRootTsConfig(
+  tree: Tree,
+  targetPath: string
+): string {
+  return offsetFromRoot(targetPath) + getRootTsConfigPathInTree(tree);
+}
+
+export function getRootTsConfigFileName(): string | null {
   for (const tsConfigName of ['tsconfig.base.json', 'tsconfig.json']) {
     const tsConfigPath = join(appRootPath, tsConfigName);
     if (existsSync(tsConfigPath)) {
@@ -118,11 +118,11 @@ export function getRootTsConfigFileName(): string | undefined {
     }
   }
 
-  return undefined;
+  return null;
 }
 
-export function getRootTsConfigPath(): string | undefined {
+export function getRootTsConfigPath(): string | null {
   const tsConfigFileName = getRootTsConfigFileName();
 
-  return tsConfigFileName ? join(appRootPath, tsConfigFileName) : undefined;
+  return tsConfigFileName ? join(appRootPath, tsConfigFileName) : null;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There are several places within Nx where it doesn't fall back to locate a root `tsconfig.json` if the expected `tsconfig.base.json` doesn't exist.

Most of the time this should be fine since Nx workspaces by default use `tsconfig.base.json`, but there are still some scenarios where a `tsconfig.json` might still be used (e.g. devs decide to use it, or Angular CLI workspaces migrated using a package like `make-angular-cli-faster` or Angular CLI workspaces migrated using the `--preserve-angular-cli-layout` flag).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The functionality within Nx should look for a root `tsconfig.json` if the `tsconfig.base.json` file doesn't exist. By default, `tsconfig.base.json` should still be used for everything and it's still the recommended file to use, but a fallback should be in place.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
