### PR TITLE
fix(core): don't allow arbitrary code execution when manipulating cache

### DIFF
--- a/packages/workspace/src/tasks-runner/cache.ts
+++ b/packages/workspace/src/tasks-runner/cache.ts
@@ -14,7 +14,7 @@ import {
 } from 'fs-extra';
 import { dirname, join, resolve, sep } from 'path';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
-import { spawn, exec } from 'child_process';
+import { spawn, execFile } from 'child_process';
 import { cacheDir } from '../utilities/cache-directory';
 import { platform } from 'os';
 
@@ -190,7 +190,7 @@ export class Cache {
     }
 
     return new Promise((res, rej) => {
-      exec(`cp -a "${src}" "${dirname(directory)}"`, (error) => {
+      execFile('cp', ['-a', src, dirname(directory)], (error) => {
         if (!error) {
           res();
         } else {
@@ -207,7 +207,7 @@ export class Cache {
     }
 
     return new Promise<void>((res, rej) => {
-      exec(`rm -rf "${folder}"`, (error) => {
+      execFile('rm', ['-rf', folder], (error) => {
         if (!error) {
           res();
         } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A carefully crafted `NX_CACHE_DIRECTORY` (environment variable) can make NX execute arbitrary commands. The same holds true for the `cacheDirectory` field in `nx.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

NX should not execute arbitrary code embedded in the `NX_CACHE_DIRECTORY` environment variable.

## Fix

The Node documentation for `exec` states:

> Never pass unsanitized user input to this function. Any input containing shell metacharacters may be used to trigger arbitrary command execution.

The `folder` variable comes directly from the `NX_CACHE_DIRECTORY` environment variable (or from `nx.json`). Careful crafting of this variable can result in NX executing arbitrary commands.

This patch fixes this by using `execFile`, which does not spawn a shell.
