### PR TITLE
fix(storybook): Allow stylePreprocessorOptions for React storybooks

### DIFF
--- a/packages/storybook/src/executors/utils.ts
+++ b/packages/storybook/src/executors/utils.ts
@@ -343,7 +343,10 @@ export function normalizeAngularBuilderStylesOptions(
     | '@storybook/svelte'
     | '@storybook/react-native'
 ): StorybookBuilderOptions | StorybookExecutorOptions {
-  if (uiFramework !== '@storybook/angular') {
+  if (
+    uiFramework !== '@storybook/angular' &&
+    uiFramework !== '@storybook/react'
+  ) {
     if (builderOptions.styles) {
       delete builderOptions.styles;
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently `styles` & `stylePreprocessorOptions` storybook options are automatically removed for non-Angular storybooks.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
These options used to work correctly with React storybooks.
We should be able to use these options with React projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

Allow Angular **AND** React project to use these options in storybooks.