### PR TITLE
fix(angular): use angular workspace defaults when generating host

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -1019,6 +1019,7 @@
           }
         },
         "required": ["name"],
+        "additionalProperties": false,
         "presets": []
       },
       "aliases": ["host"],

--- a/packages/angular/src/generators/mfe-host/mfe-host.spec.ts
+++ b/packages/angular/src/generators/mfe-host/mfe-host.spec.ts
@@ -1,6 +1,7 @@
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import mfeHost from './mfe-host';
 import applicationGenerator from '../application/application';
+import { updateJson, writeJson } from '@nrwl/devkit';
 
 describe('MFE Host App Generator', () => {
   it('should generate a host mfe app with no remotes', async () => {
@@ -57,5 +58,36 @@ describe('MFE Host App Generator', () => {
         'Could not find specified remote application (remote)'
       );
     }
+  });
+
+  it('should use any defaults when generating a host', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+
+    await mfeHost(tree, {
+      name: 'first',
+    });
+    expect(tree.exists('apps/first/src/app/app.component.css')).toBeTruthy();
+
+    // ACT
+
+    updateJson(tree, 'nx.json', (json) => {
+      return {
+        ...json,
+        generators: {
+          ...json.generators,
+          '@nrwl/angular:application': {
+            style: 'scss',
+          },
+        },
+      };
+    });
+
+    // ASSERT
+
+    await mfeHost(tree, {
+      name: 'test',
+    });
+    expect(tree.exists('apps/test/src/app/app.component.scss')).toBeTruthy();
   });
 });

--- a/packages/angular/src/generators/mfe-host/mfe-host.ts
+++ b/packages/angular/src/generators/mfe-host/mfe-host.ts
@@ -1,4 +1,4 @@
-import type { Tree } from '@nrwl/devkit';
+import { readWorkspaceConfiguration, Tree } from '@nrwl/devkit';
 import type { Schema } from './schema';
 
 import { getProjects } from '@nrwl/devkit';
@@ -17,7 +17,28 @@ export default async function mfeHost(tree: Tree, options: Schema) {
     });
   }
 
+  // check the workspace for default values for certain angular properties
+  let defaults = {};
+  const workspaceConfig = readWorkspaceConfiguration(tree);
+  if (workspaceConfig.generators) {
+    const applicationGeneratorName = [
+      '@nrwl/angular:application',
+      '@nrwl/angular:app',
+    ];
+    const applicationGeneratorKey =
+      applicationGeneratorName[0] in workspaceConfig.generators
+        ? applicationGeneratorName[0]
+        : applicationGeneratorName[1] in workspaceConfig.generators
+        ? applicationGeneratorName[1]
+        : undefined;
+
+    defaults = applicationGeneratorKey
+      ? workspaceConfig.generators[applicationGeneratorKey]
+      : {};
+  }
+
   const installTask = await applicationGenerator(tree, {
+    ...defaults,
     name: options.name,
     mfe: true,
     mfeType: 'host',

--- a/packages/angular/src/generators/mfe-host/schema.json
+++ b/packages/angular/src/generators/mfe-host/schema.json
@@ -30,5 +30,6 @@
       "default": false
     }
   },
-  "required": ["name"]
+  "required": ["name"],
+  "additionalProperties": false
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We are not using the default values for properties when generating host applications

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use workspace values for angular apps when generating host applications
