### PR TITLE
feat(nx-plugin): allow specific plugin features to be disabled on a workspace basis

### DIFF
--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -1,3 +1,4 @@
+import { NxPlugin } from '../utils/nx-plugin';
 import { PackageManager } from '../utils/package-manager';
 import { TargetDependencyConfig } from './workspace-json-project-json';
 
@@ -15,6 +16,12 @@ export interface NxAffectedConfig {
    */
   defaultBase?: string;
 }
+
+export type NxPluginOption =
+  | string
+  | ({
+      [key in keyof Omit<NxPlugin, 'name'>]: boolean;
+    } & { plugin: string });
 
 /**
  * Nx.json configuration
@@ -90,9 +97,13 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
     defaultProjectName?: string;
   };
   /**
-   * Plugins for extending the project graph
+   * Plugins for extending the project graph.
+   * Should be either a string used to resolve the plugin, or an options block.
+   *
+   * @example ["@acme/my-plugin"]
+   * @example [{"plugin": "@acme/my-plugin", "registerProjectTargets": false}]
    */
-  plugins?: string[];
+  plugins?: NxPluginOption[];
 
   /**
    * Configuration for Nx Plugins

--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -80,10 +80,10 @@ export function createCache(
   projectGraph: ProjectGraph,
   tsConfig: { compilerOptions?: { paths?: { [p: string]: any } } }
 ) {
-  const nxJsonPlugins = (nxJson.plugins || []).map((p) => ({
-    name: p,
-    version: packageJsonDeps[p],
-  }));
+  const nxJsonPlugins = (nxJson.plugins || []).map((p) => {
+    const plugin = typeof p === 'string' ? p : p.plugin;
+    return { name: plugin, version: packageJsonDeps[plugin] };
+  });
   const newValue: ProjectGraphCache = {
     version: projectGraph.version || '5.0',
     deps: packageJsonDeps,
@@ -154,9 +154,12 @@ export function shouldRecomputeWholeGraph(
   // a plugin has changed
   if (
     (nxJson.plugins || []).some((t) => {
-      const matchingPlugin = cache.nxJsonPlugins.find((p) => p.name === t);
+      const pluginName = typeof t === 'string' ? t : t.plugin;
+      const matchingPlugin = cache.nxJsonPlugins.find(
+        (p) => p.name === pluginName
+      );
       if (!matchingPlugin) return true;
-      return matchingPlugin.version !== packageJsonDeps[t];
+      return matchingPlugin.version !== packageJsonDeps[pluginName];
     })
   ) {
     return true;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Users of community plugins that want to use project graph functionality must use **_all_** of any plugins functionality. 

Ex: `@nx-dotnet/core` provides project inference, target inference, and project graph extensions. If a user wants to pick up .NET edges on the graph, they _must_ also accept the project and target inference. This can be a pain when a user uses different target names than the plugin infers. E.g. A .NET project may have a `vstest` target, but inference may also add a duplicate `test` target.

## Expected Behavior
Plugin users have a consistent way to enable / disable features of specific plugins.

## Alt. Solutions
Authors can set up a configuration file and wrap functionality behind flags on a per-plugin basis. This is the current behavior for nx-dotnet: https://github.com/nx-dotnet/nx-dotnet/blob/master/packages/core/src/graph/infer-project.ts