### PR TITLE
feat(core): add nx.json, workspace.json, and project.json JSON schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "@xstate/immer": "^0.2.0",
     "@xstate/inspect": "^0.5.1",
     "@xstate/react": "^1.6.3",
+    "ajv": "^8.11.0",
     "angular": "1.8.0",
     "autoprefixer": "^10.2.5",
     "babel-jest": "27.5.1",

--- a/packages/angular/src/generators/ng-add/utilities/e2e.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/utilities/e2e.migrator.spec.ts
@@ -331,6 +331,7 @@ describe('e2e migrator', () => {
         expect(angularJson.projects['app1-e2e']).toBe('apps/app1-e2e');
         const e2eProject = readProjectConfiguration(tree, 'app1-e2e');
         expect(e2eProject).toStrictEqual({
+          $schema: '../../node_modules/nx/schemas/project-schema.json',
           root: 'apps/app1-e2e',
           sourceRoot: 'apps/app1-e2e/src',
           projectType: 'application',
@@ -457,6 +458,7 @@ describe('e2e migrator', () => {
         expect(angularJson.projects['app1-e2e']).toBe('apps/app1-e2e');
         const e2eProject = readProjectConfiguration(tree, 'app1-e2e');
         expect(e2eProject).toStrictEqual({
+          $schema: '../../node_modules/nx/schemas/project-schema.json',
           root: 'apps/app1-e2e',
           sourceRoot: 'apps/app1-e2e/src',
           projectType: 'application',
@@ -521,6 +523,7 @@ describe('e2e migrator', () => {
 
         const e2eProject = readProjectConfiguration(tree, 'app1-e2e');
         expect(e2eProject).toStrictEqual({
+          $schema: '../../node_modules/nx/schemas/project-schema.json',
           root: 'apps/app1-e2e',
           sourceRoot: 'apps/app1-e2e/src',
           projectType: 'application',
@@ -573,6 +576,7 @@ describe('e2e migrator', () => {
 
         const e2eProject = readProjectConfiguration(tree, 'app1-e2e');
         expect(e2eProject).toStrictEqual({
+          $schema: '../../node_modules/nx/schemas/project-schema.json',
           root: 'apps/app1-e2e',
           sourceRoot: 'apps/app1-e2e/src',
           projectType: 'application',

--- a/packages/angular/src/migrations/update-13-9-0/set-build-libs-from-source.spec.ts
+++ b/packages/angular/src/migrations/update-13-9-0/set-build-libs-from-source.spec.ts
@@ -27,6 +27,9 @@ describe('set-build-libs-from-source migration', () => {
     };
     addProjectConfiguration(tree, 'app1', project);
 
+    // add $schema to projectConfig manually
+    project['$schema'] = '../../node_modules/nx/schemas/project-schema.json';
+
     await migration(tree);
 
     const resultingProject = readProjectConfiguration(tree, 'app1');

--- a/packages/next/src/migrations/update-14-0-0/add-default-development-configurations.spec.ts
+++ b/packages/next/src/migrations/update-14-0-0/add-default-development-configurations.spec.ts
@@ -58,6 +58,7 @@ describe('React default development configuration', () => {
 
     const config = readProjectConfiguration(tree, 'example');
     expect(config).toEqual({
+      $schema: '../../node_modules/nx/schemas/project-schema.json',
       root: 'apps/example',
       projectType: 'application',
     });

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -5,6 +5,12 @@
       "version": "14.0.6",
       "description": "Remove root property from project.json files",
       "factory": "./src/migrations/update-14-0-6/remove-roots"
+    },
+    "14-2-0-add-json-schema": {
+      "cli": "nx",
+      "version": "14.2.0-beta.0",
+      "description": "Add JSON Schema to Nx configuration files",
+      "factory": "./src/migrations/update-14-2-0/add-json-schema"
     }
   }
 }

--- a/packages/nx/migrations.spec.ts
+++ b/packages/nx/migrations.spec.ts
@@ -1,7 +1,7 @@
 import path = require('path');
 import json = require('./migrations.json');
 
-describe('Node migrations', () => {
+describe('Nx migrations', () => {
   it('should have valid paths', () => {
     Object.values(json.generators).forEach((m) => {
       expect(() =>

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -24,6 +24,7 @@
       "description": "NPM Scope that the workspace uses."
     },
     "tasksRunnerOptions": {
+      "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/tasksRunnerOptions"
       }
@@ -82,8 +83,7 @@
           "type": "string",
           "description": "The default schematics collection to use."
         }
-      },
-      "additionalProperties": false
+      }
     },
     "generatorOptions": {
       "type": "object",

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://nx.dev/core-concepts/configuration#nxjson",
+  "title": "JSON schema for Nx configuration",
+  "type": "object",
+  "properties": {
+    "implicitDependencies": {
+      "type": "object",
+      "description": "Map of files to projects that implicitly depend on them."
+    },
+    "affected": {
+      "type": "object",
+      "description": "Default options for `nx affected`.",
+      "properties": {
+        "defaultBase": {
+          "type": "string",
+          "description": "Default based branch used by affected commands."
+        }
+      },
+      "additionalProperties": false
+    },
+    "npmScope": {
+      "type": "string",
+      "description": "NPM Scope that the workspace uses."
+    },
+    "tasksRunnerOptions": {
+      "additionalProperties": {
+        "$ref": "#/definitions/tasksRunnerOptions"
+      }
+    },
+    "targetDependencies": {
+      "type": "object",
+      "description": "Dependencies between different target names across all projects.",
+      "additionalProperties": {
+        "$ref": "#/definitions/targetDependencyConfig"
+      }
+    },
+    "workspaceLayout": {
+      "type": "object",
+      "description": "Where new apps + libs should be placed.",
+      "properties": {
+        "libsDir": {
+          "type": "string",
+          "description": "Default folder name for libs."
+        },
+        "appsDir": {
+          "type": "string",
+          "description": "Default folder name for apps."
+        }
+      },
+      "additionalProperties": false
+    },
+    "cli": {
+      "$ref": "#/definitions/cliOptions"
+    },
+    "generators": {
+      "$ref": "#/definitions/generatorOptions"
+    },
+    "plugins": {
+      "type": "array",
+      "description": "Plugins for extending the project graph.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "defaultProject": {
+      "type": "string",
+      "description": "Default project. When project isn't provided, the default project will be used."
+    }
+  },
+  "definitions": {
+    "cliOptions": {
+      "type": "object",
+      "description": "Default generator collection.",
+      "properties": {
+        "packageManager": {
+          "type": "string",
+          "description": "The default package manager to use.",
+          "enum": ["yarn", "pnpm", "npm"]
+        },
+        "defaultCollection": {
+          "type": "string",
+          "description": "The default schematics collection to use."
+        }
+      },
+      "additionalProperties": false
+    },
+    "generatorOptions": {
+      "type": "object",
+      "description": "List of default values used by generators."
+    },
+    "tasksRunnerOptions": {
+      "type": "object",
+      "description": "Available Task Runners.",
+      "properties": {
+        "runner": {
+          "type": "string",
+          "description": "Path to resolve the runner."
+        },
+        "options": {
+          "type": "object",
+          "description": "Default options for the runner."
+        }
+      },
+      "additionalProperties": false
+    },
+    "targetDependencyConfig": {
+      "type": "array",
+      "description": "Target dependency.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "projects": {
+            "type": "string",
+            "description": "The projects that the targets belong to.",
+            "enum": ["self", "dependencies"]
+          },
+          "target": {
+            "type": "string",
+            "description": "The name of the target."
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -5,6 +5,7 @@
   "type": "object",
   "properties": {
     "targets": {
+      "type": "object",
       "description": "Configures all the targets which define what tasks you can run against the project",
       "additionalProperties": {
         "type": "object",
@@ -23,6 +24,7 @@
             }
           },
           "configurations": {
+            "type": "object",
             "description": "provides extra sets of values that will be merged into the options map",
             "additionalProperties": {
               "type": "object"

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://nx.dev/project-schema",
+  "title": "JSON schema for Nx projects",
+  "type": "object",
+  "properties": {
+    "targets": {
+      "description": "Configures all the targets which define what tasks you can run against the project",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "executor": {
+            "description": "The function that Nx will invoke when you run this target",
+            "type": "string"
+          },
+          "options": {
+            "type": "object"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "configurations": {
+            "description": "provides extra sets of values that will be merged into the options map",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "dependsOn": {
+            "type": "array",
+            "description": "Target dependency.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "projects": {
+                  "type": "string",
+                  "description": "The projects that the targets belong to.",
+                  "enum": ["self", "dependencies"]
+                },
+                "target": {
+                  "type": "string",
+                  "description": "The name of the target."
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "implicitDependencies": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/packages/nx/schemas/workspace-schema.json
+++ b/packages/nx/schemas/workspace-schema.json
@@ -12,45 +12,6 @@
   "allOf": [
     {
       "if": {
-        "properties": { "version": { "const": 1 } },
-        "required": ["version"]
-      },
-      "then": {
-        "properties": {
-          "projects": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "architect": {
-                  "description": "Configures all the targets which define what tasks you can run against the project",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "builder": {
-                        "description": "The function that Nx will invoke when you run this architect",
-                        "type": "string"
-                      },
-                      "options": {
-                        "type": "object"
-                      },
-                      "configurations": {
-                        "description": "provides extra sets of values that will be merged into the options map",
-                        "additionalProperties": {
-                          "type": "object"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "if": {
         "properties": { "version": { "const": 2 } },
         "required": ["version"]
       },
@@ -67,6 +28,7 @@
                   "type": "object",
                   "properties": {
                     "targets": {
+                      "type": "object",
                       "description": "Configures all the targets which define what tasks you can run against the project",
                       "additionalProperties": {
                         "type": "object",
@@ -85,6 +47,7 @@
                             }
                           },
                           "configurations": {
+                            "type": "object",
                             "description": "provides extra sets of values that will be merged into the options map",
                             "additionalProperties": {
                               "type": "object"
@@ -127,6 +90,41 @@
                   }
                 }
               ]
+            }
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "projects": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "architect": {
+                  "type": "object",
+                  "description": "Configures all the targets which define what tasks you can run against the project",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "builder": {
+                        "description": "The function that Nx will invoke when you run this architect",
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object"
+                      },
+                      "configurations": {
+                        "type": "object",
+                        "description": "provides extra sets of values that will be merged into the options map",
+                        "additionalProperties": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/packages/nx/schemas/workspace-schema.json
+++ b/packages/nx/schemas/workspace-schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://nx.dev",
+  "title": "JSON schema for Nx workspaces",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "number",
+      "enum": [1, 2]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "version": { "const": 1 } },
+        "required": ["version"]
+      },
+      "then": {
+        "properties": {
+          "projects": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "architect": {
+                  "description": "Configures all the targets which define what tasks you can run against the project",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "builder": {
+                        "description": "The function that Nx will invoke when you run this architect",
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object"
+                      },
+                      "configurations": {
+                        "description": "provides extra sets of values that will be merged into the options map",
+                        "additionalProperties": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "version": { "const": 2 } },
+        "required": ["version"]
+      },
+      "then": {
+        "properties": {
+          "projects": {
+            "type": "object",
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "targets": {
+                      "description": "Configures all the targets which define what tasks you can run against the project",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "executor": {
+                            "description": "The function that Nx will invoke when you run this target",
+                            "type": "string"
+                          },
+                          "options": {
+                            "type": "object"
+                          },
+                          "outputs": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "configurations": {
+                            "description": "provides extra sets of values that will be merged into the options map",
+                            "additionalProperties": {
+                              "type": "object"
+                            }
+                          },
+                          "dependsOn": {
+                            "type": "array",
+                            "description": "Target dependency.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "projects": {
+                                  "type": "string",
+                                  "description": "The projects that the targets belong to.",
+                                  "enum": ["self", "dependencies"]
+                                },
+                                "target": {
+                                  "type": "string",
+                                  "description": "The name of the target."
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "implicitDependencies": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/nx/src/generators/utils/project-configuration.spec.ts
+++ b/packages/nx/src/generators/utils/project-configuration.spec.ts
@@ -85,12 +85,7 @@ describe('project configuration', () => {
     describe('addProjectConfiguration', () => {
       it('should throw when standalone is true', () => {
         expect(() =>
-          addProjectConfiguration(
-            tree,
-            'test',
-            baseTestProjectConfigV2,
-            true
-          )
+          addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true)
         ).toThrow();
       });
 
@@ -152,22 +147,12 @@ describe('project configuration', () => {
 
       it('should throw when standalone is true', () => {
         expect(() =>
-          addProjectConfiguration(
-            tree,
-            'test',
-            baseTestProjectConfigV2,
-            true
-          )
+          addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true)
         ).toThrow();
       });
 
       it('should update workspace.json file correctly when adding a project', () => {
-        addProjectConfiguration(
-          tree,
-          'test',
-          baseTestProjectConfigV2,
-          false
-        );
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, false);
 
         expect(readJson(tree, 'workspace.json').projects.test).toEqual(
           baseTestProjectConfigV1
@@ -175,12 +160,7 @@ describe('project configuration', () => {
       });
 
       it('should update workspace.json file correctly when updating a project', () => {
-        addProjectConfiguration(
-          tree,
-          'test',
-          baseTestProjectConfigV2,
-          false
-        );
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, false);
         const updatedProjectConfiguration = {
           ...baseTestProjectConfigV2,
           targets: { build: { executor: '' } },
@@ -197,12 +177,7 @@ describe('project configuration', () => {
       });
 
       it('should remove project configuration', () => {
-        addProjectConfiguration(
-          tree,
-          'test',
-          baseTestProjectConfigV2,
-          false
-        );
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, false);
         removeProjectConfiguration(tree, 'test');
 
         expect(readJson(tree, 'workspace.json').projects.test).toBeUndefined();

--- a/packages/nx/src/generators/utils/project-configuration.spec.ts
+++ b/packages/nx/src/generators/utils/project-configuration.spec.ts
@@ -339,6 +339,15 @@ describe('project configuration', () => {
         expect(configurations.get('test')).toEqual(baseTestProjectConfigV2);
         expect(configurations.get('test2')).toEqual(baseTestProjectConfigV2);
       });
+
+      it('should have JSON $schema in project configuration for standalone projects', () => {
+        addProjectConfiguration(tree, 'test', baseTestProjectConfigV2, true);
+        const projectJson = readJson(tree, 'libs/test/project.json');
+        expect(projectJson['$schema']).toBeTruthy();
+        expect(projectJson['$schema']).toEqual(
+          '../../node_modules/nx/schemas/project-schema.json'
+        );
+      });
     });
 
     describe('updateWorkspaceConfiguration', () => {

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -352,7 +352,10 @@ function addProjectToWorkspaceJson(
     (mode === 'create' && standalone) || !workspaceConfigPath
       ? joinPathFragments(project.root, 'project.json')
       : getProjectFileLocation(tree, projectName);
-  const shouldAddJsonSchema = configFile && mode === 'create' && standalone;
+  const jsonSchema =
+    configFile && mode === 'create' && standalone
+      ? { $schema: getRelativeProjectJsonSchemaPath(tree, project) }
+      : {};
 
   if (configFile) {
     if (mode === 'delete') {
@@ -366,9 +369,7 @@ function addProjectToWorkspaceJson(
 
       // update the project.json file
       writeJson(tree, configFile, {
-        ...(shouldAddJsonSchema
-          ? { $schema: getRelativeProjectJsonSchemaPath(tree, project) }
-          : {}),
+        ...jsonSchema,
         ...project,
         root: undefined,
       });

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -1,3 +1,10 @@
+import { basename, dirname, join, relative } from 'path';
+import type { NxJsonConfiguration } from '../../config/nx-json';
+import {
+  ProjectConfiguration,
+  RawWorkspaceJsonConfiguration,
+  WorkspaceJsonConfiguration,
+} from '../../config/workspace-json-project-json';
 import {
   buildWorkspaceConfigurationFromGlobs,
   deduplicateProjectFiles,
@@ -5,18 +12,11 @@ import {
   reformattedWorkspaceJsonOrNull,
   toNewFormat,
 } from '../../config/workspaces';
-import { basename, dirname, join, relative } from 'path';
-
-import { readJson, updateJson, writeJson } from './json';
+import { joinPathFragments } from '../../utils/path';
 
 import type { Tree } from '../tree';
-import type { NxJsonConfiguration } from '../../config/nx-json';
-import { joinPathFragments } from '../../utils/path';
-import {
-  ProjectConfiguration,
-  RawWorkspaceJsonConfiguration,
-  WorkspaceJsonConfiguration,
-} from '../../config/workspace-json-project-json';
+
+import { readJson, updateJson, writeJson } from './json';
 
 export type WorkspaceConfiguration = Omit<
   WorkspaceJsonConfiguration,
@@ -314,6 +314,16 @@ function setProjectConfiguration(
   );
 }
 
+export function getRelativeProjectJsonSchemaPath(
+  tree: Tree,
+  project: ProjectConfiguration
+): string {
+  return relative(
+    join(tree.root, project.root),
+    join(tree.root, 'node_modules/nx/schemas/project-schema.json')
+  );
+}
+
 function addProjectToWorkspaceJson(
   tree: Tree,
   projectName: string,
@@ -342,6 +352,7 @@ function addProjectToWorkspaceJson(
     (mode === 'create' && standalone) || !workspaceConfigPath
       ? joinPathFragments(project.root, 'project.json')
       : getProjectFileLocation(tree, projectName);
+  const shouldAddJsonSchema = configFile && mode === 'create' && standalone;
 
   if (configFile) {
     if (mode === 'delete') {
@@ -354,15 +365,17 @@ function addProjectToWorkspaceJson(
       }
 
       // update the project.json file
-      const relativeJsonSchemaPath = relative(
-        join(tree.root, project.root),
-        join(tree.root, 'node_modules/nx/schemas/project-schema.json')
+      writeJson(
+        tree,
+        configFile,
+          {
+            ...(shouldAddJsonSchema
+              ? { $schema: getRelativeProjectJsonSchemaPath(tree, project) }
+              : {}),
+            ...project,
+            root: undefined,
+          }
       );
-      writeJson(tree, configFile, {
-        $schema: relativeJsonSchemaPath,
-        ...project,
-        root: undefined,
-      });
     }
   } else if (mode === 'delete') {
     delete workspaceJson.projects[projectName];

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -365,17 +365,13 @@ function addProjectToWorkspaceJson(
       }
 
       // update the project.json file
-      writeJson(
-        tree,
-        configFile,
-          {
-            ...(shouldAddJsonSchema
-              ? { $schema: getRelativeProjectJsonSchemaPath(tree, project) }
-              : {}),
-            ...project,
-            root: undefined,
-          }
-      );
+      writeJson(tree, configFile, {
+        ...(shouldAddJsonSchema
+          ? { $schema: getRelativeProjectJsonSchemaPath(tree, project) }
+          : {}),
+        ...project,
+        root: undefined,
+      });
     }
   } else if (mode === 'delete') {
     delete workspaceJson.projects[projectName];

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -353,7 +353,7 @@ function addProjectToWorkspaceJson(
       ? joinPathFragments(project.root, 'project.json')
       : getProjectFileLocation(tree, projectName);
   const jsonSchema =
-    configFile && mode === 'create' && standalone
+    configFile && mode === 'create'
       ? { $schema: getRelativeProjectJsonSchemaPath(tree, project) }
       : {};
 

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -5,7 +5,7 @@ import {
   reformattedWorkspaceJsonOrNull,
   toNewFormat,
 } from '../../config/workspaces';
-import { basename, dirname, relative } from 'path';
+import { basename, dirname, join, relative } from 'path';
 
 import { readJson, updateJson, writeJson } from './json';
 
@@ -352,8 +352,17 @@ function addProjectToWorkspaceJson(
       if (workspaceConfigPath && mode === 'create') {
         workspaceJson.projects[projectName] = project.root;
       }
+
       // update the project.json file
-      writeJson(tree, configFile, { ...project, root: undefined });
+      const relativeJsonSchemaPath = relative(
+        join(tree.root, project.root),
+        join(tree.root, 'node_modules/nx/schemas/project-schema.json')
+      );
+      writeJson(tree, configFile, {
+        $schema: relativeJsonSchemaPath,
+        ...project,
+        root: undefined,
+      });
     }
   } else if (mode === 'delete') {
     delete workspaceJson.projects[projectName];

--- a/packages/nx/src/migrations/update-14-2-0/add-json-schema.spec.ts
+++ b/packages/nx/src/migrations/update-14-2-0/add-json-schema.spec.ts
@@ -1,0 +1,60 @@
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import type { Tree } from '../../generators/tree';
+import { readJson } from '../../generators/utils/json';
+import { addProjectConfiguration } from '../../generators/utils/project-configuration';
+import addJsonSchema from './add-json-schema';
+
+describe('add-json-schema >', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace(2);
+  });
+
+  it('should update nx.json $schema', async () => {
+    const nxJson = readJson(tree, 'nx.json');
+    delete nxJson['$schema'];
+
+    await addJsonSchema(tree);
+    expect(readJson(tree, 'nx.json')['$schema']).toEqual(
+      './node_modules/nx/schemas/nx-schema.json'
+    );
+  });
+
+  it('should update workspace.json $schema', async () => {
+    const workspaceJson = readJson(tree, 'workspace.json');
+    delete workspaceJson['$schema'];
+
+    await addJsonSchema(tree);
+    expect(readJson(tree, 'workspace.json')['$schema']).toEqual(
+      './node_modules/nx/schemas/workspace-schema.json'
+    );
+  });
+
+  it('should update project.json $schema', async () => {
+    addProjectConfiguration(
+      tree,
+      'test',
+      { root: 'libs/test', sourceRoot: 'libs/test/src', targets: {} },
+      true
+    );
+    addProjectConfiguration(
+      tree,
+      'test-two',
+      {
+        root: 'libs/nested/test-two',
+        sourceRoot: 'libs/nested/test-two/src',
+        targets: {},
+      },
+      true
+    );
+
+    await addJsonSchema(tree);
+    expect(readJson(tree, 'libs/test/project.json')['$schema']).toEqual(
+      '../../node_modules/nx/schemas/project-schema.json'
+    );
+    expect(
+      readJson(tree, 'libs/nested/test-two/project.json')['$schema']
+    ).toEqual('../../../node_modules/nx/schemas/project-schema.json');
+  });
+});

--- a/packages/nx/src/migrations/update-14-2-0/add-json-schema.ts
+++ b/packages/nx/src/migrations/update-14-2-0/add-json-schema.ts
@@ -1,0 +1,46 @@
+import { ProjectConfiguration } from '../../config/workspace-json-project-json';
+import type { Tree } from '../../generators/tree';
+import { updateJson } from '../../generators/utils/json';
+import {
+  getProjects,
+  getRelativeProjectJsonSchemaPath,
+  updateProjectConfiguration,
+} from '../../generators/utils/project-configuration';
+
+export default async function (tree: Tree) {
+  // update nx.json $schema
+  const isNxJsonExist = tree.exists('nx.json');
+  if (isNxJsonExist) {
+    updateJson(tree, 'nx.json', (json) => {
+      if (!json['$schema']) {
+        json['$schema'] = './node_modules/nx/schemas/nx-schema.json';
+      }
+      return json;
+    });
+  }
+
+  // update workspace.json $schema
+  const isWorkspaceJsonExist = tree.exists('workspace.json');
+  if (isWorkspaceJsonExist) {
+    updateJson(tree, 'workspace.json', (json) => {
+      if (!json['$schema']) {
+        json['$schema'] = './node_modules/nx/schemas/workspace-schema.json';
+      }
+      return json;
+    });
+  }
+
+  // update projects $schema
+  for (const [projName, projConfig] of getProjects(tree)) {
+    if (projConfig['$schema']) continue;
+
+    const relativeProjectJsonSchemaPath = getRelativeProjectJsonSchemaPath(
+      tree,
+      projConfig
+    );
+    updateProjectConfiguration(tree, projName, {
+      $schema: relativeProjectJsonSchemaPath,
+      ...projConfig,
+    } as ProjectConfiguration);
+  }
+}

--- a/packages/react/src/migrations/update-14-0-0/add-default-development-configurations.spec.ts
+++ b/packages/react/src/migrations/update-14-0-0/add-default-development-configurations.spec.ts
@@ -62,6 +62,7 @@ describe('React default development configuration', () => {
 
     const config = readProjectConfiguration(tree, 'example');
     expect(config).toEqual({
+      $schema: '../../node_modules/nx/schemas/project-schema.json',
       root: 'apps/example',
       projectType: 'application',
     });

--- a/packages/workspace/src/generators/move/move.spec.ts
+++ b/packages/workspace/src/generators/move/move.spec.ts
@@ -1,4 +1,4 @@
-import { Tree } from '@nrwl/devkit';
+import { readJson, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { moveGenerator } from './move';
 import { libraryGenerator } from '../library/library';
@@ -6,7 +6,7 @@ import { libraryGenerator } from '../library/library';
 describe('move', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTreeWithEmptyWorkspace(2);
   });
 
   it('should update jest config when moving down directories', async () => {
@@ -42,6 +42,27 @@ describe('move', () => {
     expect(afterJestConfig).toContain("preset: '../../jest.preset.ts'");
     expect(afterJestConfig).toContain(
       "coverageDirectory: '../../coverage/libs/my-lib-new'"
+    );
+  });
+
+  it('should update $schema path when move', async () => {
+    await libraryGenerator(tree, { name: 'my-lib', standaloneConfig: true });
+
+    let projectJson = readJson(tree, 'libs/my-lib/project.json');
+    expect(projectJson['$schema']).toEqual(
+      '../../node_modules/nx/schemas/project-schema.json'
+    );
+
+    await moveGenerator(tree, {
+      projectName: 'my-lib',
+      importPath: '@proj/shared-mylib',
+      updateImportPath: true,
+      destination: 'shared/my-lib-new',
+    });
+
+    projectJson = readJson(tree, 'libs/shared/my-lib-new/project.json');
+    expect(projectJson['$schema']).toEqual(
+      '../../../node_modules/nx/schemas/project-schema.json'
     );
   });
 });

--- a/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
@@ -71,6 +71,7 @@ Object {
 
 exports[`new should generate an empty nx.json 1`] = `
 Object {
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "affected": Object {
     "defaultBase": "main",
   },
@@ -111,6 +112,7 @@ Object {
 
 exports[`new should generate an empty workspace.json 1`] = `
 Object {
+  "$schema": "./node_modules/nx/schemas/workspace-schema.json",
   "projects": Object {},
   "version": 2,
 }

--- a/packages/workspace/src/generators/workspace/files/__workspaceFile__.json__tmpl__
+++ b/packages/workspace/src/generators/workspace/files/__workspaceFile__.json__tmpl__
@@ -1,4 +1,5 @@
 {
+  "$schema": "./node_modules/nx/schemas/workspace-schema.json",
   "version": 2,
   "projects": {}
 }

--- a/packages/workspace/src/generators/workspace/files/nx.json__tmpl__
+++ b/packages/workspace/src/generators/workspace/files/nx.json__tmpl__
@@ -1,4 +1,5 @@
 {
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "npmScope": "<%= npmScope %>",
   "affected": {
     "defaultBase": "<%= defaultBase %>"

--- a/packages/workspace/src/generators/workspace/workspace.spec.ts
+++ b/packages/workspace/src/generators/workspace/workspace.spec.ts
@@ -25,7 +25,7 @@ describe('@nrwl/workspace:workspace', () => {
     expect(tree.exists('/proj/.prettierignore')).toBe(true);
   });
 
-  it('should create nx.json', async () => {
+  it('should create nx.json and workspace.json', async () => {
     await workspaceGenerator(tree, {
       name: 'proj',
       directory: 'proj',
@@ -35,6 +35,7 @@ describe('@nrwl/workspace:workspace', () => {
     });
     const nxJson = readJson<NxJsonConfiguration>(tree, '/proj/nx.json');
     expect(nxJson).toEqual({
+      $schema: './node_modules/nx/schemas/nx-schema.json',
       npmScope: 'proj',
       affected: {
         defaultBase: 'main',
@@ -65,6 +66,13 @@ describe('@nrwl/workspace:workspace', () => {
           },
         ],
       },
+    });
+
+    const workspaceJson = readJson(tree, '/proj/workspace.json');
+    expect(workspaceJson).toEqual({
+      $schema: './node_modules/nx/schemas/workspace-schema.json',
+      version: 2,
+      projects: {},
     });
   });
 

--- a/packages/workspace/src/generators/workspace/workspace.spec.ts
+++ b/packages/workspace/src/generators/workspace/workspace.spec.ts
@@ -1,8 +1,11 @@
 import { readJson } from '@nrwl/devkit';
 import type { Tree, NxJsonConfiguration } from '@nrwl/devkit';
+import Ajv from 'ajv';
 import { workspaceGenerator } from './workspace';
 import { createTree } from '@nrwl/devkit/testing';
 import { Preset } from '../utils/presets';
+import * as nxSchema from '../../../../nx/schemas/nx-schema.json';
+import * as workspaceSchema from '../../../../nx/schemas/workspace-schema.json';
 
 describe('@nrwl/workspace:workspace', () => {
   let tree: Tree;
@@ -26,6 +29,8 @@ describe('@nrwl/workspace:workspace', () => {
   });
 
   it('should create nx.json and workspace.json', async () => {
+    const ajv = new Ajv();
+
     await workspaceGenerator(tree, {
       name: 'proj',
       directory: 'proj',
@@ -67,6 +72,8 @@ describe('@nrwl/workspace:workspace', () => {
         ],
       },
     });
+    const validateNxJson = ajv.compile(nxSchema);
+    expect(validateNxJson(nxJson)).toEqual(true);
 
     const workspaceJson = readJson(tree, '/proj/workspace.json');
     expect(workspaceJson).toEqual({
@@ -74,6 +81,8 @@ describe('@nrwl/workspace:workspace', () => {
       version: 2,
       projects: {},
     });
+    const validateWorkspaceJson = ajv.compile(workspaceSchema);
+    expect(validateWorkspaceJson(workspaceJson)).toEqual(true);
   });
 
   it('should create a prettierrc file', async () => {

--- a/packages/workspace/src/migrations/update-13-3-0/update-tsc-executor-location.spec.ts
+++ b/packages/workspace/src/migrations/update-13-3-0/update-tsc-executor-location.spec.ts
@@ -43,6 +43,7 @@ describe('add `defaultBase` in nx.json', () => {
     const projects = Object.fromEntries(getProjects(tree).entries());
     expect(projects).toEqual({
       'tsc-project': {
+        $schema: '../../node_modules/nx/schemas/project-schema.json',
         root: 'projects/tsc-project',
         targets: {
           build: {
@@ -54,6 +55,7 @@ describe('add `defaultBase` in nx.json', () => {
         },
       },
       'other-project': {
+        $schema: '../../node_modules/nx/schemas/project-schema.json',
         root: 'projects/other-project',
         targets: {
           build: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5878,7 +5878,7 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.8.0:
+ajv@^8.0.0, ajv@^8.11.0, ajv@^8.8.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
   integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==


### PR DESCRIPTION
ISSUES CLOSED: #8574, #2299

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
There is no intellisense for `nx.json`, `workspace.json`, and `project.json`. VSCode users with Nx Console installed are happy but not us Jetbrains users

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- `nx.json`, `workspace.json`, and `project.json` are generated with proper JSON Schema to help with discoverability
- The JSON schemas are expected to be merged with the ones provided by Nx Console

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8574, #2299
