### PR TITLE
fix(angular): fix collecting secondary entry points for module federation builds

### DIFF
--- a/packages/angular/src/utils/mfe/__snapshots__/with-module-federation.spec.ts.snap
+++ b/packages/angular/src/utils/mfe/__snapshots__/with-module-federation.spec.ts.snap
@@ -24,7 +24,7 @@ Array [
           "requiredVersion": false,
         },
         "lodash": Object {
-          "requiredVersion": undefined,
+          "requiredVersion": "~4.17.20",
           "singleton": true,
           "strictVersion": true,
         },

--- a/packages/angular/src/utils/mfe/mfe-webpack.spec.ts
+++ b/packages/angular/src/utils/mfe/mfe-webpack.spec.ts
@@ -3,6 +3,7 @@ jest.mock('@nrwl/workspace/src/utilities/typescript');
 import * as fs from 'fs';
 import * as tsUtils from '@nrwl/workspace/src/utilities/typescript';
 
+import * as devkit from '@nrwl/devkit';
 import { sharePackages, shareWorkspaceLibraries } from './mfe-webpack';
 
 describe('MFE Webpack Utils', () => {
@@ -86,16 +87,14 @@ describe('MFE Webpack Utils', () => {
     it('should correctly map the shared packages to objects', () => {
       // ARRANGE
       (fs.existsSync as jest.Mock).mockReturnValue(true);
-      (fs.readFileSync as jest.Mock).mockImplementation((file) =>
-        JSON.stringify({
-          name: file.replace(/\\/g, '/').replace(/^.*node_modules[/]/, ''),
-          dependencies: {
-            '@angular/core': '~13.2.0',
-            '@angular/common': '~13.2.0',
-            rxjs: '~7.4.0',
-          },
-        })
-      );
+      jest.spyOn(devkit, 'readJsonFile').mockImplementation((file) => ({
+        name: file.replace(/\\/g, '/').replace(/^.*node_modules[/]/, ''),
+        dependencies: {
+          '@angular/core': '~13.2.0',
+          '@angular/common': '~13.2.0',
+          rxjs: '~7.4.0',
+        },
+      }));
       (fs.readdirSync as jest.Mock).mockReturnValue([]);
 
       // ACT
@@ -181,6 +180,57 @@ describe('MFE Webpack Utils', () => {
         },
       });
     });
+
+    it('should not collect a folder with a package.json when cannot be required', () => {
+      // ARRANGE
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      jest.spyOn(devkit, 'readJsonFile').mockImplementation((file) => {
+        // the "schematics" folder is not an entry point
+        if (file.endsWith('@angular/core/schematics/package.json')) {
+          return {};
+        }
+
+        return {
+          name: file
+            .replace(/\\/g, '/')
+            .replace(/^.*node_modules[/]/, '')
+            .replace('/package.json', ''),
+          dependencies: { '@angular/core': '~13.2.0' },
+        };
+      });
+      (fs.readdirSync as jest.Mock).mockImplementation(
+        (directoryPath: string) => {
+          const packages = {
+            '@angular/core': ['testing', 'schematics'],
+          };
+
+          for (const key of Object.keys(packages)) {
+            if (directoryPath.endsWith(key)) {
+              return packages[key];
+            }
+          }
+          return [];
+        }
+      );
+      (fs.lstatSync as jest.Mock).mockReturnValue({ isDirectory: () => true });
+
+      // ACT
+      const packages = sharePackages(['@angular/core']);
+
+      // ASSERT
+      expect(packages).toStrictEqual({
+        '@angular/core': {
+          singleton: true,
+          strictVersion: true,
+          requiredVersion: '~13.2.0',
+        },
+        '@angular/core/testing': {
+          singleton: true,
+          strictVersion: true,
+          requiredVersion: '~13.2.0',
+        },
+      });
+    });
   });
 });
 
@@ -193,19 +243,17 @@ function createMockedFSForNestedEntryPoints() {
     }
   });
 
