### PR TITLE
fix(testing): add tsquery as a dep for jest

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -36,6 +36,7 @@
     "@jest/reporters": "27.5.1",
     "@jest/test-result": "27.5.1",
     "@nrwl/devkit": "file:../devkit",
+    "@phenomnomnominal/tsquery": "4.1.1",
     "chalk": "4.1.0",
     "identity-obj-proxy": "3.0.0",
     "jest-config": "27.5.1",


### PR DESCRIPTION
tsquery is used in jest migrations and needs to be explicitly added to prevent runtime errors

ISSUES CLOSED: #10435

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
