### PR TITLE
feat(repo): use jsLibGenerator instead of workspaceLibGenerator

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
+  }
+
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+
+  if [ -f ~/.huskyrc ]; then
+    debug "sourcing ~/.huskyrc"
+    . ~/.huskyrc
+  fi
+
+  export readonly husky_skip_init=1
+  sh -e "$0" "$@"
+  exitCode="$?"
+
+  if [ $exitCode != 0 ]; then
+    echo "husky - $hook_name hook exited with code $exitCode (error)"
+    exit $exitCode
+  fi
+
+  exit 0
+fi

--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -140,10 +140,6 @@
             "type": "boolean",
             "description": "Whether to skip TypeScript type checking for SWC compiler.",
             "default": false
-          },
-          "standaloneConfig": {
-            "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-            "type": "boolean"
           }
         },
         "required": ["name"],

--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -68,15 +68,20 @@
             "description": "Do not update tsconfig.json for development experience.",
             "default": false
           },
-          "includeBabelRc": {
+          "skipBabelrc": {
             "type": "boolean",
-            "description": "Include a .babelrc configuration to compile TypeScript files"
+            "description": "Do not generate `.babelrc` file. Useful for Node libraries that are not compiled by Babel."
           },
           "testEnvironment": {
             "type": "string",
             "enum": ["jsdom", "node"],
             "description": "The test environment to use if unitTestRunner is set to jest.",
             "default": "jsdom"
+          },
+          "supportTsx": {
+            "type": "boolean",
+            "description": "Setup `tsx` support.",
+            "default": false
           },
           "importPath": {
             "type": "string",
@@ -125,10 +130,20 @@
             "default": "tsc",
             "description": "The compiler used by the build and test targets"
           },
+          "module": {
+            "type": "string",
+            "enum": ["cjs", "none"],
+            "default": "cjs",
+            "description": "The module type to use for this library"
+          },
           "skipTypeCheck": {
             "type": "boolean",
             "description": "Whether to skip TypeScript type checking for SWC compiler.",
             "default": false
+          },
+          "standaloneConfig": {
+            "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
+            "type": "boolean"
           }
         },
         "required": ["name"],

