### PR TITLE
fix(angular): fix stylus import

### DIFF
--- a/packages/angular/src/executors/package/ng-packagr-adjustments/styles/stylesheet-processor.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/styles/stylesheet-processor.ts
@@ -273,7 +273,7 @@ export class StylesheetProcessor {
       }
       case '.styl':
       case '.stylus': {
-        const stylus = (await import('stylus')).default;
+        const stylus = await import('stylus');
 
         return (
           stylus(css)


### PR DESCRIPTION
## Current Behavior
When building a library that uses stylus the build failed with "stylus is not a function". This is because stylus has no default export and the nx repository has "esModuleInterop" turned off in the tsconfig.json. 

## Expected Behavior
Building a library that uses succeeds.