### PR TITLE
cleanup(misc): remove dependency strip-json-comments and use devkit readJsonFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,6 @@
     "source-map": "0.7.3",
     "source-map-loader": "^3.0.0",
     "source-map-support": "0.5.19",
-    "strip-json-comments": "^3.1.1",
     "style-loader": "^3.3.0",
     "styled-components": "5.0.0",
     "stylus": "^0.55.0",

--- a/packages/add-nx-to-monorepo/package.json
+++ b/packages/add-nx-to-monorepo/package.json
@@ -32,7 +32,6 @@
     "enquirer": "~2.3.6",
     "ignore": "^5.0.4",
     "nx": "file:../nx",
-    "strip-json-comments": "^3.1.1",
     "yargs-parser": "21.0.1"
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`add-nx-to-monorepo` depends on `strip-json-comments`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
it should use the internal `readJsonFile` Method which strips the json comments

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
