### PR TITLE
fix(react): migrate react-test-renderer correctly

### DIFF
--- a/packages/react/src/migrations/update-13-10-0/update-13-10-0.ts
+++ b/packages/react/src/migrations/update-13-10-0/update-13-10-0.ts
@@ -1,7 +1,7 @@
 import {
   addDependenciesToPackageJson,
-  readJson,
   logger,
+  readJson,
   Tree,
 } from '@nrwl/devkit';
 
@@ -24,9 +24,10 @@ export async function updateToReact18(host: Tree) {
         react: '18.0.0',
         'react-dom': '18.0.0',
         'react-is': '18.0.0',
-        'react-test-renderer': '18.0.0',
       },
-      {}
+      {
+        'react-test-renderer': '18.0.0',
+      }
     );
   }
 }


### PR DESCRIPTION
This PR fixes `react-test-renderer` to migrate in `devDependencies` rather than `dependencies`.


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9734 
