### PR TITLE
fix(js): update minimal publish script to validate project name and c…

### DIFF
--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -833,7 +833,6 @@ describe('lib', () => {
           options: {
             command:
               'node tools/scripts/publish.mjs my-lib {args.ver} {args.tag}',
-            cwd: 'dist/libs/my-lib',
           },
           dependsOn: [{ projects: 'self', target: 'build' }],
         });

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -117,7 +117,6 @@ function addProject(
         executor: '@nrwl/workspace:run-commands',
         options: {
           command: `node ${publishScriptPath} ${options.name} {args.ver} {args.tag}`,
-          cwd: outputPath,
         },
         dependsOn: [{ projects: 'self', target: 'build' }],
       };

--- a/packages/js/src/utils/minimal-publish-script.ts
+++ b/packages/js/src/utils/minimal-publish-script.ts
@@ -2,28 +2,53 @@ import type { Tree } from '@nrwl/devkit';
 
 const publishScriptContent = `
 /**
-* This is a minimal script to publish your package to "npm".
-* This is meant to be used as-is or customize as you see fit.
-* 
-* This script is executed on "dist/path/to/library" as "cwd" by default.
-*
-* You might need to authenticate with NPM before running this script.
-*/
+ * This is a minimal script to publish your package to "npm".
+ * This is meant to be used as-is or customize as you see fit.
+ *
+ * This script is executed on "dist/path/to/library" as "cwd" by default.
+ *
+ * You might need to authenticate with NPM before running this script.
+ */
 
+import { readCachedProjectGraph  } from '@nrwl/devkit';
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
+
+function invariant(condition, message) {
+  if (!condition) {
+    console.error(chalk.bold.red(message));
+    process.exit(1);
+  } 
+}
 
 // Executing publish script: node path/to/publish.mjs {name} --version {version} --tag {tag}
-// Default "tag" to "next" so we won't publish the "latest" tag by accident.  
+// Default "tag" to "next" so we won't publish the "latest" tag by accident.
 const [, , name, version, tag = 'next'] = process.argv;
 
-// A simple SemVer validation to validate the version 
+// A simple SemVer validation to validate the version
 const validVersion = /^\\d+\\.\\d+\\.\\d(-\\w+\\.\\d+)?/;
-if (!version || !validVersion.test(version)) {
-  console.error(chalk.bold.red(\`No version provided or version did not match Semantic Versioning, expected: #.#.#-tag.# or #.#.#, got \${version}\`));
-  process.exit(1);
-}
+invariant(
+  version && validVersion.test(version),
+  \`No version provided or version did not match Semantic Versioning, expected: #.#.#-tag.# or #.#.#, got \${version}.\`
+);
+
+
+const graph = readCachedProjectGraph();
+const project = graph.nodes[name];
+
+invariant(
+  project,
+ \`Could not find project "\${name}" in the workspace. Is the project.json configured correctly?\`
+);
+
+const outputPath = project.data?.targets?.build?.options?.outputPath;
+invariant(
+  outputPath,
+  \`Could not find "build.options.outputPath" of project "\${name}". Is project.json configured  correctly?\`
+);
+
+process.chdir(outputPath);
 
 // Updating the version in "package.json" before publishing
 try {
@@ -31,7 +56,9 @@ try {
   json.version = version;
   writeFileSync(\`package.json\`, JSON.stringify(json, null, 2));
 } catch (e) {
-  console.error(chalk.bold.red(\`Error reading package.json file from library build output.\`))
+  console.error(
+    chalk.bold.red(\`Error reading package.json file from library build output.\`)
+  );
 }
 
 // Execute "npm publish" to publish


### PR DESCRIPTION
…onfig

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

* Getting errors in publish script (`import * as chalk from 'chalk'` should be `import chalk  from `chalk`).
* `publish` target hard-codes the output path, so it could diverge if user changes config.

## Expected Behavior

* Publish script works without errors.
* `publish` script reads project config and validates it contains `outputPath`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
