### PR TITLE
feat(js): add `--includeBabelRc` flag for @nrwl/js:library generator (#8793, #8600)

### DIFF
--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -59,6 +59,11 @@
             "description": "Do not update tsconfig.json for development experience.",
             "default": false
           },
+          "skipBabelConfig": {
+            "type": "boolean",
+            "description": "Skip creating a .babelrc configuration",
+            "default": false
+          },
           "testEnvironment": {
             "type": "string",
             "enum": ["jsdom", "node"],

--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -59,10 +59,9 @@
             "description": "Do not update tsconfig.json for development experience.",
             "default": false
           },
-          "skipBabelConfig": {
+          "includeBabelRc": {
             "type": "boolean",
-            "description": "Skip creating a .babelrc configuration",
-            "default": false
+            "description": "Include a .babelrc configuration to compile TypeScript files"
           },
           "testEnvironment": {
             "type": "string",

--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -46,6 +46,12 @@ describe('js e2e', () => {
       'match the cache'
     );
 
+    const babelRc = readJson(`libs/${lib}/.babelrc`);
+    expect(babelRc.plugins).toBeUndefined();
+    expect(babelRc.presets).toStrictEqual([
+      ['@nrwl/web/babel', { useBuiltIns: 'usage' }],
+    ]);
+
     expect(runCLI(`build ${lib}`)).toContain('Done compiling TypeScript files');
     checkFilesExist(
       `dist/libs/${lib}/README.md`,

--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -1,5 +1,6 @@
 import {
   checkFilesExist,
+  checkFilesDoNotExist,
   newProject,
   readFile,
   readJson,
@@ -45,6 +46,10 @@ describe('js e2e', () => {
     expect((await runCLIAsync(`test ${lib}`)).combinedOutput).toContain(
       'match the cache'
     );
+
+    const packageJson = readJson('package.json');
+    const devPackageNames = Object.keys(packageJson.devDependencies);
+    expect(devPackageNames).toContain('@nrwl/web');
 
     const babelRc = readJson(`libs/${lib}/.babelrc`);
     expect(babelRc.plugins).toBeUndefined();
@@ -187,6 +192,8 @@ describe('js e2e', () => {
       `dist/libs/${lib}/src/lib/${lib}.d.ts`
     );
 
+    checkFilesDoNotExist(`libs/${lib}/.babelrc`);
+
     const parentLib = uniq('parentlib');
     runCLI(`generate @nrwl/js:lib ${parentLib} --buildable --compiler=swc`);
     const parentLibPackageJson = readJson(`libs/${parentLib}/package.json`);
@@ -226,4 +233,13 @@ describe('js e2e', () => {
     expect(output).toContain('1 task(s) it depends on');
     expect(output).toContain('Successfully compiled: 2 files with swc');
   }, 120000);
+
+  it('should not create a `.babelrc` file when creating libs with js executors (--compiler=tsc)', () => {
+    const lib = uniq('lib');
+    runCLI(
+      `generate @nrwl/js:lib ${lib} --compiler=tsc --includeBabelRc=false`
+    );
+
+    checkFilesDoNotExist(`libs/${lib}/.babelrc`);
+  });
 });

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -13,6 +13,7 @@ describe('lib', () => {
   let tree: Tree;
   const defaultOptions: Omit<LibraryGeneratorSchema, 'name'> = {
     skipTsConfig: false,
+    skipBabelConfig: false,
     unitTestRunner: 'jest',
     skipFormat: false,
     linter: 'eslint',
@@ -793,17 +794,6 @@ describe('lib', () => {
         expect(tree.exists('libs/my-lib/.lib.swcrc')).toBeTruthy();
       });
 
-      it('should not generate a .babelrc for swc', async () => {
-        await libraryGenerator(tree, {
-          ...defaultOptions,
-          name: 'myLib',
-          buildable: true,
-          compiler: 'swc',
-        });
-
-        expect(tree.exists('libs/my-lib/.babelrc')).toBeFalsy();
-      });
-
       it('should setup jest project using swc', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
@@ -881,6 +871,30 @@ describe('lib', () => {
         });
 
         expect(tree.exists('tools/scripts/publish.mjs')).toBeTruthy();
+      });
+    });
+
+    describe('--skipBabelConfig', () => {
+      it('should not generate a .babelrc for swc even when set to false', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          buildable: true,
+          compiler: 'swc',
+          skipBabelConfig: false,
+        });
+
+        expect(tree.exists('libs/my-lib/.babelrc')).toBeFalsy();
+      });
+      it('should not create a .babelrc when set to true', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          compiler: 'tsc',
+          skipBabelConfig: true,
+        });
+
+        expect(tree.exists('libs/my-lib/.babelrc')).toBeFalsy();
       });
     });
   });

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -162,6 +162,27 @@ describe('lib', () => {
               `);
       });
 
+      it('should create a local .babelrc configuration', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+        });
+
+        const babelRc = readJson(tree, 'libs/my-lib/.babelrc');
+        expect(babelRc).toMatchInlineSnapshot(`
+          Object {
+            "presets": Array [
+              Array [
+                "@nrwl/web/babel",
+                Object {
+                  "useBuiltIns": "usage",
+                },
+              ],
+            ],
+          }
+        `);
+      });
+
       it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
         tree.rename('tsconfig.base.json', 'tsconfig.json');
 
@@ -222,6 +243,7 @@ describe('lib', () => {
         expect(tree.exists('libs/my-dir/my-lib/src/index.ts')).toBeTruthy();
         expect(tree.exists(`libs/my-dir/my-lib/.eslintrc.json`)).toBeTruthy();
         expect(tree.exists(`libs/my-dir/my-lib/package.json`)).toBeFalsy();
+        expect(tree.exists(`libs/my-dir/my-lib/.babelrc`)).toBeTruthy();
       });
 
       it('should update workspace.json', async () => {
@@ -769,6 +791,17 @@ describe('lib', () => {
         });
 
         expect(tree.exists('libs/my-lib/.lib.swcrc')).toBeTruthy();
+      });
+
+      it('should not generate a .babelrc for swc', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          buildable: true,
+          compiler: 'swc',
+        });
+
+        expect(tree.exists('libs/my-lib/.babelrc')).toBeFalsy();
       });
 
       it('should setup jest project using swc', async () => {

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -213,7 +213,7 @@ function createFiles(tree: Tree, options: NormalizedSchema, filesDir: string) {
     addSwcConfig(tree, options.projectRoot);
   }
 
-  if (options.compiler !== 'swc') {
+  if (options.compiler !== 'swc' && !options.skipBabelConfig) {
     addBabelConfig(tree, options);
   }
 

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -177,6 +177,18 @@ function updateTsConfig(tree: Tree, options: NormalizedSchema) {
   });
 }
 
+function addBabelConfig(tree: Tree, options: NormalizedSchema) {
+  const filename = '.babelrc';
+  const babelrc = {
+    presets: [['@nrwl/web/babel', { useBuiltIns: 'usage' }]],
+  };
+
+  tree.write(
+    join(options.projectRoot, filename),
+    JSON.stringify(babelrc, null, 2)
+  );
+}
+
 function createFiles(tree: Tree, options: NormalizedSchema, filesDir: string) {
   const { className, name, propertyName } = names(options.name);
 
@@ -199,6 +211,10 @@ function createFiles(tree: Tree, options: NormalizedSchema, filesDir: string) {
   if (options.buildable && options.compiler === 'swc') {
     addSwcDependencies(tree);
     addSwcConfig(tree, options.projectRoot);
+  }
+
+  if (options.compiler !== 'swc') {
+    addBabelConfig(tree, options);
   }
 
   if (options.unitTestRunner === 'none') {

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -52,6 +52,11 @@
       "description": "Do not update tsconfig.json for development experience.",
       "default": false
     },
+    "skipBabelConfig": {
+      "type": "boolean",
+      "description": "Skip creating a .babelrc configuration",
+      "default": false
+    },
     "testEnvironment": {
       "type": "string",
       "enum": ["jsdom", "node"],

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -52,10 +52,9 @@
       "description": "Do not update tsconfig.json for development experience.",
       "default": false
     },
-    "skipBabelConfig": {
+    "includeBabelRc": {
       "type": "boolean",
-      "description": "Skip creating a .babelrc configuration",
-      "default": false
+      "description": "Include a .babelrc configuration to compile TypeScript files"
     },
     "testEnvironment": {
       "type": "string",

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -15,6 +15,7 @@ export interface LibraryGeneratorSchema {
   tags?: string;
   simpleModuleName?: boolean;
   skipTsConfig?: boolean;
+  skipBabelConfig?: boolean;
   unitTestRunner?: 'jest' | 'none';
   linter?: Linter;
   testEnvironment?: 'jsdom' | 'node';

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -15,7 +15,7 @@ export interface LibraryGeneratorSchema {
   tags?: string;
   simpleModuleName?: boolean;
   skipTsConfig?: boolean;
-  skipBabelConfig?: boolean;
+  includeBabelRc?: boolean;
   unitTestRunner?: 'jest' | 'none';
   linter?: Linter;
   testEnvironment?: 'jsdom' | 'node';


### PR DESCRIPTION
## Current Behavior

When generating a new TypeScript library using `@nrwl/js:library` _and not using swc_, a `.babelrc` configuration is not generated by default.

This behaviour conflicts when importing such libraries within application that require the compilation step to have occurred, throwing errors for unsupported syntax (TS syntax when expecting JS).

## Expected Behavior

With this PR, the new `--includeBabelRc` flag is introduced when using the  `@nrwl/js:library` generator.

- If you select`swc` as compiler, this flag won't affect the output.
- if you enable the flag, it will create a `.babelrc`
- if you disable the flag, it will prevent creating a `.babelrc`
- if you don't pass any value, the generator will check whether you have `@nrwl/web` installed, and if so, automatically generates a `.babelrc` for your new library

## Related Issue(s)

Fixes #8600
Fixes #8793
