### PR TITLE
feat(angular): add flag for skipping the postinstall script in relevant generators

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -158,7 +158,7 @@
           "skipPostInstall": {
             "type": "boolean",
             "default": false,
-            "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+            "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
           },
           "unitTestRunner": {
             "type": "string",
@@ -645,7 +645,7 @@
           "skipPostInstall": {
             "type": "boolean",
             "default": false,
-            "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+            "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
           }
         },
         "additionalProperties": false,
@@ -782,7 +782,7 @@
           "skipPostInstall": {
             "type": "boolean",
             "default": false,
-            "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+            "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
           },
           "skipTsConfig": {
             "type": "boolean",
@@ -1235,7 +1235,7 @@
           "skipPostInstall": {
             "type": "boolean",
             "default": false,
-            "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+            "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
           },
           "unitTestRunner": {
             "type": "string",
@@ -1365,7 +1365,7 @@
           "skipPostInstall": {
             "type": "boolean",
             "default": false,
-            "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`. NOTE: only used if running the generator in an Nx workspace."
+            "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`. NOTE: only used if running the generator in an Nx workspace."
           }
         },
         "additionalProperties": false,

--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -155,6 +155,11 @@
             "default": false,
             "description": "Do not add dependencies to `package.json`."
           },
+          "skipPostInstall": {
+            "type": "boolean",
+            "default": false,
+            "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+          },
           "unitTestRunner": {
             "type": "string",
             "enum": ["karma", "jest", "none"],
@@ -636,6 +641,11 @@
             "type": "boolean",
             "default": false,
             "description": "Do not add dependencies to `package.json`."
+          },
+          "skipPostInstall": {
+            "type": "boolean",
+            "default": false,
+            "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
           }
         },
         "additionalProperties": false,
@@ -768,6 +778,11 @@
             "type": "boolean",
             "default": false,
             "description": "Do not add dependencies to `package.json`."
+          },
+          "skipPostInstall": {
+            "type": "boolean",
+            "default": false,
+            "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
           },
           "skipTsConfig": {
             "type": "boolean",
@@ -1217,6 +1232,11 @@
             "default": false,
             "description": "Do not add dependencies to `package.json`."
           },
+          "skipPostInstall": {
+            "type": "boolean",
+            "default": false,
+            "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+          },
           "unitTestRunner": {
             "type": "string",
             "enum": ["karma", "jest", "none"],
@@ -1341,6 +1361,11 @@
             "type": "boolean",
             "default": false,
             "description": "Do not add dependencies to `package.json`. NOTE: only used if running the generator in an Nx workspace."
+          },
+          "skipPostInstall": {
+            "type": "boolean",
+            "default": false,
+            "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`. NOTE: only used if running the generator in an Nx workspace."
           }
         },
         "additionalProperties": false,

--- a/packages/angular/src/generators/application/schema.d.ts
+++ b/packages/angular/src/generators/application/schema.d.ts
@@ -30,5 +30,6 @@ export interface Schema {
   host?: string;
   setParserOptionsProject?: boolean;
   skipPackageJson?: boolean;
+  skipPostInstall?: boolean;
   federationType?: 'static' | 'dynamic';
 }

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -93,6 +93,11 @@
       "default": false,
       "description": "Do not add dependencies to `package.json`."
     },