-  (fs.readFileSync as jest.Mock).mockImplementation((file) =>
-    JSON.stringify({
-      name: file
-        .replace(/\\/g, '/')
-        .replace(/^.*node_modules[/]/, '')
-        .replace('/package.json', ''),
-      dependencies: {
-        '@angular/core': '~13.2.0',
-        '@angular/common': '~13.2.0',
-        rxjs: '~7.4.0',
-      },
-    })
-  );
+  jest.spyOn(devkit, 'readJsonFile').mockImplementation((file) => ({
+    name: file
+      .replace(/\\/g, '/')
+      .replace(/^.*node_modules[/]/, '')
+      .replace('/package.json', ''),
+    dependencies: {
+      '@angular/core': '~13.2.0',
+      '@angular/common': '~13.2.0',
+      rxjs: '~7.4.0',
+    },
+  }));
 
   (fs.readdirSync as jest.Mock).mockImplementation((directoryPath: string) => {
     const PACKAGE_SETUP = {

--- a/packages/angular/src/utils/mfe/with-module-federation.spec.ts
+++ b/packages/angular/src/utils/mfe/with-module-federation.spec.ts
@@ -6,11 +6,13 @@ import * as graph from '@nrwl/devkit';
 import * as typescriptUtils from '@nrwl/workspace/src/utilities/typescript';
 import * as workspace from 'nx/src/project-graph/file-utils';
 import * as fs from 'fs';
+import * as devkit from '@nrwl/devkit';
 
 import { withModuleFederation } from './with-module-federation';
 
 describe('withModuleFederation', () => {
   afterEach(() => jest.clearAllMocks());
+
   it('should create a host config correctly', async () => {
     // ARRANGE
     (graph.readCachedProjectGraph as jest.Mock).mockReturnValue({
@@ -38,13 +40,9 @@ describe('withModuleFederation', () => {
     });
 
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readFileSync as jest.Mock).mockReturnValue(
-      JSON.stringify({
-        dependencies: {
-          '@angular/core': '~13.2.0',
-        },
-      })
-    );
+    jest.spyOn(devkit, 'readJsonFile').mockImplementation(() => ({
+      dependencies: { '@angular/core': '~13.2.0' },
+    }));
 
     (typescriptUtils.readTsConfig as jest.Mock).mockReturnValue({
       options: {
@@ -91,13 +89,9 @@ describe('withModuleFederation', () => {
     });
 
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readFileSync as jest.Mock).mockReturnValue(
-      JSON.stringify({
-        dependencies: {
-          '@angular/core': '~13.2.0',
-        },
-      })
-    );
+    jest.spyOn(devkit, 'readJsonFile').mockImplementation(() => ({
+      dependencies: { '@angular/core': '~13.2.0' },
+    }));
 
     (typescriptUtils.readTsConfig as jest.Mock).mockReturnValue({
       options: {
@@ -145,13 +139,9 @@ describe('withModuleFederation', () => {
     });
 
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readFileSync as jest.Mock).mockReturnValue(
-      JSON.stringify({
-        dependencies: {
-          '@angular/core': '~13.2.0',
-        },
-      })
-    );
+    jest.spyOn(devkit, 'readJsonFile').mockImplementation(() => ({
+      dependencies: { '@angular/core': '~13.2.0', lodash: '~4.17.20' },
+    }));
 
     (typescriptUtils.readTsConfig as jest.Mock).mockReturnValue({
       options: {
@@ -203,13 +193,9 @@ describe('withModuleFederation', () => {
     });
 
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readFileSync as jest.Mock).mockReturnValue(
-      JSON.stringify({
-        dependencies: {
-          '@angular/core': '~13.2.0',
-        },
-      })
-    );
+    jest.spyOn(devkit, 'readJsonFile').mockImplementation(() => ({
+      dependencies: { '@angular/core': '~13.2.0' },
+    }));
 
     (typescriptUtils.readTsConfig as jest.Mock).mockReturnValue({
       options: {
@@ -261,13 +247,9 @@ describe('withModuleFederation', () => {
     });
 
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readFileSync as jest.Mock).mockReturnValue(
-      JSON.stringify({
-        dependencies: {
-          '@angular/core': '~13.2.0',
-        },
-      })
-    );
+    jest.spyOn(devkit, 'readJsonFile').mockImplementation(() => ({
+      dependencies: { '@angular/core': '~13.2.0' },
+    }));
 
     (typescriptUtils.readTsConfig as jest.Mock).mockImplementation(() => ({
       options: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Building an application with Module Federation setup can fail when a dependency contains a subfolder with a `package.json` but it's not really a secondary entry point (e.g. sample folders). Also, the generated configuration for shared packages might have `requiredVersion: undefined` when the package is not in the `dependencies` property of the root `package.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Secondary entry points should be correctly identified and the shared dependencies should set the right `requiredVersion` whenever possible, otherwise, it should remove the shared dependency and warn about it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10094 
