### PR TITLE
fix(core): update local plugin resolution to use path utilities

### DIFF
--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -13,6 +13,7 @@ import {
   TargetConfiguration,
   WorkspaceJsonConfiguration,
 } from '../config/workspace-json-project-json';
+import { findMatchingProjectForPath } from './target-project-locator';
 
 export type ProjectTargetConfigurator = (
   file: string
@@ -181,17 +182,15 @@ function findNxProjectForImportPath(
   const possiblePaths = tsConfigPaths[importPath]?.map((p) =>
     path.resolve(root, p)
   );
-  if (tsConfigPaths[importPath]) {
-    const projectRootMappings = Object.entries(workspace.projects).reduce(
-      (m, [project, config]) => {
-        m[path.resolve(root, config.root)] = project;
-        return m;
-      },
-      {}
-    );
-    for (const root of Object.keys(projectRootMappings)) {
-      if (possiblePaths.some((p) => !path.relative(root, p).startsWith('..'))) {
-        return projectRootMappings[root];
+  if (possiblePaths?.length) {
+    const projectRootMappings = buildProjectRootMap(workspace.projects, root);
+    for (const tsConfigPath of possiblePaths) {
+      const nxProject = findMatchingProjectForPath(
+        tsConfigPath,
+        projectRootMappings
+      );
+      if (nxProject) {
+        return nxProject;
       }
     }
     if (process.env.NX_VERBOSE_LOGGING) {
@@ -205,6 +204,16 @@ function findNxProjectForImportPath(
       'Unable to resolve local plugin with import path ' + importPath
     );
   }
+}
+
+function buildProjectRootMap(
+  projects: Record<string, ProjectConfiguration>,
+  root: string
+) {
+  return Object.entries(projects).reduce((m, [project, config]) => {
+    m.set(path.resolve(root, config.root), project);
+    return m;
+  }, new Map<string, string>());
 }
 
 let tsconfigPaths: Record<string, string[]>;

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -190,7 +190,7 @@ function findNxProjectForImportPath(
       {}
     );
     for (const root of Object.keys(projectRootMappings)) {
-      if (possiblePaths.some((p) => p.startsWith(root))) {
+      if (possiblePaths.some((p) => !path.relative(root, p).startsWith('..'))) {
         return projectRootMappings[root];
       }
     }

--- a/packages/nx/src/utils/target-project-locator.ts
+++ b/packages/nx/src/utils/target-project-locator.ts
@@ -178,30 +178,43 @@ export class TargetProjectLocator {
   }
 
   private findMatchingProjectFiles(file: string) {
-    for (
-      let currentPath = file;
-      currentPath != dirname(currentPath);
-      currentPath = dirname(currentPath)
-    ) {
-      const p = this.projectRootMappings.get(currentPath);
-      if (p) {
-        return p;
-      }
-    }
-    return null;
+    const project = findMatchingProjectForPath(file, this.projectRootMappings);
+    return this.nodes[project];
   }
 }
 
 function createProjectRootMappings(
   nodes: Record<string, ProjectGraphProjectNode>
 ) {
-  const projectRootMappings = new Map();
+  const projectRootMappings = new Map<string, string>();
   for (const projectName of Object.keys(nodes)) {
     const root = nodes[projectName].data.root;
     projectRootMappings.set(
       root && root.endsWith('/') ? root.substring(0, root.length - 1) : root,
-      nodes[projectName]
+      projectName
     );
   }
   return projectRootMappings;
+}
+
+/**
+ * Locates a project in projectRootMap based on a file within it
+ * @param filePath path that is inside of projectName
+ * @param projectRootMap Map<projectRoot, projectName>
+ */
+export function findMatchingProjectForPath(
+  filePath: string,
+  projectRootMap: Map<string, string>
+) {
+  for (
+    let currentPath = filePath;
+    currentPath != dirname(currentPath);
+    currentPath = dirname(currentPath)
+  ) {
+    const p = projectRootMap.get(currentPath);
+    if (p) {
+      return p;
+    }
+  }
+  return null;
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -78,6 +78,7 @@
       "@nrwl/nx-dev/ui-home": ["./nx-dev/ui-home/src/index.ts"],
       "@nrwl/nx-dev/ui-member-card": ["./nx-dev/ui-member-card/src/index.ts"],
       "@nrwl/nx-dev/ui-sponsor-card": ["./nx-dev/ui-sponsor-card/src/index.ts"],
+      "@nrwl/nx-plugin": ["./packages/nx-plugin"],
       "@nrwl/react": ["./packages/react"],
       "@nrwl/react-native": ["./packages/react-native"],
       "@nrwl/react/*": ["./packages/react/*"],


### PR DESCRIPTION
## Current Behavior
Local plugin resolution may fail if project paths are similar. I.e.
```
workspace/
├─ README.md
├─ node_modules/
├─ packages/
│  ├─ nx/
│  │  ├─ index.ts
│  ├─ nx-plugin/
│  │  ├─ index.ts
├─ nx.json
```

Since the tsconfig path for nx-plugin starts with `packages/nx`, the local plugin resolved to the wrong package.
## Expected Behavior
Local resolution doesn't pick the wrong package.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
