### PR TITLE
fix: storybook global preview settings

### DIFF
--- a/packages/storybook/src/generators/configuration/project-files/.storybook/preview.js__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/preview.js__tmpl__
@@ -1,0 +1,1 @@
+export * from '<%= offsetFromRoot %>../.storybook/preview';


### PR DESCRIPTION
## Current Behavior

Global preview settings are ignored

## Expected Behavior

Global preview settings are applied
