### PR TITLE
fix(js): fix inconsistent tsconfig module casing

### DIFF
--- a/packages/js/src/generators/library/files/lib/tsconfig.json__tmpl__
+++ b/packages/js/src/generators/library/files/lib/tsconfig.json__tmpl__
@@ -1,7 +1,7 @@
 {
   "extends": "<%= rootTsConfigPath %>",
   "compilerOptions": {
-    "module": "CommonJS"<% if (js) { %>,
+    "module": "commonjs"<% if (js) { %>,
     "allowJs": true<% } %>
   },
   "files": [],

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -140,7 +140,7 @@ describe('lib', () => {
                   Object {
                     "compilerOptions": Object {
                       "forceConsistentCasingInFileNames": true,
-                      "module": "CommonJS",
+                      "module": "commonjs",
                       "noFallthroughCasesInSwitch": true,
                       "noImplicitOverride": true,
                       "noImplicitReturns": true,

--- a/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -40,7 +40,7 @@ exports[`lib --testEnvironment should set target jest testEnvironment to node by
 exports[`lib --unit-test-runner none should not generate test configuration 1`] = `
 Object {
   "compilerOptions": Object {
-    "module": "CommonJS",
+    "module": "commonjs",
   },
   "extends": "../../tsconfig.base.json",
   "files": Array [],
@@ -70,7 +70,7 @@ Object {
 exports[`lib nested should create a local tsconfig.json 1`] = `
 Object {
   "compilerOptions": Object {
-    "module": "CommonJS",
+    "module": "commonjs",
   },
   "extends": "../../../tsconfig.base.json",
   "files": Array [],
@@ -102,7 +102,7 @@ export class MyLibModule {}
 exports[`lib not nested should create a local tsconfig.json 1`] = `
 Object {
   "compilerOptions": Object {
-    "module": "CommonJS",
+    "module": "commonjs",
   },
   "extends": "../../tsconfig.base.json",
   "files": Array [],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`"module": "CommonJS"` is generated for `@nrwl/js` libraries while it is `"module": "commonjs"` everywhere else.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`"module": "commonjs"` is used everywhere.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/8986
