### PR TITLE
fix(core): always ignore imports/requires within template literals

### DIFF
--- a/packages/nx/src/project-graph/build-dependencies/typescript-import-locator.ts
+++ b/packages/nx/src/project-graph/build-dependencies/typescript-import-locator.ts
@@ -4,7 +4,7 @@ import { stripSourceCode } from '../../utils/strip-source-code';
 import { defaultFileRead } from '../file-utils';
 import { DependencyType } from '../../config/project-graph';
 
-let tsModule: any;
+let tsModule: typeof ts | undefined;
 
 export class TypeScriptImportLocator {
   private readonly scanner: ts.Scanner;

--- a/packages/nx/src/utils/strip-source-code.spec.ts
+++ b/packages/nx/src/utils/strip-source-code.spec.ts
@@ -275,6 +275,23 @@ require('./c')`;
         )
       ).toEqual('');
 
+      // Multiple subsitutions, whitespace, newlines, etc. should not interefere
+      expect(
+        stripSourceCode(
+          scanner,
+          `
+            const v = \`\${val}
+            \${val}
+                \${val} \${val}
+            
+                  \${val} \${val}
+            
+                  \`;
+            tree.write('/path/to/file.ts', \`import something from "@myorg/foo";\`);
+          `
+        )
+      ).toEqual('');
+
       const input = `    
         import { ProjectConfiguration, Tree } from '@nrwl/devkit';
         require('@myorg/qux');

--- a/packages/nx/src/utils/strip-source-code.ts
+++ b/packages/nx/src/utils/strip-source-code.ts
@@ -105,10 +105,12 @@ export function stripSourceCode(scanner: Scanner, contents: string): string {
        */
       case SyntaxKind.TemplateHead:
         token = scanner.scan();
-        while (token !== SyntaxKind.CloseBraceToken) {
-          token = scanner.scan();
+        while (token !== SyntaxKind.LastTemplateToken) {
+          while (token !== SyntaxKind.CloseBraceToken) {
+            token = scanner.scan();
+          }
+          token = scanner.reScanTemplateHeadOrNoSubstitutionTemplate();
         }
-        scanner.reScanTemplateHeadOrNoSubstitutionTemplate();
         break;
 
       default: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

In some cases, Nx will infer a relationship between projects based on templatized imports/requires in addition to actual import/require statements.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Only genuine import/require statements are considered during project-graph creation, not those found in template literals.

---

Please see the comments inline for more information regarding what was previously happening and the required fix.

All of the test cases added to assert the new behavior will produce incorrect project-graphs in the latest version of Nx

## Related Issue

https://github.com/nrwl/nx/issues/8938