### PR TITLE
fix(core): fix having multiple versions of nx/devkit

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -29,7 +29,7 @@ type Arguments = {
   style: string;
   nxCloud: boolean;
   allPrompts: boolean;
-  packageManager: string;
+  packageManager: PackageManager;
   defaultBase: string;
   ci: string[];
 };
@@ -693,10 +693,12 @@ async function determineCI(
   return [];
 }
 
-async function createSandbox(packageManager: string) {
+async function createSandbox(packageManager: PackageManager) {
   const installSpinner = ora(
     `Installing dependencies with ${packageManager}`
   ).start();
+
+  const { install } = getPackageManagerCommand(packageManager);
 
   const tmpDir = dirSync().name;
   try {
@@ -713,7 +715,7 @@ async function createSandbox(packageManager: string) {
       })
     );
 
-    await execAndWait(`${packageManager} install --silent`, tmpDir);
+    await execAndWait(`${install} --silent`, tmpDir);
 
     installSpinner.succeed();
   } catch (e) {

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -27,11 +27,13 @@
   },
   "homepage": "https://nx.dev",
   "dependencies": {
-    "nx": "*",
     "ejs": "^3.1.5",
     "ignore": "^5.0.4",
     "rxjs": "^6.5.4",
     "semver": "7.3.4",
     "tslib": "^2.3.0"
+  },
+  "peerDependencies": {
+    "nx": ">= 13.10 <= 15"
   }
 }

--- a/packages/devkit/src/tasks/install-packages-task.ts
+++ b/packages/devkit/src/tasks/install-packages-task.ts
@@ -8,8 +8,6 @@ import {
 import type { PackageManager } from 'nx/src/utils/package-manager';
 import { joinPathFragments } from 'nx/src/utils/path';
 
-let storedPackageJsonValue: string;
-
 /**
  * Runs `npm install` or `yarn install`. It will skip running the install if
  * `package.json` hasn't changed at all or it hasn't changed since the last invocation.
@@ -23,24 +21,27 @@ export function installPackagesTask(
   cwd: string = '',
   packageManager: PackageManager = detectPackageManager(cwd)
 ): void {
+  if (
+    !tree
+      .listChanges()
+      .find((f) => f.path === joinPathFragments(cwd, 'package.json')) &&
+    !alwaysRun
+  ) {
+    return;
+  }
+
   const packageJsonValue = tree.read(
     joinPathFragments(cwd, 'package.json'),
     'utf-8'
   );
-  if (
-    tree
-      .listChanges()
-      .find((f) => f.path === joinPathFragments(cwd, 'package.json')) ||
-    alwaysRun
-  ) {
-    // Don't install again if install was already executed with package.json
-    if (storedPackageJsonValue != packageJsonValue || alwaysRun) {
-      storedPackageJsonValue = packageJsonValue;
-      const pmc = getPackageManagerCommand(packageManager);
-      execSync(pmc.install, {
-        cwd: join(tree.root, cwd),
-        stdio: [0, 1, 2],
-      });
-    }
+  let storedPackageJsonValue: string = global['__packageJsonInstallCache__'];
+  // Don't install again if install was already executed with package.json
+  if (storedPackageJsonValue != packageJsonValue || alwaysRun) {
+    global['__packageJsonInstallCache__'] = packageJsonValue;
+    const pmc = getPackageManagerCommand(packageManager);
+    execSync(pmc.install, {
+      cwd: join(tree.root, cwd),
+      stdio: [0, 1, 2],
+    });
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`@nrwl/devkit` brings in `nx` as a dependency which causes an issue where `nx`'s `postinstall` is run multiple times. This causes some CI machines to run out of memory. Also, installing packages during generators, is able to dedupe installs during the same installation of devkit, but it is not able to dedupe across multiple versions of devkit.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@nrwl/devkit` has a peer dependency on `nx`. The range for this dependency goes up a major version as we should keep nx compatible with devkit. This will fix having multiple versions of `nx` installed. This fixes some CI machines to run out of memory. Also, installing packages during generators, is able to dedupe installs across different installations of devkit.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
