### PR TITLE
cleanup(angular): ban imports from @nrwl/workspace entry point

### DIFF
--- a/packages/angular/.eslintrc.json
+++ b/packages/angular/.eslintrc.json
@@ -14,6 +14,13 @@
     {
       "files": ["*.js", "*.jsx"],
       "rules": {}
+    },
+    {
+      "files": ["**/*.ts"],
+      "excludedFiles": ["./src/migrations/**"],
+      "rules": {
+        "no-restricted-imports": ["error", "@nrwl/workspace"]
+      }
     }
   ]
 }

--- a/packages/angular/src/generators/add-linting/lib/create-eslint-configuration.ts
+++ b/packages/angular/src/generators/add-linting/lib/create-eslint-configuration.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 import { joinPathFragments, offsetFromRoot, writeJson } from '@nrwl/devkit';
-import { stringUtils } from '@nrwl/workspace';
+import { camelize, dasherize } from '@nrwl/workspace/src/utils/strings';
 import type { AddLintingGeneratorSchema } from '../schema';
 
 export function createEsLintConfiguration(
@@ -44,7 +44,7 @@ export function createEsLintConfiguration(
             'error',
             {
               type: 'attribute',
-              prefix: stringUtils.camelize(options.prefix),
+              prefix: camelize(options.prefix),
               style: 'camelCase',
             },
           ],
@@ -52,7 +52,7 @@ export function createEsLintConfiguration(
             'error',
             {
               type: 'element',
-              prefix: stringUtils.dasherize(options.prefix),
+              prefix: dasherize(options.prefix),
               style: 'kebab-case',
             },
           ],

--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -5,7 +5,7 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
-import { convertToNxProjectGenerator } from '@nrwl/workspace';
+import { convertToNxProjectGenerator } from '@nrwl/workspace/generators';
 import { UnitTestRunner } from '../../utils/test-runners';
 import { angularInitGenerator } from '../init/init';
 import { setupTailwindGenerator } from '../setup-tailwind/setup-tailwind';

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -8,7 +8,7 @@ import { E2eTestRunner } from '../../../utils/test-runners';
 import { addProtractor } from './add-protractor';
 import { removeScaffoldedE2e } from './remove-scaffolded-e2e';
 import { updateE2eProject } from './update-e2e-project';
-import { convertToNxProjectGenerator } from '@nrwl/workspace';
+import { convertToNxProjectGenerator } from '@nrwl/workspace/generators';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { getWorkspaceLayout, joinPathFragments } from '@nrwl/devkit';
 

--- a/packages/angular/src/generators/application/lib/update-config-files.ts
+++ b/packages/angular/src/generators/application/lib/update-config-files.ts
@@ -9,7 +9,7 @@ import {
   removeProjectConfiguration,
   offsetFromRoot,
 } from '@nrwl/devkit';
-import { replaceAppNameWithPath } from '@nrwl/workspace';
+import { replaceAppNameWithPath } from '@nrwl/workspace/src/utils/cli-config-utils';
 import { E2eTestRunner, UnitTestRunner } from '../../../utils/test-runners';
 
 export function updateConfigFiles(host: Tree, options: NormalizedSchema) {

--- a/packages/angular/src/generators/library/lib/update-project.ts
+++ b/packages/angular/src/generators/library/lib/update-project.ts
@@ -8,7 +8,7 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import { replaceAppNameWithPath } from '@nrwl/workspace';
+import { replaceAppNameWithPath } from '@nrwl/workspace/src/utils/cli-config-utils';
 import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import * as path from 'path';
 import { NormalizedSchema } from './normalized-schema';

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -8,7 +8,7 @@ import {
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { jestProjectGenerator } from '@nrwl/jest';
 import { Linter } from '@nrwl/linter';
-import { convertToNxProjectGenerator } from '@nrwl/workspace';
+import { convertToNxProjectGenerator } from '@nrwl/workspace/generators';
 import init from '../../generators/init/init';
 import { postcssVersion } from '../../utils/versions';
 import addLintingGenerator from '../add-linting/add-linting';

--- a/packages/angular/src/generators/move/lib/update-module-name.spec.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.spec.ts
@@ -1,6 +1,6 @@
 import { Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { moveGenerator } from '@nrwl/workspace';
+import { moveGenerator } from '@nrwl/workspace/generators';
 import { Schema } from '../schema';
 import { updateModuleName } from './update-module-name';
 import libraryGenerator from '../../library/library';

--- a/packages/angular/src/generators/move/move.ts
+++ b/packages/angular/src/generators/move/move.ts
@@ -1,5 +1,5 @@
 import { convertNxGenerator, formatFiles, Tree } from '@nrwl/devkit';
-import { moveGenerator } from '@nrwl/workspace';
+import { moveGenerator } from '@nrwl/workspace/generators';
 import { updateModuleName } from './lib/update-module-name';
 import { updateNgPackage } from './lib/update-ng-package';
 import { Schema } from './schema';

--- a/packages/angular/src/generators/ngrx/lib/add-ngrx-to-package-json.ts
+++ b/packages/angular/src/generators/ngrx/lib/add-ngrx-to-package-json.ts
@@ -5,7 +5,7 @@ import {
   ngrxVersion,
   rxjsVersion as defaultRxjsVersion,
 } from '../../../utils/versions';
-import { checkAndCleanWithSemver } from '@nrwl/workspace';
+import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
 
 export function addNgRxToPackageJson(tree: Tree): GeneratorCallback {
   let rxjsVersion: string;

--- a/packages/angular/src/generators/setup-tailwind/lib/detect-tailwind-installed-version.ts
+++ b/packages/angular/src/generators/setup-tailwind/lib/detect-tailwind-installed-version.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree } from '@nrwl/devkit';
-import { checkAndCleanWithSemver } from '@nrwl/workspace';
+import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
 import { lt } from 'semver';
 
 export function detectTailwindInstalledVersion(

--- a/packages/angular/src/utils/mfe-webpack.spec.ts
+++ b/packages/angular/src/utils/mfe-webpack.spec.ts
@@ -1,7 +1,7 @@
 jest.mock('fs');
-jest.mock('@nrwl/workspace');
+jest.mock('@nrwl/workspace/src/utilities/typescript');
 import * as fs from 'fs';
-import * as workspace from '@nrwl/workspace';
+import * as tsUtils from '@nrwl/workspace/src/utilities/typescript';
 
 import { sharePackages, shareWorkspaceLibraries } from './mfe-webpack';
 
@@ -27,7 +27,7 @@ describe('MFE Webpack Utils', () => {
     it('should create an object with correct setup', () => {
       // ARRANGE
       (fs.existsSync as jest.Mock).mockReturnValue(true);
-      (workspace.readTsConfig as jest.Mock).mockReturnValue({
+      (tsUtils.readTsConfig as jest.Mock).mockReturnValue({
         options: {
           paths: {
             '@myorg/shared': ['/libs/shared/src/index.ts'],
@@ -53,7 +53,7 @@ describe('MFE Webpack Utils', () => {
     it('should create an object with empty setup when tsconfig does not contain the shared lib', () => {
       // ARRANGE
       (fs.existsSync as jest.Mock).mockReturnValue(true);
-      (workspace.readTsConfig as jest.Mock).mockReturnValue({
+      (tsUtils.readTsConfig as jest.Mock).mockReturnValue({
         options: {
           paths: {},
         },

--- a/packages/angular/src/utils/mfe-webpack.ts
+++ b/packages/angular/src/utils/mfe-webpack.ts
@@ -1,4 +1,4 @@
-import { readTsConfig } from '@nrwl/workspace';
+import { readTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import { existsSync, readFileSync } from 'fs';
 import { NormalModuleReplacementPlugin } from 'webpack';
 import { appRootPath as rootPath } from 'nx/src/utils/app-root';


### PR DESCRIPTION
Add an ESLint rule for the Angular plugin to ban imports from the `@nrwl/workspace` entry point. This brings the plugin in line with the rest of the verticals.
