### PR TITLE
fix(core): make workspace projects optional

### DIFF
--- a/packages/nx/src/project-graph/affected/affected-project-graph.ts
+++ b/packages/nx/src/project-graph/affected/affected-project-graph.ts
@@ -31,7 +31,7 @@ export function filterAffected(
 ): ProjectGraph {
   const normalizedNxJson = normalizeNxJson(
     nxJson,
-    Object.keys(workspaceJson.projects)
+    Object.keys(workspaceJson.projects || {})
   );
   // Additional affected logic should be in this array.
   const touchedProjectLocators: TouchedProjectLocator[] = [

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -76,7 +76,7 @@ export async function buildProjectGraphUsingProjectFileMap(
   assertWorkspaceValidity(workspaceJson, nxJson);
   const normalizedNxJson = normalizeNxJson(
     nxJson,
-    Object.keys(workspaceJson.projects)
+    Object.keys(workspaceJson.projects || {})
   );
   const packageJsonDeps = readCombinedDeps();
   const rootTsConfig = readRootTsConfig();
@@ -357,7 +357,7 @@ function createContext(
   const projects: Record<
     string,
     ProjectConfiguration & NxJsonProjectConfiguration
-  > = Object.keys(workspaceJson.projects).reduce((map, projectName) => {
+  > = Object.keys(workspaceJson.projects || {}).reduce((map, projectName) => {
     map[projectName] = {
       ...workspaceJson.projects[projectName],
     };

--- a/packages/nx/src/project-graph/file-map-utils.ts
+++ b/packages/nx/src/project-graph/file-map-utils.ts
@@ -6,7 +6,7 @@ function createProjectRootMappings(
   projectFileMap: ProjectFileMap
 ) {
   const projectRootMappings = new Map();
-  for (const projectName of Object.keys(workspaceJson.projects)) {
+  for (const projectName of Object.keys(workspaceJson.projects || {})) {
     if (!projectFileMap[projectName]) {
       projectFileMap[projectName] = [];
     }

--- a/packages/nx/src/utils/assert-workspace-validity.ts
+++ b/packages/nx/src/utils/assert-workspace-validity.ts
@@ -8,7 +8,7 @@ export function assertWorkspaceValidity(
   workspaceJson,
   nxJson: NxJsonConfiguration
 ) {
-  const workspaceJsonProjects = Object.keys(workspaceJson.projects);
+  const workspaceJsonProjects = Object.keys(workspaceJson.projects || {});
 
   const projects = {
     ...workspaceJson.projects,
@@ -26,7 +26,7 @@ export function assertWorkspaceValidity(
         } else if (typeof value === 'string') {
           // This is invalid because the only valid string is '*'
           throw new Error(stripIndents`
-         Configuration Error 
+         Configuration Error
          nx.json is not configured properly. "${path.join(
            ' > '
          )}" is improperly configured to implicitly depend on "${value}" but should be an array of project names or "*".


### PR DESCRIPTION
Make minimal workspace possible by making sure nx commands do not fail when projects are not yet defined.

## Current Behavior
Running nx commands fails if `workspace.json` is not present and if the `projects` field does not point to an object

## Expected Behavior
Projects should not be mandatory when starting with minimal setup

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
