### PR TITLE
fix(web): fix dev-server deprecation warning

### DIFF
--- a/packages/web/src/utils/devserver.config.ts
+++ b/packages/web/src/utils/devserver.config.ts
@@ -90,7 +90,6 @@ function getDevServerPartial(
     open: options.open,
     static: false,
     compress: scriptsOptimization || stylesOptimization,
-    https: options.ssl,
     devMiddleware: {
       publicPath: servePath,
       stats: false,
@@ -106,8 +105,13 @@ function getDevServerPartial(
     hot: options.hmr,
   };
 
-  if (options.ssl && options.sslKey && options.sslCert) {
-    config.https = getSslConfig(root, options);
+  if (options.ssl) {
+    config.server = {
+      type: 'https',
+    };
+    if (options.sslKey && options.sslCert) {
+      config.server.options = getSslConfig(root, options);
+    }
   }
 
   if (options.proxyConfig) {


### PR DESCRIPTION
This  PR will resolve deprecation warning:
(node:62713) [DEP_WEBPACK_DEV_SERVER_HTTPS] DeprecationWarning: 'https' option is deprecated. Please use the 'server' option.