### PR TITLE
chore(core): improve consistency of output colors across terminal themes

### DIFF
--- a/packages/tao/src/shared/logger.ts
+++ b/packages/tao/src/shared/logger.ts
@@ -21,7 +21,7 @@ export const logger = {
     if (typeof s === 'string' && s.startsWith('NX ')) {
       console.info(`\n${NX_PREFIX} ${chalk.bold(s.substr(3))}\n`);
     } else {
-      console.info(chalk.white(s));
+      console.info(s);
     }
   },
   log: (...s) => {

--- a/packages/workspace/src/command-line/affected.ts
+++ b/packages/workspace/src/command-line/affected.ts
@@ -50,7 +50,7 @@ export async function affected(
           if (apps.length) {
             output.log({
               title: 'Affected apps:',
-              bodyLines: apps.map((app) => `${output.colors.gray('-')} ${app}`),
+              bodyLines: apps.map((app) => `${output.dim('-')} ${app}`),
             });
           }
         }
@@ -66,7 +66,7 @@ export async function affected(
           if (libs.length) {
             output.log({
               title: 'Affected libs:',
-              bodyLines: libs.map((lib) => `${output.colors.gray('-')} ${lib}`),
+              bodyLines: libs.map((lib) => `${output.dim('-')} ${lib}`),
             });
           }
         }

--- a/packages/workspace/src/command-line/utils.ts
+++ b/packages/workspace/src/command-line/utils.ts
@@ -130,9 +130,9 @@ export function splitArgsIntoNxArgsAndOverrides(
             '--all'
           )} is not meant to be used for any sizable project or to be used in CI.`,
           '',
-          `${output.colors.gray(
-            'Learn more about checking only what is affected: '
-          )}https://nx.dev/latest/angular/cli/affected#affected.`,
+          `${output.dim(
+            'Learn more about checking only what is affected: https://nx.dev/latest/angular/cli/affected#affected'
+          )}`,
         ],
       });
     }

