### PR TITLE
fix(core): build project's that have buildable dependencies without package.json's

### DIFF
--- a/packages/workspace/src/utilities/buildable-libs-utils.ts
+++ b/packages/workspace/src/utilities/buildable-libs-utils.ts
@@ -1,5 +1,5 @@
 import { dirname, join, relative, resolve } from 'path';
-import { directoryExists } from './fileutils';
+import { directoryExists, fileExists } from './fileutils';
 import type { ProjectGraph, ProjectGraphProjectNode } from '@nrwl/devkit';
 import {
   ProjectGraphExternalNode,
@@ -50,12 +50,12 @@ export function calculateProjectDependencies(
       const depNode = projGraph.nodes[dep] || projGraph.externalNodes[dep];
       if (depNode.type === 'lib') {
         if (isBuildable(targetName, depNode)) {
-          const libPackageJson = readJsonFile(
-            join(root, depNode.data.root, 'package.json')
-          );
+          const libPackageJsonFile = join(depNode.data.root, 'package.json');
 
           project = {
-            name: libPackageJson.name, // i.e. @workspace/mylib
+            name: fileExists(libPackageJsonFile)
+              ? readJsonFile(libPackageJsonFile).name // i.e. @workspace/mylib
+              : dep,
             outputs: getOutputsForTargetAndConfiguration(
               {
                 overrides: {},

--- a/packages/workspace/src/utilities/buildable-libs-utils.ts
+++ b/packages/workspace/src/utilities/buildable-libs-utils.ts
@@ -50,7 +50,11 @@ export function calculateProjectDependencies(
       const depNode = projGraph.nodes[dep] || projGraph.externalNodes[dep];
       if (depNode.type === 'lib') {
         if (isBuildable(targetName, depNode)) {
-          const libPackageJsonFile = join(depNode.data.root, 'package.json');
+          const libPackageJsonFile = join(
+            root,
+            depNode.data.root,
+            'package.json'
+          );
 
           project = {
             name: fileExists(libPackageJsonFile)

--- a/packages/workspace/src/utilities/buildable-libs-utils.ts
+++ b/packages/workspace/src/utilities/buildable-libs-utils.ts
@@ -50,15 +50,15 @@ export function calculateProjectDependencies(
       const depNode = projGraph.nodes[dep] || projGraph.externalNodes[dep];
       if (depNode.type === 'lib') {
         if (isBuildable(targetName, depNode)) {
-          const libPackageJsonFile = join(
+          const libPackageJsonPath = join(
             root,
             depNode.data.root,
             'package.json'
           );
 
           project = {
-            name: fileExists(libPackageJsonFile)
-              ? readJsonFile(libPackageJsonFile).name // i.e. @workspace/mylib
+            name: fileExists(libPackageJsonPath)
+              ? readJsonFile(libPackageJsonPath).name // i.e. @workspace/mylib
               : dep,
             outputs: getOutputsForTargetAndConfiguration(
               {


### PR DESCRIPTION
## Current Behavior
Not able to build project's that have buildable dependencies without package.json's

## Related Issue(s)
Fixes #8707
