### PR TITLE
docs(nx-and-angular): `nx` instead of `ng` command

### DIFF
--- a/docs/shared/getting-started/nx-and-angular.md
+++ b/docs/shared/getting-started/nx-and-angular.md
@@ -34,7 +34,7 @@ Check out the following to get started:
 
 Nx integrates well with the Angular CLI:
 
-- It decorates the Angular CLI. After adding Nx to your workspace, running `ng` will run the wrapped Angular CLI that goes through Nx. Everything will work the same way but a lot faster.
+- It decorates the Angular CLI. After adding Nx to your workspace, running `nx` will run the wrapped Angular CLI that goes through Nx. Everything will work the same way but a lot faster.
 - It supports all Angular Devkit builders and schematics.
 - It supports using `angular.json` to configure projects and their targets.
 - Nx Console works with Angular CLI projects.


### PR DESCRIPTION
I believe there is mistake - there should be `nx` command instead of `ng`

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
