### PR TITLE
feat(core): prep project graph during postinstall

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -2,6 +2,9 @@
   "name": "@nrwl/workspace",
   "version": "0.0.1",
   "description": "Smart, Fast and Extensible Build System",
+  "scripts": {
+    "postinstall": "node ./src/init/init"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/nrwl/nx.git",

--- a/packages/workspace/src/init/init.ts
+++ b/packages/workspace/src/init/init.ts
@@ -1,0 +1,9 @@
+import { createProjectGraphAsync } from '../core/project-graph/project-graph';
+
+(async () => {
+  try {
+    await createProjectGraphAsync();
+  } catch (e) {
+    // Do not error since this runs in a postinstall
+  }
+})();


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

After cloning the repo for the first time and often in CI, there is a delay where the project graph must be calculated to run nx commands.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Nx Project Graph is generated and cached during the `postinstall` phase of installing dependencies.

This means that subsequent commands do not need to calculate the entire project graph.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
