### PR TITLE
docs(nxdev): add some vertical spacing on home buttons in mobile

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "build/packages/*"
-  ],
+  "packages": ["build/packages/*"],
   "version": "14.1.9",
   "granularPathspec": false,
   "command": {

--- a/nx-dev/nx-dev/pages/index.tsx
+++ b/nx-dev/nx-dev/pages/index.tsx
@@ -112,7 +112,7 @@ export function Index(): ReactComponentElement<any> {
                 >
                   <NpxCreateNxWorkspace />
                 </div>
-                <div className="my-14 flex flex-wrap text-center sm:space-x-4">
+                <div className="my-14 flex flex-wrap space-y-4 text-center sm:space-y-0 sm:space-x-4">
                   <Link href="#getting-started">
                     <a
                       title="Start using Nx by creating a workspace"


### PR DESCRIPTION
It adds some vertical space on the home buttons for nx.dev.

<img width="439" alt="xxx" src="https://user-images.githubusercontent.com/3447705/170298266-0d1016e8-eca1-41d1-bb62-97908e637e03.png">
