### PR TITLE
feat(angular): add withModuleFederation helper

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -21,7 +21,8 @@
     "./generators": "./generators.js",
     "./executors": "./executors.js",
     "./tailwind": "./tailwind.js",
-    "./src/generators/utils": "./src/generators/utils/index.js"
+    "./src/generators/utils": "./src/generators/utils/index.js",
+    "./module-federation": "./src/utils/mfe/with-module-federation.js"
   },
   "author": "Victor Savkin",
   "license": "MIT",

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -69,22 +69,21 @@ function buildAppWithCustomWebpackConfiguration(
         pathToWebpackConfig,
         options.tsConfig
       );
+      // The extra Webpack configuration file can also export a Promise, for instance:
+      // `module.exports = new Promise(...)`. If it exports a single object, but not a Promise,
+      // then await will just resolve that object.
+      const config = await customWebpackConfiguration;
+
       // The extra Webpack configuration file can export a synchronous or asynchronous function,
       // for instance: `module.exports = async config => { ... }`.
-      if (typeof customWebpackConfiguration === 'function') {
+      if (typeof config === 'function') {
         return customWebpackConfiguration(
           baseWebpackConfig,
           options,
           context.target
         );
       } else {
-        return merge(
-          baseWebpackConfig,
-          // The extra Webpack configuration file can also export a Promise, for instance:
-          // `module.exports = new Promise(...)`. If it exports a single object, but not a Promise,
-          // then await will just resolve that object.
-          await customWebpackConfiguration
-        );
+        return merge(baseWebpackConfig, config);
       }
     },
   });

--- a/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
+++ b/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
@@ -55,22 +55,21 @@ export function webpackServer(schema: Schema, context: BuilderContext) {
               pathToWebpackConfig,
               buildTarget.options.tsConfig
             );
+            // The extra Webpack configuration file can also export a Promise, for instance:
+            // `module.exports = new Promise(...)`. If it exports a single object, but not a Promise,
+            // then await will just resolve that object.
+            const config = await customWebpackConfiguration;
+
             // The extra Webpack configuration file can export a synchronous or asynchronous function,
             // for instance: `module.exports = async config => { ... }`.
-            if (typeof customWebpackConfiguration === 'function') {
-              return customWebpackConfiguration(
+            if (typeof config === 'function') {
+              return config(
                 baseWebpackConfig,
                 selectedConfiguration,
                 context.target
               );
             } else {
-              return merge(
-                baseWebpackConfig,
-                // The extra Webpack configuration file can also export a Promise, for instance:
-                // `module.exports = new Promise(...)`. If it exports a single object, but not a Promise,
-                // then await will just resolve that object.
-                await customWebpackConfiguration
-              );
+              return merge(baseWebpackConfig, config);
             }
           },
         }

