### PR TITLE
Fix unable to select multiple configurations

### DIFF
--- a/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
+++ b/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
@@ -25,7 +25,7 @@ export function webpackServer(schema: Schema, context: BuilderContext) {
     ];
 
   const selectedConfiguration = parsedBrowserTarget.configuration
-    ? buildTarget.configurations[parsedBrowserTarget.configuration]
+    ? Object.assign({}, ...parsedBrowserTarget.configuration.split(',').map(config => buildTarget.configurations[config]))
     : buildTarget.defaultConfiguration
     ? buildTarget.configurations[buildTarget.defaultConfiguration]
     : buildTarget.options;

--- a/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
+++ b/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
@@ -25,10 +25,15 @@ export function webpackServer(schema: Schema, context: BuilderContext) {
     ];
 
   const selectedConfiguration = parsedBrowserTarget.configuration
-    ? Object.assign({}, ...parsedBrowserTarget.configuration.split(',').map(config => buildTarget.configurations[config]))
+    ? Object.assign(
+        {},
+        ...parsedBrowserTarget.configuration
+          .split(',')
+          .map((config) => buildTarget.configurations[config])
+      )
     : buildTarget.defaultConfiguration
-      ? buildTarget.configurations[buildTarget.defaultConfiguration]
-      : buildTarget.options;
+    ? buildTarget.configurations[buildTarget.defaultConfiguration]
+    : buildTarget.options;
 
   const customWebpackConfig: { path: string } =
     selectedConfiguration.customWebpackConfig ??

--- a/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
+++ b/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
@@ -27,8 +27,8 @@ export function webpackServer(schema: Schema, context: BuilderContext) {
   const selectedConfiguration = parsedBrowserTarget.configuration
     ? Object.assign({}, ...parsedBrowserTarget.configuration.split(',').map(config => buildTarget.configurations[config]))
     : buildTarget.defaultConfiguration
-    ? buildTarget.configurations[buildTarget.defaultConfiguration]
-    : buildTarget.options;
+      ? buildTarget.configurations[buildTarget.defaultConfiguration]
+      : buildTarget.options;
 
   const customWebpackConfig: { path: string } =
     selectedConfiguration.customWebpackConfig ??


### PR DESCRIPTION

When passing comma separated configurations no configuration is found.

Fixes
#9245
