### PR TITLE
docs(nxdev): rename api references to official plugins in sidebar

### DIFF
--- a/nx-dev/data-access-menu/src/lib/menu.utils.ts
+++ b/nx-dev/data-access-menu/src/lib/menu.utils.ts
@@ -88,8 +88,8 @@ export function getDeepDiveSection(items: MenuItem[]): MenuSection {
 
 export function getPackageApiSection(items: MenuItem[]): MenuSection {
   return {
-    id: 'api',
-    name: 'API / Reference',
+    id: 'official-plugins',
+    name: 'Official Plugins',
     itemList: items.filter(
       (m) =>
         m.id !== 'add-nx-to-monorepo' &&


### PR DESCRIPTION
It renames the "API / References" in the sidebar to "Official Plugins" on nx.dev.