### PR TITLE
fix(storybook): ignore experimental packages during migrating to v14

### DIFF
--- a/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
@@ -76,6 +76,19 @@ export function migrateStorybookInstance(
 function maybeUpdateVersion(tree: Tree): GeneratorCallback {
   let needsInstall = false;
   updateJson(tree, 'package.json', (json) => {
+    const ignoredStorybookPackages = [
+      '@storybook/builder-vite',
+      '@storybook/jest',
+      '@storybook/react-native',
+      '@storybook/storybook-deployer',
+      '@storybook/test-runner',
+      '@storybook/testing-library',
+      '@storybook/testing-angular',
+      '@storybook/testing-react',
+      '@storybook/testing-vue',
+      '@storybook/testing-vue3',
+    ];
+
     json.dependencies = json.dependencies || {};
     json.devDependencies = json.devDependencies || {};
 
@@ -84,8 +97,7 @@ function maybeUpdateVersion(tree: Tree): GeneratorCallback {
     ).filter(
       (packageName: string) =>
         packageName.startsWith('@storybook/') &&
-        !packageName.includes('@storybook/react-native') &&
-        !packageName.includes('@storybook/storybook-deployer')
+        !ignoredStorybookPackages.includes(packageName)
     );
 
     const allStorybookPackagesInDevDependencies = Object.keys(
@@ -93,8 +105,7 @@ function maybeUpdateVersion(tree: Tree): GeneratorCallback {
     ).filter(
       (packageName: string) =>
         packageName.startsWith('@storybook/') &&
-        !packageName.includes('@storybook/react-native') &&
-        !packageName.includes('@storybook/storybook-deployer')
+        !ignoredStorybookPackages.includes(packageName)
     );
 
     const storybookPackages = [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Migration for v14 updates the version of some experimental packages.
```js
"@storybook/builder-vite": "0.1.30"       → "~6.4.12" 🚫
"@storybook/jest": "0.0.10"               → "~6.4.12" 🚫
"@storybook/react-native": "5.3.25"       → "5.3.25" ✅
"@storybook/storybook-deployer": "2.8.11" → "2.8.11" ✅
"@storybook/test-runner": "0.0.7"         → "~6.4.12" 🚫
"@storybook/testing-library": "0.0.11"    → "~6.4.12" 🚫
"@storybook/testing-angular": "0.0.12"    → "~6.4.12" 🚫
"@storybook/testing-react": "1.2.4"       → "~6.4.12" 🚫
"@storybook/testing-vue": "0.0.3"         → "~6.4.12" 🚫
"@storybook/testing-vue3": "0.0.2"        → "~6.4.12" 🚫
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Migration for v14 should keep their version.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#9380
