### PR TITLE
fix(core): fix daemon server path on client

### DIFF
--- a/packages/workspace/src/core/project-graph/daemon/client/client.ts
+++ b/packages/workspace/src/core/project-graph/daemon/client/client.ts
@@ -4,6 +4,7 @@ import { ChildProcess, spawn, spawnSync } from 'child_process';
 import { openSync, readFileSync } from 'fs';
 import { ensureDirSync, ensureFileSync } from 'fs-extra';
 import { connect } from 'net';
+import { join } from 'path';
 import { performance } from 'perf_hooks';
 import { output } from '../../../../utilities/output';
 import {
@@ -23,13 +24,17 @@ export async function startInBackground(): Promise<ChildProcess['pid']> {
 
   const out = openSync(DAEMON_OUTPUT_LOG_FILE, 'a');
   const err = openSync(DAEMON_OUTPUT_LOG_FILE, 'a');
-  const backgroundProcess = spawn(process.execPath, ['../server/start.js'], {
-    cwd: appRootPath,
-    stdio: ['ignore', out, err],
-    detached: true,
-    windowsHide: true,
-    shell: false,
-  });
+  const backgroundProcess = spawn(
+    process.execPath,
+    [join(__dirname, '../server/start.js')],
+    {
+      cwd: appRootPath,
+      stdio: ['ignore', out, err],
+      detached: true,
+      windowsHide: true,
+      shell: false,
+    }
+  );
   backgroundProcess.unref();
 
   // Persist metadata about the background process so that it can be cleaned up later if needed
@@ -84,7 +89,7 @@ export function startInCurrentProcess(): void {
     title: `Daemon Server - Starting in the current process...`,
   });
 
-  spawnSync(process.execPath, ['../server/start.js'], {
+  spawnSync(process.execPath, [join(__dirname, '../server/start.js')], {
     cwd: appRootPath,
     stdio: 'inherit',
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
A change made in https://github.com/nrwl/nx/pull/9223 to ensure the CWD is always the same when processing the project graph with or without a daemon, caused the server file path to be wrong. This causes the daemon to fail to compute the project graph with the following error:

```bash
Error: Cannot find module '/Users/leosvel/code/issues/server/start.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:885:15)
    at Function.Module._load (internal/modules/cjs/loader.js:730:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The daemon should compute the project graph correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
