### PR TITLE
docs(nxdev): add nx console redirect rule

### DIFF
--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -55,6 +55,23 @@ module.exports = withNx({
       permanent: true,
     });
 
+    // Nx Console
+    rules.push({
+      source: '/nx-console',
+      destination: '/using-nx/console',
+      permanent: true,
+    });
+    rules.push({
+      source: '/(l|latest)/(a|angular)/storybook/overview',
+      destination: '/storybook/overview-angular',
+      permanent: true,
+    });
+    rules.push({
+      source: '/(l|latest)/(a|angular|r|react)/storybook/executors',
+      destination: '/storybook/executors-storybook',
+      permanent: true,
+    });
+
     // Customs
     for (let s of Object.keys(redirectRules.guideUrls)) {
       rules.push({


### PR DESCRIPTION
It adds a redirection rule from `/nx-console` to `/using-nx/console` on nx.dev.