### PR TITLE
fix(react): migrations should not crash when adding development configuration

### DIFF
--- a/packages/next/src/migrations/update-14-0-0/add-default-development-configurations.spec.ts
+++ b/packages/next/src/migrations/update-14-0-0/add-default-development-configurations.spec.ts
@@ -42,6 +42,43 @@ describe('React default development configuration', () => {
     });
   });
 
+  it('should add development configuration if no configurations at all', async () => {
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(
+      tree,
+      'example',
+      {
+        root: 'apps/example',
+        projectType: 'application',
+        targets: {
+          build: {
+            executor: '@nrwl/next:build',
+            defaultConfiguration: 'production',
+            configurations: { production: {} },
+          },
+          serve: {
+            executor: '@nrwl/next:server',
+          },
+        },
+      },
+      true
+    );
+
+    await update(tree);
+
+    const config = readProjectConfiguration(tree, 'example');
+
+    expect(config.targets.build.defaultConfiguration).toEqual('production');
+    expect(config.targets.build.configurations.production).toEqual({});
+    expect(config.targets.build.configurations.development).toEqual({});
+
+    expect(config.targets.serve.defaultConfiguration).toEqual('development');
+    expect(config.targets.serve.configurations.development).toEqual({
+      buildTarget: `example:build:development`,
+      dev: true,
+    });
+  });
+
   it('should work without targets', async () => {
     const tree = createTreeWithEmptyWorkspace(2);
     addProjectConfiguration(

--- a/packages/next/src/migrations/update-14-0-0/add-default-development-configurations.ts
+++ b/packages/next/src/migrations/update-14-0-0/add-default-development-configurations.ts
@@ -13,12 +13,14 @@ export async function update(tree: Tree) {
     if (config.targets?.build?.executor === '@nrwl/next:build') {
       shouldUpdate = true;
       config.targets.build.defaultConfiguration ??= 'production';
+      config.targets.build.configurations ??= {};
       config.targets.build.configurations.development ??= {};
     }
 
     if (config.targets?.serve?.executor === '@nrwl/next:server') {
       shouldUpdate = true;
       config.targets.serve.defaultConfiguration ??= 'development';
+      config.targets.serve.configurations ??= {};
       config.targets.serve.configurations.development ??= {
         buildTarget: `${name}:build:development`,
         dev: true,

--- a/packages/react/src/migrations/update-14-0-0/add-default-development-configurations.spec.ts
+++ b/packages/react/src/migrations/update-14-0-0/add-default-development-configurations.spec.ts
@@ -46,6 +46,49 @@ describe('React default development configuration', () => {
     });
   });
 
+  it('should add development configuration if no configurations at all', async () => {
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(
+      tree,
+      'example',
+      {
+        root: 'apps/example',
+        projectType: 'application',
+        targets: {
+          build: {
+            executor: '@nrwl/web:webpack',
+            defaultConfiguration: 'production',
+            configurations: { production: { sourceMap: false } },
+          },
+          serve: {
+            executor: '@nrwl/web:dev-server',
+          },
+        },
+      },
+      true
+    );
+
+    await update(tree);
+
+    const config = readProjectConfiguration(tree, 'example');
+
+    expect(config.targets.build.defaultConfiguration).toEqual('production');
+    expect(config.targets.build.configurations.production).toEqual({
+      sourceMap: false,
+    });
+    expect(config.targets.build.configurations.development).toEqual({
+      extractLicenses: false,
+      optimization: false,
+      sourceMap: true,
+      vendorChunk: true,
+    });
+
+    expect(config.targets.serve.defaultConfiguration).toEqual('development');
+    expect(config.targets.serve.configurations.development).toEqual({
+      buildTarget: `example:build:development`,
+    });
+  });
+
   it('should work without targets', async () => {
     const tree = createTreeWithEmptyWorkspace(2);
     addProjectConfiguration(

--- a/packages/react/src/migrations/update-14-0-0/add-default-development-configurations.ts
+++ b/packages/react/src/migrations/update-14-0-0/add-default-development-configurations.ts
@@ -13,6 +13,7 @@ export async function update(tree: Tree) {
     if (config.targets?.build?.executor === '@nrwl/web:webpack') {
       shouldUpdate = true;
       config.targets.build.defaultConfiguration ??= 'production';
+      config.targets.build.configurations ??= {};
       config.targets.build.configurations.development ??= {
         extractLicenses: false,
         optimization: false,
@@ -24,6 +25,7 @@ export async function update(tree: Tree) {
     if (config.targets?.serve?.executor === '@nrwl/web:dev-server') {
       shouldUpdate = true;
       config.targets.serve.defaultConfiguration ??= 'development';
+      config.targets.serve.configurations ??= {};
       config.targets.serve.configurations.development ??= {
         buildTarget: `${name}:build:development`,
       };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Some `project.json` cannot be migrated automatically using the `add-default-development-configurations` script (when they don't contain the configurations key in a target)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The migration script should work smoothly for all targets!

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10259 
