### PR TITLE
docs(nxdev): display specific nx package name exception

### DIFF
--- a/nx-dev/feature-package-schema-viewer/src/lib/get-public-package-name.ts
+++ b/nx-dev/feature-package-schema-viewer/src/lib/get-public-package-name.ts
@@ -1,0 +1,15 @@
+/**
+ * Simple utility to get the public name of a package handling arbitrary use cases
+ * @param packageName
+ * @param prefix
+ */
+export function getPublicPackageName(
+  packageName: string,
+  prefix: string = '@nrwl/'
+): string {
+  /**
+   * Core Nx package is not prefixed by "@nrwl/" on NPM
+   */
+  const isNxCorePackage = packageName === 'nx';
+  return isNxCorePackage ? packageName : prefix + packageName;
+}

--- a/nx-dev/feature-package-schema-viewer/src/lib/get-schema-view-model.ts
+++ b/nx-dev/feature-package-schema-viewer/src/lib/get-schema-view-model.ts
@@ -10,6 +10,7 @@ import {
 } from '@nrwl/nx-dev/models-package';
 import { ParsedUrlQuery } from 'querystring';
 import { Errors, Example, generateJsonExampleFor } from './examples';
+import { getPublicPackageName } from './get-public-package-name';
 import { SchemaRequest } from './schema-request.models';
 
 function getReferenceFromQuery(query: string): string {
@@ -40,7 +41,7 @@ export function getSchemaViewModel(
 
   return {
     schemaMetadata,
-    packageName: `@nrwl/${schemaRequest.pkg.name}`,
+    packageName: getPublicPackageName(schemaRequest.pkg.name),
     packageUrl: `/packages/${schemaRequest.pkg.name}`,
     schemaGithubUrl: schemaRequest.pkg.githubRoot + schemaMetadata.path,
     rootReference: '#',

--- a/nx-dev/feature-package-schema-viewer/src/lib/package-schema-list.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/package-schema-list.tsx
@@ -7,6 +7,7 @@ import { NextSeo } from 'next-seo';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { ReactComponentElement } from 'react';
+import { getPublicPackageName } from './get-public-package-name';
 import { Heading1, Heading2 } from './ui/headings';
 import { Markdown } from './ui/markdown/markdown';
 
@@ -30,12 +31,12 @@ export function PackageSchemaList({
     seo: { title: string; description: string; url: string; imageUrl: string };
   } = {
     pkg: {
-      name: `@nrwl/${pkg.name}`,
+      name: getPublicPackageName(pkg.name),
       description: pkg.description,
       githubUrl: pkg.githubRoot + pkg.root,
     },
     seo: {
-      title: `@nrwl/${pkg.name} | Nx`,
+      title: `${getPublicPackageName(pkg.name)} | Nx`,
       description: pkg.description,
       imageUrl: `https://nx.dev/images/open-graph/${router.asPath
         .replace('/', '')

--- a/nx-dev/feature-package-schema-viewer/src/lib/package-schema-viewer.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/package-schema-viewer.tsx
@@ -5,6 +5,7 @@ import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 import { ReactComponentElement } from 'react';
 import Content from './content';
+import { getPublicPackageName } from './get-public-package-name';
 import { getSchemaViewModel, SchemaViewModel } from './get-schema-view-model';
 import { SchemaRequest } from './schema-request.models';
 
@@ -26,7 +27,9 @@ export function PackageSchemaViewer({
     // Process the request and make available the needed schema information
     schema: getSchemaViewModel(router.query, schemaRequest),
     seo: {
-      title: `@nrwl/${schemaRequest.pkg.name}:${schemaRequest.schemaName} | Nx`,
+      title: `${getPublicPackageName(schemaRequest.pkg.name)}:${
+        schemaRequest.schemaName
+      } | Nx`,
       description:
         'Next generation build system with first class monorepo support and powerful integrations.',
       imageUrl: `https://nx.dev/images/open-graph/${router.asPath

--- a/scripts/documentation/open-graph/generate-images.ts
+++ b/scripts/documentation/open-graph/generate-images.ts
@@ -27,20 +27,20 @@ documents.map((category) => {
 packages.map((pkg) => {
   data.push({
     title: 'Package details',
-    content: `@nrwl/${pkg.name}`,
+    content: getPublicPackageName(pkg.name),
     filename: ['packages', pkg.name].join('-'),
   });
   pkg.schemas.executors.map((schema) => {
     data.push({
       title: 'Executor details',
-      content: `@nrwl/${pkg.name}:${schema}`,
+      content: `${getPublicPackageName(pkg.name)}:${schema}`,
       filename: ['packages', pkg.name, 'executors', schema].join('-'),
     });
   });
   pkg.schemas.generators.map((schema) => {
     data.push({
       title: 'Generator details',
-      content: `@nrwl/${pkg.name}:${schema}`,
+      content: `${getPublicPackageName(pkg.name)}:${schema}`,
       filename: ['packages', pkg.name, 'generators', schema].join('-'),
     });
   });
@@ -131,3 +131,14 @@ ensureDir(targetFolder).then(() =>
     )
   )
 );
+
+export function getPublicPackageName(
+  packageName: string,
+  prefix: string = '@nrwl/'
+): string {
+  /**
+   * Core Nx package is not prefixed by "@nrwl/" on NPM
+   */
+  const isNxCorePackage = packageName === 'nx';
+  return isNxCorePackage ? packageName : prefix + packageName;
+}


### PR DESCRIPTION
It adds an exception to correctly format package name on the package view for nx.dev.