### PR TITLE
docs(angular): add missing required property "project" to ng-packagr executor presets

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -1838,11 +1838,12 @@
         "presets": [
           {
             "name": "Buildable Library with Tailwind",
-            "keys": ["tailwindConfig"]
+            "keys": ["project", "tailwindConfig"]
           },
           {
             "name": "Updating Project Dependencies for Buildable Library",
             "keys": [
+              "project",
               "updateBuildableProjectDepsInPackageJson",
               "buildableProjectDepsInPackageJsonType"
             ]
@@ -1898,11 +1899,12 @@
         "presets": [
           {
             "name": "Publishable Library with Tailwind",
-            "keys": ["tailwindConfig"]
+            "keys": ["project", "tailwindConfig"]
           },
           {
             "name": "Updating Project Dependencies for Publishable Library",
             "keys": [
+              "project",
               "updateBuildableProjectDepsInPackageJson",
               "buildableProjectDepsInPackageJsonType"
             ]

--- a/packages/angular/src/executors/ng-packagr-lite/schema.json
+++ b/packages/angular/src/executors/ng-packagr-lite/schema.json
@@ -7,11 +7,12 @@
   "presets": [
     {
       "name": "Buildable Library with Tailwind",
-      "keys": ["tailwindConfig"]
+      "keys": ["project", "tailwindConfig"]
     },
     {
       "name": "Updating Project Dependencies for Buildable Library",
       "keys": [
+        "project",
         "updateBuildableProjectDepsInPackageJson",
         "buildableProjectDepsInPackageJsonType"
       ]

--- a/packages/angular/src/executors/package/schema.json
+++ b/packages/angular/src/executors/package/schema.json
@@ -7,11 +7,12 @@
   "presets": [
     {
       "name": "Publishable Library with Tailwind",
-      "keys": ["tailwindConfig"]
+      "keys": ["project", "tailwindConfig"]
     },
     {
       "name": "Updating Project Dependencies for Publishable Library",
       "keys": [
+        "project",
         "updateBuildableProjectDepsInPackageJson",
         "buildableProjectDepsInPackageJsonType"
       ]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The preset examples for `ng-packagr-lite` and `package` executors are missing the required property `project` and therefore, a warning appears on the live editor highlighting the issue.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The preset examples should always contain the default properties.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
