### PR TITLE
docs(nxdev): add tutorial next step links

### DIFF
--- a/docs/shared/core-tutorial/01-create-blog.md
+++ b/docs/shared/core-tutorial/01-create-blog.md
@@ -173,3 +173,7 @@ Art courtesy of [cowsay](https://www.npmjs.com/package/cowsay).
 ```
 
 Once these files are in place, run `nx serve blog` again. Navigate to `http://localhost:8080/posts/ascii/` in a browser and you should see the blog post.
+
+## What's Next
+
+- Continue to [Step 2: Create cli](/core-tutorial/02-create-cli)

--- a/docs/shared/core-tutorial/02-create-cli.md
+++ b/docs/shared/core-tutorial/02-create-cli.md
@@ -153,3 +153,7 @@ Nx only caches the targets that you tell it to cache. `serve` is not in the defa
 ```
 
 If you run `nx build cli` twice, you'll see that Nx is able to cache the commands even though they're entirely written in Go.
+
+## What's Next
+
+- Continue to [Step 3: Share assets](/core-tutorial/03-share-assets)

--- a/docs/shared/core-tutorial/03-share-assets.md
+++ b/docs/shared/core-tutorial/03-share-assets.md
@@ -181,3 +181,7 @@ nx graph
 ```
 
 When the graph opens in your browser, click the `Show all projects` button in the left sidebar. You should see dependency lines drawn from `blog` and `cli` to `ascii`.
+
+## What's Next
+
+- Continue to [Step 4: Build affected projects](/core-tutorial/04-build-affected-projects)

--- a/docs/shared/core-tutorial/04-build-affected-projects.md
+++ b/docs/shared/core-tutorial/04-build-affected-projects.md
@@ -85,3 +85,7 @@ You can run any target against the affected projects in the graph like this:
 ```bash
 nx affected --target=test
 ```
+
+## What's Next
+
+- Continue to [Step 5: Auto detect dependencies](/core-tutorial/05-auto-detect-dependencies)

--- a/docs/shared/core-tutorial/05-auto-detect-dependencies.md
+++ b/docs/shared/core-tutorial/05-auto-detect-dependencies.md
@@ -116,3 +116,7 @@ If you want Nx to do more for you, you can install the `@nrwl/js` plugin to help
 - Typescript alias paths
 - Build with `tsc` or `swc`
 - Jest and ESLint configuration
+
+## What's Next
+
+- Continue to [Step 6: Summary](/core-tutorial/06-summary)

--- a/docs/shared/node-tutorial/01-create-application.md
+++ b/docs/shared/node-tutorial/01-create-application.md
@@ -126,3 +126,7 @@ Now that the application is set up, run it locally via:
 ```bash
 nx serve todos
 ```
+
+## What's Next
+
+- Continue to [Step 2: Display todos](/node-tutorial/02-display-todos)

--- a/docs/shared/node-tutorial/02-display-todos.md
+++ b/docs/shared/node-tutorial/02-display-todos.md
@@ -145,3 +145,7 @@ You changed the `@Get` decorator for the `getData` function to point to the `api
 Then you added the `root` function which renders the `index` file from our `views` directory.
 
 > The serve process should still be running. If it isn't, restart the process with `nx serve todos`
+
+## What's Next
+
+- Continue to [Step 3: Share code](/node-tutorial/03-share-code)

--- a/docs/shared/node-tutorial/03-share-code.md
+++ b/docs/shared/node-tutorial/03-share-code.md
@@ -71,3 +71,7 @@ export class TodosService {
 ```
 
 Every time you add a new library, you have to restart `nx serve`. **So restart `nx serve todos` and you should see the application running.**
+
+## What's Next
+
+- Continue to [Step 4: Create libraries](/node-tutorial/04-create-libs)

--- a/docs/shared/node-tutorial/04-create-libs.md
+++ b/docs/shared/node-tutorial/04-create-libs.md
@@ -85,3 +85,7 @@ export class AppModule {}
 ```
 
 **Restart `nx serve todos` then go to http://localhost:3333/auth. You should see `{ authenticated: true }`**
+
+## What's Next
+
+- Continue to [Step 5: Dep graph](/node-tutorial/05-dep-graph)

--- a/docs/shared/node-tutorial/05-dep-graph.md
+++ b/docs/shared/node-tutorial/05-dep-graph.md
@@ -7,3 +7,7 @@ An Nx workspace can contain dozens or hundreds of applications and libraries. As
 Previously, some senior architect would create an ad-hoc dependency diagram and upload it to a corporate wiki. The diagram is not correct even on Day 1 and gets more and more out of sync with every passing day.
 
 With Nx, you can do better than that.
+
+## What's Next
+
+- Continue to [Step 6: Computation Caching](/node-tutorial/06-computation-caching)

--- a/docs/shared/node-tutorial/06-computation-caching.md
+++ b/docs/shared/node-tutorial/06-computation-caching.md
@@ -71,3 +71,7 @@ All files pass linting.
 ```
 
 > Add --parallel to any command, and Nx does most of the work in parallel.
+
+## What's Next
+
+- Continue to [Step 7: Test affected projects](/node-tutorial/07-test-affected-projects)

--- a/docs/shared/node-tutorial/07-test-affected-projects.md
+++ b/docs/shared/node-tutorial/07-test-affected-projects.md
@@ -71,3 +71,7 @@ You can run any target against the affected projects in the graph like this:
 nx affected --target=build
 nx affected:build
 ```
+
+## What's Next
+
+- Continue to [Step 8: Summary](/node-tutorial/08-summary)

--- a/docs/shared/react-tutorial/01-create-application.md
+++ b/docs/shared/react-tutorial/01-create-application.md
@@ -126,3 +126,7 @@ or
 ```bash
 yarn nx serve todos
 ```
+
+## What's Next
+
+- Continue to [Step 2: Add E2E Tests](/react-tutorial/02-add-e2e-test)

--- a/docs/shared/react-tutorial/02-add-e2e-test.md
+++ b/docs/shared/react-tutorial/02-add-e2e-test.md
@@ -36,3 +36,7 @@ If you have not done so already, stop the `npx nx serve` command and run `npx nx
 A UI opens. Click the button on the right side that says "Run 1 integration spec". Keep the E2E tests running.
 
 As you progress through the tutorial, you work on making these E2E tests pass.
+
+## What's Next
+
+- Continue to [Step 3: Display Todos](/react-tutorial/03-display-todos)

--- a/docs/shared/react-tutorial/03-display-todos.md
+++ b/docs/shared/react-tutorial/03-display-todos.md
@@ -87,3 +87,7 @@ export default App;
 ```
 
 The tests should pass now.
+
+## What's Next
+
+- Continue to [Step 4: Connect to an API](/react-tutorial/04-connect-to-api)

--- a/docs/shared/react-tutorial/04-connect-to-api.md
+++ b/docs/shared/react-tutorial/04-connect-to-api.md
@@ -50,3 +50,7 @@ const App = () => {
 
 export default App;
 ```
+
+## What's Next
+
+- Continue to [Step 5: Add Node Application Implementing an API](/angular-tutorial/05-add-node-app)

--- a/docs/shared/react-tutorial/05-add-node-app.md
+++ b/docs/shared/react-tutorial/05-add-node-app.md
@@ -147,3 +147,7 @@ server.on('error', console.error);
 **Now run `npx nx serve api` to run the api server**
 
 Refresh the application in the browser. The React app is now able to fetch and create todos by calling the API.
+
+## What's Next
+
+- Continue to [Step 6: Proxy](/react-tutorial/06-proxy)

--- a/docs/shared/react-tutorial/06-proxy.md
+++ b/docs/shared/react-tutorial/06-proxy.md
@@ -76,3 +76,7 @@ Options:
 It helps with good editor integration (see [VSCode Support](/using-nx/console#nx-console-for-vscode)).
 
 But, most importantly, it provides a holistic dev experience regardless of the tools used, and enables advanced build features like distributed [computation caching](/using-nx/caching) and [distributed builds](/using-nx/dte).
+
+## What's Next
+
+- Continue to [Step 7: Share Code](/react-tutorial/07-share-code)

--- a/docs/shared/react-tutorial/07-share-code.md
+++ b/docs/shared/react-tutorial/07-share-code.md
@@ -87,3 +87,7 @@ export default App;
 Every time you add a new library, you have to restart `npx nx serve`.
 
 **So restart both `npx nx serve api` and `npx nx serve todos` and you should see the application running.**
+
+## What's Next
+
+- Continue to [Step 8: Create Libraries](/react-tutorial/08-create-libs)

--- a/docs/shared/react-tutorial/08-create-libs.md
+++ b/docs/shared/react-tutorial/08-create-libs.md
@@ -177,3 +177,7 @@ export default App;
 **Restart both `npx nx serve api` and `npx nx serve todos` and you should see the application running.**
 
 > Nx helps you explore code generation options. Run `npx nx g @nrwl/react:component --help` to see all options available. Pass `--dry-run` to the command to see what would be generated without actually changing anything, like this: `npx nx g @nrwl/react:component mycmp --project=ui --dry-run`.
+
+## What's Next
+
+- Continue to [Step 9: Using the Project Graph](/react-tutorial/09-dep-graph)

--- a/docs/shared/react-tutorial/09-dep-graph.md
+++ b/docs/shared/react-tutorial/09-dep-graph.md
@@ -15,3 +15,7 @@ npx nx graph
 ```
 
 The project graph page opens in a new browser window. Click on "Show all projects" to see all the apps and libraries in the workspace.
+
+## What's Next
+
+- Continue to [Step 10: Using Computation Caching](/react-tutorial/10-computation-caching)

--- a/docs/shared/react-tutorial/10-computation-caching.md
+++ b/docs/shared/react-tutorial/10-computation-caching.md
@@ -55,3 +55,7 @@ Nx read the output from the cache instead of running the command for 1 out of 2 
 Nx built `api` and retrieved `todos` from its computation cache. Read more about the cache [here](/using-nx/caching).
 
 > Add --parallel to any command, and Nx does most of the work in parallel.
+
+## What's Next
+
+- Continue to [Step 11: Test Affected Projects](/react-tutorial/11-test-affected-projects)

--- a/docs/shared/react-tutorial/11-test-affected-projects.md
+++ b/docs/shared/react-tutorial/11-test-affected-projects.md
@@ -72,3 +72,7 @@ You can run any target against the affected projects in the graph like this:
 npx nx affected --target=build
 npx nx affected:build
 ```
+
+## What's Next
+
+- Continue to [Step 12: Summary](/react-tutorial/12-summary)


### PR DESCRIPTION
Add "next" links at the bottom of each steps in the tutorial sections on nx.dev.

Fixes #9307.
