### PR TITLE
fix(react): use Routes component wrapper for react router v6

### DIFF
--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -256,24 +256,29 @@ export function addInitialRoutes(
         <li><Link to="/page-2">Page 2</Link></li>
       </ul>
     </div>
-    <Route
-      path="/"
-      element={
-        <div>This is the generated root route. <Link to="/page-2">Click here for page 2.</Link></div>
-      }
-    />
-    <Route
-      path="/page-2"
-      element={
-        <div><Link to="/">Click here to go back to root page.</Link></div>
-      }
-    />
+    <Routes>
+      <Route
+        path="/"
+        element={
+          <div>This is the generated root route. <Link to="/page-2">Click here for page 2.</Link></div>
+        }
+      />
+      <Route
+        path="/page-2"
+        element={
+          <div><Link to="/">Click here to go back to root page.</Link></div>
+        }
+      />
+    </Routes>
     {/* END: routes */}
     `,
   };
 
   return [
-    ...addImport(source, `import { Route, Link } from 'react-router-dom';`),
+    ...addImport(
+      source,
+      `import { Route, Routes, Link } from 'react-router-dom';`
+    ),
     insertRoutes,
   ];
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Right now the route generator fails when running the React app

![image](https://user-images.githubusercontent.com/542458/164543000-76a364ee-b2b9-4db9-842f-7fe627616290.png)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

With React Router v6, a `<Route>` component needs to be wrapped with `<Routes>`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
