### PR TITLE
docs(nxdev): remove nx conf lite banner announcement

### DIFF
--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -58,7 +58,6 @@ export default function CustomApp({ Component, pageProps }: AppProps) {
         Skip to content
       </a>
       <div className="documentation-app bg-white text-gray-700 antialiased">
-        <AnnouncementBanner />
         <Component {...pageProps} />
       </div>
       {/* Global Site Tag (gtag.js) - Google Analytics */}


### PR DESCRIPTION
It removes the nx conf lite banner announcement displayed on top of nx.dev. The conference is done, this is not needed anymore.