### PR TITLE
docs(nxdev): bump algolia hits displayed

### DIFF
--- a/nx-dev/feature-search/src/lib/algolia-search.tsx
+++ b/nx-dev/feature-search/src/lib/algolia-search.tsx
@@ -98,6 +98,7 @@ export function AlgoliaSearch() {
           <DocSearchModal
             searchParameters={{
               facetFilters: ['language:en'],
+              hitsPerPage: 100,
             }}
             initialQuery={initialQuery}
             placeholder="Search documentation"


### PR DESCRIPTION
It bumps the number of Algolia search hits in the dialog to `100` on nx.dev.