### PR TITLE
fix(js): execute postCompilationCallback in compileTypeScriptFiles in…

### DIFF
--- a/packages/js/src/utils/typescript/compile-typescript-files.ts
+++ b/packages/js/src/utils/typescript/compile-typescript-files.ts
@@ -54,6 +54,7 @@ export async function* compileTypeScriptFiles(
       if (normalizedOptions.watch) {
         compileTypeScriptWatcher(tscOptions, async (d: Diagnostic) => {
           if (d.code === 6194) {
+            await postCompilationCallback();
             next(getResult(true));
           }
         });


### PR DESCRIPTION
… watch mode

Execute the postCompilationCallback regardless of the watch option value

ISSUES CLOSED: #9253

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
assets are not copied if `options.watch: true`

## Expected Behavior
assets should be copied regardless of watch option value

## Related Issue(s)
[9253](https://github.com/nrwl/nx/issues/9253)

Fixes #9253
