### PR TITLE
fix(react): fix typo in testing-library migrations

### DIFF
--- a/packages/react/src/migrations/update-14-0-0/replace-testing-library-react-hook.ts
+++ b/packages/react/src/migrations/update-14-0-0/replace-testing-library-react-hook.ts
@@ -14,11 +14,11 @@ export async function update(tree: Tree) {
       if (!file.endsWith('.spec.ts')) return;
 
       const content = tree.read(file).toString();
-      if (content.includes('@testing-library/react-hook')) {
+      if (content.includes('@testing-library/react-hooks')) {
         tree.write(
           file,
           content.replace(
-            /@testing-library\/react-hook/g,
+            /@testing-library\/react-hooks/g,
             '@testing-library/react'
           )
         );


### PR DESCRIPTION
There is a typo in `@testing-library/react-hooks` all over the NX docs  (https://nx.dev/guides/react-18) and here. It's misspelled. Because of that - migration process doesn't work