### PR TITLE
fix(core): fix writing partial files to disk

### DIFF
--- a/packages/nx/src/utils/fileutils.ts
+++ b/packages/nx/src/utils/fileutils.ts
@@ -130,6 +130,8 @@ export async function extractFileFromTarball(
         stream.pipe(destinationFileStream);
         stream.on('end', () => {
           isFileExtracted = true;
+        });
+        destinationFileStream.on('close', () => {
           resolve(destinationFilePath);
         });
       }


### PR DESCRIPTION
there can be a case where a readable stream will end but the piped writeable stream has not finished
writing to the disk
in which case you'll get partial file contents aka malformed json
ensure you
resolve the function after the writeable stream has finished writing to the disk

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
