### PR TITLE
fix(nx-plugin): remove broken reference to e2e tsconfig

### DIFF
--- a/packages/nx-plugin/src/generators/e2e-project/files/tsconfig.json__tmpl__
+++ b/packages/nx-plugin/src/generators/e2e-project/files/tsconfig.json__tmpl__
@@ -2,9 +2,5 @@
   "extends": "<%= rootTsConfigPath %>",
   "files": [],
   "include": [],
-  "references": [
-    {
-      "path": "./tsconfig.e2e.json"
-    }
-  ]
+  "references": []
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

nx plugins are generated with a tsconfig reference to `tsconfig.e2e.json` which does not exist

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There shouldn't be references to files that do not exist

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9408
