### PR TITLE
feat(angular): add x-type to host and remote generators

### DIFF
--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -75,6 +75,7 @@
     "remote": {
       "factory": "./src/generators/remote/remote.compat",
       "schema": "./src/generators/remote/schema.json",
+      "x-type": "application",
       "description": "Generate a Remote Angular Module Federation Application."
     },
     "move": {
@@ -91,6 +92,7 @@
     "host": {
       "factory": "./src/generators/host/host.compat",
       "schema": "./src/generators/host/schema.json",
+      "x-type": "application",
       "description": "Generate a Host Angular Module Federation Application."
     },
     "ng-add": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `host` and `remote` generators don't show up in Nx Console when using the `Nx generate application` action from the context menu over the `apps` directory.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `host` and `remote` generators should show up in Nx Console when using the `Nx generate application` action from the context menu over the `apps` directory.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
