### PR TITLE
fix(angular): handle packages with no exported package.json when collecting secondary entry points for mf builds

### DIFF
--- a/packages/angular/src/utils/mfe/mfe-webpack.spec.ts
+++ b/packages/angular/src/utils/mfe/mfe-webpack.spec.ts
@@ -231,6 +231,25 @@ describe('MFE Webpack Utils', () => {
         },
       });
     });
+
+    it('should not throw when the main entry point package.json cannot be required', () => {
+      // ARRANGE
+      (fs.existsSync as jest.Mock).mockImplementation(
+        (file) => !file.endsWith('non-existent-top-level-package/package.json')
+      );
+      jest.spyOn(devkit, 'readJsonFile').mockImplementation((file) => ({
+        name: file
+          .replace(/\\/g, '/')
+          .replace(/^.*node_modules[/]/, '')
+          .replace('/package.json', ''),
+        dependencies: { '@angular/core': '~13.2.0' },
+      }));
+
+      // ACT & ASSERT
+      expect(() =>
+        sharePackages(['non-existent-top-level-package'])
+      ).not.toThrow();
+    });
   });
 });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When building an Angular MF application, if an npm dependency is not exporting the `package.json` file, the build errors. More info in https://github.com/nrwl/nx/issues/10094#issuecomment-1119277238.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The recollection of secondary entry points for MF apps shouldn't fail the build. If the `package.json` of any given npm dependency can't be resolved, it should be ignored.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
