### PR TITLE
fix(core): store relative file name in hash details

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
+  }
+
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+
+  if [ -f ~/.huskyrc ]; then
+    debug "sourcing ~/.huskyrc"
+    . ~/.huskyrc
+  fi
+
+  export readonly husky_skip_init=1
+  sh -e "$0" "$@"
+  exitCode="$?"
+
+  if [ $exitCode != 0 ]; then
+    echo "husky - $hook_name hook exited with code $exitCode (error)"
+    exit $exitCode
+  fi
+
+  exit 0
+fi

--- a/packages/nx/src/hasher/hasher.spec.ts
+++ b/packages/nx/src/hasher/hasher.spec.ts
@@ -1,5 +1,6 @@
 // This must come before the Hasher import
 import { DependencyType } from '../config/project-graph';
+import { defaultFileHasher } from '../hasher/file-hasher';
 
 jest.doMock('../utils/workspace-root', () => {
   return {
@@ -56,6 +57,10 @@ describe('Hasher', () => {
   }
 
   beforeAll(() => {
+    jest
+      .spyOn(defaultFileHasher, 'hashFile')
+      .mockImplementation((p) => hashes[p]);
+
     fs.readFileSync = (file) => {
       if (file === 'workspace.json') {
         return JSON.stringify(workSpaceJson);

--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -2,7 +2,7 @@ import { resolveNewFormatWithInlineProjects } from '../config/workspaces';
 import { exec } from 'child_process';
 import { existsSync } from 'fs';
 import * as minimatch from 'minimatch';
-import { join } from 'path';
+import { join, sep as pathSep } from 'path';
 import { performance } from 'perf_hooks';
 import { getRootTsConfigFileName } from '../utils/typescript';
 import { workspaceRoot } from '../utils/workspace-root';
@@ -13,6 +13,7 @@ import { NxJsonConfiguration } from '../config/nx-json';
 import { Task } from '../config/task-graph';
 import { readJsonFile } from '../utils/fileutils';
 import { ProjectsConfigurations } from '../config/workspace-json-project-json';
+import { defaultFileHasher } from './file-hasher';
 
 /**
  * A data structure returned by the default hasher.
@@ -248,20 +249,10 @@ export class Hasher {
       ];
 
       const fileHashes = [
-        ...fileNames
-          .map((maybeRelativePath) => {
-            // Normalize the path to always be absolute and starting with workspaceRoot so we can check it exists
-            if (!maybeRelativePath.startsWith(workspaceRoot)) {
-              return join(workspaceRoot, maybeRelativePath);
-            }
-            return maybeRelativePath;
-          })
-          .filter((file) => existsSync(file))
-          .map((file) => {
-            // we should use default file hasher here
-            const hash = this.hashing.hashFile(file);
-            return { file, hash };
-          }),
+        ...fileNames.map((file) => ({
+          file,
+          hash: defaultFileHasher.hashFile(file),
+        })),
         ...this.hashNxJson(),
       ];
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When `NX_VERBOSE_LOGGING` is set, the logged hash details contain absolute file paths. Since the path itself is not considered currently, this doesn't cause cache misses.

## Expected Behavior
When `NX_VERBOSE_LOGGING` is set, the logged hash details contain relative file paths. If the path itself is considered, this doesn't cause cache misses.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
