### PR TITLE
fix(react) generate app sybntax to react-router v6

### DIFF
--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -247,15 +247,13 @@ export function addInitialRoutes(
     </div>
     <Route
       path="/"
-      exact
-      render={() => (
+      children={() => (
         <div>This is the generated root route. <Link to="/page-2">Click here for page 2.</Link></div>
       )}
     />
     <Route
       path="/page-2"
-      exact
-      render={() => (
+      children={() => (
         <div><Link to="/">Click here to go back to root page.</Link></div>
       )}
     />


### PR DESCRIPTION
The syntax used in the template to generate a react app with router still used v5 syntax.

- exact parameter has been removed as it is default now
- render parameter has been deprecated

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Template uses react-router v5 syntax

## Expected Behavior
Should use new v6 syntax

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
