### PR TITLE
fix(angular): set tsconfig path correctly #9375

### DIFF
--- a/e2e/angular-core/src/projects.test.ts
+++ b/e2e/angular-core/src/projects.test.ts
@@ -297,4 +297,28 @@ describe('Angular Projects', () => {
       expect(err).toBeFalsy();
     }
   }, 300000);
+
+  it('MFE - should build the host app successfully', async () => {
+    // ARRANGE
+    const port1 = 4205;
+    const port2 = 4206;
+    const hostApp = uniq('app');
+    const remoteApp1 = uniq('remote');
+
+    // generate host app
+    runCLI(
+      `generate @nrwl/angular:host ${hostApp} -- --port=${port1} --no-interactive`
+    );
+
+    // generate remote apps
+    runCLI(
+      `generate @nrwl/angular:remote ${remoteApp1} -- --host=${hostApp} --port=${port2} --no-interactive`
+    );
+
+    // ACT
+    const buildOutput = runCLI(`build ${hostApp}`);
+
+    // ASSERT
+    expect(buildOutput).toContain('Successfully ran target build');
+  }, 300000);
 });

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -112,8 +112,8 @@ function run(
       result.target.data.root,
       dependencies
     );
+    process.env.NX_TSCONFIG_PATH = options.tsConfig;
   }
-  process.env.NX_TSCONFIG_PATH = options.tsConfig;
 
   return of(
     !options.buildLibsFromSource


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Fixing the incremental builds opt out accidentally lead to erroneous behaviour in MFEs.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Only set the env var for TS Config Path when incremental builds change the tsconfig path, otherwise fall back to the path defined in the webpack config.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9375
