### PR TITLE
chore(misc): split create tree with empty workspace to remove parameter

### DIFF
--- a/packages/angular/src/generators/add-linting/add-linting.spec.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.spec.ts
@@ -4,7 +4,7 @@ import {
   readJson,
   readProjectConfiguration,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import * as linter from '@nrwl/linter';
 import { addLintingGenerator } from './add-linting';
 import * as devkit from '@nrwl/devkit';
@@ -15,7 +15,7 @@ describe('addLinting generator', () => {
   const appProjectRoot = `apps/${appProjectName}`;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     addProjectConfiguration(tree, appProjectName, {
       root: appProjectRoot,

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -9,7 +9,10 @@ import {
   readWorkspaceConfiguration,
   updateJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  createTreeWithEmptyV1Workspace,
+  createTreeWithEmptyWorkspace,
+} from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
 import {
@@ -29,7 +32,7 @@ describe('app', () => {
   > = installedCypressVersion as never;
   beforeEach(() => {
     mockedInstalledCypressVersion.mockReturnValue(10);
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
   });
 
   describe('not nested', () => {
@@ -345,7 +348,7 @@ describe('app', () => {
 
   describe('at the root', () => {
     beforeEach(() => {
-      appTree = createTreeWithEmptyWorkspace(2);
+      appTree = createTreeWithEmptyWorkspace();
       updateJson(appTree, 'nx.json', (json) => ({
         ...json,
         workspaceLayout: { appsDir: '' },
@@ -735,7 +738,7 @@ describe('app', () => {
   describe('--e2e-test-runner', () => {
     describe(E2eTestRunner.Protractor, () => {
       it('should create the e2e project in v2 workspace', async () => {
-        appTree = createTreeWithEmptyWorkspace(2);
+        appTree = createTreeWithEmptyWorkspace();
 
         expect(
           async () =>

--- a/packages/angular/src/generators/component-cypress-spec/component-cypress-spec.spec.ts
+++ b/packages/angular/src/generators/component-cypress-spec/component-cypress-spec.spec.ts
@@ -2,7 +2,7 @@ import { installedCypressVersion } from '@nrwl/cypress/src/utils/cypress-version
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { applicationGenerator } from '../application/application';
 import * as storybookUtils from '../utils/storybook';
 import { componentCypressSpecGenerator } from './component-cypress-spec';
@@ -17,7 +17,7 @@ describe('componentCypressSpec generator', () => {
     ReturnType<typeof installedCypressVersion>
   > = installedCypressVersion as never;
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     const componentGenerator = wrapAngularDevkitSchematic(
       '@schematics/angular',

--- a/packages/angular/src/generators/component-story/component-story.spec.ts
+++ b/packages/angular/src/generators/component-story/component-story.spec.ts
@@ -1,7 +1,7 @@
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { libraryGenerator } from '../library/library';
 import * as storybookUtils from '../utils/storybook';
 import { componentStoryGenerator } from './component-story';
@@ -12,7 +12,7 @@ describe('componentStory generator', () => {
   const storyFile = `libs/${libName}/src/lib/test-button/test-button.component.stories.ts`;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     const componentGenerator = wrapAngularDevkitSchematic(
       '@schematics/angular',

--- a/packages/angular/src/generators/component/component.spec.ts
+++ b/packages/angular/src/generators/component/component.spec.ts
@@ -5,7 +5,7 @@ import componentGenerator from './component';
 describe('component Generator', () => {
   it('should create the component correctly and export it in the entry point when "export=true"', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -44,7 +44,7 @@ describe('component Generator', () => {
 
   it('should create the component correctly and export it in the entry point when is standalone and "export=true"', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -86,7 +86,7 @@ describe('component Generator', () => {
 
   it('should create the component correctly and not export it in the entry point when "export=false"', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -127,7 +127,7 @@ describe('component Generator', () => {
 
   it('should create the component correctly and not export it in the entry point when is standalone and "export=false"', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -169,7 +169,7 @@ describe('component Generator', () => {
 
   it('should create the component correctly and not export it when "--skip-import=true"', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -210,7 +210,7 @@ describe('component Generator', () => {
 
   it('should create the component correctly but not export it in the entry point when it does not exist', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -248,7 +248,7 @@ describe('component Generator', () => {
 
   it('should not export the component in the entry point when the module it belongs to is not exported', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -282,7 +282,7 @@ describe('component Generator', () => {
   describe('--flat', () => {
     it('should create the component correctly and export it in the entry point', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'lib1', {
         projectType: 'library',
         sourceRoot: 'libs/lib1/src',
@@ -322,7 +322,7 @@ describe('component Generator', () => {
 
     it('should create the component correctly and not export it when "export=false"', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'lib1', {
         projectType: 'library',
         sourceRoot: 'libs/lib1/src',
@@ -366,7 +366,7 @@ describe('component Generator', () => {
   describe('--path', () => {
     it('should create the component correctly and export it in the entry point', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'lib1', {
         projectType: 'library',
         sourceRoot: 'libs/lib1/src',
@@ -408,7 +408,7 @@ describe('component Generator', () => {
 
     it('should throw if the path specified is not under the project root', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'lib1', {
         projectType: 'library',
         sourceRoot: 'libs/lib1/src',
@@ -451,7 +451,7 @@ describe('component Generator', () => {
       'should export it in the entry point when "--module" is set to "%s"',
       async (module) => {
         // ARRANGE
-        const tree = createTreeWithEmptyWorkspace(2);
+        const tree = createTreeWithEmptyWorkspace();
         addProjectConfiguration(tree, 'lib1', {
           projectType: 'library',
           sourceRoot: 'libs/lib1/src',
@@ -491,7 +491,7 @@ describe('component Generator', () => {
 
     it('should not export it in the entry point when the module it belong to is not exported', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'lib1', {
         projectType: 'library',
         sourceRoot: 'libs/lib1/src',
@@ -540,7 +540,7 @@ describe('component Generator', () => {
   describe('secondary entry points', () => {
     it('should create the component correctly and export it in the entry point', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'lib1', {
         projectType: 'library',
         sourceRoot: 'libs/lib1/src',
@@ -603,7 +603,7 @@ describe('component Generator', () => {
 
     it('should not export the component in the entry point when the module it belongs to is not exported', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'lib1', {
         projectType: 'library',
         sourceRoot: 'libs/lib1/src',

--- a/packages/angular/src/generators/convert-to-with-mf/convert-to-with-mf.spec.ts
+++ b/packages/angular/src/generators/convert-to-with-mf/convert-to-with-mf.spec.ts
@@ -12,7 +12,7 @@ import convertToWithMF from './convert-to-with-mf';
 describe('convertToWithMF', () => {
   it('should migrate a standard previous generated host config correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'host1', {
       name: 'host1',
       root: 'apps/host1',
@@ -43,7 +43,7 @@ describe('convertToWithMF', () => {
 
   it('should migrate a standard previous generated remote config correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'remote1', {
       name: 'remote1',
       root: 'apps/remote1',
@@ -74,7 +74,7 @@ describe('convertToWithMF', () => {
 
   it('should migrate a standard previous generated remote config using object shared syntax correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'remote1', {
       name: 'remote1',
       root: 'apps/remote1',
@@ -105,7 +105,7 @@ describe('convertToWithMF', () => {
 
   it('should throw when the uniqueName doesnt match the project name', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'remote1', {
       name: 'remote1',
       root: 'apps/remote1',
@@ -134,7 +134,7 @@ describe('convertToWithMF', () => {
 
   it('should throw when the shared npm packages configs has been modified', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'host1', {
       name: 'host1',
       root: 'apps/host1',

--- a/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.spec.ts
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.spec.ts
@@ -7,7 +7,7 @@ import {
   Tree,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { exampleRootTslintJson } from '@nrwl/linter';
 import { conversionGenerator } from './convert-tslint-to-eslint';
 
@@ -133,7 +133,7 @@ describe('convert-tslint-to-eslint', () => {
   let host: Tree;
 
   beforeEach(async () => {
-    host = createTreeWithEmptyWorkspace();
+    host = createTreeWithEmptyV1Workspace();
 
     writeJson(host, 'tslint.json', exampleRootTslintJson.raw);
 

--- a/packages/angular/src/generators/downgrade-module/downgrade-module.spec.ts
+++ b/packages/angular/src/generators/downgrade-module/downgrade-module.spec.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { createApp } from '../../utils/nx-devkit/testing';
 import { angularJsVersion } from '../../utils/versions';
 import { downgradeModuleGenerator } from './downgrade-module';
@@ -11,7 +11,7 @@ describe('downgradeModule generator', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     createApp(tree, appName);
   });
 

--- a/packages/angular/src/generators/host/host.spec.ts
+++ b/packages/angular/src/generators/host/host.spec.ts
@@ -6,7 +6,7 @@ import remote from '../remote/remote';
 describe('Host App Generator', () => {
   it('should generate a host app with no remotes', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     // ACT
     await host(tree, {
@@ -19,7 +19,7 @@ describe('Host App Generator', () => {
 
   it('should generate a host app with a remote', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await applicationGenerator(tree, {
       name: 'remote',
@@ -44,7 +44,7 @@ describe('Host App Generator', () => {
 
   it('should generate a host and any remotes that dont exist with correct routing setup', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     // ACT
 
@@ -74,7 +74,7 @@ describe('Host App Generator', () => {
 
   it('should generate a host, integrate existing remotes and generate any remotes that dont exist', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     await remote(tree, {
       name: 'remote1',
     });
@@ -96,7 +96,7 @@ describe('Host App Generator', () => {
 
   it('should generate a host, integrate existing remotes and generate any remotes that dont exist, in a directory', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     await remote(tree, {
       name: 'remote1',
     });

--- a/packages/angular/src/generators/init/init.spec.ts
+++ b/packages/angular/src/generators/init/init.spec.ts
@@ -1,5 +1,5 @@
 import { NxJsonConfiguration, readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 
 import init from './init';
@@ -10,7 +10,7 @@ describe('init', () => {
   let host: Tree;
 
   beforeEach(() => {
-    host = createTreeWithEmptyWorkspace();
+    host = createTreeWithEmptyV1Workspace();
   });
 
   it('should add angular dependencies', async () => {

--- a/packages/angular/src/generators/karma-project/karma-project.spec.ts
+++ b/packages/angular/src/generators/karma-project/karma-project.spec.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { karmaProjectGenerator } from './karma-project';
 import libraryGenerator from '../library/library';
 import { Linter } from '@nrwl/linter';
@@ -11,7 +11,7 @@ describe('karmaProject', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     await libraryGenerator(tree, {
       name: 'lib1',

--- a/packages/angular/src/generators/karma/karma.spec.ts
+++ b/packages/angular/src/generators/karma/karma.spec.ts
@@ -1,12 +1,12 @@
 import * as devkit from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { karmaGenerator } from './karma';
 
 describe('karma', () => {
   let tree: devkit.Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should do nothing when karma is already installed and karma.conf.js exists', () => {

--- a/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
@@ -12,7 +12,7 @@ describe('librarySecondaryEntryPoint generator', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should throw when the library does not exist in the workspace', async () => {

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -7,7 +7,10 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  createTreeWithEmptyV1Workspace,
+  createTreeWithEmptyWorkspace,
+} from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { toNewFormat } from 'nx/src/config/workspaces';
 import { createApp } from '../../utils/nx-devkit/testing';
@@ -38,12 +41,12 @@ describe('lib', () => {
   }
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   describe('workspace v2', () => {
     beforeEach(() => {
-      tree = createTreeWithEmptyWorkspace(2);
+      tree = createTreeWithEmptyWorkspace();
     });
 
     it('should run the library generator without erroring if the directory has a trailing slash', async () => {
@@ -78,7 +81,7 @@ describe('lib', () => {
 
   describe('workspace v1', () => {
     beforeEach(() => {
-      tree = createTreeWithEmptyWorkspace(1);
+      tree = createTreeWithEmptyV1Workspace();
     });
 
     it('should default to inline project for first project', async () => {
@@ -718,7 +721,7 @@ describe('lib', () => {
 
   describe('at the root', () => {
     beforeEach(() => {
-      tree = createTreeWithEmptyWorkspace(2);
+      tree = createTreeWithEmptyWorkspace();
       updateJson(tree, 'nx.json', (json) => ({
         ...json,
         workspaceLayout: { libsDir: '' },

--- a/packages/angular/src/generators/move/lib/update-module-name.spec.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.spec.ts
@@ -1,5 +1,5 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { moveGenerator } from '@nrwl/workspace/generators';
 import { Schema } from '../schema';
 import { updateModuleName } from './update-module-name';
@@ -11,7 +11,7 @@ describe('updateModuleName Rule', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should handle nesting resulting in the same project name', async () => {

--- a/packages/angular/src/generators/move/move.spec.ts
+++ b/packages/angular/src/generators/move/move.spec.ts
@@ -1,6 +1,6 @@
 import { readJson, Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { angularMoveGenerator } from './move';
 import libraryGenerator from '../library/library';
 import { Linter } from '@nrwl/linter';
@@ -10,7 +10,7 @@ describe('@nrwl/angular:move', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     await libraryGenerator(tree, {
       name: 'mylib',

--- a/packages/angular/src/generators/ng-add/ng-add.spec.ts
+++ b/packages/angular/src/generators/ng-add/ng-add.spec.ts
@@ -8,7 +8,7 @@ describe('ngAdd generator', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
     jest
       .spyOn(angularCliMigrator, 'migrateFromAngularCli')
       .mockImplementation(() => Promise.resolve(() => {}));

--- a/packages/angular/src/generators/ng-add/utilities/app.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/utilities/app.migrator.spec.ts
@@ -7,7 +7,7 @@ import {
   Tree,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { AppMigrator } from './app.migrator';
 import { MigrationProjectConfiguration } from './types';
 
@@ -39,7 +39,7 @@ describe('app migrator', () => {
   }
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     // when this migrator is invoked, some of the workspace migration has
     // already been run, so we make some adjustments to match that state

--- a/packages/angular/src/generators/ng-add/utilities/e2e.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/utilities/e2e.migrator.spec.ts
@@ -12,7 +12,7 @@ import {
   Tree,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { E2eMigrator } from './e2e.migrator';
 import { MigrationProjectConfiguration } from './types';
 
@@ -47,7 +47,7 @@ describe('e2e migrator', () => {
   }
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     // when this migrator is invoked, some of the workspace migration has
     // already been run, so we make some adjustments to match that state

--- a/packages/angular/src/generators/ng-add/utilities/lib.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/utilities/lib.migrator.spec.ts
@@ -7,7 +7,7 @@ import {
   Tree,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { LibMigrator } from './lib.migrator';
 import { MigrationProjectConfiguration } from './types';
 
@@ -39,7 +39,7 @@ describe('lib migrator', () => {
   }
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     // when this migrator is invoked, some of the workspace migration has
     // already been run, so we make some adjustments to match that state

--- a/packages/angular/src/generators/ngrx/ngrx.classes.spec.ts
+++ b/packages/angular/src/generators/ngrx/ngrx.classes.spec.ts
@@ -1,5 +1,5 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { dirname } from 'path';
 import {
   AppConfig,
@@ -31,7 +31,7 @@ describe('NgRx generator', () => {
     expect(tree.exists(file)).not.toBeTruthy();
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     createApp(tree, 'myapp');
     appConfig = getAppConfig();
     statePath = `${dirname(appConfig.appModule)}/+state`;

--- a/packages/angular/src/generators/ngrx/ngrx.creators.spec.ts
+++ b/packages/angular/src/generators/ngrx/ngrx.creators.spec.ts
@@ -1,5 +1,5 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { dirname } from 'path';
 import {
   AppConfig,
@@ -31,7 +31,7 @@ describe('NgRx generator', () => {
     expect(tree.exists(file)).not.toBeTruthy();
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     createApp(tree, 'myapp');
     appConfig = getAppConfig();
     statePath = `${dirname(appConfig.appModule)}/+state`;

--- a/packages/angular/src/generators/ngrx/ngrx.spec.ts
+++ b/packages/angular/src/generators/ngrx/ngrx.spec.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { createApp } from '../../utils/nx-devkit/testing';
 import { ngrxVersion } from '../../utils/versions';
 import { ngrxGenerator } from './ngrx';
@@ -21,7 +21,7 @@ describe('ngrx', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     createApp(tree, 'myapp');
   });
 

--- a/packages/angular/src/generators/remote/remote.spec.ts
+++ b/packages/angular/src/generators/remote/remote.spec.ts
@@ -9,7 +9,7 @@ import remote from './remote';
 describe('MF Remote App Generator', () => {
   it('should generate a remote mf app with no host', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     // ACT
     await remote(tree, {
@@ -23,7 +23,7 @@ describe('MF Remote App Generator', () => {
 
   it('should generate a remote mf app with a host', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await applicationGenerator(tree, {
       name: 'host',
@@ -46,7 +46,7 @@ describe('MF Remote App Generator', () => {
 
   it('should error when a remote app is attempted to be generated with an incorrect host', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     // ACT
     try {
@@ -65,7 +65,7 @@ describe('MF Remote App Generator', () => {
 
   it('should generate a remote mf app and automatically find the next port available', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     await remote(tree, {
       name: 'existing',
       port: 4201,
@@ -83,7 +83,7 @@ describe('MF Remote App Generator', () => {
 
   it('should generate a remote mf app and automatically find the next port available even when there are no other targets', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     // ACT
     await remote(tree, {
@@ -97,7 +97,7 @@ describe('MF Remote App Generator', () => {
 
   it('should not set the remote as the default project', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     // ACT
     await remote(tree, {

--- a/packages/angular/src/generators/scam-directive/lib/convert-directive-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam-directive/lib/convert-directive-to-scam.spec.ts
@@ -6,7 +6,7 @@ import { convertDirectiveToScam } from './convert-directive-to-scam';
 describe('convertDirectiveToScam', () => {
   it('should create the scam directive inline correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -73,7 +73,7 @@ describe('convertDirectiveToScam', () => {
 
   it('should create the scam directive separately correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -132,7 +132,7 @@ describe('convertDirectiveToScam', () => {
 
   it('should create the scam directive inline correctly when --flat', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -199,7 +199,7 @@ describe('convertDirectiveToScam', () => {
 
   it('should create the scam directive separately correctly when --flat', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -258,7 +258,7 @@ describe('convertDirectiveToScam', () => {
 
   it('should place the directive and scam directive in the correct folder when --path is used', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -326,7 +326,7 @@ describe('convertDirectiveToScam', () => {
 
   it('should place the directive and scam directive in the correct folder when --path and --flat is used', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',

--- a/packages/angular/src/generators/scam-directive/scam-directive.spec.ts
+++ b/packages/angular/src/generators/scam-directive/scam-directive.spec.ts
@@ -5,7 +5,7 @@ import scamDirectiveGenerator from './scam-directive';
 describe('SCAM Directive Generator', () => {
   it('should create the inline scam directive correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -49,7 +49,7 @@ describe('SCAM Directive Generator', () => {
 
   it('should create the separate scam directive correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -85,7 +85,7 @@ describe('SCAM Directive Generator', () => {
 
   it('should create the scam directive correctly and export it for a secondary entrypoint', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -135,7 +135,7 @@ describe('SCAM Directive Generator', () => {
   describe('--path', () => {
     it('should not throw when the path does not exist under project', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',
@@ -180,7 +180,7 @@ describe('SCAM Directive Generator', () => {
 
     it('should not matter if the path starts with a slash', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',
@@ -225,7 +225,7 @@ describe('SCAM Directive Generator', () => {
 
     it('should throw when the path does not exist under project', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',

--- a/packages/angular/src/generators/scam-pipe/lib/convert-pipe-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam-pipe/lib/convert-pipe-to-scam.spec.ts
@@ -6,7 +6,7 @@ import { convertPipeToScam } from './convert-pipe-to-scam';
 describe('convertPipeToScam', () => {
   it('should create the scam pipe inline correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -75,7 +75,7 @@ describe('convertPipeToScam', () => {
 
   it('should create the scam pipe separately correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -134,7 +134,7 @@ describe('convertPipeToScam', () => {
 
   it('should create the scam pipe inline correctly when --flat', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -200,7 +200,7 @@ describe('convertPipeToScam', () => {
 
   it('should create the scam pipe separately correctly when --flat', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -259,7 +259,7 @@ describe('convertPipeToScam', () => {
 
   it('should place the pipe and scam pipe in the correct folder when --path is used', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -329,7 +329,7 @@ describe('convertPipeToScam', () => {
 
   it('should place the pipe and scam pipe in the correct folder when --path and --flat is used', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',

--- a/packages/angular/src/generators/scam-pipe/scam-pipe.spec.ts
+++ b/packages/angular/src/generators/scam-pipe/scam-pipe.spec.ts
@@ -5,7 +5,7 @@ import scamPipeGenerator from './scam-pipe';
 describe('SCAM Pipe Generator', () => {
   it('should create the inline scam pipe correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -51,7 +51,7 @@ describe('SCAM Pipe Generator', () => {
 
   it('should create the separate scam pipe correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -87,7 +87,7 @@ describe('SCAM Pipe Generator', () => {
 
   it('should create the scam pipe correctly and export it for a secondary entrypoint', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -137,7 +137,7 @@ describe('SCAM Pipe Generator', () => {
   describe('--path', () => {
     it('should not throw when the path does not exist under project', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',
@@ -184,7 +184,7 @@ describe('SCAM Pipe Generator', () => {
 
     it('should not matter if the path starts with a slash', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',
@@ -231,7 +231,7 @@ describe('SCAM Pipe Generator', () => {
 
     it('should throw when the path does not exist under project', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',

--- a/packages/angular/src/generators/scam/lib/convert-component-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam/lib/convert-component-to-scam.spec.ts
@@ -6,7 +6,7 @@ import { convertComponentToScam } from './convert-component-to-scam';
 describe('convertComponentToScam', () => {
   it('should create the scam inline correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -76,7 +76,7 @@ describe('convertComponentToScam', () => {
 
   it('should create the scam separately correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -133,7 +133,7 @@ describe('convertComponentToScam', () => {
 
   it('should create the scam inline correctly when --flat', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -205,7 +205,7 @@ describe('convertComponentToScam', () => {
 
   it('should create the scam separately correctly when --flat', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -264,7 +264,7 @@ describe('convertComponentToScam', () => {
 
   it('should create the scam inline correctly when --type', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -338,7 +338,7 @@ describe('convertComponentToScam', () => {
 
   it('should create the scam separately correctly when --type', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -399,7 +399,7 @@ describe('convertComponentToScam', () => {
 
   it('should place the component and scam in the correct folder when --path is used', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -472,7 +472,7 @@ describe('convertComponentToScam', () => {
 
   it('should place the component and scam in the correct folder when --path and --flat is used', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',

--- a/packages/angular/src/generators/scam/scam.spec.ts
+++ b/packages/angular/src/generators/scam/scam.spec.ts
@@ -5,7 +5,7 @@ import { scamGenerator } from './scam';
 describe('SCAM Generator', () => {
   it('should create the inline scam correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -53,7 +53,7 @@ describe('SCAM Generator', () => {
 
   it('should create the separate scam correctly', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -88,7 +88,7 @@ describe('SCAM Generator', () => {
 
   it('should create the scam correctly and export it for a secondary entrypoint', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -138,7 +138,7 @@ describe('SCAM Generator', () => {
   describe('--path', () => {
     it('should not throw when the path does not exist under project', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',
@@ -187,7 +187,7 @@ describe('SCAM Generator', () => {
 
     it('should not matter if the path starts with a slash', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',
@@ -236,7 +236,7 @@ describe('SCAM Generator', () => {
 
     it('should throw when the path does not exist under project', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app1', {
         projectType: 'application',
         sourceRoot: 'apps/app1/src',

--- a/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { setupMf } from './setup-mf';
 import applicationGenerator from '../application/application';
@@ -8,7 +8,7 @@ describe('Init MF', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     await applicationGenerator(tree, {
       name: 'app1',
       routing: true,

--- a/packages/angular/src/generators/setup-tailwind/setup-tailwind.application.spec.ts
+++ b/packages/angular/src/generators/setup-tailwind/setup-tailwind.application.spec.ts
@@ -18,7 +18,7 @@ describe('setupTailwind generator', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
     jest.clearAllMocks();
   });
 

--- a/packages/angular/src/generators/setup-tailwind/setup-tailwind.library.spec.ts
+++ b/packages/angular/src/generators/setup-tailwind/setup-tailwind.library.spec.ts
@@ -18,7 +18,7 @@ describe('setupTailwind generator', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
     jest.clearAllMocks();
   });
 

--- a/packages/angular/src/generators/stories/stories-app.spec.ts
+++ b/packages/angular/src/generators/stories/stories-app.spec.ts
@@ -1,6 +1,6 @@
 import { installedCypressVersion } from '@nrwl/cypress/src/utils/cypress-version';
 import type { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { applicationGenerator } from '../application/application';
 import { scamGenerator } from '../scam/scam';
 import { componentGenerator } from '../component/component';
@@ -18,7 +18,7 @@ describe('angularStories generator: applications', () => {
 
   beforeEach(async () => {
     mockedInstalledCypressVersion.mockReturnValue(10);
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     await applicationGenerator(tree, {
       name: appName,
     });

--- a/packages/angular/src/generators/stories/stories-lib.spec.ts
+++ b/packages/angular/src/generators/stories/stories-lib.spec.ts
@@ -1,7 +1,7 @@
 import { installedCypressVersion } from '@nrwl/cypress/src/utils/cypress-version';
 import type { Tree } from '@nrwl/devkit';
 import { writeJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { cypressProjectGenerator } from '@nrwl/storybook';
 import { componentGenerator } from '../component/component';
@@ -27,7 +27,7 @@ describe('angularStories generator: libraries', () => {
     let tree: Tree;
 
     beforeEach(async () => {
-      tree = createTreeWithEmptyWorkspace();
+      tree = createTreeWithEmptyV1Workspace();
       await libraryGenerator(tree, { name: libName });
     });
 

--- a/packages/angular/src/generators/upgrade-module/upgrade-module.spec.ts
+++ b/packages/angular/src/generators/upgrade-module/upgrade-module.spec.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { createApp } from '../../utils/nx-devkit/testing';
 import { angularJsVersion } from '../../utils/versions';
 import { upgradeModuleGenerator } from './upgrade-module';
@@ -11,7 +11,7 @@ describe('upgradeModule generator', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     createApp(tree, appName);
   });
 

--- a/packages/angular/src/generators/utils/export-scam.spec.ts
+++ b/packages/angular/src/generators/utils/export-scam.spec.ts
@@ -5,7 +5,7 @@ import { exportScam } from './export-scam';
 describe('exportScam', () => {
   it('should not throw when project is an application (does not have entry point)', () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app1', {
       projectType: 'application',
       sourceRoot: 'apps/app1/src',
@@ -33,7 +33,7 @@ describe('exportScam', () => {
 
   it('should export the component', () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -66,7 +66,7 @@ describe('exportScam', () => {
 
   it('should export the component and the module when "--inline-scam=false"', () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',
@@ -100,7 +100,7 @@ describe('exportScam', () => {
 
   it('should export the component from the secondary entrypoint', () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'lib1', {
       projectType: 'library',
       sourceRoot: 'libs/lib1/src',

--- a/packages/angular/src/generators/utils/testing.ts
+++ b/packages/angular/src/generators/utils/testing.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { UnitTestRunner } from '../../utils/test-runners';
 import libraryGenerator from '../library/library';
@@ -8,7 +8,7 @@ import libraryGenerator from '../library/library';
 export async function createStorybookTestWorkspaceForLib(
   libName: string
 ): Promise<Tree> {
-  let tree = createTreeWithEmptyWorkspace();
+  let tree = createTreeWithEmptyV1Workspace();
 
   const moduleGenerator = wrapAngularDevkitSchematic(
     '@schematics/angular',

--- a/packages/angular/src/generators/web-worker/web-worker.spec.ts
+++ b/packages/angular/src/generators/web-worker/web-worker.spec.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { applicationGenerator } from '../application/application';
 import { webWorkerGenerator } from './web-worker';
 
@@ -9,7 +9,7 @@ describe('webWorker generator', () => {
   const appName = 'ng-app1';
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     await applicationGenerator(tree, { name: appName });
     jest.clearAllMocks();
   });

--- a/packages/angular/src/migrations/update-12-0-0/update-ngcc-postinstall.spec.ts
+++ b/packages/angular/src/migrations/update-12-0-0/update-ngcc-postinstall.spec.ts
@@ -26,7 +26,7 @@ describe('Remove ngcc flags from postinstall script', () => {
     },
   ].forEach((testEntry) => {
     it(`should adjust ngcc for: "${testEntry.test}"`, async () => {
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       tree.delete('workspace.json');
       tree.write('angular.json', '{}');
       writeJson(tree, 'package.json', {

--- a/packages/angular/src/migrations/update-12-3-0/convert-webpack-browser-build-target-to-delegate-build.spec.ts
+++ b/packages/angular/src/migrations/update-12-3-0/convert-webpack-browser-build-target-to-delegate-build.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import convertWebpackBrowserBuildTargetToDelegateBuild from './convert-webpack-browser-build-target-to-delegate-build';
 
 function getWsConfig(tree: Tree) {
@@ -10,7 +10,7 @@ describe('convertWebpackBrowserBuildTargetToDelegateBuild', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     addProjectConfiguration(tree, 'ng-app1', {
       root: '',

--- a/packages/angular/src/migrations/update-12-3-0/update-storybook.spec.ts
+++ b/packages/angular/src/migrations/update-12-3-0/update-storybook.spec.ts
@@ -1,12 +1,12 @@
 import { addProjectConfiguration, readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import update from './update-storybook';
 
 describe('12.4.0 - Update Storybook', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     jest.mock('@storybook/core/package.json', () => ({
       version: '6.2.0',
     }));

--- a/packages/angular/src/migrations/update-12-3-0/update-webpack-browser-config.spec.ts
+++ b/packages/angular/src/migrations/update-12-3-0/update-webpack-browser-config.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import updateAngularConfig from './update-webpack-browser-config';
 
 function getBuildTarget(tree: Tree) {
@@ -10,7 +10,7 @@ describe('Migration to update targets with @nrwl/angular:webpack-browser executo
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     addProjectConfiguration(tree, 'ng-app', {
       root: '',

--- a/packages/angular/src/migrations/update-12-9-0/update-invalid-import-paths.spec.ts
+++ b/packages/angular/src/migrations/update-12-9-0/update-invalid-import-paths.spec.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 import { updateJson, joinPathFragments, readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import libGenerator from '../../generators/library/library';
 import updateInvalidImportPaths from './update-invalid-import-paths';
@@ -9,7 +9,7 @@ describe('Migration to fix invalid import paths in affected workspaces', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     // set up some libs
 

--- a/packages/angular/src/migrations/update-13-0-0/add-postcss-packages.spec.ts
+++ b/packages/angular/src/migrations/update-13-0-0/add-postcss-packages.spec.ts
@@ -6,7 +6,7 @@ describe('add-postcss-import migration', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should not add postcss-import when ng-packagr is not installed', () => {

--- a/packages/angular/src/migrations/update-13-2-0/opt-out-testbed-teardown.spec.ts
+++ b/packages/angular/src/migrations/update-13-2-0/opt-out-testbed-teardown.spec.ts
@@ -6,7 +6,7 @@ describe('opt-out-testbed-teardown migration', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
     jest.doMock('@nrwl/devkit', () => ({ workspaceRoot: '' }));
   });
 

--- a/packages/angular/src/migrations/update-13-2-0/update-angular-config.spec.ts
+++ b/packages/angular/src/migrations/update-13-2-0/update-angular-config.spec.ts
@@ -8,7 +8,7 @@ import updateAngularConfig from './update-angular-config';
 describe('update-angular-config migration', () => {
   it('should remove deprecated options from webpack server executor', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'testing', {
       root: 'apps/testing',
       targets: {
@@ -53,7 +53,7 @@ describe('update-angular-config migration', () => {
 
   it('should remove deprecated options from webpack browser executor', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'testing', {
       root: 'apps/testing',
       targets: {
@@ -78,7 +78,7 @@ describe('update-angular-config migration', () => {
 
   it('should not fail for projects with no targets', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'testing', {
       root: 'apps/testing',
     });

--- a/packages/angular/src/migrations/update-13-2-0/update-angular-jest-config.spec.ts
+++ b/packages/angular/src/migrations/update-13-2-0/update-angular-jest-config.spec.ts
@@ -6,7 +6,7 @@ import updateAngularJestConfig from './update-angular-jest-config';
 describe('update-angular-jest-config migration', () => {
   it('should migrate the jest config', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app', {
       root: 'apps/testing',
       targets: {
@@ -51,7 +51,7 @@ describe('update-angular-jest-config migration', () => {
   });
 
   it("shouldn't error on null targets", async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app', {
       root: 'apps/testing',
     });

--- a/packages/angular/src/migrations/update-13-2-0/update-libraries.spec.ts
+++ b/packages/angular/src/migrations/update-13-2-0/update-libraries.spec.ts
@@ -5,7 +5,7 @@ import updateLibraries from './update-libraries';
 describe('update-libraries migration', () => {
   it('should remove enableIvy flag from tsconfig and add compilationMode', () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'testing', {
       root: 'libs/testing',
       targets: {
@@ -42,7 +42,7 @@ describe('update-libraries migration', () => {
 
   it('should remove deprecated flags from ng-pacakgr', () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'testing', {
       root: 'libs/testing',
       targets: {
@@ -78,7 +78,7 @@ describe('update-libraries migration', () => {
   });
 
   it("shouldn't error on null targets", async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'app', {
       root: 'apps/testing',
     });

--- a/packages/angular/src/migrations/update-13-3-0/update-mfe-webpack-config.spec.ts
+++ b/packages/angular/src/migrations/update-13-3-0/update-mfe-webpack-config.spec.ts
@@ -9,7 +9,7 @@ describe('update-mfe-webpack-config', () => {
   describe('run the migration', () => {
     it('should skip the migration when there is no MFE config', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app', {
         root: 'apps/testing',
         targets: {
@@ -40,7 +40,7 @@ describe('update-mfe-webpack-config', () => {
 
     it('should skip the migration when using a different executor', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app', {
         root: 'apps/testing',
         targets: {
@@ -64,7 +64,7 @@ describe('update-mfe-webpack-config', () => {
 
     it('shouldnt run for non mfe configs', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app', {
         root: 'apps/testing',
         targets: {
@@ -113,7 +113,7 @@ describe('update-mfe-webpack-config', () => {
 
     it('should run the migration successfully for a host config', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app', {
         root: 'apps/testing',
         targets: {
@@ -274,7 +274,7 @@ describe('update-mfe-webpack-config', () => {
 
     it('should add outputModule to experiments object when something else exists in experiments', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app', {
         root: 'apps/testing',
         targets: {
@@ -435,7 +435,7 @@ describe('update-mfe-webpack-config', () => {
 
     it('should run the migration successfully for a remote config', async () => {
       // ARRANGE
-      const tree = createTreeWithEmptyWorkspace(2);
+      const tree = createTreeWithEmptyWorkspace();
       addProjectConfiguration(tree, 'app', {
         root: 'apps/testing',
         targets: {

--- a/packages/angular/src/migrations/update-13-5-0/remove-library-generator-style-default.spec.ts
+++ b/packages/angular/src/migrations/update-13-5-0/remove-library-generator-style-default.spec.ts
@@ -12,7 +12,7 @@ describe('remove-library-generator-style-default migration', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
     jest.clearAllMocks();
   });
 

--- a/packages/angular/src/migrations/update-13-5-0/update-mfe-configs.spec.ts
+++ b/packages/angular/src/migrations/update-13-5-0/update-mfe-configs.spec.ts
@@ -15,7 +15,7 @@ import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 describe('migrateMFEConfigs', () => {
   it('should do nothing for correct setups', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'test', {
       root: 'apps/test',
       targets: {
@@ -71,7 +71,7 @@ describe('migrateMFEConfigs', () => {
 
   it('should fix incorrect setups', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'test', {
       root: 'apps/test',
       sourceRoot: 'apps/test/src',

--- a/packages/angular/src/migrations/update-13-8-1/add-cypress-mf-workaround.spec.ts
+++ b/packages/angular/src/migrations/update-13-8-1/add-cypress-mf-workaround.spec.ts
@@ -7,7 +7,7 @@ import addCypressMfWorkaround from './add-cypress-mf-workaround';
 describe('Add Cypress MFE Workaround', () => {
   it('should add the cypress command to the index.ts for project that has associated e2e', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     await applicationGenerator(tree, {
       name: 'app1',
       routing: true,
@@ -28,7 +28,7 @@ describe('Add Cypress MFE Workaround', () => {
 
   it('should not add the cypress command to the index.ts for project that has does not have an associated e2e', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     await applicationGenerator(tree, {
       name: 'app1',
       routing: true,

--- a/packages/angular/src/migrations/update-13-8-4/migrate-karma-conf.spec.ts
+++ b/packages/angular/src/migrations/update-13-8-4/migrate-karma-conf.spec.ts
@@ -6,7 +6,7 @@ import migrateKarmaConfig from './migrate-karma-conf';
 describe('Migrate Karma Config', () => {
   it('should successfully migrate outdate karma setup', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     tree.write(
       'karma.conf.js',
       `// Karma configuration file, see link for more information

--- a/packages/angular/src/migrations/update-13-9-0/set-build-libs-from-source.spec.ts
+++ b/packages/angular/src/migrations/update-13-9-0/set-build-libs-from-source.spec.ts
@@ -11,7 +11,7 @@ describe('set-build-libs-from-source migration', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should not error when project does not have targets', async () => {

--- a/packages/angular/src/migrations/update-14-0-0/rename-mf-config.spec.ts
+++ b/packages/angular/src/migrations/update-14-0-0/rename-mf-config.spec.ts
@@ -5,7 +5,7 @@ import renameMFConfig from './rename-mf-config';
 describe('Module Federation Config Migration', () => {
   it('should rename files in projects that have an mfe.config.js', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await host(tree, {
       name: 'host1',
@@ -32,7 +32,7 @@ describe('Module Federation Config Migration', () => {
 
   it('should fix dynamic hosts', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await host(tree, {
       name: 'host1',

--- a/packages/angular/src/migrations/update-14-2-0/remove-show-circular-dependencies-option.spec.ts
+++ b/packages/angular/src/migrations/update-14-2-0/remove-show-circular-dependencies-option.spec.ts
@@ -10,7 +10,7 @@ describe('remove-show-circular-dependencies-option migration', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it.each([

--- a/packages/angular/src/migrations/update-14-2-0/update-angular-cli.spec.ts
+++ b/packages/angular/src/migrations/update-14-2-0/update-angular-cli.spec.ts
@@ -6,7 +6,7 @@ describe('update-angular-cli migration', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should update @angular/cli version when defined as a dev dependency', async () => {

--- a/packages/angular/src/migrations/update-14-2-0/update-libraries-secondary-entrypoints.spec.ts
+++ b/packages/angular/src/migrations/update-14-2-0/update-libraries-secondary-entrypoints.spec.ts
@@ -17,7 +17,7 @@ describe('update-libraries-secondary-entrypoints migration', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it.each(libraryExecutors)(

--- a/packages/angular/src/migrations/update-14-2-0/update-ngcc-target.spec.ts
+++ b/packages/angular/src/migrations/update-14-2-0/update-ngcc-target.spec.ts
@@ -1,5 +1,5 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import updateNgccTarget from './update-ngcc-target';
 
 describe('update-ngcc-postinstall-target migration', () => {
@@ -21,7 +21,7 @@ describe('update-ngcc-postinstall-target migration', () => {
     },
   ].forEach((testEntry) => {
     it(`should adjust ngcc target for: "${testEntry.test}"`, async () => {
-      const tree = createTreeWithEmptyWorkspace();
+      const tree = createTreeWithEmptyV1Workspace();
       tree.write(
         '/package.json',
         JSON.stringify({ scripts: { postinstall: testEntry.test } })
@@ -45,7 +45,7 @@ describe('update-ngcc-postinstall-target migration', () => {
     },
   ].forEach((testEntry) => {
     it(`should not update postinstall script: "${testEntry.test}"`, async () => {
-      const tree = createTreeWithEmptyWorkspace();
+      const tree = createTreeWithEmptyV1Workspace();
       tree.write(
         '/package.json',
         JSON.stringify({ scripts: { postinstall: testEntry.test } })

--- a/packages/angular/src/migrations/update-14-2-0/update-router-initial-navigation.spec.ts
+++ b/packages/angular/src/migrations/update-14-2-0/update-router-initial-navigation.spec.ts
@@ -19,7 +19,7 @@ describe('update-router-initial-navigation migration', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should update "initialNavigation" to "enabledBlocking"', async () => {

--- a/packages/angular/src/migrations/update-14-2-0/update-tsconfig-target.spec.ts
+++ b/packages/angular/src/migrations/update-14-2-0/update-tsconfig-target.spec.ts
@@ -20,7 +20,7 @@ describe('update-tsconfig-target migration', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should update target in "tsconfig.json" at the project root when it is an Angular project', async () => {

--- a/packages/angular/src/migrations/update-14-5-0/migrate-mfe-to-mf.spec.ts
+++ b/packages/angular/src/migrations/update-14-5-0/migrate-mfe-to-mf.spec.ts
@@ -11,7 +11,7 @@ describe('migrate-mfe-to-mf', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should replace any imports from nrwl/angular/mfe', () => {

--- a/packages/angular/src/migrations/update-14-5-2/update-angular-cli.spec.ts
+++ b/packages/angular/src/migrations/update-14-5-2/update-angular-cli.spec.ts
@@ -6,7 +6,7 @@ describe('update-angular-cli migration', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should update @angular/cli version when defined as a dev dependency', async () => {

--- a/packages/cypress/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.spec.ts
+++ b/packages/cypress/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.spec.ts
@@ -6,7 +6,7 @@ import {
   Tree,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { exampleRootTslintJson } from '@nrwl/linter';
 import { conversionGenerator } from './convert-tslint-to-eslint';
 
@@ -90,7 +90,7 @@ describe('convert-tslint-to-eslint', () => {
   let host: Tree;
 
   beforeEach(async () => {
-    host = createTreeWithEmptyWorkspace();
+    host = createTreeWithEmptyV1Workspace();
 
     writeJson(host, 'tslint.json', exampleRootTslintJson.raw);
 

--- a/packages/cypress/src/generators/cypress-component-project/cypress-component-project.spec.ts
+++ b/packages/cypress/src/generators/cypress-component-project/cypress-component-project.spec.ts
@@ -5,7 +5,7 @@ import {
   Tree,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { installedCypressVersion } from '../../utils/cypress-version';
 import { cypressComponentProject } from './cypress-component-project';
 
@@ -36,7 +36,7 @@ describe('Cypress Component Project', () => {
   > = installedCypressVersion as never;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'cool-lib', projectConfig);
     tree.write(
       '.gitignore',

--- a/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
@@ -6,7 +6,7 @@ import {
   updateProjectConfiguration,
   WorkspaceJsonConfiguration,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { cypressProjectGenerator } from './cypress-project';
 import { Schema } from './schema';
 import { Linter } from '@nrwl/linter';
@@ -25,7 +25,7 @@ describe('Cypress Project', () => {
   > = installedCypressVersion as never;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     addProjectConfiguration(tree, 'my-app', {
       root: 'my-app',

--- a/packages/cypress/src/generators/init/init.spec.ts
+++ b/packages/cypress/src/generators/init/init.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree, updateJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { cypressVersion } from '../../utils/versions';
 import { cypressInitGenerator } from './init';
@@ -8,7 +8,7 @@ describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should add dependencies into `package.json` file', async () => {

--- a/packages/cypress/src/generators/migrate-to-cypress-ten/migrate-to-cypress-ten.spec.ts
+++ b/packages/cypress/src/generators/migrate-to-cypress-ten/migrate-to-cypress-ten.spec.ts
@@ -27,7 +27,7 @@ describe('convertToCypressTen', () => {
   > = installedCypressVersion as never;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
     mockedInstalledCypressVersion.mockReturnValue(9);
   });
 

--- a/packages/cypress/src/migrations/update-12-8-0/remove-typescript-plugin.spec.ts
+++ b/packages/cypress/src/migrations/update-12-8-0/remove-typescript-plugin.spec.ts
@@ -1,4 +1,4 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { addProjectConfiguration, Tree, writeJson } from '@nrwl/devkit';
 import removeTypescriptPlugin from './remove-typescript-plugin';
 
@@ -6,7 +6,7 @@ describe('remove typescript plugin', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     addProjectConfiguration(tree, 'proj', {
       root: 'proj',

--- a/packages/detox/src/generators/application/application.spec.ts
+++ b/packages/detox/src/generators/application/application.spec.ts
@@ -4,7 +4,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from 'packages/linter/src/generators/utils/linter';
 
 import detoxApplicationGenerator from './application';
@@ -13,7 +13,7 @@ describe('detox application generator', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     tree.write('.gitignore', '');
   });
 

--- a/packages/detox/src/generators/application/lib/add-linting.spec.ts
+++ b/packages/detox/src/generators/application/lib/add-linting.spec.ts
@@ -1,5 +1,5 @@
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { addLinting } from './add-linting';
 import { addProject } from './add-project';
@@ -8,7 +8,7 @@ describe('Add Linting', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProject(tree, {
       name: 'my-app-e2e',
       projectName: 'my-app-e2e',

--- a/packages/detox/src/generators/application/lib/add-project.spec.ts
+++ b/packages/detox/src/generators/application/lib/add-project.spec.ts
@@ -3,7 +3,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { addProject } from './add-project';
 
@@ -11,7 +11,7 @@ describe('Add Project', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'my-app', {
       root: 'my-app',
       targets: {

--- a/packages/detox/src/generators/application/lib/create-files.spec.ts
+++ b/packages/detox/src/generators/application/lib/create-files.spec.ts
@@ -1,5 +1,5 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { createFiles } from './create-files';
 
@@ -7,7 +7,7 @@ describe('Create Files', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should generate files', () => {

--- a/packages/detox/src/generators/application/lib/normalize-options.spec.ts
+++ b/packages/detox/src/generators/application/lib/normalize-options.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { Schema } from '../schema';
 import { normalizeOptions } from './normalize-options';
@@ -8,7 +8,7 @@ describe('Normalize Options', () => {
   let appTree: Tree;
 
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
   });
 
   it('should normalize options with name in kebab case', () => {

--- a/packages/detox/src/generators/init/init.spec.ts
+++ b/packages/detox/src/generators/init/init.spec.ts
@@ -1,12 +1,12 @@
 import { Tree, readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { detoxInitGenerator } from './init';
 
 describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should add detox dependencies', async () => {

--- a/packages/detox/src/migrations/update-13-10-3/add-verbose-jest-config-13-10-3.spec.ts
+++ b/packages/detox/src/migrations/update-13-10-3/add-verbose-jest-config-13-10-3.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import update from './add-verbose-jest-config-13-10-3';
 
@@ -7,7 +7,7 @@ describe('Set verbose to true for jest.config.json for detox apps', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'products', {
       root: 'apps/products',
       sourceRoot: 'apps/products/src',

--- a/packages/detox/src/migrations/update-13-5-0/add-build-target-test-13-5-0.spec.ts
+++ b/packages/detox/src/migrations/update-13-5-0/add-build-target-test-13-5-0.spec.ts
@@ -1,12 +1,12 @@
 import { addProjectConfiguration, getProjects, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import update from './add-build-target-test-13-5-0';
 
 describe('add-e2e-targets-13-5-0', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'products-e2e', {
       root: 'apps/products-e2e',
       sourceRoot: 'apps/products-e2e/src',

--- a/packages/detox/src/migrations/update-13-8-2/remove-types-detox-13-8-2.spec.ts
+++ b/packages/detox/src/migrations/update-13-8-2/remove-types-detox-13-8-2.spec.ts
@@ -4,14 +4,14 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import update from './remove-types-detox-13-8-2';
 
 describe('remove-types-detox-13-8-2', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     updateJson(tree, 'package.json', (packageJson) => {
       packageJson.devDependencies['@types/detox'] = '*';
       return packageJson;

--- a/packages/devkit/migrations.json
+++ b/packages/devkit/migrations.json
@@ -1,0 +1,9 @@
+{
+  "schematics": {
+    "split-create-tree": {
+      "version": "14.2.0-beta.0",
+      "description": "Adjusts calls to createTreeWithEmptyWorkspace to reflect new API",
+      "factory": "./src/migrations/update-14-2-0/split-create-empty-tree"
+    }
+  }
+}

--- a/packages/devkit/migrations.spec.ts
+++ b/packages/devkit/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+const migrations = Object.entries(json.schematics);
+
+describe('devkit migrations', () => {
+  it.each(migrations)('should have valid path: %s', (key, m) => {
+    expect(() =>
+      require.resolve(path.join(__dirname, `${m.factory}.ts`))
+    ).not.toThrow();
+  });
+});

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -30,9 +30,13 @@
     "ejs": "^3.1.7",
     "ignore": "^5.0.4",
     "semver": "7.3.4",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "@phenomnomnominal/tsquery": "4.1.1"
   },
   "peerDependencies": {
     "nx": ">= 13.10 <= 15"
+  },
+  "nx-migrations": {
+    "migrations": "./migrations.json"
   }
 }

--- a/packages/devkit/src/migrations/update-14-2-0/split-create-empty-tree.spec.ts
+++ b/packages/devkit/src/migrations/update-14-2-0/split-create-empty-tree.spec.ts
@@ -1,0 +1,109 @@
+import update from './split-create-empty-tree';
+import { createTreeWithEmptyWorkspace } from '../../../testing';
+import { addProjectConfiguration, Tree } from '@nrwl/devkit';
+
+const TS_FILE_THAT_DOESNT_USE_EITHER = `import { other } from '@nrwl/devkit/testing';
+other();`;
+
+const TS_FILE_THAT_USES_DEFAULT = `import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+createTreeWithEmptyWorkspace();
+`;
+
+const TS_FILE_THAT_USES_V1 = `import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
+
+createTreeWithEmptyV1Workspace();
+`;
+
+const TS_FILE_THAT_SPECIFIED_V2 = `import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+createTreeWithEmptyWorkspace(2);
+`;
+
+const TS_FILE_THAT_SPECIFIED_V1_AND_IMPORTED_ALL = `import * as devkit from '@nrwl/devkit/testing';
+
+devkit.createTreeWithEmptyWorkspace(1);
+`;
+
+const TS_FILE_THAT_SPECIFIED_V1_AND_IMPORTED_ALL_UPDATED = `import * as devkit from '@nrwl/devkit/testing';
+
+devkit.createTreeWithEmptyV1Workspace();
+`;
+
+const TS_FILE_THAT_SPECIFIED_V1 = `import { createTreeWithEmptyWorkspace, other } from '@nrwl/devkit/testing';
+
+devkit.createTreeWithEmptyWorkspace(1);
+`;
+
+const TS_FILE_THAT_SPECIFIED_V1_UPDATED = `import { createTreeWithEmptyV1Workspace, other } from '@nrwl/devkit/testing';
+
+devkit.createTreeWithEmptyV1Workspace();
+`;
+
+const TS_FILE_THAT_SPECIFIED_BOTH = `import { createTreeWithEmptyWorkspace, other } from '@nrwl/devkit/testing';
+
+devkit.createTreeWithEmptyWorkspace(1);
+devkit.createTreeWithEmptyWorkspace(2);
+`;
+
+const TS_FILE_THAT_SPECIFIED_BOTH_UPDATED = `import { createTreeWithEmptyV1Workspace, createTreeWithEmptyWorkspace, other } from '@nrwl/devkit/testing';
+
+devkit.createTreeWithEmptyV1Workspace();
+devkit.createTreeWithEmptyWorkspace();
+`;
+
+const testCases = [
+  {
+    initial: TS_FILE_THAT_DOESNT_USE_EITHER,
+    expected: TS_FILE_THAT_DOESNT_USE_EITHER,
+    message: `doesn't use util`,
+  },
+  {
+    initial: TS_FILE_THAT_USES_DEFAULT,
+    expected: TS_FILE_THAT_USES_V1,
+    message: `uses default value`,
+  },
+  {
+    initial: TS_FILE_THAT_SPECIFIED_V2,
+    expected: TS_FILE_THAT_USES_DEFAULT,
+    message: 'only specified default',
+  },
+  {
+    initial: TS_FILE_THAT_SPECIFIED_V1,
+    expected: TS_FILE_THAT_SPECIFIED_V1_UPDATED,
+    message: 'only specified v1',
+  },
+  {
+    initial: TS_FILE_THAT_SPECIFIED_V1_AND_IMPORTED_ALL,
+    expected: TS_FILE_THAT_SPECIFIED_V1_AND_IMPORTED_ALL_UPDATED,
+    message: 'only specified v1, and imported all',
+  },
+  {
+    initial: TS_FILE_THAT_SPECIFIED_BOTH,
+    expected: TS_FILE_THAT_SPECIFIED_BOTH_UPDATED,
+    message: 'specified both',
+  },
+];
+
+describe('update-14-2-0-split-create-empty-tree', () => {
+  it.each(testCases)(
+    'should match expected if file $message',
+    async ({ initial, expected }) => {
+      const { tree, tsFilePath } = createTreeWithBoilerplate();
+      tree.write(tsFilePath, initial);
+
+      await update(tree);
+      const contents = tree.read(tsFilePath).toString();
+      expect(contents).toEqual(expected);
+    }
+  );
+});
+
+function createTreeWithBoilerplate(): { tree: Tree; tsFilePath: string } {
+  const tree = createTreeWithEmptyWorkspace();
+  const project = 'proj';
+  addProjectConfiguration(tree, project, {
+    root: `libs/${project}`,
+  });
+  return { tree, tsFilePath: `libs/${project}/some-file.ts` };
+}

--- a/packages/devkit/src/migrations/update-14-2-0/split-create-empty-tree.ts
+++ b/packages/devkit/src/migrations/update-14-2-0/split-create-empty-tree.ts
@@ -1,0 +1,84 @@
+import { Tree } from 'nx/src/generators/tree';
+import { getProjects } from 'nx/src/generators/utils/project-configuration';
+import {
+  StringChange,
+  ChangeType,
+  applyChangesToString,
+} from '../../utils/string-change';
+import { extname } from 'path';
+import { tsquery } from '@phenomnomnominal/tsquery';
+
+import { visitNotIgnoredFiles } from '../../generators/visit-not-ignored-files';
+import { formatFiles } from '@nrwl/devkit';
+
+export default async function update(tree: Tree): Promise<void> {
+  for (const [project, { root }] of getProjects(tree)) {
+    visitNotIgnoredFiles(tree, root, (filePath) => {
+      if (extname(filePath) === '.ts') {
+        let changed = false;
+        let file = tree.read(filePath).toString();
+
+        // Need to import createTreeWithEmptyV1Workspace, and use it instead
+        if (
+          file.includes('createTreeWithEmptyWorkspace(1)') ||
+          file.includes('createTreeWithEmptyWorkspace()')
+        ) {
+          changed = true;
+          file = file.replace(
+            /createTreeWithEmptyWorkspace\(1\)/g,
+            'createTreeWithEmptyV1Workspace()'
+          );
+          file = file.replace(
+            /createTreeWithEmptyWorkspace\(\)/g,
+            'createTreeWithEmptyV1Workspace()'
+          );
+
+          // Was only using v1, simple string replace updates imports.
+          if (!file.includes('createTreeWithEmptyWorkspace(2)')) {
+            file = file.replace(
+              'createTreeWithEmptyWorkspace',
+              'createTreeWithEmptyV1Workspace'
+            );
+          } else {
+            const changes: StringChange[] = [];
+            const ast = tsquery.ast(file);
+            const importDeclarations = tsquery(
+              ast,
+              'ImportDeclaration[moduleSpecifier.text="@nrwl/devkit/testing"]'
+            );
+            for (const declaration of importDeclarations) {
+              const namedImports = tsquery(
+                declaration,
+                'NamedImports ImportSpecifier'
+              );
+              if (namedImports.length) {
+                const firstImport = namedImports[0].pos;
+                changes.push({
+                  type: ChangeType.Insert,
+                  index: firstImport,
+                  text: ' createTreeWithEmptyV1Workspace,',
+                });
+                break;
+              }
+            }
+            file = applyChangesToString(file, changes);
+          }
+        }
+
+        // Replace all instances with param set to 2, to version w/o param
+        if (file.includes('createTreeWithEmptyWorkspace(2)')) {
+          file = file.replace(
+            /createTreeWithEmptyWorkspace\(2\)/g,
+            'createTreeWithEmptyWorkspace()'
+          );
+          changed = true;
+        }
+
+        if (changed) {
+          tree.write(filePath, file);
+        }
+      }
+    });
+  }
+  await formatFiles(tree);
+}

--- a/packages/devkit/testing.ts
+++ b/packages/devkit/testing.ts
@@ -1,2 +1,5 @@
-export { createTreeWithEmptyWorkspace } from 'nx/src/generators/testing-utils/create-tree-with-empty-workspace';
+export {
+  createTreeWithEmptyWorkspace,
+  createTreeWithEmptyV1Workspace,
+} from 'nx/src/generators/testing-utils/create-tree-with-empty-workspace';
 export { createTree } from 'nx/src/generators/testing-utils/create-tree';

--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { applicationGenerator } from './application';
 import { Schema } from './schema';
 
@@ -7,7 +7,7 @@ describe('app', () => {
   let appTree: Tree;
 
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
   });
 
   it('should generate files', async () => {

--- a/packages/express/src/generators/init/init.spec.ts
+++ b/packages/express/src/generators/init/init.spec.ts
@@ -6,13 +6,13 @@ import {
 } from '@nrwl/devkit';
 import { expressVersion } from '../../utils/versions';
 import initGenerator from './init';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should add dependencies', async () => {

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -1,12 +1,12 @@
 import { readJson, stripIndents, Tree, writeJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { jestInitGenerator } from './init';
 
 describe('jest', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should generate files with --js flag', async () => {

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -5,7 +5,7 @@ import {
   Tree,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { jestConfigObject } from '../../utils/config/functions';
 
 import { jestProjectGenerator } from './jest-project';
@@ -24,7 +24,7 @@ describe('jestProject', () => {
   };
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'lib1', {
       root: 'libs/lib1',
       sourceRoot: 'libs/lib1/src',

--- a/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.spec.ts
+++ b/packages/jest/src/migrations/update-12-6-0/update-base-jest-config.spec.ts
@@ -7,13 +7,13 @@ const mockResolveConfig = jest.fn(() =>
 );
 
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import update from './update-base-jest-config';
 
 describe('update 12.6.0', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     tree.write(
       'jest.config.js',
       `module.exports = {

--- a/packages/jest/src/migrations/update-13-1-2/update-tsconfigs-for-tests.spec.ts
+++ b/packages/jest/src/migrations/update-13-1-2/update-tsconfigs-for-tests.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import update from './update-tsconfigs-for-tests';
 
 const reactTsConfigs = {
@@ -170,7 +170,7 @@ const tsConfigWithExclude = {
     let tree: Tree;
 
     beforeEach(() => {
-      tree = createTreeWithEmptyWorkspace();
+      tree = createTreeWithEmptyV1Workspace();
       tree.write(
         'apps/project-one/tsconfig.app.json',
         String.raw`${JSON.stringify(configs.app, null, 2)}`

--- a/packages/jest/src/migrations/update-13-4-4/add-missing-root-babel-config.spec.ts
+++ b/packages/jest/src/migrations/update-13-4-4/add-missing-root-babel-config.spec.ts
@@ -1,11 +1,11 @@
 import { addProjectConfiguration, readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import update from './add-missing-root-babel-config';
 
 describe('Jest Migration (v13.4.4)', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     tree.write(
       'package.json',
       JSON.stringify({
@@ -76,7 +76,7 @@ describe('Jest Migration (v13.4.4)', () => {
   });
 
   it('should update w/ Array value for babel-jest transformer', async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'libs/lib-three/jest.config.js',

--- a/packages/jest/src/migrations/update-14-0-0/update-jest-config-ext.spec.ts
+++ b/packages/jest/src/migrations/update-14-0-0/update-jest-config-ext.spec.ts
@@ -59,7 +59,7 @@ async function libSetUp(tree: Tree, options = setupDefaults) {
 describe('Jest Migration (v14.0.0)', () => {
   let tree: Tree;
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should rename project jest.config.js to jest.config.ts', async () => {

--- a/packages/jest/src/migrations/update-14-1-5/update-exports-jest-config.spec.ts
+++ b/packages/jest/src/migrations/update-14-1-5/update-exports-jest-config.spec.ts
@@ -17,7 +17,7 @@ import {
 describe('Jest Migration (v14.1.2)', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should update root jest files', () => {

--- a/packages/js/src/generators/convert-to-swc/convert-to-swc.spec.ts
+++ b/packages/js/src/generators/convert-to-swc/convert-to-swc.spec.ts
@@ -22,7 +22,7 @@ describe('convert to swc', () => {
   };
 
   beforeAll(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should convert tsc to swc', async () => {

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -25,7 +25,7 @@ describe('lib', () => {
   };
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   describe('configs', () => {

--- a/packages/js/src/migrations/update-13-10-1/update-lib-swcrc-exclude.spec.ts
+++ b/packages/js/src/migrations/update-13-10-1/update-lib-swcrc-exclude.spec.ts
@@ -5,7 +5,7 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import updateSwcRcExclude from './update-lib-swcrc-exclude';
 
 const projectConfig: ProjectConfiguration = {
@@ -57,7 +57,7 @@ const oldSwcRc = {
 describe('Update .lib.swcrc exclude', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'swc-lib', projectConfig);
 
     tree.write('libs/swc-lib/.lib.swcrc', JSON.stringify(oldSwcRc));

--- a/packages/js/src/migrations/update-13-8-5/update-node-executor.spec.ts
+++ b/packages/js/src/migrations/update-13-8-5/update-node-executor.spec.ts
@@ -1,11 +1,11 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import update from './update-node-executor';
 
 describe('Migration: rename execute to node', () => {
   it(`should rename the "execute" executor to "node"`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'workspace.json',
@@ -49,7 +49,7 @@ describe('Migration: rename execute to node', () => {
   });
 
   it(`should skip migration if no projects use @nrwl/js:node`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'workspace.json',

--- a/packages/js/src/migrations/update-13-8-5/update-swcrc.spec.ts
+++ b/packages/js/src/migrations/update-13-8-5/update-swcrc.spec.ts
@@ -5,7 +5,7 @@ import {
   Tree,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { libraryGenerator } from '@nrwl/workspace';
 import { defaultExclude } from '../../utils/swc/add-swc-config';
 import update from './update-swcrc';
@@ -15,7 +15,7 @@ describe('Migration: adjust .swcrc', () => {
   let projectConfiguration: ProjectConfiguration;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     libraryGenerator(tree, {
       name: 'swc',
       buildable: true,

--- a/packages/js/src/migrations/update-14-0-0/exclude-jest-config-swcrc.spec.ts
+++ b/packages/js/src/migrations/update-14-0-0/exclude-jest-config-swcrc.spec.ts
@@ -4,7 +4,7 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { excludeJestConfigSwcrc } from './exclude-jest-config-swcrc';
 import { ProjectConfiguration } from 'nx/src/config/workspace-json-project-json';
 
@@ -57,7 +57,7 @@ const oldSwcRc = {
 describe('JS Migration (v14.0.0)', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'swc-lib', projectConfig);
 
     tree.write('libs/swc-lib/.lib.swcrc', JSON.stringify(oldSwcRc));

--- a/packages/js/src/migrations/update-14.1.5-beta.0/update-swcrc-path.spec.ts
+++ b/packages/js/src/migrations/update-14.1.5-beta.0/update-swcrc-path.spec.ts
@@ -7,7 +7,7 @@ import updateSwcrcPath from './update-swcrc-path';
 
 describe('update-swcrc-path migration', () => {
   it('should replace relative `swcrcPath` option with absolute `swcrc`', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'test-package', {
       root: 'packages/test-package',
       targets: {

--- a/packages/linter/src/generators/init/init.spec.ts
+++ b/packages/linter/src/generators/init/init.spec.ts
@@ -1,13 +1,13 @@
 import { Linter } from '../utils/linter';
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { lintInitGenerator } from './init';
 
 describe('@nrwl/linter:init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   describe('--linter', () => {

--- a/packages/linter/src/generators/lint-project/lint-project.spec.ts
+++ b/packages/linter/src/generators/lint-project/lint-project.spec.ts
@@ -5,7 +5,7 @@ import {
 } from '@nrwl/devkit';
 
 import { Linter } from '../utils/linter';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { lintProjectGenerator } from './lint-project';
 
 describe('@nrwl/linter:lint-project', () => {
@@ -16,7 +16,7 @@ describe('@nrwl/linter:lint-project', () => {
   };
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'test-lib', {
       root: 'libs/test-lib',
       targets: {},

--- a/packages/linter/src/generators/utils/eslint-file.spec.ts
+++ b/packages/linter/src/generators/utils/eslint-file.spec.ts
@@ -1,13 +1,13 @@
 import { containsEslint, findEslintFile } from './eslint-file';
 
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 describe('@nrwl/linter:eslint-file', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   describe('containsEslint', () => {

--- a/packages/linter/src/generators/workspace-rule/workspace-rule.spec.ts
+++ b/packages/linter/src/generators/workspace-rule/workspace-rule.spec.ts
@@ -1,12 +1,12 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { lintWorkspaceRuleGenerator } from './workspace-rule';
 
 describe('@nrwl/linter:workspace-rule', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should generate the required files', async () => {

--- a/packages/linter/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
+++ b/packages/linter/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
@@ -4,7 +4,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import {
   lintWorkspaceRulesProjectGenerator,
   WORKSPACE_RULES_PROJECT_NAME,
@@ -14,7 +14,7 @@ describe('@nrwl/linter:workspace-rules-project', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should update implicitDependencies in nx.json', async () => {

--- a/packages/linter/src/migrations/update-11-5-0/always-use-project-level-tsconfigs-with-eslint.spec.ts
+++ b/packages/linter/src/migrations/update-11-5-0/always-use-project-level-tsconfigs-with-eslint.spec.ts
@@ -4,13 +4,13 @@ import {
   readJson,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import updateTsConfigsWithEslint from './always-use-project-level-tsconfigs-with-eslint';
 
 describe('Always use project level tsconfigs with eslint', () => {
   let tree: Tree;
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'react-app', {
       root: 'apps/react-app',
       sourceRoot: 'apps/react-app/src',

--- a/packages/linter/src/migrations/update-12-4-0/remove-eslint-project-config-if-no-type-checking-rules.spec.ts
+++ b/packages/linter/src/migrations/update-12-4-0/remove-eslint-project-config-if-no-type-checking-rules.spec.ts
@@ -4,7 +4,7 @@ import {
   Tree,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import removeESLintProjectConfigIfNoTypeCheckingRules from './remove-eslint-project-config-if-no-type-checking-rules';
 import type { Linter } from 'eslint';
 const KNOWN_RULE_REQUIRING_TYPE_CHECKING = '@typescript-eslint/await-thenable';
@@ -12,7 +12,7 @@ const KNOWN_RULE_REQUIRING_TYPE_CHECKING = '@typescript-eslint/await-thenable';
 describe('Remove ESLint parserOptions.project config if no rules requiring type-checking are in use', () => {
   let tree: Tree;
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'react-app', {
       root: 'apps/react-app',
       sourceRoot: 'apps/react-app/src',

--- a/packages/linter/src/migrations/update-12-9-0/add-outputs.spec.ts
+++ b/packages/linter/src/migrations/update-12-9-0/add-outputs.spec.ts
@@ -4,14 +4,14 @@ import {
   TargetConfiguration,
   Tree,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import addOutputs from './add-outputs';
 
 describe('addOutputs', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     const lintWithoutOutputs: TargetConfiguration = {
       executor: '@nrwl/linter:eslint',

--- a/packages/linter/src/migrations/update-13-3-0/eslint-8-updates.spec.ts
+++ b/packages/linter/src/migrations/update-13-3-0/eslint-8-updates.spec.ts
@@ -1,12 +1,12 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import eslint8Updates from './eslint-8-updates';
 
 describe('eslint8Updates()', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     tree.write(
       `tools/eslint-rules/jest.config.js`,
       `

--- a/packages/linter/src/migrations/update-14-4-4/experimental-to-utils-deps.spec.ts
+++ b/packages/linter/src/migrations/update-14-4-4/experimental-to-utils-deps.spec.ts
@@ -1,11 +1,11 @@
 import { updateJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { WORKSPACE_PLUGIN_DIR } from '../../generators/workspace-rules-project/workspace-rules-project';
 import addTypescriptEslintUtilsIfNeeded from './experimental-to-utils-deps';
 
 describe('addTypescriptEslintUtilsIfNeeded()', () => {
   it('should remove @typescript-eslint/experimental-utils from package.json devDependencies and add @typescript-eslint/utils', async () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
     updateJson(tree, 'package.json', (json) => {
       json.devDependencies['@typescript-eslint/experimental-utils'] = '12.3.4';
       return json;
@@ -17,7 +17,7 @@ describe('addTypescriptEslintUtilsIfNeeded()', () => {
   });
 
   it('should remove @typescript-eslint/experimental-utils from package.json devDependencies and add @typescript-eslint/utils', async () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
     updateJson(tree, 'package.json', (json) => {
       json.dependencies['@typescript-eslint/experimental-utils'] = '12.3.4';
       return json;
@@ -29,7 +29,7 @@ describe('addTypescriptEslintUtilsIfNeeded()', () => {
   });
 
   it('should add @typescript-eslint/utils if plugins folder exists', async () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       `${WORKSPACE_PLUGIN_DIR}/rules/my-rule.ts`,
@@ -42,7 +42,7 @@ describe('addTypescriptEslintUtilsIfNeeded()', () => {
   });
 
   it('should not add @typescript-eslint/utils if plugins folder or experimental-utils dont exist', async () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
 
     await addTypescriptEslintUtilsIfNeeded(tree);
 

--- a/packages/linter/src/migrations/update-14-4-4/experimental-to-utils-rules.spec.ts
+++ b/packages/linter/src/migrations/update-14-4-4/experimental-to-utils-rules.spec.ts
@@ -1,12 +1,12 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import experimentalToUtilsUpdate from './experimental-to-utils-rules';
 
 describe('experimentalToUtilsUpdate()', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     tree.write(
       `tools/eslint-rules/rules/existing-rule.ts`,
       `

--- a/packages/linter/src/utils/convert-tslint-to-eslint/convert-to-eslint-config.spec.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/convert-to-eslint-config.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { join } from 'path';
 import {
   convertToESLintConfig,
@@ -113,7 +113,7 @@ describe('convertTSLintDisableCommentsForProject', () => {
   const projectRoot = `apps/${projectName}`;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, projectName, {
       root: projectRoot,
       projectType: 'application',

--- a/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.spec.ts
+++ b/packages/linter/src/utils/convert-tslint-to-eslint/project-converter.spec.ts
@@ -7,7 +7,7 @@ import {
   Tree,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { ProjectConverter } from './project-converter';
 
 /**
@@ -57,7 +57,7 @@ describe('ProjectConverter', () => {
     process.argv = process.argv.filter(
       (a) => !['--dry-run', '--dryRun', '-d'].includes(a)
     );
-    host = createTreeWithEmptyWorkspace();
+    host = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(host, projectName, {
       root: projectRoot,
       projectType: 'application',

--- a/packages/make-angular-cli-faster/jest.config.js
+++ b/packages/make-angular-cli-faster/jest.config.js
@@ -1,9 +1,0 @@
-module.exports = {
-  name: 'make-angular-cli-faster',
-  preset: '../../jest.config.js',
-  transform: {
-    '^.+\\.[tj]sx?$': 'ts-jest',
-  },
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
-  coverageDirectory: '../../coverage/projects/make-angular-cli-faster',
-};

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { applicationGenerator } from './application';
 
 describe('application generator', () => {
@@ -9,7 +9,7 @@ describe('application generator', () => {
   const appDirectory = 'my-node-app';
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.spec.ts
+++ b/packages/nest/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.spec.ts
@@ -6,7 +6,7 @@ import {
   Tree,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { exampleRootTslintJson } from '@nrwl/linter';
 import { conversionGenerator } from './convert-tslint-to-eslint';
 
@@ -101,7 +101,7 @@ describe('convert-tslint-to-eslint', () => {
   let host: Tree;
 
   beforeEach(async () => {
-    host = createTreeWithEmptyWorkspace();
+    host = createTreeWithEmptyV1Workspace();
 
     writeJson(host, 'tslint.json', exampleRootTslintJson.raw);
 

--- a/packages/nest/src/generators/init/init.spec.ts
+++ b/packages/nest/src/generators/init/init.spec.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { nestJsVersion, nxVersion } from '../../utils/versions';
 import { initGenerator } from './init';
 
@@ -8,7 +8,7 @@ describe('init generator', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -1,7 +1,7 @@
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
 import { readJson, readProjectConfiguration } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { libraryGenerator } from './library';
 
 describe('lib', () => {
@@ -10,7 +10,7 @@ describe('lib', () => {
   const libName = 'myLib';
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/utils/testing.ts
+++ b/packages/nest/src/generators/utils/testing.ts
@@ -1,8 +1,8 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 export function createTreeWithNestApplication(appName: string): Tree {
-  const tree = createTreeWithEmptyWorkspace();
+  const tree = createTreeWithEmptyV1Workspace();
   tree.write(
     'workspace.json',
     String.raw`

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -1,5 +1,5 @@
 import { Linter } from '@nrwl/linter';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { getProjects, readJson, NxJsonConfiguration, Tree } from '@nrwl/devkit';
 
 import { applicationGenerator } from './application';
@@ -8,7 +8,7 @@ describe('app', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   describe('not nested', () => {

--- a/packages/next/src/generators/component/component.spec.ts
+++ b/packages/next/src/generators/component/component.spec.ts
@@ -1,6 +1,6 @@
 import { applicationGenerator } from '../application/application';
 import { componentGenerator } from './component';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Tree } from '@nrwl/devkit';
 import { libraryGenerator } from '@nrwl/react';
 import { Linter } from '@nrwl/linter';
@@ -11,7 +11,7 @@ describe('component', () => {
   const libName = 'my-lib';
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     await applicationGenerator(tree, {
       name: appName,
       style: 'css',

--- a/packages/next/src/generators/init/init.spec.ts
+++ b/packages/next/src/generators/init/init.spec.ts
@@ -1,4 +1,4 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { readJson, NxJsonConfiguration, Tree } from '@nrwl/devkit';
 
 import { nextInitGenerator } from './init';
@@ -7,7 +7,7 @@ describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should add react dependencies', async () => {

--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -1,6 +1,6 @@
 import { installedCypressVersion } from '@nrwl/cypress/src/utils/cypress-version';
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import libraryGenerator from './library';
 import { Schema } from './schema';
@@ -22,7 +22,7 @@ describe('next library', () => {
       component: true,
     };
 
-    const appTree = createTreeWithEmptyWorkspace();
+    const appTree = createTreeWithEmptyV1Workspace();
 
     await libraryGenerator(appTree, {
       ...baseOptions,
@@ -82,7 +82,7 @@ describe('next library', () => {
       style: 'css',
       component: true,
     };
-    const appTree = createTreeWithEmptyWorkspace();
+    const appTree = createTreeWithEmptyV1Workspace();
 
     await libraryGenerator(appTree, {
       ...baseOptions,
@@ -112,7 +112,7 @@ describe('next library', () => {
       component: true,
     };
 
-    const appTree = createTreeWithEmptyWorkspace();
+    const appTree = createTreeWithEmptyV1Workspace();
 
     await libraryGenerator(appTree, {
       ...baseOptions,

--- a/packages/next/src/generators/page/page.spec.ts
+++ b/packages/next/src/generators/page/page.spec.ts
@@ -1,6 +1,6 @@
 import { applicationGenerator } from '../application/application';
 import { pageGenerator } from './page';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Tree } from '@nrwl/devkit';
 
 describe('component', () => {
@@ -9,7 +9,7 @@ describe('component', () => {
 
   beforeEach(async () => {
     projectName = 'my-app';
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     await applicationGenerator(tree, {
       name: projectName,
       style: 'css',

--- a/packages/next/src/migrations/update-11-5-0/remove-tsconfig-app-11-5-0.spec.ts
+++ b/packages/next/src/migrations/update-11-5-0/remove-tsconfig-app-11-5-0.spec.ts
@@ -1,12 +1,12 @@
 import { readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import removeTsconfigApp from './remove-tsconfig-app-11-5-0';
 
 describe('Remove tsconfig.app.json 11.5.0', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should remove tsconfig.app.json', async () => {

--- a/packages/next/src/migrations/update-11-5-0/update-babel-config.spec.ts
+++ b/packages/next/src/migrations/update-11-5-0/update-babel-config.spec.ts
@@ -1,4 +1,4 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { readJson, Tree } from '@nrwl/devkit';
 import updateBabelConfig from './update-babel-config';
 
@@ -6,7 +6,7 @@ describe('Migrate babel setup', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it(`should add web babel preset if it does not exist`, async () => {

--- a/packages/next/src/migrations/update-11-6-0/add-js-include-11-6-0.spec.ts
+++ b/packages/next/src/migrations/update-11-6-0/add-js-include-11-6-0.spec.ts
@@ -1,12 +1,12 @@
 import { readJson, Tree, writeJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import addJsInclude from './add-js-include-11-6-0';
 
 describe('Add js include 11.6.0', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should add js patterns to tsconfig "include"', async () => {

--- a/packages/next/src/migrations/update-12-10-0/fix-page-dir-for-eslint.spec.ts
+++ b/packages/next/src/migrations/update-12-10-0/fix-page-dir-for-eslint.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { applicationGenerator } from '../../generators/application/application';
 import { fixPageDirForEslint } from './fix-page-dir-for-eslint';
@@ -8,7 +8,7 @@ describe('Migration: Fix pages directory for ESLint', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     await applicationGenerator(tree, {
       style: 'none',

--- a/packages/next/src/migrations/update-12-6-0/add-next-eslint.spec.ts
+++ b/packages/next/src/migrations/update-12-6-0/add-next-eslint.spec.ts
@@ -1,12 +1,12 @@
 import { readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import addNextEslint from './add-next-eslint';
 
 describe('Add next eslint 12.6.0', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should add "next" config options', async () => {

--- a/packages/next/src/migrations/update-12-8-0/remove-styled-jsx-babel-plugin.spec.ts
+++ b/packages/next/src/migrations/update-12-8-0/remove-styled-jsx-babel-plugin.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { libraryGenerator } from '../../generators/library/library';
 import { removeStyledJsxBabelConfig } from './remove-styled-jsx-babel-plugin';
@@ -8,7 +8,7 @@ describe('Remove styled-jsx babel plugin for Next libs', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     await libraryGenerator(tree, {
       name: 'test-lib',

--- a/packages/next/src/migrations/update-13-0-0/update-emotion-setup.spec.ts
+++ b/packages/next/src/migrations/update-13-0-0/update-emotion-setup.spec.ts
@@ -1,4 +1,4 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { readJson, Tree } from '@nrwl/devkit';
 import { updateEmotionSetup } from './update-emotion-setup';
 
@@ -6,7 +6,7 @@ describe('Update tsconfig config for Emotion', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it(`should add jsxImportSource if it uses @emotion/react`, async () => {

--- a/packages/next/src/migrations/update-13-0-0/update-to-webpack-5.spec.ts
+++ b/packages/next/src/migrations/update-13-0-0/update-to-webpack-5.spec.ts
@@ -1,5 +1,5 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { applicationGenerator } from '../../generators/application/application';
 import { update } from './update-to-webpack-5';
@@ -8,7 +8,7 @@ describe('Migration: enable webpack 5', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should set webpack5 to true', async () => {

--- a/packages/next/src/migrations/update-13-1-1/enable-swc.spec.ts
+++ b/packages/next/src/migrations/update-13-1-1/enable-swc.spec.ts
@@ -3,7 +3,7 @@ import {
   Tree,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { applicationGenerator } from '../../generators/application/application';
 import { update } from './enable-swc';
@@ -12,7 +12,7 @@ describe('Migration: enable SWC', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should remove .babelrc file and fix jest config', async () => {

--- a/packages/next/src/migrations/update-14-0-0/add-default-development-configurations.spec.ts
+++ b/packages/next/src/migrations/update-14-0-0/add-default-development-configurations.spec.ts
@@ -7,7 +7,7 @@ import update from './add-default-development-configurations';
 
 describe('React default development configuration', () => {
   it('should add development configuration if it does not exist', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',
@@ -43,7 +43,7 @@ describe('React default development configuration', () => {
   });
 
   it('should add development configuration if no configurations at all', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',
@@ -80,7 +80,7 @@ describe('React default development configuration', () => {
   });
 
   it('should work without targets', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',

--- a/packages/next/src/migrations/update-14-4-3/add-dev-output-path.spec.ts
+++ b/packages/next/src/migrations/update-14-4-3/add-dev-output-path.spec.ts
@@ -7,7 +7,7 @@ import update from './add-dev-output-path';
 
 describe('React default development configuration', () => {
   it('should add output path if it does not alreayd exist', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',
@@ -37,7 +37,7 @@ describe('React default development configuration', () => {
   });
 
   it('should skip update if outputPath already exists for development', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',

--- a/packages/next/src/migrations/update-14-5-3/update-dev-output-path.spec.ts
+++ b/packages/next/src/migrations/update-14-5-3/update-dev-output-path.spec.ts
@@ -7,7 +7,7 @@ import update from './update-dev-output-path';
 
 describe('React default development configuration', () => {
   it('should add output path if it does not alreayd exist', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',
@@ -37,7 +37,7 @@ describe('React default development configuration', () => {
   });
 
   it('should add output path is default generated pat', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',
@@ -67,7 +67,7 @@ describe('React default development configuration', () => {
   });
 
   it('should skip update if outputPath already exists for development and does not match expected path', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -1,6 +1,6 @@
 import { NxJsonConfiguration, readJson, Tree, getProjects } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 // nx-ignore-next-line
 import { applicationGenerator as angularApplicationGenerator } from '@nrwl/angular/generators';
@@ -13,7 +13,7 @@ describe('app', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     overrideCollectionResolutionForTesting({
       '@nrwl/cypress': join(__dirname, '../../../../cypress/generators.json'),

--- a/packages/node/src/generators/init/init.spec.ts
+++ b/packages/node/src/generators/init/init.spec.ts
@@ -5,7 +5,7 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { nxVersion } from '../../utils/versions';
 import { initGenerator } from './init';
@@ -14,7 +14,7 @@ describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should add dependencies', async () => {

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -5,7 +5,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { Schema } from './schema.d';
 import { libraryGenerator } from './library';
@@ -20,7 +20,7 @@ describe('lib', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   describe('not nested', () => {

--- a/packages/node/src/migrations/update-13-0-0/remove-deprecated-options-13-0-0.spec.ts
+++ b/packages/node/src/migrations/update-13-0-0/remove-deprecated-options-13-0-0.spec.ts
@@ -1,11 +1,11 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import subject from './remove-deprecated-options-13-0-0';
 
 describe('Migration: Remove deprecated options', () => {
   it(`should remove deprecated node build options`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'workspace.json',

--- a/packages/node/src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0.spec.ts
+++ b/packages/node/src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0.spec.ts
@@ -1,5 +1,5 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import subject from './remove-webpack-5-packages-13-0-0';
 
@@ -26,7 +26,7 @@ describe('Migration: Remove webpack 5 packages from Nx12', () => {
   `(
     `should remove packages installed via webpack5 generator`,
     async ({ version }) => {
-      let tree = createTreeWithEmptyWorkspace();
+      let tree = createTreeWithEmptyV1Workspace();
 
       tree.write(
         'package.json',
@@ -62,7 +62,7 @@ describe('Migration: Remove webpack 5 packages from Nx12', () => {
   `(
     `should not do anything if the webpack version is not 5`,
     async ({ version }) => {
-      let tree = createTreeWithEmptyWorkspace();
+      let tree = createTreeWithEmptyV1Workspace();
 
       tree.write(
         'package.json',
@@ -94,7 +94,7 @@ describe('Migration: Remove webpack 5 packages from Nx12', () => {
   );
 
   it(`should not remove packages not every expected package is installed`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'package.json',

--- a/packages/node/src/migrations/update-13-8-5/rename-build-to-webpack.spec.ts
+++ b/packages/node/src/migrations/update-13-8-5/rename-build-to-webpack.spec.ts
@@ -1,11 +1,11 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import rename from './rename-build-to-webpack';
 
 describe('Migration: rename build to webpack', () => {
   it(`should rename the "build" executor to "webpack"`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'workspace.json',

--- a/packages/node/src/migrations/update-13-8-5/rename-execute-to-node.spec.ts
+++ b/packages/node/src/migrations/update-13-8-5/rename-execute-to-node.spec.ts
@@ -1,11 +1,11 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import rename from './rename-execute-to-node';
 
 describe('Migration: rename execute to node', () => {
   it(`should rename the "execute" executor to "node"`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'workspace.json',

--- a/packages/node/src/migrations/update-13-8-5/update-package-to-tsc.spec.ts
+++ b/packages/node/src/migrations/update-13-8-5/update-package-to-tsc.spec.ts
@@ -1,11 +1,11 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import update from './update-package-to-tsc';
 
 describe('Migration: rename package to tsc', () => {
   it(`should rename the "package" executor to "tsc"`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'workspace.json',
@@ -53,7 +53,7 @@ describe('Migration: rename package to tsc', () => {
   });
 
   it(`should skip migration if no projects use @nrwl/js:node`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'workspace.json',

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
@@ -6,13 +6,13 @@ import {
   getProjects,
   joinPathFragments,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { e2eProjectGenerator } from './e2e';
 
 describe('NxPlugin e2e-project Generator', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     // add a plugin project to the workspace for validations
     addProjectConfiguration(tree, 'my-plugin', {

--- a/packages/nx-plugin/src/generators/executor/executor.spec.ts
+++ b/packages/nx-plugin/src/generators/executor/executor.spec.ts
@@ -10,7 +10,7 @@ describe('NxPlugin Executor Generator', () => {
 
   beforeEach(async () => {
     projectName = 'my-plugin';
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
 
     await pluginGenerator(tree, {
       name: projectName,

--- a/packages/nx-plugin/src/generators/generator/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/generator/generator.spec.ts
@@ -10,7 +10,7 @@ describe('NxPlugin Generator Generator', () => {
 
   beforeEach(async () => {
     projectName = 'my-plugin';
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
     await pluginGenerator(tree, {
       name: projectName,
     } as any);

--- a/packages/nx-plugin/src/generators/lint-checks/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/lint-checks/generator.spec.ts
@@ -20,7 +20,7 @@ describe('lint-checks generator', () => {
   let appTree: Tree;
 
   beforeEach(async () => {
-    appTree = createTreeWithEmptyWorkspace(2);
+    appTree = createTreeWithEmptyWorkspace();
     await pluginGenerator(appTree, {
       name: 'plugin',
       importPath: '@acme/plugin',

--- a/packages/nx-plugin/src/generators/migration/migration.spec.ts
+++ b/packages/nx-plugin/src/generators/migration/migration.spec.ts
@@ -9,7 +9,7 @@ describe('NxPlugin migration generator', () => {
 
   beforeEach(async () => {
     projectName = 'my-plugin';
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
 
     await pluginGenerator(tree, {
       name: projectName,

--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -26,7 +26,7 @@ describe('NxPlugin Plugin Generator', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should update the workspace.json file', async () => {

--- a/packages/nx/src/generators/testing-utils/create-tree-with-empty-workspace.ts
+++ b/packages/nx/src/generators/testing-utils/create-tree-with-empty-workspace.ts
@@ -4,10 +4,19 @@ import type { Tree } from 'nx/src/generators/tree';
 /**
  * Creates a host for testing.
  */
-export function createTreeWithEmptyWorkspace(version = 1): Tree {
+export function createTreeWithEmptyWorkspace(): Tree {
   const tree = new FsTree('/virtual', false);
+  tree.write('/workspace.json', JSON.stringify({ version: 2, projects: {} }));
+  return addCommonFiles(tree);
+}
 
-  tree.write('/workspace.json', JSON.stringify({ version, projects: {} }));
+export function createTreeWithEmptyV1Workspace(): Tree {
+  const tree = new FsTree('/virtual', false);
+  tree.write('/workspace.json', JSON.stringify({ version: 1, projects: {} }));
+  return addCommonFiles(tree);
+}
+
+function addCommonFiles(tree: Tree): Tree {
   tree.write('./.prettierrc', JSON.stringify({ singleQuote: true }));
   tree.write(
     '/package.json',
@@ -38,6 +47,5 @@ export function createTreeWithEmptyWorkspace(version = 1): Tree {
     '/tsconfig.base.json',
     JSON.stringify({ compilerOptions: { paths: {} } })
   );
-
   return tree;
 }

--- a/packages/nx/src/generators/utils/project-configuration.spec.ts
+++ b/packages/nx/src/generators/utils/project-configuration.spec.ts
@@ -2,7 +2,10 @@ import Ajv from 'ajv';
 import { Tree } from '../tree';
 import { ProjectConfiguration } from '../../config/workspace-json-project-json';
 
-import { createTreeWithEmptyWorkspace } from '../testing-utils/create-tree-with-empty-workspace';
+import {
+  createTreeWithEmptyWorkspace,
+  createTreeWithEmptyV1Workspace,
+} from '../testing-utils/create-tree-with-empty-workspace';
 import { readJson, updateJson } from '../utils/json';
 import {
   addProjectConfiguration,
@@ -45,7 +48,7 @@ describe('project configuration', () => {
 
   describe('workspace v1', () => {
     beforeEach(() => {
-      tree = createTreeWithEmptyWorkspace(1);
+      tree = createTreeWithEmptyV1Workspace();
     });
 
     describe('readProjectConfiguration', () => {
@@ -187,7 +190,7 @@ describe('project configuration', () => {
 
   describe('workspace v2', () => {
     beforeEach(() => {
-      tree = createTreeWithEmptyWorkspace(2);
+      tree = createTreeWithEmptyWorkspace();
     });
 
     describe('readProjectConfiguration', () => {

--- a/packages/nx/src/migrations/update-14-0-6/remove-roots.spec.ts
+++ b/packages/nx/src/migrations/update-14-0-6/remove-roots.spec.ts
@@ -9,7 +9,7 @@ describe('remove-roots >', () => {
 
   describe('projects with project.json configs', () => {
     beforeEach(() => {
-      tree = createTreeWithEmptyWorkspace(2);
+      tree = createTreeWithEmptyWorkspace();
     });
 
     it('should remove the root property', async () => {
@@ -30,7 +30,7 @@ describe('remove-roots >', () => {
 
   describe('projects with workspace.json configs', () => {
     beforeEach(() => {
-      tree = createTreeWithEmptyWorkspace(1);
+      tree = createTreeWithEmptyV1Workspace();
     });
 
     it('should remove the root property', async () => {
@@ -48,7 +48,7 @@ describe('remove-roots >', () => {
 
   describe('projects with package.json configs', () => {
     beforeEach(() => {
-      tree = createTreeWithEmptyWorkspace(2);
+      tree = createTreeWithEmptyWorkspace();
       tree.delete('workspace.json');
     });
 

--- a/packages/nx/src/migrations/update-14-0-6/remove-roots.spec.ts
+++ b/packages/nx/src/migrations/update-14-0-6/remove-roots.spec.ts
@@ -1,5 +1,8 @@
 import { Tree } from '../../generators/tree';
-import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import {
+  createTreeWithEmptyV1Workspace,
+  createTreeWithEmptyWorkspace,
+} from '../../generators/testing-utils/create-tree-with-empty-workspace';
 import { addProjectConfiguration } from '../../generators/utils/project-configuration';
 import { readJson, updateJson, writeJson } from '../../generators/utils/json';
 import removeRoots from './remove-roots';

--- a/packages/nx/src/migrations/update-14-2-0/add-json-schema.spec.ts
+++ b/packages/nx/src/migrations/update-14-2-0/add-json-schema.spec.ts
@@ -8,7 +8,7 @@ describe('add-json-schema >', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should update nx.json $schema', async () => {

--- a/packages/nx/src/migrations/update-14-2-0/remove-default-collection.spec.ts
+++ b/packages/nx/src/migrations/update-14-2-0/remove-default-collection.spec.ts
@@ -10,7 +10,7 @@ describe('remove-default-collection', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should remove default collection from nx.json', async () => {

--- a/packages/nx/src/migrations/update-14-3-4/create-target-defaults.spec.ts
+++ b/packages/nx/src/migrations/update-14-3-4/create-target-defaults.spec.ts
@@ -10,7 +10,7 @@ describe('createTargetDefaults', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should work', async () => {

--- a/packages/react-native/src/generators/application/application.spec.ts
+++ b/packages/react-native/src/generators/application/application.spec.ts
@@ -4,7 +4,7 @@ import {
   getProjects,
   readJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { reactNativeApplicationGenerator } from './application';
 
@@ -12,7 +12,7 @@ describe('app', () => {
   let appTree: Tree;
 
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
     appTree.write('.gitignore', '');
   });
 

--- a/packages/react-native/src/generators/application/lib/nomalize-options.spec.ts
+++ b/packages/react-native/src/generators/application/lib/nomalize-options.spec.ts
@@ -1,5 +1,5 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { Schema } from '../schema';
 import { normalizeOptions } from './normalize-options';
@@ -8,7 +8,7 @@ describe('Normalize Options', () => {
   let appTree: Tree;
 
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
   });
 
   it('should normalize options with name in kebab case', () => {

--- a/packages/react-native/src/generators/component-story/component-story.spec.ts
+++ b/packages/react-native/src/generators/component-story/component-story.spec.ts
@@ -1,5 +1,5 @@
 import { getProjects, Tree, updateProjectConfiguration } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import componentStoryGenerator from './component-story';
 import { Linter } from '@nrwl/linter';
 
@@ -408,7 +408,7 @@ export async function createTestUILib(
   libName: string,
   useEsLint = false
 ): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace();
+  let appTree = createTreeWithEmptyV1Workspace();
   appTree.write('.gitignore', '');
 
   await libraryGenerator(appTree, {

--- a/packages/react-native/src/generators/component/component.spec.ts
+++ b/packages/react-native/src/generators/component/component.spec.ts
@@ -1,5 +1,5 @@
 import { logger, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { createApp, createLib } from '../../utils/testing-generators';
 import { reactNativeComponentGenerator } from './component';
 
@@ -9,7 +9,7 @@ describe('component', () => {
 
   beforeEach(async () => {
     projectName = 'my-lib';
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
     appTree.write('.gitignore', '');
     await createApp(appTree, 'my-app');
     await createLib(appTree, projectName);

--- a/packages/react-native/src/generators/init/init.spec.ts
+++ b/packages/react-native/src/generators/init/init.spec.ts
@@ -1,13 +1,13 @@
 import { logger } from '@nrwl/devkit';
 import { Tree, readJson, updateJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { reactNativeInitGenerator } from './init';
 
 describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     tree.write('.gitignore', '');
   });
 

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -1,5 +1,5 @@
 import { getProjects, readJson, Tree, updateJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import libraryGenerator from './library';
 import { Linter } from '@nrwl/linter';
 import { Schema } from './schema';
@@ -17,7 +17,7 @@ describe('lib', () => {
   };
 
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
     appTree.write('.gitignore', '');
   });
 

--- a/packages/react-native/src/generators/stories/stories-app.spec.ts
+++ b/packages/react-native/src/generators/stories/stories-app.spec.ts
@@ -1,6 +1,6 @@
 import { Tree } from '@nrwl/devkit';
 import storiesGenerator from './stories';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import applicationGenerator from '../application/application';
 import { Linter } from '@nrwl/linter';
 import { reactNativeComponentGenerator } from '../component/component';
@@ -130,7 +130,7 @@ describe('react:stories for applications', () => {
 });
 
 export async function createTestUIApp(libName: string): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace();
+  let appTree = createTreeWithEmptyV1Workspace();
   appTree.write('.gitignore', '');
 
   await applicationGenerator(appTree, {

--- a/packages/react-native/src/generators/stories/stories-lib.spec.ts
+++ b/packages/react-native/src/generators/stories/stories-lib.spec.ts
@@ -1,6 +1,6 @@
 import { Tree } from '@nrwl/devkit';
 import storiesGenerator from './stories';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import applicationGenerator from '../application/application';
 import { Linter } from '@nrwl/linter';
 import libraryGenerator from '../library/library';
@@ -90,7 +90,7 @@ describe('react-native:stories for libraries', () => {
 });
 
 export async function createTestUILib(libName: string): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace();
+  let appTree = createTreeWithEmptyV1Workspace();
   appTree.write('.gitignore', '');
 
   await libraryGenerator(appTree, {

--- a/packages/react-native/src/generators/storybook-configuration/configuration.spec.ts
+++ b/packages/react-native/src/generators/storybook-configuration/configuration.spec.ts
@@ -1,5 +1,5 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { logger } from '@nrwl/devkit';
 
@@ -103,7 +103,7 @@ describe('react-native:storybook-configuration', () => {
 });
 
 export async function createTestUILib(libName: string): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace();
+  let appTree = createTreeWithEmptyV1Workspace();
 
   await libraryGenerator(appTree, {
     linter: Linter.EsLint,
@@ -119,7 +119,7 @@ export async function createTestAppLib(
   libName: string,
   plainJS = false
 ): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace();
+  let appTree = createTreeWithEmptyV1Workspace();
 
   await applicationGenerator(appTree, {
     e2eTestRunner: 'none',

--- a/packages/react-native/src/generators/storybook-configuration/lib/add-resolver-main-fields-to-metro-config.spec.ts
+++ b/packages/react-native/src/generators/storybook-configuration/lib/add-resolver-main-fields-to-metro-config.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { formatFile } from '../../../utils/format-file';
 
@@ -9,7 +9,7 @@ describe('addResolverMainFieldsToMetroConfig', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     addProjectConfiguration(tree, 'products', {
       root: 'apps/products',

--- a/packages/react-native/src/generators/storybook-configuration/lib/replace-app-import-with-storybook-toggle.spec.ts
+++ b/packages/react-native/src/generators/storybook-configuration/lib/replace-app-import-with-storybook-toggle.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { formatFile } from '../../../utils/format-file';
 
@@ -9,7 +9,7 @@ describe('replaceAppImportWithStorybookToggle', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     addProjectConfiguration(tree, 'products', {
       root: 'apps/products',

--- a/packages/react-native/src/migrations/update-12-10-0/add-react-native-svg-12-10-0.spec.ts
+++ b/packages/react-native/src/migrations/update-12-10-0/add-react-native-svg-12-10-0.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import {
   reactNativeSvgTransformerVersion,
   reactNativeSvgVersion,
@@ -10,7 +10,7 @@ describe('Add react-native-svg to dev dependencies', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'products', {
       root: 'apps/products',
       sourceRoot: 'apps/products/src',

--- a/packages/react-native/src/migrations/update-13-5-0/add-babel-config-root-13-5-0.spec.ts
+++ b/packages/react-native/src/migrations/update-13-5-0/add-babel-config-root-13-5-0.spec.ts
@@ -1,12 +1,12 @@
 import { addProjectConfiguration, readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import update from './add-babel-config-root-13-5-0';
 
 describe('Add react-native-svg to dev dependencies', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'products', {
       root: 'apps/products',
       sourceRoot: 'apps/products/src',

--- a/packages/react-native/src/migrations/update-13-5-0/update-react-native-typing-svg-13-5-0.spec.ts
+++ b/packages/react-native/src/migrations/update-13-5-0/update-react-native-typing-svg-13-5-0.spec.ts
@@ -1,12 +1,12 @@
 import { addProjectConfiguration, readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import update from './update-react-native-typing-svg-13-5-0';
 
 describe('Update svg typings in tsconfig for react native app', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'products', {
       root: 'apps/products',
       sourceRoot: 'apps/products/src',

--- a/packages/react-native/src/migrations/update-14-0-0/add-project-root-metro-config-14-0-0.spec.ts
+++ b/packages/react-native/src/migrations/update-14-0-0/add-project-root-metro-config-14-0-0.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import update from './add-project-root-metro-config-14-0-0';
 
@@ -7,7 +7,7 @@ describe('Add projectRoot option in metro.config.js', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'products', {
       root: 'apps/products',
       sourceRoot: 'apps/products/src',

--- a/packages/react-native/src/migrations/update-14-0-0/update-entry-file-bundle-14-0-0.spec.ts
+++ b/packages/react-native/src/migrations/update-14-0-0/update-entry-file-bundle-14-0-0.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, Tree, getProjects } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import update from './update-entry-file-bundle-14-0-0';
 
@@ -7,7 +7,7 @@ describe('Update entryFile for bundle target for react native apps', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'products', {
       root: 'apps/products',
       sourceRoot: 'apps/products/src',

--- a/packages/react-native/src/migrations/update-14-0-2/change-main-to-class-name-14-0-2.spec.ts
+++ b/packages/react-native/src/migrations/update-14-0-2/change-main-to-class-name-14-0-2.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import update from './change-main-to-class-name-14-0-2';
 
@@ -7,7 +7,7 @@ describe('Change from main tag to className tag', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'products', {
       root: 'apps/products',
       sourceRoot: 'apps/products/src',

--- a/packages/react-native/src/migrations/update-14-2-1/rename-blockList-metro-config.spec.ts
+++ b/packages/react-native/src/migrations/update-14-2-1/rename-blockList-metro-config.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, Tree, getProjects } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import update from './rename-blockList-metro-config';
 
@@ -7,7 +7,7 @@ describe('Rename blacklistRE to blockList in metro.config.js for react native ap
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'products', {
       root: 'apps/products',
       sourceRoot: 'apps/products/src',

--- a/packages/react-native/src/migrations/update-14-5-5/add-exclude-sync-deps.spec.ts
+++ b/packages/react-native/src/migrations/update-14-5-5/add-exclude-sync-deps.spec.ts
@@ -1,12 +1,12 @@
 import { addProjectConfiguration, getProjects, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import update from './add-exclude-sync-deps';
 
 describe('add-exclude-sync-deps', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'products', {
       root: 'apps/products',
       sourceRoot: 'apps/products/src',

--- a/packages/react-native/src/utils/add-linting.spec.ts
+++ b/packages/react-native/src/utils/add-linting.spec.ts
@@ -1,5 +1,5 @@
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { libraryGenerator } from '@nrwl/workspace/src/generators/library/library';
 import { addLinting } from './add-linting';
@@ -8,7 +8,7 @@ describe('Add Linting', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     await libraryGenerator(tree, {
       name: 'my-lib',
       linter: Linter.None,

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -6,7 +6,7 @@ import {
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { applicationGenerator } from './application';
 import { Schema } from './schema';
@@ -31,7 +31,7 @@ describe('app', () => {
   > = installedCypressVersion as never;
   beforeEach(() => {
     mockedInstalledCypressVersion.mockReturnValue(10);
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
   });
 
   describe('not nested', () => {

--- a/packages/react/src/generators/application/lib/find-free-port.spec.ts
+++ b/packages/react/src/generators/application/lib/find-free-port.spec.ts
@@ -1,11 +1,11 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { addProjectConfiguration, Tree } from '@nrwl/devkit';
 
 import { findFreePort } from './find-free-port';
 
 describe('findFreePort', () => {
   it('should return the largest port + 1', () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
     addProject(tree, 'app1', 4200);
     addProject(tree, 'app2', 4201);
     addProject(tree, 'no-serve');
@@ -16,7 +16,7 @@ describe('findFreePort', () => {
   });
 
   it('should default to port 4200', () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
     addProject(tree, 'no-serve');
 
     const port = findFreePort(tree);

--- a/packages/react/src/generators/component-cypress-spec/component-cypress-spec.spec.ts
+++ b/packages/react/src/generators/component-cypress-spec/component-cypress-spec.spec.ts
@@ -1,5 +1,5 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { formatFile } from '../../utils/format-file';
 import applicationGenerator from '../application/application';
@@ -205,7 +205,7 @@ export async function createTestUILib(
   libName: string,
   plainJS = false
 ): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace();
+  let appTree = createTreeWithEmptyV1Workspace();
   await libraryGenerator(appTree, {
     name: libName,
     linter: Linter.EsLint,

--- a/packages/react/src/generators/component-story/component-story.spec.ts
+++ b/packages/react/src/generators/component-story/component-story.spec.ts
@@ -1,5 +1,5 @@
 import { getProjects, Tree, updateProjectConfiguration } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import libraryGenerator from '../library/library';
 import componentStoryGenerator from './component-story';
 import { Linter } from '@nrwl/linter';
@@ -699,7 +699,7 @@ export async function createTestUILib(
   libName: string,
   useEsLint = false
 ): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace();
+  let appTree = createTreeWithEmptyV1Workspace();
   await libraryGenerator(appTree, {
     name: libName,
     linter: useEsLint ? Linter.EsLint : Linter.TsLint,

--- a/packages/react/src/generators/component-test/component-test.spec.ts
+++ b/packages/react/src/generators/component-test/component-test.spec.ts
@@ -1,6 +1,6 @@
 import { assertMinimumCypressVersion } from '@nrwl/cypress/src/utils/cypress-version';
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import libraryGenerator from '../library/library';
 import { componentTestGenerator } from './component-test';
@@ -12,7 +12,7 @@ describe(componentTestGenerator.name, () => {
     ReturnType<typeof assertMinimumCypressVersion>
   > = assertMinimumCypressVersion as never;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
   it('should create component test for tsx files', async () => {
     mockedAssertMinimumCypressVersion.mockReturnValue();

--- a/packages/react/src/generators/component/component.spec.ts
+++ b/packages/react/src/generators/component/component.spec.ts
@@ -1,6 +1,6 @@
 import { installedCypressVersion } from '@nrwl/cypress/src/utils/cypress-version';
 import { logger, readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { createApp, createLib } from '../../utils/testing-generators';
 import { componentGenerator } from './component';
 // need to mock cypress otherwise it'll use the nx installed version from package.json
@@ -16,7 +16,7 @@ describe('component', () => {
   beforeEach(async () => {
     mockedInstalledCypressVersion.mockReturnValue(10);
     projectName = 'my-lib';
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
     await createApp(appTree, 'my-app', false);
     await createLib(appTree, projectName, false);
     jest.spyOn(logger, 'warn').mockImplementation(() => {});

--- a/packages/react/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
+++ b/packages/react/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
@@ -1,6 +1,6 @@
 import { assertMinimumCypressVersion } from '@nrwl/cypress/src/utils/cypress-version';
 import { readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import componentGenerator from '../component/component';
 import libraryGenerator from '../library/library';
@@ -13,7 +13,7 @@ describe('React:CypressComponentTestConfiguration', () => {
     ReturnType<typeof assertMinimumCypressVersion>
   > = assertMinimumCypressVersion as never;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
   it('should generate cypress component test config', async () => {
     mockedAssertCypressVersion.mockReturnValue();

--- a/packages/react/src/generators/hook/hook.spec.ts
+++ b/packages/react/src/generators/hook/hook.spec.ts
@@ -1,6 +1,6 @@
 import { createApp, createLib } from '../../utils/testing-generators';
 import { logger, readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { hookGenerator } from './hook';
 
 describe('hook', () => {
@@ -9,7 +9,7 @@ describe('hook', () => {
 
   beforeEach(async () => {
     projectName = 'my-lib';
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
     await createApp(appTree, 'my-app');
     await createLib(appTree, projectName);
     jest.spyOn(logger, 'warn').mockImplementation(() => {});

--- a/packages/react/src/generators/init/init.spec.ts
+++ b/packages/react/src/generators/init/init.spec.ts
@@ -1,5 +1,5 @@
 import { NxJsonConfiguration, readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import reactInitGenerator from './init';
 import { InitSchema } from './schema';
 
@@ -12,7 +12,7 @@ describe('init', () => {
   };
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should add react dependencies', async () => {

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -6,7 +6,7 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import applicationGenerator from '../application/application';
 import libraryGenerator from './library';
@@ -33,7 +33,7 @@ describe('lib', () => {
 
   beforeEach(() => {
     mockedInstalledCypressVersion.mockReturnValue(10);
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
   });
 
   describe('not nested', () => {

--- a/packages/react/src/generators/redux/redux.spec.ts
+++ b/packages/react/src/generators/redux/redux.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { applicationGenerator, libraryGenerator } from '@nrwl/react';
 import { Linter } from '@nrwl/linter';
 import { reduxGenerator } from './redux';
@@ -8,7 +8,7 @@ describe('redux', () => {
   let appTree: Tree;
 
   beforeEach(async () => {
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
     await libraryGenerator(appTree, {
       name: 'my-lib',
       linter: Linter.EsLint,

--- a/packages/react/src/generators/remote/remote.spec.ts
+++ b/packages/react/src/generators/remote/remote.spec.ts
@@ -5,7 +5,7 @@ import remote from './remote';
 
 describe('remote generator', () => {
   it('should not set the remote as the default project', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await remote(tree, {
       name: 'test',

--- a/packages/react/src/generators/setup-tailwind/setup-tailwind.spec.ts
+++ b/packages/react/src/generators/setup-tailwind/setup-tailwind.spec.ts
@@ -5,7 +5,7 @@ import {
   stripIndents,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import update from './setup-tailwind';
 
 describe('setup-tailwind', () => {
@@ -20,7 +20,7 @@ describe('setup-tailwind', () => {
     ${`pages/styles.less`}
     ${`pages/styles.styl`}
   `('should update stylesheet', async ({ stylesPath }) => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'example', {
       root: 'apps/example',
       sourceRoot: 'apps/example/src',
@@ -43,7 +43,7 @@ describe('setup-tailwind', () => {
   });
 
   it('should add postcss and tailwind config files', async () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'example', {
       root: 'apps/example',
       sourceRoot: 'apps/example/src',
@@ -77,7 +77,7 @@ describe('setup-tailwind', () => {
   });
 
   it('should skip update if postcss configuration already exists', async () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'example', {
       root: 'apps/example',
       sourceRoot: 'apps/example/src',
@@ -94,7 +94,7 @@ describe('setup-tailwind', () => {
   });
 
   it('should skip update if tailwind configuration already exists', async () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'example', {
       root: 'apps/example',
       sourceRoot: 'apps/example/src',
@@ -111,7 +111,7 @@ describe('setup-tailwind', () => {
   });
 
   it('should install packages', async () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'example', {
       root: 'apps/example',
       sourceRoot: 'apps/example/src',
@@ -145,7 +145,7 @@ describe('setup-tailwind', () => {
   });
 
   it('should support skipping package install', async () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'example', {
       root: 'apps/example',
       sourceRoot: 'apps/example/src',

--- a/packages/react/src/generators/stories/stories.app.spec.ts
+++ b/packages/react/src/generators/stories/stories.app.spec.ts
@@ -1,6 +1,6 @@
 import { installedCypressVersion } from '@nrwl/cypress/src/utils/cypress-version';
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import applicationGenerator from '../application/application';
 import storiesGenerator from './stories';
@@ -342,7 +342,7 @@ export async function createTestUIApp(
   libName: string,
   plainJS = false
 ): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace();
+  let appTree = createTreeWithEmptyV1Workspace();
 
   await applicationGenerator(appTree, {
     e2eTestRunner: 'cypress',

--- a/packages/react/src/generators/stories/stories.lib.spec.ts
+++ b/packages/react/src/generators/stories/stories.lib.spec.ts
@@ -1,6 +1,6 @@
 import { Tree } from '@nrwl/devkit';
 import storiesGenerator from './stories';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import applicationGenerator from '../application/application';
 import { Linter } from '@nrwl/linter';
 import libraryGenerator from '../library/library';
@@ -224,7 +224,7 @@ export async function createTestUILib(
   libName: string,
   plainJS = false
 ): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace();
+  let appTree = createTreeWithEmptyV1Workspace();
 
   await libraryGenerator(appTree, {
     linter: Linter.EsLint,

--- a/packages/react/src/generators/stories/stories.nextjs.spec.ts
+++ b/packages/react/src/generators/stories/stories.nextjs.spec.ts
@@ -4,7 +4,7 @@ import {
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 import storiesGenerator from './stories';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import applicationGenerator from '../application/application';
 import { Linter } from '@nrwl/linter';
 
@@ -57,7 +57,7 @@ describe('nextjs:stories for applications', () => {
 });
 
 export async function createTestUIApp(name: string): Promise<Tree> {
-  const tree = createTreeWithEmptyWorkspace();
+  const tree = createTreeWithEmptyV1Workspace();
   await applicationGenerator(tree, {
     e2eTestRunner: 'none',
     linter: Linter.EsLint,

--- a/packages/react/src/generators/storybook-configuration/configuration.spec.ts
+++ b/packages/react/src/generators/storybook-configuration/configuration.spec.ts
@@ -1,6 +1,6 @@
 import { installedCypressVersion } from '@nrwl/cypress/src/utils/cypress-version';
 import { logger, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import applicationGenerator from '../application/application';
 import componentGenerator from '../component/component';
@@ -171,7 +171,7 @@ export async function createTestUILib(
   libName: string,
   plainJS = false
 ): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace();
+  let appTree = createTreeWithEmptyV1Workspace();
 
   await libraryGenerator(appTree, {
     linter: Linter.EsLint,
@@ -190,7 +190,7 @@ export async function createTestAppLib(
   libName: string,
   plainJS = false
 ): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace();
+  let appTree = createTreeWithEmptyV1Workspace();
 
   await applicationGenerator(appTree, {
     e2eTestRunner: 'none',

--- a/packages/react/src/migrations/update-12-0-0/remove-react-redux-types-package.spec.ts
+++ b/packages/react/src/migrations/update-12-0-0/remove-react-redux-types-package.spec.ts
@@ -2,14 +2,14 @@ import { readJson, Tree } from '@nrwl/devkit';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
 import { removeReactReduxTypesFromPackageJson } from './remove-react-redux-types-package';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 describe('Remove @types/react-redux Package from package.json 12.0.0', () => {
   let tree: Tree;
   let schematicRunner: SchematicTestRunner;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     schematicRunner = new SchematicTestRunner(
       '@nrwl/react',

--- a/packages/react/src/migrations/update-12-0-0/update-emotion-setup.spec.ts
+++ b/packages/react/src/migrations/update-12-0-0/update-emotion-setup.spec.ts
@@ -1,4 +1,4 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { readJson, Tree } from '@nrwl/devkit';
 import { updateEmotionSetup } from './update-emotion-setup';
 
@@ -6,7 +6,7 @@ describe('Update babel config for emotion', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it(`should add web babel preset if it does not exist`, async () => {

--- a/packages/react/src/migrations/update-12-0-0/use-react-jsx-in-tsconfig.spec.ts
+++ b/packages/react/src/migrations/update-12-0-0/use-react-jsx-in-tsconfig.spec.ts
@@ -1,4 +1,4 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { readJson, Tree } from '@nrwl/devkit';
 import { useReactJsxInTsconfig } from './use-react-jsx-in-tsconfig';
 
@@ -6,7 +6,7 @@ describe('Update tsconfig for React apps', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it(`should add web babel preset if it does not exist`, async () => {

--- a/packages/react/src/migrations/update-13-0-0/migrate-storybook-to-webpack-5.spec.ts
+++ b/packages/react/src/migrations/update-13-0-0/migrate-storybook-to-webpack-5.spec.ts
@@ -1,11 +1,11 @@
 import { readJson, Tree, updateJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { migrateStorybookToWebPack5 } from './migrate-storybook-to-webpack-5';
 
 describe('migrateStorybookToWebPack5', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should add packages needed by Storybook if workspace has the @storybook/react package', async () => {
@@ -25,7 +25,7 @@ describe('migrateStorybookToWebPack5', () => {
   });
 
   it('should not add the webpack Storybook packages again if they already exist', async () => {
-    let newTree = createTreeWithEmptyWorkspace();
+    let newTree = createTreeWithEmptyV1Workspace();
     updateJson(newTree, 'package.json', (json) => {
       json.dependencies = {
         '@storybook/react': '~6.3.0',

--- a/packages/react/src/migrations/update-13-0-0/update-emotion-setup.spec.ts
+++ b/packages/react/src/migrations/update-13-0-0/update-emotion-setup.spec.ts
@@ -1,4 +1,4 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { readJson, Tree } from '@nrwl/devkit';
 import { updateEmotionSetup } from './update-emotion-setup';
 
@@ -6,7 +6,7 @@ describe('Update tsconfig config for Emotion', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it(`should add jsxImportSource if it uses @emotion/react`, async () => {

--- a/packages/react/src/migrations/update-13-0-0/webpack5-changes-utils.spec.ts
+++ b/packages/react/src/migrations/update-13-0-0/webpack5-changes-utils.spec.ts
@@ -1,11 +1,11 @@
 import { Tree, updateJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { allReactProjectsWithStorybookConfiguration } from '@nrwl/react/src/migrations/update-13-0-0/webpack5-changes-utils';
 
 describe('webpack5ChangesUtils', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should get project name and storybook configuration for all react projects', () => {

--- a/packages/react/src/migrations/update-13-10-0/update-13-10-0.spec.ts
+++ b/packages/react/src/migrations/update-13-10-0/update-13-10-0.spec.ts
@@ -1,4 +1,4 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { writeJson, readJson, Tree } from '@nrwl/devkit';
 import migrate from './update-13-10-0';
 
@@ -6,7 +6,7 @@ describe('Update tsconfig for React apps', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should update to React 18 if React Native is not installed', async () => {

--- a/packages/react/src/migrations/update-14-0-0/add-default-development-configurations.spec.ts
+++ b/packages/react/src/migrations/update-14-0-0/add-default-development-configurations.spec.ts
@@ -7,7 +7,7 @@ import update from './add-default-development-configurations';
 
 describe('React default development configuration', () => {
   it('should add development configuration if it does not exist', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',
@@ -47,7 +47,7 @@ describe('React default development configuration', () => {
   });
 
   it('should add development configuration if no configurations at all', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',
@@ -90,7 +90,7 @@ describe('React default development configuration', () => {
   });
 
   it('should work without targets', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',

--- a/packages/react/src/migrations/update-14-0-0/replace-testing-library-react-hook.spec.ts
+++ b/packages/react/src/migrations/update-14-0-0/replace-testing-library-react-hook.spec.ts
@@ -9,7 +9,7 @@ import update from './replace-testing-library-react-hook';
 
 describe('Remove deprecated hook testing package', () => {
   it('should replace imports for packages that has jest test target', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',

--- a/packages/react/src/migrations/update-14-0-0/update-react-dom-render-for-v18.spec.ts
+++ b/packages/react/src/migrations/update-14-0-0/update-react-dom-render-for-v18.spec.ts
@@ -9,7 +9,7 @@ import update from './update-react-dom-render-for-v18';
 
 describe('React update for Nx 14', () => {
   it('should remove deprecated @testing-library/react package', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     writeJson(tree, 'package.json', {
       devDependencies: {
         '@testing-library/react': '0.0.0',
@@ -31,7 +31,7 @@ describe('React update for Nx 14', () => {
     ${'jsx'}
     ${'tsx'}
   `('should update react-dom render call if it exists', async ({ ext }) => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',
@@ -89,7 +89,7 @@ describe('React update for Nx 14', () => {
   });
 
   it('should skip update if main file does not contain react-dom', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(
       tree,
       'example',

--- a/packages/react/src/migrations/update-14-1-0/update-external-emotion-jsx-runtime.spec.ts
+++ b/packages/react/src/migrations/update-14-1-0/update-external-emotion-jsx-runtime.spec.ts
@@ -9,7 +9,7 @@ import { updateExternalEmotionJsxRuntime } from './update-external-emotion-jsx-r
 describe('updateExternalEmotionJsxRuntime', () => {
   it('should update external for Emotion', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'components', {
       root: 'libs/components',
       targets: {
@@ -49,7 +49,7 @@ describe('updateExternalEmotionJsxRuntime', () => {
 
   it('should not fail for projects with no targets', async () => {
     // ARRANGE
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'components', {
       root: 'apps/components',
     });

--- a/packages/react/src/utils/ast-utils.spec.ts
+++ b/packages/react/src/utils/ast-utils.spec.ts
@@ -1,6 +1,6 @@
 import * as utils from './ast-utils';
 import * as ts from 'typescript';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { applyChangesToString, Tree } from '@nrwl/devkit';
 
 describe('findDefaultExport', () => {
@@ -101,7 +101,7 @@ describe('addRoute', () => {
     context = {
       warn: jest.fn(),
     };
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should add links and routes if they are not present', async () => {
@@ -182,7 +182,7 @@ describe('addBrowserRouter', () => {
     context = {
       warn: jest.fn(),
     };
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should wrap around App component', () => {
@@ -216,7 +216,7 @@ describe('findMainRenderStatement', () => {
     context = {
       warn: jest.fn(),
     };
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should return ReactDOM.render(...)', () => {
@@ -297,7 +297,7 @@ describe('addReduxStoreToMain', () => {
     context = {
       warn: jest.fn(),
     };
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should wrap around App component', () => {
@@ -333,7 +333,7 @@ describe('updateReduxStore', () => {
     context = {
       warn: jest.fn(),
     };
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should update configureStore call', () => {

--- a/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.spec.ts
+++ b/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.spec.ts
@@ -1,5 +1,5 @@
 import { readWorkspaceConfiguration, Tree, writeJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import changeStorybookTargetsGenerator from './change-storybook-targets';
 import * as defaultConfig from './test-configs/default-config.json';
 import * as customNames from './test-configs/custom-names-config.json';
@@ -13,7 +13,7 @@ describe('Change the Storybook targets for Angular projects to use native Storyb
 
   describe('for all types of angular projects - non-buildable and buildable libs/apps', () => {
     beforeEach(async () => {
-      tree = createTreeWithEmptyWorkspace();
+      tree = createTreeWithEmptyV1Workspace();
     });
 
     it(`should set the browserTarget correctly in the Storybook config according to the type of project`, async () => {
@@ -48,7 +48,7 @@ describe('Change the Storybook targets for Angular projects to use native Storyb
 
   describe('for non-angular projects', () => {
     beforeEach(async () => {
-      tree = createTreeWithEmptyWorkspace();
+      tree = createTreeWithEmptyV1Workspace();
       writeJson(tree, 'workspace.json', nonAngular);
     });
 

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -5,7 +5,7 @@ import {
   updateJson,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { Linter } from '@nrwl/linter';
 import { libraryGenerator } from '@nrwl/workspace/generators';
@@ -18,7 +18,7 @@ describe('@nrwl/storybook:configuration', () => {
     let tree: Tree;
 
     beforeEach(async () => {
-      tree = createTreeWithEmptyWorkspace();
+      tree = createTreeWithEmptyV1Workspace();
       await libraryGenerator(tree, {
         name: 'test-ui-lib',
         standaloneConfig: false,
@@ -424,7 +424,7 @@ describe('@nrwl/storybook:configuration', () => {
     describe('for js Storybook configurations', () => {
       let tree: Tree;
       beforeAll(async () => {
-        tree = createTreeWithEmptyWorkspace();
+        tree = createTreeWithEmptyV1Workspace();
         writeJson(tree, 'workspace.json', workspaceConfiguration);
         writeJson(tree, 'apps/nxapp/tsconfig.json', {});
         writeJson(tree, 'apps/reapp/tsconfig.json', {});
@@ -522,7 +522,7 @@ describe('@nrwl/storybook:configuration', () => {
     describe('for TypeScript Storybook configurations', () => {
       let tree: Tree;
       beforeAll(async () => {
-        tree = createTreeWithEmptyWorkspace();
+        tree = createTreeWithEmptyV1Workspace();
         writeJson(tree, 'workspace.json', workspaceConfiguration);
         writeJson(tree, 'apps/nxapp/tsconfig.json', {});
         writeJson(tree, 'apps/reapp/tsconfig.json', {});

--- a/packages/storybook/src/generators/cypress-project/cypress-project.spec.ts
+++ b/packages/storybook/src/generators/cypress-project/cypress-project.spec.ts
@@ -1,6 +1,6 @@
 import { installedCypressVersion } from '@nrwl/cypress/src/utils/cypress-version';
 import { readJson, readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { libraryGenerator } from '@nrwl/workspace/generators';
 import { cypressProjectGenerator } from './cypress-project';
@@ -14,7 +14,7 @@ describe('@nrwl/storybook:cypress-project', () => {
 
   beforeEach(async () => {
     mockedInstalledCypressVersion.mockReturnValue(10);
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     await libraryGenerator(tree, {
       name: 'test-ui-lib',
       standaloneConfig: false,

--- a/packages/storybook/src/generators/init/init.spec.ts
+++ b/packages/storybook/src/generators/init/init.spec.ts
@@ -4,7 +4,7 @@ import {
   readJson,
   Tree,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { storybookVersion } from '../../utils/versions';
 import { initGenerator } from './init';
@@ -13,7 +13,7 @@ describe('@nrwl/storybook:init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   describe('dependencies for package.json', () => {

--- a/packages/storybook/src/migrations/update-12-1-0/fix-storybook-tsconfig.spec.ts
+++ b/packages/storybook/src/migrations/update-12-1-0/fix-storybook-tsconfig.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree, writeJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import updateStorybookTsconfig from './fix-storybook-tsconfig';
 
 describe('Fix Storybook TSConfig to avoid VSCode error', () => {
@@ -7,7 +7,7 @@ describe('Fix Storybook TSConfig to avoid VSCode error', () => {
 
   describe('when project has valid configuration and targets', () => {
     beforeEach(async () => {
-      tree = createTreeWithEmptyWorkspace();
+      tree = createTreeWithEmptyV1Workspace();
 
       writeJson(tree, 'workspace.json', {
         projects: {
@@ -56,7 +56,7 @@ describe('Fix Storybook TSConfig to avoid VSCode error', () => {
 
   describe('when project has no targets', () => {
     beforeEach(async () => {
-      tree = createTreeWithEmptyWorkspace();
+      tree = createTreeWithEmptyV1Workspace();
 
       writeJson(tree, 'workspace.json', {
         projects: {

--- a/packages/storybook/src/migrations/update-12-5-0/migrate-storybook-6-3.spec.ts
+++ b/packages/storybook/src/migrations/update-12-5-0/migrate-storybook-6-3.spec.ts
@@ -1,12 +1,15 @@
 import { readJson, Tree, writeJson } from '@nrwl/devkit';
-import { createTree, createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  createTree,
+  createTreeWithEmptyV1Workspace,
+} from '@nrwl/devkit/testing';
 import updateStorybookv63 from './migrate-storybook-6-3';
 
 describe('Upgrade to Storybook v6.3', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   describe('migrate addon-knobs registration', () => {

--- a/packages/storybook/src/migrations/update-12-5-9/update-storybook-react-typings.spec.ts
+++ b/packages/storybook/src/migrations/update-12-5-9/update-storybook-react-typings.spec.ts
@@ -1,12 +1,12 @@
 import { readJson, Tree, writeJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import addReactTypings from './update-storybook-react-typings';
 
 describe('Adjust Storybook React Typings in Storybook tsconfig', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     writeJson(tree, 'workspace.json', {
       projects: {

--- a/packages/storybook/src/migrations/update-12-8-0/update-storybook-styled-jsx-typings.spec.ts
+++ b/packages/storybook/src/migrations/update-12-8-0/update-storybook-styled-jsx-typings.spec.ts
@@ -1,12 +1,12 @@
 import { readJson, Tree, writeJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import addStyledJsxTypings from './update-storybook-styled-jsx-typings';
 
 describe('Add styled-jsx typings to Storybook tsconfig', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     writeJson(tree, 'workspace.json', {
       projects: {

--- a/packages/storybook/src/migrations/update-13-4-6/set-project-build-config.spec.ts
+++ b/packages/storybook/src/migrations/update-13-4-6/set-project-build-config.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree, writeJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import setProjectBuildConfig from './set-project-build-config';
 import * as defaultConfig from './test-configs/default-config.json';
 import * as customNames from './test-configs/custom-names-config.json';
@@ -10,7 +10,7 @@ describe('Set the projectBuildConfig option in the Storybook configuration for A
 
   describe('for all types of angular projects - non-buildable and buildable libs/apps', () => {
     beforeEach(async () => {
-      tree = createTreeWithEmptyWorkspace();
+      tree = createTreeWithEmptyV1Workspace();
     });
 
     it(`should set the projectBuildConfig in the Storybook config according to the type of project`, async () => {
@@ -28,7 +28,7 @@ describe('Set the projectBuildConfig option in the Storybook configuration for A
 
   describe('for non-angular projects', () => {
     beforeEach(async () => {
-      tree = createTreeWithEmptyWorkspace();
+      tree = createTreeWithEmptyV1Workspace();
       writeJson(tree, 'workspace.json', nonAngular);
     });
 

--- a/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.spec.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree, updateJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { storybookVersion } from '../../../utils/versions';
 import configurationGenerator from '../../../generators/configuration/configuration';
 import {
@@ -12,7 +12,7 @@ describe('migrate-defaults-5-to-6 Generator', () => {
   let appTree: Tree;
 
   beforeEach(async () => {
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyV1Workspace();
     updateJson(appTree, 'package.json', (json) => {
       return {
         ...json,

--- a/packages/storybook/src/migrations/update-14-0-0/migrate-stories-to-6-2/migrate-stories-to-6-2.spec.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-stories-to-6-2/migrate-stories-to-6-2.spec.ts
@@ -4,7 +4,7 @@ import {
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { joinPathFragments, writeJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { storybookVersion } from '@nrwl/storybook';
 import { findNodes } from '@nrwl/workspace/src/utils/ast-utils';
 import * as ts from 'typescript';
@@ -43,7 +43,7 @@ describe('migrate-stories-to-6-2 schematic', () => {
         ),
       });
 
-      appTree = createTreeWithEmptyWorkspace();
+      appTree = createTreeWithEmptyV1Workspace();
 
       await runAngularLibrarySchematic(appTree, {
         name: 'test-ui-lib',

--- a/packages/storybook/src/utils/utilities.spec.ts
+++ b/packages/storybook/src/utils/utilities.spec.ts
@@ -3,7 +3,7 @@ import {
   overrideCollectionResolutionForTesting,
   wrapAngularDevkitSchematic,
 } from '@nrwl/devkit/ngcli-adapter';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import {
   findStorybookAndBuildTargetsAndCompiler,
   isTheFileAStory,
@@ -36,7 +36,7 @@ describe('testing utilities', () => {
         ),
       });
 
-      appTree = createTreeWithEmptyWorkspace();
+      appTree = createTreeWithEmptyV1Workspace();
 
       await runAngularLibrarySchematic(appTree, {
         name: 'test-ui-lib',

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -1,7 +1,7 @@
 import { installedCypressVersion } from '@nrwl/cypress/src/utils/cypress-version';
 import type { NxJsonConfiguration, Tree } from '@nrwl/devkit';
 import { getProjects, readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { applicationGenerator } from './application';
 import { Schema } from './schema';
@@ -16,7 +16,7 @@ describe('app', () => {
   beforeEach(() => {
     mockedInstalledCypressVersion.mockReturnValue(10);
 
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   describe('not nested', () => {

--- a/packages/web/src/generators/init/init.spec.ts
+++ b/packages/web/src/generators/init/init.spec.ts
@@ -5,7 +5,7 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { nxVersion } from '../../utils/versions';
 
@@ -15,7 +15,7 @@ describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should add web dependencies', async () => {

--- a/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.spec.ts
+++ b/packages/web/src/migrations/update-11-5-2/create-babelrc-for-workspace-libs.spec.ts
@@ -1,4 +1,4 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { readJson, writeJson, DependencyType } from '@nrwl/devkit';
 import { createBabelrcForWorkspaceLibs } from './create-babelrc-for-workspace-libs';
 import type { ProjectGraph, Tree } from '@nrwl/devkit';
@@ -15,7 +15,7 @@ describe('Create missing .babelrc files', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it(`should create .babelrc files for libs that are used in '@nrwl/web:build'`, async () => {

--- a/packages/web/src/migrations/update-11-5-2/update-existing-babelrc-files.spec.ts
+++ b/packages/web/src/migrations/update-11-5-2/update-existing-babelrc-files.spec.ts
@@ -1,4 +1,4 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { readJson, writeJson, Tree } from '@nrwl/devkit';
 import { updateExistingBabelrcFiles } from './update-existing-babelrc-files';
 
@@ -6,7 +6,7 @@ describe('Create missing .babelrc files', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it(`should add web babel preset if it does not exist`, async () => {

--- a/packages/web/src/migrations/update-11-5-2/update-root-babel-config.spec.ts
+++ b/packages/web/src/migrations/update-11-5-2/update-root-babel-config.spec.ts
@@ -1,4 +1,4 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { readJson, writeJson, Tree } from '@nrwl/devkit';
 import { updateRootBabelConfig } from './update-root-babel-config';
 
@@ -6,7 +6,7 @@ describe('Update root babel config', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it(`should add web babel preset if it does not exist`, async () => {

--- a/packages/web/src/migrations/update-13-0-0/remove-deprecated-options-13-0-0.spec.ts
+++ b/packages/web/src/migrations/update-13-0-0/remove-deprecated-options-13-0-0.spec.ts
@@ -1,11 +1,11 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import subject from './remove-deprecated-options-13-0-0';
 
 describe('Migration: Remove deprecated options', () => {
   it(`should remove deprecated web build options`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'workspace.json',

--- a/packages/web/src/migrations/update-13-0-0/remove-node-sass-13-0-0.spec.ts
+++ b/packages/web/src/migrations/update-13-0-0/remove-node-sass-13-0-0.spec.ts
@@ -1,11 +1,11 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import subject from './remove-node-sass-13-0-0';
 
 describe('Migration: node-sass to sass', () => {
   it(`should remove node-sass if present in devDependencies or dependencies`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'package.json',

--- a/packages/web/src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0.spec.ts
+++ b/packages/web/src/migrations/update-13-0-0/remove-webpack-5-packages-13-0-0.spec.ts
@@ -1,5 +1,5 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import subject from './remove-webpack-5-packages-13-0-0';
 
@@ -26,7 +26,7 @@ describe('Migration: Remove webpack 5 packages from Nx12', () => {
   `(
     `should remove packages installed via webpack5 generator`,
     async ({ version }) => {
-      let tree = createTreeWithEmptyWorkspace();
+      let tree = createTreeWithEmptyV1Workspace();
 
       tree.write(
         'package.json',
@@ -62,7 +62,7 @@ describe('Migration: Remove webpack 5 packages from Nx12', () => {
   `(
     `should not do anything if the webpack version is not 5`,
     async ({ version }) => {
-      let tree = createTreeWithEmptyWorkspace();
+      let tree = createTreeWithEmptyV1Workspace();
 
       tree.write(
         'package.json',
@@ -94,7 +94,7 @@ describe('Migration: Remove webpack 5 packages from Nx12', () => {
   );
 
   it(`should not remove packages not every expected package is installed`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'package.json',

--- a/packages/web/src/migrations/update-13-3-0/rename-build-to-webpack.spec.ts
+++ b/packages/web/src/migrations/update-13-3-0/rename-build-to-webpack.spec.ts
@@ -1,11 +1,11 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import rename from './rename-build-to-webpack';
 
 describe('Migration: rename build to webpack', () => {
   it(`should rename the "build" executor to "webpack"`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'workspace.json',

--- a/packages/web/src/migrations/update-13-3-0/rename-package-to-rollup.spec.ts
+++ b/packages/web/src/migrations/update-13-3-0/rename-package-to-rollup.spec.ts
@@ -1,11 +1,11 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import renamePackageToRollup from './rename-package-to-rollup';
 
 describe('Migration: rename package to rollup', () => {
   it(`should rename the "package" executor to "rollup"`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'workspace.json',

--- a/packages/web/src/migrations/update-13-8-0/add-postcss-config-option.spec.ts
+++ b/packages/web/src/migrations/update-13-8-0/add-postcss-config-option.spec.ts
@@ -1,11 +1,11 @@
 import { readJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import migrate from './add-postcss-config-option';
 
 describe('Migration: add PostCSS config option', () => {
   it(`should add postcssConfig option if file exists`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'workspace.json',
@@ -50,7 +50,7 @@ describe('Migration: add PostCSS config option', () => {
     });
   });
   it(`should not add postcssConfig option if file does not exist`, async () => {
-    let tree = createTreeWithEmptyWorkspace();
+    let tree = createTreeWithEmptyV1Workspace();
 
     tree.write(
       'workspace.json',

--- a/packages/web/src/migrations/update-14-1-7/rollup-format-backwards-compatibility.spec.ts
+++ b/packages/web/src/migrations/update-14-1-7/rollup-format-backwards-compatibility.spec.ts
@@ -4,7 +4,7 @@ import update from './rollup-format-backwards-compatibility';
 
 describe('rollup-format-backwards-compatibility', () => {
   it('should add format options to match previous behavior if it does not exist', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'proj1', {
       root: 'proj1',
       targets: {
@@ -27,7 +27,7 @@ describe('rollup-format-backwards-compatibility', () => {
   });
 
   it('should skip update if format exists', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'proj1', {
       root: 'proj1',
       targets: {

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -1,12 +1,12 @@
 import { NxJsonConfiguration, Tree, updateJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { ciWorkflowGenerator } from './ci-workflow';
 
 describe('lib', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should generate github CI config', async () => {

--- a/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.spec.ts
+++ b/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.spec.ts
@@ -3,7 +3,10 @@ import {
   readJson,
   readProjectConfiguration,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  createTreeWithEmptyV1Workspace,
+  createTreeWithEmptyWorkspace,
+} from '@nrwl/devkit/testing';
 import enquirer = require('enquirer');
 import { libraryGenerator } from '../library/library';
 import * as devkit from '@nrwl/devkit';
@@ -30,7 +33,7 @@ describe('convert-to-nx-project', () => {
   });
 
   it('should throw if project && all are both specified', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await libraryGenerator(tree, {
       name: 'lib',
@@ -44,7 +47,7 @@ describe('convert-to-nx-project', () => {
   it('should prompt for a project if neither project nor all are specified', async () => {
     const spy = jest.spyOn(enquirer, 'prompt');
 
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await libraryGenerator(tree, {
       name: 'lib',
@@ -58,7 +61,7 @@ describe('convert-to-nx-project', () => {
   it('should not prompt for a project if all is specified', async () => {
     const spy = jest.spyOn(enquirer, 'prompt');
 
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await libraryGenerator(tree, {
       name: 'lib',
@@ -70,7 +73,7 @@ describe('convert-to-nx-project', () => {
   });
 
   it('should extract single project configuration to project.json', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await libraryGenerator(tree, {
       name: 'lib',
@@ -90,7 +93,7 @@ describe('convert-to-nx-project', () => {
   });
 
   it('should extract all project configurations to project.json', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await libraryGenerator(tree, {
       name: 'lib',
@@ -119,7 +122,7 @@ describe('convert-to-nx-project', () => {
   });
 
   it('should include tags in project.json', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await libraryGenerator(tree, {
       name: 'lib',
@@ -139,7 +142,7 @@ describe('convert-to-nx-project', () => {
   });
 
   it('should set workspace.json to point to the root directory', async () => {
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
     await libraryGenerator(tree, {
       name: 'lib',
       standaloneConfig: false,
@@ -152,7 +155,7 @@ describe('convert-to-nx-project', () => {
   });
 
   it('should error in v1 schema with workspace.json', async () => {
-    const tree = createTreeWithEmptyWorkspace(1);
+    const tree = createTreeWithEmptyV1Workspace();
     await libraryGenerator(tree, {
       name: 'lib',
       standaloneConfig: false,
@@ -168,7 +171,7 @@ describe('convert-to-nx-project', () => {
   it('should format files by default', async () => {
     jest.spyOn(devkit, 'formatFiles');
 
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await libraryGenerator(tree, {
       name: 'lib',
@@ -184,7 +187,7 @@ describe('convert-to-nx-project', () => {
   it('should format files when passing skipFormat false', async () => {
     jest.spyOn(devkit, 'formatFiles');
 
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await libraryGenerator(tree, {
       name: 'lib',
@@ -200,7 +203,7 @@ describe('convert-to-nx-project', () => {
   it('should not format files when passing skipFormat true ', async () => {
     jest.spyOn(devkit, 'formatFiles');
 
-    const tree = createTreeWithEmptyWorkspace(2);
+    const tree = createTreeWithEmptyWorkspace();
 
     await libraryGenerator(tree, {
       name: 'lib',

--- a/packages/workspace/src/generators/library/library.spec.ts
+++ b/packages/workspace/src/generators/library/library.spec.ts
@@ -5,7 +5,10 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  createTreeWithEmptyV1Workspace,
+  createTreeWithEmptyWorkspace,
+} from '@nrwl/devkit/testing';
 
 import { libraryGenerator } from './library';
 import { Schema } from './schema.d';
@@ -25,12 +28,12 @@ describe('lib', () => {
   };
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   describe('workspace v2', () => {
     beforeEach(() => {
-      tree = createTreeWithEmptyWorkspace(2);
+      tree = createTreeWithEmptyWorkspace();
     });
 
     it('should default to standalone project for first project', async () => {
@@ -60,7 +63,7 @@ describe('lib', () => {
 
   // describe('workspace v1', () => {
   //   beforeEach(() => {
-  //     tree = createTreeWithEmptyWorkspace(1);
+  //     tree = createTreeWithEmptyV1Workspace();
   //   });
   //
   //   it('should default to inline project for first project', async () => {

--- a/packages/workspace/src/generators/move/lib/check-destination.spec.ts
+++ b/packages/workspace/src/generators/move/lib/check-destination.spec.ts
@@ -3,7 +3,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Schema } from '../schema';
 import { checkDestination } from './check-destination';
 import { libraryGenerator } from '../../library/library';
@@ -13,7 +13,7 @@ describe('checkDestination', () => {
   let projectConfig: ProjectConfiguration;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     await libraryGenerator(tree, { name: 'my-lib', standaloneConfig: false });
     projectConfig = readProjectConfiguration(tree, 'my-lib');
   });

--- a/packages/workspace/src/generators/move/lib/move-project-configuration.spec.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-configuration.spec.ts
@@ -5,7 +5,10 @@ import {
   readJson,
   readProjectConfiguration,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  createTreeWithEmptyV1Workspace,
+  createTreeWithEmptyWorkspace,
+} from '@nrwl/devkit/testing';
 import type { NormalizedSchema } from '../schema';
 import { moveProjectConfiguration } from './move-project-configuration';
 
@@ -14,7 +17,7 @@ describe('moveProjectConfiguration', () => {
   let projectConfig: ProjectConfiguration;
   let schema: NormalizedSchema;
 
-  const setupWorkspace = (version = 1) => {
+  const setupWorkspace = (version: 1 | 2 = 1) => {
     schema = {
       projectName: 'my-source',
       destination: 'subfolder/my-destination',
@@ -24,7 +27,10 @@ describe('moveProjectConfiguration', () => {
       relativeToRootDestination: 'apps/subfolder/my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace(version);
+    tree =
+      version === 1
+        ? createTreeWithEmptyV1Workspace()
+        : createTreeWithEmptyWorkspace();
 
     addProjectConfiguration(tree, 'my-source', {
       projectType: 'application',

--- a/packages/workspace/src/generators/move/lib/move-project.spec.ts
+++ b/packages/workspace/src/generators/move/lib/move-project.spec.ts
@@ -3,7 +3,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { moveProject } from '@nrwl/workspace/src/generators/move/lib/move-project';
 import { libraryGenerator } from '../../library/library';
 import { NormalizedSchema } from '../schema';
@@ -13,7 +13,7 @@ describe('moveProject', () => {
   let projectConfig: ProjectConfiguration;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     await libraryGenerator(tree, { name: 'my-lib', standaloneConfig: false });
     projectConfig = readProjectConfiguration(tree, 'my-lib');
   });

--- a/packages/workspace/src/generators/move/lib/normalize-schema.spec.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.spec.ts
@@ -6,7 +6,7 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { NormalizedSchema, Schema } from '../schema';
 import { normalizeSchema } from './normalize-schema';
 
@@ -20,7 +20,7 @@ describe('normalizeSchema', () => {
   };
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     addProjectConfiguration(tree, schema.projectName, {
       root: 'libs/my-library',

--- a/packages/workspace/src/generators/move/lib/update-build-targets.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-build-targets.spec.ts
@@ -3,7 +3,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { NormalizedSchema } from '../schema';
 import { updateBuildTargets } from './update-build-targets';
 
@@ -20,7 +20,7 @@ describe('updateBuildTargets', () => {
       newProjectName: 'subfolder-my-destination',
       relativeToRootDestination: 'libs/subfolder/my-destination',
     };
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'my-source', {
       root: 'libs/my-source',
       targets: {

--- a/packages/workspace/src/generators/move/lib/update-cypress-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-cypress-config.spec.ts
@@ -5,7 +5,7 @@ import {
   Tree,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { libraryGenerator } from '../../library/library';
 import { NormalizedSchema } from '../schema';
 import { updateCypressConfig } from './update-cypress-config';
@@ -25,7 +25,7 @@ describe('updateCypressConfig', () => {
       relativeToRootDestination: 'libs/my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     await libraryGenerator(tree, { name: 'my-lib', standaloneConfig: false });
     projectConfig = readProjectConfiguration(tree, 'my-lib');
   });

--- a/packages/workspace/src/generators/move/lib/update-default-project.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-default-project.spec.ts
@@ -4,7 +4,7 @@ import {
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { NormalizedSchema } from '../schema';
 import { updateDefaultProject } from './update-default-project';
 
@@ -12,7 +12,7 @@ describe('updateDefaultProject', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'my-source', {
       root: 'libs/my-source',
       targets: {},

--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
@@ -4,7 +4,7 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Linter } from '../../../utils/lint';
 import { libraryGenerator } from '../../library/library';
 import { NormalizedSchema } from '../schema';
@@ -24,7 +24,7 @@ describe('updateEslint', () => {
       relativeToRootDestination: 'libs/shared/my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should handle .eslintrc.json not existing', async () => {

--- a/packages/workspace/src/generators/move/lib/update-implicit-dependencies.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-implicit-dependencies.spec.ts
@@ -3,7 +3,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { NormalizedSchema } from '../schema';
 import { updateImplicitDependencies } from './update-implicit-dependencies';
 
@@ -21,7 +21,7 @@ describe('updateImplicitDepenencies', () => {
       relativeToRootDestination: 'libs/my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     addProjectConfiguration(tree, 'my-lib', {
       root: 'libs/my-lib',

--- a/packages/workspace/src/generators/move/lib/update-imports.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { libraryGenerator } from '../../library/library';
 import { NormalizedSchema } from '../schema';
 import { updateImports } from './update-imports';
@@ -9,7 +9,7 @@ describe('updateImports', () => {
   let schema: NormalizedSchema;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     schema = {
       projectName: 'my-source',

--- a/packages/workspace/src/generators/move/lib/update-jest-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-jest-config.spec.ts
@@ -1,5 +1,5 @@
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { libraryGenerator } from '../../library/library';
 import { NormalizedSchema } from '../schema';
 import { updateJestConfig } from './update-jest-config';
@@ -8,7 +8,7 @@ describe('updateJestConfig', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should handle jest config not existing', async () => {

--- a/packages/workspace/src/generators/move/lib/update-package-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-package-json.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree, writeJson } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { libraryGenerator } from '../../library/library';
 import { NormalizedSchema } from '../schema';
 import { updatePackageJson } from './update-package-json';
@@ -18,7 +18,7 @@ describe('updatePackageJson', () => {
       relativeToRootDestination: 'libs/my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     await libraryGenerator(tree, { name: 'my-lib', standaloneConfig: false });
   });
 

--- a/packages/workspace/src/generators/move/lib/update-project-root-files.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-project-root-files.spec.ts
@@ -1,5 +1,5 @@
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { libraryGenerator } from '../../library/library';
 import { NormalizedSchema } from '../schema';
 import { updateProjectRootFiles } from './update-project-root-files';
@@ -8,7 +8,7 @@ describe('updateProjectRootFiles', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should update the relative root in files at the root of the project', async () => {

--- a/packages/workspace/src/generators/move/lib/update-readme.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-readme.spec.ts
@@ -1,5 +1,5 @@
 import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { join } from 'path';
 import { libraryGenerator } from '../../library/library';
 import { NormalizedSchema } from '../schema';
@@ -19,7 +19,7 @@ describe('updateReadme', () => {
       relativeToRootDestination: 'libs/shared/my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should handle README.md not existing', async () => {

--- a/packages/workspace/src/generators/move/lib/update-storybook-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-storybook-config.spec.ts
@@ -1,5 +1,5 @@
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { libraryGenerator } from '../../library/library';
 import { NormalizedSchema } from '../schema';
 import { updateStorybookConfig } from './update-storybook-config';
@@ -8,7 +8,7 @@ describe('updateStorybookConfig', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should handle storybook config not existing', async () => {

--- a/packages/workspace/src/generators/move/move.spec.ts
+++ b/packages/workspace/src/generators/move/move.spec.ts
@@ -6,7 +6,7 @@ import { libraryGenerator } from '../library/library';
 describe('move', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should update jest config when moving down directories', async () => {

--- a/packages/workspace/src/generators/npm-package/npm-package.spec.ts
+++ b/packages/workspace/src/generators/npm-package/npm-package.spec.ts
@@ -7,14 +7,14 @@ import {
   updateWorkspaceConfiguration,
   writeJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { getWorkspacePath } from '@nrwl/devkit';
 import { npmPackageGenerator } from './npm-package';
 
 describe('@nrwl/workspace:npm-package', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     const workspaceConfig = readWorkspaceConfiguration(tree);
     workspaceConfig.workspaceLayout = {

--- a/packages/workspace/src/generators/preset/preset.spec.ts
+++ b/packages/workspace/src/generators/preset/preset.spec.ts
@@ -1,5 +1,5 @@
 import { Tree, readJson, NxJsonConfiguration } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { overrideCollectionResolutionForTesting } from '@nrwl/devkit/ngcli-adapter';
 import { presetGenerator } from './preset';
 import * as path from 'path';
@@ -9,7 +9,7 @@ describe('preset', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     overrideCollectionResolutionForTesting({
       '@nrwl/workspace': path.join(
         __dirname,

--- a/packages/workspace/src/generators/remove/lib/check-dependencies.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/check-dependencies.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@nrwl/devkit';
 import { Schema } from '../schema';
 import { checkDependencies } from './check-dependencies';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { libraryGenerator } from '../../library/library';
 // let projectGraph: ProjectGraph;
 // jest.mock('../../../core/project-graph', () => ({
@@ -29,7 +29,7 @@ describe('empty', () => {
 //   let schema: Schema;
 //
 //   beforeEach(async () => {
-//     tree = createTreeWithEmptyWorkspace();
+//     tree = createTreeWithEmptyV1Workspace();
 //
 //     schema = {
 //       projectName: 'my-source',

--- a/packages/workspace/src/generators/remove/lib/check-targets.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/check-targets.spec.ts
@@ -1,5 +1,5 @@
 import { addProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Schema } from '../schema';
 import { checkTargets } from './check-targets';
 
@@ -8,7 +8,7 @@ describe('checkTargets', () => {
   let schema: Schema;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     schema = {
       projectName: 'ng-app',

--- a/packages/workspace/src/generators/remove/lib/remove-project-config.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/remove-project-config.spec.ts
@@ -5,7 +5,7 @@ import {
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { Schema } from '../schema';
 import { removeProjectConfig } from './remove-project-config';
@@ -15,7 +15,7 @@ describe('removeProjectConfig', () => {
   let schema: Schema;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     addProjectConfiguration(tree, 'ng-app', {
       projectType: 'application',

--- a/packages/workspace/src/generators/remove/lib/remove-project.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/remove-project.spec.ts
@@ -1,5 +1,5 @@
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Schema } from '../schema';
 import { libraryGenerator } from '../../library/library';
 import { removeProject } from '@nrwl/workspace/src/generators/remove/lib/remove-project';
@@ -9,7 +9,7 @@ describe('moveProject', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     await libraryGenerator(tree, {
       name: 'my-lib',
       standaloneConfig: false,

--- a/packages/workspace/src/generators/remove/lib/update-jest-config.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/update-jest-config.spec.ts
@@ -1,5 +1,5 @@
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -13,7 +13,7 @@ describe('updateRootJestConfig', () => {
   let schema: Schema;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     schema = {
       projectName: 'my-lib',

--- a/packages/workspace/src/generators/remove/lib/update-tsconfig.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/update-tsconfig.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { Schema } from '../schema';
 import { updateTsconfig } from './update-tsconfig';
 import { libraryGenerator } from '../../library/library';
@@ -10,7 +10,7 @@ describe('updateTsconfig', () => {
   let schemaWithImportPath: Schema;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     schema = {
       projectName: 'my-lib',

--- a/packages/workspace/src/generators/run-commands/run-commands.spec.ts
+++ b/packages/workspace/src/generators/run-commands/run-commands.spec.ts
@@ -1,10 +1,10 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import runCommands from './run-commands';
 import { libraryGenerator } from '../library/library';
 
 describe('run-commands', () => {
   it('should generate a target', async () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
     const opts = {
       name: 'custom',
       project: 'lib',

--- a/packages/workspace/src/generators/workspace-generator/workspace-generator.spec.ts
+++ b/packages/workspace/src/generators/workspace-generator/workspace-generator.spec.ts
@@ -1,9 +1,9 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import workspaceGenerator from './workspace-generator';
 
 describe('workspace-generator', () => {
   it('should generate a target', async () => {
-    const tree = createTreeWithEmptyWorkspace();
+    const tree = createTreeWithEmptyV1Workspace();
     const opts = {
       name: 'custom',
       skipFormat: true,

--- a/packages/workspace/src/migrations/update-13-0-0/config-locations/config-locations.spec.ts
+++ b/packages/workspace/src/migrations/update-13-0-0/config-locations/config-locations.spec.ts
@@ -5,14 +5,17 @@ import {
   readWorkspaceConfiguration,
   readJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  createTreeWithEmptyV1Workspace,
+  createTreeWithEmptyWorkspace,
+} from '@nrwl/devkit/testing';
 import update from './config-locations';
 
 describe('update to v13 config locations', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
     updateJson(tree, 'workspace.json', (json) => ({
       ...json,
       cli: {
@@ -48,7 +51,7 @@ describe('update to v13 config locations', () => {
 
   describe('v1 workspace', () => {
     beforeEach(() => {
-      tree = createTreeWithEmptyWorkspace(1);
+      tree = createTreeWithEmptyV1Workspace();
       updateJson(tree, 'workspace.json', (json) => ({
         ...json,
         cli: {

--- a/packages/workspace/src/migrations/update-13-0-0/set-default-base-if-not-set.spec.ts
+++ b/packages/workspace/src/migrations/update-13-0-0/set-default-base-if-not-set.spec.ts
@@ -6,7 +6,7 @@ describe('add `defaultBase` in nx.json', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should set defaultBase to master if not present', async () => {

--- a/packages/workspace/src/migrations/update-13-3-0/update-tsc-executor-location.spec.ts
+++ b/packages/workspace/src/migrations/update-13-3-0/update-tsc-executor-location.spec.ts
@@ -13,7 +13,7 @@ describe('add `defaultBase` in nx.json', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace(2);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should update @nrwl/workspace:tsc -> @nrwl/js:tsc', async () => {

--- a/packages/workspace/src/migrations/update-14-0-0/change-npm-script-executor.spec.ts
+++ b/packages/workspace/src/migrations/update-14-0-0/change-npm-script-executor.spec.ts
@@ -6,14 +6,14 @@ import {
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import changeNpmScriptExecutor from './change-npm-script-executor';
 
 describe('changeNxJsonPresets', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
 
     addProjectConfiguration(tree, 'proj1', {
       root: 'proj1',

--- a/packages/workspace/src/migrations/update-14-0-0/change-nx-json-presets.spec.ts
+++ b/packages/workspace/src/migrations/update-14-0-0/change-nx-json-presets.spec.ts
@@ -4,14 +4,14 @@ import {
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import changeNxJsonPresets from '@nrwl/workspace/src/migrations/update-14-0-0/change-nx-json-presets';
 
 describe('changeNxJsonPresets', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
   });
 
   it('should not set any new extends', async () => {

--- a/packages/workspace/src/utilities/executor-options-utils.spec.ts
+++ b/packages/workspace/src/utilities/executor-options-utils.spec.ts
@@ -1,12 +1,12 @@
 import { addProjectConfiguration, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
 
 describe('forEachExecutorOptions', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyV1Workspace();
     addProjectConfiguration(tree, 'proj1', {
       root: 'proj1',
       targets: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
createTreeWithEmptyWorkspace takes a parameter to specify v1 or v2

## Expected Behavior
createTreeWithEmptyWorkspace doesn't take a parameter.
createTreeWithEmptyAngularWorkspace is used for v1

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