--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -262,9 +262,7 @@ describe('js e2e', () => {
 
   it('should not create a `.babelrc` file when creating libs with js executors (--compiler=tsc)', () => {
     const lib = uniq('lib');
-    runCLI(
-      `generate @nrwl/js:lib ${lib} --compiler=tsc --includeBabelRc=false`
-    );
+    runCLI(`generate @nrwl/js:lib ${lib} --compiler=tsc --skipBabelRc=true`);
 
     checkFilesDoNotExist(`libs/${lib}/.babelrc`);
   });

--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -262,7 +262,7 @@ describe('js e2e', () => {
 
   it('should not create a `.babelrc` file when creating libs with js executors (--compiler=tsc)', () => {
     const lib = uniq('lib');
-    runCLI(`generate @nrwl/js:lib ${lib} --compiler=tsc --skipBabelRc=true`);
+    runCLI(`generate @nrwl/js:lib ${lib} --compiler=tsc --skipBabelrc`);
 
     checkFilesDoNotExist(`libs/${lib}/.babelrc`);
   });

--- a/packages/js/generators.ts
+++ b/packages/js/generators.ts
@@ -1,0 +1,2 @@
+export { libraryGenerator } from './src/generators/library/library';
+export { convertToSwcGenerator } from './src/generators/convert-to-swc/convert-to-swc';

--- a/packages/js/src/generators/library/files/lib/__dot__babelrc__tmpl__
+++ b/packages/js/src/generators/library/files/lib/__dot__babelrc__tmpl__
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/packages/js/src/generators/library/files/lib/package.json__tmpl__
+++ b/packages/js/src/generators/library/files/lib/package.json__tmpl__
@@ -1,5 +1,5 @@
 {
   "name": "<%= importPath %>",
-  "version": "0.0.1",
-  "type": "commonjs"
+  "version": "0.0.1"<% if (module != 'none') {%>,
+  "type": <% if (module === 'cjs') { %>"commonjs"<% } %><% } %>
 }

--- a/packages/js/src/generators/library/files/lib/tsconfig.json__tmpl__
+++ b/packages/js/src/generators/library/files/lib/tsconfig.json__tmpl__
@@ -1,7 +1,7 @@
 {
   "extends": "<%= rootTsConfigPath %>",
-  "compilerOptions": {
-    "module": "commonjs"<% if (js) { %>,
+  "compilerOptions": {<% if (module === 'cjs') { %>
+    "module": "commonjs"<% } %><% if (js) { %><% if (module !== 'none') { %>,<% } %>
     "allowJs": true<% } %>
   },
   "files": [],

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -13,7 +13,7 @@ describe('lib', () => {
   let tree: Tree;
   const defaultOptions: Omit<LibraryGeneratorSchema, 'name'> = {
     skipTsConfig: false,
-    includeBabelRc: false,
+    skipBabelrc: true,
     unitTestRunner: 'jest',
     skipFormat: false,
     linter: 'eslint',
@@ -877,39 +877,39 @@ describe('lib', () => {
       });
     });
 
-    describe('--includeBabelRc', () => {
-      it('should generate a .babelrc when flag is set to true', async () => {
+    describe('--skipBabelrc', () => {
+      it('should generate a .babelrc when flag is set to false', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          includeBabelRc: true,
+          skipBabelrc: false,
         });
 
         expect(tree.exists('libs/my-lib/.babelrc')).toBeTruthy();
       });
 
-      it('should not generate a .babelrc when flag is set to false', async () => {
+      it('should not generate a .babelrc when flag is set to true', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          includeBabelRc: false,
+          skipBabelrc: true,
         });
 
         expect(tree.exists('libs/my-lib/.babelrc')).toBeFalsy();
       });
 
-      it('should not generate a .babelrc when compiler is swc (even if flag is set to true)', async () => {
+      it('should not generate a .babelrc when compiler is swc (even if flag is set to false)', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
           compiler: 'swc',
-          includeBabelRc: true,
+          skipBabelrc: false,
         });
 
         expect(tree.exists('libs/my-lib/.babelrc')).toBeFalsy();
       });
 
-      it('should generate a .babelrc when flag is set to true (even if there is no `@nrwl/web` plugin installed)', async () => {
+      it('should generate a .babelrc when flag is set to false (even if there is no `@nrwl/web` plugin installed)', async () => {
         updateJson(tree, 'package.json', (json) => {
           json.devDependencies = {};
           return json;
@@ -918,7 +918,7 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          includeBabelRc: true,
+          skipBabelrc: false,
         });
 
         expect(tree.exists('libs/my-lib/.babelrc')).toBeTruthy();
@@ -951,7 +951,7 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          includeBabelRc: undefined,
+          skipBabelrc: undefined,
         });
 
         expect(tree.exists('libs/my-lib/.babelrc')).toBeTruthy();
@@ -970,6 +970,7 @@ describe('lib', () => {
           }
         `);
       });
+
       it('should not generate a .babelrc when flag is not set and there is NOT a `@nrwl/web` package installed', async () => {
         updateJson(tree, 'package.json', (json) => {
           json.devDependencies = {
@@ -982,10 +983,26 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          includeBabelRc: undefined,
+          skipBabelrc: undefined,
         });
 
         expect(tree.exists('libs/my-lib/.babelrc')).toBeFalsy();
+      });
+    });
+
+    describe('--module', () => {
+      it('should generate commonjs library', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'cjsLib',
+          buildable: true,
+        });
+
+        const packageJson = readJson(tree, 'libs/cjs-lib/package.json');
+        expect(packageJson.type).toEqual('commonjs');
+
+        const tsconfigJson = readJson(tree, 'libs/cjs-lib/tsconfig.json');
+        expect(tsconfigJson.compilerOptions.module).toEqual('commonjs');
       });
     });
   });

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -315,10 +315,6 @@ function normalizeOptions(
     options.buildable = true;
   }
 
-  if (options.config == null || options.config === 'project') {
-    options.config = options.standaloneConfig ? 'project' : 'workspace';
-  }
-
   if (options.config === 'npm-scripts') {
     options.unitTestRunner = 'none';
     options.linter = Linter.None;

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -196,8 +196,8 @@ function shouldSkipBabelRc(
   if (options.skipBabelrc == null) {
     const packageJson = readJson(tree, 'package.json');
     return (
-      !packageJson['devDependencies']['@nrwl/web'] &&
-      !packageJson['dependencies']['@nrwl/web']
+      !packageJson['devDependencies']?.['@nrwl/web'] &&
+      !packageJson['dependencies']?.['@nrwl/web']
     );
   }
 

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -52,15 +52,20 @@
       "description": "Do not update tsconfig.json for development experience.",
       "default": false
     },
-    "includeBabelRc": {
+    "skipBabelrc": {
       "type": "boolean",
-      "description": "Include a .babelrc configuration to compile TypeScript files"
+      "description": "Do not generate `.babelrc` file. Useful for Node libraries that are not compiled by Babel."
     },
     "testEnvironment": {
       "type": "string",
       "enum": ["jsdom", "node"],
       "description": "The test environment to use if unitTestRunner is set to jest.",
       "default": "jsdom"
+    },
+    "supportTsx": {
+      "type": "boolean",
+      "description": "Setup `tsx` support.",
+      "default": false
     },
     "importPath": {
       "type": "string",
@@ -109,10 +114,20 @@
       "default": "tsc",
       "description": "The compiler used by the build and test targets"
     },
+    "module": {
+      "type": "string",
+      "enum": ["cjs", "none"],
+      "default": "cjs",
+      "description": "The module type to use for this library"
+    },
     "skipTypeCheck": {
       "type": "boolean",
       "description": "Whether to skip TypeScript type checking for SWC compiler.",
       "default": false
+    },
+    "standaloneConfig": {
+      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
+      "type": "boolean"
     }
   },
   "required": ["name"]

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -124,10 +124,6 @@
       "type": "boolean",
       "description": "Whether to skip TypeScript type checking for SWC compiler.",
       "default": false
-    },
-    "standaloneConfig": {
-      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-      "type": "boolean"
     }
   },
   "required": ["name"]

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -7,6 +7,7 @@ import type {
 import { TransformerEntry } from './typescript/types';
 
 export type Compiler = 'tsc' | 'swc';
+export type Module = 'cjs' | 'none';
 
 export interface LibraryGeneratorSchema {
   name: string;
@@ -15,10 +16,11 @@ export interface LibraryGeneratorSchema {
   tags?: string;
   simpleModuleName?: boolean;
   skipTsConfig?: boolean;
-  includeBabelRc?: boolean;
+  skipBabelrc?: boolean;
   unitTestRunner?: 'jest' | 'none';
   linter?: Linter;
   testEnvironment?: 'jsdom' | 'node';
+  supportTsx?: boolean;
   importPath?: string;
   js?: boolean;
   pascalCaseFiles?: boolean;
@@ -28,7 +30,9 @@ export interface LibraryGeneratorSchema {
   setParserOptionsProject?: boolean;
   config?: 'workspace' | 'project' | 'npm-scripts';
   compiler?: Compiler;
+  module?: Module;
   skipTypeCheck?: boolean;
+  standaloneConfig?: boolean;
 }
 
 export interface ExecutorOptions {

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -32,7 +32,6 @@ export interface LibraryGeneratorSchema {
   compiler?: Compiler;
   module?: Module;
   skipTypeCheck?: boolean;
-  standaloneConfig?: boolean;
 }
 
 export interface ExecutorOptions {

--- a/packages/js/src/utils/swc/add-swc-config.ts
+++ b/packages/js/src/utils/swc/add-swc-config.ts
@@ -1,6 +1,4 @@
-// TODO(chau): change back to 2015 when https://github.com/swc-project/swc/issues/1108 is solved
-// target: 'es2015'
-import { logger, readJson, Tree, updateJson } from '@nrwl/devkit';
+import { Tree } from '@nrwl/devkit';
 import { join } from 'path';
 
 export const defaultExclude = [

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -84,6 +84,7 @@ describe('lib', () => {
       const tsconfigJson = readJson(tree, 'libs/my-lib/tsconfig.json');
       expect(tsconfigJson).toMatchInlineSnapshot(`
         Object {
+          "compilerOptions": Object {},
           "extends": "../../tsconfig.base.json",
           "files": Array [],
           "include": Array [],

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -1,14 +1,13 @@
 import {
   getProjects,
-  NxJsonConfiguration,
   readJson,
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { libraryGenerator } from './library';
 
 import { Schema } from './schema.d';
-import { libraryGenerator } from './library';
 
 const baseLibraryConfig = {
   name: 'myLib',

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -12,10 +12,10 @@ import {
   updateProjectConfiguration,
   updateTsConfigsToJs,
 } from '@nrwl/devkit';
+import { libraryGenerator as jsLibraryGenerator } from '@nrwl/js/generators';
+import { join } from 'path';
 
 import { Schema } from './schema';
-import { libraryGenerator as workspaceLibraryGenerator } from '@nrwl/workspace/generators';
-import { join } from 'path';
 
 export interface NormalizedSchema extends Schema {
   name: string;
@@ -36,12 +36,14 @@ export async function libraryGenerator(tree: Tree, schema: Schema) {
     );
   }
 
-  const libraryInstall = await workspaceLibraryGenerator(tree, {
+  const libraryInstall = await jsLibraryGenerator(tree, {
     ...schema,
     importPath: options.importPath,
     testEnvironment: 'node',
     skipFormat: true,
     setParserOptionsProject: options.setParserOptionsProject,
+    module: 'none',
+    supportTsx: true,
   });
   createFiles(tree, options);
 

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -13,6 +13,7 @@ import {
   updateTsConfigsToJs,
 } from '@nrwl/devkit';
 import { libraryGenerator as jsLibraryGenerator } from '@nrwl/js/generators';
+import { shouldDefaultToUsingStandaloneConfigs } from 'nx/src/generators/utils/project-configuration';
 import { join } from 'path';
 
 import { Schema } from './schema';
@@ -44,7 +45,7 @@ export async function libraryGenerator(tree: Tree, schema: Schema) {
     setParserOptionsProject: options.setParserOptionsProject,
     module: 'none',
     supportTsx: true,
-    config: options.standaloneConfig ? 'project' : 'workspace',
+    config: options.standaloneConfig === false ? 'workspace' : 'project',
   });
   createFiles(tree, options);
 
@@ -84,6 +85,9 @@ function normalizeOptions(tree: Tree, options: Schema): NormalizedSchema {
 
   const importPath =
     options.importPath || `@${defaultPrefix}/${projectDirectory}`;
+
+  options.standaloneConfig =
+    options.standaloneConfig ?? shouldDefaultToUsingStandaloneConfigs(tree);
 
   return {
     ...options,

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -44,6 +44,7 @@ export async function libraryGenerator(tree: Tree, schema: Schema) {
     setParserOptionsProject: options.setParserOptionsProject,
     module: 'none',
     supportTsx: true,
+    config: options.standaloneConfig ? 'project' : 'workspace',
   });
   createFiles(tree, options);
 

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -34,10 +34,7 @@ async function createPreset(tree: Tree, options: Schema) {
   options.standaloneConfig =
     options.standaloneConfig ?? shouldDefaultToUsingStandaloneConfigs(tree);
 
-  if (
-    options.preset === Preset.Empty ||
-    options.preset === Preset.Apps
-  ) {
+  if (options.preset === Preset.Empty || options.preset === Preset.Apps) {
     return;
   } else if (options.preset === Preset.Angular) {
     const {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`nrwl/node:lib` and some presets are using `nrwl/workspace:lib`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nrwl/js:lib` is used instead of `nrwl/workspace:lib`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
