### PR TITLE
fix(core): fix missing versions from nx report

### DIFF
--- a/packages/workspace/src/command-line/report.ts
+++ b/packages/workspace/src/command-line/report.ts
@@ -97,12 +97,8 @@ export function readPackageJson(p: string) {
   }
 }
 
-export function readPackageVersion(p: string) {
-  let status = 'Not Found';
-  try {
-    status = readPackageJson(p).version;
-  } catch {}
-  return status;
+export function readPackageVersion(p: string): string {
+  return readPackageJson(p).version || 'Not Found';
 }
 
 export function findInstalledCommunityPlugins(): {


### PR DESCRIPTION
The report is broken due to double `try...catch` blocks in `readPackageJson` and `readPackageVersion` causing missing packages to show as undefined:

```
nx : 13.9.4
@nrwl/angular : undefined
@nrwl/cypress : 13.9.4
@nrwl/detox : undefined
@nrwl/devkit : 13.9.4
@nrwl/eslint-plugin-nx : 13.9.4
@nrwl/express : undefined
@nrwl/jest : 13.9.4
@nrwl/js : 13.9.4
@nrwl/linter : 13.9.4
@nrwl/nest : undefined
@nrwl/next : undefined
@nrwl/node : undefined
@nrwl/nx-cloud : 13.1.6
@nrwl/nx-plugin : undefined
@nrwl/react : undefined
@nrwl/react-native : undefined
@nrwl/schematics : undefined
@nrwl/storybook : undefined
@nrwl/web : 13.9.4
@nrwl/workspace : 13.9.4
typescript : 4.5.5
rxjs : 6.5.5
```

The proper functionality exists (showing `Not Found`) but is never reached.

## Current Behavior
The report shows `undefined` for missing packages

## Expected Behavior
The report shows `Not Found` for missing packages

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