--- a/packages/angular/src/utils/mfe/__snapshots__/with-module-federation.spec.ts.snap
+++ b/packages/angular/src/utils/mfe/__snapshots__/with-module-federation.spec.ts.snap
@@ -1,0 +1,141 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`withModuleFederation should collect dependencies correctly 1`] = `
+Array [
+  ModuleFederationPlugin {
+    "_options": Object {
+      "exposes": Object {
+        "./Module": "apps/remote1/src/module.ts",
+      },
+      "filename": "remoteEntry.mjs",
+      "library": Object {
+        "type": "module",
+      },
+      "name": "remote1",
+      "remotes": Object {},
+      "shared": Object {
+        "@angular/core": Object {
+          "requiredVersion": "~13.2.0",
+          "singleton": true,
+          "strictVersion": true,
+        },
+        "core": Object {
+          "eager": undefined,
+          "requiredVersion": false,
+        },
+        "shared": Object {
+          "eager": undefined,
+          "requiredVersion": false,
+        },
+      },
+    },
+  },
+  NormalModuleReplacementPlugin {
+    "newResource": [Function],
+    "resourceRegExp": /\\./,
+  },
+]
+`;
+
+exports[`withModuleFederation should create a host config correctly 1`] = `
+Array [
+  ModuleFederationPlugin {
+    "_options": Object {
+      "exposes": undefined,
+      "filename": "remoteEntry.mjs",
+      "library": Object {
+        "type": "module",
+      },
+      "name": "host",
+      "remotes": Object {
+        "remote1": "http:/localhost:4201/remoteEntry.mjs",
+      },
+      "shared": Object {
+        "@angular/core": Object {
+          "requiredVersion": "~13.2.0",
+          "singleton": true,
+          "strictVersion": true,
+        },
+        "shared": Object {
+          "eager": undefined,
+          "requiredVersion": false,
+        },
+      },
+    },
+  },
+  NormalModuleReplacementPlugin {
+    "newResource": [Function],
+    "resourceRegExp": /\\./,
+  },
+]
+`;
+
+exports[`withModuleFederation should create a remote config correctly 1`] = `
+Array [
+  ModuleFederationPlugin {
+    "_options": Object {
+      "exposes": Object {
+        "./Module": "apps/remote1/src/module.ts",
+      },
+      "filename": "remoteEntry.mjs",
+      "library": Object {
+        "type": "module",
+      },
+      "name": "remote1",
+      "remotes": Object {},
+      "shared": Object {
+        "@angular/core": Object {
+          "requiredVersion": "~13.2.0",
+          "singleton": true,
+          "strictVersion": true,
+        },
+        "shared": Object {
+          "eager": undefined,
+          "requiredVersion": false,
+        },
+      },
+    },
+  },
+  NormalModuleReplacementPlugin {
+    "newResource": [Function],
+    "resourceRegExp": /\\./,
+  },
+]
+`;
+
+exports[`withModuleFederation should map dependencies from project name to import name 1`] = `
+Array [
+  ModuleFederationPlugin {
+    "_options": Object {
+      "exposes": Object {
+        "./Module": "apps/remote1/src/module.ts",
+      },
+      "filename": "remoteEntry.mjs",
+      "library": Object {
+        "type": "module",
+      },
+      "name": "remote1",
+      "remotes": Object {},
+      "shared": Object {
+        "@angular/core": Object {
+          "requiredVersion": "~13.2.0",
+          "singleton": true,
+          "strictVersion": true,
+        },
+        "@myorg/core": Object {
+          "eager": undefined,
+          "requiredVersion": false,
+        },
+        "shared": Object {
+          "eager": undefined,
+          "requiredVersion": false,
+        },
+      },
+    },
+  },
+  NormalModuleReplacementPlugin {
+    "newResource": [Function],
+    "resourceRegExp": /\\./,
+  },
+]
+`;

--- a/packages/angular/src/utils/mfe/mfe-webpack.spec.ts
+++ b/packages/angular/src/utils/mfe/mfe-webpack.spec.ts
@@ -19,7 +19,7 @@ describe('MFE Webpack Utils', () => {
       } catch (error) {
         // ASSERT
         expect(error.message).toEqual(
-          'NX MFE: TsConfig Path for workspace libraries does not exist! (undefined)'
+          'NX MFE: TsConfig Path for workspace libraries does not exist! (null)'
         );
       }
     });

--- a/packages/angular/src/utils/mfe/mfe-webpack.spec.ts
+++ b/packages/angular/src/utils/mfe/mfe-webpack.spec.ts
@@ -18,8 +18,8 @@ describe('MFE Webpack Utils', () => {
         shareWorkspaceLibraries(['@myorg/shared']);
       } catch (error) {
         // ASSERT
-        expect(error.message).toEqual(
-          'NX MFE: TsConfig Path for workspace libraries does not exist! (null)'
+        expect(error.message).toContain(
+          'NX MFE: TsConfig Path for workspace libraries does not exist!'
         );
       }
     });

