### PR TITLE
docs(nxdev): fix react tutorial link

### DIFF
--- a/docs/shared/react-tutorial/04-connect-to-api.md
+++ b/docs/shared/react-tutorial/04-connect-to-api.md
@@ -53,4 +53,4 @@ export default App;
 
 ## What's Next
 
-- Continue to [Step 5: Add Node Application Implementing an API](/angular-tutorial/05-add-node-app)
+- Continue to [Step 5: Add Node Application Implementing an API](/react-tutorial/05-add-node-app)


### PR DESCRIPTION
Fixes wrong link in React tutorial on nx.dev.