### PR TITLE
fix(angular): don't share angular mfe package

### DIFF
--- a/packages/angular/src/utils/mfe/with-module-federation.ts
+++ b/packages/angular/src/utils/mfe/with-module-federation.ts
@@ -4,10 +4,10 @@ import {
   shareWorkspaceLibraries,
 } from './mfe-webpack';
 import {
-  workspaceRoot,
   createProjectGraphAsync,
   ProjectGraph,
   readCachedProjectGraph,
+  workspaceRoot,
   Workspaces,
 } from '@nrwl/devkit';
 import {
@@ -151,7 +151,7 @@ function mapRemotes(remotes: MFERemotes) {
 }
 
 export async function withModuleFederation(options: MFEConfig) {
-  const DEFAULT_NPM_PACKAGES_TO_AVOID = ['zone.js'];
+  const DEFAULT_NPM_PACKAGES_TO_AVOID = ['zone.js', '@nrwl/angular/mfe'];
 
   const dependencies = await getDependentPackagesForProject(options.name);
   const sharedLibraries = shareWorkspaceLibraries(
@@ -163,6 +163,12 @@ export async function withModuleFederation(options: MFEConfig) {
       (pkg) => !DEFAULT_NPM_PACKAGES_TO_AVOID.includes(pkg)
     )
   );
+
+  DEFAULT_NPM_PACKAGES_TO_AVOID.forEach((pkgName) => {
+    if (pkgName in npmPackages) {
+      delete npmPackages[pkgName];
+    }
+  });
 
   const sharedDependencies = {
     ...sharedLibraries.getLibraries(),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We share the Nrwl Angular MFE package by default. This causes issues with Dynamic Federation when we have to access that library before webpack has bootstrapped.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Don't automatically share Nrwl Angular MFE package

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
