### PR TITLE
fix(js): change swc default target back to es2015 as the bug upstream…

### DIFF
--- a/packages/js/src/utils/swc/add-swc-config.ts
+++ b/packages/js/src/utils/swc/add-swc-config.ts
@@ -12,7 +12,7 @@ export const defaultExclude = [
 
 const swcOptionsString = () => `{
   "jsc": {
-    "target": "es2015",
+    "target": "es2017",
     "parser": {
       "syntax": "typescript",
       "decorators": true,

--- a/packages/js/src/utils/swc/add-swc-config.ts
+++ b/packages/js/src/utils/swc/add-swc-config.ts
@@ -1,5 +1,3 @@
-// TODO(chau): change back to 2015 when https://github.com/swc-project/swc/issues/1108 is solved
-// target: 'es2015'
 import { Tree } from '@nrwl/devkit';
 import { join } from 'path';
 
@@ -14,7 +12,7 @@ export const defaultExclude = [
 
 const swcOptionsString = () => `{
   "jsc": {
-    "target": "es2017",
+    "target": "es2015",
     "parser": {
       "syntax": "typescript",
       "decorators": true,


### PR DESCRIPTION
… was fixed

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Generated `.swcrc` has `es2017` as target

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generated `.swcrc` has `es2015` as target and `commonjs`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
