### PR TITLE
fix(core): local plugins should resolve in package-manager workspaces

### DIFF
--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -47,30 +47,34 @@ export function loadNxPlugins(
     ? nxPluginCache ||
         (nxPluginCache = plugins.map((moduleName) => {
           let pluginPath: string;
-          try {
-            pluginPath = require.resolve(moduleName, {
-              paths,
-            });
-          } catch (e) {
-            if (e.code === 'MODULE_NOT_FOUND') {
-              const plugin = resolveLocalNxPlugin(moduleName);
+          let pluginName: string;
+          if (['.js', '.ts'].includes(path.extname(moduleName))) {
+            if (
+              path.extname(moduleName) === '.ts' &&
+              !tsNodeAndPathsRegistered
+            ) {
+              registerTSTranspiler();
+            }
+            pluginPath = require.resolve(moduleName, { paths });
+            pluginName = path.basename(moduleName);
+          } else {
+            const localPlugin = resolveLocalNxPlugin(moduleName);
+            pluginName = moduleName;
+            if (localPlugin) {
               const main = readPluginMainFromProjectConfiguration(
-                plugin.projectConfig
+                localPlugin.projectConfig
               );
-              pluginPath = main ? path.join(workspaceRoot, main) : plugin.path;
+              pluginPath = main
+                ? path.join(workspaceRoot, main)
+                : localPlugin.path;
             } else {
-              throw e;
+              pluginPath = require.resolve(moduleName, {
+                paths,
+              });
             }
           }
-          const packageJsonPath = path.join(pluginPath, 'package.json');
-          const { name } =
-            !['.ts', '.js'].some((x) => x === path.extname(pluginPath)) && // Not trying to point to a ts or js file
-            existsSync(packageJsonPath) // plugin has a package.json
-              ? readJsonFile(packageJsonPath) // read name from package.json
-              : { name: path.basename(pluginPath) }; // use the name of the file we point to
           const plugin = require(pluginPath) as NxPlugin;
-          plugin.name = name;
-
+          plugin.name = pluginName;
           return plugin;
         }))
     : [];
@@ -107,27 +111,23 @@ export function readPluginPackageJson(
   path: string;
   json: PackageJson;
 } {
-  let packageJsonPath: string;
-  try {
-    packageJsonPath = require.resolve(`${pluginName}/package.json`, {
-      paths,
-    });
-  } catch (e) {
-    if (e.code === 'MODULE_NOT_FOUND') {
-      const localPluginPath = resolveLocalNxPlugin(pluginName);
-      if (localPluginPath) {
-        const localPluginPackageJson = path.join(
-          localPluginPath.path,
-          'package.json'
-        );
-        return {
-          path: localPluginPackageJson,
-          json: readJsonFile(localPluginPackageJson),
-        };
-      }
-    }
-    throw e;
+  // Check for matching local plugin
+  const localPluginPath = resolveLocalNxPlugin(pluginName);
+  if (localPluginPath) {
+    const localPluginPackageJson = path.join(
+      localPluginPath.path,
+      'package.json'
+    );
+    return {
+      path: localPluginPackageJson,
+      json: readJsonFile(localPluginPackageJson),
+    };
   }
+
+  // Fallback to installed plugins
+  const packageJsonPath = require.resolve(`${pluginName}/package.json`, {
+    paths,
+  });
   return { json: readJsonFile(packageJsonPath), path: packageJsonPath };
 }
 
@@ -223,7 +223,8 @@ function readTsConfigPaths(root: string = workspaceRoot) {
       .map((x) => path.join(root, x))
       .filter((x) => existsSync(x))[0];
     if (!tsconfigPath) {
-      throw new Error('unable to find tsconfig.base.json or tsconfig.json');
+      tsconfigPaths = {};
+      return {};
     }
     const { compilerOptions } = readJsonFile(tsconfigPath);
     tsconfigPaths = compilerOptions?.paths;


### PR DESCRIPTION
In npm/pnpm/yarn workspaces, packages apparently end up symlinked to node_modules. This was causing local plugin resolution to fail, since the fallback call was never hit. The fix is to check for a local plugin *first*, and then if not found to fall back on the installed plugin.

This has the disadvantage of it not being possible to hit the installed version of a plugin's executors / generators, since the local plugin resolution will always kick in. I'm not super sure if that is worth fixing, but its  something to consider.

Fixes #9823

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
