### PR TITLE
fix(nx-plugin): projects that consume executors from a local plugin should depend on that plugin

### DIFF
--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -1,4 +1,8 @@
-import { ProjectConfiguration } from '@nrwl/devkit';
+import {
+  DependencyType,
+  ProjectConfiguration,
+  ProjectGraphDependency,
+} from '@nrwl/devkit';
 import {
   checkFilesExist,
   expectTestsPass,
@@ -14,6 +18,7 @@ import {
   createFile,
   readFile,
   removeFile,
+  readDependencyGraph,
 } from '@nrwl/e2e/utils';
 
 import { ASYNC_GENERATOR_EXECUTOR_CONTENTS } from './nx-plugin.fixtures';
@@ -268,8 +273,17 @@ describe('Nx Plugin', () => {
         return JSON.stringify(project, null, 2);
       });
 
+      const graph = readDependencyGraph();
+
       expect(() => checkFilesExist(`libs/${generatedProject}`)).not.toThrow();
       expect(() => runCLI(`execute ${generatedProject}`)).not.toThrow();
+      expect(
+        graph.dependencies[generatedProject]
+      ).toContainEqual<ProjectGraphDependency>({
+        source: generatedProject,
+        target: plugin,
+        type: DependencyType.implicit,
+      });
     });
   });
 

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -3,6 +3,7 @@ import {
   parseJson,
   ProjectConfiguration,
   readJsonFile,
+  ProjectGraph,
   WorkspaceJsonConfiguration,
 } from '@nrwl/devkit';
 import { angularCliVersion } from '@nrwl/workspace/src/utils/versions';
@@ -561,6 +562,11 @@ export function runCLI(
       throw e;
     }
   }
