### PR TITLE
fix(core): include types/node in deps when adding workspace-generator

### DIFF
--- a/packages/workspace/src/generators/workspace-generator/workspace-generator.ts
+++ b/packages/workspace/src/generators/workspace-generator/workspace-generator.ts
@@ -24,6 +24,9 @@ export default async function (host: Tree, schema: Schema) {
     {},
     {
       '@nrwl/devkit': nxVersion,
+      // types/node is neccessary for pnpm since it's used in tsconfig and transitive
+      // dependencies are not resolved correctly
+      '@types/node': 'latest',
     }
   );
 


### PR DESCRIPTION
Omitting `@types/node` from the dependencies breaks `pnpm v7` (and any other package manager with strict transitive rule).

## Current Behavior
When generating workspace-generator and running it with pnpm v7 we get the following error:
```bash
$ pnpm exec nx workspace-generator my-generator mylib
                                                                                                                                                   
error TS2688: Cannot find type definition file for 'node'.
  The file is in the program because:
    Entry point of type library 'node' specified in compilerOptions

  tools/tsconfig.generated.json:9:7
    9       "node"
            ~~~~~~
    File is entry point of type library specified here.


Found 1 error.
```

The reason is that `@types/node` is used in `tsconfig.generated.json` but it only exists as a transitive dependency. This is not allowed with pnpm v7.

> The error can be seen on nightly E2E tests for `workspace-generator`

## Expected Behavior
The default workspace-generator should run without errors in pnpm v7.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
