### PR TITLE
feat(node): add hashingExcludesTests option to webpack

### DIFF
--- a/docs/generated/packages/node.json
+++ b/docs/generated/packages/node.json
@@ -511,6 +511,7 @@
         },
         "presets": []
       },
+      "hasher": "./src/executors/webpack/hasher",
       "description": "Build a Node application using Webpack.",
       "aliases": [],
       "hidden": false,

--- a/packages/node/executors.json
+++ b/packages/node/executors.json
@@ -3,6 +3,7 @@
     "webpack": {
       "implementation": "./src/executors/webpack/webpack.impl",
       "schema": "./src/executors/webpack/schema.json",
+      "hasher": "./src/executors/webpack/hasher",
       "description": "Build a Node application using Webpack."
     },
     "node": {

--- a/packages/node/src/executors/webpack/hasher.ts
+++ b/packages/node/src/executors/webpack/hasher.ts
@@ -1,0 +1,15 @@
+import { Task, Hash, HasherContext } from '@nrwl/devkit';
+
+export default async function run(
+  task: Task,
+  context: HasherContext
+): Promise<Hash> {
+  const nodeWebpackPluginConfig = context.workspaceConfig.pluginsConfig
+    ? (context.workspaceConfig.pluginsConfig['@nrwl/node:webpack'] as any)
+    : undefined;
+  const filter =
+    nodeWebpackPluginConfig && nodeWebpackPluginConfig.hashingExcludesTests
+      ? 'exclude-tests-of-all'
+      : 'all-files';
+  return context.hasher.hashTaskWithDepsAndContext(task, filter);
+}

--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -342,12 +342,12 @@ class ProjectHasher {
           })
         )
       ).filter((r) => !!r);
-      const filterForProject =
-        filter === 'all-files'
-          ? 'all-files'
-          : filter === 'exclude-tests-of-deps' && visited[0] === projectName
-          ? 'all-files'
-          : 'exclude-tests';
+      let filterForProject: 'all-files' | 'exclude-tests' = 'all-files';
+      if (filter === 'exclude-tests-of-deps' && visited[0] === projectName) {
+        filterForProject = 'exclude-tests';
+      } else if (filter === 'exclude-tests-of-all') {
+        filterForProject = 'exclude-tests';
+      }
       const projectHash = await this.hashProjectNodeSource(
         projectName,
         filterForProject


### PR DESCRIPTION
This builds on the Jest and Cypress custom hasher to allow webpack
builds to ignore spec files. It's enabled using:

```
  "pluginsConfig": {
    "@nrwl/node:webpack": {
      "hashingExcludesTests": true
    }
  }
```