### PR TITLE
fix(core): move preset options to description to unblock custom presets

### DIFF
--- a/docs/generated/cli/create-nx-workspace.md
+++ b/docs/generated/cli/create-nx-workspace.md
@@ -85,9 +85,7 @@ Package manager to use
 
 Type: string
 
-Choices: [apps, empty, core, npm, ts, web-components, angular, angular-nest, react, react-express, react-native, next, nest, express]
-
-Customizes the initial content of your workspace. To build your own see https://nx.dev/nx-plugin/overview#preset
+Customizes the initial content of your workspace. Available options are: apps, empty, core, npm, ts, web-components, angular, angular-nest, react, react-express, react-native, next, nest, express. To build your own see https://nx.dev/nx-plugin/overview#preset
 
 ### style
 

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -132,8 +132,11 @@ export const commandsObject: yargs.Argv<Arguments> = yargs
           type: 'string',
         })
         .option('preset', {
-          describe: chalk.dim`Customizes the initial content of your workspace. To build your own see https://nx.dev/nx-plugin/overview#preset`,
-          choices: Object.values(Preset),
+          describe: chalk.dim`Customizes the initial content of your workspace. Available options are: ${Object.values(
+            Preset
+          ).join(
+            ', '
+          )}. To build your own see https://nx.dev/nx-plugin/overview#preset`,
           type: 'string',
         })
         .option('appName', {


### PR DESCRIPTION
Custom presets were no longer usable due to the hard scoping that yargs.choices puts in place

ISSUES CLOSED: #9858

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Custom workspace presets cannot be used due to the hard limit on what yargs.choices was being fed

## Expected Behavior
Custom presets can be used again, as yargs.choices was removed, and the available options were moved into the description.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9858
