### PR TITLE
fix(angular): remote failing to serve should fail host serve

### DIFF
--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -40,14 +40,9 @@ export function moduleFederationDevServer(
     ? options.devRemotes
     : [options.devRemotes];
 
-  const remotePorts: number[] = [];
   for (const remote of remotes) {
     const isDev = devServeRemotes.includes(remote);
     const target = isDev ? 'serve' : 'serve-static';
-
-    remotePorts.push(
-      workspaceConfig.projects[remote]?.targets[target]?.options.port ?? 4200
-    );
 
     scheduleTarget(
       context.workspaceRoot,
@@ -59,7 +54,13 @@ export function moduleFederationDevServer(
         executor: context.builder.builderName,
       },
       options.verbose
-    );
+    ).then((obs) => {
+      obs.toPromise().catch((err) => {
+        throw new Error(
+          `Remote '${remote}' failed to serve correctly due to the following: \r\n${err.toString()}`
+        );
+      });
+    });
   }
 
   return webpackServer(options, context);

--- a/packages/angular/src/executors/file-server/file-server.impl.ts
+++ b/packages/angular/src/executors/file-server/file-server.impl.ts
@@ -133,7 +133,11 @@ export default async function* fileServerExecutor(
         execFileSync(pmCmd, args, {
           stdio: [0, 1, 2],
         });
-      } catch {}
+      } catch {
+        throw new Error(
+          "Project failed to build. Check the build's error output for more information."
+        );
+      }
       running = false;
     }
   };


### PR DESCRIPTION
## Current Behavior
Currently if a remote fails, it does not cause the host to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should fail the serve of the host if the remotes fail to serve.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
