### PR TITLE
cleanup(core): refactor migrate.ts

### DIFF
--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -9,16 +9,12 @@ describe('Migration', () => {
         fetch: (_p, _v) => {
           throw new Error('cannot fetch');
         },
-        from: {},
         to: {},
       });
 
-      try {
-        await migrator.updatePackageJson('mypackage', 'myversion');
-        throw new Error('fail');
-      } catch (e) {
-        expect(e.message).toEqual(`cannot fetch`);
-      }
+      await expect(
+        migrator.updatePackageJson('mypackage', 'myversion')
+      ).rejects.toThrowError(/cannot fetch/);
     });
 
     it('should return a patch to the new version', async () => {
@@ -26,7 +22,6 @@ describe('Migration', () => {
         packageJson: {},
         versions: () => '1.0.0',
         fetch: (_p, _v) => Promise.resolve({ version: '2.0.0' }),
-        from: {},
         to: {},
       });
 
@@ -68,7 +63,6 @@ describe('Migration', () => {
             return Promise.resolve(null);
           }
         },
-        from: {},
         to: {},
       });
 
@@ -108,7 +102,6 @@ describe('Migration', () => {
             return Promise.resolve(null);
           }
         },
-        from: {},
         to: {},
       });
 
@@ -157,7 +150,6 @@ describe('Migration', () => {
             return Promise.resolve(null);
           }
         },
-        from: {},
         to: {},
       });
 
@@ -225,7 +217,6 @@ describe('Migration', () => {
             return Promise.resolve({ version: '4.0.0' });
           }
         },
-        from: {},
         to: {},
       });
 
@@ -275,7 +266,6 @@ describe('Migration', () => {
             return Promise.resolve({ version: '2.0.0' });
           }
         },
-        from: {},
         to: {},
       });
 
@@ -318,7 +308,6 @@ describe('Migration', () => {
             return Promise.resolve(null);
           }
         },
-        from: {},
         to: {},
       });
 
@@ -359,7 +348,6 @@ describe('Migration', () => {
         },
         versions: () => '1.0.0',
         fetch: (_p, _v) => Promise.resolve({ version: '2.0.0' }),
-        from: {},
         to: {},
       });
 
@@ -402,7 +390,6 @@ describe('Migration', () => {
             version: '2.0.0',
             packageJsonUpdates: { one: { version: '2.0.0', packages: {} } },
           }),
-        from: {},
         to: {},
       });
       await migrator.updatePackageJson('@nrwl/workspace', '2.0.0');
@@ -421,7 +408,6 @@ describe('Migration', () => {
             packageJsonUpdates: { one: { version: '2.0.0', packages: {} } },
           });
         },
-        from: {},
         to: {},
       });
       await migrator.updatePackageJson('@nrwl/workspace', '2.0.0');
@@ -455,7 +441,6 @@ describe('Migration', () => {
             throw new Error('Boom');
           }
         },
-        from: {},
         to: {},
       });
 
@@ -518,7 +503,6 @@ describe('Migration', () => {
             return Promise.resolve(null);
           }
         },
-        from: {},
         to: {},
       });
       expect(await migrator.updatePackageJson('parent', '2.0.0')).toEqual({
@@ -599,7 +583,6 @@ describe('Migration', () => {
             return Promise.resolve(null);
           }
         },
-        from: {},
         to: {},
       });
 

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -20,84 +20,89 @@ import {
 } from '../utils/package-manager';
 import { handleErrors } from '../utils/params';
 
-type Dependencies = 'dependencies' | 'devDependencies';
+export type Dependencies = 'dependencies' | 'devDependencies';
 
