### PR TITLE
fix(react-native): generate invalid entryFileRelativeToRoot path in Windows

### DIFF
--- a/packages/react-native/src/generators/application/lib/normalize-options.ts
+++ b/packages/react-native/src/generators/application/lib/normalize-options.ts
@@ -27,8 +27,8 @@ export function normalizeOptions(options: Schema): NormalizedSchema {
   const appProjectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
 
   const appProjectRoot = `apps/${projectDirectory}`;
-  const iosProjectRoot = join(appProjectRoot, 'ios');
-  const androidProjectRoot = join(appProjectRoot, 'android');
+  const iosProjectRoot = posix.join(appProjectRoot, 'ios');
+  const androidProjectRoot = posix.join(appProjectRoot, 'android');
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())

--- a/packages/react-native/src/generators/application/lib/normalize-options.ts
+++ b/packages/react-native/src/generators/application/lib/normalize-options.ts
@@ -1,5 +1,5 @@
 import { names, Tree } from '@nrwl/devkit';
-import { join } from 'path';
+import { posix } from 'path';
 import { Schema } from '../schema';
 
 export interface NormalizedSchema extends Schema {
@@ -35,7 +35,7 @@ export function normalizeOptions(options: Schema): NormalizedSchema {
     : [];
 
   const entryFile = options.js ? '/src/main.js' : '/src/main.tsx';
-  const entryFileRelativeToRoot = join(appProjectRoot, entryFile);
+  const entryFileRelativeToRoot = posix.join(appProjectRoot, entryFile);
 
   /**
    * if options.name is "my-app"


### PR DESCRIPTION
in Windows, entryFileRelativeToRoot has `'\'` instead of `'/'` which causes invalid syntax in `build.gradle`. Using `path.posix.join()` instead of `path.join()` will fix this issue.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

In the generated file `android/app/build.gradle`, the property `entryFile` on line 82 provides unescaped backslashes instead of forward slashes which causes invalid syntax in `build.gradle` when generated in Windows environment. 

```gradle
project.ext.react = [
    entryFile: "apps\<appName>\src\main.tsx",
    enableHermes: false,  // clean and rebuild if changing
]
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Since forward slashes are recognised as valid separators, we should expect the generated file content to be:

```gradle
project.ext.react = [
    entryFile: "apps/<appName>/src/main.tsx",
    enableHermes: false,  // clean and rebuild if changing
]
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

None
