### PR TITLE
fix(node): npm modules are not resolved correctly

### DIFF
--- a/packages/node/src/executors/node/node.impl.ts
+++ b/packages/node/src/executors/node/node.impl.ts
@@ -72,10 +72,9 @@ function calculateResolveMappings(
     parsed.configuration
   );
   return dependencies.reduce((m, c) => {
-    if (!c.outputs[0] && c.node.type === 'npm') {
-      c.outputs[0] = `node_modules/${c.node.data.packageName}`;
+    if (c.node.type !== 'npm' && c.outputs[0] != null) {
+      m[c.name] = joinPathFragments(context.root, c.outputs[0]);
     }
-    m[c.name] = joinPathFragments(context.root, c.outputs[0]);
     return m;
   }, {});
 }


### PR DESCRIPTION
## Current Behavior
The current implementation of the node executor resolves all npm modules that are referenced by the application from the root node_modules folder. This behavior leads to runtime errors if any of the project dependencies requires a different version off package than the project itself.

For example, if we have a project that depends on `express` in version `4.17.3` (which on the other hand depends on `path-to-regexp` version `0.1.7`) as well as on `path-to-regexp` in version `6.2.0`. In such case `express` will throw a runtime error since it would load `path-to-regexp` version `6.2.0` which is not API compatible.

## Expected Behavior
Node executor should not add resolve mappings for npm modules at all.