### PR TITLE
docs(angular): hide mfe options from the app generator

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -183,19 +183,22 @@
           "mfe": {
             "description": "Generate a Module Federation configuration for the application",
             "type": "boolean",
-            "default": false
+            "default": false,
+            "x-deprecated": "Use the `mfe-host` or `mfe-remote` generators instead. Support for generating MFE applications using the application generator will be removed in an upcoming version."
           },
           "mfeType": {
             "type": "string",
             "enum": ["host", "remote"],
             "description": "Type of application to generate the Module Federation configuration for.",
-            "default": "remote"
+            "default": "remote",
+            "x-deprecated": "Use the `mfe-host` or `mfe-remote` generators instead. Support for generating MFE applications using the application generator will be removed in an upcoming version."
           },
           "federationType": {
             "type": "string",
             "enum": ["static", "dynamic"],
             "description": "Use either Static or Dynamic Module Federation pattern for the application.",
-            "default": "static"
+            "default": "static",
+            "x-deprecated": "Use the `mfe-host` or `mfe-remote` generators instead. Support for generating MFE applications using the application generator will be removed in an upcoming version."
           },
           "port": {
             "type": "number",
@@ -203,11 +206,13 @@
           },
           "remotes": {
             "type": "array",
-            "description": "A list of remote application names that the host application should consume."
+            "description": "A list of remote application names that the host application should consume.",
+            "x-deprecated": "Use the `mfe-host` or `mfe-remote` generators instead. Support for generating MFE applications using the application generator will be removed in an upcoming version."
           },
           "host": {
             "type": "string",
-            "description": "The name of the host application that the remote application will be consumed by."
+            "description": "The name of the host application that the remote application will be consumed by.",
+            "x-deprecated": "Use the `mfe-host` or `mfe-remote` generators instead. Support for generating MFE applications using the application generator will be removed in an upcoming version."
           },
           "setParserOptionsProject": {
             "type": "boolean",

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -130,19 +130,22 @@
     "mfe": {
       "description": "Generate a Module Federation configuration for the application",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-deprecated": "Use the `mfe-host` or `mfe-remote` generators instead. Support for generating MFE applications using the application generator will be removed in an upcoming version."
     },
     "mfeType": {
       "type": "string",
       "enum": ["host", "remote"],
       "description": "Type of application to generate the Module Federation configuration for.",
-      "default": "remote"
+      "default": "remote",
+      "x-deprecated": "Use the `mfe-host` or `mfe-remote` generators instead. Support for generating MFE applications using the application generator will be removed in an upcoming version."
     },
     "federationType": {
       "type": "string",
       "enum": ["static", "dynamic"],
       "description": "Use either Static or Dynamic Module Federation pattern for the application.",
-      "default": "static"
+      "default": "static",
+      "x-deprecated": "Use the `mfe-host` or `mfe-remote` generators instead. Support for generating MFE applications using the application generator will be removed in an upcoming version."
     },
     "port": {
       "type": "number",
@@ -150,11 +153,13 @@
     },
     "remotes": {
       "type": "array",
-      "description": "A list of remote application names that the host application should consume."
+      "description": "A list of remote application names that the host application should consume.",
+      "x-deprecated": "Use the `mfe-host` or `mfe-remote` generators instead. Support for generating MFE applications using the application generator will be removed in an upcoming version."
     },
     "host": {
       "type": "string",
-      "description": "The name of the host application that the remote application will be consumed by."
+      "description": "The name of the host application that the remote application will be consumed by.",
+      "x-deprecated": "Use the `mfe-host` or `mfe-remote` generators instead. Support for generating MFE applications using the application generator will be removed in an upcoming version."
     },
     "setParserOptionsProject": {
       "type": "boolean",


### PR DESCRIPTION
## Current Behavior
We would prefer if people created MFE's using the  `nx g remote` and `nx g host` generators.   
However, it is possible to see and use the app generator to do this currently.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Let's discourage the usage of the app generator directly to create MFEs by hiding the options from the documentation.
