### PR TITLE
feat(angular): add exposed methods for dynamic federation

### DIFF
--- a/packages/angular/mfe/index.ts
+++ b/packages/angular/mfe/index.ts
@@ -1,0 +1,1 @@
+export { setRemoteUrlResolver, loadRemoteModule } from './mfe';

--- a/packages/angular/mfe/mfe.ts
+++ b/packages/angular/mfe/mfe.ts
@@ -1,0 +1,70 @@
+export type ResolveRemoteUrlFunction = (
+  remoteName: string
+) => string | Promise<string>;
+
+declare const __webpack_init_sharing__: (scope: 'default') => Promise<void>;
+declare const __webpack_share_scopes__: { default: unknown };
+
+let resolveRemoteUrl: ResolveRemoteUrlFunction;
+export function setRemoteUrlResolver(
+  _resolveRemoteUrl: ResolveRemoteUrlFunction
+) {
+  resolveRemoteUrl = _resolveRemoteUrl;
+}
+
+let remoteUrlDefinitions: Record<string, string>;
+export function setRemoteDefinitions(definitions: Record<string, string>) {
+  remoteUrlDefinitions = definitions;
+}
+
+let remoteModuleMap = new Map<string, unknown>();
+let remoteContainerMap = new Map<string, unknown>();
+export async function loadRemoteModule(remoteName: string, moduleName: string) {
+  const remoteModuleKey = `${remoteName}:${moduleName}`;
+  if (remoteModuleMap.has(remoteModuleKey)) {
+    return remoteModuleMap.get(remoteModuleKey);
+  }
+
+  const container = remoteContainerMap.has(remoteName)
+    ? remoteContainerMap.get(remoteName)
+    : await loadRemoteContainer(remoteName);
+
+  const factory = await container.get(moduleName);
+  const Module = factory();
+
+  remoteModuleMap.set(remoteModuleKey, Module);
+
+  return Module;
+}
+
+function loadModule(url: string) {
+  return import(/* webpackIgnore:true */ url);
+}
+
+let initialSharingScopeCreated = false;
+async function loadRemoteContainer(remoteName: string) {
+  if (!resolveRemoteUrl && !remoteUrlDefinitions) {
+    throw new Error(
+      'Call setRemoteDefinitions or setRemoteUrlResolver to allow Dynamic Federation to find the remote apps correctly.'
+    );
+  }
+
+  if (!initialSharingScopeCreated) {
+    initialSharingScopeCreated = true;
+    await __webpack_init_sharing__('default');
+  }
+
+  const remoteUrl = remoteUrlDefinitions
+    ? remoteUrlDefinitions[remoteName]
+    : await resolveRemoteUrl(remoteName);
+
+  const containerUrl = `${remoteUrl}${
+    remoteUrl.endsWith('/') ? '' : '/'
+  }remoteEntry.mjs`;
+
+  const container = await loadModule(containerUrl);
+  await container.init(__webpack_share_scopes__.default);
+
+  remoteContainerMap.set(remoteName, container);
+  return container;
+}

--- a/packages/angular/mfe/ng-package.json
+++ b/packages/angular/mfe/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/packages/angular/module-federation/index.ts
+++ b/packages/angular/module-federation/index.ts
@@ -1,0 +1,1 @@
+export { withModuleFederation } from '../src/utils/mfe/with-module-federation';

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -22,7 +22,7 @@
     "./executors": "./executors.js",
     "./tailwind": "./tailwind.js",
     "./src/generators/utils": "./src/generators/utils/index.js",
-    "./module-federation": "./src/utils/mfe/with-module-federation.js"
+    "./module-federation": "./module-federation/index.js"
   },
   "author": "Victor Savkin",
   "license": "MIT",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We have no native solution currently for dynamic federation

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add a solution for native dynamic federation

## Usage

In the `bootstrap.ts` file we set our remote definitions or use a  function:

```ts
import { setRemoteDefinitions, setRemoteUrlResolver } from '@nrwl/angular/mfe';

// Straightforward method would be something as simple as:
fetch('/assets/manifest.json')
  .then((res) => res.json())
  .then(definitions => setRemoteDefinitons(definitions))

// where mainfest.json has shape
//
//   {
//      "login": "",
//      "todo": ""
//   }

// However, if more flexibility is needed
setRemoteUrlResolver(async (remoteName: string) => {
 const url = await fetch('/api/' + remoteName + '/config').then(res => res.json())
 return url;
});

```

We then load our remotes in our routing config via:

```ts
            {
              path: 'todo',
              loadChildren: () =>
                loadRemoteModule('todo', './Module').then(
                  (m) => m.RemoteEntryModule
                ),
              canActivate: [AuthGuard],
            },
            {
              path: 'login',
              loadChildren: () =>
                loadRemoteModule('login', './Module').then(
                  (m) => m.RemoteEntryModule
                ),
            }
```

> Note: `'./Module'` can be different if the user exposes more than one module from their remote.
