### PR TITLE
fix(angular): add application schema options to mfe-remote

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -896,8 +896,122 @@
           "port": {
             "type": "number",
             "description": "The port on which this app should be served."
+          },
+          "directory": {
+            "description": "The directory of the new application.",
+            "type": "string"
+          },
+          "style": {
+            "description": "The file extension to be used for style files.",
+            "type": "string",
+            "default": "css",
+            "enum": ["css", "scss", "sass", "less"],
+            "x-prompt": {
+              "message": "Which stylesheet format would you like to use?",
+              "type": "list",
+              "items": [
+                { "value": "css", "label": "CSS" },
+                {
+                  "value": "scss",
+                  "label": "SASS(.scss)  [ http://sass-lang.com   ]"
+                },
+                {
+                  "value": "sass",
+                  "label": "SASS(.sass)  [ http://sass-lang.com   ]"
+                },
+                {
+                  "value": "less",
+                  "label": "LESS         [ http://lesscss.org     ]"
+                }
+              ]
+            }
+          },
+          "inlineStyle": {
+            "description": "Specifies if the style will be in the ts file.",
+            "type": "boolean",
+            "default": false,
+            "alias": "s"
+          },
+          "inlineTemplate": {
+            "description": "Specifies if the template will be in the ts file.",
+            "type": "boolean",
+            "default": false,
+            "alias": "t"
+          },
+          "viewEncapsulation": {
+            "description": "Specifies the view encapsulation strategy.",
+            "enum": ["Emulated", "None", "ShadowDom"],
+            "type": "string"
+          },
+          "prefix": {
+            "type": "string",
+            "format": "html-selector",
+            "description": "The prefix to apply to generated selectors.",
+            "alias": "p"
+          },
+          "skipTests": {
+            "description": "Skip creating spec files.",
+            "type": "boolean",
+            "default": false,
+            "alias": "S"
+          },
+          "skipPackageJson": {
+            "type": "boolean",
+            "default": false,
+            "description": "Do not add dependencies to `package.json`."
+          },
+          "unitTestRunner": {
+            "type": "string",
+            "enum": ["karma", "jest", "none"],
+            "description": "Test runner to use for unit tests.",
+            "default": "jest"
+          },
+          "e2eTestRunner": {
+            "type": "string",
+            "enum": ["protractor", "cypress", "none"],
+            "description": "Test runner to use for end to end (E2E) tests.",
+            "default": "cypress"
+          },
+          "tags": {
+            "type": "string",
+            "description": "Add tags to the application (used for linting)."
+          },
+          "linter": {
+            "description": "The tool to use for running lint checks.",
+            "type": "string",
+            "enum": ["eslint", "none"],
+            "default": "eslint"
+          },
+          "backendProject": {
+            "type": "string",
+            "description": "Backend project that provides data to this application. This sets up `proxy.config.json`."
+          },
+          "strict": {
+            "type": "boolean",
+            "description": "Create an application with stricter type checking and build optimization options.",
+            "default": true
+          },
+          "standaloneConfig": {
+            "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
+            "type": "boolean"
+          },
+          "setParserOptionsProject": {
+            "type": "boolean",
+            "description": "Whether or not to configure the ESLint `parserOptions.project` option. We do not do this by default for lint performance reasons.",
+            "default": false
+          },
+          "addTailwind": {
+            "type": "boolean",
+            "description": "Whether to configure Tailwind CSS for the application.",
+            "default": false
+          },
+          "skipFormat": {
+            "description": "Skip formatting files.",
+            "type": "boolean",
+            "default": false
           }
         },
+        "additionalProperties": false,
         "required": ["name"],
         "presets": []
       },

