### PR TITLE
fix(js): add init generator placeholder

### DIFF
--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -129,6 +129,24 @@
       "path": "/packages/js/src/generators/library/schema.json"
     },
     {
+      "name": "init",
+      "factory": "./src/generators/init/init#initGenerator",
+      "schema": {
+        "$schema": "http://json-schema.org/schema",
+        "$id": "NxTypescriptInit",
+        "cli": "nx",
+        "title": "Init nrwl/js",
+        "description": "Init generator placeholder for nrwl/js",
+        "presets": []
+      },
+      "aliases": ["lib"],
+      "x-type": "init",
+      "description": "Init placeholder.",
+      "implementation": "/packages/js/src/generators/init/init#initGenerator.ts",
+      "hidden": false,
+      "path": "/packages/js/src/generators/init/schema.json"
+    },
+    {
       "name": "convert-to-swc",
       "factory": "./src/generators/convert-to-swc/convert-to-swc#convertToSwcGenerator",
       "schema": {

--- a/docs/packages.json
+++ b/docs/packages.json
@@ -109,7 +109,7 @@
     "path": "generated/packages/js.json",
     "schemas": {
       "executors": ["tsc", "swc"],
-      "generators": ["library", "convert-to-swc"]
+      "generators": ["library", "init", "convert-to-swc"]
     }
   },
   {

--- a/packages/js/generators.json
+++ b/packages/js/generators.json
@@ -9,6 +9,13 @@
       "x-type": "library",
       "description": "Create a library."
     },
+    "init": {
+      "factory": "./src/generators/init/init#initSchematic",
+      "schema": "./src/generators/init/schema.json",
+      "aliases": ["lib"],
+      "x-type": "init",
+      "description": "Init placeholder."
+    },
     "convert-to-swc": {
       "factory": "./src/generators/convert-to-swc/convert-to-swc#convertToSwcSchematic",
       "schema": "./src/generators/convert-to-swc/schema.json",
@@ -24,6 +31,13 @@
       "aliases": ["lib"],
       "x-type": "library",
       "description": "Create a library"
+    },
+    "init": {
+      "factory": "./src/generators/init/init#initGenerator",
+      "schema": "./src/generators/init/schema.json",
+      "aliases": ["lib"],
+      "x-type": "init",
+      "description": "Init placeholder."
     },
     "convert-to-swc": {
       "factory": "./src/generators/convert-to-swc/convert-to-swc#convertToSwcGenerator",

--- a/packages/js/src/generators/init/init.ts
+++ b/packages/js/src/generators/init/init.ts
@@ -1,0 +1,10 @@
+import { convertNxGenerator, logger } from '@nrwl/devkit';
+
+export async function initGenerator() {
+  logger.info(
+    'This is a placeholder for @nrwl/js:init generator. If you want to create a library, use @nrwl/js:lib instead'
+  );
+}
+
+export default initGenerator;
+export const initSchematic = convertNxGenerator(initGenerator);

--- a/packages/js/src/generators/init/schema.json
+++ b/packages/js/src/generators/init/schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "NxTypescriptInit",
+  "cli": "nx",
+  "title": "Init nrwl/js",
+  "description": "Init generator placeholder for nrwl/js"
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`nrwl/js` does not have an `initGenerator` which would cause some confusion regarding our `list` command telling users to run `init`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nrwl/js:init` is now just a placeholder that will print information about running `nrwl/js:lib` to generate a library which is the only generator that `nrwl/js` has (beside `convert-to-swc` that is probably not related to _init_)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
