### PR TITLE
docs(nxdev): remove nxdevkit redirect rule

### DIFF
--- a/nx-dev/nx-dev/redirect-rules.config.js
+++ b/nx-dev/nx-dev/redirect-rules.config.js
@@ -152,7 +152,6 @@ const guideUrls = {
   '/core-concepts/mental-model': '/using-nx/mental-model',
   '/core-concepts/updating-nx': '/using-nx/updating-nx',
   '/core-concepts/ci-overview': '/using-nx/ci-overview',
-  '/using-nx/nx-devkit': '/getting-started/nx-devkit',
   '/getting-started/nx-cli': '/using-nx/nx-cli',
   '/getting-started/console': '/using-nx/console',
   '/core-extended/affected': '/using-nx/affected',


### PR DESCRIPTION
It removes a custom rule on nx.dev about nxdevkit's migration rule that didn't need migration because the URL did not change.