### PR TITLE
feat(core): print normalized generate command to the terminal

### DIFF
--- a/packages/nx/src/tasks-runner/utils.spec.ts
+++ b/packages/nx/src/tasks-runner/utils.spec.ts
@@ -1,4 +1,4 @@
-import { getOutputsForTargetAndConfiguration, unparse } from './utils';
+import { getOutputsForTargetAndConfiguration } from './utils';
 import { ProjectGraphProjectNode } from '../config/project-graph';
 
 describe('utils', () => {
@@ -199,75 +199,6 @@ describe('utils', () => {
           'root-myapp/public',
         ]);
       });
-    });
-  });
-
-  describe('unparse', () => {
-    it('should unparse options whose values are primitives', () => {
-      const options = {
-        boolean1: false,
-        boolean2: true,
-        number: 4,
-        string: 'foo',
-        'empty-string': '',
-        ignore: null,
-      };
-
-      expect(unparse(options)).toEqual([
-        '--no-boolean1',
-        '--boolean2',
-        '--number=4',
-        '--string=foo',
-        '--empty-string=',
-      ]);
-    });
-
-    it('should unparse options whose values are arrays', () => {
-      const options = {
-        array1: [1, 2],
-        array2: [3, 4],
-      };
-
-      expect(unparse(options)).toEqual([
-        '--array1=1',
-        '--array1=2',
-        '--array2=3',
-        '--array2=4',
-      ]);
-    });
-
-    it('should unparse options whose values are objects', () => {
-      const options = {
-        foo: {
-          x: 'x',
-          y: 'y',
-          w: [1, 2],
-          z: [3, 4],
-        },
-      };
-
-      expect(unparse(options)).toEqual([
-        '--foo.x=x',
-        '--foo.y=y',
-        '--foo.w=1',
-        '--foo.w=2',
-        '--foo.z=3',
-        '--foo.z=4',
-      ]);
-    });
-
-    it('should quote string values with space(s)', () => {
-      const options = {
-        string1: 'one',
-        string2: 'one two',
-        string3: 'one two three',
-      };
-
-      expect(unparse(options)).toEqual([
-        '--string1=one',
-        '--string2="one two"',
-        '--string3="one two three"',
-      ]);
     });
   });
 });

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -1,4 +1,3 @@
-import { flatten } from 'flat';
 import { output } from '../utils/output';
 import { Workspaces } from '../config/workspaces';
 import { mergeNpmScriptsWithTargets } from '../utils/project-graph-utils';
@@ -13,6 +12,7 @@ import { getPackageManagerCommand } from '../utils/package-manager';
 import { ProjectGraph, ProjectGraphProjectNode } from '../config/project-graph';
 import { TargetDependencyConfig } from '../config/workspace-json-project-json';
 import { workspaceRoot } from '../utils/app-root';
