### PR TITLE
docs(core): name is returned unmodified in devkit

### DIFF
--- a/docs/generated/api-nx-devkit/index.md
+++ b/docs/generated/api-nx-devkit/index.md
@@ -1193,7 +1193,7 @@ Examples:
 
 ```typescript
 names('my-name'); // {name: 'my-name', className: 'MyName', propertyName: 'myName', constantName: 'MY_NAME', fileName: 'my-name'}
-names('myName'); // {name: 'my-name', className: 'MyName', propertyName: 'myName', constantName: 'MY_NAME', fileName: 'my-name'}
+names('myName'); // {name: 'myName', className: 'MyName', propertyName: 'myName', constantName: 'MY_NAME', fileName: 'my-name'}
 ```
 
 #### Parameters

--- a/packages/devkit/src/utils/names.ts
+++ b/packages/devkit/src/utils/names.ts
@@ -5,7 +5,7 @@
  *
  * ```typescript
  * names("my-name") // {name: 'my-name', className: 'MyName', propertyName: 'myName', constantName: 'MY_NAME', fileName: 'my-name'}
- * names("myName") // {name: 'my-name', className: 'MyName', propertyName: 'myName', constantName: 'MY_NAME', fileName: 'my-name'}
+ * names("myName") // {name: 'myName', className: 'MyName', propertyName: 'myName', constantName: 'MY_NAME', fileName: 'my-name'}
  * ```
  * @param name
  */


### PR DESCRIPTION
the docs for the names function say that the name is modified to hyphenated case but it's actually returned unmodified
