### PR TITLE
fix(nextjs): dist dir issue on windows

### DIFF
--- a/packages/next/src/utils/config.spec.ts
+++ b/packages/next/src/utils/config.spec.ts
@@ -119,8 +119,8 @@ describe('Next.js webpack config builder', () => {
 
       expect(config).toEqual(
         expect.objectContaining({
-          distDir: '../../dist/apps/wibble/.next',
-          outdir: '../../dist/apps/wibble',
+          distDir: 'dist/apps/wibble/.next',
+          outdir: 'dist/apps/wibble',
         })
       );
     });

--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -165,7 +165,7 @@ export async function prepareConfig(
   const userWebpack = config.webpack;
   const userNextConfig = getConfigEnhancer(options.nextConfig, context.root);
   // Yes, these do have different capitalisation...
-  config.outdir = `${offsetFromRoot(options.root)}${options.outputPath}`;
+  config.outdir = options.outputPath;
   config.distDir =
     config.distDir && config.distDir !== '.next'
       ? config.distDir


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running `nx run frontend-web-app:serve`, I get the following error message:
EPERM: operation not permitted, mkdir 'C:\Users\dist'

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
To run `nx run frontend-web-app:serve` and get an next.js app running on local environment

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/nrwl/nx/issues/9675

Fixes #
Changing config.outdir to outputPath instead of getting offsetFromRoot fixes the issue