### PR TITLE
feat(angular): add example remote override to prod mfe

### DIFF
--- a/packages/angular/src/generators/setup-mfe/files/webpack/webpack.prod.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-mfe/files/webpack/webpack.prod.config.js__tmpl__
@@ -1,1 +1,15 @@
-module.exports = require('./webpack.config');
+const { withModuleFederation } = require('@nrwl/angular/module-federation');
+const config = require('./mfe.config');
+module.exports = withModuleFederation({
+    ...config,
+    /*
+     * Remote overrides for production.
+     * Each entry is a pair of an unique name and the URL where it is deployed.
+     *
+     * e.g.
+     * remotes: [
+     *   ['app1', 'https://app1.example.com'],
+     *   ['app2', 'https://app2.example.com'],
+     * ]
+     */
+});


### PR DESCRIPTION
Add example usage of production override of mfe config in the webpack config itself.