### PR TITLE
cleanup(angular): simplify collecting mf application dependencies

### DIFF
--- a/packages/angular/src/utils/mfe/__snapshots__/with-module-federation.spec.ts.snap
+++ b/packages/angular/src/utils/mfe/__snapshots__/with-module-federation.spec.ts.snap
@@ -144,3 +144,40 @@ Array [
   },
 ]
 `;
+
+exports[`withModuleFederation should not have duplicated entries for duplicated dependencies 1`] = `
+Array [
+  ModuleFederationPlugin {
+    "_options": Object {
+      "exposes": Object {
+        "./Module": "apps/remote1/src/module.ts",
+      },
+      "filename": "remoteEntry.mjs",
+      "library": Object {
+        "type": "module",
+      },
+      "name": "remote1",
+      "remotes": Object {},
+      "shared": Object {
+        "@angular/core": Object {
+          "requiredVersion": "~13.2.0",
+          "singleton": true,
+          "strictVersion": true,
+        },
+        "core": Object {
+          "eager": undefined,
+          "requiredVersion": false,
+        },
+        "shared": Object {
+          "eager": undefined,
+          "requiredVersion": false,
+        },
+      },
+    },
+  },
+  NormalModuleReplacementPlugin {
+    "newResource": [Function],
+    "resourceRegExp": /\\./,
+  },
+]
+`;

--- a/packages/angular/src/utils/mfe/with-module-federation.ts
+++ b/packages/angular/src/utils/mfe/with-module-federation.ts
@@ -30,51 +30,31 @@ export interface MFEConfig {
   ) => SharedLibraryConfig | false;
 }
 
-interface DependencySets {
+function collectDependencies(
+  projectGraph: ProjectGraph,
+  name: string,
+  dependencies = {
+    workspaceLibraries: new Set<string>(),
+    npmPackages: new Set<string>(),
+  },
+  seen: Set<string> = new Set()
+): {
   workspaceLibraries: Set<string>;
   npmPackages: Set<string>;
-}
-
-function recursivelyResolveWorkspaceDependents(
-  projectGraph: ProjectGraph<any>,
-  target: string,
-  dependencySets: DependencySets,
-  seenTargets: Set<string> = new Set()
-) {
-  if (seenTargets.has(target)) {
-    return [];
+} {
+  if (seen.has(name)) {
+    return dependencies;
   }
-  let dependencies = [target];
-  seenTargets.add(target);
+  seen.add(name);
 
-  const workspaceDependencies = (
-    projectGraph.dependencies[target] ?? []
-  ).filter((dep) => {
-    const isNpm = dep.target.startsWith('npm:');
-
-    // If this is a npm dep ensure it is going to be added as a dep of this MFE so it can be shared if needed
-    if (isNpm) {
-      dependencySets.npmPackages.add(dep.target.replace('npm:', ''));
+  (projectGraph.dependencies[name] ?? []).forEach((dependency) => {
+    if (dependency.target.startsWith('npm:')) {
+      dependencies.npmPackages.add(dependency.target.replace('npm:', ''));
     } else {
-      dependencySets.workspaceLibraries.add(dep.target);
+      dependencies.workspaceLibraries.add(dependency.target);
+      collectDependencies(projectGraph, dependency.target, dependencies, seen);
     }
-
-    return !isNpm;
   });
-
-  if (workspaceDependencies.length > 0) {
-    for (const dep of workspaceDependencies) {
-      dependencies = [
-        ...dependencies,
-        ...recursivelyResolveWorkspaceDependents(
-          projectGraph,
-          dep.target,
-          dependencySets,
-          seenTargets
-        ),
-      ];
-    }
-  }
 
   return dependencies;
 }
@@ -122,45 +102,17 @@ async function getDependentPackagesForProject(name: string) {
     projectGraph = await createProjectGraphAsync();
   }
 
-  // Build Sets for the direct deps (internal and external) for this MFE app
-  const dependencySets = projectGraph.dependencies[name].reduce(
-    (dependencies, dependency) => {
-      const workspaceLibraries = new Set(dependencies.workspaceLibraries);
-      const npmPackages = new Set(dependencies.npmPackages);
-
-      if (dependency.target.startsWith('npm:')) {
-        npmPackages.add(dependency.target.replace('npm:', ''));
-      } else {
-        workspaceLibraries.add(dependency.target);
-      }
-
-      return {
-        workspaceLibraries,
-        npmPackages,
-      };
-    },
-    { workspaceLibraries: new Set<string>(), npmPackages: new Set<string>() }
+  const { npmPackages, workspaceLibraries } = collectDependencies(
+    projectGraph,
+    name
   );
 
-  const seenWorkspaceLibraries = new Set<string>();
-  dependencySets.workspaceLibraries.forEach((workspaceLibrary) => {
-    recursivelyResolveWorkspaceDependents(
-      projectGraph,
-      workspaceLibrary,
-      dependencySets,
-      seenWorkspaceLibraries
-    );
-  });
-
-  const deps = {
-    workspaceLibraries: [...dependencySets.workspaceLibraries],
-    npmPackages: [...dependencySets.npmPackages],
+  return {
+    workspaceLibraries: mapWorkspaceLibrariesToTsConfigImport([
+      ...workspaceLibraries,
+    ]),
+    npmPackages: [...npmPackages],
   };
-
-  deps.workspaceLibraries = mapWorkspaceLibrariesToTsConfigImport(
-    deps.workspaceLibraries
-  );
-  return deps;
 }
 
 function determineRemoteUrl(remote: string) {


### PR DESCRIPTION
Simplify the current algorithm to collect MF application dependencies to improve readability, maintainability, and reduce memory allocations.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
