### PR TITLE
fix(core): remove slice increment on workspace move path resolution

### DIFF
--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -51,7 +51,11 @@ export function updateImports(
     from:
       fromPath ||
       normalizeSlashes(
-        `@${npmScope}/${project.root.slice(libsDir.length + 1)}`
+        `@${npmScope}/${
+          project.root.slice(libsDir.length).startsWith('/')
+            ? project.root.slice(libsDir.length + 1)
+            : project.root.slice(libsDir.length)
+        }`
       ),
     to: schema.importPath,
   };
@@ -77,7 +81,9 @@ export function updateImports(
   }
 
   const projectRoot = {
-    from: project.root.slice(libsDir.length + 1),
+    from: project.root.slice(libsDir.length).startsWith('/')
+      ? project.root.slice(libsDir.length + 1)
+      : project.root.slice(libsDir.length),
     to: schema.destination,
   };
 


### PR DESCRIPTION
It fixes the path resolution when moving a project with `@nrwl/workspace:move` generator, due to an arbitrary increment on the slice method.

## Issue
Trying to move a project inside nx’s repo and the parsing seems to remove a letter: 
```
❯ nx generate @nrwl/workspace:move --projectName=nx-dev-feature-conf --destination nx-dev/ui-conference --dry-run
unable to find "@nrwl/x-dev/feature-conf" in tsconfig.base.json compilerOptions.paths
```

So I tracked down the issue and console log this and in deed:
https://github.com/nrwl/nx/blob/master/packages/workspace/src/generators/move/lib/update-imports.ts#L80
```
{ from: '@nrwl/x-dev/feature-conf', to: '@nrwl/nx-dev-ui-conference' }
```
The first `from: '@nrwl/x-dev/feature-conf'` is missing the “n”.