### PR TITLE
cleanup(js): use import instead of require in jest config

### DIFF
--- a/packages/js/src/generators/library/files/jest-config/jest.config.__ext__
+++ b/packages/js/src/generators/library/files/jest-config/jest.config.__ext__
@@ -1,9 +1,9 @@
-const fs = require('fs');
+import { readFileSync } from 'fs';
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
 const { exclude: _, ...swcJestConfig } = JSON.parse(
-  fs.readFileSync(`${__dirname}/.lib.swcrc`, 'utf-8')
+  readFileSync(`${__dirname}/.lib.swcrc`, 'utf-8')
 );
 
 module.exports = {


### PR DESCRIPTION
if we are going to use typescript we might as well use typescript and use import instead of require
for build in modules that support it

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The generated typescript jest config is using require

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Should use import

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
