### PR TITLE
fix(js): mimic the behavior of tsc compilation for runTypeCheck

### DIFF
--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -51,7 +51,9 @@ describe('js e2e', () => {
       `dist/libs/${lib}/README.md`,
       `dist/libs/${lib}/package.json`,
       `dist/libs/${lib}/src/index.js`,
-      `dist/libs/${lib}/src/lib/${lib}.js`
+      `dist/libs/${lib}/src/lib/${lib}.js`,
+      `dist/libs/${lib}/src/index.d.ts`,
+      `dist/libs/${lib}/src/lib/${lib}.d.ts`
     );
 
     updateJson(`libs/${lib}/project.json`, (json) => {
@@ -108,7 +110,9 @@ describe('js e2e', () => {
     checkFilesExist(
       `dist/libs/${parentLib}/package.json`,
       `dist/libs/${parentLib}/src/index.js`,
-      `dist/libs/${parentLib}/src/lib/${parentLib}.js`
+      `dist/libs/${parentLib}/src/lib/${parentLib}.js`,
+      `dist/libs/${parentLib}/src/index.d.ts`,
+      `dist/libs/${parentLib}/src/lib/${parentLib}.d.ts`
     );
 
     const tsconfig = readJson(`tsconfig.base.json`);
@@ -120,6 +124,7 @@ describe('js e2e', () => {
     updateFile(`libs/${parentLib}/src/index.ts`, () => {
       return `
         import { ${lib} } from '@${scope}/${lib}'
+        export * from './lib/${parentLib}';
       `;
     });
 
@@ -172,7 +177,9 @@ describe('js e2e', () => {
     checkFilesExist(
       `dist/libs/${lib}/package.json`,
       `dist/libs/${lib}/src/index.js`,
-      `dist/libs/${lib}/src/lib/${lib}.js`
+      `dist/libs/${lib}/src/lib/${lib}.js`,
+      `dist/libs/${lib}/src/index.d.ts`,
+      `dist/libs/${lib}/src/lib/${lib}.d.ts`
     );
 
     const parentLib = uniq('parentlib');
@@ -192,7 +199,9 @@ describe('js e2e', () => {
     checkFilesExist(
       `dist/libs/${parentLib}/package.json`,
       `dist/libs/${parentLib}/src/index.js`,
-      `dist/libs/${parentLib}/src/lib/${parentLib}.js`
+      `dist/libs/${parentLib}/src/lib/${parentLib}.js`,
+      `dist/libs/${parentLib}/src/index.d.ts`,
+      `dist/libs/${parentLib}/src/lib/${parentLib}.d.ts`
     );
 
     const tsconfig = readJson(`tsconfig.base.json`);
@@ -203,7 +212,8 @@ describe('js e2e', () => {
 
     updateFile(`libs/${parentLib}/src/index.ts`, () => {
       return `
-        import { ${lib} } from '@${scope}/${lib}'
+        import { ${lib} } from '@${scope}/${lib}';
+        export * from './lib/${parentLib}';
       `;
     });
 

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -20,8 +20,9 @@ function getTypeCheckOptions(normalizedOptions: NormalizedSwcExecutorOptions) {
   const typeCheckOptions: TypeCheckOptions = {
     mode: 'emitDeclarationOnly',
     tsConfigPath: tsConfig,
-    outDir: outputPath.replace(`/${projectRoot}`, ''),
+    outDir: outputPath,
     workspaceRoot: root,
+    rootDir: projectRoot,
   };
 
   if (watch) {

--- a/packages/js/src/utils/typescript/run-type-check.ts
+++ b/packages/js/src/utils/typescript/run-type-check.ts
@@ -19,6 +19,7 @@ interface BaseTypeCheckOptions {
   tsConfigPath: string;
   cacheDir?: string;
   incremental?: boolean;
+  rootDir?: string;
 }
 
 type Mode = NoEmitMode | EmitDeclarationOnlyMode;
@@ -116,7 +117,8 @@ export async function runTypeCheck(
 
 async function setupTypeScript(options: TypeCheckOptions) {
   const ts = await import('typescript');
-  const { workspaceRoot, tsConfigPath, cacheDir, incremental } = options;
+  const { workspaceRoot, tsConfigPath, cacheDir, incremental, rootDir } =
+    options;
   const config = readTsConfig(tsConfigPath);
   if (config.errors.length) {
     throw new Error(`Invalid config file: ${config.errors}`);
@@ -132,6 +134,7 @@ async function setupTypeScript(options: TypeCheckOptions) {
     skipLibCheck: true,
     ...emitOptions,
     incremental,
+    rootDir: rootDir || config.options.rootDir,
   };
 
   return { ts, workspaceRoot, cacheDir, config, compilerOptions };


### PR DESCRIPTION
ISSUES CLOSED: #9203

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
On Windows, the `runTypeCheck` with `emitDeclarationOnly` emits the type definitions to the wrong output directory.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`runTypeCheck` now mimics the behavior of `compilationTypescript` (from `nrwl/workspace` which `nrwl/js:tsc` is utilizing) to ensure the behavior is consistent across different executors on different OS's

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9203
