### PR TITLE
feat(core): use generatorCollections to specify default configurations as fallbacks

### DIFF
--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -212,6 +212,9 @@ async function runSchematic(
 type AngularJsonConfiguration = WorkspaceJsonConfiguration &
   Pick<NxJsonConfiguration, 'cli' | 'defaultProject' | 'generators'> & {
     schematics?: NxJsonConfiguration['generators'];
+    cli?: {
+      schematicCollection?: string[];
+    };
   };
 export class NxScopedHost extends virtualFs.ScopedHost<any> {
   protected __nxInMemoryWorkspace: WorkspaceJsonConfiguration | null;

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -213,7 +213,7 @@ type AngularJsonConfiguration = WorkspaceJsonConfiguration &
   Pick<NxJsonConfiguration, 'cli' | 'defaultProject' | 'generators'> & {
     schematics?: NxJsonConfiguration['generators'];
     cli?: {
-      schematicCollection?: string[];
+      schematicCollections?: string[];
     };
   };
 export class NxScopedHost extends virtualFs.ScopedHost<any> {

--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -4,10 +4,7 @@ import {
   Options,
   Schema,
 } from '../utils/params';
-import {
-  collectionContainsGenerator,
-  Workspaces,
-} from '../config/workspaces';
+import { collectionContainsGenerator, Workspaces } from '../config/workspaces';
 import { FileChange, flushChanges, FsTree } from '../config/tree';
 import { logger } from '../utils/logger';
 import * as chalk from 'chalk';
@@ -100,7 +97,8 @@ function throwInvalidInvocation() {
 }
 
 function readDefaultCollection(nxConfig: NxJsonConfiguration) {
-  const configured = nxConfig.cli ? nxConfig.cli.defaultCollection : null;
+  const configured =
+    nxConfig.cli?.generatorCollections ?? nxConfig.cli?.defaultCollection;
   return typeof configured === 'string' ? [configured] : configured;
 }
 

--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -96,7 +96,7 @@ function throwInvalidInvocation() {
   );
 }
 
-function readDefaultCollection(nxConfig: NxJsonConfiguration) {
+function readDefaultCollections(nxConfig: NxJsonConfiguration) {
   const configured =
     nxConfig.cli?.generatorCollections ?? nxConfig.cli?.defaultCollection;
   return typeof configured === 'string' ? [configured] : configured;
@@ -174,7 +174,7 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
     const workspaceDefinition = ws.readWorkspaceConfiguration();
     const opts = convertToGenerateOptions(
       args,
-      readDefaultCollection(workspaceDefinition),
+      readDefaultCollections(workspaceDefinition),
       'generate'
     );
     const { normalizedGeneratorName, schema, implementationFactory } =

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -86,7 +86,8 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
    */
   cli?: {
     packageManager?: PackageManager;
-    defaultCollection?: string | string[];
+    defaultCollection?: string;
+    generatorCollections?: string[];
     defaultProjectName?: string;
   };
   /**

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -86,7 +86,7 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
    */
   cli?: {
     packageManager?: PackageManager;
-    defaultCollection?: string;
+    defaultCollection?: string | string[];
     defaultProjectName?: string;
   };
   /**

--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -342,6 +342,14 @@ export function toNewFormatOrNull(w: any) {
     renamePropertyWithStableKeys(w, 'schematics', 'generators');
     formatted = true;
   }
+  if (w.cli?.schematicCollection) {
+    renamePropertyWithStableKeys(
+      w.cli,
+      'schematicCollection',
+      'generatorCollections'
+    );
+    formatted = true;
+  }
   if (w.version !== 2) {
     w.version = 2;
     formatted = true;
@@ -377,6 +385,13 @@ export function toOldFormatOrNull(w: any) {
   if (w.generators) {
     renamePropertyWithStableKeys(w, 'generators', 'schematics');
     formatted = true;
+  }
+  if (w.cli?.generatorCollections) {
+    renamePropertyWithStableKeys(
+      w.cli,
+      'generatorCollections',
+      'schematicCollection'
+    );
   }
   if (w.version !== 1) {
     w.version = 1;

--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -342,10 +342,10 @@ export function toNewFormatOrNull(w: any) {
     renamePropertyWithStableKeys(w, 'schematics', 'generators');
     formatted = true;
   }
-  if (w.cli?.schematicCollection) {
+  if (w.cli?.schematicCollections) {
     renamePropertyWithStableKeys(
       w.cli,
-      'schematicCollection',
+      'schematicCollections',
       'generatorCollections'
     );
     formatted = true;
@@ -390,7 +390,7 @@ export function toOldFormatOrNull(w: any) {
     renamePropertyWithStableKeys(
       w.cli,
       'generatorCollections',
-      'schematicCollection'
+      'schematicCollections'
     );
   }
   if (w.version !== 1) {


### PR DESCRIPTION
## Current Behavior
Users can specify one default collection via `defaultCollection`, which is used when a collection isn't specified while running a generator

## Expected Behavior
Users can specify multiple collections, which are used as fallbacks if a collection isn't specified. This could allow a consumer of a plugin to specify fallbacks, rather than the plugin author needing to add "extends" to the collection/generators.json file.

This is especially important, as in Angular v14 the CLI is moving towards `schematicCollection` to allow the same behavior
