### PR TITLE
fix(core): fix migrating old workspaces without nx

### DIFF
--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -460,7 +460,7 @@ export function parseMigrationsOptions(options: {
 function versions(root: string, from: Record<string, string>) {
   const cache: Record<string, string> = {};
 
-  return (packageName: string) => {
+  function getFromVersion(packageName: string) {
     try {
       if (from[packageName]) {
         return from[packageName];
@@ -475,9 +475,15 @@ function versions(root: string, from: Record<string, string>) {
 
       return cache[packageName];
     } catch {
+      // Support migrating old workspaces without nx package
+      if (packageName === 'nx') {
+        return getFromVersion('@nrwl/workspace');
+      }
       return null;
     }
-  };
+  }
+
+  return getFromVersion;
 }
 
 // testing-fetch-start


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Migrating workspaces without `nx` to `latest` does not work anymore.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Migrating workspaces without `nx` to `latest` works.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
