### PR TITLE
docs(angular): update angular cli migration docs to reflect the generator relocation to @nrwl/angular

### DIFF
--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -6,21 +6,27 @@ using a monorepo approach. If you are currently using an Angular CLI workspace, 
 ## Prerequisites
 
 - The major version of your `Angular CLI` must align with the version of `Nx` you are upgrading to. For example, if you're using Angular CLI version 7, you must transition using the latest version 7 release of Nx.
-- Currently, transforming an Angular CLI workspace to an Nx workspace automatically only supports a single project. If you have more than one project in your Angular CLI workspace, you can still migrate manually.
+- Currently, transforming an Angular CLI workspace to an Nx workspace automatically only supports a single project. If you have more than one project in your Angular CLI workspace, you can still [migrate manually](#transitioning-manually).
 
 ## Using the Nx CLI while preserving the existing structure
 
 To use the Nx CLI in an existing Angular CLI workspace while keeping your existing file structure in place, use the `ng add` command with the `--preserve-angular-cli-layout` option:
 
 ```bash
-ng add @nrwl/workspace --preserve-angular-cli-layout
+ng add @nrwl/angular --preserve-angular-cli-layout
 ```
 
-> **Note**: If you are migrating to an Nx versions previous to `v13.8.4` (e.g. `ng add @nrwl/workspace@12`) use the `--preserveAngularCLILayout` option instead.
+**Note**: If you specify a version of Nx (e.g. `ng add @nrwl/angular@13.9.0`), please make sure to use the appropriate command as shown in the compatibility table below:
 
-This installs the `@nrwl/workspace` package into your workspace and applies the following changes to your workspace:
+| Nx version         | Collection to use | Flag to use                     | Example                                                       |
+| ------------------ | ----------------- | ------------------------------- | ------------------------------------------------------------- |
+| >= 13.9.0          | `@nrwl/angular`   | `--preserve-angular-cli-layout` | `ng add @nrwl/angular@13.9.0 --preserve-angular-cli-layout`   |
+| >= 13.8.4 < 13.9.0 | `@nrwl/workspace` | `--preserve-angular-cli-layout` | `ng add @nrwl/workspace@13.8.4 --preserve-angular-cli-layout` |
+| < 13.8.4           | `@nrwl/workspace` | `--preserveAngularCLILayout`    | `ng add @nrwl/workspace@13.5.0 --preserveAngularCLILayout`    |
 
-- Adds and installs the `@nrwl/workspace` package in your development dependencies.
+This installs the `@nrwl/angular` (or `nrwl/workspace`) package into your workspace and runs a generator (or schematic) to make following changes:
+
+- Installs the `nx` and `nrwl/workspace` packages.
 - Creates an `nx.json` file in the root of your workspace.
 - Adds a `decorate-angular-cli.js` to the root of your workspace, and a `postinstall` script in your `package.json` to run the script when your dependencies are updated. The script forwards the `ng` commands to the Nx CLI (`nx`) to enable features such as [Computation Caching](/using-nx/caching).
 
@@ -31,12 +37,19 @@ After the process completes, you can continue using the same `serve/build/lint/t
 To transform an Angular CLI workspace to an Nx workspace, run the following command:
 
 ```bash
-ng add @nrwl/workspace
+ng add @nrwl/angular
 ```
 
-This installs the `@nrwl/workspace` package into your workspace and runs a generator (or schematic) to transform your workspace. The generator applies the following changes to your workspace:
+**Note**: If you specify a version of Nx (e.g. `ng add @nrwl/angular@13.9.0`), please make sure to use the appropriate command as shown in the compatibility table below:
 
-- Installs the packages for the `Nx` plugin `@nrwl/angular` in your `package.json`.
+| Nx version | Command to run           |
+| ---------- | ------------------------ |
+| >= 13.9.0  | `ng add @nrwl/angular`   |
+| < 13.9.0   | `ng add @nrwl/workspace` |
+
+This installs the `@nrwl/angular` (or `nrwl/workspace`) package into your workspace and runs a generator (or schematic) to transform your workspace. The generator applies the following changes to your workspace:
+
+- Installs the `nx` and `@nrwl/workspace` packages.
 - Creates an `nx.json` file in the root of your workspace.
 - Creates configuration files for Prettier.
 - Creates an `apps` folder for generating applications.

--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -26,7 +26,7 @@ ng add @nrwl/angular --preserve-angular-cli-layout
 
 This installs the `@nrwl/angular` (or `nrwl/workspace`) package into your workspace and runs a generator (or schematic) to make following changes:
 
-- Installs the `nx` and `nrwl/workspace` packages.
+- Installs the `nx` and `@nrwl/workspace` packages.
 - Creates an `nx.json` file in the root of your workspace.
 - Adds a `decorate-angular-cli.js` to the root of your workspace, and a `postinstall` script in your `package.json` to run the script when your dependencies are updated. The script forwards the `ng` commands to the Nx CLI (`nx`) to enable features such as [Computation Caching](/using-nx/caching).
 

--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -24,7 +24,7 @@ ng add @nrwl/angular --preserve-angular-cli-layout
 | >= 13.8.4 < 13.9.0 | `@nrwl/workspace` | `--preserve-angular-cli-layout` | `ng add @nrwl/workspace@13.8.4 --preserve-angular-cli-layout` |
 | < 13.8.4           | `@nrwl/workspace` | `--preserveAngularCLILayout`    | `ng add @nrwl/workspace@13.5.0 --preserveAngularCLILayout`    |
 
-This installs the `@nrwl/angular` (or `nrwl/workspace`) package into your workspace and runs a generator (or schematic) to make following changes:
+This installs the `@nrwl/angular` (or `@nrwl/workspace`) package into your workspace and runs a generator (or schematic) to make following changes:
 
 - Installs the `nx` and `@nrwl/workspace` packages.
 - Creates an `nx.json` file in the root of your workspace.


### PR DESCRIPTION
Updates the Angular CLI migration docs to reflect that the `@nrwl/workspace:ng-add` generator is being moved to the `@nrwl/angular` package.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
