### PR TITLE
fix(js): .swcrc path should be customizable

### DIFF
--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -358,6 +358,11 @@
             "type": "string",
             "description": "The path to the Typescript configuration file."
           },
+          "swcConfig": {
+            "type": "string",
+            "description": "The path to the SWC configuration file.",
+            "default": ".lib.swcrc"
+          },
           "assets": {
             "type": "array",
             "description": "List of static assets.",

--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -358,7 +358,7 @@
             "type": "string",
             "description": "The path to the Typescript configuration file."
           },
-          "swcConfig": {
+          "swcrcPath": {
             "type": "string",
             "description": "The path to the SWC configuration file.",
             "default": ".lib.swcrc"

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -17,6 +17,11 @@
       "type": "string",
       "description": "The path to the Typescript configuration file."
     },
+    "swcConfig": {
+      "type": "string",
+      "description": "The path to the SWC configuration file.",
+      "default": ".lib.swcrc"
+    },
     "assets": {
       "type": "array",
       "description": "List of static assets.",

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -17,7 +17,7 @@
       "type": "string",
       "description": "The path to the Typescript configuration file."
     },
-    "swcConfig": {
+    "swcrcPath": {
       "type": "string",
       "description": "The path to the SWC configuration file.",
       "default": ".lib.swcrc"

--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -50,7 +50,7 @@ function normalizeOptions(
     srcPath: projectDir,
     destPath: relative(join(contextRoot, swcCwd), outputPath),
     swcCwd,
-    swcrcPath: join(contextRoot, projectRoot, '.lib.swcrc'),
+    swcrcPath: join(contextRoot, projectRoot, options.swcrcPath),
   };
 
   return {

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -35,7 +35,7 @@ export interface ExecutorOptions {
   main: string;
   outputPath: string;
   tsConfig: string;
-  swcrcPath?: string;
+  swcrcPath: string;
   watch: boolean;
   transformers: TransformerEntry[];
   updateBuildableProjectDepsInPackageJson?: boolean;

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -35,6 +35,7 @@ export interface ExecutorOptions {
   main: string;
   outputPath: string;
   tsConfig: string;
+  swcrcPath?: string;
   watch: boolean;
   transformers: TransformerEntry[];
   updateBuildableProjectDepsInPackageJson?: boolean;


### PR DESCRIPTION
## Current Behavior
It is currently not possible to provide a custom path to an swcrc path. Instead, JS projects using SWC must have a `.lib.swcrc` file in the project root directory.

## Expected Behavior
With these changes, the `@nrwl/js:swc` executor can optionally be be passed an `swcrcPath`. 

In `project.json`:

```json
{
  "targets": {
    "build": {
      "executor": "@nrwl/js:swc",
      "options": {
        ...
        "swcrcPath": "path/to/swcrc"
      }
    }
  }
}
```

## Related Issue(s)

Fixes #10058
