### PR TITLE
fix(core): undo removal of @nrwl/cli and add warning when it is imported

### DIFF
--- a/packages/cli/bin/nx.ts
+++ b/packages/cli/bin/nx.ts
@@ -1,2 +1,9 @@
 #!/usr/bin/env node
+
+import { logger } from 'nx/src/shared/logger';
+import { getPackageManagerCommand } from 'nx/src/shared/package-manager';
+
+logger.warn('Please update your global install of Nx');
+logger.warn(`- ${getPackageManagerCommand().addGlobal} nx`);
+
 require('nx/bin/nx');

--- a/packages/nx/src/shared/package-manager.ts
+++ b/packages/nx/src/shared/package-manager.ts
@@ -8,6 +8,7 @@ export interface PackageManagerCommands {
   install: string;
   add: string;
   addDev: string;
+  addGlobal: string;
   rm: string;
   exec: string;
   list: string;
@@ -44,6 +45,7 @@ export function getPackageManagerCommand(
       install: 'yarn',
       add: 'yarn add -W',
       addDev: 'yarn add -D -W',
+      addGlobal: 'yarn global add',
       rm: 'yarn remove',
       exec: 'yarn',
       run: (script: string, args: string) => `yarn ${script} ${args}`,
@@ -59,6 +61,7 @@ export function getPackageManagerCommand(
         install: 'pnpm install --no-frozen-lockfile', // explicitly disable in case of CI
         add: 'pnpm add',
         addDev: 'pnpm add -D',
+        addGlobal: 'pnpm add -g',
         rm: 'pnpm rm',
         exec: useExec ? 'pnpm exec' : 'pnpx',
         run: (script: string, args: string) => `pnpm run ${script} -- ${args}`,
@@ -72,6 +75,7 @@ export function getPackageManagerCommand(
         install: 'npm install',
         add: 'npm install',
         addDev: 'npm install -D',
+        addGlobal: 'npm install -g',
         rm: 'npm rm',
         exec: 'npx',
         run: (script: string, args: string) => `npm run ${script} -- ${args}`,

--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -42,11 +42,11 @@
       "cli": "nx",
       "implementation": "./src/migrations/update-13-9-0/update-decorate-cli"
     },
-    "13-9-0-replace-tao-and-cli-with-nx": {
+    "13-9-0-replace-tao-with-nx": {
       "version": "13.9.0-beta.0",
-      "description": "Replace @nrwl/tao and @nrwl/cli with nx",
+      "description": "Replace @nrwl/tao with nx",
       "cli": "nx",
-      "implementation": "./src/migrations/update-13-9-0/replace-tao-and-cli-with-nx"
+      "implementation": "./src/migrations/update-13-9-0/replace-tao-with-nx"
     }
   },
   "packageJsonUpdates": {

--- a/packages/workspace/src/generators/workspace/files/package.json__tmpl__
+++ b/packages/workspace/src/generators/workspace/files/package.json__tmpl__
@@ -10,6 +10,7 @@
   "devDependencies": {
      <% if(cli === 'angular') { %>"@angular/cli": "<%= angularCliVersion %>",<% } %>
     "nx": "<%= nxVersion %>",
+    "@nrwl/cli": "<%= nxVersion %>",
     "@nrwl/workspace": "<%= nxVersion %>",
     "@types/node": "16.11.7",
     "typescript": "<%= typescriptVersion %>",

--- a/packages/workspace/src/migrations/update-13-9-0/replace-tao-with-nx.ts
+++ b/packages/workspace/src/migrations/update-13-9-0/replace-tao-with-nx.ts
@@ -1,22 +1,21 @@
 import { Tree, updateJson } from '@nrwl/devkit';
 
-export function replaceTaoAndCLIWithNx(host: Tree) {
+export function replaceTaoWithNx(host: Tree) {
   updateJson(host, 'package.json', (json: any) => {
     if (json.dependencies['@nrwl/workspace']) {
       json.dependencies['nx'] = json.dependencies['@nrwl/workspace'];
     } else if (json.devDependencies['@nrwl/workspace']) {
       json.devDependencies['nx'] = json.devDependencies['@nrwl/workspace'];
     }
-    removeTaoAndCLI(json.dependencies);
-    removeTaoAndCLI(json.devDependencies);
+    removeTao(json.dependencies);
+    removeTao(json.devDependencies);
     return json;
   });
 }
 
-function removeTaoAndCLI(json: any) {
+function removeTao(json: any) {
   if (!json) return;
   json['@nrwl/tao'] = undefined;
-  json['@nrwl/cli'] = undefined;
 }
 
-export default replaceTaoAndCLIWithNx;
+export default replaceTaoWithNx;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

For users that have older global installs of `nx` installed, using `nx` commands in a workspace migrated to `13.9.1` will not work because it can't find the `@nrwl/cli` package anymore.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Users that have older global installs of `nx` installed, using `nx` commands in a workspace should still work but warn users to update their global version of Nx. This requires that `@nrwl/cli` is NOT removed unfortunately. However, that will still be done later.

![image](https://user-images.githubusercontent.com/8104246/158690703-5fce3858-08f7-4c55-9b6d-83179e05f731.png)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
