### PR TITLE
fix(angular): there is no cors option on the file-server

### DIFF
--- a/packages/angular/src/generators/setup-mfe/lib/setup-serve-target.ts
+++ b/packages/angular/src/generators/setup-mfe/lib/setup-serve-target.ts
@@ -29,7 +29,6 @@ export function setupServeTarget(host: Tree, options: Schema) {
       options: {
         buildTarget: `${options.appName}:build`,
         port: options.port,
-        cors: '*',
       },
       configurations: {
         development: {


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
cors option is generated when creating the serve-static for remote

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The file-server does not have a cors option
