### PR TITLE
feat(nextjs): improve asset options for build compilation

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -1,5 +1,6 @@
 import { stringUtils } from '@nrwl/workspace';
 import {
+  checkFilesDoNotExist,
   checkFilesExist,
   cleanupProject,
   createFile,
@@ -35,8 +36,8 @@ describe('Next.js Applications', () => {
     runCLI(`generate @nrwl/react:lib ${reactLib} --no-interactive`);
     runCLI(`generate @nrwl/js:lib ${jsLib} --no-interactive`);
 
-    // Create file in public that should be copied to dist
-    updateFile(`apps/${appName}/public/a/b.txt`, `Hello World!`);
+    // Create file in public that should not be copied to dist since it's not declared
+    updateFile(`apps/${appName}/a/b.txt`, `Hello World!`);
 
     // Additional assets that should be copied to dist
     const sharedLib = uniq('sharedLib');
@@ -134,11 +135,11 @@ describe('Next.js Applications', () => {
       checkExport: false,
     });
 
-    // public and shared assets should both be copied to dist
-    checkFilesExist(
-      `dist/apps/${appName}/public/a/b.txt`,
-      `dist/apps/${appName}/public/shared/ui/hello.txt`
-    );
+    // declared assets should be copied to dist
+    checkFilesExist(`dist/apps/${appName}/.next/shared/ui/hello.txt`);
+
+    // undeclared asset should not be copied to dist
+    checkFilesDoNotExist(`dist/apps/${appName}/.next/a/b.txt`);
   }, 300000);
 
   it('should be able to serve with a proxy configuration', async () => {

--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -132,15 +132,10 @@ export function createWebpackConfig(
       });
     }
 
-    // Copy (shared) assets to `public` folder during client-side compilation
+    // Copy (shared) assets to `dist` folder during client-side compilation
     if (!isServer && Array.isArray(assets) && assets.length > 0) {
       config.plugins.push(
-        createCopyPlugin(
-          normalizeAssets(assets, workspaceRoot, projectRoot).map((asset) => ({
-            ...asset,
-            output: join('../public', asset.output),
-          }))
-        )
+        createCopyPlugin(normalizeAssets(assets, workspaceRoot, projectRoot))
       );
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
All asset files are moved into `/public/` 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Asset files location are solely controlled by the config which is provided

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
