### PR TITLE
fix(web): ensure file server works on windows

### DIFF
--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -5,6 +5,10 @@ import { readFileSync } from 'fs';
 import { Schema } from './schema';
 import { watch } from 'chokidar';
 import { workspaceLayout } from '@nrwl/workspace/src/core/file-utils';
+import { platform } from 'os';
+
+// platform specific command name
+const pmCmd = platform() === 'win32' ? `npx.cmd` : 'npx';
 
 function getHttpServerArgs(options: Schema) {
   const args = ['-c-1'];
@@ -36,7 +40,7 @@ function getHttpServerArgs(options: Schema) {
 }
 
 function getBuildTargetCommand(options: Schema) {
-  const cmd = ['npx', 'nx', 'run', options.buildTarget];
+  const cmd = ['nx', 'run', options.buildTarget];
   if (options.withDeps) {
     cmd.push(`--with-deps`);
   }
@@ -115,8 +119,8 @@ export default async function* fileServerExecutor(
     if (!running) {
       running = true;
       try {
-        const [cmd, ...args] = getBuildTargetCommand(options);
-        execFileSync(cmd, args, {
+        const args = getBuildTargetCommand(options);
+        execFileSync(pmCmd, args, {
           stdio: [0, 1, 2],
         });
       } catch {}
@@ -132,7 +136,7 @@ export default async function* fileServerExecutor(
   const outputPath = getBuildTargetOutputPath(options, context);
   const args = getHttpServerArgs(options);
 
-  const serve = execFile('npx', ['http-server', outputPath, ...args], {
+  const serve = execFile(pmCmd, ['http-server', outputPath, ...args], {
     cwd: context.root,
     env: {
       FORCE_COLOR: 'true',


### PR DESCRIPTION
In https://github.com/nrwl/nx/pull/9330 we replaced `exec` with `execFile` which requires explicit shell property set on Windows otherwise commands fail with `ENOENT`.

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9444 and nightly build on Windows
