### PR TITLE
feat(storybook): add projectBuildConfig as an option in generator

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -1638,6 +1638,10 @@
             "type": "string",
             "enum": ["eslint", "none"],
             "default": "eslint"
+          },
+          "projectBuildConfig": {
+            "description": "Provide a custom projectBuildConfig for the Angular executor. If left blank, Nx will use the default.",
+            "type": "string"
           }
         },
         "additionalProperties": false,

--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -620,6 +620,10 @@
             "enum": ["eslint", "tslint"],
             "default": "eslint"
           },
+          "projectBuildConfig": {
+            "description": "Provide a custom projectBuildConfig for the Angular executor. If left blank, Nx will use the default.",
+            "type": "string"
+          },
           "standaloneConfig": {
             "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
             "type": "boolean"

--- a/docs/generated/packages/storybook.json
+++ b/docs/generated/packages/storybook.json
@@ -76,6 +76,10 @@
             "enum": ["eslint", "tslint", "none"],
             "default": "eslint"
           },
+          "projectBuildConfig": {
+            "description": "Provide a custom projectBuildConfig for the Angular executor. If left blank, Nx will use the default.",
+            "type": "string"
+          },
           "js": {
             "type": "boolean",
             "description": "Generate JavaScript files rather than TypeScript files.",

--- a/packages/angular/src/generators/storybook-configuration/schema.d.ts
+++ b/packages/angular/src/generators/storybook-configuration/schema.d.ts
@@ -7,4 +7,5 @@ export interface StorybookConfigurationOptions {
   linter: Exclude<Linter, Linter.TsLint>;
   name: string;
   cypressDirectory?: string;
+  projectBuildConfig?: string;
 }

--- a/packages/angular/src/generators/storybook-configuration/schema.json
+++ b/packages/angular/src/generators/storybook-configuration/schema.json
@@ -41,6 +41,10 @@
       "type": "string",
       "enum": ["eslint", "none"],
       "default": "eslint"
+    },
+    "projectBuildConfig": {
+      "description": "Provide a custom projectBuildConfig for the Angular executor. If left blank, Nx will use the default.",
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/packages/react/src/generators/storybook-configuration/schema.d.ts
+++ b/packages/react/src/generators/storybook-configuration/schema.d.ts
@@ -9,4 +9,5 @@ export interface StorybookConfigureSchema {
   linter?: Linter;
   cypressDirectory?: string;
   standaloneConfig?: boolean;
+  projectBuildConfig?: string;
 }

--- a/packages/react/src/generators/storybook-configuration/schema.json
+++ b/packages/react/src/generators/storybook-configuration/schema.json
@@ -47,6 +47,10 @@
       "enum": ["eslint", "tslint"],
       "default": "eslint"
     },
