### PR TITLE
fix(linter): do not remap paths that cannot be matched on fix

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -267,11 +267,13 @@ export default createESLintRule<Options, MessageIds>({
                       entryPointPath.path,
                       sourceProject.data.sourceRoot
                     );
-
-                    importsToRemap.push({
-                      member: importMember,
-                      importPath: importPath ? entryPointPath.importScope : imp, // we cannot remap, so leave it as is
-                    });
+                    // we cannot remap, so leave it as is
+                    if (importPath) {
+                      importsToRemap.push({
+                        member: importMember,
+                        importPath: entryPointPath.importScope,
+                      });
+                    }
                   }
                 }
 


### PR DESCRIPTION
This is related to #10284 in the case when the secondary entry point is having the same sub-path ( `hello`  and `hello/testing`)

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to #10284
