### PR TITLE
feat(angular): expose mfe package helpers

### DIFF
--- a/packages/angular/module-federation/index.ts
+++ b/packages/angular/module-federation/index.ts
@@ -1,1 +1,2 @@
 export { withModuleFederation } from '../src/utils/mfe/with-module-federation';
+export * from '../src/utils/mfe/mfe-webpack';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We have not exposed the `sharePackages` and `shareWorkspaceLibraries` helpers from `@nrwl/angular`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should expose those helpers to allow people to begin to use them in scenarios where they have a more involved `webpack.config.js` and cannot use `withModuleFederation`
