### PR TITLE
docs(nxdev): add conf q&a

### DIFF
--- a/nx-dev/feature-conf/src/lib/conf-schedule-short.tsx
+++ b/nx-dev/feature-conf/src/lib/conf-schedule-short.tsx
@@ -60,6 +60,15 @@ export function ConfScheduleShort(): JSX.Element {
       speakers: ['Jo Hanna Pearce'],
       videoUrl: '',
     },
+    {
+      type: 'event',
+      time: '',
+      title: 'Nx / NxCloud team panel discussion',
+      description:
+        'A Q&A panel with Nx and NxCloud teams ready to answer all your burning questions!',
+      speakers: ['Nx / NxCloud teams'],
+      videoUrl: '',
+    },
   ];
 
   return (


### PR DESCRIPTION
It adds the conference Q&A item at the end of the NxConfLite schedule on nx.dev/conf.