### PR TITLE
cleanup(core): provide better cleanup api for createTempNpmDirectory

### DIFF
--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -1,5 +1,4 @@
 import { exec, execSync } from 'child_process';
-import { remove } from 'fs-extra';
 import { dirname, join } from 'path';
 import { gt, lt, lte } from 'semver';
 import { promisify } from 'util';
@@ -608,7 +607,7 @@ async function downloadPackageMigrationsFromRegistry(
   packageVersion: string,
   { migrations: migrationsFilePath, packageGroup }: NxMigrationsConfiguration
 ): Promise<ResolvedMigrationConfiguration> {
-  const dir = createTempNpmDirectory();
+  const { dir, cleanup } = createTempNpmDirectory();
 
   let result: ResolvedMigrationConfiguration;
 
@@ -631,11 +630,7 @@ async function downloadPackageMigrationsFromRegistry(
       `Failed to find migrations file "${migrationsFilePath}" in package "${packageName}@${packageVersion}".`
     );
   } finally {
-    try {
-      await remove(dir);
-    } catch {
-      // It's okay if this fails, the OS will clean it up eventually
-    }
+    await cleanup();
   }
 
   return result;
@@ -645,7 +640,7 @@ async function getPackageMigrationsUsingInstall(
   packageName: string,
   packageVersion: string
 ): Promise<ResolvedMigrationConfiguration> {
-  const dir = createTempNpmDirectory();
+  const { dir, cleanup } = createTempNpmDirectory();
 
   let result: ResolvedMigrationConfiguration;
 
@@ -669,11 +664,7 @@ async function getPackageMigrationsUsingInstall(
 
     result = { ...migrations, packageGroup, version: packageJson.version };
   } finally {
-    try {
-      await remove(dir);
-    } catch {
-      // It's okay if this fails, the OS will clean it up eventually
-    }
+    await cleanup();
   }
 
   return result;


### PR DESCRIPTION
Implement a suggestion by @AgentEnder from a previous PR that provides a cleanup function for a
temp directory, alongside the directory path itself.

This is done since the method seems to be of use to users of NX and not only NX itself,
and we should make the burden of cleaning up the temp directory easier, with less boilerplate to copy.
