### PR TITLE
feat(linter): add cacheStrategy, rulesdir and resolvePluginsRelativeTo flags to eslint executor

### DIFF
--- a/docs/generated/packages/linter.json
+++ b/docs/generated/packages/linter.json
@@ -282,6 +282,22 @@
           "hasTypeAwareRules": {
             "type": "boolean",
             "description": "When set to `true`, the linter will invalidate its cache when any of its dependencies changes."
+          },
+          "cacheStrategy": {
+            "type": "string",
+            "description": "Strategy to use for detecting changed files in the cache.",
+            "default": "metadata",
+            "enum": ["metadata", "content"]
+          },
+          "rulesdir": {
+            "type": "array",
+            "description": "The equivalent of the `--rulesdir` flag on the ESLint CLI.",
+            "default": [],
+            "items": { "type": "string" }
+          },
+          "resolvePluginsRelativeTo": {
+            "type": "string",
+            "description": "The equivalent of the `--resolve-plugins-relative-to` flag on the ESLint CLI."
           }
         },
         "additionalProperties": false,

--- a/packages/linter/src/executors/eslint/lint.impl.spec.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.spec.ts
@@ -45,6 +45,7 @@ function createValidRunBuilderOptions(
     fix: true,
     cache: true,
     cacheLocation: 'cacheLocation1',
+    cacheStrategy: 'content',
     format: 'stylish',
     force: false,
     silent: false,
@@ -54,6 +55,8 @@ function createValidRunBuilderOptions(
     noEslintrc: false,
     quiet: false,
     hasTypeAwareRules: false,
+    rulesdir: [],
+    resolvePluginsRelativeTo: null,
     ...additionalOptions,
   };
 }
@@ -137,6 +140,7 @@ describe('Linter Builder', () => {
       fix: true,
       cache: true,
       cacheLocation: 'cacheLocation1',
+      cacheStrategy: 'content',
       format: 'stylish',
       force: false,
       silent: false,
@@ -145,6 +149,8 @@ describe('Linter Builder', () => {
       outputFile: null,
       quiet: false,
       noEslintrc: false,
+      rulesdir: [],
+      resolvePluginsRelativeTo: null,
     });
   });
 

--- a/packages/linter/src/executors/eslint/schema.d.ts
+++ b/packages/linter/src/executors/eslint/schema.d.ts
@@ -15,6 +15,9 @@ export interface Schema extends JsonObject {
   quiet: boolean;
   ignorePath: string | null;
   hasTypeAwareRules: boolean;
+  cacheStrategy: 'content' | 'metadata' | null;
+  rulesdir: string[];
+  resolvePluginsRelativeTo: string | null;
 }
 
 type Formatter =

--- a/packages/linter/src/executors/eslint/schema.json
+++ b/packages/linter/src/executors/eslint/schema.json
@@ -94,6 +94,24 @@
     "hasTypeAwareRules": {
       "type": "boolean",
       "description": "When set to `true`, the linter will invalidate its cache when any of its dependencies changes."
+    },
+    "cacheStrategy": {
+      "type": "string",
+      "description": "Strategy to use for detecting changed files in the cache.",
+      "default": "metadata",
+      "enum": ["metadata", "content"]
+    },
+    "rulesdir": {
+      "type": "array",
+      "description": "The equivalent of the `--rulesdir` flag on the ESLint CLI.",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
+    "resolvePluginsRelativeTo": {
+      "type": "string",
+      "description": "The equivalent of the `--resolve-plugins-relative-to` flag on the ESLint CLI."
     }
   },
   "additionalProperties": false,

--- a/packages/linter/src/executors/eslint/utility/eslint-utils.spec.ts
+++ b/packages/linter/src/executors/eslint/utility/eslint-utils.spec.ts
@@ -22,6 +22,7 @@ describe('eslint-utils', () => {
       fix: true,
       cache: true,
       cacheLocation: '/root/cache',
+      cacheStrategy: 'content',
     }).catch(() => {});
 
     expect(ESLint).toHaveBeenCalledWith({
@@ -29,8 +30,11 @@ describe('eslint-utils', () => {
       fix: true,
       cache: true,
       cacheLocation: '/root/cache',
+      cacheStrategy: 'content',
       ignorePath: undefined,
       useEslintrc: true,
+      resolvePluginsRelativeTo: undefined,
+      rulePaths: [],
       errorOnUnmatchedPattern: false,
     });
   });
