### PR TITLE
docs(nxdev): fix typo in micro frontend

### DIFF
--- a/docs/shared/guides/setup-mfe-with-angular.md
+++ b/docs/shared/guides/setup-mfe-with-angular.md
@@ -392,4 +392,4 @@ In this tutorial, we exposed a single module that was consumed dynamically as an
 ## References and Further Reading
 
 - Module Federation: https://webpack.js.org/concepts/module-federation/
-- Mirco Frontend Revolution Article Series: https://www.angulararchitects.io/aktuelles/the-microfrontend-revolution-module-federation-in-webpack-5/
+- Micro Frontend Revolution Article Series: https://www.angulararchitects.io/aktuelles/the-microfrontend-revolution-module-federation-in-webpack-5/

--- a/nx-dev/feature-conf/src/lib/conf-schedule-short.tsx
+++ b/nx-dev/feature-conf/src/lib/conf-schedule-short.tsx
@@ -38,7 +38,7 @@ export function ConfScheduleShort(): JSX.Element {
       time: '',
       title: 'Superpowered Micro Frontends with Monorepos',
       description:
-        'Micro Frontends are awesome, but they can be difficult to set up, maintain and scale. Learn how Nx and Monorepos not only embrace Mirco Frontends, but provide amazing benefits that improves reliability, developer experience and maintainability and also encourages strategic collaboration while reducing the risk of running into classic Micro Frontend problems such as Micro Frontend anarchy, framework version mismatch and out-of-sync shared packages.',
+        'Micro Frontends are awesome, but they can be difficult to set up, maintain and scale. Learn how Nx and Monorepos not only embrace Micro Frontends, but provide amazing benefits that improves reliability, developer experience and maintainability and also encourages strategic collaboration while reducing the risk of running into classic Micro Frontend problems such as Micro Frontend anarchy, framework version mismatch and out-of-sync shared packages.',
       speakers: ['Colum Ferry'],
       videoUrl: '',
     },


### PR DESCRIPTION
## Current Behavior
In the conference page, micro frontend has a typo: mirco frontend.

## Expected Behavior
The typo should be fixed.