### PR TITLE
fix(angular): remote port incrementer when no targets

### DIFF
--- a/packages/angular/src/generators/mfe-remote/mfe-remote.spec.ts
+++ b/packages/angular/src/generators/mfe-remote/mfe-remote.spec.ts
@@ -77,4 +77,18 @@ describe('MFE Remote App Generator', () => {
     const project = readProjectConfiguration(tree, 'test');
     expect(project.targets.serve.options.port).toEqual(4202);
   });
+
+  it('should generate a remote mfe app and automatically find the next port available even when there are no other targets', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+
+    // ACT
+    await mfeRemote(tree, {
+      name: 'test',
+    });
+
+    // ASSERT
+    const project = readProjectConfiguration(tree, 'test');
+    expect(project.targets.serve.options.port).toEqual(4201);
+  });
 });

--- a/packages/angular/src/generators/mfe-remote/mfe-remote.ts
+++ b/packages/angular/src/generators/mfe-remote/mfe-remote.ts
@@ -7,7 +7,7 @@ import { getMfeProjects } from '../../utils/get-mfe-projects';
 function findNextAvailablePort(tree: Tree) {
   const mfeProjects = getMfeProjects(tree);
 
-  const ports = new Set<number>();
+  const ports = new Set<number>([4200]);
   for (const mfeProject of mfeProjects) {
     const { targets } = readProjectConfiguration(tree, mfeProject);
     const port = targets?.serve?.options?.port ?? 4200;


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
If there are no targets, the port incrementer resolves to `Infinity`
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should always start at `4201`.