+}
+
+export function readDependencyGraph(): ProjectGraph<any> {
+  runCLI('graph --file graph.json');
+  return readJson('graph.json').graph;
 }
 
 /**

--- a/nx.json
+++ b/nx.json
@@ -76,6 +76,9 @@
     },
     "@nrwl/cypress": {
       "hashingExcludesTestsOfDeps": true
+    },
+    "nx": {
+      "includeImplicitExecutorDependencies": true
     }
   },
   "defaultProject": "dep-graph-client"

--- a/packages/nx-plugin/migrations.spec.ts
+++ b/packages/nx-plugin/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('nx-plugin migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.schematics).forEach((m) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/nx/src/project-graph/build-dependencies/build-executor-dependencies.spec.ts
+++ b/packages/nx/src/project-graph/build-dependencies/build-executor-dependencies.spec.ts
@@ -1,0 +1,136 @@
+import { buildExecutorDependencies } from './build-executor-dependencies';
+import { vol } from 'memfs';
+import { createProjectFileMap } from '../file-map-utils';
+import { defaultFileHasher } from '../../hasher/file-hasher';
+import { ProjectGraphBuilder } from '../project-graph-builder';
+import {
+  ProjectGraphProcessorContext,
+  ProjectGraphProjectNode,
+  ProjectGraphExternalNode,
+} from '../../config/project-graph';
+import { WorkspaceJsonConfiguration } from 'nx/src/config/workspace-json-project-json';
+
+jest.mock('fs', () => require('memfs').fs);
+jest.mock('nx/src/utils/app-root', () => ({
+  workspaceRoot: '/root',
+}));
+
+describe('explicit executor dependencies', () => {
+  let ctx: ProjectGraphProcessorContext;
+  let projects: Record<string, ProjectGraphProjectNode>;
+  let npmPackages: ProjectGraphExternalNode[];
+  let fsJson;
+
+  beforeEach(() => {
+    const workspaceJson: WorkspaceJsonConfiguration = {
+      version: 2,
+      projects: {
+        project: {
+          root: 'libs/project',
+          targets: {
+            build: {
+              executor: '@local/plugin:build',
+            },
+            test: {
+              executor: '@nrwl/jest:jest',
+            },
+          },
+        },
+        plugin: {
+          root: 'libs/plugin',
+        },
+      },
+    };
+
+    const nxJson = {
+      npmScope: 'local',
+    };
+
+    fsJson = {
+      './package.json': `{
+        "name": "test",
+        "dependencies": [],
+        "devDependencies": []
+      }`,
+      './workspace.json': JSON.stringify(workspaceJson),
+      './nx.json': JSON.stringify(nxJson),
+      './tsconfig.base.json': JSON.stringify({
+        compilerOptions: {
+          paths: {
+            '@local/plugin': ['./libs/plugin/index.ts'],
+            '@local/library': ['./libs/project/index.ts'],
+          },
+        },
+      }),
+      './libs/plugin/package.json': JSON.stringify({
+        name: '@local/plugin',
+      }),
+    };
+    vol.fromJSON(fsJson, '/root');
+
+    defaultFileHasher.init();
+
+    ctx = {
+      workspace: {
+        ...workspaceJson,
+        ...nxJson,
+      },
+      fileMap: createProjectFileMap(
+        workspaceJson,
+        defaultFileHasher.allFileData()
+      ).projectFileMap,
+    } as any;
+
+    projects = {
+      plugin: {
+        name: 'plugin',
+        type: 'lib',
+        data: {
+          root: 'libs/plugin',
+          files: [{ file: 'libs/plugin/package.json' } as any],
+        },
+      },
+      project: {
+        name: 'project',
+        type: 'lib',
+        data: { root: 'libs/project', files: [] },
+      },
+    };
+
+    npmPackages = [
+      {
+        type: 'npm',
+        name: `npm:@nrwl/jest`,
+        data: {
+          version: '0.0.1',
+          packageName: '@nrwl/jest',
+        },
+      },
+    ];
+  });
+
+  it(`should add dependencies for projects based on executors used in project configuration`, () => {
+    const builder = new ProjectGraphBuilder();
+    Object.values(projects).forEach((p) => {
+      builder.addNode(p);
+    });
+    npmPackages.forEach((p) => builder.addExternalNode(p));
+
+    buildExecutorDependencies(ctx, builder);
+
+    const res = builder.getUpdatedProjectGraph();
+
+    expect(res.dependencies['project']).toEqual([
+      {
+        source: 'project',
+        target: 'plugin',
+        type: 'implicit',
+      },
+      {
+        source: 'project',
+        target: 'npm:@nrwl/jest',
+        type: 'implicit',
+      },
+    ]);
+  });
+});

--- a/packages/nx/src/project-graph/build-dependencies/build-executor-dependencies.ts
+++ b/packages/nx/src/project-graph/build-dependencies/build-executor-dependencies.ts
@@ -1,0 +1,31 @@
+import { workspaceConfigName } from 'nx/src/config/workspaces';
+import { workspaceRoot } from 'nx/src/utils/app-root';
+import { resolveLocalNxPlugin } from 'nx/src/utils/nx-plugin';
+import { ProjectGraphProcessorContext } from '../../config/project-graph';
+import { ProjectGraphBuilder } from '../project-graph-builder';
+
+export function buildExecutorDependencies(
+  context: ProjectGraphProcessorContext,
+  builder: ProjectGraphBuilder
+) {
+  const projects = Object.entries(context.workspace.projects);
+  // Adds an implicit dependency between any project that
+  // consumes a local plugin's executor and the local plugin
+  for (const [project, configuration] of projects) {
+    const executorCollectionsUsed = Object.values(
+      configuration.targets || {}
+    ).map((x) => x.executor.split(':')[0]);
+
+    for (const collection of executorCollectionsUsed) {
+      const localPluginProject = resolveLocalNxPlugin(collection)?.projectName;
+      if (localPluginProject) {
+        builder.addImplicitDependency(project, localPluginProject);
+      } else {
+        const node = builder.graph.externalNodes[`npm:${collection}`];
+        if (node) {
+          builder.addImplicitDependency(project, node.name);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Current Behavior
Nx doesn't detect a cache miss when a local plugin's executor has been changed since its last run

## Expected Behavior
Changing the implementation of a plugin's executor should invalidate the cache of any project that consumes that executor

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
