### PR TITLE
fix(nx): create-nx-workspace - wrap nxWorkspaceRoot in quotes

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -777,7 +777,7 @@ async function createApp(
   let workspaceSetupSpinner = ora('Creating your workspace').start();
 
   try {
-    const fullCommand = `${pmc.exec} nx ${command} --nxWorkspaceRoot=${nxWorkspaceRoot}`;
+    const fullCommand = `${pmc.exec} nx ${command} --nxWorkspaceRoot="${nxWorkspaceRoot}"`;
     await execAndWait(fullCommand, tmpDir);
 
     workspaceSetupSpinner.succeed('Nx has successfully created the workspace.');


### PR DESCRIPTION
Closes https://github.com/nrwl/nx/issues/9282

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
See linked issue (https://github.com/nrwl/nx/issues/9282)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`create-nx-workspace` should create the workspace.
Command parameters must always be wrapped in quotes.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9282
