### PR TITLE
feat(core): prompt for available generators

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "packages/nx/schemas/nx-schema.json",
   "implicitDependencies": {
     "package.json": "*",
     ".eslintrc.json": "*",

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -11,6 +11,12 @@
       "version": "14.2.0-beta.0",
       "description": "Add JSON Schema to Nx configuration files",
       "factory": "./src/migrations/update-14-2-0/add-json-schema"
+    },
+    "14-2-0-remove-default-collection": {
+      "cli": "nx",
+      "version": "14.2.0-beta.0",
+      "description": "Remove default collection from configuration to switch to prompts for collection",
+      "factory": "./src/migrations/update-14-2-0/remove-default-collection"
     }
   }
 }

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -213,6 +213,9 @@ async function runSchematic(
 type AngularJsonConfiguration = WorkspaceJsonConfiguration &
   Pick<NxJsonConfiguration, 'cli' | 'defaultProject' | 'generators'> & {
     schematics?: NxJsonConfiguration['generators'];
+    cli?: NxJsonConfiguration['cli'] & {
+      schematicCollections?: string[];
+    };
   };
 export class NxScopedHost extends virtualFs.ScopedHost<any> {
   protected __nxInMemoryWorkspace: WorkspaceJsonConfiguration | null;
@@ -432,6 +435,7 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
         if (formatted) {
           const { cli, generators, defaultProject, ...workspaceJson } =
             formatted;
+          delete cli.schematicCollections;
           return merge(
             this.writeWorkspaceConfigFiles(context, workspaceJson),
             cli || generators || defaultProject
@@ -446,6 +450,7 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
             defaultProject,
             ...angularJson
           } = w;
+          delete cli.schematicCollections;
           return merge(
             this.writeWorkspaceConfigFiles(context, angularJson),
             cli || schematics
@@ -461,6 +466,8 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
     }
     const { cli, schematics, generators, defaultProject, ...angularJson } =
       config;
+    delete cli.schematicCollections;
+
     return merge(
       this.writeWorkspaceConfigFiles(context, angularJson),
       this.__saveNxJsonProps({

--- a/packages/nx/src/migrations/update-14-2-0/remove-default-collection.spec.ts
+++ b/packages/nx/src/migrations/update-14-2-0/remove-default-collection.spec.ts
@@ -1,0 +1,44 @@
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import type { Tree } from '../../generators/tree';
+import removeDefaultCollection from './remove-default-collection';
+import {
+  readWorkspaceConfiguration,
+  updateWorkspaceConfiguration,
+} from '../../generators/utils/project-configuration';
+
+describe('remove-default-collection', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace(2);
+  });
+
+  it('should remove default collection from nx.json', async () => {
+    const config = readWorkspaceConfiguration(tree);
+    config.cli = {
+      defaultCollection: 'default-collection',
+      defaultProjectName: 'default-project',
+    };
+    updateWorkspaceConfiguration(tree, config);
+
+    await removeDefaultCollection(tree);
+
+    expect(readWorkspaceConfiguration(tree).cli).toEqual({
+      defaultProjectName: 'default-project',
+    });
+  });
+
+  it('should remove cli entirely if defaultCollection was the only setting', async () => {
+    const config = readWorkspaceConfiguration(tree);
+    config.cli = {
+      defaultCollection: 'default-collection',
+    };
+    updateWorkspaceConfiguration(tree, config);
+
+    await removeDefaultCollection(tree);
+
+    expect(
+      readWorkspaceConfiguration(tree).cli?.defaultCollection
+    ).toBeUndefined();
+  });
+});

--- a/packages/nx/src/migrations/update-14-2-0/remove-default-collection.ts
+++ b/packages/nx/src/migrations/update-14-2-0/remove-default-collection.ts
@@ -1,0 +1,19 @@
+import { Tree } from '../../generators/tree';
+import {
+  readWorkspaceConfiguration,
+  updateWorkspaceConfiguration,
+} from '../../generators/utils/project-configuration';
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
+
+export default async function (tree: Tree) {
+  const workspaceConfiguration = readWorkspaceConfiguration(tree);
+
+  delete workspaceConfiguration.cli?.defaultCollection;
+  if (Object.keys(workspaceConfiguration.cli).length === 0) {
+    delete workspaceConfiguration.cli;
+  }
+
+  updateWorkspaceConfiguration(tree, workspaceConfiguration);
+
+  await formatChangedFilesWithPrettierIfAvailable(tree);
+}

--- a/packages/nx/src/utils/plugins/models.ts
+++ b/packages/nx/src/utils/plugins/models.ts
@@ -1,21 +1,12 @@
-export interface PluginGenerator {
-  factory: string;
-  schema: string;
-  description: string;
-  aliases: string;
-  hidden: boolean;
-}
-
-export interface PluginExecutor {
-  implementation: string;
-  schema: string;
-  description: string;
-}
+import {
+  ExecutorsJsonEntry,
+  GeneratorsJsonEntry,
+} from '../../config/misc-interfaces';
 
 export interface PluginCapabilities {
   name: string;
-  executors: { [name: string]: PluginExecutor };
-  generators: { [name: string]: PluginGenerator };
+  executors: { [name: string]: ExecutorsJsonEntry };
+  generators: { [name: string]: GeneratorsJsonEntry };
 }
 
 export interface CorePlugin {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There is no prompt when the generator does not exist on the default collection.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Default collection is deprecated and instead, Nx will prompt for the generator to use.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
