### PR TITLE
feat(node): allow executing esm compiled scripts

### DIFF
--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -21,6 +21,7 @@ import {
   tmpProjPath,
   uniq,
   updateFile,
+  updateJson,
   updateProjectConfig,
 } from '@nx/e2e/utils';
 import { exec, execSync } from 'child_process';
@@ -230,6 +231,46 @@ describe('Node Applications', () => {
       expect(err).toBeFalsy();
     }
   }, 120000);
+
+  it('should be able to run es module applications', async () => {
+    const esmapp = uniq('esmapp');
+
+    runCLI(`generate @nrwl/node:app ${esmapp} --linter=eslint`);
+    updateJson(`apps/${esmapp}/tsconfig.app.json`, (config) => {
+      config.module = 'esnext';
+      config.target = 'es2020';
+      return config;
+    });
+    updateProjectConfig(esmapp, (config) => {
+      config.targets.build.executor = '@nrwl/node:webpack';
+      config.targets.build.options.outputFileName = 'main.mjs';
+      config.targets.build.options.webpackConfig = `apps/${esmapp}/webpack.config.js`;
+      config.targets.serve.executor = '@nrwl/node:node';
+      config.targets.serve.options.watch = false;
+      return config;
+    });
+    updateFile(
+      `apps/${esmapp}/webpack.config.js`,
+      `module.exports = (config, context) => ({
+            ...config,
+            experiments: {
+                ...config.experiments,
+                outputModule: true,
+                topLevelAwait: true,
+            },
+            output: {
+                path: config.output.path,
+                chunkFormat: 'module',
+                library: {
+                    type: 'module',
+                },
+            },
+        })`
+    );
+    await runCLIAsync(`build ${esmapp}`);
+    const { stdout } = await runCLIAsync(`serve ${esmapp}`);
+    expect(stdout).toBe('Hello World!');
+  }, 300000);
 });
 
 describe('Build Node apps', () => {

--- a/packages/js/src/executors/node/node-with-require-overrides.ts
+++ b/packages/js/src/executors/node/node-with-require-overrides.ts
@@ -1,6 +1,8 @@
 const Module = require('module');
 const originalLoader = Module._load;
 
+const dynamicImport = new Function('specifier', 'return import(specifier)');
+
 const mappings = JSON.parse(process.env.NX_MAPPINGS);
 const keys = Object.keys(mappings);
 const fileToRun = process.env.NX_FILE_TO_RUN;
@@ -17,4 +19,4 @@ Module._load = function (request, parent) {
   }
 };
 
-require(fileToRun);
+dynamicImport(fileToRun);


### PR DESCRIPTION
## Current Behavior
The @nrwl/node:node executor is not able to execute esm module scripts

## Expected Behavior
The @nrwl/node:node executor is able to execute esm module scripts

Fixes: #10565
Fixes: #16036