### PR TITLE
fix(core): refine move and remove generators for projects with a target name

### DIFF
--- a/packages/workspace/src/generators/move/lib/update-build-targets.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-build-targets.spec.ts
@@ -23,6 +23,14 @@ describe('updateBuildTargets', () => {
     tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'my-source', {
       root: 'libs/my-source',
+      targets: {
+        storybook: {
+          executor: '@nrwl/storybook:storybook',
+        },
+      },
+    });
+    addProjectConfiguration(tree, 'storybook', {
+      root: 'libs/my-source',
       targets: {},
     });
     addProjectConfiguration(tree, 'my-source-e2e', {
@@ -32,6 +40,7 @@ describe('updateBuildTargets', () => {
           executor: 'test-executor:hi',
           options: {
             devServerTarget: 'my-source:serve',
+            browserTarget: 'storybook:serve',
           },
           configurations: {
             production: {
@@ -54,5 +63,23 @@ describe('updateBuildTargets', () => {
     expect(
       e2eProject.targets.e2e.configurations.production.devServerTarget
     ).toBe('subfolder-my-destination:serve:production');
+  });
+
+  it('should NOT update storybook target', async () => {
+    schema.projectName = 'storybook';
+    updateBuildTargets(tree, schema);
+
+    const myProject = readProjectConfiguration(tree, 'my-source');
+    const e2eProject = readProjectConfiguration(tree, 'my-source-e2e');
+
+    expect(myProject).toBeDefined();
+    expect(myProject.targets.storybook.executor).toBe(
+      '@nrwl/storybook:storybook'
+    );
+
+    expect(e2eProject).toBeDefined();
+    expect(e2eProject.targets.e2e.options.browserTarget).toBe(
+      'subfolder-my-destination:serve'
+    );
   });
 });

--- a/packages/workspace/src/generators/move/lib/update-build-targets.ts
+++ b/packages/workspace/src/generators/move/lib/update-build-targets.ts
@@ -1,4 +1,9 @@
-import { getProjects, Tree, updateProjectConfiguration } from '@nrwl/devkit';
+import {
+  getProjects,
+  TargetConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
 import { NormalizedSchema } from '../schema';
 
 /**
@@ -8,16 +13,40 @@ export function updateBuildTargets(tree: Tree, schema: NormalizedSchema) {
   getProjects(tree).forEach((projectConfig, project) => {
     Object.entries(projectConfig.targets || {}).forEach(
       ([target, targetConfig]) => {
-        const configString = JSON.stringify(targetConfig);
-        const updated = JSON.parse(
-          configString.replace(
-            new RegExp(`${schema.projectName}:`, 'g'),
-            `${schema.newProjectName}:`
-          )
-        );
-        projectConfig.targets[target] = updated;
+        updateJsonValue(targetConfig, (value) => {
+          const [project, target, configuration] = value.split(':');
+          if (project === schema.projectName && target) {
+            return configuration
+              ? `${schema.newProjectName}:${target}:${configuration}`
+              : `${schema.newProjectName}:${target}`;
+          }
+        });
       }
     );
     updateProjectConfiguration(tree, project, projectConfig);
+  });
+}
+
+function updateJsonValue(
+  config: TargetConfiguration,
+  callback: (x: string) => void | string
+) {
+  function recur(obj, key, value) {
+    if (typeof value === 'string') {
+      const result = callback(value);
+      if (result) {
+        obj[key] = result;
+      }
+    } else if (Array.isArray(value)) {
+      value.forEach((x, idx) => recur(value, idx, x));
+    } else if (typeof value === 'object') {
+      Object.entries(value).forEach(([k, v]) => {
+        recur(value, k, v);
+      });
+    }
+  }
+
+  Object.entries(config).forEach(([k, v]) => {
+    recur(config, k, v);
   });
 }

--- a/packages/workspace/src/generators/remove/remove.ts
+++ b/packages/workspace/src/generators/remove/remove.ts
@@ -16,7 +16,7 @@ import { updateJestConfig } from './lib/update-jest-config';
 export async function removeGenerator(tree: Tree, schema: Schema) {
   const project = readProjectConfiguration(tree, schema.projectName);
   await checkDependencies(tree, schema);
-  checkTargets(tree, schema, project);
+  checkTargets(tree, schema);
   updateJestConfig(tree, schema, project);
   removeProjectConfig(tree, schema);
   removeProject(tree, project);


### PR DESCRIPTION
## Current Behavior
For any project where this combination is the following:
```
    "storybook": {
         "executor": "@nrwl/storybook:storybook",
```
That is, `@nrwl/*` package name is the same as a `target` name.

The result is that when a workspace has a project named `storybook`, and another project that uses `@nrwl/storybook`, if a user tries to `move` or `remove` the `storybook` project the following will happen:

### In the case of `move`

The `storybook` target executors across the workspace will be changed. If the new project name is, for example, `new-name` the changes will be:

```
-      "executor": "@nrwl/storybook:storybook",
+      "executor": "@nrwl/new-name:storybook",
```

### In the case of `remove`

Nx will get confused, and it will think that the project `storybook` is used by other projects in the workspace, whereas the other projects would just be using `@nrwl/storybook`, resulting in the following error, and not letting the user remove the `storybook` project:

```
$ nx g @nrwl/workspace:remove storybook
storybook is still targeted by some projects:

"storybook:storybook" is used by "some-other-project"
```


## Expected Behavior
`move` and `remove` generators should work, regardless of the name of the project.

## Thoughts
My first thought (and I've had this thought in the past, as well) was to protect some keywords from being used as project names. However, this may create some negative experience to our users, who are used to naming projects `storybook` however confusing that may be in some cases (to Nx).
