### PR TITLE
fix(react): fix conflicting NODE_ENV values between an application an…

### DIFF
--- a/packages/web/src/executors/webpack/webpack.impl.ts
+++ b/packages/web/src/executors/webpack/webpack.impl.ts
@@ -143,7 +143,14 @@ export async function* run(
     );
   }
 
-  process.env.NODE_ENV ||= 'production';
+  const isScriptOptimizeOn =
+    typeof options.optimization === 'boolean'
+      ? options.optimization
+      : options.optimization && options.optimization.scripts
+      ? options.optimization.scripts
+      : false;
+
+  process.env.NODE_ENV ||= isScriptOptimizeOn ? 'production' : 'development';
 
   const metadata = context.workspace.projects[context.projectName];
 


### PR DESCRIPTION
Fix conflicting NODE_ENV values between an application and webpack Plugins (DefinePlugin)

ISSUES CLOSED: #7924

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently, serving a fresh Nx React application shows the following:
```
WARNING in DefinePlugin
Conflicting values for 'process.env.NODE_ENV'
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

On freshly served applications there should be no such warning as stated above.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
