### PR TITLE
docs(nxdev): add redirect rules tests

### DIFF
--- a/nx-dev/nx-dev/redirect-rules.config.spec.js
+++ b/nx-dev/nx-dev/redirect-rules.config.spec.js
@@ -1,0 +1,17 @@
+import redirectRules from './redirect-rules.config';
+
+describe('Redirect rules configuration', () => {
+  describe('Safety checks', () => {
+    it('should not redirect to itself', () => {
+      const rules = {
+        ...redirectRules.overviewUrls,
+        ...redirectRules.guideUrls,
+        ...redirectRules.schemaUrls,
+      };
+
+      for (let k of Object.keys(rules)) {
+        expect(k).not.toEqual(rules[k]);
+      }
+    });
+  });
+});


### PR DESCRIPTION
It adds a minimal test making sure we do not create a redirect rule that redirects to itself on nx.dev.