### PR TITLE
fix(angular): add missing alias for the component generator

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -343,9 +343,9 @@
         "required": ["name"],
         "presets": []
       },
+      "aliases": ["c"],
       "description": "Generate an Angular Component.",
       "implementation": "/packages/angular/src/generators/component/component.ts",
-      "aliases": [],
       "hidden": false,
       "path": "/packages/angular/src/generators/component/schema.json"
     },

--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -19,6 +19,7 @@
     "component": {
       "factory": "./src/generators/component/component.compat",
       "schema": "./src/generators/component/schema.json",
+      "aliases": ["c"],
       "description": "Generate an Angular Component."
     },
     "component-cypress-spec": {
@@ -166,6 +167,7 @@
     "component": {
       "factory": "./src/generators/component/component",
       "schema": "./src/generators/component/schema.json",
+      "aliases": ["c"],
       "description": "Generate an Angular Component."
     },
     "component-cypress-spec": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Can't generate an Angular component using the `c` alias when using the `@nrwl/angular` collection.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should support using the `c` alias to generate components when using the `@nrwl/angular` collection.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9869 
