### PR TITLE
fix(node): webpack executor doesn't respect option outputFileName

### DIFF
--- a/packages/node/src/executors/webpack/webpack.impl.spec.ts
+++ b/packages/node/src/executors/webpack/webpack.impl.spec.ts
@@ -72,6 +72,9 @@ describe('Node Build Executor', () => {
 
     expect(runWebpack).toHaveBeenCalledWith(
       expect.objectContaining({
+        entry: expect.objectContaining({
+          index: ['/root/apps/wibble/src/main.ts'],
+        }),
         output: expect.objectContaining({
           filename: 'index.js',
           libraryTarget: 'commonjs',

--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -8,6 +8,7 @@ import { loadTsTransformers } from './load-ts-transformers';
 import { BuildBuilderOptions } from './types';
 import CopyWebpackPlugin = require('copy-webpack-plugin');
 import ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+import { removeExt } from '@nrwl/workspace/src/utils/runtime-lint-utils';
 
 export const OUT_FILENAME_TEMPLATE = '[name].js';
 
@@ -33,9 +34,12 @@ export function getBaseWebpackPartial(
       }),
       {} as { [entryName: string]: string }
     ) ?? {};
+  const mainEntry = options.outputFileName
+    ? removeExt(options.outputFileName)
+    : 'main';
   const webpackConfig: Configuration = {
     entry: {
-      main: [options.main],
+      [mainEntry]: [options.main],
       ...additionalEntryPoints,
     },
     devtool: options.sourceMap ? 'source-map' : false,

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -76,7 +76,7 @@ function hasTag(proj: ProjectGraphProjectNode, tag: string) {
   return tag === '*' || (proj.data.tags || []).indexOf(tag) > -1;
 }
 
-function removeExt(file: string): string {
+export function removeExt(file: string): string {
   return file.replace(/(?<!(^|\/))\.[^/.]+$/, '');
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The output filename of main entry doesn't respect option outputFileName.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The output filename of main entry is the same as option outputFileName.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
