### PR TITLE
feat(core): expose hash file function in hasher

### DIFF
--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -153,6 +153,10 @@ export class Hasher {
     return this.hashing.hashArray(values);
   }
 
+  hashFile(path: string): string {
+    return this.hashing.hashFile(path);
+  }
+
   private async runtimeInputsHash(): Promise<RuntimeHashResult> {
     if (this.runtimeInputs) return this.runtimeInputs;
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When building a custom hasher we cannot use the hashFile method on the internal hasher but all other methods are exposed. This means we need to read the file into memory and then pass the file contents into hashArray `hashArray([filecontents])` instead.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Should be able to use hashFile like we can with hashTask and hashArray

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
