### PR TITLE
docs(js): add docs about publishable tag

### DIFF
--- a/docs/shared/workspace/buildable-and-publishable-libraries.md
+++ b/docs/shared/workspace/buildable-and-publishable-libraries.md
@@ -13,6 +13,8 @@ This document will look to explain the motivations for why you would use either 
 
 You might use the `--publishable` option when generating a new Nx library if your intention is to distribute it outside the monorepo.
 
+> If you are using `@nrwl/js:lib`, check out [Nx and Typescript](/getting-started/nx-and-typescript#publish-your-typescript-packages-to-npm)
+
 One typical scenario for this may be that you use Nx to develop your organizations UI design system component library (maybe using its Storybook integration), which should be available also to your organizations’ apps that are not hosted within the same monorepo.
 
 A normal Nx library - let’s call it "workspace library" - is not made for building or publishing. Rather it only includes common lint and test targets in its `project.json` file. These libraries are directly referenced from one of the monorepo’s applications and built together with them.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
No documentation on the new behavior of `@nrwl/js:lib` with `--publishable` flag

## Expected Behavior
- "Publish your TypeScript packages to NPM" section on "Nx and TypeScript" includes information about the `--publishable` flag behavior
- Add link to "Publish your TypeScript packages to NPM" from "Publishable libraries" section on "Publishable and Buildable Nx Libraries"

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
