### PR TITLE
fix(angular): handle newProjectRoot correctly when generating apps and libs

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -159,11 +159,7 @@ describe('app', () => {
       expect(appE2eSpec).toContain('Welcome my-app-with-prefix');
     });
 
-    // TODO: this should work
-    // This has been carried over from the Angular Devkit Schematic
-    // It seems like Jest is failing as it's trying to look for the
-    // tsconfig in the incorrect place
-    xit('should work if the new project root is changed', async () => {
+    it('should work if the new project root is changed', async () => {
       // ARRANGE
       updateJson(appTree, '/workspace.json', (json) => ({
         ...json,
@@ -171,7 +167,9 @@ describe('app', () => {
       }));
 
       // ACT
-      await generateApp(appTree);
+      await generateApp(appTree, 'my-app', {
+        e2eTestRunner: E2eTestRunner.Protractor,
+      });
 
       // ASSERT
       expect(appTree.exists('apps/my-app/src/main.ts')).toEqual(true);

--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -1,9 +1,7 @@
 import {
   formatFiles,
-  getWorkspacePath,
   installPackagesTask,
   moveFilesToNewDirectory,
-  readJson,
   Tree,
 } from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
@@ -36,20 +34,6 @@ export async function applicationGenerator(
 ) {
   const options = normalizeOptions(host, schema);
 
-  // Determine the roots where @schematics/angular will place the projects
-  // This is not where the projects actually end up
-  const workspaceJsonPath = getWorkspacePath(host);
-  let newProjectRoot = null;
-  if (workspaceJsonPath) {
-    ({ newProjectRoot } = readJson(host, workspaceJsonPath));
-  }
-  const appProjectRoot = newProjectRoot
-    ? `${newProjectRoot}/${options.name}`
-    : options.name;
-  const e2eProjectRoot = newProjectRoot
-    ? `${newProjectRoot}/${options.e2eProjectName}`
-    : `${options.name}/e2e`;
-
   await angularInitGenerator(host, {
     ...options,
     skipFormat: true,
@@ -72,9 +56,15 @@ export async function applicationGenerator(
     skipPackageJson: options.skipPackageJson,
   });
 
-  createFiles(host, options, appProjectRoot);
+  if (options.ngCliSchematicAppRoot !== options.appProjectRoot) {
+    moveFilesToNewDirectory(
+      host,
+      options.ngCliSchematicAppRoot,
+      options.appProjectRoot
+    );
+  }
 
-  moveFilesToNewDirectory(host, appProjectRoot, options.appProjectRoot);
+  createFiles(host, options);
   updateConfigFiles(host, options);
   updateAppComponentTemplate(host, options);
 
@@ -114,7 +104,7 @@ export async function applicationGenerator(
 
   addLinting(host, options);
   await addUnitTestRunner(host, options);
-  await addE2e(host, options, e2eProjectRoot);
+  await addE2e(host, options);
   updateEditorTsConfig(host, options);
 
   if (options.backendProject) {

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -12,24 +12,11 @@ import { convertToNxProjectGenerator } from '@nrwl/workspace';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { getWorkspaceLayout, joinPathFragments } from '@nrwl/devkit';
 
-/**
- * Add E2E Config
- *
- * @param tree Nx Devkit Virtual Tree
- * @param options Normalized Schema
- * @param e2eProjectRoot Raw E2E Project Root that Angular tries to write to
- *
- * @returns Function to run to add Cypres config after intial app files have been moved to correct location
- */
-export async function addE2e(
-  tree: Tree,
-  options: NormalizedSchema,
-  e2eProjectRoot: string
-) {
+export async function addE2e(tree: Tree, options: NormalizedSchema) {
   if (options.e2eTestRunner === E2eTestRunner.Protractor) {
     await addProtractor(tree, options);
   } else {
-    removeScaffoldedE2e(tree, options, e2eProjectRoot);
+    removeScaffoldedE2e(tree, options, options.ngCliSchematicE2ERoot);
   }
 
   if (options.e2eTestRunner === 'cypress') {

--- a/packages/angular/src/generators/application/lib/create-files.ts
+++ b/packages/angular/src/generators/application/lib/create-files.ts
@@ -3,13 +3,7 @@ import { generateFiles, joinPathFragments } from '@nrwl/devkit';
 import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import type { NormalizedSchema } from './normalized-schema';
 
-export function createFiles(
-  host: Tree,
-  options: NormalizedSchema,
-  appProjectRoot: string
-) {
-  host.delete(`${appProjectRoot}/src/favicon.ico`);
-
+export function createFiles(host: Tree, options: NormalizedSchema) {
   generateFiles(
     host,
     joinPathFragments(__dirname, '../files'),

--- a/packages/angular/src/generators/application/lib/normalize-options.ts
+++ b/packages/angular/src/generators/application/lib/normalize-options.ts
@@ -1,4 +1,9 @@
-import { joinPathFragments, Tree } from '@nrwl/devkit';
+import {
+  getWorkspacePath,
+  joinPathFragments,
+  readJson,
+  Tree,
+} from '@nrwl/devkit';
 import type { Schema } from '../schema';
 import type { NormalizedSchema } from './normalized-schema';
 
@@ -35,6 +40,20 @@ export function normalizeOptions(
 
   options.standaloneConfig = options.standaloneConfig ?? standaloneAsDefault;
 
+  // Determine the roots where @schematics/angular will place the projects
+  // This might not be where the projects actually end up
+  const workspaceJsonPath = getWorkspacePath(host);
+  let newProjectRoot = null;
+  if (workspaceJsonPath) {
+    ({ newProjectRoot } = readJson(host, workspaceJsonPath));
+  }
+  const ngCliSchematicAppRoot = newProjectRoot
+    ? `${newProjectRoot}/${appProjectName}`
+    : appProjectName;
+  const ngCliSchematicE2ERoot = newProjectRoot
+    ? `${newProjectRoot}/${e2eProjectName}`
+    : `${appProjectName}/e2e`;
+
   // Set defaults and then overwrite with user options
   return {
     style: 'css',
@@ -54,5 +73,7 @@ export function normalizeOptions(
     e2eProjectRoot,
     e2eProjectName,
     parsedTags,
+    ngCliSchematicAppRoot,
+    ngCliSchematicE2ERoot,
   };
 }

--- a/packages/angular/src/generators/application/lib/normalized-schema.ts
+++ b/packages/angular/src/generators/application/lib/normalized-schema.ts
@@ -10,4 +10,6 @@ export interface NormalizedSchema extends Schema {
   e2eProjectName: string;
   e2eProjectRoot: string;
   parsedTags: string[];
+  ngCliSchematicAppRoot: string;
+  ngCliSchematicE2ERoot: string;
 }

--- a/packages/angular/src/generators/application/lib/update-config-files.ts
+++ b/packages/angular/src/generators/application/lib/update-config-files.ts
@@ -38,42 +38,44 @@ function updateAppAndE2EProjectConfigurations(
   options: NormalizedSchema
 ) {
   // workspace.json
-  const project = readProjectConfiguration(host, options.name);
+  let project = readProjectConfiguration(host, options.name);
 
-  let fixedProject = replaceAppNameWithPath(
-    project,
-    options.name,
-    options.appProjectRoot
-  );
+  if (options.ngCliSchematicAppRoot !== options.appProjectRoot) {
+    project = replaceAppNameWithPath(
+      project,
+      options.ngCliSchematicAppRoot,
+      options.appProjectRoot
+    );
+  }
 
-  delete fixedProject.targets.test;
+  delete project.targets.test;
 
   // Ensure the outputs property comes after the executor for
   // better readability.
-  const { executor, ...rest } = fixedProject.targets.build;
-  fixedProject.targets.build = {
+  const { executor, ...rest } = project.targets.build;
+  project.targets.build = {
     executor,
     outputs: ['{options.outputPath}'],
     ...rest,
   };
 
-  if (fixedProject.generators) {
-    delete fixedProject.generators;
+  if (project.generators) {
+    delete project.generators;
   }
 
   if (options.port) {
-    fixedProject.targets.serve = {
-      ...fixedProject.targets.serve,
+    project.targets.serve = {
+      ...project.targets.serve,
       options: {
-        ...fixedProject.targets.serve.options,
+        ...project.targets.serve.options,
         port: options.port,
       },
     };
   }
 
-  fixedProject.tags = options.parsedTags;
+  project.tags = options.parsedTags;
 
-  updateProjectConfiguration(host, options.name, fixedProject);
+  updateProjectConfiguration(host, options.name, project);
 
   if (options.unitTestRunner === UnitTestRunner.None) {
     host.delete(`${options.appProjectRoot}/src/app/app.component.spec.ts`);

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -1,4 +1,10 @@
-import { getWorkspaceLayout, joinPathFragments, Tree } from '@nrwl/devkit';
+import {
+  getWorkspaceLayout,
+  getWorkspacePath,
+  joinPathFragments,
+  readJson,
+  Tree,
+} from '@nrwl/devkit';
 import { Schema } from '../schema';
 import { NormalizedSchema } from './normalized-schema';
 import { names } from '@nrwl/devkit';
@@ -51,6 +57,17 @@ export function normalizeOptions(
   const importPath =
     options.importPath || `@${defaultPrefix}/${projectDirectory}`;
 
+  // Determine the roots where @schematics/angular will place the projects
+  // This might not be where the projects actually end up
+  const workspaceJsonPath = getWorkspacePath(host);
+  let newProjectRoot = null;
+  if (workspaceJsonPath) {
+    ({ newProjectRoot } = readJson(host, workspaceJsonPath));
+  }
+  const ngCliSchematicLibRoot = newProjectRoot
+    ? `${newProjectRoot}/${projectName}`
+    : projectName;
+
   return {
     ...options,
     linter: options.linter ?? Linter.EsLint,
@@ -65,5 +82,6 @@ export function normalizeOptions(
     parsedTags,
     fileName,
     importPath,
+    ngCliSchematicLibRoot,
   };
 }

--- a/packages/angular/src/generators/library/lib/normalized-schema.ts
+++ b/packages/angular/src/generators/library/lib/normalized-schema.ts
@@ -12,4 +12,5 @@ export interface NormalizedSchema extends Schema {
   moduleName: string;
   projectDirectory: string;
   parsedTags: string[];
+  ngCliSchematicLibRoot: string;
 }

--- a/packages/angular/src/generators/library/lib/update-project.ts
+++ b/packages/angular/src/generators/library/lib/update-project.ts
@@ -129,23 +129,25 @@ function createFiles(host: Tree, options: NormalizedSchema) {
 }
 
 function fixProjectWorkspaceConfig(host: Tree, options: NormalizedSchema) {
-  const project = readProjectConfiguration(host, options.name);
+  let project = readProjectConfiguration(host, options.name);
   project.tags = options.parsedTags;
 
-  const fixedProject = replaceAppNameWithPath(
-    project,
-    options.name,
-    options.projectRoot
-  );
+  if (options.ngCliSchematicLibRoot !== options.projectRoot) {
+    project = replaceAppNameWithPath(
+      project,
+      options.ngCliSchematicLibRoot,
+      options.projectRoot
+    );
+  }
 
   if (!options.publishable && !options.buildable) {
-    delete fixedProject.targets.build;
+    delete project.targets.build;
   } else {
     // Set the right builder for the type of library.
     // Ensure the outputs property comes after the builder for
     // better readability.
-    const { executor, ...rest } = fixedProject.targets.build;
-    fixedProject.targets.build = {
+    const { executor, ...rest } = project.targets.build;
+    project.targets.build = {
       executor: options.publishable
         ? '@nrwl/angular:package'
         : '@nrwl/angular:ng-packagr-lite',
@@ -160,9 +162,9 @@ function fixProjectWorkspaceConfig(host: Tree, options: NormalizedSchema) {
     };
   }
 
-  delete fixedProject.targets.test;
+  delete project.targets.test;
 
-  updateProjectConfiguration(host, options.name, fixedProject);
+  updateProjectConfiguration(host, options.name, project);
 }
 
 function updateProjectTsConfig(host: Tree, options: NormalizedSchema) {

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -457,6 +457,31 @@ describe('lib', () => {
       ).toBeFalsy();
     });
 
+    it('should work if the new project root is changed', async () => {
+      // ARRANGE
+      updateJson(tree, 'workspace.json', (json) => ({
+        ...json,
+        newProjectRoot: 'newProjectRoot',
+      }));
+
+      // ACT
+      await runLibraryGeneratorWithOpts();
+
+      // ASSERT
+      expect(tree.exists('libs/my-lib/src/index.ts')).toBeTruthy();
+      expect(tree.exists('libs/my-lib/src/lib/my-lib.module.ts')).toBeTruthy();
+      expect(
+        tree.exists('libs/my-lib/src/lib/my-lib.component.ts')
+      ).toBeFalsy();
+      expect(
+        tree.exists('libs/my-lib/src/lib/my-lib.component.spec.ts')
+      ).toBeFalsy();
+      expect(tree.exists('libs/my-lib/src/lib/my-lib.service.ts')).toBeFalsy();
+      expect(
+        tree.exists('libs/my-lib/src/lib/my-lib.service.spec.ts')
+      ).toBeFalsy();
+    });
+
     it('should default the prefix to npmScope', async () => {
       // ACT
       await runLibraryGeneratorWithOpts();

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -63,7 +63,13 @@ export async function libraryGenerator(host: Tree, schema: Partial<Schema>) {
     skipTsConfig: true,
   });
 
-  moveFilesToNewDirectory(host, options.name, options.projectRoot);
+  if (options.ngCliSchematicLibRoot !== options.projectRoot) {
+    moveFilesToNewDirectory(
+      host,
+      options.ngCliSchematicLibRoot,
+      options.projectRoot
+    );
+  }
   await updateProject(host, options);
   updateTsConfig(host, options);
   await addUnitTestRunner(host, options);

--- a/packages/devkit/src/generators/project-configuration.ts
+++ b/packages/devkit/src/generators/project-configuration.ts
@@ -189,7 +189,9 @@ export function updateWorkspaceConfiguration(
         ...json,
         version: workspaceConfig.version,
       };
-      delete (config as any).newProjectRoot;
+      if (!(workspaceConfig as any).newProjectRoot) {
+        delete (config as any).newProjectRoot;
+      }
       return config;
     });
   }

--- a/packages/workspace/src/generators/preset/__snapshots__/preset.spec.ts.snap
+++ b/packages/workspace/src/generators/preset/__snapshots__/preset.spec.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`preset should create files (preset = angular) 1`] = `
 Array [
-  "src",
-  "tsconfig.editor.json",
-  "tsconfig.json",
   ".browserslistrc",
   "tsconfig.app.json",
   "tsconfig.spec.json",
+  "src",
+  "tsconfig.editor.json",
+  "tsconfig.json",
   ".eslintrc.json",
   "jest.config.js",
 ]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
In workspaces where the `newProjectRoot` config might be specified in the `angular.json` (v1 format), there are issues creating applications and libraries. The `@schematics/angular:application` or `@schematics/angular:library` generator use that property if present to create the projects and then, the `@nrwl/*` generators move the projects to the final destination.

Most workspaces won't have this issue since that option doesn't get generated in new Nx workspaces and it gets deleted when migrating an Angular CLI workspace to an Nx workspace. However, if an Angular CLI workspace is migrated preserving the Angular CLI layout, the option is not meant to be removed and therefore it still needs to be handled correctly. In that scenario, the Angular CLI schematics need to work as usual, and for that, the option needs to be present.

A recent PR https://github.com/nrwl/nx/pull/8865 made a change to always remove the option when updating the configuration which is not something desired when a workspace preserves the Angular CLI layout.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
In workspaces where the `newProjectRoot` option is set in the configuration, the `@nrwl/angular:app` and `@nrwl/angular:lib` should handle it and work correctly. The `newProjectRoot` option shouldn't be deleted when updating the configuration if it's not meant to be deleted.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
