### PR TITLE
fix(react): fixes typescript override error in the render method of a…

### DIFF
--- a/packages/react/src/generators/application/files/none/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/none/src/app/__fileName__.tsx__tmpl__
@@ -5,7 +5,7 @@ import NxWelcome from "./nx-welcome";
 
 <% if (classComponent) { %>
 export class App extends Component {
-  render() {
+  override render() {
 <% } else { %>
 export function App() {
 <% } %>


### PR DESCRIPTION
fixes typescript override error in the render method of a generated app

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
```Failed to compile.
    43 |
TS4114: This member must have an 'override' modifier because it overrides a member in the base class 'Component<{}, {}, any>'.
    44 | export class App extends Component {
  > 45 |   render() {
       |   ^^^^^^
    46 |     return (
    47 |       <>
    48 |         <NxWelcome title="react-app" />
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Solve the problem

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
