### PR TITLE
fix(core): init generators should not crash when trying to remove dependencies when package.json does not have dependencies

### DIFF
--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -1,20 +1,15 @@
 import {
   addDependenciesToPackageJson,
   convertNxGenerator,
+  removeDependenciesFromPackageJson,
   Tree,
-  updateJson,
 } from '@nrwl/devkit';
-
 import { cypressVersion, nxVersion } from '../../utils/versions';
 import { Schema } from './schema';
 
 function updateDependencies(host: Tree) {
-  updateJson(host, 'package.json', (json) => {
-    json.dependencies = json.dependencies || {};
-    delete json.dependencies['@nrwl/cypress'];
+  removeDependenciesFromPackageJson(host, ['@nrwl/cypress'], []);
 
-    return json;
-  });
   return addDependenciesToPackageJson(
     host,
     {},

--- a/packages/express/src/generators/init/init.ts
+++ b/packages/express/src/generators/init/init.ts
@@ -1,12 +1,12 @@
 import {
   addDependenciesToPackageJson,
-  updateJson,
-  formatFiles,
   convertNxGenerator,
+  formatFiles,
+  removeDependenciesFromPackageJson,
   Tree,
 } from '@nrwl/devkit';
-import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-collection';
 import { initGenerator as nodeInitGenerator } from '@nrwl/node';
+import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-collection';
 import {
   expressTypingsVersion,
   expressVersion,
@@ -15,10 +15,8 @@ import {
 import type { Schema } from './schema';
 
 function updateDependencies(tree: Tree) {
-  updateJson(tree, 'package.json', (json) => {
-    delete json.dependencies['@nrwl/express'];
-    return json;
-  });
+  removeDependenciesFromPackageJson(tree, ['@nrwl/express'], []);
+
   return addDependenciesToPackageJson(
     tree,
     {

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -2,6 +2,7 @@ import {
   addDependenciesToPackageJson,
   convertNxGenerator,
   GeneratorCallback,
+  removeDependenciesFromPackageJson,
   stripIndents,
   Tree,
   updateJson,
@@ -22,16 +23,6 @@ interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}
 const schemaDefaults = {
   compiler: 'tsc',
 } as const;
-
-function removeNrwlJestFromDeps(host: Tree) {
-  updateJson(host, 'package.json', (json) => {
-    // check whether updating the package.json is necessary
-    if (json.dependencies && json.dependencies['@nrwl/jest']) {
-      delete json.dependencies['@nrwl/jest'];
-    }
-    return json;
-  });
-}
 
 function createJestConfig(host: Tree) {
   if (!host.exists('jest.config.js')) {
@@ -103,8 +94,8 @@ export function jestInitGenerator(tree: Tree, schema: JestInitSchema) {
 
   let installTask: GeneratorCallback = () => {};
   if (!options.skipPackageJson) {
+    removeDependenciesFromPackageJson(tree, ['@nrwl/jest'], []);
     installTask = updateDependencies(tree, options);
-    removeNrwlJestFromDeps(tree);
   }
 
   updateExtensions(tree);

--- a/packages/linter/src/generators/init/init.ts
+++ b/packages/linter/src/generators/init/init.ts
@@ -1,5 +1,6 @@
 import {
   addDependenciesToPackageJson,
+  removeDependenciesFromPackageJson,
   updateJson,
   writeJson,
 } from '@nrwl/devkit';
@@ -169,13 +170,7 @@ function initEsLint(tree: Tree, options: LinterInitOptions): GeneratorCallback {
   }
 
   if (!options.skipPackageJson) {
-    updateJson(tree, 'package.json', (json) => {
-      json.dependencies ||= {};
-
-      delete json.dependencies['@nrwl/linter'];
-
-      return json;
-    });
+    removeDependenciesFromPackageJson(tree, ['@nrwl/linter'], []);
   }
 
   writeJson(tree, '.eslintrc.json', globalEsLintConfiguration);

--- a/packages/node/src/generators/init/init.spec.ts
+++ b/packages/node/src/generators/init/init.spec.ts
@@ -3,6 +3,7 @@ import {
   NxJsonConfiguration,
   readJson,
   Tree,
+  updateJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
@@ -51,5 +52,16 @@ describe('init', () => {
   it('should not add jest config if unitTestRunner is none', async () => {
     await initGenerator(tree, { unitTestRunner: 'none' });
     expect(tree.exists('jest.config.js')).toEqual(false);
+  });
+
+  it('should not fail when dependencies is missing from package.json and no other init generators are invoked', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      delete json.dependencies;
+      return json;
+    });
+
+    expect(
+      initGenerator(tree, { unitTestRunner: 'none' })
+    ).resolves.toBeTruthy();
   });
 });

--- a/packages/node/src/generators/init/init.ts
+++ b/packages/node/src/generators/init/init.ts
@@ -3,19 +3,16 @@ import {
   convertNxGenerator,
   formatFiles,
   GeneratorCallback,
+  removeDependenciesFromPackageJson,
   Tree,
-  updateJson,
 } from '@nrwl/devkit';
+import { jestInitGenerator } from '@nrwl/jest';
+import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-collection';
 import { nxVersion, tslibVersion } from '../../utils/versions';
 import { Schema } from './schema';
-import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-collection';
-import { jestInitGenerator } from '@nrwl/jest';
 
 function updateDependencies(tree: Tree) {
-  updateJson(tree, 'package.json', (json) => {
-    delete json.dependencies['@nrwl/node'];
-    return json;
-  });
+  removeDependenciesFromPackageJson(tree, ['@nrwl/node'], []);
 
   return addDependenciesToPackageJson(
     tree,

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -1,28 +1,28 @@
-import { InitSchema } from './schema';
+import { cypressInitGenerator } from '@nrwl/cypress';
 import {
   addDependenciesToPackageJson,
   convertNxGenerator,
   GeneratorCallback,
   readWorkspaceConfiguration,
+  removeDependenciesFromPackageJson,
   Tree,
-  updateJson,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { jestInitGenerator } from '@nrwl/jest';
-import { cypressInitGenerator } from '@nrwl/cypress';
 import { webInitGenerator } from '@nrwl/web';
-import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-collection';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-collection';
 import {
   nxVersion,
   reactDomVersion,
+  reactTestRendererVersion,
   reactVersion,
+  testingLibraryReactHooksVersion,
   testingLibraryReactVersion,
   typesReactDomVersion,
   typesReactVersion,
-  testingLibraryReactHooksVersion,
-  reactTestRendererVersion,
 } from '../../utils/versions';
+import { InitSchema } from './schema';
 
 function setDefault(host: Tree) {
   const workspace = readWorkspaceConfiguration(host);
@@ -45,12 +45,7 @@ function setDefault(host: Tree) {
 }
 
 function updateDependencies(host: Tree) {
-  updateJson(host, 'package.json', (json) => {
-    if (json.dependencies && json.dependencies['@nrwl/react']) {
-      delete json.dependencies['@nrwl/react'];
-    }
-    return json;
-  });
+  removeDependenciesFromPackageJson(host, ['@nrwl/react'], []);
 
   return addDependenciesToPackageJson(
     host,

--- a/packages/web/src/generators/init/init.spec.ts
+++ b/packages/web/src/generators/init/init.spec.ts
@@ -3,6 +3,7 @@ import {
   NxJsonConfiguration,
   readJson,
   Tree,
+  updateJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
@@ -78,6 +79,20 @@ describe('init', () => {
         unitTestRunner: 'none',
       });
       expect(tree.exists('babel.config.json')).toBe(false);
+    });
+
+    it('should not fail when dependencies is missing from package.json and no other init generators are invoked', async () => {
+      updateJson(tree, 'package.json', (json) => {
+        delete json.dependencies;
+        return json;
+      });
+
+      expect(
+        webInitGenerator(tree, {
+          e2eTestRunner: 'none',
+          unitTestRunner: 'none',
+        })
+      ).resolves.toBeTruthy();
     });
   });
 });

--- a/packages/web/src/generators/init/init.ts
+++ b/packages/web/src/generators/init/init.ts
@@ -1,24 +1,21 @@
+import { cypressInitGenerator } from '@nrwl/cypress';
 import {
   addDependenciesToPackageJson,
   convertNxGenerator,
   formatFiles,
   GeneratorCallback,
+  removeDependenciesFromPackageJson,
   Tree,
-  updateJson,
   writeJson,
 } from '@nrwl/devkit';
-import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-collection';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
-import { Schema } from './schema';
-import { nxVersion } from '../../utils/versions';
-import { cypressInitGenerator } from '@nrwl/cypress';
 import { jestInitGenerator } from '@nrwl/jest';
+import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-collection';
+import { nxVersion } from '../../utils/versions';
+import { Schema } from './schema';
 
 function updateDependencies(tree: Tree) {
-  updateJson(tree, 'package.json', (json) => {
-    delete json.dependencies['@nrwl/web'];
-    return json;
-  });
+  removeDependenciesFromPackageJson(tree, ['@nrwl/web'], []);
 
   return addDependenciesToPackageJson(
     tree,


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

some init generators (at least `web` and `node`) had edge cases where, when they would not invoke other init generators, they would crash when trying to delete dependencies from `package.json`, because it wouldn't have a `"dependencies"` key.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When there's no `"dependencies"` (or dev/peer/optional) in package.json, generators should not crash when trying to alter it.

This PR resolves this issue by using the `removeDependenciesFromPackageJson` method from devkit, instead of the more manual `updateJson`, in all applicable places where such an action happens.

There are several places where I opted not to update them, they were all migrators doing something specific, and I preferred to stick to the problem at hand.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9763