### PR TITLE
fix(angular): update library package.json only with direct dependencies

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-lite.impl.spec.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-lite.impl.spec.ts
@@ -31,6 +31,7 @@ describe('NgPackagrLite executor', () => {
     ).mockImplementation(() => ({
       target: {},
       dependencies: [],
+      topLevelDependencies: [],
     }));
 
     ngPackagrBuildMock = jest.fn(() => Promise.resolve());

--- a/packages/angular/src/executors/package/package.impl.spec.ts
+++ b/packages/angular/src/executors/package/package.impl.spec.ts
@@ -31,6 +31,7 @@ describe('Package executor', () => {
     ).mockImplementation(() => ({
       target: {},
       dependencies: [],
+      topLevelDependencies: [],
     }));
     ngPackagrBuildMock = jest.fn(() => Promise.resolve());
     ngPackagerWatchSubject = new BehaviorSubject<void>(undefined);

--- a/packages/angular/src/executors/package/package.impl.ts
+++ b/packages/angular/src/executors/package/package.impl.ts
@@ -66,13 +66,14 @@ export function createLibraryExecutor(
     options: BuildAngularLibraryExecutorOptions,
     context: ExecutorContext
   ) {
-    const { target, dependencies } = calculateProjectDependencies(
-      readCachedProjectGraph(),
-      context.root,
-      context.projectName,
-      context.targetName,
-      context.configurationName
-    );
+    const { target, dependencies, topLevelDependencies } =
+      calculateProjectDependencies(
+        readCachedProjectGraph(),
+        context.root,
+        context.projectName,
+        context.targetName,
+        context.configurationName
+      );
     if (
       !checkDependentProjectsHaveBeenBuilt(
         context.root,
@@ -86,7 +87,7 @@ export function createLibraryExecutor(
 
     function updatePackageJson(): void {
       if (
-        dependencies.length > 0 &&
+        topLevelDependencies.length > 0 &&
         options.updateBuildableProjectDepsInPackageJson
       ) {
         updateBuildableProjectPackageJsonDependencies(
@@ -95,7 +96,7 @@ export function createLibraryExecutor(
           context.targetName,
           context.configurationName,
           target,
-          dependencies,
+          topLevelDependencies,
           options.buildableProjectDepsInPackageJsonType
         );
       }


### PR DESCRIPTION
This is a fix similar to https://github.com/nrwl/nx/pull/9297. The difference is that for Angular all deps are still needed to be collected to properly remap the TS path mappings, but only the direct deps are needed for updating the `package.json`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When building a library, the `package.json` ends up with all the dependencies including the ones that are not direct dependencies. Transitive dependencies would be installed as part of the library's direct dependencies, there's no need to specify them as dependencies of the library.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `package.json` of a built library should only contain direct dependencies.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
