### PR TITLE
fix(angular): shared transitive npm deps from host and remote applica…

### DIFF
--- a/packages/angular/src/utils/mfe/__snapshots__/with-module-federation.spec.ts.snap
+++ b/packages/angular/src/utils/mfe/__snapshots__/with-module-federation.spec.ts.snap
@@ -23,6 +23,11 @@ Array [
           "eager": undefined,
           "requiredVersion": false,
         },
+        "npm:lodash": Object {
+          "requiredVersion": undefined,
+          "singleton": true,
+          "strictVersion": true,
+        },
         "shared": Object {
           "eager": undefined,
           "requiredVersion": false,

--- a/packages/angular/src/utils/mfe/__snapshots__/with-module-federation.spec.ts.snap
+++ b/packages/angular/src/utils/mfe/__snapshots__/with-module-federation.spec.ts.snap
@@ -23,7 +23,7 @@ Array [
           "eager": undefined,
           "requiredVersion": false,
         },
-        "npm:lodash": Object {
+        "lodash": Object {
           "requiredVersion": undefined,
           "singleton": true,
           "strictVersion": true,

--- a/packages/angular/src/utils/mfe/with-module-federation.spec.ts
+++ b/packages/angular/src/utils/mfe/with-module-federation.spec.ts
@@ -140,7 +140,7 @@ describe('withModuleFederation', () => {
           { target: 'npm:zone.js' },
           { target: 'core' },
         ],
-        core: [{ target: 'shared' }],
+        core: [{ target: 'shared' }, { target: 'npm:lodash' }],
       },
     });
 

--- a/packages/angular/src/utils/mfe/with-module-federation.ts
+++ b/packages/angular/src/utils/mfe/with-module-federation.ts
@@ -30,9 +30,15 @@ export interface MFEConfig {
   ) => SharedLibraryConfig | false;
 }
 
