### PR TITLE
fix(angular): strip trailing slash from directory #9263

### DIFF
--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -34,7 +34,7 @@ export function normalizeOptions(
 
   const name = names(options.name).fileName;
   const projectDirectory = options.directory
-    ? `${names(options.directory).fileName}/${name}`
+    ? `${names(options.directory).fileName}/${name}`.replace(/\/+/g, '/')
     : name;
 
   const { libsDir, npmScope, standaloneAsDefault } = getWorkspaceLayout(host);

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -46,6 +46,13 @@ describe('lib', () => {
       tree = createTreeWithEmptyWorkspace(2);
     });
 
+    it('should run the library generator without erroring if the directory has a trailing slash', async () => {
+      // ACT & ASSERT
+      await expect(
+        runLibraryGeneratorWithOpts({ directory: 'mylib/shared/' })
+      ).resolves.not.toThrow();
+    });
+
     it('should default to standalone project for first project', async () => {
       await runLibraryGeneratorWithOpts();
       const workspaceJsonEntry = readJson(tree, 'workspace.json').projects[


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Having a trailing slash in `directory` option is causing an error due to our parsing of it.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
strip off the trailing slash.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9263
