### PR TITLE
feat(react): add ability to serve remote apps in dev or static mode

### DIFF
--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -1162,6 +1162,11 @@
         "cli": "nx",
         "type": "object",
         "properties": {
+          "devRemotes": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of remote applications to run in development mode (i.e. using serve target)."
+          },
           "buildTarget": {
             "type": "string",
             "description": "Target which builds the application."
@@ -1228,11 +1233,6 @@
           "baseHref": {
             "type": "string",
             "description": "Base url for the application being built."
-          },
-          "apps": {
-            "type": "array",
-            "items": { "type": "string" },
-            "description": "List of remote applications to serve in addition to the host application."
           }
         },
         "presets": []

--- a/docs/generated/packages/web.json
+++ b/docs/generated/packages/web.json
@@ -876,12 +876,6 @@
             "type": "string",
             "description": "Target which builds the application."
           },
-          "withDeps": {
-            "type": "boolean",
-            "description": "Build the target and all its deps",
-            "default": false,
-            "x-deprecated": "\"withDeps\" is deprecated and it will be removed in `v14`. Configure target dependencies instead: https://nx.dev/configuration/projectjson."
-          },
           "parallel": {
             "type": "boolean",
             "description": "Build the target in parallel.",
@@ -924,6 +918,11 @@
             "default": {},
             "properties": { "secure": { "type": "boolean", "default": false } },
             "additionalProperties": true
+          },
+          "watch": {
+            "type": "boolean",
+            "description": "Watch for file changes.",
+            "default": true
           }
         },
         "additionalProperties": false,

--- a/packages/react/src/executors/module-federation-dev-server/schema.json
+++ b/packages/react/src/executors/module-federation-dev-server/schema.json
@@ -4,6 +4,13 @@
   "cli": "nx",
   "type": "object",
   "properties": {
+    "devRemotes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of remote applications to run in development mode (i.e. using serve target)."
+    },
     "buildTarget": {
       "type": "string",
       "description": "Target which builds the application."
@@ -70,13 +77,6 @@
     "baseHref": {
       "type": "string",
       "description": "Base url for the application being built."
-    },
-    "apps": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "description": "List of remote applications to serve in addition to the host application."
     }
   }
 }

--- a/packages/react/src/module-federation/load-config.ts
+++ b/packages/react/src/module-federation/load-config.ts
@@ -1,0 +1,23 @@
+import { ExecutorContext } from '@nrwl/devkit';
+import { join } from 'path';
+import { ModuleFederationConfig } from './models';
+
+export function loadModuleFederationConfigFromContext(
+  context: ExecutorContext
+): ModuleFederationConfig {
+  const p = context.workspace.projects[context.projectName];
+  const moduleFederationConfigPath = join(
+    context.root,
+    p.root,
+    'module-federation.config.js'
+  );
+
+  try {
+    return require(moduleFederationConfigPath) as ModuleFederationConfig;
+  } catch {
+    // TODO(jack): Add a link to guide
+    throw new Error(
+      `Could not load ${moduleFederationConfigPath}. Was this project generated with "@nrwl/react:host"?`
+    );
+  }
+}

--- a/packages/react/src/module-federation/models.ts
+++ b/packages/react/src/module-federation/models.ts
@@ -1,0 +1,21 @@
+export interface SharedLibraryConfig {
+  singleton: boolean;
+  strictVersion: boolean;
+  requiredVersion: string;
+  eager: boolean;
+}
+
+export type ModuleFederationLibrary = { type: string; name: string };
+
+export type Remotes = string[] | [remoteName: string, remoteUrl: string][];
+
+export interface ModuleFederationConfig {
+  name: string;
+  remotes?: string[];
+  library?: ModuleFederationLibrary;
+  exposes?: Record<string, string>;
+  shared?: (
+    libraryName: string,
+    library: SharedLibraryConfig
+  ) => undefined | false | SharedLibraryConfig;
+}

--- a/packages/react/src/module-federation/webpack-utils.ts
+++ b/packages/react/src/module-federation/webpack-utils.ts
@@ -7,13 +7,7 @@ import {
   getRootTsConfigPath,
   readTsConfig,
 } from '@nrwl/workspace/src/utilities/typescript';
