### PR TITLE
fix(core): normalize file path for node-hasher

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
@@ -14,10 +14,12 @@ jest.mock('fs', () => require('memfs').fs);
 jest.mock('@nrwl/devkit', () => ({
   ...jest.requireActual<any>('@nrwl/devkit'),
   appRootPath: '/root',
+  workspaceRoot: '/root',
 }));
 
 jest.mock('nx/src/utils/app-root', () => ({
   appRootPath: '/root',
+  workspaceRoot: '/root',
 }));
 
 const tsconfig = {

--- a/packages/nx/src/command-line/report.spec.ts
+++ b/packages/nx/src/command-line/report.spec.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 
 jest.mock('nx/src/utils/app-root', () => ({
   appRootPath: '',
+  workspaceRoot: '',
 }));
 
 jest.mock('../utils/fileutils', () => ({

--- a/packages/nx/src/core/affected-project-graph/affected-project-graph.spec.ts
+++ b/packages/nx/src/core/affected-project-graph/affected-project-graph.spec.ts
@@ -11,6 +11,7 @@ import { stripIndents } from '../../utils/strip-indents';
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('nx/src/utils/app-root', () => ({
   appRootPath: '/root',
+  workspaceRoot: '/root',
 }));
 
 describe('project graph', () => {

--- a/packages/nx/src/core/hasher/file-hasher-base.ts
+++ b/packages/nx/src/core/hasher/file-hasher-base.ts
@@ -1,8 +1,8 @@
-import { appRootPath } from 'nx/src/utils/app-root';
+import { workspaceRoot } from 'nx/src/utils/app-root';
 import { performance } from 'perf_hooks';
 import { defaultHashing } from './hashing-impl';
 import { FileData } from 'nx/src/shared/project-graph';
-import { joinPathFragments } from 'nx/src/utils/path';
+import { joinPathFragments, normalizePath } from 'nx/src/utils/path';
 
 export abstract class FileHasherBase {
   protected fileHashes: Map<string, string>;
@@ -61,16 +61,18 @@ export abstract class FileHasherBase {
     if (!this.fileHashes) {
       throw new Error('FileHasher is invoked before being initialized');
     }
-    const relativePath = path.startsWith(appRootPath)
-      ? path.substr(appRootPath.length + 1)
-      : path;
+    const relativePath = normalizePath(
+      path.startsWith(workspaceRoot)
+        ? path.substring(workspaceRoot.length + 1)
+        : path
+    );
     if (this.fileHashes.has(relativePath)) {
       return this.fileHashes.get(relativePath);
     } else {
       try {
         // this has to be absolute to avoid issues with cwd
         return defaultHashing.hashFile(
-          joinPathFragments(appRootPath, relativePath)
+          joinPathFragments(workspaceRoot, relativePath)
         );
       } catch {
         return '';

--- a/packages/nx/src/core/hasher/hasher.spec.ts
+++ b/packages/nx/src/core/hasher/hasher.spec.ts
@@ -4,6 +4,7 @@ import { DependencyType } from 'nx/src/shared/project-graph';
 jest.doMock('../../utils/app-root', () => {
   return {
     appRootPath: '',
+    workspaceRoot: '',
   };
 });
 

--- a/packages/nx/src/core/project-graph/build-dependencies/explicit-package-json-dependencies.spec.ts
+++ b/packages/nx/src/core/project-graph/build-dependencies/explicit-package-json-dependencies.spec.ts
@@ -11,6 +11,7 @@ import { ProjectGraphBuilder } from '../project-graph-builder';
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('nx/src/utils/app-root', () => ({
   appRootPath: '/root',
+  workspaceRoot: '/root',
 }));
 
 describe('explicit package json dependencies', () => {

--- a/packages/nx/src/core/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
+++ b/packages/nx/src/core/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
@@ -3,6 +3,7 @@ import { createProjectFileMap } from 'nx/src/core/file-map-utils';
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('nx/src/utils/app-root', () => ({
   appRootPath: '/root',
+  workspaceRoot: '/root',
 }));
 
 import { vol } from 'memfs';

--- a/packages/nx/src/core/project-graph/build-dependencies/implict-project-dependencies.spec.ts
+++ b/packages/nx/src/core/project-graph/build-dependencies/implict-project-dependencies.spec.ts
@@ -5,6 +5,7 @@ import { buildImplicitProjectDependencies } from './implicit-project-dependencie
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('nx/src/utils/app-root', () => ({
   appRootPath: '/root',
+  workspaceRoot: '/root',
 }));
 
 describe('explicit project dependencies', () => {

--- a/packages/nx/src/core/project-graph/build-project-graph.spec.ts
+++ b/packages/nx/src/core/project-graph/build-project-graph.spec.ts
@@ -3,6 +3,7 @@ import { vol, fs } from 'memfs';
 jest.mock('fs', () => require('memfs').fs);
 jest.mock('nx/src/utils/app-root', () => ({
   appRootPath: '/root',
+  workspaceRoot: '/root',
 }));
 import { buildProjectGraph } from './build-project-graph';
 import { defaultFileHasher } from '../hasher/file-hasher';

--- a/packages/nx/src/core/target-project-locator.spec.ts
+++ b/packages/nx/src/core/target-project-locator.spec.ts
@@ -8,6 +8,7 @@ import {
 
 jest.mock('nx/src/utils/app-root', () => ({
   appRootPath: '/root',
+  workspaceRoot: '/root',
 }));
 jest.mock('fs', () => require('memfs').fs);
 

--- a/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
+++ b/packages/workspace/src/tslint/nxEnforceModuleBoundariesRule.spec.ts
@@ -7,7 +7,10 @@ import { TargetProjectLocator } from 'nx/src/core/target-project-locator';
 import { mapProjectGraphFiles } from '@nrwl/workspace/src/utils/runtime-lint-utils';
 
 jest.mock('fs', () => require('memfs').fs);
-jest.mock('nx/src/utils/app-root', () => ({ appRootPath: '/root' }));
+jest.mock('nx/src/utils/app-root', () => ({
+  appRootPath: '/root',
+  workspaceRoot: '/root',
+}));
 
 const tsconfig = {
   compilerOptions: {


### PR DESCRIPTION
Node hasher paths need to be normalized, since on windows they return with '\\\\' instead of '/' and don't match keys in workspace configuration.

Fixes #9584
Fixes #9581
