### PR TITLE
fix(angular): remove src from lintFilePatterns

### DIFF
--- a/packages/angular/src/generators/add-linting/add-linting.spec.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.spec.ts
@@ -75,8 +75,8 @@ describe('addLinting generator', () => {
       executor: '@nrwl/linter:eslint',
       options: {
         lintFilePatterns: [
-          `${appProjectRoot}/src/**/*.ts`,
-          `${appProjectRoot}/src/**/*.html`,
+          `${appProjectRoot}/**/*.ts`,
+          `${appProjectRoot}/**/*.html`,
         ],
       },
     });

--- a/packages/angular/src/generators/add-linting/lib/add-project-lint-target.ts
+++ b/packages/angular/src/generators/add-linting/lib/add-project-lint-target.ts
@@ -14,8 +14,8 @@ export function addProjectLintTarget(
     executor: '@nrwl/linter:eslint',
     options: {
       lintFilePatterns: [
-        `${options.projectRoot}/src/**/*.ts`,
-        `${options.projectRoot}/src/**/*.html`,
+        `${options.projectRoot}/**/*.ts`,
+        `${options.projectRoot}/**/*.html`,
       ],
     },
   };

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -92,8 +92,8 @@ Object {
       "builder": "@nrwl/linter:eslint",
       "options": Object {
         "lintFilePatterns": Array [
-          "apps/my-dir/my-app/src/**/*.ts",
-          "apps/my-dir/my-app/src/**/*.html",
+          "apps/my-dir/my-app/**/*.ts",
+          "apps/my-dir/my-app/**/*.html",
         ],
       },
     },
@@ -261,8 +261,8 @@ Object {
       "builder": "@nrwl/linter:eslint",
       "options": Object {
         "lintFilePatterns": Array [
-          "apps/my-app/src/**/*.ts",
-          "apps/my-app/src/**/*.html",
+          "apps/my-app/**/*.ts",
+          "apps/my-app/**/*.html",
         ],
       },
     },

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -493,8 +493,8 @@ describe('app', () => {
             "builder": "@nrwl/linter:eslint",
             "options": Object {
               "lintFilePatterns": Array [
-                "apps/my-app/src/**/*.ts",
-                "apps/my-app/src/**/*.html",
+                "apps/my-app/**/*.ts",
+                "apps/my-app/**/*.html",
               ],
             },
           }
@@ -527,8 +527,8 @@ describe('app', () => {
             "builder": "@nrwl/linter:eslint",
             "options": Object {
               "lintFilePatterns": Array [
-                "apps/my-app/src/**/*.ts",
-                "apps/my-app/src/**/*.html",
+                "apps/my-app/**/*.ts",
+                "apps/my-app/**/*.html",
               ],
             },
           }

--- a/packages/angular/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
@@ -598,8 +598,8 @@ Object {
       "executor": "@nrwl/linter:eslint",
       "options": Object {
         "lintFilePatterns": Array [
-          "apps/angular-app-1/src/**/*.ts",
-          "apps/angular-app-1/src/**/*.html",
+          "apps/angular-app-1/**/*.ts",
+          "apps/angular-app-1/**/*.html",
         ],
       },
     },
@@ -956,8 +956,8 @@ Object {
       "executor": "@nrwl/linter:eslint",
       "options": Object {
         "lintFilePatterns": Array [
-          "libs/angular-lib-1/src/**/*.ts",
-          "libs/angular-lib-1/src/**/*.html",
+          "libs/angular-lib-1/**/*.ts",
+          "libs/angular-lib-1/**/*.html",
         ],
       },
     },

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -1313,8 +1313,8 @@ describe('lib', () => {
             "builder": "@nrwl/linter:eslint",
             "options": Object {
               "lintFilePatterns": Array [
-                "libs/my-lib/src/**/*.ts",
-                "libs/my-lib/src/**/*.html",
+                "libs/my-lib/**/*.ts",
+                "libs/my-lib/**/*.html",
               ],
             },
           }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Only files within `src` are linted.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Files not within `src` are also linted.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
