### PR TITLE
docs(nxdev): update dead links in ci section

### DIFF
--- a/docs/shared/monorepo-ci-azure.md
+++ b/docs/shared/monorepo-ci-azure.md
@@ -109,6 +109,6 @@ jobs:
         condition: always()
 ```
 
-You can also use our [ci-workflow generator](https://nx.app/packages/workspace/generators/ci-workflow) to generate the pipeline file.
+You can also use our [ci-workflow generator](https://nx.dev/packages/workspace/generators/ci-workflow) to generate the pipeline file.
 
 Learn more about [configuring your CI](https://nx.app/docs/configuring-ci) environment using Nx Cloud with [Distributed Caching](https://nx.app/docs/distributed-caching) and [Distributed Task Execution](https://nx.app/docs/distributed-execution) in the Nx Cloud docs.

--- a/docs/shared/monorepo-ci-circle-ci.md
+++ b/docs/shared/monorepo-ci-circle-ci.md
@@ -105,6 +105,6 @@ workflows:
       - main
 ```
 
-You can also use our [ci-workflow generator](https://nx.app/packages/workspace/generators/ci-workflow) to generate the configuration file.
+You can also use our [ci-workflow generator](https://nx.dev/packages/workspace/generators/ci-workflow) to generate the configuration file.
 
 Learn more about [configuring your CI](https://nx.app/docs/configuring-ci) environment using Nx Cloud with [Distributed Caching](https://nx.app/docs/distributed-caching) and [Distributed Task Execution](https://nx.app/docs/distributed-execution) in the Nx Cloud docs.

--- a/docs/shared/monorepo-ci-github-actions.md
+++ b/docs/shared/monorepo-ci-github-actions.md
@@ -82,6 +82,6 @@ jobs:
       number-of-agents: 3
 ```
 
-You can also use our [ci-workflow generator](https://nx.app/packages/workspace/generators/ci-workflow) to generate the workflow file.
+You can also use our [ci-workflow generator](https://nx.dev/packages/workspace/generators/ci-workflow) to generate the workflow file.
 
 Learn more about [configuring your CI](https://nx.app/docs/configuring-ci) environment using Nx Cloud with [Distributed Caching](https://nx.app/docs/distributed-caching) and [Distributed Task Execution](https://nx.app/docs/distributed-execution) in the Nx Cloud docs.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Links to the ci-workflow generator on multiple pages were pointing to nx.app instead of nx.dev which results in dead links.


## Expected Behavior
The links should work and point to the correct file.

