### PR TITLE
fix(testing): pass --js flag to jest generators

### DIFF
--- a/docs/generated/packages/next.json
+++ b/docs/generated/packages/next.json
@@ -32,6 +32,11 @@
             "description": "Skip formatting files.",
             "type": "boolean",
             "default": false
+          },
+          "js": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use JavaScript instead of TypeScript"
           }
         },
         "required": [],

--- a/docs/generated/packages/node.json
+++ b/docs/generated/packages/node.json
@@ -26,6 +26,11 @@
             "description": "Skip formatting files.",
             "type": "boolean",
             "default": false
+          },
+          "js": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use JavaScript instead of TypeScript"
           }
         },
         "required": [],

--- a/docs/generated/packages/react-native.json
+++ b/docs/generated/packages/react-native.json
@@ -32,6 +32,11 @@
             "type": "string",
             "enum": ["detox", "none"],
             "default": "detox"
+          },
+          "js": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use JavaScript instead of TypeScript"
           }
         },
         "required": [],

--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -32,6 +32,11 @@
             "description": "Skip formatting files.",
             "type": "boolean",
             "default": false
+          },
+          "js": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use JavaScript instead of TypeScript"
           }
         },
         "required": [],

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -27,7 +27,8 @@ const schemaDefaults = {
 } as const;
 
 function createJestConfig(host: Tree, js: boolean = false) {
-  if (!host.exists(`jest.config.${js ? 'js' : 'ts'}`)) {
+  // if the root ts config already exists then don't make a js one or vice versa
+  if (!host.exists('jest.config.ts') && !host.exists('jest.config.js')) {
     host.write(
       `jest.config.${js ? 'js' : 'ts'}`,
       stripIndents`
@@ -39,7 +40,7 @@ function createJestConfig(host: Tree, js: boolean = false) {
     );
   }
 
-  if (!host.exists(`jest.preset.${js ? 'js' : 'ts'}`)) {
+  if (!host.exists('jest.preset.ts') && !host.exists('jest.preset.js')) {
     host.write(
       `jest.preset.${js ? 'js' : 'ts'}`,
       `
@@ -57,8 +58,7 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
   const devDeps = {
     '@nrwl/jest': nxVersion,
     jest: jestVersion,
-    '@types/jest': jestTypesVersion,
-    '@types/node': '16.11.7',
+
     // because the default jest-preset uses ts-jest,
     // jest will throw an error if it's not installed
     // even if not using it in overriding transformers
@@ -67,6 +67,8 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
 
   if (!options.js) {
     devDeps['ts-node'] = tsNodeVersion;
+    devDeps['@types/jest'] = jestTypesVersion;
+    devDeps['@types/node'] = '16.11.7';
   }
 
   if (options.compiler === 'babel' || options.babelJest) {

--- a/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
+++ b/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
@@ -77,3 +77,16 @@ exports[`jestProject should create a jest.config.ts 1`] = `
 };
 "
 `;
+
+exports[`jestProject should use jest.config.js in project config with --js flag 1`] = `
+Object {
+  "executor": "@nrwl/jest:jest",
+  "options": Object {
+    "jestConfig": "libs/lib1/jest.config.js",
+    "passWithNoTests": true,
+  },
+  "outputs": Array [
+    "coverage/libs/lib1",
+  ],
+}
+`;

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -272,6 +272,31 @@ describe('jestProject', () => {
     );
   });
 
+  it('should use jest.config.js in project config with --js flag', async () => {
+    await jestProjectGenerator(tree, {
+      ...defaultOptions,
+      project: 'lib1',
+      js: true,
+    } as JestProjectSchema);
+    expect(tree.exists('libs/lib1/jest.config.js')).toBeTruthy();
+    expect(
+      readProjectConfiguration(tree, 'lib1').targets['test']
+    ).toMatchSnapshot();
+  });
+
+  it('should use the jest.preset.ts when preset with --js', async () => {
+    tree.write('jest.preset.ts', '');
+    await jestProjectGenerator(tree, {
+      ...defaultOptions,
+      project: 'lib1',
+      js: true,
+    } as JestProjectSchema);
+    expect(tree.exists('libs/lib1/jest.config.js')).toBeTruthy();
+    expect(tree.read('libs/lib1/jest.config.js', 'utf-8')).toContain(
+      "preset: '../../jest.preset.ts',"
+    );
+  });
+
   describe('--babelJest', () => {
     it('should have globals.ts-jest configured when babelJest is false', async () => {
       await jestProjectGenerator(tree, {

--- a/packages/jest/src/generators/jest-project/lib/create-files.ts
+++ b/packages/jest/src/generators/jest-project/lib/create-files.ts
@@ -4,6 +4,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
+import { findRootJestPreset } from '../../../utils/config/find-root-jest-files';
 import { join } from 'path';
 import { JestProjectSchema } from '../schema';
 
@@ -26,7 +27,7 @@ export function createFiles(tree: Tree, options: JestProjectSchema) {
     tmpl: '',
     ...options,
     transformer,
-    ext: options.js && tree.exists('jest.preset.js') ? '.js' : '.ts',
+    ext: findRootJestPreset(tree) === 'jest.preset.js' ? '.js' : '.ts',
     projectRoot: projectConfig.root,
     offsetFromRoot: offsetFromRoot(projectConfig.root),
   });

--- a/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
+++ b/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
@@ -1,22 +1,23 @@
+import { findRootJestConfig } from '../../../utils/config/find-root-jest-files';
 import { JestProjectSchema } from '../schema';
 import { addPropertyToJestConfig } from '../../../utils/config/update-config';
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
 
-function isUsingUtilityFunction(host: Tree, js = false) {
+function isUsingUtilityFunction(host: Tree) {
   return host
-    .read(`jest.config.${js ? 'js' : 'ts'}`)
+    .read(findRootJestConfig(host))
     .toString()
     .includes('getJestProjects()');
 }
 
 export function updateJestConfig(host: Tree, options: JestProjectSchema) {
-  if (isUsingUtilityFunction(host, options.js)) {
+  if (isUsingUtilityFunction(host)) {
     return;
   }
   const project = readProjectConfiguration(host, options.project);
   addPropertyToJestConfig(
     host,
-    `jest.config.${options.js ? 'js' : 'ts'}`,
+    findRootJestConfig(host),
     'projects',
     `<rootDir>/${project.root}`
   );

--- a/packages/jest/src/generators/jest-project/lib/update-workspace.ts
+++ b/packages/jest/src/generators/jest-project/lib/update-workspace.ts
@@ -20,7 +20,7 @@ export function updateWorkspace(tree: Tree, options: JestProjectSchema) {
     options: {
       jestConfig: joinPathFragments(
         normalizePath(projectConfig.root),
-        'jest.config.ts'
+        `jest.config.${options.js ? 'js' : 'ts'}`
       ),
       passWithNoTests: true,
     },

--- a/packages/jest/src/migrations/update-14-0-0/__snapshots__/update-jest-config-ext.spec.ts.snap
+++ b/packages/jest/src/migrations/update-14-0-0/__snapshots__/update-jest-config-ext.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`Jest Migration (v14.0.0) should rename project jest.config.js to jest.config.ts 1`] = `
 "module.exports = {
   displayName: 'lib-one',
-  preset: '../../jest.preset.ts',
+  
   globals: {
     'ts-jest': {
       tsconfig: '<rootDir>/tsconfig.spec.json',
@@ -13,7 +13,7 @@ exports[`Jest Migration (v14.0.0) should rename project jest.config.js to jest.c
     '^.+\\\\\\\\.[tj]sx?$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../coverage/libs/lib-one'
+  coverageDirectory: '../../coverage/libs/lib-one',\\"preset\\": \\"../../jest.preset.ts\\"
 };
 "
 `;
@@ -21,7 +21,7 @@ exports[`Jest Migration (v14.0.0) should rename project jest.config.js to jest.c
 exports[`Jest Migration (v14.0.0) should update jest.config.ts preset to use the jest.preset.ts 1`] = `
 "module.exports = {
   displayName: 'lib-one',
-  preset: '../../jest.preset.ts',
+  
   globals: {
     'ts-jest': {
       tsconfig: '<rootDir>/tsconfig.spec.json',
@@ -31,7 +31,7 @@ exports[`Jest Migration (v14.0.0) should update jest.config.ts preset to use the
     '^.+\\\\\\\\.[tj]sx?$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../coverage/libs/lib-one'
+  coverageDirectory: '../../coverage/libs/lib-one',\\"preset\\": \\"../../jest.preset.ts\\"
 };
 "
 `;

--- a/packages/jest/src/migrations/update-14-0-0/update-jest-config-ext.spec.ts
+++ b/packages/jest/src/migrations/update-14-0-0/update-jest-config-ext.spec.ts
@@ -6,6 +6,7 @@ import {
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { jestInitGenerator } from '@nrwl/jest';
 import { updateJestConfigExt } from './update-jest-config-ext';
 import { libraryGenerator as workspaceLib } from '@nrwl/workspace';
 
@@ -13,22 +14,7 @@ describe('Jest Migration (v14.0.0)', () => {
   let tree: Tree;
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace(2);
-    tree.write(
-      'jest.config.js',
-      String.raw`
-const { getJestProjects } = require('@nrwl/jest');
-module.exports = {
-  projects: getJestProjects(),
-};
-`
-    );
-    tree.write(
-      'jest.preset.js',
-      String.raw`
-const nxPreset = require('@nrwl/jest/preset');
-module.exports = { ...nxPreset };
-`
-    );
+    jestInitGenerator(tree, { js: true, skipPackageJson: true });
     await workspaceLib(tree, { name: 'lib-one' });
     tree.rename('libs/lib-one/jest.config.ts', 'libs/lib-one/jest.config.js');
     updateProjectConfiguration(tree, 'lib-one', {

--- a/packages/jest/src/utils/config/find-root-jest-files.ts
+++ b/packages/jest/src/utils/config/find-root-jest-files.ts
@@ -1,0 +1,25 @@
+import { Tree } from '@nrwl/devkit';
+
+export function findRootJestConfig(tree: Tree): string | null {
+  if (tree.exists('jest.config.js')) {
+    return 'jest.config.js';
+  }
+
+  if (tree.exists('jest.config.ts')) {
+    return 'jest.config.ts';
+  }
+
+  return null;
+}
+
+export function findRootJestPreset(tree: Tree): string | null {
+  if (tree.exists('jest.preset.js')) {
+    return 'jest.preset.js';
+  }
+
+  if (tree.exists('jest.preset.ts')) {
+    return 'jest.preset.ts';
+  }
+
+  return null;
+}

--- a/packages/js/src/generators/library/files/jest-config/jest.config.__ext__
+++ b/packages/js/src/generators/library/files/jest-config/jest.config.__ext__
@@ -8,7 +8,7 @@ const { exclude: _, ...swcJestConfig } = JSON.parse(
 
 module.exports = {
   displayName: '<%= project %>',
-  preset: '<%= offsetFromRoot %>jest.preset.ts',
+  preset: '<%= offsetFromRoot %>jest.preset.<%= ext %>',
   transform: {
     '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -570,7 +570,7 @@ describe('lib', () => {
           name: 'myLib',
           js: true,
         });
-        expect(tree.exists(`libs/my-lib/jest.config.ts`)).toBeTruthy();
+        expect(tree.exists(`libs/my-lib/jest.config.js`)).toBeTruthy();
         expect(tree.exists('libs/my-lib/src/index.js')).toBeTruthy();
         expect(tree.exists('libs/my-lib/src/lib/my-lib.js')).toBeTruthy();
         expect(tree.exists('libs/my-lib/src/lib/my-lib.spec.js')).toBeTruthy();
@@ -617,7 +617,7 @@ describe('lib', () => {
           directory: 'myDir',
           js: true,
         });
-        expect(tree.exists(`libs/my-dir/my-lib/jest.config.ts`)).toBeTruthy();
+        expect(tree.exists(`libs/my-dir/my-lib/jest.config.js`)).toBeTruthy();
         expect(tree.exists('libs/my-dir/my-lib/src/index.js')).toBeTruthy();
         expect(
           tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.js')

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -14,6 +14,7 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 import { jestProjectGenerator } from '@nrwl/jest';
+import { findRootJestPreset } from '@nrwl/jest/src/utils/config/find-root-jest-files';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import {
@@ -235,6 +236,7 @@ async function addJest(
   options: NormalizedSchema
 ): Promise<GeneratorCallback> {
   return await jestProjectGenerator(tree, {
+    ...options,
     project: options.name,
     setupFile: 'none',
     supportTsx: false,
@@ -250,12 +252,10 @@ function replaceJestConfig(
   options: NormalizedSchema,
   filesDir: string
 ) {
-  // remove the generated jest config by Jest generator
-  tree.delete(join(options.projectRoot, 'jest.config.js'));
-
   // replace with JS:SWC specific jest config
   generateFiles(tree, filesDir, options.projectRoot, {
     tmpl: '',
+    ext: findRootJestPreset(tree) === 'jest.preset.js' ? 'js' : 'ts',
     project: options.name,
     offsetFromRoot: offsetFromRoot(options.projectRoot),
     projectRoot: options.projectRoot,

--- a/packages/next/src/generators/application/lib/add-jest.ts
+++ b/packages/next/src/generators/application/lib/add-jest.ts
@@ -8,6 +8,7 @@ export async function addJest(host: Tree, options: NormalizedSchema) {
   }
 
   const jestTask = await jestProjectGenerator(host, {
+    ...options,
     project: options.projectName,
     supportTsx: true,
     skipSerializers: true,

--- a/packages/next/src/generators/application/lib/update-jest-config.ts
+++ b/packages/next/src/generators/application/lib/update-jest-config.ts
@@ -6,7 +6,9 @@ export function updateJestConfig(host: Tree, options: NormalizedSchema) {
     return;
   }
 
-  const configPath = `${options.appProjectRoot}/jest.config.ts`;
+  const configPath = `${options.appProjectRoot}/jest.config.${
+    options.js ? 'js' : 'ts'
+  }`;
   const originalContent = host.read(configPath, 'utf-8');
   const content = originalContent
     .replace(

--- a/packages/next/src/generators/init/init.ts
+++ b/packages/next/src/generators/init/init.ts
@@ -40,7 +40,7 @@ export async function nextInitGenerator(host: Tree, schema: InitSchema) {
   setDefaultCollection(host, '@nrwl/next');
 
   if (!schema.unitTestRunner || schema.unitTestRunner === 'jest') {
-    const jestTask = jestInitGenerator(host, {});
+    const jestTask = jestInitGenerator(host, schema);
     tasks.push(jestTask);
   }
   if (!schema.e2eTestRunner || schema.e2eTestRunner === 'cypress') {

--- a/packages/next/src/generators/init/schema.d.ts
+++ b/packages/next/src/generators/init/schema.d.ts
@@ -2,4 +2,5 @@ export interface InitSchema {
   unitTestRunner?: 'jest' | 'none';
   e2eTestRunner?: 'cypress' | 'none';
   skipFormat?: boolean;
+  js?: boolean;
 }

--- a/packages/next/src/generators/init/schema.json
+++ b/packages/next/src/generators/init/schema.json
@@ -22,6 +22,11 @@
       "description": "Skip formatting files.",
       "type": "boolean",
       "default": false
+    },
+    "js": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use JavaScript instead of TypeScript"
     }
   },
   "required": []

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -395,7 +395,7 @@ describe('app', () => {
         js: true,
       } as Schema);
 
-      expect(tree.exists(`apps/my-node-app/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`apps/my-node-app/jest.config.js`)).toBeTruthy();
       expect(tree.exists('apps/my-node-app/src/main.js')).toBeTruthy();
 
       const tsConfig = readJson(tree, 'apps/my-node-app/tsconfig.json');
@@ -439,7 +439,7 @@ describe('app', () => {
         js: true,
       } as Schema);
       expect(
-        tree.exists(`apps/my-dir/my-node-app/jest.config.ts`)
+        tree.exists(`apps/my-dir/my-node-app/jest.config.js`)
       ).toBeTruthy();
       expect(tree.exists('apps/my-dir/my-node-app/src/main.js')).toBeTruthy();
     });

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -212,6 +212,7 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
 
   if (options.unitTestRunner === 'jest') {
     const jestTask = await jestProjectGenerator(tree, {
+      ...options,
       project: options.name,
       setupFile: 'none',
       skipSerializers: true,

--- a/packages/node/src/generators/init/init.ts
+++ b/packages/node/src/generators/init/init.ts
@@ -41,7 +41,7 @@ export async function initGenerator(tree: Tree, schema: Schema) {
 
   let jestInstall: GeneratorCallback;
   if (options.unitTestRunner === 'jest') {
-    jestInstall = await jestInitGenerator(tree, {});
+    jestInstall = await jestInitGenerator(tree, schema);
   }
   const installTask = await updateDependencies(tree);
   if (!options.skipFormat) {

--- a/packages/node/src/generators/init/schema.d.ts
+++ b/packages/node/src/generators/init/schema.d.ts
@@ -1,4 +1,5 @@
 export interface Schema {
   unitTestRunner?: 'jest' | 'none';
   skipFormat?: boolean;
+  js?: boolean;
 }

--- a/packages/node/src/generators/init/schema.json
+++ b/packages/node/src/generators/init/schema.json
@@ -16,6 +16,11 @@
       "description": "Skip formatting files.",
       "type": "boolean",
       "default": false
+    },
+    "js": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use JavaScript instead of TypeScript"
     }
   },
   "required": []

--- a/packages/react-native/src/generators/init/init.ts
+++ b/packages/react-native/src/generators/init/init.ts
@@ -50,7 +50,7 @@ export async function reactNativeInitGenerator(host: Tree, schema: Schema) {
   const tasks = [moveDependency(host), updateDependencies(host)];
 
   if (!schema.unitTestRunner || schema.unitTestRunner === 'jest') {
-    const jestTask = jestInitGenerator(host, {});
+    const jestTask = jestInitGenerator(host, schema);
     tasks.push(jestTask);
   }
 

--- a/packages/react-native/src/generators/init/schema.d.ts
+++ b/packages/react-native/src/generators/init/schema.d.ts
@@ -2,4 +2,5 @@ export interface Schema {
   unitTestRunner?: 'jest' | 'none';
   skipFormat?: boolean;
   e2eTestRunner?: 'detox' | 'none';
+  js?: boolean;
 }

--- a/packages/react-native/src/generators/init/schema.json
+++ b/packages/react-native/src/generators/init/schema.json
@@ -22,6 +22,11 @@
       "type": "string",
       "enum": ["detox", "none"],
       "default": "detox"
+    },
+    "js": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use JavaScript instead of TypeScript"
     }
   },
   "required": []

--- a/packages/react-native/src/utils/add-jest.ts
+++ b/packages/react-native/src/utils/add-jest.ts
@@ -13,6 +13,7 @@ export async function addJest(
   }
 
   const jestTask = await jestProjectGenerator(host, {
+    js,
     project: projectName,
     supportTsx: true,
     skipSerializers: true,
@@ -21,7 +22,7 @@ export async function addJest(
   });
 
   // overwrite the jest.config.ts file because react native needs to have special transform property
-  const configPath = `${appProjectRoot}/jest.config.ts`;
+  const configPath = `${appProjectRoot}/jest.config.${js ? 'js' : 'ts'}`;
   const content = `module.exports = {
   displayName: '${projectName}',
   preset: 'react-native',

--- a/packages/react/src/generators/application/lib/add-jest.ts
+++ b/packages/react/src/generators/application/lib/add-jest.ts
@@ -8,6 +8,7 @@ export async function addJest(host: Tree, options: NormalizedSchema) {
   }
 
   return await jestProjectGenerator(host, {
+    ...options,
     project: options.projectName,
     supportTsx: true,
     skipSerializers: true,

--- a/packages/react/src/generators/application/lib/update-jest-config.ts
+++ b/packages/react/src/generators/application/lib/update-jest-config.ts
@@ -21,7 +21,9 @@ export function updateJestConfig(host: Tree, options: NormalizedSchema) {
     return json;
   });
 
-  const configPath = `${options.appProjectRoot}/jest.config.ts`;
+  const configPath = `${options.appProjectRoot}/jest.config.${
+    options.js ? 'js' : 'ts'
+  }`;
   const originalContent = host.read(configPath, 'utf-8');
   const content = updateJestConfigContent(originalContent);
   host.write(configPath, content);

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -73,7 +73,7 @@ export async function reactInitGenerator(host: Tree, schema: InitSchema) {
   setDefault(host);
 
   if (!schema.unitTestRunner || schema.unitTestRunner === 'jest') {
-    const jestTask = jestInitGenerator(host, {});
+    const jestTask = jestInitGenerator(host, schema);
     tasks.push(jestTask);
   }
   if (!schema.e2eTestRunner || schema.e2eTestRunner === 'cypress') {

--- a/packages/react/src/generators/init/schema.d.ts
+++ b/packages/react/src/generators/init/schema.d.ts
@@ -2,4 +2,5 @@ export interface InitSchema {
   unitTestRunner?: 'jest' | 'none';
   e2eTestRunner?: 'cypress' | 'none';
   skipFormat?: boolean;
+  js?: boolean;
 }

--- a/packages/react/src/generators/init/schema.json
+++ b/packages/react/src/generators/init/schema.json
@@ -22,6 +22,11 @@
       "description": "Skip formatting files.",
       "type": "boolean",
       "default": false
+    },
+    "js": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use JavaScript instead of TypeScript"
     }
   },
   "required": []

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -90,6 +90,7 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
 
   if (options.unitTestRunner === 'jest') {
     const jestTask = await jestProjectGenerator(host, {
+      ...options,
       project: options.name,
       setupFile: 'none',
       supportTsx: true,

--- a/packages/workspace/src/generators/library/library.spec.ts
+++ b/packages/workspace/src/generators/library/library.spec.ts
@@ -704,7 +704,7 @@ describe('lib', () => {
         name: 'myLib',
         js: true,
       });
-      expect(tree.exists(`libs/my-lib/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`libs/my-lib/jest.config.js`)).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/index.js')).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/lib/my-lib.js')).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/lib/my-lib.spec.js')).toBeTruthy();
@@ -758,7 +758,7 @@ describe('lib', () => {
         directory: 'myDir',
         js: true,
       });
-      expect(tree.exists(`libs/my-dir/my-lib/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`libs/my-dir/my-lib/jest.config.js`)).toBeTruthy();
       expect(tree.exists('libs/my-dir/my-lib/src/index.js')).toBeTruthy();
       expect(
         tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.js')

--- a/packages/workspace/src/generators/library/library.ts
+++ b/packages/workspace/src/generators/library/library.ts
@@ -173,6 +173,7 @@ async function addJest(
   options: NormalizedSchema
 ): Promise<GeneratorCallback> {
   return await jestProjectGenerator(tree, {
+    ...options,
     project: options.name,
     setupFile: 'none',
     supportTsx: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
jest supports js flag, but other generators don't forward the flag

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
using --js with generators create js flags for jest

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
