### PR TITLE
docs(nxdev): change header plugins link to community

### DIFF
--- a/nx-dev/ui-common/src/lib/header.tsx
+++ b/nx-dev/ui-common/src/lib/header.tsx
@@ -72,20 +72,12 @@ export function Header(props: HeaderProps) {
                 Docs
               </a>
             </Link>
-            <Link href="/extending-nx/nx-devkit">
+            <Link href="/community#create-nx-plugin">
               <a
                 title="Check Nx available plugins"
                 className="hidden px-3 py-2 leading-tight text-white md:inline-flex"
               >
                 Plugins
-              </a>
-            </Link>
-            <Link href="/community">
-              <a
-                title="Check Nx community"
-                className="hidden px-3 py-2 leading-tight text-white md:inline-flex"
-              >
-                Community
               </a>
             </Link>
             <Link href="/conf">


### PR DESCRIPTION
It changes the link of the plugins header menu item to point now towards the community page on nx.dev.
