### PR TITLE
fix(storybook): component props should only consider inputs #9417

### DIFF
--- a/packages/angular/src/generators/utils/storybook.ts
+++ b/packages/angular/src/generators/utils/storybook.ts
@@ -41,11 +41,15 @@ export function getComponentProps(
   const props = getInputPropertyDeclarations(tree, componentPath).map(
     (node) => {
       const decoratorContent = findNodes(
-        findNodes(node, SyntaxKind.Decorator)[0],
+        findNodes(node, SyntaxKind.Decorator).find((n) =>
+          n.getText().startsWith('@Input')
+        ),
         SyntaxKind.StringLiteral
       );
       const name = decoratorContent.length
-        ? decoratorContent[0].getText().slice(1, -1)
+        ? !decoratorContent[0].getText().includes('.')
+          ? decoratorContent[0].getText().slice(1, -1)
+          : node.name.getText()
         : node.name.getText();
 
       const type = getKnobType(node);


### PR DESCRIPTION



<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Previously, all decorators were being taken into consideration. However, props to an Angular component would be its Inputs.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should only consider Inputs.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Fixes #9417
