### PR TITLE
feat(angular): automatically set next remote port

### DIFF
--- a/packages/angular/src/generators/mfe-remote/mfe-remote.spec.ts
+++ b/packages/angular/src/generators/mfe-remote/mfe-remote.spec.ts
@@ -1,6 +1,7 @@
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import mfeRemote from './mfe-remote';
 import applicationGenerator from '../application/application';
+import { readProjectConfiguration } from '@nrwl/devkit';
 
 describe('MFE Remote App Generator', () => {
   it('should generate a remote mfe app with no host', async () => {
@@ -57,5 +58,23 @@ describe('MFE Remote App Generator', () => {
         'The name of the application to be used as the host app does not exist. (host)'
       );
     }
+  });
+
+  it('should generate a remote mfe app and automatically find the next port available', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    await mfeRemote(tree, {
+      name: 'existing',
+      port: 4201,
+    });
+
+    // ACT
+    await mfeRemote(tree, {
+      name: 'test',
+    });
+
+    // ASSERT
+    const project = readProjectConfiguration(tree, 'test');
+    expect(project.targets.serve.options.port).toEqual(4202);
   });
 });

--- a/packages/angular/src/generators/mfe-remote/mfe-remote.ts
+++ b/packages/angular/src/generators/mfe-remote/mfe-remote.ts
@@ -1,7 +1,23 @@
 import type { Tree } from '@nrwl/devkit';
 import type { Schema } from './schema';
-import { getProjects } from '@nrwl/devkit';
+import { getProjects, readProjectConfiguration } from '@nrwl/devkit';
 import applicationGenerator from '../application/application';
+import { getMfeProjects } from '../../utils/get-mfe-projects';
+
+function findNextAvailablePort(tree: Tree) {
+  const mfeProjects = getMfeProjects(tree);
+
+  const ports = new Set<number>();
+  for (const mfeProject of mfeProjects) {
+    const { targets } = readProjectConfiguration(tree, mfeProject);
+    const port = targets?.serve?.options?.port ?? 4200;
+    ports.add(port);
+  }
+
+  const nextAvailablePort = Math.max(...ports) + 1;
+
+  return nextAvailablePort;
+}
 
 export default async function mfeRemote(tree: Tree, options: Schema) {
   const projects = getProjects(tree);
@@ -17,7 +33,7 @@ export default async function mfeRemote(tree: Tree, options: Schema) {
     mfeType: 'remote',
     routing: true,
     host: options.host,
-    port: options.port ?? 4200,
+    port: options.port ?? findNextAvailablePort(tree),
   });
 
   return installTask;


### PR DESCRIPTION

## Current Behavior
<!-- This is the behavior we have today -->
We expect people to pass a port for their remote apps. However, we default to `4200` if they do not. This can cause conflicts when a host app has multiple remotes on the same port.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Instead of defaulting to `4200`, scan the ports used in the workspace and pick a port that is 1 greater than the highest value.

We should not run into issues with reserved ports as the current range of ports is open for use.

In development, the user shouldn't need to care where their remotes are being served if they are being accessed via host.
Also, the `serve` command on a remote app will specify the URL of the served app.
