### PR TITLE
fix(devkit): add missing parameter to prettier getFileInfo

### DIFF
--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -32,7 +32,7 @@ export async function formatFiles(tree: Tree): Promise<void> {
   await Promise.all(
     Array.from(files).map(async (file) => {
       const systemPath = path.join(tree.root, file.path);
-      let options: Prettier.Options = {
+      let options: any = {
         filepath: systemPath,
       };
 
@@ -47,7 +47,7 @@ export async function formatFiles(tree: Tree): Promise<void> {
         ...resolvedOptions,
       };
 
-      const support = await prettier.getFileInfo(systemPath);
+      const support = await prettier.getFileInfo(systemPath, options);
       if (support.ignored || !support.inferredParser) {
         return;
       }


### PR DESCRIPTION
## Current Behavior
When settings "ignorePath": "./.prettierignore" inside .prettierrc file, this is ignored when running nx generator as the second parameter of prettier.getFileInfo is missing, so formatFiles always format all the files and ignore is always false.

## Expected Behavior
When setting "ignorePath": "./.prettierignore" inside .prettierrc file, this configuration should be taken into account when running nx generator as the second parameter of prettier.getFileInfo, so formatFiles formatFiles that are not ignored based on the config.

## Related Issue(s)
Fixes #9576
