### PR TITLE
feat(testing): support extra jest cli args

### DIFF
--- a/packages/jest/src/executors/jest/jest.impl.spec.ts
+++ b/packages/jest/src/executors/jest/jest.impl.spec.ts
@@ -97,6 +97,28 @@ describe('Jest Executor', () => {
       );
     });
 
+    it('should send extra options to jestCLI', async () => {
+      await jestExecutor(
+        {
+          ...defaultOptions,
+          jestConfig: './jest.config.js',
+          watch: false,
+          // @ts-ignore
+          group: 'core',
+        },
+        mockContext
+      );
+      expect(runCLI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _: [],
+          testPathPattern: [],
+          watch: false,
+          group: 'core',
+        }),
+        ['/root/jest.config.js']
+      );
+    });
+
     it('should send appropriate options to jestCLI when testFile is specified', async () => {
       await jestExecutor(
         {

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -23,6 +23,20 @@ export async function jestExecutor(
   return { success: results.success };
 }
 
+function getExtraArgs(
+  options: JestExecutorOptions,
+  schema: { properties: Record<string, any> }
+) {
+  const extraArgs = {};
+  for (const key of Object.keys(options)) {
+    if (!schema.properties[key]) {
+      extraArgs[key] = options[key];
+    }
+  }
+
+  return extraArgs;
+}
+
 export async function jestConfigParser(
   options: JestExecutorOptions,
   context: ExecutorContext,
@@ -36,7 +50,13 @@ export async function jestConfigParser(
       }
     | undefined;
 
+  // support passing extra args to jest cli supporting 3rd party plugins
+  // like 'jest-runner-groups' --group arg
+  const schema = await import('./schema.json');
+  const extraArgs = getExtraArgs(options, schema);
+
   const config: Config.Argv = {
+    ...extraArgs,
     $0: undefined,
     _: [],
     config: options.config,


### PR DESCRIPTION
pass extra cli args to jest to allow 3rd party plugins to work correct like jest-runner-groups


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
using jest plugins like jest-runner-groups aren't receiving extra cli args i.e. --group
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
extra args are given to jest 
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9873
