### PR TITLE
fix(testing): add root karma config if one isn't present for karma-project generator

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -661,6 +661,11 @@
             "description": "Skip formatting files.",
             "type": "boolean",
             "default": false
+          },
+          "skipPackageJson": {
+            "description": "Skip updating package.json.",
+            "type": "boolean",
+            "default": false
           }
         },
         "additionalProperties": false,

--- a/packages/angular/src/generators/karma-project/karma-project.spec.ts
+++ b/packages/angular/src/generators/karma-project/karma-project.spec.ts
@@ -41,11 +41,13 @@ describe('karmaProject', () => {
   });
 
   it('should generate files', async () => {
+    expect(tree.exists('karma.conf.js')).toBeFalsy();
     await karmaProjectGenerator(tree, { project: 'lib1' });
 
     expect(tree.exists('/libs/lib1/karma.conf.js')).toBeTruthy();
     expect(tree.exists('/libs/lib1/tsconfig.spec.json')).toBeTruthy();
     expect(tree.exists('/libs/lib1/src/test.ts')).toBeTruthy();
+    expect(tree.exists('karma.conf.js')).toBeTruthy();
   });
 
   it('should create a karma.conf.js', async () => {

--- a/packages/angular/src/generators/karma-project/karma-project.ts
+++ b/packages/angular/src/generators/karma-project/karma-project.ts
@@ -5,11 +5,13 @@ import { generateKarmaProjectFiles } from './lib/generate-karma-project-files';
 import { updateTsConfigs } from './lib/update-tsconfig';
 import { updateWorkspaceConfig } from './lib/update-workspace-config';
 import type { KarmaProjectOptions } from './schema';
+import { karmaGenerator } from '../karma/karma';
 
 export async function karmaProjectGenerator(
   tree: Tree,
   options: KarmaProjectOptions
 ) {
+  karmaGenerator(tree, options);
   checkProjectTestTarget(tree, options.project);
   generateKarmaProjectFiles(tree, options.project);
   updateTsConfigs(tree, options.project);

--- a/packages/angular/src/generators/karma-project/schema.d.ts
+++ b/packages/angular/src/generators/karma-project/schema.d.ts
@@ -1,4 +1,5 @@
 export interface KarmaProjectOptions {
   project: string;
   skipFormat?: boolean;
+  skipPackageJson?: boolean;
 }

--- a/packages/angular/src/generators/karma-project/schema.json
+++ b/packages/angular/src/generators/karma-project/schema.json
@@ -17,6 +17,11 @@
       "description": "Skip formatting files.",
       "type": "boolean",
       "default": false
+    },
+    "skipPackageJson": {
+      "description": "Skip updating package.json.",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/generators/karma/karma.spec.ts
+++ b/packages/angular/src/generators/karma/karma.spec.ts
@@ -9,7 +9,21 @@ describe('karma', () => {
     tree = createTreeWithEmptyWorkspace();
   });
 
-  it('should do nothing when karma is already installed', () => {
+  it('should do nothing when karma is already installed and karma.conf.js exists', () => {
+    jest.spyOn(devkit, 'generateFiles');
+    jest.spyOn(devkit, 'addDependenciesToPackageJson');
+    devkit.updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = { karma: '~5.0.0' };
+      return json;
+    });
+    tree.write('karma.conf.js', '');
+    karmaGenerator(tree, {});
+
+    expect(devkit.generateFiles).not.toHaveBeenCalled();
+    expect(devkit.addDependenciesToPackageJson).not.toHaveBeenCalled();
+  });
+
+  it('should create karma.conf.js when karma is installed', () => {
     jest.spyOn(devkit, 'generateFiles');
     jest.spyOn(devkit, 'addDependenciesToPackageJson');
     devkit.updateJson(tree, 'package.json', (json) => {
@@ -19,7 +33,7 @@ describe('karma', () => {
 
     karmaGenerator(tree, {});
 
-    expect(devkit.generateFiles).not.toHaveBeenCalled();
+    expect(devkit.generateFiles).toHaveBeenCalled();
     expect(devkit.addDependenciesToPackageJson).not.toHaveBeenCalled();
   });
 

--- a/packages/angular/src/generators/karma/karma.ts
+++ b/packages/angular/src/generators/karma/karma.ts
@@ -9,28 +9,30 @@ import { GeneratorOptions } from './schema';
 
 export function karmaGenerator(tree: Tree, options: GeneratorOptions) {
   const packageJson = readJson(tree, 'package.json');
-  if (packageJson.devDependencies['karma']) {
-    return;
+
+  if (!tree.exists('karma.conf.js')) {
+    generateFiles(tree, joinPathFragments(__dirname, 'files'), '.', {
+      tmpl: '',
+    });
   }
 
-  generateFiles(tree, joinPathFragments(__dirname, 'files'), '.', { tmpl: '' });
-
-  return !options.skipPackageJson
-    ? addDependenciesToPackageJson(
-        tree,
-        {},
-        {
-          karma: '~6.3.0',
-          'karma-chrome-launcher': '~3.1.0',
-          'karma-coverage': '~2.2.0',
-          'karma-jasmine': '~4.0.0',
-          'karma-jasmine-html-reporter': '~1.7.0',
-          'jasmine-core': '~3.10.0',
-          'jasmine-spec-reporter': '~5.0.0',
-          '@types/jasmine': '~3.5.0',
-        }
-      )
-    : () => {};
+  if (options.skipPackageJson || packageJson.devDependencies['karma']) {
+    return () => {};
+  }
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    {
+      karma: '~6.3.0',
+      'karma-chrome-launcher': '~3.1.0',
+      'karma-coverage': '~2.2.0',
+      'karma-jasmine': '~4.0.0',
+      'karma-jasmine-html-reporter': '~1.7.0',
+      'jasmine-core': '~3.10.0',
+      'jasmine-spec-reporter': '~5.0.0',
+      '@types/jasmine': '~3.5.0',
+    }
+  );
 }
 
 export default karmaGenerator;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
root karma config isn't generated when using karma-project generator
> Note: still waiting on confirmation on a part of issue #9234 before merging

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
when using the karma-project generator directly ensure the karma generator (install deps/root config)
is called if the root karma config isn't present

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9234