### PR TITLE
fix(testing): provide descriptive message when project is missing targets for cypress-project generator

### DIFF
--- a/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
@@ -413,6 +413,23 @@ describe('schematic:cypress-project', () => {
           expect(projectConfig.tags).toEqual([]);
         });
       });
+
+      it('should not throw an error when --project does not have targets', async () => {
+        const projectConf = readProjectConfiguration(tree, 'my-app');
+        delete projectConf.targets;
+
+        updateProjectConfiguration(tree, 'my-app', projectConf);
+        await cypressProjectGenerator(tree, {
+          name: 'my-app-e2e',
+          project: 'my-app',
+          linter: Linter.EsLint,
+        });
+
+        const projectConfig = readProjectConfiguration(tree, 'my-app-e2e');
+        expect(projectConfig.targets['e2e'].options.devServerTarget).toEqual(
+          'my-app:serve'
+        );
+      });
     });
 
     describe('--linter', () => {

--- a/packages/cypress/src/generators/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.ts
@@ -13,6 +13,8 @@ import {
   Tree,
   updateJson,
   ProjectConfiguration,
+  stripIndents,
+  logger,
 } from '@nrwl/devkit';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
@@ -82,8 +84,15 @@ function addProject(tree: Tree, options: CypressProjectSchema) {
     };
   } else if (options.project) {
     const project = readProjectConfiguration(tree, options.project);
+
+    if (!project.targets) {
+      logger.warn(stripIndents`
+      NOTE: Project, "${options.project}", does not have any targets defined and a baseUrl was not provided. Nx will use  
+      "${options.project}:serve" as the devServerTarget. But you may need to define this target within the project, "${options.project}".
+      `);
+    }
     const devServerTarget =
-      project.targets.serve && project.targets.serve.defaultConfiguration
+      project.targets?.serve && project.targets?.serve?.defaultConfiguration
         ? `${options.project}:serve:${project.targets.serve.defaultConfiguration}`
         : `${options.project}:serve`;
     e2eProjectConfig = {


### PR DESCRIPTION
when trying to add cypress to a project that does not contain a serve target the project will error
out because of a null reference.
Now when trying to add to a project without a serve target a more
descriptive error is throw stating to add a serve target or use the --baseUrl flag

Note: a future update should add the parameter to override what target to use if so desired.


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9756
