### PR TITLE
feat(storybook): change executors to use buildDev instead of standalone

### DIFF
--- a/packages/storybook/src/executors/build-storybook/build-storybook.impl.spec.ts
+++ b/packages/storybook/src/executors/build-storybook/build-storybook.impl.spec.ts
@@ -1,9 +1,9 @@
 import { ExecutorContext, logger } from '@nrwl/devkit';
 import { join } from 'path';
-jest.mock('@storybook/core/standalone', () =>
+jest.mock('@storybook/core-server/standalone', () =>
   jest.fn().mockImplementation(() => Promise.resolve())
 );
-import * as storybook from '@storybook/core/standalone';
+import * as storybook from '@storybook/core-server/standalone';
 import storybookBuilder, {
   StorybookBuilderOptions,
 } from './build-storybook.impl';

--- a/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
+++ b/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext, logger } from '@nrwl/devkit';
-import * as build from '@storybook/core/standalone';
+import * as build from '@storybook/core-server/standalone';
 import 'dotenv/config';
 import { CommonNxStorybookConfig } from '../models';
 import {

--- a/packages/storybook/src/executors/storybook/storybook.impl.spec.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.spec.ts
@@ -4,9 +4,9 @@ import * as fs from 'fs';
 import { ExecutorContext } from '@nrwl/devkit';
 
 jest.mock('@storybook/core-server', () => ({
-  buildDevStandalone: jest.fn().mockImplementation(() => Promise.resolve()),
+  buildDev: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
-import { buildDevStandalone } from '@storybook/core-server';
+import { buildDev } from '@storybook/core-server';
 
 import storybookExecutor, { StorybookExecutorOptions } from './storybook.impl';
 import { join } from 'path';
@@ -89,6 +89,6 @@ describe('@nrwl/storybook:storybook', () => {
     const iterator = storybookExecutor(options, context);
     const { value } = await iterator.next();
     expect(value).toEqual({ success: true });
-    expect(buildDevStandalone).toHaveBeenCalled();
+    expect(buildDev).toHaveBeenCalled();
   });
 });

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -1,5 +1,5 @@
-import { ExecutorContext, logger } from '@nrwl/devkit';
-import { buildDevStandalone } from '@storybook/core-server';
+import { ExecutorContext } from '@nrwl/devkit';
+import { buildDev } from '@storybook/core-server';
 import 'dotenv/config';
 import { CommonNxStorybookConfig } from '../models';
 import {
@@ -42,44 +42,10 @@ export default async function* storybookExecutor(
 function runInstance(options: StorybookExecutorOptions) {
   const env = process.env.NODE_ENV ?? 'development';
   process.env.NODE_ENV = env;
-  return buildDevStandalone({
+  return buildDev({
     ...options,
     configType: env.toUpperCase(),
-  } as any).catch((error) => {
-    // TODO(juri): find a better cleaner way to handle these. Taken from:
-    // https://github.com/storybookjs/storybook/blob/dea23e5e9a3e7f5bb25cb6520d3011cc710796c8/lib/core-server/src/build-dev.ts#L138-L166
-    if (error instanceof Error) {
-      if ((error as any).error) {
-        logger.error((error as any).error);
-      } else if (
-        (error as any).stats &&
-        (error as any).stats.compilation.errors
-      ) {
-        (error as any).stats.compilation.errors.forEach((e: any) =>
-          logger.log(e)
-        );
-      } else {
-        logger.error(error as any);
-      }
-    } else if (error.compilation?.errors) {
-      error.compilation.errors.forEach((e: any) => logger.log(e));
-    }
-
-    logger.log('');
-    logger.warn(
-      error.close
-        ? `
-          FATAL broken build!, will close the process,
-          Fix the error below and restart storybook.
-        `
-        : `
-          Broken build, fix the error above.
-          You may need to refresh the browser.
-        `
-    );
-
-    process.exit(1);
-  });
+  } as any);
 }
 
 function storybookOptionMapper(


### PR DESCRIPTION
## Current Behavior
* `storybook` executor uses `buildDevStandalone`
* `build-storybook` executor imports `build` from `'@storybook/core/standalone'`

## Expected Behavior
* `storybook` executor can use `buildDev` instead, removing the need to handle some error cases on Nx, living that on Storybook
* `build-storybook` imports now from `'@storybook/core-server/standalone'`, since the `/core/` import will not work on v.6.5

Tested this locally, on angular lib, react lib, angular app, react app. All work as expected! 