### PR TITLE
fix(storybook): skip version update on storybook-deployer

### DIFF
--- a/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
@@ -84,7 +84,8 @@ function maybeUpdateVersion(tree: Tree): GeneratorCallback {
     ).filter(
       (packageName: string) =>
         packageName.startsWith('@storybook/') &&
-        !packageName.includes('@storybook/react-native')
+        !packageName.includes('@storybook/react-native') &&
+        !packageName.includes('@storybook/storybook-deployer')
     );
 
     const allStorybookPackagesInDevDependencies = Object.keys(
@@ -92,7 +93,8 @@ function maybeUpdateVersion(tree: Tree): GeneratorCallback {
     ).filter(
       (packageName: string) =>
         packageName.startsWith('@storybook/') &&
-        !packageName.includes('@storybook/react-native')
+        !packageName.includes('@storybook/react-native') &&
+        !packageName.includes('@storybook/storybook-deployer')
     );
 
     const storybookPackages = [


### PR DESCRIPTION
## Current Behavior
* Storybook 5 to 6 migration tries to update `@storybook/storybook` to a non-existent version

## Expected Behavior
* Storybook 5 to 6 migration does not update `@storybook/storybook`.
