### PR TITLE
feat(angular): support migrating angular cli workspaces with multiple projects when keeping the angular cli layout

### DIFF
--- a/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
@@ -1,5 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`workspace --preserve-angular-cli-layout should create nx.json 1`] = `
+Object {
+  "affected": Object {
+    "defaultBase": "main",
+  },
+  "implicitDependencies": Object {
+    ".eslintrc.json": "*",
+    "package.json": Object {
+      "dependencies": "*",
+      "devDependencies": "*",
+    },
+  },
+  "npmScope": "my-scope",
+  "targetDependencies": Object {
+    "build": Array [
+      Object {
+        "projects": "dependencies",
+        "target": "build",
+      },
+    ],
+  },
+  "tasksRunnerOptions": Object {
+    "default": Object {
+      "options": Object {
+        "cacheableOperations": Array [
+          "build",
+          "lint",
+          "test",
+          "e2e",
+        ],
+      },
+      "runner": "nx/tasks-runners/default",
+    },
+  },
+  "workspaceLayout": Object {
+    "appsDir": "",
+    "libsDir": "",
+  },
+}
+`;
+
+exports[`workspace --preserve-angular-cli-layout should support multiple projects 1`] = `
+Object {
+  "affected": Object {
+    "defaultBase": "main",
+  },
+  "implicitDependencies": Object {
+    ".eslintrc.json": "*",
+    "package.json": Object {
+      "dependencies": "*",
+      "devDependencies": "*",
+    },
+  },
+  "npmScope": "my-scope",
+  "targetDependencies": Object {
+    "build": Array [
+      Object {
+        "projects": "dependencies",
+        "target": "build",
+      },
+    ],
+  },
+  "tasksRunnerOptions": Object {
+    "default": Object {
+      "options": Object {
+        "cacheableOperations": Array [
+          "build",
+          "lint",
+          "test",
+          "e2e",
+        ],
+      },
+      "runner": "nx/tasks-runners/default",
+    },
+  },
+  "workspaceLayout": Object {
+    "appsDir": "projects",
+    "libsDir": "projects",
+  },
+}
+`;
+
 exports[`workspace move to nx layout cypress should handle project configuration without cypress-run or cypress-open 1`] = `
 Object {
   "implicitDependencies": Array [

--- a/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
+++ b/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
@@ -28,7 +28,7 @@ export async function migrateFromAngularCli(
   rawOptions: GeneratorOptions
 ) {
   const projects = getAllProjects(tree);
-  const options = normalizeOptions(rawOptions, projects);
+  const options = normalizeOptions(tree, rawOptions, projects);
 
   if (options.preserveAngularCliLayout) {
     addDependenciesToPackageJson(

--- a/packages/angular/src/generators/ng-add/utilities/normalize-options.ts
+++ b/packages/angular/src/generators/ng-add/utilities/normalize-options.ts
@@ -1,24 +1,33 @@
-import { names } from '@nrwl/devkit';
+import { joinPathFragments, names, readJson, Tree } from '@nrwl/devkit';
 import { GeneratorOptions } from '../schema';
 import { WorkspaceProjects } from './types';
 
 export function normalizeOptions(
+  tree: Tree,
   options: GeneratorOptions,
   projects: WorkspaceProjects
 ): GeneratorOptions {
-  // TODO: this restrictions will be removed, it's here temporarily to
-  // execute for both a full migration and a minimal one to maintain
-  // the current behavior
-  const hasLibraries = projects.libs.length > 0;
-  if (projects.apps.length > 2 || hasLibraries) {
-    throw new Error('Can only convert projects with one app');
-  }
-
   let npmScope = options.npmScope ?? options.name;
   if (npmScope) {
     npmScope = names(npmScope).fileName;
-  } else {
-    npmScope = projects.apps[0].name;
+  } else if (projects.libs.length > 0) {
+    // try get the scope from any library that have one
+    for (const lib of projects.libs) {
+      const { name } = readJson(
+        tree,
+        joinPathFragments(lib.config.root, 'package.json')
+      );
+      if (name.startsWith('@')) {
+        npmScope = name.split('/')[0].substring(1);
+        break;
+      }
+    }
+  }
+
+  if (!npmScope) {
+    // use the name (scope if exists) in the root package.json
+    const { name } = readJson(tree, 'package.json');
+    npmScope = name.startsWith('@') ? name.split('/')[0].substring(1) : name;
   }
 
   return { ...options, npmScope };

--- a/packages/angular/src/generators/ng-add/utilities/workspace.ts
+++ b/packages/angular/src/generators/ng-add/utilities/workspace.ts
@@ -43,6 +43,12 @@ export function validateWorkspace(
       throw new Error('Cannot find angular.json');
     }
 
+    // TODO: this restrictions will be removed when support for multiple
+    // projects is added
+    if (projects.apps.length > 2 || projects.libs.length > 0) {
+      throw new Error('Can only convert projects with one app');
+    }
+
     const e2eKey = getE2eKey(projects);
     const e2eApp = getE2eProject(projects);
 
@@ -97,19 +103,7 @@ export function createNxJson(
   options: GeneratorOptions,
   setWorkspaceLayoutAsNewProjectRoot: boolean = false
 ): void {
-  const { projects = {}, newProjectRoot = '' } = readJson(tree, 'angular.json');
-  // TODO: temporarily leaving this here because it's the old behavior for a
-  // minimal migration, will be removed in a later PR
-  const hasLibraries = Object.keys(projects).find(
-    (project) =>
-      projects[project].projectType &&
-      projects[project].projectType !== 'application'
-  );
-  if (Object.keys(projects).length !== 1 || hasLibraries) {
-    throw new Error(
-      `The schematic can only be used with Angular CLI workspaces with a single application.`
-    );
-  }
+  const { newProjectRoot = '' } = readJson(tree, 'angular.json');
 
   writeJson<NxJsonConfiguration>(tree, 'nx.json', {
     npmScope: options.npmScope,


### PR DESCRIPTION
When migrating an Angular CLI workspace using the `--preserve-angular-cli-layout` flag, the individual projects of the workspace are not migrated, the Angular CLI layout structure and config is kept as-is and only the CLI is replaced with the Nx CLI. As such, workspaces with multiple projects should be able to be migrated and continue to work as expected.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
It's not possible to migrate an Angular CLI workspace that contains multiple projects when preserving the Angular CLI layout.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should be able to migrate an Angular CLI workspace that contains multiple projects when preserving the Angular CLI layout.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
