### PR TITLE
feat(angular): default export to true

### DIFF
--- a/docs/generated/api-angular/generators/scam-directive.md
+++ b/docs/generated/api-angular/generators/scam-directive.md
@@ -37,7 +37,7 @@ The name of the directive.
 
 ### export
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/generated/api-angular/generators/scam-pipe.md
+++ b/docs/generated/api-angular/generators/scam-pipe.md
@@ -37,7 +37,7 @@ The name of the pipe.
 
 ### export
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/docs/generated/api-angular/generators/scam.md
+++ b/docs/generated/api-angular/generators/scam.md
@@ -59,7 +59,7 @@ Specifies if the style will contain `:host { display: block; }`.
 
 ### export
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 

--- a/packages/angular/src/generators/scam-directive/schema.json
+++ b/packages/angular/src/generators/scam-directive/schema.json
@@ -66,7 +66,7 @@
     "export": {
       "type": "boolean",
       "description": "Specifies if the SCAM should be exported from the project's entry point (normally `index.ts`). It only applies to libraries.",
-      "default": false
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/angular/src/generators/scam-pipe/schema.json
+++ b/packages/angular/src/generators/scam-pipe/schema.json
@@ -47,7 +47,7 @@
     "export": {
       "type": "boolean",
       "description": "Specifies if the SCAM should be exported from the project's entry point (normally `index.ts`). It only applies to libraries.",
-      "default": false
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/angular/src/generators/scam/schema.json
+++ b/packages/angular/src/generators/scam/schema.json
@@ -113,7 +113,7 @@
     "export": {
       "type": "boolean",
       "description": "Specifies if the SCAM should be exported from the project's entry point (normally `index.ts`). It only applies to libraries.",
-      "default": false
+      "default": true
     }
   },
   "required": ["name"]


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
By default we do not export scams from the library's entry point. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should export them by default to ensure webpack chunk loading doesn't go awry.
