### PR TITLE
feat(core): add --create-commits option to nx migrate

### DIFF
--- a/docs/generated/cli/migrate.md
+++ b/docs/generated/cli/migrate.md
@@ -52,13 +52,27 @@ Update another-package to "12.0.0". This will update other packages and will gen
 nx migrate another-package@12.0.0
 ```
 
-Run migrations from the migrations.json file. You can modify migrations.json and run this command many times:
+Run migrations from the provided migrations.json file. You can modify migrations.json and run this command many times:
 
 ```bash
 nx migrate --run-migrations=migrations.json
 ```
 
+Create a dedicated commit for each successfully completed migration. You can customize the prefix used for each commit by additionally setting --commit-prefix="PREFIX_HERE ":
+
+```bash
+nx migrate --run-migrations --create-commits
+```
+
 ## Options
+
+### commitPrefix
+
+Type: string
+
+Default: chore: [nx migration]
+
+Commit prefix to apply to the commit for each migration, when --create-commits is enabled
 
 ### createCommits
 

--- a/docs/generated/cli/migrate.md
+++ b/docs/generated/cli/migrate.md
@@ -60,6 +60,14 @@ nx migrate --run-migrations=migrations.json
 
 ## Options
 
+### createCommits
+
+Type: boolean
+
+Default: false
+
+Automatically create a git commit after each migration runs
+
 ### from
 
 Type: string

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -323,7 +323,12 @@ export const examples: Record<string, Example[]> = {
     {
       command: 'migrate --run-migrations=migrations.json',
       description:
-        'Run migrations from the migrations.json file. You can modify migrations.json and run this command many times',
+        'Run migrations from the provided migrations.json file. You can modify migrations.json and run this command many times',
+    },
+    {
+      command: 'migrate --run-migrations --create-commits',
+      description:
+        'Create a dedicated commit for each successfully completed migration. You can customize the prefix used for each commit by additionally setting --commit-prefix="PREFIX_HERE "',
     },
   ],
 };

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -1,3 +1,4 @@
+import * as chalk from 'chalk';
 import { exec, execSync } from 'child_process';
 import { remove } from 'fs-extra';
 import { dirname, join } from 'path';
@@ -882,13 +883,17 @@ function runInstall() {
 async function runMigrations(
   root: string,
   opts: { runMigrations: string },
-  isVerbose: boolean
+  isVerbose: boolean,
+  shouldCreateCommits = false
 ) {
   if (!process.env.NX_MIGRATE_SKIP_INSTALL) {
     runInstall();
   }
 
-  logger.info(`NX Running migrations from '${opts.runMigrations}'`);
+  logger.info(
+    `NX Running migrations from '${opts.runMigrations}'` +
+      (shouldCreateCommits ? ', with each applied in a dedicated commit' : '')
+  );
 
   const migrations: {
     package: string;
@@ -906,13 +911,91 @@ async function runMigrations(
         await import('../adapter/ngcli-adapter')
       ).runMigration(root, m.package, m.name, isVerbose);
     }
+
     logger.info(`Successfully finished ${m.name}`);
+
+    if (shouldCreateCommits) {
+      const commitMessage = `chore: [nx migration] ${m.name}`;
+      const { sha: committedSha, reasonForNoCommit } =
+        commitChangesIfAny(commitMessage);
+
+      if (committedSha) {
+        logger.info(chalk.dim(`- Commit created for changes: ${committedSha}`));
+      } else {
+        switch (true) {
+          // Isolate the NO_CHANGES case so that we can render it differently to errors
+          case reasonForNoCommit === 'NO_CHANGES':
+            logger.info(chalk.dim(`- There were no changes to commit`));
+            break;
+          case typeof reasonForNoCommit === 'string': // Any other string is a specific error we captured
+            logger.info(chalk.red(`- ${reasonForNoCommit}`));
+            break;
+          default:
+            logger.info(
+              chalk.red(
+                `- A commit could not be created/retrieved for an unknown reason`
+              )
+            );
+        }
+      }
+    }
     logger.info(`---------------------------------------------------------`);
   }
 
   logger.info(
     `NX Successfully finished running migrations from '${opts.runMigrations}'`
   );
+}
+
+function commitChangesIfAny(commitMessage: string): {
+  sha: string | null;
+  reasonForNoCommit: string | null;
+} {
+  try {
+    if (
+      execSync('git ls-files -m -d -o --exclude-standard').toString() === ''
+    ) {
+      return {
+        sha: null,
+        reasonForNoCommit: 'NO_CHANGES',
+      };
+    }
+  } catch (err) {
+    return {
+      sha: null,
+      reasonForNoCommit: `Error determining git changes:\n${err.stderr}`,
+    };
+  }
+
+  try {
+    execSync('git add -A', { encoding: 'utf8', stdio: 'pipe' });
+    execSync('git commit --no-verify -F -', {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      input: commitMessage,
+    });
+  } catch (err) {
+    return {
+      sha: null,
+      reasonForNoCommit: `Error committing changes:\n${err.stderr}`,
+    };
+  }
+
+  return {
+    sha: getLatestCommitSha(),
+    reasonForNoCommit: null,
+  };
+}
+
+function getLatestCommitSha(): string | null {
+  try {
+    return execSync('git rev-parse HEAD', {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    }).trim();
+  } catch {
+    return null;
+  }
 }
 
 async function runNxMigration(root: string, packageName: string, name: string) {
@@ -951,7 +1034,7 @@ export async function migrate(root: string, args: { [k: string]: any }) {
     if (opts.type === 'generateMigrations') {
       await generateMigrationsJsonAndUpdatePackageJson(root, opts);
     } else {
-      await runMigrations(root, opts, args['verbose']);
+      await runMigrations(root, opts, args['verbose'], args['createCommits']);
     }
   });
 }

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -653,6 +653,12 @@ function withMigrationOptions(yargs: yargs.Argv) {
       describe:
         'Use the provided versions for packages instead of the ones calculated by the migrator (e.g., --to="@nrwl/react:12.0.0,@nrwl/js:12.0.0")',
       type: 'string',
+    })
+    .option('createCommits', {
+      describe: 'Automatically create a git commit after each migration runs',
+      type: 'boolean',
+      alias: ['C'],
+      default: false,
     });
 }
 

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -635,6 +635,8 @@ async function withWorkspaceGeneratorOptions(yargs: yargs.Argv) {
 }
 
 function withMigrationOptions(yargs: yargs.Argv) {
+  const defaultCommitPrefix = 'chore: [nx migration] ';
+
   return yargs
     .positional('packageAndVersion', {
       describe: `The target package and version (e.g, @nrwl/workspace@13.0.0)`,
@@ -659,6 +661,20 @@ function withMigrationOptions(yargs: yargs.Argv) {
       type: 'boolean',
       alias: ['C'],
       default: false,
+    })
+    .option('commitPrefix', {
+      describe:
+        'Commit prefix to apply to the commit for each migration, when --create-commits is enabled',
+      type: 'string',
+      default: defaultCommitPrefix,
+    })
+    .check(({ createCommits, commitPrefix }) => {
+      if (!createCommits && commitPrefix !== defaultCommitPrefix) {
+        throw new Error(
+          'Error: Providing a custom commit prefix requires --create-commits to be enabled'
+        );
+      }
+      return true;
     });
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Migrations resulting in lots of changes can end up creating PRs which are very hard to review because by the time the overall work is complete it can be very hard to determine what was changed by nx migrations and what was subsquently changed by the developer(s).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There is now a `--create-commits` option for `nx migrate --run-migrations` which will create a dedicated commit after each successful migration completes.

Additionally, the commit prefix can be customized by passing `--commit-prefix="..."`

Per Victor's request I have also updated the updating Nx guide.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes #4111

---

Example:

![image](https://user-images.githubusercontent.com/900523/163548254-1797066b-e2d0-45d8-aa88-5fb8a51de735.png)

![image](https://user-images.githubusercontent.com/900523/163548377-9c1cd971-6fe8-4ba6-b01b-8d131baf5797.png)

