### PR TITLE
fix(testing): remove default testTimeout value which overrides the je…

### DIFF
--- a/docs/generated/packages/jest.json
+++ b/docs/generated/packages/jest.json
@@ -291,7 +291,6 @@
           },
           "testTimeout": {
             "description": "Default timeout of a test in milliseconds. Default value: `5000`. (https://jestjs.io/docs/cli#--testtimeoutnumber)",
-            "default": 5000,
             "type": "number"
           }
         },

--- a/packages/jest/src/executors/jest/schema.json
+++ b/packages/jest/src/executors/jest/schema.json
@@ -177,7 +177,6 @@
     },
     "testTimeout": {
       "description": "Default timeout of a test in milliseconds. Default value: `5000`. (https://jestjs.io/docs/cli#--testtimeoutnumber)",
-      "default": 5000,
       "type": "number"
     }
   },


### PR DESCRIPTION
…st config

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Having a `testTimeout` of 5000 by default overrides the value in `jest.config.js`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There should be no default for `jestTimeout` in the executor. `jest` internally will have a default of 5000 so not much changes.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
