### PR TITLE
feat(angular): add dynamic federation support to mfe generator

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -191,6 +191,12 @@
             "description": "Type of application to generate the Module Federation configuration for.",
             "default": "remote"
           },
+          "federationType": {
+            "type": "string",
+            "enum": ["static", "dynamic"],
+            "description": "Use either Static or Dynamic Module Federation pattern for the application.",
+            "default": "static"
+          },
           "port": {
             "type": "number",
             "description": "The port at which the remote application should be served."
@@ -1004,6 +1010,11 @@
           "port": {
             "type": "number",
             "description": "The port on which this app should be served."
+          },
+          "dynamic": {
+            "type": "boolean",
+            "description": "Should the host app use dynamic federation?",
+            "default": false
           }
         },
         "required": ["name"],
@@ -1453,6 +1464,12 @@
             "enum": ["host", "remote"],
             "description": "Type of application to generate the Module Federation configuration for.",
             "default": "remote"
+          },
+          "federationType": {
+            "type": "string",
+            "enum": ["static", "dynamic"],
+            "description": "Use either Static or Dynamic Module Federation pattern for the application.",
+            "default": "static"
           },
           "port": {
             "type": "number",

--- a/packages/angular/mfe/index.ts
+++ b/packages/angular/mfe/index.ts
@@ -1,1 +1,5 @@
-export { setRemoteUrlResolver, loadRemoteModule } from './mfe';
+export {
+  setRemoteUrlResolver,
+  setRemoteDefinitions,
+  loadRemoteModule,
+} from './mfe';

--- a/packages/angular/src/generators/application/lib/add-mfe.ts
+++ b/packages/angular/src/generators/application/lib/add-mfe.ts
@@ -14,5 +14,6 @@ export async function addMfe(host: Tree, options: NormalizedSchema) {
     skipFormat: true,
     skipPackageJson: options.skipPackageJson,
     e2eProjectName: options.e2eProjectName,
+    federationType: options.federationType,
   });
 }

--- a/packages/angular/src/generators/application/schema.d.ts
+++ b/packages/angular/src/generators/application/schema.d.ts
@@ -30,4 +30,5 @@ export interface Schema {
   host?: string;
   setParserOptionsProject?: boolean;
   skipPackageJson?: boolean;
+  federationType?: 'static' | 'dynamic';
 }

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -138,6 +138,12 @@
       "description": "Type of application to generate the Module Federation configuration for.",
       "default": "remote"
     },
+    "federationType": {
+      "type": "string",
+      "enum": ["static", "dynamic"],
+      "description": "Use either Static or Dynamic Module Federation pattern for the application.",
+      "default": "static"
+    },
     "port": {
       "type": "number",
       "description": "The port at which the remote application should be served."

--- a/packages/angular/src/generators/mfe-host/mfe-host.ts
+++ b/packages/angular/src/generators/mfe-host/mfe-host.ts
@@ -24,6 +24,7 @@ export default async function mfeHost(tree: Tree, options: Schema) {
     routing: true,
     remotes: options.remotes ?? [],
     port: 4200,
+    federationType: options.dynamic ? 'dynamic' : 'static',
   });
 
   return installTask;

--- a/packages/angular/src/generators/mfe-host/schema.d.ts
+++ b/packages/angular/src/generators/mfe-host/schema.d.ts
@@ -1,4 +1,5 @@
 export interface Schema {
   name: string;
   remotes?: string[];
+  dynamic?: boolean;
 }

