### PR TITLE
docs(nxdev): fix installation instruction in react nx tutorial

### DIFF
--- a/docs/shared/react-tutorial/01-create-application.md
+++ b/docs/shared/react-tutorial/01-create-application.md
@@ -118,7 +118,7 @@ yarn global add nx
 Alternatively, you can run the local installation of Nx by prepending every command with `npx`:
 
 ```bash
-npx nx -- serve todos
+npx nx serve todos
 ```
 
 or


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
According to this [React Tutorial](https://nx.dev/react-tutorial/01-create-application#note-on-the-nx-cli), you can run the local Nx installation using, `npx nx -- serve todos`. This does not work.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The correct command is `npx nx serve todos`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/nrwl/nx/issues/10278
Fixes #

I replaced it with the right command.