### PR TITLE
feat(web): add support for Node ESM when used to package SSR-ready library

### DIFF
--- a/docs/generated/packages/web.json
+++ b/docs/generated/packages/web.json
@@ -659,7 +659,7 @@
             "description": "Only build the specified comma-separated formats (`esm,umd,cjs`)",
             "alias": "f",
             "items": { "type": "string", "enum": ["esm", "umd", "cjs"] },
-            "default": ["esm", "umd"]
+            "default": ["esm"]
           },
           "external": {
             "type": "array",

--- a/e2e/react/src/react-package.test.ts
+++ b/e2e/react/src/react-package.test.ts
@@ -104,11 +104,9 @@ describe('Build React libraries and apps', () => {
       runCLI(`build ${childLib}`);
       runCLI(`build ${childLib2}`);
 
-      checkFilesExist(`dist/libs/${childLib}/index.esm.js`);
-      checkFilesExist(`dist/libs/${childLib}/index.umd.js`);
+      checkFilesExist(`dist/libs/${childLib}/index.js`);
 
-      checkFilesExist(`dist/libs/${childLib2}/index.esm.js`);
-      checkFilesExist(`dist/libs/${childLib2}/index.umd.js`);
+      checkFilesExist(`dist/libs/${childLib2}/index.js`);
 
       checkFilesExist(`dist/libs/${childLib}/assets/hello.txt`);
       checkFilesExist(`dist/libs/${childLib2}/README.md`);
@@ -118,8 +116,7 @@ describe('Build React libraries and apps', () => {
        */
       runCLI(`build ${parentLib}`);
 
-      checkFilesExist(`dist/libs/${parentLib}/index.esm.js`);
-      checkFilesExist(`dist/libs/${parentLib}/index.umd.js`);
+      checkFilesExist(`dist/libs/${parentLib}/index.js`);
 
       const jsonFile = readJson(`dist/libs/${parentLib}/package.json`);
       expect(jsonFile.peerDependencies).toEqual(
@@ -136,9 +133,9 @@ describe('Build React libraries and apps', () => {
 
       runCLI(`build ${parentLib} --skip-nx-cache`);
 
-      checkFilesExist(`dist/libs/${parentLib}/index.esm.js`);
-      checkFilesExist(`dist/libs/${childLib}/index.esm.js`);
-      checkFilesExist(`dist/libs/${childLib2}/index.esm.js`);
+      checkFilesExist(`dist/libs/${parentLib}/index.js`);
+      checkFilesExist(`dist/libs/${childLib}/index.js`);
+      checkFilesExist(`dist/libs/${childLib2}/index.js`);
     });
 
     it('should support --format option', () => {
@@ -151,25 +148,20 @@ export async function h() { return 'c'; }
 `
       );
 
-      runCLI(`build ${childLib} --format cjs,esm,umd`);
+      runCLI(`build ${childLib} --format cjs,esm`);
 
-      checkFilesExist(`dist/libs/${childLib}/index.cjs.js`);
-      checkFilesExist(`dist/libs/${childLib}/index.esm.js`);
-      checkFilesExist(`dist/libs/${childLib}/index.umd.js`);
+      checkFilesExist(`dist/libs/${childLib}/index.cjs`);
+      checkFilesExist(`dist/libs/${childLib}/index.js`);
 
       const cjsPackageSize = getSize(
-        tmpProjPath(`dist/libs/${childLib}/index.cjs.js`)
+        tmpProjPath(`dist/libs/${childLib}/index.cjs`)
       );
       const esmPackageSize = getSize(
-        tmpProjPath(`dist/libs/${childLib}/index.esm.js`)
-      );
-      const umdPackageSize = getSize(
-        tmpProjPath(`dist/libs/${childLib}/index.umd.js`)
+        tmpProjPath(`dist/libs/${childLib}/index.js`)
       );
 
-      // This is a loose requirement that ESM and CJS packages should be less than the UMD counterpart.
-      expect(esmPackageSize).toBeLessThanOrEqual(umdPackageSize);
-      expect(cjsPackageSize).toBeLessThanOrEqual(umdPackageSize);
+      // This is a loose requirement that ESM should be smaller than CJS output.
+      expect(esmPackageSize).toBeLessThanOrEqual(cjsPackageSize);
     });
 
     it('should preserve the tsconfig target set by user', () => {
@@ -214,7 +206,7 @@ export async function h() { return 'c'; }
       // What we're testing
       runCLI(`build ${myLib}`);
       // Assertion
-      const content = readFile(`dist/libs/${myLib}/index.esm.js`);
+      const content = readFile(`dist/libs/${myLib}/index.js`);
 
       /**
        * Then check if the result contains this "promise" polyfill?

--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -95,7 +95,7 @@ describe('Web Components Applications', () => {
     checkFilesExist(`dist/apps/_should_not_remove.txt`);
 
     // Asset that React runtime is imported
-    expect(readFile(`dist/libs/${libName}/index.esm.js`)).toMatch(
+    expect(readFile(`dist/libs/${libName}/index.js`)).toMatch(
       /react\/jsx-runtime/
     );
 

--- a/e2e/workspace-integrations/src/cache.test.ts
+++ b/e2e/workspace-integrations/src/cache.test.ts
@@ -168,7 +168,7 @@ describe('cache', () => {
       };
       config.targets.build = {
         executor: '@nrwl/workspace:run-commands',
-        outputs: [`dist/libs/${mylib1}/index.esm.js`],
+        outputs: [`dist/libs/${mylib1}/index.js`],
         options: {
           commands: [
             {
@@ -193,7 +193,7 @@ describe('cache', () => {
     expect(outputWithBuildTasksCached).toContain('cache');
     expectCached(outputWithBuildTasksCached, [mylib1]);
     // Ensure that only the specific file in outputs was copied to cache
-    expect(listFiles(`dist/libs/${mylib1}`)).toEqual([`index.esm.js`]);
+    expect(listFiles(`dist/libs/${mylib1}`)).toEqual([`index.js`]);
   }, 120000);
 
   function expectCached(

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -25,6 +25,14 @@ export interface PackageJson {
   name: string;
   version: string;
   scripts?: Record<string, string>;
+  type?: 'module' | 'commonjs';
+  main?: string;
+  types?: string;
+  module?: string;
+  exports?: Record<
+    string,
+    { types?: string; require?: string; import?: string }
+  >;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;

--- a/packages/web/src/executors/rollup/lib/update-package-json.spec.ts
+++ b/packages/web/src/executors/rollup/lib/update-package-json.spec.ts
@@ -1,0 +1,156 @@
+import { updatePackageJson } from './update-package-json';
+import * as utils from 'nx/src/utils/fileutils';
+import { PackageJson } from 'nx/src/utils/package-json';
+
+jest.mock('nx/src/utils/fileutils', () => ({
+  writeJsonFile: () => {},
+}));
+
+describe('updatePackageJson', () => {
+  const commonOptions = {
+    outputPath: 'dist/index.js',
+    tsConfig: './tsconfig.json',
+    project: './package.json',
+    entryFile: './index.js',
+    entryRoot: '.',
+    projectRoot: '.',
+    assets: [],
+    rollupConfig: [],
+  };
+
+  const sharedContext = {
+    isVerbose: false,
+    workspace: { version: 2, projects: {} },
+    root: '',
+    cwd: '',
+  };
+
+  it('should support ESM', () => {
+    const spy = jest.spyOn(utils, 'writeJsonFile');
+
+    updatePackageJson(
+      {
+        ...commonOptions,
+        format: ['esm'],
+      },
+      sharedContext,
+      { type: 'app', name: 'test', data: {} },
+      [],
+      {} as unknown as PackageJson
+    );
+
+    expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
+      exports: {
+        '.': {
+          types: './index.d.ts',
+          import: './index.js',
+        },
+      },
+      main: './index.js',
+      module: './index.js',
+      type: 'module',
+      types: './index.d.ts',
+    });
+
+    spy.mockRestore();
+  });
+
+  it('should support CJS', () => {
+    const spy = jest.spyOn(utils, 'writeJsonFile');
+
+    updatePackageJson(
+      {
+        ...commonOptions,
+        format: ['cjs'],
+      },
+      sharedContext,
+      { type: 'app', name: 'test', data: {} },
+      [],
+      {} as unknown as PackageJson
+    );
+
+    expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
+      exports: {
+        '.': {
+          types: './index.d.ts',
+          require: './index.cjs',
+        },
+      },
+      main: './index.cjs',
+      type: 'commonjs',
+      types: './index.d.ts',
+    });
+
+    spy.mockRestore();
+  });
+
+  it('should support ESM + CJS', () => {
+    const spy = jest.spyOn(utils, 'writeJsonFile');
+
+    updatePackageJson(
+      {
+        ...commonOptions,
+        format: ['esm', 'cjs'],
+      },
+      sharedContext,
+      { type: 'app', name: 'test', data: {} },
+      [],
+      {} as unknown as PackageJson
+    );
+
+    expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
+      exports: {
+        '.': {
+          types: './index.d.ts',
+          import: './index.js',
+          require: './index.cjs',
+        },
+      },
+      main: './index.cjs',
+      module: './index.js',
+      type: 'module',
+      types: './index.d.ts',
+    });
+
+    spy.mockRestore();
+  });
+
+  it('should support custom exports field', () => {
+    const spy = jest.spyOn(utils, 'writeJsonFile');
+
+    updatePackageJson(
+      {
+        ...commonOptions,
+        format: ['esm'],
+      },
+      sharedContext,
+      { type: 'app', name: 'test', data: {} },
+      [],
+      {
+        exports: {
+          foo: {
+            import: './foo.js',
+          },
+        },
+      } as unknown as PackageJson
+    );
+
+    expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
+      exports: {
+        '.': {
+          types: './index.d.ts',
+          import: './index.js',
+        },
+        foo: {
+          import: './foo.js',
+        },
+      },
+      main: './index.js',
+      module: './index.js',
+      type: 'module',
+      types: './index.d.ts',
+    });
+
+    spy.mockRestore();
+  });
+});

--- a/packages/web/src/executors/rollup/lib/update-package-json.ts
+++ b/packages/web/src/executors/rollup/lib/update-package-json.ts
@@ -1,0 +1,76 @@
+import { relative } from 'path';
+import { ExecutorContext } from 'nx/src/config/misc-interfaces';
+import { ProjectGraphProjectNode } from 'nx/src/config/project-graph';
+import {
+  DependentBuildableProjectNode,
+  updateBuildableProjectPackageJsonDependencies,
+} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { writeJsonFile } from 'nx/src/utils/fileutils';
+import { PackageJson } from 'nx/src/utils/package-json';
+import { NormalizedWebRollupOptions } from './normalize';
+
+export function updatePackageJson(
+  options: NormalizedWebRollupOptions,
+  context: ExecutorContext,
+  target: ProjectGraphProjectNode,
+  dependencies: DependentBuildableProjectNode[],
+  packageJson: PackageJson
+) {
+  const hasEsmFormat = options.format.includes('esm');
+  const hasCjsFormat =
+    options.format.includes('umd') || options.format.includes('cjs');
+
+  const types = `./${relative(options.entryRoot, options.entryFile).replace(
+    /\.[jt]sx?$/,
+    '.d.ts'
+  )}`;
+  const exports = {
+    // TS 4.5+
+    '.': {
+      types,
+    },
+  };
+
+  if (hasEsmFormat) {
+    // `module` field is used by bundlers like rollup and webpack to detect ESM.
+    // May not be required in the future if type is already "module".
+    packageJson.module = './index.js';
+    exports['.']['import'] = './index.js';
+
+    if (!hasCjsFormat) {
+      packageJson.main = './index.js';
+    }
+  }
+
+  if (hasCjsFormat) {
+    packageJson.main = './index.cjs';
+    exports['.']['require'] = './index.cjs';
+  }
+
+  packageJson.type = options.format.includes('esm') ? 'module' : 'commonjs';
+
+  // Support for older TS versions < 4.5
+  packageJson.types = types;
+
+  packageJson.exports = {
+    ...packageJson.exports,
+    ...exports,
+  };
+
+  writeJsonFile(`${options.outputPath}/package.json`, packageJson);
+
+  if (
+    dependencies.length > 0 &&
+    options.updateBuildableProjectDepsInPackageJson
+  ) {
+    updateBuildableProjectPackageJsonDependencies(
+      context.root,
+      context.projectName,
+      context.targetName,
+      context.configurationName,
+      target,
+      dependencies,
+      options.buildableProjectDepsInPackageJsonType
+    );
+  }
+}

--- a/packages/web/src/executors/rollup/rollup.impl.spec.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.spec.ts
@@ -30,7 +30,7 @@ describe('rollupExecutor', () => {
       project: 'libs/ui/package.json',
       tsConfig: 'libs/ui/tsconfig.json',
       watch: false,
-      format: ['esm', 'umd'],
+      format: ['esm', 'cjs'],
     };
   });
 
@@ -52,17 +52,17 @@ describe('rollupExecutor', () => {
           globals: { 'react/jsx-runtime': 'jsxRuntime' },
           name: 'Example',
           inlineDynamicImports: false,
-          chunkFileNames: '[name].esm.js',
-          entryFileNames: '[name].esm.js',
+          chunkFileNames: '[name].js',
+          entryFileNames: '[name].js',
         },
         {
           dir: '/root/dist/ui',
-          format: 'umd',
+          format: 'cjs',
           globals: { 'react/jsx-runtime': 'jsxRuntime' },
           name: 'Example',
-          inlineDynamicImports: true,
-          chunkFileNames: '[name].umd.js',
-          entryFileNames: '[name].umd.js',
+          inlineDynamicImports: false,
+          chunkFileNames: '[name].cjs',
+          entryFileNames: '[name].cjs',
         },
       ]);
     });

--- a/packages/web/src/executors/rollup/rollup.impl.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.ts
@@ -1,19 +1,22 @@
 import * as rollup from 'rollup';
 import * as peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import { getBabelInputPlugin } from '@rollup/plugin-babel';
-import { join, relative } from 'path';
+import { join } from 'path';
 import { from, Observable, of } from 'rxjs';
 import { catchError, concatMap, last, scan, tap } from 'rxjs/operators';
 import { eachValueFrom } from 'rxjs-for-await';
 import * as autoprefixer from 'autoprefixer';
-import type { ExecutorContext, ProjectGraphProjectNode } from '@nrwl/devkit';
-import { logger, names, readJsonFile, writeJsonFile } from '@nrwl/devkit';
-import { readCachedProjectGraph } from '@nrwl/devkit';
+import type { ExecutorContext } from '@nrwl/devkit';
+import {
+  logger,
+  names,
+  readCachedProjectGraph,
+  readJsonFile,
+} from '@nrwl/devkit';
 import {
   calculateProjectDependencies,
   computeCompilerOptionsPaths,
   DependentBuildableProjectNode,
-  updateBuildableProjectPackageJsonDependencies,
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import resolve from '@rollup/plugin-node-resolve';
 
@@ -28,6 +31,7 @@ import { analyze } from './lib/analyze-plugin';
 import { deleteOutputDir } from '../../utils/fs';
 import { swc } from './lib/swc-plugin';
 import { validateTypes } from './lib/validate-types';
+import { updatePackageJson } from './lib/update-package-json';
 
 // These use require because the ES import isn't correct.
 const commonjs = require('@rollup/plugin-commonjs');
@@ -59,6 +63,17 @@ export default async function* rollupExecutor(
     context.root,
     sourceRoot
   );
+
+  // TODO(jack): Remove UMD in Nx 15
+  if (options.format.includes('umd')) {
+    if (options.format.includes('cjs')) {
+      throw new Error(
+        'Cannot use both UMD and CJS. We recommend you use ESM or CJS.'
+      );
+    } else {
+      logger.warn('UMD format is deprecated and will be removed in Nx 15');
+    }
+  }
   const packageJson = readJsonFile(options.project);
 
   const npmDeps = (projectGraph.dependencies[context.projectName] ?? [])
@@ -261,8 +276,8 @@ export function createRollupOptions(
         format,
         dir: `${options.outputPath}`,
         name: options.umdName || names(context.projectName).className,
-        entryFileNames: `[name].${format}.js`,
-        chunkFileNames: `[name].${format}.js`,
+        entryFileNames: `[name].${format === 'esm' ? 'js' : 'cjs'}`,
+        chunkFileNames: `[name].${format === 'esm' ? 'js' : 'cjs'}`,
         // umd doesn't support code-split bundles
         inlineDynamicImports: format === 'umd',
       },
@@ -291,43 +306,6 @@ function createCompilerOptions(options, dependencies) {
     declaration: true,
     paths: compilerOptionPaths,
   };
-}
-
-function updatePackageJson(
-  options: NormalizedWebRollupOptions,
-  context: ExecutorContext,
-  target: ProjectGraphProjectNode,
-  dependencies: DependentBuildableProjectNode[],
-  packageJson: any
-) {
-  const entryFileTmpl = `./index.<%= extension %>.js`;
-  const typingsFile = relative(options.entryRoot, options.entryFile).replace(
-    /\.[jt]sx?$/,
-    '.d.ts'
-  );
-  if (options.format.includes('umd')) {
-    packageJson.main = entryFileTmpl.replace('<%= extension %>', 'umd');
-  } else if (options.format.includes('cjs')) {
-    packageJson.main = entryFileTmpl.replace('<%= extension %>', 'cjs');
-  }
-  packageJson.module = entryFileTmpl.replace('<%= extension %>', 'esm');
-  packageJson.typings = `./${typingsFile}`;
-  writeJsonFile(`${options.outputPath}/package.json`, packageJson);
-
-  if (
-    dependencies.length > 0 &&
-    options.updateBuildableProjectDepsInPackageJson
-  ) {
-    updateBuildableProjectPackageJsonDependencies(
-      context.root,
-      context.projectName,
-      context.targetName,
-      context.configurationName,
-      target,
-      dependencies,
-      options.buildableProjectDepsInPackageJsonType
-    );
-  }
 }
 
 interface RollupCopyAssetOption {

--- a/packages/web/src/executors/rollup/schema.json
+++ b/packages/web/src/executors/rollup/schema.json
@@ -33,7 +33,7 @@
         "type": "string",
         "enum": ["esm", "umd", "cjs"]
       },
-      "default": ["esm", "umd"]
+      "default": ["esm"]
     },
     "external": {
       "type": "array",

--- a/packages/web/src/migrations/update-14-1-7/rollup-format-backwards-compatibility.spec.ts
+++ b/packages/web/src/migrations/update-14-1-7/rollup-format-backwards-compatibility.spec.ts
@@ -1,0 +1,54 @@
+import { addProjectConfiguration, readJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import update from './rollup-format-backwards-compatibility';
+
+describe('rollup-format-backwards-compatibility', () => {
+  it('should add format options to match previous behavior if it does not exist', async () => {
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'proj1', {
+      root: 'proj1',
+      targets: {
+        build: {
+          executor: '@nrwl/web:rollup',
+        },
+      },
+    });
+
+    await update(tree);
+
+    expect(readJson(tree, 'proj1/project.json').targets).toEqual({
+      build: {
+        executor: '@nrwl/web:rollup',
+        options: {
+          format: ['esm', 'cjs'],
+        },
+      },
+    });
+  });
+
+  it('should skip update if format exists', async () => {
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(tree, 'proj1', {
+      root: 'proj1',
+      targets: {
+        build: {
+          executor: '@nrwl/web:rollup',
+          options: {
+            format: ['esm'],
+          },
+        },
+      },
+    });
+
+    await update(tree);
+
+    expect(readJson(tree, 'proj1/project.json').targets).toEqual({
+      build: {
+        executor: '@nrwl/web:rollup',
+        options: {
+          format: ['esm'],
+        },
+      },
+    });
+  });
+});

--- a/packages/web/src/migrations/update-14-1-7/rollup-format-backwards-compatibility.ts
+++ b/packages/web/src/migrations/update-14-1-7/rollup-format-backwards-compatibility.ts
@@ -1,0 +1,24 @@
+import {
+  formatFiles,
+  getProjects,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+
+/*
+ *
+ */
+export default async function update(tree: Tree) {
+  for (const [name, config] of getProjects(tree)) {
+    if (config.targets?.build?.executor !== '@nrwl/web:rollup') continue;
+    if (Array.isArray(config.targets.build.options?.format)) continue;
+
+    config.targets.build.options = {
+      ...config.targets.build.options,
+      format: ['esm', 'cjs'],
+    };
+
+    updateProjectConfiguration(tree, name, config);
+  }
+  await formatFiles(tree);
+}


### PR DESCRIPTION
This PR changes the output of libraries built with `@nrwl/web:rollup` so both ESM and CJS will work in Node.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Building with both CJS and ESM results in failed import when trying to import ESM. This error is due to missing `type: "module"` entry in `package.json`.

## Expected Behavior

Both ESM and CJS import/require works.

## Changes

* New `type: module` field for output `package.json` file.
* New `exports` field for output `package.json` file
* Set default format to ESM only (CJS isn't needed on the web, but could  be used for Node if desired)
* Migration to set format to ESM + CJS if not previously set (so previous UMD users can use CJS) -- can always override it if  needed