### PR TITLE
docs(nxdev): add skip to content shortcut

### DIFF
--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -85,7 +85,7 @@ export default function DocumentationPage({
   return (
     <>
       <Header isDocViewer={true} />
-      <main>
+      <main id="main" role="main">
         {vm.entryComponent}
         <button
           type="button"

--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -48,6 +48,14 @@ export default function CustomApp({ Component, pageProps }: AppProps) {
         <meta name="theme-color" content="#ffffff" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
+      <a
+        id="skip-to-content-link"
+        href="#main"
+        tabIndex={0}
+        className="bg-green-nx-base absolute top-3 left-8 -translate-y-24 rounded-md px-4 py-2 text-white transition focus:translate-y-0"
+      >
+        Skip to content
+      </a>
       <div className="documentation-app bg-white text-gray-700 antialiased">
         <Component {...pageProps} />
       </div>

--- a/nx-dev/nx-dev/pages/community.tsx
+++ b/nx-dev/nx-dev/pages/community.tsx
@@ -190,7 +190,7 @@ export function Community(props: CommunityProps): ReactComponentElement<any> {
         }}
       />
       <Header useDarkBackground={false} />
-      <main>
+      <main id="main" role="main">
         <div className="w-full">
           <article
             id="getting-started"

--- a/nx-dev/nx-dev/pages/conf.tsx
+++ b/nx-dev/nx-dev/pages/conf.tsx
@@ -37,6 +37,8 @@ export function ConfPage(): ReactComponentElement<any> {
       />
       <Header useDarkBackground={true} />
       <main
+        id="main"
+        role="main"
         style={{
           background: 'linear-gradient(180deg, #143055 0%, #0b1a2d 100%)',
         }}

--- a/nx-dev/nx-dev/pages/index.tsx
+++ b/nx-dev/nx-dev/pages/index.tsx
@@ -51,7 +51,7 @@ export function Index(): ReactComponentElement<any> {
       />
       <h1 className="sr-only">Next generation monorepo tool</h1>
       <Header useDarkBackground={false} />
-      <main role="main">
+      <main id="main" role="main">
         <div className="w-full">
           {/*INTRO COMPONENT*/}
           <header


### PR DESCRIPTION
Adds the "skip to content" feature on nx.dev to navigate straight to the main area. Once the website is loaded, the first _tab_ will enable the "skip to content" link.

https://user-images.githubusercontent.com/3447705/160432111-c1a2a7f6-80a9-4bc1-8262-0fa499d48988.mov
