### PR TITLE
feat(node): add deleteOutputPath option to @nrwl/node:webpack executor

### DIFF
--- a/docs/generated/packages/node.json
+++ b/docs/generated/packages/node.json
@@ -291,6 +291,11 @@
             "type": "string",
             "description": "The output path of the generated files."
           },
+          "deleteOutputPath": {
+            "type": "boolean",
+            "description": "Delete the output path before building.",
+            "default": true
+          },
           "watch": {
             "type": "boolean",
             "description": "Run build when files change.",

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -312,38 +312,37 @@ ${jslib}();
 
   it('should remove previous output before building with the --deleteOutputPath option set', async () => {
     const appName = uniq('app');
-    const libName = uniq('lib');
 
-    runCLI(
-      `generate @nrwl/node:app ${appName} --no-interactive --compiler swc`
-    );
-    runCLI(
-      `generate @nrwl/node:lib ${libName} --buildable --no-interactive --compiler swc`
-    );
+    runCLI(`generate @nrwl/node:app ${appName} --no-interactive`);
 
+    // deleteOutputPath should default to true
     createFile(`dist/apps/${appName}/_should_remove.txt`);
-    createFile(`dist/libs/${libName}/_should_remove.txt`);
     createFile(`dist/apps/_should_not_remove.txt`);
     checkFilesExist(
       `dist/apps/${appName}/_should_remove.txt`,
       `dist/apps/_should_not_remove.txt`
     );
-    runCLI(`build ${appName} --outputHashing none`);
-    runCLI(`build ${libName}`);
-    checkFilesDoNotExist(
-      `dist/apps/${appName}/_should_remove.txt`,
-      `dist/libs/${libName}/_should_remove.txt`
-    );
+    runCLI(`build ${appName} --outputHashing none`); // no explicit deleteOutputPath option set
+    checkFilesDoNotExist(`dist/apps/${appName}/_should_remove.txt`);
     checkFilesExist(`dist/apps/_should_not_remove.txt`);
 
-    // `delete-output-path`
-    createFile(`dist/apps/${appName}/_should_keep.txt`);
-    runCLI(`build ${appName} --delete-output-path=false --outputHashing none`);
-    checkFilesExist(`dist/apps/${appName}/_should_keep.txt`);
+    // Explicitly set `deleteOutputPath` to true
+    createFile(`dist/apps/${appName}/_should_remove.txt`);
+    createFile(`dist/apps/_should_not_remove.txt`);
+    checkFilesExist(
+      `dist/apps/${appName}/_should_remove.txt`,
+      `dist/apps/_should_not_remove.txt`
+    );
+    runCLI(`build ${appName} --outputHashing none --deleteOutputPath`);
+    checkFilesDoNotExist(`dist/apps/${appName}/_should_remove.txt`);
+    checkFilesExist(`dist/apps/_should_not_remove.txt`);
 
-    createFile(`dist/libs/${libName}/_should_keep.txt`);
-    runCLI(`build ${libName} --delete-output-path=false --outputHashing none`);
-    checkFilesExist(`dist/libs/${libName}/_should_keep.txt`);
+    // Explicitly set `deleteOutputPath` to false
+    createFile(`dist/apps/${appName}/_should_keep.txt`);
+    createFile(`dist/apps/_should_keep.txt`);
+    runCLI(`build ${appName} --deleteOutputPath=false --outputHashing none`);
+    checkFilesExist(`dist/apps/${appName}/_should_keep.txt`);
+    checkFilesExist(`dist/apps/_should_keep.txt`);
   }, 120000);
 
   describe('NestJS', () => {
@@ -362,35 +361,35 @@ ${jslib}();
       updateFile(
         `apps/${nestapp}/src/app/foo.dto.ts`,
         `
-export class FooDto {
-  foo: string;
-  bar: number;
-}`
+  export class FooDto {
+    foo: string;
+    bar: number;
+  }`
       );
       updateFile(
         `apps/${nestapp}/src/app/app.controller.ts`,
         `
-import { Controller, Get } from '@nestjs/common';
-import { FooDto } from './foo.dto';
-import { AppService } from './app.service';
+  import { Controller, Get } from '@nestjs/common';
+  import { FooDto } from './foo.dto';
+  import { AppService } from './app.service';
 
-@Controller()
-export class AppController {
-  constructor(private readonly appService: AppService) {}
+  @Controller()
+  export class AppController {
+    constructor(private readonly appService: AppService) {}
 
-  @Get()
-  getData() {
-    return this.appService.getData();
-  }
+    @Get()
+    getData() {
+      return this.appService.getData();
+    }
 
-  @Get('foo')
-  getFoo(): Promise<FooDto> {
-    return Promise.resolve({
-      foo: 'foo',
-      bar: 123
-    })
-  }
-}`
+    @Get('foo')
+    getFoo(): Promise<FooDto> {
+      return Promise.resolve({
+        foo: 'foo',
+        bar: 123
+      })
+    }
+  }`
       );
 
       await runCLIAsync(`build ${nestapp}`);
@@ -398,13 +397,13 @@ export class AppController {
       const mainJs = readFile(`dist/apps/${nestapp}/main.js`);
       expect(stripIndents`${mainJs}`).toContain(
         stripIndents`
-class FooDto {
-    static _OPENAPI_METADATA_FACTORY() {
-        return { foo: { required: true, type: () => String }, bar: { required: true, type: () => Number } };
-    }
-}
-exports.FooDto = FooDto;
-        `
+  class FooDto {
+      static _OPENAPI_METADATA_FACTORY() {
+          return { foo: { required: true, type: () => String }, bar: { required: true, type: () => Number } };
+      }
+  }
+  exports.FooDto = FooDto;
+          `
       );
     }, 300000);
   });

--- a/packages/node/src/executors/webpack/schema.json
+++ b/packages/node/src/executors/webpack/schema.json
@@ -16,6 +16,11 @@
       "type": "string",
       "description": "The output path of the generated files."
     },
+    "deleteOutputPath": {
+      "type": "boolean",
+      "description": "Delete the output path before building.",
+      "default": true
+    },
     "watch": {
       "type": "boolean",
       "description": "Run build when files change.",

--- a/packages/node/src/executors/webpack/webpack.impl.ts
+++ b/packages/node/src/executors/webpack/webpack.impl.ts
@@ -17,6 +17,7 @@ import { register } from 'ts-node';
 import { getNodeWebpackConfig } from '../../utils/node.config';
 import { BuildNodeBuilderOptions } from '../../utils/types';
 import { normalizeBuildOptions } from '../../utils/normalize';
+import { deleteOutputDir } from '../../utils/fs';
 import { runWebpack } from '../../utils/run-webpack';
 
 export type NodeBuildEvent = {
@@ -75,6 +76,11 @@ export async function* webpackExecutor(
     ) {
       return { success: false } as any;
     }
+  }
+
+  // Delete output path before bundling
+  if (options.deleteOutputPath) {
+    deleteOutputDir(context.root, options.outputPath);
   }
 
   const config = await options.webpackConfig.reduce(

--- a/packages/node/src/utils/fs.ts
+++ b/packages/node/src/utils/fs.ts
@@ -1,0 +1,14 @@
+import * as path from 'path';
+import { removeSync } from 'fs-extra';
+
+/**
+ * Delete an output directory, but error out if it's the root of the project.
+ */
+export function deleteOutputDir(root: string, outputPath: string) {
+  const resolvedOutputPath = path.resolve(root, outputPath);
+  if (resolvedOutputPath === root) {
+    throw new Error('Output path MUST not be project root directory!');
+  }
+
+  removeSync(resolvedOutputPath);
+}

--- a/packages/node/src/utils/normalize.ts
+++ b/packages/node/src/utils/normalize.ts
@@ -37,6 +37,7 @@ export function normalizeBuildOptions(
       options.additionalEntryPoints ?? []
     ),
     outputFileName: options.outputFileName ?? 'main.js',
+    deleteOutputPath: options.deleteOutputPath ?? true,
   };
 }
 

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -96,6 +96,7 @@ export interface BuildNodeBuilderOptions extends BuildBuilderOptions {
   externalDependencies: 'all' | 'none' | string[];
   buildLibsFromSource?: boolean;
   generatePackageJson?: boolean;
+  deleteOutputPath?: boolean;
 }
 
 export interface NormalizedBuildNodeBuilderOptions


### PR DESCRIPTION
ISSUES CLOSED: #9167

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Node webpack previous build output is left in place for subsequent builds.

## Expected Behavior
Ability to clear build output prior to subsequent builds by setting deleteOutputPath to true.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9167
