### PR TITLE
feat(js): infer tslib as a dependency when using importHelpers

### DIFF
--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -7,6 +7,7 @@ import { join, resolve } from 'path';
 import { checkDependencies } from '../../utils/check-dependencies';
 import { CopyAssetsHandler } from '../../utils/copy-assets-handler';
 import { ExecutorOptions, NormalizedExecutorOptions } from '../../utils/schema';
+import { addTslibDependencyIfNeeded } from '../../utils/tslib-dependency';
 import { compileTypeScriptFiles } from '../../utils/typescript/compile-typescript-files';
 import { updatePackageJson } from '../../utils/update-package-json';
 import { watchForSingleFileChanges } from '../../utils/watch-for-single-file-changes';
@@ -59,6 +60,8 @@ export async function* tscExecutor(
   if (tmpTsConfig) {
     options.tsConfig = tmpTsConfig;
   }
+
+  addTslibDependencyIfNeeded(options, context, dependencies);
 
   const assetHandler = new CopyAssetsHandler({
     projectDir: projectRoot,

--- a/packages/js/src/utils/tslib-dependency.ts
+++ b/packages/js/src/utils/tslib-dependency.ts
@@ -1,0 +1,47 @@
+import { ExecutorContext, getPackageManagerCommand } from '@nrwl/devkit';
+import { readCachedProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { readTsConfig } from '@nrwl/workspace/src/utilities/typescript';
+import { NormalizedExecutorOptions } from './schema';
+
+const tslibNodeName = 'npm:tslib';
+
+function shouldAddTslibDependency(
+  tsConfig: string,
+  dependencies: DependentBuildableProjectNode[]
+): boolean {
+  if (dependencies.some((dep) => dep.name === tslibNodeName)) {
+    return false;
+  }
+
+  const config = readTsConfig(tsConfig);
+  return !!config.options.importHelpers;
+}
+
+export function addTslibDependencyIfNeeded(
+  options: NormalizedExecutorOptions,
+  context: ExecutorContext,
+  dependencies: DependentBuildableProjectNode[]
+): void {
+  if (!shouldAddTslibDependency(options.tsConfig, dependencies)) {
+    return;
+  }
+
+  const depGraph = readCachedProjectGraph();
+  const tslibNode = depGraph.externalNodes[tslibNodeName];
+
+  if (!tslibNode) {
+    const pmc = getPackageManagerCommand();
+    throw new Error(
+      `"importHelpers" is enabled for ${context.targetName} but tslib is not installed. Use "${pmc.add} tslib" to install it.`
+    );
+  }
+
+  const tslibDependency: DependentBuildableProjectNode = {
+    name: tslibNodeName,
+    outputs: [],
+    node: tslibNode,
+  };
+
+  dependencies.push(tslibDependency);
+}

--- a/packages/workspace/src/utilities/typescript.ts
+++ b/packages/workspace/src/utilities/typescript.ts
@@ -10,7 +10,7 @@ export { getSourceNodes } from './typescript/get-source-nodes';
 
 const normalizedAppRoot = appRootPath.replace(/\\/g, '/');
 
-let tsModule: any;
+let tsModule: typeof import('typescript');
 
 export function readTsConfig(tsConfigPath: string) {
   if (!tsModule) {
@@ -31,18 +31,21 @@ function readTsConfigOptions(tsConfigPath: string) {
   if (!tsModule) {
     tsModule = require('typescript');
   }
+
   const readResult = tsModule.readConfigFile(
     tsConfigPath,
     tsModule.sys.readFile
   );
+
   // we don't need to scan the files, we only care about options
-  const host = {
+  const host: Partial<ts.ParseConfigHost> = {
     readDirectory: () => [],
     fileExists: tsModule.sys.fileExists,
   };
+
   return tsModule.parseJsonConfigFileContent(
     readResult.config,
-    host,
+    host as ts.ParseConfigHost,
     dirname(tsConfigPath)
   ).options;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

When using `"importHelpers": true` and building with `tsc`, the built bundle expects to be supplied the `tslib` package.

Currently, it's up to developers to add `tslib` as a dependency to those libraries' package.json files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR makes the `tsc` executor infer that `importHelpers` is used,
and subsequently, add `tslib` as a dependency to the generated `package.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9343
