### PR TITLE
fix(core): build-project-graph shouldn't fail when large number of workers are available

### DIFF
--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -49,7 +49,6 @@ export async function buildProjectGraph() {
 
   const cacheEnabled = process.env.NX_CACHE_PROJECT_GRAPH !== 'false';
   let cache = cacheEnabled ? readCache() : null;
-
   return (
     await buildProjectGraphUsingProjectFileMap(
       workspaceJson,
@@ -292,7 +291,10 @@ function buildExplicitDependenciesUsingWorkers(
   totalNumOfFilesToProcess: number,
   builder: ProjectGraphBuilder
 ) {
-  const numberOfWorkers = getNumberOfWorkers();
+  const numberOfWorkers = Math.min(
+    totalNumOfFilesToProcess,
+    getNumberOfWorkers()
+  );
   const bins = splitFilesIntoBins(
     ctx,
     totalNumOfFilesToProcess,


### PR DESCRIPTION
## Current Behavior
More workers are created than needed for processing all files

## Expected Behavior
Excess workers are not spawned

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
