### PR TITLE
chore(angular): turn off tailwind e2e tests for now

### DIFF
--- a/e2e/angular-extensions/src/tailwind.test.ts
+++ b/e2e/angular-extensions/src/tailwind.test.ts
@@ -12,7 +12,8 @@ import {
   updateProjectConfig,
 } from '@nrwl/e2e/utils';
 
-describe('Tailwind support', () => {
+// TODO(Colum or Leosvel): Investigate and fix these tests
+describe.skip('Tailwind support', () => {
   let project: string;
 
   const defaultButtonBgColor = 'bg-blue-700';


### PR DESCRIPTION
Skip the tailwind tests until we can investigate more deeply. This should unblock people getting irrelevant failures in their PRs.