### PR TITLE
feat(core): default to Yes for Nx Cloud during add-nx-to-monorepo

### DIFF
--- a/packages/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
+++ b/packages/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
@@ -76,7 +76,7 @@ async function askAboutNxCloud(parsedArgs: any) {
               name: 'No',
             },
           ],
-          initial: 'No' as any,
+          initial: 'Yes' as any,
         },
       ])
       .then((a: { NxCloud: 'Yes' | 'No' }) => a.NxCloud === 'Yes');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The default answer for adding nx cloud during `add-nx-to-monorepo` is No

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The default answer for adding nx cloud during `add-nx-to-monorepo` is Yes

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
