### PR TITLE
fix(react): update package.json only with shallow dependencies

### DIFF
--- a/packages/web/src/executors/rollup/rollup.impl.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.ts
@@ -55,18 +55,9 @@ export default async function* rollupExecutor(
     context.root,
     context.projectName,
     context.targetName,
-    context.configurationName
+    context.configurationName,
+    true
   );
-  if (
-    !checkDependentProjectsHaveBeenBuilt(
-      context.root,
-      context.projectName,
-      context.targetName,
-      dependencies
-    )
-  ) {
-    throw new Error();
-  }
 
   const options = normalizeWebRollupOptions(
     rawOptions,


### PR DESCRIPTION
This PR fixes a bug where building a parent lib includes npm dependencies from its workspace libs it depends on in the generated `package.json` file.

## Current Behavior
All npm dependencies from workspace dependencies are recursively picked up.

## Expected Behavior
Only parent lib's npm dependencies should be present.


Fixes #8640 