@@ -40,6 +44,7 @@ describe('eslint-utils', () => {
       fix: true,
       cache: true,
       cacheLocation: '/root/cache',
+      cacheStrategy: 'content',
     }).catch(() => {});
 
     expect(ESLint).toHaveBeenCalledWith({
@@ -47,8 +52,11 @@ describe('eslint-utils', () => {
       fix: true,
       cache: true,
       cacheLocation: '/root/cache',
+      cacheStrategy: 'content',
       ignorePath: undefined,
       useEslintrc: true,
+      resolvePluginsRelativeTo: undefined,
+      rulePaths: [],
       errorOnUnmatchedPattern: false,
     });
   });
@@ -67,8 +75,62 @@ describe('eslint-utils', () => {
         fix: true,
         cache: true,
         cacheLocation: '/root/cache',
+        cacheStrategy: undefined,
         ignorePath: undefined,
         useEslintrc: false,
+        resolvePluginsRelativeTo: undefined,
+        rulePaths: [],
+        errorOnUnmatchedPattern: false,
+      });
+    });
+  });
+
+  describe('rulesdir', () => {
+    it('should create the ESLint instance with "rulePaths" set to the given value for rulesdir', async () => {
+      const extraRuleDirectories = ['./some-rules', '../some-more-rules'];
+      await lint(undefined, {
+        fix: true,
+        cache: true,
+        cacheLocation: '/root/cache',
+        cacheStrategy: 'content',
+        rulesdir: extraRuleDirectories,
+      }).catch(() => {});
+
+      expect(ESLint).toHaveBeenCalledWith({
+        overrideConfigFile: undefined,
+        fix: true,
+        cache: true,
+        cacheLocation: '/root/cache',
+        cacheStrategy: 'content',
+        ignorePath: undefined,
+        useEslintrc: true,
+        resolvePluginsRelativeTo: undefined,
+        rulePaths: extraRuleDirectories,
+        errorOnUnmatchedPattern: false,
+      });
+    });
+  });
+
+  describe('resolvePluginsRelativeTo', () => {
+    it('should create the ESLint instance with "resolvePluginsRelativeTo" set to the given value for resolvePluginsRelativeTo', async () => {
+      await lint(undefined, {
+        fix: true,
+        cache: true,
+        cacheLocation: '/root/cache',
+        cacheStrategy: 'content',
+        resolvePluginsRelativeTo: './some-path',
+      }).catch(() => {});
+
+      expect(ESLint).toHaveBeenCalledWith({
+        overrideConfigFile: undefined,
+        fix: true,
+        cache: true,
+        cacheLocation: '/root/cache',
+        cacheStrategy: 'content',
+        ignorePath: undefined,
+        useEslintrc: true,
+        resolvePluginsRelativeTo: './some-path',
+        rulePaths: [],
         errorOnUnmatchedPattern: false,
       });
     });

--- a/packages/linter/src/executors/eslint/utility/eslint-utils.ts
+++ b/packages/linter/src/executors/eslint/utility/eslint-utils.ts
@@ -28,6 +28,9 @@ export async function lint(
     fix: !!options.fix,
     cache: !!options.cache,
     cacheLocation: options.cacheLocation || undefined,
+    cacheStrategy: options.cacheStrategy || undefined,
+    resolvePluginsRelativeTo: options.resolvePluginsRelativeTo || undefined,
+    rulePaths: options.rulesdir || [],
     /**
      * Default is `true` and if not overridden the eslint.lintFiles() method will throw an error
      * when no target files are found.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nrwl/linter:eslint` executor is missing some flags (`cacheStrategy`, `rulesdir`, and `resolvePluginsRelativeTo`) that are present in the `@angular-eslint/builder:lint` builder and that are part of the ESLint CLI. This prevents folks from being able to use them and it also prevents a seamless transition from an Angular CLI workspace to an Nx workspace using the `@nrwl/linter:eslint` executor.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `@nrwl/linter:eslint` executor should support the `cacheStrategy`, `rulesdir`, and `resolvePluginsRelativeTo` flags.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
