### PR TITLE
fix(js): default swcCwd to '.' to prevent ENOENT error when invoking …

### DIFF
--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -42,7 +42,9 @@ function normalizeOptions(
   // We pop the last part of the `projectRoot` to pass
   // the last part (projectDir) and the remainder (projectRootParts) to swc
   const projectDir = projectRootParts.pop();
-  const swcCwd = projectRootParts.join('/');
+  // default to current directory if projectRootParts is [].
+  // Eg: when a project is at the root level, outside of layout dir
+  const swcCwd = projectRootParts.join('/') || '.';
 
   const swcCliOptions = {
     srcPath: projectDir,


### PR DESCRIPTION
…swc cli

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Building `typedoc-theme` on `nrwl/nx` repo with `nrwl/js:swc` will error out with `ENOENT` because `typedoc-theme` is a library outside of workspace layout directory.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should be able to build with `nrwl/js:swc` regardless of the location of the project.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