+    "projectBuildConfig": {
+      "description": "Provide a custom projectBuildConfig for the Angular executor. If left blank, Nx will use the default.",
+      "type": "string"
+    },
     "standaloneConfig": {
       "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
       "type": "boolean"

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -9,9 +9,20 @@ import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
 import { Linter } from '@nrwl/linter';
 import { libraryGenerator } from '@nrwl/workspace/generators';
-
+import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { TsConfig } from '../../utils/utilities';
 import configurationGenerator from './configuration';
+import { nxVersion, storybookVersion } from '../../utils/versions';
+
+const runAngularLibrarySchematic = wrapAngularDevkitSchematic(
+  '@schematics/angular',
+  'library'
+);
+
+const runAngularApplicationSchematic = wrapAngularDevkitSchematic(
+  '@schematics/angular',
+  'application'
+);
 
 describe('@nrwl/storybook:configuration', () => {
   let tree: Tree;
@@ -263,6 +274,109 @@ describe('@nrwl/storybook:configuration', () => {
         lintFilePatterns: ['libs/test-ui-lib-5/**/*.ts'],
       },
     });
+  });
+
+  it('should update workspace file for angular libs with custom projectBuildConfig', async () => {
+    const newTree = createTreeWithEmptyWorkspace();
+
+    await runAngularLibrarySchematic(newTree, {
+      name: 'ui-lib',
+    });
+
+    await runAngularApplicationSchematic(newTree, {
+      name: 'test-app',
+    });
+
+    writeJson(newTree, 'package.json', {
+      devDependencies: {
+        '@nrwl/storybook': nxVersion,
+        '@storybook/addon-essentials': storybookVersion,
+        '@storybook/angular': storybookVersion,
+      },
+    });
+
+    writeJson(newTree, 'ui-lib/tsconfig.json', {});
+    writeJson(newTree, 'test-app/tsconfig.json', {});
+
+    await configurationGenerator(newTree, {
+      name: 'ui-lib',
+      uiFramework: '@storybook/angular',
+      standaloneConfig: false,
+      projectBuildConfig: 'test-app',
+    });
+
+    const project = readProjectConfiguration(newTree, 'ui-lib');
+
+    expect(project.targets.storybook?.options?.projectBuildConfig).toBe(
+      'test-app'
+    );
+  });
+
+  it('should update workspace file for angular libs with default projectBuildConfig if the one provided is invalid', async () => {
+    const newTree = createTreeWithEmptyWorkspace();
+
+    await runAngularLibrarySchematic(newTree, {
+      name: 'ui-lib',
+    });
+
+    await runAngularApplicationSchematic(newTree, {
+      name: 'test-app',
+    });
+
+    writeJson(newTree, 'package.json', {
+      devDependencies: {
+        '@nrwl/storybook': nxVersion,
+        '@storybook/addon-essentials': storybookVersion,
+        '@storybook/angular': storybookVersion,
+      },
+    });
+
+    writeJson(newTree, 'ui-lib/tsconfig.json', {});
+    writeJson(newTree, 'test-app/tsconfig.json', {});
+
+    await configurationGenerator(newTree, {
+      name: 'ui-lib',
+      uiFramework: '@storybook/angular',
+      standaloneConfig: false,
+      projectBuildConfig: 'test-app:asdfasdf',
+    });
+
+    const project = readProjectConfiguration(newTree, 'ui-lib');
+
+    expect(project.targets.storybook?.options?.projectBuildConfig).toBe(
+      'ui-lib:build-storybook'
+    );
+  });
+
+  it('should update workspace file for angular libs with default projectBuildConfig if the project provided does not exist', async () => {
+    const newTree = createTreeWithEmptyWorkspace();
+
+    await runAngularLibrarySchematic(newTree, {
+      name: 'ui-lib',
+    });
+
+    writeJson(newTree, 'package.json', {
+      devDependencies: {
+        '@nrwl/storybook': nxVersion,
+        '@storybook/addon-essentials': storybookVersion,
+        '@storybook/angular': storybookVersion,
+      },
+    });
+
+    writeJson(newTree, 'ui-lib/tsconfig.json', {});
+
+    await configurationGenerator(newTree, {
+      name: 'ui-lib',
+      uiFramework: '@storybook/angular',
+      standaloneConfig: false,
+      projectBuildConfig: 'test-app',
+    });
+
+    const project = readProjectConfiguration(newTree, 'ui-lib');
+
+    expect(project.targets.storybook?.options?.projectBuildConfig).toBe(
+      'ui-lib:build-storybook'
+    );
   });
 
   it('should update `tsconfig.lib.json` file', async () => {

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -30,7 +30,10 @@ import { StorybookConfigureSchema } from './schema';
 import { initGenerator } from '../init/init';
 import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
 import { gte } from 'semver';
-import { findStorybookAndBuildTargets } from '../../executors/utils';
+import {
+  customProjectBuildConfigIsValid,
+  findStorybookAndBuildTargets,
+} from '../../executors/utils';
 import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 
 export async function configurationGenerator(
@@ -63,7 +66,13 @@ export async function configurationGenerator(
   configureTsProjectConfig(tree, schema);
   configureTsSolutionConfig(tree, schema);
   updateLintConfig(tree, schema);
-  addStorybookTask(tree, schema.name, schema.uiFramework, buildTarget);
+  addStorybookTask(
+    tree,
+    schema.name,
+    schema.uiFramework,
+    buildTarget,
+    schema.projectBuildConfig
+  );
   if (schema.configureCypress) {
     if (projectType !== 'application') {
       const cypressTask = await cypressProjectGenerator(tree, {
@@ -326,7 +335,8 @@ function addStorybookTask(
   tree: Tree,
   projectName: string,
   uiFramework: string,
-  buildTargetForAngularProjects: string
+  buildTargetForAngularProjects: string,
+  customProjectBuildConfig?: string
 ) {
   if (uiFramework === '@storybook/react-native') {
     return;
@@ -342,7 +352,10 @@ function addStorybookTask(
       },
       projectBuildConfig:
         uiFramework === '@storybook/angular'
-          ? buildTargetForAngularProjects
+          ? customProjectBuildConfig &&
+            customProjectBuildConfigIsValid(tree, customProjectBuildConfig)
+            ? customProjectBuildConfig
+            : buildTargetForAngularProjects
             ? projectName
             : `${projectName}:build-storybook`
           : undefined,
@@ -364,7 +377,10 @@ function addStorybookTask(
       },
       projectBuildConfig:
         uiFramework === '@storybook/angular'
-          ? buildTargetForAngularProjects
+          ? customProjectBuildConfig &&
+            customProjectBuildConfigIsValid(tree, customProjectBuildConfig)
+            ? customProjectBuildConfig
+            : buildTargetForAngularProjects
             ? projectName
             : `${projectName}:build-storybook`
           : undefined,

--- a/packages/storybook/src/generators/configuration/schema.d.ts
+++ b/packages/storybook/src/generators/configuration/schema.d.ts
@@ -11,4 +11,5 @@ export interface StorybookConfigureSchema {
   js?: boolean;
   cypressDirectory?: string;
   standaloneConfig?: boolean;
+  projectBuildConfig?: string;
 }

--- a/packages/storybook/src/generators/configuration/schema.json
+++ b/packages/storybook/src/generators/configuration/schema.json
@@ -35,6 +35,10 @@
       "enum": ["eslint", "tslint", "none"],
       "default": "eslint"
     },
+    "projectBuildConfig": {
+      "description": "Provide a custom projectBuildConfig for the Angular executor. If left blank, Nx will use the default.",
+      "type": "string"
+    },
     "js": {
       "type": "boolean",
       "description": "Generate JavaScript files rather than TypeScript files.",


### PR DESCRIPTION
## Current Behavior
`projectBuildConfig` is set automatically when generating storybook configuration

## Expected Behavior
While setting the `projectBuildConfig` automatically is good for almost all cases, there are some niche cases where a user would want to specify a custom browser target, and not have to change it manually afterwards. 

## Related Issue(s)
[https://github.com/nrwl/nx/issues/9378](https://github.com/nrwl/nx/issues/9378)

Fixes #9378
