### PR TITLE
fix(angular): return error when name is missing from package.json

### DIFF
--- a/packages/angular/src/generators/ng-add/utilities/normalize-options.ts
+++ b/packages/angular/src/generators/ng-add/utilities/normalize-options.ts
@@ -35,6 +35,13 @@ export function normalizeOptions(
   if (!npmScope) {
     // use the name (scope if exists) in the root package.json
     const { name } = readJson(tree, 'package.json');
+
+    if (!name) {
+      throw new Error(
+        'Add the name-property to your package.json and try again.'
+      );
+    }
+
     npmScope = name.startsWith('@') ? name.split('/')[0].substring(1) : name;
   }
 

--- a/packages/angular/src/generators/ng-add/utilities/normalize-options.ts
+++ b/packages/angular/src/generators/ng-add/utilities/normalize-options.ts
@@ -36,13 +36,9 @@ export function normalizeOptions(
     // use the name (scope if exists) in the root package.json
     const { name } = readJson(tree, 'package.json');
 
-    if (!name) {
-      throw new Error(
-        'Add the name-property to your package.json and try again.'
-      );
+    if (name) {
+      npmScope = name.startsWith('@') ? name.split('/')[0].substring(1) : name;
     }
-
-    npmScope = name.startsWith('@') ? name.split('/')[0].substring(1) : name;
   }
 
   return { ...options, npmScope };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Situation: You have a angular-cli app with a package.json that has no "name"-property

```
ng add @nrwl/angular
Skipping installation: Package already installed
Cannot read properties of undefined (reading 'startsWith')
```

Traced the error back to `packages/angular/src/generators/ng-add/utilities/normalize-options.ts:38`

## Expected Behavior
Migration "just works" - somekind of fallback is used, or I am presented with an Error message so that I can fix the error.