### PR TITLE
fix(js): return success false if tsc compilation fails

### DIFF
--- a/packages/workspace/src/utilities/typescript/compilation.ts
+++ b/packages/workspace/src/utilities/typescript/compilation.ts
@@ -171,7 +171,7 @@ function createProgram(
       }
     );
     logger.error(diagnostics);
-    throw new Error(diagnostics);
+    return { success: false };
   } else {
     logger.info(
       `Done compiling TypeScript files for project "${projectName}".`


### PR DESCRIPTION
## Current Behavior
`compileTypescript` throws an error if compilation fails. This causes Node 14 + 12 to hang if compileTypescript is invoked by an async function, since unhandled promise rejections do not cause the process to fail.

## Expected Behavior
`compileTypescript` reports `success: false` on build failures.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9046 
Fixes #9251
