### PR TITLE
fix(web): @nrwl/web:file-server throws 404 after refresh

### DIFF
--- a/docs/generated/packages/web.json
+++ b/docs/generated/packages/web.json
@@ -937,6 +937,11 @@
             "type": "boolean",
             "description": "Watch for file changes.",
             "default": true
+          },
+          "spa": {
+            "type": "boolean",
+            "description": "Redirect 404 errors to index.html (useful for SPA's)",
+            "default": false
           }
         },
         "additionalProperties": false,

--- a/packages/web/src/executors/file-server/schema.d.ts
+++ b/packages/web/src/executors/file-server/schema.d.ts
@@ -11,4 +11,5 @@ export interface Schema {
   withDeps: boolean;
   proxyOptions?: object;
   watch?: boolean;
+  spa: boolean;
 }

--- a/packages/web/src/executors/file-server/schema.json
+++ b/packages/web/src/executors/file-server/schema.json
@@ -60,6 +60,11 @@
       "type": "boolean",
       "description": "Watch for file changes.",
       "default": true
+    },
+    "spa": {
+      "type": "boolean",
+      "description": "Redirect 404 errors to index.html (useful for SPA's)",
+      "default": false
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

As reported in #5118, using @nrwl/web:file-server will get a 404 code on browser refresh for any route other than the root.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Added `spa` option to allow handling of routes other than root.

```json
{
    "buildTarget": "app:build:production",
    "spa": true
}
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5118
