### PR TITLE
fix(storybook): remove hard-coded ci:true option

### DIFF
--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -46,7 +46,6 @@ function runInstance(options: StorybookExecutorOptions) {
   process.env.NODE_ENV = env;
   return buildDevStandalone({
     ...options,
-    ci: true,
     configType: env.toUpperCase(),
   } as any).catch((error) => {
     // TODO(juri): find a better cleaner way to handle these. Taken from:


### PR DESCRIPTION
ISSUES CLOSED: #9681

## Current Behavior
[This issue](https://github.com/nrwl/nx/issues/9681) is due to [this line here](https://github.com/nrwl/nx/blob/master/packages/storybook/src/executors/storybook/storybook.impl.ts#L49).

```
  return buildDevStandalone({
    ...options,
    ci: true,
```
our hard-coded `ci: true`.

In the [Storybook docs](https://storybook.js.org/docs/react/api/cli-options) it says for the `--ci` option: "CI mode (skip interactive prompts, don't open browser)"

This line `ci: true`  has been there since the beginning of time. It is believed to have been put there back in 2019 to avoid interactive prompts. Interactive prompts no longer happen, even if we remove the `ci: true`. 

Here's the [Storybook code](https://github.com/storybookjs/storybook/blob/next/lib/core-server/src/dev-server.ts#L116) for reference:
```
  if (!options.ci && !options.smokeTest && options.open) {
```

As to why for pure Storybook apps it opens automatically, it's because [this transformation here](https://github.com/storybookjs/storybook/blob/next/lib/core-server/src/build-dev.ts#L132) adds the `open: true` option. We don't do this step in our server, because we use `buildDevStandalone` (we will use `buildDev` eventually):
```
  const cliOptions = await getDevCli(loadOptions.packageJson);
```

## Expected Behavior

User can pass `--open` and it will not be ignored. 

## Related Issue(s)

#9681

