### PR TITLE
docs(nxdev): bump github stars header counter

### DIFF
--- a/nx-dev/ui-common/src/lib/header.tsx
+++ b/nx-dev/ui-common/src/lib/header.tsx
@@ -91,7 +91,7 @@ export function Header(props: HeaderProps) {
             <Link href="/conf">
               <a
                 title="Check Nx conference"
-                className="relative hidden px-3 py-2 leading-tight text-white md:inline-flex"
+                className="relative px-3 py-2 leading-tight text-white md:inline-flex"
               >
                 <span className="absolute top-0 right-0 -mt-1 -mr-1 flex h-3 w-3">
                   <span className="bg-green-nx-base absolute inline-flex h-full w-full animate-ping rounded-full opacity-75" />
@@ -140,7 +140,7 @@ export function Header(props: HeaderProps) {
                 </svg>
                 <span
                   aria-hidden="true"
-                  className="relative ml-1.5 rounded-md bg-white px-1 py-0.5 text-xs font-medium uppercase text-gray-700"
+                  className="relative ml-1.5 hidden rounded-md bg-white px-1 py-0.5 text-xs font-medium uppercase text-gray-700 lg:inline-flex"
                 >
                   <svg
                     viewBox="0 0 16 16"
@@ -149,7 +149,7 @@ export function Header(props: HeaderProps) {
                   >
                     <rect width="10" height="10" />
                   </svg>
-                  11k+
+                  12k+
                 </span>
               </div>
             </a>


### PR DESCRIPTION
Updates the Github stars counter to 12k and hide the counter for small resolution devices on nx.dev.