### PR TITLE
fix(dep-graph): fix display of nested workspaceLayout directories

### DIFF
--- a/dep-graph/client/src/app/sidebar/project-list.tsx
+++ b/dep-graph/client/src/app/sidebar/project-list.tsx
@@ -8,7 +8,7 @@ import {
   selectedProjectNamesSelector,
   workspaceLayoutSelector,
 } from '../machines/selectors';
-import { parseParentDirectoriesFromPilePath } from '../util';
+import { parseParentDirectoriesFromFilePath } from '../util';
 
 function getProjectsByType(type: string, projects: ProjectGraphNode[]) {
   return projects
@@ -35,10 +35,11 @@ function groupProjectsByDirectory(
       project.type === 'app' || project.type === 'e2e'
         ? workspaceLayout.appsDir
         : workspaceLayout.libsDir;
-    const directories = parseParentDirectoriesFromPilePath(
+    const directories = parseParentDirectoriesFromFilePath(
       project.data.root,
       workspaceRoot
     );
+
     const directory = directories.join('/');
 
     if (!groups.hasOwnProperty(directory)) {
@@ -122,7 +123,7 @@ function ProjectListItem({
 }
 
 function SubProjectList({
-  headerText,
+  headerText = '',
   projects,
   selectProject,
   deselectProject,
@@ -149,9 +150,11 @@ function SubProjectList({
 
   return (
     <>
-      <h3 className="mt-4 cursor-text py-2 text-sm font-semibold uppercase tracking-wide text-slate-800 dark:text-slate-200 lg:text-xs">
-        {headerText}
-      </h3>
+      {headerText !== '' ? (
+        <h3 className="mt-4 cursor-text py-2 text-sm font-semibold uppercase tracking-wide text-slate-800 dark:text-slate-200 lg:text-xs">
+          {headerText}
+        </h3>
+      ) : null}
       <ul className="mt-2 -ml-3">
         {sortedProjects.map((project) => {
           return (

--- a/dep-graph/client/src/app/util-cytoscape/project-node.ts
+++ b/dep-graph/client/src/app/util-cytoscape/project-node.ts
@@ -1,7 +1,7 @@
 // nx-ignore-next-line
 import type { ProjectGraphProjectNode } from '@nrwl/devkit';
 import * as cy from 'cytoscape';
-import { parseParentDirectoriesFromPilePath } from '../util';
+import { parseParentDirectoriesFromFilePath } from '../util';
 
 interface NodeDataDefinition extends cy.NodeDataDefinition {
   id: string;
@@ -14,6 +14,7 @@ interface Ancestor {
   parentId: string;
   label: string;
 }
+
 export class ProjectNode {
   affected = false;
   focused = false;
@@ -74,7 +75,7 @@ export class ProjectNode {
       return [];
     }
 
-    const directories = parseParentDirectoriesFromPilePath(
+    const directories = parseParentDirectoriesFromFilePath(
       this.project.data.root,
       this.workspaceRoot
     );

--- a/dep-graph/client/src/app/util.spec.ts
+++ b/dep-graph/client/src/app/util.spec.ts
@@ -1,4 +1,4 @@
-import { parseParentDirectoriesFromPilePath } from './util';
+import { parseParentDirectoriesFromFilePath } from './util';
 
 describe('parseParentDirectoriesFromFilePath', () => {
   // path, workspaceRoot, output
@@ -17,12 +17,15 @@ describe('parseParentDirectoriesFromFilePath', () => {
     ['packages/published', 'libs', ['packages']],
     ['libs/trailing/slash/', 'libs', ['trailing']],
     ['libs/trailing/slash', 'libs/', ['trailing']],
+    ['nested-workspace/apps/app1', 'nested-workspace/apps', []],
+    ['nested-workspace/libs/lib1', 'nested-workspace/libs', []],
+    ['nested-workspace/libs/scope/lib1', 'nested-workspace/libs', ['scope']],
   ];
 
   test.each(cases)(
     'given filepath %p and workspaceRoot %p, parent directories are %p',
     (path, workspaceRoot, expected) => {
-      const result = parseParentDirectoriesFromPilePath(path, workspaceRoot);
+      const result = parseParentDirectoriesFromFilePath(path, workspaceRoot);
 
       expect(result).toEqual(expected);
     }

--- a/dep-graph/client/src/app/util.ts
+++ b/dep-graph/client/src/app/util.ts
@@ -5,24 +5,17 @@ export function trimBackSlash(value: string): string {
   return value.replace(/\/$/, '');
 }
 
-export function parseParentDirectoriesFromPilePath(
+export function parseParentDirectoriesFromFilePath(
   path: string,
   workspaceRoot: string
 ) {
-  const root = trimBackSlash(path);
-
-  // split the source root on directory separator
-  const split: string[] = root.split('/');
-
-  // check the first part for libs or apps, depending on workspaceLayout
-  if (split[0] === trimBackSlash(workspaceRoot)) {
-    split.shift();
-  }
-
-  // pop off the last element, which should be the lib name
-  split.pop();
-
-  return split;
+  const directories = path
+    .replace(workspaceRoot, '')
+    .split('/')
+    .filter((directory) => directory !== '');
+  // last directory is the project
+  directories.pop();
+  return directories;
 }
 
 export function hasPath(

--- a/dep-graph/client/src/assets/environment.dev.js
+++ b/dep-graph/client/src/assets/environment.dev.js
@@ -47,6 +47,11 @@ window.appConfig = {
       label: 'Collapsing Edges',
       url: 'assets/graphs/collapsing-edges-testing.json',
     },
+    {
+      id: 'nested-workspace-layout',
+      label: 'Nested Workspace Layout',
+      url: 'assets/graphs/nested-workspace-layout.json',
+    },
   ],
   defaultProjectGraph: 'nx',
 };

--- a/dep-graph/client/src/assets/graphs/nested-workspace-layout.json
+++ b/dep-graph/client/src/assets/graphs/nested-workspace-layout.json
@@ -1,0 +1,119 @@
+{
+  "hash": "1c2b69586aa096dc5e42eb252d0b5bfb94f20dc969a1e7b6f381a3b13add6928",
+  "layout": {
+    "appsDir": "nested-workspace/apps",
+    "libsDir": "nested-workspace/libs"
+  },
+  "projects": [
+    {
+      "name": "app1",
+      "type": "app",
+      "data": {
+        "tags": [],
+        "root": "nested-workspace/apps/app1"
+      }
+    },
+    {
+      "name": "app2",
+      "type": "app",
+      "data": {
+        "tags": [],
+        "root": "nested-workspace/apps/app2"
+      }
+    },
+    {
+      "name": "lib1",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "nested-workspace/libs/lib1"
+      }
+    },
+    {
+      "name": "lib2",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "nested-workspace/libs/lib2"
+      }
+    },
+    {
+      "name": "lib3",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "nested-workspace/libs/scope/lib3"
+      }
+    },
+    {
+      "name": "lib4",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "nested-workspace/libs/scope/lib4"
+      }
+    },
+    {
+      "name": "lib5",
+      "type": "lib",
+      "data": {
+        "tags": [],
+        "root": "nested-workspace/libs/lib5"
+      }
+    }
+  ],
+  "dependencies": {
+    "app1": [
+      {
+        "type": "static",
+        "source": "app1",
+        "target": "lib1"
+      }
+    ],
+    "app2": [
+      {
+        "type": "static",
+        "source": "app2",
+        "target": "lib2"
+      },
+      {
+        "type": "static",
+        "source": "app2",
+        "target": "lib5"
+      }
+    ],
+    "lib1": [
+      {
+        "type": "static",
+        "source": "lib1",
+        "target": "lib3"
+      }
+    ],
+    "lib2": [
+      {
+        "type": "static",
+        "source": "lib2",
+        "target": "lib3"
+      }
+    ],
+    "lib3": [
+      {
+        "type": "static",
+        "source": "lib3",
+        "target": "lib4"
+      }
+    ],
+    "lib4": [],
+    "lib5": [
+      {
+        "type": "static",
+        "source": "lib5",
+        "target": "lib4"
+      }
+    ]
+  },
+  "affected": [],
+  "changes": {
+    "added": []
+  }
+}


### PR DESCRIPTION
## Current Behavior
* Workspaces with nested directories in their `workspaceLayout` configuration do not display these nested directories correctly.

For example, with a `workspaceLayout` of 
```json
{
  "appsDir": "surfaces/apps",
  "libsDir": "surfaces/libs"
}
```

All of the apps would appear to be under a nested folder of `surfaces/apps`. Instead, they should be created as being in the root directory of apps.

## Expected Behavior
* Workspaces with nested directories in their `workspaceLayout` configuration display these nested directories correctly.
* 
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
