### PR TITLE
fix(core): align yargs options in workspace-generator with generic options passed into other commands

### DIFF
--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -15,6 +15,12 @@ const daemonHelpOutput = generateDaemonHelpOutput(isGenerateDocsProcess);
 // Ensure that the output takes up the available width of the terminal
 yargs.wrap(yargs.terminalWidth());
 
+export const parserConfiguration: Partial<yargs.ParserConfigurationOptions> = {
+  'strip-dashed': true,
+  // allow parsing --env.SOME_ARG for cypress cli env args
+  'dot-notation': true,
+};
+
 /**
  * Exposing the Yargs commands object so the documentation generator can
  * parse it. The CLI will consume it and call the `.argv` to bootstrapped
@@ -23,11 +29,7 @@ yargs.wrap(yargs.terminalWidth());
  * le executed correctly.
  */
 export const commandsObject = yargs
-  .parserConfiguration({
-    'strip-dashed': true,
-    // allow parsing --env.SOME_ARG for cypress cli env args
-    'dot-notation': true,
-  })
+  .parserConfiguration(parserConfiguration)
   .usage(
     `
 ${chalk.bold('Smart, Fast and Extensible Build System')}` +

--- a/packages/nx/src/command-line/workspace-generators.ts
+++ b/packages/nx/src/command-line/workspace-generators.ts
@@ -13,6 +13,7 @@ import { readJsonFile, writeJsonFile } from '../utils/fileutils';
 import { logger } from '../utils/logger';
 import { getPackageManagerCommand } from '../utils/package-manager';
 import { normalizePath } from '../utils/path';
+import { parserConfiguration } from './nx-commands';
 
 const rootDirectory = workspaceRoot;
 const toolsDir = path.join(rootDirectory, 'tools');
@@ -160,6 +161,7 @@ function parseOptions(
     default: {
       interactive: true,
     },
+    configuration: parserConfiguration,
   });
   parsed['generator'] = `${collectionFile}:${parsed['_'][0]}`;
   parsed['_'] = parsed['_'].slice(1);


### PR DESCRIPTION
## Current behavior

Running `nx workspace-generator my-generator --dry-run` results in passing `dry-run: true` as an option to the workspace generator.

## Expected behavior

Running `nx workspace-generator my-generator --dry-run` doesn't pass `dry-run: true` as an option to the workspace generator, since it would be omitted when running generators from a plugin.
