### PR TITLE
fix(docs): yarn1 does not need -W flag

### DIFF
--- a/docs/shared/core-tutorial/01-create-blog.md
+++ b/docs/shared/core-tutorial/01-create-blog.md
@@ -48,7 +48,7 @@ Which tells yarn (or npm) and Nx to look in the `packages` folder for projects t
 To install Eleventy run:
 
 ```bash
-yarn add -D -W @11ty/eleventy@1.0.0
+yarn add -D @11ty/eleventy@1.0.0
 ```
 
 or
@@ -57,7 +57,7 @@ or
 npm add -D @11ty/eleventy@1.0.0
 ```
 
-Note: We are intentionally installing the package at the root of the workspace because this forces the organization to have the upfront cost of agreeing on the same versions of dependencies rather than the delayed cost of having projects using multiple different incompatible versions of dependencies. Yarn needs the `-W` flag so that you can install dependencies at the root. This is not a requirement of Nx, just a suggestion to help you maintain a growing repo.
+Note: We are intentionally installing the package at the root of the workspace because this forces the organization to have the upfront cost of agreeing on the same versions of dependencies rather than the delayed cost of having projects using multiple different incompatible versions of dependencies. This is not a requirement of Nx, just a suggestion to help you maintain a growing repo.
 
 **Eleventy Hello World**
 


### PR DESCRIPTION
I tried omitting the flag and everything seemed to work fine with yarn1.
if yarn2 needs this, it should be clarified which version  that it is talking about.

(furthermore, it is unclear what the -W flag would even do. would it mutate the package.json in a special way, or install the deps in a special way? if the latter, then someone cloning the monorepo from scratch would have failures when doing their initial `yarn` invocation, so this doesn't make much sense.)