+    "skipPostInstall": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+    },
     "unitTestRunner": {
       "type": "string",
       "enum": ["karma", "jest", "none"],

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -96,7 +96,7 @@
     "skipPostInstall": {
       "type": "boolean",
       "default": false,
-      "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+      "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
     },
     "unitTestRunner": {
       "type": "string",

--- a/packages/angular/src/generators/host/schema.d.ts
+++ b/packages/angular/src/generators/host/schema.d.ts
@@ -4,6 +4,7 @@ export interface Schema {
   dynamic?: boolean;
   setParserOptionsProject?: boolean;
   skipPackageJson?: boolean;
+  skipPostInstall?: boolean;
   addTailwind?: boolean;
   prefix?: string;
   style?: Styles;

--- a/packages/angular/src/generators/host/schema.json
+++ b/packages/angular/src/generators/host/schema.json
@@ -98,7 +98,7 @@
     "skipPostInstall": {
       "type": "boolean",
       "default": false,
-      "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+      "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
     },
     "unitTestRunner": {
       "type": "string",

--- a/packages/angular/src/generators/host/schema.json
+++ b/packages/angular/src/generators/host/schema.json
@@ -95,6 +95,11 @@
       "default": false,
       "description": "Do not add dependencies to `package.json`."
     },
+    "skipPostInstall": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+    },
     "unitTestRunner": {
       "type": "string",
       "enum": ["karma", "jest", "none"],

--- a/packages/angular/src/generators/init/init.spec.ts
+++ b/packages/angular/src/generators/init/init.spec.ts
@@ -42,7 +42,7 @@ describe('init', () => {
     expect(devDependencies['codelyzer']).toBeUndefined();
   });
 
-  it('should add a postinstall script for ngcc', async () => {
+  it('should add a postinstall script for ngcc by default', async () => {
     // ACT
     await init(host, {
       unitTestRunner: UnitTestRunner.Karma,
@@ -56,6 +56,21 @@ describe('init', () => {
     expect(packageJson.scripts.postinstall).toEqual(
       'ngcc --properties es2015 browser module main'
     );
+  });
+
+  it('should not add a postinstall script for ngcc if skipPostInstall=true', async () => {
+    // ACT
+    await init(host, {
+      unitTestRunner: UnitTestRunner.Karma,
+      linter: Linter.EsLint,
+      skipFormat: false,
+      skipPostInstall: true,
+    });
+
+    const packageJson = readJson(host, 'package.json');
+
+    // ASSERT
+    expect(packageJson?.scripts?.postinstall).toBeFalsy();
   });
 
   describe('--unit-test-runner', () => {

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -27,7 +27,10 @@ export async function angularInitGenerator(
 ): Promise<GeneratorCallback> {
   const options = normalizeOptions(rawOptions);
   setDefaults(host, options);
-  addPostInstall(host);
+
+  if (!options.skipPostInstall) {
+    addPostInstall(host);
+  }
 
   const depsTask = !options.skipPackageJson
     ? updateDependencies(host)
@@ -49,6 +52,7 @@ function normalizeOptions(options: Schema): Required<Schema> {
     linter: options.linter ?? Linter.EsLint,
     skipFormat: options.skipFormat ?? false,
     skipInstall: options.skipInstall ?? false,
+    skipPostInstall: options.skipPostInstall ?? false,
     skipPackageJson: options.skipPackageJson ?? false,
     style: options.style ?? 'css',
     unitTestRunner: options.unitTestRunner ?? UnitTestRunner.Jest,

--- a/packages/angular/src/generators/init/schema.d.ts
+++ b/packages/angular/src/generators/init/schema.d.ts
@@ -10,4 +10,5 @@ export interface Schema {
   style?: Styles;
   linter?: Exclude<Linter, Linter.TsLint>;
   skipPackageJson?: boolean;
+  skipPostInstall?: boolean;
 }

--- a/packages/angular/src/generators/init/schema.json
+++ b/packages/angular/src/generators/init/schema.json
@@ -70,7 +70,7 @@
     "skipPostInstall": {
       "type": "boolean",
       "default": false,
-      "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+      "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
     }
   },
   "additionalProperties": false

--- a/packages/angular/src/generators/init/schema.json
+++ b/packages/angular/src/generators/init/schema.json
@@ -66,6 +66,11 @@
       "type": "boolean",
       "default": false,
       "description": "Do not add dependencies to `package.json`."
+    },
+    "skipPostInstall": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
     }
   },
   "additionalProperties": false

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -30,4 +30,5 @@ export interface Schema {
   setParserOptionsProject?: boolean;
   skipModule?: boolean;
   skipPackageJson?: boolean;
+  skipPostInstall?: boolean;
 }

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -59,7 +59,7 @@
     "skipPostInstall": {
       "type": "boolean",
       "default": false,
-      "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+      "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
     },
     "skipTsConfig": {
       "type": "boolean",

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -56,6 +56,11 @@
       "default": false,
       "description": "Do not add dependencies to `package.json`."
     },
+    "skipPostInstall": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`."
+    },
     "skipTsConfig": {
       "type": "boolean",
       "default": false,

--- a/packages/angular/src/generators/ng-add/schema.d.ts
+++ b/packages/angular/src/generators/ng-add/schema.d.ts
@@ -12,6 +12,7 @@ export interface GeneratorOptions {
   e2eTestRunner?: E2eTestRunner;
   skipFormat?: boolean;
   skipInstall?: boolean;
+  skipPostInstall?: boolean;
   style?: Styles;
   linter?: Exclude<Linter, Linter.TsLint>;
   skipPackageJson?: boolean;

--- a/packages/angular/src/generators/ng-add/schema.json
+++ b/packages/angular/src/generators/ng-add/schema.json
@@ -58,6 +58,11 @@
       "type": "boolean",
       "default": false,
       "description": "Do not add dependencies to `package.json`. NOTE: only used if running the generator in an Nx workspace."
+    },
+    "skipPostInstall": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`. NOTE: only used if running the generator in an Nx workspace."
     }
   },
   "additionalProperties": false

--- a/packages/angular/src/generators/ng-add/schema.json
+++ b/packages/angular/src/generators/ng-add/schema.json
@@ -62,7 +62,7 @@
     "skipPostInstall": {
       "type": "boolean",
       "default": false,
-      "description": "Do not add or append `ngcc` to `postinstall`-script in `package.json`. NOTE: only used if running the generator in an Nx workspace."
+      "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`. NOTE: only used if running the generator in an Nx workspace."
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`ngcc` is always added to `postinstall` in `package.json` when running workspace-generators.

## Expected Behavior
That it is possible to skip adding `ngcc` if not needed. E.g if the workspace is using only Angular Ivy-compatible dependencies, this postinstall-step is not needed.

## Related Issue(s)
[<!-- Please link the issue being fixed so it gets closed when this is merged. -->](https://github.com/nrwl/nx/issues/10062)

Fixes #10062
