### PR TITLE
fix(storybook): prevent storybook from hoisting webpack 4 for angular

### DIFF
--- a/packages/storybook/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/storybook/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -13,6 +13,7 @@ Object {
     "@storybook/builder-webpack5": "~6.4.12",
     "@storybook/manager-webpack5": "~6.4.12",
     "existing": "1.0.0",
+    "webpack": "^5.64.0",
   },
   "name": "test-name",
 }

--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -18,6 +18,7 @@ import {
   storybookVersion,
   svgrVersion,
   urlLoaderVersion,
+  webpack5Version,
 } from '../../utils/versions';
 import { Schema } from './schema';
 
@@ -63,6 +64,7 @@ function checkDependenciesInstalled(host: Tree, schema: Schema) {
       !packageJson.devDependencies['@storybook/manager-webpack5']
     ) {
       devDependencies['@storybook/manager-webpack5'] = storybookVersion;
+      devDependencies['webpack'] = webpack5Version;
     }
 
     if (

--- a/packages/storybook/src/utils/versions.ts
+++ b/packages/storybook/src/utils/versions.ts
@@ -5,6 +5,6 @@ export const babelLoaderVersion = '8.1.0';
 export const babelPresetTypescriptVersion = '7.12.13';
 export const svgrVersion = '^5.4.0';
 export const urlLoaderVersion = '^3.0.0';
-
+export const webpack5Version = '^5.64.0';
 export const storybookReactNativeVersion = '6.0.1-alpha.7';
 export const reactNativeStorybookLoader = '^2.0.5';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Adding storybook configuration with `yarn` via our generators causes webpack 4 dep from `@storybook/angular` to be hoisted. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should stick to webpack 5 for Angular apps. Storybook shouldn't be overwriting the root webpack dependency in the node_modules folder

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9154