--- a/packages/angular/src/generators/mfe-host/schema.json
+++ b/packages/angular/src/generators/mfe-host/schema.json
@@ -27,6 +27,11 @@
     "port": {
       "type": "number",
       "description": "The port on which this app should be served."
+    },
+    "dynamic": {
+      "type": "boolean",
+      "description": "Should the host app use dynamic federation?",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/angular/src/generators/setup-mfe/__snapshots__/setup-mfe.spec.ts.snap
+++ b/packages/angular/src/generators/setup-mfe/__snapshots__/setup-mfe.spec.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Init MFE --federationType=dynamic should create a host with the correct configurations 1`] = `
+"import { setRemoteDefinitions } from '@nrwl/angular/mfe';
+
+  fetch('/assets/mfe.manifest.json')
+  .then((res) => res.json())
+  .then(definitions => setRemoteDefinitions(definitions))
+  .then(() => import('./bootstrap').catch(err => console.error(err)))"
+`;
+
 exports[`Init MFE should add a remote application and add it to a specified host applications router config 1`] = `
 "import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
@@ -42,6 +51,34 @@ exports[`Init MFE should add a remote application and add it to a specified host
   name: 'app1',
   remotes: ['remote1',]
 }"
+`;
+
+exports[`Init MFE should add a remote to dynamic host correctly 1`] = `
+"import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+
+import { AppComponent } from './app.component';
+import { NxWelcomeComponent } from './nx-welcome.component';
+import { RouterModule } from '@angular/router';
+import { loadRemoteModule } from '@nrwl/angular/mfe';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    NxWelcomeComponent
+  ],
+  imports: [
+    BrowserModule,
+    RouterModule.forRoot([{
+         path: 'remote1', 
+         loadChildren: () => loadRemoteModule('remote1', './Module').then(m => m.RemoteEntryModule)
+     }], {initialNavigation: 'enabledBlocking'})
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }
+"
 `;
 
 exports[`Init MFE should create webpack and mfe configs correctly 1`] = `

--- a/packages/angular/src/generators/setup-mfe/lib/add-remote-to-host.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/add-remote-to-host.ts
@@ -1,12 +1,16 @@
-import type { Tree } from '@nrwl/devkit';
+import { ProjectConfiguration, Tree, updateJson } from '@nrwl/devkit';
 import type { Schema } from '../schema';
 
 import { readProjectConfiguration, joinPathFragments } from '@nrwl/devkit';
 import { tsquery } from '@phenomnomnominal/tsquery';
 import { ArrayLiteralExpression } from 'typescript';
-import { addRoute } from '../../../utils/nx-devkit/ast-utils';
+import {
+  addImportToModule,
+  addRoute,
+} from '../../../utils/nx-devkit/ast-utils';
 
 import * as ts from 'typescript';
+import { insertImport } from '@nrwl/workspace/src/utilities/ast-utils';
 
 export function checkIsCommaNeeded(mfeRemoteText: string) {
   const remoteText = mfeRemoteText.replace(/\s+/g, '');
@@ -17,36 +21,23 @@ export function checkIsCommaNeeded(mfeRemoteText: string) {
     : false;
 }
 
-export function addRemoteToHost(host: Tree, options: Schema) {
+export function addRemoteToHost(tree: Tree, options: Schema) {
   if (options.mfeType === 'remote' && options.host) {
-    const hostProject = readProjectConfiguration(host, options.host);
-    const hostMfeConfigPath = joinPathFragments(
-      hostProject.root,
-      'mfe.config.js'
+    const hostProject = readProjectConfiguration(tree, options.host);
+    const pathToMfeManifest = joinPathFragments(
+      hostProject.sourceRoot,
+      'assets/mfe.manifest.json'
+    );
+    const hostFederationType = determineHostFederationType(
+      tree,
+      pathToMfeManifest
     );
 
-    if (!hostMfeConfigPath || !host.exists(hostMfeConfigPath)) {
-      throw new Error(
-        `The selected host application, ${options.host}, does not contain a mfe.config.js. Are you sure it has been set up as a host application?`
-      );
+    if (hostFederationType === 'static') {
+      addRemoteToStaticHost(tree, options, hostProject);
+    } else if (hostFederationType === 'dynamic') {
+      addRemoteToDynamicHost(tree, options, pathToMfeManifest);
     }
-
-    const hostMFEConfig = host.read(hostMfeConfigPath, 'utf-8');
-    const webpackAst = tsquery.ast(hostMFEConfig);
-    const mfRemotesNode = tsquery(
-      webpackAst,
-      'Identifier[name=remotes] ~ ArrayLiteralExpression',
-      { visitAllChildren: true }
-    )[0] as ArrayLiteralExpression;
-
-    const endOfPropertiesPos = mfRemotesNode.getEnd() - 1;
-    const isCommaNeeded = checkIsCommaNeeded(mfRemotesNode.getText());
-
-    const updatedConfig = `${hostMFEConfig.slice(0, endOfPropertiesPos)}${
-      isCommaNeeded ? ',' : ''
-    }'${options.appName}',${hostMFEConfig.slice(endOfPropertiesPos)}`;
-
-    host.write(hostMfeConfigPath, updatedConfig);
 
     const declarationFilePath = joinPathFragments(
       hostProject.sourceRoot,
@@ -54,24 +45,82 @@ export function addRemoteToHost(host: Tree, options: Schema) {
     );
 
     const declarationFileContent =
-      (host.exists(declarationFilePath)
-        ? host.read(declarationFilePath, 'utf-8')
+      (tree.exists(declarationFilePath)
+        ? tree.read(declarationFilePath, 'utf-8')
         : '') + `\ndeclare module '${options.appName}/Module';`;
-    host.write(declarationFilePath, declarationFileContent);
+    tree.write(declarationFilePath, declarationFileContent);
 
-    addLazyLoadedRouteToHostAppModule(host, options);
+    addLazyLoadedRouteToHostAppModule(tree, options, hostFederationType);
   }
 }
 
+function determineHostFederationType(
+  tree: Tree,
+  pathToMfeManifest: string
+): 'dynamic' | 'static' {
+  return tree.exists(pathToMfeManifest) ? 'dynamic' : 'static';
+}
+
+function addRemoteToStaticHost(
+  tree: Tree,
+  options: Schema,
+  hostProject: ProjectConfiguration
+) {
+  const hostMfeConfigPath = joinPathFragments(
+    hostProject.root,
+    'mfe.config.js'
+  );
+
+  if (!hostMfeConfigPath || !tree.exists(hostMfeConfigPath)) {
+    throw new Error(
+      `The selected host application, ${options.host}, does not contain a mfe.config.js or mfe.manifest.json file. Are you sure it has been set up as a host application?`
+    );
+  }
+
+  const hostMFEConfig = tree.read(hostMfeConfigPath, 'utf-8');
+  const webpackAst = tsquery.ast(hostMFEConfig);
+  const mfRemotesNode = tsquery(
+    webpackAst,
+    'Identifier[name=remotes] ~ ArrayLiteralExpression',
+    { visitAllChildren: true }
+  )[0] as ArrayLiteralExpression;
+
+  const endOfPropertiesPos = mfRemotesNode.getEnd() - 1;
+  const isCommaNeeded = checkIsCommaNeeded(mfRemotesNode.getText());
+
+  const updatedConfig = `${hostMFEConfig.slice(0, endOfPropertiesPos)}${
+    isCommaNeeded ? ',' : ''
+  }'${options.appName}',${hostMFEConfig.slice(endOfPropertiesPos)}`;
+
+  tree.write(hostMfeConfigPath, updatedConfig);
+}
+
+function addRemoteToDynamicHost(
+  tree: Tree,
+  options: Schema,
+  pathToMfeManifest: string
+) {
+  updateJson(tree, pathToMfeManifest, (manifest) => {
+    return {
+      ...manifest,
+      [options.appName]: `http://localhost:${options.port}`,
+    };
+  });
+}
+
 // TODO(colum): future work: allow dev to pass to path to routing module
