### PR TITLE
fix(core): fix migrating workspaces without any task runners configured

### DIFF
--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -888,11 +888,13 @@ async function generateMigrationsJsonAndUpdatePackageJson(
 function showConnectToCloudMessage() {
   try {
     const nxJson = readJsonFile<NxJsonConfiguration>('nx.json');
-    const defaultRunnerIsUsed = Object.values(nxJson.tasksRunnerOptions).find(
-      (r: any) =>
-        r.runner == '@nrwl/workspace/tasks-runners/default' ||
-        r.runner == 'nx/tasks-runners/default'
-    );
+    const defaultRunnerIsUsed =
+      !nxJson.tasksRunnerOptions ||
+      Object.values(nxJson.tasksRunnerOptions).find(
+        (r: any) =>
+          r.runner == '@nrwl/workspace/tasks-runners/default' ||
+          r.runner == 'nx/tasks-runners/default'
+      );
     return !!defaultRunnerIsUsed;
   } catch {
     return false;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If a `nx.json` does not have `taskRunnerOptions`, running `nx migrate` fails.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

If a `nx.json` does not have `taskRunnerOptions`, running `nx migrate` succeeds and asks to setup cloud.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
