### PR TITLE
docs(nxdev): remove pulsating dots for conf on header

### DIFF
--- a/nx-dev/ui-common/src/lib/header.tsx
+++ b/nx-dev/ui-common/src/lib/header.tsx
@@ -93,10 +93,10 @@ export function Header(props: HeaderProps) {
                 title="Check Nx conference"
                 className="relative px-3 py-2 leading-tight text-white md:inline-flex"
               >
-                <span className="absolute top-0 right-0 -mt-1 -mr-1 flex h-3 w-3">
-                  <span className="bg-green-nx-base absolute inline-flex h-full w-full animate-ping rounded-full opacity-75" />
-                  <span className="bg-green-nx-base relative inline-flex h-3 w-3 rounded-full" />
-                </span>
+                {/*<span className="absolute top-0 right-0 -mt-1 -mr-1 flex h-3 w-3">*/}
+                {/*  <span className="bg-green-nx-base absolute inline-flex h-full w-full animate-ping rounded-full opacity-75" />*/}
+                {/*  <span className="bg-green-nx-base relative inline-flex h-3 w-3 rounded-full" />*/}
+                {/*</span>*/}
                 Nx Conf
               </a>
             </Link>


### PR DESCRIPTION
It removes the pulsating dot indicating the Nx Conf Lite in the header on nx.dev