### PR TITLE
fix(core): projects inferrred in apps directory should be inferred as an application

### DIFF
--- a/packages/nx/jest.config.js
+++ b/packages/nx/jest.config.js
@@ -1,9 +1,10 @@
 module.exports = {
-  name: 'cli',
-  preset: '../../jest.config.js',
+  preset: '../../jest.preset.js',
   transform: {
     '^.+\\.[tj]sx?$': 'ts-jest',
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
   globals: { 'ts-jest': { tsconfig: '<rootDir>/tsconfig.spec.json' } },
+  displayName: 'nx',
+  testEnvironment: 'node',
 };

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -78,6 +78,14 @@
         ]
       },
       "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "options": {
+        "jestConfig": "packages/nx/jest.config.js",
+        "passWithNoTests": true
+      },
+      "outputs": ["coverage/packages/nx"]
     }
   }
 }

--- a/packages/nx/src/commands/migrate.spec.ts
+++ b/packages/nx/src/commands/migrate.spec.ts
@@ -369,7 +369,6 @@ describe('Migration', () => {
         migrations: [],
         packageJson: {
           '@nrwl/workspace': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/cli': { version: '2.0.0', addToPackageJson: false },
           '@nrwl/angular': { version: '2.0.0', addToPackageJson: false },
           '@nrwl/cypress': { version: '2.0.0', addToPackageJson: false },
           '@nrwl/devkit': { addToPackageJson: false, version: '2.0.0' },

--- a/packages/nx/src/shared/__snapshots__/logger.spec.ts.snap
+++ b/packages/nx/src/shared/__snapshots__/logger.spec.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tao Logger should color the NX prefix 1`] = `
+exports[`Logger should color the NX prefix 1`] = `
 "
 [36m>[39m [7m[1m[36m NX [39m[22m[27m [1msome Nx message![22m
 "
 `;
 
-exports[`Tao Logger should log the full stack trace when an object is being passed 1`] = `
+exports[`Logger should log the full stack trace when an object is being passed 1`] = `
 "[1m[31mTypeError: Cannot read property 'target' of undefined[39m[22m
 [1m[31m      at /someuser/node_modules/@storybook/angular/dist/ts3.9/server/angular-devkit-build-webpack.js:145:49[39m[22m
 [1m[31m      at step (/someuser/node_modules/@storybook/angular/dist/ts3.9/server/angular-devkit-build-webpack.js:69:23)[39m[22m

--- a/packages/nx/src/shared/workspace.spec.ts
+++ b/packages/nx/src/shared/workspace.spec.ts
@@ -14,6 +14,7 @@ const libConfig = (name) => ({
 const packageLibConfig = (root) => ({
   root,
   sourceRoot: root,
+  projectType: 'library',
 });
 
 describe('Workspaces', () => {
@@ -102,7 +103,7 @@ describe('Workspaces', () => {
       expect(libResults).toEqual('directory-my-lib');
     });
 
-    it('should custom directories from beginning', () => {
+    it('should trim custom directories from beginning', () => {
       const nxJson: NxJsonConfiguration = {
         npmScope: '',
         workspaceLayout: {
@@ -161,6 +162,7 @@ describe('Workspaces', () => {
       expect(resolved.projects['my-package']).toEqual({
         root: 'packages/my-package',
         sourceRoot: 'packages/my-package',
+        projectType: 'library',
       });
     });
   });

--- a/packages/nx/src/shared/workspace.ts
+++ b/packages/nx/src/shared/workspace.ts
@@ -804,6 +804,7 @@ function buildProjectConfigurationFromPackageJson(
     sourceRoot: directory,
     name,
     projectType:
+      nxJson.workspaceLayout?.appsDir != nxJson.workspaceLayout?.libsDir &&
       nxJson.workspaceLayout?.appsDir &&
       directory.startsWith(nxJson.workspaceLayout.appsDir)
         ? 'application'

--- a/packages/nx/src/shared/workspace.ts
+++ b/packages/nx/src/shared/workspace.ts
@@ -803,6 +803,11 @@ function buildProjectConfigurationFromPackageJson(
     root: directory,
     sourceRoot: directory,
     name,
+    projectType:
+      nxJson.workspaceLayout?.appsDir &&
+      directory.startsWith(nxJson.workspaceLayout.appsDir)
+        ? 'application'
+        : 'library',
   };
 }
 

--- a/packages/workspace/src/generators/npm-package/npm-package.spec.ts
+++ b/packages/workspace/src/generators/npm-package/npm-package.spec.ts
@@ -105,6 +105,7 @@ describe('@nrwl/workspace:npm-package', () => {
       expect(tree.exists('packages/my-package/project.json')).toBeFalsy();
       expect(tree.exists('packages/my-package/package.json')).toBeTruthy();
       expect(readProjectConfiguration(tree, 'my-package')).toEqual({
+        projectType: 'library',
         root: 'packages/my-package',
         sourceRoot: 'packages/my-package',
       });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
All inferred projects have no defined projectType, which defaults to `library`

## Expected Behavior
Projects in the apps directory should be inferred as an application

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9374 
