### PR TITLE
feat(nx-plugin): port compiler option into nx-plugin generator

### DIFF
--- a/docs/generated/api-nx-plugin/generators/plugin.md
+++ b/docs/generated/api-nx-plugin/generators/plugin.md
@@ -43,6 +43,16 @@ Type: `string`
 
 Plugin name
 
+### compiler
+
+Default: `tsc`
+
+Type: `string`
+
+Possible values: `tsc`, `swc`
+
+The compiler used by the build and test targets
+
 ### directory
 
 Alias(es): d

--- a/packages/nx-plugin/src/generators/plugin/schema.d.ts
+++ b/packages/nx-plugin/src/generators/plugin/schema.d.ts
@@ -11,4 +11,5 @@ export interface Schema {
   linter: Linter;
   standaloneConfig?: boolean;
   setParserOptionsProject?: boolean;
+  compiler: 'swc' | 'tsc';
 }

--- a/packages/nx-plugin/src/generators/plugin/schema.json
+++ b/packages/nx-plugin/src/generators/plugin/schema.json
@@ -64,6 +64,12 @@
       "type": "boolean",
       "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
       "default": false
+    },
+    "compiler": {
+      "type": "string",
+      "enum": ["tsc", "swc"],
+      "default": "tsc",
+      "description": "The compiler used by the build and test targets"
     }
   },
   "required": ["name"],


### PR DESCRIPTION
## Current Behavior
Nx plugins always generate with `@nrwl/tsc` as the executor

## Expected Behavior
`nx g @nrwl/nx-plugin:plugin` accepts the `--compiler` flag

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