-export type MigrationsJson = {
+export interface PackageJsonUpdateForPackage {
   version: string;
-  collection?: string;
-  generators?: {
-    [name: string]: { version: string; description?: string; cli?: string };
-  };
-  packageJsonUpdates?: {
-    [name: string]: {
-      version: string;
-      packages: {
-        [p: string]: {
-          version: string;
-          ifPackageInstalled?: string;
-          alwaysAddToPackageJson?: boolean;
-          addToPackageJson?: Dependencies;
-        };
-      };
+  ifPackageInstalled?: string;
+  alwaysAddToPackageJson?: boolean | Dependencies;
+  addToPackageJson?: boolean | Dependencies;
+}
+
+export type PackageJsonUpdates = {
+  [name: string]: {
+    version: string;
+    packages: {
+      [packageName: string]: PackageJsonUpdateForPackage;
     };
   };
 };
 
-export function normalizeVersion(version: string) {
-  const [v, t] = version.split('-');
-  const [major, minor, patch] = v.split('.');
-  const newV = `${major || 0}.${minor || 0}.${patch || 0}`;
-  const newVersion = t ? `${newV}-${t}` : newV;
-
-  try {
-    gt(newVersion, '0.0.0');
-    return newVersion;
-  } catch (e) {
-    try {
-      gt(newV, '0.0.0');
-      return newV;
-    } catch (e) {
-      const withoutPatch = `${major || 0}.${minor || 0}.0`;
-      try {
-        if (gt(withoutPatch, '0.0.0')) {
-          return withoutPatch;
-        }
-      } catch (e) {
-        const withoutPatchAndMinor = `${major || 0}.0.0`;
-        try {
-          if (gt(withoutPatchAndMinor, '0.0.0')) {
-            return withoutPatchAndMinor;
-          }
-        } catch (e) {
-          return '0.0.0';
-        }
-      }
-    }
-  }
+export interface GeneratorMigration {
+  version: string;
+  description?: string;
+  cli?: string;
 }
 
-function slash(packageName) {
+export interface MigrationsJson {
+  version: string;
+  collection?: string;
+  generators?: { [name: string]: GeneratorMigration };
+  packageJsonUpdates?: PackageJsonUpdates;
+}
+
+export function normalizeVersion(version: string) {
+  const [semver, prereleaseTag] = version.split('-');
+  const [major, minor, patch] = semver.split('.');
+
+  const newSemver = `${major || 0}.${minor || 0}.${patch || 0}`;
+
+  const newVersion = prereleaseTag
+    ? `${newSemver}-${prereleaseTag}`
+    : newSemver;
+
+  const withoutPatch = `${major || 0}.${minor || 0}.0`;
+  const withoutPatchAndMinor = `${major || 0}.0.0`;
+
+  const variationsToCheck = [
+    newVersion,
+    newSemver,
+    withoutPatch,
+    withoutPatchAndMinor,
+  ];
+
+  for (const variation of variationsToCheck) {
+    try {
+      if (gt(variation, '0.0.0')) {
+        return variation;
+      }
+    } catch {}
+  }
+
+  return '0.0.0';
+}
+
+function slash(packageName: string): string {
   return packageName.replace(/\\/g, '/');
 }
 
-export class Migrator {
-  private readonly packageJson: any;
-  private readonly versions: (p: string) => string;
-  private readonly fetch: (p: string, v: string) => Promise<MigrationsJson>;
-  private readonly from: { [p: string]: string };
-  private readonly to: { [p: string]: string };
+export interface MigratorOptions {
+  packageJson: any;
+  versions: (pkg: string) => string;
+  fetch: (pkg: string, version: string) => Promise<MigrationsJson>;
+  to: { [pkg: string]: string };
+}
 
-  constructor(opts: {
-    packageJson: any;
-    versions: (p: string) => string;
-    fetch: (p: string, v: string) => Promise<MigrationsJson>;
-    from: { [p: string]: string };
-    to: { [p: string]: string };
-  }) {
+export class Migrator {
+  private readonly packageJson: MigratorOptions['packageJson'];
+  private readonly versions: MigratorOptions['versions'];
+  private readonly fetch: MigratorOptions['fetch'];
+  private readonly to: MigratorOptions['to'];
+
+  constructor(opts: MigratorOptions) {
     this.packageJson = opts.packageJson;
     this.versions = opts.versions;
     this.fetch = opts.fetch;
-    this.from = opts.from;
     this.to = opts.to;
   }
 
@@ -107,47 +112,47 @@ export class Migrator {
       { version: targetVersion, addToPackageJson: false },
       {}
     );
+
     const migrations = await this._createMigrateJson(packageJson);
     return { packageJson, migrations };
   }
 
-  private async _createMigrateJson(versions: {
-    [k: string]: { version: string; addToPackageJson: Dependencies | false };
-  }) {
+  private async _createMigrateJson(
+    versions: Record<string, PackageJsonUpdateForPackage>
+  ) {
     const migrations = await Promise.all(
-      Object.keys(versions).map(async (c) => {
-        const currentVersion = this.versions(c);
+      Object.keys(versions).map(async (packageName) => {
+        const currentVersion = this.versions(packageName);
         if (currentVersion === null) return [];
 
-        const target = versions[c];
-        const migrationsJson = await this.fetch(c, target.version);
+        const target = versions[packageName];
+        const migrationsJson = await this.fetch(packageName, target.version);
         const generators = migrationsJson.generators;
+
         if (!generators) return [];
-        return Object.keys(generators)
+        return Object.entries(generators)
           .filter(
-            (r) =>
-              generators[r].version &&
-              this.gt(generators[r].version, currentVersion) &&
-              this.lte(generators[r].version, target.version)
+            ([_, migration]) =>
+              migration.version &&
+              this.gt(migration.version, currentVersion) &&
+              this.lte(migration.version, target.version)
           )
-          .map((r) => ({
-            ...migrationsJson.generators[r],
-            package: c,
-            name: r,
+          .map(([migrationName, migration]) => ({
+            ...migration,
+            package: packageName,
+            name: migrationName,
           }));
       })
     );
 
-    return migrations.reduce((m, c) => [...m, ...c], []);
+    return migrations.flat();
   }
 
   private async _updatePackageJson(
     targetPackage: string,
-    target: { version: string; addToPackageJson: Dependencies | false },
-    collectedVersions: {
-      [k: string]: { version: string; addToPackageJson: Dependencies | false };
-    }
-  ) {
+    target: PackageJsonUpdateForPackage,
+    collectedVersions: Record<string, PackageJsonUpdateForPackage>
+  ): Promise<Record<string, PackageJsonUpdateForPackage>> {
     let targetVersion = target.version;
     if (this.to[targetPackage]) {
       targetVersion = this.to[targetPackage];
@@ -158,16 +163,16 @@ export class Migrator {
         [targetPackage]: {
           version: target.version,
           addToPackageJson: target.addToPackageJson || false,
-        },
+        } as PackageJsonUpdateForPackage,
       };
     }
 
-    let migrationsJson;
+    let migrationsJson: MigrationsJson;
     try {
       migrationsJson = await this.fetch(targetPackage, targetVersion);
       targetVersion = migrationsJson.version;
     } catch (e) {
-      if (e.message.indexOf('No matching version') > -1) {
+      if (e?.message?.includes('No matching version')) {
         throw new Error(
           `${e.message}\nRun migrate with --to="package1@version1,package2@version2"`
         );
@@ -175,42 +180,53 @@ export class Migrator {
         throw e;
       }
     }
+
     const packages = this.collapsePackages(
       targetPackage,
       targetVersion,
       migrationsJson
     );
 
-    const childCalls = await Promise.all(
+    const childPackageMigrations = await Promise.all(
       Object.keys(packages)
-        .filter((r) => {
+        .filter(([packageName]) => {
           return (
-            !collectedVersions[r] ||
-            this.gt(packages[r].version, collectedVersions[r].version)
+            !collectedVersions[packageName] ||
+            this.gt(
+              packages[packageName].version,
+              collectedVersions[packageName].version
+            )
           );
         })
-        .map((u) =>
-          this._updatePackageJson(u, packages[u], {
+        .map((packageName) =>
+          this._updatePackageJson(packageName, packages[packageName], {
             ...collectedVersions,
             [targetPackage]: target,
           })
         )
     );
-    return childCalls.reduce(
-      (m, c) => {
-        Object.keys(c).forEach((r) => {
-          if (!m[r] || this.gt(c[r].version, m[r].version)) {
-            m[r] = c[r];
+
+    return childPackageMigrations.reduce(
+      (migrations, childMigrations) => {
+        for (const migrationName of Object.keys(childMigrations)) {
+          if (
+            !migrations[migrationName] ||
+            this.gt(
+              childMigrations[migrationName].version,
+              migrations[migrationName].version
+            )
+          ) {
+            migrations[migrationName] = childMigrations[migrationName];
           }
-        });
-        return m;
+        }
+        return migrations;
       },
       {
         [targetPackage]: {
           version: migrationsJson.version,
           addToPackageJson: target.addToPackageJson || false,
         },
-      }
+      } as Record<string, PackageJsonUpdateForPackage>
     );
   }
 
@@ -218,7 +234,7 @@ export class Migrator {
     packageName: string,
     targetVersion: string,
     m: MigrationsJson | null
-  ) {
+  ): Record<string, PackageJsonUpdateForPackage> {
     // this should be used to know what version to include
     // we should use from everywhere we use versions
 
@@ -274,30 +290,30 @@ export class Migrator {
       .map((packages) => {
         if (!packages) return {};
 
-        return Object.keys(packages)
-          .filter((pkg) => {
+        return Object.entries(packages)
+          .filter(([packageName, packageUpdate]) => {
             const { dependencies, devDependencies } = this.packageJson;
 
             return (
-              (!packages[pkg].ifPackageInstalled ||
-                this.versions(packages[pkg].ifPackageInstalled)) &&
-              (packages[pkg].alwaysAddToPackageJson ||
-                packages[pkg].addToPackageJson ||
-                !!dependencies?.[pkg] ||
-                !!devDependencies?.[pkg])
+              (!packageUpdate.ifPackageInstalled ||
+                this.versions(packageUpdate.ifPackageInstalled)) &&
+              (packageUpdate.alwaysAddToPackageJson ||
+                packageUpdate.addToPackageJson ||
+                !!dependencies?.[packageName] ||
+                !!devDependencies?.[packageName])
             );
           })
           .reduce(
-            (m, c) => ({
-              ...m,
-              [c]: {
-                version: packages[c].version,
-                addToPackageJson: packages[c].alwaysAddToPackageJson
+            (acc, [packageName, packageUpdate]) => ({
+              ...acc,
+              [packageName]: {
+                version: packageUpdate.version,
+                addToPackageJson: packageUpdate.alwaysAddToPackageJson
                   ? 'dependencies'
-                  : packages[c].addToPackageJson || false,
+                  : packageUpdate.addToPackageJson || false,
               },
             }),
-            {}
+            {} as Record<string, PackageJsonUpdateForPackage>
           );
       })
       .reduce((m, c) => ({ ...m, ...c }), {});
@@ -388,6 +404,7 @@ type GenerateMigrations = {
   from: { [k: string]: string };
   to: { [k: string]: string };
 };
+
 type RunMigrations = { type: 'runMigrations'; runMigrations: string };
 
 export function parseMigrationsOptions(options: {
@@ -439,7 +456,8 @@ function versions(root: string, from: { [p: string]: string }) {
 // testing-fetch-start
 function createFetcher() {
   const cache = {};
-  return async function f(
+
+  return async function nxMigrateFetcher(
     packageName: string,
     packageVersion: string
   ): Promise<MigrationsJson> {
@@ -491,7 +509,6 @@ function createFetcher() {
     return cache[`${packageName}-${packageVersion}`];
   };
 }
-
 // testing-fetch-end
 
 async function getPackageMigrations(
@@ -680,28 +697,30 @@ function createMigrationsFile(
 
 function updatePackageJson(
   root: string,
-  updatedPackages: {
-    [p: string]: { version: string; addToPackageJson: Dependencies | false };
-  }
+  updatedPackages: Record<string, PackageJsonUpdateForPackage>
 ) {
   const packageJsonPath = join(root, 'package.json');
   const parseOptions: JsonReadOptions = {};
   const json = readJsonFile(packageJsonPath, parseOptions);
+
   Object.keys(updatedPackages).forEach((p) => {
-    if (json.devDependencies && json.devDependencies[p]) {
+    if (json.devDependencies?.[p]) {
       json.devDependencies[p] = updatedPackages[p].version;
-    } else if (json.dependencies && json.dependencies[p]) {
+      return;
+    }
+
+    if (json.dependencies?.[p]) {
       json.dependencies[p] = updatedPackages[p].version;
-    } else if (updatedPackages[p].addToPackageJson) {
-      if (updatedPackages[p].addToPackageJson === 'dependencies') {
-        if (!json.dependencies) json.dependencies = {};
-        json.dependencies[p] = updatedPackages[p].version;
-      } else if (updatedPackages[p].addToPackageJson === 'devDependencies') {
-        if (!json.devDependencies) json.devDependencies = {};
-        json.devDependencies[p] = updatedPackages[p].version;
-      }
+      return;
+    }
+
+    const dependencyType = updatedPackages[p].addToPackageJson;
+    if (typeof dependencyType === 'string') {
+      json[dependencyType] ??= {};
+      json[dependencyType][p] = updatedPackages[p].version;
     }
   });
+
   writeJsonFile(packageJsonPath, json, {
     appendNewLine: parseOptions.endsWithNewline,
   });
@@ -720,18 +739,21 @@ async function generateMigrationsJsonAndUpdatePackageJson(
   try {
     logger.info(`Fetching meta data about packages.`);
     logger.info(`It may take a few minutes.`);
+
     const originalPackageJson = readJsonFile(join(root, 'package.json'));
+
     const migrator = new Migrator({
       packageJson: originalPackageJson,
       versions: versions(root, opts.from),
       fetch: createFetcher(),
-      from: opts.from,
       to: opts.to,
     });
+
     const { migrations, packageJson } = await migrator.updatePackageJson(
       opts.targetPackage,
       opts.targetVersion
     );
+
     updatePackageJson(root, packageJson);
 
     if (migrations.length > 0) {
@@ -752,13 +774,16 @@ async function generateMigrationsJsonAndUpdatePackageJson(
       `- Make sure package.json changes make sense and then run '${pmc.install}'`
     );
     if (migrations.length > 0) {
-      logger.info(`- Run 'nx migrate --run-migrations'`);
+      logger.info(`- Run '${pmc.run('nx', 'migrate --run-migrations')}'`);
     }
     logger.info(`- To learn more go to https://nx.dev/using-nx/updating-nx`);
 
     if (showConnectToCloudMessage()) {
       logger.info(
-        `- You may run "nx connect-to-nx-cloud" to get faster builds, GitHub integration, and more. Check out https://nx.app`
+        `- You may run '${pmc.run(
+          'nx',
+          'connect-to-nx-cloud'
+        )}' to get faster builds, GitHub integration, and more. Check out https://nx.app`
       );
     }
   } catch (e) {


### PR DESCRIPTION
This PR does not (intentionally) alter `migrate`'s behavior, but instead is intended to be prep work for the actual changes on it.

I felt that working on `migrate`'s source code wasn't a pleasant experience, and I wanted to handle it before I got to the real code.

I'm mostly talking about the naming and typing of variables. One character variable names, lack of type (re)use, etc.

This should make reading and maintaining `migrate`'s codebase easier for contributors.

Following this PR will be the proposed fix for #4575.