### PR TITLE
feat(nextjs): WebpackNxBuildCoordinationPlugin supports pass buildCmd using function

### DIFF
--- a/packages/web/src/plugins/webpack-nx-build-coordination-plugin.ts
+++ b/packages/web/src/plugins/webpack-nx-build-coordination-plugin.ts
@@ -8,7 +8,7 @@ import { readFileSync } from 'fs';
 export class WebpackNxBuildCoordinationPlugin {
   private currentlyRunning: 'none' | 'nx-build' | 'webpack-build' = 'none';
 
-  constructor(private readonly buildCmd: string) {
+  constructor(private readonly buildCmd: string | (() => string)) {
     this.buildChangedProjects();
     this.startWatchingBuildableLibs();
   }
@@ -40,7 +40,10 @@ export class WebpackNxBuildCoordinationPlugin {
     }
     this.currentlyRunning = 'nx-build';
     try {
-      execSync(this.buildCmd, { stdio: [0, 1, 2] });
+      execSync(
+        typeof this.buildCmd === 'function' ? this.buildCmd() : this.buildCmd,
+        { stdio: [0, 1, 2] }
+      );
       // eslint-disable-next-line no-empty
     } catch (e) {}
     this.currentlyRunning = 'none';


### PR DESCRIPTION
Previously only supported strings.
```js
new WebpackNxBuildCoordinationPlugin("tsc -b apps/nextapp/tsconfig.json",)]
```

now `WebpackNxBuildCoordinationPlugin` supports pass buildCmd using function.
```js
new WebpackNxBuildCoordinationPlugin(() => {
    if (process.env.NODE_ENV === 'production') {
        return "echo production"
    }
    return "echo development"
},
```

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
