### PR TITLE
fix(react): DefinePlugin Conflicting when run serve with production built

### DIFF
--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -20,8 +20,9 @@ export function getDevServerConfig(
   serveOptions: WebDevServerOptions
 ): Partial<WebpackDevServerConfiguration> {
   const optimizationFields = Object.keys(buildOptions.optimization);
-  const isScriptOptimizeOn = optimizationFields.length > 0 
-    && optimizationFields.some(key => buildOptions.optimization[key] === true);
+  const isScriptOptimizeOn =
+    optimizationFields.length > 0 &&
+    optimizationFields.some((key) => buildOptions.optimization[key] === true);
 
   const webpackConfig = getWebConfig(
     workspaceRoot,

--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -19,13 +19,17 @@ export function getDevServerConfig(
   buildOptions: WebWebpackExecutorOptions,
   serveOptions: WebDevServerOptions
 ): Partial<WebpackDevServerConfiguration> {
+  const optimizationFields = Object.keys(buildOptions.optimization);
+  const isScriptOptimizeOn = optimizationFields.length > 0 
+    && optimizationFields.some(key => buildOptions.optimization[key] === true);
+
   const webpackConfig = getWebConfig(
     workspaceRoot,
     projectRoot,
     sourceRoot,
     buildOptions,
     true, // Don't need to support legacy browsers for dev.
-    false
+    isScriptOptimizeOn
   );
 
   (webpackConfig as any).devServer = getDevServerPartial(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When we run production built with `create-nx-workspace` react it always warning about conflict NODE_ENV

```
WARNING in DefinePlugin
Conflicting values for 'process.env.NODE_ENV'
```

and output always be development mode even we add production configuration


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

you should able to run `yarn nx serve client --configuration production` whenout warning and the output should be production mode.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #7924
