### PR TITLE
fix(core): show static terminal output when NX_VERBOSE_LOGGING is enabled

### DIFF
--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -38,7 +38,9 @@ async function getTerminalOutputLifeCycle(
   overrides: Record<string, unknown>,
   runnerOptions: any
 ): Promise<{ lifeCycle: LifeCycle; renderIsDone: Promise<void> }> {
-  const showVerboseOutput = !!overrides.verbose;
+  const showVerboseOutput =
+    !!overrides.verbose || process.env.NX_VERBOSE_LOGGING === 'true';
+
   if (terminalOutputStrategy === 'run-one') {
     if (
       shouldUseDynamicLifeCycle(tasks, runnerOptions) &&


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When `NX_VERBOSE_LOGGING=true` without `--verbose` also being set, the verbose logging for Nx Cloud ends up getting mixed up with the dynamic output and is hard to follow.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Either `NX_VERBOSE_LOGGING=true` or `--verbose` (or both) causes the static output renderer to be used so that verbose output is easier to follow.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
