### PR TITLE
fix(core): fix importing default exports for generators+executors

### DIFF
--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -185,7 +185,9 @@ export class Workspaces {
       implementation.split('#');
     return () => {
       const module = require(path.join(directory, implementationModulePath));
-      return module[implementationExportName || 'default'] as T;
+      return implementationExportName
+        ? module[implementationExportName]
+        : module.default ?? module;
     };
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Nx does not properly get a generator/executor from a `.js` file that looks like the following:

```
module.exports = () => {}
```  

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx properly gets a generator/executor from a `.js` file that looks like the following:

```
module.exports = () => {}
```  

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
