### PR TITLE
fix(testing): add missing --js support for jest generators

### DIFF
--- a/docs/generated/packages/jest.json
+++ b/docs/generated/packages/jest.json
@@ -26,6 +26,11 @@
             "type": "boolean",
             "default": false,
             "description": "Do not add dependencies to `package.json`."
+          },
+          "js": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use JavaScript instead of TypeScript for config files"
           }
         },
         "required": [],
@@ -103,6 +108,11 @@
             "type": "boolean",
             "default": false,
             "description": "Do not add dependencies to `package.json`."
+          },
+          "js": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use JavaScript instead of TypeScript for config files"
           }
         },
         "required": [],

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -35,6 +35,7 @@ describe('jest', () => {
     expect(packageJson.devDependencies['@nrwl/jest']).toBeDefined();
     expect(packageJson.devDependencies['@types/jest']).toBeDefined();
     expect(packageJson.devDependencies['ts-jest']).toBeDefined();
+    expect(packageJson.devDependencies['ts-node']).toBeDefined();
   });
 
   describe('Deprecated: --babelJest', () => {

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -38,6 +38,11 @@ describe('jest', () => {
     expect(packageJson.devDependencies['ts-node']).toBeDefined();
   });
 
+  it('should make js jest files', () => {
+    jestInitGenerator(tree, { js: true });
+    expect(tree.exists('jest.config.js')).toBeTruthy();
+    expect(tree.exists('jest.preset.js')).toBeTruthy();
+  });
   describe('Deprecated: --babelJest', () => {
     it('should add babel dependencies', async () => {
       jestInitGenerator(tree, { babelJest: true });

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -15,6 +15,7 @@ import {
   swcJestVersion,
   tsJestVersion,
   tslibVersion,
+  tsNodeVersion,
 } from '../../utils/versions';
 import { JestInitSchema } from './schema';
 
@@ -61,6 +62,7 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
     // jest will throw an error if it's not installed
     // even if not using it in overriding transformers
     'ts-jest': tsJestVersion,
+    'ts-node': tsNodeVersion,
   };
 
   if (options.compiler === 'babel' || options.babelJest) {

--- a/packages/jest/src/generators/init/schema.d.ts
+++ b/packages/jest/src/generators/init/schema.d.ts
@@ -1,5 +1,6 @@
 export interface JestInitSchema {
   compiler?: 'tsc' | 'babel' | 'swc';
+  js?: boolean;
   skipPackageJson?: boolean;
   /**
    * @deprecated

--- a/packages/jest/src/generators/init/schema.json
+++ b/packages/jest/src/generators/init/schema.json
@@ -16,6 +16,11 @@
       "type": "boolean",
       "default": false,
       "description": "Do not add dependencies to `package.json`."
+    },
+    "js": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use JavaScript instead of TypeScript for config files"
     }
   },
   "required": []

--- a/packages/jest/src/generators/jest-project/files/jest.config.ts__tmpl__
+++ b/packages/jest/src/generators/jest-project/files/jest.config.ts__tmpl__
@@ -1,6 +1,6 @@
 module.exports = {
   displayName: '<%= project %>',
-  preset: '<%= offsetFromRoot %>jest.preset.ts',<% if(setupFile !== 'none') { %>
+  preset: '<%= offsetFromRoot %>jest.preset<%= ext %>',<% if(setupFile !== 'none') { %>
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],<% } %><% if (transformer === 'ts-jest') { %>
   globals: {
     'ts-jest': {

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -258,6 +258,20 @@ describe('jestProject', () => {
     });
   });
 
+  it('should create jest.config.js with --js flag', async () => {
+    await jestProjectGenerator(tree, {
+      ...defaultOptions,
+      project: 'lib1',
+      js: true,
+    } as JestProjectSchema);
+    expect(tree.exists('jest.preset.js')).toBeTruthy();
+    expect(tree.exists('jest.config.js')).toBeTruthy();
+    expect(tree.exists('libs/lib1/jest.config.js')).toBeTruthy();
+    expect(tree.read('libs/lib1/jest.config.js', 'utf-8')).toContain(
+      "preset: '../../jest.preset.js',"
+    );
+  });
+
   describe('--babelJest', () => {
     it('should have globals.ts-jest configured when babelJest is false', async () => {
       await jestProjectGenerator(tree, {

--- a/packages/jest/src/generators/jest-project/lib/create-files.ts
+++ b/packages/jest/src/generators/jest-project/lib/create-files.ts
@@ -26,6 +26,7 @@ export function createFiles(tree: Tree, options: JestProjectSchema) {
     tmpl: '',
     ...options,
     transformer,
+    ext: options.js && tree.exists('jest.preset.js') ? '.js' : '.ts',
     projectRoot: projectConfig.root,
     offsetFromRoot: offsetFromRoot(projectConfig.root),
   });
@@ -40,6 +41,13 @@ export function createFiles(tree: Tree, options: JestProjectSchema) {
       JSON.stringify({
         babelrcRoots: ['*'],
       })
+    );
+  }
+
+  if (options.js) {
+    tree.rename(
+      join(projectConfig.root, 'jest.config.ts'),
+      join(projectConfig.root, 'jest.config.js')
     );
   }
 }

--- a/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
+++ b/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
@@ -2,18 +2,21 @@ import { JestProjectSchema } from '../schema';
 import { addPropertyToJestConfig } from '../../../utils/config/update-config';
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
 
-function isUsingUtilityFunction(host: Tree) {
-  return host.read('jest.config.ts').toString().includes('getJestProjects()');
+function isUsingUtilityFunction(host: Tree, js = false) {
+  return host
+    .read(`jest.config.${js ? 'js' : 'ts'}`)
+    .toString()
+    .includes('getJestProjects()');
 }
 
 export function updateJestConfig(host: Tree, options: JestProjectSchema) {
-  if (isUsingUtilityFunction(host)) {
+  if (isUsingUtilityFunction(host, options.js)) {
     return;
   }
   const project = readProjectConfiguration(host, options.project);
   addPropertyToJestConfig(
     host,
-    'jest.config.ts',
+    `jest.config.${options.js ? 'js' : 'ts'}`,
     'projects',
     `<rootDir>/${project.root}`
   );

--- a/packages/jest/src/generators/jest-project/schema.d.ts
+++ b/packages/jest/src/generators/jest-project/schema.d.ts
@@ -15,4 +15,5 @@ export interface JestProjectSchema {
   skipFormat?: boolean;
   compiler?: 'tsc' | 'babel' | 'swc';
   skipPackageJson?: boolean;
+  js?: boolean;
 }

--- a/packages/jest/src/generators/jest-project/schema.json
+++ b/packages/jest/src/generators/jest-project/schema.json
@@ -63,6 +63,11 @@
       "type": "boolean",
       "default": false,
       "description": "Do not add dependencies to `package.json`."
+    },
+    "js": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use JavaScript instead of TypeScript for config files"
     }
   },
   "required": []

--- a/packages/jest/src/utils/versions.ts
+++ b/packages/jest/src/utils/versions.ts
@@ -6,3 +6,4 @@ export const tsJestVersion = '27.1.4';
 export const babelJestVersion = '27.5.1';
 export const swcJestVersion = '0.2.20';
 export const typesNodeVersion = '16.11.7';
+export const tsNodeVersion = '9.1.1';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
no --js option for jest 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
allow for --js for jest configs
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
missing ts-node dep
Fixes #
