### PR TITLE
fix(react): case sensitive file import with react app generator when …

### DIFF
--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -399,6 +399,16 @@ Object {
       expect(appTree.exists('apps/my-app/src/app/App.spec.tsx')).toBeTruthy();
       expect(appTree.exists('apps/my-app/src/app/App.module.css')).toBeTruthy();
     });
+
+    it(`should use the correct case for file import in the spec file`, async () => {
+      await applicationGenerator(appTree, { ...schema, pascalCaseFiles: true });
+
+      const appSpecContent = appTree
+        .read('apps/my-app/src/app/App.spec.tsx')
+        .toString();
+
+      expect(appSpecContent).toMatch(/import App from '.\/App'/);
+    });
   });
 
   it('should generate functional components by default', async () => {
@@ -407,6 +417,16 @@ Object {
     const appContent = appTree.read('apps/my-app/src/app/app.tsx').toString();
 
     expect(appContent).not.toMatch(/extends Component/);
+  });
+
+  it(`should use the correct case for file import in the spec file`, async () => {
+    await applicationGenerator(appTree, { ...schema });
+
+    const appSpecContent = appTree
+      .read('apps/my-app/src/app/app.spec.tsx')
+      .toString();
+
+    expect(appSpecContent).toMatch(/import App from '.\/app'/);
   });
 
   it('should add .eslintrc.json and dependencies', async () => {

--- a/packages/react/src/generators/application/files/common/src/app/__fileName__.spec.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/common/src/app/__fileName__.spec.tsx__tmpl__
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 <% } %>
 
-import App from './app';
+import App from './<%= fileName %>';
 
 describe('App', () => {
   it('should render successfully', () => {


### PR DESCRIPTION
…using the pascalCaseFiles option

Based on the flags passed into the react application generator it should use the appropriate casing
in the imports for the generated App.spec.tsx.

This only affected new react apps generated with
the `--pascalCaseFiles` flag on fully case-sensitive file systems, such as a Linux host running
docker Linux. Since it's likely people have already manually fixed it, I don't think a migration makes
sense.

closes nrwl/nx-examples#195

ISSUES CLOSED: #9666

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9666 
