### PR TITLE
Add @nrwl/workspace to nx migrations

### DIFF
--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -59,6 +59,12 @@
       "description": "Changes the presets in nx.json to come from the nx package",
       "cli": "nx",
       "implementation": "./src/migrations/update-14-0-0/change-nx-json-presets"
+    },
+    "14-0-0-change-npm-script-executor": {
+      "version": "14.0.0-beta.0",
+      "description": "Migrates from @nrwl/workspace:run-script to nx:run-script",
+      "cli": "nx",
+      "implementation": "./src/migrations/update-14-0-0/change-npm-script-executor"
     }
   },
   "packageJsonUpdates": {

--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -53,6 +53,12 @@
       "description": "Update the tasks runner property to import it from the nx package instead of @nrwl/worksapce",
       "cli": "nx",
       "implementation": "./src/migrations/update-13-10-0/update-tasks-runner"
+    },
+    "14-0-0-change-nx-json-presets": {
+      "version": "14.0.0-beta.0",
+      "description": "Changes the presets in nx.json to come from the nx package",
+      "cli": "nx",
+      "implementation": "./src/migrations/update-14-0-0/change-nx-json-presets"
     }
   },
   "packageJsonUpdates": {

--- a/packages/workspace/src/migrations/update-14-0-0/change-npm-script-executor.spec.ts
+++ b/packages/workspace/src/migrations/update-14-0-0/change-npm-script-executor.spec.ts
@@ -1,0 +1,52 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  readProjectConfiguration,
+  readWorkspaceConfiguration,
+  Tree,
+  updateWorkspaceConfiguration,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import changeNpmScriptExecutor from './change-npm-script-executor';
+
+describe('changeNxJsonPresets', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    addProjectConfiguration(tree, 'proj1', {
+      root: 'proj1',
+      targets: {
+        scriptTarget: {
+          executor: '@nrwl/workspace:run-script',
+          options: {},
+        },
+        notScriptTarget: {
+          executor: '@nrwl/workspace:something',
+          options: {},
+        },
+      },
+    });
+  });
+
+  it('should change the npm script executor to nx:npm-script', async () => {
+    await changeNpmScriptExecutor(tree);
+
+    expect(readProjectConfiguration(tree, 'proj1')).toMatchInlineSnapshot(`
+      Object {
+        "root": "proj1",
+        "targets": Object {
+          "notScriptTarget": Object {
+            "executor": "@nrwl/workspace:something",
+            "options": Object {},
+          },
+          "scriptTarget": Object {
+            "executor": "nx:run-script",
+            "options": Object {},
+          },
+        },
+      }
+    `);
+  });
+});

--- a/packages/workspace/src/migrations/update-14-0-0/change-npm-script-executor.ts
+++ b/packages/workspace/src/migrations/update-14-0-0/change-npm-script-executor.ts
@@ -1,0 +1,29 @@
+import {
+  formatFiles,
+  readProjectConfiguration,
+  readWorkspaceConfiguration,
+  TargetConfiguration,
+  Tree,
+  updateProjectConfiguration,
+  updateWorkspaceConfiguration,
+} from '@nrwl/devkit';
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+
+export async function changeNpmScriptExecutor(tree: Tree) {
+  forEachExecutorOptions(
+    tree,
+    '@nrwl/workspace:run-script',
+    (currentValue, project, target) => {
+      const projectConfig = readProjectConfiguration(tree, project);
+      const targetConfig = projectConfig.targets[target];
+
+      targetConfig.executor = 'nx:run-script';
+
+      updateProjectConfiguration(tree, project, projectConfig);
+    }
+  );
+
+  await formatFiles(tree);
+}
+
+export default changeNpmScriptExecutor;

--- a/packages/workspace/src/migrations/update-14-0-0/change-nx-json-presets.spec.ts
+++ b/packages/workspace/src/migrations/update-14-0-0/change-nx-json-presets.spec.ts
@@ -1,0 +1,47 @@
+import {
+  readJson,
+  readWorkspaceConfiguration,
+  Tree,
+  updateWorkspaceConfiguration,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import changeNxJsonPresets from '@nrwl/workspace/src/migrations/update-14-0-0/change-nx-json-presets';
+
+describe('changeNxJsonPresets', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should not set any new extends', async () => {
+    await changeNxJsonPresets(tree);
+
+    const nxJson = readJson(tree, 'nx.json');
+    expect(nxJson.extends).toBeUndefined();
+  });
+
+  it('should change @nrwl/workspace/presets/npm.json', async () => {
+    updateWorkspaceConfiguration(tree, {
+      ...readWorkspaceConfiguration(tree),
+      extends: '@nrwl/workspace/presets/npm.json',
+    });
+
+    await changeNxJsonPresets(tree);
+
+    const nxJson = readJson(tree, 'nx.json');
+    expect(nxJson.extends).toEqual('nx/presets/npm.json');
+  });
+
+  it('should change @nrwl/workspace/presets/core.json', async () => {
+    updateWorkspaceConfiguration(tree, {
+      ...readWorkspaceConfiguration(tree),
+      extends: '@nrwl/workspace/presets/core.json',
+    });
+
+    await changeNxJsonPresets(tree);
+
+    const nxJson = readJson(tree, 'nx.json');
+    expect(nxJson.extends).toEqual('nx/presets/core.json');
+  });
+});

--- a/packages/workspace/src/migrations/update-14-0-0/change-nx-json-presets.ts
+++ b/packages/workspace/src/migrations/update-14-0-0/change-nx-json-presets.ts
@@ -1,0 +1,24 @@
+import {
+  formatFiles,
+  readWorkspaceConfiguration,
+  Tree,
+  updateWorkspaceConfiguration,
+} from '@nrwl/devkit';
+
+export async function changeNxJsonPresets(tree: Tree) {
+  const workspaceConfig = readWorkspaceConfiguration(tree);
+  const replacements = {
+    '@nrwl/workspace/presets/npm.json': 'nx/presets/npm.json',
+    '@nrwl/workspace/presets/core.json': 'nx/presets/core.json',
+  };
+  if (workspaceConfig.extends && replacements[workspaceConfig.extends]) {
+    updateWorkspaceConfiguration(tree, {
+      ...workspaceConfig,
+      extends: replacements[workspaceConfig.extends],
+    });
+  }
+
+  await formatFiles(tree);
+}
+
+export default changeNxJsonPresets;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There are no migrations to move from `@nrwl/workspace/presets/npm.json => nx/presets/npm.json`.
There are no migrations to move from `@nrwl/workspace/presets/core.json => nx/presets/core.json`.
There are no migrations to move from `@nrwl/workspace:run-script => nx:run-script`. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
There are migrations to move from `@nrwl/workspace/presets/npm.json => nx/presets/npm.json`.
There are migrations to move from `@nrwl/workspace/presets/core.json => nx/presets/core.json`.
There are migrations to move from `@nrwl/workspace:run-script => nx:run-script`. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
