### PR TITLE
fix(core): allow daemon to disable glob cache

### DIFF
--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -505,7 +505,11 @@ export function globForProjectFiles(
 ) {
   // Deal w/ Caching
   const cacheKey = [root, ...(nxJson?.plugins || [])].join(',');
-  if (projectGlobCache && cacheKey === projectGlobCacheKey)
+  if (
+    process.env.NX_PROJECT_GLOB_CACHE !== 'false' &&
+    projectGlobCache &&
+    cacheKey === projectGlobCacheKey
+  )
     return projectGlobCache;
   projectGlobCacheKey = cacheKey;
 

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -17,6 +17,11 @@ import {
 } from '../tmp-dir';
 import { ProjectGraph } from '../../config/project-graph';
 
+const DAEMON_ENV_SETTINGS = {
+  ...process.env,
+  NX_PROJECT_GLOB_CACHE: 'false',
+};
+
 export async function startInBackground(): Promise<ChildProcess['pid']> {
   await safelyCleanUpExistingProcess();
   ensureDirSync(DAEMON_DIR_FOR_CURRENT_WORKSPACE);
@@ -33,6 +38,7 @@ export async function startInBackground(): Promise<ChildProcess['pid']> {
       detached: true,
       windowsHide: true,
       shell: false,
+      env: DAEMON_ENV_SETTINGS,
     }
   );
   backgroundProcess.unref();
@@ -92,6 +98,7 @@ export function startInCurrentProcess(): void {
   spawnSync(process.execPath, [join(__dirname, '../server/start.js')], {
     cwd: workspaceRoot,
     stdio: 'inherit',
+    env: DAEMON_ENV_SETTINGS,
   });
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Project glob cache is living longer than it is meant to on the daemon, since it is intended to only be used in the scope of the single CLI run. This results in new projects not being picked up aptly by the background process

## Expected Behavior
Project graph picks up new projects

## Related Issue(s)

Fixes #9862


