### PR TITLE
fix(angular): use fork in file-server for http-server

### DIFF
--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -18,7 +18,8 @@
     "ts-node",
     "tsconfig-paths",
     "semver",
-    "webpack"
+    "webpack",
+    "http-server"
   ],
   "keepLifecycleScripts": true
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -55,6 +55,7 @@
     "ts-node": "~9.1.1",
     "tsconfig-paths": "^3.9.0",
     "semver": "7.3.4",
-    "webpack": "^5.58.1"
+    "webpack": "^5.58.1",
+    "http-server": "^14.1.0"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -69,6 +69,7 @@
     "file-loader": "^6.2.0",
     "fork-ts-checker-webpack-plugin": "6.2.10",
     "fs-extra": "^9.1.0",
+    "http-server": "^14.1.0",
     "identity-obj-proxy": "3.0.0",
     "less": "3.12.2",
     "less-loader": "^10.1.0",

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -1,7 +1,8 @@
-import { execFile, execFileSync } from 'child_process';
+import { execFileSync, fork } from 'child_process';
 import {
   ExecutorContext,
   joinPathFragments,
+  readJsonFile,
   workspaceLayout,
 } from '@nrwl/devkit';
 import ignore from 'ignore';
@@ -9,6 +10,7 @@ import { readFileSync } from 'fs';
 import { Schema } from './schema';
 import { watch } from 'chokidar';
 import { platform } from 'os';
+import { resolve } from 'path';
 
 // platform specific command name
 const pmCmd = platform() === 'win32' ? `npx.cmd` : 'npx';
@@ -145,13 +147,24 @@ export default async function* fileServerExecutor(
   const outputPath = getBuildTargetOutputPath(options, context);
   const args = getHttpServerArgs(options);
 
-  const serve = execFile(pmCmd, ['http-server', outputPath, ...args], {
+  const pathToHttpServerPkgJson = require.resolve('http-server/package.json');
+  const pathToHttpServerBin = readJsonFile(pathToHttpServerPkgJson).bin[
+    'http-server'
+  ];
+  const pathToHttpServer = resolve(
+    pathToHttpServerPkgJson.replace('package.json', ''),
+    pathToHttpServerBin
+  );
+
+  const serve = fork(pathToHttpServer, [outputPath, ...args], {
+    stdio: 'pipe',
     cwd: context.root,
     env: {
       FORCE_COLOR: 'true',
       ...process.env,
     },
   });
+
   const processExitListener = () => {
     serve.kill();
     if (disposeWatch) {


### PR DESCRIPTION
## Current Behavior
We're using `execFile` to launch `http-server` via `npx`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Fork the process, pointing directly to the `http-server` binary.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
