### PR TITLE
fix(core): ensure updateStorybook in nrwl/workspace:move handle direc…

### DIFF
--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -323,7 +323,6 @@ export class FsTree implements Tree {
 
   private fsIsFile(filePath: string): boolean {
     const stat = statSync(join(this.root, filePath));
-    console.log(filePath, this.root, stat);
     return stat.isFile();
   }
 

--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -323,6 +323,7 @@ export class FsTree implements Tree {
 
   private fsIsFile(filePath: string): boolean {
     const stat = statSync(join(this.root, filePath));
+    console.log(filePath, this.root, stat);
     return stat.isFile();
   }
 

--- a/packages/workspace/src/generators/move/lib/update-storybook-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-storybook-config.spec.ts
@@ -38,6 +38,7 @@ describe('updateStorybookConfig', () => {
     `;
     const storybookMainPath =
       '/libs/namespace/my-destination/.storybook/main.js';
+
     await libraryGenerator(tree, {
       name: 'my-source',
       standaloneConfig: false,
@@ -91,5 +92,104 @@ describe('updateStorybookConfig', () => {
     expect(storybookWebpackConfigAfter).toContain(
       `const rootWebpackConfig = require('../../../../.storybook/webpack.config');`
     );
+  });
+
+  describe('directory', () => {
+    it('should update the import path for directory/main.js', async () => {
+      const storybookMain = `
+      const rootMain = require('../../../.storybook/main');
+      module.exports = rootMain;
+    `;
+      const storybookMainPath =
+        '/libs/namespace/my-destination/.storybook/main.js';
+
+      const storybookNestedMain = `
+      const rootMain = require('../../../../.storybook/main');
+      module.exports = rootMain;
+    `;
+      const storybookNestedMainPath =
+        '/libs/namespace/my-destination/.storybook/nested/main.js';
+
+      await libraryGenerator(tree, {
+        name: 'my-source',
+        standaloneConfig: false,
+      });
+      const projectConfig = readProjectConfiguration(tree, 'my-source');
+      tree.write(storybookMainPath, storybookMain);
+      tree.write(storybookNestedMainPath, storybookNestedMain);
+      const schema: NormalizedSchema = {
+        projectName: 'my-source',
+        destination: 'namespace/my-destination',
+        importPath: '@proj/namespace-my-destination',
+        updateImportPath: true,
+        newProjectName: 'namespace-my-destination',
+        relativeToRootDestination: 'libs/namespace/my-destination',
+      };
+
+      updateStorybookConfig(tree, schema, projectConfig);
+
+      const storybookMainAfter = tree.read(storybookMainPath, 'utf-8');
+      expect(storybookMainAfter).toContain(
+        `const rootMain = require('../../../../.storybook/main');`
+      );
+      const storybookNestedMainAfter = tree.read(
+        storybookNestedMainPath,
+        'utf-8'
+      );
+      expect(storybookNestedMainAfter).toContain(
+        `const rootMain = require('../../../../../.storybook/main');`
+      );
+    });
+
+    it('should update the import path for directory/webpack.config.json', async () => {
+      const storybookWebpackConfig = `
+      const rootWebpackConfig = require('../../../.storybook/webpack.config');
+    `;
+      const storybookWebpackConfigPath =
+        '/libs/namespace/my-destination/.storybook/webpack.config.js';
+
+      const storybookNestedWebpackConfig = `
+      const rootWebpackConfig = require('../../../../.storybook/webpack.config');
+    `;
+      const storybookNestedWebpackConfigPath =
+        '/libs/namespace/my-destination/.storybook/nested/webpack.config.js';
+
+      await libraryGenerator(tree, {
+        name: 'my-source',
+        standaloneConfig: false,
+      });
+      const projectConfig = readProjectConfiguration(tree, 'my-source');
+      tree.write(storybookWebpackConfigPath, storybookWebpackConfig);
+      tree.write(
+        storybookNestedWebpackConfigPath,
+        storybookNestedWebpackConfig
+      );
+      const schema: NormalizedSchema = {
+        projectName: 'my-source',
+        destination: 'namespace/my-destination',
+        importPath: '@proj/namespace-my-destination',
+        updateImportPath: true,
+        newProjectName: 'namespace-my-destination',
+        relativeToRootDestination: 'libs/namespace/my-destination',
+      };
+
+      updateStorybookConfig(tree, schema, projectConfig);
+
+      const storybookWebpackConfigAfter = tree.read(
+        storybookWebpackConfigPath,
+        'utf-8'
+      );
+      expect(storybookWebpackConfigAfter).toContain(
+        `const rootWebpackConfig = require('../../../../.storybook/webpack.config');`
+      );
+
+      const storybookNestedWebpackConfigAfter = tree.read(
+        storybookNestedWebpackConfigPath,
+        'utf-8'
+      );
+      expect(storybookNestedWebpackConfigAfter).toContain(
+        `const rootWebpackConfig = require('../../../../../.storybook/webpack.config');`
+      );
+    });
   });
 });

--- a/packages/workspace/src/generators/move/lib/update-storybook-config.ts
+++ b/packages/workspace/src/generators/move/lib/update-storybook-config.ts
@@ -7,7 +7,9 @@ import { NormalizedSchema } from '../schema';
 /**
  * Updates relative path to root storybook config for `main.js` & `webpack.config.js`
  *
- * @param schema The options provided to the schematic
+ * @param {Tree} tree
+ * @param {NormalizedSchema} schema The options provided to the schematic
+ * @param {ProjectConfiguration} project
  */
 export function updateStorybookConfig(
   tree: Tree,
@@ -42,10 +44,24 @@ export function updateStorybookConfig(
   }
 
   // Replace relative import path to root storybook folder for each file under project storybook
-  for (const file of tree.children(storybookDir)) {
-    const oldContent = tree.read(join(storybookDir, file), 'utf-8');
-    const newContent = oldContent.replace(oldRelativeRoot, newRelativeRoot);
+  updateRecursively(tree, storybookDir, oldRelativeRoot, newRelativeRoot);
+}
 
-    tree.write(join(storybookDir, file), newContent);
+function updateRecursively(
+  tree: Tree,
+  dir: string,
+  oldRoot: string,
+  newRoot: string
+) {
+  for (const child of tree.children(dir)) {
+    const childPath = join(dir, child);
+
+    if (tree.isFile(childPath)) {
+      const oldContent = tree.read(childPath, 'utf-8');
+      const newContent = oldContent.replace(oldRoot, newRoot);
+      tree.write(childPath, newContent);
+    } else {
+      updateRecursively(tree, childPath, oldRoot, newRoot);
+    }
   }
 }


### PR DESCRIPTION
…tories and files

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If nested directory is in `.storybook` folder of a lib, attempting to move the lib with `nrwl/workspace:move` fails

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should not fail with directories in `.storybook` folder on moving a lib

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
