### PR TITLE
fix(core): fix usage of --dry-run flag in workspace generators

### DIFF
--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -74,6 +74,7 @@ function convertToGenerateOptions(
 
   delete generatorOptions.d;
   delete generatorOptions.dryRun;
+  delete generatorOptions['dry-run'];
   delete generatorOptions.interactive;
   delete generatorOptions.help;
   delete generatorOptions.collection;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Passing the `--dry-run` flag to a workspace generator throws `'dry-run' is not found in schema`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Workspace generators should support the `--dry-run` flag.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
