### PR TITLE
feat: support --xxx=xxx with template {xxx.xxx/args.xxx} in run-commands

### DIFF
--- a/packages/workspace/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.ts
@@ -15,7 +15,7 @@ async function loadEnvVars(path?: string) {
   } else {
     try {
       (await import('dotenv')).config();
-    } catch { }
+    } catch {}
   }
 }
 
@@ -24,14 +24,14 @@ export interface RunCommandsBuilderOptions extends Json {
   command?: string;
   commands?: (
     | {
-      command: string;
-      forwardAllArgs?: boolean;
-      /**
-       * description was added to allow users to document their commands inline,
-       * it is not intended to be used as part of the execution of the command.
-       */
-      description?: string;
-    }
+        command: string;
+        forwardAllArgs?: boolean;
+        /**
+         * description was added to allow users to document their commands inline,
+         * it is not intended to be used as part of the execution of the command.
+         */
+        description?: string;
+      }
     | string
   )[];
   color?: boolean;
@@ -150,7 +150,7 @@ function normalizeOptions(
   (options as NormalizedRunCommandsBuilderOptions).commands.forEach((c) => {
     c.command = transformCommand(
       c.command,
-      (options as NormalizedRunCommandsBuilderOptions),
+      options as NormalizedRunCommandsBuilderOptions,
       c.forwardAllArgs ?? true
     );
   });
@@ -296,4 +296,3 @@ function interpolateCommand(template: string, data: any) {
     return value;
   });
 }
-

--- a/packages/workspace/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.ts
@@ -290,9 +290,6 @@ function interpolateCommand(template: string, data: any) {
       let value = data;
       let path = match.slice(1, -1).trim().split('.');
       for (let idx = 0; idx < path.length; idx++) {
-          if (!value[path[idx]]) {
-              return;
-          }
           value = value[camelCase(path[idx])];
       }
 

--- a/packages/workspace/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.ts
@@ -15,7 +15,7 @@ async function loadEnvVars(path?: string) {
   } else {
     try {
       (await import('dotenv')).config();
-    } catch {}
+    } catch { }
   }
 }
 
@@ -24,14 +24,14 @@ export interface RunCommandsBuilderOptions extends Json {
   command?: string;
   commands?: (
     | {
-        command: string;
-        forwardAllArgs?: boolean;
-        /**
-         * description was added to allow users to document their commands inline,
-         * it is not intended to be used as part of the execution of the command.
-         */
-        description?: string;
-      }
+      command: string;
+      forwardAllArgs?: boolean;
+      /**
+       * description was added to allow users to document their commands inline,
+       * it is not intended to be used as part of the execution of the command.
+       */
+      description?: string;
+    }
     | string
   )[];
   color?: boolean;
@@ -287,13 +287,13 @@ function camelCase(input) {
 
 function interpolateCommand(template: string, data: any) {
   return template.replace(/{([\s\S]+?)}/g, (match) => {
-      let value = data;
-      let path = match.slice(1, -1).trim().split('.');
-      for (let idx = 0; idx < path.length; idx++) {
-          value = value[camelCase(path[idx])];
-      }
+    let value = data;
+    let path = match.slice(1, -1).trim().split('.');
+    for (let idx = 0; idx < path.length; idx++) {
+      value = value[camelCase(path[idx])];
+    }
 
-      return value;
+    return value;
   });
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

```js
{
  "executor": "@nrwl/workspace:run-commands",
  "options": {
    "test": {
      "command1": "npm start",
      "command2": "npm build"
    },
    "commands": [
      "echo {test.command1}",
      "echo {test.command2}",
      "echo {args.name} &&  {parallel} && {color} && echo {tag}"
    ]
}
```

```
nx run demo:start --args='--name=name1' --tag=lib --color=true
```

`--color=true` variables that can be passed to the template `{color}`，the variables of `executor.options` in the `project.json` file can also be passed in and used，this allows executor to have more controllability.

At the same time, the writing method of `args.xxx` is also compatible. In the past, the judgment of `command.indexOf('{args.') > -1` could not match `{ args.name }`, there is a space between `{` and `args`, which can now be matched.

<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