--- a/packages/workspace/src/command-line/workspace-integrity-checks.ts
+++ b/packages/workspace/src/command-line/workspace-integrity-checks.ts
@@ -15,9 +15,7 @@ export class WorkspaceIntegrityChecks {
       .filter((n) => n.data.files.length === 0)
       .map((p) => `Cannot find project '${p.name}' in '${p.data.root}'`);
 
-    const errorGroupBodyLines = errors.map(
-      (f) => `${output.colors.gray('-')} ${f}`
-    );
+    const errorGroupBodyLines = errors.map((f) => `${output.dim('-')} ${f}`);
 
     return errors.length === 0
       ? []
@@ -42,7 +40,7 @@ export class WorkspaceIntegrityChecks {
         : allFilesWithoutProjects;
 
     const errorGroupBodyLines = first5FilesWithoutProjects.map(
-      (f) => `${output.colors.gray('-')} ${f}`
+      (f) => `${output.dim('-')} ${f}`
     );
 
     return first5FilesWithoutProjects.length === 0

--- a/packages/workspace/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
+++ b/packages/workspace/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
@@ -134,9 +134,9 @@ export async function createRunOneDynamicOutputRenderer({
           linesToRender.push(
             `   ${output.colors.cyan(
               dots.frames[dependentTargetsCurrentFrame]
-            )}    ${output.colors.white.dim(
+            )}    ${output.dim(
               `Nx is waiting on ${remainingDependentTasksNotFromInitiatingProject} dependent project tasks before running tasks from`
-            )} ${output.colors.white(`${initiatingProject}`)}...`
+            )} ${initiatingProject}${output.dim('...')}`
           );
           if (totalSuccessfulTasks > 0) {
             linesToRender.push('');
@@ -296,7 +296,7 @@ export async function createRunOneDynamicOutputRenderer({
       const pinnedFooterLines = [
         output.applyNxPrefix(
           'green',
-          output.colors.green(text) + output.dim.white(` (${timeTakenText})`)
+          output.colors.green(text) + output.dim(` (${timeTakenText})`)
         ),
         ...taskOverridesLines,
       ];
@@ -338,7 +338,7 @@ export async function createRunOneDynamicOutputRenderer({
         [
           output.applyNxPrefix(
             'red',
-            output.colors.red(text) + output.dim.white(` (${timeTakenText})`)
+            output.colors.red(text) + output.dim(` (${timeTakenText})`)
           ),
           ...taskOverridesLines,
           '',

--- a/packages/workspace/src/tasks-runner/life-cycles/static-run-many-terminal-output-life-cycle.ts
+++ b/packages/workspace/src/tasks-runner/life-cycles/static-run-many-terminal-output-life-cycle.ts
@@ -38,11 +38,11 @@ export class StaticRunManyTerminalOutputLifeCycle implements LifeCycle {
     }
 
     const bodyLines = this.projectNames.map(
-      (affectedProject) => ` ${output.colors.gray('-')} ${affectedProject}`
+      (affectedProject) => ` ${output.dim('-')} ${affectedProject}`
     );
     if (Object.keys(this.taskOverrides).length > 0) {
       bodyLines.push('');
-      bodyLines.push(`${output.colors.gray('With flags:')}`);
+      bodyLines.push(`${output.dim('With flags:')}`);
       Object.entries(this.taskOverrides)
         .map(([flag, value]) => `  --${flag}=${value}`)
         .forEach((arg) => bodyLines.push(arg));
@@ -77,7 +77,7 @@ export class StaticRunManyTerminalOutputLifeCycle implements LifeCycle {
       const bodyLines =
         this.cachedTasks.length > 0
           ? [
-              output.colors.gray(
+              output.dim(
                 `Nx read the output from the cache instead of running the command for ${this.cachedTasks.length} out of ${this.tasks.length} tasks.`
               ),
             ]
@@ -96,21 +96,17 @@ export class StaticRunManyTerminalOutputLifeCycle implements LifeCycle {
       const skippedTasks = this.skippedTasks();
       if (skippedTasks.length > 0) {
         bodyLines.push(
-          output.colors.gray(
-            'Tasks not run because their dependencies failed:'
-          ),
+          output.dim('Tasks not run because their dependencies failed:'),
           '',
-          ...skippedTasks.map(
-            (task) => `${output.colors.gray('-')} ${task.id}`
-          ),
+          ...skippedTasks.map((task) => `${output.dim('-')} ${task.id}`),
           ''
         );
       }
       bodyLines.push(
-        output.colors.gray('Failed tasks:'),
+        output.dim('Failed tasks:'),
         '',
         ...[...this.failedTasks.values()].map(
-          (task) => `${output.colors.gray('-')} ${task.id}`
+          (task) => `${output.dim('-')} ${task.id}`
         )
       );
       output.error({

--- a/packages/workspace/src/tasks-runner/life-cycles/static-run-one-terminal-output-life-cycle.ts
+++ b/packages/workspace/src/tasks-runner/life-cycles/static-run-one-terminal-output-life-cycle.ts
@@ -58,7 +58,7 @@ export class StaticRunOneTerminalOutputLifeCycle implements LifeCycle {
       const bodyLines =
         this.cachedTasks.length > 0
           ? [
-              output.colors.gray(
+              output.dim(
                 `Nx read the output from the cache instead of running the command for ${this.cachedTasks.length} out of ${this.tasks.length} tasks.`
               ),
             ]
@@ -74,15 +74,13 @@ export class StaticRunOneTerminalOutputLifeCycle implements LifeCycle {
       output.addVerticalSeparatorWithoutNewLines('red');
 
       const bodyLines = [
-        output.colors.gray('Failed tasks:'),
+        output.dim('Failed tasks:'),
         '',
-        ...this.failedTasks.map(
-          (task) => `${output.colors.gray('-')} ${task.id}`
-        ),
+        ...this.failedTasks.map((task) => `${output.dim('-')} ${task.id}`),
         '',
-        `${output.colors.gray(
-          'Hint: run the command with'
-        )} --verbose ${output.colors.gray('for more details.')}`,
+        `${output.dim('Hint: run the command with')} --verbose ${output.dim(
+          'for more details.'
+        )}`,
       ];
       output.error({
         title: `Running target "${this.initiatingProject}:${this.args.target}" failed`,

--- a/packages/workspace/src/utilities/output.ts
+++ b/packages/workspace/src/utilities/output.ts
@@ -219,11 +219,11 @@ class CLIOutput {
     this.addNewline();
     let commandOutput = `${chalk.dim('> nx run')} ${message}`;
     if (taskStatus === 'local-cache') {
-      commandOutput += `  ${chalk.grey('[local cache]')}`;
+      commandOutput += `  ${chalk.dim('[local cache]')}`;
     } else if (taskStatus === 'remote-cache') {
-      commandOutput += `  ${chalk.grey('[remote cache]')}`;
+      commandOutput += `  ${chalk.dim('[remote cache]')}`;
     } else if (taskStatus === 'local-cache-kept-existing') {
-      commandOutput += `  ${chalk.grey(
+      commandOutput += `  ${chalk.dim(
         '[existing outputs match the cache, left as is]'
       )}`;
     }


### PR DESCRIPTION
Sadly there is little room for subtlety in terminal output colors when the (understandable) goal is to be as readable and consistent as possible.

As discovered in previous PRs:

- Many themes have a problem with `.gray()` (`.dim()` produces much more consistent results)
- Some light themes will take things like `.white()` and intelligently invert it to make it readable, but many do not and so you end up with white being rendered on a light background making it very hard to read.