### PR TITLE
fix(core): fix postinstall failure due to project graph build error

### DIFF
--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -54,13 +54,8 @@ export function readCachedProjectGraph(): ProjectGraph {
 }
 
 async function buildProjectGraphWithoutDaemon() {
-  try {
-    await defaultFileHasher.ensureInitialized();
-    return await buildProjectGraph();
-  } catch (e) {
-    printErrorMessage(e);
-    process.exit(1);
-  }
+  await defaultFileHasher.ensureInitialized();
+  return await buildProjectGraph();
 }
 
 /**


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `postinstall` hook of the `nx` package fails if a `project.json` file is missing. This can happen, e.g., during a Docker build, when the layer used for `npm install`/`npm ci` only contains the workspace definition files (`workspace.json`, `package.json`, etc.) to enable caching of this step (see [this comment](https://github.com/nrwl/nx/issues/9451#issuecomment-1103660632) for details).

## Expected Behavior
The `postinstall` step no longer fails, because `buildProjectGraphWithoutDaemon()` no longer exits the process with an error code (`process.exit(1)`) and, thus, allows the init script to catch the error.

@ Nx maintainers: I don't know why the `process.exit(1)` call was introduced in the first place. Thus, I don't know if removing it has any undesired side effects. In case there are any, please inform me what needs to be fixed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9451
