### PR TITLE
fix(react): prompt for nx-cloud during cra-to-nx

### DIFF
--- a/packages/cra-to-nx/src/lib/cra-to-nx.ts
+++ b/packages/cra-to-nx/src/lib/cra-to-nx.ts
@@ -62,7 +62,7 @@ export async function createNxWorkspaceForReact(options: Record<string, any>) {
   const isCRA5 = /^[^~]?5/.test(deps['react-scripts']);
 
   execSync(
-    `npx -y create-nx-workspace@latest temp-workspace --appName=${reactAppName} --preset=react --style=css --nx-cloud --packageManager=${packageManager}`,
+    `npx -y create-nx-workspace@latest temp-workspace --appName=${reactAppName} --preset=react --style=css --packageManager=${packageManager}`,
     { stdio: [0, 1, 2] }
   );
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Installation of Nx Cloud happens automatically during `cra-to-nx`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There is a prompt to install Nx Cloud which defaults to "Yes"

![image](https://user-images.githubusercontent.com/8104246/161809373-cfd7edf8-26df-4e1a-9c2b-af8df4d6c396.png)