### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/cypress/src/utils/project-name.ts
+++ b/packages/cypress/src/utils/project-name.ts
@@ -1,7 +1,7 @@
 import { names } from '@nrwl/devkit';
 
 export function getUnscopedLibName(libRoot: string) {
-  return libRoot.substr(libRoot.lastIndexOf('/') + 1);
+  return libRoot.slice(libRoot.lastIndexOf('/') + 1);
 }
 
 export function getE2eProjectName(

--- a/packages/devkit/src/utils/names.ts
+++ b/packages/devkit/src/utils/names.ts
@@ -65,5 +65,5 @@ function toFileName(s: string): string {
  * Capitalizes the first letter of a string
  */
 function toCapitalCase(s: string): string {
-  return s.charAt(0).toUpperCase() + s.substr(1);
+  return s.charAt(0).toUpperCase() + s.slice(1);
 }

--- a/packages/devkit/src/utils/string-change.ts
+++ b/packages/devkit/src/utils/string-change.ts
@@ -84,10 +84,10 @@ export function applyChangesToString(
   for (const change of sortedChanges) {
     const index = getChangeIndex(change) + offset;
     if (isStringInsertion(change)) {
-      text = text.substr(0, index) + change.text + text.substr(index);
+      text = text.slice(0, index) + change.text + text.slice(index);
       offset += change.text.length;
     } else {
-      text = text.substr(0, index) + text.substr(index + change.length);
+      text = text.slice(0, index) + text.slice(index + change.length);
       offset -= change.length;
     }
   }

--- a/packages/js/src/utils/code-frames/highlight.ts
+++ b/packages/js/src/utils/code-frames/highlight.ts
@@ -50,7 +50,7 @@ function getTokenType(match) {
 
     if (
       JSX_TAG.test(token.value) &&
-      (text[offset - 1] === '<' || text.slice(offset - 2, offset) == '</')
+      (text[offset - 1] === '<' || text.slice(offset - 2, 2) == '</')
     ) {
       return 'jsx_tag';
     }

--- a/packages/js/src/utils/code-frames/highlight.ts
+++ b/packages/js/src/utils/code-frames/highlight.ts
@@ -50,7 +50,7 @@ function getTokenType(match) {
 
     if (
       JSX_TAG.test(token.value) &&
-      (text[offset - 1] === '<' || text.substr(offset - 2, 2) == '</')
+      (text[offset - 1] === '<' || text.slice(offset - 2, offset) == '</')
     ) {
       return 'jsx_tag';
     }

--- a/packages/nest/src/migrations/update-10-0-0/update-10-0-0.ts
+++ b/packages/nest/src/migrations/update-10-0-0/update-10-0-0.ts
@@ -71,9 +71,7 @@ function updateImports(host: Tree) {
         isStringLiteral(statement.moduleSpecifier)
       ) {
         const nodeText = statement.moduleSpecifier.getText(sourceFile);
-        const modulePath = statement.moduleSpecifier
-          .getText(sourceFile)
-          .substr(1, nodeText.length - 2);
+        const modulePath = nodeText.slice(1, -1);
         if (modulePath === 'type-graphql') {
           changes.push(
             new ReplaceChange(

--- a/packages/nx/src/adapter/decorate-cli.ts
+++ b/packages/nx/src/adapter/decorate-cli.ts
@@ -5,7 +5,7 @@ export function decorateCli() {
   const angularCLIInit = readFileSync(path, 'utf-8');
   const start = angularCLIInit.indexOf(`(options) {`) + 11;
 
-  const newContent = `${angularCLIInit.substr(0, start)}
+  const newContent = `${angularCLIInit.slice(0, start)}
   if (!process.env['NX_CLI_SET']) {
     require('nx/bin/nx');
     return new Promise(function(res, rej) {});

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -134,7 +134,7 @@ async function createRecorder(
   const actualConfigName = await host.workspaceConfigName();
   return (event: import('@angular-devkit/schematics').DryRunEvent) => {
     let eventPath = event.path.startsWith('/')
-      ? event.path.substr(1)
+      ? event.path.slice(1)
       : event.path;
 
     if (eventPath === 'workspace.json' || eventPath === 'angular.json') {
@@ -1036,7 +1036,7 @@ export function wrapAngularDevkitSchematic(
       event: import('@angular-devkit/schematics').DryRunEvent
     ) => {
       let eventPath = event.path.startsWith('/')
-        ? event.path.substr(1)
+        ? event.path.slice(1)
         : event.path;
 
       const r = convertEventTypeToHandleMultipleConfigNames(
@@ -1138,14 +1138,14 @@ const loggerColors: Partial<Record<logging.LogLevel, (s: string) => string>> = {
   warn: (s) => chalk.bold(chalk.yellow(s)),
   error: (s) => {
     if (s.startsWith('NX ')) {
-      return `\n${NX_ERROR} ${chalk.bold(chalk.red(s.substr(3)))}\n`;
+      return `\n${NX_ERROR} ${chalk.bold(chalk.red(s.slice(3)))}\n`;
     }
 
     return chalk.bold(chalk.red(s));
   },
   info: (s) => {
     if (s.startsWith('NX ')) {
-      return `\n${NX_PREFIX} ${chalk.bold(s.substr(3))}\n`;
+      return `\n${NX_PREFIX} ${chalk.bold(s.slice(3))}\n`;
     }
 
     return chalk.white(s);

--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -47,8 +47,8 @@ function convertToGenerateOptions(
     const separatorIndex = generatorDescriptor.lastIndexOf(':');
 
     if (separatorIndex > 0) {
-      collectionName = generatorDescriptor.substr(0, separatorIndex);
-      generatorName = generatorDescriptor.substr(separatorIndex + 1);
+      collectionName = generatorDescriptor.slice(0, separatorIndex);
+      generatorName = generatorDescriptor.slice(separatorIndex + 1);
     } else {
       collectionName = defaultCollectionName;
       generatorName = generatorDescriptor;

--- a/packages/nx/src/hasher/file-hasher-base.ts
+++ b/packages/nx/src/hasher/file-hasher-base.ts
@@ -63,7 +63,7 @@ export abstract class FileHasherBase {
     }
     const relativePath = normalizePath(
       path.startsWith(workspaceRoot)
-        ? path.substring(workspaceRoot.length + 1)
+        ? path.slice(workspaceRoot.length + 1)
         : path
     );
     if (this.fileHashes.has(relativePath)) {

--- a/packages/nx/src/project-graph/build-dependencies/implicit-project-dependencies.ts
+++ b/packages/nx/src/project-graph/build-dependencies/implicit-project-dependencies.ts
@@ -10,7 +10,7 @@ export function buildImplicitProjectDependencies(
     if (p.implicitDependencies && p.implicitDependencies.length > 0) {
       p.implicitDependencies.forEach((target) => {
         if (target.startsWith('!')) {
-          builder.removeDependency(source, target.substr(1));
+          builder.removeDependency(source, target.slice(1));
         } else {
           builder.addImplicitDependency(source, target);
         }

--- a/packages/nx/src/project-graph/build-dependencies/typescript-import-locator.ts
+++ b/packages/nx/src/project-graph/build-dependencies/typescript-import-locator.ts
@@ -156,6 +156,6 @@ export class TypeScriptImportLocator {
   }
 
   private getStringLiteralValue(node: ts.Node): string {
-    return node.getText().substr(1, node.getText().length - 2);
+    return node.getText().slice(1, -1);
   }
 }

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -65,7 +65,7 @@ function toFileName(s: string): string {
  * Capitalizes the first letter of a string
  */
 function toCapitalCase(s: string): string {
-  return s.charAt(0).toUpperCase() + s.substr(1);
+  return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
 const runOne: string[] = [

--- a/packages/nx/src/utils/logger.ts
+++ b/packages/nx/src/utils/logger.ts
@@ -10,7 +10,7 @@ export const logger = {
   warn: (s) => console.warn(chalk.bold(chalk.yellow(s))),
   error: (s) => {
     if (typeof s === 'string' && s.startsWith('NX ')) {
-      console.error(`\n${NX_ERROR} ${chalk.bold(chalk.red(s.substr(3)))}\n`);
+      console.error(`\n${NX_ERROR} ${chalk.bold(chalk.red(s.slice(3)))}\n`);
     } else if (s instanceof Error && s.stack) {
       console.error(chalk.bold(chalk.red(s.stack)));
     } else {
@@ -19,7 +19,7 @@ export const logger = {
   },
   info: (s) => {
     if (typeof s === 'string' && s.startsWith('NX ')) {
-      console.info(`\n${NX_PREFIX} ${chalk.bold(s.substr(3))}\n`);
+      console.info(`\n${NX_PREFIX} ${chalk.bold(s.slice(3))}\n`);
     } else {
       console.info(s);
     }

--- a/packages/nx/src/utils/print-help.ts
+++ b/packages/nx/src/utils/print-help.ts
@@ -8,7 +8,7 @@ function formatOption(
   maxPropertyNameLength: number
 ) {
   const lengthOfKey = Math.max(maxPropertyNameLength + 4, 22);
-  return `  --${`${name}                                                 `.substr(
+  return `  --${`${name}                                                 `.slice(
     0,
     lengthOfKey
   )}${description}`;

--- a/packages/storybook/src/generators/migrate-stories-to-6-2/migrate-stories-to-6-2.ts
+++ b/packages/storybook/src/generators/migrate-stories-to-6-2/migrate-stories-to-6-2.ts
@@ -167,7 +167,7 @@ function findAllComponentsWithStoriesForSpecificProject(
     const imports = file.statements?.filter(
       (statement) => statement.kind === SyntaxKind.ImportDeclaration
     );
-    const modulePath = moduleFilePath.substr(
+    const modulePath = moduleFilePath.slice(
       0,
       moduleFilePath?.lastIndexOf('/')
     );

--- a/packages/web/src/executors/rollup/rollup.impl.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.ts
@@ -63,7 +63,7 @@ export default async function* rollupExecutor(
 
   const npmDeps = (projectGraph.dependencies[context.projectName] ?? [])
     .filter((d) => d.target.startsWith('npm:'))
-    .map((d) => d.target.substr(4));
+    .map((d) => d.target.slice(4));
 
   const rollupOptions = createRollupOptions(
     options,

--- a/packages/web/src/utils/serve-path.ts
+++ b/packages/web/src/utils/serve-path.ts
@@ -5,7 +5,7 @@ export function buildServePath(browserOptions: WebWebpackExecutorOptions) {
     _findDefaultServePath(browserOptions.baseHref, browserOptions.deployUrl) ||
     '/';
   if (servePath.endsWith('/')) {
-    servePath = servePath.substr(0, servePath.length - 1);
+    servePath = servePath.slice(0, -1);
   }
   if (!servePath.startsWith('/')) {
     servePath = `/${servePath}`;

--- a/packages/web/src/utils/web.config.ts
+++ b/packages/web/src/utils/web.config.ts
@@ -153,7 +153,7 @@ export function getStylesPartial(
     plugins: [
       postcssImports({
         addModulesDirectories: includePaths,
-        resolve: (url: string) => (url.startsWith('~') ? url.substr(1) : url),
+        resolve: (url: string) => (url.startsWith('~') ? url.slice(1) : url),
       }),
     ],
   });

--- a/packages/web/src/utils/webpack/partials/styles.ts
+++ b/packages/web/src/utils/webpack/partials/styles.ts
@@ -39,7 +39,7 @@ export function getStylesConfig(
       plugins: [
         postcssImports({
           addModulesDirectories: includePaths,
-          resolve: (url: string) => (url.startsWith('~') ? url.substr(1) : url),
+          resolve: (url: string) => (url.startsWith('~') ? url.slice(1) : url),
         }),
         PostcssCliResources({
           baseHref: buildOptions.baseHref,

--- a/packages/web/src/utils/webpack/plugins/postcss-cli-resources.ts
+++ b/packages/web/src/utils/webpack/plugins/postcss-cli-resources.ts
@@ -70,7 +70,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
     // If starts with a caret, remove and return remainder
     // this supports bypassing asset processing
     if (inputUrl.startsWith('^')) {
-      return inputUrl.substr(1);
+      return inputUrl.slice(1);
     }
     const cacheKey = path.resolve(context, inputUrl);
     const cachedUrl = resourceCache.get(cacheKey);
@@ -78,7 +78,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
       return cachedUrl;
     }
     if (inputUrl.startsWith('~')) {
-      inputUrl = inputUrl.substr(1);
+      inputUrl = inputUrl.slice(1);
     }
     if (inputUrl.startsWith('/')) {
       let outputUrl = '';

--- a/packages/workspace/src/generators/move/lib/normalize-schema.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.ts
@@ -9,7 +9,7 @@ export function normalizeSchema(
   projectConfiguration: ProjectConfiguration
 ): NormalizedSchema {
   const destination = schema.destination.startsWith('/')
-    ? normalizeSlashes(schema.destination.substr(1))
+    ? normalizeSlashes(schema.destination.slice(1))
     : schema.destination;
   const newProjectName = getNewProjectName(destination);
   const { npmScope } = getWorkspaceLayout(tree);

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -51,7 +51,7 @@ export function updateImports(
     from:
       fromPath ||
       normalizeSlashes(
-        `@${npmScope}/${project.root.substr(libsDir.length + 1)}`
+        `@${npmScope}/${project.root.slice(libsDir.length + 1)}`
       ),
     to: schema.importPath,
   };
@@ -77,7 +77,7 @@ export function updateImports(
   }
 
   const projectRoot = {
-    from: project.root.substr(libsDir.length + 1),
+    from: project.root.slice(libsDir.length + 1),
     to: schema.destination,
   };
 

--- a/packages/workspace/src/generators/remove/lib/update-tsconfig.ts
+++ b/packages/workspace/src/generators/remove/lib/update-tsconfig.ts
@@ -20,7 +20,7 @@ export function updateTsconfig(
   const { appsDir, libsDir, npmScope } = getWorkspaceLayout(tree);
 
   const tsConfigPath = getRootTsConfigPathInTree(tree);
-  const defaultImportPath = `@${npmScope}/${project.root.substr(
+  const defaultImportPath = `@${npmScope}/${project.root.slice(
     project.projectType === 'application'
       ? appsDir.length + 1
       : libsDir.length + 1

--- a/packages/workspace/src/utils/strings.ts
+++ b/packages/workspace/src/utils/strings.ts
@@ -132,7 +132,7 @@ export function underscore(str: string): string {
  @return {String} The capitalized string.
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 export function group(name: string, group: string | undefined) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Current Behavior
Same as new

## Expected Behavior
Same as current

## Related Issue(s)

