### PR TITLE
fix(core): un-scope the node_modules entry in generated .gitignore

### DIFF
--- a/packages/workspace/src/generators/workspace/files/__dot__gitignore
+++ b/packages/workspace/src/generators/workspace/files/__dot__gitignore
@@ -6,7 +6,7 @@
 /out-tsc
 
 # dependencies
-/node_modules
+node_modules
 
 # IDEs and editors
 /.idea


### PR DESCRIPTION
ISSUES CLOSED: #9412

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `node_modules` entry has a leading slash. This scopes to the directory level of the .gitignore (only ignores `node_modules` at the same level of the .gitignore).

## Expected Behavior
Ignore `node_modules` at all levels.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9412
