### PR TITLE
fix(js): add missing --tag flag to the publish command

### DIFF
--- a/packages/js/src/utils/minimal-publish-script.ts
+++ b/packages/js/src/utils/minimal-publish-script.ts
@@ -62,7 +62,7 @@ try {
 }
 
 // Execute "npm publish" to publish
-execSync(\`npm publish --access public\`);
+execSync(\`npm publish --access public --tag \${tag}\`);
 `;
 
 export function addMinimalPublishScript(tree: Tree) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`tag` is being passed in but not actually used in the final `npm publish` command

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`npm publish` command should use the `--tag`flag

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
