### PR TITLE
fix(core): replaceAppNameWithPath should not consider additional properties #9706

### DIFF
--- a/packages/workspace/src/utils/cli-config-utils.ts
+++ b/packages/workspace/src/utils/cli-config-utils.ts
@@ -62,6 +62,8 @@ export function replaceAppNameWithPath(
       'executor',
       'browserTarget',
       'tags',
+      'defaultConfiguration',
+      'maximumError',
     ]; // Some of the properties should not be renamed
     return Object.keys(node).reduce(
       (m, c) => (


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The util function replaces the appName with the path to the app. It ignores certain properties that should not be replaced.
`defaultConfiguration` and `maximumError` is not one of those properties. 

If an app is called `dev` then it will have issues if the `defaultConfiguration` is `development` and it will replace it with a path.

`maximumError` conflicts with app names containing `mb` etc.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Do not consider `defaultConfiguration` or `maximumError` when replacing app name with path

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9706
