### PR TITLE
fix(nextjs): fix support for custom distDir

### DIFF
--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -168,7 +168,7 @@ export async function prepareConfig(
   config.outdir = `${offsetFromRoot(options.root)}${options.outputPath}`;
   config.distDir =
     config.distDir && config.distDir !== '.next'
-      ? config.distDir
+      ? joinPathFragments(config.outdir, config.distDir)
       : joinPathFragments(config.outdir, '.next');
   config.webpack = (a, b) =>
     createWebpackConfig(


### PR DESCRIPTION
This PR fixes an issue where custom `distDir` option in `next.config.js` causes the dist to not contain the `distDir`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10056 
