### PR TITLE
fix(core): install packages after removing tao

### DIFF
--- a/packages/workspace/src/migrations/update-13-9-0/replace-tao-with-nx.ts
+++ b/packages/workspace/src/migrations/update-13-9-0/replace-tao-with-nx.ts
@@ -1,4 +1,4 @@
-import { Tree, updateJson } from '@nrwl/devkit';
+import { installPackagesTask, Tree, updateJson } from '@nrwl/devkit';
 
 export function replaceTaoWithNx(host: Tree) {
   updateJson(host, 'package.json', (json: any) => {
@@ -11,6 +11,10 @@ export function replaceTaoWithNx(host: Tree) {
     removeTao(json.devDependencies);
     return json;
   });
+
+  return () => {
+    installPackagesTask(host);
+  };
 }
 
 function removeTao(json: any) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
After running 13.9.0 remove tao migration, the new `nx` package version isn't installed, which can lead to erroneous behaviour.

(lock file discrepancies, command failures, general user confusion)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure the version of `nx` is installed if set.
