### PR TITLE
fix(js): add missing `projectType` property to `@nrwl/js:library` generator

### DIFF
--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -91,6 +91,7 @@ function addProject(
   const projectConfiguration: ProjectConfiguration = {
     root: options.projectRoot,
     sourceRoot: joinPathFragments(options.projectRoot, 'src'),
+    projectType: 'library',
     targets: {},
     tags: options.parsedTags,
   };


### PR DESCRIPTION
## Current Behavior
When the `@nrwl/js:library` generates the project, the `project.json` doesn't have the property `projectType: library`.

## Expected Behavior
When the `@nrwl/js:library` generator creates the project, the `projectType: library` property should be in the `project.json` or `workspace.json` 

## Related Issue(s)

Fixes #10158
