### PR TITLE
chore(repo): relocate types from migrate.ts

### DIFF
--- a/docs/generated/api-nx-devkit/index.md
+++ b/docs/generated/api-nx-devkit/index.md
@@ -68,7 +68,10 @@ It only uses language primitives and immutable objects
 ### Workspace Interfaces
 
 - [ExecutorContext](../../nx-devkit/index#executorcontext)
+- [ExecutorsJson](../../nx-devkit/index#executorsjson)
+- [GeneratorsJson](../../nx-devkit/index#generatorsjson)
 - [ImplicitJsonSubsetDependency](../../nx-devkit/index#implicitjsonsubsetdependency)
+- [MigrationsJson](../../nx-devkit/index#migrationsjson)
 - [NxAffectedConfig](../../nx-devkit/index#nxaffectedconfig)
 - [NxJsonConfiguration](../../nx-devkit/index#nxjsonconfiguration)
 - [NxJsonProjectConfiguration](../../nx-devkit/index#nxjsonprojectconfiguration)
@@ -360,6 +363,18 @@ A plugin for Nx
 
 ---
 
+### ExecutorsJson
+
+• **ExecutorsJson**: `Object`
+
+---
+
+### GeneratorsJson
+
+• **GeneratorsJson**: `Object`
+
+---
+
 ### ImplicitJsonSubsetDependency
 
 • **ImplicitJsonSubsetDependency**<`T`\>: `Object`
@@ -369,6 +384,12 @@ A plugin for Nx
 | Name | Type                |
 | :--- | :------------------ |
 | `T`  | `"*"` \| `string`[] |
+
+---
+
+### MigrationsJson
+
+• **MigrationsJson**: `Object`
 
 ---
 

--- a/packages/devkit/index.ts
+++ b/packages/devkit/index.ts
@@ -35,6 +35,9 @@ export type {
   Executor,
   ExecutorContext,
   TaskGraphExecutor,
+  GeneratorsJson,
+  ExecutorsJson,
+  MigrationsJson,
 } from 'nx/src/config/misc-interfaces';
 
 /**

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -3,6 +3,10 @@ import { remove } from 'fs-extra';
 import { dirname, join } from 'path';
 import { gt, lte } from 'semver';
 import { promisify } from 'util';
+import {
+  MigrationsJson,
+  PackageJsonUpdateForPackage,
+} from '../config/misc-interfaces';
 import { NxJsonConfiguration } from '../config/nx-json';
 import { flushChanges, FsTree } from '../config/tree';
 import {
@@ -21,40 +25,6 @@ import {
   resolvePackageVersionUsingRegistry,
 } from '../utils/package-manager';
 import { handleErrors } from '../utils/params';
-
-export type Dependencies = 'dependencies' | 'devDependencies';
-
-export interface PackageJsonUpdateForPackage {
-  version: string;
-  ifPackageInstalled?: string;
-  alwaysAddToPackageJson?: boolean | Dependencies;
-  addToPackageJson?: boolean | Dependencies;
-}
-
-export type PackageJsonUpdates = {
-  [name: string]: {
-    version: string;
-    packages: {
-      [packageName: string]: PackageJsonUpdateForPackage;
-    };
-  };
-};
-
-export interface GeneratorMigration {
-  version: string;
-  description?: string;
-  cli?: string;
-  implementation?: string;
-  factory?: string;
-}
-
-export interface MigrationsJson {
-  version: string;
-  collection?: string;
-  generators?: { [name: string]: GeneratorMigration };
-  schematics?: { [name: string]: GeneratorMigration };
-  packageJsonUpdates?: PackageJsonUpdates;
-}
 
 export interface ResolvedMigrationConfiguration extends MigrationsJson {
   packageGroup?: NxMigrationsConfiguration['packageGroup'];

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -17,6 +17,69 @@ export type Generator<T = unknown> = (
   schema: T
 ) => void | GeneratorCallback | Promise<void | GeneratorCallback>;
 
+export interface GeneratorsJsonEntry {
+  schema: string;
+  implementation?: string;
+  factory?: string;
+  description?: string;
+  aliases?: string[];
+  cli?: 'nx';
+  'x-type'?: 'library' | 'application';
+}
+
+export interface ExecutorsJsonEntry {
+  schema: string;
+  implementation: string;
+  batchImplementation?: string;
+  description?: string;
+  hasher?: string;
+}
+
+export type Dependencies = 'dependencies' | 'devDependencies';
+
+export interface PackageJsonUpdateForPackage {
+  version: string;
+  ifPackageInstalled?: string;
+  alwaysAddToPackageJson?: boolean | Dependencies;
+  addToPackageJson?: boolean | Dependencies;
+}
+
+export type PackageJsonUpdates = {
+  [name: string]: {
+    version: string;
+    packages: {
+      [packageName: string]: PackageJsonUpdateForPackage;
+    };
+  };
+};
+
+export interface MigrationsJsonEntry {
+  version: string;
+  description?: string;
+  cli?: string;
+  implementation?: string;
+  factory?: string;
+}
+
+export interface MigrationsJson {
+  version: string;
+  collection?: string;
+  generators?: { [name: string]: MigrationsJsonEntry };
+  schematics?: { [name: string]: MigrationsJsonEntry };
+  packageJsonUpdates?: PackageJsonUpdates;
+}
+
+export interface GeneratorsJson {
+  extends?: string;
+  schematics?: Record<string, GeneratorsJsonEntry>;
+  generators?: Record<string, GeneratorsJsonEntry>;
+}
+
+export interface ExecutorsJson {
+  executors?: Record<string, ExecutorsJsonEntry>;
+  builders?: Record<string, ExecutorsJsonEntry>;
+}
+
 export interface ExecutorConfig {
   schema: any;
   hasherFactory?: () => any;

--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -20,6 +20,8 @@ import {
   ExecutorConfig,
   TaskGraphExecutor,
   Generator,
+  GeneratorsJson,
+  ExecutorsJson,
 } from './misc-interfaces';
 import { PackageJson } from '../utils/package-json';
 
@@ -198,7 +200,7 @@ export class Workspaces {
     const executorsFilePath = require.resolve(
       path.join(path.dirname(packageJsonPath), executorsFile)
     );
-    const executorsJson = readJsonFile(executorsFilePath);
+    const executorsJson = readJsonFile<ExecutorsJson>(executorsFilePath);
     const executorConfig: {
       implementation: string;
       batchImplementation?: string;
@@ -219,7 +221,7 @@ export class Workspaces {
     generator: string
   ): {
     generatorsFilePath: string;
-    generatorsJson: any;
+    generatorsJson: GeneratorsJson;
     normalizedGeneratorName: string;
   } {
     let generatorsFilePath;
@@ -242,7 +244,7 @@ export class Workspaces {
         path.join(path.dirname(packageJsonPath), generatorsFile)
       );
     }
-    const generatorsJson = readJsonFile(generatorsFilePath);
+    const generatorsJson = readJsonFile<GeneratorsJson>(generatorsFilePath);
 
     let normalizedGeneratorName =
       findFullGeneratorName(generator, generatorsJson.generators) ||


### PR DESCRIPTION
## Current Behavior
Some interfaces are in `migrate.ts`, a command file
## Expected Behavior
Interfaces are separated from logic.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