+import { unparse } from '../utils/params';
 
 export function getCommandAsString(task: Task) {
   const execCommand = getPackageManagerCommand().exec;
@@ -107,47 +107,6 @@ export function getOutputsForTargetAndConfiguration(
   } else {
     return [];
   }
-}
-
-export function unparse(options: Object): string[] {
-  const unparsed = [];
-  for (const key of Object.keys(options)) {
-    const value = options[key];
-    unparseOption(key, value, unparsed);
-  }
-
-  return unparsed;
-}
-
-function unparseOption(key: string, value: any, unparsed: string[]) {
-  if (value === true) {
-    unparsed.push(`--${key}`);
-  } else if (value === false) {
-    unparsed.push(`--no-${key}`);
-  } else if (Array.isArray(value)) {
-    value.forEach((item) => unparseOption(key, item, unparsed));
-  } else if (Object.prototype.toString.call(value) === '[object Object]') {
-    const flattened = flatten<any, any>(value, { safe: true });
-    for (const flattenedKey in flattened) {
-      unparseOption(
-        `${key}.${flattenedKey}`,
-        flattened[flattenedKey],
-        unparsed
-      );
-    }
-  } else if (
-    typeof value === 'string' &&
-    stringShouldBeWrappedIntoQuotes(value)
-  ) {
-    const sanitized = value.replace(/"/g, String.raw`\"`);
-    unparsed.push(`--${key}="${sanitized}"`);
-  } else if (value != null) {
-    unparsed.push(`--${key}=${value}`);
-  }
-}
-
-function stringShouldBeWrappedIntoQuotes(str: string) {
-  return str.includes(' ') || str.includes('{') || str.includes('"');
 }
 
 function interpolateOutputs(template: string, data: any): string {

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -255,6 +255,15 @@ class CLIOutput {
     }
   }
 
+  logGenerateCommand(message: string): void {
+    // normalize the message
+    message = message.replace(/^(nx generate |nx g |generate |g )/, '');
+
+    this.addNewline();
+    this.writeToStdOut(`${chalk.dim('> nx generate')} ${message}`);
+    this.addNewline();
+  }
+
   log({ title, bodyLines, color }: CLIWarnMessageConfig & { color?: string }) {
     this.addNewline();
 

--- a/packages/nx/src/utils/params.spec.ts
+++ b/packages/nx/src/utils/params.spec.ts
@@ -9,6 +9,7 @@ import {
   convertToCamelCase,
   Schema,
   setDefaults,
+  unparse,
   validateOptsAgainstSchema,
   warnDeprecations,
 } from './params';
@@ -1320,6 +1321,75 @@ describe('params', () => {
         false
       );
       expect(options).toEqual({});
+    });
+  });
+
+  describe('unparse', () => {
+    it('should unparse options whose values are primitives', () => {
+      const options = {
+        boolean1: false,
+        boolean2: true,
+        number: 4,
+        string: 'foo',
+        'empty-string': '',
+        ignore: null,
+      };
+
+      expect(unparse(options)).toEqual([
+        '--no-boolean1',
+        '--boolean2',
+        '--number=4',
+        '--string=foo',
+        '--empty-string=',
+      ]);
+    });
+
+    it('should unparse options whose values are arrays', () => {
+      const options = {
+        array1: [1, 2],
+        array2: [3, 4],
+      };
+
+      expect(unparse(options)).toEqual([
+        '--array1=1',
+        '--array1=2',
+        '--array2=3',
+        '--array2=4',
+      ]);
+    });
+
+    it('should unparse options whose values are objects', () => {
+      const options = {
+        foo: {
+          x: 'x',
+          y: 'y',
+          w: [1, 2],
+          z: [3, 4],
+        },
+      };
+
+      expect(unparse(options)).toEqual([
+        '--foo.x=x',
+        '--foo.y=y',
+        '--foo.w=1',
+        '--foo.w=2',
+        '--foo.z=3',
+        '--foo.z=4',
+      ]);
+    });
+
+    it('should quote string values with space(s)', () => {
+      const options = {
+        string1: 'one',
+        string2: 'one two',
+        string3: 'one two three',
+      };
+
+      expect(unparse(options)).toEqual([
+        '--string1=one',
+        '--string2="one two"',
+        '--string3="one two three"',
+      ]);
     });
   });
 });

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -57,7 +57,7 @@ export {
   serializeTarget,
 } from './src/utils/cli-config-utils';
 
-export { unparse } from 'nx/src/tasks-runner/utils';
+export { unparse } from 'nx/src/utils/params';
 
 export {
   getWorkspace,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The normalized generate command that is run by Nx is not printed to the terminal.

When running:
```bash
nx g lib lib1
```
Nx under the hood normalizes the arguments received. Assuming the default collection is `@nrwl/angular` (or it's selected in the prompt), it will transform the above into:
```bash
nx generate @nrwl/angular:library lib1
```

It would be helpful to print the full normalized command to the terminal for clarity on what's being run.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The normalized generate command is printed to the terminal.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
