### PR TITLE
fix(react): aliases should be an array in schematics

### DIFF
--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -530,7 +530,7 @@
         "presets": []
       },
       "description": "Create a React component.",
-      "aliases": "c",
+      "aliases": ["c"],
       "implementation": "/packages/react/src/generators/component/component#componentGenerator.ts",
       "hidden": false,
       "path": "/packages/react/src/generators/component/schema.json"
@@ -843,7 +843,7 @@
         "presets": []
       },
       "description": "Create a hook.",
-      "aliases": "c",
+      "aliases": ["c"],
       "implementation": "/packages/react/src/generators/hook/hook#hookGenerator.ts",
       "hidden": false,
       "path": "/packages/react/src/generators/hook/schema.json"

--- a/packages/react/generators.json
+++ b/packages/react/generators.json
@@ -31,7 +31,7 @@
       "factory": "./src/generators/component/component#componentSchematic",
       "schema": "./src/generators/component/schema.json",
       "description": "Create a React component.",
-      "aliases": "c"
+      "aliases": ["c"]
     },
 
     "redux": {
@@ -73,7 +73,7 @@
       "factory": "./src/generators/hook/hook#chookSchematic",
       "schema": "./src/generators/hook/schema.json",
       "description": "Create a hook.",
-      "aliases": "h"
+      "aliases": ["h"]
     }
   },
   "generators": {
@@ -105,7 +105,7 @@
       "factory": "./src/generators/component/component#componentGenerator",
       "schema": "./src/generators/component/schema.json",
       "description": "Create a React component.",
-      "aliases": "c"
+      "aliases": ["c"]
     },
 
     "redux": {
@@ -147,7 +147,7 @@
       "factory": "./src/generators/hook/hook#hookGenerator",
       "schema": "./src/generators/hook/schema.json",
       "description": "Create a hook.",
-      "aliases": "c"
+      "aliases": ["c"]
     },
 
     "host": {


### PR DESCRIPTION
Aliases is an array in the type definitions, but a string in the react JSON, which seems like a mistake.

It'd be really nice if you have a JSON schema for these JSON files and hook them up to it, so you would catch these problems much earlier on (even if just through editor support, i.e. the dev seeing their editor tell them its wrong while changing it).

You could also setup a test which uses ajv to validate each of these files against the schema in CI. that might be nice.

happy to implement either of those solutions if i know where in the repo they'd belong

## Related Issue(s)

Fixes #10193
