### PR TITLE
fix(core): Skip dependencies already added (avoid circular dependencies)

### DIFF
--- a/packages/nx/src/utils/project-graph-utils.spec.ts
+++ b/packages/nx/src/utils/project-graph-utils.spec.ts
@@ -77,6 +77,18 @@ describe('project graph utils', () => {
       expect(paths).toContain(projGraph.nodes['core'].data.sourceRoot);
     });
 
+    it('should handle circular dependencies', () => {
+      projGraph.dependencies['core'] = [
+        {
+          type: 'static',
+          source: 'core',
+          target: 'demo-app',
+        },
+      ];
+      const paths = getSourceDirOfDependentProjects('demo-app', projGraph);
+      expect(paths).toContain(projGraph.nodes['ui'].data.sourceRoot);
+    });
+
     it('should throw an error if the project does not exist', () => {
       expect(() =>
         getSourceDirOfDependentProjects('non-existent-app', projGraph)

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -139,6 +139,11 @@ function collectDependentProjectNodesNames(
       continue;
     }
 
+    // skip dependencies already added (avoid circular dependencies)
+    if(dependencyNodeNames.has(dependencyName)) {
+      continue;
+    }
+
     dependencyNodeNames.add(dependencyName);
 
     // Get the dependencies of the dependencies

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -140,7 +140,7 @@ function collectDependentProjectNodesNames(
     }
 
     // skip dependencies already added (avoid circular dependencies)
-    if(dependencyNodeNames.has(dependencyName)) {
+    if (dependencyNodeNames.has(dependencyName)) {
       continue;
     }
 


### PR DESCRIPTION
The project utility method `collectDependentProjectNodesNames()` produces a stack overflow (e.g. producing project dependencies for `tailwind.config.js` when circular dependencies exist.

Fix by adding loop detection for "already added" dependencies.

## Current Behavior

Currently, when a circular dependency exists, operations like (for example) a development build for an Angular app including Tailwind produces a stack overflow as follows:

```
⠇ Generating browser application bundles (phase: building)...Error: createGlobPatternsForDependencies: Error when generating globs.
Maximum call stack size exceeded
    at createGlobPatternsForDependencies (/<project-dir>/node_modules/@nrwl/workspace/src/utilities/generate-globs.js:31:15)
    at createGlobPatternsForDependencies (/<project-dir>/node_modules/@nrwl/angular/tailwind.js:12:71)
    at Object.<anonymous> (/<project-dir>/apps/sandbox/tailwind.config.js:72:8)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
    at Function.Module._load (internal/modules/cjs/loader.js:778:12)
    at Module.require (internal/modules/cjs/loader.js:961:19)
    at Module.require (/<project-dir>/node_modules/nx/src/compat/compat.js:14:40)
    at require (internal/modules/cjs/helpers.js:92:18)
    at getTailwindConfig (/<project-dir>/node_modules/tailwindcss/lib/lib/setupTrackingContext.js:65:53)
    at /<project-dir>/node_modules/tailwindcss/lib/lib/setupTrackingContext.js:124:92
    at /<project-dir>/node_modules/tailwindcss/lib/processTailwindFeatures.js:43:11
    at plugins (/<project-dir>/node_modules/tailwindcss/lib/index.js:20:104)
    at LazyResult.runOnRoot (/<project-dir>/node_modules/@angular-devkit/build-angular/node_modules/postcss/lib/lazy-result.js:339:16)
    at LazyResult.runAsync (/<project-dir>/node_modules/@angular-devkit/build-angular/node_modules/postcss/lib/lazy-result.js:393:26)

[createGlobPatternsForDependencies] WARNING: There was no ProjectGraph available to read from, returning an empty array of glob patterns
```

## Expected Behavior

Ideally, circular dependencies should be detected and recursion avoided. 

## Related Issue(s)

I've taken a similar approach to https://github.com/nrwl/nx/pull/2022.