### PR TITLE
feat(nest): add simpleModuleName flag to nest library generation

### DIFF
--- a/docs/generated/packages/nest.json
+++ b/docs/generated/packages/nest.json
@@ -279,6 +279,11 @@
             "type": "boolean",
             "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
             "default": false
+          },
+          "simpleModuleName": {
+            "description": "Keep the module name simple (when using `--directory`).",
+            "type": "boolean",
+            "default": false
           }
         },
         "additionalProperties": false,

--- a/packages/nest/src/generators/library/lib/create-files.ts
+++ b/packages/nest/src/generators/library/lib/create-files.ts
@@ -10,7 +10,7 @@ import type { NormalizedOptions } from '../schema';
 export function createFiles(tree: Tree, options: NormalizedOptions): void {
   const substitutions = {
     ...options,
-    ...names(options.projectName),
+    ...names(options.moduleName),
     tmpl: '',
     offsetFromRoot: offsetFromRoot(options.projectRoot),
   };

--- a/packages/nest/src/generators/library/lib/normalize-options.ts
+++ b/packages/nest/src/generators/library/lib/normalize-options.ts
@@ -15,8 +15,9 @@ export function normalizeOptions(
     : name;
 
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
-  const fileName = projectName;
+  const fileName = options.simpleModuleName ? name : projectName;
   const projectRoot = joinPathFragments(libsDir, projectDirectory);
+  const moduleName = options.simpleModuleName ? name : projectName;
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())
@@ -33,6 +34,7 @@ export function normalizeOptions(
     projectDirectory,
     projectName,
     projectRoot,
+    moduleName,
     service: options.service ?? false,
     target: options.target ?? 'es6',
     testEnvironment: options.testEnvironment ?? 'node',

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -374,4 +374,32 @@ describe('lib', () => {
       ).toMatchSnapshot();
     });
   });
+
+  describe('--simpleModuleName', () => {
+    it('should create library with simple module name', async () => {
+      await libraryGenerator(tree, {
+        name: 'alfred-auth',
+        simpleModuleName: true,
+        directory: 'api',
+      });
+
+      expect(tree.exists(`libs/api/alfred-auth/README.md`)).toBeTruthy();
+      expect(tree.exists(`libs/api/alfred-auth/src/index.ts`)).toBeTruthy();
+      expect(tree.exists(`libs/api/alfred-auth/tsconfig.json`)).toBeTruthy();
+      expect(
+        tree.exists(`libs/api/alfred-auth/tsconfig.lib.json`)
+      ).toBeTruthy();
+      expect(tree.exists(`libs/api/alfred-auth/.eslintrc.json`)).toBeTruthy();
+      expect(tree.exists(`libs/api/alfred-auth/jest.config.ts`)).toBeTruthy();
+      expect(
+        tree.exists(`libs/api/alfred-auth/tsconfig.spec.json`)
+      ).toBeTruthy();
+      expect(
+        tree.exists(`libs/api/alfred-auth/src/lib/alfred-auth.module.ts`)
+      ).toBeTruthy();
+      expect(
+        tree.exists(`libs/api/alfred-auth/src/lib/api-alfred-auth.module.ts`)
+      ).toBeFalsy();
+    });
+  });
 });

--- a/packages/nest/src/generators/library/schema.d.ts
+++ b/packages/nest/src/generators/library/schema.d.ts
@@ -29,6 +29,7 @@ export interface LibraryGeneratorOptions {
   unitTestRunner?: UnitTestRunner;
   standaloneConfig?: boolean;
   setParserOptionsProject?: boolean;
+  simpleModuleName?: boolean;
 }
 
 export interface NormalizedOptions extends LibraryGeneratorOptions {
@@ -38,4 +39,5 @@ export interface NormalizedOptions extends LibraryGeneratorOptions {
   projectDirectory: string;
   projectName: string;
   projectRoot: Path;
+  moduleName: string;
 }

--- a/packages/nest/src/generators/library/schema.json
+++ b/packages/nest/src/generators/library/schema.json
@@ -117,6 +117,11 @@
       "type": "boolean",
       "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
       "default": false
+    },
+    "simpleModuleName": {
+      "description": "Keep the module name simple (when using `--directory`).",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Current Behavior
Nest Libraries inside directories have directory name in module name.

## Expected Behavior
Schematic check if simpleModuleName is true and adjust module name.

## Related Issue(s)
#10125 

Fixes #
