### PR TITLE
feat(misc): add application x-type for host and remote generators

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -1024,6 +1024,7 @@
         "required": ["name"],
         "presets": []
       },
+      "x-type": "application",
       "description": "Generate a Remote Angular Module Federation Application.",
       "implementation": "/packages/angular/src/generators/remote/remote.ts",
       "aliases": [],
@@ -1258,6 +1259,7 @@
         "required": ["name"],
         "presets": []
       },
+      "x-type": "application",
       "description": "Generate a Host Angular Module Federation Application.",
       "implementation": "/packages/angular/src/generators/host/host.ts",
       "aliases": [],

--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -985,6 +985,7 @@
         "additionalProperties": false,
         "presets": []
       },
+      "x-type": "application",
       "description": "Generate a host react application",
       "implementation": "/packages/react/src/generators/host/host#hostGenerator.ts",
       "aliases": [],
@@ -1145,6 +1146,7 @@
         "additionalProperties": false,
         "presets": []
       },
+      "x-type": "application",
       "description": "Generate a remote react application",
       "implementation": "/packages/react/src/generators/remote/remote#remoteGenerator.ts",
       "aliases": [],

--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -221,6 +221,7 @@
     "remote": {
       "factory": "./src/generators/remote/remote",
       "schema": "./src/generators/remote/schema.json",
+      "x-type": "application",
       "description": "Generate a Remote Angular Module Federation Application."
     },
     "move": {
@@ -237,6 +238,7 @@
     "host": {
       "factory": "./src/generators/host/host",
       "schema": "./src/generators/host/schema.json",
+      "x-type": "application",
       "description": "Generate a Host Angular Module Federation Application."
     },
     "ng-add": {

--- a/packages/react/generators.json
+++ b/packages/react/generators.json
@@ -153,12 +153,14 @@
     "host": {
       "factory": "./src/generators/host/host#hostGenerator",
       "schema": "./src/generators/host/schema.json",
+      "x-type": "application",
       "description": "Generate a host react application"
     },
 
     "remote": {
       "factory": "./src/generators/remote/remote#remoteGenerator",
       "schema": "./src/generators/remote/schema.json",
+      "x-type": "application",
       "description": "Generate a remote react application"
     }
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Adds the `"x-type": "application"` property for module federation generators so that they appear in Nx Console when creating new applications 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
