### PR TITLE
feat(react): add proxy config support to file-server executor

### DIFF
--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -1,5 +1,5 @@
 import { exec, execSync } from 'child_process';
-import { ExecutorContext, joinPathFragments, logger } from '@nrwl/devkit';
+import { ExecutorContext, joinPathFragments } from '@nrwl/devkit';
 import ignore from 'ignore';
 import { readFileSync } from 'fs';
 import { Schema } from './schema';
@@ -25,6 +25,12 @@ function getHttpServerArgs(options: Schema) {
   }
   if (options.proxyUrl) {
     args.push(`-P ${options.proxyUrl}`);
+  }
+
+  if (options.proxyOptions) {
+    Object.keys(options.proxyOptions).forEach((key) => {
+      args.push(`--proxy-options.${key}`, options.proxyOptions[key]);
+    });
   }
   return args;
 }

--- a/packages/web/src/executors/file-server/schema.d.ts
+++ b/packages/web/src/executors/file-server/schema.d.ts
@@ -9,4 +9,5 @@ export interface Schema {
   parallel: boolean;
   maxParallel?: number;
   withDeps: boolean;
+  proxyOptions?: object;
 }

--- a/packages/web/src/executors/file-server/schema.json
+++ b/packages/web/src/executors/file-server/schema.json
@@ -49,6 +49,18 @@
     "proxyUrl": {
       "type": "string",
       "description": "URL to proxy unhandled requests to."
+    },
+    "proxyOptions": {
+      "type": "object",
+      "description": "Options for the proxy used by http-server",
+      "default": {},
+      "properties": {
+        "secure": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": true
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Current Behavior
The `file-server` executor uses the `http-server` library under the hood. `http-server` uses `http-proxy` under the hood, when handling things like custom SSL certificates. 

Currently, when supplying your own SSL certificate (using `ssl`,  `sslKey`, `sslCert` and `proxyUrl` options) with a single-page-app that handles its own routing, [http-server](https://www.npmjs.com/package/http-server) will _not_ correctly route paths back to the SPA. As a result, directly visiting paths like `/user/login` **will fail** with an authentication error. 

**In other words**: When serving a SPA using custom SSL certificates, directly visiting url paths other than `/` results in an authentication error response from the server.

The reason for this issue is because the underlying `http-proxy` isn't configured to correctly handle the custom SSL certificates. Currently it cannot be correctly configured, because this executor does not support accepting configuration settings for the `http-proxy`. Specifically, it does not support the  `--proxyOptions` argument in `http-proxy`.

## Expected Behavior
When serving a SPA using custom SSL certificates, directly visiting url paths will now work correctly, given the settings are correct.

Example settings that work:
```
// workspace.json 
"serve": {
  "executor": "@nrwl/web:file-server",
  "options": {
    "buildTarget": "my:target",
    "port": 9040,
    "host": "myHost.com",
    "ssl": true,
    "sslKey": "myHost.key",
    "sslCert": "myHost.crt",
    "proxyUrl": "https://myHost.com:9040?",
    "proxyConfig": "./proxy.conf.json"
  }
},
```

```
// proxy.conf.json
{
  "secure": false
}
```

## Related Issue(s)
🤷🏻‍♀️

Fixes #
🤷🏻‍♀️