### PR TITLE
fix(storybook): include all react exports for story generation

### DIFF
--- a/packages/react-native/src/generators/component-story/files/__componentFileName__.stories.__fileExt__
+++ b/packages/react-native/src/generators/component-story/files/__componentFileName__.stories.__fileExt__
@@ -6,7 +6,7 @@ import React from 'react';
 import {
   <%= componentName %>
   <% if ( propsTypeName ) { %>, <%= propsTypeName %> <% } %>
-} from './<%= componentFileName %>';
+} from './<%= componentImportFileName %>';
 
 <% if (hasActions) { %>
   const actions = {<% for (let argType of argTypes) { %>

--- a/packages/react-native/src/generators/stories/stories.ts
+++ b/packages/react-native/src/generators/stories/stories.ts
@@ -1,10 +1,6 @@
-import { getComponentName } from '@nrwl/react/src/utils/ast-utils';
-import * as ts from 'typescript';
 import {
   convertNxGenerator,
   getProjects,
-  joinPathFragments,
-  ProjectType,
   Tree,
   visitNotIgnoredFiles,
 } from '@nrwl/devkit';
@@ -12,42 +8,10 @@ import { join } from 'path';
 
 import componentStoryGenerator from '../component-story/component-story';
 import { StorybookStoriesSchema } from './schema';
-
-export function projectRootPath(
-  tree: Tree,
-  sourceRoot: string,
-  projectType: ProjectType
-): string {
-  let projectDir = '';
-  if (projectType === 'application') {
-    // apps/test-app/src/app
-    projectDir = 'app';
-  } else if (projectType == 'library') {
-    // libs/test-lib/src/lib
-    projectDir = 'lib';
-  }
-
-  return joinPathFragments(sourceRoot, projectDir);
-}
-
-function containsComponentDeclaration(
-  tree: Tree,
-  componentPath: string
-): boolean {
-  const contents = tree.read(componentPath, 'utf-8');
-  if (contents === null) {
-    throw new Error(`Failed to read ${componentPath}`);
-  }
-
-  const sourceFile = ts.createSourceFile(
-    componentPath,
-    contents,
-    ts.ScriptTarget.Latest,
-    true
-  );
-
-  return !!getComponentName(sourceFile);
-}
+import {
+  containsComponentDeclaration,
+  projectRootPath,
+} from '@nrwl/react/src/generators/stories/stories';
 
 export async function createAllStories(tree: Tree, projectName: string) {
   const projects = getProjects(tree);

--- a/packages/react/src/generators/component-story/component-story.spec.ts
+++ b/packages/react/src/generators/component-story/component-story.spec.ts
@@ -278,121 +278,126 @@ describe('react:component-story', () => {
       });
     });
 
-    [
-      {
-        name: 'default export function',
-        src: `export default function Test(props: TestProps) {
-        return (
-          <div>
-            <h1>Welcome to test component, {props.name}</h1>
-          </div>
-        );
-      };
-      `,
-      },
-      {
-        name: 'function and then export',
-        src: `
-      function Test(props: TestProps) {
-        return (
-          <div>
-            <h1>Welcome to test component, {props.name}</h1>
-          </div>
-        );
-      };
-      export default Test;
-      `,
-      },
-      {
-        name: 'arrow function',
-        src: `
-      const Test = (props: TestProps) => {
-        return (
-          <div>
-            <h1>Welcome to test component, {props.name}</h1>
-          </div>
-        );
-      };
-      export default Test;
-      `,
-      },
-      {
-        name: 'arrow function without {..}',
-        src: `
-      const Test = (props: TestProps) => <div><h1>Welcome to test component, {props.name}</h1></div>;
-      export default Test
-      `,
-      },
-      {
-        name: 'direct export of component class',
-        src: `
-        export default class Test extends React.Component<TestProps> {
-          render() {
-            return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
-          }
-        }
+    describe('Other types of component definitions', () => {
+      describe('Component files with DEFAULT export', () => {
+        const reactComponentDefinitions = [
+          {
+            name: 'default export function',
+            src: `export default function Test(props: TestProps) {
+          return (
+            <div>
+              <h1>Welcome to test component, {props.name}</h1>
+            </div>
+          );
+        };
         `,
-      },
-      {
-        name: 'component class & then default export',
-        src: `
-        class Test extends React.Component<TestProps> {
-          render() {
-            return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
-          }
-        }
+          },
+          {
+            name: 'function and then export',
+            src: `
+        function Test(props: TestProps) {
+          return (
+            <div>
+              <h1>Welcome to test component, {props.name}</h1>
+            </div>
+          );
+        };
+        export default Test;
+        `,
+          },
+          {
+            name: 'arrow function',
+            src: `
+        const Test = (props: TestProps) => {
+          return (
+            <div>
+              <h1>Welcome to test component, {props.name}</h1>
+            </div>
+          );
+        };
+        export default Test;
+        `,
+          },
+          {
+            name: 'arrow function without {..}',
+            src: `
+        const Test = (props: TestProps) => <div><h1>Welcome to test component, {props.name}</h1></div>;
         export default Test
         `,
-      },
-      {
-        name: 'PureComponent class & then default export',
-        src: `
-        class Test extends React.PureComponent<TestProps> {
-          render() {
-            return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+          },
+          {
+            name: 'direct export of component class',
+            src: `
+          export default class Test extends React.Component<TestProps> {
+            render() {
+              return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+            }
           }
-        }
-        export default Test
-        `,
-      },
-      {
-        name: 'direct export of component class new JSX transform',
-        src: `
-        export default class Test extends Component<TestProps> {
-          render() {
-            return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+          `,
+          },
+          {
+            name: 'component class & then default export',
+            src: `
+          class Test extends React.Component<TestProps> {
+            render() {
+              return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+            }
           }
-        }
-        `,
-      },
-      {
-        name: 'component class & then default export new JSX transform',
-        src: `
-        class Test extends Component<TestProps> {
-          render() {
-            return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+          export default Test
+          `,
+          },
+          {
+            name: 'PureComponent class & then default export',
+            src: `
+          class Test extends React.PureComponent<TestProps> {
+            render() {
+              return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+            }
           }
-        }
-        export default Test
-        `,
-      },
-      {
-        name: 'PureComponent class & then default export new JSX transform',
-        src: `
-        class Test extends PureComponent<TestProps> {
-          render() {
-            return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+          export default Test
+          `,
+          },
+          {
+            name: 'direct export of component class new JSX transform',
+            src: `
+          export default class Test extends Component<TestProps> {
+            render() {
+              return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+            }
           }
-        }
-        export default Test
-        `,
-      },
-    ].forEach((config) => {
-      describe(`React component defined as:${config.name}`, () => {
-        beforeEach(async () => {
-          appTree.write(
-            cmpPath,
-            `import React from 'react';
+          `,
+          },
+          {
+            name: 'component class & then default export new JSX transform',
+            src: `
+          class Test extends Component<TestProps> {
+            render() {
+              return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+            }
+          }
+          export default Test
+          `,
+          },
+          {
+            name: 'PureComponent class & then default export new JSX transform',
+            src: `
+          class Test extends PureComponent<TestProps> {
+            render() {
+              return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+            }
+          }
+          export default Test
+          `,
+          },
+        ];
+
+        describe.each(reactComponentDefinitions)(
+          'React component defined as: $name',
+          ({ src }) => {
+            beforeEach(async () => {
+              appTree.write(
+                cmpPath,
+                `import React from 'react';
     
             import './test.scss';
             
@@ -401,19 +406,19 @@ describe('react:component-story', () => {
               displayAge: boolean;
             }
             
-            ${config.src}
+            ${src}
             `
-          );
+              );
 
-          await componentStoryGenerator(appTree, {
-            componentPath: 'lib/test-ui-lib.tsx',
-            project: 'test-ui-lib',
-          });
-        });
+              await componentStoryGenerator(appTree, {
+                componentPath: 'lib/test-ui-lib.tsx',
+                project: 'test-ui-lib',
+              });
+            });
 
-        it('should properly setup the controls based on the component props', () => {
-          expect(formatFile`${appTree.read(storyFilePath, 'utf-8')}`)
-            .toContain(formatFile`
+            it('should properly setup the controls based on the component props', () => {
+              expect(formatFile`${appTree.read(storyFilePath, 'utf-8')}`)
+                .toContain(formatFile`
             import { Story, Meta } from '@storybook/react';
             import { Test, TestProps } from './test-ui-lib';
 
@@ -430,6 +435,232 @@ describe('react:component-story', () => {
               displayAge: false,
             };
           `);
+            });
+          }
+        );
+      });
+
+      describe('Component files with NO DEFAULT export', () => {
+        const noDefaultExportComponents = [
+          {
+            name: 'no default simple export function',
+            src: `export function Test(props: TestProps) {
+          return (
+            <div>
+              <h1>Welcome to test component, {props.name}</h1>
+            </div>
+          );
+        };
+        `,
+          },
+          {
+            name: 'no default arrow function',
+            src: `
+            export const Test = (props: TestProps) => {
+          return (
+            <div>
+              <h1>Welcome to test component, {props.name}</h1>
+            </div>
+          );
+        };
+        `,
+          },
+          {
+            name: 'no default arrow function without {..}',
+            src: `
+            export const Test = (props: TestProps) => <div><h1>Welcome to test component, {props.name}</h1></div>;
+        `,
+          },
+          {
+            name: 'no default direct export of component class',
+            src: `
+          export class Test extends React.Component<TestProps> {
+            render() {
+              return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+            }
+          }
+          `,
+          },
+          {
+            name: 'no default component class',
+            src: `
+            export class Test extends React.Component<TestProps> {
+            render() {
+              return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+            }
+          }
+          `,
+          },
+          {
+            name: 'no default PureComponent class & then default export',
+            src: `
+            export class Test extends React.PureComponent<TestProps> {
+            render() {
+              return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+            }
+          }
+          `,
+          },
+          {
+            name: 'no default direct export of component class new JSX transform',
+            src: `
+          export class Test extends Component<TestProps> {
+            render() {
+              return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+            }
+          }
+          `,
+          },
+          {
+            name: 'no default PureComponent class & then default export new JSX transform',
+            src: `
+            export class Test extends PureComponent<TestProps> {
+            render() {
+              return <div><h1>Welcome to test component, {this.props.name}</h1></div>;
+            }
+          }
+          `,
+          },
+        ];
+
+        describe.each(noDefaultExportComponents)(
+          'React component defined as: $name',
+          ({ src }) => {
+            beforeEach(async () => {
+              appTree.write(
+                cmpPath,
+                `import React from 'react';
+      
+              import './test.scss';
+              
+              export interface TestProps {
+                name: string;
+                displayAge: boolean;
+              }
+              
+              ${src}
+              `
+              );
+
+              await componentStoryGenerator(appTree, {
+                componentPath: 'lib/test-ui-lib.tsx',
+                project: 'test-ui-lib',
+              });
+            });
+
+            it('should properly setup the controls based on the component props', () => {
+              expect(formatFile`${appTree.read(storyFilePath, 'utf-8')}`)
+                .toContain(formatFile`
+              import { Story, Meta } from '@storybook/react';
+              import { Test, TestProps } from './test-ui-lib';
+  
+              export default {
+                component: Test,
+                title: 'Test',
+              } as Meta;
+  
+              const Template: Story<TestProps> = (args) => <Test {...args} />;
+  
+              export const Primary = Template.bind({});
+              Primary.args = {
+                name: '',
+                displayAge: false,
+              };
+            `);
+            });
+          }
+        );
+
+        it('should create stories for all components in a file with no default export', async () => {
+          appTree.write(
+            cmpPath,
+            `import React from 'react';
+  
+            function One() {
+              return <div>Hello one</div>;
+            }
+            
+            function Two() {
+              return <div>Hello two</div>;
+            }
+            
+            export interface ThreeProps {
+              name: string;
+            }           
+    
+            function Three(props: ThreeProps) {
+              return (
+                <div>
+                  <h1>Welcome to Three {props.name}!</h1>
+                </div>
+              );
+            }
+            
+            export { One, Two, Three };    
+            `
+          );
+
+          await componentStoryGenerator(appTree, {
+            componentPath: 'lib/test-ui-lib.tsx',
+            project: 'test-ui-lib',
+          });
+
+          const storyFilePathOne =
+            'libs/test-ui-lib/src/lib/test-ui-lib--One.stories.tsx';
+          const storyFilePathTwo =
+            'libs/test-ui-lib/src/lib/test-ui-lib--Two.stories.tsx';
+          const storyFilePathThree =
+            'libs/test-ui-lib/src/lib/test-ui-lib--Three.stories.tsx';
+
+          expect(formatFile`${appTree.read(storyFilePathOne, 'utf-8')}`)
+            .toContain(formatFile`
+            import { Story, Meta } from '@storybook/react';
+            import { One } from './test-ui-lib';
+            
+            export default {
+              component: One,
+              title: 'One',
+            } as Meta;
+            
+            const Template: Story = (args) => <One {...args} />;
+            
+            export const Primary = Template.bind({});
+            Primary.args = {};
+            `);
+
+          expect(formatFile`${appTree.read(storyFilePathTwo, 'utf-8')}`)
+            .toContain(formatFile`
+            import { Story, Meta } from '@storybook/react';
+            import { Two } from './test-ui-lib';
+            
+            export default {
+              component: Two,
+              title: 'Two',
+            } as Meta;
+            
+            const Template: Story = (args) => <Two {...args} />;
+            
+            export const Primary = Template.bind({});
+            Primary.args = {};
+            `);
+
+          expect(formatFile`${appTree.read(storyFilePathThree, 'utf-8')}`)
+            .toContain(formatFile`
+            import { Story, Meta } from '@storybook/react';
+            import { Three, ThreeProps } from './test-ui-lib';
+            
+            export default {
+              component: Three,
+              title: 'Three',
+            } as Meta;
+            
+            const Template: Story<ThreeProps> = (args) => <Three {...args} />;
+            
+            export const Primary = Template.bind({});
+            Primary.args = {
+              name: '',
+            };        
+            `);
         });
       });
     });

--- a/packages/react/src/generators/component-story/component-story.ts
+++ b/packages/react/src/generators/component-story/component-story.ts
@@ -9,7 +9,8 @@ import {
 } from '@nrwl/devkit';
 import * as ts from 'typescript';
 import {
-  getComponentName,
+  findExportDeclarationsForJsx,
+  getComponentNode,
   getComponentPropsInterface,
 } from '../../utils/ast-utils';
 
@@ -77,15 +78,52 @@ export function createComponentStoriesFile(
     true
   );
 
-  const cmpDeclaration = getComponentName(sourceFile);
+  const cmpDeclaration = getComponentNode(sourceFile);
 
   if (!cmpDeclaration) {
-    throw new Error(
-      `Could not find any React component in file ${componentFilePath}`
+    const componentNodes = findExportDeclarationsForJsx(sourceFile);
+    if (componentNodes?.length) {
+      componentNodes.forEach((declaration) => {
+        findPropsAndGenerateFile(
+          host,
+          sourceFile,
+          declaration,
+          componentDirectory,
+          name,
+          isPlainJs,
+          fileExt,
+          componentNodes.length > 1
+        );
+      });
+    } else {
+      throw new Error(
+        `Could not find any React component in file ${componentFilePath}`
+      );
+    }
+  } else {
+    findPropsAndGenerateFile(
+      host,
+      sourceFile,
+      cmpDeclaration,
+      componentDirectory,
+      name,
+      isPlainJs,
+      fileExt
     );
   }
+}
 
-  const propsInterface = getComponentPropsInterface(sourceFile);
+export function findPropsAndGenerateFile(
+  host: Tree,
+  sourceFile: ts.SourceFile,
+  cmpDeclaration: ts.Node,
+  componentDirectory: string,
+  name: string,
+  isPlainJs: boolean,
+  fileExt: string,
+  fromNodeArray?: boolean
+) {
+  const propsInterface = getComponentPropsInterface(sourceFile, cmpDeclaration);
 
   let propsTypeName: string = null;
   let props: {
@@ -122,7 +160,10 @@ export function createComponentStoriesFile(
     joinPathFragments(__dirname, './files'),
     normalizePath(componentDirectory),
     {
-      componentFileName: name,
+      componentFileName: fromNodeArray
+        ? `${name}--${(cmpDeclaration as any).name.text}`
+        : name,
+      componentImportFileName: name,
       propsTypeName,
       props,
       argTypes,

--- a/packages/react/src/generators/component-story/files/__componentFileName__.stories.__fileExt__
+++ b/packages/react/src/generators/component-story/files/__componentFileName__.stories.__fileExt__
@@ -1,5 +1,5 @@
 <% if ( !isPlainJs ) { %>import { Story, Meta } from '@storybook/react';<% } %>
-import<% if ( !isPlainJs ) { %> { <% } %> <%= componentName %><% if ( propsTypeName && !isPlainJs ) { %>, <%= propsTypeName %> <% } %> <% if ( !isPlainJs ) { %> } <% } %> from './<%= componentFileName %>';
+import<% if ( !isPlainJs ) { %> { <% } %> <%= componentName %><% if ( propsTypeName && !isPlainJs ) { %>, <%= propsTypeName %> <% } %> <% if ( !isPlainJs ) { %> } <% } %> from './<%= componentImportFileName %>';
 
 export default {
   component: <%= componentName %>,

--- a/packages/react/src/generators/stories/stories.ts
+++ b/packages/react/src/generators/stories/stories.ts
@@ -1,6 +1,9 @@
 import componentStoryGenerator from '../component-story/component-story';
 import componentCypressSpecGenerator from '../component-cypress-spec/component-cypress-spec';
-import { getComponentName } from '../../utils/ast-utils';
+import {
+  findExportDeclarationsForJsx,
+  getComponentNode,
+} from '../../utils/ast-utils';
 import * as ts from 'typescript';
 import {
   convertNxGenerator,
@@ -37,7 +40,7 @@ export function projectRootPath(
   return joinPathFragments(sourceRoot, projectDir);
 }
 
-function containsComponentDeclaration(
+export function containsComponentDeclaration(
   tree: Tree,
   componentPath: string
 ): boolean {
@@ -53,7 +56,10 @@ function containsComponentDeclaration(
     true
   );
 
-  return !!getComponentName(sourceFile);
+  return !!(
+    getComponentNode(sourceFile) ||
+    findExportDeclarationsForJsx(sourceFile)?.length
+  );
 }
 
 export async function createAllStories(

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -5,7 +5,6 @@ import {
   logger,
   StringChange,
   StringInsertion,
-  stripIndents,
 } from '@nrwl/devkit';
 
 export function addImport(
@@ -88,7 +87,13 @@ export function findMainRenderStatement(
   return null;
 }
 
-export function findDefaultExport(source: ts.SourceFile): ts.Node | null {
+export function findDefaultExport(
+  source: ts.SourceFile
+):
+  | ts.VariableDeclaration
+  | ts.FunctionDeclaration
+  | ts.ClassDeclaration
+  | null {
   return (
     findDefaultExportDeclaration(source) || findDefaultClassOrFunction(source)
   );
@@ -96,9 +101,12 @@ export function findDefaultExport(source: ts.SourceFile): ts.Node | null {
 
 export function findDefaultExportDeclaration(
   source: ts.SourceFile
-): ts.Node | null {
+):
+  | ts.VariableDeclaration
+  | ts.FunctionDeclaration
+  | ts.ClassDeclaration
+  | null {
   const identifier = findDefaultExportIdentifier(source);
-
   if (identifier) {
     const variables = findNodes(source, ts.SyntaxKind.VariableDeclaration);
     const fns = findNodes(source, ts.SyntaxKind.FunctionDeclaration);
@@ -117,6 +125,85 @@ export function findDefaultExportDeclaration(
   }
 }
 
+export function findExportDeclarationsForJsx(
+  source: ts.SourceFile
+): Array<
+  ts.VariableDeclaration | ts.FunctionDeclaration | ts.ClassDeclaration
+> | null {
+  const variables = findNodes(source, ts.SyntaxKind.VariableDeclaration);
+  const variableStatements = findNodes(source, ts.SyntaxKind.VariableStatement);
+  const fns = findNodes(source, ts.SyntaxKind.FunctionDeclaration);
+  const cls = findNodes(source, ts.SyntaxKind.ClassDeclaration);
+
+  const exportDeclarations: ts.ExportDeclaration[] = findNodes(
+    source,
+    ts.SyntaxKind.ExportDeclaration
+  ) as ts.ExportDeclaration[];
+
+  let componentNamesNodes: ts.Node[] = [];
+
+  exportDeclarations.forEach((node) => {
+    componentNamesNodes = [
+      ...componentNamesNodes,
+      ...findNodes(node, ts.SyntaxKind.ExportSpecifier),
+    ];
+  });
+
+  const componentNames = componentNamesNodes?.map((node) => node.getText());
+
+  const all = [...variables, ...variableStatements, ...fns, ...cls] as Array<
+    | ts.VariableDeclaration
+    | ts.VariableStatement
+    | ts.FunctionDeclaration
+    | ts.ClassDeclaration
+  >;
+  let foundExport: ts.Node[];
+  let foundJSX: ts.Node[];
+
+  const nodesContainingJSX = all.filter((x) => {
+    foundJSX = findNodes(x, [
+      ts.SyntaxKind.JsxSelfClosingElement,
+      ts.SyntaxKind.JsxOpeningElement,
+    ]);
+    return foundJSX?.length;
+  });
+
+  const exported = nodesContainingJSX.filter((x) => {
+    foundExport = findNodes(x, ts.SyntaxKind.ExportKeyword);
+    if (x.kind === ts.SyntaxKind.VariableStatement) {
+      const nameNode = findNodes(
+        x,
+        ts.SyntaxKind.VariableDeclaration
+      )?.[0] as ts.VariableDeclaration;
+      return (
+        nameNode?.name?.kind === ts.SyntaxKind.Identifier ||
+        foundExport?.length ||
+        componentNames?.includes(nameNode?.name?.getText())
+      );
+    } else {
+      return (
+        (x.name.kind === ts.SyntaxKind.Identifier && foundExport?.length) ||
+        componentNames?.includes(x.name.getText())
+      );
+    }
+  });
+
+  const exportedDeclarations: Array<
+    ts.VariableDeclaration | ts.FunctionDeclaration | ts.ClassDeclaration
+  > = exported.map((x) => {
+    if (x.kind === ts.SyntaxKind.VariableStatement) {
+      const nameNode = findNodes(
+        x,
+        ts.SyntaxKind.VariableDeclaration
+      )?.[0] as ts.VariableDeclaration;
+      return nameNode;
+    }
+    return x;
+  });
+
+  return exportedDeclarations || null;
+}
+
 export function findDefaultExportIdentifier(
   source: ts.SourceFile
 ): ts.Identifier | null {
@@ -124,7 +211,6 @@ export function findDefaultExportIdentifier(
     source,
     ts.SyntaxKind.ExportAssignment
   ) as ts.ExportAssignment[];
-
   const identifier = exports
     .map((x) => x.expression)
     .find((x) => x.kind === ts.SyntaxKind.Identifier) as ts.Identifier;
@@ -133,7 +219,7 @@ export function findDefaultExportIdentifier(
 }
 
 export function findDefaultClassOrFunction(
-  source: ts.SourceFile
+  source: ts.SourceFile | null
 ): ts.FunctionDeclaration | ts.ClassDeclaration | null {
   const fns = findNodes(
     source,
@@ -485,7 +571,7 @@ export function updateReduxStore(
   ];
 }
 
-export function getComponentName(sourceFile: ts.SourceFile): ts.Node | null {
+export function getComponentNode(sourceFile: ts.SourceFile): ts.Node | null {
   const defaultExport = findDefaultExport(sourceFile);
 
   if (
@@ -503,9 +589,9 @@ export function getComponentName(sourceFile: ts.SourceFile): ts.Node | null {
 }
 
 export function getComponentPropsInterface(
-  sourceFile: ts.SourceFile
+  sourceFile: ts.SourceFile,
+  cmpDeclaration: ts.Node
 ): ts.InterfaceDeclaration | null {
-  const cmpDeclaration = getComponentName(sourceFile);
   let propsTypeName: string = null;
 
   if (ts.isFunctionDeclaration(cmpDeclaration)) {


### PR DESCRIPTION
## Current Behavior

When generating stories for Storybook, Nx will only take into account the `default export` to specify the component.

## Expected Behavior

This should work in a variety of syntaxes.