-
-export interface SharedLibraryConfig {
-  singleton: boolean;
-  strictVersion: boolean;
-  requiredVersion: string;
-  eager: boolean;
-}
+import { SharedLibraryConfig } from './models';
 
 export function shareWorkspaceLibraries(
   libraries: string[],

--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -1,8 +1,4 @@
-import {
-  SharedLibraryConfig,
-  sharePackages,
-  shareWorkspaceLibraries,
-} from './webpack-utils';
+import { sharePackages, shareWorkspaceLibraries } from './webpack-utils';
 import {
   createProjectGraphAsync,
   ProjectGraph,
@@ -17,21 +13,7 @@ import {
 import { ParsedCommandLine } from 'typescript';
 import { readWorkspaceJson } from 'nx/src/project-graph/file-utils';
 import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
-
-export type ModuleFederationLibrary = { type: string; name: string };
-
-export type Remotes = string[] | [remoteName: string, remoteUrl: string][];
-
-export interface ModuleFederationConfig {
-  name: string;
-  remotes?: string[];
-  library?: ModuleFederationLibrary;
-  exposes?: Record<string, string>;
-  shared?: (
-    libraryName: string,
-    library: SharedLibraryConfig
-  ) => undefined | false | SharedLibraryConfig;
-}
+import { ModuleFederationConfig, Remotes } from './models';
 
 function recursivelyResolveWorkspaceDependents(
   projectGraph: ProjectGraph<any>,

--- a/packages/react/src/rules/update-module-federation-project.ts
+++ b/packages/react/src/rules/update-module-federation-project.ts
@@ -8,18 +8,40 @@ export function updateModuleFederationProject(
   host: Tree,
   options: { name: string; appProjectRoot: string; devServerPort?: number }
 ) {
-  let projectConfig = readProjectConfiguration(host, options.name);
+  const projectConfig = readProjectConfiguration(host, options.name);
+
   projectConfig.targets.build.options = {
     ...projectConfig.targets.build.options,
     main: `${options.appProjectRoot}/src/main.ts`,
     webpackConfig: `${options.appProjectRoot}/webpack.config.js`,
   };
+
   projectConfig.targets.build.configurations.production = {
     ...projectConfig.targets.build.configurations.production,
     webpackConfig: `${options.appProjectRoot}/webpack.config.prod.js`,
   };
+
   projectConfig.targets.serve.executor =
     '@nrwl/react:module-federation-dev-server';
   projectConfig.targets.serve.options.port = options.devServerPort;
+
+  // `serve-static` for remotes that don't need to be in development mode
+  projectConfig.targets['serve-static'] = {
+    executor: '@nrwl/web:file-server',
+    defaultConfiguration: 'development',
+    options: {
+      buildTarget: `${options.name}:build`,
+      port: options.devServerPort,
+    },
+    configurations: {
+      development: {
+        buildTarget: `${options.name}:build:development`,
+      },
+      production: {
+        buildTarget: `${options.name}:build:production`,
+      },
+    },
+  };
+
   updateProjectConfiguration(host, options.name, projectConfig);
 }

--- a/packages/web/src/executors/file-server/schema.d.ts
+++ b/packages/web/src/executors/file-server/schema.d.ts
@@ -10,4 +10,5 @@ export interface Schema {
   maxParallel?: number;
   withDeps: boolean;
   proxyOptions?: object;
+  watch?: boolean;
 }

--- a/packages/web/src/executors/file-server/schema.json
+++ b/packages/web/src/executors/file-server/schema.json
@@ -8,12 +8,6 @@
       "type": "string",
       "description": "Target which builds the application."
     },
-    "withDeps": {
-      "type": "boolean",
-      "description": "Build the target and all its deps",
-      "default": false,
-      "x-deprecated": "\"withDeps\" is deprecated and it will be removed in `v14`. Configure target dependencies instead: https://nx.dev/configuration/projectjson."
-    },
     "parallel": {
       "type": "boolean",
       "description": "Build the target in parallel.",
@@ -61,6 +55,11 @@
         }
       },
       "additionalProperties": true
+    },
+    "watch": {
+      "type": "boolean",
+      "description": "Watch for file changes.",
+      "default": true
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
This PR adds a `serve-static` target for apps generated with `@nrwl/react:host` or `@nrwl/react:remote`. It is used by the `@nrwl/react:module-federation-dev-server` to  serve remote apps from dist (i.e. built artifact), intended when serving a host/shell app.

So users can do:

```
nx serve shell --devRemotes=app1,app3
```

And the serve target would only run dev-server for app1 and app3--app2 and others will serve from dist.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
