### PR TITLE
fix(angular): browser builder should call correct function

### DIFF
--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -77,11 +77,7 @@ function buildAppWithCustomWebpackConfiguration(
       // The extra Webpack configuration file can export a synchronous or asynchronous function,
       // for instance: `module.exports = async config => { ... }`.
       if (typeof config === 'function') {
-        return customWebpackConfiguration(
-          baseWebpackConfig,
-          options,
-          context.target
-        );
+        return config(baseWebpackConfig, options, context.target);
       } else {
         return merge(baseWebpackConfig, config);
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Using custom webpack config for building will fail

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Using custom webpack config for building should not fail

## Notes

Not sure why original e2es passed this. Most recent run of e2es for #9454 failed on it.