+interface DependencySets {
+  workspaceLibraries: Set<string>;
+  npmPackages: Set<string>;
+}
+
 function recursivelyResolveWorkspaceDependents(
   projectGraph: ProjectGraph<any>,
   target: string,
+  dependencySets: DependencySets,
   seenTargets: Set<string> = new Set()
 ) {
   if (seenTargets.has(target)) {
@@ -43,7 +49,19 @@ function recursivelyResolveWorkspaceDependents(
 
   const workspaceDependencies = (
     projectGraph.dependencies[target] ?? []
-  ).filter((dep) => !dep.target.startsWith('npm:'));
+  ).filter((dep) => {
+    const isNpm = dep.target.startsWith('npm:');
+
+    // If this is a npm dep ensure it is going to be added as a dep of this MFE so it can be shared if needed
+    if (isNpm) {
+      dependencySets.npmPackages.add(dep.target);
+    } else {
+      dependencySets.workspaceLibraries.add(dep.target);
+    }
+
+    return !isNpm;
+  });
+
   if (workspaceDependencies.length > 0) {
     for (const dep of workspaceDependencies) {
       dependencies = [
@@ -51,6 +69,7 @@ function recursivelyResolveWorkspaceDependents(
         ...recursivelyResolveWorkspaceDependents(
           projectGraph,
           dep.target,
+          dependencySets,
           seenTargets
         ),
       ];
@@ -103,7 +122,8 @@ async function getDependentPackagesForProject(name: string) {
     projectGraph = await createProjectGraphAsync();
   }
 
-  const deps = projectGraph.dependencies[name].reduce(
+  // Build Sets for the direct deps (internal and external) for this MFE app
+  const dependencySets = projectGraph.dependencies[name].reduce(
     (dependencies, dependency) => {
       const workspaceLibraries = new Set(dependencies.workspaceLibraries);
       const npmPackages = new Set(dependencies.npmPackages);
@@ -115,24 +135,27 @@ async function getDependentPackagesForProject(name: string) {
       }
 
       return {
-        workspaceLibraries: [...workspaceLibraries],
-        npmPackages: [...npmPackages],
+        workspaceLibraries,
+        npmPackages,
       };
     },
-    { workspaceLibraries: [], npmPackages: [] }
+    { workspaceLibraries: new Set<string>(), npmPackages: new Set<string>() }
   );
+
   const seenWorkspaceLibraries = new Set<string>();
-  deps.workspaceLibraries = deps.workspaceLibraries.reduce(
-    (workspaceLibraryDeps, workspaceLibrary) => [
-      ...workspaceLibraryDeps,
-      ...recursivelyResolveWorkspaceDependents(
-        projectGraph,
-        workspaceLibrary,
-        seenWorkspaceLibraries
-      ),
-    ],
-    []
-  );
+  dependencySets.workspaceLibraries.forEach((workspaceLibrary) => {
+    recursivelyResolveWorkspaceDependents(
+      projectGraph,
+      workspaceLibrary,
+      dependencySets,
+      seenWorkspaceLibraries
+    );
+  });
+
+  const deps = {
+    workspaceLibraries: [...dependencySets.workspaceLibraries],
+    npmPackages: [...dependencySets.npmPackages],
+  };
 
   deps.workspaceLibraries = mapWorkspaceLibrariesToTsConfigImport(
     deps.workspaceLibraries

--- a/packages/angular/src/utils/mfe/with-module-federation.ts
+++ b/packages/angular/src/utils/mfe/with-module-federation.ts
@@ -54,7 +54,7 @@ function recursivelyResolveWorkspaceDependents(
 
     // If this is a npm dep ensure it is going to be added as a dep of this MFE so it can be shared if needed
     if (isNpm) {
-      dependencySets.npmPackages.add(dep.target);
+      dependencySets.npmPackages.add(dep.target.replace('npm:', ''));
     } else {
       dependencySets.workspaceLibraries.add(dep.target);
     }

--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -39,7 +39,7 @@ function recursivelyResolveWorkspaceDependents(
 
     // If this is a npm dep ensure it is going to be added as a dep of this MFE so it can be shared if needed
     if (isNpm) {
-      dependencySets.npmPackages.add(dep.target);
+      dependencySets.npmPackages.add(dep.target.replace('npm:', ''));
     } else {
       dependencySets.workspaceLibraries.add(dep.target);
     }

--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -15,9 +15,15 @@ import { readWorkspaceJson } from 'nx/src/project-graph/file-utils';
 import { ModuleFederationConfig, Remotes } from './models';
 import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
 
+interface DependencySets {
+  workspaceLibraries: Set<string>;
+  npmPackages: Set<string>;
+}
+
 function recursivelyResolveWorkspaceDependents(
   projectGraph: ProjectGraph<any>,
   target: string,
+  dependencySets: DependencySets,
   seenTargets: Set<string> = new Set()
 ) {
   if (seenTargets.has(target)) {
@@ -28,7 +34,19 @@ function recursivelyResolveWorkspaceDependents(
 
   const workspaceDependencies = (
     projectGraph.dependencies[target] ?? []
-  ).filter((dep) => !dep.target.startsWith('npm:'));
+  ).filter((dep) => {
+    const isNpm = dep.target.startsWith('npm:');
+
+    // If this is a npm dep ensure it is going to be added as a dep of this MFE so it can be shared if needed
+    if (isNpm) {
+      dependencySets.npmPackages.add(dep.target);
+    } else {
+      dependencySets.workspaceLibraries.add(dep.target);
+    }
+
+    return !isNpm;
+  });
+
   if (workspaceDependencies.length > 0) {
     for (const dep of workspaceDependencies) {
       dependencies = [
@@ -36,6 +54,7 @@ function recursivelyResolveWorkspaceDependents(
         ...recursivelyResolveWorkspaceDependents(
           projectGraph,
           dep.target,
+          dependencySets,
           seenTargets
         ),
       ];
@@ -81,15 +100,15 @@ function mapWorkspaceLibrariesToTsConfigImport(workspaceLibraries: string[]) {
 }
 
 async function getDependentPackagesForProject(name: string) {
-  let projectGraph: ProjectGraph;
-
+  let projectGraph: ProjectGraph<any>;
   try {
     projectGraph = readCachedProjectGraph();
   } catch (e) {
     projectGraph = await createProjectGraphAsync();
   }
 
-  const deps = projectGraph.dependencies[name].reduce(
+  // Build Sets for the direct deps (internal and external) for this MFE app
+  const dependencySets = projectGraph.dependencies[name].reduce(
     (dependencies, dependency) => {
       const workspaceLibraries = new Set(dependencies.workspaceLibraries);
       const npmPackages = new Set(dependencies.npmPackages);
@@ -101,24 +120,27 @@ async function getDependentPackagesForProject(name: string) {
       }
 
       return {
-        workspaceLibraries: [...workspaceLibraries],
-        npmPackages: [...npmPackages],
+        workspaceLibraries,
+        npmPackages,
       };
     },
-    { workspaceLibraries: [], npmPackages: [] }
+    { workspaceLibraries: new Set<string>(), npmPackages: new Set<string>() }
   );
+
   const seenWorkspaceLibraries = new Set<string>();
-  deps.workspaceLibraries = deps.workspaceLibraries.reduce(
-    (workspaceLibraryDeps, workspaceLibrary) => [
-      ...workspaceLibraryDeps,
-      ...recursivelyResolveWorkspaceDependents(
-        projectGraph,
-        workspaceLibrary,
-        seenWorkspaceLibraries
-      ),
-    ],
-    []
-  );
+  dependencySets.workspaceLibraries.forEach((workspaceLibrary) => {
+    recursivelyResolveWorkspaceDependents(
+      projectGraph,
+      workspaceLibrary,
+      dependencySets,
+      seenWorkspaceLibraries
+    );
+  });
+
+  const deps = {
+    workspaceLibraries: [...dependencySets.workspaceLibraries],
+    npmPackages: [...dependencySets.npmPackages],
+  };
 
   deps.workspaceLibraries = mapWorkspaceLibrariesToTsConfigImport(
     deps.workspaceLibraries


### PR DESCRIPTION
…tions

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently when building MFEs with Nx if a remote has a transitive dependency on an npm lib that npm lib is not included in the shared libs when compiling with webpack.

Example:

Host AppModule imports:
```
// ngrx store
StoreModule.forRoot()
```

Remote AppModule imports:
```
SomeCustomStateModule
```

SomeCustomStateModule imports:
```
StoreModule.forFeature()
```

will result in a DI injection issue where the ReducerManager is not provided, this is because @ngrx/store is not shared.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Should shared all npm deps between the different MFEs

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
