### PR TITLE
fix(nx-plugin): handle nx.json without npmScope during plugin generation

### DIFF
--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -187,6 +187,23 @@ describe('NxPlugin Plugin Generator', () => {
       expect(name).toEqual('@proj/my-plugin');
     });
 
+    it('should correctly setup npmScope less workspaces', async () => {
+      // remove the npmScope from nx.json
+      const nxJson = JSON.parse(tree.read('nx.json')!.toString());
+      delete nxJson.npmScope;
+      tree.write('nx.json', JSON.stringify(nxJson));
+
+      await pluginGenerator(tree, getSchema());
+
+      const { root } = readProjectConfiguration(tree, 'my-plugin');
+      const { name } = readJson<{ name: string }>(
+        tree,
+        joinPathFragments(root, 'package.json')
+      );
+
+      expect(name).toEqual('my-plugin');
+    });
+
     it('should use importPath as the package.json name', async () => {
       await pluginGenerator(
         tree,

--- a/packages/nx-plugin/src/generators/plugin/plugin.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.ts
@@ -47,7 +47,8 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
     ? options.tags.split(',').map((s) => s.trim())
     : [];
 
-  const npmPackageName = options.importPath || `@${npmScope}/${name}`;
+  const npmPackageName =
+    options.importPath || resolvePackageName(npmScope, name);
 
   return {
     ...options,
@@ -161,6 +162,14 @@ export async function pluginGenerator(host: Tree, schema: Schema) {
   await formatFiles(host);
 
   return runTasksInSerial(...tasks);
+}
+
+function resolvePackageName(npmScope: string, name: string): string {
+  if (npmScope && npmScope !== '') {
+    return `@${npmScope}/${name}`;
+  } else {
+    return name;
+  }
 }
 
 export default pluginGenerator;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

currently generating a `nx-plugin` in a workspace where the `nx.json` does not have a `npmScope` defined does not work.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
