### PR TITLE
fix(core): allow parsing dot notation cli args

### DIFF
--- a/packages/nx/src/command-line/nx-commands.spec.ts
+++ b/packages/nx/src/command-line/nx-commands.spec.ts
@@ -1,0 +1,24 @@
+import { commandsObject } from 'nx/src/command-line/nx-commands';
+
+describe('nx-commands', () => {
+  it('should parse dot notion cli args', () => {
+    const actual = commandsObject.parse(
+      'nx e2e project-e2e --env.NX_API_URL=http://localhost:4200 --abc.123.xyx=false --a.b=3'
+    );
+    expect(actual).toEqual(
+      expect.objectContaining({
+        abc: {
+          '123': {
+            xyx: 'false',
+          },
+        },
+        a: {
+          b: 3,
+        },
+        env: {
+          NX_API_URL: 'http://localhost:4200',
+        },
+      })
+    );
+  });
+});

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -25,7 +25,8 @@ yargs.wrap(yargs.terminalWidth());
 export const commandsObject = yargs
   .parserConfiguration({
     'strip-dashed': true,
-    'dot-notation': false,
+    // allow parsing --env.SOME_ARG for cypress cli env args
+    'dot-notation': true,
   })
   .usage(
     `


### PR DESCRIPTION
parse dot notation cli args for env args passed to cypress executor to override cypress.env.json
values.
i.e. `nx e2e project --env.API_URL=localhost:1234`
will now correctly give cypress e2e args to
override the cypress.env.json values

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`nx e2e project --env.API_URL=localhost:1234` does not parse the correct env args for cypress

## Expected Behavior
`nx e2e project --env.API_URL=localhost:1234` correctly is parsed for cypress

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9764
