### PR TITLE
fix(angular): support skipPackageJson for library generation

### DIFF
--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -58,7 +58,8 @@ export async function libraryGenerator(host: Tree, schema: Partial<Schema>) {
     name: options.name,
     prefix: options.prefix,
     entryFile: 'index',
-    skipPackageJson: !(options.publishable || options.buildable),
+    skipPackageJson:
+      options.skipPackageJson || !(options.publishable || options.buildable),
     skipTsConfig: true,
   });
 

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -29,4 +29,5 @@ export interface Schema {
   compilationMode?: 'full' | 'partial';
   setParserOptionsProject?: boolean;
   skipModule?: boolean;
+  skipPackageJson?: boolean;
 }


### PR DESCRIPTION
## Current Behavior
Current schema-interface isnt synced with schema.json and documentation, where`skipPackageJson` is present. This causes wrong typings when calling the libraryGenerator from a workspace-generator

## Expected Behavior
That the typed scherma is equal to the documentation

## Related Issue(s)
[<!-- Please link the issue being fixed so it gets closed when this is merged. -->](https://github.com/nrwl/nx/issues/10062#issuecomment-1118362383)