### PR TITLE
chore(nxdev): change nx core dependency lookup

### DIFF
--- a/scripts/vercel/ignore-build.sh
+++ b/scripts/vercel/ignore-build.sh
@@ -4,10 +4,9 @@
 # Exits with 0 if the build should be skipped, and exits with 1 to continue.
 
 APP=$1
-NX_VERSION=$(node -e "console.log(require('./package.json').version)")
 
 # Need the workspace in order to run affected
-yarn add -D @nrwl/workspace@$NX_VERSION --prefer-offline
+yarn add -D nx@latest --prefer-offline
 
 # We don't have a good way to check from base due to Vercel's shallow clone
 # TODO: Fix this once we figure out a better solution


### PR DESCRIPTION
It changes the core Nx dependency lookup to only use the latest version all the time. Simpler.