--- a/packages/angular/src/generators/mfe-remote/mfe-remote.ts
+++ b/packages/angular/src/generators/mfe-remote/mfe-remote.ts
@@ -28,7 +28,7 @@ export default async function mfeRemote(tree: Tree, options: Schema) {
   }
 
   const installTask = await applicationGenerator(tree, {
-    name: options.name,
+    ...options,
     mfe: true,
     mfeType: 'remote',
     routing: true,

--- a/packages/angular/src/generators/mfe-remote/schema.d.ts
+++ b/packages/angular/src/generators/mfe-remote/schema.d.ts
@@ -2,4 +2,22 @@ export interface Schema {
   name: string;
   host?: string;
   port?: number;
+  setParserOptionsProject?: boolean;
+  skipPackageJson?: boolean;
+  addTailwind?: boolean;
+  prefix?: string;
+  style?: Styles;
+  skipTests?: boolean;
+  directory?: string;
+  tags?: string;
+  linter?: AngularLinter;
+  unitTestRunner?: UnitTestRunner;
+  e2eTestRunner?: E2eTestRunner;
+  backendProject?: string;
+  strict?: boolean;
+  standaloneConfig?: boolean;
+  inlineStyle?: boolean;
+  inlineTemplate?: boolean;
+  viewEncapsulation?: 'Emulated' | 'Native' | 'None';
+  skipFormat?: boolean;
 }

--- a/packages/angular/src/generators/mfe-remote/schema.json
+++ b/packages/angular/src/generators/mfe-remote/schema.json
@@ -27,7 +27,124 @@
     "port": {
       "type": "number",
       "description": "The port on which this app should be served."
+    },
+    "directory": {
+      "description": "The directory of the new application.",
+      "type": "string"
+    },
+    "style": {
+      "description": "The file extension to be used for style files.",
+      "type": "string",
+      "default": "css",
+      "enum": ["css", "scss", "sass", "less"],
+      "x-prompt": {
+        "message": "Which stylesheet format would you like to use?",
+        "type": "list",
+        "items": [
+          {
+            "value": "css",
+            "label": "CSS"
+          },
+          {
+            "value": "scss",
+            "label": "SASS(.scss)  [ http://sass-lang.com   ]"
+          },
+          {
+            "value": "sass",
+            "label": "SASS(.sass)  [ http://sass-lang.com   ]"
+          },
+          {
+            "value": "less",
+            "label": "LESS         [ http://lesscss.org     ]"
+          }
+        ]
+      }
+    },
+    "inlineStyle": {
+      "description": "Specifies if the style will be in the ts file.",
+      "type": "boolean",
+      "default": false,
+      "alias": "s"
+    },
+    "inlineTemplate": {
+      "description": "Specifies if the template will be in the ts file.",
+      "type": "boolean",
+      "default": false,
+      "alias": "t"
+    },
+    "viewEncapsulation": {
+      "description": "Specifies the view encapsulation strategy.",
+      "enum": ["Emulated", "None", "ShadowDom"],
+      "type": "string"
+    },
+    "prefix": {
+      "type": "string",
+      "format": "html-selector",
+      "description": "The prefix to apply to generated selectors.",
+      "alias": "p"
+    },
+    "skipTests": {
+      "description": "Skip creating spec files.",
+      "type": "boolean",
+      "default": false,
+      "alias": "S"
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`."
+    },
+    "unitTestRunner": {
+      "type": "string",
+      "enum": ["karma", "jest", "none"],
+      "description": "Test runner to use for unit tests.",
+      "default": "jest"
+    },
+    "e2eTestRunner": {
+      "type": "string",
+      "enum": ["protractor", "cypress", "none"],
+      "description": "Test runner to use for end to end (E2E) tests.",
+      "default": "cypress"
+    },
+    "tags": {
+      "type": "string",
+      "description": "Add tags to the application (used for linting)."
+    },
+    "linter": {
+      "description": "The tool to use for running lint checks.",
+      "type": "string",
+      "enum": ["eslint", "none"],
+      "default": "eslint"
+    },
+    "backendProject": {
+      "type": "string",
+      "description": "Backend project that provides data to this application. This sets up `proxy.config.json`."
+    },
+    "strict": {
+      "type": "boolean",
+      "description": "Create an application with stricter type checking and build optimization options.",
+      "default": true
+    },
+    "standaloneConfig": {
+      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
+      "type": "boolean"
+    },
+    "setParserOptionsProject": {
+      "type": "boolean",
+      "description": "Whether or not to configure the ESLint `parserOptions.project` option. We do not do this by default for lint performance reasons.",
+      "default": false
+    },
+    "addTailwind": {
+      "type": "boolean",
+      "description": "Whether to configure Tailwind CSS for the application.",
+      "default": false
+    },
+    "skipFormat": {
+      "description": "Skip formatting files.",
+      "type": "boolean",
+      "default": false
     }
   },
+  "additionalProperties": false,
   "required": ["name"]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
mfe-remote generator is missing some standard options from the application generator that should be included

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
include the additional application generator options


