### PR TITLE
fix(core): normalize paths in ng cli adapter when finding matching files

### DIFF
--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -737,23 +737,25 @@ function findCreatedProjects(host: Tree): FileChange[] {
     .listChanges()
     .filter(
       (f) =>
+        f.type === 'CREATE' &&
         (basename(f.path) === 'project.json' ||
-          basename(f.path) === 'package.json') &&
-        f.type === 'CREATE'
+          basename(f.path) === 'package.json')
     );
 }
 
 function findDeletedProjects(host: Tree): FileChange[] {
   return host
     .listChanges()
-    .filter((f) => basename(f.path) === 'project.json' && f.type === 'DELETE');
+    .filter((f) => f.type === 'DELETE' && basename(f.path) === 'project.json');
 }
 
 function findMatchingFileChange(host: Tree, path: Path) {
-  const targetPath = path.startsWith('/') ? path.substring(1) : path.toString();
+  const targetPath = normalize(
+    path.startsWith('/') ? path.substring(1) : path.toString()
+  );
   return host
     .listChanges()
-    .find((f) => f.path === targetPath && f.type !== 'DELETE');
+    .find((f) => f.type !== 'DELETE' && normalize(f.path) === targetPath);
 }
 
 function isWorkspaceConfigPath(p: Path | string) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Running an Angular Schematic on Windows might fail due to mismatching path formats when trying to find a matching file change.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The Ng CLI adapter layer should make sure paths being compared are normalized so their formats are the same and they can match as expected.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10009 
