### PR TITLE
docs(nxdev): enable open-graph image generation for package view

### DIFF
--- a/scripts/documentation/open-graph/generate-images.ts
+++ b/scripts/documentation/open-graph/generate-images.ts
@@ -25,6 +25,11 @@ documents.map((category) => {
   );
 });
 packages.map((pkg) => {
+  data.push({
+    title: 'Package details',
+    content: `@nrwl/${pkg.name}`,
+    filename: ['packages', pkg.name].join('-'),
+  });
   pkg.schemas.executors.map((schema) => {
     data.push({
       title: 'Executor details',


### PR DESCRIPTION
Enables open-graph image generation for package pages on nx.dev.