### PR TITLE
fix(core): list only changed files on format:write log

### DIFF
--- a/packages/nx/src/command-line/format.ts
+++ b/packages/nx/src/command-line/format.ts
@@ -151,9 +151,12 @@ function chunkify(target: string[], size: number): string[][] {
 
 function write(patterns: string[]) {
   if (patterns.length > 0) {
-    execSync(`node "${PRETTIER_PATH}" --write ${patterns.join(' ')}`, {
-      stdio: [0, 1, 2],
-    });
+    execSync(
+      `node "${PRETTIER_PATH}" --write --list-different ${patterns.join(' ')}`,
+      {
+        stdio: [0, 1, 2],
+      }
+    );
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `format:write` currently includes explicit checks on `nx.json`, `workspace.json` and `tsconfig.base.json` and performs write on all of them including all the files matching the provided pattern.

This results in a log containing all of the files touched, although in reality only a few of them are actually changed.

The 	`format:check` lists only files that require fixing.

## Expected Behavior
The `format:write` should list only files that were changed during the formatting, not all of the files being checked.

This is useful for using `format:write` as part of the pre-commit hook and automatically add changed files to commit.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
