### PR TITLE
fix(js): pin fast-glob to 3.2.7 due to regression in 3.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
     "classnames": "^2.3.1",
     "core-js": "^3.6.5",
     "enquirer": "~2.3.6",
-    "fast-glob": "^3.2.7",
+    "fast-glob": "3.2.7",
     "framer-motion": "^4.1.17",
     "glob": "7.1.4",
     "gray-matter": "^4.0.2",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -37,7 +37,7 @@
     "@nrwl/linter": "*",
     "@parcel/watcher": "2.0.4",
     "chalk": "4.1.0",
-    "fast-glob": "^3.2.7",
+    "fast-glob": "3.2.7",
     "fs-extra": "^9.1.0",
     "ignore": "^5.0.4",
     "js-tokens": "^4.0.0",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->
See https://github.com/mrmlnc/fast-glob/issues/357

Fixes #9283 
