### PR TITLE
feat(devkit): don't replace _

### DIFF
--- a/packages/devkit/src/utils/names.spec.ts
+++ b/packages/devkit/src/utils/names.spec.ts
@@ -8,6 +8,8 @@ describe('names', () => {
     expect(names('[fooBar]').className).toEqual('FooBar');
     expect(names('[...fooBar]').className).toEqual('FooBar');
     expect(names('foo-@bar').className).toEqual('FooBar');
+    expect(names(' foo bar').className).toEqual('FooBar');
+    expect(names('_foo_bar').className).toEqual('FooBar');
   });
 
   it('should support property names', () => {
@@ -17,6 +19,8 @@ describe('names', () => {
     expect(names('[fooBar]').propertyName).toEqual('fooBar');
     expect(names('[...fooBar]').propertyName).toEqual('fooBar');
     expect(names('foo-@bar').propertyName).toEqual('fooBar');
+    expect(names(' foo bar').propertyName).toEqual('fooBar');
+    expect(names('_foo_bar').propertyName).toEqual('fooBar');
   });
 
   it('should support file names', () => {
@@ -26,5 +30,7 @@ describe('names', () => {
     expect(names('[fooBar]').fileName).toEqual('[foo-bar]');
     expect(names('[...fooBar]').fileName).toEqual('[...foo-bar]');
     expect(names('foo-@bar').fileName).toEqual('foo-@bar');
+    expect(names(' foo bar').fileName).toEqual('-foo-bar');
+    expect(names('_foo_bar').fileName).toEqual('_foo-bar');
   });
 });

--- a/packages/devkit/src/utils/names.ts
+++ b/packages/devkit/src/utils/names.ts
@@ -58,7 +58,7 @@ function toFileName(s: string): string {
   return s
     .replace(/([a-z\d])([A-Z])/g, '$1_$2')
     .toLowerCase()
-    .replace(/[ _]/g, '-');
+    .replace(/(?!^[_])[ _]/g, '-');
 }
 
 /**


### PR DESCRIPTION
Underscore is a character usually used for sorting purposes and is absolutely legit. There is no reason to replace it. :)
Further renaming of generated directory (and sometimes imports) is just an unnecessary step in the workflow that could be avoided.

ISSUES CLOSED: #8875

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when creating a file
```
npx nx generate @nrwl/angular:ngrx --name=user --module=libs/user/src/lib/user.module.ts --directory=_store
```

we obtain
```
CREATE libs/user/src/lib/-store/user.actions.ts
```


## Expected Behavior
```
npx nx generate @nrwl/angular:ngrx --name=user --module=libs/user/src/lib/user.module.ts --directory=_store
```

we obtain
```
CREATE libs/user/src/lib/_store/user.actions.ts
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8875
