### PR TITLE
fix(angular): share secondary entry points

### DIFF
--- a/packages/angular/src/utils/mfe/mfe-webpack.spec.ts
+++ b/packages/angular/src/utils/mfe/mfe-webpack.spec.ts
@@ -86,8 +86,9 @@ describe('MFE Webpack Utils', () => {
     it('should correctly map the shared packages to objects', () => {
       // ARRANGE
       (fs.existsSync as jest.Mock).mockReturnValue(true);
-      (fs.readFileSync as jest.Mock).mockReturnValue(
+      (fs.readFileSync as jest.Mock).mockImplementation((file) =>
         JSON.stringify({
+          name: file.replace(/\\/g, '/').replace(/^.*node_modules[/]/, ''),
           dependencies: {
             '@angular/core': '~13.2.0',
             '@angular/common': '~13.2.0',
@@ -95,6 +96,7 @@ describe('MFE Webpack Utils', () => {
           },
         })
       );
+      (fs.readdirSync as jest.Mock).mockReturnValue([]);
 
       // ACT
       const packages = sharePackages([
@@ -121,5 +123,105 @@ describe('MFE Webpack Utils', () => {
         },
       });
     });
+
+    it('should correctly map the shared packages to objects even with nested entry points', () => {
+      // ARRANGE
+
+      /**
+       * This creates a bunch of mocks that aims to test that
+       * the sharePackages function can handle nested
+       * entrypoints in the package that is being shared.
+       *
+       * This will set up a directory structure that matches
+       * the following:
+       *
+       * - @angular/core/
+       *   - package.json
+       * - @angular/common/
+       *   - http/
+       *     - testing/
+       *       - package.json
+       *   - package.json
+       * - rxjs
+       *   - package.json
+       *
+       * The result is that there would be 4 packages that
+       * need to be shared, as determined by the folders
+       * containing the package.json files
+       */
+      createMockedFSForNestedEntryPoints();
+
+      // ACT
+      const packages = sharePackages([
+        '@angular/core',
+        '@angular/common',
+        'rxjs',
+      ]);
+      // ASSERT
+      expect(packages).toEqual({
+        '@angular/core': {
+          singleton: true,
+          strictVersion: true,
+          requiredVersion: '~13.2.0',
+        },
+        '@angular/common': {
+          singleton: true,
+          strictVersion: true,
+          requiredVersion: '~13.2.0',
+        },
+        '@angular/common/http/testing': {
+          singleton: true,
+          strictVersion: true,
+          requiredVersion: '~13.2.0',
+        },
+        rxjs: {
+          singleton: true,
+          strictVersion: true,
+          requiredVersion: '~7.4.0',
+        },
+      });
+    });
   });
 });
+
+function createMockedFSForNestedEntryPoints() {
+  (fs.existsSync as jest.Mock).mockImplementation((file: string) => {
+    if (file.endsWith('http/package.json')) {
+      return false;
+    } else {
+      return true;
+    }
+  });
+
+  (fs.readFileSync as jest.Mock).mockImplementation((file) =>
+    JSON.stringify({
+      name: file
+        .replace(/\\/g, '/')
+        .replace(/^.*node_modules[/]/, '')
+        .replace('/package.json', ''),
+      dependencies: {
+        '@angular/core': '~13.2.0',
+        '@angular/common': '~13.2.0',
+        rxjs: '~7.4.0',
+      },
+    })
+  );
+
+  (fs.readdirSync as jest.Mock).mockImplementation((directoryPath: string) => {
+    const PACKAGE_SETUP = {
+      '@angular/core': [],
+      '@angular/common': ['http'],
+      http: ['testing'],
+      testing: [],
+    };
+
+    for (const key of Object.keys(PACKAGE_SETUP)) {
+      if (directoryPath.endsWith(key)) {
+        return PACKAGE_SETUP[key];
+      }
+    }
+    return [];
+  });
+
+  (fs.lstatSync as jest.Mock).mockReturnValue({ isDirectory: () => true });
+}

--- a/packages/angular/src/utils/mfe/with-module-federation.spec.ts
+++ b/packages/angular/src/utils/mfe/with-module-federation.spec.ts
@@ -64,6 +64,8 @@ describe('withModuleFederation', () => {
       }),
     });
 
+    (fs.readdirSync as jest.Mock).mockReturnValue([]);
+
     // ACT
     const config = (
       await withModuleFederation({
@@ -114,6 +116,8 @@ describe('withModuleFederation', () => {
         },
       }),
     });
+
+    (fs.readdirSync as jest.Mock).mockReturnValue([]);
 
     // ACT
     const config = (
@@ -171,6 +175,8 @@ describe('withModuleFederation', () => {
       }),
     });
 
+    (fs.readdirSync as jest.Mock).mockReturnValue([]);
+
     // ACT
     const config = (
       await withModuleFederation({
@@ -226,6 +232,8 @@ describe('withModuleFederation', () => {
         },
       }),
     });
+
+    (fs.readdirSync as jest.Mock).mockReturnValue([]);
 
     // ACT
     const config = (


### PR DESCRIPTION
## Current Behavior
Secondary entry points of packages are not being shared correctly

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Secondary entry points of packages should be shared

Fixes #9863