### PR TITLE
fix(js): move swc/helpers to dependencies instead of devDependencies

### DIFF
--- a/packages/js/src/utils/swc/add-swc-dependencies.ts
+++ b/packages/js/src/utils/swc/add-swc-dependencies.ts
@@ -4,10 +4,11 @@ import { swcCliVersion, swcCoreVersion, swcHelpersVersion } from '../versions';
 export function addSwcDependencies(tree: Tree) {
   addDependenciesToPackageJson(
     tree,
-    {},
+    {
+      '@swc/helpers': swcHelpersVersion,
+    },
     {
       '@swc/core': swcCoreVersion,
-      '@swc/helpers': swcHelpersVersion,
       '@swc/cli': swcCliVersion,
     }
   );


### PR DESCRIPTION
ISSUES CLOSED: #10270

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@swc/helpers` is added to lib's `devDependencies` causing runtime error for the library if the library uses `swc/helpers` utilities and it's not included in the `generatedPackageJson`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`@swc/helpers` should be in `dependencies`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10270
