### PR TITLE
fix(core): remove @nrwl/workspace when adding nx to monorepo

### DIFF
--- a/docs/generated/packages/nx.json
+++ b/docs/generated/packages/nx.json
@@ -5,5 +5,31 @@
   "root": "/packages/nx",
   "source": "/packages/nx/src",
   "generators": [],
-  "executors": []
+  "executors": [
+    {
+      "name": "run-script",
+      "implementation": "/packages/nx/src/executors/run-script/run-script.impl.ts",
+      "schema": {
+        "title": "Run Script",
+        "description": "Run any NPM script of a project in the project's root directory.",
+        "type": "object",
+        "cli": "nx",
+        "outputCapture": "pipe",
+        "properties": {
+          "script": {
+            "type": "string",
+            "description": "An npm script name in the `package.json` file of the project (e.g., `build`)."
+          }
+        },
+        "additionalProperties": true,
+        "required": ["script"],
+        "examplesFile": "`workspace.json`:\n\n```json\n\"frontend\": {\n    \"root\": \"packages/frontend\",\n    \"targets\": {\n        \"build\": {\n            \"executor\": \"@nrwl/workspace:run-script\",\n            \"options\": {\n                \"script\": \"build-my-project\"\n            }\n        }\n    }\n}\n```\n\n```bash\nnx run frontend:build\n```\n\nThe `build` target is going to run `npm run build-my-project` (or `yarn build-my-project`) in the `packages/frontend` directory.\n\n#### Caching Artifacts\n\nBy default, Nx is going to cache `dist/packages/frontend`, `packages/frontend/dist`, `packages/frontend/build`, `packages/frontend/public`. If your npm script writes files to other places, you can override the list of cached outputs as follows:\n\n```json\n\"frontend\": {\n    \"root\": \"packages/frontend\",\n    \"targets\": {\n        \"build\": {\n            \"executor\": \"@nrwl/workspace:run-script\",\n            \"outputs\": [\"packages/frontend/dist\", \"packaged/frontend/docs\"],\n            \"options\": {\n                \"script\": \"build-my-project\"\n            }\n        }\n    }\n}\n```\n",
+        "presets": []
+      },
+      "description": "Run an NPM script using Nx.",
+      "aliases": [],
+      "hidden": false,
+      "path": "/packages/nx/src/executors/run-script/schema.json"
+    }
+  ]
 }

