### PR TITLE
feat(angular): update ng-add generator so the migration result is more aligned with new nx workspaces

### DIFF
--- a/docs/generated/api-nx-devkit/index.md
+++ b/docs/generated/api-nx-devkit/index.md
@@ -792,9 +792,9 @@ Use this to expose a compatible Angular Builder
 
 ### convertNxGenerator
 
-▸ **convertNxGenerator**<`T`\>(`generator`): (`options`: `T`) => (`tree`: `any`, `context`: `any`) => `Promise`<`any`\>
+▸ **convertNxGenerator**<`T`\>(`generator`, `skipWritingConfigInOldFormat?`): (`generatorOptions`: `T`) => (`tree`: `any`, `context`: `any`) => `Promise`<`any`\>
 
-Convert an Nx Generator into an Angular Devkit Schematic
+Convert an Nx Generator into an Angular Devkit Schematic.
 
 #### Type parameters
 
@@ -804,21 +804,22 @@ Convert an Nx Generator into an Angular Devkit Schematic
 
 #### Parameters
 
-| Name        | Type                                                 |
-| :---------- | :--------------------------------------------------- |
-| `generator` | [`Generator`](../../nx-devkit/index#generator)<`T`\> |
+| Name                           | Type                                                 | Default value | Description                                                                                       |
+| :----------------------------- | :--------------------------------------------------- | :------------ | :------------------------------------------------------------------------------------------------ |
+| `generator`                    | [`Generator`](../../nx-devkit/index#generator)<`T`\> | `undefined`   | The Nx generator to convert to an Angular Devkit Schematic.                                       |
+| `skipWritingConfigInOldFormat` | `boolean`                                            | `false`       | Whether to skip writing the configuration in the old format (the one used by the Angular DevKit). |
 
 #### Returns
 
 `fn`
 
-▸ (`options`): (`tree`: `any`, `context`: `any`) => `Promise`<`any`\>
+▸ (`generatorOptions`): (`tree`: `any`, `context`: `any`) => `Promise`<`any`\>
 
 ##### Parameters
 
-| Name      | Type |
-| :-------- | :--- |
-| `options` | `T`  |
+| Name               | Type |
+| :----------------- | :--- |
+| `generatorOptions` | `T`  |
 
 ##### Returns
 

--- a/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
@@ -197,6 +197,35 @@ Object {
 }
 `;
 
+exports[`workspace move to nx layout should update project configuration 1`] = `
+Object {
+  "root": "apps/myApp",
+  "sourceRoot": "apps/myApp/src",
+  "targets": Object {
+    "build": Object {
+      "configurations": Object {},
+      "options": Object {
+        "tsConfig": "apps/myApp/tsconfig.app.json",
+      },
+    },
+    "lint": Object {
+      "options": Object {
+        "tsConfig": Array [
+          "apps/myApp/tsconfig.app.json",
+          "apps/myApp/tsconfig.spec.json",
+        ],
+      },
+    },
+    "test": Object {
+      "options": Object {
+        "karmaConfig": "apps/myApp/karma.conf.js",
+        "tsConfig": "apps/myApp/tsconfig.spec.json",
+      },
+    },
+  },
+}
+`;
+
 exports[`workspace move to nx layout should update tsconfig.base.json if present 1`] = `
 Object {
   "compilerOptions": Object {
@@ -204,6 +233,10 @@ Object {
     "paths": Object {},
     "rootDir": ".",
   },
+  "exclude": Array [
+    "node_modules",
+    "tmp",
+  ],
 }
 `;
 
@@ -214,5 +247,9 @@ Object {
     "paths": Object {},
     "rootDir": ".",
   },
+  "exclude": Array [
+    "node_modules",
+    "tmp",
+  ],
 }
 `;

--- a/packages/angular/src/generators/ng-add/compat.ts
+++ b/packages/angular/src/generators/ng-add/compat.ts
@@ -1,4 +1,4 @@
 import { convertNxGenerator } from '@nrwl/devkit';
 import { ngAddGenerator } from './ng-add';
 
-export default convertNxGenerator(ngAddGenerator);
+export default convertNxGenerator(ngAddGenerator, true);

--- a/packages/angular/src/generators/ng-add/files/prettier/__dot__prettierignore
+++ b/packages/angular/src/generators/ng-add/files/prettier/__dot__prettierignore
@@ -1,1 +1,4 @@
 # Add files here to ignore them from prettier formatting
+
+/dist
+/coverage

--- a/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
+++ b/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
@@ -3,6 +3,7 @@ import {
   formatFiles,
   installPackagesTask,
   Tree,
+  updateJson,
 } from '@nrwl/devkit';
 import { nxVersion } from '../../utils/versions';
 import type { GeneratorOptions } from './schema';
@@ -52,6 +53,11 @@ export async function migrateFromAngularCli(
     // multiple projects are supported
 
     // create and update root files and configurations
+    updateJson(tree, 'angular.json', (json) => ({
+      ...json,
+      version: 2,
+      $schema: undefined,
+    }));
     createNxJson(tree, options);
     updateWorkspaceConfigDefaults(tree);
     updateRootTsConfig(tree);

--- a/packages/angular/src/generators/ng-add/utilities/app.migrator.ts
+++ b/packages/angular/src/generators/ng-add/utilities/app.migrator.ts
@@ -5,6 +5,7 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
+import { convertToNxProjectGenerator } from '@nrwl/workspace/generators';
 import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 import { GeneratorOptions } from '../schema';
 import { E2eProjectMigrator } from './e2e-project.migrator';
@@ -25,10 +26,10 @@ export class AppMigrator extends ProjectMigrator {
   }
 
   async migrate(): Promise<void> {
-    this.e2eMigrator.migrate();
+    await this.e2eMigrator.migrate();
 
     this.moveProjectFiles();
-    this.updateProjectConfiguration();
+    await this.updateProjectConfiguration();
     this.updateTsConfigs();
     // TODO: check later if it's still needed
     this.updateProjectTsLint();
@@ -77,7 +78,7 @@ export class AppMigrator extends ProjectMigrator {
     this.moveDir(this.project.oldSourceRoot, this.project.newSourceRoot);
   }
 
-  private updateProjectConfiguration(): void {
+  private async updateProjectConfiguration(): Promise<void> {
     this.projectConfig.root = this.project.newRoot;
     this.projectConfig.sourceRoot = this.project.newSourceRoot;
 
@@ -128,6 +129,11 @@ export class AppMigrator extends ProjectMigrator {
 
     updateProjectConfiguration(this.tree, this.project.name, {
       ...this.projectConfig,
+    });
+
+    await convertToNxProjectGenerator(this.tree, {
+      project: this.project.name,
+      skipFormat: true,
     });
   }
 

--- a/packages/angular/src/generators/ng-add/utilities/e2e-project.migrator.ts
+++ b/packages/angular/src/generators/ng-add/utilities/e2e-project.migrator.ts
@@ -128,9 +128,14 @@ export class E2eProjectMigrator extends ProjectMigrator {
       implicitDependencies: [this.appName],
       tags: [],
     };
-    addProjectConfiguration(this.tree, this.project.name, {
-      ...this.projectConfig,
-    });
+    addProjectConfiguration(
+      this.tree,
+      this.project.name,
+      {
+        ...this.projectConfig,
+      },
+      true
+    );
 
     // remove e2e target from the app config
     delete this.appConfig.targets.e2e;
@@ -221,9 +226,14 @@ export class E2eProjectMigrator extends ProjectMigrator {
       );
     }
 
-    addProjectConfiguration(this.tree, this.project.name, {
-      ...this.projectConfig,
-    });
+    addProjectConfiguration(
+      this.tree,
+      this.project.name,
+      {
+        ...this.projectConfig,
+      },
+      true
+    );
 
     delete this.appConfig.targets['cypress-run'];
     delete this.appConfig.targets['cypress-open'];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When migrating an Angular CLI workspace to an Nx workspace, the migrated workspace configuration is not aligned with new Nx workspaces.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The workspace configuration for a migrated Angular CLI workspace should be more aligned to new Nx workspaces.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
