### PR TITLE
fix(react): pass correct configuration when reading build target options in dev-server executor

### DIFF
--- a/packages/node/src/executors/node/node.impl.ts
+++ b/packages/node/src/executors/node/node.impl.ts
@@ -3,9 +3,9 @@ import {
   joinPathFragments,
   logger,
   parseTargetString,
+  readCachedProjectGraph,
   runExecutor,
 } from '@nrwl/devkit';
-import { readCachedProjectGraph } from '@nrwl/devkit';
 import { calculateProjectDependencies } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import { ChildProcess, fork } from 'child_process';
 import * as treeKill from 'tree-kill';
@@ -169,6 +169,9 @@ async function* startBuild(
   context: ExecutorContext
 ) {
   const buildTarget = parseTargetString(options.buildTarget);
+
+  // TODO(jack): [Nx 14] Remove this line once we generate `development` configuration by default + add migration for it if missing
+  buildTarget.configuration ??= '';
 
   yield* await runExecutor<ExecutorEvent>(
     buildTarget,

--- a/packages/web/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/web/src/executors/dev-server/dev-server.impl.ts
@@ -108,6 +108,10 @@ function getBuildOptions(
   context: ExecutorContext
 ): WebWebpackExecutorOptions {
   const target = parseTargetString(options.buildTarget);
+
+  // TODO(jack): [Nx 14] Remove this line once we generate `development` configuration by default + add migration for it if missing
+  target.configuration ??= '';
+
   const overrides: Partial<WebWebpackExecutorOptions> = {
     watch: false,
   };


### PR DESCRIPTION
This PR fixes and issue where there are conflicting `NODE_ENV` variables being used in `DefinePlugin`. There was a regression when we fixed #8932.

The problem was that when reading build target, we did not pass the current configuration in, so it defaulted to `production` as specified  in `nx.json` (`defaultConfiguration`). This caused webpack to add its own `DefinePlugin` that conflicted with our own.

Closes #7924
