### PR TITLE
feat(angular): support alternate remote entry filenames #10206

### DIFF
--- a/packages/angular/src/utils/mfe/with-module-federation.ts
+++ b/packages/angular/src/utils/mfe/with-module-federation.ts
@@ -18,6 +18,7 @@ import {
 import { ParsedCommandLine } from 'typescript';
 import { readWorkspaceJson } from 'nx/src/project-graph/file-utils';
 import { readRootPackageJson } from './utils';
+import { extname, join } from 'path';
 import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
 
 export type MFERemotes = string[] | [remoteName: string, remoteUrl: string][];
@@ -142,12 +143,11 @@ function mapRemotes(remotes: MFERemotes) {
 
   for (const remote of remotes) {
     if (Array.isArray(remote)) {
-      const remoteLocation = remote[1].match(/remoteEntry\.(js|mjs)/)
-        ? remote[1]
-        : `${
-            remote[1].endsWith('/') ? remote[1].slice(0, -1) : remote[1]
-          }/remoteEntry.mjs`;
-      mappedRemotes[remote[0]] = remoteLocation;
+      const [remoteName, remoteLocation] = remote;
+      const remoteLocationExt = extname(remoteLocation);
+      mappedRemotes[remoteName] = ['.js', '.mjs'].includes(remoteLocationExt)
+        ? remoteLocation
+        : join(remoteLocation, 'remoteEntry.mjs');
     } else if (typeof remote === 'string') {
       mappedRemotes[remote] = determineRemoteUrl(remote);
     }

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -44,12 +44,13 @@ export default async function* moduleFederationDevServer(
     : [options.devRemotes];
 
   for (const app of knownRemotes) {
-    const isDev = devServeApps.includes(app);
+    const [appName] = Array.isArray(app) ? app : [app];
+    const isDev = devServeApps.includes(appName);
     iter = combineAsyncIterators(
       iter,
       await runExecutor(
         {
-          project: app,
+          project: appName,
           target: isDev ? 'serve' : 'serve-static',
           configuration: context.configurationName,
         },

--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -23,8 +23,9 @@ import {
   SharedFunction,
   SharedLibraryConfig,
 } from './models';
-import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
 import { readRootPackageJson } from './package-json';
+import { extname, join } from 'path';
+import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
 
 function collectDependencies(
   projectGraph: ProjectGraph,
@@ -131,14 +132,10 @@ function mapRemotes(remotes: Remotes) {
   for (const remote of remotes) {
     if (Array.isArray(remote)) {
       let [remoteName, remoteLocation] = remote;
-      if (!remoteLocation.match(/remoteEntry\.(js|mjs)$/)) {
-        remoteLocation = `${
-          remoteLocation.endsWith('/')
-            ? remoteLocation.slice(0, -1)
-            : remoteLocation
-        }/remoteEntry.js`;
-      }
-      mappedRemotes[remoteName] = remoteLocation;
+      const remoteLocationExt = extname(remoteLocation);
+      mappedRemotes[remoteName] = ['.js', '.mjs'].includes(remoteLocationExt)
+        ? remoteLocation
+        : join(remoteLocation, 'remoteEntry.js');
     } else if (typeof remote === 'string') {
       mappedRemotes[remote] = determineRemoteUrl(remote);
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We currently expect remotes to be set up using a filename with either `remoteEntry.mjs` or `remoteEntry.js`.

There are some use cases where teams will have legacy remotes outside their current Nx Monorepo that are using names that do not conform to this filename assumption.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We should allow for any filename in the remote location set up in the remotes array.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10206
