### PR TITLE
fix(core): preset core should remove workspace.json

### DIFF
--- a/packages/workspace/src/generators/preset/preset.spec.ts
+++ b/packages/workspace/src/generators/preset/preset.spec.ts
@@ -167,6 +167,19 @@ describe('preset', () => {
   });
 
   describe('core preset', () => {
+    it('should not contain workspace.json or angular.json', async () => {
+      await presetGenerator(tree, {
+        name: 'proj',
+        preset: Preset.Core,
+        linter: 'eslint',
+        cli: 'nx',
+        standaloneConfig: false,
+        packageManager: 'npm',
+      });
+      expect(tree.exists('workspace.json')).toBeFalsy();
+      expect(tree.exists('angular.json')).toBeFalsy();
+    });
+
     describe('package manager workspaces', () => {
       it('should be configured in package.json', async () => {
         await presetGenerator(tree, {

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -184,6 +184,9 @@ async function createPreset(tree: Tree, options: Schema) {
     setDefaultCollection(tree, '@nrwl/react-native');
   } else if (options.preset === Preset.Core || options.preset === Preset.NPM) {
     setupPackageManagerWorkspaces(tree, options);
+    if (options.preset === Preset.Core) {
+      tree.delete('workspace.json');
+    }
   } else {
     throw new Error(`Invalid preset ${options.preset}`);
   }


### PR DESCRIPTION
## Current Behavior
`npx create-nx-workspace --preset core` contains workspace.json. This means that the core tutorial fails due to project inference not being active.

## Expected Behavior
`--preset core` removes workspace.json.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
