### PR TITLE
fix(core): remove warning for out of date global version

### DIFF
--- a/packages/cli/bin/nx.ts
+++ b/packages/cli/bin/nx.ts
@@ -1,9 +1,3 @@
 #!/usr/bin/env node
 
-import { logger } from 'nx/src/utils/logger';
-import { getPackageManagerCommand } from 'nx/src/utils/package-manager';
-
-logger.warn('Please update your global install of Nx');
-logger.warn(`- ${getPackageManagerCommand().addGlobal} nx`);
-
 require('nx/bin/nx');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There's a warning when an old version of `@nrwl/cli` is installed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It's kind of confusing when it shows up because it's not 100% when the global version is out of date. In fact, in some instances, it shows up when there is no global version which is super confusing. Everything does work so I'm going to remove this confusion.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9672
