### PR TITLE
docs(nxdev): set schema names has lowecase

### DIFF
--- a/nx-dev/feature-package-schema-viewer/src/lib/package-schema-list.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/package-schema-list.tsx
@@ -118,7 +118,7 @@ export function PackageSchemaList({
                       role="img"
                     />
                     <div className="ml-3">
-                      <p className="text-sm font-medium capitalize text-gray-900">
+                      <p className="text-sm font-medium text-gray-900">
                         <Link
                           href={`/packages/${pkg.name}/executors/${executors.name}`}
                         >
@@ -153,7 +153,7 @@ export function PackageSchemaList({
                       role="img"
                     />
                     <div className="ml-3">
-                      <p className="text-sm font-medium capitalize text-gray-900">
+                      <p className="text-sm font-medium text-gray-900">
                         <Link
                           href={`/packages/${pkg.name}/generators/${generators.name}`}
                         >


### PR DESCRIPTION
Removes capitalization on schema names for package view pages on nx.dev. Schema names can be copied and pasted directly with lower-cased name working on the CLI.