### PR TITLE
Enabling dynamic gradle tasks on andriod-build command

### DIFF
--- a/docs/generated/packages/react-native.json
+++ b/docs/generated/packages/react-native.json
@@ -715,6 +715,10 @@
           "debug": {
             "type": "boolean",
             "description": "Generate a debug build instead of a release build."
+          },
+          "gradleTask": {
+            "type": "string",
+            "description": "Override default gradle task incase of multi build variants"
           }
         },
         "required": [],

--- a/packages/react-native/src/executors/build-android/build-android.impl.ts
+++ b/packages/react-native/src/executors/build-android/build-android.impl.ts
@@ -64,8 +64,8 @@ function runCliBuild(
 }
 
 function getGradleCommand(options: ReactNativeBuildOptions) {
-  if(options?.gradleTask) {
-    return options.gradleTask
+  if (options?.gradleTask) {
+    return options.gradleTask;
   }
   if (options.apk) {
     if (options.debug) {

--- a/packages/react-native/src/executors/build-android/build-android.impl.ts
+++ b/packages/react-native/src/executors/build-android/build-android.impl.ts
@@ -64,6 +64,9 @@ function runCliBuild(
 }
 
 function getGradleCommand(options: ReactNativeBuildOptions) {
+  if(options.gradleTask) {
+    return options.gradleTask
+  }
   if (options.apk) {
     if (options.debug) {
       return 'assembleDebug';

--- a/packages/react-native/src/executors/build-android/build-android.impl.ts
+++ b/packages/react-native/src/executors/build-android/build-android.impl.ts
@@ -64,7 +64,7 @@ function runCliBuild(
 }
 
 function getGradleCommand(options: ReactNativeBuildOptions) {
-  if(options.gradleTask) {
+  if(options?.gradleTask) {
     return options.gradleTask
   }
   if (options.apk) {

--- a/packages/react-native/src/executors/build-android/schema.d.ts
+++ b/packages/react-native/src/executors/build-android/schema.d.ts
@@ -1,4 +1,5 @@
 export interface ReactNativeBuildOptions {
   apk?: boolean;
   debug?: boolean;
+  gradleTask?: string;
 }

--- a/packages/react-native/src/executors/build-android/schema.json
+++ b/packages/react-native/src/executors/build-android/schema.json
@@ -13,6 +13,10 @@
     "debug": {
       "type": "boolean",
       "description": "Generate a debug build instead of a release build."
+    },
+    "gradleTask": {
+      "type": "string",
+      "description": "Override default gradle task incase of multi build variants"
     }
   },
   "required": []


### PR DESCRIPTION
Adding an option to override the default gradle task