### PR TITLE
feat(angular): add opinionated mfe webpack helpers

### DIFF
--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -15,7 +15,8 @@
     "webpack-merge",
     "ts-node",
     "tsconfig-paths",
-    "semver"
+    "semver",
+    "webpack"
   ],
   "keepLifecycleScripts": true
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -21,7 +21,8 @@
     "./generators": "./generators.js",
     "./executors": "./executors.js",
     "./tailwind": "./tailwind.js",
-    "./src/generators/utils": "./src/generators/utils/index.js"
+    "./src/generators/utils": "./src/generators/utils/index.js",
+    "./mfe-utils": "./src/utils/mfe-webpack.js"
   },
   "author": "Victor Savkin",
   "license": "MIT",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -21,8 +21,7 @@
     "./generators": "./generators.js",
     "./executors": "./executors.js",
     "./tailwind": "./tailwind.js",
-    "./src/generators/utils": "./src/generators/utils/index.js",
-    "./mfe-utils": "./src/utils/mfe-webpack.js"
+    "./src/generators/utils": "./src/generators/utils/index.js"
   },
   "author": "Victor Savkin",
   "license": "MIT",
@@ -51,6 +50,7 @@
     "webpack-merge": "5.7.3",
     "ts-node": "~9.1.1",
     "tsconfig-paths": "^3.9.0",
-    "semver": "7.3.4"
+    "semver": "7.3.4",
+    "webpack": "^5.58.1"
   }
 }

