### PR TITLE
fix(storybook): fixing the static-dir issue

### DIFF
--- a/docs/generated/api-storybook/executors/storybook.md
+++ b/docs/generated/api-storybook/executors/storybook.md
@@ -83,15 +83,9 @@ SSL key to use for serving HTTPS.
 
 Type: `array`
 
-**Deprecated:** This field has been renamed to staticDirs.
+**Deprecated:** In Storybook 6.4 the `--static-dir` CLI flag has been replaced with the the `staticDirs` field in `.storybook/main.js`. It will be removed completely in Storybook 7.0.
 
 Directory where to load static files from, array of strings
-
-### staticDirs
-
-Type: `array`
-
-Directory where to load static files from, array of strings or object with from, to keys
 
 ### stylePreprocessorOptions.includePaths
 

--- a/packages/storybook/src/executors/storybook/schema.json
+++ b/packages/storybook/src/executors/storybook/schema.json
@@ -50,19 +50,10 @@
     "staticDir": {
       "type": "array",
       "description": "Directory where to load static files from, array of strings",
-      "default": [],
       "items": {
         "type": "string"
       },
-      "x-deprecated": "This field has been renamed to staticDirs."
-    },
-    "staticDirs": {
-      "type": "array",
-      "description": "Directory where to load static files from, array of strings or object with from, to keys",
-      "default": [],
-      "items": {
-        "$ref": "#/definitions/staticDirPattern"
-      }
+      "x-deprecated": "In Storybook 6.4 the `--static-dir` CLI flag has been replaced with the the `staticDirs` field in `.storybook/main.js`. It will be removed completely in Storybook 7.0."
     },
     "projectBuildConfig": {
       "type": "string",
@@ -142,28 +133,6 @@
         {
           "type": "string",
           "description": "The file to include."
-        }
-      ]
-    },
-    "staticDirPattern": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "from": {
-              "type": "string",
-              "description": "From path"
-            },
-            "to": {
-              "type": "string",
-              "description": "To path"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["from", "to"]
-        },
-        {
-          "type": "string"
         }
       ]
     }

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -18,7 +18,6 @@ export interface StorybookExecutorOptions extends CommonNxStorybookConfig {
   sslCert?: string;
   sslKey?: string;
   staticDir?: string[];
-  staticDirs?: string[] | { from: string; to: string }[];
   watch?: boolean;
   docsMode?: boolean;
 }


### PR DESCRIPTION
## Current Behavior
* The addition of `"default": []` to the `staticDir` option in the Storybook executor schema, breaks it when a user provides `staticDirs` in `main.js`. This should not happen.

## Expected Behavior
* [`staticDir CLI flag deprecation`](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated---static-dir-cli-flag)
* Show deprecation message
* `staticDirs` in `main.js` works
* `staticDir` CLI option should not default to anything

## Related Issue(s)

* Mostly reverting https://github.com/nrwl/nx/pull/8885 
* Related: https://github.com/storybookjs/storybook/pull/15969
* Solves: https://github.com/nrwl/nx/issues/9306


Fixes #9306
