### PR TITLE
fix(web): in webpack style-loader should be used when extract-css is false

### DIFF
--- a/docs/generated/packages/web.json
+++ b/docs/generated/packages/web.json
@@ -429,7 +429,7 @@
           "extractCss": {
             "type": "boolean",
             "description": "Extract CSS into a `.css` file.",
-            "default": false
+            "default": true
           },
           "es2015Polyfills": {
             "description": "Conditional polyfills loaded in browsers which do not support `ES2015`.",

--- a/packages/web/src/executors/webpack/schema.json
+++ b/packages/web/src/executors/webpack/schema.json
@@ -165,7 +165,7 @@
     "extractCss": {
       "type": "boolean",
       "description": "Extract CSS into a `.css` file.",
-      "default": false
+      "default": true
     },
     "es2015Polyfills": {
       "description": "Conditional polyfills loaded in browsers which do not support `ES2015`.",

--- a/packages/web/src/executors/webpack/webpack.impl.ts
+++ b/packages/web/src/executors/webpack/webpack.impl.ts
@@ -63,6 +63,8 @@ export interface WebWebpackExecutorOptions extends BuildBuilderOptions {
   generateIndexHtml?: boolean;
 
   postcssConfig?: string;
+
+  extractCss?: boolean;
 }
 
 async function getWebpackConfigs(

--- a/packages/web/src/utils/web.config.ts
+++ b/packages/web/src/utils/web.config.ts
@@ -72,7 +72,7 @@ export function getWebConfig(
       wco.root,
       wco.projectRoot,
       wco.buildOptions,
-      true,
+      options.extractCss ?? true,
       options.postcssConfig
     ),
     getCommonPartial(wco),

--- a/packages/web/src/utils/web.config.ts
+++ b/packages/web/src/utils/web.config.ts
@@ -72,7 +72,7 @@ export function getWebConfig(
       wco.root,
       wco.projectRoot,
       wco.buildOptions,
-      options.extractCss ?? true,
+      options.extractCss,
       options.postcssConfig
     ),
     getCommonPartial(wco),


### PR DESCRIPTION
This pull request should fix issue where extractCss option is ignored and error in schema that claims that extractCss is false by default.