### PR TITLE
fix(core): ensure createPackageJson sorts dependencies consistently

### DIFF
--- a/packages/workspace/src/utilities/create-package-json.ts
+++ b/packages/workspace/src/utilities/create-package-json.ts
@@ -1,5 +1,6 @@
 import type { ProjectGraph } from '@nrwl/devkit';
 import { readJsonFile } from '@nrwl/devkit';
+import { sortObjectByKeys } from 'nx/src/utils/object-sort';
 
 /**
  * Creates a package.json in the output directory for support to install dependencies within containers.
@@ -40,6 +41,9 @@ export function createPackageJson(
       packageJson.dependencies[packageName] = version;
     }
   });
+
+  packageJson.devDependencies &&= sortObjectByKeys(packageJson.devDependencies);
+  packageJson.dependencies &&= sortObjectByKeys(packageJson.dependencies);
 
   return packageJson;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Dependencies order in the generated package.json is dependent on th eorder of the imports in the code.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Order should be consistent.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
