### PR TITLE
docs(nxdev): lookup to package.json version for vercel script

### DIFF
--- a/scripts/vercel/ignore-build.sh
+++ b/scripts/vercel/ignore-build.sh
@@ -4,7 +4,7 @@
 # Exits with 0 if the build should be skipped, and exits with 1 to continue.
 
 APP=$1
-NX_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@nrwl/workspace'])")
+NX_VERSION=$(node -e "console.log(require('./package.json').version)")
 
 # Need the workspace in order to run affected
 yarn add -D @nrwl/workspace@$NX_VERSION --prefer-offline


### PR DESCRIPTION
Makes the Vercel script looking for the current Nx version by grabbing the version number in the `package.json`.