### PR TITLE
fix(nx): calculate dependencies of other targets

### DIFF
--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -371,7 +371,7 @@ function addTasksForProjectDependencyConfig(
   };
 
   const newPath = [...path, pathFragment];
-  seenSet.add(project.name);
+  seenSet.add(targetIdentifier);
 
   if (tasksMap.has(targetIdentifier)) {
     return;
@@ -391,11 +391,11 @@ function addTasksForProjectDependencyConfig(
         ) {
           const depTargetId = getId({
             project: depProject.name,
-            target,
+            target: dependencyConfig.target,
             configuration: configuration,
           });
           exitOnCircularDep(newPath, depTargetId);
-          if (seenSet.has(dep.target)) {
+          if (seenSet.has(depTargetId)) {
             continue;
           }
 
@@ -416,18 +416,17 @@ function addTasksForProjectDependencyConfig(
           );
         } else {
           if (!depProject) {
-            seenSet.add(dep.target);
             continue;
           }
           const depTargetId = getId({
             project: depProject.name,
-            target,
+            target: dependencyConfig.target,
             configuration: configuration,
           });
 
           exitOnCircularDep(newPath, depTargetId);
 
-          if (seenSet.has(dep.target)) {
+          if (seenSet.has(depTargetId)) {
             continue;
           }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

The task list generated does not include all task for targets when the depends on includes multiple targets ie
```json
      "dependsOn": [
        {
          "target": "build",
          "projects": "dependencies"
        },
        {
          "target": "database",
          "projects": "dependencies"
        },
        {
          "target": "sqs-mock",
          "projects": "dependencies"
        }
      ]
```

This is a regression since 13.4.6 which I upgraded from when discovering this issue.

## Expected Behavior

The task generated should include all task from all of the targets in the depends on.
 
Fixes: #10028 