### PR TITLE
docs(core): fix typo in using-executors

### DIFF
--- a/docs/shared/using-executors.md
+++ b/docs/shared/using-executors.md
@@ -47,7 +47,7 @@ Each project has its executors defined in the `targets` property. In this snippe
 
 Each executor definition has an `executor` property and, optionally, an `options` and a `configurations` property.
 
-- `executor` is a string of the from `[package name]:[executor name]`. For the `build` executor, the package name is `@nrwl/web` and the executor name is `build`.
+- `executor` is a string of the form `[package name]:[executor name]`. For the `build` executor, the package name is `@nrwl/web` and the executor name is `webpack`.
 - `options` is an object that contains any configuration defaults for the executor. These options vary from executor to executor.
 - `configurations` allows you to create presets of options for different scenarios. All the configurations start with the properties defined in `options` as a baseline and then overwrite those options. In the example, there is a `production` configuration that overrides the default options to set `sourceMap` to `false`.
 


### PR DESCRIPTION
### Documentation issue

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Reporting a typo
- [ ] Reporting a documentation bug
- [ ] Documentation improvement
- [ ] Documentation feedback

<!--
  If your issue is not regarding the documentation, please choose an issue type:
  https://github.com/nrwl/nx/issues/new/choose
-->

### Is there a specific documentation page you are reporting?

https://nx.dev/executors/using-builders

### Additional context or description

* Typo: from --> form
* In the executor string the executor name is `webpack`, not `build`

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
