### PR TITLE
fix(angular): change mfe schema port type to number

### DIFF
--- a/docs/generated/api-angular/generators/mfe-host.md
+++ b/docs/generated/api-angular/generators/mfe-host.md
@@ -55,6 +55,6 @@ The name of the host app to attach this host app to.
 
 ### port
 
-Type: `string`
+Type: `number`
 
 The port on which this app should be served.

--- a/docs/generated/api-angular/generators/mfe-remote.md
+++ b/docs/generated/api-angular/generators/mfe-remote.md
@@ -55,6 +55,6 @@ The name of the host app to attach this remote app to.
 
 ### port
 
-Type: `string`
+Type: `number`
 
 The port on which this app should be served.

--- a/packages/angular/src/generators/mfe-host/schema.json
+++ b/packages/angular/src/generators/mfe-host/schema.json
@@ -25,7 +25,7 @@
       "description": "The name of the host app to attach this host app to."
     },
     "port": {
-      "type": "string",
+      "type": "number",
       "description": "The port on which this app should be served."
     }
   },

--- a/packages/angular/src/generators/mfe-remote/schema.json
+++ b/packages/angular/src/generators/mfe-remote/schema.json
@@ -25,7 +25,7 @@
       "description": "The name of the host app to attach this remote app to."
     },
     "port": {
-      "type": "string",
+      "type": "number",
       "description": "The port on which this app should be served."
     }
   },


### PR DESCRIPTION
Port should be `number`. Having it as string breaks one of the nightlies with:

```
Property 'port' does not match the schema. '4205' should be a 'string'.
```

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
