### PR TITLE
feat(storybook): use build-storybook as a build target for all libs

### DIFF
--- a/packages/storybook/src/executors/utils.ts
+++ b/packages/storybook/src/executors/utils.ts
@@ -321,10 +321,17 @@ export function findStorybookAndBuildTargets(targets: {
     if (targetConfig.executor === '@nrwl/storybook:build') {
       returnObject.storybookBuildTarget = target;
     }
-    if (
-      targetConfig.executor === '@angular-devkit/build-angular:browser' ||
-      targetConfig.executor === '@nrwl/angular:ng-packagr-lite'
-    ) {
+    /**
+     * Not looking for '@nrwl/angular:ng-packagr-lite', only
+     * looking for '@angular-devkit/build-angular:browser'
+     * because the '@nrwl/angular:ng-packagr-lite' executor
+     * does not support styles and extra options, so the user
+     * will be forced to switch to build-storybook to add extra options.
+     *
+     * So we might as well use the build-storybook by default to
+     * avoid any errors.
+     */
+    if (targetConfig.executor === '@angular-devkit/build-angular:browser') {
       returnObject.buildTarget = target;
     }
   });

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -225,6 +225,46 @@ describe('@nrwl/storybook:configuration', () => {
     });
   });
 
+  it('should update workspace file for angular buildable libs', async () => {
+    // Setup a new lib
+    await libraryGenerator(tree, {
+      name: 'test-ui-lib-5',
+      standaloneConfig: false,
+      buildable: true,
+    });
+    await configurationGenerator(tree, {
+      name: 'test-ui-lib-5',
+      uiFramework: '@storybook/angular',
+      standaloneConfig: false,
+    });
+    const project = readProjectConfiguration(tree, 'test-ui-lib-5');
+
+    expect(project.targets.storybook).toEqual({
+      executor: '@nrwl/storybook:storybook',
+      configurations: {
+        ci: {
+          quiet: true,
+        },
+      },
+      options: {
+        port: 4400,
+        projectBuildConfig: 'test-ui-lib-5:build-storybook',
+        uiFramework: '@storybook/angular',
+        config: {
+          configFolder: 'libs/test-ui-lib-5/.storybook',
+        },
+      },
+    });
+
+    expect(project.targets.lint).toEqual({
+      executor: '@nrwl/linter:eslint',
+      outputs: ['{options.outputFile}'],
+      options: {
+        lintFilePatterns: ['libs/test-ui-lib-5/**/*.ts'],
+      },
+    });
+  });
+
   it('should update `tsconfig.lib.json` file', async () => {
     await configurationGenerator(tree, {
       name: 'test-ui-lib',


### PR DESCRIPTION

## Current Behavior
Our `storybook-configuration` executor would look for build targets in Angular projects, and if it found `@nrwl/angular:ng-packagr-lite` and `@angular-devkit/build-angular:browser` as executors, it would know it's looking at a build target, and it would specify the `projectBuildConfig` of that project for Storybook to use that build target.

However, `ng-packagr-lite` does not support more options about styles and stylePreprocessor options, so users who wanted to specify these, they would manually go and change the `projectBuildConfig` in their buildable Angular libs, for Storybook. Since that was the case for a few issues on GitHub, I think it is better to only point to the project's build target when `@angular-devkit/build-angular:browser` is used, and in all other cases point directly to `build-storybook`.

## Expected Behavior
Only point to the project's build target when `@angular-devkit/build-angular:browser` is used, and in all other cases point directly to `build-storybook`.


