### PR TITLE
fix(devkit): parseTargetString should support targets with colons in their name

### DIFF
--- a/packages/devkit/src/executors/parse-target-string.spec.ts
+++ b/packages/devkit/src/executors/parse-target-string.spec.ts
@@ -1,0 +1,25 @@
+import { parseTargetString, targetToTargetString } from './parse-target-string';
+
+const cases = [
+  { input: 'one:two', expected: { project: 'one', target: 'two' } },
+  {
+    input: 'one:two:three',
+    expected: { project: 'one', target: 'two', configuration: 'three' },
+  },
+  {
+    input: 'one:"two:two":three',
+    expected: { project: 'one', target: 'two:two', configuration: 'three' },
+  },
+];
+
+describe('parseTargetString', () => {
+  it.each(cases)('$input -> $expected', ({ input, expected }) => {
+    expect(parseTargetString(input)).toEqual(expected);
+  });
+});
+
+describe('targetToTargetString', () => {
+  it.each(cases)('$expected -> $input', ({ input, expected }) => {
+    expect(targetToTargetString(expected)).toEqual(input);
+  });
+});

--- a/packages/devkit/src/executors/parse-target-string.ts
+++ b/packages/devkit/src/executors/parse-target-string.ts
@@ -1,4 +1,5 @@
 import type { Target } from 'nx/src/command-line/run';
+import { splitTarget } from 'nx/src/utils/split-target';
 
 /**
  * Parses a target string into {project, target, configuration}
@@ -12,7 +13,7 @@ import type { Target } from 'nx/src/command-line/run';
  * @param targetString - target reference
  */
 export function parseTargetString(targetString: string): Target {
-  const [project, target, configuration] = targetString.split(':');
+  const [project, target, configuration] = splitTarget(targetString);
   if (!project || !target) {
     throw new Error(`Invalid Target String: ${targetString}`);
   }
@@ -40,7 +41,7 @@ export function targetToTargetString({
   target,
   configuration,
 }: Target): string {
-  return `${project}:${target}${
+  return `${project}:${target.indexOf(':') > -1 ? `"${target}"` : target}${
     configuration !== undefined ? ':' + configuration : ''
   }`;
 }

--- a/packages/nx/src/utils/split-target.spec.ts
+++ b/packages/nx/src/utils/split-target.spec.ts
@@ -1,14 +1,14 @@
 import { splitTarget } from './split-target';
 
+const cases = [
+  { input: 'one', expected: ['one'] },
+  { input: 'one:two', expected: ['one', 'two'] },
+  { input: 'one:two:three', expected: ['one', 'two', 'three'] },
+  { input: 'one:"two:two":three', expected: ['one', 'two:two', 'three'] },
+];
+
 describe('splitTarget', () => {
-  it('should work', () => {
-    expect(splitTarget('one')).toEqual(['one']);
-    expect(splitTarget('one:two')).toEqual(['one', 'two']);
-    expect(splitTarget('one:two:three')).toEqual(['one', 'two', 'three']);
-    expect(splitTarget('one:"two:two":three')).toEqual([
-      'one',
-      'two:two',
-      'three',
-    ]);
+  it.each(cases)('$input -> $expected', ({ input, expected }) => {
+    expect(splitTarget(input)).toEqual(expected);
   });
 });

--- a/packages/nx/src/utils/split-target.ts
+++ b/packages/nx/src/utils/split-target.ts
@@ -1,4 +1,6 @@
-export function splitTarget(s: string): any {
+export function splitTarget(
+  s: string
+): [project: string, target?: string, configuration?: string] {
   const parts = [] as string[];
   let currentPart = '';
   for (let i = 0; i < s.length; ++i) {
@@ -15,5 +17,5 @@ export function splitTarget(s: string): any {
     }
   }
   parts.push(currentPart);
-  return parts;
+  return parts as [string, string?, string?];
 }


### PR DESCRIPTION
## Current Behavior
The CLI can run targets with colons in their name, but devkit fails to parse target strings containing these targets.

## Expected Behavior
The CLI and devkit behavior is the same

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related: #10398 
- This was discovered when investigating the issue, but the actual issue is more of a docs concern.