-function addLazyLoadedRouteToHostAppModule(host: Tree, options: Schema) {
-  const hostAppConfig = readProjectConfiguration(host, options.host);
+function addLazyLoadedRouteToHostAppModule(
+  tree: Tree,
+  options: Schema,
+  hostFederationType: 'dynamic' | 'static'
+) {
+  const hostAppConfig = readProjectConfiguration(tree, options.host);
   const pathToHostAppModule = `${hostAppConfig.sourceRoot}/app/app.module.ts`;
-  if (!host.exists(pathToHostAppModule)) {
+  if (!tree.exists(pathToHostAppModule)) {
     return;
   }
 
-  const hostAppModule = host.read(pathToHostAppModule, 'utf-8');
+  const hostAppModule = tree.read(pathToHostAppModule, 'utf-8');
   if (!hostAppModule.includes('RouterModule.forRoot(')) {
     return;
   }
@@ -83,13 +132,27 @@ function addLazyLoadedRouteToHostAppModule(host: Tree, options: Schema) {
     true
   );
 
+  if (hostFederationType === 'dynamic') {
+    sourceFile = insertImport(
+      tree,
+      sourceFile,
+      pathToHostAppModule,
+      'loadRemoteModule',
+      '@nrwl/angular/mfe'
+    );
+  }
+  const routeToAdd =
+    hostFederationType === 'dynamic'
+      ? `loadRemoteModule('${options.appName}', './Module')`
+      : `import('${options.appName}/Module')`;
+
   sourceFile = addRoute(
-    host,
+    tree,
     pathToHostAppModule,
     sourceFile,
     `{
          path: '${options.appName}', 
-         loadChildren: () => import('${options.appName}/Module').then(m => m.RemoteEntryModule)
+         loadChildren: () => ${routeToAdd}.then(m => m.RemoteEntryModule)
      }`
   );
 }

--- a/packages/angular/src/generators/setup-mfe/lib/index.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/index.ts
@@ -7,4 +7,5 @@ export * from './fix-bootstrap';
 export * from './generate-config';
 export * from './get-remotes-with-ports';
 export * from './set-tsconfig-target';
+export * from './setup-host-if-dynamic';
 export * from './setup-serve-target';

--- a/packages/angular/src/generators/setup-mfe/lib/setup-host-if-dynamic.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/setup-host-if-dynamic.ts
@@ -1,0 +1,19 @@
+import type { Tree } from '@nrwl/devkit';
+import type { Schema } from '../schema';
+
+import { readProjectConfiguration, joinPathFragments } from '@nrwl/devkit';
+
+export function setupHostIfDynamic(tree: Tree, options: Schema) {
+  if (options.federationType === 'static' || options.mfeType === 'remote') {
+    return;
+  }
+
+  const pathToMfeManifest = joinPathFragments(
+    readProjectConfiguration(tree, options.appName).sourceRoot,
+    'assets/mfe.manifest.json'
+  );
+
+  if (!tree.exists(pathToMfeManifest)) {
+    tree.write(pathToMfeManifest, '{}');
+  }
+}

--- a/packages/angular/src/generators/setup-mfe/schema.d.ts
+++ b/packages/angular/src/generators/setup-mfe/schema.d.ts
@@ -4,6 +4,7 @@ export interface Schema {
   port?: number;
   remotes?: string[];
   host?: string;
+  federationType?: 'static' | 'dynamic';
   routing?: boolean;
   skipFormat?: boolean;
   skipPackageJson?: boolean;

--- a/packages/angular/src/generators/setup-mfe/schema.json
+++ b/packages/angular/src/generators/setup-mfe/schema.json
@@ -21,6 +21,12 @@
       "description": "Type of application to generate the Module Federation configuration for.",
       "default": "remote"
     },
+    "federationType": {
+      "type": "string",
+      "enum": ["static", "dynamic"],
+      "description": "Use either Static or Dynamic Module Federation pattern for the application.",
+      "default": "static"
+    },
     "port": {
       "type": "number",
       "description": "The port at which the remote application should be served."

--- a/packages/angular/src/generators/setup-mfe/setup-mfe.ts
+++ b/packages/angular/src/generators/setup-mfe/setup-mfe.ts
@@ -13,30 +13,35 @@ import {
   generateWebpackConfig,
   getRemotesWithPorts,
   setupServeTarget,
+  setupHostIfDynamic,
   updateTsConfigTarget,
 } from './lib';
 
-export async function setupMfe(host: Tree, options: Schema) {
-  const projectConfig = readProjectConfiguration(host, options.appName);
+export async function setupMfe(tree: Tree, options: Schema) {
+  const projectConfig = readProjectConfiguration(tree, options.appName);
 
-  const remotesWithPorts = getRemotesWithPorts(host, options);
-  addRemoteToHost(host, options);
+  options.federationType = options.federationType ?? 'static';
 
-  generateWebpackConfig(host, options, projectConfig.root, remotesWithPorts);
+  setupHostIfDynamic(tree, options);
 
-  addEntryModule(host, options, projectConfig.root);
-  addImplicitDeps(host, options);
-  changeBuildTarget(host, options);
-  updateTsConfigTarget(host, options);
-  setupServeTarget(host, options);
+  const remotesWithPorts = getRemotesWithPorts(tree, options);
+  addRemoteToHost(tree, options);
 
-  fixBootstrap(host, projectConfig.root);
+  generateWebpackConfig(tree, options, projectConfig.root, remotesWithPorts);
 
-  addCypressOnErrorWorkaround(host, options);
+  addEntryModule(tree, options, projectConfig.root);
+  addImplicitDeps(tree, options);
+  changeBuildTarget(tree, options);
+  updateTsConfigTarget(tree, options);
+  setupServeTarget(tree, options);
+
+  fixBootstrap(tree, projectConfig.root, options);
+
+  addCypressOnErrorWorkaround(tree, options);
 
   // format files
   if (!options.skipFormat) {
-    await formatFiles(host);
+    await formatFiles(tree);
   }
 }
 


### PR DESCRIPTION
## Current Behavior
Our generators currently have no method of generating a Module Federation setup that uses Dynamic Federation.

## Expected Behavior
Our `setup-mfe` generator should support creating a Dynamic Federation setup.

Only `host` apps really need to understand the concept of Dynamic Federation as it is within the host app that the wiring of the remote apps takes place.

We want to promote a Dynamic Federation pattern that consists of:
- Build once, deploy anywhere strategy
- A host application that resolves its remotes' locations at runtime
- A JSON file with a structure of: `Record<string, string>` matching: `remoteName: remoteUrl`
- A method of fetching the JSON file at runtime to initialise the remote containers.
- A method for routing to the module exposed by the remote apps

Therefore we should aim to achieve 3 things:
 - `setup-mfe` should be able to create a host app with a pattern for dynamic federation
 - `host` generator should have a `--dynamic` flag that will specify that the host should be created following the dynamic federation pattern
 - `remote` generator should _NOT_ have a `--dynamic` flag, as it makes no sense for a remote itself. HOWEVER, the logic of adding the remote to a specified `--host` _SHOULD_ still take into account if the host app has been configured with dynamic federation in mind.