### PR TITLE
docs(angular): remove incremental builds preset from the webpack-browser executor

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -1977,21 +1977,6 @@
               "scripts",
               "customWebpackConfig"
             ]
-          },
-          {
-            "name": "Incremental Builds",
-            "keys": [
-              "outputs",
-              "buildLibsFromSource",
-              "outputPath",
-              "index",
-              "main",
-              "polyfills",
-              "tsConfig",
-              "assets",
-              "styles",
-              "scripts"
-            ]
           }
         ],
         "properties": {

--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -19,21 +19,6 @@
         "scripts",
         "customWebpackConfig"
       ]
-    },
-    {
-      "name": "Incremental Builds",
-      "keys": [
-        "outputs",
-        "buildLibsFromSource",
-        "outputPath",
-        "index",
-        "main",
-        "polyfills",
-        "tsConfig",
-        "assets",
-        "styles",
-        "scripts"
-      ]
     }
   ],
   "properties": {


### PR DESCRIPTION
The "Incremental Builds" doc preset showcases the right options to configure the incremental builds, but the `buildLibsFromSource` option has a wrong value of `true`. As of now, the right value can't be specified for the docs generator to pick it, so the wrong preset is removed until that's addressed.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