--- a/docs/packages.json
+++ b/docs/packages.json
@@ -170,7 +170,7 @@
   {
     "name": "nx",
     "path": "generated/packages/nx.json",
-    "schemas": { "executors": [], "generators": [] }
+    "schemas": { "executors": ["run-script"], "generators": [] }
   },
   {
     "name": "nx-plugin",

--- a/packages/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
+++ b/packages/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
@@ -189,7 +189,7 @@ function detectWorkspaceScope(repoRoot: string) {
 function createNxJsonFile(repoRoot: string) {
   const scope = detectWorkspaceScope(repoRoot);
   const res = {
-    extends: '@nrwl/workspace/presets/npm.json',
+    extends: 'nx/presets/npm.json',
     npmScope: scope,
     tasksRunnerOptions: {
       default: {
@@ -267,7 +267,6 @@ function deduceDefaultBase() {
 function addDepsToPackageJson(repoRoot: string, useCloud: boolean) {
   const json = readJsonFile(repoRoot, `package.json`);
   if (!json.devDependencies) json.devDependencies = {};
-  json.devDependencies['@nrwl/workspace'] = 'NX_VERSION';
   json.devDependencies['nx'] = 'NX_VERSION';
   if (useCloud) {
     json.devDependencies['@nrwl/nx-cloud'] = 'latest';

--- a/packages/nx/docs/run-script-examples.md
+++ b/packages/nx/docs/run-script-examples.md
@@ -1,0 +1,40 @@
+`workspace.json`:
+
+```json
+"frontend": {
+    "root": "packages/frontend",
+    "targets": {
+        "build": {
+            "executor": "@nrwl/workspace:run-script",
+            "options": {
+                "script": "build-my-project"
+            }
+        }
+    }
+}
+```
+
+```bash
+nx run frontend:build
+```
+
+The `build` target is going to run `npm run build-my-project` (or `yarn build-my-project`) in the `packages/frontend` directory.
+
+#### Caching Artifacts
+
+By default, Nx is going to cache `dist/packages/frontend`, `packages/frontend/dist`, `packages/frontend/build`, `packages/frontend/public`. If your npm script writes files to other places, you can override the list of cached outputs as follows:
+
+```json
+"frontend": {
+    "root": "packages/frontend",
+    "targets": {
+        "build": {
+            "executor": "@nrwl/workspace:run-script",
+            "outputs": ["packages/frontend/dist", "packaged/frontend/docs"],
+            "options": {
+                "script": "build-my-project"
+            }
+        }
+    }
+}
+```

--- a/packages/nx/executors.json
+++ b/packages/nx/executors.json
@@ -1,0 +1,9 @@
+{
+  "executors": {
+    "run-script": {
+      "implementation": "./src/executors/run-script/run-script.impl",
+      "schema": "./src/executors/run-script/schema.json",
+      "description": "Run an NPM script using Nx."
+    }
+  }
+}

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -1,0 +1,3 @@
+{
+  "migrations": {}
+}

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -61,29 +61,33 @@
     "enquirer": "~2.3.6",
     "tslib": "^2.3.0"
   },
-  "ng-update": {
-    "requirements": {},
-    "packageGroup": {
-      "@nrwl/workspace": "*",
-      "@nrwl/angular": "*",
-      "@nrwl/cypress": "*",
-      "@nrwl/devkit": "*",
-      "@nrwl/eslint-plugin-nx": "*",
-      "@nrwl/express": "*",
-      "@nrwl/jest": "*",
-      "@nrwl/linter": "*",
-      "@nrwl/nest": "*",
-      "@nrwl/next": "*",
-      "@nrwl/node": "*",
-      "@nrwl/nx-plugin": "*",
-      "@nrwl/react": "*",
-      "@nrwl/storybook": "*",
-      "@nrwl/web": "*",
-      "@nrwl/js": "*",
-      "@nrwl/cli": "*",
-      "@nrwl/nx-cloud": "latest",
-      "@nrwl/react-native": "*",
-      "@nrwl/detox": "*"
-    }
-  }
+  "nx-migrations": {
+    "migrations": "./migrations.json",
+    "packageGroup": [
+      "@nrwl/workspace",
+      "@nrwl/angular",
+      "@nrwl/cypress",
+      "@nrwl/devkit",
+      "@nrwl/eslint-plugin-nx",
+      "@nrwl/express",
+      "@nrwl/jest",
+      "@nrwl/linter",
+      "@nrwl/nest",
+      "@nrwl/next",
+      "@nrwl/node",
+      "@nrwl/nx-plugin",
+      "@nrwl/react",
+      "@nrwl/storybook",
+      "@nrwl/web",
+      "@nrwl/js",
+      "@nrwl/cli",
+      {
+        "package": "@nrwl/nx-cloud",
+        "version": "latest"
+      },
+      "@nrwl/react-native",
+      "@nrwl/detox"
+    ]
+  },
+  "executors": "./executors.json"
 }

--- a/packages/nx/presets/core.json
+++ b/packages/nx/presets/core.json
@@ -1,0 +1,21 @@
+{
+  "implicitDependencies": {
+    "package.json": {
+      "dependencies": "*",
+      "devDependencies": "*"
+    },
+    ".eslintrc.json": "*"
+  },
+  "targetDependencies": {
+    "build": [
+      {
+        "target": "build",
+        "projects": "dependencies"
+      }
+    ]
+  },
+  "workspaceLayout": {
+    "appsDir": "packages",
+    "libsDir": "packages"
+  }
+}

--- a/packages/nx/presets/npm.json
+++ b/packages/nx/presets/npm.json
@@ -1,0 +1,20 @@
+{
+  "implicitDependencies": {
+    "package.json": {
+      "dependencies": "*",
+      "devDependencies": "*"
+    },
+    ".eslintrc.json": "*"
+  },
+  "targetDependencies": {
+    "build": [
+      {
+        "target": "build",
+        "projects": "dependencies"
+      }
+    ]
+  },
+  "workspaceLayout": {
+    "libsDir": "packages"
+  }
+}

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -49,6 +49,12 @@
       },
       "outputs": ["{options.outputPath}"]
     },
+    "echo": {
+      "executor": "nx:command",
+      "options": {
+        "command": "echo hi"
+      }
+    },
     "build": {
       "executor": "@nrwl/workspace:run-commands",
       "outputs": ["build/packages/nx"],

--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -771,8 +771,14 @@ describe('Migration', () => {
       expect(
         parseMigrationsOptions({ packageAndVersion: 'next' })
       ).toMatchObject({
-        targetPackage: '@nrwl/workspace',
+        targetPackage: 'nx',
         targetVersion: 'next',
+      });
+      expect(
+        parseMigrationsOptions({ packageAndVersion: '13.10.0' })
+      ).toMatchObject({
+        targetPackage: '@nrwl/workspace',
+        targetVersion: '13.10.0',
       });
       expect(
         parseMigrationsOptions({ packageAndVersion: '@nrwl/workspace@8.12' })

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -229,8 +229,28 @@ export class Migrator {
       packageName === '@nrwl/workspace' &&
       lt(targetVersion, '14.0.0-beta.0')
     ) {
-      migration.packageGroup =
-        require('../../package.json')['ng-update'].packageGroup;
+      migration.packageGroup = {
+        '@nrwl/workspace': targetVersion,
+        '@nrwl/angular': targetVersion,
+        '@nrwl/cypress': targetVersion,
+        '@nrwl/devkit': targetVersion,
+        '@nrwl/eslint-plugin-nx': targetVersion,
+        '@nrwl/express': targetVersion,
+        '@nrwl/jest': targetVersion,
+        '@nrwl/linter': targetVersion,
+        '@nrwl/nest': targetVersion,
+        '@nrwl/next': targetVersion,
+        '@nrwl/node': targetVersion,
+        '@nrwl/nx-plugin': targetVersion,
+        '@nrwl/react': targetVersion,
+        '@nrwl/storybook': targetVersion,
+        '@nrwl/web': targetVersion,
+        '@nrwl/js': targetVersion,
+        '@nrwl/cli': targetVersion,
+        '@nrwl/nx-cloud': 'latest',
+        '@nrwl/react-native': targetVersion,
+        '@nrwl/detox': targetVersion,
+      };
     }
 
     if (migration.packageGroup) {
@@ -348,7 +368,7 @@ function versionOverrides(overrides: string, param: string) {
 function parseTargetPackageAndVersion(args: string) {
   if (!args) {
     throw new Error(
-      `Provide the correct package name and version. E.g., @nrwl/workspace@9.0.0.`
+      `Provide the correct package name and version. E.g., my-package@9.0.0.`
     );
   }
 
@@ -363,7 +383,7 @@ function parseTargetPackageAndVersion(args: string) {
       const maybeVersion = args.substring(i + 1);
       if (!targetPackage || !maybeVersion) {
         throw new Error(
-          `Provide the correct package name and version. E.g., @nrwl/workspace@9.0.0.`
+          `Provide the correct package name and version. E.g., my-package@9.0.0.`
         );
       }
       const targetVersion = normalizeVersionWithTagCheck(maybeVersion);
@@ -375,9 +395,16 @@ function parseTargetPackageAndVersion(args: string) {
       args === 'latest' ||
       args === 'next'
     ) {
+      const targetVersion = normalizeVersionWithTagCheck(args);
+      const targetPackage =
+        args.match(/^\d+(?:\.\d+)?(?:\.\d+)?$/) &&
+        lt(targetVersion, '14.0.0-beta.0')
+          ? '@nrwl/workspace'
+          : 'nx';
+
       return {
-        targetPackage: '@nrwl/workspace',
-        targetVersion: normalizeVersionWithTagCheck(args),
+        targetPackage,
+        targetVersion,
       };
     } else {
       return {

--- a/packages/nx/src/executors/run-script/run-script.impl.ts
+++ b/packages/nx/src/executors/run-script/run-script.impl.ts
@@ -1,0 +1,35 @@
+import { execSync } from 'child_process';
+import { getPackageManagerCommand } from '../../utils/package-manager';
+import type { ExecutorContext } from '../../config/misc-interfaces';
+import * as path from 'path';
+
+export interface RunScriptOptions {
+  script: string;
+}
+
+export default async function (
+  options: RunScriptOptions,
+  context: ExecutorContext
+) {
+  const pm = getPackageManagerCommand();
+  const script = options.script;
+  delete options.script;
+
+  const args = [];
+  Object.keys(options).forEach((r) => {
+    args.push(`--${r}=${options[r]}`);
+  });
+
+  try {
+    execSync(pm.run(script, args.join(' ')), {
+      stdio: ['inherit', 'inherit', 'inherit'],
+      cwd: path.join(
+        context.root,
+        context.workspace.projects[context.projectName].root
+      ),
+    });
+    return { success: true };
+  } catch (e) {
+    return { success: false };
+  }
+}

--- a/packages/nx/src/executors/run-script/schema.json
+++ b/packages/nx/src/executors/run-script/schema.json
@@ -1,0 +1,16 @@
+{
+  "title": "Run Script",
+  "description": "Run any NPM script of a project in the project's root directory.",
+  "type": "object",
+  "cli": "nx",
+  "outputCapture": "pipe",
+  "properties": {
+    "script": {
+      "type": "string",
+      "description": "An npm script name in the `package.json` file of the project (e.g., `build`)."
+    }
+  },
+  "additionalProperties": true,
+  "required": ["script"],
+  "examplesFile": "../../../docs/run-script-examples.md"
+}

--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -4,9 +4,9 @@ import {
 } from './package-json';
 
 describe('buildTargetFromScript', () => {
-  it('should use @nrwl/workspace:run-script', () => {
+  it('should use nx:run-script', () => {
     const target = buildTargetFromScript('build', null);
-    expect(target.executor).toEqual('@nrwl/workspace:run-script');
+    expect(target.executor).toEqual('nx:run-script');
   });
 
   it('should use options provided in nx target package json configuration', () => {
@@ -35,6 +35,6 @@ describe('buildTargetFromScript', () => {
     });
 
     expect(target.options.script).toEqual('build');
-    expect(target.executor).toEqual('@nrwl/workspace:run-script');
+    expect(target.executor).toEqual('nx:run-script');
   });
 });

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -52,7 +52,7 @@ export function buildTargetFromScript(
 
   return {
     ...nxTargetConfiguration,
-    executor: '@nrwl/workspace:run-script',
+    executor: 'nx:run-script',
     options: {
       ...(nxTargetConfiguration.options || {}),
       script,

--- a/packages/nx/src/utils/project-graph-utils.spec.ts
+++ b/packages/nx/src/utils/project-graph-utils.spec.ts
@@ -114,7 +114,7 @@ describe('project graph utils', () => {
     };
 
     const packageJsonBuildTarget = {
-      executor: '@nrwl/workspace:run-script',
+      executor: 'nx:run-script',
       options: {
         script: 'build',
       },
@@ -191,7 +191,7 @@ describe('project graph utils', () => {
 
       expect(result).toEqual({
         build: {
-          executor: '@nrwl/workspace:run-script',
+          executor: 'nx:run-script',
           options: {
             script: 'build',
           },
@@ -220,7 +220,7 @@ describe('project graph utils', () => {
           options: { command: 'echo hi' },
         },
         test: {
-          executor: '@nrwl/workspace:run-script',
+          executor: 'nx:run-script',
           options: { script: 'test' },
         },
       });

--- a/packages/workspace/src/executors/run-script/run-script.impl.ts
+++ b/packages/workspace/src/executors/run-script/run-script.impl.ts
@@ -1,35 +1,5 @@
-import { execSync } from 'child_process';
-import { getPackageManagerCommand } from '@nrwl/devkit';
-import type { ExecutorContext } from '@nrwl/devkit';
-import * as path from 'path';
+import runScript from 'nx/src/executors/run-script/run-script.impl';
 
-export interface RunScriptOptions {
-  script: string;
-}
+export { RunScriptOptions } from 'nx/src/executors/run-script/run-script.impl';
 
-export default async function (
-  options: RunScriptOptions,
-  context: ExecutorContext
-) {
-  const pm = getPackageManagerCommand();
-  const script = options.script;
-  delete options.script;
-
-  const args = [];
-  Object.keys(options).forEach((r) => {
-    args.push(`--${r}=${options[r]}`);
-  });
-
-  try {
-    execSync(pm.run(script, args.join(' ')), {
-      stdio: ['inherit', 'inherit', 'inherit'],
-      cwd: path.join(
-        context.root,
-        context.workspace.projects[context.projectName].root
-      ),
-    });
-    return { success: true };
-  } catch (e) {
-    return { success: false };
-  }
-}
+export default runScript;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`@nrwl/workspace` is added as part of `add-nx-to-monorepo` and is pretty much necessary for most nx workspaces.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@nrwl/workspace` is not added as part of `add-nx-to-monorepo`, leaving only `nx` being added.

1. `nx migrate latest` will equate to `nx migrate nx@latest` instead of `nx migrate @nrwl/workspace@latest`
2. `nx` also exposes `nx/presets/npm.json`
3. `nx` exposes `run-script`
  a. `@nrwl/workspace:run-script` re-exports `nx:run-script`