--- a/packages/angular/src/utils/mfe/mfe-webpack.ts
+++ b/packages/angular/src/utils/mfe/mfe-webpack.ts
@@ -1,11 +1,13 @@
-import { readTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import { existsSync, readFileSync } from 'fs';
 import { NormalModuleReplacementPlugin } from 'webpack';
 import { appRootPath as rootPath } from 'nx/src/utils/app-root';
 import { normalizePath, joinPathFragments } from '@nrwl/devkit';
 import { dirname } from 'path';
 import { ParsedCommandLine } from 'typescript';
-import { getRootTsConfigPath } from '@nrwl/workspace/src/utilities/typescript';
+import {
+  getRootTsConfigPath,
+  readTsConfig,
+} from '@nrwl/workspace/src/utilities/typescript';
 
 export interface SharedLibraryConfig {
   singleton: boolean;

--- a/packages/angular/src/utils/mfe/with-module-federation.spec.ts
+++ b/packages/angular/src/utils/mfe/with-module-federation.spec.ts
@@ -1,0 +1,241 @@
+jest.mock('fs');
+jest.mock('@nrwl/workspace/src/core/project-graph');
+jest.mock('@nrwl/workspace');
+jest.mock('nx/src/shared/workspace');
+import * as graph from '@nrwl/workspace/src/core/project-graph';
+import * as workspace from '@nrwl/workspace';
+import * as taoWorkspace from 'nx/src/shared/workspace';
+import * as fs from 'fs';
+
+import { withModuleFederation } from './with-module-federation';
+
+describe('withModuleFederation', () => {
+  afterEach(() => jest.clearAllMocks());
+  it('should create a host config correctly', async () => {
+    // ARRANGE
+    (graph.readCachedProjectGraph as jest.Mock).mockReturnValue({
+      dependencies: {
+        host: [
+          { target: 'npm:@angular/core' },
+          { target: 'npm:zone.js' },
+          { target: 'shared' },
+        ],
+      },
+    });
+
+    (workspace.readWorkspaceJson as jest.Mock).mockReturnValue({
+      projects: {
+        remote1: {
+          targets: {
+            serve: {
+              options: {
+                publicHost: 'http://localhost:4201',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.readFileSync as jest.Mock).mockReturnValue(
+      JSON.stringify({
+        dependencies: {
+          '@angular/core': '~13.2.0',
+        },
+      })
+    );
+
+    (workspace.readTsConfig as jest.Mock).mockReturnValue({
+      options: {
+        paths: {
+          shared: ['/libs/shared/src/index.ts'],
+        },
+      },
+    });
+
+    (taoWorkspace.Workspaces as jest.Mock).mockReturnValue({
+      readWorkspaceConfiguration: () => ({
+        projects: {
+          shared: {
+            sourceRoot: '/libs/shared/src/',
+          },
+        },
+      }),
+    });
+
+    // ACT
+    const config = (
+      await withModuleFederation({
+        name: 'host',
+        remotes: ['remote1'],
+      })
+    )({});
+
+    // ASSERT
+    expect(config.plugins).toMatchSnapshot();
+  });
+
+  it('should create a remote config correctly', async () => {
+    // ARRANGE
+    (graph.readCachedProjectGraph as jest.Mock).mockReturnValue({
+      dependencies: {
+        remote1: [
+          { target: 'npm:@angular/core' },
+          { target: 'npm:zone.js' },
+          { target: 'shared' },
+        ],
+      },
+    });
+
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.readFileSync as jest.Mock).mockReturnValue(
+      JSON.stringify({
+        dependencies: {
+          '@angular/core': '~13.2.0',
+        },
+      })
+    );
+
+    (workspace.readTsConfig as jest.Mock).mockReturnValue({
+      options: {
+        paths: {
+          shared: ['/libs/shared/src/index.ts'],
+        },
+      },
+    });
+
+    (taoWorkspace.Workspaces as jest.Mock).mockReturnValue({
+      readWorkspaceConfiguration: () => ({
+        projects: {
+          shared: {
+            sourceRoot: '/libs/shared/src/',
+          },
+        },
+      }),
+    });
+
+    // ACT
+    const config = (
+      await withModuleFederation({
+        name: 'remote1',
+        exposes: { './Module': 'apps/remote1/src/module.ts' },
+      })
+    )({});
+
+    // ASSERT
+    expect(config.plugins).toMatchSnapshot();
+  });
+
+  it('should collect dependencies correctly', async () => {
+    // ARRANGE
+    (graph.readCachedProjectGraph as jest.Mock).mockReturnValue({
+      dependencies: {
+        remote1: [
+          { target: 'npm:@angular/core' },
+          { target: 'npm:zone.js' },
+          { target: 'core' },
+        ],
+        core: [{ target: 'shared' }],
+      },
+    });
+
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.readFileSync as jest.Mock).mockReturnValue(
+      JSON.stringify({
+        dependencies: {
+          '@angular/core': '~13.2.0',
+        },
+      })
+    );
+
+    (workspace.readTsConfig as jest.Mock).mockReturnValue({
+      options: {
+        paths: {
+          shared: ['/libs/shared/src/index.ts'],
+          core: ['/libs/core/src/index.ts'],
+        },
+      },
+    });
+
+    (taoWorkspace.Workspaces as jest.Mock).mockReturnValue({
+      readWorkspaceConfiguration: () => ({
+        projects: {
+          shared: {
+            sourceRoot: '/libs/shared/src/',
+          },
+          core: {
+            sourceRoot: '/libs/core/src/',
+          },
+        },
+      }),
+    });
+
+    // ACT
+    const config = (
+      await withModuleFederation({
+        name: 'remote1',
+        exposes: { './Module': 'apps/remote1/src/module.ts' },
+      })
+    )({});
+
+    // ASSERT
+    expect(config.plugins).toMatchSnapshot();
+  });
+
+  it('should map dependencies from project name to import name', async () => {
+    // ARRANGE
+    (graph.readCachedProjectGraph as jest.Mock).mockReturnValue({
+      dependencies: {
+        remote1: [
+          { target: 'npm:@angular/core' },
+          { target: 'npm:zone.js' },
+          { target: 'core' },
+        ],
+        core: [{ target: 'shared' }],
+      },
+    });
+
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.readFileSync as jest.Mock).mockReturnValue(
+      JSON.stringify({
+        dependencies: {
+          '@angular/core': '~13.2.0',
+        },
+      })
+    );
+
+    (workspace.readTsConfig as jest.Mock).mockImplementation(() => ({
+      options: {
+        paths: {
+          shared: ['/libs/shared/src/index.ts'],
+          '@myorg/core': ['/libs/core/src/index.ts'],
+        },
+      },
+    }));
+
+    (taoWorkspace.Workspaces as jest.Mock).mockReturnValue({
+      readWorkspaceConfiguration: () => ({
+        projects: {
+          shared: {
+            sourceRoot: '/libs/shared/src/',
+          },
+          core: {
+            sourceRoot: '/libs/core/src/',
+          },
+        },
+      }),
+    });
+
+    // ACT
+    const config = (
+      await withModuleFederation({
+        name: 'remote1',
+        exposes: { './Module': 'apps/remote1/src/module.ts' },
+      })
+    )({});
+
+    // ASSERT
+    expect(config.plugins).toMatchSnapshot();
+  });
+});

--- a/packages/angular/src/utils/mfe/with-module-federation.spec.ts
+++ b/packages/angular/src/utils/mfe/with-module-federation.spec.ts
@@ -1,9 +1,11 @@
 jest.mock('fs');
 jest.mock('@nrwl/workspace/src/core/project-graph');
-jest.mock('@nrwl/workspace');
+jest.mock('@nrwl/workspace/src/utilities/typescript');
+jest.mock('@nrwl/workspace/src/core/file-utils');
 jest.mock('nx/src/shared/workspace');
 import * as graph from '@nrwl/workspace/src/core/project-graph';
-import * as workspace from '@nrwl/workspace';
+import * as typescriptUtils from '@nrwl/workspace/src/utilities/typescript';
+import * as workspace from '@nrwl/workspace/src/core/file-utils';
 import * as taoWorkspace from 'nx/src/shared/workspace';
 import * as fs from 'fs';
 
@@ -46,7 +48,7 @@ describe('withModuleFederation', () => {
       })
     );
 
-    (workspace.readTsConfig as jest.Mock).mockReturnValue({
+    (typescriptUtils.readTsConfig as jest.Mock).mockReturnValue({
       options: {
         paths: {
           shared: ['/libs/shared/src/index.ts'],
@@ -97,7 +99,7 @@ describe('withModuleFederation', () => {
       })
     );
 
-    (workspace.readTsConfig as jest.Mock).mockReturnValue({
+    (typescriptUtils.readTsConfig as jest.Mock).mockReturnValue({
       options: {
         paths: {
           shared: ['/libs/shared/src/index.ts'],
@@ -149,7 +151,7 @@ describe('withModuleFederation', () => {
       })
     );
 
-    (workspace.readTsConfig as jest.Mock).mockReturnValue({
+    (typescriptUtils.readTsConfig as jest.Mock).mockReturnValue({
       options: {
         paths: {
           shared: ['/libs/shared/src/index.ts'],
@@ -205,7 +207,7 @@ describe('withModuleFederation', () => {
       })
     );
 
-    (workspace.readTsConfig as jest.Mock).mockImplementation(() => ({
+    (typescriptUtils.readTsConfig as jest.Mock).mockImplementation(() => ({
       options: {
         paths: {
           shared: ['/libs/shared/src/index.ts'],

--- a/packages/angular/src/utils/mfe/with-module-federation.ts
+++ b/packages/angular/src/utils/mfe/with-module-federation.ts
@@ -1,0 +1,222 @@
+import {
+  SharedLibraryConfig,
+  sharePackages,
+  shareWorkspaceLibraries,
+} from './mfe-webpack';
+import {
+  createProjectGraphAsync,
+  readCachedProjectGraph,
+} from '@nrwl/workspace/src/core/project-graph';
+import { readWorkspaceJson } from '@nrwl/workspace';
+import { joinPathFragments, ProjectGraph } from '@nrwl/devkit';
+import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
+import { Workspaces } from 'nx/src/shared/workspace';
+import { appRootPath } from 'nx/src/utils/app-root';
+import { getRootTsConfigPath } from '@nrwl/workspace/src/utilities/typescript';
+import { readTsConfig } from '@nrwl/workspace';
+import { ParsedCommandLine } from 'typescript';
+
+export type MFERemotes = string[] | [remoteName: string, remoteUrl: string][];
+
+export interface MFEConfig {
+  name: string;
+  remotes?: MFERemotes;
+  exposes?: Record<string, string>;
+  shared?: (
+    libraryName: string,
+    library: SharedLibraryConfig
+  ) => SharedLibraryConfig | false;
+}
+
+function recursivelyResolveWorkspaceDependents(
+  projectGraph: ProjectGraph<any>,
+  target: string
+) {
+  let dependencies = [target];
+
+  const workspaceDependencies = (
+    projectGraph.dependencies[target] ?? []
+  ).filter((dep) => !dep.target.startsWith('npm:'));
+  if (workspaceDependencies.length > 0) {
+    for (const dep of workspaceDependencies) {
+      dependencies = [
+        ...dependencies,
+        ...recursivelyResolveWorkspaceDependents(projectGraph, dep.target),
+      ];
+    }
+  }
+  return dependencies;
+}
+
+function mapWorkspaceLibrariesToTsConfigImport(workspaceLibraries: string[]) {
+  const { projects } = new Workspaces(appRootPath).readWorkspaceConfiguration();
+  const tsConfigPath = process.env.NX_TSCONFIG_PATH ?? getRootTsConfigPath();
+  const tsConfig: ParsedCommandLine = readTsConfig(tsConfigPath);
+
+  const tsconfigPathAliases: Record<string, string[]> = tsConfig.options?.paths;
+
+  if (!tsconfigPathAliases) {
+    return workspaceLibraries;
+  }
+
+  const mappedLibraries = [];
+  for (const lib of workspaceLibraries) {
+    const sourceRoot = projects[lib].sourceRoot;
+    let found = false;
+
+    for (const [key, value] of Object.entries(tsconfigPathAliases)) {
+      if (value.find((p) => p.startsWith(sourceRoot))) {
+        mappedLibraries.push(key);
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      mappedLibraries.push(lib);
+    }
+  }
+
+  return mappedLibraries;
+}
+
+async function getDependentPackagesForProject(name: string) {
+  let projectGraph: ProjectGraph<any>;
+  try {
+    projectGraph = readCachedProjectGraph();
+  } catch (e) {
+    projectGraph = await createProjectGraphAsync();
+  }
+
+  const deps = projectGraph.dependencies[name].reduce(
+    (dependencies, dependency) => {
+      const workspaceLibraries = dependencies.workspaceLibraries;
+      const npmPackages = dependencies.npmPackages;
+
+      if (dependency.target.startsWith('npm')) {
+        npmPackages.push(dependency.target.replace('npm:', ''));
+      } else {
+        workspaceLibraries.push(dependency.target);
+      }
+
+      return {
+        workspaceLibraries,
+        npmPackages,
+      };
+    },
+    { workspaceLibraries: [], npmPackages: [] }
+  );
+  deps.workspaceLibraries = deps.workspaceLibraries.reduce(
+    (workspaceLibraryDeps, workspaceLibrary) => [
+      ...workspaceLibraryDeps,
+      ...recursivelyResolveWorkspaceDependents(projectGraph, workspaceLibrary),
+    ],
+    []
+  );
+
+  deps.workspaceLibraries = mapWorkspaceLibrariesToTsConfigImport(
+    deps.workspaceLibraries
+  );
+  return deps;
+}
+
+function determineRemoteUrl(remote: string) {
+  const workspace = readWorkspaceJson();
+  return joinPathFragments(
+    workspace.projects[remote].targets.serve.options.publicHost,
+    'remoteEntry.mjs'
+  );
+}
+
+function mapRemotes(remotes: MFERemotes) {
+  const mappedRemotes = {};
+
+  for (const remote of remotes) {
+    if (Array.isArray(remote)) {
+      mappedRemotes[remote[0]] = remote[1];
+    } else if (typeof remote === 'string') {
+      mappedRemotes[remote] = determineRemoteUrl(remote);
+    }
+  }
+
+  return mappedRemotes;
+}
+
+export async function withModuleFederation(options: MFEConfig) {
+  const DEFAULT_NPM_PACKAGES_TO_AVOID = ['zone.js'];
+
+  const dependencies = await getDependentPackagesForProject(options.name);
+  const sharedLibraries = shareWorkspaceLibraries(
+    dependencies.workspaceLibraries
+  );
+
+  const npmPackages = sharePackages(
+    dependencies.npmPackages.filter(
+      (pkg) => !DEFAULT_NPM_PACKAGES_TO_AVOID.includes(pkg)
+    )
+  );
+
+  const sharedDependencies = {
+    ...sharedLibraries.getLibraries(),
+    ...npmPackages,
+  };
+
+  if (options.shared) {
+    for (const [libraryName, library] of Object.entries(sharedDependencies)) {
+      const mappedDependency = options.shared(libraryName, library);
+      if (mappedDependency === false) {
+        delete sharedDependencies[libraryName];
+        continue;
+      } else if (!mappedDependency) {
+        continue;
+      }
+
+      sharedDependencies[libraryName] = mappedDependency;
+    }
+  }
+
+  const mappedRemotes =
+    !options.remotes || options.remotes.length === 0
+      ? {}
+      : mapRemotes(options.remotes);
+
+  return (config) => ({
+    ...(config ?? {}),
+    output: {
+      ...(config.output ?? {}),
+      uniqueName: options.name,
+      publicPath: 'auto',
+    },
+    optimization: {
+      ...(config.optimization ?? {}),
+      runtimeChunk: false,
+    },
+    resolve: {
+      ...(config.resolve ?? {}),
+      alias: {
+        ...(config.resolve?.alias ?? {}),
+        ...sharedLibraries.getAliases(),
+      },
+    },
+    experiments: {
+      ...(config.experiments ?? {}),
+      outputModule: true,
+    },
+    plugins: [
+      ...(config.plugins ?? []),
+      new ModuleFederationPlugin({
+        name: options.name,
+        filename: 'remoteEntry.mjs',
+        exposes: options.exposes,
+        remotes: mappedRemotes,
+        shared: {
+          ...sharedDependencies,
+        },
+        library: {
+          type: 'module',
+        },
+      }),
+      sharedLibraries.getReplacementPlugin(),
+    ],
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5861,6 +5861,14 @@
     "@types/eslint" "*"
     "@types/estree" "*"
 
+"@types/eslint-scope@^3.7.3":
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
+  integrity sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==
+  dependencies:
+    "@types/eslint" "*"
+    "@types/estree" "*"
+
 "@types/eslint@*":
   version "8.2.0"
   resolved "https://registry.npmjs.org/@types/eslint/-/eslint-8.2.0.tgz"
@@ -5886,6 +5894,11 @@
   version "0.0.39"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/estree@^0.0.51":
+  version "0.0.51"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
+  integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
   version "4.17.28"
@@ -6351,6 +6364,15 @@
     "@types/webpack-sources" "*"
     anymatch "^3.0.0"
     source-map "^0.6.0"
+
+"@types/webpack@^5.28.0":
+  version "5.28.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-5.28.0.tgz#78dde06212f038d77e54116cfe69e88ae9ed2c03"
+  integrity sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==
+  dependencies:
+    "@types/node" "*"
+    tapable "^2.2.0"
+    webpack "^5"
 
 "@types/ws@^8.2.2":
   version "8.2.2"
@@ -11075,6 +11097,14 @@ enhanced-resolve@^5.0.0, enhanced-resolve@^5.7.0, enhanced-resolve@^5.8.3:
   version "5.8.3"
   resolved "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz"
   integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
+enhanced-resolve@^5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz#0224dcd6a43389ebfb2d55efee517e5466772dd9"
+  integrity sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -24539,6 +24569,36 @@ webpack@5.67.0:
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
     enhanced-resolve "^5.8.3"
+    es-module-lexer "^0.9.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.9"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.1.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.3.1"
+    webpack-sources "^3.2.3"
+
+webpack@^5:
+  version "5.70.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.70.0.tgz#3461e6287a72b5e6e2f4872700bc8de0d7500e6d"
+  integrity sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==
+  dependencies:
+    "@types/eslint-scope" "^3.7.3"
+    "@types/estree" "^0.0.51"
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/wasm-edit" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    acorn "^8.4.1"
+    acorn-import-assertions "^1.7.6"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.9.2"
     es-module-lexer "^0.9.0"
     eslint-scope "5.1.1"
     events "^3.2.0"


### PR DESCRIPTION
## Current Behavior
We have a large webpack config file that gets generated for host and remote MFE apps. It provides too much flexibility and it can be complex for the average developer to configure correctly.

## Expected Behavior
Create a helper function that will 
- generate a webpack config, but with a lot more constraints in place.
- automatically find and share project dependencies to enforce a single version policy
- provide options for configuring host's remotes and their location
- provide option for remotes to specify what they expose
- provide option to override or remove libraries and packages from being shared 

For Remotes: this allows us to go from:

```js
const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
const mf = require('@angular-architects/module-federation/webpack');
const path = require('path');
const share = mf.share;

/**
 * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
 * builder as it will generate a temporary tsconfig file which contains any required remappings of
 * shared libraries.
 * A remapping will occur when a library is buildable, as webpack needs to know the location of the
 * built files for the buildable library.
 * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
 * the location of the generated temporary tsconfig file.
 */
const tsConfigPath =
  process.env.NX_TSCONFIG_PATH ??
  path.join(__dirname, '../../tsconfig.base.json');

const workspaceRootPath = path.join(__dirname, '../../');
const sharedMappings = new mf.SharedMappings();
sharedMappings.register(
  tsConfigPath,
  [
    /* mapped paths to share */
  ],
  workspaceRootPath
);

module.exports = {
  output: {
    uniqueName: 'todo',
    publicPath: 'auto',
  },
  optimization: {
    runtimeChunk: false,
  },
  experiments: {
    outputModule: true,
  },
  resolve: {
    alias: {
      ...sharedMappings.getAliases(),
    },
  },
  plugins: [
    new ModuleFederationPlugin({
      name: 'todo',
      filename: 'remoteEntry.js',
      exposes: {
        './Module': 'apps/todo/src/app/remote-entry/entry.module.ts',
      },
      shared: share({
        '@angular/core': {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        '@angular/common': {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        '@angular/common/http': {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        '@angular/router': {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        rxjs: {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        ...sharedMappings.getDescriptors(),
      }),
      library: {
        type: 'module',
      },
    }),
    sharedMappings.getPlugin(),
  ],
};
```

to 

```js
const { withModuleFederation } = require('@nrwl/angular/module-federation');
module.exports = withModuleFederation({
  name: 'todo',
  exposes: {
    './Module': 'apps/todo/src/app/remote-entry/entry.module.ts',
  },
});
```

and for hosts, from:

```js
const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
const mf = require('@angular-architects/module-federation/webpack');
const path = require('path');
const share = mf.share;

/**
 * We use the NX_TSCONFIG_PATH environment variable when using the @nrwl/angular:webpack-browser
 * builder as it will generate a temporary tsconfig file which contains any required remappings of
 * shared libraries.
 * A remapping will occur when a library is buildable, as webpack needs to know the location of the
 * built files for the buildable library.
 * This NX_TSCONFIG_PATH environment variable is set by the @nrwl/angular:webpack-browser and it contains
 * the location of the generated temporary tsconfig file.
 */
const tsConfigPath =
  process.env.NX_TSCONFIG_PATH ??
  path.join(__dirname, '../../tsconfig.base.json');

const workspaceRootPath = path.join(__dirname, '../../');
const sharedMappings = new mf.SharedMappings();
sharedMappings.register(
  tsConfigPath,
  [
    /* mapped paths to share */
    '@mfe-netlify/shared/auth',
  ],
  workspaceRootPath
);

module.exports = {
  output: {
    uniqueName: 'dashboard',
    publicPath: 'auto',
  },
  optimization: {
    runtimeChunk: false,
  },
  experiments: {
    outputModule: true,
  },
  resolve: {
    alias: {
      ...sharedMappings.getAliases(),
    },
  },
  plugins: [
    new ModuleFederationPlugin({
      remotes: {
        todo: 'https://todo-mfe-video.netlify.app/remoteEntry.js',
        login: 'https://login-mfe-video.netlify.app/remoteEntry.js',
      },
      shared: share({
        '@angular/core': {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        '@angular/common': {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        '@angular/common/http': {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        '@angular/router': {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        rxjs: {
          singleton: true,
          strictVersion: true,
          requiredVersion: 'auto',
          includeSecondaries: true,
        },
        ...sharedMappings.getDescriptors(),
      }),
      library: {
        type: 'module',
      },
    }),
    sharedMappings.getPlugin(),
  ],
};
```

to

```js
const { withModuleFederation } = require('@nrwl/angular/module-federation');
module.exports = withModuleFederation({
  name: 'dashboard',
  remotes: ['todo', 'login'],
});

```