### PR TITLE
feat(testing): add diagnostics option to jest generator

### DIFF
--- a/docs/generated/packages/jest.json
+++ b/docs/generated/packages/jest.json
@@ -121,6 +121,11 @@
             "type": "boolean",
             "default": false,
             "description": "Use JavaScript instead of TypeScript for config files"
+          },
+          "diagnostics": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set diagnostics option for ts-jest configuration"
           }
         },
         "required": [],

--- a/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
+++ b/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
@@ -1,5 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`jestProject  --diagnostics should generate jest config with diagnostics enabled on ts-jest 1`] = `
+"/* eslint-disable */
+export default {
+  displayName: 'lib1',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      diagnostics: true,
+    }
+  },
+  coverageDirectory: '../../coverage/libs/lib1'
+};
+"
+`;
+
+exports[`jestProject  --diagnostics should generate jest config with diagnostics enabled on ts-jest for angular project 1`] = `
+"/* eslint-disable */
+export default {
+  displayName: 'lib1',
+  preset: '../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\\\\\\\.(html|svg)$',
+      diagnostics: true,
+    }
+  },
+  coverageDirectory: '../../coverage/libs/lib1',
+  transform: {
+    '^.+\\\\\\\\.(ts|mjs|js|html)$': 'jest-preset-angular'
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\\\\\\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ]
+};
+"
+`;
+
 exports[`jestProject --babelJest should generate proper jest.transform when --compiler=swc and supportTsx is true 1`] = `
 "/* eslint-disable */
 export default {

--- a/packages/jest/src/generators/jest-project/files-angular/jest.config.ts__tmpl__
+++ b/packages/jest/src/generators/jest-project/files-angular/jest.config.ts__tmpl__
@@ -6,7 +6,8 @@
   globals: {
     'ts-jest': {
       tsconfig: '<rootDir>/tsconfig.spec.json',
-      stringifyContentPathRegex: '\\.(html|svg)$',
+      stringifyContentPathRegex: '\\.(html|svg)$',<% if(diagnostics) { %>
+      diagnostics: true,<% } %>
     }
   },<% if(testEnvironment) { %>
   testEnvironment: '<%= testEnvironment %>',<% } %>

--- a/packages/jest/src/generators/jest-project/files/jest.config.ts__tmpl__
+++ b/packages/jest/src/generators/jest-project/files/jest.config.ts__tmpl__
@@ -5,7 +5,8 @@
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],<% } %><% if (transformer === 'ts-jest') { %>
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
+      tsconfig: '<rootDir>/tsconfig.spec.json',<% if(diagnostics) { %>
+      diagnostics: true,<% } %>
     }
   },<% } %><% if(testEnvironment) { %>
   testEnvironment: '<%= testEnvironment %>',<% } %><% if(skipSerializers){ %>

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -362,4 +362,23 @@ describe('jestProject', () => {
       expect(tree.read('libs/lib1/jest.config.ts', 'utf-8')).toMatchSnapshot();
     });
   });
+  describe(' --diagnostics', () => {
+    it('should generate jest config with diagnostics enabled on ts-jest', async () => {
+      await jestProjectGenerator(tree, {
+        ...defaultOptions,
+        project: 'lib1',
+        diagnostics: true,
+      } as JestProjectSchema);
+      expect(tree.read('libs/lib1/jest.config.ts', 'utf-8')).toMatchSnapshot();
+    });
+    it('should generate jest config with diagnostics enabled on ts-jest for angular project', async () => {
+      await jestProjectGenerator(tree, {
+        ...defaultOptions,
+        project: 'lib1',
+        setupFile: 'angular',
+        diagnostics: true,
+      } as JestProjectSchema);
+      expect(tree.read('libs/lib1/jest.config.ts', 'utf-8')).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/jest/src/generators/jest-project/jest-project.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.ts
@@ -13,6 +13,7 @@ const schemaDefaults = {
   supportTsx: false,
   skipSetupFile: false,
   skipSerializers: false,
+  diagnostics: false,
 } as const;
 
 function normalizeOptions(options: JestProjectSchema) {

--- a/packages/jest/src/generators/jest-project/lib/create-files.ts
+++ b/packages/jest/src/generators/jest-project/lib/create-files.ts
@@ -27,6 +27,7 @@ export function createFiles(tree: Tree, options: JestProjectSchema) {
     ...options,
     transformer,
     js: !!options.js,
+    diagnostics: !!options.diagnostics,
     projectRoot: projectConfig.root,
     offsetFromRoot: offsetFromRoot(projectConfig.root),
   });

--- a/packages/jest/src/generators/jest-project/schema.d.ts
+++ b/packages/jest/src/generators/jest-project/schema.d.ts
@@ -16,4 +16,5 @@ export interface JestProjectSchema {
   compiler?: 'tsc' | 'babel' | 'swc';
   skipPackageJson?: boolean;
   js?: boolean;
+  diagnostics?: boolean;
 }

--- a/packages/jest/src/generators/jest-project/schema.json
+++ b/packages/jest/src/generators/jest-project/schema.json
@@ -68,6 +68,11 @@
       "type": "boolean",
       "default": false,
       "description": "Use JavaScript instead of TypeScript for config files"
+    },
+    "diagnostics": {
+      "type": "boolean",
+      "default": false,
+      "description": "Set diagnostics option for ts-jest configuration"
     }
   },
   "required": []


### PR DESCRIPTION
`ts-jest` config accepts `diagnostics` option that makes the test run fail on TypeScript compilation errors.
This PR add option to generator to set `diagnostics`.

