### PR TITLE
feat(core): remove @types/node from default workspace

### DIFF
--- a/packages/angular/src/generators/application/files/tsconfig.editor.json__tpl__
+++ b/packages/angular/src/generators/application/files/tsconfig.editor.json__tpl__
@@ -1,11 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["**/*.ts"],
-  "compilerOptions": {
-    "types": [
-      <% if (unitTestRunner === 'jest') { %>"jest",<% } %>
-      <% if (unitTestRunner === 'karma') { %>"jasmine",<% } %>
-      "node"
-    ]
-  }
+  "compilerOptions": {}
 }

--- a/packages/angular/src/generators/application/lib/update-editor-tsconfig.ts
+++ b/packages/angular/src/generators/application/lib/update-editor-tsconfig.ts
@@ -1,12 +1,47 @@
 import type { Tree } from '@nrwl/devkit';
 import type { NormalizedSchema } from './normalized-schema';
 
-import { joinPathFragments, updateJson } from '@nrwl/devkit';
+import { joinPathFragments, readJson, updateJson } from '@nrwl/devkit';
 
-export function updateEditorTsConfig(host: Tree, options: NormalizedSchema) {
+interface TsConfig {
+  compilerOptions: { types: string[] };
+}
+
+function getCompilerOptionsTypes(tsConfig: TsConfig): string[] {
+  return tsConfig?.compilerOptions?.types ?? [];
+}
+
+export function updateEditorTsConfig(tree: Tree, options: NormalizedSchema) {
+  const types = getCompilerOptionsTypes(
+    readJson<TsConfig>(
+      tree,
+      joinPathFragments(options.appProjectRoot, 'tsconfig.app.json')
+    )
+  );
+
+  if (options.unitTestRunner !== 'none') {
+    types.concat(
+      getCompilerOptionsTypes(
+        readJson<TsConfig>(
+          tree,
+          joinPathFragments(options.appProjectRoot, 'tsconfig.spec.json')
+        )
+      )
+    );
+  }
+
+  updateJson(
+    tree,
+    joinPathFragments(options.appProjectRoot, 'tsconfig.editor.json'),
+    (json) => {
+      json.compilerOptions.types = types;
+      return json;
+    }
+  );
+
   // This should be the last tsconfig references so it's not in the template
   updateJson(
-    host,
+    tree,
     joinPathFragments(options.appProjectRoot, 'tsconfig.json'),
     (json) => {
       json.references.push({

--- a/packages/angular/src/generators/karma/karma.spec.ts
+++ b/packages/angular/src/generators/karma/karma.spec.ts
@@ -49,6 +49,7 @@ describe('karma', () => {
     expect(devDependencies['jasmine-core']).toBeDefined();
     expect(devDependencies['jasmine-spec-reporter']).toBeDefined();
     expect(devDependencies['@types/jasmine']).toBeDefined();
+    expect(devDependencies['@types/node']).toBeDefined();
   });
 
   it('should add karma configuration', () => {

--- a/packages/angular/src/generators/karma/karma.ts
+++ b/packages/angular/src/generators/karma/karma.ts
@@ -31,6 +31,7 @@ export function karmaGenerator(tree: Tree, options: GeneratorOptions) {
       'jasmine-core': '~3.10.0',
       'jasmine-spec-reporter': '~5.0.0',
       '@types/jasmine': '~3.5.0',
+      '@types/node': '16.11.7',
     }
   );
 }

--- a/packages/cypress/src/generators/init/init.spec.ts
+++ b/packages/cypress/src/generators/init/init.spec.ts
@@ -26,6 +26,7 @@ describe('init', () => {
 
     expect(packageJson.devDependencies.cypress).toBeDefined();
     expect(packageJson.devDependencies['@nrwl/cypress']).toBeDefined();
+    expect(packageJson.devDependencies['@types/node']).toBeDefined();
     expect(packageJson.devDependencies[existing]).toBeDefined();
     expect(packageJson.dependencies['@nrwl/cypress']).toBeUndefined();
     expect(packageJson.dependencies[existing]).toBeDefined();

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -4,7 +4,11 @@ import {
   removeDependenciesFromPackageJson,
   Tree,
 } from '@nrwl/devkit';
-import { cypressVersion, nxVersion } from '../../utils/versions';
+import {
+  cypressVersion,
+  nxVersion,
+  typesNodeVersion,
+} from '../../utils/versions';
 import { Schema } from './schema';
 
 function updateDependencies(host: Tree) {
@@ -16,6 +20,7 @@ function updateDependencies(host: Tree) {
     {
       ['@nrwl/cypress']: nxVersion,
       cypress: cypressVersion,
+      '@types/node': typesNodeVersion,
     }
   );
 }

--- a/packages/cypress/src/utils/versions.ts
+++ b/packages/cypress/src/utils/versions.ts
@@ -1,3 +1,4 @@
 export const nxVersion = '*';
 export const cypressVersion = '^9.1.0';
 export const eslintPluginCypressVersion = '^2.10.3';
+export const typesNodeVersion = '16.11.7';

--- a/packages/detox/src/generators/init/init.spec.ts
+++ b/packages/detox/src/generators/init/init.spec.ts
@@ -13,6 +13,7 @@ describe('init', () => {
     await detoxInitGenerator(tree, {});
     const packageJson = readJson(tree, 'package.json');
     expect(packageJson.devDependencies['@nrwl/detox']).toBeDefined();
+    expect(packageJson.devDependencies['@types/node']).toBeDefined();
     expect(packageJson.devDependencies['detox']).toBeDefined();
   });
 });

--- a/packages/detox/src/generators/init/init.ts
+++ b/packages/detox/src/generators/init/init.ts
@@ -5,7 +5,7 @@ import {
   removeDependenciesFromPackageJson,
   Tree,
 } from '@nrwl/devkit';
-import { jestVersion } from '@nrwl/jest/src/utils/versions';
+import { jestVersion, typesNodeVersion } from '@nrwl/jest/src/utils/versions';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import { Schema } from './schema';
 import {
@@ -32,6 +32,7 @@ export function updateDependencies(host: Tree) {
       '@nrwl/detox': nxVersion,
       detox: detoxVersion,
       '@testing-library/jest-dom': testingLibraryJestDom,
+      '@types/node': typesNodeVersion,
       'jest-circus': jestVersion,
     }
   );

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -56,6 +56,7 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
     '@nrwl/jest': nxVersion,
     jest: jestVersion,
     '@types/jest': jestTypesVersion,
+    '@types/node': '16.11.7',
     // because the default jest-preset uses ts-jest,
     // jest will throw an error if it's not installed
     // even if not using it in overriding transformers

--- a/packages/jest/src/utils/versions.ts
+++ b/packages/jest/src/utils/versions.ts
@@ -5,3 +5,4 @@ export const tslibVersion = '^2.0.0';
 export const tsJestVersion = '27.0.5';
 export const babelJestVersion = '27.2.3';
 export const swcJestVersion = '0.2.15';
+export const typesNodeVersion = '16.11.7';

--- a/packages/next/src/generators/application/files/tsconfig.json__tmpl__
+++ b/packages/next/src/generators/application/files/tsconfig.json__tmpl__
@@ -6,7 +6,6 @@
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["node", "jest"],
     "strict": false,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,

--- a/packages/next/src/generators/application/lib/add-jest.ts
+++ b/packages/next/src/generators/application/lib/add-jest.ts
@@ -1,4 +1,4 @@
-import { Tree, updateJson } from '@nrwl/devkit';
+import { joinPathFragments, readJson, Tree, updateJson } from '@nrwl/devkit';
 import { jestProjectGenerator } from '@nrwl/jest';
 import { NormalizedSchema } from './normalize-options';
 
@@ -15,10 +15,33 @@ export async function addJest(host: Tree, options: NormalizedSchema) {
     compiler: 'babel',
   });
 
-  updateJson(host, `${options.appProjectRoot}/tsconfig.spec.json`, (json) => {
-    json.compilerOptions.jsx = 'react';
-    return json;
-  });
+  const tsConfigSpecJson = readJson(
+    host,
+    joinPathFragments(options.appProjectRoot, 'tsconfig.spec.json')
+  );
+
+  updateJson(
+    host,
+    joinPathFragments(options.appProjectRoot, 'tsconfig.json'),
+    (json) => {
+      json.compilerOptions ??= {};
+      json.compilerOptions.types ??= [];
+      json.compilerOptions.types.push(
+        ...(tsConfigSpecJson?.compilerOptions?.types ?? [])
+      );
+
+      return json;
+    }
+  );
+
+  updateJson(
+    host,
+    joinPathFragments(options.appProjectRoot, 'tsconfig.spec.json'),
+    (json) => {
+      json.compilerOptions.jsx = 'react';
+      return json;
+    }
+  );
 
   return jestTask;
 }

--- a/packages/node/src/generators/init/init.ts
+++ b/packages/node/src/generators/init/init.ts
@@ -8,7 +8,11 @@ import {
 } from '@nrwl/devkit';
 import { jestInitGenerator } from '@nrwl/jest';
 import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-collection';
-import { nxVersion, tslibVersion } from '../../utils/versions';
+import {
+  nxVersion,
+  tslibVersion,
+  typesNodeVersion,
+} from '../../utils/versions';
 import { Schema } from './schema';
 
 function updateDependencies(tree: Tree) {
@@ -19,7 +23,7 @@ function updateDependencies(tree: Tree) {
     {
       tslib: tslibVersion,
     },
-    { '@nrwl/node': nxVersion }
+    { '@nrwl/node': nxVersion, '@types/node': typesNodeVersion }
   );
 }
 

--- a/packages/node/src/utils/versions.ts
+++ b/packages/node/src/utils/versions.ts
@@ -1,3 +1,5 @@
 export const nxVersion = '*';
 
 export const tslibVersion = '^2.0.0';
+
+export const typesNodeVersion = '16.11.7';

--- a/packages/react-native/src/generators/init/init.spec.ts
+++ b/packages/react-native/src/generators/init/init.spec.ts
@@ -16,6 +16,7 @@ describe('init', () => {
     const packageJson = readJson(tree, 'package.json');
     expect(packageJson.dependencies['react']).toBeDefined();
     expect(packageJson.dependencies['react-native']).toBeDefined();
+    expect(packageJson.devDependencies['@types/node']).toBeDefined();
     expect(packageJson.devDependencies['@types/react']).toBeDefined();
     expect(packageJson.devDependencies['@types/react-native']).toBeDefined();
   });

--- a/packages/react-native/src/generators/init/init.ts
+++ b/packages/react-native/src/generators/init/init.ts
@@ -33,6 +33,7 @@ import {
   reactVersion,
   testingLibraryJestNativeVersion,
   testingLibraryReactNativeVersion,
+  typesNodeVersion,
   typesReactNativeVersion,
 } from '../../utils/versions';
 
@@ -80,6 +81,7 @@ export function updateDependencies(host: Tree) {
     },
     {
       '@nrwl/react-native': nxVersion,
+      '@types/node': typesNodeVersion,
       '@types/react': typesReactVersion,
       '@types/react-native': typesReactNativeVersion,
       '@react-native-community/cli': reactNativeCommunityCli,

--- a/packages/react-native/src/utils/versions.ts
+++ b/packages/react-native/src/utils/versions.ts
@@ -3,6 +3,8 @@ export const nxVersion = '*';
 export const reactNativeVersion = '0.67.4';
 export const typesReactNativeVersion = '0.67.3';
 
+export const typesNodeVersion = '16.11.7';
+
 export const metroVersion = '0.70.0';
 
 // TODO(jack): Remove this once react-native 0.68.0 is released.

--- a/packages/react/src/generators/init/init.spec.ts
+++ b/packages/react/src/generators/init/init.spec.ts
@@ -20,6 +20,7 @@ describe('init', () => {
     const packageJson = readJson(tree, 'package.json');
     expect(packageJson.dependencies['react']).toBeDefined();
     expect(packageJson.dependencies['react-dom']).toBeDefined();
+    expect(packageJson.devDependencies['@types/node']).toBeDefined();
     expect(packageJson.devDependencies['@types/react']).toBeDefined();
     expect(packageJson.devDependencies['@types/react-dom']).toBeDefined();
     expect(packageJson.devDependencies['@testing-library/react']).toBeDefined();

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -19,6 +19,7 @@ import {
   reactVersion,
   testingLibraryReactHooksVersion,
   testingLibraryReactVersion,
+  typesNodeVersion,
   typesReactDomVersion,
   typesReactVersion,
 } from '../../utils/versions';
@@ -58,6 +59,7 @@ function updateDependencies(host: Tree) {
     },
     {
       '@nrwl/react': nxVersion,
+      '@types/node': typesNodeVersion,
       '@types/react': typesReactVersion,
       '@types/react-dom': typesReactDomVersion,
       '@testing-library/react': testingLibraryReactVersion,

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -7,6 +7,8 @@ export const typesReactVersion = '18.0.0';
 export const typesReactDomVersion = '18.0.0';
 export const typesReactIsVersion = '17.0.3';
 
+export const typesNodeVersion = '16.11.7';
+
 export const styledComponentsVersion = '5.3.5';
 export const typesStyledComponentsVersion = '5.1.25';
 

--- a/packages/web/src/generators/init/init.ts
+++ b/packages/web/src/generators/init/init.ts
@@ -11,7 +11,7 @@ import {
 import { jestInitGenerator } from '@nrwl/jest';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import { setDefaultCollection } from '@nrwl/workspace/src/utilities/set-default-collection';
-import { nxVersion } from '../../utils/versions';
+import { nxVersion, typesNodeVersion } from '../../utils/versions';
 import { Schema } from './schema';
 
 function updateDependencies(tree: Tree) {
@@ -26,6 +26,7 @@ function updateDependencies(tree: Tree) {
     },
     {
       '@nrwl/web': nxVersion,
+      '@types/node': typesNodeVersion,
     }
   );
 }

--- a/packages/web/src/utils/versions.ts
+++ b/packages/web/src/utils/versions.ts
@@ -1,4 +1,4 @@
 export const nxVersion = '*';
 
 export const swcLoaderVersion = '0.1.15';
-export const sassVersion = '1.43.2';
+export const typesNodeVersion = '16.11.7';

--- a/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
@@ -8,7 +8,6 @@ Object {
   "devDependencies": Object {
     "@nrwl/cli": "*",
     "@nrwl/workspace": "*",
-    "@types/node": "16.11.7",
     "nx": "*",
     "prettier": "^2.5.1",
     "typescript": "~4.6.2",
@@ -31,7 +30,6 @@ Object {
   "devDependencies": Object {
     "@nrwl/cli": "*",
     "@nrwl/workspace": "*",
-    "@types/node": "16.11.7",
     "nx": "*",
     "prettier": "^2.5.1",
     "typescript": "~4.6.2",
@@ -55,7 +53,6 @@ Object {
     "@nrwl/cli": "*",
     "@nrwl/react": "*",
     "@nrwl/workspace": "*",
-    "@types/node": "16.11.7",
     "nx": "*",
     "prettier": "^2.5.1",
     "typescript": "~4.6.2",

--- a/packages/workspace/src/generators/workspace/files/package.json__tmpl__
+++ b/packages/workspace/src/generators/workspace/files/package.json__tmpl__
@@ -12,7 +12,6 @@
     "nx": "<%= nxVersion %>",
     "@nrwl/cli": "<%= nxVersion %>",
     "@nrwl/workspace": "<%= nxVersion %>",
-    "@types/node": "16.11.7",
     "typescript": "<%= typescriptVersion %>",
     "prettier": "<%= prettierVersion %>"
   }

--- a/packages/workspace/src/generators/workspace/workspace.spec.ts
+++ b/packages/workspace/src/generators/workspace/workspace.spec.ts
@@ -165,7 +165,7 @@ Object {
     expect(tree.exists('/proj/apps/.gitkeep')).toBe(false);
     expect(tree.exists('/proj/libs/.gitkeep')).toBe(false);
     const nx = readJson(tree, '/proj/nx.json');
-    expect(nx.extends).toEqual('@nrwl/workspace/presets/core.json');
+    expect(nx.extends).toEqual('nx/presets/core.json');
 
     const { scripts } = readJson(tree, '/proj/package.json');
     expect(scripts).toMatchInlineSnapshot(`Object {}`);

--- a/packages/workspace/src/generators/workspace/workspace.ts
+++ b/packages/workspace/src/generators/workspace/workspace.ts
@@ -38,11 +38,7 @@ function setPresetProperty(tree: Tree, options: Schema) {
       options.preset === Preset.TS ||
       options.preset === Preset.NPM
     ) {
-      addPropertyWithStableKeys(
-        json,
-        'extends',
-        '@nrwl/workspace/presets/core.json'
-      );
+      addPropertyWithStableKeys(json, 'extends', 'nx/presets/core.json');
       delete json.implicitDependencies;
       delete json.targetDependencies;
       delete json.workspaceLayout;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`@types/node` is a part of every single workspace created by Nx.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@types/node` is brought in as necessary. It's pretty often.. but not always.
* `node` apps/libs
* Projects that use `jest`
* Projects that use `karma`
* Projects that use `cypress`
* Projects that use `detox`
* `react` projects?

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
