### PR TITLE
fix(core): only migrate projects with project.json

### DIFF
--- a/packages/nx/src/migrations/update-14-0-6/remove-roots.spec.ts
+++ b/packages/nx/src/migrations/update-14-0-6/remove-roots.spec.ts
@@ -1,7 +1,7 @@
 import { Tree } from '../../generators/tree';
 import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
 import { addProjectConfiguration } from '../../generators/utils/project-configuration';
-import { readJson, updateJson } from '../../generators/utils/json';
+import { readJson, updateJson, writeJson } from '../../generators/utils/json';
 import removeRoots from './remove-roots';
 
 describe('remove-roots >', () => {
@@ -28,7 +28,7 @@ describe('remove-roots >', () => {
     });
   });
 
-  describe('projects with project.json configs', () => {
+  describe('projects with workspace.json configs', () => {
     beforeEach(() => {
       tree = createTreeWithEmptyWorkspace(1);
     });
@@ -43,6 +43,24 @@ describe('remove-roots >', () => {
       expect(readJson(tree, 'workspace.json').projects.proj1.root).toEqual(
         'proj1'
       );
+    });
+  });
+
+  describe('projects with package.json configs', () => {
+    beforeEach(() => {
+      tree = createTreeWithEmptyWorkspace(2);
+    });
+
+    it('should remove the root property', async () => {
+      writeJson(tree, 'proj1/package.json', {
+        name: 'proj1',
+      });
+
+      await removeRoots(tree);
+
+      expect(readJson(tree, 'proj1/package.json')).toEqual({
+        name: 'proj1',
+      });
     });
   });
 });

--- a/packages/nx/src/migrations/update-14-0-6/remove-roots.ts
+++ b/packages/nx/src/migrations/update-14-0-6/remove-roots.ts
@@ -4,11 +4,14 @@ import {
   updateProjectConfiguration,
 } from '../../generators/utils/project-configuration';
 import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
+import { join } from 'path';
 
 export default async function (tree: Tree) {
   // This looks like it does nothing, but this will actually effectively migrate over all the configs that need to be moved over, but won't touch configs that don't need to be moved
   for (const [projName, projConfig] of getProjects(tree)) {
-    updateProjectConfiguration(tree, projName, projConfig);
+    if (tree.exists(join(projConfig.root, 'project.json'))) {
+      updateProjectConfiguration(tree, projName, projConfig);
+    }
   }
 
   await formatChangedFilesWithPrettierIfAvailable(tree);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Projects with `package.json` cause the migration removing roots to error

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Projects with `package.json` are skipped during the migration removing roots

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
