### PR TITLE
fix(core): new and migrate commands should exit with code

### DIFF
--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -10,9 +10,9 @@ import {
   readJson,
   runCLI,
   runCreateWorkspace,
-  updateJson,
-  updateFile,
   uniq,
+  updateFile,
+  updateJson,
 } from '@nrwl/e2e/utils';
 import { existsSync, mkdirSync } from 'fs-extra';
 import { execSync } from 'child_process';
@@ -93,9 +93,28 @@ describe('create-nx-workspace', () => {
     });
   });
 
+  it('should fail correctly when preset errors', () => {
+    // Using Angular Preset as the example here to test
+    // It will error when npmScope is of form `<char>-<num>-<char>`
+    // Due to a validation error Angular will throw.
+    const wsName = uniq('angular-1-test');
+    const appName = uniq('app');
+    try {
+      runCreateWorkspace(wsName, {
+        preset: 'angular',
+        style: 'css',
+        appName,
+        packageManager,
+      });
+    } catch (e) {
+      expect(e).toBeTruthy();
+    }
+  });
+
   it('should be able to create an react workspace', () => {
     const wsName = uniq('react');
     const appName = uniq('app');
+
     runCreateWorkspace(wsName, {
       preset: 'react',
       style: 'css',

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -293,9 +293,10 @@ ${daemonHelpOutput}
     builder: (yargs) => withNewOptions(yargs),
     handler: async (args) => {
       args._ = args._.slice(1);
-      return (await import('./generate')).newWorkspace(
-        args['nxWorkspaceRoot'] as string,
-        args
+      process.exit(
+        await (
+          await import('./generate')
+        ).newWorkspace(args['nxWorkspaceRoot'] as string, args)
       );
     },
   })
@@ -303,7 +304,10 @@ ${daemonHelpOutput}
     '_migrate [packageAndVersion]',
     false,
     (yargs) => withMigrationOptions(yargs),
-    async (args) => (await import('./migrate')).migrate(process.cwd(), args)
+    async (args) =>
+      process.exit(
+        await (await import('./migrate')).migrate(process.cwd(), args)
+      )
   )
   .help('help')
   .version(nxVersion);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
New and Migrate commands do not exit correctly when an error is thrown.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
They should report the error code correct to `process.exit` to allow the command to fail correctly.