--- a/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
+++ b/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
@@ -13,6 +13,11 @@ import { normalizeOptions } from './lib';
 import type { Schema } from './schema';
 
 export function webpackServer(schema: Schema, context: BuilderContext) {
+  process.env.NX_TSCONFIG_PATH = joinPathFragments(
+    context.workspaceRoot,
+    'tsconfig.base.json'
+  );
+
   const options = normalizeOptions(schema);
   const workspaceConfig = new Workspaces(
     context.workspaceRoot

--- a/packages/angular/src/utils/mfe-webpack.spec.ts
+++ b/packages/angular/src/utils/mfe-webpack.spec.ts
@@ -3,65 +3,123 @@ jest.mock('@nrwl/workspace');
 import * as fs from 'fs';
 import * as workspace from '@nrwl/workspace';
 
-import { shareWorkspaceLibraries } from './mfe-webpack';
+import { sharePackages, shareWorkspaceLibraries } from './mfe-webpack';
 
 describe('MFE Webpack Utils', () => {
   afterEach(() => jest.clearAllMocks());
 
-  it('should error when the tsconfig file does not exist', () => {
-    // ARRANGE
-    (fs.existsSync as jest.Mock).mockReturnValue(false);
+  describe('ShareWorkspaceLibraries', () => {
+    it('should error when the tsconfig file does not exist', () => {
+      // ARRANGE
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
 
-    // ACT
-    try {
-      shareWorkspaceLibraries(['@myorg/shared']);
-    } catch (error) {
-      // ASSERT
-      expect(error.message).toEqual(
-        'NX MFE: TsConfig Path for workspace libraries does not exist! (undefined)'
-      );
-    }
-  });
+      // ACT
+      try {
+        shareWorkspaceLibraries(['@myorg/shared']);
+      } catch (error) {
+        // ASSERT
+        expect(error.message).toEqual(
+          'NX MFE: TsConfig Path for workspace libraries does not exist! (undefined)'
+        );
+      }
+    });
 
-  it('should create an object with correct setup', () => {
-    // ARRANGE
-    (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (workspace.readTsConfig as jest.Mock).mockReturnValue({
-      options: {
-        paths: {
-          '@myorg/shared': ['/libs/shared/src/index.ts'],
+    it('should create an object with correct setup', () => {
+      // ARRANGE
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (workspace.readTsConfig as jest.Mock).mockReturnValue({
+        options: {
+          paths: {
+            '@myorg/shared': ['/libs/shared/src/index.ts'],
+          },
         },
-      },
+      });
+
+      // ACT
+      const sharedLibraries = shareWorkspaceLibraries(['@myorg/shared']);
+      // ASSERT
+      expect(sharedLibraries.getAliases()).toHaveProperty('@myorg/shared');
+      expect(sharedLibraries.getAliases()['@myorg/shared']).toContain(
+        'libs/shared/src/index.ts'
+      );
+      expect(sharedLibraries.getLibraries()).toEqual({
+        '@myorg/shared': {
+          eager: undefined,
+          requiredVersion: false,
+        },
+      });
     });
 
-    // ACT
-    const sharedLibraries = shareWorkspaceLibraries(['@myorg/shared']);
-    // ASSERT
-    expect(sharedLibraries.getAliases()).toHaveProperty('@myorg/shared');
-    expect(sharedLibraries.getAliases()['@myorg/shared']).toContain(
-      'libs/shared/src/index.ts'
-    );
-    expect(sharedLibraries.getLibraries()).toEqual({
-      '@myorg/shared': {
-        eager: undefined,
-        requiredVersion: false,
-      },
+    it('should create an object with empty setup when tsconfig does not contain the shared lib', () => {
+      // ARRANGE
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (workspace.readTsConfig as jest.Mock).mockReturnValue({
+        options: {
+          paths: {},
+        },
+      });
+
+      // ACT
+      const sharedLibraries = shareWorkspaceLibraries(['@myorg/shared']);
+      // ASSERT
+      expect(sharedLibraries.getAliases()).toEqual({});
+      expect(sharedLibraries.getLibraries()).toEqual({});
     });
   });
 
-  it('should create an object with empty setup when tsconfig does not contain the shared lib', () => {
-    // ARRANGE
-    (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (workspace.readTsConfig as jest.Mock).mockReturnValue({
-      options: {
-        paths: {},
-      },
+  describe('SharePackages', () => {
+    it('should throw when it cannot find root package.json', () => {
+      // ARRANGE
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+      // ACT
+      try {
+        sharePackages(['@angular/core']);
+      } catch (error) {
+        // ASSERT
+        expect(error.message).toEqual(
+          'NX MFE: Could not find root package.json to determine dependency versions.'
+        );
+      }
     });
 
-    // ACT
-    const sharedLibraries = shareWorkspaceLibraries(['@myorg/shared']);
-    // ASSERT
-    expect(sharedLibraries.getAliases()).toEqual({});
-    expect(sharedLibraries.getLibraries()).toEqual({});
+    it('should correctly map the shared packages to objects', () => {
+      // ARRANGE
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        JSON.stringify({
+          dependencies: {
+            '@angular/core': '~13.2.0',
+            '@angular/common': '~13.2.0',
+            rxjs: '~7.4.0',
+          },
+        })
+      );
+
+      // ACT
+      const packages = sharePackages([
+        '@angular/core',
+        '@angular/common',
+        'rxjs',
+      ]);
+      // ASSERT
+      expect(packages).toEqual({
+        '@angular/core': {
+          singleton: true,
+          strictVersion: true,
+          requiredVersion: '~13.2.0',
+        },
+        '@angular/common': {
+          singleton: true,
+          strictVersion: true,
+          requiredVersion: '~13.2.0',
+        },
+        rxjs: {
+          singleton: true,
+          strictVersion: true,
+          requiredVersion: '~7.4.0',
+        },
+      });
+    });
   });
 });

--- a/packages/angular/src/utils/mfe-webpack.spec.ts
+++ b/packages/angular/src/utils/mfe-webpack.spec.ts
@@ -1,0 +1,67 @@
+jest.mock('fs');
+jest.mock('@nrwl/workspace');
+import * as fs from 'fs';
+import * as workspace from '@nrwl/workspace';
+
+import { shareWorkspaceLibraries } from './mfe-webpack';
+
+describe('MFE Webpack Utils', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('should error when the tsconfig file does not exist', () => {
+    // ARRANGE
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+    // ACT
+    try {
+      shareWorkspaceLibraries(['@myorg/shared']);
+    } catch (error) {
+      // ASSERT
+      expect(error.message).toEqual(
+        'NX MFE: TsConfig Path for workspace libraries does not exist! (undefined)'
+      );
+    }
+  });
+
+  it('should create an object with correct setup', () => {
+    // ARRANGE
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (workspace.readTsConfig as jest.Mock).mockReturnValue({
+      options: {
+        paths: {
+          '@myorg/shared': ['/libs/shared/src/index.ts'],
+        },
+      },
+    });
+
+    // ACT
+    const sharedLibraries = shareWorkspaceLibraries(['@myorg/shared']);
+    // ASSERT
+    expect(sharedLibraries.getAliases()).toHaveProperty('@myorg/shared');
+    expect(sharedLibraries.getAliases()['@myorg/shared']).toContain(
+      'libs/shared/src/index.ts'
+    );
+    expect(sharedLibraries.getLibraries()).toEqual({
+      '@myorg/shared': {
+        eager: undefined,
+        requiredVersion: false,
+      },
+    });
+  });
+
+  it('should create an object with empty setup when tsconfig does not contain the shared lib', () => {
+    // ARRANGE
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (workspace.readTsConfig as jest.Mock).mockReturnValue({
+      options: {
+        paths: {},
+      },
+    });
+
+    // ACT
+    const sharedLibraries = shareWorkspaceLibraries(['@myorg/shared']);
+    // ASSERT
+    expect(sharedLibraries.getAliases()).toEqual({});
+    expect(sharedLibraries.getLibraries()).toEqual({});
+  });
+});

--- a/packages/angular/src/utils/mfe-webpack.ts
+++ b/packages/angular/src/utils/mfe-webpack.ts
@@ -1,0 +1,73 @@
+import { readTsConfig } from '@nrwl/workspace';
+import { existsSync } from 'fs';
+import { NormalModuleReplacementPlugin } from 'webpack';
+import { appRootPath as rootPath } from '@nrwl/tao/src/utils/app-root';
+import { normalizePath, joinPathFragments } from '@nrwl/devkit';
+import { dirname } from 'path';
+import { ParsedCommandLine } from 'typescript';
+
+export function shareWorkspaceLibraries(
+  libraries: string[],
+  tsConfigPath = process.env.NX_TSCONFIG_PATH
+) {
+  if (!existsSync(tsConfigPath)) {
+    throw new Error(
+      `NX MFE: TsConfig Path for workspace libraries does not exist! (${tsConfigPath})`
+    );
+  }
+
+  const tsConfig: ParsedCommandLine = readTsConfig(tsConfigPath);
+  const tsconfigPathAliases = tsConfig.options?.paths;
+
+  if (!tsconfigPathAliases) {
+    return {
+      getAliases: () => [],
+      getLibraries: () => [],
+      getReplacementPlugin: () =>
+        new NormalModuleReplacementPlugin(/./, () => {}),
+    };
+  }
+
+  const pathMappings: { name: string; path: string }[] = [];
+  for (const [key, paths] of Object.entries(tsconfigPathAliases)) {
+    if (libraries && libraries.includes(key)) {
+      const pathToLib = normalizePath(joinPathFragments(rootPath, paths[0]));
+      pathMappings.push({
+        name: key,
+        path: pathToLib,
+      });
+    }
+  }
+
+  return {
+    getAliases: () =>
+      pathMappings.reduce(
+        (aliases, library) => ({ ...aliases, [library.name]: library.path }),
+        {}
+      ),
+    getLibraries: (eager?: boolean) =>
+      pathMappings.reduce(
+        (libraries, library) => ({
+          ...libraries,
+          [library.name]: { requiredVersion: false, eager },
+        }),
+        {}
+      ),
+    getReplacementPlugin: () =>
+      new NormalModuleReplacementPlugin(/./, (req) => {
+        if (!req.request.startsWith('.')) {
+          return;
+        }
+
+        const from = req.context;
+        const to = normalizePath(joinPathFragments(req.context, req.request));
+
+        for (const library of pathMappings) {
+          const libFolder = normalizePath(dirname(library.path));
+          if (!from.startsWith(libFolder) && to.startsWith(libFolder)) {
+            req.request = library.name;
+          }
+        }
+      }),
+  };
+}

--- a/packages/angular/src/utils/mfe-webpack.ts
+++ b/packages/angular/src/utils/mfe-webpack.ts
@@ -1,5 +1,5 @@
 import { readTsConfig } from '@nrwl/workspace';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { NormalModuleReplacementPlugin } from 'webpack';
 import { appRootPath as rootPath } from '@nrwl/tao/src/utils/app-root';
 import { normalizePath, joinPathFragments } from '@nrwl/devkit';
@@ -70,4 +70,27 @@ export function shareWorkspaceLibraries(
         }
       }),
   };
+}
+
+export function sharePackages(packages: string[]) {
+  const pkgJsonPath = joinPathFragments(rootPath, 'package.json');
+  if (!existsSync(pkgJsonPath)) {
+    throw new Error(
+      'NX MFE: Could not find root package.json to determine dependency versions.'
+    );
+  }
+
+  const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+
+  return packages.reduce(
+    (shared, pkgName) => ({
+      ...shared,
+      [pkgName]: {
+        singleton: true,
+        strictVersion: true,
+        requiredVersion: pkgJson.dependencies[pkgName],
+      },
+    }),
+    {}
+  );
 }


### PR DESCRIPTION
## Context
Currently, when generating Angular MFE Webpack Configurations we rely on `@angular-architects/module-federation`. However, what we use from this package does not involve Angular specifically. 

It is also not built to think exclusively about Nx Monorepos. In this regard, it is possible to improve DX for Nx Workspaces using MFEs. 

It also offers a lot of flexibility, which may be useful for some use cases, however, it would be preferable to retain some additional control.

## Added Behaviour

This PR adds two helper functions to replace what we require from `@angular-architects/module-federation`. 

The aims with these helpers are:
 - Reduce cognitive load for average developer
 - Improve DX for developers
 - Simplify the resulting Webpack Configuration
 - Retain control over "Single Version Policy"


## Results

A current Webpack host config that is generated including a single shared workspace library:

```js
const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
const mf = require('@angular-architects/module-federation/webpack');
const path = require('path');
const share = mf.share;

/**
 * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
 * builder as it will generate a temporary tsconfig file which contains any required remappings of
 * shared libraries.
 * A remapping will occur when a library is buildable, as webpack needs to know the location of the
 * built files for the buildable library.
 * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
 * the location of the generated temporary tsconfig file.
 */
const tsConfigPath =
  process.env.NX_TSCONFIG_PATH ??
  path.join(__dirname, '../../tsconfig.base.json');

const workspaceRootPath = path.join(__dirname, '../../');
const sharedMappings = new mf.SharedMappings();
sharedMappings.register(tsConfigPath, ['@mfe/shared-lib'], workspaceRootPath);

module.exports = {
  output: {
    uniqueName: 'host2',
    publicPath: 'auto',
  },
  optimization: {
    runtimeChunk: false,
  },
  experiments: {
    outputModule: true,
  },
  resolve: {
    alias: {
      ...sharedMappings.getAliases(),
    },
  },
  plugins: [
    new ModuleFederationPlugin({
      remotes: {},
      shared: share({
        '@angular/core': {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        '@angular/common': {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        '@angular/common/http': {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        '@angular/router': {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        rxjs: {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        ...sharedMappings.getDescriptors(),
      }),
      library: {
        type: 'module',
      },
    }),
    sharedMappings.getPlugin(),
  ],
};
```

A Webpack config for a host using our new helpers:

```js
const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
const {
  shareWorkspaceLibraries,
  sharePackages,
} = require('@nrwl/angular/mfe-utils');

const sharedLibraries = shareWorkspaceLibraries(['@mfe/shared-lib']);

module.exports = {
  output: {
    uniqueName: 'host2',
    publicPath: 'auto',
  },
  optimization: {
    runtimeChunk: false,
  },
  experiments: {
    outputModule: true,
  },
  resolve: {
    alias: {
      ...sharedLibraries.getAliases(),
    },
  },
  plugins: [
    new ModuleFederationPlugin({
      remotes: {},
      shared: {
        ...sharePackages([
          '@angular/core',
          '@angular/common',
          '@angular/common/http',
          '@angular/router',
          'rxjs',
        ]),
        ...sharedLibraries.getLibraries(),
      },
      library: {
        type: 'module',
      },
    }),
    sharedLibraries.getReplacementPlugin(),
  ],
};
```
