### PR TITLE
feat(core): respect packageGroup in nx migrate

### DIFF
--- a/e2e/cli/src/cli.test.ts
+++ b/e2e/cli/src/cli.test.ts
@@ -15,7 +15,7 @@ import { packagesWeCareAbout } from 'nx/src/command-line/report';
 describe('Cli', () => {
   beforeEach(() => newProject());
 
-  it('vvvshould execute long running tasks', async () => {
+  it('should execute long running tasks', async () => {
     const myapp = uniq('myapp');
     runCLI(`generate @nrwl/web:app ${myapp}`);
     updateProjectConfig(myapp, (c) => {
@@ -156,7 +156,7 @@ describe('list', () => {
 describe('migrate', () => {
   beforeEach(() => newProject());
 
-  it('clear-cacheshould run migrations', () => {
+  it('should run migrations', () => {
     updateFile(
       `./node_modules/migrate-parent-package/package.json`,
       JSON.stringify({

--- a/packages/make-angular-cli-faster/src/utilities/migration.ts
+++ b/packages/make-angular-cli-faster/src/utilities/migration.ts
@@ -32,13 +32,13 @@ export async function determineMigration(
 ): Promise<MigrationDefinition> {
   const angularVersion = getInstalledAngularVersion();
   const majorAngularVersion = major(angularVersion);
-  latestWorkspaceVersionWithMigration = resolvePackageVersion(
+  latestWorkspaceVersionWithMigration = await resolvePackageVersion(
     '@nrwl/angular',
     latestWorkspaceRangeVersionWithMigration
   );
 
   if (version) {
-    const normalizedVersion = normalizeVersion(version);
+    const normalizedVersion = await normalizeVersion(version);
     if (lte(normalizedVersion, latestWorkspaceVersionWithMigration)) {
       // specified version should use @nrwl/workspace:ng-add
       return { packageName: '@nrwl/workspace', version: normalizedVersion };
@@ -66,10 +66,11 @@ export async function determineMigration(
     );
   }
 
-  const latestNxCompatibleVersion = getNxVersionBasedOnInstalledAngularVersion(
-    angularVersion,
-    majorAngularVersion
-  );
+  const latestNxCompatibleVersion =
+    await getNxVersionBasedOnInstalledAngularVersion(
+      angularVersion,
+      majorAngularVersion
+    );
 
   // should use @nrwl/workspace:ng-add if the version is less than the
   // latest workspace version that has the migration, otherwise use
@@ -105,10 +106,11 @@ async function findAndSuggestVersionToUse(
   majorAngularVersion: number,
   userSpecifiedVersion: string
 ): Promise<MigrationDefinition> {
-  const latestNxCompatibleVersion = getNxVersionBasedOnInstalledAngularVersion(
-    angularVersion,
-    majorAngularVersion
-  );
+  const latestNxCompatibleVersion =
+    await getNxVersionBasedOnInstalledAngularVersion(
+      angularVersion,
+      majorAngularVersion
+    );
   const useSuggestedVersion = await promptForVersion(latestNxCompatibleVersion);
   if (useSuggestedVersion) {
     // should use @nrwl/workspace:ng-add if the version is less than the
@@ -134,10 +136,10 @@ async function findAndSuggestVersionToUse(
   process.exit(1);
 }
 
-function getNxVersionBasedOnInstalledAngularVersion(
+async function getNxVersionBasedOnInstalledAngularVersion(
   angularVersion: string,
   majorAngularVersion: number
-): string {
+): Promise<string> {
   if (lt(angularVersion, '13.0.0')) {
     // the @nrwl/angular:ng-add generator is only available for versions supporting
     // Angular >= 13.0.0, fall back to @nrwl/workspace:ng-add
@@ -154,7 +156,7 @@ function getNxVersionBasedOnInstalledAngularVersion(
   }
 
   // use latest, only the last version in the map should not contain a max
-  return resolvePackageVersion('@nrwl/angular', 'latest');
+  return await resolvePackageVersion('@nrwl/angular', 'latest');
 }
 
 async function promptForVersion(version: string): Promise<boolean> {
@@ -177,13 +179,13 @@ function getInstalledAngularVersion(): string {
   return readJsonFile(packageJsonPath).version;
 }
 
-function normalizeVersion(version: string): string {
+async function normalizeVersion(version: string): Promise<string> {
   if (
     version.startsWith('^') ||
     version.startsWith('~') ||
     version.split('.').length < 3
   ) {
-    return resolvePackageVersion('@nrwl/angular', version);
+    return await resolvePackageVersion('@nrwl/angular', version);
   }
 
   return version;

--- a/packages/make-angular-cli-faster/src/utilities/package-manager.ts
+++ b/packages/make-angular-cli-faster/src/utilities/package-manager.ts
@@ -55,13 +55,13 @@ export function installDependencies(
   });
 }
 
-export function resolvePackageVersion(
+export async function resolvePackageVersion(
   packageName: string,
   version: string
-): string {
+): Promise<string> {
   try {
-    return resolvePackageVersionUsingRegistry(packageName, version);
+    return await resolvePackageVersionUsingRegistry(packageName, version);
   } catch {
-    return resolvePackageVersionUsingInstallation(packageName, version);
+    return await resolvePackageVersionUsingInstallation(packageName, version);
   }
 }

--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -344,6 +344,7 @@ describe('Migration', () => {
             '@my-company/lib-1': '0.9.0',
             '@my-company/lib-2': '0.9.0',
             '@my-company/lib-3': '0.9.0',
+            '@my-company/lib-3-child': '0.9.0',
             '@my-company/lib-4': '0.9.0',
             '@my-company/lib-5': '0.9.0',
           },
@@ -359,6 +360,12 @@ describe('Migration', () => {
                 '@my-company/lib-3',
                 { package: '@my-company/lib-4', version: 'latest' },
               ],
+            };
+          }
+          if (pkg === '@my-company/lib-3') {
+            return {
+              version: '2.0.0',
+              packageGroup: ['@my-company/lib-3-child'],
             };
           }
           if (version === 'latest') {
@@ -381,6 +388,10 @@ describe('Migration', () => {
           '@my-company/lib-1': { version: '2.0.0', addToPackageJson: false },
           '@my-company/lib-2': { version: '2.0.0', addToPackageJson: false },
           '@my-company/lib-3': { version: '2.0.0', addToPackageJson: false },
+          '@my-company/lib-3-child': {
+            version: '2.0.0',
+            addToPackageJson: false,
+          },
           '@my-company/lib-4': { version: '2.0.1', addToPackageJson: false },
         },
       });

--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -9,16 +9,12 @@ describe('Migration', () => {
         fetch: (_p, _v) => {
           throw new Error('cannot fetch');
         },
-        from: {},
         to: {},
       });
 
-      try {
-        await migrator.updatePackageJson('mypackage', 'myversion');
-        throw new Error('fail');
-      } catch (e) {
-        expect(e.message).toEqual(`cannot fetch`);
-      }
+      await expect(
+        migrator.updatePackageJson('mypackage', 'myversion')
+      ).rejects.toThrowError(/cannot fetch/);
     });
 
     it('should return a patch to the new version', async () => {
@@ -26,7 +22,6 @@ describe('Migration', () => {
         packageJson: {},
         versions: () => '1.0.0',
         fetch: (_p, _v) => Promise.resolve({ version: '2.0.0' }),
-        from: {},
         to: {},
       });
 
@@ -68,7 +63,6 @@ describe('Migration', () => {
             return Promise.resolve(null);
           }
         },
-        from: {},
         to: {},
       });
 
@@ -108,7 +102,6 @@ describe('Migration', () => {
             return Promise.resolve(null);
           }
         },
-        from: {},
         to: {},
       });
 
@@ -157,7 +150,6 @@ describe('Migration', () => {
             return Promise.resolve(null);
           }
         },
-        from: {},
         to: {},
       });
 
@@ -225,7 +217,6 @@ describe('Migration', () => {
             return Promise.resolve({ version: '4.0.0' });
           }
         },
-        from: {},
         to: {},
       });
 
@@ -275,7 +266,6 @@ describe('Migration', () => {
             return Promise.resolve({ version: '2.0.0' });
           }
         },
-        from: {},
         to: {},
       });
 
@@ -318,7 +308,6 @@ describe('Migration', () => {
             return Promise.resolve(null);
           }
         },
-        from: {},
         to: {},
       });
 
@@ -359,7 +348,6 @@ describe('Migration', () => {
         },
         versions: () => '1.0.0',
         fetch: (_p, _v) => Promise.resolve({ version: '2.0.0' }),
-        from: {},
         to: {},
       });
 
@@ -402,7 +390,6 @@ describe('Migration', () => {
             version: '2.0.0',
             packageJsonUpdates: { one: { version: '2.0.0', packages: {} } },
           }),
-        from: {},
         to: {},
       });
       await migrator.updatePackageJson('@nrwl/workspace', '2.0.0');
@@ -421,7 +408,6 @@ describe('Migration', () => {
             packageJsonUpdates: { one: { version: '2.0.0', packages: {} } },
           });
         },
-        from: {},
         to: {},
       });
       await migrator.updatePackageJson('@nrwl/workspace', '2.0.0');
@@ -455,7 +441,6 @@ describe('Migration', () => {
             throw new Error('Boom');
           }
         },
-        from: {},
         to: {},
       });
 
@@ -518,7 +503,6 @@ describe('Migration', () => {
             return Promise.resolve(null);
           }
         },
-        from: {},
         to: {},
       });
       expect(await migrator.updatePackageJson('parent', '2.0.0')).toEqual({
@@ -599,7 +583,6 @@ describe('Migration', () => {
             return Promise.resolve(null);
           }
         },
-        from: {},
         to: {},
       });
 

--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -1,10 +1,19 @@
+import { PackageJson } from '../utils/package-json';
 import { Migrator, normalizeVersion, parseMigrationsOptions } from './migrate';
+
+const createPackageJson = (
+  overrides: Partial<PackageJson> = {}
+): PackageJson => ({
+  name: 'some-workspace',
+  version: '0.0.0',
+  ...overrides,
+});
 
 describe('Migration', () => {
   describe('packageJson patch', () => {
     it('should throw an error when the target package is not available', async () => {
       const migrator = new Migrator({
-        packageJson: {},
+        packageJson: createPackageJson(),
         versions: () => '1.0',
         fetch: (_p, _v) => {
           throw new Error('cannot fetch');
@@ -19,7 +28,7 @@ describe('Migration', () => {
 
     it('should return a patch to the new version', async () => {
       const migrator = new Migrator({
-        packageJson: {},
+        packageJson: createPackageJson(),
         versions: () => '1.0.0',
         fetch: (_p, _v) => Promise.resolve({ version: '2.0.0' }),
         to: {},
@@ -35,7 +44,7 @@ describe('Migration', () => {
 
     it('should collect the information recursively from upserts', async () => {
       const migrator = new Migrator({
-        packageJson: { dependencies: { child: '1.0.0' } },
+        packageJson: createPackageJson({ dependencies: { child: '1.0.0' } }),
         versions: () => '1.0.0',
         fetch: (p, _v) => {
           if (p === 'parent') {
@@ -78,7 +87,7 @@ describe('Migration', () => {
 
     it('should support the deprecated "alwaysAddToPackageJson" option', async () => {
       const migrator = new Migrator({
-        packageJson: { dependencies: { child1: '1.0.0' } },
+        packageJson: createPackageJson({ dependencies: { child1: '1.0.0' } }),
         versions: () => '1.0.0',
         fetch: (p, _v) => {
           if (p === 'mypackage') {
@@ -117,7 +126,7 @@ describe('Migration', () => {
 
     it('should stop recursive calls when exact version', async () => {
       const migrator = new Migrator({
-        packageJson: { dependencies: { child: '1.0.0' } },
+        packageJson: createPackageJson({ dependencies: { child: '1.0.0' } }),
         versions: () => '1.0.0',
         fetch: (p, _v) => {
           if (p === 'parent') {
@@ -164,13 +173,13 @@ describe('Migration', () => {
 
     it('should set the version of a dependency to the newest', async () => {
       const migrator = new Migrator({
-        packageJson: {
+        packageJson: createPackageJson({
           dependencies: {
             child1: '1.0.0',
             child2: '1.0.0',
             grandchild: '1.0.0',
           },
-        },
+        }),
         versions: () => '1.0.0',
         fetch: (p, _v) => {
           if (p === 'parent') {
@@ -233,7 +242,9 @@ describe('Migration', () => {
 
     it('should skip the versions <= currently installed', async () => {
       const migrator = new Migrator({
-        packageJson: { dependencies: { child: '1.0.0', grandchild: '2.0.0' } },
+        packageJson: createPackageJson({
+          dependencies: { child: '1.0.0', grandchild: '2.0.0' },
+        }),
         versions: () => '1.0.0',
         fetch: (p, _v) => {
           if (p === 'parent') {
@@ -280,7 +291,9 @@ describe('Migration', () => {
 
     it('should conditionally process packages if they are installed', async () => {
       const migrator = new Migrator({
-        packageJson: { dependencies: { child1: '1.0.0', child2: '1.0.0' } },
+        packageJson: createPackageJson({
+          dependencies: { child1: '1.0.0', child2: '1.0.0' },
+        }),
         versions: (p) => (p !== 'not-installed' ? '1.0.0' : null),
         fetch: (p, _v) => {
           if (p === 'parent') {
@@ -320,70 +333,62 @@ describe('Migration', () => {
       });
     });
 
-    // this is temporary. if nx gets used by other projects,
-    // we will extract the special casing
-    it('should special case @nrwl/workspace', async () => {
+    it('should migrate related libraries using packageGroup', async () => {
       const migrator = new Migrator({
         packageJson: {
+          name: 'some-workspace',
+          version: '0.0.0',
+
           devDependencies: {
-            '@nrwl/workspace': '0.9.0',
-            '@nrwl/cli': '0.9.0',
-            '@nrwl/angular': '0.9.0',
-            '@nrwl/cypress': '0.9.0',
-            '@nrwl/devkit': '0.9.0',
-            '@nrwl/eslint-plugin-nx': '0.9.0',
-            '@nrwl/express': '0.9.0',
-            '@nrwl/jest': '0.9.0',
-            '@nrwl/js': '0.9.0',
-            '@nrwl/linter': '0.9.0',
-            '@nrwl/nest': '0.9.0',
-            '@nrwl/next': '0.9.0',
-            '@nrwl/node': '0.9.0',
-            '@nrwl/nx-cloud': '0.9.0',
-            '@nrwl/nx-plugin': '0.9.0',
-            '@nrwl/react': '0.9.0',
-            '@nrwl/storybook': '0.9.0',
-            '@nrwl/web': '0.9.0',
+            '@my-company/nx-workspace': '0.9.0',
+            '@my-company/lib-1': '0.9.0',
+            '@my-company/lib-2': '0.9.0',
+            '@my-company/lib-3': '0.9.0',
+            '@my-company/lib-4': '0.9.0',
+            '@my-company/lib-5': '0.9.0',
           },
         },
         versions: () => '1.0.0',
-        fetch: (_p, _v) => Promise.resolve({ version: '2.0.0' }),
+        fetch: async (pkg, version) => {
+          if (pkg === '@my-company/nx-workspace') {
+            return {
+              version: '2.0.0',
+              packageGroup: [
+                '@my-company/lib-1',
+                '@my-company/lib-2',
+                '@my-company/lib-3',
+                { package: '@my-company/lib-4', version: 'latest' },
+              ],
+            };
+          }
+          if (version === 'latest') {
+            return { version: '2.0.1' };
+          }
+          return { version: '2.0.0' };
+        },
         to: {},
       });
 
       expect(
-        await migrator.updatePackageJson('@nrwl/workspace', '2.0.0')
+        await migrator.updatePackageJson('@my-company/nx-workspace', '2.0.0')
       ).toEqual({
         migrations: [],
         packageJson: {
-          '@nrwl/workspace': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/angular': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/cypress': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/devkit': { addToPackageJson: false, version: '2.0.0' },
-          '@nrwl/eslint-plugin-nx': {
+          '@my-company/nx-workspace': {
             version: '2.0.0',
             addToPackageJson: false,
           },
-          '@nrwl/express': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/jest': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/js': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/linter': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/nest': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/next': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/node': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/nx-cloud': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/nx-plugin': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/react': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/storybook': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/web': { version: '2.0.0', addToPackageJson: false },
-          '@nrwl/cli': { version: '2.0.0', addToPackageJson: false },
+          '@my-company/lib-1': { version: '2.0.0', addToPackageJson: false },
+          '@my-company/lib-2': { version: '2.0.0', addToPackageJson: false },
+          '@my-company/lib-3': { version: '2.0.0', addToPackageJson: false },
+          '@my-company/lib-4': { version: '2.0.1', addToPackageJson: false },
         },
       });
     });
 
     it('should not throw when packages are missing', async () => {
       const migrator = new Migrator({
-        packageJson: {},
+        packageJson: createPackageJson(),
         versions: (p) => (p === '@nrwl/nest' ? null : '1.0.0'),
         fetch: (_p, _v) =>
           Promise.resolve({
@@ -397,7 +402,7 @@ describe('Migration', () => {
 
     it('should only fetch packages that are installed', async () => {
       const migrator = new Migrator({
-        packageJson: {},
+        packageJson: createPackageJson(),
         versions: (p) => (p === '@nrwl/nest' ? null : '1.0.0'),
         fetch: (p, _v) => {
           if (p === '@nrwl/nest') {
@@ -415,7 +420,9 @@ describe('Migration', () => {
 
     it('should only fetch packages that are top-level deps', async () => {
       const migrator = new Migrator({
-        packageJson: { devDependencies: { parent: '1.0.0', child1: '1.0.0' } },
+        packageJson: createPackageJson({
+          devDependencies: { parent: '1.0.0', child1: '1.0.0' },
+        }),
         versions: () => '1.0.0',
         fetch: (p, _v) => {
           if (p === 'parent') {
@@ -451,7 +458,9 @@ describe('Migration', () => {
   describe('migrations', () => {
     it('should create a list of migrations to run', async () => {
       const migrator = new Migrator({
-        packageJson: { dependencies: { child: '1.0.0', newChild: '1.0.0' } },
+        packageJson: createPackageJson({
+          dependencies: { child: '1.0.0', newChild: '1.0.0' },
+        }),
         versions: (p) => {
           if (p === 'parent') return '1.0.0';
           if (p === 'child') return '1.0.0';
@@ -530,7 +539,7 @@ describe('Migration', () => {
 
     it('should not generate migrations for non top-level packages', async () => {
       const migrator = new Migrator({
-        packageJson: { dependencies: { child: '1.0.0' } },
+        packageJson: createPackageJson({ dependencies: { child: '1.0.0' } }),
         versions: (p) => {
           if (p === 'parent') return '1.0.0';
           if (p === 'child') return '1.0.0';

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -20,84 +20,89 @@ import {
 } from '../utils/package-manager';
 import { handleErrors } from '../utils/params';
 
-type Dependencies = 'dependencies' | 'devDependencies';
+export type Dependencies = 'dependencies' | 'devDependencies';
 
-export type MigrationsJson = {
+export interface PackageJsonUpdateForPackage {
   version: string;
-  collection?: string;
-  generators?: {
-    [name: string]: { version: string; description?: string; cli?: string };
-  };
-  packageJsonUpdates?: {
-    [name: string]: {
-      version: string;
-      packages: {
-        [p: string]: {
-          version: string;
-          ifPackageInstalled?: string;
-          alwaysAddToPackageJson?: boolean;
-          addToPackageJson?: Dependencies;
-        };
-      };
+  ifPackageInstalled?: string;
+  alwaysAddToPackageJson?: boolean | Dependencies;
+  addToPackageJson?: boolean | Dependencies;
+}
+
+export type PackageJsonUpdates = {
+  [name: string]: {
+    version: string;
+    packages: {
+      [packageName: string]: PackageJsonUpdateForPackage;
     };
   };
 };
 
-export function normalizeVersion(version: string) {
-  const [v, t] = version.split('-');
-  const [major, minor, patch] = v.split('.');
-  const newV = `${major || 0}.${minor || 0}.${patch || 0}`;
-  const newVersion = t ? `${newV}-${t}` : newV;
-
-  try {
-    gt(newVersion, '0.0.0');
-    return newVersion;
-  } catch (e) {
-    try {
-      gt(newV, '0.0.0');
-      return newV;
-    } catch (e) {
-      const withoutPatch = `${major || 0}.${minor || 0}.0`;
-      try {
-        if (gt(withoutPatch, '0.0.0')) {
-          return withoutPatch;
-        }
-      } catch (e) {
-        const withoutPatchAndMinor = `${major || 0}.0.0`;
-        try {
-          if (gt(withoutPatchAndMinor, '0.0.0')) {
-            return withoutPatchAndMinor;
-          }
-        } catch (e) {
-          return '0.0.0';
-        }
-      }
-    }
-  }
+export interface GeneratorMigration {
+  version: string;
+  description?: string;
+  cli?: string;
 }
 
-function slash(packageName) {
+export interface MigrationsJson {
+  version: string;
+  collection?: string;
+  generators?: { [name: string]: GeneratorMigration };
+  packageJsonUpdates?: PackageJsonUpdates;
+}
+
+export function normalizeVersion(version: string) {
+  const [semver, prereleaseTag] = version.split('-');
+  const [major, minor, patch] = semver.split('.');
+
+  const newSemver = `${major || 0}.${minor || 0}.${patch || 0}`;
+
+  const newVersion = prereleaseTag
+    ? `${newSemver}-${prereleaseTag}`
+    : newSemver;
+
+  const withoutPatch = `${major || 0}.${minor || 0}.0`;
+  const withoutPatchAndMinor = `${major || 0}.0.0`;
+
+  const variationsToCheck = [
+    newVersion,
+    newSemver,
+    withoutPatch,
+    withoutPatchAndMinor,
+  ];
+
+  for (const variation of variationsToCheck) {
+    try {
+      if (gt(variation, '0.0.0')) {
+        return variation;
+      }
+    } catch {}
+  }
+
+  return '0.0.0';
+}
+
+function slash(packageName: string): string {
   return packageName.replace(/\\/g, '/');
 }
 
-export class Migrator {
-  private readonly packageJson: any;
-  private readonly versions: (p: string) => string;
-  private readonly fetch: (p: string, v: string) => Promise<MigrationsJson>;
-  private readonly from: { [p: string]: string };
-  private readonly to: { [p: string]: string };
+export interface MigratorOptions {
+  packageJson: any;
+  versions: (pkg: string) => string;
+  fetch: (pkg: string, version: string) => Promise<MigrationsJson>;
+  to: { [pkg: string]: string };
+}
 
-  constructor(opts: {
-    packageJson: any;
-    versions: (p: string) => string;
-    fetch: (p: string, v: string) => Promise<MigrationsJson>;
-    from: { [p: string]: string };
-    to: { [p: string]: string };
-  }) {
+export class Migrator {
+  private readonly packageJson: MigratorOptions['packageJson'];
+  private readonly versions: MigratorOptions['versions'];
+  private readonly fetch: MigratorOptions['fetch'];
+  private readonly to: MigratorOptions['to'];
+
+  constructor(opts: MigratorOptions) {
     this.packageJson = opts.packageJson;
     this.versions = opts.versions;
     this.fetch = opts.fetch;
-    this.from = opts.from;
     this.to = opts.to;
   }
 
@@ -107,47 +112,47 @@ export class Migrator {
       { version: targetVersion, addToPackageJson: false },
       {}
     );
+
     const migrations = await this._createMigrateJson(packageJson);
     return { packageJson, migrations };
   }
 
-  private async _createMigrateJson(versions: {
-    [k: string]: { version: string; addToPackageJson: Dependencies | false };
-  }) {
+  private async _createMigrateJson(
+    versions: Record<string, PackageJsonUpdateForPackage>
+  ) {
     const migrations = await Promise.all(
-      Object.keys(versions).map(async (c) => {
-        const currentVersion = this.versions(c);
+      Object.keys(versions).map(async (packageName) => {
+        const currentVersion = this.versions(packageName);
         if (currentVersion === null) return [];
 
-        const target = versions[c];
-        const migrationsJson = await this.fetch(c, target.version);
+        const target = versions[packageName];
+        const migrationsJson = await this.fetch(packageName, target.version);
         const generators = migrationsJson.generators;
+
         if (!generators) return [];
-        return Object.keys(generators)
+        return Object.entries(generators)
           .filter(
-            (r) =>
-              generators[r].version &&
-              this.gt(generators[r].version, currentVersion) &&
-              this.lte(generators[r].version, target.version)
+            ([_, migration]) =>
+              migration.version &&
+              this.gt(migration.version, currentVersion) &&
+              this.lte(migration.version, target.version)
           )
-          .map((r) => ({
-            ...migrationsJson.generators[r],
-            package: c,
-            name: r,
+          .map(([migrationName, migration]) => ({
+            ...migration,
+            package: packageName,
+            name: migrationName,
           }));
       })
     );
 
-    return migrations.reduce((m, c) => [...m, ...c], []);
+    return migrations.flat();
   }
 
   private async _updatePackageJson(
     targetPackage: string,
-    target: { version: string; addToPackageJson: Dependencies | false },
-    collectedVersions: {
-      [k: string]: { version: string; addToPackageJson: Dependencies | false };
-    }
-  ) {
+    target: PackageJsonUpdateForPackage,
+    collectedVersions: Record<string, PackageJsonUpdateForPackage>
+  ): Promise<Record<string, PackageJsonUpdateForPackage>> {
     let targetVersion = target.version;
     if (this.to[targetPackage]) {
       targetVersion = this.to[targetPackage];
@@ -158,16 +163,16 @@ export class Migrator {
         [targetPackage]: {
           version: target.version,
           addToPackageJson: target.addToPackageJson || false,
-        },
+        } as PackageJsonUpdateForPackage,
       };
     }
 
-    let migrationsJson;
+    let migrationsJson: MigrationsJson;
     try {
       migrationsJson = await this.fetch(targetPackage, targetVersion);
       targetVersion = migrationsJson.version;
     } catch (e) {
-      if (e.message.indexOf('No matching version') > -1) {
+      if (e?.message?.includes('No matching version')) {
         throw new Error(
           `${e.message}\nRun migrate with --to="package1@version1,package2@version2"`
         );
@@ -175,42 +180,53 @@ export class Migrator {
         throw e;
       }
     }
+
     const packages = this.collapsePackages(
       targetPackage,
       targetVersion,
       migrationsJson
     );
 
-    const childCalls = await Promise.all(
+    const childPackageMigrations = await Promise.all(
       Object.keys(packages)
-        .filter((r) => {
+        .filter(([packageName]) => {
           return (
-            !collectedVersions[r] ||
-            this.gt(packages[r].version, collectedVersions[r].version)
+            !collectedVersions[packageName] ||
+            this.gt(
+              packages[packageName].version,
+              collectedVersions[packageName].version
+            )
           );
         })
-        .map((u) =>
-          this._updatePackageJson(u, packages[u], {
+        .map((packageName) =>
+          this._updatePackageJson(packageName, packages[packageName], {
             ...collectedVersions,
             [targetPackage]: target,
           })
         )
     );
-    return childCalls.reduce(
-      (m, c) => {
-        Object.keys(c).forEach((r) => {
-          if (!m[r] || this.gt(c[r].version, m[r].version)) {
-            m[r] = c[r];
+
+    return childPackageMigrations.reduce(
+      (migrations, childMigrations) => {
+        for (const migrationName of Object.keys(childMigrations)) {
+          if (
+            !migrations[migrationName] ||
+            this.gt(
+              childMigrations[migrationName].version,
+              migrations[migrationName].version
+            )
+          ) {
+            migrations[migrationName] = childMigrations[migrationName];
           }
-        });
-        return m;
+        }
+        return migrations;
       },
       {
         [targetPackage]: {
           version: migrationsJson.version,
           addToPackageJson: target.addToPackageJson || false,
         },
-      }
+      } as Record<string, PackageJsonUpdateForPackage>
     );
   }
 
@@ -218,7 +234,7 @@ export class Migrator {
     packageName: string,
     targetVersion: string,
     m: MigrationsJson | null
-  ) {
+  ): Record<string, PackageJsonUpdateForPackage> {
     // this should be used to know what version to include
     // we should use from everywhere we use versions
 
@@ -274,30 +290,30 @@ export class Migrator {
       .map((packages) => {
         if (!packages) return {};
 
-        return Object.keys(packages)
-          .filter((pkg) => {
+        return Object.entries(packages)
+          .filter(([packageName, packageUpdate]) => {
             const { dependencies, devDependencies } = this.packageJson;
 
             return (
-              (!packages[pkg].ifPackageInstalled ||
-                this.versions(packages[pkg].ifPackageInstalled)) &&
-              (packages[pkg].alwaysAddToPackageJson ||
-                packages[pkg].addToPackageJson ||
-                !!dependencies?.[pkg] ||
-                !!devDependencies?.[pkg])
+              (!packageUpdate.ifPackageInstalled ||
+                this.versions(packageUpdate.ifPackageInstalled)) &&
+              (packageUpdate.alwaysAddToPackageJson ||
+                packageUpdate.addToPackageJson ||
+                !!dependencies?.[packageName] ||
+                !!devDependencies?.[packageName])
             );
           })
           .reduce(
-            (m, c) => ({
-              ...m,
-              [c]: {
-                version: packages[c].version,
-                addToPackageJson: packages[c].alwaysAddToPackageJson
+            (acc, [packageName, packageUpdate]) => ({
+              ...acc,
+              [packageName]: {
+                version: packageUpdate.version,
+                addToPackageJson: packageUpdate.alwaysAddToPackageJson
                   ? 'dependencies'
-                  : packages[c].addToPackageJson || false,
+                  : packageUpdate.addToPackageJson || false,
               },
             }),
-            {}
+            {} as Record<string, PackageJsonUpdateForPackage>
           );
       })
       .reduce((m, c) => ({ ...m, ...c }), {});
@@ -388,6 +404,7 @@ type GenerateMigrations = {
   from: { [k: string]: string };
   to: { [k: string]: string };
 };
+
 type RunMigrations = { type: 'runMigrations'; runMigrations: string };
 
 export function parseMigrationsOptions(options: {
@@ -439,7 +456,8 @@ function versions(root: string, from: { [p: string]: string }) {
 // testing-fetch-start
 function createFetcher() {
   const cache = {};
-  return async function f(
+
+  return async function nxMigrateFetcher(
     packageName: string,
     packageVersion: string
   ): Promise<MigrationsJson> {
@@ -491,7 +509,6 @@ function createFetcher() {
     return cache[`${packageName}-${packageVersion}`];
   };
 }
-
 // testing-fetch-end
 
 async function getPackageMigrations(
@@ -680,28 +697,30 @@ function createMigrationsFile(
 
 function updatePackageJson(
   root: string,
-  updatedPackages: {
-    [p: string]: { version: string; addToPackageJson: Dependencies | false };
-  }
+  updatedPackages: Record<string, PackageJsonUpdateForPackage>
 ) {
   const packageJsonPath = join(root, 'package.json');
   const parseOptions: JsonReadOptions = {};
   const json = readJsonFile(packageJsonPath, parseOptions);
+
   Object.keys(updatedPackages).forEach((p) => {
-    if (json.devDependencies && json.devDependencies[p]) {
+    if (json.devDependencies?.[p]) {
       json.devDependencies[p] = updatedPackages[p].version;
-    } else if (json.dependencies && json.dependencies[p]) {
+      return;
+    }
+
+    if (json.dependencies?.[p]) {
       json.dependencies[p] = updatedPackages[p].version;
-    } else if (updatedPackages[p].addToPackageJson) {
-      if (updatedPackages[p].addToPackageJson === 'dependencies') {
-        if (!json.dependencies) json.dependencies = {};
-        json.dependencies[p] = updatedPackages[p].version;
-      } else if (updatedPackages[p].addToPackageJson === 'devDependencies') {
-        if (!json.devDependencies) json.devDependencies = {};
-        json.devDependencies[p] = updatedPackages[p].version;
-      }
+      return;
+    }
+
+    const dependencyType = updatedPackages[p].addToPackageJson;
+    if (typeof dependencyType === 'string') {
+      json[dependencyType] ??= {};
+      json[dependencyType][p] = updatedPackages[p].version;
     }
   });
+
   writeJsonFile(packageJsonPath, json, {
     appendNewLine: parseOptions.endsWithNewline,
   });
@@ -720,18 +739,21 @@ async function generateMigrationsJsonAndUpdatePackageJson(
   try {
     logger.info(`Fetching meta data about packages.`);
     logger.info(`It may take a few minutes.`);
+
     const originalPackageJson = readJsonFile(join(root, 'package.json'));
+
     const migrator = new Migrator({
       packageJson: originalPackageJson,
       versions: versions(root, opts.from),
       fetch: createFetcher(),
-      from: opts.from,
       to: opts.to,
     });
+
     const { migrations, packageJson } = await migrator.updatePackageJson(
       opts.targetPackage,
       opts.targetVersion
     );
+
     updatePackageJson(root, packageJson);
 
     if (migrations.length > 0) {
@@ -752,13 +774,16 @@ async function generateMigrationsJsonAndUpdatePackageJson(
       `- Make sure package.json changes make sense and then run '${pmc.install}'`
     );
     if (migrations.length > 0) {
-      logger.info(`- Run 'nx migrate --run-migrations'`);
+      logger.info(`- Run '${pmc.run('nx', 'migrate --run-migrations')}'`);
     }
     logger.info(`- To learn more go to https://nx.dev/using-nx/updating-nx`);
 
     if (showConnectToCloudMessage()) {
       logger.info(
-        `- You may run "nx connect-to-nx-cloud" to get faster builds, GitHub integration, and more. Check out https://nx.app`
+        `- You may run '${pmc.run(
+          'nx',
+          'connect-to-nx-cloud'
+        )}' to get faster builds, GitHub integration, and more. Check out https://nx.app`
       );
     }
   } catch (e) {

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -1,7 +1,7 @@
 import { exec, execSync } from 'child_process';
 import { remove } from 'fs-extra';
 import { dirname, join } from 'path';
-import { gt, lte, parse as parseSemver } from 'semver';
+import { gt, lte } from 'semver';
 import { promisify } from 'util';
 import { NxJsonConfiguration } from '../config/nx-json';
 import { flushChanges, FsTree } from '../config/tree';
@@ -61,12 +61,8 @@ export interface ResolvedMigrationConfiguration extends MigrationsJson {
 const execAsync = promisify(exec);
 
 export function normalizeVersion(version: string) {
-  const {
-    major,
-    minor,
-    patch,
-    prerelease: [prereleaseTag],
-  } = parseSemver(version);
+  const [semver, prereleaseTag] = version.split('-');
+  const [major, minor, patch] = semver.split('.');
 
   const newSemver = `${major || 0}.${minor || 0}.${patch || 0}`;
 
@@ -100,7 +96,7 @@ function normalizeSlashes(packageName: string): string {
 }
 
 export interface MigratorOptions {
-  packageJson: any;
+  packageJson: PackageJson;
   versions: (pkg: string) => string;
   fetch: (
     pkg: string,

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -16,6 +16,8 @@ import { NxMigrationsConfiguration, PackageJson } from '../utils/package-json';
 import {
   createTempNpmDirectory,
   getPackageManagerCommand,
+  packageRegistryPack,
+  packageRegistryView,
   resolvePackageVersionUsingRegistry,
 } from '../utils/package-manager';
 import { handleErrors } from '../utils/params';
@@ -565,13 +567,11 @@ async function getPackageMigrationsConfigFromRegistry(
   packageName: string,
   packageVersion: string
 ): Promise<NxMigrationsConfiguration> {
-  const pmc = getPackageManagerCommand();
-
-  const { stdout } = await execAsync(
-    `${pmc.view} ${packageName}@${packageVersion} nx-migrations ng-update --json`
+  const result = await packageRegistryView(
+    packageName,
+    packageVersion,
+    'nx-migrations ng-update --json'
   );
-
-  const result = stdout.toString().trim();
 
   if (!result) {
     return null;
@@ -590,14 +590,11 @@ async function downloadPackageMigrationsFromRegistry(
   let result: ResolvedMigrationConfiguration;
 
   try {
-    const pmc = getPackageManagerCommand();
-
-    const { stdout } = await execAsync(
-      `${pmc.pack} ${packageName}@${packageVersion}`,
-      { cwd: dir }
+    const { tarballPath } = await packageRegistryPack(
+      dir,
+      packageName,
+      packageVersion
     );
-
-    const tarballPath = stdout.trim();
 
     const migrations = await extractFileFromTarball(
       join(dir, tarballPath),

--- a/packages/nx/src/utils/fileutils.ts
+++ b/packages/nx/src/utils/fileutils.ts
@@ -119,7 +119,7 @@ export async function extractFileFromTarball(
   file: string,
   destinationFilePath: string
 ) {
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<string>((resolve, reject) => {
     ensureDirSync(dirname(destinationFilePath));
     var tarExtractStream = tar.extract();
     const destinationFileStream = createWriteStream(destinationFilePath);
@@ -130,7 +130,7 @@ export async function extractFileFromTarball(
         stream.pipe(destinationFileStream);
         stream.on('end', () => {
           isFileExtracted = true;
-          resolve();
+          resolve(destinationFilePath);
         });
       }
 

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -9,9 +9,15 @@ export interface NxProjectPackageJsonConfiguration {
   targets?: Record<string, PackageJsonTargetConfiguration>;
 }
 
+export interface NxMigrationsConfiguration {
+  migrations?: string;
+  packageGroup?: (string | { package: string; version: string })[];
+}
+
 export interface PackageJson {
   // Generic Package.Json Configuration
   name: string;
+  version: string;
   scripts?: Record<string, string>;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
@@ -25,7 +31,8 @@ export interface PackageJson {
   schematics?: string;
   builders?: string;
   executors?: string;
-  'nx-migrations'?: string;
+  'nx-migrations'?: string | NxMigrationsConfiguration;
+  'ng-update'?: string | NxMigrationsConfiguration;
 }
 
 export function buildTargetFromScript(

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -149,29 +149,6 @@ export function createTempNpmDirectory(): string {
 }
 
 /**
- * Creates a temp directory using {@link createTempNpmDirectory} and ensures it is cleaned-up properly.
- */
-export async function withTempNpmDirectory<T>(
-  action: (dir: string) => Promise<T>
-): Promise<T> {
-  const dir = createTempNpmDirectory();
-
-  let result: T;
-
-  try {
-    result = await action(dir);
-  } finally {
-    try {
-      await remove(dir);
-    } catch {
-      // It's okay if this fails, the OS will clean it up eventually
-    }
-  }
-
-  return result;
-}
-
-/**
  * Returns the resolved version for a given package and version tag using the
  * NPM registry (when using Yarn it will fall back to NPM to fetch the info).
  */

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -127,6 +127,13 @@ export function checkForNPMRC(
   return existsSync(path) ? path : null;
 }
 
+/**
+ * Creates a temporary directory where you can run package manager commands safely.
+ *
+ * For cases where you'd want to install packages that require an `.npmrc` set up,
+ * this function looks up for the nearest `.npmrc` (if exists) and copies it over to the
+ * temp directory.
+ */
 export function createTempNpmDirectory(): string {
   const dir = dirSync().name;
 
@@ -139,6 +146,29 @@ export function createTempNpmDirectory(): string {
   }
 
   return dir;
+}
+
+/**
+ * Creates a temp directory using {@link createTempNpmDirectory} and ensures it is cleaned-up properly.
+ */
+export async function withTempNpmDirectory<T>(
+  action: (dir: string) => Promise<T>
+): Promise<T> {
+  const dir = createTempNpmDirectory();
+
+  let result: T;
+
+  try {
+    result = await action(dir);
+  } finally {
+    try {
+      await remove(dir);
+    } catch {
+      // It's okay if this fails, the OS will clean it up eventually
+    }
+  }
+
+  return result;
 }
 
 /**

--- a/packages/nx/src/utils/project-graph-utils.spec.ts
+++ b/packages/nx/src/utils/project-graph-utils.spec.ts
@@ -107,6 +107,7 @@ describe('project graph utils', () => {
   describe('mergeNpmScriptsWithTargets', () => {
     const packageJson: PackageJson = {
       name: 'my-app',
+      version: '0.0.0',
       scripts: {
         build: 'echo 1',
       },

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -47,7 +47,12 @@
       "@nrwl/nx-plugin",
       "@nrwl/react",
       "@nrwl/storybook",
-      "@nrwl/web"
+      "@nrwl/web",
+      "@nrwl/js",
+      "@nrwl/cli",
+      "@nrwl/nx-cloud",
+      "@nrwl/react-native",
+      "@nrwl/detox"
     ]
   },
   "peerDependencies": {
@@ -82,6 +87,32 @@
     "tslib": "^2.3.0"
   },
   "nx-migrations": {
-    "migrations": "./migrations.json"
+    "migrations": "./migrations.json",
+    "packageGroup": [
+      "@nrwl/workspace",
+      "@nrwl/angular",
+      "nx",
+      "@nrwl/cypress",
+      "@nrwl/devkit",
+      "@nrwl/eslint-plugin-nx",
+      "@nrwl/express",
+      "@nrwl/jest",
+      "@nrwl/linter",
+      "@nrwl/nest",
+      "@nrwl/next",
+      "@nrwl/node",
+      "@nrwl/nx-plugin",
+      "@nrwl/react",
+      "@nrwl/storybook",
+      "@nrwl/web",
+      "@nrwl/js",
+      "@nrwl/cli",
+      "@nrwl/react-native",
+      "@nrwl/detox",
+      {
+        "package": "@nrwl/nx-cloud",
+        "version": "latest"
+      }
+    ]
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`package.json#ng-update.packageGroup` is not respected by `nx migrate`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The following configurations in `package.json` should work:

```jsonc
"ng-update": {
  "migrations": "./migrations.json",
  "packageGroup": [
    "@my-company/my-package-1",
    "@my-company/my-package-2",
    {
      "package": "@my-company/my-package-3",
      "version": "latest", // any version/tag respected by package managers would work
    },
    {
      "package": "@my-company/my-package-3",
      "version": "1.0.0",
    }
  ]
},

// nx-migrations is the equivalent of ng-update for nx
"nx-migrations": {
  "migrations": "./migrations.json",
  "packageGroup": [
    "@my-company/my-package-1",
    "@my-company/my-package-2",
    {
      "package": "@my-company/my-package-3",
      "version": "latest", // any version/tag respected by package managers would work
    },
    {
      "package": "@my-company/my-package-3",
      "version": "1.0.0",
    }
  ]
}
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #4575
