### PR TITLE
docs(core): Add example of using global scripts for jest and nx libraries

### DIFF
--- a/docs/shared/jest-plugin.md
+++ b/docs/shared/jest-plugin.md
@@ -118,6 +118,23 @@ By default, coverage reports will be generated in the `coverage/` directory unde
 
 > `coverageDirectory` and `coverageReporters` are configurable via the project configuration file as well.
 
+### Global setup/teardown with nx libraries
+
+In order to use Jest's global setup/teardown functions that reference nx libraries, you'll need to register the TS path for jest to resolve the libraries.
+Nx provides a helper function that you can import within your setup/teardown file.
+
+```ts
+import { registerTsProject } from 'nx/src/utils/register';
+const cleanupRegisteredPaths = registerTsProject('.', 'tsconfig.base.json');
+
+import { yourFancyFunction } from '@some-org/my-util-library';
+export default async function () {
+  yourFancyFunction();
+}
+// make sure to run the clean up!
+cleanupRegisteredPaths();
+```
+
 ## Debugging Failing Tests
 
 If your code editor doesn't provide a way to debug your tests, you can leverage the Chrome DevTools to debug your tests with the `--inspect-brk` flag for node.

--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -8,7 +8,9 @@ import {
 } from '@nrwl/e2e/utils';
 
 describe('Jest', () => {
-  beforeEach(() => newProject());
+  beforeAll(() => {
+    newProject({ name: uniq('proj') });
+  });
 
   it('should be able test projects using jest', async () => {
     const mylib = uniq('mylib');
@@ -23,7 +25,18 @@ describe('Jest', () => {
   it('should merge with jest config globals', async () => {
     const testGlobal = `'My Test Global'`;
     const mylib = uniq('mylib');
+    const utilLib = uniq('util-lib');
     runCLI(`generate @nrwl/workspace:lib ${mylib} --unit-test-runner jest`);
+    runCLI(
+      `generate @nrwl/workspace:lib ${utilLib} --importPath=@global-fun/globals`
+    );
+    updateFile(
+      `libs/${utilLib}/src/index.ts`,
+      stripIndents`
+      export function setup() {console.log('i am a global setup function')}
+      export function teardown() {console.log('i am a global teardown function')}
+    `
+    );
 
     updateFile(`libs/${mylib}/src/lib/${mylib}.ts`, `export class Test { }`);
 
@@ -34,6 +47,31 @@ describe('Jest', () => {
             expect((global as any).testGlobal).toBe(${testGlobal});
           });
         `
+    );
+
+    updateFile(
+      `libs/${mylib}/setup.ts`,
+      stripIndents`
+      const { registerTsProject } = require('nx/src/utils/register');
+      const cleanup = registerTsProject('.', 'tsconfig.base.json');
+      
+      import {setup} from '@global-fun/globals'; 
+      export default async function() {setup();}
+      
+      cleanup();
+    `
+    );
+
+    updateFile(
+      `libs/${mylib}/teardown.ts`,
+      stripIndents`
+      import { registerTsProject } from 'nx/src/utils/register';
+      const cleanup = registerTsProject('.', 'tsconfig.base.json');
+      
+      import {teardown} from '@global-fun/globals'; 
+      export default async function() {teardown();}
+      cleanup();
+    `
     );
 
     updateFile(
@@ -48,7 +86,9 @@ describe('Jest', () => {
             moduleFileExtensions: ['ts', 'js', 'html'],
             coverageReporters: ['html'],
             passWithNoTests: true,
-            globals: { testGlobal: ${testGlobal} }
+            globals: { testGlobal: ${testGlobal} },
+            globalSetup: '<rootDir>/setup.ts',
+            globalTeardown: '<rootDir>/teardown.ts'
           };`
     );
 


### PR DESCRIPTION

## Current Behavior
unsure how to use jest global (setup/teardown) scripts that reference an nx library.

## Expected Behavior
explain how to use jest global (setup/teardown) scripts that use an nx library

## Background
initially, PR #9145 tried to fix this issue internally in the jest resolver, but after further thought, it makes more sense to not do this within nx but explain how to set it up for those wanting this feature.

## Related Issue(s)

Fixes #8709
