### PR TITLE
fix(core): targets referred to by targetDependencies should be optional by default

### DIFF
--- a/packages/workspace/src/tasks-runner/run-command.ts
+++ b/packages/workspace/src/tasks-runner/run-command.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { appRootPath } from 'nx/src/utils/app-root';
 import type {
   NxJsonConfiguration,
+  ProjectConfiguration,
   ProjectGraph,
   ProjectGraphProjectNode,
   TargetDependencyConfig,
@@ -347,7 +348,7 @@ export function createTask({
 }
 
 function addTasksForProjectDependencyConfig(
-  project: ProjectGraphProjectNode,
+  project: ProjectGraphProjectNode<ProjectConfiguration>,
   {
     target,
     configuration,
@@ -428,7 +429,7 @@ function addTasksForProjectDependencyConfig(
         }
       }
     }
-  } else {
+  } else if (projectHasTarget(project, dependencyConfig.target)) {
     addTasksForProjectTarget(
       {
         project,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Adding a targetDependency such as below requires that all projects have build-base available

```json
{
  "build": [{
     "target": "build-base",
     "projects": "dependencies"
  }]
}
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
