### PR TITLE
docs(core): add information about disabling the nx daemon for plugin dev

### DIFF
--- a/docs/shared/workspace/project-graph-plugins.md
+++ b/docs/shared/workspace/project-graph-plugins.md
@@ -115,7 +115,7 @@ If a file hasn't changed since the last invocation, it doesn't need to be reanal
 
 ## Visualizing the Project Graph
 
-You can then visualize the project graph as described [here](/structure/dependency-graph). However, there is a cache that Nx uses to avoid recalculating the project graph as much as possible. As you develop your project graph plugin, it might be a good idea to set the following environment variable to disable the project graph cache: `NX_CACHE_PROJECT_GRAPH=false`.
+You can then visualize the project graph as described [here](/structure/dependency-graph). However, there is a cache that Nx uses to avoid recalculating the project graph as much as possible. As you develop your project graph plugin, it might be a good idea to set the following environment variable to disable the project graph cache: `NX_CACHE_PROJECT_GRAPH=false`. It might also be a good idea to ensure that the dep graph is not running on the nx daemon by setting `NX_DAEMON=false`, as this will ensure you will be able to see any `console.log` statements you add as you're developing.
 
 ## Example Project Graph Plugin
 


### PR DESCRIPTION
Added information about disabling the nx daemon for developing project graph plugins to ensure `console.log`s and other debug statements are visible.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
