### PR TITLE
feat(core): add NX_MIGRATE_USE_NEXT flag to test next version of migrate

### DIFF
--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -714,9 +714,11 @@ function nxCliPath() {
 
     const { dirSync } = require('tmp');
     const tmpDir = dirSync().name;
+    const version =
+      process.env.NX_MIGRATE_USE_NEXT === 'true' ? 'next' : 'latest';
     writeJsonFile(path.join(tmpDir, 'package.json'), {
       dependencies: {
-        nx: 'latest',
+        nx: version,
       },
       license: 'MIT',
     });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `latest` version of the Nx cli is used to run `nx migrate` 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `next` version of the Nx cli is used to run `nx migrate` if the `NX_MIGRATE_USE_NEXT` environment variable is true.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
