### PR TITLE
fix(angular): add missing skipImport option to the component generator

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -319,6 +319,11 @@
             "description": "Create the new files at the top level of the current project.",
             "default": false
           },
+          "skipImport": {
+            "type": "boolean",
+            "description": "Do not import this component into the owning NgModule.",
+            "default": false
+          },
           "selector": {
             "type": "string",
             "format": "html-selector",

--- a/packages/angular/src/generators/component/__snapshots__/component.spec.ts.snap
+++ b/packages/angular/src/generators/component/__snapshots__/component.spec.ts.snap
@@ -100,6 +100,25 @@ export class ExampleComponent implements OnInit {
 "
 `;
 
+exports[`component Generator should create the component correctly and not export it when "--skip-import=true" 1`] = `
+"import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'example',
+  templateUrl: './example.component.html',
+  styleUrls: ['./example.component.css']
+})
+export class ExampleComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}
+"
+`;
+
 exports[`component Generator should create the component correctly but not export it when no entry point exists 1`] = `
 "import { Component, OnInit } from '@angular/core';
 

--- a/packages/angular/src/generators/component/component.spec.ts
+++ b/packages/angular/src/generators/component/component.spec.ts
@@ -83,6 +83,47 @@ describe('component Generator', () => {
     );
   });
 
+  it('should create the component correctly and not export it when "--skip-import=true"', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'lib1', {
+      projectType: 'library',
+      sourceRoot: 'libs/lib1/src',
+      root: 'libs/lib1',
+    });
+    tree.write(
+      'libs/lib1/src/lib/lib.module.ts',
+      `
+    import { NgModule } from '@angular/core';
+    
+    @NgModule({
+      declarations: [],
+      exports: []
+    })
+    export class LibModule {}`
+    );
+    tree.write('libs/lib1/src/index.ts', '');
+
+    // ACT
+    await componentGenerator(tree, {
+      name: 'example',
+      project: 'lib1',
+      skipImport: true,
+    });
+
+    // ASSERT
+    const componentSource = tree.read(
+      'libs/lib1/src/lib/example/example.component.ts',
+      'utf-8'
+    );
+    expect(componentSource).toMatchSnapshot();
+
+    const indexSource = tree.read('libs/lib1/src/index.ts', 'utf-8');
+    expect(indexSource).not.toContain(
+      `export * from "./lib/example/example.component"`
+    );
+  });
+
   it('should create the component correctly but not export it when no entry point exists', async () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace(2);

--- a/packages/angular/src/generators/component/component.ts
+++ b/packages/angular/src/generators/component/component.ts
@@ -47,7 +47,7 @@ function checkPathUnderProjectRoot(tree: Tree, schema: Partial<Schema>) {
 }
 
 function exportComponent(tree: Tree, schema: Schema) {
-  if (!schema.export) {
+  if (!schema.export || schema.skipImport) {
     return;
   }
 

--- a/packages/angular/src/generators/component/schema.d.ts
+++ b/packages/angular/src/generators/component/schema.d.ts
@@ -11,6 +11,7 @@ export interface Schema {
   skipTests?: boolean;
   type?: string;
   flat?: boolean;
+  skipImport?: boolean;
   selector?: string;
   module?: string;
   skipSelector?: boolean;

--- a/packages/angular/src/generators/component/schema.json
+++ b/packages/angular/src/generators/component/schema.json
@@ -81,6 +81,11 @@
       "description": "Create the new files at the top level of the current project.",
       "default": false
     },
+    "skipImport": {
+      "type": "boolean",
+      "description": "Do not import this component into the owning NgModule.",
+      "default": false
+    },
     "selector": {
       "type": "string",
       "format": "html-selector",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `skipImport` option is missing from the component generator schema.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The component generator should support the `skipImport` option.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10133
