### PR TITLE
feat(react): add support for passing additional shared dependencies in the module federation config

### DIFF
--- a/packages/react/src/module-federation/models.ts
+++ b/packages/react/src/module-federation/models.ts
@@ -1,21 +1,30 @@
-export interface SharedLibraryConfig {
-  singleton: boolean;
-  strictVersion: boolean;
-  requiredVersion: string;
-  eager: boolean;
-}
-
 export type ModuleFederationLibrary = { type: string; name: string };
 
 export type Remotes = string[] | [remoteName: string, remoteUrl: string][];
+
+export interface SharedLibraryConfig {
+  singleton?: boolean;
+  strictVersion?: boolean;
+  requiredVersion?: false | string;
+  eager?: boolean;
+}
+
+export type SharedFunction = (
+  libraryName: string,
+  sharedConfig: SharedLibraryConfig
+) => undefined | false | SharedLibraryConfig;
+
+export type AdditionalSharedConfig = Array<
+  | string
+  | [libraryName: string, sharedConfig: SharedLibraryConfig]
+  | { libraryName: string; sharedConfig: SharedLibraryConfig }
+>;
 
 export interface ModuleFederationConfig {
   name: string;
   remotes?: string[];
   library?: ModuleFederationLibrary;
   exposes?: Record<string, string>;
-  shared?: (
-    libraryName: string,
-    library: SharedLibraryConfig
-  ) => undefined | false | SharedLibraryConfig;
+  shared?: SharedFunction;
+  additionalShared?: AdditionalSharedConfig;
 }

--- a/packages/react/src/module-federation/package-json.ts
+++ b/packages/react/src/module-federation/package-json.ts
@@ -1,0 +1,16 @@
+import { joinPathFragments, readJsonFile, workspaceRoot } from '@nrwl/devkit';
+import { existsSync } from 'fs';
+
+export function readRootPackageJson(): {
+  dependencies?: { [key: string]: string };
+  devDependencies?: { [key: string]: string };
+} {
+  const pkgJsonPath = joinPathFragments(workspaceRoot, 'package.json');
+  if (!existsSync(pkgJsonPath)) {
+    throw new Error(
+      'NX MFE: Could not find root package.json to determine dependency versions.'
+    );
+  }
+
+  return readJsonFile(pkgJsonPath);
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
There isn't a way to specify additional shared dependencies to the Module Federation config.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should be possible to add additional shared dependencies that might have not been collected automatically. A new optional `additionalShared` property is available in the `withModuleFederation` function options that allow providing additional shared dependencies. The property is an array that supports:

- `string`: name of the dependency, the `withModuleFederation` utility function will generate the recommended configuration for it.
- `[string, SharedLibraryConfig]`: tuple where the first index is the name of the dependency and the second index, is the shared configuration for it.
- `{ libraryName: string; sharedConfig: SharedLibraryConfig }`: object specifying the dependency name and the shared configuration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
