### PR TITLE
fix(core): fix cli to properly handle the migrate command after the packages consolidation

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -6,7 +6,11 @@ import { output } from '../src/cli/output';
 import { detectPackageManager } from '../src/shared/package-manager';
 import { Workspace } from '../src/cli/workspace';
 
-if (process.argv[2] === 'new' || process.argv[2] === '_migrate') {
+if (
+  process.argv[2] === 'new' ||
+  process.argv[2] === '_migrate' ||
+  process.argv[2] === 'migrate'
+) {
   require('../src/cli/index');
 } else {
   const workspace = findWorkspaceRoot(process.cwd());

--- a/packages/nx/src/cli/index.ts
+++ b/packages/nx/src/cli/index.ts
@@ -51,6 +51,7 @@ export async function invokeCommand(
         commandArgs,
         isVerbose
       );
+    case 'migrate':
     case '_migrate':
       return (await import('../commands/migrate')).migrate(
         root,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running the `migrate` command from a version older than v13.9.0 to latest, the command doesn't run properly and keeps opening new processes to run itself.

This happens because in the old versions `tao migrate` will be run, but the `migrate` command installs the latest version of `@nrwl/tao` which now defers the execution to the `nx` package and this one is only handling `_migrate` as the command for running the migration but not `migrate`. Because of that, it doesn't identify it as the migration command and it continues the execution which ends up running the `migrate` command again.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Migrations should run successfully.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9345 
