### PR TITLE
fix(core): add dependency for cliui + string-width

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,7 +298,9 @@
     "send": "0.17.1",
     "tailwindcss": "^3.0.13",
     "tslib": "^2.3.0",
-    "weak-napi": "^2.0.2"
+    "weak-napi": "^2.0.2",
+    "cliui": "^7.0.2",
+    "string-width": "^4.2.3"
   },
   "resolutions": {
     "ng-packagr/rxjs": "6.6.7",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -55,6 +55,8 @@
     "tmp": "~0.2.1",
     "yargs": "^17.4.0",
     "yargs-parser": "21.0.1",
+    "cliui": "^7.0.2",
+    "string-width": "^4.2.3",
     "chalk": "4.1.0",
     "flat": "^5.0.2",
     "minimatch": "3.0.4",

--- a/scripts/depcheck/missing.ts
+++ b/scripts/depcheck/missing.ts
@@ -100,13 +100,6 @@ const IGNORE_MATCHES = {
     '@angular-devkit/core',
     '@angular-devkit/architect',
     '@angular/cli',
-    /**
-     * cliui is the CLI layout engine developed by yargs and we want to use the version of it
-     * which our currently installed yargs version brings in. It in turn depends on a specific
-     * version of string-width which we also leverage directly in print-help.
-     */
-    'cliui',
-    'string-width',
   ],
   web: [
     // we don't want to bloat the install of @nrwl/web by including @swc/core and swc-loader as a dependency.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When `astro` is installed, Nx commands error as they are unable to import `string-width`?

```
require() of ES Module D:\foo\node_modules\.pnpm\string-width@5.1.2\node_modules\string-width\index.js from D:\foo\node_modules\.pnpm\nx@14.0.1\node_modules\nx\src\utils\print-help.js not supported.
Instead change the require of index.js in D:\foo\node_modules\.pnpm\nx@14.0.1\node_modules\nx\src\utils\print-help.js to a dynamic import() which is available in all CommonJS modules.
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx brings its own version of `string-width` and isn't broken when installing other package?

@JamesHenry I understand we wanted to transitively depend on these dependencies but I wonder if there's a way that `yargs` exposes itself that we can use to do this? :shrug:

Better to maintain the version ourselves than to throw errors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://nrwlcommunity.slack.com/archives/CMFKWPU6Q/p1650660946152879
