### PR TITLE
fix(nx-plugin): use importPath as package.json name when passed

### DIFF
--- a/packages/nx-plugin/src/generators/generator/generator.ts
+++ b/packages/nx-plugin/src/generators/generator/generator.ts
@@ -1,14 +1,15 @@
+import type { Tree } from '@nrwl/devkit';
 import {
-  readProjectConfiguration,
-  names,
   convertNxGenerator,
   generateFiles,
-  updateJson,
   getWorkspaceLayout,
+  names,
+  readJson,
+  readProjectConfiguration,
+  updateJson,
 } from '@nrwl/devkit';
-import type { Tree } from '@nrwl/devkit';
-import type { Schema } from './schema';
 import * as path from 'path';
+import type { Schema } from './schema';
 
 interface NormalizedSchema extends Schema {
   fileName: string;
@@ -26,7 +27,10 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   const { root: projectRoot, sourceRoot: projectSourceRoot } =
     readProjectConfiguration(host, options.project);
 
-  const npmPackageName = `@${npmScope}/${options.project}`;
+  const npmPackageName = readJson<{ name: string }>(
+    host,
+    path.join(projectRoot, 'package.json')
+  ).name;
 
   let description: string;
   if (options.description) {

--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -1,5 +1,10 @@
 import { pluginGenerator } from './plugin';
-import { Tree, readProjectConfiguration } from '@nrwl/devkit';
+import {
+  Tree,
+  readProjectConfiguration,
+  readJson,
+  joinPathFragments,
+} from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Schema } from './schema';
 import { Linter } from '@nrwl/linter';
@@ -166,6 +171,35 @@ describe('NxPlugin Plugin Generator', () => {
       const { build } = readProjectConfiguration(tree, 'my-plugin').targets;
 
       expect(build.executor).toEqual('@nrwl/js:swc');
+    });
+  });
+
+  describe('--importPath', () => {
+    it('should use the workspace npmScope by default for the package.json', async () => {
+      await pluginGenerator(tree, getSchema());
+
+      const { root } = readProjectConfiguration(tree, 'my-plugin');
+      const { name } = readJson<{ name: string }>(
+        tree,
+        joinPathFragments(root, 'package.json')
+      );
+
+      expect(name).toEqual('@proj/my-plugin');
+    });
+
+    it('should use importPath as the package.json name', async () => {
+      await pluginGenerator(
+        tree,
+        getSchema({ importPath: '@my-company/my-plugin' })
+      );
+
+      const { root } = readProjectConfiguration(tree, 'my-plugin');
+      const { name } = readJson<{ name: string }>(
+        tree,
+        joinPathFragments(root, 'package.json')
+      );
+
+      expect(name).toEqual('@my-company/my-plugin');
     });
   });
 });

--- a/packages/nx-plugin/src/generators/plugin/plugin.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.ts
@@ -46,7 +46,8 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())
     : [];
-  const npmPackageName = `@${npmScope}/${name}`;
+
+  const npmPackageName = options.importPath || `@${npmScope}/${name}`;
 
   return {
     ...options,
@@ -128,8 +129,9 @@ export async function pluginGenerator(host: Tree, schema: Schema) {
     ...schema,
     config: options.standaloneConfig !== false ? 'project' : 'workspace',
     buildable: true,
-    importPath: schema.importPath ?? options.npmPackageName,
+    importPath: options.npmPackageName,
   });
+
   tasks.push(libraryTask);
 
   const installTask = addDependenciesToPackageJson(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- What is the behavior that currently you experience? -->

When creating a new plugin using `importPath`, the generated plugin's package.json is not using it.

F.E:

```console
$ npx create-nx-workspace@latest --packageManager=yarn --preset=empty my-workspace
$ cd my-workspace
$ yarn add -D @nrwl/nx-plugin
$ nx g @nrwl/nx-plugin:plugin --name=my-plugin --importPath=@my-company/my-plugin
$ jq '.name' libs/my-plugin/package.json
"@my-workspace/my-plugin"
```

## Expected Behavior
<!-- What is the behavior that you expect to happen? -->
<!-- Is this a regression? .i.e Did this used to be the behavior at one point?  -->

```console
$ npx create-nx-workspace@latest --packageManager=yarn --preset=empty my-workspace
$ cd my-workspace
$ yarn add -D @nrwl/nx-plugin
$ nx g @nrwl/nx-plugin:plugin --name=my-plugin --importPath=@my-company/my-plugin
$ jq '.name' libs/my-plugin/package.json
"@my-company/my-plugin"
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9415
