### PR TITLE
fix(angular): add --module option to component generator

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -291,6 +291,11 @@
             "default": "Default",
             "alias": "c"
           },
+          "module": {
+            "type": "string",
+            "description": "The filename or path to the NgModule that will declare this component.",
+            "alias": "m"
+          },
           "style": {
             "description": "The file extension or preprocessor to use for style files, or `none` to skip generating the style file.",
             "type": "string",

--- a/packages/angular/src/generators/component/component.spec.ts
+++ b/packages/angular/src/generators/component/component.spec.ts
@@ -11,6 +11,17 @@ describe('component Generator', () => {
       sourceRoot: 'libs/lib1/src',
       root: 'libs/lib1',
     });
+    tree.write(
+      'libs/lib1/src/lib/lib.module.ts',
+      `
+    import { NgModule } from '@angular/core';
+    
+    @NgModule({
+      declarations: [],
+      exports: []
+    })
+    export class LibModule {}`
+    );
     tree.write('libs/lib1/src/index.ts', '');
 
     // ACT
@@ -39,6 +50,17 @@ describe('component Generator', () => {
       sourceRoot: 'libs/lib1/src',
       root: 'libs/lib1',
     });
+    tree.write(
+      'libs/lib1/src/lib/lib.module.ts',
+      `
+    import { NgModule } from '@angular/core';
+    
+    @NgModule({
+      declarations: [],
+      exports: []
+    })
+    export class LibModule {}`
+    );
     tree.write('libs/lib1/src/index.ts', '');
 
     // ACT
@@ -69,6 +91,17 @@ describe('component Generator', () => {
       sourceRoot: 'libs/lib1/src',
       root: 'libs/lib1',
     });
+    tree.write(
+      'libs/lib1/src/lib/lib.module.ts',
+      `
+    import { NgModule } from '@angular/core';
+    
+    @NgModule({
+      declarations: [],
+      exports: []
+    })
+    export class LibModule {}`
+    );
 
     // ACT
     await componentGenerator(tree, {
@@ -97,6 +130,17 @@ describe('component Generator', () => {
         sourceRoot: 'libs/lib1/src',
         root: 'libs/lib1',
       });
+      tree.write(
+        'libs/lib1/src/lib/lib.module.ts',
+        `
+    import { NgModule } from '@angular/core';
+    
+    @NgModule({
+      declarations: [],
+      exports: []
+    })
+    export class LibModule {}`
+      );
       tree.write('libs/lib1/src/index.ts', '');
 
       // ACT
@@ -126,6 +170,17 @@ describe('component Generator', () => {
         sourceRoot: 'libs/lib1/src',
         root: 'libs/lib1',
       });
+      tree.write(
+        'libs/lib1/src/lib/lib.module.ts',
+        `
+    import { NgModule } from '@angular/core';
+    
+    @NgModule({
+      declarations: [],
+      exports: []
+    })
+    export class LibModule {}`
+      );
       tree.write('libs/lib1/src/index.ts', '');
 
       // ACT
@@ -159,6 +214,17 @@ describe('component Generator', () => {
         sourceRoot: 'libs/lib1/src',
         root: 'libs/lib1',
       });
+      tree.write(
+        'libs/lib1/src/lib/lib.module.ts',
+        `
+    import { NgModule } from '@angular/core';
+    
+    @NgModule({
+      declarations: [],
+      exports: []
+    })
+    export class LibModule {}`
+      );
       tree.write('libs/lib1/src/index.ts', '');
 
       // ACT
@@ -190,6 +256,17 @@ describe('component Generator', () => {
         sourceRoot: 'libs/lib1/src',
         root: 'libs/lib1',
       });
+      tree.write(
+        'libs/lib1/src/lib/lib.module.ts',
+        `
+    import { NgModule } from '@angular/core';
+    
+    @NgModule({
+      declarations: [],
+      exports: []
+    })
+    export class LibModule {}`
+      );
       tree.write('libs/lib1/src/index.ts', '');
 
       // ACT & ASSERT

--- a/packages/angular/src/generators/component/component.ts
+++ b/packages/angular/src/generators/component/component.ts
@@ -7,7 +7,6 @@ import {
   readProjectConfiguration,
   normalizePath,
 } from '@nrwl/devkit';
-import { normalize } from 'path';
 import { pathStartsWith } from '../utils/path';
 
 export async function componentGenerator(tree: Tree, schema: Schema) {
@@ -19,7 +18,6 @@ export async function componentGenerator(tree: Tree, schema: Schema) {
   );
   await angularComponentSchematic(tree, {
     ...schema,
-    skipImport: true,
   });
 
   exportComponent(tree, schema);

--- a/packages/angular/src/generators/component/schema.d.ts
+++ b/packages/angular/src/generators/component/schema.d.ts
@@ -12,6 +12,7 @@ export interface Schema {
   type?: string;
   flat?: boolean;
   selector?: string;
+  module?: string;
   skipSelector?: boolean;
   export?: boolean;
 }

--- a/packages/angular/src/generators/component/schema.json
+++ b/packages/angular/src/generators/component/schema.json
@@ -60,6 +60,11 @@
       "default": "Default",
       "alias": "c"
     },
+    "module": {
+      "type": "string",
+      "description": "The filename or path to the NgModule that will declare this component.",
+      "alias": "m"
+    },
     "style": {
       "description": "The file extension or preprocessor to use for style files, or `none` to skip generating the style file.",
       "type": "string",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Our component generator does not support the `--module` flag.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Our component generator should support the `--module` flag.


