### PR TITLE
docs(nxdev): make sure rendered command string includes param indication

### DIFF
--- a/docs/generated/cli/list.md
+++ b/docs/generated/cli/list.md
@@ -10,7 +10,7 @@ Lists installed plugins, capabilities of installed plugins and other available p
 ## Usage
 
 ```bash
-nx list
+nx list [plugin]
 ```
 
 [Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.

--- a/docs/generated/cli/migrate.md
+++ b/docs/generated/cli/migrate.md
@@ -16,7 +16,7 @@ Creates a migrations file or runs migrations from the migrations file.
 ## Usage
 
 ```bash
-nx migrate
+nx migrate [packageAndVersion]
 ```
 
 [Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.

--- a/docs/generated/cli/workspace-generator.md
+++ b/docs/generated/cli/workspace-generator.md
@@ -10,7 +10,7 @@ Runs a workspace generator from the tools/generators directory
 ## Usage
 
 ```bash
-nx workspace-generator
+nx workspace-generator [name]
 ```
 
 [Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.

--- a/docs/generated/cli/workspace-lint.md
+++ b/docs/generated/cli/workspace-lint.md
@@ -10,7 +10,7 @@ Lint nx specific workspace files (nx.json, workspace.json)
 ## Usage
 
 ```bash
-nx workspace-lint
+nx workspace-lint [files..]
 ```
 
 [Install `nx` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpx nx`.

--- a/scripts/documentation/generate-cli-data.ts
+++ b/scripts/documentation/generate-cli-data.ts
@@ -33,6 +33,7 @@ interface ParsedCommandOption {
 
 interface ParsedCommand {
   name: string;
+  commandString: string;
   description: string;
   options?: Array<ParsedCommandOption>;
 }
@@ -80,7 +81,11 @@ export async function generateCLIDocumentation() {
         command.builder.apply
       )
     ) {
-      return { name, description: command.description };
+      return {
+        name,
+        commandString: command.original,
+        description: command.description,
+      };
     }
     // Show all the options we can get from yargs
     const builder = await command.builder(
@@ -92,6 +97,7 @@ export async function generateCLIDocumentation() {
     return {
       name,
       description: command.description,
+      commandString: command.original,
       options:
         Object.keys(builderDescriptions).map((key) => ({
           name: key,
@@ -117,7 +123,7 @@ ${command.description}
 ## Usage
 
 \`\`\`bash
-nx ${command.name}
+nx ${command.commandString}
 \`\`\`
 
 [Install \`nx\` globally](/getting-started/nx-setup#install-nx) to invoke the command directly using \`nx\`, or use \`npx nx\`, \`yarn nx\`, or \`pnpx nx\`.\n`;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Right now the rendered command string does not include possible params, which in some cases is confusing. Example of `nx migrate` rendering:

<img width="774" alt="image" src="https://user-images.githubusercontent.com/542458/159878405-edb0d6b1-a196-46a8-be4a-76bb46d4a044.png">

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Instead, the rendering should look like

<img width="775" alt="image" src="https://user-images.githubusercontent.com/542458/159878486-270bf816-8104-4a85-b8fb-d6d30aa36315.png">


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
